### PR TITLE
feat(design-system): extract InlineResult shared chrome primitive (#124)

### DIFF
--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useMemo } from "react";
-import { Button } from "@design-system";
+import { Button, InlineResult } from "@design-system";
 import type {
   ResumeRewriteResult,
   SectionOutcome,
@@ -38,15 +38,11 @@ export function ProposedPanel({
   onDismiss: () => void;
 }) {
   const aggregated = useMemo(() => aggregateDrift(result), [result]);
-  const borderClass = result.allNumbersPreserved
-    ? "border-feedback-success-border"
-    : "border-feedback-warning-border";
-  const bgClass = result.allNumbersPreserved
-    ? "bg-feedback-success-bg"
-    : "bg-feedback-warning-bg";
-
   return (
-    <div className={`flex flex-col gap-4 rounded border p-3 ${borderClass} ${bgClass}`}>
+    <InlineResult
+      tone={result.allNumbersPreserved ? "success" : "warning"}
+      className="flex flex-col gap-4"
+    >
       {!result.allNumbersPreserved && (
         <NumberPreservationWarning
           dropped={aggregated.dropped}
@@ -70,7 +66,7 @@ export function ProposedPanel({
           Discard
         </Button>
       </div>
-    </div>
+    </InlineResult>
   );
 }
 

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -11,7 +11,7 @@
  *
  * Non-negotiable rules from issue #63:
  *   - On browsers without WebGPU, returns null. Silent absence — matches
- *     `RewriteButton`. Not a greyed CTA, not a banner.
+ *     `InlineResult`. Not a greyed CTA, not a banner.
  *   - Model weights download on click only. The shared `loadEngine()` cache
  *     means clicking section-rewrite after per-bullet (or in a sibling role)
  *     reuses the same engine — no second multi-GB download.
@@ -23,10 +23,10 @@
  * Reuse analysis (CLAUDE.md 3-tier rule):
  *   - Primitive: `Button` from `@design-system` for every interactive
  *     control. No raw `<button>` in this file.
- *   - Shared: the inline before/after panel follows the same inline-result
- *     pattern as `RewriteButton`'s `RewriteResult` (rounded border + feedback
- *     bg). Top-level `Card` would be the wrong chrome — Cards own panel
- *     framing on the page; this is a result strip *inside* the role list.
+ *   - Shared: the inline before/after panel uses the `InlineResult` primitive
+ *     from `@design-system` (rounded border + feedback bg + tone). Top-level
+ *     `Card` would be the wrong chrome — Cards own panel framing on the page;
+ *     this is a result strip *inside* the role list.
  *
  * Concurrency: see `useSectionRewriteLock` for the synchronous atomic lock
  * that gates concurrent `engine.chat.completions.create()` calls.
@@ -44,7 +44,7 @@ import type {
 import type { SectionRewriteResult } from "../../lib/webllm/rewrite-section.ts";
 import { useSectionRewriteLock } from "../../hooks/useSectionRewriteLock.ts";
 import { useModelSelection } from "../../hooks/useModelSelection.ts";
-import { Button, ModelLoadProgress } from "@design-system";
+import { Button, ModelLoadProgress, InlineResult } from "@design-system";
 
 /** What `useSectionRewrite` hands back so the caller can place the trigger and
  *  the result panel in separate slots (trigger beside the role title, panel
@@ -280,16 +280,10 @@ export function ProposedSection({
   onCopyAll: () => void;
   onReject: () => void;
 }) {
-  const borderClass = result.numbersPreserved
-    ? "border-feedback-success-border"
-    : "border-feedback-warning-border";
-  const bgClass = result.numbersPreserved
-    ? "bg-feedback-success-bg"
-    : "bg-feedback-warning-bg";
-
   return (
-    <div
-      className={`flex flex-col gap-3 rounded border p-3 ${borderClass} ${bgClass}`}
+    <InlineResult
+      tone={result.numbersPreserved ? "success" : "warning"}
+      className="flex flex-col gap-3"
     >
       {!result.numbersPreserved && (
         <NumberPreservationWarning
@@ -329,7 +323,7 @@ export function ProposedSection({
           Discard
         </Button>
       </div>
-    </div>
+    </InlineResult>
   );
 }
 

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -20,6 +20,7 @@ export * from "./primitives/Dialog.tsx";
 export * from "./primitives/EditableField.tsx";
 export * from "./primitives/StarRating.tsx";
 export * from "./shared/Card.tsx";
+export * from "./shared/InlineResult.tsx";
 export * from "./shared/ModelLoadProgress.tsx";
 export * from "./shared/StatusBadge.tsx";
 export * from "./shared/Tabs.tsx";

--- a/src/design-system/shared/InlineResult.tsx
+++ b/src/design-system/shared/InlineResult.tsx
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * InlineResult — feedback-toned result-strip chrome (rounded border +
+ * feedback bg + tone). Distinct concern from Card's neutral surface panel
+ * framing: InlineResult is used for outcome strips *inside* a feature panel
+ * (e.g. a proposed rewrite result), never for top-level page cards.
+ *
+ * Layout (flex/gap) stays caller-side — pass via `className`.
+ * Renders a `<div>` (not a landmark element) since these strips are
+ * content within an already-structured section.
+ */
+
+import type { ReactNode } from "react";
+
+const TONE_CHROME: Record<"success" | "warning", string> = {
+  success: "rounded border border-feedback-success-border bg-feedback-success-bg p-3",
+  warning: "rounded border border-feedback-warning-border bg-feedback-warning-bg p-3",
+};
+
+interface InlineResultProps {
+  /** Feedback tone — controls border + background colour. */
+  tone: "success" | "warning";
+  children: ReactNode;
+  /** Extra classes layered after the shared chrome — layout, gap, etc. */
+  className?: string;
+}
+
+export function InlineResult({ tone, children, className }: InlineResultProps) {
+  const chrome = TONE_CHROME[tone];
+  const cls = className ? `${chrome} ${className}` : chrome;
+  return <div className={cls}>{children}</div>;
+}


### PR DESCRIPTION
## Summary

Extracts the hand-rolled feedback-toned "inline result strip" chrome into a new shared design-system primitive `InlineResult` (tone `success`/`warning` → rounded border + feedback bg), and wires both feature call-sites to it. No visual change — layout (flex/gap) stays caller-side.

- New: `src/design-system/shared/InlineResult.tsx`, exported from the `@design-system` barrel
- `SectionRewrite.tsx` `ProposedSection` and `ResumeRewriteProposed.tsx` `ProposedPanel` now consume `InlineResult` (gap stays caller-owned: `gap-3` vs `gap-4`)
- Corrected stale `RewriteButton`/`RewriteResult` comments (phantom symbols) to reference the real `InlineResult` primitive

Closes #124

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (928 passed)
- [x] `npm run build` succeeds