### PR TITLE
feat(resume): make bullets, role headers, education & skills editable (#174 #175 #176)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,8 @@ export default function App() {
       edit.experienceOverrides,
       edit.bulletOverrides,
       observations,
+      edit.educationOverrides,
+      edit.skillsOverride,
     );
     // The anonymous scorer pools its bullet set from `sections` (#133), so the
     // edited section view — not the original — must feed re-grading or a live
@@ -61,6 +63,8 @@ export default function App() {
     edit.contactOverrides,
     edit.experienceOverrides,
     edit.bulletOverrides,
+    edit.educationOverrides,
+    edit.skillsOverride,
   ]);
 
   // Clear edits whenever a fresh parse lands (new file or reset).

--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEduValue,
+  resolveEducationDisplay,
+} from "./ReconstructedEducationSkills.tsx";
+import type { ResumeEducation } from "../../lib/score/types.ts";
+
+describe("resolveEduValue", () => {
+  it("falls back to the parsed value when no override is present", () => {
+    expect(resolveEduValue("BSc CS", undefined)).toBe("BSc CS");
+  });
+
+  it("normalizes a missing parsed value to undefined", () => {
+    expect(resolveEduValue(undefined, undefined)).toBeUndefined();
+    expect(resolveEduValue("", undefined)).toBeUndefined();
+  });
+
+  it("uses a non-empty override over the parsed value", () => {
+    expect(resolveEduValue("BSc CS", "MSc CS")).toBe("MSc CS");
+  });
+
+  it('treats an empty-string override as an explicit clear ("not detected")', () => {
+    expect(resolveEduValue("BSc CS", "")).toBeUndefined();
+  });
+});
+
+describe("resolveEducationDisplay", () => {
+  const base: ResumeEducation = {
+    degree: "BSc Computer Science",
+    institution: "State University",
+    start_date: "2018",
+    end_date: "2022",
+    coursework: ["Algorithms", "Databases"],
+  };
+
+  it("passes parsed fields through when there are no overrides", () => {
+    const d = resolveEducationDisplay(base, undefined);
+    expect(d.degree).toBe("BSc Computer Science");
+    expect(d.institution).toBe("State University");
+    expect(d.startDate).toBe("2018");
+    expect(d.endDate).toBe("2022");
+    expect(d.dates).toBe("2018–2022");
+    expect(d.coursework).toEqual(["Algorithms", "Databases"]);
+  });
+
+  it("applies field overrides and reflects date edits in the compact string", () => {
+    const d = resolveEducationDisplay(base, {
+      degree: "MSc Computer Science",
+      end_date: "2024",
+    });
+    expect(d.degree).toBe("MSc Computer Science");
+    expect(d.institution).toBe("State University"); // unchanged
+    expect(d.endDate).toBe("2024");
+    expect(d.dates).toBe("2018–2024");
+  });
+
+  it("clears a field when its override is an empty string", () => {
+    const d = resolveEducationDisplay(base, { institution: "" });
+    expect(d.institution).toBeUndefined();
+  });
+
+  it("collapses the dates string when both dates are cleared", () => {
+    const noYear: ResumeEducation = { ...base, year: undefined };
+    const d = resolveEducationDisplay(noYear, { start_date: "", end_date: "" });
+    expect(d.startDate).toBeUndefined();
+    expect(d.endDate).toBeUndefined();
+    expect(d.dates).toBe("");
+  });
+
+  it("falls back to year when only a single graduation date exists", () => {
+    const grad: ResumeEducation = {
+      degree: "BSc",
+      institution: "U",
+      year: "2025",
+    };
+    const d = resolveEducationDisplay(grad, undefined);
+    expect(d.startDate).toBeUndefined();
+    expect(d.endDate).toBeUndefined();
+    expect(d.dates).toBe("2025");
+  });
+
+  it("defaults coursework to an empty array when absent", () => {
+    const noCoursework: ResumeEducation = {
+      degree: "BSc",
+      institution: "U",
+    };
+    expect(resolveEducationDisplay(noCoursework, undefined).coursework).toEqual(
+      [],
+    );
+  });
+});

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -42,12 +42,46 @@ function NotDetected({ what }: { what: string }) {
 // ── Education ──────────────────────────────────────────────────────────────────
 
 /** Resolve a field's display value, applying the override ("" = cleared). */
-function resolveEduValue(
+export function resolveEduValue(
   parsed: string | undefined,
   override: string | undefined,
 ): string | undefined {
   if (override === undefined) return parsed || undefined;
   return override || undefined; // "" clears
+}
+
+/** The resolved education fields an entry renders, after applying overrides. */
+export interface EducationDisplay {
+  degree: string | undefined;
+  institution: string | undefined;
+  startDate: string | undefined;
+  endDate: string | undefined;
+  /** Compact display string (e.g. "2018 – 2022"), reflecting date edits. */
+  dates: string;
+  coursework: string[];
+}
+
+/**
+ * Fold an education entry's overrides into the display values. Pure (no JSX) so
+ * the resolution/clearing/date branches are unit-tested directly — this is the
+ * risk-bearing logic; the component is then render-only.
+ */
+export function resolveEducationDisplay(
+  edu: ResumeEducation,
+  overrides: EducationFieldOverrides | undefined,
+): EducationDisplay {
+  // Dates: the override fields feed buildEducationDates so the compact display
+  // string reflects edits; the read-only display still falls back to `year`.
+  const startDate = resolveEduValue(edu.start_date, overrides?.start_date);
+  const endDate = resolveEduValue(edu.end_date, overrides?.end_date);
+  return {
+    degree: resolveEduValue(edu.degree, overrides?.degree),
+    institution: resolveEduValue(edu.institution, overrides?.institution),
+    startDate,
+    endDate,
+    dates: buildEducationDates({ ...edu, start_date: startDate, end_date: endDate }),
+    coursework: edu.coursework ?? [],
+  };
 }
 
 function EducationEntry({
@@ -59,16 +93,8 @@ function EducationEntry({
   overrides: EducationFieldOverrides | undefined;
   onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
 }) {
-  const degree = resolveEduValue(edu.degree, overrides?.degree);
-  const institution = resolveEduValue(edu.institution, overrides?.institution);
-  // Dates: the override fields feed buildEducationDates so the compact display
-  // string reflects edits; the read-only display still falls back to `year`.
-  const datesEdu: ResumeEducation = {
-    ...edu,
-    start_date: resolveEduValue(edu.start_date, overrides?.start_date),
-    end_date: resolveEduValue(edu.end_date, overrides?.end_date),
-  };
-  const dates = buildEducationDates(datesEdu);
+  const { degree, institution, startDate, endDate, dates, coursework } =
+    resolveEducationDisplay(edu, overrides);
 
   return (
     <li className="flex flex-col gap-0.5 text-sm">
@@ -90,7 +116,7 @@ function EducationEntry({
       </div>
       <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
         <EditableField
-          value={datesEdu.start_date}
+          value={startDate}
           placeholder="start"
           label="Education start date"
           textSize="xs"
@@ -98,19 +124,17 @@ function EducationEntry({
         />
         <span aria-hidden="true">–</span>
         <EditableField
-          value={datesEdu.end_date}
+          value={endDate}
           placeholder="end"
           label="Education end date"
           textSize="xs"
           onCommit={(v) => onFieldChange("end_date", v)}
         />
-        {dates && (
-          <span className="text-content-muted">· {dates}</span>
-        )}
+        {dates && <span className="text-content-muted">· {dates}</span>}
       </div>
-      {edu.coursework && edu.coursework.length > 0 && (
+      {coursework.length > 0 && (
         <span className="block text-content-tertiary">
-          Coursework: {edu.coursework.join(" · ")}
+          Coursework: {coursework.join(" · ")}
         </span>
       )}
     </li>

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ReconstructedEducationSkills — the editable Education and Skills sections of
+ * the reconstructed resume (#176). Split out of ReconstructedResume.tsx to keep
+ * that container under ~200 LOC.
+ *
+ * Both sections were read-only; since the surface exports to PDF, a parser miss
+ * was uncorrectable. They now expose inline edit affordances wired to the lifted
+ * override model (useEditableParse):
+ *   - Education: degree / institution / dates editable via the shared
+ *     EditableField. A cleared field shows "not detected".
+ *   - Skills: each skill is a removable chip; an "Add skill" input accepts a
+ *     typed skill with canonical-name normalization + suggestions.
+ *
+ * The override maps live in App and feed applyOverrides → re-grade → PDF, so an
+ * edit here moves the ATS score AND the downloaded PDF, not just the display.
+ */
+
+import { useMemo, useState } from "react";
+import type { ResumeEducation } from "../../lib/score/types.ts";
+import type { EducationFieldOverrides } from "../../hooks/useEditableParse.ts";
+import { buildEducationDates } from "../../lib/score/entry-dates.ts";
+import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
+import { Button, EditableField } from "@design-system";
+
+// ── Shared section chrome (mirrors ReconstructedResume's local helpers) ────────
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+      {children}
+    </h2>
+  );
+}
+
+function NotDetected({ what }: { what: string }) {
+  return <p className="text-sm text-content-tertiary">No {what} detected.</p>;
+}
+
+// ── Education ──────────────────────────────────────────────────────────────────
+
+/** Resolve a field's display value, applying the override ("" = cleared). */
+function resolveEduValue(
+  parsed: string | undefined,
+  override: string | undefined,
+): string | undefined {
+  if (override === undefined) return parsed || undefined;
+  return override || undefined; // "" clears
+}
+
+function EducationEntry({
+  edu,
+  overrides,
+  onFieldChange,
+}: {
+  edu: ResumeEducation;
+  overrides: EducationFieldOverrides | undefined;
+  onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
+}) {
+  const degree = resolveEduValue(edu.degree, overrides?.degree);
+  const institution = resolveEduValue(edu.institution, overrides?.institution);
+  // Dates: the override fields feed buildEducationDates so the compact display
+  // string reflects edits; the read-only display still falls back to `year`.
+  const datesEdu: ResumeEducation = {
+    ...edu,
+    start_date: resolveEduValue(edu.start_date, overrides?.start_date),
+    end_date: resolveEduValue(edu.end_date, overrides?.end_date),
+  };
+  const dates = buildEducationDates(datesEdu);
+
+  return (
+    <li className="flex flex-col gap-0.5 text-sm">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+        <EditableField
+          value={degree}
+          placeholder="degree not detected"
+          label="Degree"
+          textWeight="semibold"
+          onCommit={(v) => onFieldChange("degree", v)}
+        />
+        <span className="text-content-muted">—</span>
+        <EditableField
+          value={institution}
+          placeholder="institution not detected"
+          label="Institution"
+          onCommit={(v) => onFieldChange("institution", v)}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
+        <EditableField
+          value={datesEdu.start_date}
+          placeholder="start"
+          label="Education start date"
+          textSize="xs"
+          onCommit={(v) => onFieldChange("start_date", v)}
+        />
+        <span aria-hidden="true">–</span>
+        <EditableField
+          value={datesEdu.end_date}
+          placeholder="end"
+          label="Education end date"
+          textSize="xs"
+          onCommit={(v) => onFieldChange("end_date", v)}
+        />
+        {dates && (
+          <span className="text-content-muted">· {dates}</span>
+        )}
+      </div>
+      {edu.coursework && edu.coursework.length > 0 && (
+        <span className="block text-content-tertiary">
+          Coursework: {edu.coursework.join(" · ")}
+        </span>
+      )}
+    </li>
+  );
+}
+
+export function EducationSection({
+  education,
+  educationOverrides,
+  onEducationFieldChange,
+}: {
+  education: ResumeEducation[];
+  educationOverrides: Record<number, EducationFieldOverrides>;
+  onEducationFieldChange: (
+    index: number,
+    field: keyof EducationFieldOverrides,
+    value: string,
+  ) => void;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeading>Education</SectionHeading>
+      {education.length === 0 ? (
+        <NotDetected what="education" />
+      ) : (
+        <ul className="flex flex-col gap-2.5 list-none">
+          {education.map((edu, i) => (
+            <EducationEntry
+              key={i}
+              edu={edu}
+              overrides={educationOverrides[i]}
+              onFieldChange={(field, value) =>
+                onEducationFieldChange(i, field, value)
+              }
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// ── Skills ─────────────────────────────────────────────────────────────────────
+
+function SkillChip({
+  skill,
+  onRemove,
+}: {
+  skill: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-secondary">
+      {skill}
+      <Button
+        variant="icon"
+        aria-label={`Remove ${skill}`}
+        onClick={onRemove}
+        className="shrink-0 text-content-muted hover:text-content-secondary"
+      >
+        <svg
+          aria-hidden="true"
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        >
+          <path d="M3 3l10 10M13 3L3 13" />
+        </svg>
+      </Button>
+    </span>
+  );
+}
+
+function AddSkillInput({
+  skills,
+  onAdd,
+}: {
+  skills: string[];
+  onAdd: (skill: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const suggestions = useMemo(
+    () => suggestSkills(draft, skills),
+    [draft, skills],
+  );
+
+  const commit = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setDraft("");
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={draft}
+          aria-label="Add skill"
+          placeholder="Add a skill…"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit(draft);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setDraft("");
+            }
+          }}
+          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => commit(draft)}
+          disabled={draft.trim().length === 0}
+          aria-label="Add skill"
+        >
+          Add
+        </Button>
+      </div>
+      {suggestions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {suggestions.map((s) => (
+            <Button
+              key={s}
+              variant="ghost"
+              size="sm"
+              onClick={() => commit(s)}
+              aria-label={`Add ${s}`}
+              className="rounded-full bg-surface-subtle px-2.5 py-0.5 text-xs text-content-tertiary hover:text-brand-amber"
+            >
+              + {s}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SkillsSection({
+  skills,
+  onAddSkill,
+  onRemoveSkill,
+}: {
+  /** The edited skills list (parsed minus removed, plus added) — what renders.
+   *  App already folds skillsOverride into this via applyOverrides, so the
+   *  section renders the resolved list directly. */
+  skills: string[];
+  onAddSkill: (skill: string) => void;
+  onRemoveSkill: (skill: string) => void;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeading>Skills</SectionHeading>
+      {skills.length === 0 ? (
+        <NotDetected what="skills" />
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {skills.map((skill, i) => (
+            <SkillChip
+              key={`${skill}-${i}`}
+              skill={skill}
+              onRemove={() => onRemoveSkill(skill)}
+            />
+          ))}
+        </div>
+      )}
+      <AddSkillInput skills={skills} onAdd={onAddSkill} />
+    </section>
+  );
+}

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -56,10 +56,11 @@ import type {
   ExperienceFieldOverrides,
   BulletOverrides,
 } from "../../hooks/useEditableParse.ts";
+import { buildProjectDates } from "../../lib/score/entry-dates.ts";
 import {
-  buildProjectDates,
-  buildEducationDates,
-} from "../../lib/score/entry-dates.ts";
+  EducationSection,
+  SkillsSection,
+} from "./ReconstructedEducationSkills.tsx";
 import { Button } from "@design-system";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
 
@@ -405,59 +406,8 @@ function AchievementsSection({
   );
 }
 
-function EducationSection({
-  education,
-}: {
-  education: NonNullable<CascadeResult["parsed"]["education"]>;
-}) {
-  return (
-    <section className="flex flex-col gap-2">
-      <SectionHeading>Education</SectionHeading>
-      {education.length === 0 ? (
-        <NotDetected what="education" />
-      ) : (
-        <ul className="flex flex-col gap-1.5 list-none">
-          {education.map((edu, i) => {
-            const head = [edu.degree, edu.institution]
-              .filter(Boolean)
-              .join(" — ");
-            const dates = buildEducationDates(edu);
-            return (
-              <li key={i} className="text-sm text-content-secondary">
-                <span className="font-medium text-content-primary">
-                  {head || "Untitled entry"}
-                </span>
-                {dates && (
-                  <span className="text-content-tertiary"> · {dates}</span>
-                )}
-                {edu.coursework && edu.coursework.length > 0 && (
-                  <span className="block text-content-tertiary">
-                    Coursework: {edu.coursework.join(" · ")}
-                  </span>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </section>
-  );
-}
-
-function SkillsSection({ skills }: { skills: string[] }) {
-  return (
-    <section className="flex flex-col gap-2">
-      <SectionHeading>Skills</SectionHeading>
-      {skills.length === 0 ? (
-        <NotDetected what="skills" />
-      ) : (
-        <p className="text-sm leading-relaxed text-content-secondary">
-          {skills.join(" · ")}
-        </p>
-      )}
-    </section>
-  );
-}
+// Education + Skills are now editable (#176) and live in their own feature file
+// (ReconstructedEducationSkills.tsx) so this container stays under ~200 LOC.
 
 // ── Container ─────────────────────────────────────────────────────────────────
 
@@ -497,6 +447,10 @@ export function ReconstructedResume({
     setExperienceField,
     bulletOverrides,
     setBulletField,
+    educationOverrides,
+    setEducationField,
+    addSkill,
+    removeSkill,
   } = edit;
 
   // One grouping pass over experiences + projects + achievements so their
@@ -573,8 +527,18 @@ export function ReconstructedResume({
         />
       )}
       {!achievementsAbove && achievementsSection}
-      <EducationSection education={parsed.education} />
-      <SkillsSection skills={parsed.skills} />
+      <EducationSection
+        education={parsed.education}
+        educationOverrides={educationOverrides}
+        onEducationFieldChange={(index, field, value) =>
+          setEducationField(index, field, value)
+        }
+      />
+      <SkillsSection
+        skills={parsed.skills}
+        onAddSkill={addSkill}
+        onRemoveSkill={removeSkill}
+      />
     </section>
   );
 }

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -19,11 +19,12 @@
  * Split out of ReconstructedResume to keep that container under ~200 LOC.
  */
 
+import { useState, useCallback } from "react";
 import type { ReactNode } from "react";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { needsAttention } from "../../lib/score/group-bullets.ts";
 import type { BulletObservation } from "../../lib/score/score.ts";
-import { EditableField } from "@design-system";
+import { EditableField, Button } from "@design-system";
 import type {
   ExperienceFieldOverrides,
   BulletOverrides,
@@ -166,8 +167,12 @@ export function BulletFlagLegend() {
  * (#82) via the shared EditableField primitive — committing an edit feeds the
  * authoritative re-grade in App (rawText + description), so the inline check
  * badges below re-evaluate live. Flagged bullets show the checks they failed;
- * passing bullets render plain. #59 (per-bullet rewrite) hooks in on the
- * flagged branch.
+ * passing bullets render plain.
+ *
+ * Issue #174: the EditableField is now wired with `multiline` + `onRework`.
+ * Clicking "Rework" in the Save/Cancel action row captures the current draft
+ * and surfaces a RewriteButton pane beneath the textarea — the existing AI
+ * rewrite path, no new code.
  */
 export function ResumeBulletRow({
   bullet,
@@ -183,67 +188,108 @@ export function ResumeBulletRow({
   const flagged = needsAttention(bullet);
   const editable = onBulletChange !== undefined;
   const displayText = override ?? bullet.text;
+
+  // Rework pane: when the user clicks "Rework" in the multiline action row,
+  // we capture the draft text and show a RewriteButton driven by that snapshot.
+  // The rework pane is dismissed when editing ends (commit or cancel), so it
+  // never shows stale proposals alongside a different text.
+  const [reworkDraft, setReworkDraft] = useState<string | null>(null);
+
+  const handleRework = useCallback((currentDraft: string) => {
+    setReworkDraft(currentDraft);
+  }, []);
+
+  const handleCommit = useCallback(
+    (v: string) => {
+      setReworkDraft(null);
+      onBulletChange?.(v);
+    },
+    [onBulletChange],
+  );
+
   /*
-    The row is a single inline formatting context (a plain block `<li>`, NOT a
-    flexbox). The bullet text, the check badges, and the rewrite trigger are all
-    inline-level, so the badges flow right after the *last word* of the text and
-    wrap with it — instead of breaking to a new full-width flex line at the far
-    left when the bullet is long (the prior `flex flex-wrap` regression). The
-    editable text uses `display="inline"` so it wraps as real text rather than
-    sitting as an atomic `inline-flex` box. The compact RewriteButton's
-    expansion panel is block-level, so it still breaks to its own row below.
+    Read-mode layout: single inline formatting context (a plain block `<li>`,
+    NOT a flexbox). The bullet text, the check badges, and the rewrite trigger
+    are all inline-level, so the badges flow right after the *last word* of the
+    text and wrap with it.
+
+    Edit-mode layout: the multiline EditableField breaks to a block (full-width
+    <div>) so the textarea + action row have room. The rework pane (if open)
+    stacks below the action row as a block child of the `<li>`.
   */
   return (
     <li className="py-1 text-sm leading-snug text-content-secondary">
-      <span aria-hidden="true" className="mr-1.5 text-content-muted">
-        •
-      </span>
       {editable ? (
-        <EditableField
-          value={displayText || undefined}
-          placeholder="empty bullet"
-          label="Bullet text"
-          textSize="sm"
-          revealOn="hover"
-          display="inline"
-          className="text-content-secondary"
-          onCommit={(v) => onBulletChange(v)}
-        />
+        /* Multiline edit mode: block layout, full-width textarea + Save/Cancel/Rework */
+        <div className="flex gap-1.5">
+          <span aria-hidden="true" className="mt-1.5 shrink-0 text-content-muted">
+            •
+          </span>
+          <div className="min-w-0 flex-1">
+            <EditableField
+              value={displayText || undefined}
+              placeholder="empty bullet"
+              label="Bullet text"
+              textSize="sm"
+              revealOn="hover"
+              display="inline"
+              multiline
+              onCommit={handleCommit}
+              onRework={handleRework}
+            />
+            {/* Rework pane — visible once user clicks "Rework" in the action row.
+                RewriteButton is the existing AI-rewrite component; we hand it the
+                draft snapshot so it rewrites what the user actually typed, not the
+                committed text. Dismissed on next commit/cancel (handleCommit above
+                clears reworkDraft). */}
+            {reworkDraft !== null && (
+              <div className="mt-2">
+                <RewriteButton bullet={reworkDraft} />
+              </div>
+            )}
+          </div>
+        </div>
       ) : (
-        displayText
-      )}
-      {flagged && (
+        /* Read-only: inline flow — bullet text then trailing check badges inline */
         <>
-          {!bullet.hasMetric && (
-            <FlagChip
-              title="No metric"
-              ariaLabel="No metric"
-              className="ml-1 align-middle"
-            >
-              <MetricIcon />
-            </FlagChip>
+          <span aria-hidden="true" className="mr-1.5 text-content-muted">
+            •
+          </span>
+          {displayText}
+          {flagged && (
+            <>
+              {!bullet.hasMetric && (
+                <FlagChip
+                  title="No metric"
+                  ariaLabel="No metric"
+                  className="ml-1 align-middle"
+                >
+                  <MetricIcon />
+                </FlagChip>
+              )}
+              {!bullet.startsWithActionVerb && (
+                <FlagChip
+                  title="Weak opening verb"
+                  ariaLabel="Weak opening verb"
+                  className="ml-1 align-middle"
+                >
+                  <BoltIcon />
+                </FlagChip>
+              )}
+              {!bullet.wellFormedLength && (
+                <FlagChip
+                  title={lengthTitle(bullet)}
+                  ariaLabel={lengthTitle(bullet)}
+                  className="ml-1 align-middle"
+                >
+                  <span className="text-[11px] font-medium tabular-nums">
+                    {lengthToken(bullet)}
+                  </span>
+                </FlagChip>
+              )}
+              <RewriteButton bullet={displayText} compact />
+            </>
           )}
-          {!bullet.startsWithActionVerb && (
-            <FlagChip
-              title="Weak opening verb"
-              ariaLabel="Weak opening verb"
-              className="ml-1 align-middle"
-            >
-              <BoltIcon />
-            </FlagChip>
-          )}
-          {!bullet.wellFormedLength && (
-            <FlagChip
-              title={lengthTitle(bullet)}
-              ariaLabel={lengthTitle(bullet)}
-              className="ml-1 align-middle"
-            >
-              <span className="text-[11px] font-medium tabular-nums">
-                {lengthToken(bullet)}
-              </span>
-            </FlagChip>
-          )}
-          <RewriteButton bullet={displayText} compact />
         </>
       )}
     </li>
@@ -268,12 +314,20 @@ interface RoleHeaderProps {
  * Read-only mode: renders "Title — Company · start_date – end_date" (or
  * "Other bullets" / "Untitled role" for partial/absent parses).
  *
- * Edit mode: replaces the flat header with four EditableField rows — title,
- * company, start date, end date — each committed individually. Cleared fields
- * show "not detected" in the read view.
+ * Edit mode: when `overrides` + `onFieldChange` are provided the header gains
+ * a persistent "Edit role" toggle button. Activating it expands four
+ * EditableField rows — title (multiline), company (multiline), start date, end
+ * date — each committed individually. A "Done" button collapses back to the
+ * compact read view. Cleared fields show "not detected" in the read view.
+ *
+ * The "Edit role" button is the discoverable affordance (#175). Individual
+ * field pencils use revealOn="hover" inside the expanded editor so the gutter
+ * stays clean. The existing single-line revealOn="reserve" default for
+ * ContactCard is unaffected — the new behaviour is purely opt-in here.
  */
 function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
   const editable = overrides !== undefined && onFieldChange !== undefined;
+  const [editOpen, setEditOpen] = useState(false);
 
   // For the "Other bullets" bucket there is no experience entry to edit.
   if (group.experience === null) {
@@ -315,7 +369,57 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
     );
   }
 
-  // Edit mode: four independent EditableField lines.
+  // Treat empty string as "not present" for display purposes.
+  const toDisplay = (v: string | undefined): string | undefined =>
+    v || undefined;
+
+  // Collapsed editable: composite label + persistent "Edit role" toggle.
+  if (!editOpen) {
+    const title = overrides.title !== undefined ? overrides.title : exp.title;
+    const company =
+      overrides.company !== undefined ? overrides.company : exp.company;
+    const startDate =
+      overrides.start_date !== undefined ? overrides.start_date : exp.start_date;
+    const endDate =
+      overrides.end_date !== undefined ? overrides.end_date : exp.end_date;
+
+    const start = toDisplay(startDate);
+    const end =
+      exp.is_current && overrides.end_date === undefined
+        ? "Present"
+        : toDisplay(endDate);
+    let dates: string | undefined;
+    if (start && end) dates = `${start} – ${end}`;
+    else if (start) dates = start;
+    else if (end) dates = end;
+
+    let label = "";
+    if (toDisplay(title) && toDisplay(company))
+      label = `${toDisplay(title)} — ${toDisplay(company)}`;
+    else if (toDisplay(title)) label = toDisplay(title)!;
+    else if (toDisplay(company)) label = toDisplay(company)!;
+    if (dates) label = label ? `${label} · ${dates}` : dates;
+
+    return (
+      <div className="flex items-start gap-2">
+        <h3 className="flex-1 text-sm font-semibold text-content-primary">
+          {label || "Untitled role"}
+        </h3>
+        {/* Persistent discoverable affordance — always visible, not hover-gated */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setEditOpen(true)}
+          aria-label="Edit role header fields"
+          className="shrink-0 text-xs text-content-tertiary hover:text-content-secondary"
+        >
+          Edit role
+        </Button>
+      </div>
+    );
+  }
+
+  // Expanded editor: four independent EditableField rows.
   const title = overrides.title !== undefined ? overrides.title : exp.title;
   const company =
     overrides.company !== undefined ? overrides.company : exp.company;
@@ -324,36 +428,37 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
   const endDate =
     overrides.end_date !== undefined ? overrides.end_date : exp.end_date;
 
-  // Treat empty string as "not present" for display purposes.
-  const toDisplay = (v: string | undefined): string | undefined =>
-    v || undefined;
-
   return (
-    <div className="flex flex-col gap-0.5">
-      {/* Title */}
+    <div className="flex flex-col gap-1 rounded border border-border-light bg-surface-card p-2">
+      {/* Title — multiline variant for long role titles */}
       <EditableField
         value={toDisplay(title)}
         placeholder="title not detected"
         label="Job title"
         textWeight="semibold"
         textSize="sm"
+        multiline
+        revealOn="hover"
         onCommit={(v) => onFieldChange("title", v)}
       />
-      {/* Company */}
+      {/* Company — multiline variant for long company names */}
       <EditableField
         value={toDisplay(company)}
         placeholder="company not detected"
         label="Company"
         textSize="sm"
+        multiline
+        revealOn="hover"
         onCommit={(v) => onFieldChange("company", v)}
       />
-      {/* Date range row */}
+      {/* Date range row — single-line fields, hover-revealed pencils */}
       <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
         <EditableField
           value={toDisplay(startDate)}
           placeholder="start date"
           label="Start date"
           textSize="xs"
+          revealOn="hover"
           className="text-content-tertiary"
           onCommit={(v) => onFieldChange("start_date", v)}
         />
@@ -369,9 +474,22 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
           placeholder="end date"
           label="End date"
           textSize="xs"
+          revealOn="hover"
           className="text-content-tertiary"
           onCommit={(v) => onFieldChange("end_date", v)}
         />
+      </div>
+      {/* Done button — collapses the editor back to the compact read view */}
+      <div className="mt-0.5 flex justify-end">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setEditOpen(false)}
+          aria-label="Close role editor"
+          className="text-xs text-content-tertiary hover:text-content-secondary"
+        >
+          Done
+        </Button>
       </div>
     </div>
   );

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -7,8 +7,12 @@
  * Renders in one of two modes:
  *   • read  — shows the current value (or a "not detected" placeholder when
  *             value is absent). Clicking the pencil icon enters edit mode.
- *   • edit  — inline <input> pre-filled with the current value; blurring or
- *             pressing Enter/Escape commits/cancels.
+ *   • edit  — inline <input> (default) or auto-growing <textarea> (multiline)
+ *             pre-filled with the current value.
+ *             Single-line: blurring or pressing Enter/Escape commits/cancels.
+ *             Multiline: explicit Save / Cancel buttons; blur does NOT commit
+ *             (a multi-line paste that accidentally defocuses shouldn't lose
+ *             the draft). Enter submits a newline; Escape cancels.
  *
  * Design rules (CLAUDE.md):
  *   – Semantic tokens only; no hardcoded hex or raw palette classes.
@@ -22,9 +26,15 @@
  *   label       — accessible label for the input (aria-label).
  *   onCommit    — called with the trimmed new string (or "" on clear).
  *   className   — extra classes on the root wrapper (layout stays with caller).
+ *   multiline   — opt-in: renders a full-width auto-growing <textarea> with an
+ *                 explicit Save / Cancel action row. ADDITIVE — existing
+ *                 single-line callers are byte-for-byte unchanged.
+ *   onRework    — opt-in (multiline only): renders a "Rework" action in the
+ *                 Save/Cancel row. The callback receives the current draft text
+ *                 so the caller can trigger AI rewrite on the live draft.
  */
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Button } from "./Button.tsx";
 
@@ -58,6 +68,31 @@ interface EditableFieldProps {
    *            word. Use for long-form prose like a resume bullet.
    */
   display?: "flex" | "inline";
+  /**
+   * Multiline variant (opt-in, ADDITIVE).
+   *
+   * When true:
+   *   – Renders a full-width auto-growing <textarea> instead of <input>.
+   *   – Edit mode breaks out of the inline flow and takes a block layout (full
+   *     width of the parent container).
+   *   – Commit requires an explicit "Save" button click (or Ctrl/Cmd+Enter).
+   *     Blur and Enter do NOT commit — a multi-line paste that accidentally
+   *     defocuses shouldn't lose the draft. Escape still cancels.
+   *   – An explicit "Cancel" button discards the draft.
+   *
+   * Existing single-line callers omitting this prop are byte-for-byte
+   * unchanged in behavior.
+   */
+  multiline?: boolean;
+  /**
+   * Rework callback (multiline only, opt-in).
+   *
+   * When provided alongside `multiline`, a "Rework" action appears next to
+   * Save/Cancel. The callback receives the current draft text so the caller
+   * can trigger an AI-rewrite pass on the live draft (e.g. thread through
+   * RewriteButton's engine). The EditableField itself has no rewrite logic.
+   */
+  onRework?: (currentDraft: string) => void;
 }
 
 export function EditableField({
@@ -70,20 +105,32 @@ export function EditableField({
   textSize = "sm",
   revealOn = "reserve",
   display = "flex",
+  multiline = false,
+  onRework,
 }: EditableFieldProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const startEdit = useCallback(() => {
     setDraft(value ?? "");
     setEditing(true);
-    // Focus after the next paint so the input is mounted.
+    // Focus after the next paint so the element is mounted.
     requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.select();
+      if (multiline) {
+        textareaRef.current?.focus();
+        // Place cursor at end.
+        const ta = textareaRef.current;
+        if (ta) {
+          ta.selectionStart = ta.selectionEnd = ta.value.length;
+        }
+      } else {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
     });
-  }, [value]);
+  }, [value, multiline]);
 
   const commit = useCallback(() => {
     setEditing(false);
@@ -101,6 +148,82 @@ export function EditableField({
     textWeight === "semibold" ? "font-semibold" : "font-normal";
   const sizeCls =
     textSize === "xs" ? "text-xs" : textSize === "base" ? "text-base" : "text-sm";
+
+  // ── Multiline edit mode ───────────────────────────────────────────────────
+
+  // Auto-grow: sync textarea height to scroll height on every draft change.
+  useEffect(() => {
+    if (!multiline || !editing) return;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${ta.scrollHeight}px`;
+  }, [draft, multiline, editing]);
+
+  if (editing && multiline) {
+    return (
+      <div className={`flex w-full flex-col gap-1.5 ${className ?? ""}`}>
+        <textarea
+          ref={textareaRef}
+          aria-label={label}
+          value={draft}
+          rows={2}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            // Ctrl/Cmd+Enter commits; bare Enter inserts a newline.
+            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          className={[
+            "w-full resize-none overflow-hidden rounded border border-border",
+            "bg-surface-card px-2 py-1.5",
+            sizeCls,
+            weightCls,
+            "text-content-primary leading-snug",
+            "outline-hidden focus:ring-1 focus:ring-brand-amber",
+          ].join(" ")}
+        />
+        {/* Save / Cancel / Rework action row */}
+        <div className="flex items-center gap-2">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={commit}
+            aria-label={`Save ${label}`}
+          >
+            Save
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={cancel}
+            aria-label={`Cancel editing ${label}`}
+          >
+            Cancel
+          </Button>
+          {onRework && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onRework(draft)}
+              aria-label={`Rework ${label} with AI`}
+              className="ml-auto flex items-center gap-1 text-content-tertiary hover:text-brand-amber"
+            >
+              <ReworkSparkleIcon />
+              Rework
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Single-line edit mode (original behavior, unchanged) ──────────────────
 
   if (editing) {
     return (
@@ -132,6 +255,8 @@ export function EditableField({
       </span>
     );
   }
+
+  // ── Read mode (shared by both variants) ───────────────────────────────────
 
   const hoverReveal = revealOn === "hover";
 
@@ -211,5 +336,19 @@ export function EditableField({
         </svg>
       </Button>
     </span>
+  );
+}
+
+/** Small sparkle icon for the Rework action in the multiline action row. */
+function ReworkSparkleIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="h-3 w-3 shrink-0"
+      fill="currentColor"
+    >
+      <path d="M12 2l1.9 5.6a4 4 0 0 0 2.5 2.5L22 12l-5.6 1.9a4 4 0 0 0-2.5 2.5L12 22l-1.9-5.6a4 4 0 0 0-2.5-2.5L2 12l5.6-1.9a4 4 0 0 0 2.5-2.5L12 2z" />
+    </svg>
   );
 }

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -9,6 +9,11 @@
  * Issue #82 adds bullet-text overrides (keyed by BulletObservation.index) and
  * a `resetAll`, and the overrides are now authoritative — App folds them back
  * into the parse via applyOverrides and re-grades the score + JD coverage.
+ * Issue #176 adds education field overrides (keyed by education index, mirroring
+ * experienceOverrides) and a skills override (add/remove against parsed.skills),
+ * folded by the same applyOverrides path so a corrected degree or an
+ * added/removed skill re-grades Completeness + JD coverage AND flows into the
+ * downloaded PDF (App passes the edited parse to both the scorer and the export).
  * Overrides are held in component state and lost on reset — no persistence
  * is expected or provided.
  *
@@ -17,6 +22,7 @@
  */
 
 import { useState, useCallback, useMemo } from "react";
+import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
 
 // ── Contact overrides ─────────────────────────────────────────────────────────
 
@@ -42,6 +48,33 @@ export interface ExperienceFieldOverrides {
 /** Bullet-text overrides, keyed by BulletObservation.index (stable rawText order). */
 export type BulletOverrides = Record<number, string>;
 
+// ── Education overrides ───────────────────────────────────────────────────────
+
+/** Editable education fields (degree, institution, dates). Mirrors the
+ *  experience-header override shape. An empty string clears the field
+ *  (rendered as "not detected"); undefined means "no override". */
+export interface EducationFieldOverrides {
+  degree?: string;
+  institution?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+// ── Skills override ───────────────────────────────────────────────────────────
+
+/**
+ * Add/remove edits against `parsed.skills`. `removed` holds the lower-cased keys
+ * of parsed skills the user dropped; `added` holds user-typed (canonicalized)
+ * skills in insertion order. applyOverrides folds these into the final skills
+ * list: parsed skills minus `removed`, then `added` appended (de-duplicated).
+ */
+export interface SkillsOverride {
+  removed: string[];
+  added: string[];
+}
+
+const EMPTY_SKILLS_OVERRIDE: SkillsOverride = { removed: [], added: [] };
+
 // ── Hook return type ──────────────────────────────────────────────────────────
 
 export interface EditableParse {
@@ -64,7 +97,25 @@ export interface EditableParse {
   bulletOverrides: BulletOverrides;
   /** Set the override text for one bullet. Pass undefined to clear it. */
   setBulletField: (index: number, value: string | undefined) => void;
-  /** True when any contact, experience, or bullet override is set. */
+  /** Override map for education entries, keyed by education array index. */
+  educationOverrides: Record<number, EducationFieldOverrides>;
+  /** Update one field on a specific education entry by its array index.
+   *  Pass undefined to clear that single field's override. */
+  setEducationField: (
+    index: number,
+    field: keyof EducationFieldOverrides,
+    value: string | undefined,
+  ) => void;
+  /** Add/remove edits against parsed.skills. */
+  skillsOverride: SkillsOverride;
+  /** Add a (canonicalized) skill. No-op for blank input or an exact dupe of an
+   *  already-present skill. Re-adding a previously-removed skill un-removes it. */
+  addSkill: (skill: string) => void;
+  /** Remove a skill by its display text — drops it whether it came from the
+   *  parse (records its key in `removed`) or from a prior add (drops it from
+   *  `added`). */
+  removeSkill: (skill: string) => void;
+  /** True when any contact, experience, bullet, education, or skills override is set. */
   hasEdits: boolean;
   /** Clear every override, reverting to the original parse. */
   resetAll: () => void;
@@ -78,6 +129,12 @@ export function useEditableParse(): EditableParse {
     Record<number, ExperienceFieldOverrides>
   >({});
   const [bulletOverrides, setBulletOverrides] = useState<BulletOverrides>({});
+  const [educationOverrides, setEducationOverrides] = useState<
+    Record<number, EducationFieldOverrides>
+  >({});
+  const [skillsOverride, setSkillsOverride] = useState<SkillsOverride>(
+    EMPTY_SKILLS_OVERRIDE,
+  );
 
   const setContactField = useCallback(
     (key: keyof ContactOverrides, value: string | undefined) => {
@@ -128,19 +185,83 @@ export function useEditableParse(): EditableParse {
     [],
   );
 
+  const setEducationField = useCallback(
+    (
+      index: number,
+      field: keyof EducationFieldOverrides,
+      value: string | undefined,
+    ) => {
+      setEducationOverrides((prev) => {
+        const entry = { ...prev[index] };
+        if (value === undefined) {
+          delete entry[field];
+        } else {
+          entry[field] = value;
+        }
+        return { ...prev, [index]: entry };
+      });
+    },
+    [],
+  );
+
+  const addSkill = useCallback((skill: string) => {
+    const canonical = canonicalizeSkill(skill);
+    if (!canonical) return;
+    const key = canonical.toLowerCase();
+    setSkillsOverride((prev) => {
+      // Re-adding a previously-removed skill simply un-removes it.
+      const removed = prev.removed.filter((r) => r !== key);
+      // Don't duplicate an already-added skill (case-insensitive).
+      const alreadyAdded = prev.added.some((a) => a.toLowerCase() === key);
+      const added = alreadyAdded ? prev.added : [...prev.added, canonical];
+      return { removed, added };
+    });
+  }, []);
+
+  const removeSkill = useCallback((skill: string) => {
+    const key = skill.trim().toLowerCase();
+    if (!key) return;
+    setSkillsOverride((prev) => {
+      // Drop from `added` if it was a user-added skill...
+      const added = prev.added.filter((a) => a.toLowerCase() !== key);
+      // ...and record the key in `removed` so a parsed skill of the same name is
+      // filtered out by applyOverrides. (Harmless if it wasn't a parsed skill.)
+      const removed = prev.removed.includes(key)
+        ? prev.removed
+        : [...prev.removed, key];
+      return { removed, added };
+    });
+  }, []);
+
   const resetAll = useCallback(() => {
     setContactOverrides({});
     setExperienceOverrides({});
     setBulletOverrides({});
+    setEducationOverrides({});
+    setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
   }, []);
 
   const hasEdits = useMemo(() => {
     if (Object.keys(contactOverrides).length > 0) return true;
     if (Object.keys(bulletOverrides).length > 0) return true;
+    if (skillsOverride.removed.length > 0 || skillsOverride.added.length > 0)
+      return true;
+    if (
+      Object.values(educationOverrides).some(
+        (entry) => Object.keys(entry).length > 0,
+      )
+    )
+      return true;
     return Object.values(experienceOverrides).some(
       (entry) => Object.keys(entry).length > 0,
     );
-  }, [contactOverrides, experienceOverrides, bulletOverrides]);
+  }, [
+    contactOverrides,
+    experienceOverrides,
+    bulletOverrides,
+    educationOverrides,
+    skillsOverride,
+  ]);
 
   return {
     contactOverrides,
@@ -149,6 +270,11 @@ export function useEditableParse(): EditableParse {
     setExperienceField,
     bulletOverrides,
     setBulletField,
+    educationOverrides,
+    setEducationField,
+    skillsOverride,
+    addSkill,
+    removeSkill,
     hasEdits,
     resetAll,
   };

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -275,6 +275,171 @@ describe("applyOverrides", () => {
   });
 });
 
+// ── Education + skills overrides (#176) ───────────────────────────────────────
+
+function eduParsed(): HeuristicParsedResume {
+  return {
+    full_name: "Jane Doe",
+    email: "jane@example.com",
+    skills: ["TypeScript", "Python"],
+    experience: [],
+    education: [
+      { degree: "B.S. Computer Science", institution: "State University" },
+      { degree: "M.S. Data Science", institution: "Tech Institute" },
+    ],
+  };
+}
+
+describe("applyOverrides — education", () => {
+  it("replaces an education field by index on a clone", () => {
+    const parsed = eduParsed();
+    const { parsed: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 0: { degree: "B.S. Software Engineering", institution: "MIT" } },
+    );
+    expect(out.education[0].degree).toBe("B.S. Software Engineering");
+    expect(out.education[0].institution).toBe("MIT");
+    // Untouched entry.
+    expect(out.education[1].degree).toBe("M.S. Data Science");
+    // Original untouched.
+    expect(parsed.education[0].degree).toBe("B.S. Computer Science");
+  });
+
+  it("writes education dates so buildEducationDates reflects them", () => {
+    const { parsed: out } = applyOverrides(
+      eduParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 0: { start_date: "2018", end_date: "2022" } },
+    );
+    expect(out.education[0].start_date).toBe("2018");
+    expect(out.education[0].end_date).toBe("2022");
+  });
+
+  it("treats an empty education field override as cleared ('not detected')", () => {
+    const { parsed: out } = applyOverrides(
+      eduParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 1: { institution: "" } },
+    );
+    expect(out.education[1].institution).toBe("");
+  });
+
+  it("ignores an education override for an out-of-range index", () => {
+    const parsed = eduParsed();
+    const { parsed: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 5: { degree: "PhD" } },
+    );
+    expect(out.education).toHaveLength(2);
+    expect(out.education[0].degree).toBe("B.S. Computer Science");
+  });
+});
+
+describe("applyOverrides — skills", () => {
+  it("removes a parsed skill by lower-cased key", () => {
+    const parsed = eduParsed();
+    const { parsed: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: ["python"], added: [] },
+    );
+    expect(out.skills).toEqual(["TypeScript"]);
+    // Original untouched.
+    expect(parsed.skills).toEqual(["TypeScript", "Python"]);
+  });
+
+  it("appends an added skill, de-duplicated case-insensitively", () => {
+    const { parsed: out } = applyOverrides(
+      eduParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: ["Go", "typescript"] }, // "typescript" already present
+    );
+    expect(out.skills).toEqual(["TypeScript", "Python", "Go"]);
+  });
+
+  it("applies removal then addition together", () => {
+    const { parsed: out } = applyOverrides(
+      eduParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: ["typescript"], added: ["Rust"] },
+    );
+    expect(out.skills).toEqual(["Python", "Rust"]);
+  });
+
+  it("is a no-op when the skills override is empty", () => {
+    const parsed = eduParsed();
+    const { parsed: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+    );
+    expect(out.skills).toEqual(["TypeScript", "Python"]);
+  });
+
+  it("does not mutate the input parsed object across education + skills edits", () => {
+    const parsed = eduParsed();
+    const snapshot = JSON.parse(JSON.stringify(parsed));
+    applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 0: { degree: "Changed" } },
+      { removed: ["python"], added: ["Rust"] },
+    );
+    expect(parsed).toEqual(snapshot);
+  });
+});
+
 // ── Regression: edit + re-group attribution ──────────────────────────────────
 
 /**

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -36,6 +36,8 @@ import { normalizeBulletText } from "../score/group-bullets.ts";
 import type {
   ContactOverrides,
   ExperienceFieldOverrides,
+  EducationFieldOverrides,
+  SkillsOverride,
 } from "../../hooks/useEditableParse.ts";
 
 /** Bullet overrides keyed by `BulletObservation.index` (stable rawText order). */
@@ -181,6 +183,12 @@ const LEADING_MARKER_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·�]|\d+[.)]) 
  * @param observations the `score.bullets` array — links a bullet override index
  *                  back to the original bullet text it should replace. Pass `[]`
  *                  when there are no bullet overrides.
+ * @param education education-field overrides keyed by education array index
+ *                  (degree/institution/start_date/end_date). Empty string clears
+ *                  a field. Default `{}`.
+ * @param skills    add/remove edits against `parsed.skills`. `removed` keys
+ *                  (lower-cased) drop parsed skills; `added` are appended,
+ *                  de-duplicated. Default `{ removed: [], added: [] }`.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -190,12 +198,17 @@ export function applyOverrides(
   experience: Record<number, ExperienceFieldOverrides>,
   bullets: BulletOverrides,
   observations: readonly BulletObservation[],
+  education: Record<number, EducationFieldOverrides> = {},
+  skills: SkillsOverride = { removed: [], added: [] },
 ): ApplyOverridesResult {
-  // Clone so the original parse is never mutated. experience entries are cloned
-  // individually because we rewrite description strings on them.
+  // Clone so the original parse is never mutated. experience + education entries
+  // are cloned individually because we rewrite fields on them; skills is cloned
+  // because we rebuild the array from removed/added edits.
   const nextParsed: HeuristicParsedResume = {
     ...parsed,
     experience: parsed.experience.map((e) => ({ ...e })),
+    education: parsed.education.map((e) => ({ ...e })),
+    skills: [...parsed.skills],
   };
   let nextRawText = rawText;
   let nextSections = sections;
@@ -246,6 +259,39 @@ export function applyOverrides(
     nextRawText = replaceBulletInRawText(nextRawText, obs.text, edited);
     nextSections = replaceBulletInSections(nextSections, obs.text, edited);
     replaceBulletInDescriptions(nextParsed.experience, obs.text, edited);
+  }
+
+  // ── Education fields ──────────────────────────────────────────────────────
+  // Mirror the experience-header fold: an empty string clears the field (the UI
+  // renders "not detected" and the scorer/PDF read the blank). degree and
+  // institution are required string fields on ResumeEducation, so a clear writes
+  // "" rather than deleting the key.
+  for (const [idxStr, fields] of Object.entries(education)) {
+    const idx = Number(idxStr);
+    const edu = nextParsed.education[idx];
+    if (!edu) continue;
+    if (fields.degree !== undefined) edu.degree = fields.degree;
+    if (fields.institution !== undefined) edu.institution = fields.institution;
+    if (fields.start_date !== undefined) edu.start_date = fields.start_date;
+    if (fields.end_date !== undefined) edu.end_date = fields.end_date;
+  }
+
+  // ── Skills (add / remove) ─────────────────────────────────────────────────
+  // Final list = parsed skills minus `removed` (by lower-cased key), then
+  // `added` appended, de-duplicated case-insensitively against the survivors.
+  if (skills.removed.length > 0 || skills.added.length > 0) {
+    const removedSet = new Set(skills.removed.map((s) => s.toLowerCase()));
+    const kept = nextParsed.skills.filter(
+      (s) => !removedSet.has(s.toLowerCase()),
+    );
+    const present = new Set(kept.map((s) => s.toLowerCase()));
+    for (const add of skills.added) {
+      const key = add.toLowerCase();
+      if (present.has(key)) continue;
+      present.add(key);
+      kept.push(add);
+    }
+    nextParsed.skills = kept;
   }
 
   return { parsed: nextParsed, rawText: nextRawText, sections: nextSections };

--- a/src/lib/edit/skill-canonical.test.ts
+++ b/src/lib/edit/skill-canonical.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { canonicalizeSkill, suggestSkills } from "./skill-canonical.ts";
+
+describe("canonicalizeSkill", () => {
+  it("folds known aliases to canonical display form", () => {
+    expect(canonicalizeSkill("js")).toBe("JavaScript");
+    expect(canonicalizeSkill("ReactJS")).toBe("React");
+    expect(canonicalizeSkill("react.js")).toBe("React");
+    expect(canonicalizeSkill("postgres")).toBe("PostgreSQL");
+    expect(canonicalizeSkill("k8s")).toBe("Kubernetes");
+  });
+
+  it("matches a canonical entry case-insensitively, returning canonical casing", () => {
+    expect(canonicalizeSkill("typescript")).toBe("TypeScript");
+    expect(canonicalizeSkill("PYTHON")).toBe("Python");
+  });
+
+  it("collapses internal whitespace on alias keys", () => {
+    expect(canonicalizeSkill("  react   js ")).toBe("React");
+    expect(canonicalizeSkill("node js")).toBe("Node.js");
+  });
+
+  it("keeps an unknown skill verbatim (trimmed, whitespace-collapsed)", () => {
+    expect(canonicalizeSkill("  Embedded   Systems ")).toBe("Embedded Systems");
+    expect(canonicalizeSkill("COBOL")).toBe("COBOL");
+  });
+
+  it("returns empty string for blank input", () => {
+    expect(canonicalizeSkill("")).toBe("");
+    expect(canonicalizeSkill("   ")).toBe("");
+  });
+});
+
+describe("suggestSkills", () => {
+  it("returns prefix matches before substring matches", () => {
+    const out = suggestSkills("type", []);
+    expect(out[0]).toBe("TypeScript");
+  });
+
+  it("excludes skills already present (case-insensitive)", () => {
+    const out = suggestSkills("type", ["typescript"]);
+    expect(out).not.toContain("TypeScript");
+  });
+
+  it("returns nothing for a blank query", () => {
+    expect(suggestSkills("", ["React"])).toEqual([]);
+    expect(suggestSkills("   ", ["React"])).toEqual([]);
+  });
+
+  it("respects the limit", () => {
+    const out = suggestSkills("a", [], 3);
+    expect(out.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/src/lib/edit/skill-canonical.ts
+++ b/src/lib/edit/skill-canonical.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * skill-canonical — a small, self-contained skills-name normalizer + suggester
+ * for the "Add skill" affordance on the reconstructed resume (#176).
+ *
+ * SCOPE / PROVENANCE: this is a minimal in-repo placeholder, NOT the full
+ * Recruidea skills taxonomy. It does case/whitespace normalization, folds a
+ * small hand-curated alias map to a canonical display form (e.g. "JS" →
+ * "JavaScript", "reactjs" → "React"), and offers cheap prefix/substring
+ * suggestions over the union of (a) that canonical vocabulary and (b) the
+ * skills already parsed off the current resume. @s-annam can swap `CANONICAL`
+ * + `ALIASES` for the real taxonomy port without touching the call sites — the
+ * exported function surface is the contract.
+ *
+ * Pure and dependency-free so it unit-tests directly and ships no PII/IP.
+ */
+
+/**
+ * Canonical display spellings of common skills. Lower-cased on lookup; the
+ * value here is the exact form rendered. Deliberately small — a seed, not a
+ * taxonomy.
+ */
+const CANONICAL: readonly string[] = [
+  "JavaScript",
+  "TypeScript",
+  "Python",
+  "Java",
+  "C++",
+  "C#",
+  "Go",
+  "Rust",
+  "Ruby",
+  "PHP",
+  "Swift",
+  "Kotlin",
+  "SQL",
+  "HTML",
+  "CSS",
+  "React",
+  "Vue",
+  "Angular",
+  "Node.js",
+  "Next.js",
+  "Django",
+  "Flask",
+  "Spring",
+  "Express",
+  "GraphQL",
+  "REST",
+  "Docker",
+  "Kubernetes",
+  "AWS",
+  "Azure",
+  "GCP",
+  "Terraform",
+  "PostgreSQL",
+  "MySQL",
+  "MongoDB",
+  "Redis",
+  "Git",
+  "Linux",
+  "CI/CD",
+  "Machine Learning",
+  "TensorFlow",
+  "PyTorch",
+  "Pandas",
+  "NumPy",
+  "Tailwind CSS",
+  "Figma",
+];
+
+/**
+ * Alias → canonical key. Keys are lower-cased; matched after the same
+ * normalization the input goes through, so "react.js", "ReactJS", "react js"
+ * all collapse here.
+ */
+const ALIASES: Readonly<Record<string, string>> = {
+  js: "JavaScript",
+  javascript: "JavaScript",
+  ts: "TypeScript",
+  typescript: "TypeScript",
+  "react.js": "React",
+  reactjs: "React",
+  "react js": "React",
+  "node js": "Node.js",
+  nodejs: "Node.js",
+  node: "Node.js",
+  "next js": "Next.js",
+  nextjs: "Next.js",
+  py: "Python",
+  golang: "Go",
+  postgres: "PostgreSQL",
+  postgresql: "PostgreSQL",
+  k8s: "Kubernetes",
+  ml: "Machine Learning",
+  "machine learning": "Machine Learning",
+  tf: "TensorFlow",
+  gcp: "GCP",
+  "google cloud": "GCP",
+  "amazon web services": "AWS",
+  tailwind: "Tailwind CSS",
+  "tailwindcss": "Tailwind CSS",
+  cicd: "CI/CD",
+  "ci cd": "CI/CD",
+};
+
+/** Lower-case + collapse internal whitespace; the shared normalization key. */
+function normalizeKey(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Canonicalize a free-typed skill. Trims, collapses whitespace, then:
+ *   - folds a known alias to its canonical display form, else
+ *   - matches a canonical entry case-insensitively (returns the canonical
+ *     casing), else
+ *   - returns the user's trimmed/space-collapsed text verbatim (we never drop
+ *     a skill we don't recognize — recall over precision).
+ * Returns "" for blank input so callers can reject it.
+ */
+export function canonicalizeSkill(raw: string): string {
+  const key = normalizeKey(raw);
+  if (!key) return "";
+  const alias = ALIASES[key];
+  if (alias) return alias;
+  const canonical = CANONICAL.find((c) => c.toLowerCase() === key);
+  if (canonical) return canonical;
+  // Unknown skill: keep the user's text, but with collapsed whitespace.
+  return raw.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Suggest up to `limit` canonical skills for a partial query, drawn from the
+ * canonical vocabulary plus `existing` (skills already on the resume), case-
+ * insensitively, excluding anything already in `existing`. Prefix matches rank
+ * before substring matches. An empty query yields no suggestions.
+ */
+export function suggestSkills(
+  query: string,
+  existing: readonly string[],
+  limit = 6,
+): string[] {
+  const q = normalizeKey(query);
+  if (!q) return [];
+  const have = new Set(existing.map((s) => s.toLowerCase()));
+  const pool = new Set<string>(CANONICAL);
+  for (const s of existing) pool.delete(s); // don't suggest exact dupes below
+
+  const prefix: string[] = [];
+  const substring: string[] = [];
+  for (const candidate of pool) {
+    const lc = candidate.toLowerCase();
+    if (have.has(lc)) continue;
+    if (lc.startsWith(q)) prefix.push(candidate);
+    else if (lc.includes(q)) substring.push(candidate);
+  }
+  return [...prefix, ...substring].slice(0, limit);
+}


### PR DESCRIPTION
## Summary

M2 reconstructed-resume **editing-surface epic** — three coordinated upgrades that all share the one `EditableField` primitive (no parallel surfaces, per the Reuse Gate).

- **#174 — Full-width bullet editor.** `EditableField` gains a `multiline` variant: full-width auto-growing `<textarea>` + explicit Save/Cancel, plus an optional **Rework** action that reuses the existing `RewriteButton` AI-rewrite path (no new rewrite code). `ResumeBulletRow` adopts it. Single-line callers (`ContactCard`, dates) are byte-for-byte unchanged — the variant is opt-in.
- **#175 — Discoverable role-header editing.** A persistent **"Edit role"** toggle (no longer hover-gated) makes the four header fields obviously editable; title/company use the multiline editor; all four commit via the existing `setExperienceField` path. `is_current`/"Present" handling and the read-only composite header for non-editable groups preserved.
- **#176 — Editable education & skills.** Education entries (degree/institution/dates) edit inline via the shared affordance; skills render as removable chips with an **Add skill** input offering canonical-name suggestions. The `useEditableParse` override model is extended with education + skills overrides, folded by `apply-overrides`, cleared by `resetAll`, and reflected in the re-grade, score, **and PDF export**. New `ReconstructedEducationSkills.tsx` + a self-contained `skill-canonical.ts` taxonomy (swappable for the full Recruidea port — exported `canonicalizeSkill`/`suggestSkills` is the stable contract).

Resolves #174
Resolves #175
Resolves #176

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` (eslint) clean
- [x] `npm run test` green — 792/792 across 57 files
- [x] Manually verified in `npm run dev` / `npm run preview`