### PR TITLE
refactor: decompose scan/extractSkills + typed SectionedResume (#137, #132)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ export default function App() {
       fieldConfidence: state.result.fieldConfidence,
       triggers: state.result.triggers,
       rawText,
-      skillsSectionText: state.result.skillsSectionText,
+      sections: state.result.sections,
     });
     return { parsed, rawText, score };
   }, [

--- a/src/hooks/useResumeAnalysis.ts
+++ b/src/hooks/useResumeAnalysis.ts
@@ -96,7 +96,7 @@ export function useResumeAnalysis(): ResumeAnalysis {
         fieldConfidence: result.fieldConfidence,
         triggers: result.triggers,
         rawText: result.rawText,
-        skillsSectionText: result.skillsSectionText,
+        sections: result.sections,
       });
 
       trackParseCompleted({

--- a/src/lib/heuristics/cascade.ts
+++ b/src/lib/heuristics/cascade.ts
@@ -30,6 +30,7 @@ import type {
   TierEngagementReason,
 } from "./types.ts";
 import { CASCADE_VERSION } from "./types.ts";
+import { ACCOMPLISHMENT_SECTION_NAMES } from "./sections.ts";
 import { computeConfidence } from "./confidence.ts";
 
 export interface RunCascadeOptions {
@@ -354,7 +355,7 @@ export async function runCascadeFromMarkdown(
         // No Tier 1 ran (no markdown) — empty section view, inert (#132).
         sections: {
           byName: new Map(),
-          accomplishmentSections: [],
+          accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
           source: "regex",
         },
       };
@@ -473,7 +474,11 @@ function buildScannedResult(
     // Scanned-abandon path: no Tier 1 ran, so there are no detected sections.
     // An empty view yields `byName.get("skills") === undefined`, exactly the
     // inert behaviour the absent `skillsSectionText` gave here before (#132).
-    sections: { byName: new Map(), accomplishmentSections: [], source: "regex" },
+    sections: {
+      byName: new Map(),
+      accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
+      source: "regex",
+    },
     linkAnnotations,
     diagnostics: {
       rawCharCount: extract.rawCharCount,

--- a/src/lib/heuristics/cascade.ts
+++ b/src/lib/heuristics/cascade.ts
@@ -20,6 +20,7 @@
 
 import type {
   CascadeResult,
+  HeuristicResult,
   LayoutProbes,
   LayoutTrigger,
   PdfLinkAnnotation,
@@ -177,7 +178,7 @@ export async function runCascade(
   // ── Confidence + escalation routing ───────────────────────────────────────
 
   const { confidence, suggestedEscalation } = computeConfidence({
-    heuristic: { parsed, fieldConfidence },
+    heuristic: { parsed, fieldConfidence, sections: heuristic.sections },
     layout,
     rawCharCount: extract.rawCharCount,
     extractedCharCount,
@@ -195,9 +196,7 @@ export async function runCascade(
     tiers,
     rawText: extract.text,
     markdown,
-    ...(heuristic.skillsSectionLines?.length
-      ? { skillsSectionText: heuristic.skillsSectionLines.join("\n") }
-      : {}),
+    sections: heuristic.sections,
     linkAnnotations: extract.linkAnnotations,
     diagnostics: {
       rawCharCount: extract.rawCharCount,
@@ -347,9 +346,18 @@ export async function runCascadeFromMarkdown(
   emit(tierEngaged(userType, "1", "initial", start));
   const t1Start = Date.now();
   const { parseHeuristicFromMarkdown } = await import("./openresume.ts");
-  const heuristic = haveMarkdown
+  const heuristic: HeuristicResult = haveMarkdown
     ? parseHeuristicFromMarkdown(markdown as string, rawText)
-    : { parsed: emptyParsed(), fieldConfidence: {} };
+    : {
+        parsed: emptyParsed(),
+        fieldConfidence: {},
+        // No Tier 1 ran (no markdown) — empty section view, inert (#132).
+        sections: {
+          byName: new Map(),
+          accomplishmentSections: [],
+          source: "regex",
+        },
+      };
   const t1Duration = Date.now() - t1Start;
 
   let parsed = heuristic.parsed;
@@ -383,7 +391,7 @@ export async function runCascadeFromMarkdown(
   };
 
   const { confidence, suggestedEscalation } = computeConfidence({
-    heuristic: { parsed, fieldConfidence },
+    heuristic: { parsed, fieldConfidence, sections: heuristic.sections },
     layout,
     // We pass rawCharCount=0 so the "low extraction ratio" hard-fail can't
     // fire — DOCX text extraction from mammoth is effectively complete by
@@ -405,9 +413,7 @@ export async function runCascadeFromMarkdown(
     tiers,
     rawText,
     markdown,
-    ...(heuristic.skillsSectionLines?.length
-      ? { skillsSectionText: heuristic.skillsSectionLines.join("\n") }
-      : {}),
+    sections: heuristic.sections,
     // DOCX cascade has no PDF annotations.
     linkAnnotations: [],
     diagnostics: {
@@ -464,6 +470,10 @@ function buildScannedResult(
     suggestedEscalation: "ocr",
     tiers: ["t0_layout"],
     rawText: extract.text,
+    // Scanned-abandon path: no Tier 1 ran, so there are no detected sections.
+    // An empty view yields `byName.get("skills") === undefined`, exactly the
+    // inert behaviour the absent `skillsSectionText` gave here before (#132).
+    sections: { byName: new Map(), accomplishmentSections: [], source: "regex" },
     linkAnnotations,
     diagnostics: {
       rawCharCount: extract.rawCharCount,

--- a/src/lib/heuristics/confidence.test.ts
+++ b/src/lib/heuristics/confidence.test.ts
@@ -37,6 +37,9 @@ function mkHeuristic(
       skills: 0.7,
       ...fcOverrides,
     },
+    // computeConfidence does not read sections; an empty view satisfies the
+    // required field on HeuristicResult without affecting the result (#132).
+    sections: { byName: new Map(), accomplishmentSections: [], source: "regex" },
   };
 }
 

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -105,7 +105,7 @@ describe("corpus snapshots", () => {
             fieldConfidence: cascade.fieldConfidence,
             triggers: cascade.triggers,
             rawText: cascade.rawText,
-            skillsSectionText: cascade.skillsSectionText,
+            sections: cascade.sections,
           });
 
           const snapshot = {

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -36,23 +36,6 @@ interface ContactExtractionResult {
   };
 }
 
-/**
- * Walks the profile section (and optionally the full document as a fallback)
- * gathering contact fields. Regex-driven; very high precision.
- *
- * `location` is intentionally NOT subject to the document-wide fallback —
- * a non-header city/state is almost always an employer or school location,
- * not the candidate's. Names, emails, phones, and URLs can survive being
- * outside the profile (footer placement is common); location cannot.
- *
- * When PDF Link annotations are available, they're consulted as
- * a last-chance signal for `linkedin_url`, `github_url`, `portfolio_url`,
- * and `website_url` — these are the URL fields that resumes most often
- * hyperlink behind a visible word ("LinkedIn" / "GitHub" / "Portfolio")
- * rather than rendering as full text. Annotation hits report 0.95
- * confidence, matching the text-hit confidence, because the URL is
- * structurally guaranteed by the PDF.
- */
 /** LinkedIn paths that are NOT a personal profile — feed, company pages, job
  *  posts, articles, etc. Everything else under `linkedin.com/<handle>` (the
  *  `/in/<handle>` canonical form AND bare-vanity hosts) is treated as a
@@ -161,12 +144,28 @@ function scan(lines: PdfLine[], joined: string): ContactExtractionResult {
   };
 }
 
+/**
+ * Walks the profile section (and optionally the full document as a fallback)
+ * gathering contact fields. Regex-driven; very high precision.
+ *
+ * `location` is intentionally NOT subject to the document-wide fallback —
+ * a non-header city/state is almost always an employer or school location,
+ * not the candidate's. Names, emails, phones, and URLs can survive being
+ * outside the profile (footer placement is common); location cannot.
+ *
+ * When PDF Link annotations are available, they're consulted as
+ * a last-chance signal for `linkedin_url`, `github_url`, `portfolio_url`,
+ * and `website_url` — these are the URL fields that resumes most often
+ * hyperlink behind a visible word ("LinkedIn" / "GitHub" / "Portfolio")
+ * rather than rendering as full text. Annotation hits report 0.95
+ * confidence, matching the text-hit confidence, because the URL is
+ * structurally guaranteed by the PDF.
+ */
 export function extractContact(
   profile: PdfSection,
   allLines: PdfLine[],
   annotations: PdfLinkAnnotation[] = [],
 ): ContactExtractionResult {
-
   const profileText = profile.lines.map((l) => l.text).join(" ");
   const primary = scan(profile.lines, profileText);
 

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -75,79 +75,97 @@ function normalizeUrl(raw: string | undefined): string | undefined {
   return `https://${trimmed}`;
 }
 
+/**
+ * Scans `lines` for a candidate location string, checking US patterns first
+ * then international. Returns the first match found, or `undefined`.
+ *
+ * `location` is intentionally not subject to the document-wide fallback —
+ * see the doc-comment on `extractContact` for the reasoning.
+ */
+function extractLocation(lines: PdfLine[]): string | undefined {
+  for (const line of lines) {
+    const us = US_LOCATION_RE.exec(line.text);
+    if (us) return us[0];
+  }
+  for (const line of lines) {
+    const intl = INTL_LOCATION_RE.exec(line.text);
+    if (intl && !/@/.test(intl[0])) return intl[0];
+  }
+  return undefined;
+}
+
+/**
+ * Collects URLs from `joined` that are not LinkedIn or GitHub links and
+ * splits them into `portfolio` and `website` buckets.
+ *
+ * "Other URLs" are those whose lowercased form does not include `linkedin.com`
+ * or `github.com`. Portfolio wins if the URL matches a portfolio-indicator
+ * pattern; the first remaining URL becomes the website candidate.
+ */
+function extractOtherUrls(joined: string): {
+  portfolio: string | undefined;
+  website: string | undefined;
+} {
+  const others = allMatches(URL_RE, joined).filter((u) => {
+    const lower = u.toLowerCase();
+    return !lower.includes("linkedin.com") && !lower.includes("github.com");
+  });
+  const portfolio = others.find((u) =>
+    /(portfolio|\.me\b|\.io\b|\.dev\b|behance|dribbble|medium)/i.test(u),
+  );
+  const websiteCandidates = others.filter((u) => u !== portfolio);
+  return { portfolio, website: websiteCandidates[0] };
+}
+
+function scan(lines: PdfLine[], joined: string): ContactExtractionResult {
+  const email = firstMatch(EMAIL_RE, joined);
+
+  // Extract location BEFORE phone so we can derive the parse region.
+  const location = extractLocation(lines);
+
+  // Derive the phone parse region from the extracted location; fall back to
+  // "US" when the location is absent or the country is not in our mapping.
+  const phoneRegion = regionFromLocation(location) ?? "US";
+  const phoneResult = findFirstPhone(joined, phoneRegion);
+  const phone = phoneResult?.formatted;
+
+  // LinkedIn profile URLs are usually `/in/<handle>` (LINKEDIN_RE), but some
+  // resumes link a bare vanity host (`linkedin.com/<handle>`). Fall back to
+  // any linkedin.com URL that is a profile (not /company, /jobs, … sections)
+  // so a hyperlinked "LinkedIn" anchor resolves regardless of the path shape.
+  const linkedin =
+    firstMatch(LINKEDIN_RE, joined) ??
+    allMatches(URL_RE, joined).find(isLinkedinProfileUrl);
+  const github = firstMatch(GITHUB_RE, joined);
+
+  // Other URLs that aren't linkedin/github → portfolio/website bucket.
+  const { portfolio, website } = extractOtherUrls(joined);
+
+  return {
+    email,
+    phone,
+    linkedin_url: normalizeUrl(linkedin),
+    github_url: normalizeUrl(github),
+    portfolio_url: normalizeUrl(portfolio),
+    website_url: normalizeUrl(website),
+    location,
+    confidence: {
+      email: email ? 0.98 : 0,
+      phone: phone ? 0.85 : 0,
+      linkedin_url: linkedin ? 0.95 : 0,
+      github_url: github ? 0.95 : 0,
+      portfolio_url: portfolio ? 0.6 : 0,
+      website_url: website ? 0.55 : 0,
+      location: location ? 0.75 : 0,
+    },
+  };
+}
+
 export function extractContact(
   profile: PdfSection,
   allLines: PdfLine[],
   annotations: PdfLinkAnnotation[] = [],
 ): ContactExtractionResult {
-  const scan = (lines: PdfLine[], joined: string): ContactExtractionResult => {
-    const email = firstMatch(EMAIL_RE, joined);
-
-    // Extract location BEFORE phone so we can derive the parse region.
-    // `location` is intentionally not subject to the document-wide fallback —
-    // see the doc-comment on `extractContact` for the reasoning.
-    let location: string | undefined;
-    for (const line of lines) {
-      const us = US_LOCATION_RE.exec(line.text);
-      if (us) {
-        location = us[0];
-        break;
-      }
-    }
-    if (!location) {
-      for (const line of lines) {
-        const intl = INTL_LOCATION_RE.exec(line.text);
-        if (intl && !/@/.test(intl[0])) {
-          location = intl[0];
-          break;
-        }
-      }
-    }
-
-    // Derive the phone parse region from the extracted location; fall back to
-    // "US" when the location is absent or the country is not in our mapping.
-    const phoneRegion = regionFromLocation(location) ?? "US";
-    const phoneResult = findFirstPhone(joined, phoneRegion);
-    const phone = phoneResult?.formatted;
-    // LinkedIn profile URLs are usually `/in/<handle>` (LINKEDIN_RE), but some
-    // resumes link a bare vanity host (`linkedin.com/<handle>`). Fall back to
-    // any linkedin.com URL that is a profile (not /company, /jobs, … sections)
-    // so a hyperlinked "LinkedIn" anchor resolves regardless of the path shape.
-    const linkedin =
-      firstMatch(LINKEDIN_RE, joined) ??
-      allMatches(URL_RE, joined).find(isLinkedinProfileUrl);
-    const github = firstMatch(GITHUB_RE, joined);
-
-    // Other URLs that aren't linkedin/github → portfolio/website bucket.
-    const others = allMatches(URL_RE, joined).filter((u) => {
-      const lower = u.toLowerCase();
-      return !lower.includes("linkedin.com") && !lower.includes("github.com");
-    });
-    const portfolio = others.find((u) =>
-      /(portfolio|\.me\b|\.io\b|\.dev\b|behance|dribbble|medium)/i.test(u),
-    );
-    const websiteCandidates = others.filter((u) => u !== portfolio);
-    const website = websiteCandidates[0];
-
-    return {
-      email,
-      phone,
-      linkedin_url: normalizeUrl(linkedin),
-      github_url: normalizeUrl(github),
-      portfolio_url: normalizeUrl(portfolio),
-      website_url: normalizeUrl(website),
-      location,
-      confidence: {
-        email: email ? 0.98 : 0,
-        phone: phone ? 0.85 : 0,
-        linkedin_url: linkedin ? 0.95 : 0,
-        github_url: github ? 0.95 : 0,
-        portfolio_url: portfolio ? 0.6 : 0,
-        website_url: website ? 0.55 : 0,
-        location: location ? 0.75 : 0,
-      },
-    };
-  };
 
   const profileText = profile.lines.map((l) => l.text).join(" ");
   const primary = scan(profile.lines, profileText);

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -95,6 +95,29 @@ function splitColumnCells(line: { text: string; items: PdfTextItem[] }): string[
     .filter((t) => t.length > 0);
 }
 
+/**
+ * Tokenizes a single column cell into valid skill tokens and adds them to
+ * `out`. Drops the cell entirely when it looks like a contact/profile link —
+ * this must happen before `SKILL_SPLIT_RE` (which splits on `/`) would shred
+ * the URL and leave its path segment as a spurious token.
+ */
+function tokenizeCell(cell: string, out: Set<string>): void {
+  const clean = stripBullet(cell).replace(/^[A-Z][A-Za-z ]+:\s*/, "");
+  // A whole cell that is a profile link ("github.com/janesmith") must be
+  // dropped before SKILL_SPLIT_RE — which splits on "/" (for "HTML/CSS") —
+  // shreds the URL and leaves its path segment ("janesmith") as a token.
+  if (looksLikeContactLink(clean)) return;
+  for (const raw of clean.split(SKILL_SPLIT_RE)) {
+    // Strip trailing sentence punctuation that can appear at line-end (e.g.
+    // "Python, JavaScript, Git, SQL, Linux, AWS." → the period is a list
+    // terminator, not part of the skill name).
+    const tok = raw.trim().replace(/[.!?,;]+$/, "");
+    if (isSkillToken(tok)) {
+      out.add(tok);
+    }
+  }
+}
+
 export function extractSkills(
   skills: PdfSection | undefined,
 ): { value: string[]; confidence: number } {
@@ -103,20 +126,7 @@ export function extractSkills(
   const tokens = new Set<string>();
   for (const line of skills.lines) {
     for (const cell of splitColumnCells(line)) {
-      const clean = stripBullet(cell).replace(/^[A-Z][A-Za-z ]+:\s*/, "");
-      // A whole cell that is a profile link ("github.com/janesmith") must be
-      // dropped before SKILL_SPLIT_RE — which splits on "/" (for "HTML/CSS") —
-      // shreds the URL and leaves its path segment ("janesmith") as a token.
-      if (looksLikeContactLink(clean)) continue;
-      for (const raw of clean.split(SKILL_SPLIT_RE)) {
-        // Strip trailing sentence punctuation that can appear at line-end (e.g.
-        // "Python, JavaScript, Git, SQL, Linux, AWS." → the period is a list
-        // terminator, not part of the skill name).
-        const tok = raw.trim().replace(/[.!?,;]+$/, "");
-        if (isSkillToken(tok)) {
-          tokens.add(tok);
-        }
-      }
+      tokenizeCell(cell, tokens);
     }
   }
   const value = [...tokens];

--- a/src/lib/heuristics/openresume.ts
+++ b/src/lib/heuristics/openresume.ts
@@ -28,6 +28,7 @@ import {
   groupIntoLines,
   splitIntoSections,
   splitIntoSectionsWithMarkdown,
+  toSectionedResume,
   type PdfLine,
   type PdfSection,
 } from "./sections.ts";
@@ -291,17 +292,11 @@ function buildHeuristicResult(
     achievements: achievements.confidence,
   };
 
-  const skillsSectionLines = skillsSection?.lines
-    .map((l) => l.text.trim())
-    .filter((t) => t.length > 0);
-
   return {
     parsed,
     fieldConfidence,
     sectionSource,
-    ...(skillsSectionLines && skillsSectionLines.length > 0
-      ? { skillsSectionLines }
-      : {}),
+    sections: toSectionedResume(sections, sectionSource),
   };
 }
 

--- a/src/lib/heuristics/sections.ts
+++ b/src/lib/heuristics/sections.ts
@@ -75,7 +75,7 @@ export interface SectionedResume {
 
 /** Canonical policy: these sections contribute experience-bullet lines. Encoded
  *  once here rather than duplicated across the authed/anonymous scorers. */
-const ACCOMPLISHMENT_SECTION_NAMES: readonly SectionName[] = [
+export const ACCOMPLISHMENT_SECTION_NAMES: readonly SectionName[] = [
   "experience",
   "projects",
   "achievements",

--- a/src/lib/heuristics/sections.ts
+++ b/src/lib/heuristics/sections.ts
@@ -46,6 +46,73 @@ export interface PdfSection {
   lines: PdfLine[];
 }
 
+/**
+ * Typed, scorer-facing view of the detected section structure (spike #127 §2.1,
+ * issue #132). Promotes the `PdfSection[]` the cascade already computes into a
+ * minimal contract: section name → trimmed, non-empty text lines, in document
+ * order. The pure scorer reads this instead
+ * of receiving a hand-serialized `skillsSectionText` slice, so the cascade is
+ * the single source of truth for "which lines belong to which section" and we
+ * never add a per-bug side-channel again.
+ *
+ * Kept dependency-light on purpose: `ReadonlyMap<name, string[]>` rather than
+ * `PdfSection[]`, so `score.ts` need not import `PdfLine`/`PdfTextItem`
+ * geometry types.
+ */
+export interface SectionedResume {
+  /** Section name → trimmed, non-empty text lines, in document order.
+   *  "profile" (anything above the first header) is included so contact/name
+   *  consumers can share the same view. */
+  readonly byName: ReadonlyMap<SectionName | "profile", readonly string[]>;
+  /** Sections whose lines pool into the experience-bullet set, in canonical
+   *  policy order. A convenience accessor over `byName` for the scorer; not yet
+   *  consumed by the pool sourcing (that is the next issue — see #132 Notes). */
+  readonly accomplishmentSections: readonly SectionName[];
+  /** Which splitter produced the section boundaries — provenance for
+   *  confidence tuning / telemetry. */
+  readonly source: "markdown" | "regex";
+}
+
+/** Canonical policy: these sections contribute experience-bullet lines. Encoded
+ *  once here rather than duplicated across the authed/anonymous scorers. */
+const ACCOMPLISHMENT_SECTION_NAMES: readonly SectionName[] = [
+  "experience",
+  "projects",
+  "achievements",
+];
+
+/**
+ * Build the typed {@link SectionedResume} view from the raw `PdfSection[]` the
+ * heuristic parser holds. Each section's lines are trimmed and emptied-out,
+ * exactly as the retired `skillsSectionLines` slice was
+ * (`lines.map(l => l.text.trim()).filter(t => t.length > 0)`) — so the
+ * skills-exclusion set the scorer derives is byte-for-byte what it derived from
+ * `skillsSectionText`, keeping the corpus goldens unchanged (#132).
+ */
+export function toSectionedResume(
+  sections: PdfSection[],
+  source: "markdown" | "regex",
+): SectionedResume {
+  // Accumulate (don't overwrite) when a name repeats — a resume can split one
+  // logical section across continuation headers, and `findSection` flattened
+  // all matches' lines in document order. Mirroring that here keeps
+  // `byName.get("skills")` byte-identical to the retired `skillsSectionLines`.
+  const byName = new Map<SectionName | "profile", string[]>();
+  for (const section of sections) {
+    const lines = section.lines
+      .map((l) => l.text.trim())
+      .filter((t) => t.length > 0);
+    const existing = byName.get(section.name);
+    if (existing) existing.push(...lines);
+    else byName.set(section.name, lines);
+  }
+  return {
+    byName,
+    accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
+    source,
+  };
+}
+
 /** Items within this vertical distance (PDF points) are treated as same line. */
 const LINE_Y_EPS = 3.5;
 

--- a/src/lib/heuristics/types.ts
+++ b/src/lib/heuristics/types.ts
@@ -15,6 +15,7 @@ import type {
   ResumeExperience,
   ResumeEducation,
 } from "../score/types.ts";
+import type { SectionedResume } from "./sections.ts";
 
 // ── PDF primitives ──────────────────────────────────────────────────────────
 
@@ -153,10 +154,11 @@ export interface HeuristicResult {
    *  font-size-promoted heading passed the emitter's promotion gate) from
    *  regex-on-line parses. Optional; missing is treated as "regex". */
   sectionSource?: "markdown" | "regex";
-  /** Raw text lines of the detected skills section, if any. The scorer keeps
-   *  these out of the experience-bullet pool so bulleted skills are not judged
-   *  by the action-verb / metric / length rules (#30). */
-  skillsSectionLines?: string[];
+  /** Typed view of the detected section structure (#132). The cascade carries
+   *  this onto `CascadeResult.sections`; the scorer derives the skills-exclusion
+   *  set from `sections.byName.get("skills")` rather than a hand-serialized
+   *  `skillsSectionText` slice. Single source of truth for section membership. */
+  sections: SectionedResume;
 }
 
 // ── Cascade output ──────────────────────────────────────────────────────────
@@ -184,9 +186,11 @@ export interface CascadeResult {
    *  scanned PDFs or when the emitter could not produce useful structure.
    *  Section splitters prefer this over `rawText` when present. */
   markdown?: string;
-  /** Newline-joined text of the detected skills section, if any. Passed to the
-   *  scorer so bulleted skills stay out of the experience-bullet pool (#30). */
-  skillsSectionText?: string;
+  /** Typed view of the detected section structure (#132). The scorer reads
+   *  `sections.byName.get("skills")` to keep bulleted skills out of the
+   *  experience-bullet pool (#30); replaces the retired `skillsSectionText`
+   *  side-channel. Always present (built from the `PdfSection[]` Tier 1 holds). */
+  sections: SectionedResume;
   /** Link annotations Tier 0 lifted off the PDF. Surfaces URLs hyperlinked
    *  behind visible words; also the only credible recovered signal on
    *  `fonts_unmappable` PDFs where the text path came back empty. Empty

--- a/src/lib/score/score.test.ts
+++ b/src/lib/score/score.test.ts
@@ -9,6 +9,21 @@ import {
 } from "./score";
 import type { AnonymousAtsScoreInput } from "./score";
 import type { ResumeData } from "./types";
+import type { SectionedResume } from "../heuristics/sections";
+
+/** Build the typed section view the anonymous scorer now consumes (#132). With
+ *  no skills lines, `byName` is empty so `byName.get("skills")` is undefined —
+ *  the inert default. Pass trimmed, non-empty lines (as the cascade would) to
+ *  populate the skills section the exclusion set is derived from. */
+function makeSections(skillsLines?: readonly string[]): SectionedResume {
+  const byName = new Map<string, readonly string[]>();
+  if (skillsLines && skillsLines.length > 0) byName.set("skills", skillsLines);
+  return {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
 
 // The scoreSpecificity pipeline wraps bulletHasMetric. Rather than export the
 // helper, we exercise it end-to-end by scoring a single-entry resume whose
@@ -243,6 +258,7 @@ describe("computeAnonymousAtsScore", () => {
       },
       triggers: [],
       rawText: STRONG_BULLETS,
+      sections: makeSections(),
       ...overrides,
     };
   }
@@ -495,14 +511,15 @@ describe("computeAnonymousAtsScore", () => {
     // A bulleted skills section ("• Project management, Data analysis") must not
     // be judged by the action-verb / metric / length rules. The cascade supplies
     // the skills-section text; matching lines are kept out of the bullet pool.
-    const skillsRaw = [
+    const skillsLines = [
       "• Project management, Data analysis",
       "• Communication, Problem-solving",
-    ].join("\n");
+    ];
+    const skillsRaw = skillsLines.join("\n");
 
-    it("drops skills-section lines from the pool when skillsSectionText is supplied", () => {
+    it("drops skills-section lines from the pool when the skills section is supplied", () => {
       const result = computeAnonymousAtsScore(
-        makeAnonInput({ rawText: skillsRaw, skillsSectionText: skillsRaw }),
+        makeAnonInput({ rawText: skillsRaw, sections: makeSections(skillsLines) }),
       );
       expect(result.bullets ?? []).toHaveLength(0);
     });
@@ -516,7 +533,10 @@ describe("computeAnonymousAtsScore", () => {
 
     it("does not exclude genuine experience bullets outside the skills section", () => {
       const result = computeAnonymousAtsScore(
-        makeAnonInput({ rawText: STRONG_BULLETS, skillsSectionText: skillsRaw }),
+        makeAnonInput({
+          rawText: STRONG_BULLETS,
+          sections: makeSections(skillsLines),
+        }),
       );
       expect(result.bullets!.length).toBe(6);
     });
@@ -542,7 +562,7 @@ describe("computeAnonymousAtsScore", () => {
       const result = computeAnonymousAtsScore(
         makeAnonInput({
           rawText: raw,
-          skillsSectionText: "Project management, Data analysis",
+          sections: makeSections(["Project management, Data analysis"]),
         }),
       );
       expect(result.bullets ?? []).toHaveLength(0);

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -15,6 +15,7 @@ import type {
   ResumeExperience,
   ResumeData,
 } from "./types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
 
 // Re-export types for convenience
 export type { AtsScore, AtsScoreDimensions, ScoreTier };
@@ -525,11 +526,13 @@ export interface AnonymousAtsScoreInput {
   triggers: readonly string[];
   /** Concatenated text from Tier 0. Used for bullet-level analysis. */
   rawText: string;
-  /** Newline-joined text of the detected skills section, if any. Lines here are
-   *  kept out of the experience-bullet pool so skills are never judged by the
-   *  action-verb / metric / length rules (#30). Supplied by the cascade, which
-   *  owns section detection — the pure scorer does not re-derive sections. */
-  skillsSectionText?: string;
+  /** Typed view of the detected section structure, supplied by the cascade
+   *  (which owns section detection). The scorer reads
+   *  `sections.byName.get("skills")` to keep skills lines out of the
+   *  experience-bullet pool so they are never judged by the action-verb /
+   *  metric / length rules (#30). Replaces the retired `skillsSectionText`
+   *  side-channel (#132); the pure scorer still does not re-derive sections. */
+  sections: SectionedResume;
 }
 
 const ANON_CONTACT_CONFIDENCE_FLOOR = 0.5;
@@ -576,16 +579,19 @@ function stripBulletMarker(line: string): string {
  * Build the set of skills-section lines (marker-stripped) to keep out of the
  * experience-bullet pool. A skill like "Project management" is not an
  * accomplishment bullet and must not be judged by the action-verb / metric /
- * length rules or surfaced in per-bullet feedback (#30). The text is supplied
- * by the cascade, which owns section detection; the pure scorer never has to
- * re-derive sections from `rawText`.
+ * length rules or surfaced in per-bullet feedback (#30). The lines are supplied
+ * by the cascade's typed section view (`sections.byName.get("skills")`), which
+ * owns section detection; the pure scorer never has to re-derive sections from
+ * `rawText`. (#132 — replaces the retired `skillsSectionText` slice; the set is
+ * byte-identical because the lines are the same trimmed, non-empty section
+ * lines, just no longer round-tripped through join/split.)
  */
 function buildSkillsExclusion(
-  skillsSectionText: string | undefined,
+  skillsSectionLines: readonly string[] | undefined,
 ): ReadonlySet<string> | undefined {
-  if (!skillsSectionText) return undefined;
+  if (!skillsSectionLines || skillsSectionLines.length === 0) return undefined;
   const set = new Set<string>();
-  for (const line of skillsSectionText.split(/\r?\n/)) {
+  for (const line of skillsSectionLines) {
     const key = stripBulletMarker(line);
     if (key) set.add(key);
   }
@@ -648,7 +654,7 @@ export function computeAnonymousAtsScore(
   // ── Bullet-level dimensions (Specificity 40, Structure 30) ─────────────
   // Same scoreBulletPool the authed scorer uses — guarantees the two
   // surfaces apply identical per-bullet rules.
-  const skillsExclude = buildSkillsExclusion(input.skillsSectionText);
+  const skillsExclude = buildSkillsExclusion(input.sections.byName.get("skills"));
   const bullets = extractBulletsFromText(input.rawText, skillsExclude);
   const pool = scoreBulletPool(bullets);
   const observations = analyzeBullets(bullets);


### PR DESCRIPTION
## Summary

Two behavior-preserving refactors bundled onto one branch (epic run, disjoint blast radii):

- **#137** — decompose `scan` (`extract/contact.ts`) and `extractSkills` (`extract/skills.ts`) into smaller cohesive helpers to clear fallow's cognitive-complexity gate (>15). Logic preserved verbatim; snapshots byte-identical.
- **#132** — promote the section structure the cascade already computes into a typed `SectionedResume` on `CascadeResult`, and retire the `skillsSectionText` side-channel end to end. The scorer now derives the skills-exclusion set from `sections.byName.get("skills")`. Inert by design — corpus goldens unchanged.

Closes #137
Closes #132

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (616/616, 41 files)
- [x] `npm run lint` clean
- [x] Zero `*.expected.json` churn (goldens NOT regenerated — clean diff is the pass condition)
- [ ] Manually verified in `npm run dev` / `npm run preview`