### PR TITLE
docs: document client-side storage & GitHub-API star fetch in Telemetry note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ resumelint is a browser-side PDF parser stress test for resumes: drop a PDF in, 
 
 - Vite 7 + React 19 + TypeScript 5.8 + Tailwind 3.4. Vitest runs against `vite.config.ts` (Node env, globals on).
 - pdfjs-dist 4.x; the worker is configured once at app boot in `src/main.tsx` via Vite's `?url` import.
-- No router (single-page app), no SSR/prerender. Analytics are env-gated (`VITE_POSTHOG_KEY`) and dead-code-eliminated when unset — see `src/lib/analytics.ts` and the README's Telemetry section. `.env` and `.env.example` are gitignored so the repo ships zero env-file PostHog surface.
+- No router (single-page app), no SSR/prerender. Analytics are env-gated (`VITE_POSTHOG_KEY`) and dead-code-eliminated when unset — see `src/lib/analytics.ts` and the README's Telemetry section, which also documents the functional `localStorage` keys (`rl_*`) and the unauthenticated `api.github.com` star-count call (discloses the user's IP to GitHub on load). `.env` and `.env.example` are gitignored so the repo ships zero env-file PostHog surface.
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ for the env vars is this section. To enable telemetry in a local build,
 set `VITE_POSTHOG_KEY` (and optionally `VITE_POSTHOG_HOST`, defaulting to
 `https://us.i.posthog.com`) in the environment at build time.
 
+### Browser storage
+
+Beyond PostHog, the app writes a few functional `localStorage` keys to
+remember UX state across reloads. These are **first-party**, carry **no PII**,
+hold **no tracking or profiling identifier**, and are **not HTTP cookies**
+(`document.cookie` is never touched) — they are boolean/counter UX state
+scoped to your browser:
+
+| Key | Purpose |
+|---|---|
+| `rl_feedback_seen` | counts how many times the feedback ask has rendered; after 2 the panel switches from the full card to a quiet compact star strip |
+| `rl_feedback_submitted` | set after a successful feedback submit so the panel never re-asks in that browser |
+| `rl_star_cta_seen` | one-time flag so the post-feedback GitHub-star prompt shows only once per browser |
+| `rl_gh_stars_cache` | caches the fetched star count (~1h TTL) to avoid re-hitting the GitHub API on every parse |
+
+### GitHub star count
+
+The footer shows the live repo star count via an unauthenticated call to
+`https://api.github.com/repos/resumelint-org/resumelint` (`src/hooks/useGitHubStars.ts`).
+It runs from your browser on app load whenever the ~1h cache
+(`rl_gh_stars_cache`) is stale, and is **fail-silent** — on network error or
+rate-limit (GitHub allows 60 req/hr/IP unauthenticated) the count is hidden
+and the rest of the UI is unaffected. Because the request originates in your
+browser, **your IP address is seen by GitHub** (a US third party) as a result
+of loading the app.
+
 ## Theming
 
 Colors are plain CSS custom properties split into two layers:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,6 +200,14 @@ export default function App() {
           >
             Further reading: HBS Hidden Workers
           </a>
+          <a
+            href="https://github.com/resumelint-org/resumelint/blob/main/README.md#telemetry"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="hover:underline"
+          >
+            Privacy &amp; data
+          </a>
         </div>
       </footer>
     </main>


### PR DESCRIPTION
## Summary

Extends the README `## Telemetry` section to cover the two client-side data surfaces that landed in #193/#194 but went undocumented: the four functional `rl_*` localStorage keys (first-party, no PII, no tracking ID, not cookies) and the unauthenticated `api.github.com` star-count call (fires on load, ~1h cached, fail-silent, discloses the user's IP to GitHub). Adds a quiet "Privacy & data" footer link in `src/App.tsx` pointing to it, and a one-line cross-ref in `CLAUDE.md`. Docs + one link only — no consent banner, no behavioral change.

Closes #195

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (938 tests)
- [ ] Manually verified footer link in `npm run dev`