### PR TITLE
fix(webllm): close loadEngine TOCTOU race by acquiring inference before await (#148)

### DIFF
--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -35,7 +35,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { detectWebGpu } from "../../lib/webllm/capability.ts";
-import { loadEngine } from "../../lib/webllm/web-llm.ts";
+import {
+  acquireInference,
+  loadEngine,
+  releaseInference,
+} from "../../lib/webllm/web-llm.ts";
 import { rewriteSectionWithLlm } from "../../lib/webllm/rewrite-section.ts";
 import type {
   ProgressUpdate,
@@ -140,19 +144,27 @@ export function useSectionRewrite(
     // (and updates one render late, so it can't be relied on alone).
     const release = acquire();
     if (release === null) return;
+    // Snapshot the model id so the same id is released that we acquired —
+    // ModelSelector could in principle update `selectedModelId` mid-run.
+    const modelId = selectedModelId;
+    // Acquire the inference guard SYNCHRONOUSLY, before any await — closes
+    // the load→use TOCTOU window from #148. A concurrent picker switch's
+    // eviction will see the positive count and park `.unload()` until the
+    // matching release runs in `finally`.
+    acquireInference(modelId);
     try {
       setStatus({
         kind: "loading",
         progress: { progress: 0, text: "Starting…" },
       });
-      const engine = await loadEngine(selectedModelId, (progress) => {
+      const engine = await loadEngine(modelId, (progress) => {
         setStatus({ kind: "loading", progress });
       });
       setStatus({ kind: "rewriting" });
       const result = await rewriteSectionWithLlm(
         trimmedBullets,
         engine,
-        selectedModelId,
+        modelId,
       );
       if (result.bullets.length === 0) {
         setStatus({
@@ -169,6 +181,7 @@ export function useSectionRewrite(
           err instanceof Error ? err.message : "Couldn't load the rewrite model",
       });
     } finally {
+      releaseInference(modelId);
       release();
     }
   }, [trimmedBullets, acquire, selectedModelId]);

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -30,7 +30,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { detectWebGpu } from "../lib/webllm/capability.ts";
-import { loadEngine } from "../lib/webllm/web-llm.ts";
+import {
+  acquireInference,
+  loadEngine,
+  releaseInference,
+} from "../lib/webllm/web-llm.ts";
 import {
   rewriteResumeWithLlm,
   type ResumeRewriteProgress,
@@ -155,18 +159,28 @@ export function useResumeRewrite(
   const start = useCallback(async () => {
     const release = acquire();
     if (release === null) return;
+    // Snapshot the model id so the same id is released that we acquired —
+    // ModelSelector could in principle update `selectedModelId` mid-run.
+    const modelId = selectedModelId;
+    // Acquire the inference guard SYNCHRONOUSLY, before any await — closes
+    // the load→use TOCTOU window from #148. Held across the WHOLE chain
+    // (summary + every experience role) so the engine cannot be torn down
+    // by a concurrent picker switch at any step boundary, not just at the
+    // first loadEngine. Released in `finally` whether the run completes
+    // successfully or errors out.
+    acquireInference(modelId);
     try {
       setStatus({
         kind: "loading",
         progress: { progress: 0, text: "Starting…" },
       });
-      const engine = await loadEngine(selectedModelId, (progress) => {
+      const engine = await loadEngine(modelId, (progress) => {
         setStatus({ kind: "loading", progress });
       });
       const result = await rewriteResumeWithLlm(
         rewriteableSections,
         engine,
-        selectedModelId,
+        modelId,
         (progress) => {
           setStatus({ kind: "running", progress });
         },
@@ -190,6 +204,7 @@ export function useResumeRewrite(
           err instanceof Error ? err.message : "Couldn't load the rewrite model",
       });
     } finally {
+      releaseInference(modelId);
       release();
     }
   }, [acquire, rewriteableSections, selectedModelId]);

--- a/src/lib/webllm/eval/run-eval-browser.ts
+++ b/src/lib/webllm/eval/run-eval-browser.ts
@@ -37,7 +37,11 @@ import {
   sectionMaxTokens,
 } from "../rewrite-section.ts";
 import { MODEL_REGISTRY, getModelById } from "../models.ts";
-import { loadEngine } from "../web-llm.ts";
+import {
+  acquireInference,
+  loadEngine,
+  releaseInference,
+} from "../web-llm.ts";
 import { detectWebGpu } from "../capability.ts";
 import type { WebLlmEngine } from "../types.ts";
 
@@ -141,55 +145,68 @@ async function runForModel(refs: DomRefs, modelId: string): Promise<void> {
 
   appendLog(refs, `loading model ${modelId}`);
   setStatus(refs, `Loading ${display} …`);
-  const engine = await loadEngine(modelId, (update) => {
-    refs.progress.textContent = `${display}: ${(update.progress * 100).toFixed(0)}% — ${update.text}`;
-  });
-  appendLog(
-    refs,
-    `model loaded; running ${PROMPT_VARIANTS.length} variants × ${REWRITE_FIXTURES.length} fixtures`,
-  );
-  // Refresh the status line so it reflects "running" instead of staying
-  // on "Loading …" for the whole cell loop.
-  setStatus(refs, `Running ${display} (${PROMPT_VARIANTS.length} variants × ${REWRITE_FIXTURES.length} fixtures) …`);
+  // Acquire the inference guard SYNCHRONOUSLY, before any await — closes
+  // the load→use TOCTOU window from #148. This path is the most exposed of
+  // all call sites: `makeRealRewriteFn` calls `engine.chat.completions.create`
+  // directly, bypassing the rewrite primitives' internal acquire/release
+  // belt, so the engine has NO inflight tracking during the eval loop
+  // without this wrapper. Held across the whole eval (load + N × variant
+  // × fixture rewrites + report wiring) so a re-click of the run button
+  // with a different model can't tear down our engine mid-eval.
+  acquireInference(modelId);
+  try {
+    const engine = await loadEngine(modelId, (update) => {
+      refs.progress.textContent = `${display}: ${(update.progress * 100).toFixed(0)}% — ${update.text}`;
+    });
+    appendLog(
+      refs,
+      `model loaded; running ${PROMPT_VARIANTS.length} variants × ${REWRITE_FIXTURES.length} fixtures`,
+    );
+    // Refresh the status line so it reflects "running" instead of staying
+    // on "Loading …" for the whole cell loop.
+    setStatus(refs, `Running ${display} (${PROMPT_VARIANTS.length} variants × ${REWRITE_FIXTURES.length} fixtures) …`);
 
-  const report = await runEval({
-    modelIds: [modelId],
-    variantIds: PROMPT_VARIANTS.map((v) => v.id),
-    fixtures: REWRITE_FIXTURES,
-    rewriteFn: makeRealRewriteFn(engine),
-    appVersion: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : null,
-    onProgress: (done, total, cell) => {
-      refs.progress.textContent = `${display}: ${done}/${total} — ${cell.variantId} × ${cell.fixtureId}`;
-    },
-  });
+    const report = await runEval({
+      modelIds: [modelId],
+      variantIds: PROMPT_VARIANTS.map((v) => v.id),
+      fixtures: REWRITE_FIXTURES,
+      rewriteFn: makeRealRewriteFn(engine),
+      appVersion: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : null,
+      onProgress: (done, total, cell) => {
+        refs.progress.textContent = `${display}: ${done}/${total} — ${cell.variantId} × ${cell.fixtureId}`;
+      },
+    });
 
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  // Slugify the model id for the filename so it's filesystem-safe and
-  // easy to read in the reports/ directory.
-  const slug = modelId.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  // Explicit `;charset=utf-8` so the saved files don't get re-decoded as
-  // Latin-1 by some text viewers — without it, multi-byte chars like
-  // `×` and `—` in the markdown render as mojibake.
-  wireDownload(
-    refs.downloadJson,
-    `eval-rewrite-${slug}-${stamp}.json`,
-    renderJsonReport(report),
-    "application/json;charset=utf-8",
-  );
-  wireDownload(
-    refs.downloadMd,
-    `eval-rewrite-${slug}-${stamp}.md`,
-    renderMarkdownReport(report),
-    "text/markdown;charset=utf-8",
-  );
-  setStatus(
-    refs,
-    `Done. ${report.records.length} records scored for ${display}.`,
-  );
-  appendLog(
-    refs,
-    "report ready — download below and commit under tests/fixtures/rewrite/reports/",
-  );
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    // Slugify the model id for the filename so it's filesystem-safe and
+    // easy to read in the reports/ directory.
+    const slug = modelId.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    // Explicit `;charset=utf-8` so the saved files don't get re-decoded as
+    // Latin-1 by some text viewers — without it, multi-byte chars like
+    // `×` and `—` in the markdown render as mojibake.
+    wireDownload(
+      refs.downloadJson,
+      `eval-rewrite-${slug}-${stamp}.json`,
+      renderJsonReport(report),
+      "application/json;charset=utf-8",
+    );
+    wireDownload(
+      refs.downloadMd,
+      `eval-rewrite-${slug}-${stamp}.md`,
+      renderMarkdownReport(report),
+      "text/markdown;charset=utf-8",
+    );
+    setStatus(
+      refs,
+      `Done. ${report.records.length} records scored for ${display}.`,
+    );
+    appendLog(
+      refs,
+      "report ready — download below and commit under tests/fixtures/rewrite/reports/",
+    );
+  } finally {
+    releaseInference(modelId);
+  }
 }
 
 async function main(): Promise<void> {

--- a/src/lib/webllm/web-llm.test.ts
+++ b/src/lib/webllm/web-llm.test.ts
@@ -27,7 +27,9 @@ vi.mock("../analytics.ts", async (importOriginal) => {
 
 import {
   _resetEngineCacheForTesting,
+  acquireInference,
   loadEngine,
+  releaseInference,
 } from "./web-llm.ts";
 import { DEFAULT_MODEL_ID, MODEL_REGISTRY } from "./models.ts";
 import type { WebLlmEngine } from "./types.ts";
@@ -244,5 +246,128 @@ describe("loadEngine", () => {
     expect(trackLoadedMock).toHaveBeenCalledTimes(2);
     expect(trackLoadedMock).toHaveBeenNthCalledWith(1, { model: MODEL_A });
     expect(trackLoadedMock).toHaveBeenNthCalledWith(2, { model: MODEL_B });
+  });
+});
+
+// ── #148 — acquire-before-load TOCTOU regression ────────────────────────────
+//
+// Background. `loadEngine` + `acquireInference` had a time-of-check-to-
+// time-of-use gap. When a rewrite caller hit `loadEngine`'s fast path for an
+// already-loaded engine A, the returned promise resolved synchronously, but
+// the `await` yielded to the microtask queue before `acquireInference(A)`
+// could run (acquire happened INSIDE the rewrite primitive, not before
+// loadEngine). In that gap, a concurrent picker switch to B could run its
+// chain entry → `evictAllExcept(B)` → see `inflightInferenceCount[A] === 0`
+// → call `A.unload()` immediately. The rewrite caller's continuation then
+// tried to use a torn-down engine.
+//
+// Fix. Consumers acquireInference(modelId) BEFORE awaiting loadEngine, paired
+// with releaseInference in finally. Then evictAllExcept sees the positive
+// count and parks A in `pendingUnload`; the deferred `.unload()` runs the
+// moment the caller releases. The pair below pins both halves: the negative
+// shape (without the contract, the race is real) and the positive shape
+// (with the contract, the engine survives until release).
+describe("acquire-before-load TOCTOU (#148)", () => {
+  beforeEach(() => {
+    _resetEngineCacheForTesting();
+    mockCreateMLCEngine.mockReset();
+  });
+
+  it("WITHOUT acquireInference before loadEngine: a concurrent eviction unloads the engine — this is the #148 race", async () => {
+    // Pre-load A so `loadEngine(A)` hits the fast path.
+    const engineA = fakeEngine(MODEL_A);
+    mockCreateMLCEngine.mockResolvedValueOnce(engineA);
+    await loadEngine(MODEL_A, noop);
+
+    // Queue a concurrent switch to B. Its chain entry runs eviction inside
+    // a microtask — exactly the window the bug exploits.
+    const engineB = fakeEngine(MODEL_B);
+    mockCreateMLCEngine.mockResolvedValueOnce(engineB);
+    const bLoadPromise = loadEngine(MODEL_B, noop);
+
+    // Simulate the buggy consumer pattern: await loadEngine, then acquire.
+    const engine = await loadEngine(MODEL_A, noop);
+    expect(engine).toBe(engineA);
+
+    // Drain microtasks so the B chain entry's eviction runs.
+    await bLoadPromise;
+
+    // Without the fix, A.unload was called between the await resolving and
+    // the (would-be later) acquireInference call. Count was 0 at eviction
+    // time, so eviction proceeded to unload immediately rather than parking.
+    expect(engineA.unload).toHaveBeenCalledTimes(1);
+  });
+
+  it("WITH acquireInference before loadEngine: eviction parks the engine and defers .unload() until releaseInference", async () => {
+    // Pre-load A.
+    const engineA = fakeEngine(MODEL_A);
+    mockCreateMLCEngine.mockResolvedValueOnce(engineA);
+    await loadEngine(MODEL_A, noop);
+
+    // The CORRECT consumer pattern — acquire SYNCHRONOUSLY, before any await
+    // that could yield to a queued chain entry. The acquire pairs with a
+    // release in `finally` (here split out at the bottom for clarity).
+    acquireInference(MODEL_A);
+
+    // Queue the concurrent switch to B — same shape as the negative test.
+    const engineB = fakeEngine(MODEL_B);
+    mockCreateMLCEngine.mockResolvedValueOnce(engineB);
+    const bLoadPromise = loadEngine(MODEL_B, noop);
+
+    // Await the fast-path resolve. The microtask gap is open — but the
+    // count is already 1, so the chain entry's eviction parks A.
+    const engine = await loadEngine(MODEL_A, noop);
+    expect(engine).toBe(engineA);
+
+    // Drain microtasks so the B chain entry's eviction runs.
+    await bLoadPromise;
+
+    // A is parked in pendingUnload — NOT unloaded yet.
+    expect(engineA.unload).not.toHaveBeenCalled();
+
+    // The engine handle remains usable for inference here (in production
+    // this is where rewriteSectionWithLlm / rewriteSummaryWithLlm would
+    // call engine.chat.completions.create()).
+    expect(engine).toBe(engineA);
+
+    // Release. Count drops to 0 → pending unload drains.
+    releaseInference(MODEL_A);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engineA.unload).toHaveBeenCalledTimes(1);
+  });
+
+  it("WITH acquireInference before loadEngine: nested acquire from a rewrite primitive does not change the deferral semantics (count rises to 2, both releases drain to 0)", async () => {
+    // Belt-and-suspenders: the rewrite primitives still call acquire/release
+    // INTERNALLY. With the outer pair from the fix, count goes 1 → 2 → 1 → 0.
+    // The unload must still defer to the final release.
+    const engineA = fakeEngine(MODEL_A);
+    mockCreateMLCEngine.mockResolvedValueOnce(engineA);
+    await loadEngine(MODEL_A, noop);
+
+    // Outer pair — added by the #148 fix at consumer call sites.
+    acquireInference(MODEL_A);
+
+    const engineB = fakeEngine(MODEL_B);
+    mockCreateMLCEngine.mockResolvedValueOnce(engineB);
+    const bLoadPromise = loadEngine(MODEL_B, noop);
+    await loadEngine(MODEL_A, noop);
+    await bLoadPromise;
+    expect(engineA.unload).not.toHaveBeenCalled();
+
+    // Inner pair — mirrors what rewriteSectionWithLlm / rewriteSummaryWithLlm
+    // do today around the model call. Count rises to 2.
+    acquireInference(MODEL_A);
+    // Inner release — back to 1. Still parked, not drained.
+    releaseInference(MODEL_A);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engineA.unload).not.toHaveBeenCalled();
+
+    // Outer release — back to 0. Park drains.
+    releaseInference(MODEL_A);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(engineA.unload).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/webllm/web-llm.ts
+++ b/src/lib/webllm/web-llm.ts
@@ -86,16 +86,36 @@ const pendingUnload = new Map<string, CacheableEngine>();
 /**
  * Lazily import and construct the WebLLM engine for `modelId`.
  *
+ * ## Inference callers MUST acquire BEFORE awaiting (issue #148)
+ *
+ * The fast path returns `Promise.resolve(engine)`, but `await` still yields
+ * to the microtask queue. A concurrent picker switch's chain entry can run
+ * `evictAllExcept(otherId)` in that gap, see `inflightInferenceCount[id]`
+ * is 0, and call `engine.unload()` immediately — tearing the engine down
+ * before the caller's continuation gets to use it.
+ *
+ * Inference callers therefore MUST wrap the whole load-and-use sequence with
+ * `acquireInference(modelId)` / `releaseInference(modelId)`:
+ *
+ *     acquireInference(modelId);
+ *     try {
+ *       const engine = await loadEngine(modelId, onProgress);
+ *       await rewriteSectionWithLlm(bullets, engine, modelId); // or similar
+ *     } finally {
+ *       releaseInference(modelId);
+ *     }
+ *
+ * With a positive count, `evictAllExcept` parks the engine in `pendingUnload`
+ * and the deferred `.unload()` only runs once the caller releases. The inner
+ * `acquireInference` inside the rewrite primitives is defensive belt — it
+ * does not close the load→use gap on its own.
+ *
+ * Non-inference callers (the model picker preloading a model) do NOT need
+ * the wrapper — the gap is harmless if no inference is about to run on the
+ * returned engine.
+ *
  * Fast paths (no chaining):
- *   - Same model already loaded → returns the engine immediately. The
- *     post-return eviction race (a queued cross-model load running
- *     `evictAllExcept` + `.unload()` mid-inference) IS reachable in PR B:
- *     `SectionRewrite` / `ResumeRewrite` are separate consumers from the
- *     picker, not disabled by its loading state, so a rewrite caller can
- *     fast-path to engine A while the picker is downloading B. Callers must
- *     wrap their `chat.completions.create()` in `acquireInference(modelId)`
- *     / `releaseInference(modelId)` — `evictAllExcept` consults the
- *     in-flight counter and defers `.unload()` for any engine still in use.
+ *   - Same model already loaded → returns the engine immediately.
  *   - Same model already pending → returns the in-flight promise.
  *
  * New cross-model load:


### PR DESCRIPTION
## Summary

Closes the time-of-check-to-time-of-use race between `loadEngine`'s fast-path resolve and `acquireInference()`. The `await` after `loadEngine` returns yielded to the microtask queue; in that gap a concurrent picker switch's chain entry could run `evictAllExcept(B)`, see `inflightInferenceCount[A] === 0` (acquire happened **inside** the rewrite primitive, after the load resolved), and call `A.unload()` immediately — leaving the rewrite caller's continuation about to run on a torn-down engine.

Fix per issue option 1: consumers acquire the inference guard **synchronously**, before any `await`, paired with release in `finally`. With the count already positive, `evictAllExcept` parks A in `pendingUnload` and the deferred `.unload()` only runs once the caller releases.

Closes #148

## What changed

| File | Change |
|---|---|
| `src/lib/webllm/web-llm.ts` | Tightened the `loadEngine` docstring — contract is now **mandatory** ("inference callers MUST acquire BEFORE awaiting"), with an explicit code example. Preloaders (ModelSelector) explicitly exempted. No behavioral change to the function itself. |
| `src/components/features/SectionRewrite.tsx` | `useSectionRewrite.onClick` wraps with outer `acquireInference` / `releaseInference`. `modelId` snapshotted at the top so the release ID matches the acquire ID. |
| `src/hooks/useResumeRewrite.ts` | `start()` callback — same outer pair, held across the **whole** chain-of-sections run (summary + every experience role) so no step boundary leaks. |
| `src/lib/webllm/eval/run-eval-browser.ts` | `runForModel()` — same outer pair. This path was the **most exposed**: `makeRealRewriteFn` calls `engine.chat.completions.create` directly, bypassing the rewrite primitives' inner defensive belt. |

The inner `acquireInference / releaseInference` inside `rewrite-section.ts` / `rewrite-summary.ts` stays as defensive belt for direct primitive callers (count rises to 2, falls to 0 — no behavioral change to the deferral semantics).

## Tests

3 new tests in `src/lib/webllm/web-llm.test.ts` under `describe("acquire-before-load TOCTOU (#148)")`:

1. **Negative** — demonstrates the bug shape: without the outer acquire, eviction unloads A immediately while the caller's continuation was about to use it.
2. **Positive** — verifies the fix contract: with the outer acquire, eviction parks A and `.unload()` defers until release.
3. **Nested** — verifies the inner acquire from rewrite primitives doesn't disrupt the deferral (count 1 → 2 → 1 → 0; unload only fires at 0).

## Acceptance criteria (#148)

- [x] A test reproduces the interleave: load A, start a rewrite on A, fire a picker switch to B in the same tick, assert A is not unloaded until `releaseInference` — covered by the positive + nested tests.
- [x] Fix chosen (Option 1) and applied; existing web-llm cache/serialization tests stay green — all 12 pre-existing tests in `web-llm.test.ts` pass alongside the 3 new ones.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — **942 / 942 pass**
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Manual smoke not required — the race window is microseconds, not reliably triggerable by hand. Unit tests pin both bug and fix mechanically. (Happy-path regression for `Rewrite section` + `Rewrite full résumé` would only confirm no regression in the *non-racing* path, which the test suite already covers.)

## Reviewer-blocker scan

- [x] No raw `<button>` introduced, no hardcoded colors, semantic tokens only
- [x] SPDX header preserved on every touched file
- [x] No backwards-compat shims or commented-out code
- [x] `loadEngine` signature unchanged — no churn to ModelSelector / spike / other non-inference callers
- [x] `modelId` snapshotted at the top of each callback so the release ID matches the acquire ID even if `selectedModelId` changes mid-run
- [x] Release order in `finally`: `releaseInference` runs **before** the section-rewrite-lock release so the deferred unload drains while the lock is still held
- [x] ModelSelector correctly NOT wrapped (it's the preloader — the one *causing* the race, not a victim)
- [x] Inner `acquireInference / releaseInference` inside `rewrite-section.ts` / `rewrite-summary.ts` preserved as defensive belt for direct callers