### PR TITLE
fix(heuristics): let contact proximity overturn a tagline name pick (#16)

### DIFF
--- a/src/lib/heuristics/extract-fields.test.ts
+++ b/src/lib/heuristics/extract-fields.test.ts
@@ -245,6 +245,60 @@ describe("extractName — document-title boilerplate rejection (issue #10)", () 
   });
 });
 
+describe("extractName — name set apart from contact block (issue #16, mode 2)", () => {
+  it("prefers the contact-adjacent name over a LARGER job-title tagline above it", () => {
+    // Mode 2 of #10/#16: a "Product Designer" tagline renders in a larger font
+    // on the first profile line, so position+size alone make it the winner —
+    // even though the real name sits one line below, immediately above the
+    // contact cluster. The contact-cluster proximity must be strong enough to
+    // *change the winner*, not merely nudge confidence.
+    const { profile } = buildContext([
+      { text: "Product Designer", fontSize: 16 },
+      { text: "Jane Smith", fontSize: 12 },
+      { text: "jane.smith@example.com", fontSize: 11 },
+      { text: "(555) 010-0123", fontSize: 11 },
+      { text: "" },
+      { text: "EXPERIENCE", fontSize: 13 },
+    ]);
+    const result = extractName(profile);
+    expect(result.value).toBe("Jane Smith");
+    // Must clear ANON_CONTACT_CONFIDENCE_FLOOR (0.5) so completeness scoring
+    // doesn't mark the (correctly-detected) name as missing — the exact
+    // failure @sriyau64 reported.
+    expect(result.confidence).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("prefers the contact-adjacent name over a same-size job-title line above it", () => {
+    // Same defect without the font cue: a "Senior Marketing Lead" line sits
+    // higher at the same size, so it would win the first-line bonus. Proximity
+    // to the contact cluster has to overturn that.
+    const { profile } = buildContext([
+      { text: "Senior Marketing Lead", fontSize: 12 },
+      { text: "Jane Smith", fontSize: 12 },
+      { text: "jane.smith@example.com", fontSize: 11 },
+      { text: "" },
+      { text: "EXPERIENCE", fontSize: 13 },
+    ]);
+    const result = extractName(profile);
+    expect(result.value).toBe("Jane Smith");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("no regression: name + title + contact in reading order still picks the name", () => {
+    // The common "Name / Title / contact" stack must be unaffected — the name
+    // is the first eligible line and stays the winner even though the title
+    // line is closer to the contact cluster.
+    const { profile } = buildContext([
+      { text: "Jane Smith", fontSize: 18 },
+      { text: "Product Designer", fontSize: 12 },
+      { text: "jane.smith@example.com", fontSize: 11 },
+      { text: "" },
+      { text: "EXPERIENCE", fontSize: 13 },
+    ]);
+    expect(extractName(profile).value).toBe("Jane Smith");
+  });
+});
+
 describe("US_LOCATION_RE — preposition-phrase city rejection", () => {
   it("does not eat lowercase prepositions like 'and' / 'of' inside the city capture", () => {
     // Pre-fix the regex captured "CS and Engineering Seattle" (26 chars

--- a/src/lib/heuristics/extract-fields.ts
+++ b/src/lib/heuristics/extract-fields.ts
@@ -129,10 +129,18 @@ function findContactClusterY(lines: PdfLine[]): number | undefined {
  *   +0.3 font size larger than the rest of profile
  *   +0.2 all-caps OR title-case
  *   +0.1 2–4 words, 2–40 chars, no digits/emails
- *   +0.15 within ~80pt of the email/phone/linkedin line (contact-cluster proximity)
+ *   +0.15 first eligible line within ~80pt of the contact cluster (soft confirm)
+ *   +0.4  *later* line within ~80pt of the contact cluster (mode-2 recovery —
+ *         lets a name set apart below a tagline/header overtake the higher line)
+ *   −0.6  line looks like a job title ("Product Designer", "Senior Marketing
+ *         Lead") — a tagline must not out-score the real name on position/size
  *
  * Hard rejection: lines that are mostly resume-document-title boilerplate
  * ("Functional Resume Sample", "Curriculum Vitae", etc.) — see issue #10.
+ *
+ * The proximity split + title penalty together let contact-cluster proximity
+ * *change the winner*, not merely nudge confidence — issue #16 (mode 2 of #10),
+ * where the real name is vertically separated from the contact block.
  */
 export function extractName(
   profile: PdfSection,
@@ -177,8 +185,17 @@ export function extractName(
     if (line.allCaps || titleCase) score += 0.2;
     if (words.length >= 2 && words.length <= 4) score += 0.1;
     if (contactY !== undefined && Math.abs(line.y - contactY) < 80) {
-      score += 0.15;
+      // First eligible line near contact: soft confirmation. A *later* line
+      // near contact: a recovery bonus large enough to overtake a higher /
+      // larger line that won only on position/size — the mode-2 case in #16.
+      // Gating the strong bonus on `i !== firstEligibleIdx` keeps the #14
+      // mode-1 fixture (first-eligible name) byte-identical.
+      score += i === firstEligibleIdx ? 0.15 : 0.4;
     }
+    // A job-title tagline ("Product Designer", "Senior Marketing Lead") must
+    // not win the name slot on position/size. Real names never match the
+    // title-keyword set, so this only ever penalizes non-name lines.
+    if (looksLikeTitle(text)) score -= 0.6;
 
     if (!best || score > best.score) best = { line, score };
   }

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "cascade": {
+    "confidence": 0.79,
+    "triggers": [],
+    "tiers": [
+      "t0_layout",
+      "t1_openresume"
+    ],
+    "suggestedEscalation": "llm",
+    "fieldsPopulated": [
+      "current_company",
+      "current_title",
+      "education",
+      "email",
+      "experience",
+      "family_name",
+      "full_name",
+      "given_name",
+      "location",
+      "phone",
+      "summary",
+      "website_url"
+    ],
+    "skillsCount": 0,
+    "experienceCount": 2,
+    "educationCount": 1,
+    "rawTextCharCount": 730,
+    "pageCount": 1,
+    "linkAnnotationCount": 0,
+    "hasMarkdown": true,
+    "sectionSource": "markdown"
+  },
+  "score": {
+    "overall": 83,
+    "preLayoutOverall": 83,
+    "specificity": {
+      "score": 33,
+      "max": 40,
+      "gradable": true,
+      "metricBullets": 2,
+      "totalBullets": 4
+    },
+    "structure": {
+      "score": 26,
+      "max": 30,
+      "gradable": true,
+      "goodBullets": 4,
+      "totalBullets": 4
+    },
+    "completeness": {
+      "score": 24,
+      "max": 30,
+      "gradable": true,
+      "missing": [
+        "LinkedIn",
+        "skills"
+      ]
+    },
+    "layout": {
+      "triggers": [],
+      "multiplier": 1,
+      "scanned": false
+    },
+    "bulletCount": 4,
+    "algoVersion": "1.0"
+  }
+}

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.pdf
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260608170624-07'00') /Creator (anonymous) /Keywords () /ModDate (D:20260608170624-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 846
+>>
+stream
+GatU0?#Q2t&:Dg-fU#3%'iQ3o`d+VU3)u]#.6(3UjlHo/\J4Jqh%@\*IXLm?1iA4dTumFp24gA0R6:aAqQTf;(BF%QHoboUHs!8]!\])c'eGXUFkm:Pkj&.BQ*gUc%j@]o!Jbl&,und?%#n@^e46`jK&t#n(cJDQa53U*BQE+a5aP_"7"qkuT+JrFB&\&Y!JCoG-N`dr"8Ig.]I7jn@RX50!^%Naa5b2b(p`+.aF^WK7U3g@jt[]!<l]/?l_*+.b\lU:TcQ@%?dJ/Tp#YT@Y$f[-#TFZ_:olG\>NFLga[B8=\V=3X;\epsTiN@-i%fimY51&"^J\Qh.8^J;0q)TC2//o7:r>6pRqYm)1WYBk+;G4F_J[2<4eplbI5AI62"c0q2@cX-qo.1!`Vmd8k&euO_.ndgf0-rpdS+VT[*:L\fNds3+eO1T]T#_pV.!^dpS]nY-?$Gj:%0#/#a+bA[P-"++oB?t&?[]1PoHbiV'ImLOt4LoiXAS'[5itHUt.^!fSX<ZKp'6K+$`B$)[/GUXt=D[Qh(#uYfStfGpRK8qcIe\/R:cgObpJ$Al.XFVFhYA.)B_Z`<%MVDlpH5';8[[J%B=[FY@DeI]ctr%AaFV>9uVL)>KiL"`;%-/*@l[agj3dSVb7u8/)#/ZBgK68L+4<_6PoBo$DEs=B_p9EaD>k,4\I`7^^ApR:mn0^7GMEoUWc\-#nS44l;D7S@Z>'1h[:$`7/(/V&dC:2M1L0-o",e5!>h_e&JPqe$"6SCsWB!EV=?4>@-+AoQGV(dYnc@D@mqc4%5*<h\n]QcFoY/!rbX[1)"XXG#,M8e)j%Edmmr[o6poF%XnI#6eP?~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000843 00000 n 
+0000000902 00000 n 
+trailer
+<<
+/ID 
+[<2b19e868e1b65d17683a7b074b16cfe1><2b19e868e1b65d17683a7b074b16cfe1>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1838
+%%EOF


### PR DESCRIPTION
## Summary

Mode 2 of #10: when the real candidate name is set apart **below** a larger job-title tagline (e.g. `Product Designer` over `Jane Smith`), `extractName` picked the tagline — position + size alone won the name slot, and the `+0.15` contact-cluster proximity bonus from #14 was too small to overturn it.

Re-weights `extractName` so contact proximity can **change the winner**, not just nudge confidence:
- A *later* eligible line within ~80pt of the contact cluster now gets `+0.4` (vs `+0.15` for the first eligible line). The split gates the strong bonus on `i !== firstEligibleIdx`, keeping the #14 mode-1 fixture byte-identical.
- A line that `looksLikeTitle()` gets `−0.6` — a job-title tagline must not win the name slot. Real names never match the title-keyword set, so this only penalizes non-name lines.

Verified pre/post-fix on the new fixture: **pre-fix** picks `Product Designer` (conf 1.0), **post-fix** picks `Jane Smith` (conf 0.70).

Resolves #16

## Scope note (please read before reviewing acceptance criteria)

#10/#16 framed mode 2 as *"right name detected at low confidence (≤0.5), marked missing."* In the current code the actual reproducible failure is **"wrong name (tagline) picked confidently"** — the `+0.4` first-eligible floor structurally prevents a *sole correct* name from landing ≤0.5. The fixture + tests reflect the real defect rather than the issue's literal wording.

## Fixture

`tests/fixtures/pdfs/unknown/name-set-apart-tagline.pdf` — synthetic, PII-free (Jane Smith / `@example.com` / `555` phone / fake orgs; Info dict `anonymous`). Generated with reportlab; full regeneration script is in the commit body. Corpus grows 7→8.

Note: the corpus snapshot is value-lossy (counts + field-presence, never the name string), so the **unit tests** in `extract-fields.test.ts` carry the value-level proof of the flip; the corpus snapshot pins no-crash / counts.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (181/181)
- [x] 6 existing corpus snapshots + #14 mode-1 fixture byte-identical (no re-bake)
- [x] Fixture personas verified synthetic — no real PII (Step 3.5: body + Info dict)
- [ ] Manually verified in `npm run dev` / `npm run preview`