### PR TITLE
fix: raise muted-text contrast to WCAG AA and adopt Poppins font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@fontsource/poppins": "^5.2.7",
         "pdfjs-dist": "^4.10.38",
         "posthog-js": "^1.205.0",
         "react": "^19.1.1",
@@ -761,6 +762,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/poppins": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/poppins/-/poppins-5.2.7.tgz",
+      "integrity": "sha512-6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deploy": "./scripts/deploy_resumelint.sh"
   },
   "dependencies": {
+    "@fontsource/poppins": "^5.2.7",
     "pdfjs-dist": "^4.10.38",
     "posthog-js": "^1.205.0",
     "react": "^19.1.1",

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -263,7 +263,7 @@ function Dimension({
           />
         </div>
       )}
-      <p className="text-[11px] text-content-muted">{hint}</p>
+      <p className="text-[11px] text-content-tertiary">{hint}</p>
     </div>
   );
 }

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -61,10 +61,10 @@ function ContactRow({
         {label}
       </dt>
       {gated ? (
-        <dd className="flex-1 text-sm italic text-content-muted">
+        <dd className="flex-1 text-sm italic text-content-tertiary">
           — not detected
           {reason === "low_confidence" && (
-            <span className="ml-1 text-[11px] not-italic text-content-muted">
+            <span className="ml-1 text-[11px] not-italic text-content-tertiary">
               (low confidence)
             </span>
           )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,10 @@ import { GlobalWorkerOptions } from "pdfjs-dist";
 import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.mjs?url";
 import App from "./App";
 import { initAnalytics } from "./lib/analytics";
+import "@fontsource/poppins/400.css";
+import "@fontsource/poppins/500.css";
+import "@fontsource/poppins/600.css";
+import "@fontsource/poppins/700.css";
 import "./styles.css";
 
 GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,7 +22,7 @@ html {
   --color-text-primary: #111827;
   --color-text-secondary: #374151;
   --color-text-tertiary: #4b5563;
-  --color-text-muted: #9ca3af;
+  --color-text-muted: #6b7280;
   --color-text-inverse: #ffffff;
   --color-border-light: #e5e7eb;
   --color-border-default: #d1d5db;
@@ -64,7 +64,7 @@ html {
     --color-text-primary: #f0f2f5;
     --color-text-secondary: #b8bfcc;
     --color-text-tertiary: #8892a4;
-    --color-text-muted: #4d5668;
+    --color-text-muted: #8a93a6;
     --color-text-inverse: #0f1419;
     --color-border-light: #2c3549;
     --color-border-default: #3a4459;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
     extend: {
       fontFamily: {
         sans: [
+          "Poppins",
           "-apple-system",
           "BlinkMacSystemFont",
           '"Segoe UI"',


### PR DESCRIPTION
## Summary

Raises `--color-text-muted` to pass WCAG AA contrast in both light (#9ca3af → #6b7280, ~4.6:1) and dark (#4d5668 → #8a93a6, ~4.9:1) modes. Re-tiers dimension hints and "not detected" fallbacks to `text-content-tertiary` so they stay visually subordinate after the raise. Wires Poppins via `@fontsource/poppins` (no CDN — all woff2 served from local node_modules).

Closes #46

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green
- [x] Manually verified in `npm run dev` — Poppins loads from localhost, no external font requests, muted text visibly darker