### PR TITLE
fix(resume): make all role-header fields editable + fix PDF download race

### DIFF
--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -96,6 +96,12 @@ function EducationEntry({
   const { degree, institution, startDate, endDate, dates, coursework } =
     resolveEducationDisplay(edu, overrides);
 
+  // The editable start/end fields ARE the date display, so the compact `dates`
+  // string would duplicate them. Show it ONLY in the legacy year-only fallback
+  // (no start/end parsed, just a graduation `year`), where no editable field
+  // surfaces it otherwise.
+  const yearOnly = !startDate && !endDate && Boolean(dates);
+
   return (
     <li className="flex flex-col gap-0.5 text-sm">
       <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
@@ -130,7 +136,7 @@ function EducationEntry({
           textSize="xs"
           onCommit={(v) => onFieldChange("end_date", v)}
         />
-        {dates && <span className="text-content-muted">· {dates}</span>}
+        {yearOnly && <span className="text-content-muted">{dates}</span>}
       </div>
       {coursework.length > 0 && (
         <span className="block text-content-tertiary">

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -498,7 +498,10 @@ export function ReconstructedResume({
         <p className="max-w-prose text-sm text-content-tertiary">
           What the parser recognized, in resume shape. Each bullet is checked
           against three rules — an action verb, the 8–30-word length window, and
-          a metric — and flagged inline where it falls short.
+          a metric — and flagged inline where it falls short.{" "}
+          <span className="text-content-secondary">
+            Click any field to edit it.
+          </span>
         </p>
         {bullets.length > 0 && <RollupStrip bullets={bullets} />}
       </div>

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -24,7 +24,7 @@ import type { ReactNode } from "react";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { needsAttention } from "../../lib/score/group-bullets.ts";
 import type { BulletObservation } from "../../lib/score/score.ts";
-import { EditableField, Button } from "@design-system";
+import { EditableField } from "@design-system";
 import type {
   ExperienceFieldOverrides,
   BulletOverrides,
@@ -231,7 +231,6 @@ export function ResumeBulletRow({
               placeholder="empty bullet"
               label="Bullet text"
               textSize="sm"
-              revealOn="hover"
               display="inline"
               multiline
               onCommit={handleCommit}
@@ -314,20 +313,21 @@ interface RoleHeaderProps {
  * Read-only mode: renders "Title — Company · start_date – end_date" (or
  * "Other bullets" / "Untitled role" for partial/absent parses).
  *
- * Edit mode: when `overrides` + `onFieldChange` are provided the header gains
- * a persistent "Edit role" toggle button. Activating it expands four
- * EditableField rows — title (multiline), company (multiline), start date, end
- * date — each committed individually. A "Done" button collapses back to the
- * compact read view. Cleared fields show "not detected" in the read view.
- *
- * The "Edit role" button is the discoverable affordance (#175). Individual
- * field pencils use revealOn="hover" inside the expanded editor so the gutter
- * stays clean. The existing single-line revealOn="reserve" default for
- * ContactCard is unaffected — the new behaviour is purely opt-in here.
+ * Edit mode: when `overrides` + `onFieldChange` are provided the header renders
+ * inline EditableField affordances — title (multiline), company (multiline),
+ * start date, end date — each committed individually. Every field uses the same
+ * paradigm as the rest of the reconstructed résumé: the value itself is the
+ * click/keyboard/tap target (quiet inline affordance). Cleared fields show
+ * "not detected".
  */
 function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
-  const editable = overrides !== undefined && onFieldChange !== undefined;
-  const [editOpen, setEditOpen] = useState(false);
+  // Editability hinges on the commit handler alone — `overrides` is `undefined`
+  // for any role the user hasn't edited yet (the per-index map starts empty), so
+  // gating on it would wrongly fall back to the read-only composite for every
+  // un-edited role. Mirror EducationEntry: render fields whenever the section is
+  // editable, treating a missing override map as "no overrides applied yet".
+  const editable = onFieldChange !== undefined;
+  const ov = overrides ?? {};
 
   // For the "Other bullets" bucket there is no experience entry to edit.
   if (group.experience === null) {
@@ -373,123 +373,59 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
   const toDisplay = (v: string | undefined): string | undefined =>
     v || undefined;
 
-  // Collapsed editable: composite label + persistent "Edit role" toggle.
-  if (!editOpen) {
-    const title = overrides.title !== undefined ? overrides.title : exp.title;
-    const company =
-      overrides.company !== undefined ? overrides.company : exp.company;
-    const startDate =
-      overrides.start_date !== undefined ? overrides.start_date : exp.start_date;
-    const endDate =
-      overrides.end_date !== undefined ? overrides.end_date : exp.end_date;
-
-    const start = toDisplay(startDate);
-    const end =
-      exp.is_current && overrides.end_date === undefined
-        ? "Present"
-        : toDisplay(endDate);
-    let dates: string | undefined;
-    if (start && end) dates = `${start} – ${end}`;
-    else if (start) dates = start;
-    else if (end) dates = end;
-
-    let label = "";
-    if (toDisplay(title) && toDisplay(company))
-      label = `${toDisplay(title)} — ${toDisplay(company)}`;
-    else if (toDisplay(title)) label = toDisplay(title)!;
-    else if (toDisplay(company)) label = toDisplay(company)!;
-    if (dates) label = label ? `${label} · ${dates}` : dates;
-
-    return (
-      <div className="flex items-start gap-2">
-        <h3 className="flex-1 text-sm font-semibold text-content-primary">
-          {label || "Untitled role"}
-        </h3>
-        {/* Persistent discoverable affordance — always visible, not hover-gated */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setEditOpen(true)}
-          aria-label="Edit role header fields"
-          className="shrink-0 text-xs text-content-tertiary hover:text-content-secondary"
-        >
-          Edit role
-        </Button>
-      </div>
-    );
-  }
-
-  // Expanded editor: four independent EditableField rows.
-  const title = overrides.title !== undefined ? overrides.title : exp.title;
-  const company =
-    overrides.company !== undefined ? overrides.company : exp.company;
-  const startDate =
-    overrides.start_date !== undefined ? overrides.start_date : exp.start_date;
+  // Inline editable: quiet click-to-edit, mirroring the Education section.
+  const title = toDisplay(ov.title !== undefined ? ov.title : exp.title);
+  const company = toDisplay(
+    ov.company !== undefined ? ov.company : exp.company,
+  );
+  const startDate = toDisplay(
+    ov.start_date !== undefined ? ov.start_date : exp.start_date,
+  );
   const endDate =
-    overrides.end_date !== undefined ? overrides.end_date : exp.end_date;
+    exp.is_current && ov.end_date === undefined
+      ? "Present"
+      : toDisplay(ov.end_date !== undefined ? ov.end_date : exp.end_date);
 
   return (
-    <div className="flex flex-col gap-1 rounded border border-border-light bg-surface-card p-2">
-      {/* Title — multiline variant for long role titles */}
-      <EditableField
-        value={toDisplay(title)}
-        placeholder="title not detected"
-        label="Job title"
-        textWeight="semibold"
-        textSize="sm"
-        multiline
-        revealOn="hover"
-        onCommit={(v) => onFieldChange("title", v)}
-      />
-      {/* Company — multiline variant for long company names */}
-      <EditableField
-        value={toDisplay(company)}
-        placeholder="company not detected"
-        label="Company"
-        textSize="sm"
-        multiline
-        revealOn="hover"
-        onCommit={(v) => onFieldChange("company", v)}
-      />
-      {/* Date range row — single-line fields, hover-revealed pencils */}
+    <div className="flex flex-col gap-0.5">
+      {/* Title — Company row (multiline fields for long titles/names) */}
       <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
         <EditableField
-          value={toDisplay(startDate)}
+          value={title}
+          placeholder="title not detected"
+          label="Job title"
+          textWeight="semibold"
+          textSize="sm"
+          multiline
+          onCommit={(v) => onFieldChange("title", v)}
+        />
+        {(title || company) && <span className="text-content-muted">—</span>}
+        <EditableField
+          value={company}
+          placeholder="company not detected"
+          label="Company"
+          textSize="sm"
+          multiline
+          onCommit={(v) => onFieldChange("company", v)}
+        />
+      </div>
+      {/* Date range row — single-line quiet-edit fields */}
+      <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
+        <EditableField
+          value={startDate}
           placeholder="start date"
           label="Start date"
           textSize="xs"
-          revealOn="hover"
-          className="text-content-tertiary"
           onCommit={(v) => onFieldChange("start_date", v)}
         />
-        {(toDisplay(startDate) !== undefined || toDisplay(endDate) !== undefined) && (
-          <span className="text-xs text-content-muted">–</span>
-        )}
+        <span aria-hidden="true">–</span>
         <EditableField
-          value={
-            exp.is_current && overrides.end_date === undefined
-              ? "Present"
-              : toDisplay(endDate)
-          }
+          value={endDate}
           placeholder="end date"
           label="End date"
           textSize="xs"
-          revealOn="hover"
-          className="text-content-tertiary"
           onCommit={(v) => onFieldChange("end_date", v)}
         />
-      </div>
-      {/* Done button — collapses the editor back to the compact read view */}
-      <div className="mt-0.5 flex justify-end">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setEditOpen(false)}
-          aria-label="Close role editor"
-          className="text-xs text-content-tertiary hover:text-content-secondary"
-        >
-          Done
-        </Button>
       </div>
     </div>
   );

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -6,7 +6,13 @@
  *
  * Renders in one of two modes:
  *   • read  — shows the current value (or a "not detected" placeholder when
- *             value is absent). Clicking the pencil icon enters edit mode.
+ *             value is absent). The value itself is the edit affordance: a text
+ *             cursor + a subtle hover tint signal editability; clicking/tapping
+ *             it (or focusing it and pressing Enter/Space) enters edit mode.
+ *             No pencil icon — one icon per field reads as clutter on a
+ *             document-shaped surface, and a hover-only pencil is invisible on
+ *             touch. The quiet hover affordance works with mouse, keyboard, and
+ *             touch alike (Notion/Linear/Docs pattern).
  *   • edit  — inline <input> (default) or auto-growing <textarea> (multiline)
  *             pre-filled with the current value.
  *             Single-line: blurring or pressing Enter/Escape commits/cancels.
@@ -49,15 +55,6 @@ interface EditableFieldProps {
   textWeight?: "normal" | "semibold";
   /** Text size of the read-mode text. Defaults to "sm". */
   textSize?: "xs" | "sm" | "base";
-  /**
-   * How the edit affordance is revealed in read mode:
-   *   reserve — pencil always occupies layout (opacity-0 → visible on hover).
-   *             Keeps the affordance focusable; no layout shift. Default.
-   *   hover   — pencil takes no layout space until hover/focus; the value text
-   *             itself becomes the click/keyboard edit trigger. Use inline (e.g.
-   *             a resume bullet) where a reserved pencil leaves an awkward gap.
-   */
-  revealOn?: "reserve" | "hover";
   /**
    * Read-mode root box model:
    *   flex   — `inline-flex` atom; value + pencil stay on one line, the box
@@ -103,7 +100,6 @@ export function EditableField({
   className,
   textWeight = "normal",
   textSize = "sm",
-  revealOn = "reserve",
   display = "flex",
   multiline = false,
   onRework,
@@ -258,83 +254,44 @@ export function EditableField({
 
   // ── Read mode (shared by both variants) ───────────────────────────────────
 
-  const hoverReveal = revealOn === "hover";
+  // Quiet inline-edit affordance: the value itself is the click/keyboard/tap
+  // target. No pencil icon — a text cursor + a subtle hover tint signal
+  // editability, which (unlike a hover-revealed pencil) also works on touch.
+  const inlineFlow = display === "inline";
 
-  // hover mode: the value text is the primary edit trigger (so the pencil can
-  // take zero layout space without losing keyboard access). reserve mode: plain
-  // text, pencil owns the affordance.
-  const valueText = (
+  // Inline mode: plain `inline` so the value wraps as text and trailing siblings
+  // flow after the last word. Flex mode: `inline-flex` atom. The negative margin
+  // offsets the hover-tint padding so the tinted box doesn't shift the layout.
+  const rootBox = inlineFlow
+    ? "inline"
+    : "inline-flex min-w-0 items-center";
+
+  return (
     <span
-      {...(hoverReveal
-        ? {
-            role: "button" as const,
-            tabIndex: 0,
-            "aria-label": `Edit ${label}`,
-            onClick: startEdit,
-            onKeyDown: (e: ReactKeyboardEvent) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                startEdit();
-              }
-            },
-          }
-        : {})}
+      role="button"
+      tabIndex={0}
+      aria-label={`Edit ${label}`}
+      onClick={startEdit}
+      onKeyDown={(e: ReactKeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          startEdit();
+        }
+      }}
       className={[
+        rootBox,
+        "cursor-text rounded px-1 -mx-1 transition-colors",
+        "hover:bg-surface-subtle",
+        "outline-hidden focus-visible:ring-1 focus-visible:ring-brand-amber",
         sizeCls,
         weightCls,
         hasValue ? "text-content-primary" : "text-content-muted italic",
-        hoverReveal
-          ? "cursor-text rounded-xs outline-hidden focus-visible:ring-1 focus-visible:ring-brand-amber"
-          : "",
+        className ?? "",
       ]
         .filter(Boolean)
         .join(" ")}
     >
       {hasValue ? value : placeholder}
-    </span>
-  );
-
-  const inlineFlow = display === "inline";
-
-  // reserve: opacity-0 keeps the pencil in flow + focusable (no shift).
-  // hover: display:none collapses its width; the value text covers keyboard a11y.
-  // Inline flow has no flex `gap`, so the pencil carries its own left margin.
-  const pencilSpacing = inlineFlow ? "ml-1 align-middle " : "";
-  const pencilCls =
-    pencilSpacing +
-    (hoverReveal
-      ? "shrink-0 hidden group-hover:inline-flex group-focus-within:inline-flex text-content-muted hover:text-content-secondary"
-      : "shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 text-content-muted hover:text-content-secondary");
-
-  // Inline mode: plain `inline` so the value wraps as text and trailing siblings
-  // flow after the last word. Flex mode: `inline-flex` atom (value + pencil never
-  // split). `min-w-0`/`items-center`/`gap-1` only bite in flex mode.
-  const rootBox = inlineFlow
-    ? "inline"
-    : "inline-flex min-w-0 items-center gap-1";
-
-  return (
-    <span className={`group ${rootBox} ${className ?? ""}`}>
-      {valueText}
-      {/* Pencil-icon edit button — hover bonus in hover mode, primary in reserve mode */}
-      <Button
-        variant="icon"
-        aria-label={`Edit ${label}`}
-        onClick={startEdit}
-        tabIndex={hoverReveal ? -1 : undefined}
-        className={pencilCls}
-      >
-        {/* Pencil SVG — 12×12 */}
-        <svg
-          aria-hidden="true"
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="currentColor"
-        >
-          <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354l-1.086-1.086zM11.189 6.25 9.75 4.81l-6.286 6.287a.25.25 0 0 0-.064.108l-.558 1.953 1.953-.558a.25.25 0 0 0 .108-.064L11.19 6.25z" />
-        </svg>
-      </Button>
     </span>
   );
 }

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -59,6 +59,14 @@ export function useDownloadPdf(
       document.body.appendChild(a);
       a.click();
       a.remove();
+      // Defer the revoke: a.click() only SCHEDULES the download — the browser
+      // reads the object URL asynchronously afterward. Revoking synchronously
+      // (e.g. in finally) invalidates the URL before the fetch starts, which
+      // silently kills the download on slower/remote contexts and on
+      // Firefox/Safari. Hand the URL off, then revoke on a later task.
+      const settledUrl = url;
+      url = null;
+      setTimeout(() => URL.revokeObjectURL(settledUrl), 60_000);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not generate PDF.");
     } finally {


### PR DESCRIPTION
## Summary

Two fixes on the reconstructed-resume surface:

1. **Role-header fields were not editable.** `RoleHeader` gated editability on `overrides !== undefined`, but the per-index experience-override map starts empty — so every un-edited role rendered the read-only composite "Title — Company · dates" line instead of inline edit fields. Bullets and Education escaped the bug (neither gates on a pre-existing override). Now gates on the commit handler alone, defaulting a missing override map to `{}` (mirrors `EducationEntry`/`ContactCard`). Title, company, start date, end date are all editable on first interaction.

2. **"Download PDF" silently no-op'd on slower/remote contexts and Firefox/Safari.** `URL.revokeObjectURL` ran synchronously in `finally`, immediately after `a.click()`. `click()` only *schedules* the download; the browser reads the `blob:` URL asynchronously afterward, so revoking that fast invalidated the URL before the fetch began. The URL is now handed off and revoked on a later task; the `finally` path still cleans up when no download started.

Also drops the last "pencil-on-hover" doc comments left over from the quiet-inline edit pivot.

Refs #174 #175 #176

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (802 tests)
- [x] `npm run lint` clean
- [x] Manually verified in `npm run dev`