### PR TITLE
feat(jd-match): Ashby adapter + host-aware fallback + trackJdUrlFetch (closes #72)

### DIFF
--- a/src/components/features/JdInput.test.ts
+++ b/src/components/features/JdInput.test.ts
@@ -53,6 +53,17 @@ describe("JdInput — static render", () => {
     expect(html).toContain("Fetch");
   });
 
+  it("lists Ashby alongside the other supported ATS hosts in the URL placeholder", () => {
+    // Closes #74 from the user-facing surface: Ashby URLs should be advertised
+    // as supported now that the adapter exists.
+    const html = renderIdle();
+    expect(html).toContain("Ashby");
+    // Existing supported hosts stay in the placeholder.
+    for (const host of ["Greenhouse", "Lever", "Workable", "Recruitee"]) {
+      expect(html).toContain(host);
+    }
+  });
+
   it("shows the contextual hint when value is non-empty and resume is not parsed", () => {
     const html = renderIdle("some jd", false);
     expect(html).toContain("Drop a resume above");

--- a/src/components/features/JdInput.tsx
+++ b/src/components/features/JdInput.tsx
@@ -5,9 +5,14 @@
  * JdInput — Job description entry panel.
  *
  * Owns the JD textarea (paste path) and a URL-fetch affordance
- * (Greenhouse / Lever / Workable / Recruitee). On a successful fetch the
- * textarea is populated; on failure (unsupported host, network, CORS) an
+ * (Greenhouse / Lever / Workable / Recruitee / Ashby). On a successful fetch
+ * the textarea is populated; on failure (unsupported host, network, CORS) an
  * inline message keeps the paste path fully usable.
+ *
+ * Host-aware fallback: when the user pastes a URL from a well-known closed
+ * surface (LinkedIn / Indeed / Glassdoor / Workday / Wellfound) the inline
+ * message names the host's specific limitation so it lands as honest rather
+ * than generic. Unknown hosts get the generic copy.
  *
  * Privacy contract: JD text never leaves the browser except the explicit
  * user-initiated fetch to the posting URL. No other network send is made.
@@ -18,7 +23,12 @@
 
 import { useState } from "react";
 import { Card, Button, ErrorState } from "@design-system";
-import { fetchJdFromUrl } from "../../lib/jd-match/fetch-jd.ts";
+import {
+  fetchJdFromUrl,
+  classifyUnsupportedHost,
+  type UnsupportedHost,
+} from "../../lib/jd-match/fetch-jd.ts";
+import { trackJdUrlFetch } from "../../lib/analytics.ts";
 
 export interface JdInputProps {
   value: string;
@@ -27,34 +37,60 @@ export interface JdInputProps {
   resumeParsed?: boolean;
 }
 
-type FetchStatus = "idle" | "loading" | "error-unsupported" | "error-network";
+type FetchStatus =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "error-unsupported"; host: UnsupportedHost | null }
+  | { kind: "error-network" };
 
 const SUPPORTED_HOSTS_COPY =
-  "Greenhouse, Lever, Workable, or Recruitee URLs are supported.";
+  "Greenhouse, Lever, Workable, Recruitee, or Ashby URLs are supported.";
+
+/**
+ * Named-host fallback copy. Each line names the reason the host can't be
+ * read client-side, so the message lands as honest rather than generic.
+ * The trailing "Paste …" call-to-action stays uniform across hosts.
+ */
+const UNSUPPORTED_HOST_REASON: Record<UnsupportedHost, string> = {
+  linkedin: "LinkedIn blocks automated reads.",
+  indeed: "Indeed blocks automated reads.",
+  glassdoor: "Glassdoor blocks automated reads.",
+  workday: "Workday job boards don't allow browser-side reads.",
+  wellfound: "Wellfound blocks automated reads.",
+};
 
 export function JdInput({ value, onChange, resumeParsed = false }: JdInputProps) {
   const [urlInput, setUrlInput] = useState("");
-  const [fetchStatus, setFetchStatus] = useState<FetchStatus>("idle");
+  const [fetchStatus, setFetchStatus] = useState<FetchStatus>({ kind: "idle" });
 
   const handleFetch = async () => {
     const trimmed = urlInput.trim();
     if (!trimmed) return;
 
-    setFetchStatus("loading");
+    setFetchStatus({ kind: "loading" });
 
     try {
       const result = await fetchJdFromUrl(trimmed);
       if (result === null) {
         // URL parsed but fetch returned null — unsupported host or no match.
-        setFetchStatus("error-unsupported");
+        // Classify against the known closed-surface list so the user-facing
+        // message names LinkedIn / Indeed / etc. when relevant.
+        const host = classifyUnsupportedHost(trimmed);
+        setFetchStatus({ kind: "error-unsupported", host });
+        trackJdUrlFetch({
+          outcome: host !== null ? "unsupported_known" : "unsupported_unknown",
+          platform: null,
+        });
         return;
       }
       onChange(result.text);
-      setFetchStatus("idle");
+      setFetchStatus({ kind: "idle" });
+      trackJdUrlFetch({ outcome: "ok", platform: result.source });
       // Clear the URL field after a successful populate.
       setUrlInput("");
     } catch {
-      setFetchStatus("error-network");
+      setFetchStatus({ kind: "error-network" });
+      trackJdUrlFetch({ outcome: "network_error", platform: null });
     }
   };
 
@@ -65,8 +101,8 @@ export function JdInput({ value, onChange, resumeParsed = false }: JdInputProps)
   };
 
   const clearError = () => {
-    if (fetchStatus !== "idle" && fetchStatus !== "loading") {
-      setFetchStatus("idle");
+    if (fetchStatus.kind !== "idle" && fetchStatus.kind !== "loading") {
+      setFetchStatus({ kind: "idle" });
     }
   };
 
@@ -95,7 +131,7 @@ export function JdInput({ value, onChange, resumeParsed = false }: JdInputProps)
             clearError();
           }}
           onKeyDown={handleUrlKeyDown}
-          placeholder="Or paste a job posting URL (Greenhouse, Lever, Workable, Recruitee)…"
+          placeholder="Or paste a job posting URL (Greenhouse, Lever, Workable, Recruitee, Ashby)…"
           aria-label="Job posting URL"
           className="min-w-0 flex-1 rounded-lg border border-border-light bg-surface-subtle px-3 py-1.5 text-sm text-content-primary placeholder:text-content-muted focus:border-border focus:outline-hidden"
         />
@@ -103,21 +139,22 @@ export function JdInput({ value, onChange, resumeParsed = false }: JdInputProps)
           variant="primary"
           size="sm"
           onClick={() => void handleFetch()}
-          disabled={fetchStatus === "loading" || urlInput.trim().length === 0}
+          disabled={fetchStatus.kind === "loading" || urlInput.trim().length === 0}
           aria-label="Fetch job description from URL"
         >
-          {fetchStatus === "loading" ? "Fetching…" : "Fetch"}
+          {fetchStatus.kind === "loading" ? "Fetching…" : "Fetch"}
         </Button>
       </div>
 
       {/* Inline fetch error messages — keep the paste textarea usable */}
-      {fetchStatus === "error-unsupported" && (
+      {fetchStatus.kind === "error-unsupported" && (
         <ErrorState tone="warning">
-          That URL isn't from a supported ATS. {SUPPORTED_HOSTS_COPY} Paste the
-          job description below instead.
+          {fetchStatus.host !== null
+            ? `${UNSUPPORTED_HOST_REASON[fetchStatus.host]} Paste the job description below instead.`
+            : `That URL isn't from a supported ATS. ${SUPPORTED_HOSTS_COPY} Paste the job description below instead.`}
         </ErrorState>
       )}
-      {fetchStatus === "error-network" && (
+      {fetchStatus.kind === "error-network" && (
         <ErrorState tone="warning">
           Couldn't reach that URL — the request may have been blocked by the
           browser or the server. Paste the job description below instead.

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -208,3 +208,29 @@ export function trackWebllmSectionRewriteCompleted(args: {
 export function trackWebllmFirstSectionRewrite(): void {
   track("webllm_first_section_rewrite", {});
 }
+
+// JD URL ingestion funnel (#72 / #75). Fires on every user-initiated fetch
+// from the JD URL input. The `outcome` enum lets us tell apart the four
+// platform-relevant funnel states without ever recording the URL itself —
+// privacy-safe by construction. No URL, no JD text, no host fragment.
+//
+//   ok                      — fetch succeeded; `platform` is the parsed ATS
+//   unsupported_known       — host classified (linkedin/indeed/…); platform null
+//   unsupported_unknown     — host not recognised at all; platform null
+//   network_error           — supported ATS, but the API call failed
+export type JdUrlOutcome =
+  | "ok"
+  | "unsupported_known"
+  | "unsupported_unknown"
+  | "network_error";
+
+export function trackJdUrlFetch(args: {
+  outcome: JdUrlOutcome;
+  /** Set when `outcome === "ok"`; otherwise null. */
+  platform: string | null;
+}): void {
+  track("jd_url_fetch", {
+    outcome: args.outcome,
+    platform: args.platform,
+  });
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,6 +3,7 @@
 
 import type { LayoutTrigger, ParseEvent } from "./heuristics/types";
 import type { WebGpuCapability } from "./webllm/types";
+import type { AtsPlatform } from "./jd-match/fetch-jd";
 
 type PostHog = {
   capture: (event: string, props?: Record<string, unknown>) => void;
@@ -227,7 +228,7 @@ export type JdUrlOutcome =
 export function trackJdUrlFetch(args: {
   outcome: JdUrlOutcome;
   /** Set when `outcome === "ok"`; otherwise null. */
-  platform: string | null;
+  platform: AtsPlatform | null;
 }): void {
   track("jd_url_fetch", {
     outcome: args.outcome,

--- a/src/lib/jd-match/fetch-jd.test.ts
+++ b/src/lib/jd-match/fetch-jd.test.ts
@@ -255,7 +255,7 @@ describe("fetchJdFromUrl — Ashby", () => {
     expect(result!.text).not.toMatch(/<[^>]+>/);
   });
 
-  it("returns null when the posting id isn't in the board listing", async () => {
+  it("throws when the posting id isn't in the board listing (caller routes to network_error)", async () => {
     const fakeResponse = {
       jobBoard: { name: "Acme Corp" },
       jobPostings: [
@@ -274,21 +274,37 @@ describe("fetchJdFromUrl — Ashby", () => {
       ),
     );
 
-    const result = await fetchJdFromUrl(
-      "https://jobs.ashbyhq.com/acmecorp/22222222-2222-2222-2222-222222222222",
-    );
-    expect(result).toBeNull();
+    await expect(
+      fetchJdFromUrl(
+        "https://jobs.ashbyhq.com/acmecorp/22222222-2222-2222-2222-222222222222",
+      ),
+    ).rejects.toThrow(/Ashby/);
   });
 
-  it("returns null when the API call fails (non-2xx)", async () => {
+  it("throws when the API call fails (non-2xx) so the caller can route the network_error funnel", async () => {
+    // Distinguishes "URL parsed; fetch failed" (throw) from "URL didn't parse"
+    // (null). Without this, a transient ATS-side 500 misroutes through the
+    // `result === null` branch and gets tracked as `unsupported_unknown`.
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("nope", { status: 404 })),
     );
 
-    const result = await fetchJdFromUrl(
-      "https://jobs.ashbyhq.com/missingco/12345678-90ab-cdef-1234-567890abcdef",
-    );
+    await expect(
+      fetchJdFromUrl(
+        "https://jobs.ashbyhq.com/missingco/12345678-90ab-cdef-1234-567890abcdef",
+      ),
+    ).rejects.toThrow(/Ashby API 404/);
+  });
+
+  it("still returns null when the URL doesn't parse to any ATS (no network call made)", async () => {
+    // Contract-pin: `null` means "couldn't identify an ATS"; throws mean "could
+    // identify, but the fetch itself failed." Keeps the JdInput routing honest.
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchJdFromUrl("https://example.com/careers/123");
     expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/jd-match/fetch-jd.test.ts
+++ b/src/lib/jd-match/fetch-jd.test.ts
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-import { describe, it, expect } from "vitest";
-import { parseAtsUrl, htmlToPlaintext } from "./fetch-jd.ts";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  parseAtsUrl,
+  htmlToPlaintext,
+  classifyUnsupportedHost,
+  fetchJdFromUrl,
+} from "./fetch-jd.ts";
 
 describe("parseAtsUrl", () => {
   it("parses a Greenhouse URL", () => {
@@ -47,6 +52,25 @@ describe("parseAtsUrl", () => {
       company: "acmecorp",
       jobId: "senior-software-engineer",
     });
+  });
+
+  it("parses an Ashby URL", () => {
+    const result = parseAtsUrl(
+      "https://jobs.ashbyhq.com/acmecorp/12345678-90ab-cdef-1234-567890abcdef",
+    );
+    expect(result).toEqual({
+      platform: "ashby",
+      company: "acmecorp",
+      jobId: "12345678-90ab-cdef-1234-567890abcdef",
+    });
+  });
+
+  it("does not match an Ashby URL with a non-UUID jobId", () => {
+    // The UUID-strict tail keeps a stray ATS-shaped path from producing a
+    // 404 on the public API. Falls through to "unsupported" instead.
+    expect(
+      parseAtsUrl("https://jobs.ashbyhq.com/acmecorp/not-a-uuid"),
+    ).toBeNull();
   });
 
   it("returns null for a non-ATS URL", () => {
@@ -152,5 +176,119 @@ describe("htmlToPlaintext", () => {
     expect(text).not.toContain("&#");
     expect(text).toContain("line1");
     expect(text).toContain("line2");
+  });
+});
+
+describe("classifyUnsupportedHost", () => {
+  it.each([
+    ["https://www.linkedin.com/jobs/view/1234567890", "linkedin"],
+    ["https://linkedin.com/jobs/view/1234", "linkedin"],
+    ["https://www.indeed.com/viewjob?jk=abc", "indeed"],
+    ["https://www.glassdoor.com/Job/whatever-JV_IC.htm", "glassdoor"],
+    ["https://www.glassdoor.co.uk/Job/whatever.htm", "glassdoor"],
+    ["https://acme.wd5.myworkdayjobs.com/External/job/X", "workday"],
+    ["https://acme.workday.com/jobs/foo", "workday"],
+    ["https://wellfound.com/jobs/12345", "wellfound"],
+  ])("classifies %s as the known unsupported host", (url, expected) => {
+    expect(classifyUnsupportedHost(url)).toBe(expected);
+  });
+
+  it("returns null for a Greenhouse URL (those are supported, not unsupported)", () => {
+    expect(
+      classifyUnsupportedHost("https://boards.greenhouse.io/acmecorp/jobs/123"),
+    ).toBeNull();
+  });
+
+  it("returns null for an unknown host", () => {
+    expect(classifyUnsupportedHost("https://example.com/careers/123")).toBeNull();
+  });
+
+  it("classifies a bare host with no scheme via the fallback substring scan", () => {
+    expect(classifyUnsupportedHost("linkedin.com/jobs/view/1")).toBe("linkedin");
+  });
+
+  it("returns null for an empty string", () => {
+    expect(classifyUnsupportedHost("")).toBeNull();
+  });
+});
+
+describe("fetchJdFromUrl — Ashby", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("hits the public job-board API and returns the matched posting as plaintext", async () => {
+    const targetId = "12345678-90ab-cdef-1234-567890abcdef";
+    const fakeResponse = {
+      jobBoard: { name: "Acme Corp" },
+      jobPostings: [
+        {
+          id: "00000000-0000-0000-0000-000000000000",
+          title: "Other Role",
+          descriptionHtml: "<p>not this one</p>",
+        },
+        {
+          id: targetId,
+          title: "Staff Engineer",
+          descriptionHtml: "<p>Build distributed systems with Kubernetes.</p>",
+        },
+      ],
+    };
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe(
+        "https://api.ashbyhq.com/posting-api/job-board/acmecorp",
+      );
+      return new Response(JSON.stringify(fakeResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchJdFromUrl(
+      `https://jobs.ashbyhq.com/acmecorp/${targetId}`,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("ashby");
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.company).toBe("Acme Corp");
+    expect(result!.text).toContain("Build distributed systems with Kubernetes.");
+    expect(result!.text).not.toMatch(/<[^>]+>/);
+  });
+
+  it("returns null when the posting id isn't in the board listing", async () => {
+    const fakeResponse = {
+      jobBoard: { name: "Acme Corp" },
+      jobPostings: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          title: "Unrelated Role",
+          descriptionHtml: "<p>nope</p>",
+        },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(fakeResponse), { status: 200 }),
+      ),
+    );
+
+    const result = await fetchJdFromUrl(
+      "https://jobs.ashbyhq.com/acmecorp/22222222-2222-2222-2222-222222222222",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the API call fails (non-2xx)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 404 })),
+    );
+
+    const result = await fetchJdFromUrl(
+      "https://jobs.ashbyhq.com/missingco/12345678-90ab-cdef-1234-567890abcdef",
+    );
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -4,7 +4,12 @@
 // ATS public JSON API clients — fetch a job description as plaintext.
 // These APIs are free, unauthenticated, and legally safe.
 
-export type AtsPlatform = "greenhouse" | "lever" | "workable" | "recruitee";
+export type AtsPlatform =
+  | "greenhouse"
+  | "lever"
+  | "workable"
+  | "recruitee"
+  | "ashby";
 
 interface ParsedAtsUrl {
   platform: AtsPlatform;
@@ -19,7 +24,8 @@ export function parseAtsUrl(url: string): ParsedAtsUrl | null {
     parseGreenhouseUrl(url) ||
     parseLeverUrl(url) ||
     parseWorkableUrl(url) ||
-    parseRecruiteeUrl(url)
+    parseRecruiteeUrl(url) ||
+    parseAshbyUrl(url)
   );
 }
 
@@ -48,6 +54,19 @@ function parseRecruiteeUrl(url: string): ParsedAtsUrl | null {
   const match = url.match(/([\w-]+)\.recruitee\.com\/o\/([\w-]+)/);
   return match
     ? { platform: "recruitee", company: match[1], jobId: match[2] }
+    : null;
+}
+
+// Ashby job-board URLs: `jobs.ashbyhq.com/{token}/{uuid}` — `token` is the
+// board slug (the public-API path component), `uuid` identifies the posting.
+// UUID-strict on the tail so a non-UUID path falls through to "unsupported"
+// instead of producing a 404 on the API.
+function parseAshbyUrl(url: string): ParsedAtsUrl | null {
+  const match = url.match(
+    /jobs\.ashbyhq\.com\/([\w-]+)\/([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})/i,
+  );
+  return match
+    ? { platform: "ashby", company: match[1], jobId: match[2] }
     : null;
 }
 
@@ -159,6 +178,31 @@ async function fetchRecruiteeJob(
   };
 }
 
+// Ashby job-board API: a single GET returns the whole board's posting list.
+// Public, no auth, CORS-open. Shape (relevant fields only):
+//   { jobBoard: { name }, jobPostings: [{ id, title, descriptionHtml }] }
+async function fetchAshbyJob(
+  token: string,
+  jobId: string,
+): Promise<FetchedJd> {
+  const resp = await fetchWithTimeout(
+    `https://api.ashbyhq.com/posting-api/job-board/${token}`,
+  );
+  if (!resp.ok) throw new Error(`Ashby API ${resp.status}`);
+  const data = await resp.json();
+
+  const posting = data.jobPostings?.find(
+    (p: { id: string }) => p.id === jobId,
+  );
+  if (!posting) throw new Error("Job not found in Ashby listing");
+
+  return {
+    title: posting.title,
+    company: data.jobBoard?.name || token,
+    descriptionHtml: posting.descriptionHtml,
+  };
+}
+
 // ─── HTML → plaintext ─────────────────────────────────────────────────────────
 
 /**
@@ -250,7 +294,65 @@ const FETCHERS: Record<
   lever: fetchLeverJob,
   workable: fetchWorkableJob,
   recruitee: fetchRecruiteeJob,
+  ashby: fetchAshbyJob,
 };
+
+// ─── Unsupported-host classifier ──────────────────────────────────────────────
+
+/**
+ * Hosts the UI knows are out of reach client-side, with the user-facing
+ * reason. Drives the tailored fallback message in `JdInput` so the user
+ * gets "LinkedIn blocks automated reads" instead of a generic "couldn't
+ * fetch" when their paste target is a well-known closed surface.
+ *
+ * `null` means "we don't recognise this host" — the UI falls back to its
+ * generic unsupported copy.
+ *
+ * Why these five:
+ *   - LinkedIn / Indeed / Glassdoor — Cloudflare + JA3/TLS fingerprinting +
+ *     HTTP 999 + datacenter-IP blocklists; no browser header trick gets past
+ *     these. Acknowledged closed surfaces (per #72 research).
+ *   - Workday — has a JSON endpoint but does NOT send CORS `*`, so the
+ *     browser blocks the response. Different reason from the others; same
+ *     paste-fallback outcome.
+ *   - Wellfound (formerly AngelList) — heavy bot-protection, paste-only.
+ */
+export type UnsupportedHost =
+  | "linkedin"
+  | "indeed"
+  | "glassdoor"
+  | "workday"
+  | "wellfound";
+
+const UNSUPPORTED_HOST_PATTERNS: ReadonlyArray<readonly [UnsupportedHost, RegExp]> = [
+  ["linkedin", /(^|\.)linkedin\.com\b/i],
+  ["indeed", /(^|\.)indeed\.com\b/i],
+  ["glassdoor", /(^|\.)glassdoor\.(com|co\.[a-z]{2})\b/i],
+  ["workday", /\bmyworkdayjobs\.com\b|\bworkday\.com\b/i],
+  ["wellfound", /(^|\.)wellfound\.com\b|(^|\.)angel\.co\b/i],
+];
+
+/**
+ * Match a URL string against the closed-surface host list. Returns the
+ * canonical id when the URL belongs to a known-unsupported host, else null.
+ * Pure — no network, safe to call repeatedly.
+ *
+ * Robust against malformed URLs: tries `new URL(...)` first; falls back to a
+ * raw substring scan so a bare `linkedin.com/jobs/view/123` (no scheme) still
+ * classifies.
+ */
+export function classifyUnsupportedHost(url: string): UnsupportedHost | null {
+  let host = "";
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    host = url;
+  }
+  for (const [id, pattern] of UNSUPPORTED_HOST_PATTERNS) {
+    if (pattern.test(host)) return id;
+  }
+  return null;
+}
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -358,8 +358,19 @@ export function classifyUnsupportedHost(url: string): UnsupportedHost | null {
 
 /**
  * Fetch a job description as plaintext from a supported ATS URL.
- * Returns null if the URL isn't a supported ATS or the API call fails.
- * Analytics capture is a separate intern task (#75) — not emitted here.
+ *
+ * Two distinct failure modes, surfaced separately so the caller can route to
+ * the right user-facing copy and the right telemetry bucket (#75):
+ *   - **`null`** — the URL did not parse to any supported ATS host; the
+ *     callee should consult `classifyUnsupportedHost` to pick the message.
+ *     No network call was made.
+ *   - **throws** — the URL parsed, but the platform's API call failed
+ *     (non-2xx, network error, JSON parse, "job not found"). The thrown
+ *     error preserves the underlying failure on its `cause`. The caller's
+ *     catch is the `network_error` funnel state.
+ *
+ * Analytics are wired in the caller (see `JdInput`), not here, so this
+ * module stays pure (#75).
  */
 export async function fetchJdFromUrl(
   url: string,
@@ -367,22 +378,17 @@ export async function fetchJdFromUrl(
   const parsed = parseAtsUrl(url);
   if (!parsed) return null;
 
-  try {
-    const result = await FETCHERS[parsed.platform](parsed.company, parsed.jobId);
+  const result = await FETCHERS[parsed.platform](parsed.company, parsed.jobId);
 
-    const text =
-      result.descriptionText ??
-      (result.descriptionHtml ? htmlToPlaintext(result.descriptionHtml) : null) ??
-      [result.title, result.company].filter(Boolean).join(" — ");
+  const text =
+    result.descriptionText ??
+    (result.descriptionHtml ? htmlToPlaintext(result.descriptionHtml) : null) ??
+    [result.title, result.company].filter(Boolean).join(" — ");
 
-    return {
-      text,
-      title: result.title,
-      company: result.company,
-      source: parsed.platform,
-    };
-  } catch (err) {
-    console.warn(`[fetch-jd] ${parsed.platform} fetch failed:`, err);
-    return null;
-  }
+  return {
+    text,
+    title: result.title,
+    company: result.company,
+    source: parsed.platform,
+  };
 }


### PR DESCRIPTION
## Summary

Closes the three remaining sub-issues under M3 JD Matching (#72) in one PR.

- **#74 — Ashby adapter** — `parseAshbyUrl` (UUID-strict) + `fetchAshbyJob` against the public `api.ashbyhq.com/posting-api/job-board/{token}` endpoint. Wired into `parseAtsUrl` + the `FETCHERS` dispatch. `AtsPlatform` union extended to include `ashby`.
- **#75 — Host-aware fallback + analytics** —
  - New `classifyUnsupportedHost(url)` returns a tagged id (`linkedin` / `indeed` / `glassdoor` / `workday` / `wellfound`) when the URL belongs to a known closed surface, else `null`. Pure helper; no network.
  - `JdInput`'s `FetchStatus` is now a discriminated union; on an unsupported-host error it renders `UNSUPPORTED_HOST_REASON[host]` so the user sees "LinkedIn blocks automated reads — paste the JD below" instead of the generic "not a supported ATS" copy. Unknown hosts keep the generic copy.
  - URL placeholder now advertises Ashby alongside the existing four ATSes.
  - New `trackJdUrlFetch({ outcome, platform })` event in `analytics.ts` (env-gated, no URL or text ever crosses), firing on every outcome — `ok` / `unsupported_known` / `unsupported_unknown` / `network_error`.
- **#76 — Tests** — URL-parse + non-UUID-rejection for Ashby, three mocked-fetch end-to-end tests (happy / missing-id / non-2xx), a parameterised `classifyUnsupportedHost` table covering `.com`, `.co.uk`, `myworkdayjobs.com`, the bare-host fallback path, and a structural assertion that JdInput's placeholder lists Ashby.

## Files

- `src/lib/jd-match/fetch-jd.ts` — Ashby URL parser + fetcher + dispatch entry; `classifyUnsupportedHost` + `UNSUPPORTED_HOST_PATTERNS`.
- `src/lib/jd-match/fetch-jd.test.ts` — Ashby parse + mocked fetch suite; `classifyUnsupportedHost` table.
- `src/components/features/JdInput.tsx` — discriminated-union `FetchStatus`, host-aware error copy, telemetry calls, Ashby in placeholder.
- `src/components/features/JdInput.test.ts` — Ashby placeholder assertion.
- `src/lib/analytics.ts` — `trackJdUrlFetch` + `JdUrlOutcome` enum.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 553/553 green (+18 new)
- [x] `npm run build` — clean
- [ ] Manual: paste a real Greenhouse/Lever/Workable/Recruitee/Ashby URL → JD populates. Paste a LinkedIn / Indeed / Workday URL → tailored fallback copy. Confirm in `npm run dev`.

## Out of scope (per #72)

- JSON-LD `JobPosting` parser (deferred to a separate issue).
- Tier-C "any URL" relay (would add a server; breaks the bytes-stay-in-browser story).
- Semantic JD↔resume matching (separate M3 thread).

Closes #72
Closes #74
Closes #75
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)