### PR TITLE
fix: parse prose bodies, redacted dates, role-comma split (#158)

### DIFF
--- a/src/components/features/AtsScoreReadout.tsx
+++ b/src/components/features/AtsScoreReadout.tsx
@@ -143,11 +143,11 @@ export function AtsScoreReadout({ score }: AtsScoreReadoutProps) {
         </p>
       </details>
       <div className="flex flex-col gap-4 md:flex-row md:items-start">
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-4 md:min-w-0 md:flex-1">
           <ScoreRing score={score.overall} />
           <VerdictHeader score={score.overall} dimensions={dimensions} />
         </div>
-        <dl className="grid flex-1 grid-cols-1 gap-3 text-xs sm:grid-cols-3">
+        <dl className="grid min-w-0 flex-1 grid-cols-1 gap-3 text-xs sm:grid-cols-3">
           <Dimension
             label="Specificity"
             value={score.specificity.score}

--- a/src/lib/heuristics/cascade.ts
+++ b/src/lib/heuristics/cascade.ts
@@ -505,6 +505,7 @@ function countExtractedChars(parsed: CascadeResult["parsed"]): number {
   for (const e of parsed.experience ?? []) {
     n += (e.company ?? "").length;
     n += (e.title ?? "").length;
+    n += (e.team ?? "").length;
     n += (e.description ?? "").length;
   }
   for (const e of parsed.education ?? []) {

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -32,6 +32,7 @@ import {
   parseDateRange,
   stripDateRange,
   isBulletLine,
+  isProseLine,
   stripBullet,
 } from "./line-primitives.ts";
 
@@ -179,6 +180,49 @@ function isWrappedContinuation(line: PdfLine, markerX: number): boolean {
 }
 
 /**
+ * A description paragraph begins after a vertical gap wider than this multiple
+ * of the section's single line-height. Word/Office templates write the role
+ * description as a glyph-less prose paragraph set off by paragraph spacing, so
+ * the blank-line gap — not a bullet glyph or a sentence period — is the
+ * structural signal that the header has ended and the body has begun.
+ */
+const BODY_GAP_FACTOR = 1.4;
+
+/**
+ * Median of the positive consecutive y-gaps in a section — its baseline single
+ * line-height. Returns 0 when the lines carry no usable y (markdown / DOCX
+ * extraction sets every `y` equal, so no positive gaps), which disables the
+ * gap-based body signal and leaves `isProseLine` as the sole text fallback.
+ */
+function sectionLineHeight(lines: PdfLine[]): number {
+  const gaps: number[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const g = lines[i].y - lines[i - 1].y;
+    if (g > 0) gaps.push(g);
+  }
+  if (gaps.length === 0) return 0;
+  gaps.sort((a, b) => a - b);
+  const mid = Math.floor(gaps.length / 2);
+  return gaps.length % 2 === 0 ? (gaps[mid - 1] + gaps[mid]) / 2 : gaps[mid];
+}
+
+/**
+ * True when line `i` starts a body paragraph by the y-gap signal: it is set off
+ * from the line above by a paragraph-sized gap (> `BODY_GAP_FACTOR`× the section
+ * line-height) and reads like prose (carries a lowercase letter). This is the
+ * PDF-path primary for glyph-less descriptions — it catches a periodless
+ * paragraph that `isProseLine` (which needs a sentence break) misses. A no-op
+ * when `baseline` is 0 (no usable y data), so the DOCX/markdown path falls back
+ * to `isProseLine` unchanged.
+ */
+function startsBodyByGap(lines: PdfLine[], i: number, baseline: number): boolean {
+  if (baseline <= 0 || i <= 0) return false;
+  const gap = lines[i].y - lines[i - 1].y;
+  if (gap <= BODY_GAP_FACTOR * baseline) return false;
+  return /[a-z]/.test(lines[i].text);
+}
+
+/**
  * Split a section into entry blocks per `cfg`. Returns an empty array for an
  * absent/empty section or one with no anchors.
  *
@@ -206,7 +250,10 @@ export function parseEntryBlocks(
   }
 
   const lookback = cfg.headerLookback ?? 0;
-  return anchors.map((_, a) => buildEntryBlock(lines, anchors, a, cfg, lookback));
+  const baseline = sectionLineHeight(lines);
+  return anchors.map((_, a) =>
+    buildEntryBlock(lines, anchors, a, cfg, lookback, baseline),
+  );
 }
 
 /**
@@ -288,6 +335,45 @@ function buildBulletEntry(
 }
 
 /**
+ * Index where the NEXT entry's header run begins — the boundary the current
+ * entry's content window must not cross. Walks up from just below `nextAnchorIdx`,
+ * claiming up to `lookback` consecutive header-shaped lines (non-bullet,
+ * non-prose, non-wrapped) for the next entry. Returns `nextAnchorIdx` unchanged
+ * for the last entry (no next header) or when `lookback` is 0 (anchors below
+ * carry no above-header, e.g. institution/first_line styles).
+ */
+function nextHeaderStart(
+  lines: PdfLine[],
+  anchorIdx: number,
+  nextAnchorIdx: number,
+  lookback: number,
+  markerX: number,
+  baseline: number,
+): number {
+  if (lookback <= 0 || nextAnchorIdx >= lines.length) return nextAnchorIdx;
+  let start = nextAnchorIdx;
+  let claimed = 0;
+  for (let i = nextAnchorIdx - 1; i > anchorIdx && claimed < lookback; i--) {
+    const l = lines[i];
+    if (isBulletLine(l) || isProseLine(l.text) || isWrappedContinuation(l, markerX)) {
+      break;
+    }
+    // y-gap backstop: once a header line is claimed, a paragraph-sized gap
+    // between this candidate and the line just claimed below it means we've
+    // stepped up out of the next entry's tight header run into the previous
+    // entry's description — stop before claiming a periodless body line that
+    // `isProseLine` would not catch.
+    if (claimed > 0 && baseline > 0) {
+      const gapToClaimed = lines[i + 1].y - lines[i].y;
+      if (gapToClaimed > BODY_GAP_FACTOR * baseline) break;
+    }
+    start = i;
+    claimed++;
+  }
+  return start;
+}
+
+/**
  * Build the single `EntryBlock` anchored at `anchors[a]`. The entry spans from
  * just after the previous anchor to just before the next: header lines are the
  * (lookback) non-bullet lines above the anchor, the anchor line with its dates
@@ -301,6 +387,7 @@ function buildEntryBlock(
   a: number,
   cfg: EntryBlockConfig,
   lookback: number,
+  baseline: number,
 ): EntryBlock {
   const anchorIdx = anchors[a];
   const nextAnchorIdx = a + 1 < anchors.length ? anchors[a + 1] : lines.length;
@@ -308,27 +395,69 @@ function buildEntryBlock(
   const markerX = bulletMarkerX(lines);
 
   // Header candidates above the anchor (e.g. "Title\nCompany <dates>").
-  // Bounded by the previous entry's window and the configured lookback; bullets
-  // and wrapped-bullet tails (indented past the marker) from the previous entry
-  // are skipped so they never leak into this entry's header (#boundary).
+  // Bounded by the previous entry's window and the configured lookback; bullets,
+  // wrapped-bullet tails (indented past the marker), and prose description lines
+  // from the previous entry are skipped so they never leak into this entry's
+  // header (#boundary). The prose filter matters for glyph-less templates whose
+  // description paragraph sits directly above the next role's date — and the
+  // y-gap exclusion is its structural twin: a line set off from the line below
+  // it (toward the anchor) by a paragraph-sized gap is the previous entry's
+  // description tail, not this entry's header, even when it carries no period.
   const aboveStart = Math.max(prevAnchorIdx, anchorIdx - lookback);
-  const aboveLines =
-    lookback > 0
-      ? lines
-          .slice(aboveStart, anchorIdx)
-          .filter((l) => !isBulletLine(l) && !isWrappedContinuation(l, markerX))
-      : [];
+  const aboveLines: PdfLine[] = [];
+  if (lookback > 0) {
+    for (let i = aboveStart; i < anchorIdx; i++) {
+      const l = lines[i];
+      if (
+        isBulletLine(l) ||
+        isWrappedContinuation(l, markerX) ||
+        isProseLine(l.text)
+      ) {
+        continue;
+      }
+      if (baseline > 0) {
+        const gapBelow = lines[i + 1].y - lines[i].y;
+        if (gapBelow > BODY_GAP_FACTOR * baseline) continue;
+      }
+      aboveLines.push(l);
+    }
+  }
+
+  // The next entry claims up to `lookback` header-shaped lines directly above
+  // its anchor (the "Title\nCompany <dates>" lead). This entry's content window
+  // must stop before them, or a glyph-less description would swallow the next
+  // role's company/title as a trailing body line. Walk up from just below the
+  // next anchor, claiming consecutive header-shaped lines for the next entry.
+  const windowEnd = nextHeaderStart(
+    lines,
+    anchorIdx,
+    nextAnchorIdx,
+    lookback,
+    markerX,
+    baseline,
+  );
 
   const anchorLine = lines[anchorIdx];
   const dates = parseDateRange(anchorLine.text);
   const anchorTextWithoutDates = stripDateRange(anchorLine.text);
 
   // Header candidates below the anchor (e.g. "Company <dates>\nTitle"):
-  // consecutive non-bullet lines until the first bullet or the next anchor.
-  // A wrapped-bullet tail is skipped (not a header) but does not end the run.
+  // consecutive non-bullet lines until the body begins or the next anchor. The
+  // body begins at the first bullet OR the first prose paragraph — a glyph-less
+  // description line (Word/Office templates write the description as prose, not
+  // a bulleted list), which must not be folded into company/title. A
+  // wrapped-bullet tail is skipped (not a header) but does not end the run.
   const belowHeaderLines: PdfLine[] = [];
-  for (let i = anchorIdx + 1; i < nextAnchorIdx; i++) {
-    if (isBulletLine(lines[i])) break;
+  let bodyStart = windowEnd;
+  for (let i = anchorIdx + 1; i < windowEnd; i++) {
+    if (
+      isBulletLine(lines[i]) ||
+      isProseLine(lines[i].text) ||
+      startsBodyByGap(lines, i, baseline)
+    ) {
+      bodyStart = i;
+      break;
+    }
     if (isWrappedContinuation(lines[i], markerX)) continue;
     belowHeaderLines.push(lines[i]);
   }
@@ -341,17 +470,36 @@ function buildEntryBlock(
     .map((t) => t.trim())
     .filter(Boolean);
 
-  // Body: bullets after the below-header run, until the next anchor.
-  const bodyStart = anchorIdx + 1 + belowHeaderLines.length;
-  const bulletLines = cfg.collectBody
-    ? lines.slice(bodyStart, nextAnchorIdx).filter((l) => isBulletLine(l))
-    : [];
-  const body = cfg.collectBody
-    ? bulletLines
-        .map((l) => stripBullet(l.text))
-        .join("\n")
-        .trim() || undefined
-    : undefined;
+  // Body: every bullet or prose paragraph from where the body began to the next
+  // anchor. Bullet glyphs are stripped; a wrapped tail folds onto its bullet.
+  // Two fold signals: an x-indent past the bullet marker (wrapped glyph bullet),
+  // or — for marker-less prose, which has no marker to wrap past — a line that
+  // sits a baseline (sub-paragraph) gap below its predecessor, i.e. the same
+  // paragraph continued onto the next visual line. A paragraph-sized gap (or a
+  // real bullet glyph) instead starts a new unit, so one prose blurb stays one
+  // bullet rather than splitting mid-sentence.
+  const bodyUnits: string[] = [];
+  if (cfg.collectBody) {
+    for (let i = bodyStart; i < windowEnd; i++) {
+      const text = stripBullet(lines[i].text).trim();
+      if (!text) continue;
+      const foldsAsProseWrap =
+        baseline > 0 &&
+        i > bodyStart &&
+        !isBulletLine(lines[i]) &&
+        lines[i].y - lines[i - 1].y > 0 &&
+        lines[i].y - lines[i - 1].y <= BODY_GAP_FACTOR * baseline;
+      if (
+        bodyUnits.length > 0 &&
+        (isWrappedContinuation(lines[i], markerX) || foldsAsProseWrap)
+      ) {
+        bodyUnits[bodyUnits.length - 1] += " " + text;
+      } else {
+        bodyUnits.push(text);
+      }
+    }
+  }
+  const body = cfg.collectBody ? bodyUnits.join("\n").trim() || undefined : undefined;
 
-  return { headerLines, dates, body, bulletCount: bulletLines.length };
+  return { headerLines, dates, body, bulletCount: bodyUnits.length };
 }

--- a/src/lib/heuristics/extract/experience.role-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.role-comma.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression for the `"Title, Location"` role-comma split (PR #159 review):
+ * `splitRoleComma` must split `"Role, Company"` headers (the chanchal Word
+ * template form) but NOT split `"Title, City"` headers — otherwise a city is
+ * recorded as the company. Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("splitRoleComma — Title, Location must not become Title, Company", () => {
+  it("splits a real 'Role, Company' header (no legal suffix)", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Office manager, Nod Publishing", fontSize: 11 },
+      { text: "March 2023 - December 2024", fontSize: 11 },
+      { text: "• Ran the front office for a 40-person team.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].title.toLowerCase()).toContain("office manager");
+    expect(roles[0].company).toContain("Nod Publishing");
+  });
+
+  it("does NOT record a bare city as the company for 'Title, City'", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Marketing Manager, San Francisco", fontSize: 11 },
+      { text: "January 2022 - Present", fontSize: 11 },
+      { text: "• Owned the demand-gen funnel end to end.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).not.toContain("San Francisco");
+  });
+
+  it("does NOT record a 'City, ST' tail as the company", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Product Designer, Austin, TX", fontSize: 11 },
+      { text: "June 2020 - December 2021", fontSize: 11 },
+      { text: "• Shipped a redesigned onboarding flow.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).not.toMatch(/Austin/);
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -5,6 +5,7 @@ import type { ResumeExperience } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
+import { US_LOCATION_RE, INTL_LOCATION_RE } from "../regex.ts";
 import { looksLikeTitle, looksLikeCompany, avgScore } from "./shared.ts";
 
 // ── Experience ──────────────────────────────────────────────────────────────
@@ -80,13 +81,32 @@ function experienceFromBlock(block: EntryBlock): {
 const LEGAL_SUFFIX_RE =
   /^(inc\.?|llc|l\.l\.c\.?|ltd\.?|corp\.?|co\.?|gmbh|plc|lp|llp|pc|s\.a\.?|n\.a\.?|sa)$/i;
 
+/** Bare city/region names (no "City, ST" state tail, so `US_LOCATION_RE` misses
+ *  them) that show up as a `"Title, Location"` header tail — must NOT be cleaved
+ *  off as the company. Exact whole-string match keeps a real company that merely
+ *  contains a city word ("New York Times", "Boston Consulting") splittable. */
+const BARE_LOCATION_RE =
+  /^(remote|hybrid|on-?site|san francisco|san diego|san jose|san antonio|los angeles|las vegas|new york|new york city|new orleans|salt lake city|washington|washington d\.?c\.?|boston|chicago|seattle|austin|denver|portland|atlanta|dallas|houston|phoenix|miami|detroit|philadelphia|pittsburgh|minneapolis|nashville|charlotte|columbus|indianapolis|baltimore|sacramento|raleigh|london|paris|berlin|munich|tokyo|singapore|bangalore|bengaluru|mumbai|delhi|hyderabad|toronto|vancouver|sydney|melbourne|dublin|amsterdam)$/i;
+
+/** True when the comma tail reads like a location rather than an employer —
+ *  either a "City, ST"/"City, Country" shape or a bare well-known city. Used to
+ *  veto the `"Title, Location"` split so a city is never recorded as company. */
+function looksLikeLocationTail(after: string): boolean {
+  return (
+    BARE_LOCATION_RE.test(after) ||
+    US_LOCATION_RE.test(after) ||
+    INTL_LOCATION_RE.test(after)
+  );
+}
+
 /**
  * Split a single "Role, Company" header line into [title, company]. Guarded so
  * it only fires when the part before the comma reads like a job title
- * (`looksLikeTitle`) and the part after is not a bare legal suffix — so
- * "Office manager, The Phone Company" splits, but "Acme, Inc" and a location
- * tail like "Acme Analytics (…) New York, NY" (no title keyword before the
- * comma) do not. Returns null when no guarded split applies.
+ * (`looksLikeTitle`), the part after is not a bare legal suffix, and the part
+ * after does not read like a location — so "Office manager, The Phone Company"
+ * splits, but "Acme, Inc", "Acme Analytics (…) New York, NY" (no title keyword
+ * before the comma), and "Marketing Manager, San Francisco" (location tail) do
+ * not. Returns null when no guarded split applies.
  */
 function splitRoleComma(h: string): [string, string] | null {
   const comma = h.indexOf(",");
@@ -96,6 +116,7 @@ function splitRoleComma(h: string): [string, string] | null {
   if (!before || !after) return null;
   if (!looksLikeTitle(before)) return null;
   if (LEGAL_SUFFIX_RE.test(after)) return null;
+  if (looksLikeLocationTail(after)) return null;
   return [before, after];
 }
 

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -75,6 +75,30 @@ function experienceFromBlock(block: EntryBlock): {
   };
 }
 
+/** Legal-entity suffix that must NOT be cleaved off as a separate field by the
+ *  comma split — "Acme, Inc" is one employer, not "Acme" + a role "Inc". */
+const LEGAL_SUFFIX_RE =
+  /^(inc\.?|llc|l\.l\.c\.?|ltd\.?|corp\.?|co\.?|gmbh|plc|lp|llp|pc|s\.a\.?|n\.a\.?|sa)$/i;
+
+/**
+ * Split a single "Role, Company" header line into [title, company]. Guarded so
+ * it only fires when the part before the comma reads like a job title
+ * (`looksLikeTitle`) and the part after is not a bare legal suffix — so
+ * "Office manager, The Phone Company" splits, but "Acme, Inc" and a location
+ * tail like "Acme Analytics (…) New York, NY" (no title keyword before the
+ * comma) do not. Returns null when no guarded split applies.
+ */
+function splitRoleComma(h: string): [string, string] | null {
+  const comma = h.indexOf(",");
+  if (comma <= 0) return null;
+  const before = h.slice(0, comma).trim();
+  const after = h.slice(comma + 1).trim();
+  if (!before || !after) return null;
+  if (!looksLikeTitle(before)) return null;
+  if (LEGAL_SUFFIX_RE.test(after)) return null;
+  return [before, after];
+}
+
 /**
  * Given 1..3 header lines, decide which is the company and which is the title.
  * Heuristics (in priority order):
@@ -96,15 +120,21 @@ function disambiguateCompanyTitle(headers: string[]): {
   const filtered = headers.filter((h) => h.length > 0);
   if (filtered.length === 0) return {};
 
-  // Split any header that has an obvious "Title, Company" or "Title @ Company" pattern.
+  // Split any header that has an obvious "Title @ Company", "Title — Company",
+  // "Title | Company", or guarded "Title, Company" pattern.
   const splits: Array<{ text: string; source: number }> = [];
   filtered.forEach((h, idx) => {
     const atSplit = h.split(/\s+@\s+|\s+—\s+|\s+\|\s+/);
     if (atSplit.length > 1) {
       atSplit.forEach((s) => splits.push({ text: s.trim(), source: idx }));
-    } else {
-      splits.push({ text: h, source: idx });
+      return;
     }
+    const roleComma = splitRoleComma(h);
+    if (roleComma) {
+      roleComma.forEach((s) => splits.push({ text: s, source: idx }));
+      return;
+    }
+    splits.push({ text: h, source: idx });
   });
 
   const companyIdx = splits.findIndex((s) => looksLikeCompany(s.text));

--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -25,6 +25,34 @@ export function stripBullet(text: string): string {
   return text.replace(/^\s*[•‣▪●◦⁃*\-–—]\s*/, "").trim();
 }
 
+/**
+ * True when a line reads like a description sentence rather than an entry
+ * header (company / title / institution). Some templates — notably the Word /
+ * Office résumé templates — write the role description as a glyph-less prose
+ * paragraph instead of a bulleted list, so `isBulletLine` alone can't tell the
+ * description apart from the header lines around the date.
+ *
+ * Two signals, both required, plus a word floor:
+ *   - a lowercase letter (a long ALL-CAPS company/title isn't prose), and
+ *   - an INTERNAL sentence break ("…accomplishments. Where…") — a period
+ *     between two letters followed by a capitalized word. This is what keeps a
+ *     long-but-header line like "Acme Analytics (8 employee venture-backed
+ *     startup) New York, NY" out: it has commas and parentheses but no
+ *     sentence period, so it stays a header (and its company is preserved).
+ * The 8-word floor sits just under the scorer's 8-30-word bullet window, so a
+ * paragraph the scorer would grade as a bullet is captured as body here too.
+ * Glyph-less descriptions WITHOUT a sentence period (e.g. indented one-line
+ * bullets) are left to the bullet/indent path, unchanged by this predicate.
+ */
+const PROSE_MIN_WORDS = 8;
+const SENTENCE_BREAK_RE = /[a-z]{2}\.\s+[A-Z]/;
+export function isProseLine(text: string): boolean {
+  const trimmed = text.trim();
+  if (!/[a-z]/.test(trimmed)) return false;
+  if (!SENTENCE_BREAK_RE.test(trimmed)) return false;
+  return trimmed.split(/\s+/).filter(Boolean).length >= PROSE_MIN_WORDS;
+}
+
 /** Collapse internal whitespace and trim — the canonical date-token normalizer. */
 export function normalizeDate(raw: string): string {
   return raw.replace(/\s+/g, " ").trim();

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -66,14 +66,25 @@ export const YEAR_RE = /\b(19|20)\d{2}\b/g;
 /** "Present" / "Current" / "Now" — open-ended end dates. */
 export const PRESENT_RE = /\b(Present|Current|Now|Ongoing)\b/i;
 
+// Year-position forms a date anchor may carry. Beyond real years (4-digit and
+// apostrophe-2-digit) this includes the redacted placeholder stubs Word/Office
+// templates ship — `20XX`, `XXXX`, `####` — so a redacted role header like
+// "March 20XX – December 20XX" still parses as a date range and the role isn't
+// dropped (#31 handles redaction at the completeness layer; this is the parser
+// recognizing the structure). `XXXX`/`####` are admitted ONLY here, in the
+// month-anchored slot, so they never anchor a date bare — mirrors the same
+// false-positive guard `REDACTED_DATE_RE` uses in score.ts.
+const YEAR_FORMS = `\\d{4}|'\\d{2}|20XX|XXXX|####`;
+
 // Shared fragment for one date anchor (Mmm YYYY | 'YY, mm/yyyy, YYYY).
 // Reused by DATE_RANGE_RE's start and end groups. Apostrophe-year keeps
-// DOCX parsing compatible with older resumes that use "Dec '00".
-const DATE_ANCHOR = `${MONTH}\\.?\\s+(?:\\d{4}|'\\d{2})|\\d{1,2}[\\/\\-]\\d{4}|\\d{4}`;
+// DOCX parsing compatible with older resumes that use "Dec '00". The bare-year
+// tail admits `20XX` (unambiguous) but NOT bare `XXXX`/`####` (too weak alone).
+const DATE_ANCHOR = `${MONTH}\\.?\\s+(?:${YEAR_FORMS})|\\d{1,2}[\\/\\-]\\d{4}|20XX|\\d{4}`;
 
 // Strict month-year anchor (no bare-year / numeric-slash forms) for the
 // separator-less branch — bare years adjacent are too weak a signal.
-const MONTH_YEAR_ANCHOR = `${MONTH}\\.?\\s+(?:\\d{4}|'\\d{2})`;
+const MONTH_YEAR_ANCHOR = `${MONTH}\\.?\\s+(?:${YEAR_FORMS})`;
 
 /**
  * Date range between two anchors. Captures both halves. Tolerant of spacing,

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -533,6 +533,9 @@ export interface AnonymousAtsScoreInput {
       start_date?: string;
       end_date?: string;
       is_current?: boolean;
+      /** Role body. Used as a fallback bullet source for glyph-less prose
+       *  templates whose accomplishment sections yield no marker bullets. */
+      description?: string;
     }[];
     education?: { degree?: string; institution?: string }[];
   };
@@ -662,13 +665,39 @@ function extractBulletsFromSections(sections: SectionedResume): string[] {
   return out;
 }
 
+/**
+ * Fallback bullet pool for marker-less prose templates: each parsed role's
+ * `description` (one paragraph per line, the shape the entry-block parser folds
+ * wrapped prose into) becomes one or more bullets via `splitBullets`. Only used
+ * when the section pool is empty, so glyph resumes never double-count.
+ */
+function poolExperienceDescriptions(
+  experience: { description?: string }[] | undefined,
+): string[] {
+  const out: string[] = [];
+  for (const e of experience ?? []) {
+    if (e.description) out.push(...splitBullets(e.description));
+  }
+  return out;
+}
+
 export function computeAnonymousAtsScore(
   input: AnonymousAtsScoreInput,
 ): AnonymousAtsScore {
   // ── Bullet-level dimensions (Specificity 40, Structure 30) ─────────────
   // Same scoreBulletPool the authed scorer uses — guarantees the two
   // surfaces apply identical per-bullet rules.
-  const bullets = extractBulletsFromSections(input.sections);
+  // Primary bullet source: marker-bearing lines pooled from the accomplishment
+  // sections. Fallback: glyph-less prose templates (Word / Office) write each
+  // role's description as a marker-less paragraph, so the section pool comes back
+  // empty — pool the parsed per-role descriptions instead (mirrors the authed
+  // scorer's per-role `splitBullets`). The description lines split exactly as
+  // `groupBulletsByExperience` keys on them, so the UI attributes each pooled
+  // bullet to its role.
+  let bullets = extractBulletsFromSections(input.sections);
+  if (bullets.length === 0) {
+    bullets = poolExperienceDescriptions(input.parsed.experience);
+  }
   const pool = scoreBulletPool(bullets);
   const observations = analyzeBullets(bullets);
   const gradable = pool.total >= ANON_MIN_BULLETS_TO_GRADE;

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -670,6 +670,12 @@ function extractBulletsFromSections(sections: SectionedResume): string[] {
  * `description` (one paragraph per line, the shape the entry-block parser folds
  * wrapped prose into) becomes one or more bullets via `splitBullets`. Only used
  * when the section pool is empty, so glyph resumes never double-count.
+ *
+ * Scope note: pools experience descriptions only — not project (#95) or
+ * achievement (#96) descriptions, which the authed scorer also pools. A
+ * glyph-less template whose prose lives solely in a projects/achievements
+ * section (with an empty accomplishment-section pool) still grades 0; broaden
+ * the fallback source if such a fixture surfaces.
  */
 function poolExperienceDescriptions(
   experience: { description?: string }[] | undefined,

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.9,
+    "confidence": 0.89,
     "triggers": [],
     "tiers": [
       "t0_layout",

--- a/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.86,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
       "current_title",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.64,
     "triggers": [
       "two_column"
     ],
@@ -9,7 +9,7 @@
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "ner",
     "fieldsPopulated": [
       "current_company",
       "current_title",

--- a/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.9,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -23,7 +23,7 @@
       "website_url"
     ],
     "skillsCount": 5,
-    "experienceCount": 2,
+    "experienceCount": 3,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,
@@ -34,21 +34,21 @@
     "sectionSource": "regex"
   },
   "score": {
-    "overall": 24,
-    "preLayoutOverall": 24,
+    "overall": 79,
+    "preLayoutOverall": 79,
     "specificity": {
-      "score": 0,
+      "score": 40,
       "max": 40,
-      "gradable": false,
-      "metricBullets": 0,
-      "totalBullets": 0
+      "gradable": true,
+      "metricBullets": 2,
+      "totalBullets": 3
     },
     "structure": {
-      "score": 0,
+      "score": 15,
       "max": 30,
-      "gradable": false,
-      "goodBullets": 0,
-      "totalBullets": 0
+      "gradable": true,
+      "goodBullets": 2,
+      "totalBullets": 3
     },
     "completeness": {
       "score": 24,
@@ -64,7 +64,7 @@
       "multiplier": 1,
       "scanned": false
     },
-    "bulletCount": 0,
+    "bulletCount": 3,
     "algoVersion": "1.3"
   }
 }

--- a/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.9,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -23,7 +23,7 @@
       "website_url"
     ],
     "skillsCount": 6,
-    "experienceCount": 1,
+    "experienceCount": 3,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,
@@ -34,29 +34,28 @@
     "sectionSource": "regex"
   },
   "score": {
-    "overall": 23,
-    "preLayoutOverall": 23,
+    "overall": 79,
+    "preLayoutOverall": 79,
     "specificity": {
-      "score": 0,
+      "score": 40,
       "max": 40,
-      "gradable": false,
-      "metricBullets": 0,
-      "totalBullets": 0
+      "gradable": true,
+      "metricBullets": 2,
+      "totalBullets": 3
     },
     "structure": {
-      "score": 0,
+      "score": 15,
       "max": 30,
-      "gradable": false,
-      "goodBullets": 0,
-      "totalBullets": 0
+      "gradable": true,
+      "goodBullets": 2,
+      "totalBullets": 3
     },
     "completeness": {
-      "score": 23,
+      "score": 24,
       "max": 30,
       "gradable": true,
       "missing": [
         "LinkedIn",
-        "role dates",
         "summary"
       ]
     },
@@ -65,7 +64,7 @@
       "multiplier": 1,
       "scanned": false
     },
-    "bulletCount": 0,
+    "bulletCount": 3,
     "algoVersion": "1.3"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the three defects the `chanchal-sharma-sample.pdf` referred-resume fixture (a Word/Office template with redacted `20XX` placeholder years and glyph-less prose descriptions) surfaced, plus the score-readout render collapse:

- **Render** — `AtsScoreReadout` score row no longer collapses when the completeness hint is long; the 3 dimension cards keep full width.
- **Parser — redacted years** — `DATE_ANCHOR`/`MONTH_YEAR_ANCHOR` admit `20XX` (and `XXXX`/`####` only when month-anchored), so `March 20XX – December 20XX` parses as a date range. All 3 roles now parse with correct title/company/dates.
- **Parser — prose bodies** — bullet-less prose descriptions are captured as the role body (R1 hybrid y-gap split on the PDF path, `isProseLine` fallback for flat-y DOCX/markdown), and a wrapped paragraph folds into one body unit.
- **Parser — R2** — guarded `"Role, Company"` single-line headers split into title + company (guarded against `Acme, Inc` and location tails), making all three roles map consistently.
- **Scoring** — pool per-role descriptions as a fallback bullet source when the accomplishment sections yield no marker bullets (glyph-less templates), mirroring the authed scorer. Specificity/Structure now grade the prose and the bullets render per role. `chanchal-sample` goes 1→3 roles, overall 24→79.
- `cascade.ts` counts the experience `team` field in `countExtractedChars` so the better field mapping doesn't trip the low-extraction-ratio hard-fail.

5 corpus snapshots re-baked — all improvements or negligible drift (chanchal-sample/-bulleted-skills 0→0.9; single-word-name-mononym 0→0.86; weasyprint-two-column 0→0.64; awesome-cv 0.9→0.89).

Closes #158

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (718 pass)
- [x] `npm run lint` clean
- [x] Manually verified in `npm run dev` on the target fixture (3 roles, descriptions render as bullets, score breakdown no longer collapses)