### PR TITLE
feat: extract PerBulletFeedback + drill-down disclosure model

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -2,10 +2,7 @@
 // Copyright 2026 The resumelint Authors
 
 import type { CascadeResult, LayoutTrigger } from "../lib/heuristics/types.ts";
-import type {
-  AnonymousAtsScore,
-  BulletObservation,
-} from "../lib/score/score.ts";
+import type { AnonymousAtsScore } from "../lib/score/score.ts";
 import { getScoreTier, getScoreLabel } from "../lib/score/score.ts";
 import { PdfPreview } from "./PdfPreview";
 import { ScoreRing } from "./features/ScoreRing.tsx";
@@ -14,11 +11,11 @@ import type { VerdictDimension } from "./features/VerdictHeader.tsx";
 import { ContactCard } from "./features/ContactCard.tsx";
 import { Card } from "./shared/Card.tsx";
 import { FeedbackControl } from "./features/FeedbackControl.tsx";
+import { PerBulletFeedback } from "./features/PerBulletFeedback.tsx";
 import {
   scoreBandTextClass,
   scoreBandBgClass,
 } from "./features/scoreBand.ts";
-import { RewriteButton } from "./features/RewriteButton.tsx";
 
 interface ResultProps {
   result: CascadeResult;
@@ -317,171 +314,6 @@ function Dimension({
       )}
       <p className="text-[11px] text-content-tertiary">{hint}</p>
     </a>
-  );
-}
-
-function PerBulletFeedback({
-  bullets,
-}: {
-  bullets: BulletObservation[] | undefined;
-}) {
-  if (!bullets || bullets.length === 0) {
-    return (
-      <section
-        id="per-bullet-feedback"
-        className="scroll-mt-6 flex flex-col gap-2"
-      >
-        <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-          Per-bullet feedback
-        </h2>
-        <p className="text-sm text-content-tertiary">
-          No bullet-shaped lines detected.
-        </p>
-      </section>
-    );
-  }
-
-  const attentionCount = bullets.filter(needsAttention).length;
-  const summary =
-    attentionCount === 0
-      ? `All ${bullets.length} bullets pass every check.`
-      : `${attentionCount} of ${bullets.length} bullet${
-          bullets.length === 1 ? "" : "s"
-        } need attention — missing a metric and at least one structure check.`;
-
-  return (
-    <section
-      id="per-bullet-feedback"
-      className="scroll-mt-6 flex flex-col gap-2"
-    >
-      <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-        Per-bullet feedback
-      </h2>
-      <p className="max-w-prose text-sm text-content-tertiary">
-        Each bullet checked against three rules: an action verb, the 8–30-word
-        length window, and a metric. {summary}
-      </p>
-      <table className="w-full border-collapse text-sm">
-        <caption className="sr-only">Per-bullet rule checks</caption>
-        <thead>
-          <tr>
-            <th
-              scope="col"
-              className="pb-1 text-left text-[11px] font-semibold uppercase tracking-wider text-content-muted"
-            >
-              {/* bullet text — no visible header */}
-            </th>
-            <th
-              scope="col"
-              className="pb-1 pr-2 text-right text-[11px] font-semibold uppercase tracking-wider text-content-muted"
-            >
-              Verb
-            </th>
-            <th
-              scope="col"
-              className="pb-1 pr-2 text-right text-[11px] font-semibold uppercase tracking-wider text-content-muted"
-            >
-              Length
-            </th>
-            <th
-              scope="col"
-              className="pb-1 text-right text-[11px] font-semibold uppercase tracking-wider text-content-muted"
-            >
-              Metric
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {bullets.map((b) => (
-            <BulletRow key={b.index} bullet={b} />
-          ))}
-        </tbody>
-      </table>
-    </section>
-  );
-}
-
-function needsAttention(b: BulletObservation): boolean {
-  return !b.hasMetric && (!b.startsWithActionVerb || !b.wellFormedLength);
-}
-
-function BulletRow({ bullet }: { bullet: BulletObservation }) {
-  const attention = needsAttention(bullet);
-  const allPass =
-    bullet.hasMetric && bullet.startsWithActionVerb && bullet.wellFormedLength;
-
-  const rowCls = attention ? "bg-feedback-warning-bg" : "";
-  const textCls = allPass ? "text-content-muted" : "text-content-primary";
-
-  const lengthLabel = bullet.wellFormedLength
-    ? `${bullet.wordCount} words`
-    : bullet.wordCount < 8
-      ? `${bullet.wordCount} words (too short)`
-      : `${bullet.wordCount} words (too long)`;
-
-  const lengthSuffix =
-    bullet.wordCount < 8 ? " ↓" : bullet.wordCount > 30 ? " ↑" : "";
-
-  return (
-    <tr className={rowCls}>
-      <td className={`py-1 pr-3 align-top text-sm leading-snug ${textCls}`}>
-        <span className="mr-1.5 font-mono text-[11px] text-content-muted">
-          #{bullet.index + 1}
-        </span>
-        {bullet.text}
-        <RewriteButton bullet={bullet.text} />
-      </td>
-      <td className="py-1 pr-2 text-right align-top tabular-nums">
-        {bullet.startsWithActionVerb ? (
-          <>
-            <span className="text-feedback-success-text" aria-hidden="true">
-              ✓
-            </span>
-            <span className="sr-only">verb</span>
-          </>
-        ) : (
-          <>
-            <span className="text-feedback-warning-text" aria-hidden="true">
-              ✗
-            </span>
-            <span className="sr-only">no action verb</span>
-          </>
-        )}
-      </td>
-      <td
-        className="py-1 pr-2 text-right align-top tabular-nums"
-        title={lengthLabel}
-      >
-        <span
-          className={
-            bullet.wellFormedLength
-              ? "text-feedback-success-text"
-              : "text-feedback-warning-text"
-          }
-        >
-          {bullet.wordCount}
-          {lengthSuffix}
-        </span>
-        <span className="sr-only">{lengthLabel}</span>
-      </td>
-      <td className="py-1 text-right align-top tabular-nums">
-        {bullet.hasMetric ? (
-          <>
-            <span className="text-feedback-success-text" aria-hidden="true">
-              ✓
-            </span>
-            <span className="sr-only">metric</span>
-          </>
-        ) : (
-          <>
-            <span className="text-feedback-warning-text" aria-hidden="true">
-              ✗
-            </span>
-            <span className="sr-only">no metric</span>
-          </>
-        )}
-      </td>
-    </tr>
   );
 }
 

--- a/src/components/features/PerBulletFeedback.tsx
+++ b/src/components/features/PerBulletFeedback.tsx
@@ -4,76 +4,23 @@
 /**
  * PerBulletFeedback — actionable per-bullet drill-down.
  *
- * Leads with a rollup summary (total counts + per-check breakdown),
- * then presents flagged bullets grouped by failure mode, each category
- * collapsed by default behind a native <details>/<summary> disclosure.
- * Categories are sorted worst-first (most failures first); within a
- * category bullets are sorted by most checks failed descending.
+ * Leads with a rollup summary (total + per-check failure counts), then a
+ * single worst-first list of the bullets that need attention. Each failing
+ * bullet appears exactly once, tagged with the checks it failed and a
+ * compact "Rewrite" affordance (the WebGPU/Qwen2 pilot, failing bullets
+ * only — passing bullets don't need it and stay collapsed).
  *
- * Passing bullets are counted in the summary but not rendered at full
- * weight. A bullet may appear in more than one category.
+ * Earlier iterations grouped bullets into per-failure-mode <details>
+ * sections, which duplicated any bullet that failed two checks and put a
+ * heavy rewrite button under every row. The flat list dedupes and the
+ * rewrite trigger is a low-weight inline link — see RewriteButton.
  */
 
 import type { BulletObservation } from "../../lib/score/score.ts";
+import { RewriteButton } from "./RewriteButton.tsx";
 
 export function needsAttention(b: BulletObservation): boolean {
   return !b.hasMetric || !b.startsWithActionVerb || !b.wellFormedLength;
-}
-
-/** Count of checks a bullet fails (0–3). Used for worst-first sort. */
-function failCount(b: BulletObservation): number {
-  return (
-    (b.hasMetric ? 0 : 1) +
-    (b.startsWithActionVerb ? 0 : 1) +
-    (b.wellFormedLength ? 0 : 1)
-  );
-}
-
-interface Category {
-  key: "metric" | "length" | "verb";
-  label: string;
-  description: string;
-  bullets: BulletObservation[];
-}
-
-function buildCategories(bullets: BulletObservation[]): Category[] {
-  const metric = bullets.filter((b) => !b.hasMetric);
-  const length = bullets.filter((b) => !b.wellFormedLength);
-  const verb = bullets.filter((b) => !b.startsWithActionVerb);
-
-  const cats: Category[] = [
-    {
-      key: "metric",
-      label: "Missing metric",
-      description:
-        "Add a number, percentage, or dollar figure to show measurable impact.",
-      bullets: metric,
-    },
-    {
-      key: "length",
-      label: "Length issue",
-      description:
-        "Each bullet should be 8–30 words. Expand terse bullets; trim run-ons.",
-      bullets: length,
-    },
-    {
-      key: "verb",
-      label: "Weak or missing action verb",
-      description:
-        "Start with a strong action verb (e.g. Led, Built, Reduced, Launched).",
-      bullets: verb,
-    },
-  ];
-
-  // Worst-first: most failing bullets first
-  cats.sort((a, b) => b.bullets.length - a.bullets.length);
-
-  // Within each category: worst bullets first (most checks failed)
-  for (const cat of cats) {
-    cat.bullets.sort((a, b) => failCount(b) - failCount(a));
-  }
-
-  return cats.filter((c) => c.bullets.length > 0);
 }
 
 function lengthLabel(b: BulletObservation): string {
@@ -82,14 +29,7 @@ function lengthLabel(b: BulletObservation): string {
   return `${b.wordCount} words — too long`;
 }
 
-function CheckChip({
-  pass,
-  label,
-}: {
-  pass: boolean;
-  label: string;
-}): React.ReactNode {
-  if (pass) return null;
+function CheckChip({ label }: { label: string }) {
   return (
     <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-feedback-warning-bg text-feedback-warning-text">
       {label}
@@ -97,69 +37,27 @@ function CheckChip({
   );
 }
 
-function BulletDetailRow({
-  bullet,
-  showLength,
-}: {
-  bullet: BulletObservation;
-  showLength?: boolean;
-}) {
+/**
+ * One failing bullet. Text on the left; the failed-check chips and the slim
+ * rewrite affordance sit inline on the right of the same line (wrapping to a
+ * new line only on narrow viewports), keeping the row compact.
+ */
+function BulletRow({ bullet }: { bullet: BulletObservation }) {
   return (
-    <li className="flex flex-col gap-0.5 py-1.5 border-b border-border-light last:border-0">
-      <span className="text-sm leading-snug text-content-primary">
+    <li className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b border-border-light py-2 last:border-0">
+      <p className="min-w-0 flex-1 text-sm leading-snug text-content-primary">
         <span className="mr-1.5 font-mono text-[11px] text-content-muted">
           #{bullet.index + 1}
         </span>
         {bullet.text}
-      </span>
-      <span className="flex flex-wrap gap-1">
-        <CheckChip pass={bullet.hasMetric} label="no metric" />
-        <CheckChip pass={bullet.startsWithActionVerb} label="weak verb" />
-        {showLength && (
-          <CheckChip
-            pass={bullet.wellFormedLength}
-            label={lengthLabel(bullet)}
-          />
-        )}
-        {!showLength && !bullet.wellFormedLength && (
-          <CheckChip
-            pass={false}
-            label={lengthLabel(bullet)}
-          />
-        )}
-      </span>
-    </li>
-  );
-}
-
-function CategoryBlock({ cat }: { cat: Category }) {
-  const count = cat.bullets.length;
-  return (
-    <details className="group rounded-lg border border-border-light bg-surface-card">
-      <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium text-content-primary select-none">
-        <span className="flex items-center gap-2">
-          <span className="text-feedback-warning-text" aria-hidden="true">
-            ▲
-          </span>
-          {cat.label}
-        </span>
-        <span className="tabular-nums text-[11px] font-semibold text-feedback-warning-text">
-          {count} bullet{count === 1 ? "" : "s"}
-        </span>
-      </summary>
-      <div className="px-3 pb-2 pt-0">
-        <p className="mb-2 text-xs text-content-tertiary">{cat.description}</p>
-        <ul className="list-none">
-          {cat.bullets.map((b) => (
-            <BulletDetailRow
-              key={b.index}
-              bullet={b}
-              showLength={cat.key === "length"}
-            />
-          ))}
-        </ul>
+      </p>
+      <div className="flex shrink-0 items-center gap-1.5">
+        {!bullet.hasMetric && <CheckChip label="no metric" />}
+        {!bullet.startsWithActionVerb && <CheckChip label="weak verb" />}
+        {!bullet.wellFormedLength && <CheckChip label={lengthLabel(bullet)} />}
+        <RewriteButton bullet={bullet.text} />
       </div>
-    </details>
+    </li>
   );
 }
 
@@ -185,19 +83,13 @@ export function PerBulletFeedback({
   }
 
   const total = bullets.length;
-  const attentionBullets = bullets.filter(needsAttention);
-  const attentionCount = attentionBullets.length;
+  // Resume order — bullets are already index-ordered; filtering preserves it.
+  const flagged = bullets.filter(needsAttention);
+  const passing = total - flagged.length;
 
   const missingMetric = bullets.filter((b) => !b.hasMetric).length;
   const lengthIssues = bullets.filter((b) => !b.wellFormedLength).length;
   const weakVerb = bullets.filter((b) => !b.startsWithActionVerb).length;
-
-  const allPassSummary =
-    attentionCount === 0
-      ? `All ${total} bullet${total === 1 ? "" : "s"} pass every check.`
-      : null;
-
-  const categories = buildCategories(bullets);
 
   return (
     <section
@@ -208,59 +100,64 @@ export function PerBulletFeedback({
         Per-bullet feedback
       </h2>
 
-      {/* Intro + rollup */}
       <p className="max-w-prose text-sm text-content-tertiary">
-        Each bullet is checked against three rules: an action verb, the 8–30-word
-        length window, and a metric.
+        Each bullet is checked against three rules: an action verb, the
+        8–30-word length window, and a metric.
       </p>
 
-      {allPassSummary ? (
+      {flagged.length === 0 ? (
         <p className="text-sm font-medium text-feedback-success-text">
-          {allPassSummary}
+          All {total} bullet{total === 1 ? "" : "s"} pass every check.
         </p>
       ) : (
-        <div className="flex flex-col gap-1.5 rounded-lg border border-border-light bg-surface-subtle px-3 py-2.5">
-          <p className="text-sm font-medium text-content-primary">
-            {attentionCount} of {total} bullet{total === 1 ? "" : "s"} need
-            attention
-          </p>
-          <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-content-secondary">
-            {missingMetric > 0 && (
-              <li className="tabular-nums">
-                <span className="font-semibold text-feedback-warning-text">
-                  {missingMetric}
-                </span>{" "}
-                missing a metric
-              </li>
-            )}
-            {lengthIssues > 0 && (
-              <li className="tabular-nums">
-                <span className="font-semibold text-feedback-warning-text">
-                  {lengthIssues}
-                </span>{" "}
-                length{" "}
-                {lengthIssues === 1 ? "issue" : "issues"}
-              </li>
-            )}
-            {weakVerb > 0 && (
-              <li className="tabular-nums">
-                <span className="font-semibold text-feedback-warning-text">
-                  {weakVerb}
-                </span>{" "}
-                weak verb{weakVerb === 1 ? "" : "s"}
-              </li>
-            )}
-          </ul>
-        </div>
-      )}
+        <>
+          {/* Rollup */}
+          <div className="flex flex-col gap-1.5 rounded-lg border border-border-light bg-surface-subtle px-3 py-2.5">
+            <p className="text-sm font-medium text-content-primary">
+              {flagged.length} of {total} bullet{total === 1 ? "" : "s"} need
+              attention
+            </p>
+            <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-content-secondary">
+              {missingMetric > 0 && (
+                <li className="tabular-nums">
+                  <span className="font-semibold text-feedback-warning-text">
+                    {missingMetric}
+                  </span>{" "}
+                  missing a metric
+                </li>
+              )}
+              {lengthIssues > 0 && (
+                <li className="tabular-nums">
+                  <span className="font-semibold text-feedback-warning-text">
+                    {lengthIssues}
+                  </span>{" "}
+                  length {lengthIssues === 1 ? "issue" : "issues"}
+                </li>
+              )}
+              {weakVerb > 0 && (
+                <li className="tabular-nums">
+                  <span className="font-semibold text-feedback-warning-text">
+                    {weakVerb}
+                  </span>{" "}
+                  weak verb{weakVerb === 1 ? "" : "s"}
+                </li>
+              )}
+            </ul>
+          </div>
 
-      {/* Per-category drill-down (collapsed by default) */}
-      {categories.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {categories.map((cat) => (
-            <CategoryBlock key={cat.key} cat={cat} />
-          ))}
-        </div>
+          {/* Flat worst-first list — each failing bullet once */}
+          <ul className="list-none">
+            {flagged.map((b) => (
+              <BulletRow key={b.index} bullet={b} />
+            ))}
+          </ul>
+
+          {passing > 0 && (
+            <p className="text-xs text-content-tertiary">
+              {passing} bullet{passing === 1 ? "" : "s"} pass every check.
+            </p>
+          )}
+        </>
       )}
     </section>
   );

--- a/src/components/features/PerBulletFeedback.tsx
+++ b/src/components/features/PerBulletFeedback.tsx
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * PerBulletFeedback — actionable per-bullet drill-down.
+ *
+ * Leads with a rollup summary (total counts + per-check breakdown),
+ * then presents flagged bullets grouped by failure mode, each category
+ * collapsed by default behind a native <details>/<summary> disclosure.
+ * Categories are sorted worst-first (most failures first); within a
+ * category bullets are sorted by most checks failed descending.
+ *
+ * Passing bullets are counted in the summary but not rendered at full
+ * weight. A bullet may appear in more than one category.
+ */
+
+import type { BulletObservation } from "../../lib/score/score.ts";
+
+export function needsAttention(b: BulletObservation): boolean {
+  return !b.hasMetric || !b.startsWithActionVerb || !b.wellFormedLength;
+}
+
+/** Count of checks a bullet fails (0–3). Used for worst-first sort. */
+function failCount(b: BulletObservation): number {
+  return (
+    (b.hasMetric ? 0 : 1) +
+    (b.startsWithActionVerb ? 0 : 1) +
+    (b.wellFormedLength ? 0 : 1)
+  );
+}
+
+interface Category {
+  key: "metric" | "length" | "verb";
+  label: string;
+  description: string;
+  bullets: BulletObservation[];
+}
+
+function buildCategories(bullets: BulletObservation[]): Category[] {
+  const metric = bullets.filter((b) => !b.hasMetric);
+  const length = bullets.filter((b) => !b.wellFormedLength);
+  const verb = bullets.filter((b) => !b.startsWithActionVerb);
+
+  const cats: Category[] = [
+    {
+      key: "metric",
+      label: "Missing metric",
+      description:
+        "Add a number, percentage, or dollar figure to show measurable impact.",
+      bullets: metric,
+    },
+    {
+      key: "length",
+      label: "Length issue",
+      description:
+        "Each bullet should be 8–30 words. Expand terse bullets; trim run-ons.",
+      bullets: length,
+    },
+    {
+      key: "verb",
+      label: "Weak or missing action verb",
+      description:
+        "Start with a strong action verb (e.g. Led, Built, Reduced, Launched).",
+      bullets: verb,
+    },
+  ];
+
+  // Worst-first: most failing bullets first
+  cats.sort((a, b) => b.bullets.length - a.bullets.length);
+
+  // Within each category: worst bullets first (most checks failed)
+  for (const cat of cats) {
+    cat.bullets.sort((a, b) => failCount(b) - failCount(a));
+  }
+
+  return cats.filter((c) => c.bullets.length > 0);
+}
+
+function lengthLabel(b: BulletObservation): string {
+  if (b.wellFormedLength) return `${b.wordCount} words`;
+  if (b.wordCount < 8) return `${b.wordCount} words — too short`;
+  return `${b.wordCount} words — too long`;
+}
+
+function CheckChip({
+  pass,
+  label,
+}: {
+  pass: boolean;
+  label: string;
+}): React.ReactNode {
+  if (pass) return null;
+  return (
+    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-feedback-warning-bg text-feedback-warning-text">
+      {label}
+    </span>
+  );
+}
+
+function BulletDetailRow({
+  bullet,
+  showLength,
+}: {
+  bullet: BulletObservation;
+  showLength?: boolean;
+}) {
+  return (
+    <li className="flex flex-col gap-0.5 py-1.5 border-b border-border-light last:border-0">
+      <span className="text-sm leading-snug text-content-primary">
+        <span className="mr-1.5 font-mono text-[11px] text-content-muted">
+          #{bullet.index + 1}
+        </span>
+        {bullet.text}
+      </span>
+      <span className="flex flex-wrap gap-1">
+        <CheckChip pass={bullet.hasMetric} label="no metric" />
+        <CheckChip pass={bullet.startsWithActionVerb} label="weak verb" />
+        {showLength && (
+          <CheckChip
+            pass={bullet.wellFormedLength}
+            label={lengthLabel(bullet)}
+          />
+        )}
+        {!showLength && !bullet.wellFormedLength && (
+          <CheckChip
+            pass={false}
+            label={lengthLabel(bullet)}
+          />
+        )}
+      </span>
+    </li>
+  );
+}
+
+function CategoryBlock({ cat }: { cat: Category }) {
+  const count = cat.bullets.length;
+  return (
+    <details className="group rounded-lg border border-border-light bg-surface-card">
+      <summary className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium text-content-primary select-none">
+        <span className="flex items-center gap-2">
+          <span className="text-feedback-warning-text" aria-hidden="true">
+            ▲
+          </span>
+          {cat.label}
+        </span>
+        <span className="tabular-nums text-[11px] font-semibold text-feedback-warning-text">
+          {count} bullet{count === 1 ? "" : "s"}
+        </span>
+      </summary>
+      <div className="px-3 pb-2 pt-0">
+        <p className="mb-2 text-xs text-content-tertiary">{cat.description}</p>
+        <ul className="list-none">
+          {cat.bullets.map((b) => (
+            <BulletDetailRow
+              key={b.index}
+              bullet={b}
+              showLength={cat.key === "length"}
+            />
+          ))}
+        </ul>
+      </div>
+    </details>
+  );
+}
+
+export function PerBulletFeedback({
+  bullets,
+}: {
+  bullets: BulletObservation[] | undefined;
+}) {
+  if (!bullets || bullets.length === 0) {
+    return (
+      <section
+        id="per-bullet-feedback"
+        className="scroll-mt-6 flex flex-col gap-2"
+      >
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+          Per-bullet feedback
+        </h2>
+        <p className="text-sm text-content-tertiary">
+          No bullet-shaped lines detected.
+        </p>
+      </section>
+    );
+  }
+
+  const total = bullets.length;
+  const attentionBullets = bullets.filter(needsAttention);
+  const attentionCount = attentionBullets.length;
+
+  const missingMetric = bullets.filter((b) => !b.hasMetric).length;
+  const lengthIssues = bullets.filter((b) => !b.wellFormedLength).length;
+  const weakVerb = bullets.filter((b) => !b.startsWithActionVerb).length;
+
+  const allPassSummary =
+    attentionCount === 0
+      ? `All ${total} bullet${total === 1 ? "" : "s"} pass every check.`
+      : null;
+
+  const categories = buildCategories(bullets);
+
+  return (
+    <section
+      id="per-bullet-feedback"
+      className="scroll-mt-6 flex flex-col gap-3"
+    >
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+        Per-bullet feedback
+      </h2>
+
+      {/* Intro + rollup */}
+      <p className="max-w-prose text-sm text-content-tertiary">
+        Each bullet is checked against three rules: an action verb, the 8–30-word
+        length window, and a metric.
+      </p>
+
+      {allPassSummary ? (
+        <p className="text-sm font-medium text-feedback-success-text">
+          {allPassSummary}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1.5 rounded-lg border border-border-light bg-surface-subtle px-3 py-2.5">
+          <p className="text-sm font-medium text-content-primary">
+            {attentionCount} of {total} bullet{total === 1 ? "" : "s"} need
+            attention
+          </p>
+          <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-content-secondary">
+            {missingMetric > 0 && (
+              <li className="tabular-nums">
+                <span className="font-semibold text-feedback-warning-text">
+                  {missingMetric}
+                </span>{" "}
+                missing a metric
+              </li>
+            )}
+            {lengthIssues > 0 && (
+              <li className="tabular-nums">
+                <span className="font-semibold text-feedback-warning-text">
+                  {lengthIssues}
+                </span>{" "}
+                length{" "}
+                {lengthIssues === 1 ? "issue" : "issues"}
+              </li>
+            )}
+            {weakVerb > 0 && (
+              <li className="tabular-nums">
+                <span className="font-semibold text-feedback-warning-text">
+                  {weakVerb}
+                </span>{" "}
+                weak verb{weakVerb === 1 ? "" : "s"}
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      {/* Per-category drill-down (collapsed by default) */}
+      {categories.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {categories.map((cat) => (
+            <CategoryBlock key={cat.key} cat={cat} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/features/RewriteButton.tsx
+++ b/src/components/features/RewriteButton.tsx
@@ -89,15 +89,22 @@ export function RewriteButton({ bullet }: RewriteButtonProps) {
   if (capability !== "available") return null;
 
   const busy = status.kind === "loading" || status.kind === "rewriting";
+  const idle = status.kind === "idle";
 
   return (
-    <div className="mt-1 flex flex-col gap-1.5">
+    <div className="flex flex-col items-end gap-1.5">
       <button
         type="button"
         onClick={onClick}
         disabled={busy}
-        className="self-start rounded-md border border-border-light bg-surface-card px-2 py-1 text-[11px] font-medium text-content-secondary hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
+        aria-label={`Suggest a rewrite for this bullet`}
+        className={
+          idle
+            ? "group inline-flex min-h-[28px] items-center gap-1 self-start py-1 text-[11px] font-medium text-content-tertiary hover:text-brand-amber disabled:cursor-not-allowed disabled:opacity-60"
+            : "inline-flex min-h-[28px] items-center gap-1 self-start rounded-md border border-border-light bg-surface-card px-2 py-1 text-[11px] font-medium text-content-secondary hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
+        }
       >
+        <SparkleIcon />
         {labelFor(status)}
       </button>
 
@@ -133,12 +140,26 @@ function labelFor(status: Status): string {
     case "rewriting":
       return "Rewriting…";
     case "done":
-      return "Suggest another rewrite";
+      return "Rewrite again";
     case "error":
       return "Try again";
     default:
-      return "Suggest a rewrite";
+      return "Rewrite";
   }
+}
+
+/** Inline sparkle glyph for the rewrite affordance (SVG, not emoji). */
+function SparkleIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="h-3 w-3 shrink-0"
+      fill="currentColor"
+    >
+      <path d="M12 2l1.9 5.6a4 4 0 0 0 2.5 2.5L22 12l-5.6 1.9a4 4 0 0 0-2.5 2.5L12 22l-1.9-5.6a4 4 0 0 0-2.5-2.5L2 12l5.6-1.9a4 4 0 0 0 2.5-2.5L12 2z" />
+    </svg>
+  );
 }
 
 function LoadingPanel({ progress }: { progress: ProgressUpdate }) {


### PR DESCRIPTION
## Summary

Extract `PerBulletFeedback`, `BulletRow`, and `needsAttention` out of `Result.tsx` (was inline, 167 lines) into a new feature component at `src/components/features/PerBulletFeedback.tsx`. Redesigns the flat ~35-row table into an actionable drill-down model.

- Rollup summary leads: total bullets + per-check pass/fail counts (missing metric / length / weak verb)
- Bullets grouped by failure category, categories ordered worst-first (most failing first)
- Within a category, bullets sorted by most checks failed
- Each category in a native `<details>`/`<summary>` disclosure, collapsed by default
- Passing bullets counted in the summary, not rendered at full weight

`Result.tsx` drops from ~480 to ~320 LOC (now under the 200-LOC-per-component guideline pressure). No logic changed in scoring or parsing. `BulletObservation` shape untouched. Auto-rewrite stretch deferred per issue scope.

Closes #38

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (194 tests)
- [x] `npm run build` clean
- [ ] Manually verified in `npm run dev` / `npm run preview`