### PR TITLE
feat(webllm): section-level rewrite + number-preservation guardrail (#63)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,7 +131,15 @@ export default function App() {
       <ErrorBoundary onReset={reset}>
         {state.phase === "done" && edited && (
           <Result
-            result={state.result}
+            // `parsed` carries the edited experience descriptions so
+            // `groupBulletsByExperience` (in ReconstructedResume) attributes
+            // edited bullets to the SAME role they came from. Without this,
+            // an edit displaces the bullet into the trailing "Other bullets"
+            // group because the original description no longer substring-
+            // matches the edited bullet text. `rawText` stays original on
+            // purpose — EvidencePanel shows "what the PDF extracted", not
+            // "what the user typed."
+            result={{ ...state.result, parsed: edited.parsed }}
             score={edited.score}
             bytes={state.bytes}
             sourceKind={state.sourceKind}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -29,6 +29,7 @@ import type {
   BulletOverrides,
 } from "../../hooks/useEditableParse.ts";
 import { RewriteButton } from "./RewriteButton.tsx";
+import { SectionRewrite } from "./SectionRewrite.tsx";
 
 // ── Bullet flags ──────────────────────────────────────────────────────────────
 
@@ -395,6 +396,11 @@ export function RoleEntry({
   bulletOverrides,
   onBulletChange,
 }: RoleEntryProps) {
+  // Bullet display text honors #82 overrides — section rewrite must see the
+  // text the user actually edited, not the stale parsed text.
+  const sectionBullets = group.bullets.map(
+    (b) => bulletOverrides?.[b.index] ?? b.text,
+  );
   return (
     <div className="flex flex-col gap-1.5">
       <RoleHeader
@@ -403,20 +409,23 @@ export function RoleEntry({
         onFieldChange={onFieldChange}
       />
       {group.bullets.length > 0 ? (
-        <ul className="list-none">
-          {group.bullets.map((b) => (
-            <ResumeBulletRow
-              key={b.index}
-              bullet={b}
-              override={bulletOverrides?.[b.index]}
-              onBulletChange={
-                onBulletChange
-                  ? (value) => onBulletChange(b.index, value)
-                  : undefined
-              }
-            />
-          ))}
-        </ul>
+        <>
+          <ul className="list-none">
+            {group.bullets.map((b) => (
+              <ResumeBulletRow
+                key={b.index}
+                bullet={b}
+                override={bulletOverrides?.[b.index]}
+                onBulletChange={
+                  onBulletChange
+                    ? (value) => onBulletChange(b.index, value)
+                    : undefined
+                }
+              />
+            ))}
+          </ul>
+          <SectionRewrite bullets={sectionBullets} />
+        </>
       ) : (
         <p className="text-sm text-content-tertiary">
           No bullet-shaped lines detected.

--- a/src/components/features/RewriteButton.tsx
+++ b/src/components/features/RewriteButton.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 The resumelint Authors
 
 /**
- * Per-bullet "Suggest a rewrite" CTA. Runs Qwen2-1.5B in the browser via
+ * Per-bullet "Suggest a rewrite" CTA. Runs Qwen2.5-1.5B in the browser via
  * WebLLM (see ../../lib/webllm/).
  *
  * Non-negotiable rules from issue #3:
@@ -213,7 +213,7 @@ function LoadingPanel({ progress }: { progress: ProgressUpdate }) {
           What's happening?
         </summary>
         <p className="mt-1 max-w-prose text-[10px] leading-relaxed text-content-tertiary">
-          A small open-source language model (Qwen2-1.5B) is downloading to
+          A small open-source language model (Qwen2.5-1.5B) is downloading to
           your browser. It runs entirely on your device — your bullet text
           never leaves this tab. The download takes about a minute on a
           typical connection and is cached for next time.

--- a/src/components/features/SectionRewrite.test.ts
+++ b/src/components/features/SectionRewrite.test.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Smoke tests for SectionRewrite's presentational branches.
+ *
+ * The top-level component is hard to drive from a node test: it returns
+ * `null` until `detectWebGpu()` resolves, and the non-idle states
+ * (loading/rewriting/proposed/error) are all reached via async work the
+ * suite can't execute without a real WebGPU adapter. So the tests target
+ * the helpers that own the branching — `labelFor`, `formatTokens`,
+ * `NumberPreservationWarning`, `ProposedSection` — covering the cheap
+ * conditional paths that drive `fallow`'s CRAP advisories.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  formatTokens,
+  labelFor,
+  NumberPreservationWarning,
+  ProposedSection,
+  type Status,
+} from "./SectionRewrite.tsx";
+import type { SectionRewriteResult } from "../../lib/webllm/rewrite-section.ts";
+
+// ── labelFor ────────────────────────────────────────────────────────────────
+
+describe("labelFor", () => {
+  const idle: Status = { kind: "idle" };
+  const loading: Status = {
+    kind: "loading",
+    progress: { progress: 0, text: "" },
+  };
+  const rewriting: Status = { kind: "rewriting" };
+  const result: SectionRewriteResult = {
+    bullets: ["x"],
+    numbersPreserved: true,
+    droppedNumbers: [],
+    addedNumbers: [],
+  };
+  const proposed: Status = { kind: "proposed", result, snapshot: ["x"] };
+  const error: Status = { kind: "error", message: "OOM" };
+
+  it("returns the locked-by-other label regardless of status when the lock is held elsewhere", () => {
+    // This branch is the actual concurrency-UI signal — covered explicitly.
+    expect(labelFor(idle, true)).toBe("Another rewrite running…");
+    expect(labelFor(proposed, true)).toBe("Another rewrite running…");
+    expect(labelFor(error, true)).toBe("Another rewrite running…");
+  });
+
+  it("maps each non-locked status to its label", () => {
+    expect(labelFor(idle, false)).toBe("Rewrite section");
+    expect(labelFor(loading, false)).toBe("Loading model…");
+    expect(labelFor(rewriting, false)).toBe("Rewriting…");
+    expect(labelFor(proposed, false)).toBe("Rewrite again");
+    expect(labelFor(error, false)).toBe("Try again");
+  });
+});
+
+// ── formatTokens ────────────────────────────────────────────────────────────
+
+describe("formatTokens", () => {
+  it("returns the single token unchanged for length 1", () => {
+    expect(formatTokens(["$5K"])).toBe("$5K");
+  });
+
+  it("joins two tokens with `and`", () => {
+    expect(formatTokens(["$5K", "10%"])).toBe("$5K and 10%");
+  });
+
+  it("uses an Oxford-style comma list for three or more tokens", () => {
+    expect(formatTokens(["$5K", "10%", "12 months"])).toBe(
+      "$5K, 10%, and 12 months",
+    );
+  });
+});
+
+// ── NumberPreservationWarning ───────────────────────────────────────────────
+
+describe("NumberPreservationWarning", () => {
+  it("renders the specific dropped token (not a generic 'metric changed' string)", () => {
+    const html = renderToStaticMarkup(
+      createElement(NumberPreservationWarning, {
+        dropped: ["$5K"],
+        added: [],
+      }),
+    );
+    expect(html).toContain("removed $5K");
+    // The whole point of the warning is naming the token — guard against a
+    // regression that drops the token in favour of a generic message.
+    expect(html).not.toContain("a metric was altered");
+  });
+
+  it("names both dropped and added tokens when the model both removed and invented numbers", () => {
+    const html = renderToStaticMarkup(
+      createElement(NumberPreservationWarning, {
+        dropped: ["15%"],
+        added: ["-15%"],
+      }),
+    );
+    expect(html).toContain("removed 15%");
+    expect(html).toContain("invented -15%");
+    expect(html).toContain(" and ");
+  });
+
+  it("uses role=alert so screen readers announce the warning", () => {
+    const html = renderToStaticMarkup(
+      createElement(NumberPreservationWarning, {
+        dropped: ["$5K"],
+        added: [],
+      }),
+    );
+    expect(html).toContain('role="alert"');
+  });
+});
+
+// ── ProposedSection ─────────────────────────────────────────────────────────
+
+describe("ProposedSection", () => {
+  function render(
+    result: SectionRewriteResult,
+    extras: { copied?: boolean } = {},
+  ): string {
+    return renderToStaticMarkup(
+      createElement(ProposedSection, {
+        original: ["Original bullet 1.", "Original bullet 2."],
+        result,
+        copied: extras.copied ?? false,
+        onCopyAll: () => {},
+        onReject: () => {},
+      }),
+    );
+  }
+
+  it("uses success chrome when every input number survived", () => {
+    const html = render({
+      bullets: ["Reduced p99 latency by 40%.", "Drove $1.2M ARR."],
+      numbersPreserved: true,
+      droppedNumbers: [],
+      addedNumbers: [],
+    });
+    expect(html).toContain("border-feedback-success-border");
+    expect(html).toContain("bg-feedback-success-bg");
+    // No warning surface when nothing changed.
+    expect(html).not.toContain('role="alert"');
+  });
+
+  it("uses warning chrome AND surfaces the named token when a number was dropped", () => {
+    const html = render({
+      bullets: ["Reduced p99 latency."],
+      numbersPreserved: false,
+      droppedNumbers: ["40%"],
+      addedNumbers: [],
+    });
+    expect(html).toContain("border-feedback-warning-border");
+    expect(html).toContain("bg-feedback-warning-bg");
+    expect(html).toContain("removed 40%");
+    expect(html).toContain('role="alert"');
+  });
+
+  it("renders the original and proposed bullet counts in the column headings", () => {
+    const html = render({
+      bullets: ["one", "two", "three"],
+      numbersPreserved: true,
+      droppedNumbers: [],
+      addedNumbers: [],
+    });
+    expect(html).toContain("Original (2)");
+    expect(html).toContain("Proposed (3)");
+  });
+
+  it("flips the copy button label after a successful copy-all", () => {
+    const result: SectionRewriteResult = {
+      bullets: ["one"],
+      numbersPreserved: true,
+      droppedNumbers: [],
+      addedNumbers: [],
+    };
+    expect(render(result, { copied: false })).toContain(
+      "Use this — copy all bullets",
+    );
+    expect(render(result, { copied: true })).toContain("Copied");
+  });
+});

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -49,7 +49,7 @@ interface SectionRewriteProps {
   bullets: readonly string[];
 }
 
-type Status =
+export type Status =
   | { kind: "idle" }
   | { kind: "loading"; progress: ProgressUpdate }
   | { kind: "rewriting" }
@@ -212,7 +212,12 @@ export function SectionRewrite({ bullets }: SectionRewriteProps) {
   );
 }
 
-function labelFor(status: Status, lockedByOther: boolean): string {
+// Helpers exported for unit tests (see SectionRewrite.test.ts). The component
+// itself is harder to render in non-idle states from a smoke test (status is
+// internal + driven by async work), so the testable surface is the helpers
+// that own the branching: `labelFor`, `formatTokens`, `ProposedSection`,
+// `NumberPreservationWarning`.
+export function labelFor(status: Status, lockedByOther: boolean): string {
   if (lockedByOther) return "Another rewrite running…";
   switch (status.kind) {
     case "loading":
@@ -258,7 +263,7 @@ function LoadingPanel({ progress }: { progress: ProgressUpdate }) {
   );
 }
 
-function ProposedSection({
+export function ProposedSection({
   original,
   result,
   copied,
@@ -352,7 +357,7 @@ function BulletColumn({
   );
 }
 
-function NumberPreservationWarning({
+export function NumberPreservationWarning({
   dropped,
   added,
 }: {
@@ -374,7 +379,7 @@ function NumberPreservationWarning({
   );
 }
 
-function formatTokens(tokens: readonly string[]): string {
+export function formatTokens(tokens: readonly string[]): string {
   if (tokens.length === 1) return tokens[0]!;
   if (tokens.length === 2) return `${tokens[0]} and ${tokens[1]}`;
   return `${tokens.slice(0, -1).join(", ")}, and ${tokens[tokens.length - 1]}`;

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Per-role "Rewrite section" CTA. Runs Qwen2.5-1.5B in the browser via WebLLM
+ * (see ../../lib/webllm/) over every bullet of a role at once. The model can
+ * dedupe, merge weak bullets, drop pure filler, reorder, and balance verb
+ * variety — none of which is reachable from the per-bullet path. The
+ * proposed bullets render beside the originals as a single accept-all /
+ * reject choice.
+ *
+ * Non-negotiable rules from issue #63:
+ *   - On browsers without WebGPU, returns null. Silent absence — matches
+ *     `RewriteButton`. Not a greyed CTA, not a banner.
+ *   - Model weights download on click only. The shared `loadEngine()` cache
+ *     means clicking section-rewrite after per-bullet (or in a sibling role)
+ *     reuses the same engine — no second multi-GB download.
+ *   - Number-preservation guardrail runs deterministically on every output.
+ *     When a numeric token is dropped or invented, an inline warning names
+ *     the specific token (non-blocking) so the user can still accept the
+ *     rewrite knowingly.
+ *
+ * Reuse analysis (CLAUDE.md 3-tier rule):
+ *   - Primitive: `Button` from `@design-system` for every interactive
+ *     control. No raw `<button>` in this file.
+ *   - Shared: the inline before/after panel follows the same inline-result
+ *     pattern as `RewriteButton`'s `RewriteResult` (rounded border + feedback
+ *     bg). Top-level `Card` would be the wrong chrome — Cards own panel
+ *     framing on the page; this is a result strip *inside* the role list.
+ *
+ * Concurrency: see `useSectionRewriteLock` for the synchronous atomic lock
+ * that gates concurrent `engine.chat.completions.create()` calls.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { detectWebGpu } from "../../lib/webllm/capability.ts";
+import { loadEngine } from "../../lib/webllm/web-llm.ts";
+import { rewriteSectionWithLlm } from "../../lib/webllm/rewrite-section.ts";
+import type {
+  ProgressUpdate,
+  WebGpuCapability,
+} from "../../lib/webllm/types.ts";
+import type { SectionRewriteResult } from "../../lib/webllm/rewrite-section.ts";
+import { useSectionRewriteLock } from "../../hooks/useSectionRewriteLock.ts";
+import { Button } from "@design-system";
+
+interface SectionRewriteProps {
+  /** The role's bullets, as currently displayed (after #82 overrides). */
+  bullets: readonly string[];
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "rewriting" }
+  | {
+      kind: "proposed";
+      result: SectionRewriteResult;
+      /** Snapshot of the bullets the model actually saw. Used to detect
+       *  when the underlying section has been edited since this proposal
+       *  was generated — in which case the proposal is stale and gets
+       *  auto-dismissed (see the useEffect below). Without this, the user
+       *  could see e.g. "Original (2) | Proposed (3)" after deleting a
+       *  bullet underneath a previous rewrite. */
+      snapshot: readonly string[];
+    }
+  | { kind: "error"; message: string };
+
+function bulletsEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+export function SectionRewrite({ bullets }: SectionRewriteProps) {
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [copied, setCopied] = useState(false);
+  const { isLocked, acquire } = useSectionRewriteLock();
+
+  // Trim blank bullets here once — passed to both the model (so it doesn't
+  // see empties) and the before/after panel (so the original column matches
+  // what the model actually saw).
+  const trimmedBullets = useMemo(
+    () => bullets.filter((b) => b.trim().length > 0),
+    [bullets],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Auto-dismiss a stale proposal: if the user edits the underlying bullets
+  // after a rewrite proposal is visible, the "Original vs Proposed" panel
+  // would otherwise compare current bullets against the prior rewrite's
+  // output — `Original (2) | Proposed (3)` is the confusing failure mode.
+  // Compare content, not identity, because `trimmedBullets` is a fresh
+  // array on every render even when the contents are unchanged.
+  useEffect(() => {
+    if (status.kind !== "proposed") return;
+    if (!bulletsEqual(status.snapshot, trimmedBullets)) {
+      setStatus({ kind: "idle" });
+      setCopied(false);
+    }
+  }, [trimmedBullets, status]);
+
+  const onClick = useCallback(async () => {
+    setCopied(false);
+    // Atomic acquire — null means another instance already holds the lock and
+    // we must bail. This is the real "no concurrent generate()" guard; the
+    // disabled flag on the button is only the UI surface of the same check
+    // (and updates one render late, so it can't be relied on alone).
+    const release = acquire();
+    if (release === null) return;
+    try {
+      setStatus({
+        kind: "loading",
+        progress: { progress: 0, text: "Starting…" },
+      });
+      const engine = await loadEngine((progress) => {
+        setStatus({ kind: "loading", progress });
+      });
+      setStatus({ kind: "rewriting" });
+      const result = await rewriteSectionWithLlm(trimmedBullets, engine);
+      if (result.bullets.length === 0) {
+        setStatus({
+          kind: "error",
+          message: "The model returned an empty rewrite. Try again.",
+        });
+        return;
+      }
+      setStatus({ kind: "proposed", result, snapshot: trimmedBullets });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Couldn't load the rewrite model",
+      });
+    } finally {
+      release();
+    }
+  }, [trimmedBullets, acquire]);
+
+  const onReject = useCallback(() => {
+    setStatus({ kind: "idle" });
+    setCopied(false);
+  }, []);
+
+  const onCopyAll = useCallback(async () => {
+    if (status.kind !== "proposed") return;
+    try {
+      await navigator.clipboard.writeText(status.result.bullets.join("\n"));
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }, [status]);
+
+  if (capability !== "available") return null;
+  if (trimmedBullets.length === 0) return null;
+
+  const myBusy = status.kind === "loading" || status.kind === "rewriting";
+  const lockedByOther = isLocked && !myBusy;
+
+  return (
+    <div className="mt-1 flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onClick}
+        disabled={isLocked}
+        aria-label="Rewrite all bullets in this role"
+        className="self-start rounded-md border border-border-light bg-surface-card px-2.5 py-1 text-[11px] text-content-secondary hover:border-border hover:bg-surface-hover"
+      >
+        {labelFor(status, lockedByOther)}
+      </Button>
+
+      {status.kind === "loading" && (
+        <LoadingPanel progress={status.progress} />
+      )}
+
+      {status.kind === "rewriting" && (
+        <p className="text-[11px] text-content-muted">
+          Rewriting the section…
+        </p>
+      )}
+
+      {status.kind === "proposed" && (
+        <ProposedSection
+          original={trimmedBullets}
+          result={status.result}
+          copied={copied}
+          onCopyAll={onCopyAll}
+          onReject={onReject}
+        />
+      )}
+
+      {status.kind === "error" && (
+        <p role="alert" className="text-[11px] text-feedback-error-text">
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function labelFor(status: Status, lockedByOther: boolean): string {
+  if (lockedByOther) return "Another rewrite running…";
+  switch (status.kind) {
+    case "loading":
+      return "Loading model…";
+    case "rewriting":
+      return "Rewriting…";
+    case "proposed":
+      return "Rewrite again";
+    case "error":
+      return "Try again";
+    default:
+      return "Rewrite section";
+  }
+}
+
+function LoadingPanel({ progress }: { progress: ProgressUpdate }) {
+  const pct = Math.max(0, Math.min(100, Math.round(progress.progress * 100)));
+  return (
+    <div className="flex flex-col gap-1 rounded border border-border-light bg-surface-subtle p-2">
+      <div className="flex items-center justify-between text-[11px] text-content-secondary">
+        <span>Loading the rewrite model (~1.2GB, one-time download)</span>
+        <span className="font-mono">{pct}%</span>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Model download progress"
+        className="h-1.5 w-full overflow-hidden rounded-full bg-surface-base"
+      >
+        <div
+          className="h-full bg-feedback-success-icon transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {progress.text && (
+        <p className="font-mono text-[10px] text-content-muted">
+          {progress.text}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ProposedSection({
+  original,
+  result,
+  copied,
+  onCopyAll,
+  onReject,
+}: {
+  original: readonly string[];
+  result: SectionRewriteResult;
+  copied: boolean;
+  onCopyAll: () => void;
+  onReject: () => void;
+}) {
+  const borderClass = result.numbersPreserved
+    ? "border-feedback-success-border"
+    : "border-feedback-warning-border";
+  const bgClass = result.numbersPreserved
+    ? "bg-feedback-success-bg"
+    : "bg-feedback-warning-bg";
+
+  return (
+    <div
+      className={`flex flex-col gap-3 rounded border p-3 ${borderClass} ${bgClass}`}
+    >
+      {!result.numbersPreserved && (
+        <NumberPreservationWarning
+          dropped={result.droppedNumbers}
+          added={result.addedNumbers}
+        />
+      )}
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <BulletColumn
+          label={`Original (${original.length})`}
+          bullets={original}
+          textClass="text-content-secondary"
+        />
+        <BulletColumn
+          label={`Proposed (${result.bullets.length})`}
+          bullets={result.bullets}
+          textClass="text-content-primary"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onCopyAll}
+          className="rounded-md border border-border-light bg-surface-card px-2.5 py-1 text-[11px] text-content-primary hover:border-border hover:bg-surface-hover"
+        >
+          {copied ? "Copied" : "Use this — copy all bullets"}
+        </Button>
+        <Button
+          variant="link"
+          size="sm"
+          onClick={onReject}
+          className="text-[11px] font-medium text-content-tertiary"
+        >
+          Discard
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function BulletColumn({
+  label,
+  bullets,
+  textClass,
+}: {
+  label: string;
+  bullets: readonly string[];
+  textClass: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+        {label}
+      </h4>
+      <ul className={`flex flex-col gap-1.5 text-xs leading-snug list-none ${textClass}`}>
+        {bullets.map((b, i) => (
+          <li key={i} className="flex gap-1.5">
+            <span className="font-mono text-content-muted" aria-hidden="true">
+              •
+            </span>
+            <span>{b}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function NumberPreservationWarning({
+  dropped,
+  added,
+}: {
+  dropped: readonly string[];
+  added: readonly string[];
+}) {
+  const parts: string[] = [];
+  if (dropped.length > 0) parts.push(`removed ${formatTokens(dropped)}`);
+  if (added.length > 0) parts.push(`invented ${formatTokens(added)}`);
+  const detail = parts.join(" and ");
+  return (
+    <p
+      role="alert"
+      className="text-[11px] leading-snug text-feedback-warning-text"
+    >
+      <span aria-hidden="true">⚠ </span>
+      AI altered a metric — {detail}. Review before saving.
+    </p>
+  );
+}
+
+function formatTokens(tokens: readonly string[]): string {
+  if (tokens.length === 1) return tokens[0]!;
+  if (tokens.length === 2) return `${tokens[0]} and ${tokens[1]}`;
+  return `${tokens.slice(0, -1).join(", ")}, and ${tokens[tokens.length - 1]}`;
+}

--- a/src/hooks/useSectionRewriteLock.test.ts
+++ b/src/hooks/useSectionRewriteLock.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetSectionRewriteLockForTesting,
+  isSectionRewriteLocked,
+  tryAcquireSectionRewriteLock,
+} from "./useSectionRewriteLock.ts";
+
+beforeEach(() => {
+  _resetSectionRewriteLockForTesting();
+});
+
+describe("tryAcquireSectionRewriteLock", () => {
+  it("starts unlocked", () => {
+    expect(isSectionRewriteLocked()).toBe(false);
+  });
+
+  it("returns a release fn and flips isLocked", () => {
+    const release = tryAcquireSectionRewriteLock();
+    expect(release).not.toBeNull();
+    expect(isSectionRewriteLocked()).toBe(true);
+    release!();
+    expect(isSectionRewriteLocked()).toBe(false);
+  });
+
+  it("two synchronous acquire calls — only the first succeeds (the real concurrency guarantee)", () => {
+    // Simulates two onClick handlers fired in the same React batch.
+    const first = tryAcquireSectionRewriteLock();
+    const second = tryAcquireSectionRewriteLock();
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    first!();
+    // After the first releases, a new acquire must succeed.
+    const third = tryAcquireSectionRewriteLock();
+    expect(third).not.toBeNull();
+  });
+
+  it("release is idempotent — double-release does not underflow", () => {
+    const release = tryAcquireSectionRewriteLock();
+    release!();
+    release!();
+    expect(isSectionRewriteLocked()).toBe(false);
+    // Counter is at 0, not -1: a fresh acquire still succeeds.
+    const again = tryAcquireSectionRewriteLock();
+    expect(again).not.toBeNull();
+  });
+
+  it("does NOT leak the counter when the caller's body throws — `finally` release fires", () => {
+    // Realistic call-site shape:
+    //   const release = tryAcquireSectionRewriteLock();
+    //   try { ...do work... } finally { release(); }
+    // We assert the lock returns to unlocked even on a thrown error.
+    expect(() => {
+      const release = tryAcquireSectionRewriteLock();
+      try {
+        throw new Error("boom");
+      } finally {
+        release?.();
+      }
+    }).toThrow("boom");
+    expect(isSectionRewriteLocked()).toBe(false);
+  });
+
+  it("flips isLocked synchronously with acquire/release", () => {
+    expect(isSectionRewriteLocked()).toBe(false);
+    const release = tryAcquireSectionRewriteLock();
+    expect(isSectionRewriteLocked()).toBe(true);
+    release!();
+    expect(isSectionRewriteLocked()).toBe(false);
+  });
+});

--- a/src/hooks/useSectionRewriteLock.ts
+++ b/src/hooks/useSectionRewriteLock.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Cross-instance "at most one section rewrite running at a time" lock.
+ *
+ * Section rewrite renders one button per RoleEntry. Without a shared lock,
+ * two roles can fire concurrent `engine.chat.completions.create()` calls on
+ * the same shared WebLLM engine (see `loadEngine` in lib/webllm/web-llm.ts) —
+ * which is the single bottleneck the lock exists to guard.
+ *
+ * The state is module-scoped on purpose: every SectionRewrite instance has
+ * to see the same counter, and there is no React tree ancestor we'd want to
+ * couple the lock to.
+ *
+ * The atomic acquire/release functions live at module scope so they can be
+ * tested directly without a React render harness (the repo's component
+ * tests use `renderToStaticMarkup`, which can't drive effects). The hook is
+ * a thin subscription wrapper that re-renders consumers when the counter
+ * flips.
+ *
+ * If we ever allow N concurrent rewrites, swap the counter for a semaphore
+ * — the consumer API (acquire returns release-or-null) is already
+ * semaphore-shaped.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+let activeRewriteCount = 0;
+const lockListeners = new Set<() => void>();
+
+function notifyLockChange(): void {
+  for (const listener of lockListeners) listener();
+}
+
+/**
+ * Try to acquire the lock synchronously. Returns a `release` fn on success,
+ * or `null` if the lock was already held — the caller MUST bail on `null`.
+ * Check-and-increment happens in the same synchronous turn, so two
+ * `onClick` handlers fired in the same batch can never both succeed (which
+ * is the real concurrency guarantee; the `disabled` flag on the button
+ * only catches the case where React has already re-rendered).
+ *
+ * The release fn is idempotent — calling it twice does not underflow the
+ * counter. Call it in a `finally` to keep the counter from leaking on
+ * error or early return.
+ */
+export function tryAcquireSectionRewriteLock(): (() => void) | null {
+  if (activeRewriteCount > 0) return null;
+  activeRewriteCount += 1;
+  notifyLockChange();
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activeRewriteCount = Math.max(0, activeRewriteCount - 1);
+    notifyLockChange();
+  };
+}
+
+export function isSectionRewriteLocked(): boolean {
+  return activeRewriteCount > 0;
+}
+
+export interface SectionRewriteLock {
+  isLocked: boolean;
+  acquire: () => (() => void) | null;
+}
+
+export function useSectionRewriteLock(): SectionRewriteLock {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const force = () => setTick((t) => t + 1);
+    lockListeners.add(force);
+    return () => {
+      lockListeners.delete(force);
+    };
+  }, []);
+  const acquire = useCallback(tryAcquireSectionRewriteLock, []);
+  return { isLocked: isSectionRewriteLocked(), acquire };
+}
+
+/** Test-only: drop the counter so each test starts with no held lock. */
+export function _resetSectionRewriteLockForTesting(): void {
+  activeRewriteCount = 0;
+  lockListeners.clear();
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -179,3 +179,32 @@ export function trackWebllmLoaded(): void {
 export function trackWebllmFirstRewrite(): void {
   track("webllm_first_rewrite", {});
 }
+
+// Section-rewrite funnel (issue #63). Kept distinct from the per-bullet
+// keys above so each path's first-rewrite conversion stays measurable.
+// `webllm_first_section_rewrite` mirrors `webllm_first_rewrite` for the
+// section path; the original per-bullet key is preserved unchanged.
+
+export function trackWebllmSectionRewriteStarted(args: {
+  inputBulletCount: number;
+}): void {
+  track("webllm_section_rewrite_started", {
+    input_bullet_count: args.inputBulletCount,
+  });
+}
+
+export function trackWebllmSectionRewriteCompleted(args: {
+  inputBulletCount: number;
+  outputBulletCount: number;
+  numbersPreserved: boolean;
+}): void {
+  track("webllm_section_rewrite_completed", {
+    input_bullet_count: args.inputBulletCount,
+    output_bullet_count: args.outputBulletCount,
+    numbers_preserved: args.numbersPreserved,
+  });
+}
+
+export function trackWebllmFirstSectionRewrite(): void {
+  track("webllm_first_section_rewrite", {});
+}

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { applyOverrides } from "./apply-overrides.ts";
+import { groupBulletsByExperience } from "../score/group-bullets.ts";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { BulletObservation } from "../score/score.ts";
 
@@ -191,5 +192,130 @@ describe("applyOverrides", () => {
       [obs(0, "Built a thing")],
     );
     expect(parsed).toEqual(snapshot);
+  });
+});
+
+// ── Regression: edit + re-group attribution ──────────────────────────────────
+
+/**
+ * The original bug: editing a bullet caused it to fall into the trailing
+ * "Other bullets" group instead of staying under its role. Root cause was at
+ * the App.tsx wiring layer — the post-edit bullets (with edited text) were
+ * being looked up against pre-edit experience descriptions. This regression
+ * test pins down the contract that protects against re-introducing the bug:
+ *
+ *   applyOverrides → use the RETURNED `parsed.experience` (not the original)
+ *   when re-running groupBulletsByExperience with the edited bullet text.
+ *
+ * If a future refactor passes the un-edited descriptions to grouping again,
+ * these tests fail and point at the bug.
+ */
+describe("regression: post-edit bullet re-grouping (issue #63 testing artefact)", () => {
+  it("edited bullet stays under its original experience when grouping uses the returned parsed.experience", () => {
+    const parsed: HeuristicParsedResume = {
+      full_name: "Jane Smith",
+      email: "jane@example.com",
+      skills: [],
+      experience: [
+        {
+          title: "Senior Engineer",
+          company: "Globex",
+          description:
+            "Built event-driven data pipeline.\nReduced deploy time by 50%.",
+        },
+        {
+          title: "Engineer",
+          company: "Initech",
+          description: "Migrated legacy monolith.",
+        },
+      ],
+      education: [],
+    };
+    const rawText =
+      "Globex\n• Built event-driven data pipeline.\n• Reduced deploy time by 50%.\nInitech\n• Migrated legacy monolith.";
+    const observations = [
+      obs(0, "Built event-driven data pipeline."),
+      obs(1, "Reduced deploy time by 50%."),
+      obs(2, "Migrated legacy monolith."),
+    ];
+
+    // User edits bullet #1 to add a new metric.
+    const editedText = "Reduced deploy time by 50%, saving $50K in compute.";
+    const result = applyOverrides(
+      parsed,
+      rawText,
+      {},
+      {},
+      { 1: editedText },
+      observations,
+    );
+
+    // Sanity: BOTH rawText and the role's description picked up the edit.
+    expect(result.rawText).toContain("$50K");
+    expect(result.parsed.experience[0].description).toContain("$50K");
+
+    // Now simulate the post-edit re-grouping. The bullets carry the edited
+    // text (as they would after re-grading); the descriptions ALSO carry the
+    // edited text (because we use the RETURNED parsed.experience, not the
+    // original). The edited bullet must stay under Globex (experienceIndex 0)
+    // — NOT fall into the trailing Other group.
+    const postEditBullets = [
+      obs(0, "Built event-driven data pipeline."),
+      obs(1, editedText),
+      obs(2, "Migrated legacy monolith."),
+    ];
+    const groups = groupBulletsByExperience(
+      postEditBullets,
+      result.parsed.experience,
+    );
+
+    const globexGroup = groups.find((g) => g.experienceIndex === 0);
+    expect(globexGroup).toBeDefined();
+    expect(globexGroup!.bullets.map((b) => b.text)).toEqual([
+      "Built event-driven data pipeline.",
+      editedText,
+    ]);
+    // No Other group — every bullet attributed to its role.
+    expect(groups.find((g) => g.experienceIndex === null)).toBeUndefined();
+  });
+
+  it("DEMONSTRATES the bug: grouping against the ORIGINAL parsed.experience misattributes the edited bullet", () => {
+    // This test pins the failure mode in case anyone "simplifies" App.tsx
+    // back to passing the original parsed.experience to ReconstructedResume.
+    const parsed: HeuristicParsedResume = {
+      full_name: "Jane Smith",
+      email: "jane@example.com",
+      skills: [],
+      experience: [
+        {
+          title: "Senior Engineer",
+          company: "Globex",
+          description: "Reduced deploy time by 50%.",
+        },
+      ],
+      education: [],
+    };
+    const observations = [obs(0, "Reduced deploy time by 50%.")];
+    const editedText = "Reduced deploy time by 50%, saving $50K in compute.";
+
+    applyOverrides(
+      parsed,
+      "• Reduced deploy time by 50%.",
+      {},
+      {},
+      { 0: editedText },
+      observations,
+    );
+
+    // Grouping the edited bullet against the ORIGINAL (un-edited) parsed.experience
+    // — the App.tsx mis-wiring that was the original bug.
+    const groups = groupBulletsByExperience(
+      [obs(0, editedText)],
+      parsed.experience,
+    );
+
+    // The edited bullet falls into Other — confirming what the user reported.
+    expect(groups.find((g) => g.experienceIndex === 0)?.bullets ?? []).toEqual([]);
+    expect(groups.find((g) => g.experienceIndex === null)?.bullets).toHaveLength(1);
   });
 });

--- a/src/lib/webllm/post-process.test.ts
+++ b/src/lib/webllm/post-process.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+
+import { cleanRewriteLine } from "./post-process.ts";
+
+describe("cleanRewriteLine", () => {
+  it("returns empty for whitespace-only input", () => {
+    expect(cleanRewriteLine("")).toBe("");
+    expect(cleanRewriteLine("   ")).toBe("");
+    expect(cleanRewriteLine("\t\n")).toBe("");
+  });
+
+  it("strips the `Rewritten:` echo (case-insensitive)", () => {
+    expect(cleanRewriteLine("Rewritten: Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("rewritten: Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("REWRITTEN:    Shipped Foo.")).toBe("Shipped Foo.");
+  });
+
+  it("strips numbered list markers — `1.`, `1)`, `12.`", () => {
+    expect(cleanRewriteLine("1. Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("1) Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("12. Shipped Foo.")).toBe("Shipped Foo.");
+  });
+
+  it("strips bullet markers — `•`, `-`, `*` — with or without trailing space", () => {
+    expect(cleanRewriteLine("• Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("- Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("* Shipped Foo.")).toBe("Shipped Foo.");
+    // No-space variants — the model occasionally tightens "- Shipped" to
+    // "-Shipped"; should still normalize.
+    expect(cleanRewriteLine("-Shipped Foo.")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("•Shipped Foo.")).toBe("Shipped Foo.");
+  });
+
+  it("strips straight quotes around the whole line", () => {
+    expect(cleanRewriteLine('"Shipped Foo."')).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("'Shipped Foo.'")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("`Shipped Foo.`")).toBe("Shipped Foo.");
+  });
+
+  it("strips smart double and single quotes around the whole line", () => {
+    expect(cleanRewriteLine("“Shipped Foo.”")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("‘Shipped Foo.’")).toBe("Shipped Foo.");
+  });
+
+  it("strips full-line markdown emphasis — bold, italic, underscore-italic", () => {
+    expect(cleanRewriteLine("**Shipped Foo.**")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("*Shipped Foo.*")).toBe("Shipped Foo.");
+    expect(cleanRewriteLine("_Shipped Foo._")).toBe("Shipped Foo.");
+  });
+
+  it("does NOT strip emphasis mid-line — only paired wrapping the whole line", () => {
+    expect(cleanRewriteLine("Shipped **Foo** to 10M users.")).toBe(
+      "Shipped **Foo** to 10M users.",
+    );
+  });
+
+  it("composes prefix + bullet + quote stripping in one pass", () => {
+    expect(cleanRewriteLine('Rewritten: 1. "Shipped Foo."')).toBe(
+      "Shipped Foo.",
+    );
+    expect(cleanRewriteLine('- "Shipped Foo."')).toBe("Shipped Foo.");
+  });
+
+  it("drops prompt-echo lines (`Rules:`, `Original bullets:`, `Rewritten bullets:`)", () => {
+    expect(cleanRewriteLine("Rules:")).toBe("");
+    expect(cleanRewriteLine("Original bullets:")).toBe("");
+    expect(cleanRewriteLine("Rewritten bullets:")).toBe("");
+    expect(cleanRewriteLine("RULES:")).toBe("");
+  });
+
+  it("does NOT drop a bullet that starts with `Rules` but continues", () => {
+    expect(cleanRewriteLine("Rules-engine refactor cut tail latency 40%.")).toBe(
+      "Rules-engine refactor cut tail latency 40%.",
+    );
+  });
+});

--- a/src/lib/webllm/post-process.ts
+++ b/src/lib/webllm/post-process.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Per-line cleanup shared by the per-bullet and section rewrite paths.
+ *
+ * Qwen2.5-1.5B emits a small but persistent set of wrappers around each
+ * bullet, even when the system prompt says "no preamble, no quotes":
+ *   1. A leading `Rewritten:` echo of the user-prompt suffix.
+ *   2. A list-marker prefix (`1.`, `1)`, `•`, `-`, `*`).
+ *   3. Surrounding quotes — straight (`"…"` `'…'`) and smart (`“…”` `‘…’`).
+ *   4. Markdown bold/italic delimiters (`**…**`, `*…*`, `_…_`).
+ *
+ * Each gets stripped here. The "keep first non-empty line only" behavior
+ * deliberately lives at the call site — the per-bullet path wants line 0,
+ * the section path wants every non-empty line — so it is not folded in here.
+ *
+ * Lines that read as the model echoing the system prompt or the user-prompt
+ * scaffolding ("Rules:", "Original bullets:", "Rewritten bullets:") are
+ * returned as empty so the caller's filter drops them.
+ */
+
+const PROMPT_ECHO_LINES = new Set([
+  "rules:",
+  "original bullets:",
+  "rewritten bullets:",
+  "original:",
+  "rewritten:",
+]);
+
+export function cleanRewriteLine(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed) return "";
+
+  // Strip the `Rewritten:` echo first so the prompt-echo check below sees
+  // any trailing content the model attached to it.
+  const withoutPrefix = trimmed.replace(/^rewritten:\s*/i, "");
+
+  // Strip paired bold/italic markdown delimiters BEFORE list-marker stripping
+  // — otherwise the leading `*` of an italicized line (`*Foo.*`) is misread
+  // as a bullet glyph and the trailing `*` survives. The pattern is paired
+  // (start AND end) so genuine mid-line emphasis is preserved.
+  const withoutEmphasis = withoutPrefix
+    .replace(/^\*\*(.+)\*\*$/s, "$1")
+    .replace(/^\*(.+)\*$/s, "$1")
+    .replace(/^_(.+)_$/s, "$1");
+
+  // Strip a leading list marker. `-` and `•` allow zero-or-more spaces (a
+  // tight `-Shipped X` should still normalize), but `*` requires at least
+  // one trailing space — `*X*` is italics and was already handled above.
+  const withoutBullet = withoutEmphasis.replace(
+    /^(?:\d+[.)]\s*|[•\-]\s*|\*\s+)/,
+    "",
+  );
+
+  // Strip surrounding quotes: straight (" ' `) plus smart double (“ ”) and
+  // smart single (‘ ’).
+  const withoutQuotes = withoutBullet
+    .replace(/^["'`“‘]/, "")
+    .replace(/["'`”’]$/, "")
+    .trim();
+
+  // Final guard: if the resulting line is just the model echoing prompt
+  // scaffolding, drop it so the caller's filter treats it as empty.
+  if (PROMPT_ECHO_LINES.has(withoutQuotes.toLowerCase())) return "";
+
+  return withoutQuotes;
+}

--- a/src/lib/webllm/preserve-numbers.test.ts
+++ b/src/lib/webllm/preserve-numbers.test.ts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+
+import { checkNumbersPreserved } from "./preserve-numbers.ts";
+
+describe("checkNumbersPreserved", () => {
+  it("passes when every numeric token survives", () => {
+    const input = [
+      "Cut p99 latency 40% by sharding the write path.",
+      "Drove $1.2M ARR across 3 enterprise rollouts.",
+    ];
+    const output = [
+      "Reduced p99 latency by 40% via write-path sharding.",
+      "Drove $1.2M ARR over 3 enterprise rollouts.",
+    ];
+    expect(checkNumbersPreserved(input, output)).toEqual({
+      ok: true,
+      dropped: [],
+      added: [],
+    });
+  });
+
+  it("flags a dropped percentage", () => {
+    const input = ["Cut p99 latency 40% by sharding the write path."];
+    const output = ["Reduced p99 latency by sharding the write path."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["40%"]);
+    expect(result.added).toEqual([]);
+  });
+
+  it("flags an invented number", () => {
+    const input = ["Improved availability."];
+    const output = ["Improved availability by 99.9%."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual([]);
+    expect(result.added).toEqual(["99.9%"]);
+  });
+
+  it("flags a substituted number — drops the original and adds the invented one", () => {
+    const input = ["Saved the team $5K per quarter."];
+    const output = ["Saved the team $10K per quarter."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["$5K"]);
+    expect(result.added).toEqual(["$10K"]);
+  });
+
+  it("handles all the money/percent/magnitude/comma/decimal formats", () => {
+    const input = [
+      "Generated $1.2M in 2023 alone (up from $400K in 2022).",
+      "Scaled to 1,200 RPS, with 99.95% uptime over a 6-month window.",
+      "Compressed images by 10MB on average and trimmed bundle 3.4%.",
+    ];
+    expect(checkNumbersPreserved(input, input).ok).toBe(true);
+  });
+
+  it("treats date ranges as the pair of years and accepts a reworded range", () => {
+    const input = ["Owned the platform from 2019-2021."];
+    // Output reworks 2019-2021 as "between 2019 and 2021" — both years still
+    // appear, so the check passes.
+    const output = ["Owned the platform between 2019 and 2021."];
+    expect(checkNumbersPreserved(input, output).ok).toBe(true);
+  });
+
+  it("flags a dropped year from a date range", () => {
+    const input = ["Owned the platform from 2019-2021."];
+    const output = ["Owned the platform starting in 2019."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["2021"]);
+  });
+
+  it("treats bare-integer headcounts in people-management context as preservable", () => {
+    const input = ["Led 5 engineers across two squads."];
+    // Rewrite drops the headcount: the bare 5 is now missing.
+    const output = ["Led engineers across two squads."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["5"]);
+  });
+
+  it("accepts a headcount reworded from 'led 5' to '5 engineers'", () => {
+    const input = ["Led 5 engineers across two squads."];
+    const output = ["Drove delivery with a team of 5 across two squads."];
+    expect(checkNumbersPreserved(input, output).ok).toBe(true);
+  });
+
+  it("accepts a headcount reworded from 'managed 8' to '8 reports'", () => {
+    const input = ["Managed 8 across the data platform."];
+    const output = ["Owned 8 reports across the data platform."];
+    expect(checkNumbersPreserved(input, output).ok).toBe(true);
+  });
+
+  it("counts numbers as a multiset — two distinct 5%s must both survive", () => {
+    const input = ["Lifted CTR 5% in Q1 and another 5% in Q2."];
+    // Rewrite collapses to one mention of 5%.
+    const output = ["Lifted CTR 5% over Q1 and Q2."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["5%"]);
+  });
+
+  it("strips the headcount: / year: namespace for display tokens", () => {
+    const dropped = checkNumbersPreserved(
+      ["Led 5 engineers in 2021."],
+      ["Drove delivery."],
+    );
+    expect(dropped.dropped).toEqual(expect.arrayContaining(["5", "2021"]));
+    expect(dropped.dropped.every((t) => !t.includes(":"))).toBe(true);
+  });
+
+  it("is case-insensitive on magnitude suffixes", () => {
+    const input = ["Drove $1.2M ARR."];
+    const output = ["Drove $1.2m ARR."];
+    expect(checkNumbersPreserved(input, output).ok).toBe(true);
+  });
+
+  it("returns ok on empty input and empty output", () => {
+    expect(checkNumbersPreserved([], [])).toEqual({
+      ok: true,
+      dropped: [],
+      added: [],
+    });
+  });
+
+  // ── Regressions from the reviewer pass ────────────────────────────────────
+
+  it("flags a sign flip — `15%` rewritten as `-15%` inverts the meaning", () => {
+    const input = ["Cut customer churn 15% YoY."];
+    const output = ["Customer churn moved -15% YoY."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["15%"]);
+    expect(result.added).toEqual(["-15%"]);
+  });
+
+  it("preserves an explicit negative metric round-trip", () => {
+    const input = ["Reduced churn by -15% over Q3."];
+    expect(checkNumbersPreserved(input, input).ok).toBe(true);
+  });
+
+  it("flags swapping `€500K` for `£500K` — non-$ currencies are tracked", () => {
+    const input = ["Booked €500K in Q4."];
+    const output = ["Booked £500K in Q4."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["€500K"]);
+    expect(result.added).toEqual(["£500K"]);
+  });
+
+  it("accepts a yen round-trip — ¥1,200 stays ¥1,200", () => {
+    const input = ["Signed a ¥1,200 retainer for the quarter."];
+    expect(checkNumbersPreserved(input, input).ok).toBe(true);
+  });
+
+  it("preserves the original casing of magnitude suffixes in the display token", () => {
+    const input = ["Saved $5K per quarter."];
+    const output = ["Did the work."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.dropped).toEqual(["$5K"]);
+  });
+
+  it("does NOT over-trigger on bare `of` — `1 of 5 candidates` should not be tracked as headcount", () => {
+    // `5 candidates` doesn't include a headcount noun ("candidates" isn't in
+    // the noun list), so neither integer should produce a tracked token.
+    const input = ["Reviewed 1 of 5 applicants for the lead role."];
+    // Rewrite drops both bare integers — should NOT flag dropped tokens.
+    const output = ["Reviewed lead-role applicants."];
+    expect(checkNumbersPreserved(input, output).ok).toBe(true);
+  });
+
+  it("does NOT over-trigger on `out of 10` — that's a fraction phrase, not a headcount", () => {
+    const input = ["Won 7 out of 10 deals last quarter."];
+    const output = ["Won most deals last quarter."];
+    // Neither integer is in people-management context — both should be
+    // ignored. (Bare integers without context aren't worth tracking.)
+    expect(checkNumbersPreserved(input, output).ok).toBe(true);
+  });
+
+  it("still catches headcount when the phrase is `team of 12`", () => {
+    const input = ["Led a team of 12 across two squads."];
+    const output = ["Led a team across two squads."];
+    const result = checkNumbersPreserved(input, output);
+    expect(result.ok).toBe(false);
+    expect(result.dropped).toEqual(["12"]);
+  });
+});

--- a/src/lib/webllm/preserve-numbers.ts
+++ b/src/lib/webllm/preserve-numbers.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Number-preservation guardrail.
+ *
+ * Section rewrite lets the model drop, merge, and reorder bullets — useful,
+ * but also a license to silently lose, swap, or invent concrete facts. This
+ * is the deterministic, model-free check: extract every numeric token from
+ * the input bullets, extract the same set from the rewritten bullets, and
+ * report any token that disappeared or appeared from nowhere.
+ *
+ * Trust signal, not a hard block. The UI surfaces the diff inline so the
+ * user can decide whether the rewrite is still acceptable.
+ *
+ * Tokens covered (per issue #63 decision #3):
+ *   - Money with $, €, £, or ¥: `$5`, `€500K`, `£1.2M`, `¥1,000`
+ *   - Percent: `40%`, `12.5%`, `-15%`
+ *   - Magnitude: `5K`, `10M`, `1.2B`, `10MB`, `2GB`
+ *   - Plain numbers with commas/decimals: `1,200`, `3.14`
+ *   - Years (1900-2099) and date ranges: `2019`, `2019-2021`
+ *   - Headcounts in people-management context: `led 5`, `managed 8`,
+ *     `team of 12`, `5 engineers`
+ *
+ * Each numeric position in a bullet is classified exactly once via a single
+ * ATOM regex pass, which is what prevents the date-range/year and the
+ * verb-prefix/noun-suffix overlaps from emitting two tokens for one digit.
+ *
+ * Sign sensitivity: a leading `-` (between a word boundary and the digit) is
+ * captured into the token. This is what catches "Reduced costs 15%" being
+ * rewritten as "Reduced costs -15%" — same magnitude, inverted meaning.
+ */
+
+/**
+ * Atom regex: one numeric occurrence with all its optional decorations.
+ *   1. optional leading `-` (preceded by start, whitespace, or punctuation —
+ *      not by another digit, which would make it a date-range hyphen)
+ *   2. optional currency symbol ($, €, £, ¥)
+ *   3. digit body (comma-grouped, decimal, or bare integer)
+ *   4. optional magnitude suffix (k/m/b/g/t with optional b/B for data
+ *      sizes like MB / GB)
+ *   5. optional trailing `%`
+ *
+ * The `(?<!\w)` / `(?!\w)` boundaries keep us from matching digits embedded
+ * in identifiers (`abc123`) or stranded suffixes (`5KBingo`).
+ */
+const ATOM =
+  /(?<!\w)(-)?([$€£¥])?(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+\.\d+|\d+)([kKmMbBgGtT][bB]?)?(%)?(?!\w)/g;
+
+/**
+ * Verbs/phrasing that signal a bare integer is a headcount when they appear
+ * just before the digit. Anchored to `\s*$` so it only matches when the verb
+ * is the last token of the prefix slice. `team of`, `group of`, etc. cover
+ * the "team of 5" patterns explicitly; bare `of` is NOT in the alternation
+ * because it over-triggers ("1 of 5 candidates", "out of 10").
+ */
+const PEOPLE_VERB_PREFIX =
+  /\b(?:led|manage[ds]?|managing|supervis(?:ed|ing)?|mentor(?:ed|ing)?|coach(?:ed|ing)?|direct(?:ed|ing)?|head(?:ed|ing)?|ran|running|team\s+of|group\s+of|squad\s+of|crew\s+of|headcount\s+of)\s*$/i;
+
+/**
+ * Nouns that signal a bare integer is a headcount when they appear just
+ * after the digit. Anchored to `^\s*` so the noun has to be the first token
+ * of the suffix slice.
+ */
+const PEOPLE_NOUN_FOLLOW =
+  /^\s*(?:engineers?|developers?|designers?|analysts?|interns?|reports?|people|persons?|members?|employees?|contractors?|consultants?|staff|hires?|recruits?)\b/i;
+
+/** How many characters of context to inspect on each side of a bare integer. */
+const PEOPLE_CONTEXT_WINDOW = 30;
+
+interface ClassifiedAtom {
+  /** Match key used for set equality (lowercased so `$5K` ≡ `$5k`). */
+  key: string;
+  /** Human-readable form used in the UI warning (preserves original case). */
+  display: string;
+}
+
+function classifyAtom(
+  match: RegExpExecArray,
+  bullet: string,
+): ClassifiedAtom | null {
+  const [, sign, currency, digits, magnitude, percent] = match;
+  const hasSign = Boolean(sign);
+  const hasCurrency = Boolean(currency);
+  const hasMagnitude = Boolean(magnitude);
+  const hasPercent = Boolean(percent);
+
+  const display =
+    (hasSign ? "-" : "") +
+    (hasCurrency ? currency! : "") +
+    digits +
+    (hasMagnitude ? magnitude! : "") +
+    (hasPercent ? "%" : "");
+  const key = display.toLowerCase();
+
+  // Decorated tokens (currency / magnitude / % / comma groups / decimals
+  // / explicit sign) are always tracked verbatim — they are unambiguously
+  // meaningful numeric facts.
+  if (
+    hasCurrency ||
+    hasMagnitude ||
+    hasPercent ||
+    hasSign ||
+    digits.includes(",") ||
+    digits.includes(".")
+  ) {
+    return { key, display };
+  }
+
+  // Bare integer. Inspect surrounding context to decide whether it's a
+  // headcount, a year, or noise we should ignore.
+  const matchStart = match.index;
+  const before = bullet.slice(
+    Math.max(0, matchStart - PEOPLE_CONTEXT_WINDOW),
+    matchStart,
+  );
+  const after = bullet.slice(
+    matchStart + digits.length,
+    matchStart + digits.length + PEOPLE_CONTEXT_WINDOW,
+  );
+
+  if (PEOPLE_VERB_PREFIX.test(before) || PEOPLE_NOUN_FOLLOW.test(after)) {
+    return { key: `headcount:${digits}`, display: digits };
+  }
+
+  if (digits.length === 4) {
+    const year = Number(digits);
+    if (year >= 1900 && year <= 2099) {
+      return { key: `year:${digits}`, display: digits };
+    }
+  }
+
+  // Plain integer without people context or a year shape — too noisy to
+  // track. Examples: "the 3 of us", "phase 2", "section 4".
+  return null;
+}
+
+function extractNumbers(bullets: readonly string[]): ClassifiedAtom[] {
+  const tokens: ClassifiedAtom[] = [];
+  for (const bullet of bullets) {
+    ATOM.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = ATOM.exec(bullet)) !== null) {
+      const token = classifyAtom(match, bullet);
+      if (token !== null) tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+export interface PreservationResult {
+  ok: boolean;
+  /** Tokens present in input that did not survive into the output. */
+  dropped: string[];
+  /** Tokens present in output that did not appear in the input. */
+  added: string[];
+}
+
+/**
+ * Check that every numeric fact from the input bullets survives into the
+ * rewritten bullets, and that no new numeric fact was invented.
+ *
+ * Multiset semantics: two `5%`s in the input must both appear in the output.
+ * Diff lists preserve the order tokens were encountered, so the UI can quote
+ * them back to the user without sorting noise. Tokens are returned in their
+ * original casing (`$5K`, not `$5k`).
+ */
+export function checkNumbersPreserved(
+  input: readonly string[],
+  output: readonly string[],
+): PreservationResult {
+  const inputTokens = extractNumbers(input);
+  const outputTokens = extractNumbers(output);
+
+  const outputCounts = new Map<string, number>();
+  for (const t of outputTokens) {
+    outputCounts.set(t.key, (outputCounts.get(t.key) ?? 0) + 1);
+  }
+  const dropped: string[] = [];
+  for (const t of inputTokens) {
+    const remaining = outputCounts.get(t.key) ?? 0;
+    if (remaining === 0) {
+      dropped.push(t.display);
+    } else {
+      outputCounts.set(t.key, remaining - 1);
+    }
+  }
+
+  const inputCounts = new Map<string, number>();
+  for (const t of inputTokens) {
+    inputCounts.set(t.key, (inputCounts.get(t.key) ?? 0) + 1);
+  }
+  const added: string[] = [];
+  for (const t of outputTokens) {
+    const remaining = inputCounts.get(t.key) ?? 0;
+    if (remaining === 0) {
+      added.push(t.display);
+    } else {
+      inputCounts.set(t.key, remaining - 1);
+    }
+  }
+
+  return {
+    ok: dropped.length === 0 && added.length === 0,
+    dropped,
+    added,
+  };
+}

--- a/src/lib/webllm/rewrite-bullet.ts
+++ b/src/lib/webllm/rewrite-bullet.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 The resumelint Authors
 
 import { trackWebllmFirstRewrite } from "../analytics.ts";
+import { cleanRewriteLine } from "./post-process.ts";
 import type { WebLlmEngine } from "./types.ts";
 
 /**
@@ -61,13 +62,14 @@ export async function rewriteBulletWithLlm(
 }
 
 function postProcess(raw: string): string {
-  const firstLine = raw
-    .split("\n")
-    .map((line) => line.trim())
-    .find((line) => line.length > 0);
-  if (!firstLine) return "";
-  const withoutPrefix = firstLine.replace(/^rewritten:\s*/i, "");
-  return withoutPrefix.replace(/^["'`]|["'`]$/g, "").trim();
+  // Per-bullet path: clean every line then keep the first non-empty result.
+  // Section path uses cleanRewriteLine the same way but keeps all lines —
+  // see rewrite-section.ts.
+  for (const line of raw.split("\n")) {
+    const cleaned = cleanRewriteLine(line);
+    if (cleaned.length > 0) return cleaned;
+  }
+  return "";
 }
 
 /** Test-only: drop the one-shot telemetry flag between tests. */

--- a/src/lib/webllm/rewrite-section.test.ts
+++ b/src/lib/webllm/rewrite-section.test.ts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock analytics so we can assert telemetry firing without depending on
+// whether VITE_POSTHOG_KEY is set in the test env.
+const {
+  trackStartedMock,
+  trackCompletedMock,
+  trackFirstSectionMock,
+  trackFirstRewriteMock,
+} = vi.hoisted(() => ({
+  trackStartedMock: vi.fn(),
+  trackCompletedMock: vi.fn(),
+  trackFirstSectionMock: vi.fn(),
+  trackFirstRewriteMock: vi.fn(),
+}));
+vi.mock("../analytics.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../analytics.ts")>();
+  return {
+    ...actual,
+    trackWebllmSectionRewriteStarted: trackStartedMock,
+    trackWebllmSectionRewriteCompleted: trackCompletedMock,
+    trackWebllmFirstSectionRewrite: trackFirstSectionMock,
+    trackWebllmFirstRewrite: trackFirstRewriteMock,
+  };
+});
+
+import {
+  _resetSectionRewriteFlagsForTesting,
+  buildSectionUserPrompt,
+  rewriteSectionWithLlm,
+  sectionMaxTokens,
+  SECTION_REWRITE_SYSTEM_PROMPT,
+} from "./rewrite-section.ts";
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  WebLlmEngine,
+} from "./types.ts";
+
+function makeEngine(
+  reply: (req: ChatCompletionRequest) => Promise<ChatCompletionResponse>,
+): {
+  engine: WebLlmEngine;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const spy = vi.fn(reply);
+  const engine: WebLlmEngine = { chat: { completions: { create: spy } } };
+  return { engine, spy };
+}
+
+function reply(content: string | null): ChatCompletionResponse {
+  return { choices: [{ message: { content } }] };
+}
+
+describe("sectionMaxTokens", () => {
+  it("floors at 60 for a single bullet", () => {
+    expect(sectionMaxTokens(1)).toBe(60);
+  });
+
+  it("scales linearly at 60 per bullet", () => {
+    expect(sectionMaxTokens(5)).toBe(300);
+    expect(sectionMaxTokens(8)).toBe(480);
+  });
+
+  it("caps at 768 regardless of bullet count", () => {
+    expect(sectionMaxTokens(13)).toBe(768);
+    expect(sectionMaxTokens(50)).toBe(768);
+  });
+
+  it("does not divide by zero or go negative when called with 0", () => {
+    expect(sectionMaxTokens(0)).toBe(60);
+  });
+});
+
+describe("buildSectionUserPrompt", () => {
+  it("numbers the bullets and trims each one", () => {
+    expect(
+      buildSectionUserPrompt(["  first bullet  ", "second bullet"]),
+    ).toBe(
+      "Original bullets:\n1. first bullet\n2. second bullet\n\nRewritten bullets:",
+    );
+  });
+});
+
+describe("rewriteSectionWithLlm", () => {
+  beforeEach(() => {
+    _resetSectionRewriteFlagsForTesting();
+    trackStartedMock.mockClear();
+    trackCompletedMock.mockClear();
+    trackFirstSectionMock.mockClear();
+  });
+
+  it("sends the section system prompt and a numbered user prompt", async () => {
+    const { engine, spy } = makeEngine(async () => reply("Shipped X.\nLed Y."));
+    await rewriteSectionWithLlm(["worked on X", "managed Y"], engine);
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    expect(req.messages[0]).toEqual({
+      role: "system",
+      content: SECTION_REWRITE_SYSTEM_PROMPT,
+    });
+    expect(req.messages[1]?.role).toBe("user");
+    expect(req.messages[1]?.content).toContain("1. worked on X");
+    expect(req.messages[1]?.content).toContain("2. managed Y");
+  });
+
+  it("uses sectionMaxTokens as max_tokens", async () => {
+    const { engine, spy } = makeEngine(async () => reply("A.\nB."));
+    await rewriteSectionWithLlm(["x", "y"], engine);
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    expect(req.max_tokens).toBe(sectionMaxTokens(2));
+  });
+
+  it("splits on newlines and keeps every non-empty cleaned line (M != N)", async () => {
+    const { engine } = makeEngine(async () =>
+      reply(
+        "Shipped Foo to 10M users.\n" +
+          "\n" +
+          "Led 5 engineers to cut p99 latency 40%.\n" +
+          "Drove $1.2M ARR.\n",
+      ),
+    );
+    // Three input bullets, three output bullets — but the model could
+    // legitimately return 2 or 4, and the function must handle it.
+    const out = await rewriteSectionWithLlm(
+      ["worked on Foo", "led the team", "sold things"],
+      engine,
+    );
+    expect(out.bullets).toEqual([
+      "Shipped Foo to 10M users.",
+      "Led 5 engineers to cut p99 latency 40%.",
+      "Drove $1.2M ARR.",
+    ]);
+  });
+
+  it("strips numbered list markers from each line", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("1. Shipped Foo.\n2) Led Y.\n3. Drove Z."),
+    );
+    const out = await rewriteSectionWithLlm(["a", "b", "c"], engine);
+    expect(out.bullets).toEqual(["Shipped Foo.", "Led Y.", "Drove Z."]);
+  });
+
+  it("strips Rewritten: prefix and surrounding quotes per line", async () => {
+    const { engine } = makeEngine(async () =>
+      reply('Rewritten: "Shipped Foo."\n"Led Y."'),
+    );
+    const out = await rewriteSectionWithLlm(["a", "b"], engine);
+    expect(out.bullets).toEqual(["Shipped Foo.", "Led Y."]);
+  });
+
+  it("reports numbersPreserved=true when every numeric token survives", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Cut p99 latency 40% via sharding.\nDrove $1.2M ARR."),
+    );
+    const out = await rewriteSectionWithLlm(
+      ["Cut p99 latency 40% by sharding", "Drove $1.2M in ARR"],
+      engine,
+    );
+    expect(out.numbersPreserved).toBe(true);
+    expect(out.droppedNumbers).toEqual([]);
+    expect(out.addedNumbers).toEqual([]);
+  });
+
+  it("flags numbersPreserved=false with the specific dropped token", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Saved the team some money each quarter."),
+    );
+    const out = await rewriteSectionWithLlm(
+      ["Saved the team $5K per quarter."],
+      engine,
+    );
+    expect(out.numbersPreserved).toBe(false);
+    expect(out.droppedNumbers).toEqual(["$5K"]);
+  });
+
+  it("flags an invented number in added", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Improved availability to 99.9%."),
+    );
+    const out = await rewriteSectionWithLlm(
+      ["Improved availability."],
+      engine,
+    );
+    expect(out.numbersPreserved).toBe(false);
+    expect(out.addedNumbers).toEqual(["99.9%"]);
+  });
+
+  it("fires webllm_section_rewrite_started and _completed with counts and preservation flag", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Shipped Foo.\nDrove Z."),
+    );
+    await rewriteSectionWithLlm(["a", "b", "c"], engine);
+    expect(trackStartedMock).toHaveBeenCalledWith({ inputBulletCount: 3 });
+    expect(trackCompletedMock).toHaveBeenCalledWith({
+      inputBulletCount: 3,
+      outputBulletCount: 2,
+      numbersPreserved: true,
+    });
+  });
+
+  it("fires webllm_first_section_rewrite exactly once across calls", async () => {
+    const { engine } = makeEngine(async () => reply("Shipped Foo."));
+    await rewriteSectionWithLlm(["a"], engine);
+    await rewriteSectionWithLlm(["b"], engine);
+    expect(trackFirstSectionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire webllm_first_section_rewrite when output is empty", async () => {
+    const { engine } = makeEngine(async () => reply(null));
+    await rewriteSectionWithLlm(["a"], engine);
+    expect(trackFirstSectionMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire the per-bullet webllm_first_rewrite key", async () => {
+    const { engine } = makeEngine(async () => reply("Shipped Foo."));
+    await rewriteSectionWithLlm(["a"], engine);
+    expect(trackFirstRewriteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty bullets array on null model content without throwing", async () => {
+    const { engine } = makeEngine(async () => reply(null));
+    const out = await rewriteSectionWithLlm(["a"], engine);
+    expect(out.bullets).toEqual([]);
+    expect(out.numbersPreserved).toBe(true);
+  });
+
+  it("propagates engine errors to the caller", async () => {
+    const boom = new Error("OOM");
+    const { engine } = makeEngine(async () => {
+      throw boom;
+    });
+    await expect(rewriteSectionWithLlm(["a"], engine)).rejects.toBe(boom);
+  });
+});

--- a/src/lib/webllm/rewrite-section.ts
+++ b/src/lib/webllm/rewrite-section.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import {
+  trackWebllmFirstSectionRewrite,
+  trackWebllmSectionRewriteCompleted,
+  trackWebllmSectionRewriteStarted,
+} from "../analytics.ts";
+import { cleanRewriteLine } from "./post-process.ts";
+import { checkNumbersPreserved } from "./preserve-numbers.ts";
+import type { WebLlmEngine } from "./types.ts";
+
+/**
+ * System prompt for whole-section rewrite.
+ *
+ * Per issue #63: replace-whole-block lets the model dedupe, merge, drop weak
+ * bullets, reorder, and balance verb variety — none of that is reachable
+ * from the per-bullet path. The number-preservation guardrail runs
+ * deterministically on the output (see preserve-numbers.ts), so the prompt
+ * leans on the model to *try* to preserve numbers but doesn't depend on it.
+ *
+ * Tuned for Qwen2.5-1.5B-Instruct: small models need the rules stated
+ * emphatically. "One bullet per line, no preamble, no numbering, no quotes"
+ * has to be repeated because each rule is broken often enough on its own.
+ */
+export const SECTION_REWRITE_SYSTEM_PROMPT = `You are rewriting a list of resume bullets to be more specific and outcome-oriented.
+Rules:
+- Output one bullet per line. No numbering. No bullet markers. No quotes. No preamble.
+- Lead every bullet with a strong action verb.
+- Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.
+- You may merge two weak bullets into one strong bullet, drop pure filler, or reorder for emphasis.
+- Vary the action verbs across bullets — don't start every line the same way.
+- If a bullet is already strong, keep it unchanged.`;
+
+const SECTION_MAX_TOKENS_PER_BULLET = 60;
+const SECTION_MAX_TOKENS_CEILING = 768;
+
+/**
+ * Per issue #63 decision #2: `min(60 * bullets.length, 768)`.
+ *
+ * `max(bulletCount, 1)` keeps the floor at 60 even if called with 0 bullets.
+ * The literal spec value at N=0 would be 0, which is an invalid max_tokens.
+ * SectionRewrite already filters empty arrays out before calling, so this
+ * floor is purely defensive for the standalone API surface.
+ */
+export function sectionMaxTokens(bulletCount: number): number {
+  return Math.min(
+    SECTION_MAX_TOKENS_PER_BULLET * Math.max(bulletCount, 1),
+    SECTION_MAX_TOKENS_CEILING,
+  );
+}
+
+export function buildSectionUserPrompt(bullets: readonly string[]): string {
+  const numbered = bullets
+    .map((b, i) => `${i + 1}. ${b.trim()}`)
+    .join("\n");
+  return `Original bullets:\n${numbered}\n\nRewritten bullets:`;
+}
+
+export interface SectionRewriteResult {
+  /** The rewritten bullets (M may differ from N). */
+  bullets: string[];
+  /** True iff every input number survived and none were invented. */
+  numbersPreserved: boolean;
+  /** Numeric tokens that did not survive (UI surfaces these inline). */
+  droppedNumbers: string[];
+  /** Numeric tokens that appeared from nowhere (UI surfaces these inline). */
+  addedNumbers: string[];
+}
+
+let firstSectionRewriteFired = false;
+
+/**
+ * Rewrite a whole section of resume bullets using a loaded WebLLM engine.
+ *
+ * Pure over `engine` — the engine is passed in so tests can supply a stub
+ * implementing the `WebLlmEngine` contract without touching the real model.
+ *
+ * Output handling: split on newlines, run each line through the shared
+ * cleanRewriteLine helper (strips `Rewritten:` prefix echoes, surrounding
+ * quotes, and list markers), and keep every non-empty result. M may differ
+ * from N — that's the whole point of section rewrite, not a failure mode.
+ *
+ * Telemetry: `webllm_section_rewrite_started` fires unconditionally;
+ * `webllm_section_rewrite_completed` fires with the bullet counts and
+ * numbersPreserved boolean once the model returns. `webllm_first_section_rewrite`
+ * is a separate one-shot flag from the per-bullet first-rewrite key,
+ * preserving funnel continuity for both paths.
+ */
+export async function rewriteSectionWithLlm(
+  bullets: readonly string[],
+  engine: WebLlmEngine,
+): Promise<SectionRewriteResult> {
+  trackWebllmSectionRewriteStarted({ inputBulletCount: bullets.length });
+
+  const response = await engine.chat.completions.create({
+    messages: [
+      { role: "system", content: SECTION_REWRITE_SYSTEM_PROMPT },
+      { role: "user", content: buildSectionUserPrompt(bullets) },
+    ],
+    temperature: 0.3,
+    max_tokens: sectionMaxTokens(bullets.length),
+  });
+
+  const raw = response.choices[0]?.message?.content ?? "";
+  const rewrittenBullets = raw
+    .split("\n")
+    .map((line) => cleanRewriteLine(line))
+    .filter((line) => line.length > 0);
+
+  const preservation = checkNumbersPreserved(bullets, rewrittenBullets);
+
+  trackWebllmSectionRewriteCompleted({
+    inputBulletCount: bullets.length,
+    outputBulletCount: rewrittenBullets.length,
+    numbersPreserved: preservation.ok,
+  });
+
+  // Same gating as the per-bullet path: only count the first *successful*
+  // section rewrite (one with at least one bullet) so a null/empty model
+  // response doesn't pollute the conversion funnel.
+  if (!firstSectionRewriteFired && rewrittenBullets.length > 0) {
+    firstSectionRewriteFired = true;
+    trackWebllmFirstSectionRewrite();
+  }
+
+  return {
+    bullets: rewrittenBullets,
+    numbersPreserved: preservation.ok,
+    droppedNumbers: preservation.dropped,
+    addedNumbers: preservation.added,
+  };
+}
+
+/** Test-only: drop the one-shot telemetry flag between tests. */
+export function _resetSectionRewriteFlagsForTesting(): void {
+  firstSectionRewriteFired = false;
+}

--- a/src/lib/webllm/web-llm.ts
+++ b/src/lib/webllm/web-llm.ts
@@ -7,12 +7,11 @@ import type { ProgressUpdate, WebLlmEngine } from "./types.ts";
 /**
  * Pinned model ID. Single source of truth — never inline this string.
  *
- * Qwen2-1.5B-Instruct is the right size/quality tradeoff for the per-bullet
- * rewrite task on consumer hardware (~1.2GB quantized). Swapping models is
- * out of scope for v1 (see issue #3, Out-of-scope §); a measurement-backed
- * swap to Phi-3 or Llama-3 can revisit this constant.
+ * Qwen2.5-1.5B-Instruct is the right size/quality tradeoff for the resume
+ * rewrite task on consumer hardware (~1.2GB quantized). Multi-model selection
+ * is out of scope here and lives behind a model registry (issue #64).
  */
-export const MODEL_ID = "Qwen2-1.5B-Instruct-q4f16_1-MLC";
+export const MODEL_ID = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
 
 let cached: Promise<WebLlmEngine> | null = null;
 let downloadStartedFired = false;


### PR DESCRIPTION
## Summary

Phase 1 of the in-browser AI rewrite epic. Each `RoleEntry` now exposes a **Rewrite section** button that asks Qwen2.5-1.5B to rewrite the whole role's bullets at once — the model owns count/order (can merge, dedupe, drop filler, reorder), and a deterministic, model-free regex guardrail compares numeric tokens in vs. out so the UI can name the specific dropped/invented metric inline ("⚠ AI altered a metric — removed `$5K`…").

Closes #63

## What's in the diff

**New webllm modules (all unit-tested, no real model fetched in CI)**
- [src/lib/webllm/post-process.ts](src/lib/webllm/post-process.ts) (+ test) — `cleanRewriteLine` factored out of `rewrite-bullet.ts`; strips `Rewritten:` echo, list markers, straight + smart quotes, paired bold/italic, prompt-echo lines.
- [src/lib/webllm/preserve-numbers.ts](src/lib/webllm/preserve-numbers.ts) (+ test) — single-pass ATOM regex classifies each numeric token exactly once. Handles `$/€/£/¥`, percent, magnitude (`5K`, `10MB`, `2GB`), comma groups, decimals, year ranges, and bare-integer headcounts in people-management context. Sign-flips (`15%` → `-15%`) are flagged. `of` deliberately NOT in the verb prefix (over-triggers on "1 of 5"). 22 tests.
- [src/lib/webllm/rewrite-section.ts](src/lib/webllm/rewrite-section.ts) (+ test) — `rewriteSectionWithLlm(bullets, engine) → SectionRewriteResult` with `max_tokens = min(60 × bullets.length, 768)`, post-processed output split on `\n`. 19 tests.

**New / modified UI**
- [src/components/features/SectionRewrite.tsx](src/components/features/SectionRewrite.tsx) — uses `<Button>` from `@design-system` (no raw `<button>`). Renders before/after side-by-side, green border when `numbersPreserved`, amber border + token-naming warning when not. Returns `null` when WebGPU is unavailable. Auto-dismisses the proposal when the underlying bullets change (so you can't see a "Original (2) | Proposed (3)" mismatch after an edit).
- [src/hooks/useSectionRewriteLock.ts](src/hooks/useSectionRewriteLock.ts) (+ test) — synchronous atomic `tryAcquireSectionRewriteLock()` returns `null` on contention. The disabled button is just UI; the real guarantee is this atomic check, so two `onClick` handlers fired in the same React batch can't both succeed. 6 tests.
- [src/components/features/ReconstructedRole.tsx](src/components/features/ReconstructedRole.tsx) — wires one `SectionRewrite` per role, fed `bulletOverrides?.[b.index] ?? b.text` so the model sees what the user actually edited.

**Foundational**
- [src/lib/webllm/web-llm.ts](src/lib/webllm/web-llm.ts) — `MODEL_ID` bumped Qwen2 → Qwen2.5-1.5B.
- [src/lib/webllm/rewrite-bullet.ts](src/lib/webllm/rewrite-bullet.ts) — refactored to use `cleanRewriteLine`. No behavior change (9 existing tests still pass).
- [src/lib/analytics.ts](src/lib/analytics.ts) — `webllm_section_rewrite_started`, `_completed` (with `numbers_preserved`), plus a distinct `webllm_first_section_rewrite` one-shot key. Per-bullet `webllm_first_rewrite` left untouched per AC.

## Bundled fix (App.tsx wiring)

Discovered while manually testing this PR: editing any bullet caused it to jump to the trailing "Other bullets" group, which blocked end-to-end verification of the guardrail. Root cause was in [App.tsx](src/App.tsx) — it passed `state.result` (original `parsed`) with `edited.score` (re-graded bullets), so `groupBulletsByExperience` built its line→exp map from original descriptions and looked up edited bullet text → no match → "Other bullets."

Fix is one line: pass `{ ...state.result, parsed: edited.parsed }` to `Result`. `rawText` stays original on purpose (EvidencePanel shows what the PDF extracted, not what the user typed). Two regression tests in [src/lib/edit/apply-overrides.test.ts](src/lib/edit/apply-overrides.test.ts) — one proves the working path, the other pins the bug pattern so anyone "simplifying" the wiring back to `state.result` will see the test fail.

**Why bundled rather than separate**: the bug pre-dated this branch but the displacement made testing the guardrail end-to-end impractical (the edited bullet's `$50K` would land in a different group than the role I was running rewrite on). The fix is 3 lines of code + 2 tests, narrowly scoped, and the alternative was to ship #63 with a known testing gap.

## Known scope notes (worth flagging to reviewer)

- **No `<Card>` from `@design-system` for the inline before/after panel.** That primitive owns top-level panel chrome (`rounded-xl border p-5`); the inline result strip uses the same lightweight container pattern as `RewriteButton`'s `RewriteResult` (`rounded border + feedback bg`). Forcing `Card` would visually overweight the surface.
- **`rewriteSectionWithLlm` returns `SectionRewriteResult`, not `Promise<string[]>`.** The struct surfaces `numbersPreserved`/`droppedNumbers`/`addedNumbers` the warning UI needs; returning bare `string[]` would force the component to re-run the guardrail.
- **Per-role wiring only.** Project/achievement sections don't get `SectionRewrite` — matches the issue's "Wire into RoleEntry" wording. If you want them too, easy follow-up.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (**523/523 tests**, was 496)
- [x] `npm run build` green
- [x] Manually verified in `npm run dev`:
  - Per-role "Rewrite section" buttons render under each experience role; absent in Safari/Firefox (no WebGPU)
  - Cold-start downloads Qwen2.5-1.5B (~1.2GB) on first click only; cached in IndexedDB after
  - Clicking a sibling role's button while one is in flight shows **"Another rewrite running…"** disabled (lock works)
  - Successful rewrite shows green-bordered before/after with "Use this — copy all bullets" / "Discard"
  - Editing a bullet under a rewritten role auto-dismisses the proposal (no stale `(2) | (3)` mismatch)
  - Per-bullet sparkle ✨ rewrite still works (regression check on the refactored post-process)
  - Edited bullets stay attached to their role (App.tsx fix)