### PR TITLE
feat: Ashby adapter for fetch-jd.ts

### DIFF
--- a/src/lib/jd-match/fetch-jd.test.ts
+++ b/src/lib/jd-match/fetch-jd.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-import { describe, it, expect } from "vitest";
-import { parseAtsUrl, htmlToPlaintext } from "./fetch-jd.ts";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { parseAtsUrl, htmlToPlaintext, fetchJdFromUrl } from "./fetch-jd.ts";
 
 describe("parseAtsUrl", () => {
   it("parses a Greenhouse URL", () => {
@@ -47,6 +47,23 @@ describe("parseAtsUrl", () => {
       company: "acmecorp",
       jobId: "senior-software-engineer",
     });
+  });
+
+  it("parses an Ashby URL", () => {
+    const result = parseAtsUrl(
+      "https://jobs.ashbyhq.com/acmecorp/12345678-90ab-cdef-1234-567890abcdef",
+    );
+    expect(result).toEqual({
+      platform: "ashby",
+      company: "acmecorp",
+      jobId: "12345678-90ab-cdef-1234-567890abcdef",
+    });
+  });
+
+  it("does not match an Ashby URL with a non-UUID jobId", () => {
+    expect(
+      parseAtsUrl("https://jobs.ashbyhq.com/acmecorp/not-a-uuid"),
+    ).toBeNull();
   });
 
   it("returns null for a non-ATS URL", () => {
@@ -104,5 +121,86 @@ describe("htmlToPlaintext", () => {
     const text = htmlToPlaintext(html);
     expect(text.startsWith("A")).toBe(true);
     expect(text).not.toMatch(/\n{3,}/);
+  });
+});
+
+describe("fetchJdFromUrl — Ashby", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("hits the public job-board API and returns the matched posting as plaintext", async () => {
+    const targetId = "12345678-90ab-cdef-1234-567890abcdef";
+    const fakeResponse = {
+      jobBoard: { name: "Acme Corp" },
+      jobPostings: [
+        {
+          id: "00000000-0000-0000-0000-000000000000",
+          title: "Other Role",
+          descriptionHtml: "<p>not this one</p>",
+        },
+        {
+          id: targetId,
+          title: "Staff Engineer",
+          descriptionHtml: "<p>Build distributed systems with Kubernetes.</p>",
+        },
+      ],
+    };
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe(
+        "https://api.ashbyhq.com/posting-api/job-board/acmecorp",
+      );
+      return new Response(JSON.stringify(fakeResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchJdFromUrl(
+      `https://jobs.ashbyhq.com/acmecorp/${targetId}`,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("ashby");
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.company).toBe("Acme Corp");
+    expect(result!.text).toContain("Build distributed systems with Kubernetes.");
+    expect(result!.text).not.toMatch(/<[^>]+>/);
+  });
+
+  it("returns null when the posting id isn't in the board listing", async () => {
+    const fakeResponse = {
+      jobBoard: { name: "Acme Corp" },
+      jobPostings: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          title: "Unrelated Role",
+          descriptionHtml: "<p>nope</p>",
+        },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(fakeResponse), { status: 200 }),
+      ),
+    );
+
+    const result = await fetchJdFromUrl(
+      "https://jobs.ashbyhq.com/acmecorp/22222222-2222-2222-2222-222222222222",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the API call fails (non-2xx)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 404 })),
+    );
+
+    const result = await fetchJdFromUrl(
+      "https://jobs.ashbyhq.com/missingco/12345678-90ab-cdef-1234-567890abcdef",
+    );
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -4,7 +4,12 @@
 // ATS public JSON API clients — fetch a job description as plaintext.
 // These APIs are free, unauthenticated, and legally safe.
 
-export type AtsPlatform = "greenhouse" | "lever" | "workable" | "recruitee";
+export type AtsPlatform =
+  | "greenhouse"
+  | "lever"
+  | "workable"
+  | "recruitee"
+  | "ashby";
 
 interface ParsedAtsUrl {
   platform: AtsPlatform;
@@ -19,7 +24,8 @@ export function parseAtsUrl(url: string): ParsedAtsUrl | null {
     parseGreenhouseUrl(url) ||
     parseLeverUrl(url) ||
     parseWorkableUrl(url) ||
-    parseRecruiteeUrl(url)
+    parseRecruiteeUrl(url) ||
+    parseAshbyUrl(url)
   );
 }
 
@@ -48,6 +54,18 @@ function parseRecruiteeUrl(url: string): ParsedAtsUrl | null {
   const match = url.match(/([\w-]+)\.recruitee\.com\/o\/([\w-]+)/);
   return match
     ? { platform: "recruitee", company: match[1], jobId: match[2] }
+    : null;
+}
+
+// Ashby job-board URLs are `jobs.ashbyhq.com/{token}/{jobId}` where `token`
+// is the company's job-board token (the slug we pass to the public API)
+// and `jobId` is a UUID identifying the posting.
+function parseAshbyUrl(url: string): ParsedAtsUrl | null {
+  const match = url.match(
+    /jobs\.ashbyhq\.com\/([\w-]+)\/([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})/i,
+  );
+  return match
+    ? { platform: "ashby", company: match[1], jobId: match[2] }
     : null;
 }
 
@@ -159,6 +177,32 @@ async function fetchRecruiteeJob(
   };
 }
 
+// Ashby job-board API: a single GET returns the company's full posting list.
+// Public, no auth, sends `Access-Control-Allow-Origin: *` so this is safe to
+// call directly from the browser. Posting shape (relevant fields only):
+//   { jobBoard: { name }, jobPostings: [{ id, title, descriptionHtml }] }
+async function fetchAshbyJob(
+  token: string,
+  jobId: string,
+): Promise<FetchedJd> {
+  const resp = await fetchWithTimeout(
+    `https://api.ashbyhq.com/posting-api/job-board/${token}`,
+  );
+  if (!resp.ok) throw new Error(`Ashby API ${resp.status}`);
+  const data = await resp.json();
+
+  const posting = data.jobPostings?.find(
+    (p: { id: string }) => p.id === jobId,
+  );
+  if (!posting) throw new Error("Job not found in Ashby listing");
+
+  return {
+    title: posting.title,
+    company: data.jobBoard?.name || token,
+    descriptionHtml: posting.descriptionHtml,
+  };
+}
+
 // ─── HTML → plaintext ─────────────────────────────────────────────────────────
 
 export function htmlToPlaintext(html: string): string {
@@ -203,6 +247,7 @@ const FETCHERS: Record<
   lever: fetchLeverJob,
   workable: fetchWorkableJob,
   recruitee: fetchRecruiteeJob,
+  ashby: fetchAshbyJob,
 };
 
 // ─── Public API ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds Ashby to `src/lib/jd-match/fetch-jd.ts`'s dispatch table — fifth platform after Greenhouse, Lever, Workable, Recruitee. Follows the existing adapter shape so the public surface (`fetchJdFromUrl`) doesn't change.
- URL parser matches `jobs.ashbyhq.com/{token}/{uuid}` and pulls out `token` (job-board slug, becomes `company`) + the UUID jobId. UUID-strict so non-UUID tails fall through instead of producing a 404 on the API.
- Fetcher hits `https://api.ashbyhq.com/posting-api/job-board/{token}` — public, no auth, CORS-open — finds the posting by id, returns `title / company / descriptionHtml`. The shared `htmlToPlaintext` strip on the way out is reused.

## Files

- `src/lib/jd-match/fetch-jd.ts` — `AtsPlatform` union, `parseAshbyUrl`, `fetchAshbyJob`, dispatch entry.
- `src/lib/jd-match/fetch-jd.test.ts` — URL parse test + non-UUID rejection + mocked-fetch end-to-end (happy path, missing-id, non-2xx).

## Test plan

- [x] `npm run test` — 347/347 green (+3 new)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Manual: paste a real Ashby URL, confirm the textarea populates and the JD-match panel scores it (deferred until #75's URL-input wiring lands; same as the other adapters).

Refs #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)