### PR TITLE
feat: rewrite steering + per-bullet accept/reject/edit review (#210, #211)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ export default function App() {
       edit.skillsOverride,
       edit.addedEntries,
       edit.addedBullets,
+      edit.removedBullets,
     );
     // The anonymous scorer pools its bullet set from `sections` (#133), so the
     // edited section view — not the original — must feed re-grading or a live
@@ -71,6 +72,7 @@ export default function App() {
     edit.skillsOverride,
     edit.addedEntries,
     edit.addedBullets,
+    edit.removedBullets,
   ]);
 
   // Clear edits whenever a fresh parse lands (new file or reset).

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -374,7 +374,6 @@ function ExperienceSection({
   // SectionRewrite. The hook owns the WebGPU/empty-input gating.
   const {
     trigger: resumeRewriteTrigger,
-    controls: resumeRewriteControls,
     panel: resumeRewritePanel,
   } = useResumeRewriteUi(resumeSections);
   return (
@@ -397,7 +396,6 @@ function ExperienceSection({
           {resumeRewriteTrigger}
         </div>
       )}
-      {hasBullets && resumeRewriteControls}
       {hasBullets && resumeRewritePanel}
       {roleCount === 0 ? (
         <NotDetected what="roles" />

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -52,8 +52,11 @@ import {
   ResumeBulletRow,
   BulletFlagLegend,
 } from "./ReconstructedRole.tsx";
+import { useMemo } from "react";
 import { ModelSelector } from "./ModelSelector.tsx";
 import { useResumeRewriteUi } from "./ResumeRewrite.tsx";
+import type { SectionRewriteApply } from "./SectionRewrite.tsx";
+import type { ResumeRewriteApply } from "./ResumeRewriteProposed.tsx";
 import type { SectionInput } from "../../lib/webllm/rewrite-resume.ts";
 import type {
   ResumeProject,
@@ -368,6 +371,29 @@ function ExperienceSection({
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
+  // Per-section write-back handlers for the whole-résumé review (#211 apply on
+  // the whole-résumé path), keyed by the same `experience:<index>` id
+  // `buildResumeSections` mints. `obsIndices` is parallel to each section's
+  // bullet list (same order the model saw); adds target that role's entry key
+  // (its added id, or the parsed-entry key). Mirrors `RoleEntry`'s per-role
+  // `SectionRewriteApply` so both rewrite paths write through one edit model.
+  const rewriteApplyBySection = useMemo<ResumeRewriteApply>(() => {
+    const map = new Map<string, SectionRewriteApply>();
+    for (const group of groups) {
+      const idx = group.experienceIndex;
+      if (idx === null) continue;
+      const added =
+        idx >= originalCount ? addedExperience[idx - originalCount] : undefined;
+      const entryKey = added ? added.id : parsedEntryKey("experience", idx);
+      map.set(`experience:${idx}`, {
+        obsIndices: group.bullets.map((b) => b.index),
+        onReplace: (obsIndex, text) => onBulletChange(obsIndex, text),
+        onRemove: (obsIndex) => onRemoveBullet(obsIndex),
+        onAdd: (text) => onAddBullet(entryKey, text),
+      });
+    }
+    return map;
+  }, [groups, originalCount, addedExperience, onBulletChange, onRemoveBullet, onAddBullet]);
   // The whole-résumé rewrite CTA (#67) lives at the top of Experience next to
   // the picker. Trigger + panel render only when WebGPU is available AND
   // there's at least one rewriteable section — same silent-absence rule as
@@ -375,7 +401,7 @@ function ExperienceSection({
   const {
     trigger: resumeRewriteTrigger,
     panel: resumeRewritePanel,
-  } = useResumeRewriteUi(resumeSections);
+  } = useResumeRewriteUi(resumeSections, rewriteApplyBySection);
   return (
     <section className="flex flex-col gap-3">
       {/* Heading row: the flag legend sits beside the Experience title (next to

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -334,6 +334,7 @@ function ExperienceSection({
   onExperienceFieldChange,
   bulletOverrides,
   onBulletChange,
+  onRemoveBullet,
   addedExperience,
   originalCount,
   onAddEntry,
@@ -354,6 +355,8 @@ function ExperienceSection({
   ) => void;
   bulletOverrides: BulletOverrides;
   onBulletChange: (index: number, value: string) => void;
+  /** Drop a parsed bullet by BulletObservation.index (rewrite-review apply, #211). */
+  onRemoveBullet: (index: number) => void;
   /** User-added experience entries, append-aligned to indices ≥ originalCount. */
   addedExperience: AddedEntry[];
   /** Count of PARSED experience roles; indices at/above this are user-added. */
@@ -369,8 +372,11 @@ function ExperienceSection({
   // the picker. Trigger + panel render only when WebGPU is available AND
   // there's at least one rewriteable section — same silent-absence rule as
   // SectionRewrite. The hook owns the WebGPU/empty-input gating.
-  const { trigger: resumeRewriteTrigger, panel: resumeRewritePanel } =
-    useResumeRewriteUi(resumeSections);
+  const {
+    trigger: resumeRewriteTrigger,
+    controls: resumeRewriteControls,
+    panel: resumeRewritePanel,
+  } = useResumeRewriteUi(resumeSections);
   return (
     <section className="flex flex-col gap-3">
       {/* Heading row: the flag legend sits beside the Experience title (next to
@@ -391,6 +397,7 @@ function ExperienceSection({
           {resumeRewriteTrigger}
         </div>
       )}
+      {hasBullets && resumeRewriteControls}
       {hasBullets && resumeRewritePanel}
       {roleCount === 0 ? (
         <NotDetected what="roles" />
@@ -426,6 +433,7 @@ function ExperienceSection({
                 }
                 bulletOverrides={bulletOverrides}
                 onBulletChange={onBulletChange}
+                onRemoveBullet={onRemoveBullet}
                 onAddBullet={(text) =>
                   onAddBullet(
                     added ? added.id : parsedEntryKey("experience", idx),
@@ -744,6 +752,7 @@ export function ReconstructedResume({
     setExperienceField,
     bulletOverrides,
     setBulletField,
+    removeBullet,
     educationOverrides,
     setEducationField,
     addEntry,
@@ -873,6 +882,7 @@ export function ReconstructedResume({
         }
         bulletOverrides={bulletOverrides}
         onBulletChange={(index, value) => setBulletField(index, value)}
+        onRemoveBullet={(index) => removeBullet(index)}
         addedExperience={addedExperience}
         originalCount={originalExpCount}
         onAddEntry={() => addEntry("experience")}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -15,7 +15,7 @@
  * Split out of ReconstructedResume to keep that container under ~200 LOC.
  */
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { needsAttention } from "../../lib/score/group-bullets.ts";
@@ -25,7 +25,10 @@ import type {
   ExperienceFieldOverrides,
   BulletOverrides,
 } from "../../hooks/useEditableParse.ts";
-import { useSectionRewrite } from "./SectionRewrite.tsx";
+import {
+  useSectionRewrite,
+  type SectionRewriteApply,
+} from "./SectionRewrite.tsx";
 import { InlineBulletAdd, RemoveButton } from "./ReconstructedAdd.tsx";
 
 // ── Bullet flags ──────────────────────────────────────────────────────────────
@@ -420,6 +423,10 @@ interface RoleEntryProps {
   /** Append a new bullet to this role (#180-followup). Renders a "+ Add bullet"
    *  affordance under the bullet list when provided. */
   onAddBullet?: (text: string) => void;
+  /** Drop a parsed bullet by its BulletObservation.index (#211). Required —
+   *  alongside onBulletChange + onAddBullet — to wire the section-rewrite
+   *  per-bullet Apply (accept/reject/edit writes back here). */
+  onRemoveBullet?: (index: number) => void;
   /** Remove this role (only set for user-ADDED roles). Renders an X control in
    *  the header row when provided. */
   onRemove?: () => void;
@@ -437,6 +444,7 @@ export function RoleEntry({
   bulletOverrides,
   onBulletChange,
   onAddBullet,
+  onRemoveBullet,
   onRemove,
 }: RoleEntryProps) {
   // Bullet display text honors #82 overrides — section rewrite must see the
@@ -444,10 +452,28 @@ export function RoleEntry({
   const sectionBullets = group.bullets.map(
     (b) => bulletOverrides?.[b.index] ?? b.text,
   );
+  // Wire the per-bullet rewrite review/apply (#211) only when the full editable
+  // surface is present (replace + add + remove). The obsIndices are parallel to
+  // sectionBullets so an accepted change maps back to its BulletObservation.
+  // Memoized so the proposal's decision state doesn't reset on every render.
+  const obsIndices = group.bullets.map((b) => b.index);
+  const obsIndicesKey = obsIndices.join(",");
+  const rewriteApply = useMemo<SectionRewriteApply | undefined>(() => {
+    if (!onBulletChange || !onAddBullet || !onRemoveBullet) return undefined;
+    return {
+      obsIndices,
+      onReplace: (index, text) => onBulletChange(index, text),
+      onRemove: (index) => onRemoveBullet(index),
+      onAdd: (text) => onAddBullet(text),
+    };
+    // obsIndices identity churns each render; key on its stable string form.
+  }, [obsIndicesKey, onBulletChange, onAddBullet, onRemoveBullet]);
   // The "Rewrite section" trigger sits on the header row (right of the title);
   // its result panel renders full-width below the bullet list.
-  const { trigger: rewriteTrigger, panel: rewritePanel } =
-    useSectionRewrite(sectionBullets);
+  const { trigger: rewriteTrigger, panel: rewritePanel } = useSectionRewrite(
+    sectionBullets,
+    rewriteApply,
+  );
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-start justify-between gap-2">

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -28,19 +28,36 @@
  * résumé). Silent absence — matches `RewriteButton` and `SectionRewrite`.
  */
 
-import { Button, ModelLoadProgress } from "@design-system";
+import { Button, ModelLoadProgress, TextAreaField } from "@design-system";
 import {
   labelForResumeRewrite,
   useResumeRewrite,
+  type ResumeRewriteController,
   type ResumeRewriteStatus,
 } from "../../hooks/useResumeRewrite.ts";
 import type { SectionInput, SectionOutcome } from "../../lib/webllm/rewrite-resume.ts";
+import type { PageTarget } from "../../lib/webllm/steering.ts";
 import { ProposedPanel } from "./ResumeRewriteProposed.tsx";
 
 export interface ResumeRewriteParts {
   trigger: React.ReactNode;
+  /** The steering box (freeform instructions + page-length chips), #210. */
+  controls: React.ReactNode;
   panel: React.ReactNode;
 }
+
+/**
+ * Page-length presets (#210). Selecting a chip sets the controller's
+ * `pageTarget` (which drives the precise length budget injected into the
+ * prompt) and — only when the box is empty — prefills a short, editable
+ * human-readable hint so the user sees what was applied. The label drives the
+ * chip; the `hint` is what lands in the freeform box.
+ */
+const PAGE_PRESETS: { target: PageTarget; label: string; hint: string }[] = [
+  { target: 1, label: "1 page", hint: "Trim this résumé to a single page." },
+  { target: 2, label: "2 pages", hint: "Keep this résumé to about two pages." },
+  { target: 3, label: "3 pages", hint: "Allow up to three pages of detail." },
+];
 
 export function useResumeRewriteUi(
   sections: readonly SectionInput[],
@@ -48,7 +65,7 @@ export function useResumeRewriteUi(
   const controller = useResumeRewrite(sections);
 
   if (!controller.isAvailable) {
-    return { trigger: null, panel: null };
+    return { trigger: null, controls: null, panel: null };
   }
 
   const trigger = (
@@ -65,12 +82,77 @@ export function useResumeRewriteUi(
     </Button>
   );
 
+  const controls = <RewriteSteeringBox controller={controller} />;
+
   const panel =
     controller.status.kind === "idle" ? null : (
       <ResumeRewritePanel status={controller.status} onDismiss={controller.dismiss} />
     );
 
-  return { trigger, panel };
+  return { trigger, controls, panel };
+}
+
+/**
+ * Freeform "Instructions for the rewrite" box with page-length preset chips
+ * (#210). One input: the chips prefill editable guidance into the same box and
+ * set the page-length target. Inputs disable while any rewrite is in flight so
+ * the user can't change steering mid-run. Reuses the `TextAreaField` and
+ * `Button` primitives — no raw `<textarea>` / `<button>`.
+ */
+export function RewriteSteeringBox({
+  controller,
+}: {
+  controller: ResumeRewriteController;
+}) {
+  const { pageTarget, setPageTarget, userInstructions, setUserInstructions } =
+    controller;
+  const disabled = controller.isLocked;
+
+  const onChipClick = (preset: (typeof PAGE_PRESETS)[number]) => {
+    if (pageTarget === preset.target) {
+      // Toggle off. Clear the prefilled hint too, but never clobber text the
+      // user has since edited away from the preset's hint.
+      setPageTarget(null);
+      if (userInstructions.trim() === preset.hint) setUserInstructions("");
+      return;
+    }
+    setPageTarget(preset.target);
+    // Prefill only when the box is empty — don't overwrite custom text.
+    if (userInstructions.trim().length === 0) setUserInstructions(preset.hint);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[11px] font-medium text-content-secondary">
+          Target length:
+        </span>
+        {PAGE_PRESETS.map((preset) => {
+          const selected = pageTarget === preset.target;
+          return (
+            <Button
+              key={preset.target}
+              variant={selected ? "primary" : "ghost"}
+              size="sm"
+              disabled={disabled}
+              aria-pressed={selected}
+              onClick={() => onChipClick(preset)}
+              className="rounded-full border border-border-light px-2.5 py-0.5 text-[11px]"
+            >
+              {preset.label}
+            </Button>
+          );
+        })}
+      </div>
+      <TextAreaField
+        label="Instructions for the rewrite (optional)"
+        value={userInstructions}
+        onChange={setUserInstructions}
+        placeholder="e.g. 'target a staff engineer role' or 'keep bullets under 20 words'"
+        disabled={disabled}
+      />
+    </div>
+  );
 }
 
 export function ResumeRewritePanel({

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -6,7 +6,9 @@
  *
  * This file owns:
  *   - The single primary CTA (mounted next to the model picker at the
- *     top of the Experience section)
+ *     top of the Experience section), which opens a steering dialog
+ *   - The steering dialog (#210 page-length chips + instructions), shown
+ *     before the run; "Run rewrite" starts it and closes the dialog
  *   - The status-to-UI routing (loading → running → proposed → error)
  *   - The in-flight `StepIndicator` + `CompletedList`
  *
@@ -28,7 +30,8 @@
  * résumé). Silent absence — matches `RewriteButton` and `SectionRewrite`.
  */
 
-import { Button, ModelLoadProgress, TextAreaField } from "@design-system";
+import { useState } from "react";
+import { Button, Dialog, ModelLoadProgress, TextAreaField } from "@design-system";
 import {
   labelForResumeRewrite,
   useResumeRewrite,
@@ -40,9 +43,9 @@ import type { PageTarget } from "../../lib/webllm/steering.ts";
 import { ProposedPanel } from "./ResumeRewriteProposed.tsx";
 
 export interface ResumeRewriteParts {
+  /** The CTA button; opens the steering dialog (#210 steering box now lives
+   *  inside that dialog, not inline). */
   trigger: React.ReactNode;
-  /** The steering box (freeform instructions + page-length chips), #210. */
-  controls: React.ReactNode;
   panel: React.ReactNode;
 }
 
@@ -53,11 +56,16 @@ export interface ResumeRewriteParts {
  * human-readable hint so the user sees what was applied. The label drives the
  * chip; the `hint` is what lands in the freeform box.
  */
-const PAGE_PRESETS: { target: PageTarget; label: string; hint: string }[] = [
+const PAGE_PRESETS: { target: PageTarget | null; label: string; hint: string }[] = [
+  { target: null, label: "No limit", hint: "" },
   { target: 1, label: "1 page", hint: "Trim this résumé to a single page." },
   { target: 2, label: "2 pages", hint: "Keep this résumé to about two pages." },
   { target: 3, label: "3 pages", hint: "Allow up to three pages of detail." },
 ];
+
+/** A page-length hint string the chips prefill, used to tell a chip-prefilled
+ *  box from one the user typed (so "No limit" / toggle-off can clear it). */
+const PRESET_HINTS = new Set(PAGE_PRESETS.map((p) => p.hint).filter(Boolean));
 
 export function useResumeRewriteUi(
   sections: readonly SectionInput[],
@@ -65,31 +73,72 @@ export function useResumeRewriteUi(
   const controller = useResumeRewrite(sections);
 
   if (!controller.isAvailable) {
-    return { trigger: null, controls: null, panel: null };
+    return { trigger: null, panel: null };
   }
 
-  const trigger = (
-    <Button
-      variant="primary"
-      size="sm"
-      onClick={() => {
-        void controller.start();
-      }}
-      disabled={controller.isLocked}
-      aria-label="Rewrite every section of the résumé"
-    >
-      {labelForResumeRewrite(controller.status, controller.isLockedByOther)}
-    </Button>
-  );
-
-  const controls = <RewriteSteeringBox controller={controller} />;
+  const trigger = <RewriteLauncher controller={controller} />;
 
   const panel =
     controller.status.kind === "idle" ? null : (
       <ResumeRewritePanel status={controller.status} onDismiss={controller.dismiss} />
     );
 
-  return { trigger, controls, panel };
+  return { trigger, panel };
+}
+
+/**
+ * The CTA button + its steering dialog. Clicking the button opens a modal that
+ * collects the rewrite options (page-length chips + freeform instructions);
+ * "Run rewrite" starts the rewrite and closes the dialog — progress then renders
+ * inline via {@link ResumeRewritePanel} (option (a): dialog is options-only, it
+ * doesn't host the run). Disabled while a rewrite is locked/in flight.
+ */
+function RewriteLauncher({
+  controller,
+}: {
+  controller: ResumeRewriteController;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={() => setOpen(true)}
+        disabled={controller.isLocked}
+        aria-label="Rewrite every section of the résumé"
+      >
+        {labelForResumeRewrite(controller.status, controller.isLockedByOther)}
+      </Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Rewrite full résumé"
+        className="fixed left-1/2 top-1/2 w-[min(28rem,90vw)] -translate-x-1/2 -translate-y-1/2"
+      >
+        <div className="flex flex-col gap-4">
+          <RewriteSteeringBox controller={controller} />
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                void controller.start();
+                setOpen(false);
+              }}
+              aria-label="Run the full-résumé rewrite"
+            >
+              Run rewrite
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
 }
 
 /**
@@ -109,6 +158,13 @@ function RewriteSteeringBox({
   const disabled = controller.isLocked;
 
   const onChipClick = (preset: (typeof PAGE_PRESETS)[number]) => {
+    // "No limit" (target null): clear the page target and drop any
+    // chip-prefilled hint, but never clobber text the user typed themselves.
+    if (preset.target === null) {
+      setPageTarget(null);
+      if (PRESET_HINTS.has(userInstructions.trim())) setUserInstructions("");
+      return;
+    }
     if (pageTarget === preset.target) {
       // Toggle off. Clear the prefilled hint too, but never clobber text the
       // user has since edited away from the preset's hint.
@@ -131,7 +187,7 @@ function RewriteSteeringBox({
           const selected = pageTarget === preset.target;
           return (
             <Button
-              key={preset.target}
+              key={preset.label}
               variant={selected ? "primary" : "ghost"}
               size="sm"
               disabled={disabled}

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -40,7 +40,10 @@ import {
 } from "../../hooks/useResumeRewrite.ts";
 import type { SectionInput, SectionOutcome } from "../../lib/webllm/rewrite-resume.ts";
 import type { PageTarget } from "../../lib/webllm/steering.ts";
-import { ProposedPanel } from "./ResumeRewriteProposed.tsx";
+import {
+  ProposedPanel,
+  type ResumeRewriteApply,
+} from "./ResumeRewriteProposed.tsx";
 
 export interface ResumeRewriteParts {
   /** The CTA button; opens the steering dialog (#210 steering box now lives
@@ -69,6 +72,7 @@ const PRESET_HINTS = new Set(PAGE_PRESETS.map((p) => p.hint).filter(Boolean));
 
 export function useResumeRewriteUi(
   sections: readonly SectionInput[],
+  applyBySection?: ResumeRewriteApply,
 ): ResumeRewriteParts {
   const controller = useResumeRewrite(sections);
 
@@ -80,7 +84,11 @@ export function useResumeRewriteUi(
 
   const panel =
     controller.status.kind === "idle" ? null : (
-      <ResumeRewritePanel status={controller.status} onDismiss={controller.dismiss} />
+      <ResumeRewritePanel
+        status={controller.status}
+        onDismiss={controller.dismiss}
+        applyBySection={applyBySection}
+      />
     );
 
   return { trigger, panel };
@@ -214,9 +222,11 @@ function RewriteSteeringBox({
 export function ResumeRewritePanel({
   status,
   onDismiss,
+  applyBySection,
 }: {
   status: ResumeRewriteStatus;
   onDismiss: () => void;
+  applyBySection?: ResumeRewriteApply;
 }) {
   if (status.kind === "idle") return null;
   if (status.kind === "loading") {
@@ -253,7 +263,13 @@ export function ResumeRewritePanel({
       </div>
     );
   }
-  return <ProposedPanel result={status.result} onDismiss={onDismiss} />;
+  return (
+    <ProposedPanel
+      result={status.result}
+      onDismiss={onDismiss}
+      applyBySection={applyBySection}
+    />
+  );
 }
 
 export function StepIndicator({

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -99,7 +99,7 @@ export function useResumeRewriteUi(
  * the user can't change steering mid-run. Reuses the `TextAreaField` and
  * `Button` primitives — no raw `<textarea>` / `<button>`.
  */
-export function RewriteSteeringBox({
+function RewriteSteeringBox({
   controller,
 }: {
   controller: ResumeRewriteController;

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -138,7 +138,6 @@ function RewriteLauncher({
                 void controller.start();
                 setOpen(false);
               }}
-              aria-label="Run the full-résumé rewrite"
             >
               Run rewrite
             </Button>
@@ -181,8 +180,13 @@ function RewriteSteeringBox({
       return;
     }
     setPageTarget(preset.target);
-    // Prefill only when the box is empty — don't overwrite custom text.
-    if (userInstructions.trim().length === 0) setUserInstructions(preset.hint);
+    // Prefill when the box is empty OR still holds another preset's hint — so
+    // switching 1→2 pages refreshes the visible copy instead of leaving a stale
+    // "single page" line. Never clobber text we don't recognize as a preset hint.
+    const current = userInstructions.trim();
+    if (current.length === 0 || PRESET_HINTS.has(current)) {
+      setUserInstructions(preset.hint);
+    }
   };
 
   return (

--- a/src/components/features/ResumeRewriteProposed.test.tsx
+++ b/src/components/features/ResumeRewriteProposed.test.tsx
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render + apply test for the whole-résumé `ProposedPanel` (#211 apply on the
+ * whole-résumé path). Verifies the gap this closes: the panel now mounts a
+ * per-bullet review per experience section (Accept/Reject rows + section
+ * Accept-all), and one global Apply writes every accepted decision back through
+ * the per-section handlers — mapping each pair's section-relative index to the
+ * real BulletObservation index — then dismisses.
+ *
+ * jsdom via the pragma, raw `createRoot`, matching `RewriteReviewList.test.tsx`.
+ */
+
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ProposedPanel, type ResumeRewriteApply } from "./ResumeRewriteProposed.tsx";
+import type { ResumeRewriteResult } from "../../lib/webllm/rewrite-resume.ts";
+import type { SectionRewriteApply } from "./SectionRewrite.tsx";
+
+// One experience section: bullet 0 reworded (matched), bullet 1 dropped
+// (removed), one fresh bullet (added). "a team of 5" overlap keeps 0↔0 matched;
+// the unrelated pair falls to remove + add.
+const RESULT: ResumeRewriteResult = {
+  allNumbersPreserved: true,
+  sections: [
+    {
+      kind: "experience",
+      input: {
+        kind: "experience",
+        id: "experience:0",
+        label: "Senior Engineer — Acme",
+        bullets: ["Managed a team of 5", "Filler bullet to drop"],
+      },
+      data: {
+        bullets: ["Led a team of 5 engineers", "Mentored two interns"],
+        numbersPreserved: true,
+        droppedNumbers: [],
+        addedNumbers: [],
+      },
+    },
+  ],
+};
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function render(node: React.ReactNode): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(node);
+  });
+  return container;
+}
+
+function click(btn: HTMLButtonElement | undefined) {
+  act(() => {
+    btn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+describe("ProposedPanel — whole-résumé per-bullet review + apply", () => {
+  function makeApply(): {
+    map: ResumeRewriteApply;
+    handlers: SectionRewriteApply;
+  } {
+    const handlers: SectionRewriteApply = {
+      // section bullet 0 → observation 10, bullet 1 → observation 11.
+      obsIndices: [10, 11],
+      onReplace: vi.fn(),
+      onRemove: vi.fn(),
+      onAdd: vi.fn(),
+    };
+    return { map: new Map([["experience:0", handlers]]), handlers };
+  }
+
+  it("renders accept/reject rows under the section header", () => {
+    const { map } = makeApply();
+    const el = render(
+      createElement(ProposedPanel, {
+        result: RESULT,
+        onDismiss: vi.fn(),
+        applyBySection: map,
+      }),
+    );
+
+    expect(el.textContent).toContain("Senior Engineer — Acme");
+    // One Accept control per pair (matched + removed + added = 3).
+    const acceptButtons = [...el.querySelectorAll("button")].filter((b) =>
+      b.getAttribute("aria-label")?.startsWith("Accept this"),
+    );
+    expect(acceptButtons.length).toBe(3);
+    // The global Apply starts disabled (nothing accepted yet).
+    const apply = el.querySelector(
+      'button[aria-label="Apply accepted changes to the resume"]',
+    ) as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+  });
+
+  it("Accept all + global Apply writes back through mapped obsIndices, then dismisses", () => {
+    const { map, handlers } = makeApply();
+    const onDismiss = vi.fn();
+    const el = render(
+      createElement(ProposedPanel, {
+        result: RESULT,
+        onDismiss,
+        applyBySection: map,
+      }),
+    );
+
+    const acceptAll = [...el.querySelectorAll("button")].find(
+      (b) => b.textContent === "Accept all",
+    ) as HTMLButtonElement;
+    click(acceptAll);
+
+    const apply = el.querySelector(
+      'button[aria-label="Apply accepted changes to the resume"]',
+    ) as HTMLButtonElement;
+    expect(apply.disabled).toBe(false);
+    expect(apply.textContent).toContain("Apply 3 changes");
+    click(apply);
+
+    // matched bullet 0 (obs 10) replaced; removed bullet 1 (obs 11) removed;
+    // the new bullet added — section-relative index joined to obsIndices.
+    expect(handlers.onReplace).toHaveBeenCalledWith(10, "Led a team of 5 engineers");
+    expect(handlers.onRemove).toHaveBeenCalledWith(11);
+    expect(handlers.onAdd).toHaveBeenCalledWith("Mentored two interns");
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to read-only (no review controls) when no apply wiring is given", () => {
+    const el = render(
+      createElement(ProposedPanel, { result: RESULT, onDismiss: vi.fn() }),
+    );
+    // No per-bullet Accept controls without an apply map; the diff still renders.
+    const acceptButtons = [...el.querySelectorAll("button")].filter((b) =>
+      b.getAttribute("aria-label")?.startsWith("Accept this"),
+    );
+    expect(acceptButtons.length).toBe(0);
+    expect(el.textContent).toContain("Senior Engineer — Acme");
+  });
+});

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -29,16 +29,97 @@ import type {
   ResumeRewriteResult,
   SectionOutcome,
 } from "../../lib/webllm/rewrite-resume.ts";
-import { NumberPreservationWarning } from "./SectionRewrite.tsx";
+import {
+  alignBullets,
+  type AlignedPair,
+} from "../../lib/rewrite-review/align-bullets.ts";
+import { resolveSectionWrites } from "../../lib/rewrite-review/apply-accepted.ts";
+import { useRewriteReview, type RewriteReview } from "../../hooks/useRewriteReview.ts";
+import {
+  NumberPreservationWarning,
+  type SectionRewriteApply,
+} from "./SectionRewrite.tsx";
+import { BulletReviewRow } from "./RewriteReviewList.tsx";
+
+/** Per-section apply wiring for the whole-résumé review, keyed by the
+ *  `SectionInput.id` (`experience:<index>`). Summary sections have no entry —
+ *  they stay read-only redlines (no per-bullet model). */
+export type ResumeRewriteApply = ReadonlyMap<string, SectionRewriteApply>;
+
+/** One experience section made reviewable: its aligned pairs (ids namespaced
+ *  by section so they're unique across the combined decision map) plus the
+ *  apply handlers that write accepted bullets back. */
+interface ReviewSection {
+  id: string;
+  label: string;
+  pairs: AlignedPair[];
+  apply: SectionRewriteApply;
+}
 
 export function ProposedPanel({
   result,
   onDismiss,
+  applyBySection,
 }: {
   result: ResumeRewriteResult;
   onDismiss: () => void;
+  /** Per-section write-back handlers (#211 apply for the whole-résumé path).
+   *  Absent → every section renders read-only (graceful fallback). */
+  applyBySection?: ResumeRewriteApply;
 }) {
   const aggregated = useMemo(() => aggregateDrift(result), [result]);
+
+  // Experience sections with an apply wiring become per-bullet reviewable;
+  // pair ids are namespaced by section id so the one combined decision map
+  // below never collides (`alignBullets` reuses `m:i:j` / `add:j` across
+  // sections). Everything else (summary) falls through to the read-only redline.
+  const reviewSections = useMemo<ReviewSection[]>(() => {
+    const out: ReviewSection[] = [];
+    for (const outcome of result.sections) {
+      if (outcome.kind !== "experience") continue;
+      const apply = applyBySection?.get(outcome.input.id);
+      if (!apply) continue;
+      const pairs = alignBullets(outcome.input.bullets, outcome.data.bullets).map(
+        (p): AlignedPair => ({ ...p, id: `${outcome.input.id}|${p.id}` }),
+      );
+      out.push({ id: outcome.input.id, label: outcome.input.label, pairs, apply });
+    }
+    return out;
+  }, [result, applyBySection]);
+
+  // ONE review hook over every section's pairs. Per-section incremental apply
+  // is impossible — writing a section's bullets back changes `resumeSections`,
+  // tripping the controller's stale-source guard, which dismisses the whole
+  // proposal. So apply is global: accept across sections, then one Apply.
+  const allPairs = useMemo(
+    () => reviewSections.flatMap((s) => s.pairs),
+    [reviewSections],
+  );
+  const review = useRewriteReview(allPairs);
+  const reviewById = useMemo(
+    () => new Map(reviewSections.map((s) => [s.id, s])),
+    [reviewSections],
+  );
+
+  const onApply = () => {
+    for (const sec of reviewSections) {
+      const writes = resolveSectionWrites(
+        sec.pairs,
+        sec.apply.obsIndices,
+        review.decisions,
+        review.edits,
+      );
+      for (const w of writes) {
+        if (w.kind === "add") sec.apply.onAdd(w.text);
+        else if (w.kind === "replace") sec.apply.onReplace(w.obsIndex, w.text);
+        else sec.apply.onRemove(w.obsIndex);
+      }
+    }
+    onDismiss();
+  };
+
+  const accepted = review.acceptedCount;
+
   return (
     <InlineResult
       tone={result.allNumbersPreserved ? "success" : "warning"}
@@ -51,13 +132,34 @@ export function ProposedPanel({
         />
       )}
       <ul className="flex flex-col gap-4 list-none">
-        {result.sections.map((outcome, i) => (
-          <li key={`${outcome.kind}-${i}`}>
-            <SectionResult outcome={outcome} />
-          </li>
-        ))}
+        {result.sections.map((outcome, i) => {
+          const rs =
+            outcome.kind === "experience"
+              ? reviewById.get(outcome.input.id)
+              : undefined;
+          return (
+            <li key={`${outcome.kind}-${i}`}>
+              {rs ? (
+                <ReviewSectionGroup section={rs} review={review} />
+              ) : (
+                <SectionResult outcome={outcome} />
+              )}
+            </li>
+          );
+        })}
       </ul>
       <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onApply}
+          disabled={accepted === 0}
+          aria-label="Apply accepted changes to the resume"
+        >
+          {accepted === 0
+            ? "Apply changes"
+            : `Apply ${accepted} change${accepted === 1 ? "" : "s"}`}
+        </Button>
         <Button
           variant="link"
           size="sm"
@@ -68,6 +170,51 @@ export function ProposedPanel({
         </Button>
       </div>
     </InlineResult>
+  );
+}
+
+/** One experience section in the whole-résumé review: a header with
+ *  section-scoped Accept-all / Reject-all, then a `BulletReviewRow` per pair
+ *  (the same row the per-role `RewriteReviewList` uses). */
+function ReviewSectionGroup({
+  section,
+  review,
+}: {
+  section: ReviewSection;
+  review: RewriteReview;
+}) {
+  const ids = section.pairs.map((p) => p.id);
+  return (
+    <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+          {section.label}
+        </h4>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => review.acceptMany(ids)}
+            className="rounded-md px-2 py-0.5 text-[11px]"
+          >
+            Accept all
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => review.rejectMany(ids)}
+            className="rounded-md px-2 py-0.5 text-[11px] text-content-tertiary"
+          >
+            Reject all
+          </Button>
+        </div>
+      </div>
+      <ul className="flex flex-col gap-2 list-none">
+        {section.pairs.map((pair) => (
+          <BulletReviewRow key={pair.id} pair={pair} review={review} />
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -22,7 +22,7 @@
  * cross-section aggregation contract without re-rendering the whole panel.
  */
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Button, InlineResult, InlineDiff } from "@design-system";
 import { computeTextDiff } from "../../lib/diff/text-diff.ts";
 import type {
@@ -101,7 +101,7 @@ export function ProposedPanel({
     [reviewSections],
   );
 
-  const onApply = () => {
+  const onApply = useCallback(() => {
     for (const sec of reviewSections) {
       const writes = resolveSectionWrites(
         sec.pairs,
@@ -116,7 +116,7 @@ export function ProposedPanel({
       }
     }
     onDismiss();
-  };
+  }, [reviewSections, review.decisions, review.edits, onDismiss]);
 
   const accepted = review.acceptedCount;
 

--- a/src/components/features/RewriteReviewList.test.tsx
+++ b/src/components/features/RewriteReviewList.test.tsx
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render tests for RewriteReviewList + its BulletReviewRow (#211). The decision
+ * model itself is covered in `src/hooks/useRewriteReview.test.tsx`; this file
+ * covers the React surface — that each `AlignedPair` kind paints the right
+ * row (kind label, redline old/new sides, edit affordance only for
+ * non-removals) and that the controls wire to the `RewriteReview` actions.
+ *
+ * Runs in jsdom (per the `@vitest-environment jsdom` pragma) with raw
+ * `createRoot`, matching `ContactCard.test.tsx`.
+ */
+
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { RewriteReviewList } from "./RewriteReviewList.tsx";
+import type { AlignedPair } from "../../lib/rewrite-review/align-bullets.ts";
+import type { RewriteReview } from "../../hooks/useRewriteReview.ts";
+
+const PAIRS: AlignedPair[] = [
+  {
+    kind: "matched",
+    id: "m:0:0",
+    original: "Led the migration",
+    originalIndex: 0,
+    proposed: "Led the database migration",
+    proposedIndex: 0,
+  },
+  { kind: "added", id: "add:1", proposed: "Mentored two interns", proposedIndex: 1 },
+  { kind: "removed", id: "del:1", original: "Misc filler bullet", originalIndex: 1 },
+];
+
+/** A `RewriteReview` stub: spy actions plus fixed decision/edit/count reads. */
+function makeReview(overrides: Partial<RewriteReview> = {}): RewriteReview {
+  return {
+    decisions: new Map(),
+    edits: new Map(),
+    accept: vi.fn(),
+    reject: vi.fn(),
+    toggle: vi.fn(),
+    setEdit: vi.fn(),
+    acceptMany: vi.fn(),
+    rejectMany: vi.fn(),
+    acceptAll: vi.fn(),
+    rejectAll: vi.fn(),
+    reset: vi.fn(),
+    acceptedCount: 0,
+    decisionOf: () => undefined,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function render(node: React.ReactNode): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(node);
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+describe("RewriteReviewList", () => {
+  it("renders one row per pair with kind labels, edit only for non-removals", () => {
+    const review = makeReview();
+    const el = render(
+      createElement(RewriteReviewList, {
+        pairs: PAIRS,
+        review,
+        onApply: vi.fn(),
+        onDiscard: vi.fn(),
+      }),
+    );
+
+    expect(el.querySelectorAll("li")).toHaveLength(3);
+    const labels = [...el.querySelectorAll("li span")].map((s) => s.textContent);
+    expect(labels).toContain("Edited bullet");
+    expect(labels).toContain("New bullet");
+    expect(labels).toContain("Removed bullet");
+
+    // EditableField (edit affordance) only renders for the two non-removed rows.
+    const editControls = el.querySelectorAll(
+      '[aria-label="Edit Edit proposed bullet"]',
+    );
+    expect(editControls.length).toBeGreaterThanOrEqual(2);
+
+    // Footer summary + disabled Apply (nothing accepted yet).
+    expect(el.textContent).toContain("3 changes proposed");
+    const apply = el.querySelector(
+      'button[aria-label="Apply accepted changes to the resume"]',
+    ) as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+  });
+
+  it("reflects accepted/rejected decision state on the controls", () => {
+    const review = makeReview({
+      acceptedCount: 1,
+      decisionOf: (id) =>
+        id === "m:0:0" ? "accepted" : id === "del:1" ? "rejected" : undefined,
+    });
+    const el = render(
+      createElement(RewriteReviewList, {
+        pairs: PAIRS,
+        review,
+        onApply: vi.fn(),
+        onDiscard: vi.fn(),
+      }),
+    );
+
+    expect(el.textContent).toContain("Accepted");
+    expect(el.textContent).toContain("Rejected");
+    // One accepted → Apply enabled and counts.
+    const apply = el.querySelector(
+      'button[aria-label="Apply accepted changes to the resume"]',
+    ) as HTMLButtonElement;
+    expect(apply.disabled).toBe(false);
+    expect(apply.textContent).toContain("Apply 1 change");
+  });
+
+  it("wires per-row and bulk controls to the review actions", () => {
+    const review = makeReview();
+    const onApply = vi.fn();
+    const onDiscard = vi.fn();
+    const el = render(
+      createElement(RewriteReviewList, {
+        pairs: PAIRS,
+        review,
+        onApply,
+        onDiscard,
+      }),
+    );
+
+    const click = (selector: string) => {
+      const btn = el.querySelector(selector) as HTMLButtonElement;
+      act(() => {
+        btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+    };
+
+    click('button[aria-label="Accept this edited bullet"]');
+    expect(review.accept).toHaveBeenCalledWith("m:0:0");
+    click('button[aria-label="Reject this removed bullet"]');
+    expect(review.reject).toHaveBeenCalledWith("del:1");
+
+    const acceptAll = [...el.querySelectorAll("button")].find(
+      (b) => b.textContent === "Accept all",
+    )!;
+    act(() => acceptAll.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(review.acceptMany).toHaveBeenCalledWith(["m:0:0", "add:1", "del:1"]);
+  });
+});

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * RewriteReviewList — per-bullet accept/reject/edit surface for a rewrite
+ * proposal (issue #211). Presentational: it renders one row per aligned pair
+ * (from `alignBullets`) as an inline diff plus Accept / Reject / Edit controls,
+ * a section-level Accept-all / Reject-all header, and a footer with the global
+ * "Apply N" action. All decision state lives in the `useRewriteReview` hook the
+ * caller owns (so the caller can drive Apply against the reconstructed résumé);
+ * this component only reads `review` and calls its actions.
+ *
+ * Reuse (CLAUDE.md 3-tier rule):
+ *   - `Button` primitive for every control — no raw `<button>`.
+ *   - `InlineDiff` + `computeTextDiff` (#209) for each row's redline.
+ *   - `EditableField` (multiline) for edit-in-place — the one inline-edit
+ *     primitive, never a hand-rolled textarea.
+ *   - Wrapped by the caller in the shared `InlineResult` strip, so this owns no
+ *     panel chrome of its own.
+ */
+
+import { Button, EditableField, InlineDiff } from "@design-system";
+import { computeTextDiff } from "../../lib/diff/text-diff.ts";
+import type { AlignedPair } from "../../lib/rewrite-review/align-bullets.ts";
+import type { RewriteReview } from "../../hooks/useRewriteReview.ts";
+
+/** The text a pair currently shows as its "new" side: the user's edit if any,
+ *  else the proposed text. Removed pairs have no new side. */
+function newSideText(pair: AlignedPair, review: RewriteReview): string {
+  if (pair.kind === "removed") return "";
+  const edited = review.edits.get(pair.id);
+  return edited !== undefined && edited.trim().length > 0
+    ? edited
+    : pair.proposed;
+}
+
+function oldSideText(pair: AlignedPair): string {
+  return pair.kind === "added" ? "" : pair.original;
+}
+
+/** One reviewable bullet: redline + accept/reject + (for non-removals) edit. */
+function BulletReviewRow({
+  pair,
+  review,
+}: {
+  pair: AlignedPair;
+  review: RewriteReview;
+}) {
+  const decision = review.decisionOf(pair.id);
+  const accepted = decision === "accepted";
+  const rejected = decision === "rejected";
+  const editable = pair.kind !== "removed";
+
+  const kindLabel =
+    pair.kind === "added"
+      ? "New bullet"
+      : pair.kind === "removed"
+        ? "Removed bullet"
+        : "Edited bullet";
+
+  return (
+    <li className="flex flex-col gap-1.5 rounded border border-border-light bg-surface-card p-2.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+          {kindLabel}
+        </span>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant={accepted ? "primary" : "ghost"}
+            size="sm"
+            onClick={() => review.accept(pair.id)}
+            aria-pressed={accepted}
+            aria-label={`Accept this ${kindLabel.toLowerCase()}`}
+            className="rounded-md px-2 py-0.5 text-[11px]"
+          >
+            {accepted ? "Accepted" : "Accept"}
+          </Button>
+          <Button
+            variant={rejected ? "primary" : "ghost"}
+            size="sm"
+            onClick={() => review.reject(pair.id)}
+            aria-pressed={rejected}
+            aria-label={`Reject this ${kindLabel.toLowerCase()}`}
+            className="rounded-md px-2 py-0.5 text-[11px] text-content-tertiary"
+          >
+            {rejected ? "Rejected" : "Reject"}
+          </Button>
+        </div>
+      </div>
+
+      <InlineDiff
+        segments={computeTextDiff(oldSideText(pair), newSideText(pair, review))}
+      />
+
+      {editable && (
+        <EditableField
+          value={newSideText(pair, review)}
+          placeholder="edit this bullet"
+          label="Edit proposed bullet"
+          textSize="xs"
+          display="inline"
+          multiline
+          onCommit={(v) => review.setEdit(pair.id, v)}
+        />
+      )}
+    </li>
+  );
+}
+
+export function RewriteReviewList({
+  pairs,
+  review,
+  onApply,
+  onDiscard,
+  warning,
+}: {
+  pairs: readonly AlignedPair[];
+  review: RewriteReview;
+  /** Apply the accepted decisions to the reconstructed résumé. */
+  onApply: () => void;
+  /** Drop the whole proposal back to idle. */
+  onDiscard: () => void;
+  /** Optional metric-drift warning rendered above the list. */
+  warning?: React.ReactNode;
+}) {
+  const ids = pairs.map((p) => p.id);
+  const total = pairs.length;
+  const accepted = review.acceptedCount;
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      {warning}
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-[11px] text-content-secondary">
+          {total} change{total === 1 ? "" : "s"} proposed — review each below.
+        </span>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => review.acceptMany(ids)}
+            className="rounded-md px-2 py-0.5 text-[11px]"
+          >
+            Accept all
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => review.rejectMany(ids)}
+            className="rounded-md px-2 py-0.5 text-[11px] text-content-tertiary"
+          >
+            Reject all
+          </Button>
+        </div>
+      </div>
+
+      <ul className="flex flex-col gap-2 list-none">
+        {pairs.map((pair) => (
+          <BulletReviewRow key={pair.id} pair={pair} review={review} />
+        ))}
+      </ul>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onApply}
+          disabled={accepted === 0}
+          aria-label="Apply accepted changes to the resume"
+        >
+          {accepted === 0 ? "Apply changes" : `Apply ${accepted} change${accepted === 1 ? "" : "s"}`}
+        </Button>
+        <Button
+          variant="link"
+          size="sm"
+          onClick={onDiscard}
+          className="text-[11px] font-medium text-content-tertiary"
+        >
+          Discard
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -38,8 +38,10 @@ function oldSideText(pair: AlignedPair): string {
   return pair.kind === "added" ? "" : pair.original;
 }
 
-/** One reviewable bullet: redline + accept/reject + (for non-removals) edit. */
-function BulletReviewRow({
+/** One reviewable bullet: redline + accept/reject + (for non-removals) edit.
+ *  Exported so the whole-résumé review (ResumeRewriteProposed) can reuse the
+ *  same row under section headers — the single reviewable-bullet primitive. */
+export function BulletReviewRow({
   pair,
   review,
 }: {

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -78,12 +78,16 @@ export function BulletReviewRow({
             {accepted ? "Accepted" : "Accept"}
           </Button>
           <Button
-            variant={rejected ? "primary" : "ghost"}
+            variant="ghost"
             size="sm"
             onClick={() => review.reject(pair.id)}
             aria-pressed={rejected}
             aria-label={`Reject this ${kindLabel.toLowerCase()}`}
-            className="rounded-md px-2 py-0.5 text-[11px] text-content-tertiary"
+            className={`rounded-md px-2 py-0.5 text-[11px] ${
+              rejected
+                ? "border border-border bg-surface-hover text-content-secondary"
+                : "text-content-tertiary"
+            }`}
           >
             {rejected ? "Rejected" : "Reject"}
           </Button>

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -46,6 +46,34 @@ import { useSectionRewriteLock } from "../../hooks/useSectionRewriteLock.ts";
 import { useModelSelection } from "../../hooks/useModelSelection.ts";
 import { Button, ModelLoadProgress, InlineResult, InlineDiff } from "@design-system";
 import { computeTextDiff } from "../../lib/diff/text-diff.ts";
+import {
+  alignBullets,
+  type AlignedPair,
+} from "../../lib/rewrite-review/align-bullets.ts";
+import { resolveBulletActions } from "../../lib/rewrite-review/apply-accepted.ts";
+import { useRewriteReview } from "../../hooks/useRewriteReview.ts";
+import { RewriteReviewList } from "./RewriteReviewList.tsx";
+
+/**
+ * Wiring a per-role rewrite to the reconstructed-résumé edit model so accepted
+ * bullets can be written back (#211). `obsIndices` is parallel to the `bullets`
+ * passed to `useSectionRewrite` (same order/length, BEFORE blank-trimming), so
+ * an accepted change at trimmed position i resolves to its
+ * BulletObservation.index. When omitted, the proposed panel keeps its legacy
+ * copy-all/discard surface (used by callers without an edit model).
+ */
+export interface SectionRewriteApply {
+  obsIndices: readonly number[];
+  /** Replace a parsed bullet's text (→ setBulletField). */
+  onReplace: (obsIndex: number, text: string) => void;
+  /** Drop a parsed bullet (→ removeBullet). */
+  onRemove: (obsIndex: number) => void;
+  /** Append a new bullet to this role (→ addBullet on the role's entry key). */
+  onAdd: (text: string) => void;
+}
+
+/** Stable empty alignment so the review hook doesn't reset on every idle render. */
+const NO_PAIRS: AlignedPair[] = [];
 
 /** What `useSectionRewrite` hands back so the caller can place the trigger and
  *  the result panel in separate slots (trigger beside the role title, panel
@@ -94,6 +122,7 @@ function bulletsEqual(a: readonly string[], b: readonly string[]): boolean {
  */
 export function useSectionRewrite(
   bullets: readonly string[],
+  apply?: SectionRewriteApply,
 ): SectionRewriteParts {
   const [capability, setCapability] = useState<WebGpuCapability | null>(null);
   const [status, setStatus] = useState<Status>({ kind: "idle" });
@@ -103,11 +132,36 @@ export function useSectionRewrite(
 
   // Trim blank bullets here once — passed to both the model (so it doesn't
   // see empties) and the before/after panel (so the original column matches
-  // what the model actually saw).
-  const trimmedBullets = useMemo(
-    () => bullets.filter((b) => b.trim().length > 0),
-    [bullets],
+  // what the model actually saw). When an edit model is wired (`apply`), the
+  // surviving bullets' BulletObservation indices are kept parallel so an
+  // accepted change at trimmed position i maps back to the right bullet.
+  const { trimmedBullets, keptObsIndices } = useMemo(() => {
+    const texts: string[] = [];
+    const idxs: number[] = [];
+    bullets.forEach((b, i) => {
+      if (b.trim().length === 0) return;
+      texts.push(b);
+      if (apply) idxs.push(apply.obsIndices[i] ?? -1);
+    });
+    return { trimmedBullets: texts, keptObsIndices: idxs };
+  }, [bullets, apply]);
+
+  // Per-bullet review state (#211). Aligned against the snapshot the model
+  // actually saw (stable per proposal) — not the live bullets — so the rows and
+  // the decision map don't churn under unrelated re-renders.
+  const pairs = useMemo<AlignedPair[]>(
+    () =>
+      status.kind === "proposed"
+        ? alignBullets(status.snapshot, status.result.bullets)
+        : NO_PAIRS,
+    [status],
   );
+  const review = useRewriteReview(pairs);
+  const { reset: resetReview } = review;
+  // A fresh proposal (new aligned pairs) starts with a clean decision slate.
+  useEffect(() => {
+    resetReview();
+  }, [pairs, resetReview]);
 
   useEffect(() => {
     let cancelled = false;
@@ -179,6 +233,27 @@ export function useSectionRewrite(
     setCopied(false);
   }, []);
 
+  // Apply accepted decisions back into the reconstructed résumé via the edit
+  // model, then dismiss the proposal. Each action's `originalIndex` is a
+  // position in the trimmed snapshot, mapped to its BulletObservation.index
+  // through `keptObsIndices`.
+  const onApply = useCallback(() => {
+    if (!apply) return;
+    const actions = resolveBulletActions(pairs, review.decisions, review.edits);
+    for (const action of actions) {
+      if (action.kind === "add") {
+        apply.onAdd(action.text);
+        continue;
+      }
+      const obsIndex = keptObsIndices[action.originalIndex];
+      if (obsIndex === undefined || obsIndex < 0) continue;
+      if (action.kind === "replace") apply.onReplace(obsIndex, action.text);
+      else apply.onRemove(obsIndex);
+    }
+    setStatus({ kind: "idle" });
+    setCopied(false);
+  }, [apply, pairs, review.decisions, review.edits, keptObsIndices]);
+
   const onCopyAll = useCallback(async () => {
     if (status.kind !== "proposed") return;
     try {
@@ -226,15 +301,36 @@ export function useSectionRewrite(
           </p>
         )}
 
-        {status.kind === "proposed" && (
-          <ProposedSection
-            original={trimmedBullets}
-            result={status.result}
-            copied={copied}
-            onCopyAll={onCopyAll}
-            onReject={onReject}
-          />
-        )}
+        {status.kind === "proposed" &&
+          (apply ? (
+            <InlineResult
+              tone={status.result.numbersPreserved ? "success" : "warning"}
+              className="flex flex-col gap-3"
+            >
+              <RewriteReviewList
+                pairs={pairs}
+                review={review}
+                onApply={onApply}
+                onDiscard={onReject}
+                warning={
+                  status.result.numbersPreserved ? undefined : (
+                    <NumberPreservationWarning
+                      dropped={status.result.droppedNumbers}
+                      added={status.result.addedNumbers}
+                    />
+                  )
+                }
+              />
+            </InlineResult>
+          ) : (
+            <ProposedSection
+              original={trimmedBullets}
+              result={status.result}
+              copied={copied}
+              onCopyAll={onCopyAll}
+              onReject={onReject}
+            />
+          ))}
 
         {status.kind === "error" && (
           <p role="alert" className="text-[11px] text-feedback-error-text">

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -19,6 +19,7 @@ export * from "./primitives/Chip.tsx";
 export * from "./primitives/Dialog.tsx";
 export * from "./primitives/EditableField.tsx";
 export * from "./primitives/StarRating.tsx";
+export * from "./primitives/TextAreaField.tsx";
 export * from "./shared/Card.tsx";
 export * from "./shared/InlineResult.tsx";
 export * from "./shared/ModelLoadProgress.tsx";

--- a/src/design-system/primitives/Dialog.tsx
+++ b/src/design-system/primitives/Dialog.tsx
@@ -41,9 +41,12 @@ interface DialogProps {
   /** Required when `title` is omitted — the accessible name for the dialog. */
   ariaLabel?: string;
   /**
-   * Optional class for the inner panel layout (caller-side flex/gap,
-   * max-width, etc.). Chrome (radius/border/bg/padding) stays owned by the
-   * primitive.
+   * Optional classes appended to the `<dialog>` element itself — caller-side
+   * positioning/sizing (e.g. `fixed left-1/2 -translate-x-1/2`, max-width).
+   * Use positioning/layout utilities only: the chrome (radius/border/bg/
+   * padding) and the UA `dialog:not([open]){display:none}` rule that hides a
+   * closed dialog stay owned by the primitive, so don't pass `display`/`hidden`
+   * utilities here — they'd break the closed-state hide.
    */
   className?: string;
   children: ReactNode;

--- a/src/design-system/primitives/TextAreaField.tsx
+++ b/src/design-system/primitives/TextAreaField.tsx
@@ -50,12 +50,15 @@ export function TextAreaField({
 }: TextAreaFieldProps) {
   const ref = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-grow: sync height to scroll height on every value change.
+  // Auto-grow: sync height to scroll height on every value change. Skip the
+  // pin when the element is detached/hidden (scrollHeight 0) — e.g. mounted
+  // inside a closed <dialog> — so it doesn't collapse to 0px; the natural
+  // `rows` height then shows once the field becomes visible.
   useEffect(() => {
     const ta = ref.current;
     if (!ta) return;
     ta.style.height = "auto";
-    ta.style.height = `${ta.scrollHeight}px`;
+    if (ta.scrollHeight > 0) ta.style.height = `${ta.scrollHeight}px`;
   }, [value]);
 
   return (

--- a/src/design-system/primitives/TextAreaField.tsx
+++ b/src/design-system/primitives/TextAreaField.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * TextAreaField — the ONE always-visible multiline text input primitive.
+ *
+ * Distinct from `EditableField` (multiline): EditableField is a click-to-edit
+ * affordance for an existing value on a document-shaped surface (read mode →
+ * edit mode → commit). TextAreaField is a plain, always-editable, controlled
+ * textarea for free composition — e.g. the rewrite "Instructions" box (#210)
+ * where there's no read/edit toggle and the empty state should show example
+ * placeholder text, not a "not detected" affordance.
+ *
+ * Owns the raw <textarea> so feature code never hand-rolls one (the textarea is
+ * a UI primitive concern; CLAUDE.md's 3-tier rule keeps it here, not in
+ * src/components/). Auto-grows to fit content like EditableField's multiline
+ * variant.
+ *
+ * Design rules (CLAUDE.md): semantic tokens only; no hardcoded hex or raw
+ * palette classes.
+ */
+
+import { useEffect, useRef } from "react";
+
+interface TextAreaFieldProps {
+  /** Controlled value. */
+  value: string;
+  /** Called with the raw textarea value on every keystroke. */
+  onChange: (value: string) => void;
+  /** Accessible label (aria-label) for the textarea. */
+  label: string;
+  /** Placeholder shown when empty (e.g. example asks). */
+  placeholder?: string;
+  /** Minimum visible rows before auto-grow kicks in. Defaults to 2. */
+  rows?: number;
+  /** When true, the textarea is read-only and dimmed. */
+  disabled?: boolean;
+  /** Extra classes on the root wrapper (layout stays with the caller). */
+  className?: string;
+}
+
+export function TextAreaField({
+  value,
+  onChange,
+  label,
+  placeholder,
+  rows = 2,
+  disabled = false,
+  className,
+}: TextAreaFieldProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-grow: sync height to scroll height on every value change.
+  useEffect(() => {
+    const ta = ref.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${ta.scrollHeight}px`;
+  }, [value]);
+
+  return (
+    <textarea
+      ref={ref}
+      aria-label={label}
+      value={value}
+      rows={rows}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+      className={[
+        "w-full resize-none overflow-hidden rounded border border-border",
+        "bg-surface-card px-2 py-1.5 text-sm leading-snug",
+        "text-content-primary placeholder:text-content-muted",
+        "outline-hidden focus:ring-1 focus:ring-brand-amber",
+        "disabled:opacity-60",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    />
+  );
+}

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -162,6 +162,12 @@ export interface EditableParse {
   bulletOverrides: BulletOverrides;
   /** Set the override text for one bullet. Pass undefined to clear it. */
   setBulletField: (index: number, value: string | undefined) => void;
+  /** Indices of parsed bullets the user dropped (rewrite-review removals, #211),
+   *  keyed by BulletObservation.index — folded by applyOverrides to drop the
+   *  line from the graded pool, rawText, and the role description. */
+  removedBullets: ReadonlySet<number>;
+  /** Drop a parsed bullet by its BulletObservation.index. Idempotent. */
+  removeBullet: (index: number) => void;
   /** Override map for education entries, keyed by education array index. */
   educationOverrides: Record<number, EducationFieldOverrides>;
   /** Update one field on a specific education entry by its array index.
@@ -208,6 +214,9 @@ export function useEditableParse(): EditableParse {
     Record<number, ExperienceFieldOverrides>
   >({});
   const [bulletOverrides, setBulletOverrides] = useState<BulletOverrides>({});
+  const [removedBullets, setRemovedBullets] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
   const [educationOverrides, setEducationOverrides] = useState<
     Record<number, EducationFieldOverrides>
   >({});
@@ -269,6 +278,15 @@ export function useEditableParse(): EditableParse {
     },
     [],
   );
+
+  const removeBullet = useCallback((index: number) => {
+    setRemovedBullets((prev) => {
+      if (prev.has(index)) return prev;
+      const next = new Set(prev);
+      next.add(index);
+      return next;
+    });
+  }, []);
 
   const setEducationField = useCallback(
     (
@@ -356,6 +374,7 @@ export function useEditableParse(): EditableParse {
     setContactOverrides({});
     setExperienceOverrides({});
     setBulletOverrides({});
+    setRemovedBullets(new Set());
     setEducationOverrides({});
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
     setAddedEntries([]);
@@ -365,6 +384,7 @@ export function useEditableParse(): EditableParse {
   const hasEdits = useMemo(() => {
     if (Object.keys(contactOverrides).length > 0) return true;
     if (Object.keys(bulletOverrides).length > 0) return true;
+    if (removedBullets.size > 0) return true;
     if (skillsOverride.removed.length > 0 || skillsOverride.added.length > 0)
       return true;
     if (addedEntries.length > 0) return true;
@@ -382,6 +402,7 @@ export function useEditableParse(): EditableParse {
     contactOverrides,
     experienceOverrides,
     bulletOverrides,
+    removedBullets,
     educationOverrides,
     skillsOverride,
     addedEntries,
@@ -395,6 +416,8 @@ export function useEditableParse(): EditableParse {
     setExperienceField,
     bulletOverrides,
     setBulletField,
+    removedBullets,
+    removeBullet,
     educationOverrides,
     setEducationField,
     addedEntries,

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -38,11 +38,26 @@ import {
   type SectionInput,
 } from "../lib/webllm/rewrite-resume.ts";
 import type {
+  PageTarget,
+  RewriteSteering,
+} from "../lib/webllm/steering.ts";
+import type {
   ProgressUpdate,
   WebGpuCapability,
 } from "../lib/webllm/types.ts";
 import { useModelSelection } from "./useModelSelection.ts";
+import { usePersistentFlag } from "./usePersistentFlag.ts";
 import { useSectionRewriteLock } from "./useSectionRewriteLock.ts";
+
+/** localStorage keys for the last-used steering (issue #210). */
+const INSTRUCTIONS_KEY = "rl_rewrite_instructions";
+const PAGE_TARGET_KEY = "rl_rewrite_page_target";
+
+function parsePageTarget(stored: string): PageTarget | null {
+  return stored === "1" || stored === "2" || stored === "3"
+    ? (Number(stored) as PageTarget)
+    : null;
+}
 
 export type ResumeRewriteStatus =
   | { kind: "idle" }
@@ -78,6 +93,14 @@ export interface ResumeRewriteController {
   start: () => Promise<void>;
   /** Drop a proposed/error state back to idle. */
   dismiss: () => void;
+  /** Freeform "what I want from this rewrite" text (#210). Persisted. */
+  userInstructions: string;
+  /** Update the freeform instructions (persists to localStorage). */
+  setUserInstructions: (value: string) => void;
+  /** Selected page-length target, or null when none is chosen (#210). */
+  pageTarget: PageTarget | null;
+  /** Set/clear the page-length target (persists to localStorage). */
+  setPageTarget: (target: PageTarget | null) => void;
 }
 
 export function labelForResumeRewrite(
@@ -129,6 +152,20 @@ export function useResumeRewrite(
   const { isLocked, acquire } = useSectionRewriteLock();
   const { selectedModelId } = useModelSelection();
 
+  // Steering (#210): freeform instructions + page-length target, persisted so a
+  // re-run keeps the user's last intent. pageTarget round-trips through a string
+  // key ("" | "1" | "2" | "3").
+  const [userInstructions, setUserInstructionsRaw] =
+    usePersistentFlag(INSTRUCTIONS_KEY);
+  const [pageTargetRaw, setPageTargetRaw] = usePersistentFlag(PAGE_TARGET_KEY);
+  const pageTarget = parsePageTarget(pageTargetRaw);
+  const setPageTarget = useCallback(
+    (target: PageTarget | null) => {
+      setPageTargetRaw(target === null ? "" : String(target));
+    },
+    [setPageTargetRaw],
+  );
+
   const rewriteableSections = useMemo(
     () => sections.filter(isNonEmptyForUi),
     [sections],
@@ -163,6 +200,16 @@ export function useResumeRewrite(
       const engine = await loadEngine(selectedModelId, (progress) => {
         setStatus({ kind: "loading", progress });
       });
+      const trimmedInstructions = userInstructions.trim();
+      const steering: RewriteSteering | undefined =
+        trimmedInstructions || pageTarget !== null
+          ? {
+              ...(trimmedInstructions
+                ? { userInstructions: trimmedInstructions }
+                : {}),
+              ...(pageTarget !== null ? { pageTarget } : {}),
+            }
+          : undefined;
       const result = await rewriteResumeWithLlm(
         rewriteableSections,
         engine,
@@ -170,6 +217,7 @@ export function useResumeRewrite(
         (progress) => {
           setStatus({ kind: "running", progress });
         },
+        steering,
       );
       if (result.sections.length === 0) {
         setStatus({
@@ -192,7 +240,7 @@ export function useResumeRewrite(
     } finally {
       release();
     }
-  }, [acquire, rewriteableSections, selectedModelId]);
+  }, [acquire, rewriteableSections, selectedModelId, userInstructions, pageTarget]);
 
   const dismiss = useCallback(() => {
     setStatus({ kind: "idle" });
@@ -212,6 +260,10 @@ export function useResumeRewrite(
     isLockedByOther,
     start,
     dismiss,
+    userInstructions,
+    setUserInstructions: setUserInstructionsRaw,
+    pageTarget,
+    setPageTarget,
   };
 }
 

--- a/src/hooks/useRewriteReview.test.tsx
+++ b/src/hooks/useRewriteReview.test.tsx
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useRewriteReview behaviour, exercised through a probe component rendered with
+ * react-dom/client (the project has no @testing-library/react — same pattern as
+ * useModelSelection.integration.test.tsx). The pure decision math lives in
+ * apply-accepted.ts (covered there); this file covers the hook's state
+ * transitions: single accept/reject, edit-implies-accept, section/all batches,
+ * and reset.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { alignBullets } from "../lib/rewrite-review/align-bullets.ts";
+import { applyAcceptedBullets } from "../lib/rewrite-review/apply-accepted.ts";
+import { useRewriteReview, type RewriteReview } from "./useRewriteReview.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const original = ["Built feature A here", "Old filler bullet line", "Wrote the docs"];
+const proposed = ["Built and shipped feature A here", "Wrote the docs", "New bullet"];
+const pairs = alignBullets(original, proposed);
+
+let container: HTMLDivElement;
+let root: Root;
+let api: RewriteReview;
+
+function Probe() {
+  api = useRewriteReview(pairs);
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(<Probe />);
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useRewriteReview", () => {
+  it("starts with no decisions and zero accepted", () => {
+    expect(api.acceptedCount).toBe(0);
+    expect(applyAcceptedBullets(pairs, api.decisions, api.edits)).toEqual(original);
+  });
+
+  it("accept then reject a single pair flips its decision", () => {
+    const id = pairs[0]!.id;
+    act(() => api.accept(id));
+    expect(api.decisionOf(id)).toBe("accepted");
+    expect(api.acceptedCount).toBe(1);
+    act(() => api.reject(id));
+    expect(api.decisionOf(id)).toBe("rejected");
+    expect(api.acceptedCount).toBe(0);
+  });
+
+  it("toggle alternates a pair between accepted and rejected", () => {
+    const id = pairs[0]!.id;
+    act(() => api.toggle(id));
+    expect(api.decisionOf(id)).toBe("accepted");
+    act(() => api.toggle(id));
+    expect(api.decisionOf(id)).toBe("rejected");
+  });
+
+  it("editing a bullet auto-accepts it and feeds Apply the edited text", () => {
+    const matched = pairs.find((p) => p.kind === "matched")!;
+    act(() => api.setEdit(matched.id, "Edited replacement text"));
+    expect(api.decisionOf(matched.id)).toBe("accepted");
+    const out = applyAcceptedBullets(pairs, api.decisions, api.edits);
+    expect(out).toContain("Edited replacement text");
+  });
+
+  it("clearing an edit (empty string) drops it but leaves the pair accepted", () => {
+    const matched = pairs.find((p) => p.kind === "matched")!;
+    act(() => api.setEdit(matched.id, "temp"));
+    act(() => api.setEdit(matched.id, ""));
+    expect(api.edits.has(matched.id)).toBe(false);
+    expect(api.decisionOf(matched.id)).toBe("accepted");
+  });
+
+  it("acceptAll then rejectAll move every pair together", () => {
+    act(() => api.acceptAll());
+    expect(api.acceptedCount).toBe(pairs.length);
+    act(() => api.rejectAll());
+    expect(api.acceptedCount).toBe(0);
+  });
+
+  it("acceptMany accepts only the listed ids", () => {
+    const ids = [pairs[0]!.id, pairs[1]!.id];
+    act(() => api.acceptMany(ids));
+    expect(api.acceptedCount).toBe(2);
+  });
+
+  it("reset clears decisions and edits", () => {
+    act(() => api.acceptAll());
+    act(() => api.setEdit(pairs[0]!.id, "x"));
+    act(() => api.reset());
+    expect(api.acceptedCount).toBe(0);
+    expect(api.edits.size).toBe(0);
+  });
+});

--- a/src/hooks/useRewriteReview.ts
+++ b/src/hooks/useRewriteReview.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useRewriteReview — in-memory per-bullet accept/reject/edit decision model for
+ * a rewrite proposal (issue #211). The hook half of Recruidea's
+ * `useArtifactReview` (its Supabase persistence half is intentionally dropped —
+ * cloud versioning of accepted edits is the paid-tier lane, out of scope here).
+ *
+ * It is told the aligned pairs (from `alignBullets`) up front and owns two maps,
+ * both keyed by `AlignedPair.id`:
+ *   - `decisions`  — accepted | rejected (absent = undecided).
+ *   - `edits`      — per-bullet edited text (an edit auto-accepts its pair, the
+ *     same affordance as `editSuggestionValue` in the source).
+ *
+ * Section/batch actions operate over an explicit id list the caller passes (a
+ * section's pair ids, or "all"), so the hook never needs to know the section
+ * structure — it just flips entries in the maps.
+ *
+ * Pure interaction state: no I/O. The actual write-back into the reconstructed
+ * résumé is `resolveBulletActions` + the edit primitives, driven by the caller
+ * on Apply — this hook only records intent.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type { AlignedPair } from "../lib/rewrite-review/align-bullets.ts";
+import {
+  acceptedCount as countAccepted,
+  type Decision,
+  type Decisions,
+  type Edits,
+} from "../lib/rewrite-review/apply-accepted.ts";
+
+export interface RewriteReview {
+  /** Decision per pair id (absent = undecided). */
+  decisions: Decisions;
+  /** Edited text per pair id (absent = use the proposed text). */
+  edits: Edits;
+  /** Accept one pair. */
+  accept: (id: string) => void;
+  /** Reject one pair. */
+  reject: (id: string) => void;
+  /** Toggle one pair between accepted and not (rejected). Convenience for a
+   *  single accept/reject control that flips state. */
+  toggle: (id: string) => void;
+  /** Set the edited text for one pair; editing auto-accepts it (matches the
+   *  source's edit-implies-accept affordance). An empty string clears the edit
+   *  (and leaves the pair accepted — Apply falls back to the proposed text). */
+  setEdit: (id: string, value: string) => void;
+  /** Accept every pair in `ids` (a section's pairs). */
+  acceptMany: (ids: readonly string[]) => void;
+  /** Reject every pair in `ids` (a section's pairs). */
+  rejectMany: (ids: readonly string[]) => void;
+  /** Accept every pair in the whole proposal. */
+  acceptAll: () => void;
+  /** Reject every pair in the whole proposal. */
+  rejectAll: () => void;
+  /** Clear all decisions and edits back to undecided. */
+  reset: () => void;
+  /** Count of accepted pairs across the whole proposal. */
+  acceptedCount: number;
+  /** Decision for one pair, or undefined when undecided. */
+  decisionOf: (id: string) => Decision | undefined;
+}
+
+export function useRewriteReview(
+  pairs: readonly AlignedPair[],
+): RewriteReview {
+  const [decisions, setDecisions] = useState<Map<string, Decision>>(
+    () => new Map(),
+  );
+  const [edits, setEdits] = useState<Map<string, string>>(() => new Map());
+
+  const allIds = useMemo(() => pairs.map((p) => p.id), [pairs]);
+
+  const setDecision = useCallback((ids: readonly string[], value: Decision) => {
+    setDecisions((prev) => {
+      const next = new Map(prev);
+      for (const id of ids) next.set(id, value);
+      return next;
+    });
+  }, []);
+
+  const accept = useCallback((id: string) => setDecision([id], "accepted"), [
+    setDecision,
+  ]);
+  const reject = useCallback((id: string) => setDecision([id], "rejected"), [
+    setDecision,
+  ]);
+
+  const toggle = useCallback((id: string) => {
+    setDecisions((prev) => {
+      const next = new Map(prev);
+      next.set(id, prev.get(id) === "accepted" ? "rejected" : "accepted");
+      return next;
+    });
+  }, []);
+
+  const setEdit = useCallback((id: string, value: string) => {
+    setEdits((prev) => {
+      const next = new Map(prev);
+      if (value === "") next.delete(id);
+      else next.set(id, value);
+      return next;
+    });
+    // Editing implies accepting — a user only edits a bullet they intend to keep.
+    setDecisions((prev) => {
+      if (prev.get(id) === "accepted") return prev;
+      const next = new Map(prev);
+      next.set(id, "accepted");
+      return next;
+    });
+  }, []);
+
+  const acceptMany = useCallback(
+    (ids: readonly string[]) => setDecision(ids, "accepted"),
+    [setDecision],
+  );
+  const rejectMany = useCallback(
+    (ids: readonly string[]) => setDecision(ids, "rejected"),
+    [setDecision],
+  );
+
+  const acceptAll = useCallback(
+    () => setDecision(allIds, "accepted"),
+    [setDecision, allIds],
+  );
+  const rejectAll = useCallback(
+    () => setDecision(allIds, "rejected"),
+    [setDecision, allIds],
+  );
+
+  const reset = useCallback(() => {
+    setDecisions(new Map());
+    setEdits(new Map());
+  }, []);
+
+  const acceptedCount = useMemo(
+    () => countAccepted(pairs, decisions),
+    [pairs, decisions],
+  );
+
+  const decisionOf = useCallback(
+    (id: string) => decisions.get(id),
+    [decisions],
+  );
+
+  return {
+    decisions,
+    edits,
+    accept,
+    reject,
+    toggle,
+    setEdit,
+    acceptMany,
+    rejectMany,
+    acceptAll,
+    rejectAll,
+    reset,
+    acceptedCount,
+    decisionOf,
+  };
+}

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -212,6 +212,52 @@ describe("applyOverrides", () => {
     );
   });
 
+  it("removes a bullet from rawText, sections, and the role description", () => {
+    const rawText = "• Built a thing\n• Shipped another thing";
+    const {
+      parsed: out,
+      rawText: outRaw,
+      sections: outSections,
+    } = applyOverrides(
+      baseParsed(),
+      rawText,
+      makeSections(["• Built a thing", "• Shipped another thing"]),
+      {},
+      {},
+      {},
+      [obs(0, "Built a thing"), obs(1, "Shipped another thing")],
+      {},
+      undefined,
+      [],
+      {},
+      new Set([0]),
+    );
+    expect(outRaw).toBe("• Shipped another thing");
+    expect(out.experience[0].description).toBe("Shipped another thing");
+    expect(outSections.byName.get("experience")).toEqual([
+      "• Shipped another thing",
+    ]);
+  });
+
+  it("removal is a no-op when the index has no matching observation", () => {
+    const rawText = "• Built a thing\n• Shipped another thing";
+    const { rawText: outRaw } = applyOverrides(
+      baseParsed(),
+      rawText,
+      makeSections(["• Built a thing", "• Shipped another thing"]),
+      {},
+      {},
+      {},
+      [obs(0, "Built a thing")],
+      {},
+      undefined,
+      [],
+      {},
+      new Set([99]), // index not in observations
+    );
+    expect(outRaw).toBe(rawText);
+  });
+
   it("is a no-op when overrides are empty", () => {
     const parsed = baseParsed();
     const rawText = "• Built a thing";

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -168,6 +168,80 @@ function replaceBulletInDescriptions(
   }
 }
 
+/**
+ * Remove the first rawText line whose normalised form equals `originalText`.
+ * Returns the text unchanged when no line matches. Mirrors
+ * `replaceBulletInRawText`'s first-match contract, but drops the line entirely
+ * (the rewrite-review "accept this removal" path, #211).
+ */
+function removeBulletFromRawText(
+  rawText: string,
+  originalText: string,
+): string {
+  const target = normalizeBulletText(originalText);
+  if (!target) return rawText;
+  const lines = rawText.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (normalizeBulletText(lines[i]) !== target) continue;
+    lines.splice(i, 1);
+    return lines.join("\n");
+  }
+  return rawText;
+}
+
+/**
+ * Remove the first accomplishment-section line whose normalised form equals
+ * `originalText`, returning a NEW {@link SectionedResume} with only the mutated
+ * section's array cloned. This is the pool the anonymous scorer grades from
+ * (#133), so an accepted removal must drop the line here to move the score.
+ */
+function removeBulletFromSections(
+  sections: SectionedResume,
+  originalText: string,
+): SectionedResume {
+  const target = normalizeBulletText(originalText);
+  if (!target) return sections;
+  for (const name of sections.accomplishmentSections) {
+    const lines = sections.byName.get(name);
+    if (!lines) continue;
+    for (let i = 0; i < lines.length; i++) {
+      if (normalizeBulletText(lines[i]) !== target) continue;
+      const nextLines = lines.slice();
+      nextLines.splice(i, 1);
+      const nextByName = new Map<SectionName | "profile", readonly string[]>(
+        sections.byName,
+      );
+      nextByName.set(name, nextLines);
+      return { ...sections, byName: nextByName };
+    }
+  }
+  return sections;
+}
+
+/**
+ * Remove the first description line (in any role) whose normalised form equals
+ * `originalText`, mutating the cloned experience entries in place. Mirrors
+ * `replaceBulletInDescriptions`' first-match tiebreak.
+ */
+function removeBulletFromDescriptions(
+  experience: HeuristicParsedResume["experience"],
+  originalText: string,
+): void {
+  const target = normalizeBulletText(originalText);
+  if (!target) return;
+  for (const exp of experience) {
+    if (!exp.description) continue;
+    const descLines = exp.description.split("\n");
+    for (let i = 0; i < descLines.length; i++) {
+      if (normalizeBulletText(descLines[i]) === target) {
+        descLines.splice(i, 1);
+        exp.description = descLines.join("\n");
+        return; // first-match tiebreak
+      }
+    }
+  }
+}
+
 /** Leading bullet/numbered markers — mirrors group-bullets.ts LEADING_MARKER_RE. */
 const LEADING_MARKER_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·�]|\d+[.)]) */;
 
@@ -214,6 +288,7 @@ export function applyOverrides(
   skills: SkillsOverride = { removed: [], added: [] },
   addedEntries: readonly AddedEntry[] = [],
   addedBullets: AddedBullets = {},
+  removedBullets: ReadonlySet<number> = new Set(),
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -273,6 +348,20 @@ export function applyOverrides(
     nextRawText = replaceBulletInRawText(nextRawText, obs.text, edited);
     nextSections = replaceBulletInSections(nextSections, obs.text, edited);
     replaceBulletInDescriptions(nextParsed.experience, obs.text, edited);
+  }
+
+  // ── Removed bullets — drop the line from the pool, rawText, description ────
+  // Accepted "this bullet was removed" decisions from the rewrite review (#211).
+  // Removal changes the bullet COUNT, so re-grading produces fresh
+  // BulletObservation indices; that's fine because removals are applied as a
+  // batch and the proposal is dismissed afterward (the override maps that key
+  // by index are reconciled on the next render against the new observations).
+  for (const idx of removedBullets) {
+    const obs = byIndex.get(idx);
+    if (!obs) continue;
+    nextRawText = removeBulletFromRawText(nextRawText, obs.text);
+    nextSections = removeBulletFromSections(nextSections, obs.text);
+    removeBulletFromDescriptions(nextParsed.experience, obs.text);
   }
 
   // ── Education fields ──────────────────────────────────────────────────────

--- a/src/lib/rewrite-review/align-bullets.test.ts
+++ b/src/lib/rewrite-review/align-bullets.test.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  alignBullets,
+  bulletSimilarity,
+  MATCH_THRESHOLD,
+  type AlignedPair,
+} from "./align-bullets.ts";
+
+/** Compact a pair list to a readable shape for assertions. */
+function shape(pairs: AlignedPair[]): string[] {
+  return pairs.map((p) => {
+    if (p.kind === "matched") return `M ${p.originalIndex}->${p.proposedIndex}`;
+    if (p.kind === "added") return `A ${p.proposedIndex}`;
+    return `D ${p.originalIndex}`;
+  });
+}
+
+describe("bulletSimilarity", () => {
+  it("scores identical bullets as 1", () => {
+    expect(bulletSimilarity("Led the team", "Led the team")).toBe(1);
+  });
+
+  it("ignores casing, whitespace, and a leading bullet marker", () => {
+    expect(bulletSimilarity("• Led  the   team", "led the team")).toBe(1);
+  });
+
+  it("scores disjoint bullets as 0", () => {
+    expect(bulletSimilarity("Cooked dinner", "Filed taxes")).toBe(0);
+  });
+
+  it("two empty bullets are identical, one empty is 0", () => {
+    expect(bulletSimilarity("", "")).toBe(1);
+    expect(bulletSimilarity("", "anything")).toBe(0);
+  });
+
+  it("a reworded bullet scores partially (between 0 and 1)", () => {
+    const s = bulletSimilarity(
+      "Built a dashboard for sales",
+      "Built an analytics dashboard for the sales team",
+    );
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThan(1);
+  });
+
+  it("counts repeated words by min occurrence (multiset, not set)", () => {
+    // "the the" vs "the" — overlap is 1 (min), not 2.
+    const s = bulletSimilarity("the the", "the");
+    // 2*1 / (2 + 1) = 0.666…
+    expect(s).toBeCloseTo(2 / 3, 5);
+  });
+});
+
+describe("alignBullets — degenerate inputs", () => {
+  it("both empty → []", () => {
+    expect(alignBullets([], [])).toEqual([]);
+  });
+
+  it("empty original → all additions in order", () => {
+    expect(shape(alignBullets([], ["a", "b"]))).toEqual(["A 0", "A 1"]);
+  });
+
+  it("empty proposed → all removals in order", () => {
+    expect(shape(alignBullets(["a", "b"], []))).toEqual(["D 0", "D 1"]);
+  });
+});
+
+describe("alignBullets — 1:1 and edits", () => {
+  it("aligns identical lists 1:1", () => {
+    const pairs = alignBullets(["one", "two", "three"], ["one", "two", "three"]);
+    expect(shape(pairs)).toEqual(["M 0->0", "M 1->1", "M 2->2"]);
+  });
+
+  it("pairs a lightly-reworded bullet as a match, not add+remove", () => {
+    const pairs = alignBullets(
+      ["Managed a team of 5 engineers"],
+      ["Managed a team of 5 senior engineers"],
+    );
+    expect(shape(pairs)).toEqual(["M 0->0"]);
+  });
+});
+
+describe("alignBullets — M ≠ N", () => {
+  it("more proposed than original → matches + a trailing addition", () => {
+    const pairs = alignBullets(
+      ["Shipped the API", "Wrote the docs"],
+      ["Shipped the API", "Wrote the docs", "Mentored two interns"],
+    );
+    expect(shape(pairs)).toEqual(["M 0->0", "M 1->1", "A 2"]);
+  });
+
+  it("fewer proposed than original → matches + a removal", () => {
+    const pairs = alignBullets(
+      ["Shipped the API", "Filler line here", "Wrote the docs"],
+      ["Shipped the API", "Wrote the docs"],
+    );
+    expect(shape(pairs)).toEqual(["M 0->0", "D 1", "M 2->1"]);
+  });
+
+  it("an unrelated proposed bullet becomes add + remove, not a forced match", () => {
+    const pairs = alignBullets(
+      ["Optimized the database queries"],
+      ["Organized the company picnic"],
+    );
+    // Below threshold → must NOT be a match.
+    expect(pairs.every((p) => p.kind !== "matched")).toBe(true);
+    expect(shape(pairs).sort()).toEqual(["A 0", "D 0"]);
+  });
+});
+
+describe("alignBullets — reordering and duplicates", () => {
+  it("reordered bullets still each match exactly one original", () => {
+    const original = ["Alpha task done well", "Beta task done well"];
+    const proposed = ["Beta task done well", "Alpha task done well"];
+    const pairs = alignBullets(original, proposed);
+    const matched = pairs.filter((p) => p.kind === "matched");
+    // Each original index appears at most once; each proposed index at most once.
+    const oIdx = matched.map((p) => (p as { originalIndex: number }).originalIndex);
+    const pIdx = matched.map((p) => (p as { proposedIndex: number }).proposedIndex);
+    expect(new Set(oIdx).size).toBe(oIdx.length);
+    expect(new Set(pIdx).size).toBe(pIdx.length);
+  });
+
+  it("duplicate-text originals are each consumed at most once", () => {
+    const original = ["Same bullet text", "Same bullet text"];
+    const proposed = ["Same bullet text"];
+    const pairs = alignBullets(original, proposed);
+    const matched = pairs.filter((p) => p.kind === "matched");
+    expect(matched).toHaveLength(1);
+    const removed = pairs.filter((p) => p.kind === "removed");
+    expect(removed).toHaveLength(1);
+    // Distinct original indices across match + removal — neither double-used.
+    const used = [
+      ...matched.map((p) => (p as { originalIndex: number }).originalIndex),
+      ...removed.map((p) => (p as { originalIndex: number }).originalIndex),
+    ];
+    expect(new Set(used).size).toBe(2);
+  });
+});
+
+describe("alignBullets — invariants", () => {
+  it("every original index and every proposed index appears exactly once", () => {
+    const original = ["aaa bbb ccc", "ddd eee fff", "ggg hhh iii"];
+    const proposed = ["aaa bbb ccc zzz", "brand new bullet", "ggg hhh iii"];
+    const pairs = alignBullets(original, proposed);
+
+    const oSeen = new Set<number>();
+    const pSeen = new Set<number>();
+    for (const p of pairs) {
+      if (p.kind === "matched") {
+        oSeen.add(p.originalIndex);
+        pSeen.add(p.proposedIndex);
+      } else if (p.kind === "removed") {
+        oSeen.add(p.originalIndex);
+      } else {
+        pSeen.add(p.proposedIndex);
+      }
+    }
+    expect([...oSeen].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+    expect([...pSeen].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+
+  it("ids are unique across the pair list", () => {
+    const pairs = alignBullets(
+      ["one two three", "four five six"],
+      ["one two three", "seven eight nine", "four five six"],
+    );
+    const ids = pairs.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("MATCH_THRESHOLD is a sane fraction", () => {
+    expect(MATCH_THRESHOLD).toBeGreaterThan(0);
+    expect(MATCH_THRESHOLD).toBeLessThan(1);
+  });
+});

--- a/src/lib/rewrite-review/align-bullets.ts
+++ b/src/lib/rewrite-review/align-bullets.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * align-bullets.ts — greedily align a rewrite's proposed bullets to the
+ * originals so each proposed bullet can render as an inline diff against its
+ * nearest original and be accepted/rejected individually (issue #211).
+ *
+ * The WebLLM rewrite emits a *new* bullet list (M may ≠ N original) — it can
+ * merge, drop, reorder, or add bullets — so there is no inherent 1:1 mapping.
+ * We recover one with an order-preserving sequence alignment (Needleman–Wunsch
+ * over a word-level similarity score, gated by a threshold): a monotonic
+ * matching that maximises total similarity. The result is a flat, in-order list
+ * of pairs:
+ *
+ *   - `matched`  — a proposed bullet aligned to an original (its inline diff).
+ *   - `added`    — a proposed bullet with no original (a pure insertion).
+ *   - `removed`  — an original bullet with no proposed (a pure deletion).
+ *
+ * Why order-preserving (not nearest-neighbour greedy): a per-proposed
+ * "find the best original anywhere" greedy mis-pairs reordered or
+ * duplicate-text bullets, and can map two proposed bullets onto the same
+ * original. A monotonic DP consumes each bullet exactly once and keeps the
+ * diff readable top-to-bottom.
+ *
+ * Pure and deterministic: same inputs → same pairs, no I/O, no clock/random.
+ */
+
+/** One aligned unit in the review list. Exactly one of the three kinds. */
+export type AlignedPair =
+  | {
+      kind: "matched";
+      /** Stable id for the decision/edit maps — unique within one alignment. */
+      id: string;
+      original: string;
+      /** Index of the original bullet in the input `original[]`. */
+      originalIndex: number;
+      proposed: string;
+      /** Index of the proposed bullet in the input `proposed[]`. */
+      proposedIndex: number;
+    }
+  | {
+      kind: "added";
+      id: string;
+      proposed: string;
+      proposedIndex: number;
+    }
+  | {
+      kind: "removed";
+      id: string;
+      original: string;
+      originalIndex: number;
+    };
+
+/**
+ * Minimum word-level similarity for two bullets to be considered "the same
+ * bullet, reworded" rather than an unrelated add+remove. Tuned so a typical
+ * tightening edit (verb swap, metric added, trailing clause trimmed) still
+ * pairs, while two genuinely different bullets fall to add/remove. A matched
+ * pair below this never forms — the DP prefers the two gaps.
+ */
+export const MATCH_THRESHOLD = 0.3;
+
+/** Lowercase + collapse whitespace; the normaliser both similarity and the
+ *  word split run on, so casing/spacing never changes a score. */
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Word multiset for `text`, after stripping a leading bullet marker so a
+ *  "• "-prefixed line scores the same as its bare form. */
+function words(text: string): string[] {
+  const stripped = normalize(text).replace(/^[-*•●–▪◦‣▶►·]+\s*/, "");
+  if (!stripped) return [];
+  return stripped.split(" ").filter((w) => w.length > 0);
+}
+
+/**
+ * Word-level Sørensen–Dice similarity in [0, 1] over the two bullets' word
+ * MULTISETS — so repeated words count by their min occurrence, not collapsed
+ * to a set (which would over-score boilerplate-heavy bullets). Two empty
+ * bullets are defined as identical (1); one empty is 0.
+ */
+export function bulletSimilarity(a: string, b: string): number {
+  const wa = words(a);
+  const wb = words(b);
+  if (wa.length === 0 && wb.length === 0) return 1;
+  if (wa.length === 0 || wb.length === 0) return 0;
+
+  const countsA = new Map<string, number>();
+  for (const w of wa) countsA.set(w, (countsA.get(w) ?? 0) + 1);
+
+  let overlap = 0;
+  const remaining = new Map(countsA);
+  for (const w of wb) {
+    const c = remaining.get(w);
+    if (c !== undefined && c > 0) {
+      overlap += 1;
+      remaining.set(w, c - 1);
+    }
+  }
+
+  return (2 * overlap) / (wa.length + wb.length);
+}
+
+/**
+ * Align `proposed` to `original`, returning an in-order list of pairs.
+ *
+ * Algorithm: Needleman–Wunsch with
+ *   - match score = `bulletSimilarity` when it clears {@link MATCH_THRESHOLD},
+ *     else `-Infinity` (a sub-threshold cell can never be chosen as a match —
+ *     the DP routes through the two gap moves instead);
+ *   - gap score = 0 (an add or a remove neither helps nor hurts the total).
+ * Backtracking from the bottom-right corner yields the pairs in reading order;
+ * ties favour `matched` over the gaps, then `removed` (original) before
+ * `added` (proposed) so the diff reads original-then-new at a divergence.
+ *
+ * Edge cases:
+ *   - empty `original`  → every proposed is `added`, in order.
+ *   - empty `proposed`  → every original is `removed`, in order.
+ *   - both empty        → `[]`.
+ */
+export function alignBullets(
+  original: readonly string[],
+  proposed: readonly string[],
+): AlignedPair[] {
+  const n = original.length;
+  const m = proposed.length;
+
+  if (n === 0) {
+    return proposed.map((p, j) => ({
+      kind: "added" as const,
+      id: `add:${j}`,
+      proposed: p,
+      proposedIndex: j,
+    }));
+  }
+  if (m === 0) {
+    return original.map((o, i) => ({
+      kind: "removed" as const,
+      id: `del:${i}`,
+      original: o,
+      originalIndex: i,
+    }));
+  }
+
+  // Precompute the gated match scores once (O(n·m) similarity calls).
+  const sim: number[][] = Array.from({ length: n }, () =>
+    new Array<number>(m).fill(0),
+  );
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < m; j++) {
+      const s = bulletSimilarity(original[i]!, proposed[j]!);
+      sim[i]![j] = s >= MATCH_THRESHOLD ? s : Number.NEGATIVE_INFINITY;
+    }
+  }
+
+  // dp[i][j] = best total score aligning original[0..i) with proposed[0..j).
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0),
+  );
+  for (let i = 1; i <= n; i++) dp[i]![0] = 0; // leading removals: gap = 0
+  for (let j = 1; j <= m; j++) dp[0]![j] = 0; // leading additions: gap = 0
+
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      const matchScore = sim[i - 1]![j - 1]!;
+      const diag =
+        matchScore === Number.NEGATIVE_INFINITY
+          ? Number.NEGATIVE_INFINITY
+          : dp[i - 1]![j - 1]! + matchScore;
+      const up = dp[i - 1]![j]!; // original[i-1] removed
+      const left = dp[i]![j - 1]!; // proposed[j-1] added
+      dp[i]![j] = Math.max(diag, up, left);
+    }
+  }
+
+  // Backtrack from (n, m) to (0, 0), collecting pairs in reverse, then flip.
+  const reversed: AlignedPair[] = [];
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0) {
+      const matchScore = sim[i - 1]![j - 1]!;
+      const diag =
+        matchScore === Number.NEGATIVE_INFINITY
+          ? Number.NEGATIVE_INFINITY
+          : dp[i - 1]![j - 1]! + matchScore;
+      // Prefer a real match on ties; it keeps related bullets paired rather
+      // than split into an add+remove of equal total score.
+      if (diag !== Number.NEGATIVE_INFINITY && dp[i]![j]! === diag) {
+        reversed.push({
+          kind: "matched",
+          id: `m:${i - 1}:${j - 1}`,
+          original: original[i - 1]!,
+          originalIndex: i - 1,
+          proposed: proposed[j - 1]!,
+          proposedIndex: j - 1,
+        });
+        i -= 1;
+        j -= 1;
+        continue;
+      }
+    }
+    // Tie-break the two gaps so a divergence reads original-then-new: take the
+    // removal (up) before the addition (left) when both are optimal.
+    if (i > 0 && dp[i]![j]! === dp[i - 1]![j]!) {
+      reversed.push({
+        kind: "removed",
+        id: `del:${i - 1}`,
+        original: original[i - 1]!,
+        originalIndex: i - 1,
+      });
+      i -= 1;
+      continue;
+    }
+    // j > 0 here (the loop guard guarantees i>0 || j>0, and i's branch failed).
+    reversed.push({
+      kind: "added",
+      id: `add:${j - 1}`,
+      proposed: proposed[j - 1]!,
+      proposedIndex: j - 1,
+    });
+    j -= 1;
+  }
+
+  reversed.reverse();
+  return reversed;
+}

--- a/src/lib/rewrite-review/align-bullets.ts
+++ b/src/lib/rewrite-review/align-bullets.ts
@@ -103,6 +103,109 @@ export function bulletSimilarity(a: string, b: string): number {
   return (2 * overlap) / (wa.length + wb.length);
 }
 
+/** A pure insertion: a proposed bullet with no original. */
+function addedPair(proposed: string, j: number): AlignedPair {
+  return { kind: "added", id: `add:${j}`, proposed, proposedIndex: j };
+}
+
+/** A pure deletion: an original bullet with no proposed. */
+function removedPair(original: string, i: number): AlignedPair {
+  return { kind: "removed", id: `del:${i}`, original, originalIndex: i };
+}
+
+/**
+ * Diagonal (match) score at cell (i, j): the running total `dp[i-1][j-1]` plus
+ * the gated similarity, or `-Infinity` when the pair is sub-threshold (so the
+ * DP can never route a match through it). Reads only already-computed cells, so
+ * it serves both the forward fill and the backtrack.
+ */
+function diagScore(
+  sim: readonly number[][],
+  dp: readonly number[][],
+  i: number,
+  j: number,
+): number {
+  const matchScore = sim[i - 1]![j - 1]!;
+  return matchScore === Number.NEGATIVE_INFINITY
+    ? Number.NEGATIVE_INFINITY
+    : dp[i - 1]![j - 1]! + matchScore;
+}
+
+/** Gated word-similarity matrix: `sim[i][j]` is the pair score when it clears
+ *  {@link MATCH_THRESHOLD}, else `-Infinity`. O(n·m) similarity calls. */
+function gatedSimMatrix(
+  original: readonly string[],
+  proposed: readonly string[],
+): number[][] {
+  return original.map((o) =>
+    proposed.map((p) => {
+      const s = bulletSimilarity(o, p);
+      return s >= MATCH_THRESHOLD ? s : Number.NEGATIVE_INFINITY;
+    }),
+  );
+}
+
+/**
+ * Needleman–Wunsch table: `dp[i][j]` = best total score aligning
+ * `original[0..i)` with `proposed[0..j)`. Gap score is 0 (an add or a remove
+ * neither helps nor hurts), so the leading row/column stay 0.
+ */
+function fillDpTable(sim: readonly number[][], n: number, m: number): number[][] {
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0),
+  );
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i]![j] = Math.max(
+        diagScore(sim, dp, i, j),
+        dp[i - 1]![j]!, // original[i-1] removed
+        dp[i]![j - 1]!, // proposed[j-1] added
+      );
+    }
+  }
+  return dp;
+}
+
+/**
+ * Walk the filled DP table from (n, m) to (0, 0), emitting pairs in reading
+ * order. Ties favour `matched` over the gaps (keeps related bullets paired),
+ * then `removed` before `added` so a divergence reads original-then-new.
+ */
+function backtrackPairs(
+  original: readonly string[],
+  proposed: readonly string[],
+  sim: readonly number[][],
+  dp: readonly number[][],
+): AlignedPair[] {
+  const reversed: AlignedPair[] = [];
+  let i = original.length;
+  let j = proposed.length;
+  while (i > 0 || j > 0) {
+    const diag = i > 0 && j > 0 ? diagScore(sim, dp, i, j) : Number.NEGATIVE_INFINITY;
+    if (diag !== Number.NEGATIVE_INFINITY && dp[i]![j]! === diag) {
+      reversed.push({
+        kind: "matched",
+        id: `m:${i - 1}:${j - 1}`,
+        original: original[i - 1]!,
+        originalIndex: i - 1,
+        proposed: proposed[j - 1]!,
+        proposedIndex: j - 1,
+      });
+      i -= 1;
+      j -= 1;
+    } else if (i > 0 && dp[i]![j]! === dp[i - 1]![j]!) {
+      reversed.push(removedPair(original[i - 1]!, i - 1));
+      i -= 1;
+    } else {
+      // j > 0 here (loop guard guarantees i>0 || j>0, and the prior branch failed).
+      reversed.push(addedPair(proposed[j - 1]!, j - 1));
+      j -= 1;
+    }
+  }
+  reversed.reverse();
+  return reversed;
+}
+
 /**
  * Align `proposed` to `original`, returning an in-order list of pairs.
  *
@@ -127,103 +230,10 @@ export function alignBullets(
   const n = original.length;
   const m = proposed.length;
 
-  if (n === 0) {
-    return proposed.map((p, j) => ({
-      kind: "added" as const,
-      id: `add:${j}`,
-      proposed: p,
-      proposedIndex: j,
-    }));
-  }
-  if (m === 0) {
-    return original.map((o, i) => ({
-      kind: "removed" as const,
-      id: `del:${i}`,
-      original: o,
-      originalIndex: i,
-    }));
-  }
+  if (n === 0) return proposed.map(addedPair);
+  if (m === 0) return original.map(removedPair);
 
-  // Precompute the gated match scores once (O(n·m) similarity calls).
-  const sim: number[][] = Array.from({ length: n }, () =>
-    new Array<number>(m).fill(0),
-  );
-  for (let i = 0; i < n; i++) {
-    for (let j = 0; j < m; j++) {
-      const s = bulletSimilarity(original[i]!, proposed[j]!);
-      sim[i]![j] = s >= MATCH_THRESHOLD ? s : Number.NEGATIVE_INFINITY;
-    }
-  }
-
-  // dp[i][j] = best total score aligning original[0..i) with proposed[0..j).
-  const dp: number[][] = Array.from({ length: n + 1 }, () =>
-    new Array<number>(m + 1).fill(0),
-  );
-  for (let i = 1; i <= n; i++) dp[i]![0] = 0; // leading removals: gap = 0
-  for (let j = 1; j <= m; j++) dp[0]![j] = 0; // leading additions: gap = 0
-
-  for (let i = 1; i <= n; i++) {
-    for (let j = 1; j <= m; j++) {
-      const matchScore = sim[i - 1]![j - 1]!;
-      const diag =
-        matchScore === Number.NEGATIVE_INFINITY
-          ? Number.NEGATIVE_INFINITY
-          : dp[i - 1]![j - 1]! + matchScore;
-      const up = dp[i - 1]![j]!; // original[i-1] removed
-      const left = dp[i]![j - 1]!; // proposed[j-1] added
-      dp[i]![j] = Math.max(diag, up, left);
-    }
-  }
-
-  // Backtrack from (n, m) to (0, 0), collecting pairs in reverse, then flip.
-  const reversed: AlignedPair[] = [];
-  let i = n;
-  let j = m;
-  while (i > 0 || j > 0) {
-    if (i > 0 && j > 0) {
-      const matchScore = sim[i - 1]![j - 1]!;
-      const diag =
-        matchScore === Number.NEGATIVE_INFINITY
-          ? Number.NEGATIVE_INFINITY
-          : dp[i - 1]![j - 1]! + matchScore;
-      // Prefer a real match on ties; it keeps related bullets paired rather
-      // than split into an add+remove of equal total score.
-      if (diag !== Number.NEGATIVE_INFINITY && dp[i]![j]! === diag) {
-        reversed.push({
-          kind: "matched",
-          id: `m:${i - 1}:${j - 1}`,
-          original: original[i - 1]!,
-          originalIndex: i - 1,
-          proposed: proposed[j - 1]!,
-          proposedIndex: j - 1,
-        });
-        i -= 1;
-        j -= 1;
-        continue;
-      }
-    }
-    // Tie-break the two gaps so a divergence reads original-then-new: take the
-    // removal (up) before the addition (left) when both are optimal.
-    if (i > 0 && dp[i]![j]! === dp[i - 1]![j]!) {
-      reversed.push({
-        kind: "removed",
-        id: `del:${i - 1}`,
-        original: original[i - 1]!,
-        originalIndex: i - 1,
-      });
-      i -= 1;
-      continue;
-    }
-    // j > 0 here (the loop guard guarantees i>0 || j>0, and i's branch failed).
-    reversed.push({
-      kind: "added",
-      id: `add:${j - 1}`,
-      proposed: proposed[j - 1]!,
-      proposedIndex: j - 1,
-    });
-    j -= 1;
-  }
-
-  reversed.reverse();
-  return reversed;
+  const sim = gatedSimMatrix(original, proposed);
+  const dp = fillDpTable(sim, n, m);
+  return backtrackPairs(original, proposed, sim, dp);
 }

--- a/src/lib/rewrite-review/apply-accepted.test.ts
+++ b/src/lib/rewrite-review/apply-accepted.test.ts
@@ -6,6 +6,7 @@ import { alignBullets } from "./align-bullets.ts";
 import {
   applyAcceptedBullets,
   resolveBulletActions,
+  resolveSectionWrites,
   acceptedCount,
   type Decision,
 } from "./apply-accepted.ts";
@@ -165,6 +166,40 @@ describe("resolveBulletActions", () => {
     const proposed = ["Built feature A reworded heavily now"];
     const pairs = alignBullets(original, proposed);
     expect(resolveBulletActions(pairs, new Map())).toEqual([]);
+  });
+});
+
+describe("resolveSectionWrites — join section-relative index to obsIndex", () => {
+  it("maps replace/remove originalIndex through obsIndices; adds pass through", () => {
+    // original[0] replaced, original[1] removed, one pure add.
+    const original = ["Managed a team of 5", "Filler bullet to drop"];
+    const proposed = ["Led a team of 5 engineers", "Mentored two interns"];
+    const pairs = alignBullets(original, proposed);
+    // obsIndices: section bullet 0 → observation 12, bullet 1 → observation 7.
+    const obsIndices = [12, 7];
+    const writes = resolveSectionWrites(pairs, obsIndices, accept(pairs.map((p) => p.id)));
+
+    const replace = writes.find((w) => w.kind === "replace");
+    const remove = writes.find((w) => w.kind === "remove");
+    const add = writes.find((w) => w.kind === "add");
+    expect(replace).toMatchObject({ kind: "replace", obsIndex: 12 });
+    expect(remove).toMatchObject({ kind: "remove", obsIndex: 7 });
+    expect(add).toMatchObject({ kind: "add", text: "Mentored two interns" });
+  });
+
+  it("drops a write whose originalIndex has no (or a -1) observation index", () => {
+    const original = ["Built feature A here", "Built feature B here"];
+    const proposed = ["Built feature A reworded", "Built feature B reworded"];
+    const pairs = alignBullets(original, proposed);
+    // Second bullet maps to a -1 placeholder → its replace must be dropped.
+    const writes = resolveSectionWrites(pairs, [9, -1], accept(pairs.map((p) => p.id)));
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({ kind: "replace", obsIndex: 9 });
+  });
+
+  it("returns nothing when no pair is accepted", () => {
+    const pairs = alignBullets(["a b c d"], ["a b c d e"]);
+    expect(resolveSectionWrites(pairs, [3], new Map())).toEqual([]);
   });
 });
 

--- a/src/lib/rewrite-review/apply-accepted.test.ts
+++ b/src/lib/rewrite-review/apply-accepted.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { alignBullets } from "./align-bullets.ts";
+import {
+  applyAcceptedBullets,
+  resolveBulletActions,
+  acceptedCount,
+  type Decision,
+} from "./apply-accepted.ts";
+
+/** Build a decisions map from the aligned pairs by accepting the given ids. */
+function accept(ids: string[]): Map<string, Decision> {
+  return new Map(ids.map((id) => [id, "accepted" as const]));
+}
+
+describe("applyAcceptedBullets — matched replace", () => {
+  const original = ["Managed a team of 5", "Wrote integration tests"];
+  const proposed = ["Led a team of 5 engineers", "Wrote integration tests"];
+  const pairs = alignBullets(original, proposed);
+
+  it("undecided keeps every original (no silent changes)", () => {
+    expect(applyAcceptedBullets(pairs, new Map())).toEqual(original);
+  });
+
+  it("accepting a matched pair replaces that original with the proposed text", () => {
+    const matched = pairs.find((p) => p.kind === "matched" && p.originalIndex === 0)!;
+    const out = applyAcceptedBullets(pairs, accept([matched.id]));
+    expect(out).toEqual(["Led a team of 5 engineers", "Wrote integration tests"]);
+  });
+
+  it("rejecting a matched pair keeps the original", () => {
+    const matched = pairs.find((p) => p.kind === "matched" && p.originalIndex === 0)!;
+    const decisions = new Map<string, Decision>([[matched.id, "rejected"]]);
+    expect(applyAcceptedBullets(pairs, decisions)).toEqual(original);
+  });
+});
+
+describe("applyAcceptedBullets — additions", () => {
+  const original = ["Shipped the API"];
+  const proposed = ["Shipped the API", "Mentored two interns"];
+  const pairs = alignBullets(original, proposed);
+
+  it("accepting an addition inserts it", () => {
+    const add = pairs.find((p) => p.kind === "added")!;
+    expect(applyAcceptedBullets(pairs, accept([add.id]))).toEqual([
+      "Shipped the API",
+      "Mentored two interns",
+    ]);
+  });
+
+  it("an un-accepted addition is not inserted", () => {
+    expect(applyAcceptedBullets(pairs, new Map())).toEqual(["Shipped the API"]);
+  });
+});
+
+describe("applyAcceptedBullets — removals", () => {
+  const original = ["Shipped the API", "Did some filler work", "Wrote the docs"];
+  const proposed = ["Shipped the API", "Wrote the docs"];
+  const pairs = alignBullets(original, proposed);
+
+  it("accepting a removal drops the original", () => {
+    const del = pairs.find((p) => p.kind === "removed")!;
+    expect(applyAcceptedBullets(pairs, accept([del.id]))).toEqual([
+      "Shipped the API",
+      "Wrote the docs",
+    ]);
+  });
+
+  it("a rejected/undecided removal keeps the original", () => {
+    expect(applyAcceptedBullets(pairs, new Map())).toEqual(original);
+  });
+});
+
+describe("applyAcceptedBullets — edits", () => {
+  const original = ["Managed a team of 5"];
+  const proposed = ["Led a team of 5 engineers"];
+  const pairs = alignBullets(original, proposed);
+  const matched = pairs.find((p) => p.kind === "matched")!;
+
+  it("an accepted edit overrides the proposed text", () => {
+    const edits = new Map([[matched.id, "Directed a 5-person engineering team"]]);
+    expect(applyAcceptedBullets(pairs, accept([matched.id]), edits)).toEqual([
+      "Directed a 5-person engineering team",
+    ]);
+  });
+
+  it("a blank edit falls back to the proposed text (never an empty bullet)", () => {
+    const edits = new Map([[matched.id, "   "]]);
+    expect(applyAcceptedBullets(pairs, accept([matched.id]), edits)).toEqual([
+      "Led a team of 5 engineers",
+    ]);
+  });
+
+  it("an edit without accept is inert", () => {
+    const edits = new Map([[matched.id, "ignored"]]);
+    expect(applyAcceptedBullets(pairs, new Map(), edits)).toEqual(original);
+  });
+});
+
+describe("applyAcceptedBullets — combined M≠N scenario", () => {
+  it("replace + remove + add together produce the right ordered list", () => {
+    const original = ["Built feature A", "Old filler bullet", "Built feature C"];
+    const proposed = [
+      "Built and shipped feature A", // edit of #0
+      "Built feature C", // match #2
+      "Brand new achievement", // addition
+    ];
+    const pairs = alignBullets(original, proposed);
+    // Accept everything the alignment produced.
+    const out = applyAcceptedBullets(
+      pairs,
+      new Map(pairs.map((p) => [p.id, "accepted" as const])),
+    );
+    // Removal of #1 drops it; #0 replaced; #2 kept; addition lands in place.
+    expect(out).toContain("Built and shipped feature A");
+    expect(out).toContain("Built feature C");
+    expect(out).toContain("Brand new achievement");
+    expect(out).not.toContain("Old filler bullet");
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe("resolveBulletActions", () => {
+  it("emits replace/remove/add only for accepted, non-noop pairs", () => {
+    // o0 reworded (replace), o1 dropped (remove), o2 unchanged (kept verbatim
+    // via its proposed twin), plus a brand-new bullet (add).
+    const original = ["Built feature A", "Old filler", "Kept verbatim exactly"];
+    const proposed = [
+      "Built and shipped feature A",
+      "Kept verbatim exactly",
+      "New bullet",
+    ];
+    const pairs = alignBullets(original, proposed);
+    const actions = resolveBulletActions(
+      pairs,
+      new Map(pairs.map((p) => [p.id, "accepted" as const])),
+    );
+
+    const replaces = actions.filter((a) => a.kind === "replace");
+    const removes = actions.filter((a) => a.kind === "remove");
+    const adds = actions.filter((a) => a.kind === "add");
+
+    expect(replaces).toEqual([
+      { kind: "replace", originalIndex: 0, text: "Built and shipped feature A" },
+    ]);
+    expect(removes).toEqual([{ kind: "remove", originalIndex: 1 }]);
+    expect(adds).toEqual([{ kind: "add", text: "New bullet" }]);
+  });
+
+  it("skips a matched-accept whose text is unchanged (no-op replace)", () => {
+    const original = ["Unchanged bullet text here"];
+    const proposed = ["Unchanged bullet text here"];
+    const pairs = alignBullets(original, proposed);
+    const actions = resolveBulletActions(
+      pairs,
+      new Map(pairs.map((p) => [p.id, "accepted" as const])),
+    );
+    expect(actions).toEqual([]);
+  });
+
+  it("ignores rejected/undecided pairs entirely", () => {
+    const original = ["Built feature A"];
+    const proposed = ["Built feature A reworded heavily now"];
+    const pairs = alignBullets(original, proposed);
+    expect(resolveBulletActions(pairs, new Map())).toEqual([]);
+  });
+});
+
+describe("acceptedCount", () => {
+  it("counts only accepted pairs", () => {
+    const pairs = alignBullets(["a b c", "d e f"], ["a b c", "d e f", "g h i"]);
+    const decisions = new Map<string, Decision>([
+      [pairs[0]!.id, "accepted"],
+      [pairs[1]!.id, "rejected"],
+    ]);
+    expect(acceptedCount(pairs, decisions)).toBe(1);
+  });
+});

--- a/src/lib/rewrite-review/apply-accepted.ts
+++ b/src/lib/rewrite-review/apply-accepted.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * apply-accepted.ts — fold per-bullet accept/reject/edit decisions over an
+ * alignment into a result the caller can write back (issue #211).
+ *
+ * Two pure outputs from the same fold:
+ *   - {@link applyAcceptedBullets}    — the final ORDERED bullet list for a
+ *     section, the textual "what the résumé would read after accepting these".
+ *     This is the unit-tested contract (M≠N, additions, removals, edits).
+ *   - {@link resolveBulletActions}    — the same decisions expressed as
+ *     per-original-bullet WRITE actions (replace / remove / add) the UI layer
+ *     maps onto the reconstructed-résumé edit primitives
+ *     (`setBulletField` / `removeBullet` / `addBullet`). It carries no
+ *     BulletObservation indices itself — the caller joins `originalIndex`
+ *     (position within the section) to the real observation index.
+ *
+ * Decision semantics (per aligned pair id):
+ *   - matched, accepted  → original is REPLACED by the edited value (if the
+ *     user edited it) else the proposed text.
+ *   - matched, rejected/undecided → original kept verbatim.
+ *   - added,   accepted  → the edited-or-proposed text is INSERTED.
+ *   - added,   rejected/undecided → nothing inserted.
+ *   - removed, accepted  → the original is DROPPED.
+ *   - removed, rejected/undecided → original kept verbatim.
+ *
+ * "undecided" (no entry in the decisions map) is treated exactly like
+ * "rejected": Apply never changes a bullet the user didn't explicitly accept.
+ * Edits without an accept are inert — an edit auto-accepts in the hook layer,
+ * so by the time decisions reach here an edited pair is already accepted; but
+ * even if it weren't, an un-accepted edit is ignored, never silently applied.
+ *
+ * Pure: no I/O, no mutation of the inputs.
+ */
+
+import type { AlignedPair } from "./align-bullets.ts";
+
+export type Decision = "accepted" | "rejected";
+
+/** Read-only decision lookup keyed by `AlignedPair.id`. */
+export type Decisions = ReadonlyMap<string, Decision>;
+/** Read-only per-pair edited text keyed by `AlignedPair.id`. */
+export type Edits = ReadonlyMap<string, string>;
+
+/** The text a pair contributes when accepted: the user's edit if present and
+ *  non-blank, else the pair's proposed text. Trimmed; a blank edit falls back
+ *  to the proposed text rather than inserting an empty bullet. */
+function acceptedText(
+  id: string,
+  proposed: string,
+  edits: Edits,
+): string {
+  const edited = edits.get(id);
+  if (edited === undefined) return proposed;
+  const trimmed = edited.trim();
+  return trimmed.length > 0 ? trimmed : proposed;
+}
+
+/**
+ * Produce the final ordered bullet list after applying the decisions over
+ * `pairs` (which are already in reading order from {@link alignBullets}).
+ * This is the pure textual contract the unit tests pin.
+ */
+export function applyAcceptedBullets(
+  pairs: readonly AlignedPair[],
+  decisions: Decisions,
+  edits: Edits = new Map(),
+): string[] {
+  const out: string[] = [];
+  for (const pair of pairs) {
+    const accepted = decisions.get(pair.id) === "accepted";
+    switch (pair.kind) {
+      case "matched":
+        out.push(
+          accepted ? acceptedText(pair.id, pair.proposed, edits) : pair.original,
+        );
+        break;
+      case "added":
+        if (accepted) out.push(acceptedText(pair.id, pair.proposed, edits));
+        break;
+      case "removed":
+        if (!accepted) out.push(pair.original);
+        break;
+    }
+  }
+  return out;
+}
+
+/** A write action against the reconstructed résumé's bullet edit model. The
+ *  caller resolves `originalIndex` (position in the section's bullet list) to
+ *  the real `BulletObservation.index` before calling the edit primitives. */
+export type BulletAction =
+  | { kind: "replace"; originalIndex: number; text: string }
+  | { kind: "remove"; originalIndex: number }
+  | { kind: "add"; text: string };
+
+/**
+ * Express the accepted decisions as the minimal set of write actions, skipping
+ * every no-op (a rejected/undecided pair, or a matched-accept whose text is
+ * unchanged from the original). The caller applies these to the edit model:
+ *   - `replace` → `setBulletField(obsIndexOf(originalIndex), text)`
+ *   - `remove`  → `removeBullet(obsIndexOf(originalIndex))`
+ *   - `add`     → `addBullet(entryKey, text)`
+ *
+ * `add` actions come out in alignment order, so insertions read in the
+ * model's natural append order.
+ */
+export function resolveBulletActions(
+  pairs: readonly AlignedPair[],
+  decisions: Decisions,
+  edits: Edits = new Map(),
+): BulletAction[] {
+  const actions: BulletAction[] = [];
+  for (const pair of pairs) {
+    const accepted = decisions.get(pair.id) === "accepted";
+    if (!accepted) continue;
+    switch (pair.kind) {
+      case "matched": {
+        const text = acceptedText(pair.id, pair.proposed, edits);
+        if (text !== pair.original) {
+          actions.push({ kind: "replace", originalIndex: pair.originalIndex, text });
+        }
+        break;
+      }
+      case "removed":
+        actions.push({ kind: "remove", originalIndex: pair.originalIndex });
+        break;
+      case "added":
+        actions.push({
+          kind: "add",
+          text: acceptedText(pair.id, pair.proposed, edits),
+        });
+        break;
+    }
+  }
+  return actions;
+}
+
+/** Count of pairs the user has accepted — drives the global "Apply N" bar. */
+export function acceptedCount(
+  pairs: readonly AlignedPair[],
+  decisions: Decisions,
+): number {
+  let n = 0;
+  for (const pair of pairs) if (decisions.get(pair.id) === "accepted") n += 1;
+  return n;
+}

--- a/src/lib/rewrite-review/apply-accepted.ts
+++ b/src/lib/rewrite-review/apply-accepted.ts
@@ -137,6 +137,47 @@ export function resolveBulletActions(
   return actions;
 }
 
+/** A write resolved against a real `BulletObservation.index`. The whole-résumé
+ *  review (`ResumeRewriteProposed`) reviews many sections under one combined
+ *  decision map, then resolves each section's accepted actions to these — the
+ *  section-relative `originalIndex` is joined to `obsIndices` here, and any
+ *  unmapped index (no observation, or a `-1` placeholder) is dropped. */
+export type ResolvedWrite =
+  | { kind: "replace"; obsIndex: number; text: string }
+  | { kind: "remove"; obsIndex: number }
+  | { kind: "add"; text: string };
+
+/**
+ * Resolve one section's accepted decisions into concrete writes against the
+ * reconstructed-résumé edit model. `obsIndices` is parallel to the section's
+ * bullet list (the same order `alignBullets` saw), so `originalIndex` indexes
+ * straight into it; an absent or negative index drops the write rather than
+ * editing the wrong bullet. `add` actions carry no index and always pass
+ * through. Pure — no I/O, the caller dispatches the returned writes.
+ */
+export function resolveSectionWrites(
+  pairs: readonly AlignedPair[],
+  obsIndices: readonly number[],
+  decisions: Decisions,
+  edits: Edits = new Map(),
+): ResolvedWrite[] {
+  const writes: ResolvedWrite[] = [];
+  for (const action of resolveBulletActions(pairs, decisions, edits)) {
+    if (action.kind === "add") {
+      writes.push({ kind: "add", text: action.text });
+      continue;
+    }
+    const obsIndex = obsIndices[action.originalIndex];
+    if (obsIndex === undefined || obsIndex < 0) continue;
+    writes.push(
+      action.kind === "replace"
+        ? { kind: "replace", obsIndex, text: action.text }
+        : { kind: "remove", obsIndex },
+    );
+  }
+  return writes;
+}
+
 /** Count of pairs the user has accepted — drives the global "Apply N" bar. */
 export function acceptedCount(
   pairs: readonly AlignedPair[],

--- a/src/lib/webllm/rewrite-resume.ts
+++ b/src/lib/webllm/rewrite-resume.ts
@@ -45,6 +45,7 @@ import {
   rewriteSummaryWithLlm,
   type SummaryRewriteResult,
 } from "./rewrite-summary.ts";
+import type { RewriteSteering } from "./steering.ts";
 import type { WebLlmEngine } from "./types.ts";
 import { accumulatePhrases, buildPhraseBrief } from "./phrase-tracking.ts";
 import { accumulateVerbs, buildVerbBrief } from "./verb-tracking.ts";
@@ -213,6 +214,7 @@ export async function rewriteResumeWithLlm(
   engine: WebLlmEngine,
   modelId: string,
   onProgress: (progress: ResumeRewriteProgress) => void,
+  steering?: RewriteSteering,
 ): Promise<ResumeRewriteResult> {
   const rewriteable = sections.filter(isNonEmptySection);
   const totalSections = rewriteable.length;
@@ -233,7 +235,7 @@ export async function rewriteResumeWithLlm(
     });
 
     const context = buildResumeContext(completed, usedVerbs, usedPhrases);
-    const outcome = await runOne(section, engine, modelId, context);
+    const outcome = await runOne(section, engine, modelId, context, steering);
     completed.push(outcome);
     accumulateOutcomeSignals(outcome, usedVerbs, usedPhrases);
 
@@ -286,13 +288,24 @@ async function runOne(
   engine: WebLlmEngine,
   modelId: string,
   context: string | undefined,
+  steering: RewriteSteering | undefined,
 ): Promise<SectionOutcome> {
+  // `context` and `steering` are independently optional; build the options
+  // object with only the keys that are set so a no-steering / first-section
+  // call stays bit-identical to the pre-#210 / pre-context path.
+  const options =
+    context !== undefined || steering !== undefined
+      ? {
+          ...(context !== undefined ? { context } : {}),
+          ...(steering !== undefined ? { steering } : {}),
+        }
+      : undefined;
   if (section.kind === "summary") {
     const data = await rewriteSummaryWithLlm(
       section.text,
       engine,
       modelId,
-      context !== undefined ? { context } : undefined,
+      options,
     );
     return { kind: "summary", input: section, data };
   }
@@ -300,7 +313,7 @@ async function runOne(
     section.bullets,
     engine,
     modelId,
-    context !== undefined ? { context } : undefined,
+    options,
   );
   return { kind: "experience", input: section, data };
 }

--- a/src/lib/webllm/rewrite-section.ts
+++ b/src/lib/webllm/rewrite-section.ts
@@ -8,6 +8,7 @@ import {
 } from "../analytics.ts";
 import { cleanRewriteLine } from "./post-process.ts";
 import { checkNumbersPreserved } from "./preserve-numbers.ts";
+import { buildSteeringSuffix, type RewriteSteering } from "./steering.ts";
 import type { WebLlmEngine } from "./types.ts";
 import { acquireInference, releaseInference } from "./web-llm.ts";
 
@@ -72,16 +73,20 @@ export function buildSectionUserPrompt(bullets: readonly string[]): string {
  * message is the input to rewrite, the system message is the world the
  * model rewrites within. See #67 follow-up where this misfire was caught.
  */
-export function buildSectionSystemPrompt(context?: string): string {
-  if (!context || context.trim().length === 0) {
-    return SECTION_REWRITE_SYSTEM_PROMPT;
-  }
-  return `${SECTION_REWRITE_SYSTEM_PROMPT}
+export function buildSectionSystemPrompt(
+  context?: string,
+  steering?: RewriteSteering,
+): string {
+  const base =
+    !context || context.trim().length === 0
+      ? SECTION_REWRITE_SYSTEM_PROMPT
+      : `${SECTION_REWRITE_SYSTEM_PROMPT}
 
 Earlier sections of this résumé have already been rewritten. The user's NEXT message contains a NEW section's bullets — only rewrite THOSE. Do not include content from earlier sections in your output.
 
 Context from earlier sections (reference only — never echo into your output):
 ${context.trim()}`;
+  return `${base}${buildSteeringSuffix(steering)}`;
 }
 
 /**
@@ -96,6 +101,12 @@ ${context.trim()}`;
 export interface SectionRewriteOptions {
   /** Rolling soft-constraint brief from earlier sections in the chain. */
   context?: string;
+  /**
+   * User-supplied rewrite steering (#210): freeform instructions + an optional
+   * page-length target. Folded into the SYSTEM message as a suffix after the
+   * guardrails. Undefined → no behaviour change.
+   */
+  steering?: RewriteSteering;
 }
 
 export interface SectionRewriteResult {
@@ -158,7 +169,7 @@ export async function rewriteSectionWithLlm(
       messages: [
         {
           role: "system",
-          content: buildSectionSystemPrompt(options.context),
+          content: buildSectionSystemPrompt(options.context, options.steering),
         },
         { role: "user", content: buildSectionUserPrompt(bullets) },
       ],

--- a/src/lib/webllm/rewrite-summary.ts
+++ b/src/lib/webllm/rewrite-summary.ts
@@ -3,6 +3,7 @@
 
 import { cleanRewriteLine } from "./post-process.ts";
 import { checkNumbersPreserved } from "./preserve-numbers.ts";
+import { buildSteeringSuffix, type RewriteSteering } from "./steering.ts";
 import type { WebLlmEngine } from "./types.ts";
 import { acquireInference, releaseInference } from "./web-llm.ts";
 
@@ -55,21 +56,31 @@ export function buildSummaryUserPrompt(summary: string): string {
  * SYSTEM message, not the user message, so small instruct models don't
  * read the prior-section preview as content to echo.
  */
-export function buildSummarySystemPrompt(context?: string): string {
-  if (!context || context.trim().length === 0) {
-    return SUMMARY_REWRITE_SYSTEM_PROMPT;
-  }
-  return `${SUMMARY_REWRITE_SYSTEM_PROMPT}
+export function buildSummarySystemPrompt(
+  context?: string,
+  steering?: RewriteSteering,
+): string {
+  const base =
+    !context || context.trim().length === 0
+      ? SUMMARY_REWRITE_SYSTEM_PROMPT
+      : `${SUMMARY_REWRITE_SYSTEM_PROMPT}
 
 Other sections of this résumé will be rewritten next. The user's NEXT message contains the summary paragraph — only rewrite THAT. Do not include content from later sections in your output.
 
 Context for tone consistency (reference only — never echo into your output):
 ${context.trim()}`;
+  return `${base}${buildSteeringSuffix(steering)}`;
 }
 
 export interface SummaryRewriteOptions {
   /** Rolling soft-constraint brief from the chain-of-sections orchestrator. */
   context?: string;
+  /**
+   * User-supplied rewrite steering (#210): freeform instructions + an optional
+   * page-length target, appended to the SYSTEM message after the guardrails.
+   * Undefined → no behaviour change.
+   */
+  steering?: RewriteSteering;
 }
 
 export interface SummaryRewriteResult {
@@ -107,7 +118,7 @@ export async function rewriteSummaryWithLlm(
       messages: [
         {
           role: "system",
-          content: buildSummarySystemPrompt(options.context),
+          content: buildSummarySystemPrompt(options.context, options.steering),
         },
         { role: "user", content: buildSummaryUserPrompt(summary) },
       ],

--- a/src/lib/webllm/steering.test.ts
+++ b/src/lib/webllm/steering.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import { buildSteeringSuffix } from "./steering.ts";
+
+describe("buildSteeringSuffix", () => {
+  it("returns empty string for undefined steering", () => {
+    expect(buildSteeringSuffix(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty steering object", () => {
+    expect(buildSteeringSuffix({})).toBe("");
+  });
+
+  it("returns empty string for blank/whitespace-only instructions", () => {
+    expect(buildSteeringSuffix({ userInstructions: "   " })).toBe("");
+  });
+
+  it("appends trimmed instructions verbatim after a blank line", () => {
+    const suffix = buildSteeringSuffix({
+      userInstructions: "  target a staff role  ",
+    });
+    expect(suffix).toBe(
+      "\n\nThe user has these additional instructions: target a staff role",
+    );
+  });
+
+  it("emits a page budget with older-experience compression guidance", () => {
+    const suffix = buildSteeringSuffix({ pageTarget: 1 });
+    expect(suffix.startsWith("\n\n")).toBe(true);
+    expect(suffix).toContain("one-page");
+    // The recency-compression instruction is the load-bearing half of the
+    // page-target design (issue #210) — assert it's present for every tier.
+    expect(suffix).toContain("older experience entries");
+  });
+
+  it.each([1, 2, 3] as const)(
+    "includes the older-experience compression guidance for page target %i",
+    (target) => {
+      expect(buildSteeringSuffix({ pageTarget: target })).toContain(
+        "older experience entries",
+      );
+    },
+  );
+
+  it("combines page budget then instructions, budget first", () => {
+    const suffix = buildSteeringSuffix({
+      pageTarget: 2,
+      userInstructions: "lean technical",
+    });
+    const budgetIdx = suffix.indexOf("two-page");
+    const instrIdx = suffix.indexOf("lean technical");
+    expect(budgetIdx).toBeGreaterThan(-1);
+    expect(instrIdx).toBeGreaterThan(-1);
+    expect(budgetIdx).toBeLessThan(instrIdx);
+    // Parts separated by a blank line.
+    expect(suffix).toContain("\n\n");
+  });
+
+  it("distinguishes the three page tiers", () => {
+    expect(buildSteeringSuffix({ pageTarget: 1 })).toContain("one-page");
+    expect(buildSteeringSuffix({ pageTarget: 2 })).toContain("two-page");
+    expect(buildSteeringSuffix({ pageTarget: 3 })).toContain("three-page");
+  });
+});

--- a/src/lib/webllm/steering.ts
+++ b/src/lib/webllm/steering.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Rewrite steering (issue #210) — the user's freeform intent + a page-length
+ * target, folded into the rewrite system prompt as a SUFFIX appended after
+ * the base guardrails.
+ *
+ * Why a suffix and not a template: the base prompts
+ * (`SECTION_REWRITE_SYSTEM_PROMPT` / `SUMMARY_REWRITE_SYSTEM_PROMPT`) carry the
+ * number-preservation / no-fabrication guardrails. Interleaving user text into
+ * those rules risks the small instruct model dropping a guardrail. Appending
+ * the steering AFTER the rules keeps them intact and just layers intent on top
+ * — the same shape Recruidea uses for `custom_instructions` (a system-message
+ * suffix), see issue #210 references.
+ *
+ * Both halves are independent and optional:
+ *   - `userInstructions` → appended verbatim ("The user has these additional
+ *     instructions: …"). Empty/blank → contributes nothing.
+ *   - `pageTarget` → a derived length-budget sentence PLUS explicit
+ *     recency-weighted compression guidance (compress/combine OLDER experience
+ *     entries preferentially, so the budget is spent on recent roles). Unset →
+ *     contributes nothing.
+ *
+ * WebLLM is text-only and rewrites section-by-section, so it never sees PDF
+ * pagination — `pageTarget` is therefore approximated as a per-page length
+ * budget, NOT enforced as true pagination (issue #210 "Out of scope").
+ */
+
+/** A page-length target. 1 = tightest budget, 3 = loosest. */
+export type PageTarget = 1 | 2 | 3;
+
+export interface RewriteSteering {
+  /** The user's freeform "what I want from this rewrite" text. */
+  userInstructions?: string;
+  /** Optional page-length target driving a per-page length budget. */
+  pageTarget?: PageTarget;
+}
+
+/**
+ * Per-page length budget + recency-compression guidance, keyed by target.
+ *
+ * The word/bullet caps are deliberately soft ("about", "under ~N words") —
+ * a small instruct model follows directional guidance far better than a hard
+ * count it will silently violate. Each tier carries the same
+ * compress-older-entries-first instruction so a tightened budget trims the
+ * least-relevant history rather than uniformly gutting recent roles.
+ */
+const PAGE_BUDGET: Record<PageTarget, string> = {
+  1: "Target a one-page résumé: keep each bullet under ~15 words and at most 3 to 4 bullets per role. Compress or combine older experience entries preferentially so the limited space goes to the most recent, relevant roles.",
+  2: "Target a two-page résumé: keep bullets concise (under ~22 words) with about 4 to 5 bullets per role. Where space is tight, compress or combine older experience entries before trimming recent ones.",
+  3: "Target a three-page résumé: there is room for fuller detail, but still cut filler. If any trimming is needed, compress or combine older experience entries first.",
+};
+
+/**
+ * Build the steering suffix appended to a rewrite system prompt.
+ *
+ * Returns `""` when there's nothing to add (no steering, blank instructions,
+ * no page target) — callers append unconditionally, so an empty string means
+ * the prompt is byte-identical to the pre-#210 behaviour (no output change).
+ *
+ * Order: the length budget first (it constrains the shape), then the user's
+ * verbatim instructions last (most salient position for a small model). Each
+ * present part is separated by a blank line and the whole block is preceded by
+ * a blank line so it reads as a distinct section after the guardrails.
+ */
+export function buildSteeringSuffix(steering?: RewriteSteering): string {
+  if (!steering) return "";
+
+  const parts: string[] = [];
+
+  if (steering.pageTarget !== undefined) {
+    parts.push(PAGE_BUDGET[steering.pageTarget]);
+  }
+
+  const instructions = steering.userInstructions?.trim();
+  if (instructions) {
+    parts.push(`The user has these additional instructions: ${instructions}`);
+  }
+
+  if (parts.length === 0) return "";
+
+  return `\n\n${parts.join("\n\n")}`;
+}


### PR DESCRIPTION
## Summary

Two rewrite-flow features landed on one branch:

- **#210 — Steer the rewrite prompt.** A freeform "Instructions for the rewrite" box plus page-length preset chips (1/2/3 pages) near the rewrite trigger. Instructions are injected as a *system-prompt suffix* (after the existing guardrails, never interleaved) via the new pure `src/lib/webllm/steering.ts`; page targets map to a length budget + recency-weighted older-experience-compression guidance. Blank box + no chip → byte-identical prompt (no behaviour change). New `TextAreaField` design-system primitive; instructions/target persisted in `localStorage`.
- **#211 — Per-bullet review + apply.** Each proposed bullet is aligned to its nearest original (pure `alignBullets`, order-preserving Needleman–Wunsch over word-level Dice similarity), rendered as an inline redline (reusing #209's `InlineDiff`/`computeTextDiff`), and individually Accept / Reject / Edit. Section-level accept-all/reject-all + a global Apply bar. Accepted bullets merge back into the reconstructed résumé via pure `applyAcceptedBullets` (replace / add / new `removeBullet` capability). Cloud persistence punted (paid-tier lane).

Per-bullet apply is wired on the per-role `SectionRewrite` surface (the reconstructed-résumé edit surface that owns the bullet callbacks); the whole-résumé proposed panel keeps its existing inline-diff + Discard.

Resolves #210
Resolves #211

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (997/997, 73 files)
- [x] `npm run lint` / style guard clean (DS primitives only, no raw interactive HTML, no hardcoded colors)
- [x] `alignBullets` + `applyAcceptedBullets` unit-tested (M≠N, additions, removals, edits, reorder, duplicates)
- [x] Manually verified in `npm run dev`