### PR TITLE
feat(hosting): env-driven Vite base + CNAME for resumelint.org apex

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bake-fixtures": "UPDATE_FIXTURES=1 vitest run src/lib/heuristics/corpus.test.ts",
-    "eval:rewrite": "vite --open=/resumelint/eval-rewrite.html",
-    "eval:jd-spike": "vite --open=/resumelint/jd-spike.html",
+    "eval:rewrite": "vite --open=/eval-rewrite.html",
+    "eval:jd-spike": "vite --open=/jd-spike.html",
     "typecheck": "tsc -b --noEmit",
     "lint": "eslint .",
     "test:coverage": "vitest run --coverage"

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+resumelint.org

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,14 @@ function resolveAppVersion(): string {
 
 const APP_VERSION = resolveAppVersion();
 
+// Base path. The custom domain (resumelint.org) and the GCS bucket root both
+// serve at "/"; the bare github.io project-Pages fallback
+// (resumelint-org.github.io/resumelint/) needs "/resumelint/". Env-driven so
+// each deploy target builds with its own prefix without a code edit — set
+// VITE_BASE_PATH to override. Default "/" is the custom-domain production
+// target and local dev.
+const BASE_PATH = process.env.VITE_BASE_PATH ?? "/";
+
 // Emit dist/version.json at build time only. Unhashed + at the site root so the
 // proactive update checker can poll a stable URL. GitHub Pages forces its own
 // short-lived Cache-Control, so the client cache-busts the fetch anyway.
@@ -66,10 +74,10 @@ function emitVersionJson(version: string): Plugin {
 }
 
 export default defineConfig({
-  base: "/resumelint/",
+  base: BASE_PATH,
   server: {
     // Bind 0.0.0.0 so the dev server is reachable from other machines on the
-    // LAN (e.g. http://<your-host>.local:5173/resumelint/), not just loopback.
+    // LAN (e.g. http://<your-host>.local:5173/), not just loopback.
     host: true,
     // Allow LAN mDNS hostnames through Vite's DNS-rebind host check.
     // ".local" matches any *.local host.


### PR DESCRIPTION
## Summary

Serve the OSS preview at the **custom-domain root** (`resumelint.org/`) instead of the project-Pages `/resumelint/` prefix.

- `base` is now **env-driven** — `VITE_BASE_PATH`, default `"/"`. Custom domain + GCS bucket root build at `/`; the bare `resumelint-org.github.io/resumelint/` fallback can still set `/resumelint/`. No hardcoded prefix.
- Add `public/CNAME` (`resumelint.org`) so the **workflow deploy re-asserts the custom domain every run** instead of silently dropping it (workflow deploys overwrite the Pages artifact).
- Update `eval:rewrite` / `eval:jd-spike` scripts to the new root paths.

**Fixes the blank apex page:** HTML served at `resumelint.org/` referenced `/resumelint/assets/*.js`, which 404'd → JS never loaded → blank page. Built `dist/index.html` now emits root-relative `/assets/…` and `dist/CNAME`.

Part of the #226 hosting/base split (surface split itself is separate).

Refs #226

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1020 passed)
- [x] `npm run build` → `dist/index.html` references `/assets/…` (root-relative); `dist/CNAME` = `resumelint.org`
- [x] Post-merge: confirm `https://resumelint.org/` loads (not blank) and assets 200