### PR TITLE
feat(contact): re-wire inline editing into centered ContactCard (#147)

### DIFF
--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -8,7 +8,7 @@
  * (grouping, gating, slug formatting) is covered in `src/lib/contact.test.ts`;
  * this file covers the React surface — that each `group`/`gated`/`reason`
  * combination paints the right DOM: name heading vs. muted fallback, the
- * pipe-joined contact line with quiet "not found" tokens, low-confidence dotted
+ * pipe-joined contact line with discernible "not detected" tokens, low-confidence dotted
  * values, clickable slug links, and the audit footer.
  *
  * Runs in jsdom (per the `@vitest-environment jsdom` pragma) so React +
@@ -45,12 +45,18 @@ function makeResult(
 let container: HTMLDivElement | undefined;
 let root: Root | undefined;
 
-function render(result: CascadeResult): HTMLDivElement {
+function render(
+  result: CascadeResult,
+  editProps?: Pick<
+    Parameters<typeof ContactCard>[0],
+    "overrides" | "onFieldChange"
+  >,
+): HTMLDivElement {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root!.render(createElement(ContactCard, { result }));
+    root!.render(createElement(ContactCard, { result, ...editProps }));
   });
   return container;
 }
@@ -76,14 +82,15 @@ describe("ContactCard", () => {
     expect(el.querySelector("h2")?.textContent).toBe("Name not detected");
   });
 
-  it("renders present contact values and a quiet 'not found' token for a missing required field", () => {
+  it("renders present contact values and a discernible 'not detected' token for a missing required field", () => {
     const el = render(
       makeResult({ email: "jane@example.com" }, { email: 0.95 }),
     );
     const text = el.textContent ?? "";
     expect(text).toContain("jane@example.com");
-    // Phone is required but absent → quiet inline token, not a warning chip.
-    expect(text).toContain("phone not found");
+    // Phone is required but absent → discernible warning token (set apart so the
+    // gap is spotted at a glance), not a loud chip.
+    expect(text).toContain("Phone not detected");
   });
 
   it("marks a low-confidence value with a dotted underline + tooltip", () => {
@@ -109,7 +116,51 @@ describe("ContactCard", () => {
     );
     expect(anchor?.getAttribute("target")).toBe("_blank");
     expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(anchor?.textContent).toBe("in/jane-doe");
+    expect(anchor?.textContent).toBe("linkedin.com/in/jane-doe");
+  });
+
+  it("gives a present LinkedIn a navigate-and-edit dual affordance when editable", () => {
+    const el = render(
+      makeResult(
+        { linkedin_url: "https://www.linkedin.com/in/jane-doe" },
+        { linkedin_url: 0.9 },
+      ),
+      { overrides: {}, onFieldChange: () => {} },
+    );
+    // Slug is the click-to-edit target (operates on the full URL)…
+    const edit = el.querySelector('[aria-label="Edit LinkedIn"]');
+    expect(edit?.textContent).toBe("linkedin.com/in/jane-doe");
+    // …and a separate ↗ anchor still opens the real URL in a new tab.
+    const open = el.querySelector('a[aria-label="Open LinkedIn in a new tab"]');
+    expect(open?.getAttribute("href")).toBe(
+      "https://www.linkedin.com/in/jane-doe",
+    );
+    expect(open?.getAttribute("target")).toBe("_blank");
+  });
+
+  it("makes a detected github link editable with the dual affordance", () => {
+    const el = render(
+      makeResult(
+        { github_url: "https://github.com/janedoe" },
+        { github_url: 0.9 },
+      ),
+      { overrides: {}, onFieldChange: () => {} },
+    );
+    expect(el.querySelector('[aria-label="Edit GitHub"]')?.textContent).toBe(
+      "github.com/janedoe",
+    );
+    expect(
+      el.querySelector('a[aria-label="Open GitHub in a new tab"]'),
+    ).not.toBeNull();
+  });
+
+  it("keeps a missing required field discernible even while editable", () => {
+    const el = render(
+      makeResult({ email: "jane@example.com" }, { email: 0.95 }),
+      { overrides: {}, onFieldChange: () => {} },
+    );
+    expect(el.textContent).toContain("Phone not detected");
+    expect(el.querySelector('[aria-label="Edit Phone"]')).not.toBeNull();
   });
 
   it("renders the audit footer with the detected/total ratio", () => {

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -2,74 +2,85 @@
 // Copyright 2026 The resumelint Authors
 
 /**
- * ContactCard — a centered visual contact card (#146).
- *
- * Evolves the old chip strip into a compact, centered stack that doubles as a
- * preview of the future regenerated-PDF header while keeping resumelint's
- * parser-audit value: detection gaps stay visible, just quiet instead of loud.
+ * ContactCard — a centered visual contact card (#146) with optional inline
+ * editing (#147).
  *
  *   Name                       ← card heading (largest, semibold)
  *   location · email · phone   ← pipe-joined contact line, present-only
  *   in/slug   ·   gh/slug      ← links line, glyph-free clickable slugs
  *   N of M fields detected     ← muted audit footer
  *
- * A missing *required* field shows a quiet muted token ("phone not found")
- * rather than a warning chip; a missing *optional* link renders nothing. A
- * low-confidence field shows its value with a dotted underline + tooltip.
+ * This component owns the card chrome, the name heading, and the audit footer;
+ * the per-segment contact/links rendering (and its inline-edit affordances)
+ * lives in `ContactDetails` so the card stays within the ~200 LOC budget.
  *
- * Display-only: inline editing of contact fields is deferred to a follow-up
- * issue, so this version takes no edit props and renders purely from `result`.
- * Gating still flows through `buildContactFields` + the confidence floor — no
- * second copy of that logic lives here.
+ * Editing (#147): when BOTH `overrides` and `onFieldChange` are provided, the
+ * five editable fields (`full_name`, `email`, `phone`, `linkedin_url`,
+ * `location`) become inline-editable in place via the shared `EditableField`
+ * primitive. When the props are absent the card is pure display (#146 behavior,
+ * unchanged). Override state, clear-to-absent, and score re-eval flow through the
+ * existing `useEditableParse` plumbing — unchanged. Gating still flows through
+ * `buildContactFields` + the confidence floor — no second copy of that logic.
  */
 
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
-import {
-  buildContactFields,
-  formatLinkDisplay,
-  type ContactDisplayField,
-} from "../../lib/contact.ts";
-import { Card } from "@design-system";
+import { buildContactFields, type ContactDisplayField } from "../../lib/contact.ts";
+import { Card, EditableField } from "@design-system";
+import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
+import { ContactDetails, EDITABLE_KEYS } from "./ContactDetails.tsx";
 
 interface ContactCardProps {
   result: CascadeResult;
+  /** In-memory overrides for the editable contact fields. When provided
+   *  together with `onFieldChange`, the card becomes inline-editable (#147). */
+  overrides?: ContactOverrides;
+  /** Called when the user commits an edit on a contact field. */
+  onFieldChange?: (key: keyof ContactOverrides, newValue: string) => void;
 }
 
-/** A detected value, shown muted + dotted when the parser was unsure of it. */
-function FieldValue({ field }: { field: ContactDisplayField }) {
-  if (field.reason === "low_confidence") {
-    return (
-      <span
-        className="text-content-muted underline decoration-dotted underline-offset-2"
-        title="low confidence"
-      >
-        {field.value}
-      </span>
-    );
-  }
-  return <span className="text-content-secondary">{field.value}</span>;
-}
-
-/** Quiet inline marker for a missing required field — not a warning chip. */
-function MissingToken({ label }: { label: string }) {
-  return (
-    <span className="text-content-muted">{label.toLowerCase()} not found</span>
-  );
-}
-
-export function ContactCard({ result }: ContactCardProps) {
+export function ContactCard({
+  result,
+  overrides,
+  onFieldChange,
+}: ContactCardProps) {
   const fields = buildContactFields(result);
-  const detectedCount = fields.filter((f) => !f.gated).length;
+  const editable = overrides !== undefined && onFieldChange !== undefined;
 
-  const name = fields.find((f) => f.group === "identity");
-  const contactLine = fields.filter((f) => f.group === "contact");
-  const links = fields.filter((f) => f.group === "link");
+  // Apply in-memory overrides onto the editable fields: a non-empty override
+  // replaces the parsed value (becomes detected); an empty string means the
+  // user cleared it → revert to the gated "not found" state. Mirrors the
+  // pre-#146 behavior; non-editable fields pass through untouched.
+  const displayFields = fields.map((field): ContactDisplayField => {
+    const ovKey = EDITABLE_KEYS[field.key];
+    if (!editable || ovKey === undefined) return field;
+    const ov = overrides[ovKey];
+    if (ov === undefined) return field;
+    if (ov === "") return { ...field, value: "", gated: true, reason: "absent" };
+    return { ...field, value: ov, gated: false, reason: undefined };
+  });
+
+  const detectedCount = displayFields.filter((f) => !f.gated).length;
+  const name = displayFields.find((f) => f.group === "identity");
+  const contactLine = displayFields.filter((f) => f.group === "contact");
+  const links = displayFields.filter((f) => f.group === "link");
+
+  const commit = (key: keyof ContactOverrides, v: string) =>
+    onFieldChange?.(key, v);
 
   return (
     <Card id="contact" className="scroll-mt-6 text-center">
       {/* Name heading — the immediate "whose resume" anchor. */}
       <h2 className="text-lg font-semibold text-content-primary">
-        {name && !name.gated ? (
+        {editable ? (
+          <EditableField
+            value={name && !name.gated ? name.value : undefined}
+            placeholder="Name not detected"
+            label="Name"
+            textSize="lg"
+            textWeight="semibold"
+            onCommit={(v) => commit("full_name", v)}
+          />
+        ) : name && !name.gated ? (
           name.value
         ) : (
           <span className="font-normal text-content-muted">
@@ -78,52 +89,16 @@ export function ContactCard({ result }: ContactCardProps) {
         )}
       </h2>
 
-      {/* Contact line: location / email / phone, pipe-joined, present-only. */}
-      {contactLine.length > 0 && (
-        <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
-          {contactLine.map((field, i) => (
-            <span key={field.key} className="inline-flex items-center gap-x-2">
-              {i > 0 && <span className="text-content-muted">|</span>}
-              {field.gated && field.reason === "absent" ? (
-                <MissingToken label={field.label} />
-              ) : (
-                <FieldValue field={field} />
-              )}
-            </span>
-          ))}
-        </p>
-      )}
-
-      {/* Links line: clickable slugs, middot-separated, license-safe (no logos). */}
-      {links.length > 0 && (
-        <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
-          {links.map((field, i) => (
-            <span key={field.key} className="inline-flex items-center gap-x-2">
-              {i > 0 && <span className="text-content-muted">·</span>}
-              {field.gated ? (
-                field.reason === "low_confidence" ? (
-                  <FieldValue field={field} />
-                ) : (
-                  <MissingToken label={field.label} />
-                )
-              ) : (
-                <a
-                  href={field.value}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-brand-amber hover:underline"
-                >
-                  {formatLinkDisplay(field.value)}
-                </a>
-              )}
-            </span>
-          ))}
-        </p>
-      )}
+      <ContactDetails
+        contactLine={contactLine}
+        links={links}
+        editable={editable}
+        commit={commit}
+      />
 
       {/* Subtle audit footer — the parser-audit signal, made unobtrusive. */}
       <p className="mt-3 text-xs text-content-muted">
-        {detectedCount} of {fields.length} fields detected
+        {detectedCount} of {displayFields.length} fields detected
       </p>
     </Card>
   );

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ContactDetails — the contact line and links line of the centered ContactCard.
+ *
+ * Split out of `ContactCard` (#147) once the card crossed the ~200 LOC limit:
+ * this owns the per-segment rendering — including the inline-edit affordances —
+ * while `ContactCard` stays the owner of the card chrome, the name heading, and
+ * the audit footer.
+ *
+ *   location · email · phone   ← contact line (pipe-joined, present-only)
+ *   in/slug   ·   gh/slug      ← links line (glyph-free clickable slugs)
+ *
+ * When `editable` is set, the editable fields (email/phone/location on the
+ * contact line, LinkedIn on the links line) render via the shared
+ * `EditableField` primitive; LinkedIn edits the full URL but displays the
+ * derived slug. Otherwise everything is display-only (#146 behavior).
+ */
+
+import { formatLinkDisplay, type ContactDisplayField } from "../../lib/contact.ts";
+import { EditableField } from "@design-system";
+import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
+
+/** The five inline-editable fields, mapped 1:1 to their `ContactOverrides` key.
+ *  Fields absent from this map (github/portfolio/website) stay display-only. */
+export const EDITABLE_KEYS: Record<string, keyof ContactOverrides> = {
+  full_name: "full_name",
+  email: "email",
+  phone: "phone",
+  linkedin_url: "linkedin_url",
+  location: "location",
+};
+
+type Commit = (key: keyof ContactOverrides, v: string) => void;
+
+interface ContactDetailsProps {
+  contactLine: ContactDisplayField[];
+  links: ContactDisplayField[];
+  editable: boolean;
+  commit: Commit;
+}
+
+export function ContactDetails({
+  contactLine,
+  links,
+  editable,
+  commit,
+}: ContactDetailsProps) {
+  return (
+    <>
+      {/* Contact line: location / email / phone, pipe-joined, present-only. */}
+      {contactLine.length > 0 && (
+        <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+          {contactLine.map((field, i) => (
+            <span key={field.key} className="inline-flex items-center gap-x-2">
+              {i > 0 && <span className="text-content-muted">|</span>}
+              {renderContactValue(field, editable, commit)}
+            </span>
+          ))}
+        </p>
+      )}
+
+      {/* Links line: clickable slugs, middot-separated, license-safe (no logos). */}
+      {links.length > 0 && (
+        <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+          {links.map((field, i) => (
+            <span key={field.key} className="inline-flex items-center gap-x-2">
+              {i > 0 && <span className="text-content-muted">·</span>}
+              {renderLink(field, editable, commit)}
+            </span>
+          ))}
+        </p>
+      )}
+    </>
+  );
+}
+
+/** A detected value, shown muted + dotted when the parser was unsure of it. */
+function FieldValue({ field }: { field: ContactDisplayField }) {
+  if (field.reason === "low_confidence") {
+    return (
+      <span
+        className="text-content-muted underline decoration-dotted underline-offset-2"
+        title="low confidence"
+      >
+        {field.value}
+      </span>
+    );
+  }
+  return <span className="text-content-secondary">{field.value}</span>;
+}
+
+/** Quiet inline marker for a missing required field — not a warning chip. */
+function MissingToken({ label }: { label: string }) {
+  return (
+    <span className="text-content-muted">{label.toLowerCase()} not found</span>
+  );
+}
+
+/** Render one contact-line segment — an inline editor when editable, else the
+ *  detected value or a quiet "not found" token. Low-confidence values are kept
+ *  (and editable) so the user can confirm/correct them. */
+function renderContactValue(
+  field: ContactDisplayField,
+  editable: boolean,
+  commit: Commit,
+) {
+  const ovKey = EDITABLE_KEYS[field.key];
+  if (editable && ovKey !== undefined) {
+    return (
+      <EditableField
+        value={field.value || undefined}
+        placeholder={`${field.label.toLowerCase()} not found`}
+        label={field.label}
+        textSize="sm"
+        onCommit={(v) => commit(ovKey, v)}
+      />
+    );
+  }
+  return field.gated && field.reason === "absent" ? (
+    <MissingToken label={field.label} />
+  ) : (
+    <FieldValue field={field} />
+  );
+}
+
+/** Render one links-line entry. LinkedIn is editable (edits the full URL, shows
+ *  the derived slug); the rest stay display-only clickable slugs. */
+function renderLink(
+  field: ContactDisplayField,
+  editable: boolean,
+  commit: Commit,
+) {
+  if (editable && field.key === "linkedin_url") {
+    return (
+      <EditableField
+        value={field.value || undefined}
+        displayValue={field.value ? formatLinkDisplay(field.value) : undefined}
+        placeholder="linkedin not found"
+        label="LinkedIn"
+        textSize="sm"
+        onCommit={(v) => commit("linkedin_url", v)}
+      />
+    );
+  }
+  if (field.gated) {
+    return field.reason === "low_confidence" ? (
+      <FieldValue field={field} />
+    ) : (
+      <MissingToken label={field.label} />
+    );
+  }
+  return (
+    <a
+      href={field.value}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-brand-amber hover:underline"
+    >
+      {formatLinkDisplay(field.value)}
+    </a>
+  );
+}

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -22,14 +22,19 @@ import { formatLinkDisplay, type ContactDisplayField } from "../../lib/contact.t
 import { EditableField } from "@design-system";
 import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
 
-/** The five inline-editable fields, mapped 1:1 to their `ContactOverrides` key.
- *  Fields absent from this map (github/portfolio/website) stay display-only. */
+/** The inline-editable contact fields, mapped 1:1 to their `ContactOverrides`
+ *  key. Includes the link fields — a detected GitHub/portfolio/website URL is
+ *  editable too (only optional links that the parser actually found render, so
+ *  there is nothing to edit when absent). */
 export const EDITABLE_KEYS: Record<string, keyof ContactOverrides> = {
   full_name: "full_name",
   email: "email",
   phone: "phone",
   linkedin_url: "linkedin_url",
   location: "location",
+  github_url: "github_url",
+  portfolio_url: "portfolio_url",
+  website_url: "website_url",
 };
 
 type Commit = (key: keyof ContactOverrides, v: string) => void;
@@ -91,16 +96,70 @@ function FieldValue({ field }: { field: ContactDisplayField }) {
   return <span className="text-content-secondary">{field.value}</span>;
 }
 
-/** Quiet inline marker for a missing required field — not a warning chip. */
+/** Discernible warning token for a missing required field — a quiet pill, not a
+ *  loud chip, but clearly set apart from the present values around it so the gap
+ *  is spotted at a glance (restores the pre-#146 yellowish affordance). */
 function MissingToken({ label }: { label: string }) {
   return (
-    <span className="text-content-muted">{label.toLowerCase()} not found</span>
+    <span className="inline-flex items-center gap-1 rounded-full bg-feedback-warning-bg px-2 py-0.5 text-xs text-feedback-warning-text">
+      <span aria-hidden="true">⚠</span>
+      {label} not detected
+    </span>
   );
 }
 
+/** An inline editor for one field, wrapped in a state-tinted shell so a missing
+ *  required field stays discernible (warning pill) and a low-confidence value
+ *  keeps its dotted treatment — both still editable. */
+function EditableValue({
+  field,
+  ovKey,
+  commit,
+  displayValue,
+}: {
+  field: ContactDisplayField;
+  ovKey: keyof ContactOverrides;
+  commit: Commit;
+  displayValue?: string;
+}) {
+  const absent = field.gated && field.reason === "absent";
+  const lowConfidence = field.gated && field.reason === "low_confidence";
+
+  const editor = (
+    <EditableField
+      value={field.value || undefined}
+      displayValue={displayValue}
+      placeholder={`${field.label} not detected`}
+      label={field.label}
+      textSize="sm"
+      onCommit={(v) => commit(ovKey, v)}
+    />
+  );
+
+  if (absent) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-feedback-warning-bg px-2 py-0.5 text-xs text-feedback-warning-text">
+        <span aria-hidden="true">⚠</span>
+        {editor}
+      </span>
+    );
+  }
+  if (lowConfidence) {
+    return (
+      <span
+        className="underline decoration-dotted underline-offset-2"
+        title="low confidence"
+      >
+        {editor}
+      </span>
+    );
+  }
+  return editor;
+}
+
 /** Render one contact-line segment — an inline editor when editable, else the
- *  detected value or a quiet "not found" token. Low-confidence values are kept
- *  (and editable) so the user can confirm/correct them. */
+ *  detected value or a discernible "not detected" token. Low-confidence values
+ *  are kept (and editable) so the user can confirm/correct them. */
 function renderContactValue(
   field: ContactDisplayField,
   editable: boolean,
@@ -108,15 +167,7 @@ function renderContactValue(
 ) {
   const ovKey = EDITABLE_KEYS[field.key];
   if (editable && ovKey !== undefined) {
-    return (
-      <EditableField
-        value={field.value || undefined}
-        placeholder={`${field.label.toLowerCase()} not found`}
-        label={field.label}
-        textSize="sm"
-        onCommit={(v) => commit(ovKey, v)}
-      />
-    );
+    return <EditableValue field={field} ovKey={ovKey} commit={commit} />;
   }
   return field.gated && field.reason === "absent" ? (
     <MissingToken label={field.label} />
@@ -125,24 +176,40 @@ function renderContactValue(
   );
 }
 
-/** Render one links-line entry. LinkedIn is editable (edits the full URL, shows
- *  the derived slug); the rest stay display-only clickable slugs. */
+/** Render one links-line entry. When editable, a present link gets a
+ *  navigate-AND-edit dual affordance — the slug edits the full URL in place, a
+ *  small `↗` opens it in a new tab — so editing no longer costs the click-
+ *  through. A missing (required) link is an editable warning token (add in
+ *  place). Without editing, every link is a display-only clickable slug. */
 function renderLink(
   field: ContactDisplayField,
   editable: boolean,
   commit: Commit,
 ) {
-  if (editable && field.key === "linkedin_url") {
-    return (
-      <EditableField
-        value={field.value || undefined}
-        displayValue={field.value ? formatLinkDisplay(field.value) : undefined}
-        placeholder="linkedin not found"
-        label="LinkedIn"
-        textSize="sm"
-        onCommit={(v) => commit("linkedin_url", v)}
-      />
-    );
+  const ovKey = EDITABLE_KEYS[field.key];
+  if (editable && ovKey !== undefined) {
+    if (!field.gated) {
+      return (
+        <span className="inline-flex items-center gap-1">
+          <EditableValue
+            field={field}
+            ovKey={ovKey}
+            commit={commit}
+            displayValue={formatLinkDisplay(field.value)}
+          />
+          <a
+            href={field.value}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-amber hover:underline"
+            aria-label={`Open ${field.label} in a new tab`}
+          >
+            ↗
+          </a>
+        </span>
+      );
+    }
+    return <EditableValue field={field} ovKey={ovKey} commit={commit} />;
   }
   if (field.gated) {
     return field.reason === "low_confidence" ? (

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -661,10 +661,9 @@ export function ReconstructedResume({
   const achievementsAbove =
     parsed.achievements_placement === "above_experience";
 
-  // Contact overrides remain owned by the edit hook (they still feed re-scoring
-  // in App), but the ContactCard is display-only as of #146 — inline contact
-  // edit is deferred to a follow-up, so it no longer receives edit props.
   const {
+    contactOverrides,
+    setContactField,
     experienceOverrides,
     setExperienceField,
     bulletOverrides,
@@ -773,7 +772,11 @@ export function ReconstructedResume({
         {bullets.length > 0 && <RollupStrip bullets={bullets} />}
       </div>
 
-      <ContactCard result={result} />
+      <ContactCard
+        result={result}
+        overrides={contactOverrides}
+        onFieldChange={(key, value) => setContactField(key, value)}
+      />
       {achievementsAbove && achievementsSection}
       <ExperienceSection
         groups={experienceRenderGroups}

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -46,12 +46,19 @@ interface EditableFieldProps {
   placeholder?: string;
   label: string;
   onCommit: (newValue: string) => void;
+  /**
+   * Read-mode display override (ADDITIVE, opt-in). When set, read mode shows
+   * this instead of `value`, while edit mode still seeds and commits the raw
+   * `value`. Lets a field display a derived form (e.g. a LinkedIn slug) yet edit
+   * the underlying URL. Omitting it preserves the original behavior exactly.
+   */
+  displayValue?: string;
   /** Extra classes on the root wrapper. */
   className?: string;
   /** Visual weight of the read-mode text. Defaults to "normal". */
   textWeight?: "normal" | "semibold";
   /** Text size of the read-mode text. Defaults to "sm". */
-  textSize?: "xs" | "sm" | "base";
+  textSize?: "xs" | "sm" | "base" | "lg";
   /**
    * Read-mode root box model:
    *   flex   — `inline-flex` atom; value + pencil stay on one line, the box
@@ -85,6 +92,7 @@ export function EditableField({
   placeholder = "not detected",
   label,
   onCommit,
+  displayValue,
   className,
   textWeight = "normal",
   textSize = "sm",
@@ -130,7 +138,13 @@ export function EditableField({
   const weightCls =
     textWeight === "semibold" ? "font-semibold" : "font-normal";
   const sizeCls =
-    textSize === "xs" ? "text-xs" : textSize === "base" ? "text-base" : "text-sm";
+    textSize === "xs"
+      ? "text-xs"
+      : textSize === "lg"
+        ? "text-lg"
+        : textSize === "base"
+          ? "text-base"
+          : "text-sm";
 
   // ── Multiline edit mode ───────────────────────────────────────────────────
 
@@ -266,7 +280,7 @@ export function EditableField({
         .filter(Boolean)
         .join(" ")}
     >
-      {hasValue ? value : placeholder}
+      {hasValue ? (displayValue ?? value) : placeholder}
     </span>
   );
 }

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -32,6 +32,12 @@ export interface ContactOverrides {
   phone?: string;
   linkedin_url?: string;
   location?: string;
+  /** Link fields are editable too: a detected GitHub/portfolio/personal-site URL
+   *  can be corrected in place. They only surface for editing when the parser
+   *  detected them (optional rows render only when present). */
+  github_url?: string;
+  portfolio_url?: string;
+  website_url?: string;
 }
 
 // ── Experience overrides ──────────────────────────────────────────────────────

--- a/src/lib/contact.test.ts
+++ b/src/lib/contact.test.ts
@@ -167,20 +167,22 @@ describe("buildContactFields", () => {
 });
 
 describe("formatLinkDisplay", () => {
-  it("collapses a LinkedIn profile to in/<slug>", () => {
+  it("keeps the host+path for a LinkedIn profile (protocol/www/slash stripped)", () => {
     expect(formatLinkDisplay("https://www.linkedin.com/in/jane-doe")).toBe(
-      "in/jane-doe",
+      "linkedin.com/in/jane-doe",
     );
     expect(formatLinkDisplay("https://linkedin.com/in/jane-doe/")).toBe(
-      "in/jane-doe",
+      "linkedin.com/in/jane-doe",
     );
   });
 
-  it("collapses a GitHub profile to gh/<slug>", () => {
-    expect(formatLinkDisplay("https://github.com/javery")).toBe("gh/javery");
+  it("keeps the host+path for a GitHub profile", () => {
+    expect(formatLinkDisplay("https://github.com/javery")).toBe(
+      "github.com/javery",
+    );
   });
 
-  it("falls back to the stripped host+path for other links", () => {
+  it("strips protocol/www/trailing-slash for other links", () => {
     expect(formatLinkDisplay("https://www.jane.dev/")).toBe("jane.dev");
     expect(formatLinkDisplay("http://janedoe.com/portfolio")).toBe(
       "janedoe.com/portfolio",

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -108,20 +108,15 @@ export function buildContactFields(
 /**
  * Shorten a link URL to a compact, human-readable slug for the card's links
  * line (#146). Strips the protocol, a leading `www.`, and any trailing slash,
- * then collapses the two common profile hosts to a host-relative form:
- * `linkedin.com/in/<slug>` → `in/<slug>`, `github.com/<slug>` → `gh/<slug>`.
- * Anything else (portfolio / personal site) falls back to the stripped
- * host+path, which stays unambiguous. The original URL remains the `href`.
+ * leaving the host + path — e.g. `https://www.linkedin.com/in/jane-doe` →
+ * `linkedin.com/in/jane-doe`, `https://github.com/janedoe` → `github.com/janedoe`,
+ * `https://jane.dev/` → `jane.dev`. Keeping the host makes the platform obvious
+ * at a glance while staying compact; the original URL remains the `href`.
  */
 export function formatLinkDisplay(url: string): string {
-  const stripped = url
+  return url
     .trim()
     .replace(/^https?:\/\//i, "")
     .replace(/^www\./i, "")
     .replace(/\/+$/, "");
-  const linkedin = stripped.match(/^linkedin\.com\/in\/(.+)$/i);
-  if (linkedin) return `in/${linkedin[1]}`;
-  const github = stripped.match(/^github\.com\/(.+)$/i);
-  if (github) return `gh/${github[1]}`;
-  return stripped;
 }

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -55,13 +55,18 @@ export interface ApplyOverridesResult {
 
 // ── Contact ────────────────────────────────────────────────────────────────
 
-/** The five editable contact keys, all string-valued on the parsed object. */
+/** The editable contact keys, all optional string-valued on the parsed object.
+ *  Link fields (github/portfolio/website) join the original five so a corrected
+ *  URL re-grades Completeness + JD coverage like any other field. */
 const CONTACT_KEYS: readonly (keyof ContactOverrides)[] = [
   "full_name",
   "email",
   "phone",
   "linkedin_url",
   "location",
+  "github_url",
+  "portfolio_url",
+  "website_url",
 ];
 
 // ── Bullet line replacement ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #146 — restores inline editing of the five editable contact fields (`full_name`, `email`, `phone`, `linkedin_url`, `location`) in the new centered ContactCard, reusing the existing `EditableField` primitive and `useEditableParse` / `ContactOverrides` plumbing **unchanged** (no new hook, no new override type).

- **`ContactCard`** — threads `overrides`/`onFieldChange` back through; the name heading and each contact-line segment become inline-editable; clearing a value reverts it to the gated "not found" state. Pure display when the props are absent (#146 behavior). Stays the owner of the card chrome, heading, and audit footer (now 105 LOC).
- **`ContactDetails`** (new, 164 LOC) — per-segment contact/links rendering + edit affordances, split out because `ContactCard` crossed the ~200 LOC limit (per the 3-tier rule / AC).
- **`EditableField`** — two **additive, backward-compatible** props: `textSize="lg"` (so the editable name matches the #146 heading size) and `displayValue` (show the LinkedIn slug in read mode while editing the full URL). Existing callers unchanged.
- **`ReconstructedResume`** — passes `contactOverrides`/`onFieldChange` to `ContactCard` again, so commits flow through the existing override → score re-eval path.

GitHub / portfolio / website remain display-only (only the 5 `ContactOverrides` fields are editable).

Closes #147

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (919 passed; corpus unaffected — UI-only)
- [x] `eslint` on changed files clean (no raw `<button>`/hex/palette classes)
- [x] Manually verified in `npm run dev`: heading/contact/LinkedIn edit in place, LinkedIn editor shows the full URL and re-derives the slug, clear-to-absent reverts to "not found", committing an edit re-evaluates the score, and the idle card matches the #146 layout