### PR TITLE
feat: tab-based result view with accessible Tabs primitive

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-import type { CascadeResult } from "../lib/heuristics/types.ts";
+import { useState } from "react";
+import type { CascadeResult, LayoutTrigger } from "../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../lib/score/score.ts";
 import { getScoreLabel, getScoreTier } from "../lib/score/score.ts";
 import type { EditableParse } from "../hooks/useEditableParse.ts";
-import { Card, StatusBadge, Button } from "@design-system";
+import { Card, StatusBadge, Button, Tabs, TabList, Tab, TabPanel } from "@design-system";
 import { FeedbackControl } from "./features/FeedbackControl.tsx";
 import { ReconstructedResume } from "./features/ReconstructedResume.tsx";
 import { AtsScoreReadout } from "./features/AtsScoreReadout.tsx";
-import { EvidencePanel } from "./features/EvidencePanel.tsx";
+import { LayoutFlagsList } from "./features/LayoutFlagsList.tsx";
+import {
+  SourcePdfPanel,
+  ExtractedTextPanel,
+} from "./features/EvidencePanel.tsx";
 
 // LAYOUT_TRIGGER_BLURBS for fonts_unmappable is still needed by LimitedParsingCard.
 const FONTS_UNMAPPABLE_BLURB =
@@ -70,6 +75,8 @@ function ParsedCard({
   onReset: () => void;
   edit: EditableParse;
 }) {
+  const [tab, setTab] = useState("reconstructed");
+  const triggerCount = result.triggers.length;
   return (
     <Card className="flex flex-col gap-6 shadow-xs">
       <header className="flex items-center justify-between">
@@ -98,15 +105,39 @@ function ParsedCard({
       </header>
 
       <AtsScoreReadout score={score} />
-      <ReconstructedResume result={result} score={score} edit={edit} />
 
-      {/* Evidence — how a generic extractor read this file. Reference
-          material, so it sits below the score and per-bullet findings.
-          Layout flags head the block (the verdict); the preview and
-          extracted-text panes are the raw material under it. Both panes are
-          height-bounded so a two-page resume scrolls inside the row instead
-          of pushing it open. */}
-      <EvidencePanel result={result} bytes={bytes} sourceKind={sourceKind} />
+      {/* Score stays pinned above; the detail sits behind tabs so only one
+          panel shows at a time and every panel is advertised by a label
+          (issue #177). All panels stay mounted (hidden when inactive) so the
+          reconstructed resume keeps any local UI state across tab switches —
+          overrides themselves live above in App/useEditableParse. */}
+      <Tabs id="result" value={tab} onValueChange={setTab}>
+        <TabList aria-label="Parsed result views">
+          <Tab id="reconstructed">Reconstructed resume</Tab>
+          <Tab id="source">Source PDF</Tab>
+          <Tab id="extracted">Extracted text</Tab>
+          <Tab id="flags" count={triggerCount}>
+            Layout flags
+          </Tab>
+        </TabList>
+
+        <div className="pt-4">
+          <TabPanel id="reconstructed">
+            <ReconstructedResume result={result} score={score} edit={edit} />
+          </TabPanel>
+          <TabPanel id="source">
+            <SourcePdfPanel bytes={bytes} sourceKind={sourceKind} />
+          </TabPanel>
+          <TabPanel id="extracted">
+            <ExtractedTextPanel result={result} />
+          </TabPanel>
+          <TabPanel id="flags">
+            <LayoutFlagsList
+              triggers={result.triggers as readonly LayoutTrigger[]}
+            />
+          </TabPanel>
+        </div>
+      </Tabs>
     </Card>
   );
 }

--- a/src/components/features/EvidencePanel.tsx
+++ b/src/components/features/EvidencePanel.tsx
@@ -2,52 +2,48 @@
 // Copyright 2026 The resumelint Authors
 
 /**
- * EvidencePanel — renders the "how a generic extractor read this file" section:
- * layout flags, source PDF preview, and extracted plain text.
- * Extracted from Result.tsx (issue #83). Pure display; no state.
+ * Evidence panel bodies — "how a generic extractor read this file".
+ *
+ * These were a single stacked 2-up grid (issue #83); #177 splits them into
+ * separate tab-panel bodies so Result's Tabs consume each one directly:
+ *   – SourcePdfPanel     — the source PDF preview (or DOCX no-preview fallback)
+ *   – ExtractedTextPanel — the extracted plain-text <pre>
+ * Layout flags reuse the standalone <LayoutFlagsList> directly. Pure display.
  */
 
-import type { CascadeResult, LayoutTrigger } from "../../lib/heuristics/types.ts";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import { PdfPreview } from "../PdfPreview.tsx";
-import { LayoutFlagsList } from "./LayoutFlagsList.tsx";
 
 type SourceKind = "pdf" | "docx";
 
-interface EvidencePanelProps {
-  result: CascadeResult;
+interface SourcePdfPanelProps {
   bytes?: ArrayBuffer;
   sourceKind: SourceKind;
 }
 
-export function EvidencePanel({ result, bytes, sourceKind }: EvidencePanelProps) {
-  return (
-    <section className="flex flex-col gap-4">
-      <LayoutFlagsList triggers={result.triggers as readonly LayoutTrigger[]} />
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-            {sourceKind === "pdf" ? "Source PDF" : "Source document"}
-          </h2>
-          {sourceKind === "pdf" && bytes != null ? (
-            <div className="max-h-[600px] overflow-y-auto">
-              <PdfPreview bytes={bytes} />
-            </div>
-          ) : (
-            <p className="text-sm text-content-muted">
-              No source preview available for DOCX — extracted text is shown
-              to the right.
-            </p>
-          )}
-        </div>
-        <div className="flex flex-col gap-2">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-            Extracted plain text
-          </h2>
-          <pre className="max-h-[600px] overflow-auto rounded border border-border-light bg-surface-subtle p-3 text-sm leading-relaxed">
-            {result.rawText || "(no text extracted)"}
-          </pre>
-        </div>
+export function SourcePdfPanel({ bytes, sourceKind }: SourcePdfPanelProps) {
+  if (sourceKind === "pdf" && bytes != null) {
+    return (
+      <div className="max-h-[600px] overflow-y-auto">
+        <PdfPreview bytes={bytes} />
       </div>
-    </section>
+    );
+  }
+  return (
+    <p className="text-sm text-content-muted">
+      No source preview available for DOCX — see the Extracted text tab.
+    </p>
+  );
+}
+
+interface ExtractedTextPanelProps {
+  result: CascadeResult;
+}
+
+export function ExtractedTextPanel({ result }: ExtractedTextPanelProps) {
+  return (
+    <pre className="max-h-[600px] overflow-auto rounded border border-border-light bg-surface-subtle p-3 text-sm leading-relaxed">
+      {result.rawText || "(no text extracted)"}
+    </pre>
   );
 }

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -21,6 +21,7 @@ export * from "./primitives/EditableField.tsx";
 export * from "./shared/Card.tsx";
 export * from "./shared/ModelLoadProgress.tsx";
 export * from "./shared/StatusBadge.tsx";
+export * from "./shared/Tabs.tsx";
 export * from "./shared/ErrorState.tsx";
 export * from "./shared/ErrorBoundary.tsx";
 export * from "./shared/UpdateBanner.tsx";

--- a/src/design-system/shared/Tabs.tsx
+++ b/src/design-system/shared/Tabs.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Tabs — the ONE accessible, controlled tabbed-navigation primitive.
+ *
+ * Composition:
+ *   <Tabs value onValueChange>            context provider wrapper
+ *     <TabList aria-label>                role="tablist", roving arrow-key focus
+ *       <Tab id label count?>             role="tab", aria-selected, roving tabIndex
+ *     <TabPanel id>…</TabPanel>           role="tabpanel", hidden when inactive
+ *
+ * Accessibility:
+ *   – role="tablist"/"tab"/"tabpanel", aria-selected, aria-controls/id wiring,
+ *     aria-labelledby on panels.
+ *   – Arrow Left/Right (+ Home/End) move between tabs AND move focus (roving
+ *     tabindex). Enter/Space activate (native button behaviour).
+ *
+ * Design rules (CLAUDE.md):
+ *   – Semantic tokens only; no hardcoded hex or raw palette classes.
+ *   – Triggers use the <Button> primitive — no raw <button> in feature/primitive code.
+ *   – Inactive panels stay mounted (hidden attr) so child UI state survives a switch.
+ */
+
+import {
+  createContext,
+  useContext,
+  useRef,
+  type ReactNode,
+  type KeyboardEvent,
+} from "react";
+import { Button } from "../primitives/Button.tsx";
+
+interface TabsContextValue {
+  value: string;
+  onValueChange: (value: string) => void;
+  baseId: string;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string): TabsContextValue {
+  const ctx = useContext(TabsContext);
+  if (ctx == null) {
+    throw new Error(`${component} must be used within <Tabs>`);
+  }
+  return ctx;
+}
+
+const tabId = (baseId: string, id: string) => `${baseId}-tab-${id}`;
+const panelId = (baseId: string, id: string) => `${baseId}-panel-${id}`;
+
+interface TabsProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  /** Stable prefix for tab/panel id wiring. */
+  id: string;
+  children: ReactNode;
+}
+
+export function Tabs({ value, onValueChange, id, children }: TabsProps) {
+  return (
+    <TabsContext.Provider value={{ value, onValueChange, baseId: id }}>
+      {children}
+    </TabsContext.Provider>
+  );
+}
+
+interface TabListProps {
+  "aria-label": string;
+  children: ReactNode;
+}
+
+export function TabList({ "aria-label": ariaLabel, children }: TabListProps) {
+  const { value, onValueChange } = useTabsContext("TabList");
+  const listRef = useRef<HTMLDivElement>(null);
+
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    const keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
+    if (!keys.includes(event.key)) return;
+    const tabs = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [],
+    );
+    if (tabs.length === 0) return;
+    const currentIndex = tabs.findIndex(
+      (t) => t.getAttribute("data-tab-id") === value,
+    );
+    let nextIndex = currentIndex;
+    if (event.key === "ArrowLeft") {
+      nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    } else if (event.key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % tabs.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = tabs.length - 1;
+    }
+    const next = tabs[nextIndex];
+    if (next == null) return;
+    event.preventDefault();
+    const nextId = next.getAttribute("data-tab-id");
+    if (nextId != null) onValueChange(nextId);
+    next.focus();
+  }
+
+  return (
+    <div
+      ref={listRef}
+      role="tablist"
+      aria-label={ariaLabel}
+      onKeyDown={onKeyDown}
+      className="flex flex-wrap gap-1 overflow-x-auto border-b border-border-light"
+    >
+      {children}
+    </div>
+  );
+}
+
+interface TabProps {
+  id: string;
+  children: ReactNode;
+  /** Optional count badge rendered after the label (e.g. layout-flag count). */
+  count?: number;
+}
+
+export function Tab({ id, children, count }: TabProps) {
+  const { value, onValueChange, baseId } = useTabsContext("Tab");
+  const isActive = value === id;
+  const activeCls = isActive
+    ? "border-brand-amber text-content-primary"
+    : "border-transparent text-content-muted hover:text-content-secondary";
+
+  return (
+    <Button
+      variant="ghost"
+      role="tab"
+      id={tabId(baseId, id)}
+      data-tab-id={id}
+      aria-selected={isActive}
+      aria-controls={panelId(baseId, id)}
+      tabIndex={isActive ? 0 : -1}
+      onClick={() => onValueChange(id)}
+      className={`-mb-px rounded-none border-b-2 px-3 py-2 text-sm hover:bg-transparent ${activeCls}`}
+    >
+      {children}
+      {count != null && count > 0 && (
+        <span className="ml-1.5 rounded-full bg-surface-subtle px-1.5 text-xs text-content-secondary">
+          {count}
+        </span>
+      )}
+    </Button>
+  );
+}
+
+interface TabPanelProps {
+  id: string;
+  children: ReactNode;
+}
+
+export function TabPanel({ id, children }: TabPanelProps) {
+  const { value, baseId } = useTabsContext("TabPanel");
+  const isActive = value === id;
+  return (
+    <div
+      role="tabpanel"
+      id={panelId(baseId, id)}
+      aria-labelledby={tabId(baseId, id)}
+      hidden={!isActive}
+      tabIndex={0}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Re-organizes the post-parse result surface into a discoverable tabbed view (issue #177). The ATS score stays pinned above a new tab bar, and the four detail surfaces — **Reconstructed resume** (default), **Source PDF**, **Extracted text**, and **Layout flags** — each live behind a labelled tab instead of one long stacked scroll. The Layout flags tab shows a count badge when triggers > 0.

Adds one reusable, accessible `Tabs` primitive to the design system (`src/design-system/shared/Tabs.tsx`): `role="tablist"/"tab"/"tabpanel"`, `aria-selected`/`aria-controls`/`aria-labelledby` wiring, roving arrow-key focus (Left/Right/Home/End), Enter/Space activation, and inactive panels kept mounted via the `hidden` attribute so the reconstructed resume keeps its inline edits across tab switches. Pure presentation — no `src/lib/` changes; the edit/override/scoring flow is untouched.

Closes #177

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (774 passing)
- [x] `npm run lint` (ESLint) clean — no raw `<button>`, hardcoded hex, raw palette, or manual `dark:` variants
- [x] Manually verified in `npm run dev` / `npm run preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)