### PR TITLE
feat: download reconstructed resume as ATS-friendly PDF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jszip": "^3.10.1",
         "libphonenumber-js": "^1.13.6",
         "mammoth": "^1.12.0",
+        "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^4.10.38",
         "posthog-js": "^1.205.0",
         "react": "^19.1.1",
@@ -1855,6 +1856,24 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6640,6 +6659,18 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
     "node_modules/pdfjs-dist": {
       "version": "4.10.38",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
@@ -7788,6 +7819,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/turndown": {
       "version": "7.2.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jszip": "^3.10.1",
     "libphonenumber-js": "^1.13.6",
     "mammoth": "^1.12.0",
+    "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^4.10.38",
     "posthog-js": "^1.205.0",
     "react": "^19.1.1",

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -428,6 +428,11 @@ function EducationSection({
                 {dates && (
                   <span className="text-content-tertiary"> · {dates}</span>
                 )}
+                {edu.coursework && edu.coursework.length > 0 && (
+                  <span className="block text-content-tertiary">
+                    Coursework: {edu.coursework.join(" · ")}
+                  </span>
+                )}
               </li>
             );
           })}

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -60,6 +60,8 @@ import {
   buildProjectDates,
   buildEducationDates,
 } from "../../lib/score/entry-dates.ts";
+import { Button } from "@design-system";
+import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
 
 // ── Rollup strip ──────────────────────────────────────────────────────────────
 
@@ -507,6 +509,11 @@ export function ReconstructedResume({
     ? [...experienceGroups, other]
     : experienceGroups;
 
+  // Download the reconstructed (possibly edited) résumé as an ATS-safe,
+  // text-only PDF — built fully client-side from the already-parsed fields,
+  // so no PDF bytes ever leave the browser (#171).
+  const { download, isGenerating } = useDownloadPdf(result, score, edit);
+
   const achievementsSection = achievements.length > 0 && (
     <AchievementsSection
       achievements={achievements}
@@ -521,9 +528,19 @@ export function ReconstructedResume({
       className="scroll-mt-6 flex flex-col gap-6"
     >
       <div className="flex flex-col gap-2">
-        <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-          Reconstructed resume
-        </h2>
+        <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            Reconstructed resume
+          </h2>
+          <Button
+            variant="primary"
+            onClick={download}
+            disabled={isGenerating}
+            aria-label="Download the reconstructed resume as an ATS-friendly PDF"
+          >
+            {isGenerating ? "Generating…" : "Download PDF"}
+          </Button>
+        </div>
         <p className="max-w-prose text-sm text-content-tertiary">
           What the parser recognized, in resume shape. Each bullet is checked
           against three rules — an action verb, the 8–30-word length window, and

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useDownloadPdf — drives the "Download PDF" action on the reconstructed-resume
+ * surface (#171).
+ *
+ * Flow: build the flat ATS model from the surface's own props → render bytes
+ * with the pdf-lib draw engine → wrap in a Blob → trigger a same-document
+ * download via a temporary object URL. Everything is client-side; no network
+ * request is made (no font fetch, no upload), satisfying the zero-egress AC.
+ */
+
+import { useCallback, useState } from "react";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../lib/score/score.ts";
+import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
+import { renderAtsResumePdf } from "../lib/pdf/render-ats-pdf.ts";
+import type { EditableParse } from "./useEditableParse.ts";
+
+export interface UseDownloadPdf {
+  download: () => Promise<void>;
+  isGenerating: boolean;
+  error: string | null;
+}
+
+/** Turn a candidate name into a safe, lower-kebab PDF filename. */
+function filenameFromName(name: string | undefined): string {
+  const slug = (name ?? "")
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+  return slug ? `${slug}-resume-ats.pdf` : "resume-ats.pdf";
+}
+
+export function useDownloadPdf(
+  result: CascadeResult,
+  score: AnonymousAtsScore,
+  edit?: Pick<EditableParse, "contactOverrides" | "bulletOverrides">,
+): UseDownloadPdf {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const download = useCallback(async () => {
+    setIsGenerating(true);
+    setError(null);
+    let url: string | null = null;
+    try {
+      const model = buildAtsResumeModel(result, score, edit);
+      const bytes = await renderAtsResumePdf(model);
+      // Copy into a fresh ArrayBuffer-backed view so Blob gets a clean buffer.
+      const blob = new Blob([bytes.slice()], { type: "application/pdf" });
+      url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filenameFromName(model.contact.name);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not generate PDF.");
+    } finally {
+      if (url) URL.revokeObjectURL(url);
+      setIsGenerating(false);
+    }
+  }, [result, score, edit]);
+
+  return { download, isGenerating, error };
+}

--- a/src/lib/heuristics/extract-fields.test.ts
+++ b/src/lib/heuristics/extract-fields.test.ts
@@ -751,6 +751,84 @@ describe("extractEducation — date-range parsing (issue #97)", () => {
   });
 });
 
+describe("extractEducation — relevant-coursework recovery (#164)", () => {
+  const mkLine = (text: string): PdfLine => ({
+    page: 0,
+    y: 0,
+    x: 0,
+    items: [],
+    text,
+    maxFontSize: 11,
+    allCaps: false,
+  });
+  const mkEduSection = (texts: string[]): PdfSection => ({
+    name: "education",
+    lines: texts.map(mkLine),
+  });
+
+  it("collects bullet coursework items onto the primary (first) entry", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "San Jose State University",
+        "B.S. Business Administration — Expected Graduation: May 2027",
+        "● Financial Accounting",
+        "● Microeconomics",
+        "● Macroeconomics",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].coursework).toEqual([
+      "Financial Accounting",
+      "Microeconomics",
+      "Macroeconomics",
+    ]);
+  });
+
+  it("rejoins a coursework cell that wrapped onto a following non-bullet line", () => {
+    // A de-interleaved grid cell ("● Global Dimensions of" + "Business") must be
+    // joined back into one item, not truncated at the wrap and not mistaken for
+    // an institution.
+    const { value } = extractEducation(
+      mkEduSection([
+        "San Jose State University",
+        "B.S. Business Administration — May 2027",
+        "● Global Dimensions of",
+        "Business",
+        "● Legal Environment of",
+        "Business",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].institution).toBe("San Jose State University");
+    expect(value[0].coursework).toEqual([
+      "Global Dimensions of Business",
+      "Legal Environment of Business",
+    ]);
+  });
+
+  it("drops a lowercase degree sub-note bullet — not a course title", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Kwansei Gakuin University",
+        "Study Abroad in Japan — Sep 2024 - July 2025",
+        "-including courses taught in Japanese",
+        "● Financial Accounting",
+      ]),
+    );
+    expect(value[0].coursework).toEqual(["Financial Accounting"]);
+  });
+
+  it("leaves coursework undefined when the section has no bullets", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Stanford University",
+        "B.S. Computer Science, 2019 - 2023",
+      ]),
+    );
+    expect(value[0].coursework).toBeUndefined();
+  });
+});
+
 // ── Entry-block extractors (experience / projects / achievements) ─────────────
 // Cover the per-block mapping helpers (`experienceFromBlock`, `projectFromBlock`,
 // `achievementFromBlock`) directly: fully-populated entries exercise every

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -13,6 +13,7 @@ import {
   isBulletLine,
   parseDateRange,
   normalizeDate,
+  stripBullet,
 } from "../line-primitives.ts";
 import { avgScore } from "./shared.ts";
 
@@ -196,8 +197,49 @@ export function extractEducation(
   if (!education || education.lines.length === 0)
     return { value: [], confidence: 0 };
 
-  const lines = education.lines
-    .filter((l) => !isBulletLine(l))
+  // Bullet lines inside an education section are relevant-coursework items
+  // (a "Relevant Coursework" block, #164) — not degree/institution lines, so
+  // they were dropped before. Recover them as section-level coursework and
+  // attach to the primary entry below.
+  //
+  // Two wrinkles from real grids (the de-interleaved 3-column reproducer):
+  //   - A cell can wrap: "● Global Dimensions of" + a following non-bullet
+  //     "Business" line. The continuation is joined back into the item and
+  //     excluded from entry detection (`consumed`) so it is not mistaken for
+  //     an institution.
+  //   - A degree sub-note ("-including courses taught in Japanese") is also a
+  //     bullet but reads as lowercase prose, not a course title. The Title-case
+  //     guard drops it; course titles lead uppercase.
+  const ls = education.lines;
+  const coursework: string[] = [];
+  const consumed = new Set<number>();
+  for (let i = 0; i < ls.length; i++) {
+    if (!isBulletLine(ls[i])) continue;
+    let item = stripBullet(ls[i].text);
+    const span = [i];
+    let j = i + 1;
+    while (
+      j < ls.length &&
+      !isBulletLine(ls[j]) &&
+      !DEGREE_RE.test(ls[j].text) &&
+      !INSTITUTION_HINTS.test(ls[j].text) &&
+      !isDateOnlyLine(ls[j].text)
+    ) {
+      item += ` ${ls[j].text.trim()}`;
+      span.push(j);
+      j++;
+    }
+    item = item.trim();
+    if (/^[A-Z0-9]/.test(item)) {
+      coursework.push(item);
+      for (const k of span) consumed.add(k);
+    }
+    i = j - 1;
+  }
+
+  const lines = ls
+    .map((l, idx) => ({ text: l.text, bullet: isBulletLine(l), idx }))
+    .filter((l) => !l.bullet && !consumed.has(l.idx))
     .map((l) => l.text)
     .filter((t) => t.trim().length > 0);
   if (lines.length === 0) return { value: [], confidence: 0 };
@@ -232,8 +274,14 @@ export function extractEducation(
     .map(educationFromChunk)
     .filter((b) => b.entry.degree || b.entry.institution);
   if (built.length === 0) return { value: [], confidence: 0 };
+
+  const value = built.map((b) => b.entry);
+  // Attach section-level coursework to the primary (first) entry — per-degree
+  // attribution is ambiguous when the block sits in its own sub-section (#164).
+  if (coursework.length > 0) value[0].coursework = coursework;
+
   return {
-    value: built.map((b) => b.entry),
+    value,
     confidence: avgScore(built.map((b) => b.score)),
   };
 }

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import type { AnonymousAtsScore, BulletObservation } from "../score/score.ts";
+
+function bullet(text: string, index: number): BulletObservation {
+  return {
+    text,
+    index,
+    hasMetric: true,
+    startsWithActionVerb: true,
+    wellFormedLength: true,
+    wordCount: text.split(/\s+/).length,
+  };
+}
+
+function makeResult(
+  parsed: Partial<CascadeResult["parsed"]> = {},
+): CascadeResult {
+  return {
+    parsed: {
+      full_name: "Jane Candidate",
+      email: "jane@example.com",
+      phone: "(312) 555-0123",
+      location: "Chicago, IL",
+      linkedin_url: "linkedin.com/in/jane",
+      summary: "Product leader with a decade of B2B SaaS experience.",
+      skills: ["TypeScript", "Product Strategy", "SQL"],
+      experience: [
+        {
+          title: "Senior PM",
+          company: "Acme",
+          start_date: "2020",
+          end_date: "2024",
+          description:
+            "Led migration of legacy auth system to OAuth\nDrove 30% revenue growth across the platform",
+        },
+      ],
+      education: [
+        {
+          degree: "BS Computer Science",
+          institution: "State University",
+          year: "2016",
+          coursework: ["Algorithms", "Databases"],
+        },
+      ],
+      projects: [],
+      heuristic_achievements: [],
+      ...parsed,
+    },
+    fieldConfidence: {
+      full_name: 1,
+      email: 1,
+      phone: 1,
+      location: 1,
+      linkedin_url: 1,
+      github_url: 1,
+    },
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+function makeScore(bullets: BulletObservation[]): AnonymousAtsScore {
+  return { bullets } as unknown as AnonymousAtsScore;
+}
+
+describe("buildAtsResumeModel", () => {
+  it("builds contact, summary, and standard-order sections", () => {
+    const result = makeResult();
+    const score = makeScore([
+      bullet("Led migration of legacy auth system to OAuth", 0),
+      bullet("Drove 30% revenue growth across the platform", 1),
+    ]);
+
+    const model = buildAtsResumeModel(result, score);
+
+    expect(model.contact.name).toBe("Jane Candidate");
+    expect(model.contact.email).toBe("jane@example.com");
+    expect(model.contact.phone).toBe("(312) 555-0123");
+    expect(model.contact.location).toBe("Chicago, IL");
+    expect(model.contact.links).toContain("linkedin.com/in/jane");
+    expect(model.summary).toMatch(/Product leader/);
+
+    const headings = model.sections.map((s) => s.heading);
+    // Experience precedes Education precedes Skills.
+    expect(headings).toEqual(["Experience", "Education", "Skills"]);
+
+    const exp = model.sections[0].entries[0];
+    expect(exp.headerLine).toBe("Senior PM · Acme");
+    expect(exp.subLine).toBe("2020 – 2024");
+    expect(exp.bullets).toEqual([
+      "Led migration of legacy auth system to OAuth",
+      "Drove 30% revenue growth across the platform",
+    ]);
+
+    const edu = model.sections[1].entries[0];
+    expect(edu.headerLine).toBe("BS Computer Science — State University");
+    expect(edu.bullets[0]).toMatch(/Coursework: Algorithms, Databases/);
+
+    const skills = model.sections[2].entries[0];
+    expect(skills.headerLine).toContain("TypeScript");
+  });
+
+  it("falls back to description split when no graded bullets are attributed", () => {
+    const result = makeResult();
+    const model = buildAtsResumeModel(result, makeScore([]));
+    expect(model.sections[0].entries[0].bullets).toEqual([
+      "Led migration of legacy auth system to OAuth",
+      "Drove 30% revenue growth across the platform",
+    ]);
+  });
+
+  it("applies contact overrides like ContactCard ('' clears, value replaces)", () => {
+    const result = makeResult();
+    const model = buildAtsResumeModel(result, makeScore([]), {
+      contactOverrides: { full_name: "Janet Q. Candidate", phone: "" },
+      bulletOverrides: {},
+    });
+    expect(model.contact.name).toBe("Janet Q. Candidate");
+    expect(model.contact.phone).toBeUndefined();
+  });
+
+  it("applies bullet overrides to the rendered bullet text", () => {
+    const result = makeResult();
+    const score = makeScore([
+      bullet("Led migration of legacy auth system to OAuth", 0),
+      bullet("Drove 30% revenue growth across the platform", 1),
+    ]);
+    const model = buildAtsResumeModel(result, score, {
+      contactOverrides: {},
+      bulletOverrides: { 0: "Rewrote the auth layer, cutting login latency 40%" },
+    });
+    expect(model.sections[0].entries[0].bullets[0]).toBe(
+      "Rewrote the auth layer, cutting login latency 40%",
+    );
+  });
+
+  it("promotes Achievements above Experience when placement says so", () => {
+    const result = makeResult({
+      heuristic_achievements: [{ title: "Patent US123", year: "2022" }],
+      achievements_placement: "above_experience",
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const headings = model.sections.map((s) => s.heading);
+    expect(headings[0]).toBe("Achievements");
+    expect(headings.indexOf("Achievements")).toBeLessThan(
+      headings.indexOf("Experience"),
+    );
+  });
+
+  it("omits empty sections", () => {
+    const result = makeResult({
+      experience: [],
+      education: [],
+      skills: [],
+      summary: undefined,
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    expect(model.sections).toEqual([]);
+    expect(model.summary).toBeUndefined();
+  });
+});

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ats-resume-model — a pure, UI-free adapter that flattens a parsed résumé
+ * (the same `result` / `score` / `edit` the ReconstructedResume surface renders)
+ * into a render-ready model for the ATS-safe PDF exporter (#171).
+ *
+ * Goals:
+ *   - Mirror the on-screen reconstructed view: same contact fields (with
+ *     in-memory edits applied the way ContactCard does), same per-experience
+ *     bullet attribution (via `groupBulletsByExperience`), same edited bullet
+ *     text (via `bulletOverrides`), same section order.
+ *   - Stay free of React / pdf-lib so it is directly unit-testable.
+ *
+ * Section order is standard ATS top-to-bottom:
+ *   Summary → (Achievements if "above_experience") → Experience → Projects →
+ *   Achievements (default placement) → Education → Skills.
+ */
+
+import type { CascadeResult } from "../heuristics/types.ts";
+import type { AnonymousAtsScore, BulletObservation } from "../score/score.ts";
+import type {
+  ResumeProject,
+  ResumeEducation,
+  HeuristicAchievement,
+} from "../score/types.ts";
+import {
+  groupBulletsByExperience,
+  type BulletExperience,
+} from "../score/group-bullets.ts";
+import { buildEducationDates, buildProjectDates } from "../score/entry-dates.ts";
+import { buildContactFields } from "../contact.ts";
+import type {
+  ContactOverrides,
+  EditableParse,
+} from "../../hooks/useEditableParse.ts";
+
+// ── Model shape ───────────────────────────────────────────────────────────────
+
+export interface AtsContact {
+  name: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  /** LinkedIn / GitHub / portfolio / website / other links, label-prefixed. */
+  links: string[];
+}
+
+export interface AtsEntry {
+  /** Primary header line, e.g. "Senior PM · Google". */
+  headerLine: string;
+  /** Secondary line under the header, e.g. a date range. */
+  subLine?: string;
+  /** Bullet body lines (already stripped of leading markers, non-empty). */
+  bullets: string[];
+}
+
+export interface AtsSection {
+  heading: string;
+  entries: AtsEntry[];
+}
+
+export interface AtsResumeModel {
+  contact: AtsContact;
+  summary?: string;
+  sections: AtsSection[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Apply ContactCard's override semantics: "" clears, undefined keeps parsed. */
+function resolveContactValue(
+  parsedValue: string,
+  override: string | undefined,
+): string {
+  if (override === undefined) return parsedValue;
+  return override; // "" clears, non-empty replaces
+}
+
+function buildContact(
+  result: CascadeResult,
+  contactOverrides: ContactOverrides,
+): AtsContact {
+  const fields = buildContactFields(result);
+  const byKey = new Map(fields.map((f) => [f.key, f]));
+
+  const valueFor = (key: keyof ContactOverrides): string => {
+    const field = byKey.get(key);
+    const parsed = field && !field.gated ? field.value : "";
+    return resolveContactValue(parsed, contactOverrides[key]).trim();
+  };
+
+  const name = valueFor("full_name") || result.parsed.full_name || "";
+  const email = valueFor("email");
+  const phone = valueFor("phone");
+  const location = valueFor("location");
+
+  // Links: LinkedIn comes from the editable/contact path; the remaining link
+  // fields are read straight off the parsed resume (they're not edited inline).
+  const links: string[] = [];
+  const linkedin = valueFor("linkedin_url");
+  if (linkedin) links.push(linkedin);
+  const parsed = result.parsed;
+  if (parsed.github_url) links.push(parsed.github_url);
+  if (parsed.portfolio_url) links.push(parsed.portfolio_url);
+  if (parsed.website_url) links.push(parsed.website_url);
+
+  return {
+    name,
+    email: email || undefined,
+    phone: phone || undefined,
+    location: location || undefined,
+    links,
+  };
+}
+
+/** Split a "\n"-joined description into trimmed, non-empty bullet lines. */
+function bulletsFromDescription(description: string | undefined): string[] {
+  if (!description) return [];
+  return description
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the bullets for one entry. Prefers the graded `BulletObservation`
+ * pool (which mirrors what the surface shows, including edited text via
+ * `bulletOverrides`); falls back to the raw `description` split when no graded
+ * bullets were attributed to the entry.
+ */
+function resolveBullets(
+  observations: BulletObservation[] | undefined,
+  bulletOverrides: Record<number, string>,
+  description: string | undefined,
+): string[] {
+  if (observations && observations.length > 0) {
+    return observations
+      .map((b) => (bulletOverrides[b.index] ?? b.text).trim())
+      .filter(Boolean);
+  }
+  return bulletsFromDescription(description);
+}
+
+function asBulletExperience(
+  entries: ReadonlyArray<{
+    title?: string;
+    name?: string;
+    description?: string;
+    start_date?: string;
+    end_date?: string;
+    is_current?: boolean;
+  }>,
+): BulletExperience[] {
+  return entries.map((e) => ({
+    title: e.title ?? e.name,
+    description: e.description,
+    start_date: e.start_date,
+    end_date: e.end_date,
+    is_current: e.is_current,
+  }));
+}
+
+function experienceDateRange(exp: {
+  start_date?: string;
+  end_date?: string;
+  is_current?: boolean;
+}): string {
+  const start = exp.start_date || undefined;
+  const end = exp.is_current ? "Present" : exp.end_date || undefined;
+  if (start && end) return `${start} – ${end}`;
+  if (start) return start;
+  if (end) return end;
+  return "";
+}
+
+function joinHeader(parts: Array<string | undefined>, sep: string): string {
+  return parts.filter((p) => p && p.trim()).join(sep);
+}
+
+// ── Builder ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build the flat ATS render model from the surface's own props.
+ *
+ * `edit` is optional — when omitted, no in-memory overrides are applied and the
+ * model reflects the raw parse (used by tests / non-edit callers).
+ */
+export function buildAtsResumeModel(
+  result: CascadeResult,
+  score: AnonymousAtsScore,
+  edit?: Pick<EditableParse, "contactOverrides" | "bulletOverrides">,
+): AtsResumeModel {
+  const parsed = result.parsed;
+  const contactOverrides = edit?.contactOverrides ?? {};
+  const bulletOverrides = edit?.bulletOverrides ?? {};
+
+  const contact = buildContact(result, contactOverrides);
+
+  const experiences = parsed.experience ?? [];
+  const projects: ResumeProject[] = parsed.projects ?? [];
+  const achievements: HeuristicAchievement[] =
+    parsed.heuristic_achievements ?? [];
+  const education: ResumeEducation[] = parsed.education ?? [];
+  const skills = parsed.skills ?? [];
+  const bulletPool = score.bullets ?? [];
+
+  // One grouping pass over experiences + projects + achievements, mirroring the
+  // surface, so bullets are attributed to their own entry.
+  const combined = [
+    ...asBulletExperience(experiences),
+    ...asBulletExperience(projects),
+    ...asBulletExperience(achievements),
+  ];
+  const grouped = groupBulletsByExperience([...bulletPool], combined);
+  const bulletsByIndex = new Map<number, BulletObservation[]>();
+  for (const g of grouped) {
+    if (g.experienceIndex !== null)
+      bulletsByIndex.set(g.experienceIndex, g.bullets);
+  }
+  const expOffset = 0;
+  const projOffset = experiences.length;
+  const achOffset = experiences.length + projects.length;
+
+  const sections: AtsSection[] = [];
+
+  // ── Experience ──
+  const experienceEntries: AtsEntry[] = experiences.map((exp, i) => ({
+    headerLine: joinHeader([exp.title, exp.company], " · ") || "Experience",
+    subLine: experienceDateRange(exp) || undefined,
+    bullets: resolveBullets(
+      bulletsByIndex.get(expOffset + i),
+      bulletOverrides,
+      exp.description,
+    ),
+  }));
+
+  // ── Projects ──
+  const projectEntries: AtsEntry[] = projects.map((proj, i) => ({
+    headerLine: joinHeader([proj.name, buildProjectDates(proj)], " · ") ||
+      "Project",
+    subLine: undefined,
+    bullets: resolveBullets(
+      bulletsByIndex.get(projOffset + i),
+      bulletOverrides,
+      proj.description,
+    ),
+  }));
+
+  // ── Achievements ──
+  const achievementEntries: AtsEntry[] = achievements.map((ach, i) => ({
+    headerLine: joinHeader([ach.title, ach.year], " · ") || "Achievement",
+    subLine: undefined,
+    bullets: resolveBullets(
+      bulletsByIndex.get(achOffset + i),
+      bulletOverrides,
+      ach.description,
+    ),
+  }));
+
+  // ── Education ──
+  const educationEntries: AtsEntry[] = education.map((edu) => {
+    const bullets: string[] = [];
+    if (edu.coursework && edu.coursework.length > 0) {
+      bullets.push(`Coursework: ${edu.coursework.join(", ")}`);
+    }
+    return {
+      headerLine: joinHeader([edu.degree, edu.institution], " — ") ||
+        "Education",
+      subLine: buildEducationDates(edu) || undefined,
+      bullets,
+    };
+  });
+
+  // ── Skills (one entry, no header line — bullets carry the joined list) ──
+  const skillsEntries: AtsEntry[] =
+    skills.length > 0
+      ? [{ headerLine: skills.join(" · "), bullets: [] }]
+      : [];
+
+  const achievementsAbove =
+    parsed.achievements_placement === "above_experience";
+  const achievementsSection: AtsSection | null =
+    achievementEntries.length > 0
+      ? { heading: "Achievements", entries: achievementEntries }
+      : null;
+
+  if (achievementsAbove && achievementsSection)
+    sections.push(achievementsSection);
+  if (experienceEntries.length > 0)
+    sections.push({ heading: "Experience", entries: experienceEntries });
+  if (projectEntries.length > 0)
+    sections.push({ heading: "Projects", entries: projectEntries });
+  if (!achievementsAbove && achievementsSection)
+    sections.push(achievementsSection);
+  if (educationEntries.length > 0)
+    sections.push({ heading: "Education", entries: educationEntries });
+  if (skillsEntries.length > 0)
+    sections.push({ heading: "Skills", entries: skillsEntries });
+
+  return {
+    contact,
+    summary: parsed.summary?.trim() || undefined,
+    sections,
+  };
+}

--- a/src/lib/pdf/load-pdf-lib.ts
+++ b/src/lib/pdf/load-pdf-lib.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * load-pdf-lib — dynamic-import-and-cache for `pdf-lib`.
+ *
+ * pdf-lib is only needed when the user clicks "Download PDF", so we keep it out
+ * of the entry chunk by dynamic-importing it on first use (mirroring the
+ * dynamic-import convention the heuristics cascade uses for its tiers). The
+ * import promise is cached at module scope so repeated downloads reuse the same
+ * loaded module.
+ *
+ * We deliberately load ONLY the parts we use — `PDFDocument`, `StandardFonts`,
+ * `rgb` — and NO fontkit / custom-font machinery, so the exporter can only ever
+ * use the 14 built-in PDF fonts. That is what guarantees zero network egress
+ * (no font fetch) and the most ATS-safe output.
+ */
+
+type PdfLib = typeof import("pdf-lib");
+
+export interface PdfLibParts {
+  PDFDocument: PdfLib["PDFDocument"];
+  StandardFonts: PdfLib["StandardFonts"];
+  rgb: PdfLib["rgb"];
+}
+
+let cached: Promise<PdfLibParts> | null = null;
+
+/** Load pdf-lib once and return the small subset the exporter needs. */
+export function loadPdfLibOnce(): Promise<PdfLibParts> {
+  if (!cached) {
+    cached = import("pdf-lib").then(({ PDFDocument, StandardFonts, rgb }) => ({
+      PDFDocument,
+      StandardFonts,
+      rgb,
+    }));
+  }
+  return cached;
+}

--- a/src/lib/pdf/render-ats-pdf.test.ts
+++ b/src/lib/pdf/render-ats-pdf.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+import type { AtsResumeModel } from "./ats-resume-model.ts";
+
+const MODEL: AtsResumeModel = {
+  contact: {
+    name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    location: "Chicago, IL",
+    links: ["linkedin.com/in/jane"],
+  },
+  summary: "Product leader with a decade of B2B SaaS experience.",
+  sections: [
+    {
+      heading: "Experience",
+      entries: [
+        {
+          headerLine: "Senior PM · Acme",
+          subLine: "2020 – 2024",
+          bullets: [
+            "Led migration of the legacy auth system to OAuth, cutting login latency by 40 percent across the platform",
+            "Drove 30% revenue growth across the platform over four quarters",
+          ],
+        },
+      ],
+    },
+    {
+      heading: "Skills",
+      entries: [{ headerLine: "TypeScript · Product Strategy · SQL", bullets: [] }],
+    },
+  ],
+};
+
+/** Extract all text from PDF bytes using pdfjs-dist (proves selectable text). */
+async function extractText(bytes: Uint8Array): Promise<string> {
+  const pdfjs = await import("pdfjs-dist");
+  const doc = await pdfjs.getDocument({
+    data: bytes.slice(),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+    useSystemFonts: false,
+  }).promise;
+  let text = "";
+  for (let p = 1; p <= doc.numPages; p++) {
+    const page = await doc.getPage(p);
+    const content = await page.getTextContent();
+    text += content.items
+      .map((i) => ("str" in i ? (i as { str: string }).str : ""))
+      .join(" ");
+    text += " ";
+  }
+  return text;
+}
+
+describe("renderAtsResumePdf", () => {
+  it("returns a non-trivial PDF with the %PDF magic header", async () => {
+    const bytes = await renderAtsResumePdf(MODEL);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(500);
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-");
+  });
+
+  it("produces selectable, searchable text (AC#3) for name + headings", async () => {
+    const bytes = await renderAtsResumePdf(MODEL);
+    const text = await extractText(bytes);
+    expect(text).toContain("Jane Candidate");
+    expect(text).toMatch(/EXPERIENCE/i);
+    expect(text).toMatch(/SKILLS/i);
+    expect(text).toContain("Senior PM");
+    expect(text).toContain("OAuth");
+  });
+
+  it("paginates: a long résumé spans more than one page", async () => {
+    const manyEntries = Array.from({ length: 40 }, (_, i) => ({
+      headerLine: `Role ${i} · Company ${i}`,
+      subLine: "2018 – 2020",
+      bullets: [
+        "Built and shipped a substantial feature that materially moved a key business metric for the team",
+        "Partnered cross-functionally to deliver an initiative that improved customer outcomes meaningfully",
+      ],
+    }));
+    const bigModel: AtsResumeModel = {
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [{ heading: "Experience", entries: manyEntries }],
+    };
+    const bytes = await renderAtsResumePdf(bigModel);
+    const pdfjs = await import("pdfjs-dist");
+    const doc = await pdfjs.getDocument({
+      data: bytes.slice(),
+      useWorkerFetch: false,
+      isEvalSupported: false,
+      useSystemFonts: false,
+    }).promise;
+    expect(doc.numPages).toBeGreaterThan(1);
+  });
+});

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * render-ats-pdf — the single-column, text-only ATS PDF draw engine (#171).
+ *
+ * Renders an `AtsResumeModel` to PDF bytes using ONLY pdf-lib's built-in
+ * Helvetica / Helvetica-Bold (`StandardFonts`). No embedded custom fonts, no
+ * images, no rasterization, no network — every glyph is selectable, searchable
+ * text drawn with a standard PDF font, which is the most ATS-safe form and
+ * guarantees zero egress.
+ *
+ * Layout: US Letter (612×792 pt), single column, ~54pt margins. The engine
+ * tracks a `y` cursor from the top margin downward; when the next line would
+ * cross the bottom margin it adds a page and resets the cursor. Long lines are
+ * word-wrapped by measuring with `font.widthOfTextAtSize`; bullets get a "• "
+ * marker with a hanging indent.
+ *
+ * The `rgb()` colors here are PDF graphics-state values (black text, a muted
+ * gray rule) — NOT Tailwind tokens. The style guard scans component/feature
+ * code, not this draw module.
+ */
+
+import { loadPdfLibOnce, type PdfLibParts } from "./load-pdf-lib.ts";
+import type { AtsResumeModel, AtsEntry } from "./ats-resume-model.ts";
+
+// ── Page geometry (points) ────────────────────────────────────────────────────
+
+const PAGE_WIDTH = 612; // US Letter
+const PAGE_HEIGHT = 792;
+const MARGIN = 54;
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+const CONTENT_BOTTOM = MARGIN;
+
+// ── Type scale (points) ───────────────────────────────────────────────────────
+
+const SIZE_NAME = 18;
+const SIZE_CONTACT = 9;
+const SIZE_SECTION = 11;
+const SIZE_HEADER = 10.5;
+const SIZE_SUB = 9.5;
+const SIZE_BODY = 10;
+
+// Line-height multiplier applied to the font size for vertical advance.
+const LINE_GAP = 1.25;
+// Extra vertical breathing room (points) between blocks.
+const GAP_AFTER_CONTACT = 10;
+const GAP_BEFORE_SECTION = 12;
+const GAP_AFTER_RULE = 6;
+const GAP_BETWEEN_ENTRIES = 7;
+const GAP_AFTER_HEADER = 2;
+
+const BULLET_MARKER = "• ";
+const BULLET_INDENT = 12; // hanging-indent width for wrapped bullet lines
+
+type RGB = ReturnType<PdfLibParts["rgb"]>;
+type Doc = Awaited<ReturnType<PdfLibParts["PDFDocument"]["create"]>>;
+type Page = ReturnType<Doc["addPage"]>;
+type PdfFont = Awaited<ReturnType<Doc["embedFont"]>>;
+
+/**
+ * Mutable cursor + page state threaded through the draw routines. We keep one
+ * "current page" and append new pages as the cursor overflows.
+ */
+class Layout {
+  page: Page;
+  y: number;
+
+  constructor(
+    private doc: Doc,
+    private fonts: { regular: PdfFont; bold: PdfFont },
+    private black: RGB,
+    private gray: RGB,
+  ) {
+    this.page = doc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    this.y = PAGE_HEIGHT - MARGIN;
+  }
+
+  private newPage() {
+    this.page = this.doc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    this.y = PAGE_HEIGHT - MARGIN;
+  }
+
+  /** Ensure room for `height` pt; add a page if the cursor would overflow. */
+  private ensure(height: number) {
+    if (this.y - height < CONTENT_BOTTOM) this.newPage();
+  }
+
+  advance(points: number) {
+    this.y -= points;
+  }
+
+  /** Word-wrap `text` to `maxWidth` using the given font/size. */
+  private wrap(
+    text: string,
+    font: PdfFont,
+    size: number,
+    maxWidth: number,
+  ): string[] {
+    const words = text.split(/\s+/).filter(Boolean);
+    if (words.length === 0) return [];
+    const lines: string[] = [];
+    let current = words[0];
+    for (let i = 1; i < words.length; i++) {
+      const candidate = `${current} ${words[i]}`;
+      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+        current = candidate;
+      } else {
+        lines.push(current);
+        current = words[i];
+      }
+    }
+    lines.push(current);
+    return lines;
+  }
+
+  /**
+   * Draw a wrapped block of text. `x` is the left edge; `hangingIndent`
+   * indents continuation lines (for bullet hanging indent). Returns nothing;
+   * mutates the cursor and paginates as needed.
+   */
+  drawText(
+    text: string,
+    opts: {
+      bold?: boolean;
+      size?: number;
+      color?: RGB;
+      x?: number;
+      hangingIndent?: number;
+      uppercase?: boolean;
+    } = {},
+  ) {
+    const size = opts.size ?? SIZE_BODY;
+    const font = opts.bold ? this.fonts.bold : this.fonts.regular;
+    const color = opts.color ?? this.black;
+    const x = opts.x ?? MARGIN;
+    const hanging = opts.hangingIndent ?? 0;
+    const value = opts.uppercase ? text.toUpperCase() : text;
+    const maxWidth = CONTENT_WIDTH - (x - MARGIN);
+
+    const lines = this.wrap(value, font, size, maxWidth);
+    const lineHeight = size * LINE_GAP;
+    for (let i = 0; i < lines.length; i++) {
+      this.ensure(lineHeight);
+      const lineX = i === 0 ? x : x + hanging;
+      this.page.drawText(lines[i], {
+        x: lineX,
+        y: this.y - size,
+        size,
+        font,
+        color,
+      });
+      this.advance(lineHeight);
+    }
+  }
+
+  drawRule() {
+    this.ensure(2);
+    this.page.drawLine({
+      start: { x: MARGIN, y: this.y },
+      end: { x: PAGE_WIDTH - MARGIN, y: this.y },
+      thickness: 0.75,
+      color: this.gray,
+    });
+    this.advance(2);
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/** Render an ATS résumé model to PDF bytes (Uint8Array). */
+export async function renderAtsResumePdf(
+  model: AtsResumeModel,
+): Promise<Uint8Array> {
+  const { PDFDocument, StandardFonts, rgb } = await loadPdfLibOnce();
+
+  const doc = await PDFDocument.create();
+  doc.setTitle(model.contact.name || "Resume");
+
+  const regular = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  const black = rgb(0.1, 0.1, 0.1);
+  const gray = rgb(0.55, 0.55, 0.55);
+  const muted = rgb(0.35, 0.35, 0.35);
+
+  const layout = new Layout(doc, { regular, bold }, black, gray);
+
+  // ── Header: name + contact line ──
+  if (model.contact.name) {
+    layout.drawText(model.contact.name, { bold: true, size: SIZE_NAME });
+  }
+  const contactParts = [
+    model.contact.email,
+    model.contact.phone,
+    model.contact.location,
+    ...model.contact.links,
+  ].filter((p): p is string => Boolean(p));
+  if (contactParts.length > 0) {
+    layout.drawText(contactParts.join("  •  "), {
+      size: SIZE_CONTACT,
+      color: muted,
+    });
+  }
+  layout.advance(GAP_AFTER_CONTACT);
+
+  // ── Summary ──
+  if (model.summary) {
+    drawSectionHeading(layout, "Summary");
+    layout.drawText(model.summary, { size: SIZE_BODY });
+    layout.advance(GAP_BETWEEN_ENTRIES);
+  }
+
+  // ── Sections ──
+  for (const section of model.sections) {
+    drawSectionHeading(layout, section.heading);
+    for (let i = 0; i < section.entries.length; i++) {
+      drawEntry(layout, section.entries[i], muted);
+      if (i < section.entries.length - 1) layout.advance(GAP_BETWEEN_ENTRIES);
+    }
+    layout.advance(GAP_BETWEEN_ENTRIES);
+  }
+
+  return doc.save();
+}
+
+function drawSectionHeading(layout: Layout, heading: string) {
+  layout.advance(GAP_BEFORE_SECTION);
+  layout.drawText(heading, { bold: true, size: SIZE_SECTION, uppercase: true });
+  layout.drawRule();
+  layout.advance(GAP_AFTER_RULE);
+}
+
+function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
+  if (entry.headerLine) {
+    layout.drawText(entry.headerLine, { bold: true, size: SIZE_HEADER });
+  }
+  if (entry.subLine) {
+    layout.advance(GAP_AFTER_HEADER);
+    layout.drawText(entry.subLine, { size: SIZE_SUB, color: mutedColor });
+  }
+  for (const bullet of entry.bullets) {
+    layout.drawText(`${BULLET_MARKER}${bullet}`, {
+      size: SIZE_BODY,
+      hangingIndent: BULLET_INDENT,
+    });
+  }
+}

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -143,6 +143,11 @@ export interface ResumeEducation {
   end_date?: string;
   end_date_precision?: "day" | "month" | "year" | null;
   description?: string;
+  /** Relevant-coursework items recovered from bullet lines inside the education
+   *  section (e.g. a "Relevant Coursework" block, #164). Section-level by nature
+   *  — attribution to a specific degree is ambiguous, so the heuristic parser
+   *  attaches the whole list to the first (primary) entry. */
+  coursework?: string[];
 }
 
 // ── Projects ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a **Download PDF** button to the `ReconstructedResume` surface that generates an ATS-safe, single-column PDF **fully client-side** from the already-parsed (and inline-edited) fields. The PDF is rendered with `pdf-lib` using only the built-in Helvetica / Helvetica-Bold standard fonts — no font fetch, no rasterization, no network of any kind — so the output is fully selectable, searchable text and zero PDF bytes leave the browser.

Closes #171

> **Stacked on #169** (`feat/education-coursework-issue-168`). GitHub will auto-retarget this PR's base to `main` once #169 merges; rebase onto `main` then to drop the duplicated parent commit.

## What changed

- `src/lib/pdf/load-pdf-lib.ts` — cached dynamic `import("pdf-lib")` so it stays out of the entry chunk (lands in its own lazy chunk; verified via build).
- `src/lib/pdf/ats-resume-model.ts` — pure, UI-free adapter that flattens `CascadeResult` + `score` + edit overrides into a render-ready model (contact, summary, Experience → Projects → Achievements → Education → Skills, honoring `achievements_placement`). Mirrors the on-screen view: same contact fields, same per-entry bullet attribution via `groupBulletsByExperience`, same edited bullet/contact text.
- `src/lib/pdf/render-ats-pdf.ts` — single-column draw engine: word-wrap via `widthOfTextAtSize`, bullet hanging indents, section headings + rule lines, top-down `y` cursor with page-overflow pagination. Returns `Uint8Array`.
- `src/hooks/useDownloadPdf.ts` — `{ download, isGenerating, error }`; build → render → Blob → object-URL → `<a download>` click → revoke. Filename derived from candidate name.
- `src/components/features/ReconstructedResume.tsx` — wires the `<Button>` (design-system primitive) into the header; no raw `<button>`, no new parallel surface.
- `package.json` — adds `pdf-lib` ^1.17.1.

## Acceptance criteria

1. ✅ Download PDF button on the surface, reuses `<Button>` from `@design-system` (no raw `<button>`).
2. ✅ Client-side download, zero network (built-in fonts only, no fetch/upload anywhere in `src/lib/pdf/` or the hook).
3. ✅ Selectable/searchable text — round-trip test extracts the name + section headings via pdfjs.
4. ✅ Single-column, plain-prose section headers (Experience/Education/Skills…), no images/custom fonts.
5. ✅ Round-trip: model built from the original `CascadeResult` (graded bullets with `description` fallback).
6. ✅ No new raw palette / hex (PDF `rgb()` is graphics state, not Tailwind); lint passes.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (774 tests; 9 new across 2 pdf test files)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds; pdf-lib confirmed code-split into its own chunk (not the entry chunk)