### PR TITLE
feat: add /open-pr skill and scope commit hook to main only

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: open-pr
+description: Open a pull request against resumelint from your current work — branch if needed, commit, push, and create the PR with a filled body that links the issue. Use when the user says "open a PR", "send a PR", "/open-pr", or has finished a change and wants it reviewed.
+---
+
+# Open PR
+
+Take a contributor from a working change all the way to an **open pull request**
+against `main`, in one skill: branch (if needed) → commit → push → create the PR
+with a filled body that links the issue.
+
+## Input
+
+Parse the argument for an **issue number** (e.g. `5`, `#5`) and/or a short commit
+message. If the issue number is absent, try to recover it from the current
+branch name (`feat/...-issue-5`, `gh-5`) or a `Closes #N` / `Refs #N` trailer in
+an existing commit. If still unknown, open the PR without an issue link and note
+that in the output — don't block on it.
+
+## Why this skill exists
+
+`main` is protected: every change merges through a PR that needs **1 approving
+review** and a green **`verify`** CI check. Direct pushes and direct commits to
+`main` are blocked (server-side branch protection + a local `block_commit`
+hook). This skill is the fast, correct path: it always works on a feature
+branch, never on `main`.
+
+## Process
+
+### Step 0: Detect repo + base
+
+```bash
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"          # resumelint-org/resumelint
+BASE="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"  # main
+```
+
+### Step 1: Get onto a feature branch (never commit on `main`)
+
+```bash
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+```
+
+- If `BRANCH` is `main`:
+  - If there are **committed** commits ahead of `origin/main`, move them onto a
+    new branch and reset `main`:
+    ```bash
+    git switch -c feat/<short-slug>
+    git branch --force main origin/main
+    ```
+  - If there are only **uncommitted** changes, just create the branch (the
+    changes follow): `git switch -c feat/<short-slug>`.
+  - Pick `<short-slug>` from the issue/topic (e.g. `feat/per-bullet-feedback-issue-5`).
+- If `BRANCH` is already a feature branch: continue.
+
+### Step 2: Commit any uncommitted work
+
+If `git status --porcelain` shows changes, stage and commit them on the feature
+branch (the `block_commit` hook allows commits on non-`main` branches):
+
+```bash
+git add -A
+git commit -m "<type: concise summary>"   # feat/fix/chore/refactor/docs/test
+```
+
+Use a `COMMIT_EDITMSG` file if one is already prepared (`git commit -F COMMIT_EDITMSG`).
+If the tree is already clean and there are commits ahead of `origin/$BASE`, skip
+to push.
+
+### Step 3: Confirm there's something to propose
+
+```bash
+git log --oneline origin/$BASE..HEAD
+```
+
+If empty, there's nothing to PR — say so and stop.
+
+### Step 4: Push the branch
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+### Step 5: Create the PR
+
+Build the title from the commits (first subject, or the issue title) and a body
+with a short summary + test checklist. Use a closing keyword **only if** this PR
+fully resolves the issue.
+
+```bash
+gh pr create --repo "$REPO" --base "$BASE" --head "$BRANCH" \
+  --title "<type: concise summary>" \
+  --body  "$(cat <<'BODY'
+## Summary
+
+<1–3 sentences: what changed and why.>
+
+Closes #<N>   <!-- omit if not fully resolving an issue; use "Refs #<N>" if partial -->
+
+## Test plan
+
+- [ ] `npm run typecheck` clean
+- [ ] `npm run test` green
+- [ ] Manually verified in `npm run dev` / `npm run preview`
+BODY
+)"
+```
+
+`gh pr create --fill` derives title/body from the commits — fine for small PRs.
+
+### Step 6: Report
+
+Print the PR URL. Remind the user the PR needs **1 approval** (the author can't
+approve their own) and a green **`verify`** check before it can merge. Reviewers
+can be requested with `gh pr edit <num> --add-reviewer <user>`. (Repo admins can
+merge their own PR via admin bypass.)
+
+## Rules
+
+- **Never commit or push to `main`** — always a feature branch + PR. (The local
+  hook enforces the no-commit-on-`main` half; server-side protection enforces
+  the rest.)
+- **One PR per issue/topic.** Keep the diff focused so a single reviewer can
+  approve it quickly.
+- Use a closing keyword (`Closes #N`) only when the PR fully resolves the issue;
+  otherwise `Refs #N`.
+- Match the commit-type prefix conventions from `CONTRIBUTING.md`
+  (`feat`/`fix`/`chore`/`refactor`/`docs`/`test`).

--- a/scripts/hooks/block_commit.sh
+++ b/scripts/hooks/block_commit.sh
@@ -2,10 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 The resumelint Authors
 #
-# PreToolUse(Bash) hook: refuse direct `git commit` inside this repo so
-# every commit lands through `commit-all.sh` (formatting, tests,
-# structured commit). `commit-all.sh` itself is also blocked by default
-# — the user runs the commit script; Claude only prepares COMMIT_EDITMSG.
+# PreToolUse(Bash) hook: refuse `git commit` on the protected `main`
+# branch, so changes land on a feature branch and merge through a
+# reviewed pull request (see the /open-pr skill). Commits on feature
+# branches are allowed — contributors (and Claude via /open-pr) commit
+# normally, then open a PR.
+#
+# This is a local mirror of the server-side branch protection on `main`
+# (PR + 1 approval + the `verify` CI check). It is intentionally generic:
+# no dependency on any per-machine commit script.
 #
 # Scope: only enforces when the effective cwd is inside this repo.
 # Sibling repos (e.g. ~/claude-memory during /primer) are untouched.
@@ -16,9 +21,7 @@
 # Not bulletproof (subshells, pushd) but covers day-to-day shapes.
 #
 # Override (rare): export RESUMELINT_SKIP_HOOKS=1 in the shell that
-# launched `claude` BEFORE starting the session. Inline prefixing —
-# `RESUMELINT_SKIP_HOOKS=1 git commit ...` — does NOT work, because the
-# env assignment is part of the command string the hook never executes.
+# launched `claude` BEFORE starting the session.
 
 set -euo pipefail
 
@@ -49,7 +52,7 @@ if [[ "$command" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:];|\&]+) ]]; then
 fi
 [[ -z "$effective_cwd" ]] && effective_cwd="${PWD:-}"
 
-# Definitively outside this repo → skip. Unknown → fall through (block)
+# Definitively outside this repo → skip. Unknown → fall through (check)
 # so we false-positive rather than silently allow a commit inside it.
 if [[ -n "$effective_cwd" \
       && "$effective_cwd" != "$REPO_ROOT" \
@@ -57,20 +60,15 @@ if [[ -n "$effective_cwd" \
   exit 0
 fi
 
-# 1) Direct git commit — never allowed in this project.
+# Only gate `git commit`. Anything else passes.
 if [[ "$command" =~ (^|[[:space:];|&]|\|\|)git[[:space:]]+commit([[:space:]]|$|\;) ]]; then
-  echo "resumelint: refusing direct \`git commit\` inside this repo." >&2
-  echo "Commits go through commit-all.sh, and the user runs the script — Claude prepares COMMIT_EDITMSG only." >&2
-  echo "Sibling repos (~/claude-memory etc.) are not affected by this hook." >&2
-  exit 2
-fi
-
-# 2) commit-all.sh — user-driven by default.
-if [[ "$command" =~ (^|[[:space:];|&/]|\|\|)commit-all\.sh([[:space:]]|$|\;) ]]; then
-  echo "resumelint: refusing commit-all.sh — the user runs the commit script." >&2
-  echo "Claude's job ends at writing COMMIT_EDITMSG and reporting tests pass." >&2
-  echo "If you really need to bypass: export RESUMELINT_SKIP_HOOKS=1 in the shell that launched \`claude\`." >&2
-  exit 2
+  current_branch="$(git -C "$effective_cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+  if [[ "$current_branch" == "main" ]]; then
+    echo "resumelint: refusing \`git commit\` on main." >&2
+    echo "main is protected — commit on a feature branch and open a PR (see the /open-pr skill)." >&2
+    echo "  git switch -c feat/<slug>   # then commit, then /open-pr" >&2
+    exit 2
+  fi
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

Adds a self-contained `/open-pr` Claude Code skill and fixes the commit hook so the contributor flow works for everyone (not just the maintainer).

- **`.claude/skills/open-pr/SKILL.md`** — takes a contributor from a working change to an open PR: branch off `main` if needed → commit → push → `gh pr create` with a filled body that links the issue.
- **`scripts/hooks/block_commit.sh`** — now refuses commits only on the protected `main` branch (a local mirror of the server-side branch protection) and allows feature-branch commits. Drops the previous routing through the maintainer's personal commit script, which public contributors don't have.

## Test plan

- [x] Commit on a feature branch succeeds under the reworked hook
- [x] `verify` CI (typecheck + test + build) green on this branch
- [ ] (reviewer) confirm a `git commit` on `main` is still refused locally