### PR TITLE
feat(resume): "+ Add" affordance across all reconstructed-resume sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,8 @@ export default function App() {
       observations,
       edit.educationOverrides,
       edit.skillsOverride,
+      edit.addedEntries,
+      edit.addedBullets,
     );
     // The anonymous scorer pools its bullet set from `sections` (#133), so the
     // edited section view — not the original — must feed re-grading or a live
@@ -65,6 +67,8 @@ export default function App() {
     edit.bulletOverrides,
     edit.educationOverrides,
     edit.skillsOverride,
+    edit.addedEntries,
+    edit.addedBullets,
   ]);
 
   // Clear edits whenever a fresh parse lands (new file or reset).

--- a/src/components/features/ReconstructedAdd.tsx
+++ b/src/components/features/ReconstructedAdd.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ReconstructedAdd — shared "+ Add" affordances for the reconstructed-resume
+ * surface (#180-followup). The parser can only correct what it found; these let
+ * the user ADD what it missed entirely — a whole role / degree / project /
+ * achievement, or a bullet under any entry — wired to useEditableParse's added*
+ * channels so an addition re-grades the score AND flows into the PDF.
+ *
+ * Reuse analysis: this is a NEW shared file (not a parallel surface). It owns
+ * the one progressive-disclosure "+ pill" pattern the Skills add input pioneered
+ * (#180), so every section discloses an add affordance the same way instead of
+ * each re-rolling it. Built entirely from the @design-system Button primitive +
+ * semantic tokens — no raw <button>, no hardcoded palette.
+ */
+
+import { useState } from "react";
+import { Button } from "@design-system";
+
+/** A small X glyph, matching the SkillChip remove control. */
+function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="10"
+      height="10"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <path d="M3 3l10 10M13 3L3 13" />
+    </svg>
+  );
+}
+
+/**
+ * The collapsed progressive-disclosure trigger — a chip-shaped "+ <label>" pill
+ * that sits inline with the content it adds to. Quiet by default; warms to the
+ * brand accent on hover.
+ */
+export function AddPill({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      aria-label={label}
+      className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-brand-amber"
+    >
+      + {label}
+    </Button>
+  );
+}
+
+/** A quiet remove (X) control for a user-added entry or bullet. */
+export function RemoveButton({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      variant="icon"
+      aria-label={label}
+      onClick={onClick}
+      className="shrink-0 text-content-muted hover:text-content-secondary"
+    >
+      <CloseIcon />
+    </Button>
+  );
+}
+
+/**
+ * Single-line progressive-disclosure add input — collapses to a "+ <label>"
+ * pill, expands on click to an autofocused field + Add button, and collapses
+ * back on Escape or empty blur. Stays open after a commit so several lines can
+ * be added in a row. Mirrors the Skills add pattern, minus skill suggestions.
+ */
+export function InlineBulletAdd({
+  onAdd,
+  label = "Add bullet",
+  placeholder = "Bullet text…",
+}: {
+  onAdd: (text: string) => void;
+  label?: string;
+  placeholder?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setDraft("");
+  };
+
+  if (!expanded) {
+    return <AddPill label={label} onClick={() => setExpanded(true)} />;
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      onBlur={(e) => {
+        if (
+          !e.currentTarget.contains(e.relatedTarget as Node | null) &&
+          draft.trim().length === 0
+        ) {
+          setExpanded(false);
+        }
+      }}
+    >
+      <input
+        type="text"
+        value={draft}
+        autoFocus
+        aria-label={label}
+        placeholder={placeholder}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft("");
+            setExpanded(false);
+          }
+        }}
+        className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+      />
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={commit}
+        disabled={draft.trim().length === 0}
+        aria-label={label}
+      >
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -11,8 +11,9 @@
  * override model (useEditableParse):
  *   - Education: degree / institution / dates editable via the shared
  *     EditableField. A cleared field shows "not detected".
- *   - Skills: each skill is a removable chip; an "Add skill" input accepts a
- *     typed skill with canonical-name normalization + suggestions.
+ *   - Skills: each skill is a removable chip; a "+ Add skill" pill expands
+ *     inline into an input (canonical-name normalization + suggestions),
+ *     collapsing back on Escape or empty blur.
  *
  * The override maps live in App and feed applyOverrides → re-grade → PDF, so an
  * edit here moves the ATS score AND the downloaded PDF, not just the display.
@@ -20,10 +21,26 @@
 
 import { useMemo, useState } from "react";
 import type { ResumeEducation } from "../../lib/score/types.ts";
-import type { EducationFieldOverrides } from "../../hooks/useEditableParse.ts";
+import type {
+  EducationFieldOverrides,
+  AddedEntry,
+  AddedEntryField,
+} from "../../hooks/useEditableParse.ts";
 import { buildEducationDates } from "../../lib/score/entry-dates.ts";
 import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
 import { Button, EditableField } from "@design-system";
+import { AddPill, RemoveButton } from "./ReconstructedAdd.tsx";
+
+/** Map an EducationEntry field name to the flat AddedEntry field it edits. */
+const EDUCATION_FIELD_MAP: Record<
+  keyof EducationFieldOverrides,
+  AddedEntryField
+> = {
+  degree: "title",
+  institution: "subtitle",
+  start_date: "start_date",
+  end_date: "end_date",
+};
 
 // ── Shared section chrome (mirrors ReconstructedResume's local helpers) ────────
 
@@ -88,10 +105,13 @@ function EducationEntry({
   edu,
   overrides,
   onFieldChange,
+  onRemove,
 }: {
   edu: ResumeEducation;
   overrides: EducationFieldOverrides | undefined;
   onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
+  /** Remove this entry (only set for user-ADDED entries). */
+  onRemove?: () => void;
 }) {
   const { degree, institution, startDate, endDate, dates, coursework } =
     resolveEducationDisplay(edu, overrides);
@@ -104,21 +124,26 @@ function EducationEntry({
 
   return (
     <li className="flex flex-col gap-0.5 text-sm">
-      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-        <EditableField
-          value={degree}
-          placeholder="degree not detected"
-          label="Degree"
-          textWeight="semibold"
-          onCommit={(v) => onFieldChange("degree", v)}
-        />
-        <span className="text-content-muted">—</span>
-        <EditableField
-          value={institution}
-          placeholder="institution not detected"
-          label="Institution"
-          onCommit={(v) => onFieldChange("institution", v)}
-        />
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+          <EditableField
+            value={degree}
+            placeholder="degree not detected"
+            label="Degree"
+            textWeight="semibold"
+            onCommit={(v) => onFieldChange("degree", v)}
+          />
+          <span className="text-content-muted">—</span>
+          <EditableField
+            value={institution}
+            placeholder="institution not detected"
+            label="Institution"
+            onCommit={(v) => onFieldChange("institution", v)}
+          />
+        </div>
+        {onRemove && (
+          <RemoveButton label="Remove education" onClick={onRemove} />
+        )}
       </div>
       <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
         <EditableField
@@ -151,6 +176,11 @@ export function EducationSection({
   education,
   educationOverrides,
   onEducationFieldChange,
+  addedEducation,
+  originalCount,
+  onAddEntry,
+  onRemoveEntry,
+  onEntryField,
 }: {
   education: ResumeEducation[];
   educationOverrides: Record<number, EducationFieldOverrides>;
@@ -159,6 +189,13 @@ export function EducationSection({
     field: keyof EducationFieldOverrides,
     value: string,
   ) => void;
+  /** User-added education entries, append-aligned to indices ≥ originalCount. */
+  addedEducation: AddedEntry[];
+  /** Count of PARSED education entries; indices at/above this are user-added. */
+  originalCount: number;
+  onAddEntry: () => void;
+  onRemoveEntry: (id: string) => void;
+  onEntryField: (id: string, field: AddedEntryField, value: string) => void;
 }) {
   return (
     <section className="flex flex-col gap-2">
@@ -167,18 +204,28 @@ export function EducationSection({
         <NotDetected what="education" />
       ) : (
         <ul className="flex flex-col gap-2.5 list-none">
-          {education.map((edu, i) => (
-            <EducationEntry
-              key={i}
-              edu={edu}
-              overrides={educationOverrides[i]}
-              onFieldChange={(field, value) =>
-                onEducationFieldChange(i, field, value)
-              }
-            />
-          ))}
+          {education.map((edu, i) => {
+            const added =
+              i >= originalCount
+                ? addedEducation[i - originalCount]
+                : undefined;
+            return (
+              <EducationEntry
+                key={added ? added.id : i}
+                edu={edu}
+                overrides={added ? undefined : educationOverrides[i]}
+                onFieldChange={(field, value) =>
+                  added
+                    ? onEntryField(added.id, EDUCATION_FIELD_MAP[field], value)
+                    : onEducationFieldChange(i, field, value)
+                }
+                onRemove={added ? () => onRemoveEntry(added.id) : undefined}
+              />
+            );
+          })}
         </ul>
       )}
+      <AddPill label="Add education" onClick={onAddEntry} />
     </section>
   );
 }
@@ -231,6 +278,8 @@ function AddSkillInput({
     [draft, skills],
   );
 
+  const [expanded, setExpanded] = useState(false);
+
   const commit = (value: string) => {
     const trimmed = value.trim();
     if (!trimmed) return;
@@ -238,12 +287,43 @@ function AddSkillInput({
     setDraft("");
   };
 
+  // Collapsed: a chip-shaped "+ Add skill" pill that sits inline with the
+  // skill chips. Progressive disclosure — the input only exists while adding,
+  // so it doesn't sit heavy under the lightweight chip cluster (#180-followup).
+  if (!expanded) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setExpanded(true)}
+        aria-label="Add skill"
+        className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-brand-amber"
+      >
+        + Add skill
+      </Button>
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-1.5">
+    <div
+      className="flex flex-col gap-1.5"
+      onBlur={(e) => {
+        // Collapse back to the pill when focus leaves the editor entirely and
+        // nothing is typed. relatedTarget within the container (suggestion or
+        // Add button click) keeps it open.
+        if (
+          !e.currentTarget.contains(e.relatedTarget as Node | null) &&
+          draft.trim().length === 0
+        ) {
+          setExpanded(false);
+        }
+      }}
+    >
       <div className="flex items-center gap-2">
         <input
           type="text"
           value={draft}
+          autoFocus
           aria-label="Add skill"
           placeholder="Add a skill…"
           onChange={(e) => setDraft(e.target.value)}
@@ -254,6 +334,7 @@ function AddSkillInput({
             } else if (e.key === "Escape") {
               e.preventDefault();
               setDraft("");
+              setExpanded(false);
             }
           }}
           className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -55,13 +55,17 @@ import type {
   EditableParse,
   ExperienceFieldOverrides,
   BulletOverrides,
+  AddedEntry,
+  AddedEntryField,
 } from "../../hooks/useEditableParse.ts";
+import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
+import { AddPill, RemoveButton, InlineBulletAdd } from "./ReconstructedAdd.tsx";
 import { buildProjectDates } from "../../lib/score/entry-dates.ts";
 import {
   EducationSection,
   SkillsSection,
 } from "./ReconstructedEducationSkills.tsx";
-import { Button } from "@design-system";
+import { Button, EditableField } from "@design-system";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
 
 // ── Rollup strip ──────────────────────────────────────────────────────────────
@@ -233,6 +237,17 @@ function buildEntryGroups(
   return { experienceGroups, projectGroups, achievementGroups, other };
 }
 
+/** Map a RoleHeader field name to the flat AddedEntry field it edits. */
+const EXPERIENCE_FIELD_MAP: Record<
+  keyof ExperienceFieldOverrides,
+  AddedEntryField
+> = {
+  title: "title",
+  company: "subtitle",
+  start_date: "start_date",
+  end_date: "end_date",
+};
+
 function ExperienceSection({
   groups,
   hasBullets,
@@ -240,6 +255,12 @@ function ExperienceSection({
   onExperienceFieldChange,
   bulletOverrides,
   onBulletChange,
+  addedExperience,
+  originalCount,
+  onAddEntry,
+  onRemoveEntry,
+  onEntryField,
+  onAddBullet,
 }: {
   /** Pre-built experience groups + the shared "Other" group appended last. */
   groups: BulletGroup[];
@@ -252,6 +273,14 @@ function ExperienceSection({
   ) => void;
   bulletOverrides: BulletOverrides;
   onBulletChange: (index: number, value: string) => void;
+  /** User-added experience entries, append-aligned to indices ≥ originalCount. */
+  addedExperience: AddedEntry[];
+  /** Count of PARSED experience roles; indices at/above this are user-added. */
+  originalCount: number;
+  onAddEntry: () => void;
+  onRemoveEntry: (id: string) => void;
+  onEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  onAddBullet: (entryKey: string, text: string) => void;
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
@@ -275,44 +304,79 @@ function ExperienceSection({
         <div className="flex flex-col gap-4">
           {groups.map((group, i) => {
             const idx = group.experienceIndex;
+            if (idx === null) {
+              return (
+                <RoleEntry
+                  key={`other-${i}`}
+                  group={group}
+                  experienceIndex={null}
+                  bulletOverrides={bulletOverrides}
+                  onBulletChange={onBulletChange}
+                />
+              );
+            }
+            const added =
+              idx >= originalCount
+                ? addedExperience[idx - originalCount]
+                : undefined;
             return (
               <RoleEntry
-                key={idx ?? `other-${i}`}
+                key={added ? added.id : idx}
                 group={group}
                 experienceIndex={idx}
-                overrides={idx !== null ? experienceOverrides[idx] : undefined}
-                onFieldChange={
-                  idx !== null
-                    ? (field, value) =>
-                        onExperienceFieldChange(idx, field, value)
-                    : undefined
+                overrides={added ? undefined : experienceOverrides[idx]}
+                onFieldChange={(field, value) =>
+                  added
+                    ? onEntryField(added.id, EXPERIENCE_FIELD_MAP[field], value)
+                    : onExperienceFieldChange(idx, field, value)
                 }
                 bulletOverrides={bulletOverrides}
                 onBulletChange={onBulletChange}
+                onAddBullet={(text) =>
+                  onAddBullet(
+                    added ? added.id : parsedEntryKey("experience", idx),
+                    text,
+                  )
+                }
+                onRemove={added ? () => onRemoveEntry(added.id) : undefined}
               />
             );
           })}
         </div>
       )}
+      <AddPill label="Add experience" onClick={onAddEntry} />
     </section>
   );
 }
 
 /**
  * Projects render as their OWN section (#95) — a name-led header + the same
- * graded bullet rows used everywhere else (`ResumeBulletRow`), so project
- * bullets are checked and flagged the same way experience bullets are. Read-only:
- * the edit affordances (#82) target experience/contact, not projects.
+ * graded bullet rows used everywhere else (`ResumeBulletRow`). Parsed projects
+ * stay read-only; user-ADDED projects expose an editable name, a "+ Add bullet"
+ * affordance, and a remove control (#180-followup), so an added project's
+ * bullets grade and export like any other.
  */
 function ProjectsSection({
   projects,
   groups,
   bulletOverrides,
+  addedProjects,
+  originalCount,
+  onAddEntry,
+  onRemoveEntry,
+  onEntryField,
+  onAddBullet,
 }: {
   projects: ResumeProject[];
   /** Pre-built project groups, index-aligned with `projects`. */
   groups: BulletGroup[];
   bulletOverrides: BulletOverrides;
+  addedProjects: AddedEntry[];
+  originalCount: number;
+  onAddEntry: () => void;
+  onRemoveEntry: (id: string) => void;
+  onEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  onAddBullet: (entryKey: string, text: string) => void;
 }) {
   return (
     <section className="flex flex-col gap-3">
@@ -320,14 +384,36 @@ function ProjectsSection({
       <div className="flex flex-col gap-4">
         {projects.map((project, i) => {
           const group = groups[i];
+          const added =
+            i >= originalCount ? addedProjects[i - originalCount] : undefined;
           const header = [project.name, buildProjectDates(project)]
             .filter(Boolean)
             .join(" · ");
           return (
-            <div key={i} className="flex flex-col gap-1.5">
-              <h3 className="text-sm font-semibold text-content-primary">
-                {header || "Untitled project"}
-              </h3>
+            <div key={added ? added.id : i} className="flex flex-col gap-1.5">
+              <div className="flex items-start justify-between gap-2">
+                {added ? (
+                  <EditableField
+                    value={project.name || undefined}
+                    placeholder="project name"
+                    label="Project name"
+                    textWeight="semibold"
+                    textSize="sm"
+                    multiline
+                    onCommit={(v) => onEntryField(added.id, "title", v)}
+                  />
+                ) : (
+                  <h3 className="text-sm font-semibold text-content-primary">
+                    {header || "Untitled project"}
+                  </h3>
+                )}
+                {added && (
+                  <RemoveButton
+                    label="Remove project"
+                    onClick={() => onRemoveEntry(added.id)}
+                  />
+                )}
+              </div>
               {group && group.bullets.length > 0 ? (
                 <ul className="list-none">
                   {group.bullets.map((b) => (
@@ -339,14 +425,20 @@ function ProjectsSection({
                   ))}
                 </ul>
               ) : (
-                <p className="text-sm text-content-tertiary">
-                  No bullet-shaped lines detected.
-                </p>
+                !added && (
+                  <p className="text-sm text-content-tertiary">
+                    No bullet-shaped lines detected.
+                  </p>
+                )
+              )}
+              {added && (
+                <InlineBulletAdd onAdd={(text) => onAddBullet(added.id, text)} />
               )}
             </div>
           );
         })}
       </div>
+      <AddPill label="Add project" onClick={onAddEntry} />
     </section>
   );
 }
@@ -363,11 +455,23 @@ function AchievementsSection({
   achievements,
   groups,
   bulletOverrides,
+  addedAchievements,
+  originalCount,
+  onAddEntry,
+  onRemoveEntry,
+  onEntryField,
+  onAddBullet,
 }: {
   achievements: HeuristicAchievement[];
   /** Pre-built achievement groups, index-aligned with `achievements`. */
   groups: BulletGroup[];
   bulletOverrides: BulletOverrides;
+  addedAchievements: AddedEntry[];
+  originalCount: number;
+  onAddEntry: () => void;
+  onRemoveEntry: (id: string) => void;
+  onEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  onAddBullet: (entryKey: string, text: string) => void;
 }) {
   return (
     <section className="flex flex-col gap-3">
@@ -375,14 +479,48 @@ function AchievementsSection({
       <div className="flex flex-col gap-4">
         {achievements.map((achievement, i) => {
           const group = groups[i];
+          const added =
+            i >= originalCount
+              ? addedAchievements[i - originalCount]
+              : undefined;
           const header = [achievement.title, achievement.year]
             .filter(Boolean)
             .join(" · ");
           return (
-            <div key={i} className="flex flex-col gap-1.5">
-              <h3 className="text-sm font-semibold text-content-primary">
-                {header || "Untitled achievement"}
-              </h3>
+            <div key={added ? added.id : i} className="flex flex-col gap-1.5">
+              <div className="flex items-start justify-between gap-2">
+                {added ? (
+                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                    <EditableField
+                      value={achievement.title || undefined}
+                      placeholder="achievement title"
+                      label="Achievement title"
+                      textWeight="semibold"
+                      textSize="sm"
+                      multiline
+                      onCommit={(v) => onEntryField(added.id, "title", v)}
+                    />
+                    <span className="text-content-muted">·</span>
+                    <EditableField
+                      value={achievement.year || undefined}
+                      placeholder="year"
+                      label="Year"
+                      textSize="xs"
+                      onCommit={(v) => onEntryField(added.id, "year", v)}
+                    />
+                  </div>
+                ) : (
+                  <h3 className="text-sm font-semibold text-content-primary">
+                    {header || "Untitled achievement"}
+                  </h3>
+                )}
+                {added && (
+                  <RemoveButton
+                    label="Remove achievement"
+                    onClick={() => onRemoveEntry(added.id)}
+                  />
+                )}
+              </div>
               {group && group.bullets.length > 0 ? (
                 <ul className="list-none">
                   {group.bullets.map((b) => (
@@ -394,14 +532,20 @@ function AchievementsSection({
                   ))}
                 </ul>
               ) : (
-                <p className="text-sm text-content-tertiary">
-                  No bullet-shaped lines detected.
-                </p>
+                !added && (
+                  <p className="text-sm text-content-tertiary">
+                    No bullet-shaped lines detected.
+                  </p>
+                )
+              )}
+              {added && (
+                <InlineBulletAdd onAdd={(text) => onAddBullet(added.id, text)} />
               )}
             </div>
           );
         })}
       </div>
+      <AddPill label="Add achievement" onClick={onAddEntry} />
     </section>
   );
 }
@@ -449,9 +593,34 @@ export function ReconstructedResume({
     setBulletField,
     educationOverrides,
     setEducationField,
+    addEntry,
+    removeEntry,
+    setEntryField,
+    addBullet,
     addSkill,
     removeSkill,
   } = edit;
+
+  // Added entries are appended to their parsed array by applyOverrides (so they
+  // grade + export), which means they already arrive here inside `parsed.*`. We
+  // split them back out by section to (a) render their indices ≥ originalCount
+  // with edit/remove affordances and (b) map an appended index → its stable id.
+  const addedExperience = edit.addedEntries.filter(
+    (e) => e.section === "experience",
+  );
+  const addedEducation = edit.addedEntries.filter(
+    (e) => e.section === "education",
+  );
+  const addedProjects = edit.addedEntries.filter(
+    (e) => e.section === "projects",
+  );
+  const addedAchievements = edit.addedEntries.filter(
+    (e) => e.section === "achievements",
+  );
+  const originalExpCount = parsed.experience.length - addedExperience.length;
+  const originalEduCount = parsed.education.length - addedEducation.length;
+  const originalProjCount = projects.length - addedProjects.length;
+  const originalAchCount = achievements.length - addedAchievements.length;
 
   // One grouping pass over experiences + projects + achievements so their
   // bullets are attributed to their own entry and never leak into the experience
@@ -468,11 +637,20 @@ export function ReconstructedResume({
   // so no PDF bytes ever leave the browser (#171).
   const { download, isGenerating } = useDownloadPdf(result, score, edit);
 
-  const achievementsSection = achievements.length > 0 && (
+  // Always rendered (even with zero parsed achievements) so the "+ Add
+  // achievement" affordance is reachable on every resume — matching Education /
+  // Skills, which also render an add affordance unconditionally.
+  const achievementsSection = (
     <AchievementsSection
       achievements={achievements}
       groups={achievementGroups}
       bulletOverrides={bulletOverrides}
+      addedAchievements={addedAchievements}
+      originalCount={originalAchCount}
+      onAddEntry={() => addEntry("achievements")}
+      onRemoveEntry={removeEntry}
+      onEntryField={setEntryField}
+      onAddBullet={addBullet}
     />
   );
 
@@ -521,14 +699,24 @@ export function ReconstructedResume({
         }
         bulletOverrides={bulletOverrides}
         onBulletChange={(index, value) => setBulletField(index, value)}
+        addedExperience={addedExperience}
+        originalCount={originalExpCount}
+        onAddEntry={() => addEntry("experience")}
+        onRemoveEntry={removeEntry}
+        onEntryField={setEntryField}
+        onAddBullet={addBullet}
       />
-      {projects.length > 0 && (
-        <ProjectsSection
-          projects={projects}
-          groups={projectGroups}
-          bulletOverrides={bulletOverrides}
-        />
-      )}
+      <ProjectsSection
+        projects={projects}
+        groups={projectGroups}
+        bulletOverrides={bulletOverrides}
+        addedProjects={addedProjects}
+        originalCount={originalProjCount}
+        onAddEntry={() => addEntry("projects")}
+        onRemoveEntry={removeEntry}
+        onEntryField={setEntryField}
+        onAddBullet={addBullet}
+      />
       {!achievementsAbove && achievementsSection}
       <EducationSection
         education={parsed.education}
@@ -536,6 +724,11 @@ export function ReconstructedResume({
         onEducationFieldChange={(index, field, value) =>
           setEducationField(index, field, value)
         }
+        addedEducation={addedEducation}
+        originalCount={originalEduCount}
+        onAddEntry={() => addEntry("education")}
+        onRemoveEntry={removeEntry}
+        onEntryField={setEntryField}
       />
       <SkillsSection
         skills={parsed.skills}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -31,6 +31,7 @@ import type {
 } from "../../hooks/useEditableParse.ts";
 import { RewriteButton } from "./RewriteButton.tsx";
 import { useSectionRewrite } from "./SectionRewrite.tsx";
+import { InlineBulletAdd, RemoveButton } from "./ReconstructedAdd.tsx";
 
 // ── Bullet flags ──────────────────────────────────────────────────────────────
 
@@ -449,6 +450,12 @@ interface RoleEntryProps {
   bulletOverrides?: BulletOverrides;
   /** Commit a bullet edit, keyed by BulletObservation.index (#82). */
   onBulletChange?: (index: number, value: string) => void;
+  /** Append a new bullet to this role (#180-followup). Renders a "+ Add bullet"
+   *  affordance under the bullet list when provided. */
+  onAddBullet?: (text: string) => void;
+  /** Remove this role (only set for user-ADDED roles). Renders an X control in
+   *  the header row when provided. */
+  onRemove?: () => void;
 }
 
 /**
@@ -462,6 +469,8 @@ export function RoleEntry({
   onFieldChange,
   bulletOverrides,
   onBulletChange,
+  onAddBullet,
+  onRemove,
 }: RoleEntryProps) {
   // Bullet display text honors #82 overrides — section rewrite must see the
   // text the user actually edited, not the stale parsed text.
@@ -480,7 +489,12 @@ export function RoleEntry({
           overrides={overrides}
           onFieldChange={onFieldChange}
         />
-        {rewriteTrigger}
+        <div className="flex shrink-0 items-center gap-1">
+          {rewriteTrigger}
+          {onRemove && (
+            <RemoveButton label="Remove role" onClick={onRemove} />
+          )}
+        </div>
       </div>
       {group.bullets.length > 0 ? (
         <>
@@ -501,10 +515,17 @@ export function RoleEntry({
           {rewritePanel}
         </>
       ) : (
-        <p className="text-sm text-content-tertiary">
-          No bullet-shaped lines detected.
-        </p>
+        // A user-added role (onRemove set) starts empty — the "+ Add bullet"
+        // affordance below is its call to action, so suppress the note for it.
+        // A PARSED role with no bullets still shows the note: that the parser
+        // found none is the diagnostic signal this surface exists to expose.
+        !onRemove && (
+          <p className="text-sm text-content-tertiary">
+            No bullet-shaped lines detected.
+          </p>
+        )
       )}
+      {onAddBullet && <InlineBulletAdd onAdd={onAddBullet} />}
     </div>
   );
 }

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -21,7 +21,7 @@
  * state boilerplate (CLAUDE.md §Data & Hooks).
  */
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
 
 // ── Contact overrides ─────────────────────────────────────────────────────────
@@ -58,6 +58,65 @@ export interface EducationFieldOverrides {
   institution?: string;
   start_date?: string;
   end_date?: string;
+}
+
+// ── Added entries + bullets ─────────────────────────────────────────────────
+// Edit overrides above CORRECT what the parser found; these ADD what it missed
+// entirely — a whole role/degree/project/achievement, or a bullet under any
+// entry. applyOverrides appends added entries to the parsed arrays and folds
+// added bullets into BOTH the entry description and the graded bullet pool, so
+// an addition moves Completeness (entries) and Specificity / Structure (bullets)
+// AND flows into the downloaded PDF — same authoritative path as the edits.
+
+/** Sections that accept a user-added entry. Education carries no bullets. */
+export type AddableSection =
+  | "experience"
+  | "education"
+  | "projects"
+  | "achievements";
+
+/**
+ * A user-added entry appended to a section. Header fields share one flat shape
+ * so a single list holds every added entry, mapped per section in applyOverrides:
+ *   - experience:   title, subtitle (company), start_date, end_date
+ *   - education:    title (degree), subtitle (institution), start_date, end_date
+ *   - projects:     title (name)
+ *   - achievements: title, year
+ * `id` is a stable per-session key (`"added:<n>"`) so the entry's bullets (in
+ * `addedBullets`) and inline header edits track it without relying on array
+ * position.
+ */
+export interface AddedEntry {
+  id: string;
+  section: AddableSection;
+  /** Primary header: job title / degree / project name / achievement title. */
+  title: string;
+  /** Secondary header: company / institution. Unused for projects/achievements. */
+  subtitle?: string;
+  start_date?: string;
+  end_date?: string;
+  /** Achievement year (achievements carry a single year, not a range). */
+  year?: string;
+}
+
+/** Editable header fields on an added entry. */
+export type AddedEntryField =
+  | "title"
+  | "subtitle"
+  | "start_date"
+  | "end_date"
+  | "year";
+
+/**
+ * Bullet lines a user appended to an entry, keyed by entry key. A PARSED entry's
+ * key is `"<section>:<index>"` (see {@link parsedEntryKey}); an ADDED entry's key
+ * is its `id`. The two namespaces never collide (added ids are `"added:<n>"`).
+ */
+export type AddedBullets = Record<string, string[]>;
+
+/** The stable bullet key for a PARSED entry at `index` within `section`. */
+export function parsedEntryKey(section: AddableSection, index: number): string {
+  return `${section}:${index}`;
 }
 
 // ── Skills override ───────────────────────────────────────────────────────────
@@ -106,6 +165,20 @@ export interface EditableParse {
     field: keyof EducationFieldOverrides,
     value: string | undefined,
   ) => void;
+  /** User-added entries across all sections, in insertion order. */
+  addedEntries: AddedEntry[];
+  /** Append a new (empty-header) entry to a section. Returns its stable id. */
+  addEntry: (section: AddableSection) => string;
+  /** Remove a previously-added entry by id (also drops its added bullets). */
+  removeEntry: (id: string) => void;
+  /** Edit one header field on an added entry. */
+  setEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  /** Bullet lines appended to entries, keyed by entry key (parsedEntryKey or
+   *  an added entry's id). */
+  addedBullets: AddedBullets;
+  /** Append a bullet line to an entry. No-op on blank text. An added entry's
+   *  bullets are dropped wholesale when the entry is removed. */
+  addBullet: (entryKey: string, text: string) => void;
   /** Add/remove edits against parsed.skills. */
   skillsOverride: SkillsOverride;
   /** Add a (canonicalized) skill. No-op for blank input or an exact dupe of an
@@ -135,6 +208,12 @@ export function useEditableParse(): EditableParse {
   const [skillsOverride, setSkillsOverride] = useState<SkillsOverride>(
     EMPTY_SKILLS_OVERRIDE,
   );
+  const [addedEntries, setAddedEntries] = useState<AddedEntry[]>([]);
+  const [addedBullets, setAddedBullets] = useState<AddedBullets>({});
+  // Monotonic source of stable added-entry ids. A ref (not state) because a new
+  // id must not itself trigger a re-render, and the value need only be unique
+  // within the session — never reset, even across resetAll.
+  const idCounter = useRef(0);
 
   const setContactField = useCallback(
     (key: keyof ContactOverrides, value: string | undefined) => {
@@ -233,12 +312,48 @@ export function useEditableParse(): EditableParse {
     });
   }, []);
 
+  const addEntry = useCallback((section: AddableSection) => {
+    const id = `added:${idCounter.current++}`;
+    setAddedEntries((prev) => [...prev, { id, section, title: "" }]);
+    return id;
+  }, []);
+
+  const removeEntry = useCallback((id: string) => {
+    setAddedEntries((prev) => prev.filter((e) => e.id !== id));
+    setAddedBullets((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const setEntryField = useCallback(
+    (id: string, field: AddedEntryField, value: string) => {
+      setAddedEntries((prev) =>
+        prev.map((e) => (e.id === id ? { ...e, [field]: value } : e)),
+      );
+    },
+    [],
+  );
+
+  const addBullet = useCallback((entryKey: string, text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setAddedBullets((prev) => ({
+      ...prev,
+      [entryKey]: [...(prev[entryKey] ?? []), trimmed],
+    }));
+  }, []);
+
   const resetAll = useCallback(() => {
     setContactOverrides({});
     setExperienceOverrides({});
     setBulletOverrides({});
     setEducationOverrides({});
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
+    setAddedEntries([]);
+    setAddedBullets({});
   }, []);
 
   const hasEdits = useMemo(() => {
@@ -246,6 +361,8 @@ export function useEditableParse(): EditableParse {
     if (Object.keys(bulletOverrides).length > 0) return true;
     if (skillsOverride.removed.length > 0 || skillsOverride.added.length > 0)
       return true;
+    if (addedEntries.length > 0) return true;
+    if (Object.keys(addedBullets).length > 0) return true;
     if (
       Object.values(educationOverrides).some(
         (entry) => Object.keys(entry).length > 0,
@@ -261,6 +378,8 @@ export function useEditableParse(): EditableParse {
     bulletOverrides,
     educationOverrides,
     skillsOverride,
+    addedEntries,
+    addedBullets,
   ]);
 
   return {
@@ -272,6 +391,12 @@ export function useEditableParse(): EditableParse {
     setBulletField,
     educationOverrides,
     setEducationField,
+    addedEntries,
+    addEntry,
+    removeEntry,
+    setEntryField,
+    addedBullets,
+    addBullet,
     skillsOverride,
     addSkill,
     removeSkill,

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { applyOverrides } from "./apply-overrides.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
 import { groupBulletsByExperience } from "../score/group-bullets.ts";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { BulletObservation } from "../score/score.ts";
@@ -568,5 +569,133 @@ describe("regression: post-edit bullet re-grouping (issue #63 testing artefact)"
     // The edited bullet falls into Other — confirming what the user reported.
     expect(groups.find((g) => g.experienceIndex === 0)?.bullets ?? []).toEqual([]);
     expect(groups.find((g) => g.experienceIndex === null)?.bullets).toHaveLength(1);
+  });
+});
+
+describe("applyOverrides — added entries + bullets", () => {
+  it("appends an added experience entry with its bullets in the description", () => {
+    const parsed = baseParsed();
+    const { parsed: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [
+        {
+          id: "added:0",
+          section: "experience",
+          title: "PM",
+          subtitle: "Google",
+          start_date: "2019",
+          end_date: "2021",
+        },
+      ],
+      { "added:0": ["Led a team of five to ship the launch on time"] },
+    );
+    expect(out.experience).toHaveLength(2);
+    expect(out.experience[1]).toMatchObject({
+      title: "PM",
+      company: "Google",
+      description: "Led a team of five to ship the launch on time",
+    });
+    // Original parse untouched.
+    expect(parsed.experience).toHaveLength(1);
+  });
+
+  it("appends added education / project / achievement entries to their arrays", () => {
+    const { parsed: out } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [
+        { id: "added:0", section: "education", title: "BS CS", subtitle: "MIT" },
+        { id: "added:1", section: "projects", title: "Side project" },
+        { id: "added:2", section: "achievements", title: "Patent", year: "2021" },
+      ],
+      {},
+    );
+    expect(out.education).toHaveLength(1);
+    expect(out.education[0]).toMatchObject({ degree: "BS CS", institution: "MIT" });
+    expect(out.projects).toHaveLength(1);
+    expect(out.projects?.[0]).toMatchObject({ name: "Side project" });
+    expect(out.heuristic_achievements).toHaveLength(1);
+    expect(out.heuristic_achievements?.[0]).toMatchObject({
+      title: "Patent",
+      year: "2021",
+    });
+  });
+
+  it("folds an added bullet on an existing role into description AND the pool", () => {
+    const parsed = baseParsed();
+    const { parsed: out, sections } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(["• Built a thing"]),
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [],
+      { "experience:0": ["Cut latency by 40% across the fleet"] },
+    );
+    // Appended to the existing role's description.
+    expect(out.experience[0].description).toContain(
+      "Cut latency by 40% across the fleet",
+    );
+    // And pooled (with a marker) into the last accomplishment section so it grades.
+    const pooled = sections.byName.get("achievements") ?? [];
+    expect(pooled).toContain("• Cut latency by 40% across the fleet");
+    // Original untouched.
+    expect(parsed.experience[0].description).toBe(
+      "Built a thing\nShipped another thing",
+    );
+  });
+
+  it("raises Completeness when an education entry is added (counts toward score)", () => {
+    const base = baseParsed();
+    const sections = makeSections();
+    const before = computeAnonymousAtsScore({
+      parsed: base,
+      fieldConfidence: {},
+      triggers: [],
+      rawText: "raw",
+      sections,
+    });
+    const { parsed: out, sections: outSections } = applyOverrides(
+      base,
+      "raw",
+      sections,
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [{ id: "added:0", section: "education", title: "BS", subtitle: "MIT" }],
+      {},
+    );
+    const after = computeAnonymousAtsScore({
+      parsed: out,
+      fieldConfidence: {},
+      triggers: [],
+      rawText: "raw",
+      sections: outSections,
+    });
+    expect(before.completeness.missing).toContain("education");
+    expect(after.completeness.missing).not.toContain("education");
+    expect(after.completeness.score).toBeGreaterThan(before.completeness.score);
   });
 });

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -38,10 +38,10 @@ import type {
   ExperienceFieldOverrides,
   EducationFieldOverrides,
   SkillsOverride,
+  AddedEntry,
+  AddedBullets,
+  BulletOverrides,
 } from "../../hooks/useEditableParse.ts";
-
-/** Bullet overrides keyed by `BulletObservation.index` (stable rawText order). */
-export type BulletOverrides = Record<number, string>;
 
 export interface ApplyOverridesResult {
   parsed: HeuristicParsedResume;
@@ -189,6 +189,13 @@ const LEADING_MARKER_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·�]|\d+[.)]) 
  * @param skills    add/remove edits against `parsed.skills`. `removed` keys
  *                  (lower-cased) drop parsed skills; `added` are appended,
  *                  de-duplicated. Default `{ removed: [], added: [] }`.
+ * @param addedEntries user-added entries appended to their section arrays
+ *                  (experience/education/projects/achievements). Default `[]`.
+ * @param addedBullets bullet lines a user appended to an entry, keyed by entry
+ *                  key — `"<section>:<index>"` for a parsed entry or an added
+ *                  entry's id. Folded into the entry description AND the graded
+ *                  bullet pool so an addition moves Specificity / Structure.
+ *                  Default `{}`.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -200,6 +207,8 @@ export function applyOverrides(
   observations: readonly BulletObservation[],
   education: Record<number, EducationFieldOverrides> = {},
   skills: SkillsOverride = { removed: [], added: [] },
+  addedEntries: readonly AddedEntry[] = [],
+  addedBullets: AddedBullets = {},
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -292,6 +301,112 @@ export function applyOverrides(
       kept.push(add);
     }
     nextParsed.skills = kept;
+  }
+
+  // ── Added entries + bullets ────────────────────────────────────────────────
+  // Append user-added entries to their section arrays and fold added bullet
+  // lines into BOTH the entry description (display / PDF / grouping / fallback
+  // grading) and the graded bullet pool (Specificity / Structure). Pool lines
+  // land in the LAST accomplishment section so they sort after every existing
+  // bullet — keeping prior BulletObservation indices (which bulletOverrides are
+  // keyed by) stable.
+  const hasAdds =
+    addedEntries.length > 0 || Object.keys(addedBullets).length > 0;
+  if (hasAdds) {
+    // projects + heuristic_achievements weren't cloned above (only experience /
+    // education / skills were). Clone them — and their entries — before we push
+    // or mutate descriptions, so the original parse is never touched.
+    nextParsed.projects = (nextParsed.projects ?? []).map((p) => ({ ...p }));
+    nextParsed.heuristic_achievements = (
+      nextParsed.heuristic_achievements ?? []
+    ).map((a) => ({ ...a }));
+
+    // "• "-prefixed copies of every added bullet, pooled for grading.
+    const poolLines: string[] = [];
+
+    // Added entries: build each from its header fields, with description from
+    // its own added bullets (keyed by the entry id).
+    for (const entry of addedEntries) {
+      const entryBullets = addedBullets[entry.id] ?? [];
+      const description = entryBullets.join("\n") || undefined;
+      if (entry.section === "experience") {
+        nextParsed.experience.push({
+          title: entry.title,
+          company: entry.subtitle ?? "",
+          start_date: entry.start_date,
+          end_date: entry.end_date,
+          description,
+        });
+      } else if (entry.section === "education") {
+        nextParsed.education.push({
+          degree: entry.title,
+          institution: entry.subtitle ?? "",
+          start_date: entry.start_date,
+          end_date: entry.end_date,
+        });
+      } else if (entry.section === "projects") {
+        nextParsed.projects.push({ name: entry.title, description });
+      } else {
+        nextParsed.heuristic_achievements.push({
+          title: entry.title,
+          year: entry.year,
+          description,
+        });
+      }
+      for (const b of entryBullets) poolLines.push(`• ${b}`);
+    }
+
+    // Resolve a parsed-entry bullet key ("<section>:<index>") to the cloned
+    // entry whose description carries the bullet. Added-entry keys ("added:<n>")
+    // are handled above and skipped here. Education carries no bullets.
+    const parsedDescTarget = (
+      key: string,
+    ): { description?: string } | undefined => {
+      const colon = key.indexOf(":");
+      if (colon < 0) return undefined;
+      const section = key.slice(0, colon);
+      const index = Number(key.slice(colon + 1));
+      if (!Number.isInteger(index)) return undefined;
+      if (section === "experience") return nextParsed.experience[index];
+      if (section === "projects") return nextParsed.projects![index];
+      if (section === "achievements")
+        return nextParsed.heuristic_achievements![index];
+      return undefined;
+    };
+
+    // Added bullets on EXISTING parsed entries: append to that entry's
+    // description (cloned) and to the pool.
+    for (const [key, lines] of Object.entries(addedBullets)) {
+      if (key.startsWith("added:")) continue; // added entries handled above
+      if (lines.length === 0) continue;
+      const target = parsedDescTarget(key);
+      if (!target) continue;
+      const existing = target.description ? [target.description] : [];
+      target.description = [...existing, ...lines].join("\n");
+      for (const b of lines) poolLines.push(`• ${b}`);
+    }
+
+    if (poolLines.length > 0) {
+      const order = nextSections.accomplishmentSections;
+      // Last accomplishment section in canonical order — its lines pool last, so
+      // appended bullets get the highest indices. Fall back to "achievements".
+      const tail: SectionName =
+        order.length > 0 ? order[order.length - 1] : "achievements";
+      const nextByName = new Map<
+        SectionName | "profile",
+        readonly string[]
+      >(nextSections.byName);
+      const existing = nextByName.get(tail) ?? [];
+      nextByName.set(tail, [...existing, ...poolLines]);
+      const accomplishmentSections = order.includes(tail)
+        ? order
+        : [...order, tail];
+      nextSections = {
+        ...nextSections,
+        byName: nextByName,
+        accomplishmentSections,
+      };
+    }
   }
 
   return { parsed: nextParsed, rawText: nextRawText, sections: nextSections };


### PR DESCRIPTION
## Summary

Extends the progressive-disclosure **"+ Add"** pill (pioneered by Skills, #180) to every reconstructed-resume section: add an **experience role**, a **bullet under any role**, an **education entry**, and a **project/achievement entry**. Additions re-grade the anonymous ATS score (same path as edits) and flow into the downloaded ATS-friendly PDF (#173) with **no PDF-builder changes**.

- **New shared module** `ReconstructedAdd.tsx` — `AddPill` / `RemoveButton` / `InlineBulletAdd`, built only from the `@design-system` `Button` primitive + semantic tokens (no raw `<button>`, no hardcoded palette).
- **`useEditableParse`** — `addedEntries` + `addedBullets` channels with `addEntry` / `removeEntry` / `setEntryField` / `addBullet`; `resetAll` + `hasEdits` updated.
- **`applyOverrides`** — folds added entries into the parsed arrays (cloning `projects`/`heuristic_achievements` first so the original parse isn't corrupted) and added bullets into **both** the entry `description` and the graded bullet pool (`• …`); pool lines append to the **last** accomplishment section to keep `bulletOverrides` indices stable.
- **`App.tsx`** threads the two channels into `applyOverrides` + its `useMemo` deps.

## Intentional behavior changes

1. **Projects + Achievements sections now always render** (even when empty) so their "+ Add" pill is reachable — matching Education/Skills. Empty resumes gain two section headers.
2. Individual added bullets aren't separately removable (they render as normal graded bullets); removing the **entry** drops its bullets. Bullet text stays editable.

Resolves #181

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (806 tests; +4 in `apply-overrides.test.ts` incl. a before/after Completeness-score proof)
- [x] `npm run lint` (eslint) clean — no raw `<button>` / hardcoded palette
- [x] `npm run build` succeeds (only pre-existing chunk-size warning)
- [ ] Manually verified in `npm run dev` (UI wiring is typecheck/build-verified; suite is node-env, no render tests)