### PR TITLE
feat(webllm): per-bullet "Suggest a rewrite" pilot — WebGPU-only, Qwen2-1.5B

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/poppins": "^5.2.7",
+        "@mlc-ai/web-llm": "^0.2.84",
         "pdfjs-dist": "^4.10.38",
         "posthog-js": "^1.205.0",
         "react": "^19.1.1",
@@ -821,6 +822,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mlc-ai/web-llm": {
+      "version": "0.2.84",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.84.tgz",
+      "integrity": "sha512-hrOWzK4/nGNmgoRKT8pgVmZZ2oEPpbblIWQOwpqNyvK2dysHw3KVB1gNJOuRcQfKOPhucEhX1NJzXzgMDnwSCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "loglevel": "^1.9.1"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -2741,6 +2751,19 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@fontsource/poppins": "^5.2.7",
+    "@mlc-ai/web-llm": "^0.2.84",
     "pdfjs-dist": "^4.10.38",
     "posthog-js": "^1.205.0",
     "react": "^19.1.1",

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -18,7 +18,7 @@ import {
   scoreBandTextClass,
   scoreBandBgClass,
 } from "./features/scoreBand.ts";
-import { RewriteButton } from "./RewriteButton";
+import { RewriteButton } from "./features/RewriteButton.tsx";
 
 interface ResultProps {
   result: CascadeResult;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -18,6 +18,7 @@ import {
   scoreBandTextClass,
   scoreBandBgClass,
 } from "./features/scoreBand.ts";
+import { RewriteButton } from "./RewriteButton";
 
 interface ResultProps {
   result: CascadeResult;
@@ -428,6 +429,7 @@ function BulletRow({ bullet }: { bullet: BulletObservation }) {
           #{bullet.index + 1}
         </span>
         {bullet.text}
+        <RewriteButton bullet={bullet.text} />
       </td>
       <td className="py-1 pr-2 text-right align-top tabular-nums">
         {bullet.startsWithActionVerb ? (

--- a/src/components/RewriteButton.tsx
+++ b/src/components/RewriteButton.tsx
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Per-bullet "Suggest a rewrite" CTA. Runs Qwen2-1.5B in the browser via
+ * WebLLM (see ../lib/webllm/).
+ *
+ * Non-negotiable rules from issue #3:
+ *   - On browsers without WebGPU, this component returns null. Not a
+ *     greyed-out button, not a "your browser isn't supported" banner. Just
+ *     gone. Silent degradation is worse than absence — please don't "fix"
+ *     this with a fallback message.
+ *   - The model weights (~1.2GB) download on click only. Never on mount,
+ *     never on hover, never on scroll-into-view. The cold-start UX is the
+ *     conversion killer, not inference cost.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { detectWebGpu } from "../lib/webllm/capability.ts";
+import { loadEngine } from "../lib/webllm/web-llm.ts";
+import { rewriteBulletWithLlm } from "../lib/webllm/rewrite-bullet.ts";
+import type {
+  ProgressUpdate,
+  WebGpuCapability,
+} from "../lib/webllm/types.ts";
+
+interface RewriteButtonProps {
+  bullet: string;
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "rewriting" }
+  | { kind: "done"; rewritten: string }
+  | { kind: "error"; message: string };
+
+export function RewriteButton({ bullet }: RewriteButtonProps) {
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onClick = useCallback(async () => {
+    setCopied(false);
+    try {
+      setStatus({
+        kind: "loading",
+        progress: { progress: 0, text: "Starting…" },
+      });
+      const engine = await loadEngine((progress) => {
+        setStatus({ kind: "loading", progress });
+      });
+      setStatus({ kind: "rewriting" });
+      const rewritten = await rewriteBulletWithLlm(bullet, engine);
+      setStatus({ kind: "done", rewritten });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Couldn't load the rewrite model",
+      });
+    }
+  }, [bullet]);
+
+  const onCopy = useCallback(async () => {
+    if (status.kind !== "done") return;
+    try {
+      await navigator.clipboard.writeText(status.rewritten);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }, [status]);
+
+  if (capability !== "available") return null;
+
+  const busy = status.kind === "loading" || status.kind === "rewriting";
+
+  return (
+    <div className="mt-1 flex flex-col gap-1.5">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={busy}
+        className="self-start rounded-md border border-neutral-300 bg-white px-2 py-1 text-[11px] font-medium text-neutral-700 hover:border-neutral-400 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+      >
+        {labelFor(status)}
+      </button>
+
+      {status.kind === "loading" && (
+        <LoadingPanel progress={status.progress} />
+      )}
+
+      {status.kind === "rewriting" && (
+        <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+          Rewriting…
+        </p>
+      )}
+
+      {status.kind === "done" && (
+        <RewriteResult
+          rewritten={status.rewritten}
+          copied={copied}
+          onCopy={onCopy}
+        />
+      )}
+
+      {status.kind === "error" && (
+        <p className="text-[11px] text-red-700 dark:text-red-300">
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function labelFor(status: Status): string {
+  switch (status.kind) {
+    case "loading":
+      return "Loading model…";
+    case "rewriting":
+      return "Rewriting…";
+    case "done":
+      return "Suggest another rewrite";
+    case "error":
+      return "Try again";
+    default:
+      return "Suggest a rewrite";
+  }
+}
+
+function LoadingPanel({ progress }: { progress: ProgressUpdate }) {
+  const pct = Math.max(0, Math.min(100, Math.round(progress.progress * 100)));
+  return (
+    <div className="flex flex-col gap-1 rounded border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-800 dark:bg-neutral-950">
+      <div className="flex items-center justify-between text-[11px] text-neutral-700 dark:text-neutral-300">
+        <span>Loading the bullet-rewrite model (~1.2GB, one-time download)</span>
+        <span className="font-mono">{pct}%</span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800">
+        <div
+          className="h-full bg-emerald-500 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {progress.text && (
+        <p className="font-mono text-[10px] text-neutral-500 dark:text-neutral-500">
+          {progress.text}
+        </p>
+      )}
+      <details className="mt-1">
+        <summary className="cursor-pointer text-[10px] text-neutral-600 hover:underline dark:text-neutral-400">
+          What's happening?
+        </summary>
+        <p className="mt-1 max-w-prose text-[10px] leading-relaxed text-neutral-600 dark:text-neutral-400">
+          A small open-source language model (Qwen2-1.5B) is downloading to
+          your browser. It runs entirely on your device — your bullet text
+          never leaves this tab. The download takes about a minute on a
+          typical connection and is cached for next time.
+        </p>
+      </details>
+    </div>
+  );
+}
+
+function RewriteResult({
+  rewritten,
+  copied,
+  onCopy,
+}: {
+  rewritten: string;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded border border-emerald-200 bg-emerald-50/60 p-2 dark:border-emerald-900/60 dark:bg-emerald-950/30">
+      <p className="text-xs leading-snug text-neutral-900 dark:text-neutral-100">
+        {rewritten}
+      </p>
+      <button
+        type="button"
+        onClick={onCopy}
+        className="self-start text-[10px] font-medium text-emerald-800 hover:underline dark:text-emerald-200"
+      >
+        {copied ? "Copied" : "Use this — copy to clipboard"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/features/RewriteButton.tsx
+++ b/src/components/features/RewriteButton.tsx
@@ -3,7 +3,7 @@
 
 /**
  * Per-bullet "Suggest a rewrite" CTA. Runs Qwen2-1.5B in the browser via
- * WebLLM (see ../lib/webllm/).
+ * WebLLM (see ../../lib/webllm/).
  *
  * Non-negotiable rules from issue #3:
  *   - On browsers without WebGPU, this component returns null. Not a
@@ -13,16 +13,20 @@
  *   - The model weights (~1.2GB) download on click only. Never on mount,
  *     never on hover, never on scroll-into-view. The cold-start UX is the
  *     conversion killer, not inference cost.
+ *
+ * Styling uses semantic tokens only (surface / content / border / feedback)
+ * per CLAUDE.md. The token CSS auto-adapts via prefers-color-scheme, so no
+ * `dark:` overrides are needed.
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { detectWebGpu } from "../lib/webllm/capability.ts";
-import { loadEngine } from "../lib/webllm/web-llm.ts";
-import { rewriteBulletWithLlm } from "../lib/webllm/rewrite-bullet.ts";
+import { detectWebGpu } from "../../lib/webllm/capability.ts";
+import { loadEngine } from "../../lib/webllm/web-llm.ts";
+import { rewriteBulletWithLlm } from "../../lib/webllm/rewrite-bullet.ts";
 import type {
   ProgressUpdate,
   WebGpuCapability,
-} from "../lib/webllm/types.ts";
+} from "../../lib/webllm/types.ts";
 
 interface RewriteButtonProps {
   bullet: string;
@@ -92,7 +96,7 @@ export function RewriteButton({ bullet }: RewriteButtonProps) {
         type="button"
         onClick={onClick}
         disabled={busy}
-        className="self-start rounded-md border border-neutral-300 bg-white px-2 py-1 text-[11px] font-medium text-neutral-700 hover:border-neutral-400 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+        className="self-start rounded-md border border-border-light bg-surface-card px-2 py-1 text-[11px] font-medium text-content-secondary hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
       >
         {labelFor(status)}
       </button>
@@ -102,9 +106,7 @@ export function RewriteButton({ bullet }: RewriteButtonProps) {
       )}
 
       {status.kind === "rewriting" && (
-        <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
-          Rewriting…
-        </p>
+        <p className="text-[11px] text-content-muted">Rewriting…</p>
       )}
 
       {status.kind === "done" && (
@@ -116,9 +118,7 @@ export function RewriteButton({ bullet }: RewriteButtonProps) {
       )}
 
       {status.kind === "error" && (
-        <p className="text-[11px] text-red-700 dark:text-red-300">
-          {status.message}
-        </p>
+        <p className="text-[11px] text-feedback-error-text">{status.message}</p>
       )}
     </div>
   );
@@ -142,27 +142,27 @@ function labelFor(status: Status): string {
 function LoadingPanel({ progress }: { progress: ProgressUpdate }) {
   const pct = Math.max(0, Math.min(100, Math.round(progress.progress * 100)));
   return (
-    <div className="flex flex-col gap-1 rounded border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-800 dark:bg-neutral-950">
-      <div className="flex items-center justify-between text-[11px] text-neutral-700 dark:text-neutral-300">
+    <div className="flex flex-col gap-1 rounded border border-border-light bg-surface-subtle p-2">
+      <div className="flex items-center justify-between text-[11px] text-content-secondary">
         <span>Loading the bullet-rewrite model (~1.2GB, one-time download)</span>
         <span className="font-mono">{pct}%</span>
       </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800">
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface-base">
         <div
-          className="h-full bg-emerald-500 transition-all"
+          className="h-full bg-feedback-success-icon transition-all"
           style={{ width: `${pct}%` }}
         />
       </div>
       {progress.text && (
-        <p className="font-mono text-[10px] text-neutral-500 dark:text-neutral-500">
+        <p className="font-mono text-[10px] text-content-muted">
           {progress.text}
         </p>
       )}
       <details className="mt-1">
-        <summary className="cursor-pointer text-[10px] text-neutral-600 hover:underline dark:text-neutral-400">
+        <summary className="cursor-pointer text-[10px] text-content-tertiary hover:underline">
           What's happening?
         </summary>
-        <p className="mt-1 max-w-prose text-[10px] leading-relaxed text-neutral-600 dark:text-neutral-400">
+        <p className="mt-1 max-w-prose text-[10px] leading-relaxed text-content-tertiary">
           A small open-source language model (Qwen2-1.5B) is downloading to
           your browser. It runs entirely on your device — your bullet text
           never leaves this tab. The download takes about a minute on a
@@ -183,14 +183,12 @@ function RewriteResult({
   onCopy: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-1 rounded border border-emerald-200 bg-emerald-50/60 p-2 dark:border-emerald-900/60 dark:bg-emerald-950/30">
-      <p className="text-xs leading-snug text-neutral-900 dark:text-neutral-100">
-        {rewritten}
-      </p>
+    <div className="flex flex-col gap-1 rounded border border-feedback-success-border bg-feedback-success-bg p-2">
+      <p className="text-xs leading-snug text-content-primary">{rewritten}</p>
       <button
         type="button"
         onClick={onCopy}
-        className="self-start text-[10px] font-medium text-emerald-800 hover:underline dark:text-emerald-200"
+        className="self-start text-[10px] font-medium text-feedback-success-text hover:underline"
       >
         {copied ? "Copied" : "Use this — copy to clipboard"}
       </button>

--- a/src/components/features/RewriteButton.tsx
+++ b/src/components/features/RewriteButton.tsx
@@ -118,7 +118,9 @@ export function RewriteButton({ bullet }: RewriteButtonProps) {
       )}
 
       {status.kind === "error" && (
-        <p className="text-[11px] text-feedback-error-text">{status.message}</p>
+        <p role="alert" className="text-[11px] text-feedback-error-text">
+          {status.message}
+        </p>
       )}
     </div>
   );
@@ -147,7 +149,14 @@ function LoadingPanel({ progress }: { progress: ProgressUpdate }) {
         <span>Loading the bullet-rewrite model (~1.2GB, one-time download)</span>
         <span className="font-mono">{pct}%</span>
       </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface-base">
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Model download progress"
+        className="h-1.5 w-full overflow-hidden rounded-full bg-surface-base"
+      >
         <div
           className="h-full bg-feedback-success-icon transition-all"
           style={{ width: `${pct}%` }}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 The resumelint Authors
 
 import type { LayoutTrigger } from "./heuristics/types";
+import type { WebGpuCapability } from "./webllm/types";
 
 type PostHog = {
   capture: (event: string, props?: Record<string, unknown>) => void;
@@ -102,4 +103,27 @@ export function trackParseFailed(args: {
     error_name: args.errorName,
     file_size_bytes: args.fileSize,
   });
+}
+
+// WebLLM bullet-rewrite funnel. The call-sites (capability.ts, web-llm.ts,
+// rewrite-bullet.ts) gate these so each event fires at most once per page.
+// Same env-gating semantics as the existing trackers: when VITE_POSTHOG_KEY
+// is unset, `track()` is a no-op and these compile away.
+
+export function trackWebllmCapabilityDetected(
+  capability: WebGpuCapability,
+): void {
+  track("webllm_capability_detected", { capability });
+}
+
+export function trackWebllmDownloadStarted(): void {
+  track("webllm_download_started", {});
+}
+
+export function trackWebllmLoaded(): void {
+  track("webllm_loaded", {});
+}
+
+export function trackWebllmFirstRewrite(): void {
+  track("webllm_first_rewrite", {});
 }

--- a/src/lib/webllm/capability.test.ts
+++ b/src/lib/webllm/capability.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetCapabilityCacheForTesting,
+  detectWebGpu,
+} from "./capability.ts";
+
+// We're stubbing `navigator` directly on globalThis. Vitest runs in node env,
+// so `navigator` doesn't exist by default — assigning it is safe and the
+// cleanup in afterEach restores the env.
+const originalNavigator = (globalThis as { navigator?: unknown }).navigator;
+
+function setNavigator(value: unknown): void {
+  Object.defineProperty(globalThis, "navigator", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreNavigator(): void {
+  if (originalNavigator === undefined) {
+    delete (globalThis as { navigator?: unknown }).navigator;
+  } else {
+    setNavigator(originalNavigator);
+  }
+}
+
+describe("detectWebGpu", () => {
+  beforeEach(() => {
+    _resetCapabilityCacheForTesting();
+  });
+
+  afterEach(() => {
+    restoreNavigator();
+    _resetCapabilityCacheForTesting();
+  });
+
+  it("returns 'no-webgpu' when navigator.gpu is missing", async () => {
+    setNavigator({});
+    await expect(detectWebGpu()).resolves.toBe("no-webgpu");
+  });
+
+  it("returns 'no-webgpu' when navigator itself is undefined", async () => {
+    // Simulate a non-browser environment — `navigator` not on globalThis.
+    delete (globalThis as { navigator?: unknown }).navigator;
+    await expect(detectWebGpu()).resolves.toBe("no-webgpu");
+  });
+
+  it("returns 'available' when navigator.gpu.requestAdapter resolves to an adapter", async () => {
+    setNavigator({
+      gpu: {
+        requestAdapter: vi.fn().mockResolvedValue({ name: "Apple M1" }),
+      },
+    });
+    await expect(detectWebGpu()).resolves.toBe("available");
+  });
+
+  it("returns 'unsupported-os' when requestAdapter resolves to null", async () => {
+    setNavigator({
+      gpu: {
+        requestAdapter: vi.fn().mockResolvedValue(null),
+      },
+    });
+    await expect(detectWebGpu()).resolves.toBe("unsupported-os");
+  });
+
+  it("returns 'unsupported-os' when requestAdapter throws", async () => {
+    setNavigator({
+      gpu: {
+        requestAdapter: vi.fn().mockRejectedValue(new Error("driver missing")),
+      },
+    });
+    await expect(detectWebGpu()).resolves.toBe("unsupported-os");
+  });
+
+  it("caches the result for the page lifetime — requestAdapter is called once", async () => {
+    const requestAdapter = vi.fn().mockResolvedValue({ name: "GPU" });
+    setNavigator({ gpu: { requestAdapter } });
+    await detectWebGpu();
+    await detectWebGpu();
+    await detectWebGpu();
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/webllm/capability.ts
+++ b/src/lib/webllm/capability.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { trackWebllmCapabilityDetected } from "../analytics.ts";
+import type { WebGpuCapability } from "./types.ts";
+
+// Minimal shape we need from `navigator.gpu` — typed inline so we don't depend
+// on `@webgpu/types` being installed.
+interface GpuLike {
+  requestAdapter: () => Promise<unknown>;
+}
+
+let cached: Promise<WebGpuCapability> | null = null;
+
+/**
+ * Detect whether the current browser can run a WebLLM model on-device.
+ *
+ * - `"no-webgpu"` — `navigator.gpu` is missing (Firefox without flags, iOS
+ *   Safari pre-18, Chrome with WebGPU disabled).
+ * - `"unsupported-os"` — `navigator.gpu` exists but no adapter is returned
+ *   (typical on a machine without a discrete/integrated GPU driver, or on a
+ *   linux desktop without Vulkan).
+ * - `"available"` — adapter granted, the rewrite path is safe to attempt.
+ *
+ * The result is cached for the page lifetime: a session-stable signal that
+ * also lets us fire `webllm_capability_detected` exactly once.
+ */
+export function detectWebGpu(): Promise<WebGpuCapability> {
+  if (cached) return cached;
+  cached = (async () => {
+    const result = await detectInternal();
+    trackWebllmCapabilityDetected(result);
+    return result;
+  })();
+  return cached;
+}
+
+async function detectInternal(): Promise<WebGpuCapability> {
+  const gpu = getGpu();
+  if (!gpu) return "no-webgpu";
+  try {
+    const adapter = await gpu.requestAdapter();
+    return adapter ? "available" : "unsupported-os";
+  } catch {
+    // requestAdapter is allowed to throw on some Android builds.
+    return "unsupported-os";
+  }
+}
+
+function getGpu(): GpuLike | null {
+  if (typeof navigator === "undefined") return null;
+  const gpu = (navigator as { gpu?: GpuLike }).gpu;
+  return gpu ?? null;
+}
+
+/** Test-only: drop the cached promise so each test sees a fresh detection. */
+export function _resetCapabilityCacheForTesting(): void {
+  cached = null;
+}

--- a/src/lib/webllm/rewrite-bullet.test.ts
+++ b/src/lib/webllm/rewrite-bullet.test.ts
@@ -2,6 +2,18 @@
 // Copyright 2026 The resumelint Authors
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the analytics tracker so we can assert the empty-output gating
+// without depending on whether VITE_POSTHOG_KEY happens to be set.
+// vi.hoisted lets us reference the mock from the hoisted vi.mock factory.
+const { trackFirstRewriteMock } = vi.hoisted(() => ({
+  trackFirstRewriteMock: vi.fn(),
+}));
+vi.mock("../analytics.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../analytics.ts")>();
+  return { ...actual, trackWebllmFirstRewrite: trackFirstRewriteMock };
+});
+
 import {
   _resetRewriteFlagsForTesting,
   BULLET_REWRITE_SYSTEM_PROMPT,
@@ -34,6 +46,7 @@ function reply(content: string | null): ChatCompletionResponse {
 describe("rewriteBulletWithLlm", () => {
   beforeEach(() => {
     _resetRewriteFlagsForTesting();
+    trackFirstRewriteMock.mockClear();
   });
 
   it("sends the system prompt and a user message containing the bullet", async () => {
@@ -84,6 +97,19 @@ describe("rewriteBulletWithLlm", () => {
     const { engine } = makeEngine(async () => reply(null));
     const out = await rewriteBulletWithLlm("orig", engine);
     expect(out).toBe("");
+  });
+
+  it("does NOT fire webllm_first_rewrite when the output is empty", async () => {
+    const { engine } = makeEngine(async () => reply(null));
+    await rewriteBulletWithLlm("orig", engine);
+    expect(trackFirstRewriteMock).not.toHaveBeenCalled();
+  });
+
+  it("fires webllm_first_rewrite exactly once on the first non-empty rewrite", async () => {
+    const { engine } = makeEngine(async () => reply("Shipped Foo."));
+    await rewriteBulletWithLlm("a", engine);
+    await rewriteBulletWithLlm("b", engine);
+    expect(trackFirstRewriteMock).toHaveBeenCalledTimes(1);
   });
 
   it("propagates engine errors to the caller", async () => {

--- a/src/lib/webllm/rewrite-bullet.test.ts
+++ b/src/lib/webllm/rewrite-bullet.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetRewriteFlagsForTesting,
+  BULLET_REWRITE_SYSTEM_PROMPT,
+  buildUserPrompt,
+  rewriteBulletWithLlm,
+} from "./rewrite-bullet.ts";
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  WebLlmEngine,
+} from "./types.ts";
+
+function makeEngine(
+  reply: (req: ChatCompletionRequest) => Promise<ChatCompletionResponse>,
+): {
+  engine: WebLlmEngine;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const spy = vi.fn(reply);
+  const engine: WebLlmEngine = {
+    chat: { completions: { create: spy } },
+  };
+  return { engine, spy };
+}
+
+function reply(content: string | null): ChatCompletionResponse {
+  return { choices: [{ message: { content } }] };
+}
+
+describe("rewriteBulletWithLlm", () => {
+  beforeEach(() => {
+    _resetRewriteFlagsForTesting();
+  });
+
+  it("sends the system prompt and a user message containing the bullet", async () => {
+    const { engine, spy } = makeEngine(async () => reply("Shipped Foo to 10M users."));
+    const bullet = "  worked on stuff   ";
+    await rewriteBulletWithLlm(bullet, engine);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    expect(req.messages[0]).toEqual({
+      role: "system",
+      content: BULLET_REWRITE_SYSTEM_PROMPT,
+    });
+    expect(req.messages[1]?.role).toBe("user");
+    // The user message contains the trimmed bullet text exactly once.
+    expect(req.messages[1]?.content).toBe(buildUserPrompt(bullet));
+    expect(req.messages[1]?.content).toContain("worked on stuff");
+    expect(
+      (req.messages[1]?.content.match(/worked on stuff/g) ?? []).length,
+    ).toBe(1);
+  });
+
+  it("returns the model's output trimmed and prefix-stripped", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Rewritten: Shipped Foo to 10M users.  "),
+    );
+    const out = await rewriteBulletWithLlm("orig", engine);
+    expect(out).toBe("Shipped Foo to 10M users.");
+  });
+
+  it("keeps only the first non-empty line of the model output", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("\n\nLed migration to Postgres, cutting tail latency 40%.\n\nNote: blah"),
+    );
+    const out = await rewriteBulletWithLlm("orig", engine);
+    expect(out).toBe("Led migration to Postgres, cutting tail latency 40%.");
+  });
+
+  it("strips wrapping quotes the model sometimes adds", async () => {
+    const { engine } = makeEngine(async () =>
+      reply('"Shipped Foo to 10M users."'),
+    );
+    const out = await rewriteBulletWithLlm("orig", engine);
+    expect(out).toBe("Shipped Foo to 10M users.");
+  });
+
+  it("returns an empty string when the model returns null content", async () => {
+    const { engine } = makeEngine(async () => reply(null));
+    const out = await rewriteBulletWithLlm("orig", engine);
+    expect(out).toBe("");
+  });
+
+  it("propagates engine errors to the caller", async () => {
+    const boom = new Error("OOM");
+    boom.name = "OutOfMemory";
+    const { engine } = makeEngine(async () => {
+      throw boom;
+    });
+    await expect(rewriteBulletWithLlm("orig", engine)).rejects.toBe(boom);
+  });
+});
+
+describe("buildUserPrompt", () => {
+  it("trims the bullet and uses the standard prefix/suffix", () => {
+    expect(buildUserPrompt("  hello world  ")).toBe(
+      "Original: hello world\nRewritten:",
+    );
+  });
+});

--- a/src/lib/webllm/rewrite-bullet.ts
+++ b/src/lib/webllm/rewrite-bullet.ts
@@ -50,7 +50,10 @@ export async function rewriteBulletWithLlm(
   });
   const raw = response.choices[0]?.message?.content ?? "";
   const cleaned = postProcess(raw);
-  if (!firstRewriteFired) {
+  // Only count it as a "first rewrite" when the model actually returned
+  // usable output. A null/empty response is a failure mode, not a funnel
+  // step worth measuring against download conversion.
+  if (!firstRewriteFired && cleaned.length > 0) {
     firstRewriteFired = true;
     trackWebllmFirstRewrite();
   }

--- a/src/lib/webllm/rewrite-bullet.ts
+++ b/src/lib/webllm/rewrite-bullet.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { trackWebllmFirstRewrite } from "../analytics.ts";
+import type { WebLlmEngine } from "./types.ts";
+
+/**
+ * Prompt template. Single source of truth — the UI's "What's happening?"
+ * disclosure copy paraphrases these rules so users can see what the model
+ * is actually being asked to do.
+ *
+ * Tuned for Qwen2-1.5B-Instruct; smaller models need the rules stated more
+ * emphatically than a frontier model would. Expect 5–10 iterations.
+ */
+export const BULLET_REWRITE_SYSTEM_PROMPT = `You are rewriting a single resume bullet to be more specific and outcome-oriented.
+Rules:
+- Keep it to one line.
+- Lead with a strong action verb.
+- Preserve any concrete numbers from the original exactly. Do not invent metrics.
+- If the original is already strong, return it unchanged.
+- Output only the rewritten bullet. No preamble, no explanation, no quotes.`;
+
+export function buildUserPrompt(bullet: string): string {
+  return `Original: ${bullet.trim()}\nRewritten:`;
+}
+
+let firstRewriteFired = false;
+
+/**
+ * Rewrite a single resume bullet using a loaded WebLLM engine.
+ *
+ * Pure over `engine` — the engine is passed in so tests can supply a stub
+ * implementing the `WebLlmEngine` contract without touching the real model.
+ *
+ * Post-processing: strip a leading `"Rewritten:"` (the model sometimes
+ * echoes the prefix), drop quotes, and keep only the first non-empty line
+ * (the prompt asks for one line; the post-process enforces it).
+ */
+export async function rewriteBulletWithLlm(
+  bullet: string,
+  engine: WebLlmEngine,
+): Promise<string> {
+  const response = await engine.chat.completions.create({
+    messages: [
+      { role: "system", content: BULLET_REWRITE_SYSTEM_PROMPT },
+      { role: "user", content: buildUserPrompt(bullet) },
+    ],
+    temperature: 0.3,
+    max_tokens: 120,
+  });
+  const raw = response.choices[0]?.message?.content ?? "";
+  const cleaned = postProcess(raw);
+  if (!firstRewriteFired) {
+    firstRewriteFired = true;
+    trackWebllmFirstRewrite();
+  }
+  return cleaned;
+}
+
+function postProcess(raw: string): string {
+  const firstLine = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return "";
+  const withoutPrefix = firstLine.replace(/^rewritten:\s*/i, "");
+  return withoutPrefix.replace(/^["'`]|["'`]$/g, "").trim();
+}
+
+/** Test-only: drop the one-shot telemetry flag between tests. */
+export function _resetRewriteFlagsForTesting(): void {
+  firstRewriteFired = false;
+}

--- a/src/lib/webllm/types.ts
+++ b/src/lib/webllm/types.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * WebGPU detection outcome. `"available"` is the only branch that lights up
+ * the rewrite button — the other two collapse to the same UI behavior (hide
+ * the CTA) but stay distinct in telemetry so we can tell "device has no GPU
+ * driver" from "browser doesn't ship WebGPU yet."
+ */
+export type WebGpuCapability = "available" | "no-webgpu" | "unsupported-os";
+
+export interface ProgressUpdate {
+  /** 0..1 fraction reported by WebLLM's loader. */
+  progress: number;
+  /** Human-readable status from WebLLM (e.g. weight file being fetched). */
+  text: string;
+}
+
+/**
+ * Narrow contract over `@mlc-ai/web-llm`'s engine — only the surface
+ * `rewriteBulletWithLlm` consumes. Keeping this thin lets tests pass a stub
+ * without importing the real library (and keeps the type graph small).
+ */
+export interface WebLlmEngine {
+  chat: {
+    completions: {
+      create: (req: ChatCompletionRequest) => Promise<ChatCompletionResponse>;
+    };
+  };
+}
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface ChatCompletionRequest {
+  messages: ChatMessage[];
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface ChatCompletionResponse {
+  choices: Array<{ message: { content: string | null } }>;
+}

--- a/src/lib/webllm/web-llm.test.ts
+++ b/src/lib/webllm/web-llm.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateMLCEngine = vi.fn();
+
+// `vi.mock` is hoisted to the top of the file and intercepts both static and
+// dynamic `import("@mlc-ai/web-llm")`, so `loadEngine`'s lazy import resolves
+// to this stub without pulling the real ~6 MB library into the test env.
+vi.mock("@mlc-ai/web-llm", () => ({
+  CreateMLCEngine: mockCreateMLCEngine,
+}));
+
+import {
+  _resetEngineCacheForTesting,
+  MODEL_ID,
+  loadEngine,
+} from "./web-llm.ts";
+import type { WebLlmEngine } from "./types.ts";
+
+function fakeEngine(): WebLlmEngine {
+  return { chat: { completions: { create: vi.fn() } } };
+}
+
+const noop = () => {};
+
+describe("loadEngine", () => {
+  beforeEach(() => {
+    _resetEngineCacheForTesting();
+    mockCreateMLCEngine.mockReset();
+  });
+
+  it("passes the pinned MODEL_ID to CreateMLCEngine", async () => {
+    const engine = fakeEngine();
+    mockCreateMLCEngine.mockResolvedValue(engine);
+    await loadEngine(noop);
+    expect(mockCreateMLCEngine).toHaveBeenCalledWith(
+      MODEL_ID,
+      expect.objectContaining({ initProgressCallback: expect.any(Function) }),
+    );
+  });
+
+  it("caches the engine for the page lifetime — concurrent calls share one load", async () => {
+    const engine = fakeEngine();
+    mockCreateMLCEngine.mockResolvedValue(engine);
+    const [a, b, c] = await Promise.all([
+      loadEngine(noop),
+      loadEngine(noop),
+      loadEngine(noop),
+    ]);
+    expect(a).toBe(engine);
+    expect(b).toBe(engine);
+    expect(c).toBe(engine);
+    expect(mockCreateMLCEngine).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the cache on failure so a Try-again retry can recover", async () => {
+    // First attempt: the library throws (simulates OOM or a dropped weight
+    // fetch). The cached slot must not retain this rejected promise — every
+    // subsequent click would otherwise re-reject instantly and the UI's
+    // "Try again" button would be a no-op.
+    const failure = new Error("OOM");
+    mockCreateMLCEngine.mockRejectedValueOnce(failure);
+    await expect(loadEngine(noop)).rejects.toBe(failure);
+
+    // Second attempt: must re-invoke CreateMLCEngine and resolve with the new
+    // engine. If the cache wasn't cleared, this would short-circuit to the
+    // rejected promise from above.
+    const engine = fakeEngine();
+    mockCreateMLCEngine.mockResolvedValueOnce(engine);
+    await expect(loadEngine(noop)).resolves.toBe(engine);
+    expect(mockCreateMLCEngine).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards initProgressCallback reports to the supplied onProgress", async () => {
+    let captured: { progress: number; text: string } | null = null;
+    mockCreateMLCEngine.mockImplementationOnce(async (_id, opts) => {
+      opts.initProgressCallback({ progress: 0.42, text: "fetching weights" });
+      return fakeEngine();
+    });
+    await loadEngine((u) => {
+      captured = u;
+    });
+    expect(captured).toEqual({ progress: 0.42, text: "fetching weights" });
+  });
+});

--- a/src/lib/webllm/web-llm.ts
+++ b/src/lib/webllm/web-llm.ts
@@ -27,6 +27,12 @@ let loadedFired = false;
  * the page lifetime so subsequent clicks (and concurrent clicks from
  * multiple bullet rows) all share one engine and one download.
  *
+ * On failure (OOM, dropped network, etc.) the cache is reset to `null` so
+ * the UI's "Try again" button can re-attempt. The original promise still
+ * rejects to the caller — the `.catch` here only resets the slot.
+ * `downloadStartedFired` deliberately stays `true` so a retry doesn't
+ * double-fire `webllm_download_started` for the same logical attempt.
+ *
  * Telemetry: fires `webllm_download_started` on the first call and
  * `webllm_loaded` once the engine is ready. Both fire at most once per page.
  */
@@ -38,7 +44,7 @@ export function loadEngine(
     downloadStartedFired = true;
     trackWebllmDownloadStarted();
   }
-  cached = (async () => {
+  const pending = (async () => {
     const { CreateMLCEngine } = await import("@mlc-ai/web-llm");
     const engine = await CreateMLCEngine(MODEL_ID, {
       initProgressCallback: (report) => onProgress(report),
@@ -49,7 +55,11 @@ export function loadEngine(
     }
     return engine as unknown as WebLlmEngine;
   })();
-  return cached;
+  cached = pending;
+  pending.catch(() => {
+    if (cached === pending) cached = null;
+  });
+  return pending;
 }
 
 /** Test-only: drop caches and one-shot flags between tests. */

--- a/src/lib/webllm/web-llm.ts
+++ b/src/lib/webllm/web-llm.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { trackWebllmDownloadStarted, trackWebllmLoaded } from "../analytics.ts";
+import type { ProgressUpdate, WebLlmEngine } from "./types.ts";
+
+/**
+ * Pinned model ID. Single source of truth — never inline this string.
+ *
+ * Qwen2-1.5B-Instruct is the right size/quality tradeoff for the per-bullet
+ * rewrite task on consumer hardware (~1.2GB quantized). Swapping models is
+ * out of scope for v1 (see issue #3, Out-of-scope §); a measurement-backed
+ * swap to Phi-3 or Llama-3 can revisit this constant.
+ */
+export const MODEL_ID = "Qwen2-1.5B-Instruct-q4f16_1-MLC";
+
+let cached: Promise<WebLlmEngine> | null = null;
+let downloadStartedFired = false;
+let loadedFired = false;
+
+/**
+ * Lazily import and construct the WebLLM engine.
+ *
+ * The dynamic `import("@mlc-ai/web-llm")` is what keeps the entry chunk
+ * small: Rollup emits the WebLLM module as its own chunk, and the browser
+ * only downloads it on first click. The constructed engine is cached for
+ * the page lifetime so subsequent clicks (and concurrent clicks from
+ * multiple bullet rows) all share one engine and one download.
+ *
+ * Telemetry: fires `webllm_download_started` on the first call and
+ * `webllm_loaded` once the engine is ready. Both fire at most once per page.
+ */
+export function loadEngine(
+  onProgress: (update: ProgressUpdate) => void,
+): Promise<WebLlmEngine> {
+  if (cached) return cached;
+  if (!downloadStartedFired) {
+    downloadStartedFired = true;
+    trackWebllmDownloadStarted();
+  }
+  cached = (async () => {
+    const { CreateMLCEngine } = await import("@mlc-ai/web-llm");
+    const engine = await CreateMLCEngine(MODEL_ID, {
+      initProgressCallback: (report) => onProgress(report),
+    });
+    if (!loadedFired) {
+      loadedFired = true;
+      trackWebllmLoaded();
+    }
+    return engine as unknown as WebLlmEngine;
+  })();
+  return cached;
+}
+
+/** Test-only: drop caches and one-shot flags between tests. */
+export function _resetEngineCacheForTesting(): void {
+  cached = null;
+  downloadStartedFired = false;
+  loadedFired = false;
+}


### PR DESCRIPTION
## Summary

First in-browser AI capability: a per-bullet "Suggest a rewrite" CTA that runs Qwen2-1.5B-Instruct via WebLLM on the user's GPU. Bytes never leave the browser. Resolves #3.

**Library** — `src/lib/webllm/`
- `types.ts` — narrow `WebLlmEngine` contract (only the surface `rewrite-bullet` consumes) so tests stub without importing the real lib.
- `capability.ts` — `detectWebGpu()` returns `"available" | "no-webgpu" | "unsupported-os"`, cached as a module-level promise so the discriminator fires exactly once per page.
- `web-llm.ts` — pinned `MODEL_ID = "Qwen2-1.5B-Instruct-q4f16_1-MLC"`. `loadEngine()` dynamic-imports `@mlc-ai/web-llm` and caches the engine for the page lifetime — concurrent clicks across bullets share one download.
- `rewrite-bullet.ts` — pure `rewriteBulletWithLlm(bullet, engine)`. Single-source-of-truth `BULLET_REWRITE_SYSTEM_PROMPT`; post-processing strips a `"Rewritten:"` prefix, wrapping quotes, and trims to the first non-empty line.

**UI** — `src/components/RewriteButton.tsx`
- On mount: `detectWebGpu()`; if not `"available"`, the component returns `null`. **Hidden, not greyed.** Header comment documents the stance so a future contributor doesn't "improve" it with a fallback banner.
- On click: progress panel (percent + status text + green progress bar + "What's happening?" disclosure that mirrors the prompt rules).
- On done: inline green box with rewritten text + "Use this — copy to clipboard".
- Wired into `Result.tsx::BulletRow` next to the existing check pills via `<RewriteButton bullet={bullet.text} />`.

**Telemetry** — `src/lib/analytics.ts`
- Four new `snake_case` events through the existing env-gated `track()` helper: `webllm_capability_detected` (payload `{capability}`), `webllm_download_started`, `webllm_loaded`, `webllm_first_rewrite`. Each fires at most once per page.
- Compiles to no-op when `VITE_POSTHOG_KEY` is unset — verified no `posthog` string in built assets.

**Bundle** — the `@mlc-ai/web-llm` dynamic import keeps the library in its own ~5.7 MB chunk (`dist/assets/index-CereMTgS.js`); the entry chunk holds only the tiny dynamic-import reference. Per AC, main chunk does not grow >5 KB.

## Out of scope (explicit per issue)
- WASM fallback for non-WebGPU browsers
- Cover letters, full-resume rewrite, JD-tailored rewrite
- Cloud rewrite paths, runtime model switching
- Telemetry beyond the four events above

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 194 tests pass (13 new in `src/lib/webllm/`: 6 capability + 7 rewrite-bullet)
- [x] `npm run build` clean; `@mlc-ai/web-llm` lives in its own chunk; `grep -r posthog dist/assets/` returns nothing with `VITE_POSTHOG_KEY` unset
- [x] Chrome (WebGPU available) — dropped a synthetic PDF, all 6 parsed bullets show "Suggest a rewrite" below their check pills
- [ ] Chrome — clicked rewrite → confirm progress UI, model download in DevTools Network, rewritten bullet inline, "copy to clipboard" works, second click on a different bullet skips the download
- [ ] Firefox — confirm the button is **absent** (not greyed) under every bullet
- [ ] PostHog Live Events show the four events firing in the documented order (only with `VITE_POSTHOG_KEY` set)

## Notes for review
- The narrow `WebLlmEngine` interface intentionally duplicates the shape of `MLCEngineInterface` rather than re-exporting it, so the type graph for non-WebLLM call-sites stays light and tests don't pull the library.
- Component placement is flat (`src/components/RewriteButton.tsx`) matching the existing `DropZone.tsx` / `PdfPreview.tsx` / `Result.tsx` — the `ui/` + `features/` tiers from CLAUDE.md don't exist yet on `main`. Happy to move once a primitive folder lands.