### PR TITLE
refactor(#134, #135): contact-link ownership model + real profile-section boundary

### DIFF
--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -11,12 +11,13 @@ import {
   US_LOCATION_RE,
   INTL_LOCATION_RE,
 } from "../regex.ts";
+import { escapeRegex } from "../../jd-match/regex-utils.ts";
 import { findFirstPhone, regionFromLocation } from "../phone.ts";
 import { firstMatch, allMatches } from "./shared.ts";
 
 // ── Contact (email, phone, urls, location) ──────────────────────────────────
 
-interface ContactExtractionResult {
+export interface ContactExtractionResult {
   email?: string;
   phone?: string;
   linkedin_url?: string;
@@ -34,7 +35,29 @@ interface ContactExtractionResult {
     website_url: number;
     location: number;
   };
+  /**
+   * Provenance / ownership signal (#134). The `PdfLine`s document-wide whose
+   * ENTIRE content was a promoted identity link (LinkedIn/GitHub) the contact
+   * card claimed — optionally fronted by an introducing label ("LinkedIn:",
+   * "Links —"). The caller removes these lines from every section's candidate
+   * pool BEFORE the body extractors run, so a footer "Links" line lifted into
+   * the contact card never also renders as a phantom project/achievement entry.
+   *
+   * Only *pure* identity-link lines are owned: a line that also carries real
+   * prose (a bullet that merely mentions a repo, a deeper path under the same
+   * handle, or a different longer handle) is NOT in this set and survives in the
+   * body — the same identity boundary the retired `stripPromotedUrls` enforced,
+   * now applied to whole-line ownership instead of after-the-fact slug
+   * subtraction.
+   */
+  consumedLines: ReadonlySet<PdfLine>;
 }
+
+/** Result of a single regex scan over a text region — the contact fields and
+ *  their confidences, before ownership is computed. `extractContact` combines a
+ *  profile scan and a full-document scan into the public {@link
+ *  ContactExtractionResult} (which adds `consumedLines`). */
+type ContactScanResult = Omit<ContactExtractionResult, "consumedLines">;
 
 /** LinkedIn paths that are NOT a personal profile — feed, company pages, job
  *  posts, articles, etc. Everything else under `linkedin.com/<handle>` (the
@@ -56,6 +79,89 @@ function normalizeUrl(raw: string | undefined): string | undefined {
   const trimmed = raw.replace(/[,;.)]$/, "").trim();
   if (/^https?:\/\//i.test(trimmed)) return trimmed;
   return `https://${trimmed}`;
+}
+
+// ── Promoted-identity-link ownership (#134) ─────────────────────────────────
+// LinkedIn/GitHub identity links are matched document-wide (see `anywhereOnDoc`
+// below), so an identity link sitting in a "Links"/footer block that segmented
+// into a body section is promoted into the contact card. That same line would
+// otherwise survive as a phantom entry whose only content is the bare URL.
+// Instead of scrubbing the URL out of every rendered body after extraction
+// (the retired `stripPromotedUrls`), the contact extractor CLAIMS the lines it
+// consumed: any line that is nothing but the promoted identity link(s) — plus
+// an optional introducing label — is reported on `consumedLines`, and the
+// caller drops those lines from the candidate pools before the body extractors
+// run. Ownership is recorded here, at the single point the link is promoted.
+
+/** Host+path of a URL, lowercased, with scheme / `www.` / trailing punctuation
+ *  removed — the comparable identity of a link across "https://github.com/x",
+ *  "github.com/x" and "github.com/x/". */
+function urlSlug(u: string | undefined): string | undefined {
+  if (!u) return undefined;
+  const s = u
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/[/.,;:)\]]+$/, "")
+    .toLowerCase();
+  return s.length > 0 ? s : undefined;
+}
+
+/** Leading introducing label that a bare identity link sits behind ("LinkedIn:",
+ *  "GitHub —", "Links", "Find me online") — stripped before testing whether a
+ *  line is nothing but its promoted URL(s). */
+const PROMOTED_LABEL_PREFIX_RE =
+  /^[•\-–—*\s]*(?:linkedin|github|profile|portfolio|links?|find me(?: online)?|connect|social(?: media)?|online|website)\b[\s:|/–—-]*/i;
+
+/**
+ * Decide which `lines` the contact card has consumed: a line is OWNED iff,
+ * after removing every promoted identity URL AT THE EXACT-IDENTITY BOUNDARY and
+ * then stripping an optional introducing label, nothing else remains. (URLs are
+ * removed before the label so the label regex — whose alternatives include
+ * "github"/"linkedin" — cannot chew the host out of the URL itself.)
+ *
+ * The `(?![\w./-])` lookahead is the load-bearing precision rule (carried over
+ * from the retired `stripPromotedUrls`): the slug matches the identity link
+ * itself, NOT a deeper path or longer handle under it. So a bare
+ * "github.com/x" line is owned and dropped, while a real bullet mentioning
+ * "github.com/x/some-repo" or a different handle "github.com/x-team" leaves a
+ * residue and is therefore NOT owned — it survives in the body.
+ */
+function findConsumedLines(
+  lines: PdfLine[],
+  promotedSlugs: string[],
+): Set<PdfLine> {
+  const consumed = new Set<PdfLine>();
+  if (promotedSlugs.length === 0) return consumed;
+  const matchers = promotedSlugs.map(
+    (slug) =>
+      new RegExp(
+        `(?:https?:\\/\\/)?(?:www\\.)?${escapeRegex(slug)}\\/?(?![\\w./-])`,
+        "ig",
+      ),
+  );
+  for (const line of lines) {
+    // Remove the identity URL(s) FIRST — before any label strip — so the label
+    // regex (whose alternatives include "github"/"linkedin") can never chew the
+    // host out of the URL itself ("github.com/x"). Each matcher's `(?![\w./-])`
+    // boundary keeps a deeper path / longer handle intact (#134 precision rule).
+    let residue = line.text;
+    let hadMatch = false;
+    for (const re of matchers) {
+      re.lastIndex = 0;
+      if (re.test(residue)) hadMatch = true;
+      re.lastIndex = 0;
+      residue = residue.replace(re, " ");
+    }
+    if (!hadMatch) continue;
+    // With the URL(s) gone, strip an introducing label ("LinkedIn:", "Links —").
+    residue = residue.replace(PROMOTED_LABEL_PREFIX_RE, "");
+    // Owned only when the URL(s) (and the label) were the WHOLE line — any real
+    // prose left over means this is a genuine body line, not a phantom.
+    const leftover = residue.replace(/[•\-–—*\s|/]+/g, "");
+    if (leftover.length === 0) consumed.add(line);
+  }
+  return consumed;
 }
 
 /**
@@ -100,7 +206,7 @@ function extractOtherUrls(joined: string): {
   return { portfolio, website: websiteCandidates[0] };
 }
 
-function scan(lines: PdfLine[], joined: string): ContactExtractionResult {
+function scan(lines: PdfLine[], joined: string): ContactScanResult {
   const email = firstMatch(EMAIL_RE, joined);
 
   // Extract location BEFORE phone so we can derive the parse region.
@@ -178,13 +284,26 @@ export function extractContact(
   // Annotation fallback: URLs hyperlinked behind a visible word
   // ("LinkedIn", "GitHub") only show up here. LinkedIn/GitHub are matched
   // document-wide (see `anywhereOnDoc` below); only the looser-but-still-bounded
-  // portfolio/website lookup keeps a Y-band.
-  // Portfolio/website use a header-region band — some design templates
-  // place the portfolio link in a sidebar or under the name block. "Top
-  // third of page 1" approximated with a fixed PDF-points cutoff that
-  // works for both Letter (792pt) and A4 (842pt).
-  const inHeaderRegion = (ann: PdfLinkAnnotation) =>
-    ann.page === 1 && ann.yTop < 280;
+  // portfolio/website lookup keeps a section-based region filter.
+  // Portfolio/website use the profile-section boundary — the profile section
+  // covers everything above the first recognized header, which is exactly
+  // the contact/links block. Annotations whose top edge falls within (or just
+  // below) the last profile line are accepted; this replaces the old fixed
+  // 280-PDF-points proxy (#135).
+  //
+  // Implementation: collect the max y of any profile line and add a small
+  // slack (12 pts ≈ one line-height) so an annotation rect whose anchor
+  // sits a hair below the last text line is still accepted. When the profile
+  // has no lines (edge case: empty document / single-section resume) we
+  // accept any annotation on page 1 as a conservative fallback.
+  const profileLineMaxY: number = profile.lines.length > 0
+    ? Math.max(...profile.lines.map((l) => l.y))
+    : Infinity; // Infinity → accept everything on page 1
+  const PROFILE_REGION_SLACK_PTS = 12;
+  const inProfileSection = (ann: PdfLinkAnnotation): boolean =>
+    ann.page === 1 &&
+    ann.yTop <= profileLineMaxY + PROFILE_REGION_SLACK_PTS;
+
   // LinkedIn / GitHub identity links are commonly hyperlinked behind an icon
   // placed in a footer or a "Links"/"Contact" block below a later heading
   // (e.g. after Skills), so the profile-band filter dropped them. The
@@ -234,7 +353,7 @@ export function extractContact(
   const portfolio = pickUrl(
     "portfolio_url",
     (u) => isPortfolioUrl(u) && !isLinkedinUrl(u) && !isGithubUrl(u),
-    inHeaderRegion,
+    inProfileSection,
   );
   // Website is the catch-all: any remaining annotation URL not already
   // claimed by linkedin/github/portfolio.
@@ -249,8 +368,21 @@ export function extractContact(
       !isGithubUrl(u) &&
       !u.startsWith("mailto:") &&
       !u.startsWith("tel:"),
-    inHeaderRegion,
+    inProfileSection,
   );
+
+  // Ownership (#134): claim the document-wide body lines that are nothing but a
+  // promoted identity link. Slugs are derived from the *claimed* linkedin/github
+  // values — whether they came from the profile, the full-doc fallback, or an
+  // annotation — so the line that carried the link is removed from the body
+  // pools and never renders a second time. Only LinkedIn/GitHub participate:
+  // those are the identity links matched document-wide and thus the only ones
+  // that produce phantom body entries (portfolio/website stay header-banded).
+  const promotedSlugs = [
+    urlSlug(linkedin.value),
+    urlSlug(github.value),
+  ].filter((s): s is string => s !== undefined);
+  const consumedLines = findConsumedLines(allLines, promotedSlugs);
 
   return {
     email: primary.email ?? fallback.email,
@@ -270,5 +402,6 @@ export function extractContact(
       website_url: website.confidence,
       location: primary.confidence.location,
     },
+    consumedLines,
   };
 }

--- a/src/lib/heuristics/openresume.ts
+++ b/src/lib/heuristics/openresume.ts
@@ -33,7 +33,6 @@ import {
   type PdfSection,
 } from "./sections.ts";
 import { sectionizeMarkdown } from "./markdown-lines.ts";
-import { escapeRegex } from "../jd-match/regex-utils.ts";
 import {
   extractName,
   extractContact,
@@ -96,72 +95,28 @@ export function parseHeuristicFromMarkdown(
   return buildHeuristicResult(lines, sections, "markdown");
 }
 
-// ── Promoted-identity-link de-duplication ───────────────────────────────────
-// LinkedIn/GitHub are detected document-wide (see `extractContact`), so an
-// identity link sitting in a "Links"/footer block at the bottom of the résumé
-// is promoted into the contact card. The same line also survives in whatever
-// section it fell into — most often as a phantom project/achievement entry
-// whose only content is the bare URL. We strip the promoted URLs out of the
-// rendered section bodies and drop any entry left empty, so the reconstructed
-// résumé never shows the same link twice (once in contact, once in the body it
-// was lifted from).
-
-/** Host+path of a URL, lowercased, with scheme / `www.` / trailing punctuation
- *  removed — the comparable identity of a link across "https://github.com/x",
- *  "github.com/x" and "github.com/x/". */
-function urlSlug(u: string | undefined): string | undefined {
-  if (!u) return undefined;
-  const s = u
-    .trim()
-    .replace(/^https?:\/\//i, "")
-    .replace(/^www\./i, "")
-    .replace(/[/.,;:)\]]+$/, "")
-    .toLowerCase();
-  return s.length > 0 ? s : undefined;
-}
-
-/** A line left as nothing but an introducing label ("LinkedIn:", "GitHub —",
- *  "Find me online") once its URL has been stripped. */
-const PROMOTED_LABEL_RE =
-  /^[•\-–—*\s]*(?:linkedin|github|profile|portfolio|links?|find me(?: online)?|connect|social(?: media)?|online|website)\b[\s:|/–—-]*$/i;
-
-/** Remove every occurrence of `slugs` (and any orphaned label they leave
- *  behind) from a newline-joined bullet body. A slug matches the exact identity
- *  link, NOT a deeper path or longer handle under it — a real bullet mentioning
- *  "github.com/x/some-repo" or a different handle "github.com/x-team" is
- *  preserved (the lookahead rejects a following `\w`, `/`, `.` or `-`). Returns
- *  undefined when nothing survives. */
-function stripPromotedUrls(
-  text: string | undefined,
-  slugs: string[],
-): string | undefined {
-  if (!text || slugs.length === 0) return text;
-  // Compile one matcher per slug, hoisted out of the per-line loop. The `g`
-  // flag strips every occurrence on a line (String.replace resets lastIndex
-  // between calls, so reusing the object across lines is safe).
-  const matchers = slugs.map(
-    (slug) =>
-      new RegExp(
-        `(?:https?:\\/\\/)?(?:www\\.)?${escapeRegex(slug)}\\/?(?![\\w./-])`,
-        "ig",
-      ),
-  );
-  const kept = text
-    .split("\n")
-    .map((line) => {
-      let l = line;
-      for (const re of matchers) l = l.replace(re, " ");
-      return l.replace(/\s{2,}/g, " ").trim();
-    })
-    .filter((l) => l.length > 0 && !PROMOTED_LABEL_RE.test(l));
-  return kept.length > 0 ? kept.join("\n") : undefined;
-}
-
-/** True when `url` IS one of the promoted identity links (exact, not a deeper
- *  path), so a phantom entry's header url can be cleared. */
-function isPromotedUrl(url: string | undefined, slugs: string[]): boolean {
-  const s = urlSlug(url);
-  return s !== undefined && slugs.includes(s);
+/**
+ * Remove the lines the contact extractor consumed from every section's
+ * candidate pool (#134). A promoted identity link (LinkedIn/GitHub) lifted into
+ * the contact card sits on its own line in whatever body section it fell into;
+ * `extractContact` reports those `PdfLine`s on `consumedLines`, and dropping
+ * them here — BEFORE the body extractors run — is what keeps the link from
+ * rendering a second time as a phantom project/achievement entry. Identity
+ * (referential equality) is the ownership key: the same `PdfLine` objects flow
+ * into both `extractContact` and the body extractors, so a consumed line is
+ * recognized regardless of its text. Sections whose lines are untouched are
+ * returned as-is (no new array) so the common no-promotion case is allocation-
+ * free.
+ */
+function stripConsumedLines(
+  sections: PdfSection[],
+  consumed: ReadonlySet<PdfLine>,
+): PdfSection[] {
+  if (consumed.size === 0) return sections;
+  return sections.map((section) => {
+    if (!section.lines.some((l) => consumed.has(l))) return section;
+    return { ...section, lines: section.lines.filter((l) => !consumed.has(l)) };
+  });
 }
 
 function buildHeuristicResult(
@@ -175,80 +130,30 @@ function buildHeuristicResult(
     name: "profile" as const,
     lines: [],
   };
-  const summarySection = findSection(sections, "summary");
-  const experienceSection = findSection(sections, "experience");
-  const educationSection = findSection(sections, "education");
-  const skillsSection = findSection(sections, "skills");
-  const projectsSection = findSection(sections, "projects");
-  const achievementsSection = findSection(sections, "achievements");
 
+  // Name + contact run FIRST, on the original sections — the contact extractor
+  // must see the promoted identity link to claim it. It reports the body lines
+  // it consumed (a footer "Links" line lifted into the contact card); those are
+  // stripped from every section's candidate pool BEFORE the body extractors run
+  // (#134), so the link never re-renders as a phantom project/achievement entry.
   const name = extractName(profile);
   const contact = extractContact(profile, lines, annotations);
+
+  const ownedSections = stripConsumedLines(sections, contact.consumedLines);
+
+  const summarySection = findSection(ownedSections, "summary");
+  const experienceSection = findSection(ownedSections, "experience");
+  const educationSection = findSection(ownedSections, "education");
+  const skillsSection = findSection(ownedSections, "skills");
+  const projectsSection = findSection(ownedSections, "projects");
+  const achievementsSection = findSection(ownedSections, "achievements");
+
   const summary = extractSummary(summarySection);
   const skills = extractSkills(skillsSection);
   const experience = extractExperience(experienceSection);
   const education = extractEducation(educationSection);
   const projects = extractProjects(projectsSection);
   const achievements = extractAchievements(achievementsSection);
-
-  // Strip promoted LinkedIn/GitHub links out of the rendered body so they don't
-  // render twice — once in the contact card, once in the section they were
-  // lifted from (see helpers above).
-  const promotedSlugs = [
-    urlSlug(contact.linkedin_url),
-    urlSlug(contact.github_url),
-  ].filter((s): s is string => s !== undefined);
-
-  const experienceValue =
-    promotedSlugs.length === 0
-      ? experience.value
-      : experience.value
-          .map((e) => ({
-            ...e,
-            description: stripPromotedUrls(e.description, promotedSlugs),
-          }))
-          .filter((e) => e.title.trim() || e.company.trim() || e.description);
-
-  const educationValue =
-    promotedSlugs.length === 0
-      ? education.value
-      : education.value
-          .map((e) => ({
-            ...e,
-            description: stripPromotedUrls(e.description, promotedSlugs),
-          }))
-          .filter((e) => e.institution.trim() || e.degree.trim() || e.description);
-
-  const projectsValue =
-    promotedSlugs.length === 0
-      ? projects.value
-      : projects.value
-          .map((p) => ({
-            ...p,
-            description: stripPromotedUrls(p.description, promotedSlugs),
-            url: isPromotedUrl(p.url, promotedSlugs) ? undefined : p.url,
-          }))
-          .filter((p) => p.name.trim() || p.description || p.url);
-
-  const achievementsValue =
-    promotedSlugs.length === 0
-      ? achievements.value
-      : achievements.value
-          .map((a) => ({
-            ...a,
-            description: stripPromotedUrls(a.description, promotedSlugs),
-            url: isPromotedUrl(a.url, promotedSlugs) ? undefined : a.url,
-          }))
-          .filter((a) => a.title.trim() || a.description || a.url);
-
-  const skillsValue =
-    promotedSlugs.length === 0
-      ? skills.value
-      : skills.value.filter(
-          (s) => !promotedSlugs.some((slug) => s.toLowerCase().includes(slug)),
-        );
-
-  const summaryValue = stripPromotedUrls(summary.value, promotedSlugs);
 
   const parsed: HeuristicParsedResume = {
     ...(name.value ? { full_name: name.value } : {}),
@@ -260,19 +165,21 @@ function buildHeuristicResult(
     ...(contact.github_url ? { github_url: contact.github_url } : {}),
     ...(contact.portfolio_url ? { portfolio_url: contact.portfolio_url } : {}),
     ...(contact.website_url ? { website_url: contact.website_url } : {}),
-    ...(summaryValue ? { summary: summaryValue } : {}),
-    skills: skillsValue,
+    ...(summary.value ? { summary: summary.value } : {}),
+    skills: skills.value,
     skills_explicit: [],
     skills_inferred: [],
-    experience: experienceValue,
-    education: educationValue,
-    ...(projectsValue.length > 0 ? { projects: projectsValue } : {}),
-    ...(achievementsValue.length > 0
-      ? { heuristic_achievements: achievementsValue }
+    experience: experience.value,
+    education: education.value,
+    ...(projects.value.length > 0 ? { projects: projects.value } : {}),
+    ...(achievements.value.length > 0
+      ? { heuristic_achievements: achievements.value }
       : {}),
     // Best-effort current role derivation.
-    ...(experienceValue[0]?.title ? { current_title: experienceValue[0].title } : {}),
-    ...(experienceValue[0]?.company ? { current_company: experienceValue[0].company } : {}),
+    ...(experience.value[0]?.title ? { current_title: experience.value[0].title } : {}),
+    ...(experience.value[0]?.company
+      ? { current_company: experience.value[0].company }
+      : {}),
   };
 
   const fieldConfidence: FieldConfidence = {
@@ -296,7 +203,9 @@ function buildHeuristicResult(
     parsed,
     fieldConfidence,
     sectionSource,
-    sections: toSectionedResume(sections, sectionSource),
+    // The scorer-facing view is built from the OWNED sections so the consumed
+    // identity-link lines don't double-count there either (#134).
+    sections: toSectionedResume(ownedSections, sectionSource),
   };
 }
 


### PR DESCRIPTION
## Summary

Replaces two segmentation-imprecision workarounds in contact extraction with the proper signals from the typed `SectionedResume` (#138). **Stacked on #138** — base is `refactor-137-132-fallow-sectioned`, not `main`.

- **#134** — retire the `stripPromotedUrls` after-the-fact slug-subtraction scrub (`isPromotedUrl`, `PROMOTED_LABEL_RE`, `urlSlug`, the per-section strip driver) for a **line-level ownership model**: `extractContact` returns `consumedLines: ReadonlySet<PdfLine>`, and `buildHeuristicResult` strips owned lines from body pools before extraction, so a promoted identity link is claimed by contact and never re-renders as a phantom project/achievement entry.
- **#135** — replace the geometric y-band header proxy (`inHeaderRegion: ann.yTop < 280`) with `inProfileSection`, a real boundary from the profile section's line extents; `portfolio_url`/`website_url` annotation lookups consult it. Document-wide LinkedIn/GitHub identity match (`anywhereOnDoc`) retained by design (spike §1.4).

Closes #134
Closes #135
Refs #109, #127

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 616/616, 24/24 corpus snapshots unchanged
- [x] #125 identity-link fixtures pass; no identity link renders twice
- [x] No `yTop < 280` magic-number band remains in contact extraction
- [ ] Manually verified in `npm run preview`

## Stacked-PR note

Base is the unmerged #138 branch. GitHub auto-retargets this PR to `main` once #138 merges; then rebase to drop #138's commits:
`git rebase --onto main refactor-137-132-fallow-sectioned gh-134-135-contact-ownership`