### PR TITLE
chore: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Bumped 2026-06-01 (#4): Node 20 actions deprecated, runner forces Node 24 by 2026-06-02.
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,8 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Bumped 2026-06-01 (#4): Node 20 actions deprecated, runner forces Node 24 by 2026-06-02.
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -28,7 +29,8 @@ jobs:
         env:
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
           VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
-      - uses: actions/upload-pages-artifact@v3
+      # v3 → v5 because v4 predates the Node 24 push; v5 (Apr 2026) is the first post-deprecation release.
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -40,4 +42,5 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        # Bumped 2026-06-01 (#4): v5.0.0 release notes explicitly cite the Node 24 upgrade.
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Closes #4. Bumps actions/checkout v4→v5, actions/setup-node v4→v5, actions/upload-pages-artifact v3→v5, and actions/deploy-pages v4→v5 so the Node 20 deprecation warning clears without using FORCE_JAVASCRIPT_ACTIONS_TO_NODE24. Inline comments on each bump per the issue's acceptance criteria. Local: typecheck + 161/161 tests + build all green.