### PR TITLE
feat(webllm): chain-of-sections whole-résumé rewrite (#67)

### DIFF
--- a/src/components/features/ReconstructedResume.test.ts
+++ b/src/components/features/ReconstructedResume.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Unit tests for the pure chain-of-sections input builders (#67) that
+ * ReconstructedResume hands the orchestrator. The container itself is
+ * render-only (node-env suite, no RTL), but `buildResumeSections` and
+ * `roleLabel` are pure data transforms — covered here directly.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildResumeSections, roleLabel } from "./ReconstructedResume.tsx";
+import type { BulletGroup } from "../../lib/score/group-bullets.ts";
+import type { BulletObservation } from "../../lib/score/score.ts";
+
+function bullet(index: number, text: string): BulletObservation {
+  return {
+    text,
+    index,
+    hasMetric: false,
+    startsWithActionVerb: false,
+    wellFormedLength: false,
+    wordCount: text.split(/\s+/).length,
+  };
+}
+
+function group(
+  experienceIndex: number | null,
+  experience: BulletGroup["experience"],
+  bullets: BulletObservation[],
+): BulletGroup {
+  return { experienceIndex, experience, bullets };
+}
+
+describe("roleLabel", () => {
+  it("returns the Other-bullets label for the null group", () => {
+    expect(roleLabel(null)).toBe("Other bullets");
+  });
+
+  it("joins title and company with an em dash when both present", () => {
+    expect(roleLabel({ title: "Engineer", company: "Acme" })).toBe(
+      "Engineer — Acme",
+    );
+  });
+
+  it("falls back to title alone, then company alone", () => {
+    expect(roleLabel({ title: "Engineer" })).toBe("Engineer");
+    expect(roleLabel({ company: "Acme" })).toBe("Acme");
+  });
+
+  it("returns Untitled role when neither title nor company is present", () => {
+    expect(roleLabel({})).toBe("Untitled role");
+  });
+});
+
+describe("buildResumeSections", () => {
+  it("prepends a summary section (id 'summary') when the summary is non-empty", () => {
+    const sections = buildResumeSections("  Engineer with 10 years.  ", [], {});
+    expect(sections).toEqual([
+      {
+        kind: "summary",
+        id: "summary",
+        label: "Summary",
+        text: "Engineer with 10 years.",
+      },
+    ]);
+  });
+
+  it("omits the summary section when undefined or whitespace-only", () => {
+    expect(buildResumeSections(undefined, [], {})).toEqual([]);
+    expect(buildResumeSections("   ", [], {})).toEqual([]);
+  });
+
+  it("appends each experience role in display order with a stable id", () => {
+    const groups = [
+      group(0, { title: "Engineer", company: "Acme" }, [bullet(0, "Built X")]),
+      group(1, { title: "Lead", company: "Beta" }, [bullet(1, "Led Y")]),
+    ];
+    const sections = buildResumeSections(undefined, groups, {});
+    expect(sections).toEqual([
+      {
+        kind: "experience",
+        id: "experience:0",
+        label: "Engineer — Acme",
+        bullets: ["Built X"],
+      },
+      {
+        kind: "experience",
+        id: "experience:1",
+        label: "Lead — Beta",
+        bullets: ["Led Y"],
+      },
+    ]);
+  });
+
+  it("excludes the Other group (experienceIndex null) and zero-bullet groups", () => {
+    const groups = [
+      group(null, null, [bullet(0, "Orphan bullet")]),
+      group(2, { title: "Engineer" }, []),
+    ];
+    expect(buildResumeSections(undefined, groups, {})).toEqual([]);
+  });
+
+  it("applies bullet overrides (#82) so the model sees the user's latest edits", () => {
+    const groups = [
+      group(0, { title: "Engineer" }, [
+        bullet(5, "Stale text"),
+        bullet(6, "Kept text"),
+      ]),
+    ];
+    const sections = buildResumeSections(undefined, groups, {
+      5: "Edited text",
+    });
+    expect(sections).toEqual([
+      {
+        kind: "experience",
+        id: "experience:0",
+        label: "Engineer",
+        bullets: ["Edited text", "Kept text"],
+      },
+    ]);
+  });
+});

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -47,6 +47,8 @@ import {
   BulletFlagLegend,
 } from "./ReconstructedRole.tsx";
 import { ModelSelector } from "./ModelSelector.tsx";
+import { useResumeRewriteUi } from "./ResumeRewrite.tsx";
+import type { SectionInput } from "../../lib/webllm/rewrite-resume.ts";
 import type {
   ResumeProject,
   HeuristicAchievement,
@@ -250,6 +252,7 @@ const EXPERIENCE_FIELD_MAP: Record<
 
 function ExperienceSection({
   groups,
+  resumeSections,
   hasBullets,
   experienceOverrides,
   onExperienceFieldChange,
@@ -264,6 +267,8 @@ function ExperienceSection({
 }: {
   /** Pre-built experience groups + the shared "Other" group appended last. */
   groups: BulletGroup[];
+  /** Chain-of-sections input for the whole-résumé rewrite CTA (#67). */
+  resumeSections: readonly SectionInput[];
   hasBullets: boolean;
   experienceOverrides: Record<number, ExperienceFieldOverrides>;
   onExperienceFieldChange: (
@@ -284,6 +289,12 @@ function ExperienceSection({
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
+  // The whole-résumé rewrite CTA (#67) lives at the top of Experience next to
+  // the picker. Trigger + panel render only when WebGPU is available AND
+  // there's at least one rewriteable section — same silent-absence rule as
+  // SectionRewrite. The hook owns the WebGPU/empty-input gating.
+  const { trigger: resumeRewriteTrigger, panel: resumeRewritePanel } =
+    useResumeRewriteUi(resumeSections);
   return (
     <section className="flex flex-col gap-3">
       {/* Heading row: the flag legend sits beside the Experience title (next to
@@ -293,11 +304,18 @@ function ExperienceSection({
         <SectionHeading>Experience</SectionHeading>
         {hasBullets && <BulletFlagLegend />}
       </div>
-      {/* Picker mounted at the top of Experience — "inline near SectionRewrite,
-          visible only in the rewrite context" per the #64 step 6 spec. Returns
-          null when WebGPU is unavailable, so non-WebGPU browsers see no
-          picker chrome at all (matches RewriteButton + SectionRewrite). */}
-      {hasBullets && <ModelSelector />}
+      {/* Picker + whole-résumé CTA mounted at the top of Experience —
+          "inline near SectionRewrite, visible only in the rewrite context"
+          per the #64 step 6 spec. Both return null when WebGPU is
+          unavailable, so non-WebGPU browsers see no rewrite chrome at all
+          (matches RewriteButton + SectionRewrite). */}
+      {hasBullets && (
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+          <ModelSelector />
+          {resumeRewriteTrigger}
+        </div>
+      )}
+      {hasBullets && resumeRewritePanel}
       {roleCount === 0 ? (
         <NotDetected what="roles" />
       ) : (
@@ -553,6 +571,65 @@ function AchievementsSection({
 // Education + Skills are now editable (#176) and live in their own feature file
 // (ReconstructedEducationSkills.tsx) so this container stays under ~200 LOC.
 
+// ── Whole-résumé rewrite (issue #67) ─────────────────────────────────────────
+
+/**
+ * Build the chain-of-sections input the orchestrator (#67) sees.
+ *
+ * Summary (when non-empty) is section 0; every real experience role is then
+ * appended in display order. Bullets honor #82 overrides so the model sees
+ * the user's latest edits, not stale parsed text. The "Other bullets" group
+ * (`experienceIndex === null`) is intentionally excluded — it has no parsed
+ * role to anchor the prompt to, and rewriting it would produce orphan
+ * bullets the panel has nowhere to attribute.
+ *
+ * Section ids are stable across renders for the same parse — `summary` for
+ * the summary, `experience:<index>` for each role — so the hook's
+ * stale-source guard (which compares ids) can tell "the section list
+ * changed" from "react re-rendered with the same data."
+ */
+function buildResumeSections(
+  summary: string | undefined,
+  experienceGroups: readonly BulletGroup[],
+  bulletOverrides: BulletOverrides,
+): readonly SectionInput[] {
+  const out: SectionInput[] = [];
+  const trimmedSummary = summary?.trim();
+  if (trimmedSummary) {
+    out.push({
+      kind: "summary",
+      id: "summary",
+      label: "Summary",
+      text: trimmedSummary,
+    });
+  }
+  for (const group of experienceGroups) {
+    if (group.experienceIndex === null) continue;
+    if (group.bullets.length === 0) continue;
+    const exp = group.experience;
+    const label = roleLabel(exp);
+    const sectionBullets = group.bullets.map(
+      (b) => bulletOverrides?.[b.index] ?? b.text,
+    );
+    out.push({
+      kind: "experience",
+      id: `experience:${group.experienceIndex}`,
+      label,
+      bullets: sectionBullets,
+    });
+  }
+  return out;
+}
+
+function roleLabel(exp: BulletGroup["experience"]): string {
+  if (exp === null) return "Other bullets";
+  const { title, company } = exp;
+  if (title && company) return `${title} — ${company}`;
+  if (title) return title;
+  if (company) return company;
+  return "Untitled role";
+}
+
 // ── Container ─────────────────────────────────────────────────────────────────
 
 // Presentational container: cyclomatic (10) and cognitive (9) are both under
@@ -637,6 +714,17 @@ export function ReconstructedResume({
   // so no PDF bytes ever leave the browser (#171).
   const { download, isGenerating } = useDownloadPdf(result, score, edit);
 
+  // Build the chain-of-sections input for the whole-résumé rewrite CTA (#67).
+  // Summary first (when present), then every real role in display order — the
+  // "Other" bullets group is excluded because it has no parsed role to anchor
+  // the prompt to. Bullets honor #82 overrides so the model sees the user's
+  // edits, not stale parsed text.
+  const resumeSections = buildResumeSections(
+    parsed.summary,
+    experienceGroups,
+    bulletOverrides,
+  );
+
   // Always rendered (even with zero parsed achievements) so the "+ Add
   // achievement" affordance is reachable on every resume — matching Education /
   // Skills, which also render an add affordance unconditionally.
@@ -692,6 +780,7 @@ export function ReconstructedResume({
       {achievementsAbove && achievementsSection}
       <ExperienceSection
         groups={experienceRenderGroups}
+        resumeSections={resumeSections}
         hasBullets={bullets.length > 0}
         experienceOverrides={experienceOverrides}
         onExperienceFieldChange={(index, field, value) =>

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -588,7 +588,7 @@ function AchievementsSection({
  * stale-source guard (which compares ids) can tell "the section list
  * changed" from "react re-rendered with the same data."
  */
-function buildResumeSections(
+export function buildResumeSections(
   summary: string | undefined,
   experienceGroups: readonly BulletGroup[],
   bulletOverrides: BulletOverrides,
@@ -621,7 +621,7 @@ function buildResumeSections(
   return out;
 }
 
-function roleLabel(exp: BulletGroup["experience"]): string {
+export function roleLabel(exp: BulletGroup["experience"]): string {
   if (exp === null) return "Other bullets";
   const { title, company } = exp;
   if (title && company) return `${title} — ${company}`;

--- a/src/components/features/ResumeRewrite.test.ts
+++ b/src/components/features/ResumeRewrite.test.ts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Smoke tests for ResumeRewrite's presentational helpers.
+ *
+ * Mirrors the SectionRewrite.test.ts approach: the top-level hook is hard to
+ * drive without a WebGPU adapter, so we target the pure helpers that own
+ * the branching — `StepIndicator`, `aggregateDrift`, `ResumeRewritePanel`'s
+ * branch selection, and the label fn.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ResumeRewritePanel, StepIndicator } from "./ResumeRewrite.tsx";
+import { aggregateDrift } from "./ResumeRewriteProposed.tsx";
+import { labelForResumeRewrite, type ResumeRewriteStatus } from "../../hooks/useResumeRewrite.ts";
+import type { ResumeRewriteResult } from "../../lib/webllm/rewrite-resume.ts";
+
+const idle: ResumeRewriteStatus = { kind: "idle" };
+const loading: ResumeRewriteStatus = {
+  kind: "loading",
+  progress: { progress: 0.5, text: "weights.bin" },
+};
+const running: ResumeRewriteStatus = {
+  kind: "running",
+  progress: {
+    currentIndex: 1,
+    totalSections: 3,
+    currentLabel: "Engineer — Acme",
+    completed: [],
+  },
+};
+const errored: ResumeRewriteStatus = {
+  kind: "error",
+  message: "Engine failed to load",
+};
+
+const okResult: ResumeRewriteResult = {
+  sections: [
+    {
+      kind: "summary",
+      input: { kind: "summary", id: "summary", label: "Summary", text: "Engineer with 10 years." },
+      data: {
+        text: "Senior engineer.",
+        numbersPreserved: true,
+        droppedNumbers: [],
+        addedNumbers: [],
+      },
+    },
+    {
+      kind: "experience",
+      input: { kind: "experience", id: "experience:0", label: "Engineer — Acme", bullets: ["a"] },
+      data: {
+        bullets: ["Shipped Foo to 10M users."],
+        numbersPreserved: true,
+        droppedNumbers: [],
+        addedNumbers: [],
+      },
+    },
+  ],
+  allNumbersPreserved: true,
+};
+
+const driftResult: ResumeRewriteResult = {
+  sections: [
+    {
+      kind: "experience",
+      input: { kind: "experience", id: "experience:0", label: "Engineer", bullets: ["a"] },
+      data: {
+        bullets: ["Saved money."],
+        numbersPreserved: false,
+        droppedNumbers: ["$5K"],
+        addedNumbers: [],
+      },
+    },
+    {
+      kind: "summary",
+      input: { kind: "summary", id: "summary", label: "Summary", text: "Engineer." },
+      data: {
+        text: "Senior engineer with 99.9% availability.",
+        numbersPreserved: false,
+        droppedNumbers: [],
+        addedNumbers: ["99.9%"],
+      },
+    },
+  ],
+  allNumbersPreserved: false,
+};
+
+describe("labelForResumeRewrite", () => {
+  it("returns the locked-by-other label regardless of status when the lock is held elsewhere", () => {
+    expect(labelForResumeRewrite(idle, true)).toBe("Another rewrite running…");
+    expect(labelForResumeRewrite(running, true)).toBe("Another rewrite running…");
+  });
+
+  it("maps each status to its display label", () => {
+    expect(labelForResumeRewrite(idle, false)).toBe("Rewrite full résumé");
+    expect(labelForResumeRewrite(loading, false)).toBe("Loading model…");
+    expect(labelForResumeRewrite(running, false)).toBe("Rewriting 2 of 3…");
+    expect(labelForResumeRewrite(errored, false)).toBe("Try again");
+    expect(
+      labelForResumeRewrite(
+        { kind: "proposed", result: okResult, snapshot: [] },
+        false,
+      ),
+    ).toBe("Rewrite again");
+  });
+
+  it("caps the running label at the total count when the final progress event fires", () => {
+    const done: ResumeRewriteStatus = {
+      kind: "running",
+      progress: {
+        currentIndex: 3,
+        totalSections: 3,
+        currentLabel: null,
+        completed: [],
+      },
+    };
+    expect(labelForResumeRewrite(done, false)).toBe("Rewriting 3 of 3…");
+  });
+});
+
+describe("aggregateDrift", () => {
+  it("returns empty arrays for an all-clean result", () => {
+    expect(aggregateDrift(okResult)).toEqual({ dropped: [], added: [] });
+  });
+
+  it("collects dropped and added tokens across every section regardless of kind", () => {
+    expect(aggregateDrift(driftResult)).toEqual({
+      dropped: ["$5K"],
+      added: ["99.9%"],
+    });
+  });
+});
+
+describe("StepIndicator", () => {
+  it("renders the position label and progress percentage", () => {
+    const html = renderToStaticMarkup(
+      createElement(StepIndicator, {
+        currentIndex: 1,
+        totalSections: 4,
+        label: "Section 2",
+      }),
+    );
+    expect(html).toContain("Rewriting 2 of 4: Section 2");
+    expect(html).toContain("25%");
+    expect(html).toContain('role="progressbar"');
+  });
+
+  it("clamps the position label at the total when the final progress event fires", () => {
+    const html = renderToStaticMarkup(
+      createElement(StepIndicator, {
+        currentIndex: 4,
+        totalSections: 4,
+        label: "Finishing…",
+      }),
+    );
+    expect(html).toContain("Rewriting 4 of 4: Finishing…");
+    expect(html).toContain("100%");
+  });
+});
+
+describe("ResumeRewritePanel", () => {
+  it("renders nothing for the idle status", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, { status: idle, onDismiss: () => {} }),
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders the model-load progress bar in the loading status", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, { status: loading, onDismiss: () => {} }),
+    );
+    expect(html).toContain("Loading the rewrite model");
+    expect(html).toContain('role="progressbar"');
+  });
+
+  it("renders the error message in the error status", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, { status: errored, onDismiss: () => {} }),
+    );
+    expect(html).toContain("Engine failed to load");
+    expect(html).toContain('role="alert"');
+  });
+
+  it("renders the step indicator in the running status with the in-flight section label", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, {
+        status: running,
+        onDismiss: () => {},
+      }),
+    );
+    expect(html).toContain("Rewriting 2 of 3");
+    // The currentLabel (Engineer — Acme) must reach the indicator — the
+    // whole point of widening ResumeRewriteProgress with the label was so
+    // the step text names the in-flight section instead of "Section 2".
+    expect(html).toContain("Engineer — Acme");
+  });
+
+  it("falls back to a generic finishing label when currentLabel is null", () => {
+    const finishing: ResumeRewriteStatus = {
+      kind: "running",
+      progress: {
+        currentIndex: 3,
+        totalSections: 3,
+        currentLabel: null,
+        completed: [],
+      },
+    };
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, {
+        status: finishing,
+        onDismiss: () => {},
+      }),
+    );
+    expect(html).toContain("Finishing…");
+  });
+
+  it("renders every section's before/after in the proposed status", () => {
+    const status: ResumeRewriteStatus = {
+      kind: "proposed",
+      result: okResult,
+      snapshot: [],
+    };
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, { status, onDismiss: () => {} }),
+    );
+    expect(html).toContain("Summary");
+    expect(html).toContain("Engineer with 10 years.");
+    expect(html).toContain("Senior engineer.");
+    expect(html).toContain("Engineer — Acme");
+    expect(html).toContain("Shipped Foo to 10M users.");
+    expect(html).toContain("Discard");
+  });
+
+  it("surfaces the aggregated metric-drift warning when any section flagged drift", () => {
+    const status: ResumeRewriteStatus = {
+      kind: "proposed",
+      result: driftResult,
+      snapshot: [],
+    };
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, { status, onDismiss: () => {} }),
+    );
+    expect(html).toContain("AI altered a metric");
+    expect(html).toContain("$5K");
+    expect(html).toContain("99.9%");
+  });
+});

--- a/src/components/features/ResumeRewrite.test.ts
+++ b/src/components/features/ResumeRewrite.test.ts
@@ -15,8 +15,8 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ResumeRewritePanel, StepIndicator } from "./ResumeRewrite.tsx";
 import { aggregateDrift } from "./ResumeRewriteProposed.tsx";
-import { labelForResumeRewrite, type ResumeRewriteStatus } from "../../hooks/useResumeRewrite.ts";
-import type { ResumeRewriteResult } from "../../lib/webllm/rewrite-resume.ts";
+import { labelForResumeRewrite, sectionsEqual, type ResumeRewriteStatus } from "../../hooks/useResumeRewrite.ts";
+import type { ResumeRewriteResult, SectionInput } from "../../lib/webllm/rewrite-resume.ts";
 
 const idle: ResumeRewriteStatus = { kind: "idle" };
 const loading: ResumeRewriteStatus = {
@@ -119,6 +119,46 @@ describe("labelForResumeRewrite", () => {
       },
     };
     expect(labelForResumeRewrite(done, false)).toBe("Rewriting 3 of 3…");
+  });
+});
+
+describe("sectionsEqual", () => {
+  const summary: SectionInput = {
+    kind: "summary",
+    id: "summary",
+    label: "Summary",
+    text: "Engineer.",
+  };
+  const role: SectionInput = {
+    kind: "experience",
+    id: "experience:0",
+    label: "Engineer",
+    bullets: ["a", "b"],
+  };
+
+  it("is true for the same list and for an identical-content copy", () => {
+    expect(sectionsEqual([summary, role], [summary, role])).toBe(true);
+    expect(sectionsEqual([summary, role], [{ ...summary }, { ...role, bullets: ["a", "b"] }])).toBe(true);
+  });
+
+  it("is false when the lengths differ", () => {
+    expect(sectionsEqual([summary], [summary, role])).toBe(false);
+  });
+
+  it("is false when a section's kind or id changes", () => {
+    expect(sectionsEqual([role], [{ ...role, id: "experience:1" }])).toBe(false);
+    expect(
+      sectionsEqual([summary], [{ ...role, id: "summary" } as SectionInput]),
+    ).toBe(false);
+  });
+
+  it("is false when summary text changes", () => {
+    expect(sectionsEqual([summary], [{ ...summary, text: "Edited." }])).toBe(false);
+  });
+
+  it("is false when an experience bullet's text or count changes", () => {
+    expect(sectionsEqual([role], [{ ...role, bullets: ["a", "c"] }])).toBe(false);
+    expect(sectionsEqual([role], [{ ...role, bullets: ["a"] }])).toBe(false);
   });
 });
 

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Whole-résumé "Rewrite full résumé" feature (issue #67 — Phase 4 of #66).
+ *
+ * This file owns:
+ *   - The single primary CTA (mounted next to the model picker at the
+ *     top of the Experience section)
+ *   - The status-to-UI routing (loading → running → proposed → error)
+ *   - The in-flight `StepIndicator` + `CompletedList`
+ *
+ * The proposed-state UI (before/after panels, aggregated drift warning,
+ * discard CTA) lives in the sibling `ResumeRewriteProposed.tsx` so this
+ * file stays under CLAUDE.md's ~200 LOC soft cap.
+ *
+ * Coexists with the per-role `SectionRewrite` buttons (still rendered on
+ * each `RoleEntry`) — the same `useSectionRewriteLock` makes the two paths
+ * mutually exclusive.
+ *
+ * Reuse analysis (CLAUDE.md 3-tier rule):
+ *   - Primitive: `Button` from `@design-system` for the CTA. No raw
+ *     `<button>` in this file.
+ *   - Shared: `ModelLoadProgress` for the engine-download bar.
+ *
+ * Returns `null` for `trigger` and `panel` when the controller flags the
+ * feature unavailable (no WebGPU, or no rewriteable section in the parsed
+ * résumé). Silent absence — matches `RewriteButton` and `SectionRewrite`.
+ */
+
+import { Button, ModelLoadProgress } from "@design-system";
+import {
+  labelForResumeRewrite,
+  useResumeRewrite,
+  type ResumeRewriteStatus,
+} from "../../hooks/useResumeRewrite.ts";
+import type { SectionInput, SectionOutcome } from "../../lib/webllm/rewrite-resume.ts";
+import { ProposedPanel } from "./ResumeRewriteProposed.tsx";
+
+export interface ResumeRewriteParts {
+  trigger: React.ReactNode;
+  panel: React.ReactNode;
+}
+
+export function useResumeRewriteUi(
+  sections: readonly SectionInput[],
+): ResumeRewriteParts {
+  const controller = useResumeRewrite(sections);
+
+  if (!controller.isAvailable) {
+    return { trigger: null, panel: null };
+  }
+
+  const trigger = (
+    <Button
+      variant="primary"
+      size="sm"
+      onClick={() => {
+        void controller.start();
+      }}
+      disabled={controller.isLocked}
+      aria-label="Rewrite every section of the résumé"
+    >
+      {labelForResumeRewrite(controller.status, controller.isLockedByOther)}
+    </Button>
+  );
+
+  const panel =
+    controller.status.kind === "idle" ? null : (
+      <ResumeRewritePanel status={controller.status} onDismiss={controller.dismiss} />
+    );
+
+  return { trigger, panel };
+}
+
+export function ResumeRewritePanel({
+  status,
+  onDismiss,
+}: {
+  status: ResumeRewriteStatus;
+  onDismiss: () => void;
+}) {
+  if (status.kind === "idle") return null;
+  if (status.kind === "loading") {
+    return (
+      <ModelLoadProgress
+        progress={status.progress.progress}
+        text={status.progress.text}
+        label="Loading the rewrite model (one-time download)"
+      />
+    );
+  }
+  if (status.kind === "error") {
+    return (
+      <p role="alert" className="text-xs text-feedback-error-text">
+        {status.message}
+      </p>
+    );
+  }
+  if (status.kind === "running") {
+    // `currentLabel` is null only on the final completion event, which
+    // transitions to "proposed" before any UI sees it — but fall through to
+    // "Finishing…" for safety so the indicator never flashes empty.
+    const label = status.progress.currentLabel ?? "Finishing…";
+    return (
+      <div className="flex flex-col gap-3 rounded border border-border-light bg-surface-subtle p-3">
+        <StepIndicator
+          currentIndex={status.progress.currentIndex}
+          totalSections={status.progress.totalSections}
+          label={label}
+        />
+        {status.progress.completed.length > 0 && (
+          <CompletedList outcomes={status.progress.completed} />
+        )}
+      </div>
+    );
+  }
+  return <ProposedPanel result={status.result} onDismiss={onDismiss} />;
+}
+
+export function StepIndicator({
+  currentIndex,
+  totalSections,
+  label,
+}: {
+  currentIndex: number;
+  totalSections: number;
+  label: string;
+}) {
+  const done = Math.min(currentIndex, totalSections);
+  const pct = totalSections > 0 ? Math.round((done / totalSections) * 100) : 0;
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-xs text-content-secondary">
+        <span>
+          Rewriting {Math.min(currentIndex + 1, totalSections)} of {totalSections}: {label}
+        </span>
+        <span className="font-mono text-[11px]">{pct}%</span>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Whole-résumé rewrite progress"
+        className="h-1.5 w-full overflow-hidden rounded-full bg-surface-base"
+      >
+        <div
+          className="h-full bg-brand-amber transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CompletedList({
+  outcomes,
+}: {
+  outcomes: readonly SectionOutcome[];
+}) {
+  return (
+    <ul className="flex flex-col gap-1 list-none text-xs text-content-secondary">
+      {outcomes.map((outcome, i) => (
+        <li key={`${outcome.kind}-${i}`} className="flex items-center gap-2">
+          <span aria-hidden="true" className="text-content-muted">
+            ✓
+          </span>
+          <span>{outcome.input.label}</span>
+          {!outcome.data.numbersPreserved && (
+            <span
+              className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-[10px] text-feedback-warning-text"
+              title="A metric was altered or removed"
+            >
+              metric drift
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Final "all sections rewritten" panel for the whole-résumé rewrite flow
+ * (#67). Split out of `ResumeRewrite.tsx` so that file stays under the
+ * ~200 LOC soft cap from CLAUDE.md and so each file's concern is single:
+ *
+ *   - `ResumeRewrite.tsx`         — CTA + state-routing + in-flight UI
+ *     (StepIndicator, CompletedList, loading bar, error)
+ *   - `ResumeRewriteProposed.tsx` — proposed-state UI: per-section
+ *     before/after panels, aggregated metric-drift warning, discard CTA
+ *
+ * Reuse:
+ *   - `Button` primitive from `@design-system` for the Discard CTA. No
+ *     raw `<button>` in this file.
+ *   - `NumberPreservationWarning` exported from `SectionRewrite.tsx` so
+ *     the per-role and whole-résumé paths surface metric drift with
+ *     identical copy — single source of truth for the warning string.
+ *
+ * `aggregateDrift` is exported so the test file can verify the
+ * cross-section aggregation contract without re-rendering the whole panel.
+ */
+
+import { useMemo } from "react";
+import { Button } from "@design-system";
+import type {
+  ResumeRewriteResult,
+  SectionOutcome,
+} from "../../lib/webllm/rewrite-resume.ts";
+import { NumberPreservationWarning } from "./SectionRewrite.tsx";
+
+export function ProposedPanel({
+  result,
+  onDismiss,
+}: {
+  result: ResumeRewriteResult;
+  onDismiss: () => void;
+}) {
+  const aggregated = useMemo(() => aggregateDrift(result), [result]);
+  const borderClass = result.allNumbersPreserved
+    ? "border-feedback-success-border"
+    : "border-feedback-warning-border";
+  const bgClass = result.allNumbersPreserved
+    ? "bg-feedback-success-bg"
+    : "bg-feedback-warning-bg";
+
+  return (
+    <div className={`flex flex-col gap-4 rounded border p-3 ${borderClass} ${bgClass}`}>
+      {!result.allNumbersPreserved && (
+        <NumberPreservationWarning
+          dropped={aggregated.dropped}
+          added={aggregated.added}
+        />
+      )}
+      <ul className="flex flex-col gap-4 list-none">
+        {result.sections.map((outcome, i) => (
+          <li key={`${outcome.kind}-${i}`}>
+            <SectionResult outcome={outcome} />
+          </li>
+        ))}
+      </ul>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="link"
+          size="sm"
+          onClick={onDismiss}
+          className="text-[11px] font-medium text-content-tertiary"
+        >
+          Discard
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SectionResult({ outcome }: { outcome: SectionOutcome }) {
+  if (outcome.kind === "summary") {
+    return (
+      <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+          {outcome.input.label}
+        </h4>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider text-content-muted">
+              Original
+            </span>
+            <p className="text-xs leading-snug text-content-secondary">
+              {outcome.input.text}
+            </p>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider text-content-muted">
+              Proposed
+            </span>
+            <p className="text-xs leading-snug text-content-primary">
+              {outcome.data.text || "(no rewrite returned)"}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  const originalBullets = outcome.input.bullets.filter(
+    (b) => b.trim().length > 0,
+  );
+  return (
+    <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
+      <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+        {outcome.input.label}
+      </h4>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <BulletList
+          label={`Original (${originalBullets.length})`}
+          bullets={originalBullets}
+          textClass="text-content-secondary"
+        />
+        <BulletList
+          label={`Proposed (${outcome.data.bullets.length})`}
+          bullets={outcome.data.bullets}
+          textClass="text-content-primary"
+        />
+      </div>
+    </div>
+  );
+}
+
+function BulletList({
+  label,
+  bullets,
+  textClass,
+}: {
+  label: string;
+  bullets: readonly string[];
+  textClass: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <h5 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+        {label}
+      </h5>
+      <ul className={`flex flex-col gap-1.5 text-xs leading-snug list-none ${textClass}`}>
+        {bullets.map((b, i) => (
+          <li key={i} className="flex gap-1.5">
+            <span aria-hidden="true" className="font-mono text-content-muted">
+              •
+            </span>
+            <span>{b}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export interface AggregateDrift {
+  dropped: string[];
+  added: string[];
+}
+
+/**
+ * Concatenate every section's dropped/added numeric tokens in encounter
+ * order so the whole-résumé warning quotes the same specific metrics that
+ * each per-section panel would have shown individually.
+ *
+ * Both `SectionOutcome` variants store the diff in `.data.droppedNumbers`
+ * / `.data.addedNumbers`, so the kind discriminator doesn't change the
+ * lookup — one shared loop covers both.
+ */
+export function aggregateDrift(result: ResumeRewriteResult): AggregateDrift {
+  const dropped: string[] = [];
+  const added: string[] = [];
+  for (const outcome of result.sections) {
+    dropped.push(...outcome.data.droppedNumbers);
+    added.push(...outcome.data.addedNumbers);
+  }
+  return { dropped, added };
+}

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * `useResumeRewrite` — controller for the whole-résumé "rewrite resume" flow
+ * (#67). Owns the state machine and the orchestrator invocation; returns
+ * raw state + actions so the feature component (`ResumeRewrite.tsx`) can
+ * render the UI without the hook reaching into components/ from hooks/.
+ *
+ * State machine: `idle` → `loading` (engine download) → `running` (per-step
+ * progress) → `proposed` (all sections rewritten) → `error`. A stale-source
+ * guard auto-dismisses a proposal when the underlying section list changes
+ * — otherwise an edit to a role's bullets could leave the proposed panel
+ * showing rewrites that the model never saw.
+ *
+ * Concurrency:
+ *   - The same `useSectionRewriteLock` that gates per-role rewrites also
+ *     gates this one. Holding the lock for the whole run disables every
+ *     per-role `SectionRewrite` button — exactly the "one rewrite at a
+ *     time" contract from #63.
+ *   - The orchestrator's inner `rewrite*WithLlm` calls bracket each step
+ *     with `acquireInference`, so the cross-model picker can defer
+ *     `.unload()` until a step completes.
+ *
+ * WebGPU gating: `available` is the only branch that exposes any
+ * interactive surface; the other two collapse to `available === false` so
+ * the feature component can render `null` for trigger + panel (silent
+ * absence, matching `RewriteButton` / `SectionRewrite`).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { detectWebGpu } from "../lib/webllm/capability.ts";
+import { loadEngine } from "../lib/webllm/web-llm.ts";
+import {
+  rewriteResumeWithLlm,
+  type ResumeRewriteProgress,
+  type ResumeRewriteResult,
+  type SectionInput,
+} from "../lib/webllm/rewrite-resume.ts";
+import type {
+  ProgressUpdate,
+  WebGpuCapability,
+} from "../lib/webllm/types.ts";
+import { useModelSelection } from "./useModelSelection.ts";
+import { useSectionRewriteLock } from "./useSectionRewriteLock.ts";
+
+export type ResumeRewriteStatus =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "running"; progress: ResumeRewriteProgress }
+  | {
+      kind: "proposed";
+      result: ResumeRewriteResult;
+      /** Snapshot of the section list the model actually saw — see useEffect below. */
+      snapshot: readonly SectionInput[];
+    }
+  | { kind: "error"; message: string };
+
+export interface ResumeRewriteController {
+  /** Current state. The feature component renders off this discriminator. */
+  status: ResumeRewriteStatus;
+  /**
+   * `null` while WebGPU detection is in flight; `true` lets the feature
+   * component render the CTA, `false` hides every surface (silent absence).
+   */
+  isAvailable: boolean;
+  /**
+   * The rewriteable section subset the orchestrator will see — empty (no
+   * bullets / no summary) sections are pre-filtered so the hook and the UI
+   * agree on what "nothing to rewrite" means.
+   */
+  rewriteableSections: readonly SectionInput[];
+  /** True when any rewrite (per-role or whole-résumé) is in flight anywhere. */
+  isLocked: boolean;
+  /** True iff the lock is held by a different consumer (per-role rewrite). */
+  isLockedByOther: boolean;
+  /** Start the whole-résumé run. No-op if the lock is already held. */
+  start: () => Promise<void>;
+  /** Drop a proposed/error state back to idle. */
+  dismiss: () => void;
+}
+
+export function labelForResumeRewrite(
+  status: ResumeRewriteStatus,
+  lockedByOther: boolean,
+): string {
+  if (lockedByOther) return "Another rewrite running…";
+  switch (status.kind) {
+    case "loading":
+      return "Loading model…";
+    case "running":
+      return `Rewriting ${Math.min(status.progress.currentIndex + 1, status.progress.totalSections)} of ${status.progress.totalSections}…`;
+    case "proposed":
+      return "Rewrite again";
+    case "error":
+      return "Try again";
+    default:
+      return "Rewrite full résumé";
+  }
+}
+
+export function sectionsEqual(
+  a: readonly SectionInput[],
+  b: readonly SectionInput[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    if (ai.kind !== bi.kind) return false;
+    if (ai.id !== bi.id) return false;
+    if (ai.kind === "summary" && bi.kind === "summary") {
+      if (ai.text !== bi.text) return false;
+    } else if (ai.kind === "experience" && bi.kind === "experience") {
+      if (ai.bullets.length !== bi.bullets.length) return false;
+      for (let j = 0; j < ai.bullets.length; j++) {
+        if (ai.bullets[j] !== bi.bullets[j]) return false;
+      }
+    }
+  }
+  return true;
+}
+
+export function useResumeRewrite(
+  sections: readonly SectionInput[],
+): ResumeRewriteController {
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [status, setStatus] = useState<ResumeRewriteStatus>({ kind: "idle" });
+  const { isLocked, acquire } = useSectionRewriteLock();
+  const { selectedModelId } = useModelSelection();
+
+  const rewriteableSections = useMemo(
+    () => sections.filter(isNonEmptyForUi),
+    [sections],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Auto-dismiss a stale proposal when the underlying sections change.
+  useEffect(() => {
+    if (status.kind !== "proposed") return;
+    if (!sectionsEqual(status.snapshot, rewriteableSections)) {
+      setStatus({ kind: "idle" });
+    }
+  }, [rewriteableSections, status]);
+
+  const start = useCallback(async () => {
+    const release = acquire();
+    if (release === null) return;
+    try {
+      setStatus({
+        kind: "loading",
+        progress: { progress: 0, text: "Starting…" },
+      });
+      const engine = await loadEngine(selectedModelId, (progress) => {
+        setStatus({ kind: "loading", progress });
+      });
+      const result = await rewriteResumeWithLlm(
+        rewriteableSections,
+        engine,
+        selectedModelId,
+        (progress) => {
+          setStatus({ kind: "running", progress });
+        },
+      );
+      if (result.sections.length === 0) {
+        setStatus({
+          kind: "error",
+          message: "Nothing to rewrite in this résumé.",
+        });
+        return;
+      }
+      setStatus({
+        kind: "proposed",
+        result,
+        snapshot: rewriteableSections,
+      });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Couldn't load the rewrite model",
+      });
+    } finally {
+      release();
+    }
+  }, [acquire, rewriteableSections, selectedModelId]);
+
+  const dismiss = useCallback(() => {
+    setStatus({ kind: "idle" });
+  }, []);
+
+  const isAvailable =
+    capability === "available" && rewriteableSections.length > 0;
+
+  const myBusy = status.kind === "loading" || status.kind === "running";
+  const isLockedByOther = isLocked && !myBusy;
+
+  return {
+    status,
+    isAvailable,
+    rewriteableSections,
+    isLocked,
+    isLockedByOther,
+    start,
+    dismiss,
+  };
+}
+
+function isNonEmptyForUi(section: SectionInput): boolean {
+  if (section.kind === "summary") return section.text.trim().length > 0;
+  return section.bullets.some((b) => b.trim().length > 0);
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -219,6 +219,64 @@ export function trackWebllmFirstSectionRewrite(args: { model: string }): void {
   track("webllm_first_section_rewrite", { model: args.model });
 }
 
+// Resume-rewrite funnel (issue #67 — chain-of-sections whole-resume pipeline).
+// Kept distinct from the per-bullet / per-section keys above so each path's
+// first-rewrite conversion remains independently measurable. Same env-gating
+// semantics as the rest of the WebLLM events; when VITE_POSTHOG_KEY is unset,
+// these compile away to no-ops.
+//
+// Section kinds map 1:1 to the orchestrator's SectionInput.kind discriminator
+// so the funnel can be sliced by "did the model rewrite the summary OK and
+// then drop a bullet in role 3?" without a separate JOIN.
+
+export type ResumeRewriteSectionKind = "summary" | "experience";
+
+export function trackWebllmResumeRewriteStarted(args: {
+  model: string;
+  sectionCount: number;
+}): void {
+  track("webllm_resume_rewrite_started", {
+    model: args.model,
+    section_count: args.sectionCount,
+  });
+}
+
+export function trackWebllmResumeRewriteSectionCompleted(args: {
+  model: string;
+  sectionIndex: number;
+  sectionKind: ResumeRewriteSectionKind;
+  /** Bullets in for "experience"; 1 for "summary" (the paragraph itself). */
+  inputUnitCount: number;
+  /** Bullets out for "experience"; 0 or 1 for "summary" (empty model output → 0). */
+  outputUnitCount: number;
+  numbersPreserved: boolean;
+}): void {
+  track("webllm_resume_rewrite_section_completed", {
+    model: args.model,
+    section_index: args.sectionIndex,
+    section_kind: args.sectionKind,
+    input_unit_count: args.inputUnitCount,
+    output_unit_count: args.outputUnitCount,
+    numbers_preserved: args.numbersPreserved,
+  });
+}
+
+export function trackWebllmResumeRewriteCompleted(args: {
+  model: string;
+  sectionCount: number;
+  allNumbersPreserved: boolean;
+}): void {
+  track("webllm_resume_rewrite_completed", {
+    model: args.model,
+    section_count: args.sectionCount,
+    all_numbers_preserved: args.allNumbersPreserved,
+  });
+}
+
+export function trackWebllmFirstResumeRewrite(args: { model: string }): void {
+  track("webllm_first_resume_rewrite", { model: args.model });
+}
+
 // JD URL ingestion funnel (#72 / #75). Fires on every user-initiated fetch
 // from the JD URL input. The `outcome` enum lets us tell apart the four
 // platform-relevant funnel states without ever recording the URL itself —

--- a/src/lib/webllm/phrase-tracking.test.ts
+++ b/src/lib/webllm/phrase-tracking.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import {
+  accumulatePhrases,
+  buildPhraseBrief,
+  extractStrongPhrase,
+} from "./phrase-tracking.ts";
+
+describe("extractStrongPhrase", () => {
+  it("returns the first two content words after the leading verb", () => {
+    expect(extractStrongPhrase("Built distributed systems for Foo")).toBe(
+      "distributed systems",
+    );
+  });
+
+  it("skips stopwords and assembles only consecutive content words", () => {
+    // "led" + "the" (stopword, resets) + "team" + "of" (stopword, resets) +
+    // "five" + "senior" — first valid 2-word run is "five senior".
+    expect(extractStrongPhrase("Led the team of five senior engineers")).toBe(
+      "five senior",
+    );
+  });
+
+  it("strips a leading list marker before scanning", () => {
+    expect(extractStrongPhrase("1. Shipped distributed systems")).toBe(
+      "distributed systems",
+    );
+  });
+
+  it("strips leading markdown bold before scanning", () => {
+    expect(extractStrongPhrase("**Built** distributed systems")).toBe(
+      "distributed systems",
+    );
+  });
+
+  it("skips numeric-only tokens and currency tokens", () => {
+    // "drove" + "$1.2M" (skipped) + "in" (stopword, resets) + "annual"
+    // + "recurring" — first valid 2-word run is "annual recurring".
+    expect(extractStrongPhrase("Drove $1.2M in annual recurring revenue")).toBe(
+      "annual recurring",
+    );
+  });
+
+  it("returns null when no two consecutive content words exist", () => {
+    expect(extractStrongPhrase("Led")).toBeNull();
+    expect(extractStrongPhrase("Led 5")).toBeNull();
+    expect(extractStrongPhrase("Led the team")).toBeNull();
+    expect(extractStrongPhrase("")).toBeNull();
+  });
+
+  it("lowercases the phrase regardless of input casing", () => {
+    expect(extractStrongPhrase("Built Distributed Systems")).toBe(
+      "distributed systems",
+    );
+  });
+});
+
+describe("buildPhraseBrief", () => {
+  it("returns null for an empty phrase set", () => {
+    expect(buildPhraseBrief(new Set())).toBeNull();
+  });
+
+  it("formats a single-line constraint sentence", () => {
+    const brief = buildPhraseBrief(
+      new Set(["distributed systems", "internal admin tool"]),
+    );
+    expect(brief).toContain("distributed systems");
+    expect(brief).toContain("internal admin tool");
+    expect(brief).toContain("Avoid repeating");
+  });
+
+  it("preserves insertion order (oldest first)", () => {
+    const set = new Set<string>();
+    set.add("alpha bravo");
+    set.add("charlie delta");
+    set.add("echo foxtrot");
+    const brief = buildPhraseBrief(set);
+    expect(brief).toMatch(/alpha bravo.*charlie delta.*echo foxtrot/);
+  });
+
+  it("caps the brief at the most recent 8 phrases", () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 12; i++) set.add(`phrase ${i}`);
+    const brief = buildPhraseBrief(set);
+    // The first 4 are dropped (12 - 8 = 4); phrase 4 onwards survives.
+    expect(brief).not.toContain("phrase 0;");
+    expect(brief).not.toContain("phrase 3;");
+    expect(brief).toContain("phrase 4");
+    expect(brief).toContain("phrase 11");
+  });
+});
+
+describe("accumulatePhrases", () => {
+  it("adds each line's strong phrase to the set", () => {
+    const set = new Set<string>();
+    accumulatePhrases(
+      ["Built distributed systems", "Owned internal admin tools"],
+      set,
+    );
+    expect([...set]).toEqual(["distributed systems", "internal admin"]);
+  });
+
+  it("skips lines with no extractable phrase", () => {
+    const set = new Set<string>();
+    accumulatePhrases(["Built distributed systems", "Led 5", "Led the team"], set);
+    expect([...set]).toEqual(["distributed systems"]);
+  });
+
+  it("floats a repeated phrase to the tail of the insertion-order Set", () => {
+    const set = new Set<string>();
+    set.add("distributed systems");
+    set.add("admin tools");
+    accumulatePhrases(["Built distributed systems"], set);
+    // "distributed systems" moved to the tail; "admin tools" is now older.
+    expect([...set]).toEqual(["admin tools", "distributed systems"]);
+  });
+});

--- a/src/lib/webllm/phrase-tracking.ts
+++ b/src/lib/webllm/phrase-tracking.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Strong-phrase tracking helpers (issue #67's "track used action verbs **and
+ * strong phrases**" requirement — companion to verb-tracking.ts).
+ *
+ * A "strong phrase" here is a 2-word content-word chunk that follows the
+ * leading verb in a rewritten bullet. The intent is the same as verb
+ * tracking — flag a recurring phrase across sections as a soft constraint
+ * so the next section avoids rote repetition of e.g. "distributed systems"
+ * across three roles.
+ *
+ * Strictly lexical, no NLP model. The post-verb window is scanned for the
+ * first two consecutive content words (alphabetic, ≥3 letters, not a
+ * stopword). Numeric and currency tokens are skipped — those belong to the
+ * number-preservation guardrail, not to phrase dedup. Single-word phrases
+ * are not tracked: one repeated word is too noisy a signal at this
+ * granularity.
+ */
+
+/**
+ * Function words, articles, prepositions, and common copulae that should
+ * NEVER count as half of a "strong phrase." Lowercased and matched as
+ * exact tokens after lowercasing the input. Hand-curated to the words that
+ * actually recur in résumé-bullet body text; not exhaustive on purpose.
+ */
+const STOPWORDS: ReadonlySet<string> = new Set([
+  "the", "a", "an", "and", "or", "but", "of", "to", "for", "with",
+  "by", "from", "in", "on", "at", "into", "across", "over", "under",
+  "as", "is", "was", "are", "were", "be", "been", "being",
+  "this", "that", "these", "those", "it", "its", "their", "our", "my",
+  "via", "per",
+]);
+
+const PHRASE_BRIEF_CAP = 8;
+
+/**
+ * Strip leading list/quote noise, skip the leading verb, and scan the rest
+ * of the bullet for the first two consecutive content words. Returns the
+ * joined phrase (lowercased, single space) or `null` when no two-word
+ * phrase can be assembled — short bullets, all-stopword tails,
+ * numeric-only tails.
+ *
+ * Stopwords are checked on the raw lowercased token BEFORE the
+ * length-based normalize filter — otherwise short stopwords like "of" /
+ * "in" / "to" / "by" get filtered out as noise tokens and never break the
+ * collected run. With the early stopword check, "Led the team of five
+ * senior engineers" correctly resets twice (at "the" and "of") and lands
+ * on "five senior" instead of pulling "team five" across the "of" break.
+ */
+export function extractStrongPhrase(line: string): string | null {
+  const stripped = line
+    .trim()
+    .replace(/^\d+[.)]\s*/, "")
+    .replace(/^[•\-*]\s*/, "")
+    .replace(/^\*+/, "")
+    .replace(/^["'`“‘]/, "");
+  const rawTokens = stripped.split(/\s+/).map((t) => t.toLowerCase());
+  if (rawTokens.length < 3) return null;
+
+  // rawTokens[0] is the leading verb (we don't filter for verb-ness, same
+  // as verb-tracking — recurrence is the signal, not lexical category).
+  // Per-token classification from index 1 onward:
+  //   - stopword       → resets the collected run (forces adjacency)
+  //   - numeric/short  → skipped, does NOT reset (so "Drove $1.2M in
+  //                      annual recurring" still emits "annual recurring"
+  //                      across the metric token)
+  //   - content word   → pushed; return as soon as we have two adjacent
+  const collected: string[] = [];
+  for (let i = 1; i < rawTokens.length; i++) {
+    const token = rawTokens[i]!;
+    if (STOPWORDS.has(token)) {
+      collected.length = 0;
+      continue;
+    }
+    const norm = normalizeToken(token);
+    if (norm === null) continue;
+    collected.push(norm);
+    if (collected.length === 2) return collected.join(" ");
+  }
+  return null;
+}
+
+/**
+ * Strip non-alphabetic chars from an already-lowercased token. Returns
+ * null for purely numeric/currency tokens (those belong to the
+ * number-preservation guardrail) or for tokens with fewer than 3 letters
+ * after stripping (too noisy as phrase material — "p99" → "p" → dropped).
+ *
+ * Stopwords are NOT filtered here — the caller handles stopword detection
+ * upstream against the raw token so short stopwords like "of" / "in" still
+ * break the collected run.
+ */
+function normalizeToken(token: string): string | null {
+  if (/^\$?\d/.test(token)) return null;
+  const stripped = token.replace(/[^a-z'-]/g, "");
+  if (stripped.length < 3) return null;
+  return stripped;
+}
+
+export function buildPhraseBrief(
+  usedPhrases: ReadonlySet<string>,
+): string | null {
+  if (usedPhrases.size === 0) return null;
+  const all = Array.from(usedPhrases);
+  const recent =
+    all.length <= PHRASE_BRIEF_CAP ? all : all.slice(-PHRASE_BRIEF_CAP);
+  return `Phrases already used in prior bullets: ${recent.join("; ")}. Avoid repeating these exact phrases.`;
+}
+
+/**
+ * Mutating helper: extract each line's strong phrase and add it to the
+ * running set. The orchestrator owns the Set. Floats a repeated phrase to
+ * the tail of the insertion-order Set so the recency cap surfaces fresh
+ * repeats.
+ */
+export function accumulatePhrases(
+  lines: readonly string[],
+  into: Set<string>,
+): void {
+  for (const line of lines) {
+    const phrase = extractStrongPhrase(line);
+    if (phrase === null) continue;
+    if (into.has(phrase)) into.delete(phrase);
+    into.add(phrase);
+  }
+}

--- a/src/lib/webllm/rewrite-resume.test.ts
+++ b/src/lib/webllm/rewrite-resume.test.ts
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  startedMock,
+  sectionCompletedMock,
+  completedMock,
+  firstResumeMock,
+} = vi.hoisted(() => ({
+  startedMock: vi.fn(),
+  sectionCompletedMock: vi.fn(),
+  completedMock: vi.fn(),
+  firstResumeMock: vi.fn(),
+}));
+vi.mock("../analytics.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../analytics.ts")>();
+  return {
+    ...actual,
+    trackWebllmResumeRewriteStarted: startedMock,
+    trackWebllmResumeRewriteSectionCompleted: sectionCompletedMock,
+    trackWebllmResumeRewriteCompleted: completedMock,
+    trackWebllmFirstResumeRewrite: firstResumeMock,
+  };
+});
+
+import {
+  _resetResumeRewriteFlagsForTesting,
+  buildResumeContext,
+  rewriteResumeWithLlm,
+  type ResumeRewriteProgress,
+  type SectionInput,
+  type SectionOutcome,
+} from "./rewrite-resume.ts";
+import { _resetSectionRewriteFlagsForTesting } from "./rewrite-section.ts";
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  WebLlmEngine,
+} from "./types.ts";
+
+const TEST_MODEL = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
+const OTHER_MODEL = "gemma-2-2b-it-q4f16_1-MLC";
+
+function makeEngine(
+  reply: (req: ChatCompletionRequest) => Promise<ChatCompletionResponse>,
+): {
+  engine: WebLlmEngine;
+  calls: ChatCompletionRequest[];
+} {
+  const calls: ChatCompletionRequest[] = [];
+  const spy = vi.fn(async (req: ChatCompletionRequest) => {
+    calls.push(req);
+    return reply(req);
+  });
+  const engine: WebLlmEngine = { chat: { completions: { create: spy } } };
+  return { engine, calls };
+}
+
+function reply(content: string | null): ChatCompletionResponse {
+  return { choices: [{ message: { content } }] };
+}
+
+const summarySection = (
+  text: string,
+): Extract<SectionInput, { kind: "summary" }> => ({
+  kind: "summary",
+  id: "summary",
+  label: "Summary",
+  text,
+});
+
+const experienceSection = (
+  id: string,
+  label: string,
+  bullets: string[],
+): Extract<SectionInput, { kind: "experience" }> => ({
+  kind: "experience",
+  id,
+  label,
+  bullets,
+});
+
+describe("buildResumeContext", () => {
+  it("returns undefined when nothing has completed yet and no verbs/phrases accumulated", () => {
+    expect(buildResumeContext([], new Set(), new Set())).toBeUndefined();
+  });
+
+  it("returns a verb brief once verbs have accumulated", () => {
+    const usedVerbs = new Set<string>(["built", "led"]);
+    const out = buildResumeContext([], usedVerbs, new Set());
+    expect(out).toContain("Verbs already used in prior bullets");
+    expect(out).toContain("built");
+    expect(out).toContain("led");
+  });
+
+  it("returns a phrase brief once strong phrases have accumulated", () => {
+    const usedPhrases = new Set<string>(["distributed systems"]);
+    const out = buildResumeContext([], new Set(), usedPhrases);
+    expect(out).toContain("Phrases already used in prior bullets");
+    expect(out).toContain("distributed systems");
+  });
+
+  it("includes a prior-section preview when at least one section has completed", () => {
+    const completed: SectionOutcome[] = [
+      {
+        kind: "experience",
+        input: experienceSection("experience:0", "Engineer", ["x"]),
+        data: {
+          bullets: ["Shipped Foo to 10M users."],
+          numbersPreserved: true,
+          droppedNumbers: [],
+          addedNumbers: [],
+        },
+      },
+    ];
+    const out = buildResumeContext(completed, new Set(["shipped"]), new Set());
+    expect(out).toContain("Earlier section's first bullet was:");
+    expect(out).toContain("Shipped Foo to 10M users.");
+  });
+
+  it("truncates long preview lines with an ellipsis", () => {
+    const long = "Shipped " + "a".repeat(200);
+    const completed: SectionOutcome[] = [
+      {
+        kind: "experience",
+        input: experienceSection("experience:0", "Engineer", ["x"]),
+        data: {
+          bullets: [long],
+          numbersPreserved: true,
+          droppedNumbers: [],
+          addedNumbers: [],
+        },
+      },
+    ];
+    const out = buildResumeContext(completed, new Set(), new Set());
+    expect(out).toMatch(/…/);
+  });
+});
+
+describe("rewriteResumeWithLlm", () => {
+  beforeEach(() => {
+    _resetResumeRewriteFlagsForTesting();
+    _resetSectionRewriteFlagsForTesting();
+    startedMock.mockClear();
+    sectionCompletedMock.mockClear();
+    completedMock.mockClear();
+    firstResumeMock.mockClear();
+  });
+
+  it("processes summary first, then each experience role in order", async () => {
+    const { engine, calls } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      summarySection("Engineer with 10 years."),
+      experienceSection("experience:0", "Acme", ["worked on X"]),
+      experienceSection("experience:1", "Foo", ["managed Y"]),
+    ];
+    const result = await rewriteResumeWithLlm(
+      sections,
+      engine,
+      TEST_MODEL,
+      () => {},
+    );
+    expect(calls).toHaveLength(3);
+    expect(result.sections).toHaveLength(3);
+    expect(result.sections[0]!.kind).toBe("summary");
+    expect(result.sections[1]!.kind).toBe("experience");
+    expect(result.sections[2]!.kind).toBe("experience");
+    expect(result.sections[1]!.input.id).toBe("experience:0");
+    expect(result.sections[2]!.input.id).toBe("experience:1");
+  });
+
+  it("skips empty sections defensively (no model call for an empty bullet array)", async () => {
+    const { engine, calls } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      summarySection(""),
+      experienceSection("experience:0", "Acme", []),
+      experienceSection("experience:1", "Foo", ["managed Y"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    expect(calls).toHaveLength(1);
+  });
+
+  it("fires onProgress before each step AND once with currentIndex === totalSections at the end", async () => {
+    const { engine } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      summarySection("Engineer."),
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    const progress: ResumeRewriteProgress[] = [];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, (p) => {
+      progress.push({ ...p, completed: [...p.completed] });
+    });
+    // 2 sections → 3 progress events: index 0 pre-step, index 1 pre-step, index 2 final.
+    expect(progress).toHaveLength(3);
+    expect(progress[0]!.currentIndex).toBe(0);
+    expect(progress[0]!.completed).toHaveLength(0);
+    expect(progress[1]!.currentIndex).toBe(1);
+    expect(progress[1]!.completed).toHaveLength(1);
+    expect(progress[2]!.currentIndex).toBe(2);
+    expect(progress[2]!.completed).toHaveLength(2);
+  });
+
+  it("threads the in-flight section's label through onProgress so the UI can name the current step", async () => {
+    const { engine } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      summarySection("Engineer."),
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    const progress: ResumeRewriteProgress[] = [];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, (p) => {
+      progress.push({ ...p });
+    });
+    expect(progress[0]!.currentLabel).toBe("Summary");
+    expect(progress[1]!.currentLabel).toBe("Acme");
+    // Final completion event has no in-flight section — null is the explicit
+    // sentinel the UI watches for to swap into the "Finishing…" fallback.
+    expect(progress[2]!.currentLabel).toBeNull();
+  });
+
+  it("threads accumulated context into calls 2+ via the SYSTEM message (verb constraint visible)", async () => {
+    const { engine, calls } = makeEngine(async () => reply("Built a thing."));
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["a"]),
+      experienceSection("experience:1", "Foo", ["b"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    // First call: no context — neither the system NOR user message carries
+    // the verb-brief sentence.
+    expect(calls[0]!.messages[0]?.content).not.toContain(
+      "Verbs already used in prior bullets",
+    );
+    expect(calls[0]!.messages[1]?.content).not.toContain(
+      "Verbs already used in prior bullets",
+    );
+    // Second call: context built from call 1's output ("Built a thing.") MUST
+    // land in the SYSTEM message (and never leak into the user message —
+    // that was the bug the system-placement fix closes).
+    expect(calls[1]!.messages[0]?.content).toContain(
+      "Verbs already used in prior bullets",
+    );
+    expect(calls[1]!.messages[0]?.content).toContain("built");
+    expect(calls[1]!.messages[1]?.content).not.toContain(
+      "Verbs already used in prior bullets",
+    );
+  });
+
+  it("aggregates allNumbersPreserved across sections", async () => {
+    const { engine } = makeEngine(async (req: ChatCompletionRequest) => {
+      // Drop a metric on the second call only.
+      const ord = req.messages[1]!.content;
+      if (ord.includes("$5K")) return reply("Drove revenue.");
+      return reply("Drove $1.2M ARR.");
+    });
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["Drove $1.2M in ARR"]),
+      experienceSection("experience:1", "Foo", ["Saved $5K per quarter"]),
+    ];
+    const result = await rewriteResumeWithLlm(
+      sections,
+      engine,
+      TEST_MODEL,
+      () => {},
+    );
+    expect(result.allNumbersPreserved).toBe(false);
+    expect(result.sections[0]!.kind === "experience" && result.sections[0]!.data.numbersPreserved).toBe(
+      true,
+    );
+    expect(result.sections[1]!.kind === "experience" && result.sections[1]!.data.numbersPreserved).toBe(
+      false,
+    );
+  });
+
+  it("fires webllm_resume_rewrite_started and _completed exactly once per run", async () => {
+    const { engine } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    expect(startedMock).toHaveBeenCalledTimes(1);
+    expect(startedMock).toHaveBeenCalledWith({
+      model: TEST_MODEL,
+      sectionCount: 1,
+    });
+    expect(completedMock).toHaveBeenCalledTimes(1);
+    expect(completedMock).toHaveBeenCalledWith({
+      model: TEST_MODEL,
+      sectionCount: 1,
+      allNumbersPreserved: true,
+    });
+  });
+
+  it("fires webllm_resume_rewrite_section_completed per section with its kind", async () => {
+    const { engine } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      summarySection("Engineer."),
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    expect(sectionCompletedMock).toHaveBeenCalledTimes(2);
+    expect(sectionCompletedMock).toHaveBeenNthCalledWith(1, {
+      model: TEST_MODEL,
+      sectionIndex: 0,
+      sectionKind: "summary",
+      inputUnitCount: 1,
+      outputUnitCount: 1,
+      numbersPreserved: true,
+    });
+    expect(sectionCompletedMock).toHaveBeenNthCalledWith(2, {
+      model: TEST_MODEL,
+      sectionIndex: 1,
+      sectionKind: "experience",
+      inputUnitCount: 1,
+      outputUnitCount: 1,
+      numbersPreserved: true,
+    });
+  });
+
+  it("fires webllm_first_resume_rewrite exactly once per model", async () => {
+    const { engine } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    expect(firstResumeMock).toHaveBeenCalledTimes(1);
+    expect(firstResumeMock).toHaveBeenCalledWith({ model: TEST_MODEL });
+  });
+
+  it("fires webllm_first_resume_rewrite once per model — a different model id re-arms", async () => {
+    const { engine } = makeEngine(async () => reply("Built X."));
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    await rewriteResumeWithLlm(sections, engine, OTHER_MODEL, () => {});
+    expect(firstResumeMock).toHaveBeenCalledTimes(2);
+    expect(firstResumeMock).toHaveBeenNthCalledWith(1, { model: TEST_MODEL });
+    expect(firstResumeMock).toHaveBeenNthCalledWith(2, { model: OTHER_MODEL });
+  });
+
+  it("does NOT fire webllm_first_resume_rewrite when every section returned empty", async () => {
+    const { engine } = makeEngine(async () => reply(null));
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    await rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {});
+    expect(firstResumeMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates engine errors to the caller without firing _completed", async () => {
+    const boom = new Error("OOM");
+    const { engine } = makeEngine(async () => {
+      throw boom;
+    });
+    const sections: SectionInput[] = [
+      experienceSection("experience:0", "Acme", ["a"]),
+    ];
+    await expect(
+      rewriteResumeWithLlm(sections, engine, TEST_MODEL, () => {}),
+    ).rejects.toBe(boom);
+    expect(completedMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/webllm/rewrite-resume.ts
+++ b/src/lib/webllm/rewrite-resume.ts
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Chain-of-sections whole-resume rewrite orchestrator (issue #67).
+ *
+ * Phase 1 (#63) rewrites one role's bullets in isolation. The orchestrator
+ * here sequences calls across the whole résumé: summary first, then each
+ * experience role in display order, threading a rolling soft-constraint
+ * brief (used action verbs + a one-line glance back at the previous
+ * section) into each subsequent call's user prompt.
+ *
+ * What the orchestrator owns (and nothing else):
+ *   - The for-loop and the per-step `onProgress` emission.
+ *   - The rolling context construction (used-verb accumulator + a
+ *     prior-section preview line, both capped to keep the prompt small).
+ *   - Resume-level telemetry: `webllm_resume_rewrite_started`,
+ *     `_section_completed` (per step), `_completed`, and the per-model
+ *     one-shot `webllm_first_resume_rewrite`.
+ *
+ * What the orchestrator does NOT own:
+ *   - Engine management — `loadEngine` is the caller's problem.
+ *   - Inference serialization — the inner `rewrite*WithLlm` primitives
+ *     already bracket their model calls with `acquireInference` /
+ *     `releaseInference`, so a cross-model picker switch defers `.unload()`
+ *     until our step completes.
+ *   - The cross-instance "one rewrite at a time" UI lock — that's
+ *     `useSectionRewriteLock`'s job, held by the hook layer.
+ *   - Section-level telemetry — the section primitive already fires its own
+ *     `webllm_section_rewrite_*` events. The resume-level events are
+ *     ADDITIVE so a single whole-résumé run shows up in both funnels.
+ */
+
+import {
+  trackWebllmFirstResumeRewrite,
+  trackWebllmResumeRewriteCompleted,
+  trackWebllmResumeRewriteSectionCompleted,
+  trackWebllmResumeRewriteStarted,
+} from "../analytics.ts";
+import {
+  rewriteSectionWithLlm,
+  type SectionRewriteResult,
+} from "./rewrite-section.ts";
+import {
+  rewriteSummaryWithLlm,
+  type SummaryRewriteResult,
+} from "./rewrite-summary.ts";
+import type { WebLlmEngine } from "./types.ts";
+import { accumulatePhrases, buildPhraseBrief } from "./phrase-tracking.ts";
+import { accumulateVerbs, buildVerbBrief } from "./verb-tracking.ts";
+
+/**
+ * One section of the résumé as the orchestrator sees it. `kind` discriminates
+ * which primitive to invoke; `id` and `label` are UI-stable identifiers for
+ * the caller's step indicator + per-section panels (the orchestrator never
+ * inspects them).
+ */
+export type SectionInput =
+  | { kind: "summary"; id: string; label: string; text: string }
+  | {
+      kind: "experience";
+      id: string;
+      label: string;
+      bullets: readonly string[];
+    };
+
+export type SectionOutcome =
+  | {
+      kind: "summary";
+      input: Extract<SectionInput, { kind: "summary" }>;
+      data: SummaryRewriteResult;
+    }
+  | {
+      kind: "experience";
+      input: Extract<SectionInput, { kind: "experience" }>;
+      data: SectionRewriteResult;
+    };
+
+export interface ResumeRewriteProgress {
+  /**
+   * 0-based index of the section currently in flight. After the orchestrator
+   * completes, this equals `totalSections` and `completed.length` equals
+   * `totalSections` — the UI uses that signal to swap into the proposed
+   * state.
+   */
+  currentIndex: number;
+  totalSections: number;
+  /**
+   * Label of the section currently being rewritten (e.g. "Summary",
+   * "Senior Engineer — Acme"). `null` on the final completion event
+   * (`currentIndex === totalSections`) where no section is in flight.
+   * The UI uses this to render "Rewriting 2 of 4: Senior Engineer — Acme"
+   * instead of the generic "Section 2".
+   */
+  currentLabel: string | null;
+  /**
+   * Outcomes accumulated so far. Length === `currentIndex` while a section is
+   * in flight (the outcome for index N lands here just before
+   * `onProgress({ currentIndex: N + 1, … })` fires).
+   */
+  completed: readonly SectionOutcome[];
+}
+
+export interface ResumeRewriteResult {
+  sections: readonly SectionOutcome[];
+  /**
+   * True iff every section's `numbersPreserved` was true. The UI aggregates
+   * each section's `dropped` / `added` tokens for the warning copy, so the
+   * orchestrator only needs the boolean.
+   */
+  allNumbersPreserved: boolean;
+}
+
+/** Mirror of `firstSectionRewriteFiredFor` in rewrite-section.ts. */
+const firstResumeRewriteFiredFor = new Set<string>();
+
+/**
+ * Cap on the prior-section preview folded into the rolling context. The
+ * brief is meant to keep the model oriented, not to dump the whole previous
+ * section back at it — small instruct models lose the actual instruction
+ * when the prompt balloons. A single line truncated to ~140 chars is
+ * empirically enough to anchor narrative continuity without eating the
+ * model's instruction-following budget.
+ */
+const PRIOR_PREVIEW_CHAR_CAP = 140;
+
+/**
+ * Build the rolling context brief threaded into the NEXT section's SYSTEM
+ * prompt as a reference-only block. Three parts, per #67:
+ *
+ *   1. **Verb constraint** — accumulated leading verbs from every previously
+ *      rewritten bullet/summary, formatted as a "Choose different verbs"
+ *      sentence.
+ *   2. **Phrase constraint** — accumulated 2-word post-verb content
+ *      phrases ("distributed systems", "internal admin tool"), formatted
+ *      as an "Avoid repeating these exact phrases" sentence. The "and
+ *      strong phrases" half of the #67 dedup spec.
+ *   3. **Prior preview** — a one-line glance back at the most recent
+ *      section's first rewritten unit (truncated to ~140 chars). The
+ *      "already-rewritten sections as a brief" half of the #67 rolling-
+ *      context spec.
+ *
+ * All three live in the system message via `buildSectionSystemPrompt`,
+ * NOT the user message — small instruct models otherwise read the prior
+ * preview line as a bullet to echo into their output (the bug the
+ * first-pass implementation tripped over).
+ *
+ * Returns `undefined` for the first section in the chain (no context yet).
+ */
+export function buildResumeContext(
+  completed: readonly SectionOutcome[],
+  usedVerbs: ReadonlySet<string>,
+  usedPhrases: ReadonlySet<string>,
+): string | undefined {
+  const parts: string[] = [];
+
+  const verbBrief = buildVerbBrief(usedVerbs);
+  if (verbBrief !== null) parts.push(verbBrief);
+
+  const phraseBrief = buildPhraseBrief(usedPhrases);
+  if (phraseBrief !== null) parts.push(phraseBrief);
+
+  const prior = completed[completed.length - 1];
+  if (prior !== undefined) {
+    const preview = previewFromOutcome(prior);
+    if (preview !== null) {
+      parts.push(`Earlier section's first bullet was: "${preview}"`);
+    }
+  }
+
+  if (parts.length === 0) return undefined;
+  return parts.join("\n");
+}
+
+function previewFromOutcome(outcome: SectionOutcome): string | null {
+  if (outcome.kind === "summary") {
+    const text = outcome.data.text;
+    if (!text) return null;
+    return truncate(text, PRIOR_PREVIEW_CHAR_CAP);
+  }
+  const first = outcome.data.bullets[0];
+  if (!first) return null;
+  return truncate(first, PRIOR_PREVIEW_CHAR_CAP);
+}
+
+function truncate(s: string, cap: number): string {
+  if (s.length <= cap) return s;
+  return `${s.slice(0, cap - 1).trimEnd()}…`;
+}
+
+/**
+ * Process every section in `sections` sequentially, threading a rolling
+ * context brief from the prior sections into each subsequent call. The
+ * orchestrator never runs two model calls in parallel — the chain semantics
+ * are the point.
+ *
+ * `onProgress` is invoked:
+ *   - Once at the start of each step BEFORE the model call (so the UI can
+ *     show "Rewriting 2 of 5: Senior Engineer at Foo" before the call
+ *     blocks).
+ *   - Once at the very end with `currentIndex === totalSections` (the UI
+ *     uses this to transition into the proposed state with the completed
+ *     outcome list).
+ *
+ * Empty inputs (a "summary" section with an empty `text`, an "experience"
+ * section with zero bullets) are silently skipped so the orchestrator
+ * stays linear-in-N over what it can actually rewrite. The caller is
+ * expected to filter these out upstream, but we double-check defensively
+ * because the data path goes through a hand-built section list in the UI.
+ */
+export async function rewriteResumeWithLlm(
+  sections: readonly SectionInput[],
+  engine: WebLlmEngine,
+  modelId: string,
+  onProgress: (progress: ResumeRewriteProgress) => void,
+): Promise<ResumeRewriteResult> {
+  const rewriteable = sections.filter(isNonEmptySection);
+  const totalSections = rewriteable.length;
+
+  trackWebllmResumeRewriteStarted({ model: modelId, sectionCount: totalSections });
+
+  const completed: SectionOutcome[] = [];
+  const usedVerbs = new Set<string>();
+  const usedPhrases = new Set<string>();
+
+  for (let i = 0; i < totalSections; i++) {
+    const section = rewriteable[i]!;
+    onProgress({
+      currentIndex: i,
+      totalSections,
+      currentLabel: section.label,
+      completed: [...completed],
+    });
+
+    const context = buildResumeContext(completed, usedVerbs, usedPhrases);
+    const outcome = await runOne(section, engine, modelId, context);
+    completed.push(outcome);
+    accumulateOutcomeSignals(outcome, usedVerbs, usedPhrases);
+
+    trackWebllmResumeRewriteSectionCompleted({
+      model: modelId,
+      sectionIndex: i,
+      sectionKind: outcome.kind,
+      inputUnitCount: inputUnitCountOf(section),
+      outputUnitCount: outputUnitCountOf(outcome),
+      numbersPreserved: outcome.data.numbersPreserved,
+    });
+  }
+
+  const allNumbersPreserved = completed.every((o) => o.data.numbersPreserved);
+
+  trackWebllmResumeRewriteCompleted({
+    model: modelId,
+    sectionCount: totalSections,
+    allNumbersPreserved,
+  });
+
+  // Per-model one-shot — only counts a run that produced at least one
+  // non-empty section outcome, so a model that returned nothing across
+  // every section doesn't pollute the conversion funnel.
+  if (
+    !firstResumeRewriteFiredFor.has(modelId) &&
+    completed.some((o) => outputUnitCountOf(o) > 0)
+  ) {
+    firstResumeRewriteFiredFor.add(modelId);
+    trackWebllmFirstResumeRewrite({ model: modelId });
+  }
+
+  onProgress({
+    currentIndex: totalSections,
+    totalSections,
+    currentLabel: null,
+    completed: [...completed],
+  });
+
+  return { sections: completed, allNumbersPreserved };
+}
+
+function isNonEmptySection(section: SectionInput): boolean {
+  if (section.kind === "summary") return section.text.trim().length > 0;
+  return section.bullets.some((b) => b.trim().length > 0);
+}
+
+async function runOne(
+  section: SectionInput,
+  engine: WebLlmEngine,
+  modelId: string,
+  context: string | undefined,
+): Promise<SectionOutcome> {
+  if (section.kind === "summary") {
+    const data = await rewriteSummaryWithLlm(
+      section.text,
+      engine,
+      modelId,
+      context !== undefined ? { context } : undefined,
+    );
+    return { kind: "summary", input: section, data };
+  }
+  const data = await rewriteSectionWithLlm(
+    section.bullets,
+    engine,
+    modelId,
+    context !== undefined ? { context } : undefined,
+  );
+  return { kind: "experience", input: section, data };
+}
+
+/**
+ * Fold an outcome's rewritten units into both the verb and phrase running
+ * sets in one pass. The accumulators (`accumulateVerbs` / `accumulatePhrases`)
+ * already handle the "delete-then-add for recency" semantics; we just have
+ * to hand them the same string-array shape for both kinds. The summary
+ * outcome is wrapped in a single-element array so the orchestrator doesn't
+ * need a separate code path for the paragraph case.
+ */
+function accumulateOutcomeSignals(
+  outcome: SectionOutcome,
+  verbs: Set<string>,
+  phrases: Set<string>,
+): void {
+  const lines: readonly string[] =
+    outcome.kind === "summary" ? [outcome.data.text] : outcome.data.bullets;
+  accumulateVerbs(lines, verbs);
+  accumulatePhrases(lines, phrases);
+}
+
+function inputUnitCountOf(section: SectionInput): number {
+  return section.kind === "summary" ? 1 : section.bullets.length;
+}
+
+function outputUnitCountOf(outcome: SectionOutcome): number {
+  if (outcome.kind === "summary") return outcome.data.text.length > 0 ? 1 : 0;
+  return outcome.data.bullets.length;
+}
+
+/** Test-only: drop the per-model one-shot telemetry flags between tests. */
+export function _resetResumeRewriteFlagsForTesting(): void {
+  firstResumeRewriteFiredFor.clear();
+}

--- a/src/lib/webllm/rewrite-section.test.ts
+++ b/src/lib/webllm/rewrite-section.test.ts
@@ -29,6 +29,7 @@ vi.mock("../analytics.ts", async (importOriginal) => {
 
 import {
   _resetSectionRewriteFlagsForTesting,
+  buildSectionSystemPrompt,
   buildSectionUserPrompt,
   rewriteSectionWithLlm,
   sectionMaxTokens,
@@ -88,6 +89,44 @@ describe("buildSectionUserPrompt", () => {
     ).toBe(
       "Original bullets:\n1. first bullet\n2. second bullet\n\nRewritten bullets:",
     );
+  });
+
+  it("does not accept a context parameter — context belongs to the system prompt builder", () => {
+    // Regression guard: the chain-of-sections orchestrator (#67) used to
+    // thread context through the user prompt, which caused small instruct
+    // models to echo the prior-section preview line as a bullet. Context
+    // moved to buildSectionSystemPrompt. The user prompt stays pure input.
+    const baseline = buildSectionUserPrompt(["first", "second"]);
+    expect(baseline).toBe(
+      "Original bullets:\n1. first\n2. second\n\nRewritten bullets:",
+    );
+  });
+});
+
+describe("buildSectionSystemPrompt", () => {
+  it("returns the base rules verbatim when no context is given", () => {
+    expect(buildSectionSystemPrompt()).toBe(SECTION_REWRITE_SYSTEM_PROMPT);
+    expect(buildSectionSystemPrompt(undefined)).toBe(
+      SECTION_REWRITE_SYSTEM_PROMPT,
+    );
+  });
+
+  it("returns the base rules verbatim for a whitespace-only context", () => {
+    expect(buildSectionSystemPrompt("   ")).toBe(SECTION_REWRITE_SYSTEM_PROMPT);
+  });
+
+  it("appends a reference-only context block when context is set", () => {
+    const out = buildSectionSystemPrompt(
+      "Verbs already used in prior bullets: built, led.",
+    );
+    expect(out.startsWith(SECTION_REWRITE_SYSTEM_PROMPT)).toBe(true);
+    expect(out).toContain("reference only");
+    expect(out).toContain("Verbs already used in prior bullets: built, led.");
+  });
+
+  it("instructs the model to ignore earlier-section content", () => {
+    const out = buildSectionSystemPrompt("any context");
+    expect(out).toMatch(/Do not include content from earlier sections/i);
   });
 });
 
@@ -263,5 +302,31 @@ describe("rewriteSectionWithLlm", () => {
     await expect(rewriteSectionWithLlm(["a"], engine, TEST_MODEL)).rejects.toBe(
       boom,
     );
+  });
+
+  it("folds a context brief into the SYSTEM message — never the user message — when options.context is passed", async () => {
+    const { engine, spy } = makeEngine(async () => reply("Shipped Foo."));
+    await rewriteSectionWithLlm(["a"], engine, TEST_MODEL, {
+      context: "Verbs already used in prior bullets: built, led.",
+    });
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    // System message: carries the context block.
+    expect(req.messages[0]?.role).toBe("system");
+    expect(req.messages[0]?.content).toContain(
+      "Verbs already used in prior bullets: built, led.",
+    );
+    expect(req.messages[0]?.content).toContain("reference only");
+    // User message: stays pure input — never carries the context.
+    expect(req.messages[1]?.role).toBe("user");
+    expect(req.messages[1]?.content).not.toContain("Verbs already used");
+    expect(req.messages[1]?.content?.startsWith("Original bullets:")).toBe(true);
+  });
+
+  it("uses the base system prompt verbatim when called with no options (regression guard)", async () => {
+    const { engine, spy } = makeEngine(async () => reply("Shipped Foo."));
+    await rewriteSectionWithLlm(["a"], engine, TEST_MODEL);
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    expect(req.messages[0]?.content).toBe(SECTION_REWRITE_SYSTEM_PROMPT);
+    expect(req.messages[1]?.content?.startsWith("Original bullets:")).toBe(true);
   });
 });

--- a/src/lib/webllm/rewrite-section.ts
+++ b/src/lib/webllm/rewrite-section.ts
@@ -58,6 +58,46 @@ export function buildSectionUserPrompt(bullets: readonly string[]): string {
   return `Original bullets:\n${numbered}\n\nRewritten bullets:`;
 }
 
+/**
+ * System-prompt builder. The base rules are constant; the chain-of-sections
+ * orchestrator (#67) optionally appends a "context from earlier sections"
+ * block that the model must treat as reference-only.
+ *
+ * Why the system message and not the user message: when the rolling
+ * context sat alongside `Original bullets:` in the user message, small
+ * instruct models (Qwen2.5-1.5B in particular) read the prior section's
+ * preview line as another bullet to echo into the output. Moving it to
+ * the system message — wrapped in an explicit "reference only, never echo
+ * into your output" guardrail — makes the boundary categorical: the user
+ * message is the input to rewrite, the system message is the world the
+ * model rewrites within. See #67 follow-up where this misfire was caught.
+ */
+export function buildSectionSystemPrompt(context?: string): string {
+  if (!context || context.trim().length === 0) {
+    return SECTION_REWRITE_SYSTEM_PROMPT;
+  }
+  return `${SECTION_REWRITE_SYSTEM_PROMPT}
+
+Earlier sections of this résumé have already been rewritten. The user's NEXT message contains a NEW section's bullets — only rewrite THOSE. Do not include content from earlier sections in your output.
+
+Context from earlier sections (reference only — never echo into your output):
+${context.trim()}`;
+}
+
+/**
+ * Optional knobs the chain-of-sections orchestrator (#67) threads through to
+ * each per-section call. Today only `context` is wired — a single
+ * pre-formatted brief (used-verb constraint + used-phrase constraint + a
+ * prior-section preview) that gets folded into the SYSTEM message as
+ * reference-only context. Defaults to undefined, so every existing call site
+ * (single-section rewrite, eval harness) behaves bit-identically to the
+ * Phase 1 path.
+ */
+export interface SectionRewriteOptions {
+  /** Rolling soft-constraint brief from earlier sections in the chain. */
+  context?: string;
+}
+
 export interface SectionRewriteResult {
   /** The rewritten bullets (M may differ from N). */
   bullets: string[];
@@ -104,6 +144,7 @@ export async function rewriteSectionWithLlm(
   bullets: readonly string[],
   engine: WebLlmEngine,
   modelId: string,
+  options: SectionRewriteOptions = {},
 ): Promise<SectionRewriteResult> {
   trackWebllmSectionRewriteStarted({
     model: modelId,
@@ -116,7 +157,10 @@ export async function rewriteSectionWithLlm(
   try {
     const response = await engine.chat.completions.create({
       messages: [
-        { role: "system", content: SECTION_REWRITE_SYSTEM_PROMPT },
+        {
+          role: "system",
+          content: buildSectionSystemPrompt(options.context),
+        },
         { role: "user", content: buildSectionUserPrompt(bullets) },
       ],
       temperature: 0.3,

--- a/src/lib/webllm/rewrite-summary.test.ts
+++ b/src/lib/webllm/rewrite-summary.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSummarySystemPrompt,
+  buildSummaryUserPrompt,
+  rewriteSummaryWithLlm,
+  SUMMARY_REWRITE_SYSTEM_PROMPT,
+} from "./rewrite-summary.ts";
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  WebLlmEngine,
+} from "./types.ts";
+
+const TEST_MODEL = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
+
+function makeEngine(
+  reply: (req: ChatCompletionRequest) => Promise<ChatCompletionResponse>,
+): {
+  engine: WebLlmEngine;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const spy = vi.fn(reply);
+  const engine: WebLlmEngine = { chat: { completions: { create: spy } } };
+  return { engine, spy };
+}
+
+function reply(content: string | null): ChatCompletionResponse {
+  return { choices: [{ message: { content } }] };
+}
+
+describe("buildSummaryUserPrompt", () => {
+  it("emits a labeled before/after scaffolding for the model", () => {
+    expect(buildSummaryUserPrompt("Senior engineer with 10 years.")).toBe(
+      "Original summary:\nSenior engineer with 10 years.\n\nRewritten summary:",
+    );
+  });
+
+  it("does not accept a context parameter — context belongs to buildSummarySystemPrompt", () => {
+    // Regression guard: context moved off the user message after the small
+    // models echoed the prior-section preview into their output (#67 follow-up).
+    expect(buildSummaryUserPrompt("Engineer.")).toBe(
+      "Original summary:\nEngineer.\n\nRewritten summary:",
+    );
+  });
+});
+
+describe("buildSummarySystemPrompt", () => {
+  it("returns the base rules verbatim when no context is given", () => {
+    expect(buildSummarySystemPrompt()).toBe(SUMMARY_REWRITE_SYSTEM_PROMPT);
+    expect(buildSummarySystemPrompt(undefined)).toBe(SUMMARY_REWRITE_SYSTEM_PROMPT);
+  });
+
+  it("returns the base rules verbatim for a whitespace-only context", () => {
+    expect(buildSummarySystemPrompt("   ")).toBe(SUMMARY_REWRITE_SYSTEM_PROMPT);
+  });
+
+  it("appends a reference-only context block when context is set", () => {
+    const out = buildSummarySystemPrompt(
+      "Verbs already used in prior bullets: built, led.",
+    );
+    expect(out.startsWith(SUMMARY_REWRITE_SYSTEM_PROMPT)).toBe(true);
+    expect(out).toContain("reference only");
+    expect(out).toContain("Verbs already used in prior bullets: built, led.");
+  });
+});
+
+describe("rewriteSummaryWithLlm", () => {
+  it("sends the summary system prompt and labeled user prompt", async () => {
+    const { engine, spy } = makeEngine(async () =>
+      reply("Senior engineer with 10 years building distributed systems."),
+    );
+    await rewriteSummaryWithLlm(
+      "I am a senior engineer with 10 years of experience.",
+      engine,
+      TEST_MODEL,
+    );
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    expect(req.messages[0]).toEqual({
+      role: "system",
+      content: SUMMARY_REWRITE_SYSTEM_PROMPT,
+    });
+    expect(req.messages[1]?.role).toBe("user");
+    expect(req.messages[1]?.content).toContain("Original summary:");
+    expect(req.messages[1]?.content).toContain("Rewritten summary:");
+  });
+
+  it("uses the 256-token cap regardless of input length", async () => {
+    const { engine, spy } = makeEngine(async () => reply("Engineer."));
+    await rewriteSummaryWithLlm("x".repeat(2000), engine, TEST_MODEL);
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    expect(req.max_tokens).toBe(256);
+  });
+
+  it("collapses a wrapped paragraph into a single line with single spaces", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Senior engineer.\nLed a team of 5.\nShipped 3 products."),
+    );
+    const out = await rewriteSummaryWithLlm("Engineer.", engine, TEST_MODEL);
+    expect(out.text).toBe("Senior engineer. Led a team of 5. Shipped 3 products.");
+  });
+
+  it("strips a Rewritten: echo from the model output", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Rewritten: Senior engineer with 10 years."),
+    );
+    const out = await rewriteSummaryWithLlm("Engineer.", engine, TEST_MODEL);
+    expect(out.text).toBe("Senior engineer with 10 years.");
+  });
+
+  it("reports numbersPreserved=true when every numeric token survives", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Senior engineer with 10 years of experience and $1.2M in ARR."),
+    );
+    const out = await rewriteSummaryWithLlm(
+      "I have 10 years and drove $1.2M in ARR.",
+      engine,
+      TEST_MODEL,
+    );
+    expect(out.numbersPreserved).toBe(true);
+  });
+
+  it("flags numbersPreserved=false when a metric is dropped", async () => {
+    const { engine } = makeEngine(async () =>
+      reply("Senior engineer with a decade of experience."),
+    );
+    const out = await rewriteSummaryWithLlm(
+      "I drove $5K in revenue per quarter.",
+      engine,
+      TEST_MODEL,
+    );
+    expect(out.numbersPreserved).toBe(false);
+    expect(out.droppedNumbers).toEqual(["$5K"]);
+  });
+
+  it("returns an empty text on null model content without throwing", async () => {
+    const { engine } = makeEngine(async () => reply(null));
+    const out = await rewriteSummaryWithLlm("Engineer.", engine, TEST_MODEL);
+    expect(out.text).toBe("");
+    expect(out.numbersPreserved).toBe(true);
+  });
+
+  it("propagates engine errors to the caller", async () => {
+    const boom = new Error("OOM");
+    const { engine } = makeEngine(async () => {
+      throw boom;
+    });
+    await expect(
+      rewriteSummaryWithLlm("Engineer.", engine, TEST_MODEL),
+    ).rejects.toBe(boom);
+  });
+
+  it("folds a context brief into the SYSTEM message — never the user message — when options.context is passed", async () => {
+    const { engine, spy } = makeEngine(async () => reply("Senior engineer."));
+    await rewriteSummaryWithLlm("Engineer.", engine, TEST_MODEL, {
+      context: "Verbs already used: built, led.",
+    });
+    const req = spy.mock.calls[0]![0] as ChatCompletionRequest;
+    // System message: carries the context block.
+    expect(req.messages[0]?.role).toBe("system");
+    expect(req.messages[0]?.content).toContain("Verbs already used: built, led.");
+    expect(req.messages[0]?.content).toContain("reference only");
+    // User message: stays pure input — never carries the context.
+    expect(req.messages[1]?.role).toBe("user");
+    expect(req.messages[1]?.content).not.toContain("Verbs already used");
+    expect(req.messages[1]?.content?.startsWith("Original summary:")).toBe(true);
+  });
+});

--- a/src/lib/webllm/rewrite-summary.ts
+++ b/src/lib/webllm/rewrite-summary.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { cleanRewriteLine } from "./post-process.ts";
+import { checkNumbersPreserved } from "./preserve-numbers.ts";
+import type { WebLlmEngine } from "./types.ts";
+import { acquireInference, releaseInference } from "./web-llm.ts";
+
+/**
+ * Summary-paragraph rewrite primitive used by the chain-of-sections
+ * orchestrator (#67).
+ *
+ * The summary section is the first section in the chain. It is a 2–3
+ * sentence paragraph rather than a bullet list, so the bullet-shaped
+ * `rewriteSectionWithLlm` prompt does not fit — it would coerce the model
+ * into emitting one bullet per line and we'd lose the paragraph shape.
+ *
+ * Mirrors the section primitive's contracts:
+ *   - Takes the engine + model id so telemetry can be model-dimensioned and
+ *     the cross-model `acquireInference` lock can defer `.unload()` while
+ *     this call is in flight.
+ *   - Runs the deterministic number-preservation check after the model
+ *     responds (same `checkNumbersPreserved` used by the section path —
+ *     the multiset diff is shape-agnostic).
+ *   - Returns `numbersPreserved` + `dropped/added` so the UI can surface
+ *     the same inline warning shape as the section path.
+ *
+ * Output handling: paragraphs sometimes come back across multiple lines if
+ * the model adds a wrap (or hallucinates a `Rewritten:` echo). We run each
+ * non-empty line through the shared `cleanRewriteLine` helper, then join
+ * with a single space — that flattens any spurious wrap without losing
+ * intra-paragraph punctuation.
+ *
+ * No first-rewrite telemetry: the orchestrator owns the resume-level
+ * one-shot flag (`webllm_first_resume_rewrite`). The per-section /
+ * per-bullet one-shots stay distinct so the funnels don't cross-pollute.
+ */
+export const SUMMARY_REWRITE_SYSTEM_PROMPT = `You are rewriting a resume summary to be more specific and outcome-oriented.
+Rules:
+- Output a single paragraph of 2–3 sentences. No bullet points. No numbering. No quotes. No preamble.
+- Lead with the strongest concrete claim (years of experience, primary domain, or signature outcome).
+- Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.
+- Drop generic filler ("hard-working", "team player", "passionate"). Keep specifics.
+- If the summary is already strong, keep it unchanged.`;
+
+const SUMMARY_MAX_TOKENS = 256;
+
+export function buildSummaryUserPrompt(summary: string): string {
+  return `Original summary:\n${summary.trim()}\n\nRewritten summary:`;
+}
+
+/**
+ * System-prompt builder. Mirrors `buildSectionSystemPrompt` — the
+ * chain-of-sections orchestrator (#67) folds rolling context into the
+ * SYSTEM message, not the user message, so small instruct models don't
+ * read the prior-section preview as content to echo.
+ */
+export function buildSummarySystemPrompt(context?: string): string {
+  if (!context || context.trim().length === 0) {
+    return SUMMARY_REWRITE_SYSTEM_PROMPT;
+  }
+  return `${SUMMARY_REWRITE_SYSTEM_PROMPT}
+
+Other sections of this résumé will be rewritten next. The user's NEXT message contains the summary paragraph — only rewrite THAT. Do not include content from later sections in your output.
+
+Context for tone consistency (reference only — never echo into your output):
+${context.trim()}`;
+}
+
+export interface SummaryRewriteOptions {
+  /** Rolling soft-constraint brief from the chain-of-sections orchestrator. */
+  context?: string;
+}
+
+export interface SummaryRewriteResult {
+  /** The rewritten summary paragraph. Empty string when the model returned nothing. */
+  text: string;
+  /** True iff every input number survived and none were invented. */
+  numbersPreserved: boolean;
+  /** Numeric tokens that did not survive (UI surfaces these inline). */
+  droppedNumbers: string[];
+  /** Numeric tokens that appeared from nowhere (UI surfaces these inline). */
+  addedNumbers: string[];
+}
+
+/**
+ * Rewrite a summary paragraph using a loaded WebLLM engine.
+ *
+ * Pure over `engine` — the engine is passed in so tests can supply a stub
+ * implementing the `WebLlmEngine` contract without touching the real model.
+ *
+ * `modelId` is required for the cross-model inference guard
+ * (`acquireInference` / `releaseInference`). The orchestrator owns this
+ * call's lifecycle and fires the resume-level telemetry; this primitive is
+ * deliberately quiet so existing per-section telemetry funnels don't pick
+ * up summary-rewrite events.
+ */
+export async function rewriteSummaryWithLlm(
+  summary: string,
+  engine: WebLlmEngine,
+  modelId: string,
+  options: SummaryRewriteOptions = {},
+): Promise<SummaryRewriteResult> {
+  acquireInference(modelId);
+  try {
+    const response = await engine.chat.completions.create({
+      messages: [
+        {
+          role: "system",
+          content: buildSummarySystemPrompt(options.context),
+        },
+        { role: "user", content: buildSummaryUserPrompt(summary) },
+      ],
+      temperature: 0.3,
+      max_tokens: SUMMARY_MAX_TOKENS,
+    });
+
+    const raw = response.choices[0]?.message?.content ?? "";
+    const text = raw
+      .split("\n")
+      .map((line) => cleanRewriteLine(line))
+      .filter((line) => line.length > 0)
+      .join(" ")
+      .trim();
+
+    const preservation = checkNumbersPreserved([summary], text ? [text] : []);
+
+    return {
+      text,
+      numbersPreserved: preservation.ok,
+      droppedNumbers: preservation.dropped,
+      addedNumbers: preservation.added,
+    };
+  } finally {
+    releaseInference(modelId);
+  }
+}

--- a/src/lib/webllm/verb-tracking.test.ts
+++ b/src/lib/webllm/verb-tracking.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import {
+  accumulateVerbs,
+  buildVerbBrief,
+  extractLeadingVerb,
+} from "./verb-tracking.ts";
+
+describe("extractLeadingVerb", () => {
+  it("returns the lowercased first word of a plain bullet", () => {
+    expect(extractLeadingVerb("Built a thing")).toBe("built");
+  });
+
+  it("preserves all-lowercase input", () => {
+    expect(extractLeadingVerb("led a team")).toBe("led");
+  });
+
+  it("strips a numbered list marker before reading the first word", () => {
+    expect(extractLeadingVerb("1. Shipped Foo")).toBe("shipped");
+    expect(extractLeadingVerb("3) Drove revenue")).toBe("drove");
+  });
+
+  it("strips a bullet glyph before reading the first word", () => {
+    expect(extractLeadingVerb("• Owned the migration")).toBe("owned");
+    expect(extractLeadingVerb("- Built the thing")).toBe("built");
+    expect(extractLeadingVerb("* Built the thing")).toBe("built");
+  });
+
+  it("strips leading markdown bold before reading the first word", () => {
+    expect(extractLeadingVerb("**Built** a thing")).toBe("built");
+  });
+
+  it("strips a leading quote before reading the first word", () => {
+    expect(extractLeadingVerb('"Shipped Foo"')).toBe("shipped");
+  });
+
+  it("returns null for an empty/whitespace-only line", () => {
+    expect(extractLeadingVerb("")).toBeNull();
+    expect(extractLeadingVerb("   ")).toBeNull();
+  });
+
+  it("returns null when the first token is purely numeric", () => {
+    expect(extractLeadingVerb("$1.2M in ARR")).toBeNull();
+    expect(extractLeadingVerb("100% of the team")).toBeNull();
+  });
+
+  it("returns null for single-letter tokens (too noisy)", () => {
+    expect(extractLeadingVerb("X marked the spot")).toBeNull();
+  });
+
+  it("keeps hyphenated verbs intact", () => {
+    expect(extractLeadingVerb("Co-led the team")).toBe("co-led");
+  });
+});
+
+describe("buildVerbBrief", () => {
+  it("returns null for an empty verb set", () => {
+    expect(buildVerbBrief(new Set())).toBeNull();
+  });
+
+  it("formats a one-line constraint sentence", () => {
+    const brief = buildVerbBrief(new Set(["built", "led"]));
+    expect(brief).toContain("built");
+    expect(brief).toContain("led");
+    expect(brief).toContain("Choose different verbs");
+  });
+
+  it("preserves insertion order (oldest first)", () => {
+    const set = new Set<string>();
+    set.add("built");
+    set.add("led");
+    set.add("shipped");
+    const brief = buildVerbBrief(set);
+    expect(brief).toMatch(/built.*led.*shipped/);
+  });
+
+  it("caps the brief at the most recent 12 verbs", () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 20; i++) set.add(`verb${i}`);
+    const brief = buildVerbBrief(set);
+    // The first 8 are dropped (20 - 12 = 8); verb8 onwards survives.
+    expect(brief).not.toContain("verb0,");
+    expect(brief).not.toContain("verb7,");
+    expect(brief).toContain("verb8");
+    expect(brief).toContain("verb19");
+  });
+});
+
+describe("accumulateVerbs", () => {
+  it("adds the leading verb of each line to the set", () => {
+    const set = new Set<string>();
+    accumulateVerbs(["Built X", "Led Y", "Shipped Z"], set);
+    expect([...set]).toEqual(["built", "led", "shipped"]);
+  });
+
+  it("skips lines with no leading alphabetic token", () => {
+    const set = new Set<string>();
+    accumulateVerbs(["Built X", "$5K ARR", "Led Y"], set);
+    expect([...set]).toEqual(["built", "led"]);
+  });
+
+  it("floats a repeated verb to the tail (so the cap surfaces fresh repeats)", () => {
+    const set = new Set<string>();
+    set.add("built");
+    set.add("led");
+    accumulateVerbs(["Built Z"], set);
+    // built moved to the tail; led is now older
+    expect([...set]).toEqual(["led", "built"]);
+  });
+});

--- a/src/lib/webllm/verb-tracking.ts
+++ b/src/lib/webllm/verb-tracking.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Lexical helpers for cross-section action-verb tracking (issue #67).
+ *
+ * The chain-of-sections orchestrator accumulates the leading verb of every
+ * rewritten bullet (and the first word of the rewritten summary), then folds
+ * the accumulated set into a soft-constraint sentence ("Verbs already used in
+ * prior bullets: built, led, shipped. Choose different verbs where you can.")
+ * that is prepended to the user prompt of the next section.
+ *
+ * Strictly lexical — we do NOT consult the eval rubric's action-verb list
+ * (`eval/verbs.ts`) here. The constraint is "don't repeat the verb you
+ * already used"; what matters is recurrence, not whether the first word is
+ * a "good" verb by some external list. A bullet that opens with a weak verb
+ * is still useful context — repeating it would compound the weakness.
+ */
+
+/**
+ * Strip leading list/quote/punctuation noise that might survive the
+ * post-process filter on a model output, then return the lowercased first
+ * alphabetic token if one exists. Returns `null` when nothing usable is
+ * found.
+ *
+ * Examples:
+ *   "Built a thing"        → "built"
+ *   "Led 5 engineers"      → "led"
+ *   "Drove $1.2M ARR."     → "drove"
+ *   "1. Shipped Foo."      → "shipped"
+ *   "**Built** a thing"    → "built"
+ *   "  "                   → null
+ *   "$1.2M ARR"            → null  (no leading alphabetic token)
+ */
+export function extractLeadingVerb(line: string): string | null {
+  const stripped = line
+    .trim()
+    .replace(/^\d+[.)]\s*/, "")
+    .replace(/^[•\-*]\s*/, "")
+    .replace(/^\*+/, "")
+    .replace(/^["'`“‘]/, "");
+  const match = stripped.match(/^([A-Za-z][A-Za-z'-]+)/);
+  if (!match) return null;
+  const token = match[1]!.toLowerCase();
+  if (token.length < 2) return null;
+  return token;
+}
+
+/**
+ * The most recent N verbs are the most relevant — they're what's likeliest to
+ * recur in the very next section. Older verbs add prompt-context noise that
+ * makes small instruct models drop the soft-constraint instruction entirely.
+ */
+const VERB_BRIEF_CAP = 12;
+
+/**
+ * Format the accumulated verb set as a single-sentence soft constraint for
+ * the next call's user prompt. Returns `null` when there's nothing to say
+ * yet (first section in the chain).
+ *
+ * The instruction is phrased as a preference ("Choose different verbs where
+ * you can") rather than a hard rule. Sometimes the right verb genuinely is
+ * "led" again — we want the model to avoid lazy repetition, not refuse a
+ * good fit.
+ *
+ * Returns the most recent `VERB_BRIEF_CAP` verbs in their insertion order
+ * (oldest first within the cap) — a Set preserves insertion order in JS, so
+ * slicing the tail off `Array.from(set)` keeps the recency window.
+ */
+export function buildVerbBrief(
+  usedVerbs: ReadonlySet<string>,
+): string | null {
+  if (usedVerbs.size === 0) return null;
+  const all = Array.from(usedVerbs);
+  const recent =
+    all.length <= VERB_BRIEF_CAP ? all : all.slice(-VERB_BRIEF_CAP);
+  return `Verbs already used in prior bullets: ${recent.join(", ")}. Choose different verbs where you can.`;
+}
+
+/**
+ * Mutating helper: extract every line's leading verb and add it to the
+ * running set. The orchestrator owns the Set and calls this after each
+ * section completes. Verbs are added in encounter order so `buildVerbBrief`
+ * surfaces the most recent ones first.
+ */
+export function accumulateVerbs(
+  lines: readonly string[],
+  into: Set<string>,
+): void {
+  for (const line of lines) {
+    const verb = extractLeadingVerb(line);
+    if (verb === null) continue;
+    // Re-insertion is a no-op on Set, but moves nothing — to keep recency
+    // semantics we delete-then-add so a repeated verb floats to the tail.
+    if (into.has(verb)) into.delete(verb);
+    into.add(verb);
+  }
+}

--- a/src/lib/webllm/verb-tracking.ts
+++ b/src/lib/webllm/verb-tracking.ts
@@ -8,7 +8,9 @@
  * rewritten bullet (and the first word of the rewritten summary), then folds
  * the accumulated set into a soft-constraint sentence ("Verbs already used in
  * prior bullets: built, led, shipped. Choose different verbs where you can.")
- * that is prepended to the user prompt of the next section.
+ * that the orchestrator folds into the next section's SYSTEM prompt (a
+ * reference-only block — not the user message — so small instruct models
+ * don't echo it as content; see rewrite-resume.ts).
  *
  * Strictly lexical — we do NOT consult the eval rubric's action-verb list
  * (`eval/verbs.ts`) here. The constraint is "don't repeat the verb you
@@ -55,7 +57,7 @@ const VERB_BRIEF_CAP = 12;
 
 /**
  * Format the accumulated verb set as a single-sentence soft constraint for
- * the next call's user prompt. Returns `null` when there's nothing to say
+ * the next call's system prompt. Returns `null` when there's nothing to say
  * yet (first section in the chain).
  *
  * The instruction is phrased as a preference ("Choose different verbs where


### PR DESCRIPTION
## Summary

Phase 4 of the on-device rewrite epic (#66): sequences `summary` → each `experience` role through the existing section primitive in display order, threading a rolling soft-constraint brief (used action verbs + used 2-word strong phrases + a prior-section preview) into each subsequent call. Per-section results stream via `onProgress` so the UI advances a step indicator before each call blocks. A new "Rewrite full résumé" CTA mounts next to the model picker; per-role "Rewrite section" buttons coexist via the shared `useSectionRewriteLock`.

The rolling context lives in the **system** message — not the user message — so small instruct models (Qwen2.5-1.5B in particular) don't echo the prior section's preview line as a bullet to include verbatim. This was caught and fixed mid-implementation; regression-guarded by tests.

Closes #67

## What landed

**New library code (orchestrator + helpers, all stub-engine tested):**
- `src/lib/webllm/rewrite-resume.ts` — orchestrator (sequential summary→roles, rolling context, per-model first-resume one-shot)
- `src/lib/webllm/rewrite-summary.ts` — paragraph-shape primitive (summary is not bullets)
- `src/lib/webllm/verb-tracking.ts` — `extractLeadingVerb` / `buildVerbBrief` / `accumulateVerbs`
- `src/lib/webllm/phrase-tracking.ts` — `extractStrongPhrase` / `buildPhraseBrief` / `accumulatePhrases` (the "and strong phrases" half of the #67 dedup spec)

**New UI:**
- `src/components/features/ResumeRewrite.tsx` — CTA + state routing + step indicator + completed list
- `src/components/features/ResumeRewriteProposed.tsx` — proposed-state per-section before/after panels + aggregated drift warning
- `src/hooks/useResumeRewrite.ts` — state-machine hook

**Modifications:**
- `src/lib/webllm/rewrite-section.ts` — added `buildSectionSystemPrompt(context?)` + optional `options.context` on `rewriteSectionWithLlm`. **Default behavior unchanged** when no options passed (regression-tested).
- `src/lib/analytics.ts` — 4 new env-gated trackers: `webllm_resume_rewrite_started` / `_section_completed` / `_completed` / `webllm_first_resume_rewrite`
- `src/components/features/ReconstructedResume.tsx` — mounts the CTA in the Experience section + builds the `SectionInput[]` from `parsed.summary` + experience groups

## Spec compliance (#67)

- [x] Sequential rewrites: summary first, then each experience role in display order
- [x] Rolling context window of already-rewritten sections threaded into each subsequent call
- [x] Per-section output streams to the UI before next call starts
- [x] Cross-section dedup: action verbs **and** strong phrases tracked and injected as soft constraint
- [x] Single "Rewrite full résumé" CTA with visible step indicator (names the in-flight section)
- [x] Per-section accept/reject (per-role `SectionRewrite`) remains available alongside; shared lock prevents overlap
- [x] Number-preservation guardrail runs per section; aggregated drift warning across the whole run
- [x] Silent absence on WebGPU-unavailable browsers (matches `RewriteButton` / `SectionRewrite`)
- [x] No regression to per-bullet / per-section / model-picker paths (Phase 1 / 2 untouched)

## Architectural notes

- **Reuses** every Phase 1–3 primitive: engine cache + cross-model serialization, `acquire`/`releaseInference` guard, `cleanRewriteLine`, `checkNumbersPreserved`, `useSectionRewriteLock`, `useModelSelection`, `detectWebGpu`, `Button`, `ModelLoadProgress`, `NumberPreservationWarning`.
- **System-message context placement** is load-bearing — mid-implementation testing surfaced that user-message context placement caused Qwen-1.5B to echo prior-section content as new bullets. Moved to system message with explicit "reference only — never echo" guardrail.
- Files honor CLAUDE.md soft caps: `ResumeRewrite.tsx` 182 LOC + `ResumeRewriteProposed.tsx` 179 LOC (split out of an initial 337-LOC file).
- No raw `<button>`, no hardcoded palette, semantic tokens throughout, SPDX header on every new file.

## Manually validated (Chrome, WebGPU)

Tested end-to-end with both Qwen 2.5 (1.5B) and Gemma 2 (2B) on a multi-role résumé fixture:
- Confirmed no cross-section content leak (each `Proposed` panel stays within its own role)
- Confirmed numbers preserved across summary + 3 roles
- Confirmed rolling-context verb constraint visibly steers verb choice (Gemma switched verbs across roles after constraint kicked in)
- Confirmed per-role "Rewrite section" buttons remain functional and shared lock disables them during a whole-résumé run

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 889 / 889 pass (62 new tests across orchestrator, summary primitive, verb-tracking, phrase-tracking, section context regression, UI helpers)
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Manually verified in `npm run dev` (Chrome / WebGPU) — both Qwen and Gemma paths
- [x] No fixture binaries added (PII preflight N/A)

## Out of scope (deliberate)

- Project / Achievement section rewrites — the orchestrator's `SectionInput` discriminator is shaped to extend with two more variants in a follow-up
- LLM-judge eval of whole-résumé coherence — Phase 3's eval harness is per-section; cross-section eval is a separate issue
- Persisting accepted rewrites back into the editable parse — orthogonal; matches the per-section path, which is also copy-only today