### PR TITLE
feat(contact): centered visual contact card, display-only (#146)

### DIFF
--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render tests for the centered visual ContactCard (#146). The pure data layer
+ * (grouping, gating, slug formatting) is covered in `src/lib/contact.test.ts`;
+ * this file covers the React surface — that each `group`/`gated`/`reason`
+ * combination paints the right DOM: name heading vs. muted fallback, the
+ * pipe-joined contact line with quiet "not found" tokens, low-confidence dotted
+ * values, clickable slug links, and the audit footer.
+ *
+ * Runs in jsdom (per the `@vitest-environment jsdom` pragma) so React +
+ * `react-dom/client` have a document to render into; uses raw `createRoot`
+ * rather than RTL, matching `useModelSelection.integration.test.tsx`.
+ */
+
+import { describe, expect, it, afterEach } from "vitest";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ContactCard } from "./ContactCard.tsx";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+
+function makeResult(
+  parsedOverrides: Partial<CascadeResult["parsed"]> = {},
+  confidenceOverrides: Partial<CascadeResult["fieldConfidence"]> = {},
+): CascadeResult {
+  return {
+    parsed: {
+      skills: [],
+      experience: [],
+      education: [],
+      ...parsedOverrides,
+    },
+    fieldConfidence: confidenceOverrides,
+  } as CascadeResult;
+}
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+function render(result: CascadeResult): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(createElement(ContactCard, { result }));
+  });
+  return container;
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe("ContactCard", () => {
+  it("renders the name as the heading when confidently detected", () => {
+    const el = render(
+      makeResult({ full_name: "Jane Doe" }, { full_name: 0.9 }),
+    );
+    const heading = el.querySelector("h2");
+    expect(heading?.textContent).toBe("Jane Doe");
+  });
+
+  it("shows a muted 'Name not detected' when the name is absent", () => {
+    const el = render(makeResult());
+    expect(el.querySelector("h2")?.textContent).toBe("Name not detected");
+  });
+
+  it("renders present contact values and a quiet 'not found' token for a missing required field", () => {
+    const el = render(
+      makeResult({ email: "jane@example.com" }, { email: 0.95 }),
+    );
+    const text = el.textContent ?? "";
+    expect(text).toContain("jane@example.com");
+    // Phone is required but absent → quiet inline token, not a warning chip.
+    expect(text).toContain("phone not found");
+  });
+
+  it("marks a low-confidence value with a dotted underline + tooltip", () => {
+    const floor = 0.5 - 0.01;
+    const el = render(
+      makeResult({ email: "jane@example.com" }, { email: floor }),
+    );
+    const dotted = el.querySelector('[title="low confidence"]');
+    expect(dotted?.textContent).toBe("jane@example.com");
+    expect(dotted?.className).toContain("decoration-dotted");
+  });
+
+  it("renders a detected link as a clickable new-tab slug anchor", () => {
+    const el = render(
+      makeResult(
+        { linkedin_url: "https://www.linkedin.com/in/jane-doe" },
+        { linkedin_url: 0.9 },
+      ),
+    );
+    const anchor = el.querySelector("a");
+    expect(anchor?.getAttribute("href")).toBe(
+      "https://www.linkedin.com/in/jane-doe",
+    );
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(anchor?.textContent).toBe("in/jane-doe");
+  });
+
+  it("renders the audit footer with the detected/total ratio", () => {
+    const el = render(
+      makeResult(
+        {
+          full_name: "Jane Doe",
+          email: "jane@example.com",
+          phone: "(312) 555-0100",
+          linkedin_url: "https://linkedin.com/in/jane",
+          location: "Chicago, IL",
+        },
+        {
+          full_name: 0.9,
+          email: 0.95,
+          phone: 0.9,
+          linkedin_url: 0.8,
+          location: 0.8,
+        },
+      ),
+    );
+    // All five required rows detected, none gated.
+    expect(el.textContent).toContain("5 of 5 fields detected");
+  });
+});

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -80,7 +80,7 @@ export function ContactCard({ result }: ContactCardProps) {
 
       {/* Contact line: location / email / phone, pipe-joined, present-only. */}
       {contactLine.length > 0 && (
-        <p className="mt-2 inline-flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+        <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
           {contactLine.map((field, i) => (
             <span key={field.key} className="inline-flex items-center gap-x-2">
               {i > 0 && <span className="text-content-muted">|</span>}
@@ -96,7 +96,7 @@ export function ContactCard({ result }: ContactCardProps) {
 
       {/* Links line: clickable slugs, middot-separated, license-safe (no logos). */}
       {links.length > 0 && (
-        <p className="mt-2 inline-flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+        <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
           {links.map((field, i) => (
             <span key={field.key} className="inline-flex items-center gap-x-2">
               {i > 0 && <span className="text-content-muted">·</span>}

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -2,127 +2,129 @@
 // Copyright 2026 The resumelint Authors
 
 /**
- * ContactCard — displays extracted contact fields as a chip strip.
+ * ContactCard — a centered visual contact card (#146).
  *
- * Detected fields show the value with a success chip; undetected required
- * fields show a warning chip with a "not detected" label so the reader can
- * spot gaps at a glance. Optional fields (e.g. GitHub) render only when
- * detected — see `buildContactFields`.
+ * Evolves the old chip strip into a compact, centered stack that doubles as a
+ * preview of the future regenerated-PDF header while keeping resumelint's
+ * parser-audit value: detection gaps stay visible, just quiet instead of loud.
  *
- * Edit mode (#58): when `overrides` and `onFieldChange` are provided, each
- * field chip gains an inline EditableField affordance. Edited values replace
- * the parser-detected value in the display (in memory only; lost on reset).
- * A cleared field reverts to the "not detected" chip state.
+ *   Name                       ← card heading (largest, semibold)
+ *   location · email · phone   ← pipe-joined contact line, present-only
+ *   in/slug   ·   gh/slug      ← links line, glyph-free clickable slugs
+ *   N of M fields detected     ← muted audit footer
+ *
+ * A missing *required* field shows a quiet muted token ("phone not found")
+ * rather than a warning chip; a missing *optional* link renders nothing. A
+ * low-confidence field shows its value with a dotted underline + tooltip.
+ *
+ * Display-only: inline editing of contact fields is deferred to a follow-up
+ * issue, so this version takes no edit props and renders purely from `result`.
+ * Gating still flows through `buildContactFields` + the confidence floor — no
+ * second copy of that logic lives here.
  */
 
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
-import { buildContactFields } from "../../lib/contact.ts";
-import { Chip, Card, EditableField } from "@design-system";
-import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
+import {
+  buildContactFields,
+  formatLinkDisplay,
+  type ContactDisplayField,
+} from "../../lib/contact.ts";
+import { Card } from "@design-system";
 
 interface ContactCardProps {
   result: CascadeResult;
-  /** In-memory overrides for contact fields. When provided, each field gains
-   *  an inline edit affordance. */
-  overrides?: ContactOverrides;
-  /** Called when the user commits an edit on a contact field. */
-  onFieldChange?: (key: keyof ContactOverrides, newValue: string) => void;
 }
 
-/** Map from ContactOverrides key → display label. */
-const FIELD_LABELS: Record<keyof ContactOverrides, string> = {
-  full_name: "Name",
-  email: "Email",
-  phone: "Phone",
-  linkedin_url: "LinkedIn",
-  location: "Location",
-};
+/** A detected value, shown muted + dotted when the parser was unsure of it. */
+function FieldValue({ field }: { field: ContactDisplayField }) {
+  if (field.reason === "low_confidence") {
+    return (
+      <span
+        className="text-content-muted underline decoration-dotted underline-offset-2"
+        title="low confidence"
+      >
+        {field.value}
+      </span>
+    );
+  }
+  return <span className="text-content-secondary">{field.value}</span>;
+}
 
-/** Map from ContactDisplayField.key → ContactOverrides key (only the 5 editable ones). */
-const KEY_MAP: Record<string, keyof ContactOverrides> = {
-  full_name: "full_name",
-  email: "email",
-  phone: "phone",
-  linkedin_url: "linkedin_url",
-  location: "location",
-};
+/** Quiet inline marker for a missing required field — not a warning chip. */
+function MissingToken({ label }: { label: string }) {
+  return (
+    <span className="text-content-muted">{label.toLowerCase()} not found</span>
+  );
+}
 
-export function ContactCard({
-  result,
-  overrides,
-  onFieldChange,
-}: ContactCardProps) {
+export function ContactCard({ result }: ContactCardProps) {
   const fields = buildContactFields(result);
-  const editable = overrides !== undefined && onFieldChange !== undefined;
+  const detectedCount = fields.filter((f) => !f.gated).length;
 
-  // Apply in-memory overrides: a non-empty override replaces the parsed value;
-  // an empty string means "user cleared it" → treat as absent.
-  const displayFields = fields.map((field) => {
-    const overrideKey = KEY_MAP[field.key];
-    if (!editable || overrideKey === undefined) return field;
-    const ov = overrides[overrideKey];
-    if (ov === undefined) return field; // no override yet
-    if (ov === "") {
-      // User cleared → show as absent.
-      return { ...field, value: "", gated: true, reason: "absent" as const };
-    }
-    // User set a value → show as detected.
-    return { ...field, value: ov, gated: false, reason: undefined };
-  });
-
-  const detectedCount = displayFields.filter((f) => !f.gated).length;
+  const name = fields.find((f) => f.group === "identity");
+  const contactLine = fields.filter((f) => f.group === "contact");
+  const links = fields.filter((f) => f.group === "link");
 
   return (
-    <Card id="contact" className="scroll-mt-6">
-      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-content-muted">
-        Contact — {detectedCount} of {displayFields.length} detected
+    <Card id="contact" className="scroll-mt-6 text-center">
+      {/* Name heading — the immediate "whose resume" anchor. */}
+      <h2 className="text-lg font-semibold text-content-primary">
+        {name && !name.gated ? (
+          name.value
+        ) : (
+          <span className="font-normal text-content-muted">
+            Name not detected
+          </span>
+        )}
       </h2>
-      <div className="flex flex-wrap gap-2">
-        {displayFields.map((field) => {
-          const overrideKey = KEY_MAP[field.key] as
-            | keyof ContactOverrides
-            | undefined;
 
-          if (!editable || overrideKey === undefined) {
-            // Read-only rendering (no edit hooks provided).
-            return field.gated ? (
-              <Chip key={field.key} tone="warning" icon="⚠">
-                {field.label} not detected
-                {field.reason === "low_confidence" && " (low confidence)"}
-              </Chip>
-            ) : (
-              <Chip key={field.key} tone="success" icon="✓">
-                {field.value}
-              </Chip>
-            );
-          }
-
-          // Editable chip: wraps value in EditableField inside a chip-shaped shell.
-          const fieldLabel = FIELD_LABELS[overrideKey];
-          const currentValue = field.gated ? "" : field.value;
-
-          return (
-            <span
-              key={field.key}
-              className={[
-                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs",
-                field.gated
-                  ? "bg-feedback-warning-bg text-feedback-warning-text"
-                  : "bg-feedback-success-bg text-feedback-success-text",
-              ].join(" ")}
-            >
-              <span aria-hidden="true">{field.gated ? "⚠" : "✓"}</span>
-              <EditableField
-                value={currentValue || undefined}
-                placeholder={`${field.label} not detected`}
-                label={fieldLabel}
-                textSize="xs"
-                onCommit={(v) => onFieldChange(overrideKey, v)}
-              />
+      {/* Contact line: location / email / phone, pipe-joined, present-only. */}
+      {contactLine.length > 0 && (
+        <p className="mt-2 inline-flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+          {contactLine.map((field, i) => (
+            <span key={field.key} className="inline-flex items-center gap-x-2">
+              {i > 0 && <span className="text-content-muted">|</span>}
+              {field.gated && field.reason === "absent" ? (
+                <MissingToken label={field.label} />
+              ) : (
+                <FieldValue field={field} />
+              )}
             </span>
-          );
-        })}
-      </div>
+          ))}
+        </p>
+      )}
+
+      {/* Links line: clickable slugs, middot-separated, license-safe (no logos). */}
+      {links.length > 0 && (
+        <p className="mt-2 inline-flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+          {links.map((field, i) => (
+            <span key={field.key} className="inline-flex items-center gap-x-2">
+              {i > 0 && <span className="text-content-muted">·</span>}
+              {field.gated ? (
+                field.reason === "low_confidence" ? (
+                  <FieldValue field={field} />
+                ) : (
+                  <MissingToken label={field.label} />
+                )
+              ) : (
+                <a
+                  href={field.value}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-brand-amber hover:underline"
+                >
+                  {formatLinkDisplay(field.value)}
+                </a>
+              )}
+            </span>
+          ))}
+        </p>
+      )}
+
+      {/* Subtle audit footer — the parser-audit signal, made unobtrusive. */}
+      <p className="mt-3 text-xs text-content-muted">
+        {detectedCount} of {fields.length} fields detected
+      </p>
     </Card>
   );
 }

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -661,9 +661,10 @@ export function ReconstructedResume({
   const achievementsAbove =
     parsed.achievements_placement === "above_experience";
 
+  // Contact overrides remain owned by the edit hook (they still feed re-scoring
+  // in App), but the ContactCard is display-only as of #146 — inline contact
+  // edit is deferred to a follow-up, so it no longer receives edit props.
   const {
-    contactOverrides,
-    setContactField,
     experienceOverrides,
     setExperienceField,
     bulletOverrides,
@@ -772,11 +773,7 @@ export function ReconstructedResume({
         {bullets.length > 0 && <RollupStrip bullets={bullets} />}
       </div>
 
-      <ContactCard
-        result={result}
-        overrides={contactOverrides}
-        onFieldChange={(key, value) => setContactField(key, value)}
-      />
+      <ContactCard result={result} />
       {achievementsAbove && achievementsSection}
       <ExperienceSection
         groups={experienceRenderGroups}

--- a/src/lib/contact.test.ts
+++ b/src/lib/contact.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildContactFields,
+  formatLinkDisplay,
   CONTACT_DISPLAY_CONFIDENCE_FLOOR,
 } from "./contact.ts";
 import type { CascadeResult } from "./heuristics/types.ts";
@@ -81,7 +82,7 @@ describe("buildContactFields", () => {
     expect(nameField.reason).toBeUndefined();
   });
 
-  it("gates a field with reason=low_confidence when value exists but confidence is below the floor", () => {
+  it("gates a low-confidence field but retains its value for subtle display (#146)", () => {
     const conf = CONTACT_DISPLAY_CONFIDENCE_FLOOR - 0.01;
     const fields = buildContactFields(
       makeCascade({ email: "jane@example.com" }, { email: conf }),
@@ -89,7 +90,9 @@ describe("buildContactFields", () => {
     const emailField = fields.find((f) => f.key === "email")!;
     expect(emailField.gated).toBe(true);
     expect(emailField.reason).toBe("low_confidence");
-    expect(emailField.value).toBe("");
+    // Retained (not blanked) so the card can render it dotted/muted; `gated`
+    // still keeps it out of the detected count and score-facing consumers.
+    expect(emailField.value).toBe("jane@example.com");
   });
 
   it("gates a field with reason=absent when no value is present", () => {
@@ -130,5 +133,57 @@ describe("buildContactFields", () => {
       "https://github.com/jane",
       "San Francisco, CA",
     ]);
+  });
+
+  it("tags each row with its visual group (#146)", () => {
+    const fields = buildContactFields(makeCascade());
+    const byKey = Object.fromEntries(fields.map((f) => [f.key, f.group]));
+    expect(byKey.full_name).toBe("identity");
+    expect(byKey.email).toBe("contact");
+    expect(byKey.phone).toBe("contact");
+    expect(byKey.location).toBe("contact");
+    expect(byKey.linkedin_url).toBe("link");
+  });
+
+  it("includes portfolio and website link rows only when confidently detected (#146)", () => {
+    const fields = buildContactFields(
+      makeCascade(
+        {
+          portfolio_url: "https://jane.dev",
+          website_url: "https://janedoe.com",
+        },
+        { portfolio_url: 0.9, website_url: 0.9 },
+      ),
+    );
+    const portfolio = fields.find((f) => f.key === "portfolio_url");
+    const website = fields.find((f) => f.key === "website_url");
+    expect(portfolio?.group).toBe("link");
+    expect(portfolio?.gated).toBe(false);
+    expect(website?.gated).toBe(false);
+    // Absent by default — no gap, no penalty.
+    expect(buildContactFields(makeCascade()).some((f) => f.key === "portfolio_url")).toBe(false);
+    expect(buildContactFields(makeCascade()).some((f) => f.key === "website_url")).toBe(false);
+  });
+});
+
+describe("formatLinkDisplay", () => {
+  it("collapses a LinkedIn profile to in/<slug>", () => {
+    expect(formatLinkDisplay("https://www.linkedin.com/in/jane-doe")).toBe(
+      "in/jane-doe",
+    );
+    expect(formatLinkDisplay("https://linkedin.com/in/jane-doe/")).toBe(
+      "in/jane-doe",
+    );
+  });
+
+  it("collapses a GitHub profile to gh/<slug>", () => {
+    expect(formatLinkDisplay("https://github.com/javery")).toBe("gh/javery");
+  });
+
+  it("falls back to the stripped host+path for other links", () => {
+    expect(formatLinkDisplay("https://www.jane.dev/")).toBe("jane.dev");
+    expect(formatLinkDisplay("http://janedoe.com/portfolio")).toBe(
+      "janedoe.com/portfolio",
+    );
   });
 });

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -13,12 +13,22 @@ import type { CascadeResult } from "./heuristics/types.ts";
 
 export const CONTACT_DISPLAY_CONFIDENCE_FLOOR = 0.5;
 
+/** Which visual row of the centered card a field belongs to (#146): `identity`
+ *  is the name heading, `contact` is the pipe-joined location/email/phone line,
+ *  `link` is the slug links line. */
+export type ContactGroup = "identity" | "contact" | "link";
+
 export interface ContactDisplayField {
   key: string;
   label: string;
-  /** The displayable value. Empty string when `gated` is true. */
+  /** Which row of the visual card this field renders into (#146). */
+  group: ContactGroup;
+  /** The displayable value. Empty string when absent; for a low-confidence
+   *  field the parsed value is retained (so the card can show it subtly) even
+   *  though `gated` is true. */
   value: string;
-  /** True when the field should not be displayed (absent or low confidence). */
+  /** True when the field should not count toward the detected total (absent or
+   *  below the confidence floor). */
   gated: boolean;
   /** Present only when `gated` is true. */
   reason?: "absent" | "low_confidence";
@@ -27,19 +37,22 @@ export interface ContactDisplayField {
 const CONTACT_ROWS: readonly {
   key: keyof typeof FIELD_KEYS;
   label: string;
+  group: ContactGroup;
   /** Optional rows surface only when actually detected. Not every candidate
-   *  keeps a GitHub profile, so its absence is not a gap — an optional row
-   *  never renders a "not detected" chip nor counts against the detected/total
-   *  ratio. Required rows (the rest) always render so the reader can spot a
-   *  missing email/phone/etc. at a glance. */
+   *  keeps a GitHub/portfolio/personal-site link, so its absence is not a gap —
+   *  an optional row never renders a "not detected" marker nor counts against
+   *  the detected/total ratio. Required rows (the rest) always render so the
+   *  reader can spot a missing email/phone/etc. at a glance. */
   optional?: boolean;
 }[] = [
-  { key: "full_name", label: "Name" },
-  { key: "email", label: "Email" },
-  { key: "phone", label: "Phone" },
-  { key: "linkedin_url", label: "LinkedIn" },
-  { key: "github_url", label: "GitHub", optional: true },
-  { key: "location", label: "Location" },
+  { key: "full_name", label: "Name", group: "identity" },
+  { key: "email", label: "Email", group: "contact" },
+  { key: "phone", label: "Phone", group: "contact" },
+  { key: "linkedin_url", label: "LinkedIn", group: "link" },
+  { key: "github_url", label: "GitHub", group: "link", optional: true },
+  { key: "portfolio_url", label: "Portfolio", group: "link", optional: true },
+  { key: "website_url", label: "Website", group: "link", optional: true },
+  { key: "location", label: "Location", group: "contact" },
 ];
 
 // TypeScript trick: enumerate the valid keys for indexing `parsed`.
@@ -49,23 +62,27 @@ const FIELD_KEYS = {
   phone: true,
   linkedin_url: true,
   github_url: true,
+  portfolio_url: true,
+  website_url: true,
   location: true,
 } as const;
 
 /**
  * Build the ordered contact display rows from a `CascadeResult`.
  *
- * Returns the required rows in order — Name, Email, Phone, LinkedIn, Location —
- * each always present (and `gated` when absent / below
- * `CONTACT_DISPLAY_CONFIDENCE_FLOOR`). Optional rows (GitHub) are included only
- * when confidently detected, so a candidate without a GitHub profile sees no
- * "GitHub not detected" gap and no penalty in the detected/total ratio.
+ * Returns the required rows — Name, Email, Phone, LinkedIn, Location — each
+ * always present (and `gated` when absent / below
+ * `CONTACT_DISPLAY_CONFIDENCE_FLOOR`). Optional link rows (GitHub, Portfolio,
+ * Website) are included only when confidently detected, so a candidate without
+ * those profiles sees no gap and no penalty in the detected/total ratio. Each
+ * row carries a `group` (`identity` | `contact` | `link`) so the visual card
+ * (#146) can partition them into its name heading, contact line, and links line.
  */
 export function buildContactFields(
   cascade: Pick<CascadeResult, "parsed" | "fieldConfidence">,
 ): ContactDisplayField[] {
   const rows: ContactDisplayField[] = [];
-  for (const { key, label, optional } of CONTACT_ROWS) {
+  for (const { key, label, group, optional } of CONTACT_ROWS) {
     const raw = cascade.parsed[key as keyof typeof FIELD_KEYS];
     const value = typeof raw === "string" ? raw : "";
     const conf = cascade.fieldConfidence[key as keyof typeof FIELD_KEYS] ?? 0;
@@ -75,12 +92,36 @@ export function buildContactFields(
     if (optional && !detected) continue;
 
     if (!value) {
-      rows.push({ key, label, value: "", gated: true, reason: "absent" });
+      rows.push({ key, label, group, value: "", gated: true, reason: "absent" });
     } else if (conf < CONTACT_DISPLAY_CONFIDENCE_FLOOR) {
-      rows.push({ key, label, value: "", gated: true, reason: "low_confidence" });
+      // Retain the parsed value so the card can render it with a subtle
+      // low-confidence treatment (#146); `gated` still keeps it out of the
+      // detected count and the score-facing consumers (which check `gated`).
+      rows.push({ key, label, group, value, gated: true, reason: "low_confidence" });
     } else {
-      rows.push({ key, label, value, gated: false });
+      rows.push({ key, label, group, value, gated: false });
     }
   }
   return rows;
+}
+
+/**
+ * Shorten a link URL to a compact, human-readable slug for the card's links
+ * line (#146). Strips the protocol, a leading `www.`, and any trailing slash,
+ * then collapses the two common profile hosts to a host-relative form:
+ * `linkedin.com/in/<slug>` → `in/<slug>`, `github.com/<slug>` → `gh/<slug>`.
+ * Anything else (portfolio / personal site) falls back to the stripped
+ * host+path, which stays unambiguous. The original URL remains the `href`.
+ */
+export function formatLinkDisplay(url: string): string {
+  const stripped = url
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+  const linkedin = stripped.match(/^linkedin\.com\/in\/(.+)$/i);
+  if (linkedin) return `in/${linkedin[1]}`;
+  const github = stripped.match(/^github\.com\/(.+)$/i);
+  if (github) return `gh/${github[1]}`;
+  return stripped;
 }


### PR DESCRIPTION
## Summary

Evolves `ContactCard` from a flat chip strip into a compact, **centered visual contact card** that doubles as a preview of the future regenerated-PDF header — while keeping resumelint's parser-audit value (detection gaps stay visible, just quiet instead of loud). Display-only; inline editing is deferred to #147.

- **`src/lib/contact.ts`** — extend the existing data helper (no new component): tag each row with a `group` (`identity`|`contact`|`link`), add optional `portfolio_url`/`website_url` link rows (gated like GitHub), retain low-confidence values for subtle display (still `gated`, so score-facing consumers are unaffected), and add a `formatLinkDisplay` slug helper (`linkedin.com/in/x → in/x`, `github.com/x → gh/x`, else stripped host+path).
- **`src/components/features/ContactCard.tsx`** — centered stack inside the same `<Card id="contact">`: name heading (muted "Name not detected" when absent), pipe-joined present-only contact line with quiet "not found" tokens for missing required fields (no warning chips), middot-separated clickable **text-slug** links (license-safe, **no brand logos**), dotted underline + tooltip for low-confidence values, and a muted "N of M fields detected" footer.
- **`src/components/features/ReconstructedResume.tsx`** — drop the now-unused `overrides`/`onFieldChange` props; the contact-override scoring plumbing stays in App, dormant until #147 re-wires editing.

Link glyphs: went with **text slugs only** since the design system ships no sanctioned icon source — matches the issue's explicit license-safe text-slug fallback and avoids adopting brand logos.

Closes #146

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (911 passed; corpus snapshots unaffected — UI-only, no scoring change)
- [x] `eslint` on changed files clean (no raw `<button>`/hex/palette classes)
- [ ] Manually verified in `npm run dev` (centered layout, slug links, quiet gap tokens)