### PR TITLE
feat: expand experience section aliases + bullets completeness fallback

### DIFF
--- a/src/lib/heuristics/sections.config.json
+++ b/src/lib/heuristics/sections.config.json
@@ -23,7 +23,18 @@
         "employment history",
         "work history",
         "career",
-        "career history"
+        "career history",
+        "volunteer experience",
+        "community service",
+        "leadership",
+        "involvement",
+        "on campus involvement",
+        "campus involvement",
+        "extracurricular",
+        "extracurricular activities",
+        "activities",
+        "volunteer",
+        "volunteering"
       ],
       "anchors": ["experience", "employment"],
       "splitLetterNormalizable": true,
@@ -77,7 +88,6 @@
       "aliases": [
         "achievements",
         "accomplishments",
-        "activities",
         "awards",
         "awards & honors",
         "awards and honors",
@@ -96,8 +106,6 @@
         "focus areas",
         "interests",
         "languages",
-        "volunteer",
-        "volunteering",
         "references",
         "hobbies",
         "publications"

--- a/src/lib/heuristics/sections.test.ts
+++ b/src/lib/heuristics/sections.test.ts
@@ -347,11 +347,14 @@ describe("splitIntoSections — corpus section-count regression (#112)", () => {
       hasLocation: true,
     },
     {
-      // Invented all-caps labels ("INTERNSHIPS", "ON CAMPUS INVOLVEMENT") at
-      // body size — handled by the keyword/anchor path, not over-split.
+      // Non-standard headers — "ON CAMPUS INVOLVEMENT" and "VOLUNTEER
+      // EXPERIENCE" now route to experience (Part A, issue #19); "INTERNSHIPS"
+      // was already an experience alias via anchor-fallback. Education drops
+      // to 1 (the single degree entry; prior count of 2 included involvement
+      // content misrouted into education).
       file: "google-docs/google-docs-skia-proxy-nonstandard-headers.pdf",
-      experience: 2,
-      education: 2,
+      experience: 3,
+      education: 1,
       hasLocation: false,
     },
   ];

--- a/src/lib/score/score.test.ts
+++ b/src/lib/score/score.test.ts
@@ -360,8 +360,11 @@ describe("computeAnonymousAtsScore", () => {
   });
 
   it("flags missing sections in completeness", () => {
+    // rawText must be empty so bullets.length === 0; Part C passes the
+    // experience check when bullets are present even if expEntries is empty.
     const result = computeAnonymousAtsScore(
       makeAnonInput({
+        rawText: "",
         parsed: {
           full_name: "Jane",
           email: "jane@example.com",

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -588,7 +588,7 @@ export function computeAnonymousAtsScore(
   });
   completenessChecks.push({
     key: "experience",
-    passed: expEntries.length > 0,
+    passed: expEntries.length > 0 || bullets.length > 0,
     label: "work experience",
   });
   completenessChecks.push({

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.82,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -24,8 +24,8 @@
       "website_url"
     ],
     "skillsCount": 9,
-    "experienceCount": 2,
-    "educationCount": 2,
+    "experienceCount": 3,
+    "educationCount": 1,
     "projectsCount": 2,
     "achievementsCount": 0,
     "rawTextCharCount": 1530,

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -34,8 +34,8 @@
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 63,
-    "preLayoutOverall": 63,
+    "overall": 67,
+    "preLayoutOverall": 67,
     "specificity": {
       "score": 17,
       "max": 40,
@@ -51,12 +51,11 @@
       "totalBullets": 31
     },
     "completeness": {
-      "score": 23,
+      "score": 27,
       "max": 30,
       "gradable": true,
       "missing": [
-        "skills",
-        "work experience"
+        "skills"
       ]
     },
     "layout": {

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.86,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -17,7 +17,6 @@
       "family_name",
       "full_name",
       "given_name",
-      "heuristic_achievements",
       "linkedin_url",
       "location",
       "phone",
@@ -26,10 +25,10 @@
       "website_url"
     ],
     "skillsCount": 13,
-    "experienceCount": 2,
+    "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 4,
-    "achievementsCount": 4,
+    "achievementsCount": 0,
     "rawTextCharCount": 2331,
     "pageCount": 2,
     "linkAnnotationCount": 0,

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.82,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -24,8 +24,8 @@
       "website_url"
     ],
     "skillsCount": 9,
-    "experienceCount": 2,
-    "educationCount": 2,
+    "experienceCount": 3,
+    "educationCount": 1,
     "projectsCount": 2,
     "achievementsCount": 0,
     "rawTextCharCount": 1530,

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -1,16 +1,17 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.9,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume",
       "t1_5_regex"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
+      "current_title",
       "education",
       "email",
       "experience",
@@ -23,8 +24,8 @@
       "website_url"
     ],
     "skillsCount": 7,
-    "experienceCount": 1,
-    "educationCount": 2,
+    "experienceCount": 2,
+    "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,
     "rawTextCharCount": 1371,


### PR DESCRIPTION
## Summary

- **Part A** (`sections.config.json`): Add volunteer/campus/activity headings to `sections.experience.aliases` — \"on campus involvement\", \"volunteer experience\", \"community service\", \"leadership\", \"involvement\", \"extracurricular\", \"extracurricular activities\", \"activities\", \"volunteer\", \"volunteering\". Remove \"volunteer\"/\"volunteering\" from `sections.other.aliases` and move \"activities\" from `sections.achievements` (where it lived in practice, not `other` as the issue body said — intent is clear, routing is correct).
- **Part C** (`score.ts`): Pass the experience completeness check when `bullets.length > 0` even if `expEntries` is empty, so resumes with parseable bullet content aren't penalised for unrecognised section headings.

Closes #19

## Snapshot changes (all genuine improvements)

| Fixture | Before | After | Why |
|---|---|---|---|
| `laverne` (word) | experienceCount=1, confidence=0, escalation=ocr | experienceCount=2, confidence=0.9, escalation=none | "on campus involvement" now routes to experience |
| `student-projects-activities-singlecol` | achievementsCount=4, experienceCount=2, confidence=0 | achievementsCount=0, experienceCount=3, confidence=0.86 | "activities" moved from achievements → experience |
| `google-docs-nonstandard-headers` + `weasyprint-nonstandard-headers` | experienceCount=2, educationCount=2, confidence=0 | experienceCount=3, educationCount=1, confidence=0.82 | involvement/volunteer headings routed out of education |
| `awesome-cv-resume` | score=63, missing=[\"skills\",\"work experience\"] | score=67, missing=[\"skills\"] | Part C bullets fallback clears the experience check |

Two-column fixtures (chromium-asymmetric-sidebar, chromium-two-column-sidebar, google-docs-two-column, weasyprint-two-column, two-column-achievements-sidebar): **unchanged** — no regression.

## Deviation from issue body

The issue says move \"activities\" from `sections.other` → `sections.experience`. In practice it was in `sections.achievements` (a drift since config externalisation). Moved from `achievements` → `experience` per the issue's clear routing intent. Noted in commit message.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (454/454 — updated 2 hardcoded expectations: `sections.test.ts` nonstandard-headers count + `score.test.ts` missing-sections test now uses `rawText: ""` to correctly test the zero-content case)
- [ ] Manually verified in `npm run dev` / `npm run preview`