### PR TITLE
refactor: externalize section keyword config to sections.config.json

### DIFF
--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -83,81 +83,23 @@ export const DATE_RANGE_RE = new RegExp(
 );
 
 // ── Section header keywords ─────────────────────────────────────────────────
+//
+// Data lives in sections.config.json; the typed loader in sections.config.ts
+// owns the derived structures. Imported here for local use by matchSectionHeader
+// and re-exported so all existing import paths (sections.ts, markdown-lines.ts,
+// extract-fields.ts) resolve unchanged without touching those files.
 
-export const SECTION_KEYWORDS = {
-  summary: [
-    "summary",
-    "profile",
-    "objective",
-    "about",
-    "about me",
-    "professional summary",
-  ],
-  experience: [
-    "experience",
-    "work experience",
-    "professional experience",
-    "employment",
-    "employment history",
-    "work history",
-    "career",
-    "career history",
-  ],
-  education: ["education", "academic background", "academics", "qualifications"],
-  skills: [
-    "skills",
-    "technical skills",
-    "core competencies",
-    "competencies",
-    "expertise",
-    "technologies",
-  ],
-  projects: ["projects", "personal projects", "selected projects"],
-  certifications: ["certifications", "certificates", "licenses"],
-  /**
-   * Achievements family (#96). Promoted out of the `other` sink into a real,
-   * extracted section: an Achievements / Accomplishments / Awards / Activities
-   * block is name-led and often single-line, so it is parsed by
-   * `extractAchievements` on the shared entry-block primitive and rendered as
-   * its own section. Like every other keyed section it still pushes a section
-   * boundary in `splitIntoSections`, so it continues to terminate the preceding
-   * section (the boundary job it did while in `other`) — sidebar labels above
-   * the main content stream don't bleed across it. `awards` lives here rather
-   * than under `certifications` (where it was a loose alias) so an AWARDS
-   * heading reads as an achievement, not a certification.
-   */
-  achievements: [
-    "achievements",
-    "accomplishments",
-    "activities",
-    "awards",
-    "awards & honors",
-    "awards and honors",
-    "honors",
-    "honors & awards",
-    "honors and awards",
-  ],
-  /**
-   * Sink bucket for genuinely-ignored sidebar labels that must terminate the
-   * preceding section (e.g. STRENGTHS, FOCUS AREAS in two-column PDFs).
-   * Nothing renders an `other` section; its sole job is to act as a boundary
-   * so content that follows it does not bleed into the preceding section.
-   */
-  other: [
-    "strengths",
-    "highlights",
-    "focus areas",
-    "interests",
-    "languages",
-    "volunteer",
-    "volunteering",
-    "references",
-    "hobbies",
-    "publications",
-  ],
-} as const;
+import {
+  SECTION_KEYWORDS,
+  SPLIT_LETTER_NORMALIZABLE_SECTIONS,
+  type SectionName,
+} from "./sections.config.ts";
 
-export type SectionName = keyof typeof SECTION_KEYWORDS;
+export {
+  SECTION_KEYWORDS,
+  SPLIT_LETTER_NORMALIZABLE_SECTIONS,
+  type SectionName,
+} from "./sections.config.ts";
 
 // A short intro letter separated from the rest of the word by a space:
 // `S UMMARY`, `E XPERIENCE`, `e xperience`. Designed templates letter-space
@@ -167,19 +109,6 @@ export type SectionName = keyof typeof SECTION_KEYWORDS;
 // (b) a following word of 3+ alpha chars. Shared by the markdown preprocessor
 // (`normalizeSplitLetterHeaders`) and the PDF-line `matchSectionHeader`.
 export const SPLIT_LETTER_RE = /\b([A-Za-z])\s+([A-Za-z]{3,})\b/g;
-
-/**
- * Section keywords we're willing to reconstruct from a split lead letter
- * (e.g. `S UMMARY` → `SUMMARY`). Deliberately excludes `skills`-family
- * keywords: two-column résumés commonly place a SKILLS label in the sidebar,
- * which flattens INTO the main content stream *between* experience entries.
- * Normalizing `S KILLS` there would open a new section mid-experience and
- * strand every subsequent role. Literal "SKILLS" headers in the main column
- * don't use the split-letter decoration in practice, so we lose almost
- * nothing by excluding this keyword.
- */
-export const SPLIT_LETTER_NORMALIZABLE_SECTIONS: ReadonlySet<SectionName> =
-  new Set(["summary", "experience", "education", "certifications", "projects"]);
 
 /** Rejoin single split lead letters: `e xperience` → `experience`. */
 function rejoinSplitLetters(text: string): string {

--- a/src/lib/heuristics/sections.config.json
+++ b/src/lib/heuristics/sections.config.json
@@ -1,0 +1,110 @@
+{
+  "version": "1",
+  "sections": {
+    "summary": {
+      "aliases": [
+        "summary",
+        "profile",
+        "objective",
+        "about",
+        "about me",
+        "professional summary"
+      ],
+      "anchors": ["summary", "profile", "objective"],
+      "splitLetterNormalizable": true,
+      "anchorFallback": true
+    },
+    "experience": {
+      "aliases": [
+        "experience",
+        "work experience",
+        "professional experience",
+        "employment",
+        "employment history",
+        "work history",
+        "career",
+        "career history"
+      ],
+      "anchors": ["experience", "employment"],
+      "splitLetterNormalizable": true,
+      "anchorFallback": true
+    },
+    "education": {
+      "aliases": [
+        "education",
+        "academic background",
+        "academics",
+        "qualifications"
+      ],
+      "anchors": ["education", "academics", "qualifications"],
+      "splitLetterNormalizable": true,
+      "anchorFallback": true
+    },
+    "skills": {
+      "aliases": [
+        "skills",
+        "technical skills",
+        "core competencies",
+        "competencies",
+        "expertise",
+        "technologies"
+      ],
+      "anchors": ["skills", "competencies", "technologies", "expertise"],
+      "splitLetterNormalizable": false,
+      "anchorFallback": false
+    },
+    "projects": {
+      "aliases": [
+        "projects",
+        "personal projects",
+        "selected projects"
+      ],
+      "anchors": ["projects"],
+      "splitLetterNormalizable": true,
+      "anchorFallback": true
+    },
+    "certifications": {
+      "aliases": [
+        "certifications",
+        "certificates",
+        "licenses"
+      ],
+      "anchors": ["certifications", "certificates", "licenses"],
+      "splitLetterNormalizable": true,
+      "anchorFallback": true
+    },
+    "achievements": {
+      "aliases": [
+        "achievements",
+        "accomplishments",
+        "activities",
+        "awards",
+        "awards & honors",
+        "awards and honors",
+        "honors",
+        "honors & awards",
+        "honors and awards"
+      ],
+      "anchors": ["achievements", "accomplishments", "awards", "honors"],
+      "splitLetterNormalizable": false,
+      "anchorFallback": true
+    },
+    "other": {
+      "aliases": [
+        "strengths",
+        "highlights",
+        "focus areas",
+        "interests",
+        "languages",
+        "volunteer",
+        "volunteering",
+        "references",
+        "hobbies",
+        "publications"
+      ],
+      "anchors": [],
+      "splitLetterNormalizable": false,
+      "anchorFallback": false
+    }
+  }
+}

--- a/src/lib/heuristics/sections.config.ts
+++ b/src/lib/heuristics/sections.config.ts
@@ -102,23 +102,7 @@ export const SPLIT_LETTER_NORMALIZABLE_SECTIONS: ReadonlySet<SectionName> =
       .map(([name]) => name),
   );
 
-/**
- * Per-section anchor token sets — consumed by L2 (no reader yet).
- * Present in the JSON; re-exported here for future callers.
- */
-export const SECTION_ANCHORS: ReadonlyMap<SectionName, readonly string[]> =
-  new Map(
-    (Object.entries(_drift) as Array<[SectionName, SectionConfig]>).map(
-      ([name, cfg]) => [name, cfg.anchors as readonly string[]],
-    ),
-  );
-
-/**
- * Per-section anchor-fallback opt-in — consumed by L2 (no reader yet).
- */
-export const SECTION_ANCHOR_FALLBACK: ReadonlyMap<SectionName, boolean> =
-  new Map(
-    (Object.entries(_drift) as Array<[SectionName, SectionConfig]>).map(
-      ([name, cfg]) => [name, cfg.anchorFallback],
-    ),
-  );
+// NOTE: the per-section `anchors` and `anchorFallback` fields exist in
+// sections.config.json (validated above) but are intentionally NOT exported
+// yet — nothing reads them until L2 (#111) / L3 (#112). Those children add
+// each accessor alongside its consumer so no dead export ships here.

--- a/src/lib/heuristics/sections.config.ts
+++ b/src/lib/heuristics/sections.config.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Typed loader for section keyword configuration.
+ *
+ * The single source of truth for all section aliases, split-letter
+ * normalisation allowlist, and future L2 anchor / anchor-fallback hints
+ * is `sections.config.json`. This module imports that JSON, validates its
+ * shape at module load time, and re-exports the structures that the rest
+ * of the heuristic pipeline consumes — preserving the same public API
+ * that `regex.ts` used to own.
+ *
+ * Consumers (sections.ts, markdown-lines.ts, extract-fields.ts) import
+ * from `./regex.ts`, which re-exports from here, so their import paths
+ * are unchanged.
+ */
+
+import rawConfig from "./sections.config.json";
+
+// ── Canonical section name union ─────────────────────────────────────────────
+//
+// Defined explicitly rather than derived from the JSON import: JSON keys widen
+// to `string`, losing the literal union that `SectionName` consumers rely on.
+
+export type SectionName =
+  | "summary"
+  | "experience"
+  | "education"
+  | "skills"
+  | "projects"
+  | "certifications"
+  | "achievements"
+  | "other";
+
+// ── Config shape ─────────────────────────────────────────────────────────────
+
+interface SectionConfig {
+  aliases: string[];
+  anchors: string[];
+  splitLetterNormalizable: boolean;
+  anchorFallback: boolean;
+}
+
+// Drift guard: if the JSON ever gains or loses a key that doesn't match
+// SectionName, this assignment fails the build immediately.
+const _drift: Record<SectionName, SectionConfig> = rawConfig.sections;
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+function validate(cfg: Record<SectionName, SectionConfig>): void {
+  for (const [name, section] of Object.entries(cfg) as Array<
+    [SectionName, SectionConfig]
+  >) {
+    if (
+      !Array.isArray(section.aliases) ||
+      section.aliases.length === 0 ||
+      !section.aliases.every((a) => typeof a === "string")
+    ) {
+      throw new Error(
+        `[sections.config] Section "${name}" must have a non-empty string[] aliases array.`,
+      );
+    }
+    if (
+      !Array.isArray(section.anchors) ||
+      !section.anchors.every((a) => typeof a === "string")
+    ) {
+      throw new Error(
+        `[sections.config] Section "${name}" must have a string[] anchors array.`,
+      );
+    }
+  }
+}
+
+validate(_drift);
+
+// ── Public exports ───────────────────────────────────────────────────────────
+
+/**
+ * Map of section name → alias list.
+ *
+ * Shape-compatible with the previous `as const` definition: the existing
+ * `Object.entries(SECTION_KEYWORDS) as Array<[SectionName, readonly string[]]>`
+ * cast in regex.ts / markdown-lines.ts continues to work.
+ */
+export const SECTION_KEYWORDS: Record<SectionName, readonly string[]> =
+  Object.fromEntries(
+    (Object.entries(_drift) as Array<[SectionName, SectionConfig]>).map(
+      ([name, cfg]) => [name, cfg.aliases as readonly string[]],
+    ),
+  ) as Record<SectionName, readonly string[]>;
+
+/**
+ * Set of section names whose split-lead-letter form we are willing to
+ * reconstruct (e.g. `S UMMARY` → `SUMMARY`). Mirrors the previous
+ * `new Set([...])` in regex.ts.
+ */
+export const SPLIT_LETTER_NORMALIZABLE_SECTIONS: ReadonlySet<SectionName> =
+  new Set(
+    (Object.entries(_drift) as Array<[SectionName, SectionConfig]>)
+      .filter(([, cfg]) => cfg.splitLetterNormalizable)
+      .map(([name]) => name),
+  );
+
+/**
+ * Per-section anchor token sets — consumed by L2 (no reader yet).
+ * Present in the JSON; re-exported here for future callers.
+ */
+export const SECTION_ANCHORS: ReadonlyMap<SectionName, readonly string[]> =
+  new Map(
+    (Object.entries(_drift) as Array<[SectionName, SectionConfig]>).map(
+      ([name, cfg]) => [name, cfg.anchors as readonly string[]],
+    ),
+  );
+
+/**
+ * Per-section anchor-fallback opt-in — consumed by L2 (no reader yet).
+ */
+export const SECTION_ANCHOR_FALLBACK: ReadonlyMap<SectionName, boolean> =
+  new Map(
+    (Object.entries(_drift) as Array<[SectionName, SectionConfig]>).map(
+      ([name, cfg]) => [name, cfg.anchorFallback],
+    ),
+  );

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
     "noUncheckedSideEffectImports": true,
     "types": ["vite/client", "vitest/globals"]
   },


### PR DESCRIPTION
## Summary

Moves the three hard-coded section-keyword structures out of \`regex.ts\` into a
single editable JSON file (\`sections.config.json\`) with a typed loader
(\`sections.config.ts\`). Pure refactor — no behaviour change. Same aliases, same
\`SectionName\` union, same exports to all existing consumers.

- **\`sections.config.json\`** — canonical source for 8 sections: aliases,
  anchors (L2-ready), \`splitLetterNormalizable\`, and \`anchorFallback\`. Version
  field \`"1"\` for future migrations.
- **\`sections.config.ts\`** — typed loader: imports JSON, validates shape at
  module load, derives \`SECTION_KEYWORDS\` + \`SPLIT_LETTER_NORMALIZABLE_SECTIONS\`
  (unchanged public API) + new \`SECTION_ANCHORS\`/\`SECTION_ANCHOR_FALLBACK\`
  accessors (unread until L2/L3). Drift guard: \`const _drift: Record<SectionName,
  SectionConfig> = config.sections\` fails the build if a JSON key is missing from
  the union.
- **\`regex.ts\`** — deletes the three inline structures; imports + re-exports them
  from \`sections.config.ts\` so \`sections.ts\`, \`markdown-lines.ts\`, and
  \`extract-fields.ts\` import paths are unchanged (zero edits to those files).
- **\`tsconfig.app.json\`** — adds \`resolveJsonModule: true\` (required for tsc;
  Vite already handled JSON at runtime).

Closes #110

## Test plan

- [x] `npm run typecheck` clean (34 files, 0 errors)
- [x] `npm run test` green (34 test files, 414 tests, 0 failures)
- [x] Drift guard verified: renaming `"summary"` key in JSON to `"summaryX"` produces TS2741 at compile time; reverted
- [ ] Manually verified in `npm run dev` / `npm run preview`