### PR TITLE
feat: separator-less month-year date ranges (#119)

### DIFF
--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -40,8 +40,8 @@ export function parseDateRange(text: string): {
   const m = DATE_RANGE_RE.exec(text);
   DATE_RANGE_RE.lastIndex = 0;
   if (m) {
-    const start = normalizeDate(m[1]);
-    const endRaw = m[2];
+    const start = normalizeDate(m[1] ?? m[3]);
+    const endRaw = m[2] ?? m[4];
     if (/^(present|current|now|ongoing)$/i.test(endRaw)) {
       return { start_date: start, is_current: true };
     }

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -2,7 +2,8 @@
 // Copyright 2026 The resumelint Authors
 
 import { describe, it, expect } from "vitest";
-import { matchSectionHeader, matchSectionAnchorToken } from "./regex.ts";
+import { matchSectionHeader, matchSectionAnchorToken, DATE_RANGE_RE } from "./regex.ts";
+import { parseDateRange } from "./line-primitives.ts";
 
 describe("matchSectionHeader — split-letter headers (#56)", () => {
   it("matches a clean header unchanged", () => {
@@ -121,6 +122,71 @@ describe("matchSectionHeader — head-noun anchor fallback (#108 / #111)", () =>
     // "other" has no anchors and anchorFallback false; qualified forms over its
     // aliases stay unclassified.
     expect(matchSectionHeader("Spoken Languages")).toBeNull();
+  });
+});
+
+describe("DATE_RANGE_RE — separator-less month-year pairs (#119)", () => {
+  // Awesome-CV / LaTeX templates: pdfjs drops the dash glyph entirely, leaving
+  // a bare space between the two month-year anchors. Branch (b) of DATE_RANGE_RE
+  // must match without any – / — / - / to / through separator.
+
+  it("matches a bare space-separated month-year pair", () => {
+    expect(DATE_RANGE_RE.test("Sep. 2023 Mar. 2024")).toBe(true);
+    DATE_RANGE_RE.lastIndex = 0;
+  });
+
+  it("matches additional separator-less cases", () => {
+    expect(DATE_RANGE_RE.test("Mar. 2021 Jun. 2023")).toBe(true);
+    DATE_RANGE_RE.lastIndex = 0;
+    expect(DATE_RANGE_RE.test("Jun. 2017 May. 2018")).toBe(true);
+    DATE_RANGE_RE.lastIndex = 0;
+  });
+
+  it("matches a separator-less range embedded in a title-bearing line", () => {
+    // e.g. "Site Reliability Engineer Feb. 2021 Mar. 2021"
+    expect(DATE_RANGE_RE.test("Site Reliability Engineer Feb. 2021 Mar. 2021")).toBe(
+      true,
+    );
+    DATE_RANGE_RE.lastIndex = 0;
+  });
+
+  it("parseDateRange extracts correct start and end dates (sep-less)", () => {
+    const result = parseDateRange("Sep. 2023 Mar. 2024");
+    expect(result.start_date).toBe("Sep. 2023");
+    expect(result.end_date).toBe("Mar. 2024");
+    expect(result.is_current).toBeUndefined();
+  });
+
+  it("parseDateRange extracts is_current when end is Present (sep-less)", () => {
+    const result = parseDateRange("Feb. 2022 Present");
+    expect(result.start_date).toBe("Feb. 2022");
+    expect(result.is_current).toBe(true);
+  });
+
+  it("does NOT match bare adjacent years (too weak a signal)", () => {
+    // "shipped 2020 2021 release" must not fire the separator-less branch.
+    const m = DATE_RANGE_RE.exec("shipped 2020 2021 release");
+    DATE_RANGE_RE.lastIndex = 0;
+    expect(m).toBeNull();
+  });
+
+  it("existing dash-separator ranges still parse correctly (branch a)", () => {
+    // Regression guard: classic dash branch must be byte-identical.
+    const result = parseDateRange("Jan 2019 – Dec 2021");
+    expect(result.start_date).toBe("Jan 2019");
+    expect(result.end_date).toBe("Dec 2021");
+  });
+
+  it("existing 'to'-separator ranges still parse correctly (branch a)", () => {
+    const result = parseDateRange("Mar. 2020 to Jun. 2023");
+    expect(result.start_date).toBe("Mar. 2020");
+    expect(result.end_date).toBe("Jun. 2023");
+  });
+
+  it("existing Present ranges still parse correctly (branch a)", () => {
+    const result = parseDateRange("Apr 2021 – Present");
+    expect(result.start_date).toBe("Apr 2021");
+    expect(result.is_current).toBe(true);
   });
 });
 

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -71,14 +71,26 @@ export const PRESENT_RE = /\b(Present|Current|Now|Ongoing)\b/i;
 // DOCX parsing compatible with older resumes that use "Dec '00".
 const DATE_ANCHOR = `${MONTH}\\.?\\s+(?:\\d{4}|'\\d{2})|\\d{1,2}[\\/\\-]\\d{4}|\\d{4}`;
 
+// Strict month-year anchor (no bare-year / numeric-slash forms) for the
+// separator-less branch — bare years adjacent are too weak a signal.
+const MONTH_YEAR_ANCHOR = `${MONTH}\\.?\\s+(?:\\d{4}|'\\d{2})`;
+
 /**
  * Date range between two anchors. Captures both halves. Tolerant of spacing,
  * dashes (—, –, -, to, through).
+ *
+ * Two branches:
+ *   (a) classic — any anchor, explicit separator (–/—/-/to/through), any anchor or Present.
+ *       Groups: m[1] = start, m[2] = end.
+ *   (b) separator-less — month-year WS month-year (or Present), no dash.
+ *       Covers LaTeX/Awesome-CV where pdfjs drops the dash glyph.
+ *       Groups: m[3] = start, m[4] = end.
  */
 export const DATE_RANGE_RE = new RegExp(
-  `(${DATE_ANCHOR})` +
-    `\\s*(?:–|—|-|to|through)\\s*` +
-    `(${DATE_ANCHOR}|Present|Current|Now|Ongoing)`,
+  // (a) classic: any anchor, explicit separator, any anchor|Present
+  `(?:(${DATE_ANCHOR})\\s*(?:–|—|-|to|through)\\s*(${DATE_ANCHOR}|Present|Current|Now|Ongoing))` +
+    // (b) separator-less: month-year WS month-year (or Present)
+    `|(?:(${MONTH_YEAR_ANCHOR})\\s+(${MONTH_YEAR_ANCHOR}|Present|Current|Now|Ongoing))`,
   "i",
 );
 

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -41,7 +41,10 @@ export const WEIGHTS = {
  * - 1.0 (2026-04-28): initial release.
  * - 1.1 (2026-06-17): separator-less month-year date ranges now anchor experience entries (#119).
  */
-export const ATS_SCORE_ALGO_VERSION = "1.1";
+// Internal-only: surfaced to the UI via the `algoVersion` score field, not
+// imported by name anywhere — so it stays unexported to satisfy the dead-code
+// gate (fallow flags exported symbols with no external consumer).
+const ATS_SCORE_ALGO_VERSION = "1.1";
 
 // ── Shared scoring rules ────────────────────────────────────────────────────
 //

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -39,8 +39,9 @@ export const WEIGHTS = {
  *
  * Changelog:
  * - 1.0 (2026-04-28): initial release.
+ * - 1.1 (2026-06-17): separator-less month-year date ranges now anchor experience entries (#119).
  */
-export const ATS_SCORE_ALGO_VERSION = "1.0";
+export const ATS_SCORE_ALGO_VERSION = "1.1";
 
 // ── Shared scoring rules ────────────────────────────────────────────────────
 //

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
@@ -64,6 +64,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
@@ -71,6 +71,6 @@
       "scanned": false
     },
     "bulletCount": 23,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.9,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -26,7 +26,7 @@
       "website_url"
     ],
     "skillsCount": 27,
-    "experienceCount": 3,
+    "experienceCount": 16,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 1,
@@ -67,6 +67,6 @@
       "scanned": false
     },
     "bulletCount": 59,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -1,16 +1,19 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.9,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
+      "current_company",
+      "current_title",
       "education",
       "email",
+      "experience",
       "family_name",
       "full_name",
       "github_url",
@@ -23,7 +26,7 @@
       "website_url"
     ],
     "skillsCount": 0,
-    "experienceCount": 0,
+    "experienceCount": 8,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 1,
@@ -34,8 +37,8 @@
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 63,
-    "preLayoutOverall": 63,
+    "overall": 67,
+    "preLayoutOverall": 67,
     "specificity": {
       "score": 17,
       "max": 40,
@@ -51,12 +54,11 @@
       "totalBullets": 31
     },
     "completeness": {
-      "score": 23,
+      "score": 27,
       "max": 30,
       "gradable": true,
       "missing": [
-        "skills",
-        "work experience"
+        "skills"
       ]
     },
     "layout": {
@@ -65,6 +67,6 @@
       "scanned": false
     },
     "bulletCount": 31,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -71,6 +71,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -71,6 +71,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -69,6 +69,6 @@
       "scanned": false
     },
     "bulletCount": 11,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
@@ -64,6 +64,6 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -71,6 +71,6 @@
       "scanned": false
     },
     "bulletCount": 27,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
+++ b/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 14,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
@@ -63,6 +63,6 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -67,6 +67,6 @@
       "scanned": false
     },
     "bulletCount": 23,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -70,6 +70,6 @@
       "scanned": false
     },
     "bulletCount": 16,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
@@ -64,6 +64,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -72,6 +72,6 @@
       "scanned": false
     },
     "bulletCount": 23,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.0"
+    "algoVersion": "1.1"
   }
 }


### PR DESCRIPTION
## Summary

Awesome-CV / LaTeX résumés have pdfjs drop the dash glyph between role date anchors, so a date line reads `"Sep. 2023 Mar. 2024"` (bare space, no separator). `DATE_RANGE_RE` previously required a separator (`–`/`—`/`-`/`to`/`through`), so it never matched → `collectAnchors` returned `[]` → `experienceCount: 0` and a blank experience UI while the score still floated ~63.

This adds a second, separator-less alternation branch to `DATE_RANGE_RE` that matches `month-year WS month-year` (or `Present`). Branch (a) — the classic separator path — is byte-identical, so existing dash/`to`/`through`/`Present` ranges are unaffected. The new branch uses a strict month-year anchor (no bare-year / numeric-slash forms) because adjacent bare years are too weak a signal (e.g. `"shipped 2020 2021 release"` must not match).

On `awesome-cv-resume.pdf`, experience now parses: `experienceCount 0 → 8`, `"work experience"` drops from `completeness.missing`. `ATS_SCORE_ALGO_VERSION` bumped `1.0 → 1.1` (global, so all snapshots carry the version field change).

Closes #119

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (463 passed)
- [x] Fixtures re-baked; only the two Awesome-CV fixtures show structural `experienceCount` gains, all others are version-bump only