### PR TITLE
refactor(#133): pool anon scorer bullets from accomplishment sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,20 +36,24 @@ export default function App() {
   const edited = useMemo(() => {
     if (state.phase !== "done") return null;
     const observations = state.score.bullets ?? [];
-    const { parsed, rawText } = applyOverrides(
+    const { parsed, rawText, sections } = applyOverrides(
       state.result.parsed,
       state.result.rawText,
+      state.result.sections,
       edit.contactOverrides,
       edit.experienceOverrides,
       edit.bulletOverrides,
       observations,
     );
+    // The anonymous scorer pools its bullet set from `sections` (#133), so the
+    // edited section view — not the original — must feed re-grading or a live
+    // bullet edit would not move Specificity / Structure.
     const score = computeAnonymousAtsScore({
       parsed,
       fieldConfidence: state.result.fieldConfidence,
       triggers: state.result.triggers,
       rawText,
-      sections: state.result.sections,
+      sections,
     });
     return { parsed, rawText, score };
   }, [

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -6,6 +6,7 @@ import { applyOverrides } from "./apply-overrides.ts";
 import { groupBulletsByExperience } from "../score/group-bullets.ts";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { BulletObservation } from "../score/score.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
 
 /** Minimal BulletObservation factory — only `text` and `index` matter here. */
 function obs(index: number, text: string): BulletObservation {
@@ -16,6 +17,18 @@ function obs(index: number, text: string): BulletObservation {
     startsWithActionVerb: false,
     wellFormedLength: false,
     wordCount: text.split(/\s+/).filter(Boolean).length,
+  };
+}
+
+/** Minimal SectionedResume — bullet edits target the experience section, so
+ *  put any bullet lines (with their leading markers) there. */
+function makeSections(experience: readonly string[] = []): SectionedResume {
+  const byName = new Map<string, readonly string[]>();
+  if (experience.length > 0) byName.set("experience", experience);
+  return {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
   };
 }
 
@@ -43,6 +56,7 @@ describe("applyOverrides", () => {
     const { parsed: out } = applyOverrides(
       parsed,
       "raw",
+      makeSections(),
       { full_name: "John Smith", email: "john@example.com" },
       {},
       {},
@@ -59,6 +73,7 @@ describe("applyOverrides", () => {
     const { parsed: out } = applyOverrides(
       baseParsed(),
       "raw",
+      makeSections(),
       { full_name: "" },
       {},
       {},
@@ -72,6 +87,7 @@ describe("applyOverrides", () => {
     const { parsed: out } = applyOverrides(
       parsed,
       "raw",
+      makeSections(),
       {},
       { 0: { title: "Senior Engineer", company: "Globex" } },
       {},
@@ -84,12 +100,18 @@ describe("applyOverrides", () => {
     expect(parsed.experience[0].title).toBe("Engineer");
   });
 
-  it("propagates a bullet edit to BOTH rawText and the matching description", () => {
+  it("propagates a bullet edit to rawText, sections, and the matching description", () => {
     const parsed = baseParsed();
     const rawText = "• Built a thing\n• Shipped another thing";
-    const { parsed: out, rawText: outRaw } = applyOverrides(
+    const sections = makeSections(["• Built a thing", "• Shipped another thing"]);
+    const {
+      parsed: out,
+      rawText: outRaw,
+      sections: outSections,
+    } = applyOverrides(
       parsed,
       rawText,
+      sections,
       {},
       {},
       { 0: "Built a thing that increased revenue by 30%" },
@@ -98,6 +120,17 @@ describe("applyOverrides", () => {
     // rawText: marker preserved, body swapped → still extracts as a bullet.
     expect(outRaw).toContain("• Built a thing that increased revenue by 30%");
     expect(outRaw).not.toContain("• Built a thing\n");
+    // sections (#133): the anonymous scorer pools from here, so the edited line
+    // must land in the experience section — marker preserved.
+    expect(outSections.byName.get("experience")).toEqual([
+      "• Built a thing that increased revenue by 30%",
+      "• Shipped another thing",
+    ]);
+    // Original section view untouched (immutability).
+    expect(sections.byName.get("experience")).toEqual([
+      "• Built a thing",
+      "• Shipped another thing",
+    ]);
     // description: line swapped so JD coverage corpus re-grades.
     expect(out.experience[0].description).toBe(
       "Built a thing that increased revenue by 30%\nShipped another thing",
@@ -124,6 +157,7 @@ describe("applyOverrides", () => {
         ],
       },
       rawText,
+      makeSections(["- Led the migration effort"]),
       {},
       {},
       { 5: "Led the migration of 12 services to k8s" },
@@ -141,6 +175,7 @@ describe("applyOverrides", () => {
     const { parsed: out, rawText: outRaw } = applyOverrides(
       parsed,
       rawText,
+      makeSections(),
       {},
       {},
       {},
@@ -155,6 +190,7 @@ describe("applyOverrides", () => {
     const { rawText: outRaw } = applyOverrides(
       baseParsed(),
       rawText,
+      makeSections(["• Built a thing"]),
       {},
       {},
       { 0: "Built a thing" },
@@ -169,6 +205,7 @@ describe("applyOverrides", () => {
     const { rawText: outRaw, parsed: out } = applyOverrides(
       parsed,
       rawText,
+      makeSections(["• Built a thing"]),
       {},
       {},
       { 0: "   " },
@@ -186,6 +223,7 @@ describe("applyOverrides", () => {
     applyOverrides(
       parsed,
       "• Built a thing",
+      makeSections(["• Built a thing"]),
       { full_name: "X" },
       { 0: { title: "Y" } },
       { 0: "Built a different thing" },
@@ -244,6 +282,11 @@ describe("regression: post-edit bullet re-grouping (issue #63 testing artefact)"
     const result = applyOverrides(
       parsed,
       rawText,
+      makeSections([
+        "• Built event-driven data pipeline.",
+        "• Reduced deploy time by 50%.",
+        "• Migrated legacy monolith.",
+      ]),
       {},
       {},
       { 1: editedText },
@@ -301,6 +344,7 @@ describe("regression: post-edit bullet re-grouping (issue #63 testing artefact)"
     applyOverrides(
       parsed,
       "• Reduced deploy time by 50%.",
+      makeSections(["• Reduced deploy time by 50%."]),
       {},
       {},
       { 0: editedText },

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -7,18 +7,22 @@
  * The reconstructed-resume UI lets the user correct mis-parsed contact fields,
  * experience headers, and bullet text (#82). Those edits must feed the scorer
  * and the JD-coverage check, not just the display. This module folds the
- * override maps back into a fresh `{ parsed, rawText }` pair that the score and
- * coverage functions re-grade from.
+ * override maps back into a fresh `{ parsed, rawText, sections }` triple that
+ * the score and coverage functions re-grade from.
  *
  * The load-bearing fact (verified against score.ts + coverage.ts):
- *   - Specificity + Structure (and `score.bullets`) are graded from
- *     `input.rawText` via `extractBulletsFromText`.
+ *   - Specificity + Structure (and `score.bullets`) are pooled from the
+ *     accomplishment sections of `input.sections` via
+ *     `extractBulletsFromSections` (#133). The section rewrite below is what
+ *     re-grades a live bullet edit; the parallel `rawText` rewrite is retained
+ *     for any remaining rawText consumer (e.g. the redacted-date scan), it is
+ *     no longer the bullet-pool source.
  *   - JD coverage + per-role flagged lists are built from
  *     `parsed.experience[].description` (+ skills/summary/education).
- * So a bullet edit has to land in BOTH rawText and the matching role's
- * `description`, or the display would move while the score stayed frozen — the
- * exact bug #82 fixes. Contact + header edits only touch `parsed` (Completeness
- * + coverage read parsed directly).
+ * So a bullet edit has to land in the matching accomplishment section AND the
+ * matching role's `description`, or the display would move while the score
+ * stayed frozen — the exact bug #82 fixes. Contact + header edits only touch
+ * `parsed` (Completeness + coverage read parsed directly).
  *
  * Pure and total: it clones the input, never mutates it, and an empty/missing
  * override is a no-op.
@@ -26,6 +30,8 @@
 
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { BulletObservation } from "../score/score.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import type { SectionName } from "../heuristics/regex.ts";
 import { normalizeBulletText } from "../score/group-bullets.ts";
 import type {
   ContactOverrides,
@@ -38,6 +44,11 @@ export type BulletOverrides = Record<number, string>;
 export interface ApplyOverridesResult {
   parsed: HeuristicParsedResume;
   rawText: string;
+  /** The section view with any live bullet edits folded into the matching
+   *  accomplishment-section line. This is what the anonymous scorer pools its
+   *  bullet set from (#133), so a live edit must be reflected here to re-grade
+   *  Specificity / Structure. */
+  sections: SectionedResume;
 }
 
 // ── Contact ────────────────────────────────────────────────────────────────
@@ -79,6 +90,45 @@ function replaceBulletInRawText(
 }
 
 /**
+ * Replace the first accomplishment-section line whose normalised form equals
+ * `originalText` with `editedText`, preserving the leading marker, and return a
+ * NEW {@link SectionedResume} with a cloned `byName` map (only the mutated
+ * section's array is cloned; the input map and arrays are never mutated).
+ * Returns the input unchanged when no line matches.
+ *
+ * This mirrors `replaceBulletInRawText`'s first-match, preserve-marker logic,
+ * but walks the accomplishment sections in policy order so the live edit lands
+ * in the exact pool the anonymous scorer grades from (#133).
+ */
+function replaceBulletInSections(
+  sections: SectionedResume,
+  originalText: string,
+  editedText: string,
+): SectionedResume {
+  const target = normalizeBulletText(originalText);
+  if (!target) return sections;
+
+  for (const name of sections.accomplishmentSections) {
+    const lines = sections.byName.get(name);
+    if (!lines) continue;
+    for (let i = 0; i < lines.length; i++) {
+      if (normalizeBulletText(lines[i]) !== target) continue;
+      // First match wins — clone the map + this one section's array, swap the
+      // line body while preserving its leading marker, and return a new view.
+      const marker = lines[i].match(LEADING_MARKER_RE)?.[0] ?? "";
+      const nextLines = lines.slice();
+      nextLines[i] = marker + editedText;
+      const nextByName = new Map<SectionName | "profile", readonly string[]>(
+        sections.byName,
+      );
+      nextByName.set(name, nextLines);
+      return { ...sections, byName: nextByName };
+    }
+  }
+  return sections;
+}
+
+/**
  * Replace the first description line (in any role) whose normalised form equals
  * `originalText` with `editedText`. Mutates the cloned experience entries in
  * place via the returned descriptions. Mirrors `groupBulletsByExperience`'s
@@ -117,10 +167,14 @@ const LEADING_MARKER_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·�]|\d+[.)]) 
 // ── Entry point ──────────────────────────────────────────────────────────────
 
 /**
- * Fold the override maps into a fresh `{ parsed, rawText }` pair.
+ * Fold the override maps into a fresh `{ parsed, rawText, sections }` triple.
  *
  * @param parsed    the cascade's parsed resume (NOT mutated — deep-ish cloned).
  * @param rawText   the cascade's raw extracted text (NOT mutated).
+ * @param sections  the cascade's typed section view (NOT mutated — cloned only
+ *                  where a bullet edit lands). The anonymous scorer pools its
+ *                  bullet set from this (#133), so a live edit must be folded
+ *                  here to re-grade Specificity / Structure.
  * @param contact   contact-field overrides (full_name/email/phone/linkedin/location).
  * @param experience experience-header overrides keyed by experience array index.
  * @param bullets   bullet-text overrides keyed by BulletObservation.index.
@@ -131,6 +185,7 @@ const LEADING_MARKER_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·�]|\d+[.)]) 
 export function applyOverrides(
   parsed: HeuristicParsedResume,
   rawText: string,
+  sections: SectionedResume,
   contact: ContactOverrides,
   experience: Record<number, ExperienceFieldOverrides>,
   bullets: BulletOverrides,
@@ -143,6 +198,7 @@ export function applyOverrides(
     experience: parsed.experience.map((e) => ({ ...e })),
   };
   let nextRawText = rawText;
+  let nextSections = sections;
 
   // ── Contact fields ──────────────────────────────────────────────────────
   for (const key of CONTACT_KEYS) {
@@ -183,8 +239,9 @@ export function applyOverrides(
     // change the bullet count); clearing the field reverts to the parsed text.
     if (edited === "") continue;
     nextRawText = replaceBulletInRawText(nextRawText, obs.text, edited);
+    nextSections = replaceBulletInSections(nextSections, obs.text, edited);
     replaceBulletInDescriptions(nextParsed.experience, obs.text, edited);
   }
 
-  return { parsed: nextParsed, rawText: nextRawText };
+  return { parsed: nextParsed, rawText: nextRawText, sections: nextSections };
 }

--- a/src/lib/heuristics/pdf-extract.ts
+++ b/src/lib/heuristics/pdf-extract.ts
@@ -29,7 +29,8 @@ import type {
  * line breaks vanish on LaTeX/Word/macOS-Preview exports. Walking the same
  * items through `groupIntoLines` (the helper Tier 1 already uses) preserves
  * one `\n` per visual line and keeps bullet glyphs at line start so the
- * downstream bullet detector (score.ts:extractBulletsFromText) can see them.
+ * downstream bullet detector (score.ts:extractBulletsFromSections, via the
+ * per-section line arrays) can see them.
  */
 export function assembleTextFromLines(
   items: PdfTextItem[],

--- a/src/lib/score/score.test.ts
+++ b/src/lib/score/score.test.ts
@@ -11,13 +11,25 @@ import type { AnonymousAtsScoreInput } from "./score";
 import type { ResumeData } from "./types";
 import type { SectionedResume } from "../heuristics/sections";
 
-/** Build the typed section view the anonymous scorer now consumes (#132). With
- *  no skills lines, `byName` is empty so `byName.get("skills")` is undefined —
- *  the inert default. Pass trimmed, non-empty lines (as the cascade would) to
- *  populate the skills section the exclusion set is derived from. */
-function makeSections(skillsLines?: readonly string[]): SectionedResume {
+/** Build the typed section view the anonymous scorer now consumes (#133). The
+ *  scorer pools bullets from the accomplishment sections (experience /
+ *  projects / achievements) and never from skills, so populate `byName` per the
+ *  options. Lines are passed exactly as the cascade would supply them: trimmed,
+ *  non-empty, leading bullet markers intact. */
+function makeSections(opts: {
+  experience?: readonly string[];
+  skills?: readonly string[];
+  projects?: readonly string[];
+  achievements?: readonly string[];
+} = {}): SectionedResume {
   const byName = new Map<string, readonly string[]>();
-  if (skillsLines && skillsLines.length > 0) byName.set("skills", skillsLines);
+  if (opts.experience && opts.experience.length > 0)
+    byName.set("experience", opts.experience);
+  if (opts.projects && opts.projects.length > 0)
+    byName.set("projects", opts.projects);
+  if (opts.achievements && opts.achievements.length > 0)
+    byName.set("achievements", opts.achievements);
+  if (opts.skills && opts.skills.length > 0) byName.set("skills", opts.skills);
   return {
     byName: byName as SectionedResume["byName"],
     accomplishmentSections: ["experience", "projects", "achievements"],
@@ -234,7 +246,7 @@ describe("computeAnonymousAtsScore", () => {
   function makeAnonInput(
     overrides: Partial<AnonymousAtsScoreInput> = {},
   ): AnonymousAtsScoreInput {
-    return {
+    const base: AnonymousAtsScoreInput = {
       parsed: {
         full_name: "Jane Doe",
         email: "jane@example.com",
@@ -258,9 +270,23 @@ describe("computeAnonymousAtsScore", () => {
       },
       triggers: [],
       rawText: STRONG_BULLETS,
+      // Placeholder; replaced below from the (post-override) rawText unless the
+      // caller explicitly passes its own sections.
       sections: makeSections(),
       ...overrides,
     };
+    // The bullet pool now comes from the experience section (#133), not rawText.
+    // To keep the legacy `makeAnonInput({ rawText: ... })` tests working, route
+    // the rawText bullet lines into the experience section by default — but only
+    // when the caller didn't supply its own `sections`.
+    if (overrides.sections === undefined) {
+      const expLines = base.rawText
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+      base.sections = makeSections({ experience: expLines });
+    }
+    return base;
   }
 
   it("scores near-100 for a clean resume with strong bullets", () => {
@@ -376,8 +402,10 @@ describe("computeAnonymousAtsScore", () => {
   });
 
   it("flags missing sections in completeness", () => {
-    // rawText must be empty so bullets.length === 0; Part C passes the
-    // experience check when bullets are present even if expEntries is empty.
+    // With empty parsed.experience AND no experience section, the experience
+    // completeness check fails (#133 — it now asks "is there a non-empty
+    // experience section?", not "did we see any bullet anywhere?"). rawText is
+    // empty so the default makeAnonInput builds an empty experience section.
     const result = computeAnonymousAtsScore(
       makeAnonInput({
         rawText: "",
@@ -507,35 +535,44 @@ describe("computeAnonymousAtsScore", () => {
     });
   });
 
-  describe("skills bullets excluded from the experience pool (#30)", () => {
+  describe("skills are never in the experience pool — by construction (#133)", () => {
     // A bulleted skills section ("• Project management, Data analysis") must not
-    // be judged by the action-verb / metric / length rules. The cascade supplies
-    // the skills-section text; matching lines are kept out of the bullet pool.
+    // be judged by the action-verb / metric / length rules. Under #133 the pool
+    // is sourced from the accomplishment sections only, so skills lines can
+    // never enter it — there is no subtraction step. Section membership, not a
+    // subtraction set, is what determines pooling.
     const skillsLines = [
       "• Project management, Data analysis",
       "• Communication, Problem-solving",
     ];
-    const skillsRaw = skillsLines.join("\n");
 
-    it("drops skills-section lines from the pool when the skills section is supplied", () => {
+    it("drops skills-section lines from the pool", () => {
+      // Skills lines live only in the skills section (no experience section) →
+      // nothing pools.
       const result = computeAnonymousAtsScore(
-        makeAnonInput({ rawText: skillsRaw, sections: makeSections(skillsLines) }),
+        makeAnonInput({ sections: makeSections({ skills: skillsLines }) }),
       );
       expect(result.bullets ?? []).toHaveLength(0);
     });
 
-    it("would otherwise count them — proving the exclusion is what drops them", () => {
+    it("counts the SAME lines when placed in the experience section — proving section membership is what pools them", () => {
+      // The exact lines that were dropped from the skills section DO count when
+      // they sit in the experience section. This pins that pooling is by section
+      // identity, not by a subtraction set.
       const result = computeAnonymousAtsScore(
-        makeAnonInput({ rawText: skillsRaw }),
+        makeAnonInput({ sections: makeSections({ experience: skillsLines }) }),
       );
       expect((result.bullets ?? []).length).toBe(2);
     });
 
     it("does not exclude genuine experience bullets outside the skills section", () => {
+      const expLines = STRONG_BULLETS.split("\n");
       const result = computeAnonymousAtsScore(
         makeAnonInput({
-          rawText: STRONG_BULLETS,
-          sections: makeSections(skillsLines),
+          sections: makeSections({
+            experience: expLines,
+            skills: skillsLines,
+          }),
         }),
       );
       expect(result.bullets!.length).toBe(6);
@@ -544,25 +581,31 @@ describe("computeAnonymousAtsScore", () => {
 
   describe("lone-bullet glyph merge (Word-table layout, #30)", () => {
     // pdfjs/pdftotext can split a table-cell bullet so the "•" lands on its own
-    // line and the text on the next. The extractor merges them before scoring.
-    it("merges a marker-only line with the following non-empty text line", () => {
-      const raw = [
-        "•",
-        "",
-        "Led migration of 3 microservices reducing latency by 40%",
-      ].join("\n");
-      const result = computeAnonymousAtsScore(makeAnonInput({ rawText: raw }));
+    // line and the text on the next. toSectionedResume filters blank lines, so
+    // within a section the glyph line is immediately followed by its text line;
+    // the extractor merges them before scoring.
+    it("merges a marker-only line with the following text line in the same section", () => {
+      const result = computeAnonymousAtsScore(
+        makeAnonInput({
+          sections: makeSections({
+            experience: [
+              "•",
+              "Led migration of 3 microservices reducing latency by 40%",
+            ],
+          }),
+        }),
+      );
       expect(result.bullets!.map((b) => b.text)).toEqual([
         "Led migration of 3 microservices reducing latency by 40%",
       ]);
     });
 
-    it("still excludes a lone-bullet skills entry after the merge", () => {
-      const raw = ["•", "Project management, Data analysis"].join("\n");
+    it("a lone-bullet skills entry never enters the pool (skills is not an accomplishment section)", () => {
       const result = computeAnonymousAtsScore(
         makeAnonInput({
-          rawText: raw,
-          sections: makeSections(["Project management, Data analysis"]),
+          sections: makeSections({
+            skills: ["•", "Project management, Data analysis"],
+          }),
         }),
       );
       expect(result.bullets ?? []).toHaveLength(0);

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -48,11 +48,20 @@ export const WEIGHTS = {
  *   links are recovered document-wide; multi-degree education sections extract
  *   every entry; and wrapped-bullet tails no longer leak into the next
  *   experience entry's header.
+ * - 1.3 (2026-06-20): the anonymous scorer now pools experience bullets from
+ *   the accomplishment sections (experience / projects / achievements) via
+ *   SectionedResume instead of walking all of rawText and subtracting skills
+ *   (#133). Bullets outside those sections (e.g. in summary / education / an
+ *   un-segmented "other" region) no longer enter the Specificity / Structure
+ *   pool; skills are excluded by construction (skills is not an accomplishment
+ *   section), so the retired "pool everything, subtract skills" side-channel is
+ *   gone. The experience-completeness check now asks "is there a non-empty
+ *   experience section?" rather than "did we see any bullet anywhere?".
  */
 // Internal-only: surfaced to the UI via the `algoVersion` score field, not
 // imported by name anywhere — so it stays unexported to satisfy the dead-code
 // gate (fallow flags exported symbols with no external consumer).
-const ATS_SCORE_ALGO_VERSION = "1.2";
+const ATS_SCORE_ALGO_VERSION = "1.3";
 
 // ── Shared scoring rules ────────────────────────────────────────────────────
 //
@@ -60,7 +69,7 @@ const ATS_SCORE_ALGO_VERSION = "1.2";
 // apply. Hoisted out of the per-scorer functions so the two surfaces can never
 // silently disagree (e.g. authed counting `-` as a bullet but anonymous also
 // counting `–`). When tuning these, every consumer that calls scoreBulletPool,
-// splitBullets, or extractBulletsFromText sees the change.
+// splitBullets, or extractBulletsFromSections sees the change.
 
 /** Bullet markers we recognize at the start of a line. Wider than typical to
  *  catch en-dash / mid-dot resumes alongside the common dash/asterisk/bullet.
@@ -171,9 +180,10 @@ function splitBullets(description: string): string[] {
  * Specificity." Same three checks scoreBulletPool aggregates, kept per-bullet.
  */
 export interface BulletObservation {
-  /** Original text of the bullet, as extracted from rawText. */
+  /** Original text of the bullet, as extracted from the accomplishment sections. */
   text: string;
-  /** Index in the order bullets were extracted from rawText. Stable for UI lists. */
+  /** Index in the order bullets were extracted from the accomplishment sections.
+   *  Stable for UI lists. */
   index: number;
   hasMetric: boolean;
   startsWithActionVerb: boolean;
@@ -438,9 +448,12 @@ export function getScoreLabel(tier: ScoreTier): string {
 // / Structure 30 / Completeness 30) so the anonymous /ats-resume-check page produces
 // a number close to what a signed-in user would see. The only inputs we don't
 // have without the LLM are per-role bullet attribution and skill extraction —
-// the authed scorer walks `experience[i].description` per role; we walk the
-// raw text once and treat all detected bullets as a single pool. This loses
-// the per-role flagging but keeps the aggregate score honest.
+// the authed scorer walks `experience[i].description` per role; we pool bullets
+// from the accomplishment sections (experience / projects / achievements) of
+// the typed `SectionedResume` and treat them as a single pool (#133). This
+// loses the per-role flagging but keeps the aggregate score honest, and — by
+// pooling from the sections rather than walking all of rawText and subtracting
+// skills — keeps skills out of the pool by construction.
 //
 // Layout becomes a multiplier (penalty), not a free additive dimension:
 // scanned PDFs zero the score, one non-scanned trigger applies a 15% cap,
@@ -524,20 +537,24 @@ export interface AnonymousAtsScoreInput {
    *  a layout failure regardless of other triggers because the parser can't
    *  read image-only / un-decodable text. */
   triggers: readonly string[];
-  /** Concatenated text from Tier 0. Used for bullet-level analysis. */
+  /** Concatenated text from Tier 0. No longer the bullet pool source (#133 —
+   *  bullets now come from `sections`); retained only for the redacted-date
+   *  scan (`REDACTED_DATE_RE`), which checks the whole document for year-stub
+   *  tokens like "August 20XX" regardless of section. */
   rawText: string;
   /** Typed view of the detected section structure, supplied by the cascade
-   *  (which owns section detection). The scorer reads
-   *  `sections.byName.get("skills")` to keep skills lines out of the
-   *  experience-bullet pool so they are never judged by the action-verb /
-   *  metric / length rules (#30). Replaces the retired `skillsSectionText`
-   *  side-channel (#132); the pure scorer still does not re-derive sections. */
+   *  (which owns section detection). The scorer pools experience bullets from
+   *  `sections.accomplishmentSections` (experience / projects / achievements)
+   *  via `extractBulletsFromSections` (#133). Skills are excluded by
+   *  construction — skills is not an accomplishment section, so its lines are
+   *  never in the pool and never judged by the action-verb / metric / length
+   *  rules. The pure scorer does not re-derive sections from `rawText`. */
   sections: SectionedResume;
 }
 
 const ANON_CONTACT_CONFIDENCE_FLOOR = 0.5;
 const ANON_MIN_BULLETS_TO_GRADE = 3;
-/** Word-count floor for raw-text bullet extraction. Set to 1 so the displayed
+/** Word-count floor for section bullet extraction. Set to 1 so the displayed
  *  bullet count matches what the user can see in the PDF — every line that
  *  begins with a recognised marker AND has at least one non-empty word is a
  *  bullet. Quality grading (well-formed length window, action verb, metric)
@@ -566,70 +583,34 @@ const ANON_CONTACT_FIELDS: readonly {
  *  than a bullet whose text wandered onto the next line. */
 const LONE_BULLET_RE = /^\s*[•●▪◦‣▶►·�]\s*$/;
 
-/** Marker-strip a single line (bullet glyph or numbered prefix) and trim. The
- *  key both `extractBulletsFromText` and the skills-exclusion set match on. */
-function stripBulletMarker(line: string): string {
-  return line
-    .replace(BULLET_MARKER_RE, "")
-    .replace(NUMBERED_BULLET_RE, "")
-    .trim();
-}
-
 /**
- * Build the set of skills-section lines (marker-stripped) to keep out of the
- * experience-bullet pool. A skill like "Project management" is not an
- * accomplishment bullet and must not be judged by the action-verb / metric /
- * length rules or surfaced in per-bullet feedback (#30). The lines are supplied
- * by the cascade's typed section view (`sections.byName.get("skills")`), which
- * owns section detection; the pure scorer never has to re-derive sections from
- * `rawText`. (#132 — replaces the retired `skillsSectionText` slice; the set is
- * byte-identical because the lines are the same trimmed, non-empty section
- * lines, just no longer round-tripped through join/split.)
- */
-function buildSkillsExclusion(
-  skillsSectionLines: readonly string[] | undefined,
-): ReadonlySet<string> | undefined {
-  if (!skillsSectionLines || skillsSectionLines.length === 0) return undefined;
-  const set = new Set<string>();
-  for (const line of skillsSectionLines) {
-    const key = stripBulletMarker(line);
-    if (key) set.add(key);
-  }
-  return set.size > 0 ? set : undefined;
-}
-
-/**
- * Pull bullet-like lines out of raw resume text. A line counts as a bullet
- * when it starts with a recognized bullet marker (`-`, `•`, etc.) or a
- * numbered list prefix and the stripped line contains at least one word.
- * The displayed count is meant to match what a reader sees in the PDF —
- * short or low-quality bullets are still bullets, they just get flagged
- * by the downstream length / verb / metric checks in `scoreBulletPool`
- * and `analyzeBullets`.
+ * Pull bullet-like lines out of one section's line array. A line counts as a
+ * bullet when it starts with a recognized bullet marker (`-`, `•`, etc.) or a
+ * numbered list prefix and the stripped line contains at least one word. The
+ * displayed count is meant to match what a reader sees in the PDF — short or
+ * low-quality bullets are still bullets, they just get flagged by the
+ * downstream length / verb / metric checks in `scoreBulletPool` and
+ * `analyzeBullets`.
  *
- * We deliberately do NOT try to grade unmarked indented lines — most modern
- * resumes use markers, and grading paragraphs would either over-count
- * narrative summary lines or require the experience-section detection we
- * don't have without an LLM.
+ * `lines` is one section's already trimmed, non-empty text lines (as produced
+ * by `toSectionedResume` in sections.ts), so we don't skip blanks — but the
+ * lone-bullet merge still looks at the NEXT element in the same array.
  *
- * `excludeStripped` (optional) is the marker-stripped skills-section line set;
- * matching lines are dropped so bulleted skills never enter the pool (#30).
+ * We deliberately do NOT grade unmarked lines — pooling unmarked lines would
+ * over-count narrative role-summary lines. The section boundary is what scopes
+ * the pool to accomplishment content; marker detection scopes it to bullets.
  */
-function extractBulletsFromText(
-  text: string,
-  excludeStripped?: ReadonlySet<string>,
-): string[] {
-  if (!text) return [];
-  const lines = text.split(/\r?\n/);
+function extractBulletsFromLines(lines: readonly string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < lines.length; i++) {
     let rawLine = lines[i];
-    // Lone-bullet merge (#30): a marker-only line adopts the next non-empty
-    // line as its text, recovering Word-table layouts that split the glyph and
-    // its text into separate cells (and thus separate extracted lines).
+    // Lone-bullet merge (#30): a marker-only line adopts the next line in this
+    // same section as its text, recovering Word-table layouts that split the
+    // glyph and its text into separate cells (and thus separate extracted
+    // lines). The section lines are already non-empty, so the next element is
+    // the text — no blank-skipping needed.
     if (LONE_BULLET_RE.test(rawLine)) {
-      let j = i + 1;
-      while (j < lines.length && lines[j].trim() === "") j++;
+      const j = i + 1;
       if (j >= lines.length) break;
       rawLine = `${rawLine.trimEnd()} ${lines[j].trim()}`;
       i = j;
@@ -641,9 +622,30 @@ function extractBulletsFromText(
     }
     const trimmed = stripped.trim();
     if (trimmed.split(/\s+/).filter(Boolean).length < ANON_BULLET_MIN_WORDS) continue;
-    // Section-aware (#30): skills entries are not experience bullets.
-    if (excludeStripped?.has(trimmed)) continue;
     out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Pool experience bullets from the accomplishment sections (experience /
+ * projects / achievements) of the typed {@link SectionedResume}, in canonical
+ * policy order (#133). This is what the authed scorer already does per-role
+ * (`scoreSpecificity` walks `experience[i].description` then pools project /
+ * achievement bullets); pooling directly from the sections aligns the two
+ * surfaces and removes the last raw-text re-derivation.
+ *
+ * Skills are excluded by construction — skills is not an accomplishment
+ * section, so its lines never enter the pool and are never judged by the
+ * action-verb / metric / length rules. This is the structural replacement for
+ * the retired "pool all of rawText, subtract a skills-line set" shape (#30 /
+ * #132), which was the reason a skills side-channel was needed at all.
+ */
+function extractBulletsFromSections(sections: SectionedResume): string[] {
+  const out: string[] = [];
+  for (const name of sections.accomplishmentSections) {
+    const lines = sections.byName.get(name);
+    if (lines && lines.length > 0) out.push(...extractBulletsFromLines(lines));
   }
   return out;
 }
@@ -654,8 +656,7 @@ export function computeAnonymousAtsScore(
   // ── Bullet-level dimensions (Specificity 40, Structure 30) ─────────────
   // Same scoreBulletPool the authed scorer uses — guarantees the two
   // surfaces apply identical per-bullet rules.
-  const skillsExclude = buildSkillsExclusion(input.sections.byName.get("skills"));
-  const bullets = extractBulletsFromText(input.rawText, skillsExclude);
+  const bullets = extractBulletsFromSections(input.sections);
   const pool = scoreBulletPool(bullets);
   const observations = analyzeBullets(bullets);
   const gradable = pool.total >= ANON_MIN_BULLETS_TO_GRADE;
@@ -701,7 +702,13 @@ export function computeAnonymousAtsScore(
   });
   completenessChecks.push({
     key: "experience",
-    passed: expEntries.length > 0 || bullets.length > 0,
+    // Pass when the parser found experience entries OR there is a non-empty
+    // experience section (#133, spike §1.5 — ask the typed section structure
+    // directly instead of guessing from the global bullet count, the same
+    // re-derive-from-rawText anti-pattern this PR retires).
+    passed:
+      expEntries.length > 0 ||
+      (input.sections.byName.get("experience")?.length ?? 0) > 0,
     label: "work experience",
   });
   completenessChecks.push({

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
@@ -64,6 +64,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
@@ -39,21 +39,21 @@
     "sectionSource": "regex"
   },
   "score": {
-    "overall": 63,
-    "preLayoutOverall": 74,
+    "overall": 74,
+    "preLayoutOverall": 87,
     "specificity": {
-      "score": 33,
+      "score": 40,
       "max": 40,
       "gradable": true,
-      "metricBullets": 9,
-      "totalBullets": 18
+      "metricBullets": 8,
+      "totalBullets": 13
     },
     "structure": {
-      "score": 14,
+      "score": 20,
       "max": 30,
       "gradable": true,
       "goodBullets": 9,
-      "totalBullets": 18
+      "totalBullets": 13
     },
     "completeness": {
       "score": 27,
@@ -70,7 +70,7 @@
       "multiplier": 0.85,
       "scanned": false
     },
-    "bulletCount": 18,
-    "algoVersion": "1.2"
+    "bulletCount": 13,
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -37,21 +37,21 @@
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 58,
-    "preLayoutOverall": 58,
+    "overall": 60,
+    "preLayoutOverall": 60,
     "specificity": {
-      "score": 11,
+      "score": 13,
       "max": 40,
       "gradable": true,
       "metricBullets": 10,
-      "totalBullets": 59
+      "totalBullets": 52
     },
     "structure": {
       "score": 20,
       "max": 30,
       "gradable": true,
-      "goodBullets": 39,
-      "totalBullets": 59
+      "goodBullets": 35,
+      "totalBullets": 52
     },
     "completeness": {
       "score": 27,
@@ -66,7 +66,7 @@
       "multiplier": 1,
       "scanned": false
     },
-    "bulletCount": 59,
-    "algoVersion": "1.2"
+    "bulletCount": 52,
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -37,21 +37,21 @@
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 67,
-    "preLayoutOverall": 67,
+    "overall": 68,
+    "preLayoutOverall": 68,
     "specificity": {
-      "score": 17,
+      "score": 18,
       "max": 40,
       "gradable": true,
       "metricBullets": 8,
-      "totalBullets": 31
+      "totalBullets": 30
     },
     "structure": {
       "score": 23,
       "max": 30,
       "gradable": true,
-      "goodBullets": 24,
-      "totalBullets": 31
+      "goodBullets": 23,
+      "totalBullets": 30
     },
     "completeness": {
       "score": 27,
@@ -66,7 +66,7 @@
       "multiplier": 1,
       "scanned": false
     },
-    "bulletCount": 31,
-    "algoVersion": "1.2"
+    "bulletCount": 30,
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -72,6 +72,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -72,6 +72,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -69,6 +69,6 @@
       "scanned": false
     },
     "bulletCount": 11,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
@@ -64,6 +64,6 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -71,6 +71,6 @@
       "scanned": false
     },
     "bulletCount": 27,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
+++ b/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
@@ -41,15 +41,15 @@
       "score": 40,
       "max": 40,
       "gradable": true,
-      "metricBullets": 9,
-      "totalBullets": 12
+      "metricBullets": 8,
+      "totalBullets": 8
     },
     "structure": {
       "score": 17,
       "max": 30,
       "gradable": true,
-      "goodBullets": 7,
-      "totalBullets": 12
+      "goodBullets": 5,
+      "totalBullets": 8
     },
     "completeness": {
       "score": 27,
@@ -64,7 +64,7 @@
       "multiplier": 1,
       "scanned": false
     },
-    "bulletCount": 12,
-    "algoVersion": "1.2"
+    "bulletCount": 8,
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
@@ -63,6 +63,6 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 19,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -70,6 +70,6 @@
       "scanned": false
     },
     "bulletCount": 16,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
@@ -64,6 +64,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -39,21 +39,21 @@
     "sectionSource": "regex"
   },
   "score": {
-    "overall": 53,
-    "preLayoutOverall": 62,
+    "overall": 60,
+    "preLayoutOverall": 70,
     "specificity": {
-      "score": 22,
+      "score": 26,
       "max": 40,
       "gradable": true,
-      "metricBullets": 6,
-      "totalBullets": 18
+      "metricBullets": 5,
+      "totalBullets": 13
     },
     "structure": {
-      "score": 13,
+      "score": 17,
       "max": 30,
       "gradable": true,
       "goodBullets": 8,
-      "totalBullets": 18
+      "totalBullets": 13
     },
     "completeness": {
       "score": 27,
@@ -70,7 +70,7 @@
       "multiplier": 0.85,
       "scanned": false
     },
-    "bulletCount": 18,
-    "algoVersion": "1.2"
+    "bulletCount": 13,
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
@@ -65,6 +65,6 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -66,6 +66,6 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.2"
+    "algoVersion": "1.3"
   }
 }


### PR DESCRIPTION
## Summary

Sources the anonymous scorer's experience-bullet pool from the accomplishment sections (experience / projects / achievements) of `SectionedResume` via a new `extractBulletsFromSections`, instead of walking all of `rawText` and subtracting a skills-line set. Skills are now excluded **by construction** (skills is not an accomplishment section), retiring `extractBulletsFromText`, `buildSkillsExclusion`, and `stripBulletMarker` — the "pool everything, subtract" shape that forced the #30 side-channel. The experience-completeness check now asks "is there a non-empty experience section?" rather than guessing from the global bullet count (spike §1.5). The #82 live bullet-edit path is threaded so an edit re-grades Specificity/Structure: `applyOverrides` now takes and returns the edited `SectionedResume` (new `replaceBulletInSections`), and `App.tsx` feeds the edited sections into the scorer.

This is a **deliberate scoring change**: `ATS_SCORE_ALGO_VERSION` bumped 1.2 → 1.3 with a changelog entry.

> **Stacked on #138** (`refactor-137-132-fallow-sectioned`, the SectionedResume proof PR). Based against that branch, not `main` — GitHub will auto-retarget to `main` once #138 merges. Review/merge #138 first.

Resolves #133
Refs #109, #127, #82

## Goldens movement (regenerated + spot-audited fixture-by-fixture)

19 of 24 fixtures are **version-stamp-only** (their bullets were already inside accomplishment sections — unchanged, as expected). 5 moved, all **narrowing** (totalBullets dropped; none increased → no double-counting):

| fixture | totalBullets | overall | why |
|---|---|---|---|
| google-docs-skia-proxy-two-column | 18→13 | 63→74 | 5 bulleted CONTACT lines in the profile sidebar (`• jane@…`, `• (312)…`) were falsely pooled as experience bullets; removed → ratios rise |
| weasyprint-cairo-two-column | 18→13 | 53→60 | same 5 bulleted-contact-sidebar lines leave the pool |
| awesome-cv-cv | 59→52 | 58→60 | 6 certifications + 1 education bullet leave the pool |
| awesome-cv-resume | 31→30 | 67→68 | 1 education bullet leaves the pool |
| openresume-react-pdf | 12→8 | 84→84 | 3 education bullets + 1 project bullet leave the pool (the project bullet lands under a mis-segmented singular "PROJECT" header → education; #109 territory, pre-existing) |

Only lossy keys/counts `*.expected.json` snapshots changed — no fixture binaries touched, so no PII surface.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (616 tests, 41 files; 24 corpus fixtures match regenerated goldens)
- [x] `npm run lint` (eslint) clean