### PR TITLE
fix(parser): harden M1 extraction — intl location, skills tokenizer, page-2 entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: fallow.sarif
+          # Pin the analysis category explicitly (not only via the SARIF's
+          # automationDetails). Code scanning diffs a PR against the base branch
+          # PER CATEGORY: a category registered on `main` but absent on a PR
+          # surfaces as a neutral "configuration not found" warning. A single
+          # fixed `fallow` category — set here at the action level so it can't
+          # drift from the SARIF injection — keeps every branch on the same
+          # category, so the PR-vs-main diff always lines up. (One-time legacy
+          # `fallow/0`/`fallow/1` configs from the pre-collapse scheme were
+          # purged from `main`'s code-scanning history so they stop being
+          # expected.)
+          category: fallow

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -222,6 +222,33 @@ function collectAnchors(lines: PdfLine[], anchor: EntryAnchor): number[] {
  * unaffected: its lines sit between a date anchor with no bullets between them,
  * so the "introduces a bullet" gate rejects them.
  */
+/** A bullet line that ends on a dangling conjunction / article / preposition
+ *  ("…Board of Directors and", "…reported to") has WRAPPED onto the next line —
+ *  that next line is its tail, not a new header. The decisive signal for the
+ *  no-geometry x=0 DOCX path, where {@link isWrappedContinuation} is a no-op and
+ *  a short capital-led wrap ("Senior Leadership on strategic planning") would
+ *  otherwise be promoted as a phantom role (#219). A real role's last bullet ends
+ *  on a metric / noun, not a dangling word, so genuine dateless headers survive. */
+const DANGLING_BULLET_TAIL_RE =
+  /\b(and|or|with|the|to|of|for|a|an|in|on|at|by|as|&)\s*$/i;
+
+/** Whether the (non-bullet) header run starting at `i` introduces a bullet body
+ *  before the next real date anchor — a header with no body is a stray line, not
+ *  a recoverable role. Walks forward over the header run; reaching a date anchor
+ *  first means that anchor owns the bullets, not this candidate. */
+function introducesBulletBody(
+  lines: PdfLine[],
+  i: number,
+  isDate: Set<number>,
+): boolean {
+  for (let j = i + 1; j < lines.length; j++) {
+    if (isDate.has(j)) return false;
+    if (isBulletLine(lines[j])) return true;
+    // a non-bullet line continues the header run — keep walking
+  }
+  return false;
+}
+
 function collectDatelessAnchors(lines: PdfLine[], dateAnchors: number[]): number[] {
   const isDate = new Set(dateAnchors);
   const markerX = bulletMarkerX(lines);
@@ -231,24 +258,17 @@ function collectDatelessAnchors(lines: PdfLine[], dateAnchors: number[]): number
     if (isBulletLine(line) || isDate.has(i)) continue;
     // First non-bullet line of a header run: predecessor must be a bullet.
     if (!isBulletLine(lines[i - 1])) continue;
+    // A predecessor bullet that ends on a dangling conjunction/article/prep has
+    // wrapped — this line is its tail, not a header. Decisive when geometry is
+    // degenerate (all x=0), where the indent filter below can't tell them apart.
+    if (DANGLING_BULLET_TAIL_RE.test(lines[i - 1].text.trim())) continue;
     // Reject a wrapped-bullet tail (indented past the marker) or sentence prose.
     if (isWrappedContinuation(line, markerX) || isProseLine(line.text)) continue;
     // A role header is a proper noun (capital/digit lead); a bullet tail that
     // slipped past the geometry/prose filters is lowercase-led sentence prose.
     if (!/^[A-Z0-9]/.test(line.text.trim())) continue;
-    // Must introduce a bullet body before the next header/anchor line. Scan
-    // forward over the (non-bullet) header run; the run must reach a bullet
-    // without first hitting a real date anchor (which would own that bullet).
-    let sawBullet = false;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (isDate.has(j)) break;
-      if (isBulletLine(lines[j])) {
-        sawBullet = true;
-        break;
-      }
-      // a non-bullet line continues the header run — keep walking
-    }
-    if (sawBullet) out.push(i);
+    // Must introduce a bullet body before the next header/anchor line.
+    if (introducesBulletBody(lines, i, isDate)) out.push(i);
   }
   return out;
 }

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -141,6 +141,13 @@ function isAnchorLine(line: PdfLine, anchor: EntryAnchor): boolean {
  * each header run (a non-bullet line whose predecessor is a bullet, or the
  * first line of the section) — so a multi-line project header opens exactly
  * one entry, not one per line.
+ *
+ * For `"date_range"`, a second pass also recovers a DATELESS entry — a role
+ * whose header carries no `MM/YYYY - MM/YYYY` range (so no date anchor formed)
+ * yet which clearly opens a new entry because it introduces its own bullet run.
+ * See {@link collectDatelessAnchors} for the precise, conservative signature.
+ * Without this, a trailing dateless role (the page-2 "Early Career: …" shape,
+ * #219) is folded into the previous dated role's body window and lost.
  */
 function collectAnchors(lines: PdfLine[], anchor: EntryAnchor): number[] {
   const anchors: number[] = [];
@@ -166,7 +173,84 @@ function collectAnchors(lines: PdfLine[], anchor: EntryAnchor): number[] {
     }
     anchors.push(i);
   }
+
+  if (anchor === "date_range" && anchors.length > 0) {
+    // Merge in dateless-header anchors (a new role whose header has no date
+    // range, #219). Gated on `anchors.length > 0` so a section with bullets but
+    // ZERO real dates still returns [] (the "no date range ⇒ []" contract — a
+    // truly date-optional section routes through the `first_line` anchor, not
+    // here). The merged list is re-sorted so the generic windowing in
+    // `buildEntryBlock` sees anchors in document order.
+    const dateless = collectDatelessAnchors(lines, anchors);
+    if (dateless.length > 0) {
+      const merged = [...anchors, ...dateless];
+      merged.sort((p, q) => p - q);
+      return merged;
+    }
+  }
   return anchors;
+}
+
+/**
+ * Extra `date_range` anchors for DATELESS role headers (#219).
+ *
+ * Signature of a dateless role header that must open its own entry — kept
+ * deliberately strict, because the hazard is a WRAPPED-BULLET TAIL (a marker-less
+ * continuation line of the previous role's last bullet) masquerading as a header:
+ * such a tail also sits "non-bullet line between two bullets," so a loose rule
+ * splits a sentence fragment off as a phantom role (empty title, a bullet-tail
+ * fragment as company). All of these must hold:
+ *   - a non-bullet, non-date line whose immediate predecessor is a bullet (the
+ *     previous role's body just ended — not a header that's already mid-entry), and
+ *   - it sits at or LEFT of the bullet-marker margin — a real header sits at the
+ *     header margin, whereas a wrapped bullet tail indents past the marker
+ *     ({@link isWrappedContinuation}); a no-op for markerless markdown/DOCX
+ *     (markerX = Infinity), where the lead-capital + prose filters below carry it, and
+ *   - it LEADS WITH A CAPITAL / digit — a role header is a proper noun
+ *     ("Early Career: …", "Acme Co"); a wrapped bullet tail is lowercase-led
+ *     sentence prose ("infrastructure cost by 28%", "and social change"). This is
+ *     the decisive filter for the no-x DOCX path, and
+ *   - it does NOT read as prose ({@link isProseLine} — a mid-thought sentence
+ *     fragment), and
+ *   - it introduces at least one bullet before the next anchor / section end (a
+ *     header with no body is a stray line, not a recoverable role).
+ *
+ * Anchoring on the FIRST line of the run (predecessor is a bullet) and skipping
+ * subsequent header lines (predecessor is a non-bullet header) means a two-line
+ * dateless header ("Title" / "Company") opens exactly one entry, mirroring the
+ * `first_line` anchor's run discipline. A dated role's own multi-line header is
+ * unaffected: its lines sit between a date anchor with no bullets between them,
+ * so the "introduces a bullet" gate rejects them.
+ */
+function collectDatelessAnchors(lines: PdfLine[], dateAnchors: number[]): number[] {
+  const isDate = new Set(dateAnchors);
+  const markerX = bulletMarkerX(lines);
+  const out: number[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (isBulletLine(line) || isDate.has(i)) continue;
+    // First non-bullet line of a header run: predecessor must be a bullet.
+    if (!isBulletLine(lines[i - 1])) continue;
+    // Reject a wrapped-bullet tail (indented past the marker) or sentence prose.
+    if (isWrappedContinuation(line, markerX) || isProseLine(line.text)) continue;
+    // A role header is a proper noun (capital/digit lead); a bullet tail that
+    // slipped past the geometry/prose filters is lowercase-led sentence prose.
+    if (!/^[A-Z0-9]/.test(line.text.trim())) continue;
+    // Must introduce a bullet body before the next header/anchor line. Scan
+    // forward over the (non-bullet) header run; the run must reach a bullet
+    // without first hitting a real date anchor (which would own that bullet).
+    let sawBullet = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (isDate.has(j)) break;
+      if (isBulletLine(lines[j])) {
+        sawBullet = true;
+        break;
+      }
+      // a non-bullet line continues the header run — keep walking
+    }
+    if (sawBullet) out.push(i);
+  }
+  return out;
 }
 
 /** True when the whole trimmed line is JUST a "City, ST" location — a pure city

--- a/src/lib/heuristics/extract/dateless-entries.test.ts
+++ b/src/lib/heuristics/extract/dateless-entries.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression tests for page-2 entry loss (#219).
+ *
+ * On a 2-page resume the page break is incidental; the structural triggers are:
+ *
+ *   1. EXPERIENCE — a trailing role whose header carries NO `MM/YYYY - MM/YYYY`
+ *      date range (e.g. "Early Career: IC & Consultant"). Date-range anchoring
+ *      used to be REQUIRED to open an entry, so the dateless block folded into
+ *      the previous role's body and was lost. It must now emit as its own entry
+ *      with empty date fields — WITHOUT splitting a wrapped bullet tail off as a
+ *      phantom role.
+ *
+ *   2. EDUCATION — two schools where only one carries a year. A second school
+ *      whose program name has no degree/institution keyword but carries its own
+ *      inline graduation year ("MIT Applied Data Science (2023)") used to merge
+ *      into the first chunk, dropping the second entry AND bleeding its year
+ *      onto the first (yearless) school. The year must stay with its own entry.
+ *
+ * Synthetic personas only, per the fixtures PII policy. Driven directly against
+ * the entry-segmentation functions, so this fixture is PII-free by construction.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractExperience } from "./experience.ts";
+import { extractEducation } from "./education.ts";
+import { type PdfLine, type PdfSection } from "../sections.ts";
+
+const mkLine = (text: string, x = 0, y = 0): PdfLine => ({
+  page: 0,
+  y,
+  x,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkSection = (
+  name: PdfSection["name"],
+  rows: Array<[string, number, number]> | string[],
+): PdfSection => ({
+  name,
+  lines: rows.map((r) => (Array.isArray(r) ? mkLine(r[0], r[1], r[2]) : mkLine(r))),
+});
+
+describe("dateless trailing experience role (#219)", () => {
+  it("emits a dateless trailing role (header + bullets) with empty dates", () => {
+    const { value } = extractExperience(
+      mkSection("experience", [
+        ["Senior Engineer", 0, 100],
+        ["Northwind Labs   01/2020 - 12/2022", 0, 90],
+        ["• Built scalable services", 10, 80],
+        ["• Led a team of 5", 10, 70],
+        ["Early Career: IC & Consultant", 0, 50],
+        ["Acme Co", 0, 40],
+        ["• Consulted on data pipelines", 10, 30],
+        ["• Shipped ETL jobs", 10, 20],
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    // The dated role keeps only its own two bullets — the dateless block no
+    // longer contaminates its description.
+    expect(value[0]).toMatchObject({
+      title: "Senior Engineer",
+      company: "Northwind Labs",
+      start_date: "01/2020",
+      end_date: "12/2022",
+    });
+    expect(value[0].description).toBe(
+      "Built scalable services\nLed a team of 5",
+    );
+    // The dateless role emits with empty date fields and its own bullets.
+    expect(value[1]).toMatchObject({
+      title: "Early Career: IC & Consultant",
+      company: "Acme Co",
+    });
+    expect(value[1].start_date).toBeUndefined();
+    expect(value[1].end_date).toBeUndefined();
+    expect(value[1].description).toBe(
+      "Consulted on data pipelines\nShipped ETL jobs",
+    );
+  });
+
+  it("does NOT split a wrapped, lowercase-led bullet tail into a phantom role", () => {
+    // The previous role's last bullet wraps onto a marker-less continuation line
+    // ("infrastructure cost by 28%.") that sits between two bullets. A loose
+    // dateless-anchor rule would split it off as an empty-title phantom role.
+    const { value } = extractExperience(
+      mkSection("experience", [
+        ["Senior Software Engineer", 0, 100],
+        ["Acme Corp   Jan 2022 - Present", 0, 90],
+        ["• Cut p99 latency by 42% and", 10, 80],
+        ["infrastructure cost by 28%.", 14, 73],
+        ["• Owned the payments service", 10, 65],
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].title).toBe("Senior Software Engineer");
+  });
+
+  it("returns no entries for a section with bullets but zero dated anchors", () => {
+    // The "no date range ⇒ []" contract for the date_range anchor still holds:
+    // a fully dateless section routes through the first_line anchor elsewhere,
+    // not through experience's date_range path.
+    const { value } = extractExperience(
+      mkSection("experience", [
+        ["Volunteer Lead", 0, 100],
+        ["• Organized weekend events", 10, 90],
+      ]),
+    );
+    expect(value).toHaveLength(0);
+  });
+});
+
+describe("education year mis-attribution across entries (#219)", () => {
+  it("keeps an inline-dated second program separate; no year bleed", () => {
+    const { value } = extractEducation(
+      mkSection("education", [
+        "Stanford University",
+        "B.S. Computer Science",
+        "MIT Applied Data Science (2023)",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    const stanford = value.find((e) => e.institution.includes("Stanford"));
+    const mit = value.find((e) => e.institution.includes("MIT"));
+    // The year belongs only to the entry it appears under.
+    expect(stanford?.year).toBeUndefined();
+    expect(mit?.year).toBe("2023");
+  });
+
+  it("does not split a school's own graduation-date line into a phantom entry", () => {
+    // "Grad. May 2011 | Kolkata, India" is the DATE line of the school above it,
+    // not a new program — the inline-dated-program split must NOT fire on a
+    // graduation-date/location line, so no phantom "Grad …" entry appears and
+    // the year stays with the real school.
+    const { value } = extractEducation(
+      mkSection("education", [
+        "Cornell University",
+        "B.S. Computer Science, May 2014",
+        "GPA: 3.8",
+        "La Martiniere For Boys",
+        "Grad. May 2011 | Kolkata, India",
+      ]),
+    );
+    // No entry is the spurious graduation-date line: the inline-dated-program
+    // split must not fire on a "Grad. … | City, Country" date/location line.
+    expect(
+      value.some((e) => /^grad\b/i.test(e.institution.trim())),
+    ).toBe(false);
+    // And the trailing 2011 grad year does not bleed onto the real degree above
+    // it — Cornell keeps its own 2014, never 2011.
+    const cornell = value.find((e) => e.institution.includes("Cornell"));
+    expect(cornell?.year).toBe("2014");
+  });
+});

--- a/src/lib/heuristics/extract/dateless-entries.test.ts
+++ b/src/lib/heuristics/extract/dateless-entries.test.ts
@@ -101,6 +101,29 @@ describe("dateless trailing experience role (#219)", () => {
     expect(value[0].title).toBe("Senior Software Engineer");
   });
 
+  it("does NOT split a CAPITAL-led wrapped bullet tail when geometry is degenerate (x=0 DOCX)", () => {
+    // DOCX→PDF conversions collapse every glyph to x=0, so the indent-based
+    // wrapped-continuation filter is a no-op and a short, Title-case wrap tail
+    // ("Senior Leadership on strategic planning") slips past the prose/capital
+    // gates. The predecessor bullet ends on a dangling conjunction ("…and"),
+    // which is the decisive signal that this line is its wrap, not a new header.
+    const { value } = extractExperience(
+      mkSection("experience", [
+        ["Acme Corp — Senior Engineer", 0, 100],
+        ["Jan 2020 - Mar 2023", 0, 90],
+        ["• Collaborated with the Board of Directors and", 0, 80],
+        ["Senior Leadership on strategic planning", 0, 70],
+        ["• Reduced cloud spend by 30%", 0, 60],
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].title).toBe("Senior Engineer");
+    expect(value[0].company).toBe("Acme Corp");
+    // The wrap tail stays inside the role body — not promoted to a phantom role.
+    expect(value[0].description).toContain("Senior Leadership on strategic planning");
+    expect(value[0].description).toContain("Reduced cloud spend by 30%");
+  });
+
   it("returns no entries for a section with bullets but zero dated anchors", () => {
     // The "no date range ⇒ []" contract for the date_range anchor still holds:
     // a fully dateless section routes through the first_line anchor elsewhere,
@@ -156,4 +179,30 @@ describe("education year mis-attribution across entries (#219)", () => {
     const cornell = value.find((e) => e.institution.includes("Cornell"));
     expect(cornell?.year).toBe("2014");
   });
+
+  it.each([
+    ["Dean's List 2020, 2021, 2022"],
+    ["Awards and Honors 2023"],
+    ["Honors Thesis: AI Systems (2024)"],
+    ["Teaching Assistant for Web (2022 - 2023)"],
+    ["Study Abroad, Florence 2021"],
+  ])(
+    "does not split an in-chunk honors/awards annotation with an inline year into a phantom entry: %s",
+    (annotation) => {
+      // An honors/awards/activity line that happens to carry a year is a
+      // sub-field of the school above it, NOT a second program. The
+      // inline-dated-program split must not fire on it (it would create a
+      // degree-less phantom education entry whose institution is the annotation).
+      const { value } = extractEducation(
+        mkSection("education", [
+          "Bachelor of Science in Computer Science",
+          "Stanford University",
+          "Sep 2018 - Jun 2022",
+          annotation,
+        ]),
+      );
+      expect(value).toHaveLength(1);
+      expect(value[0].institution).toContain("Stanford");
+    },
+  );
 });

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -163,6 +163,53 @@ function isCourseworkContinuation(line: string): boolean {
   return true;
 }
 
+/** Whether `line` is a hint-less, degree-less PROGRAM NAME that carries its own
+ *  graduation year inline — the second-school shape from #219, e.g.
+ *  "MIT Applied Data Science (2023)" or "Google Data Analytics Certificate 2022".
+ *  Used to split a NEW education entry off a chunk that already holds a full
+ *  degree + institution, when the program carries no `DEGREE_RE`/`INSTITUTION_HINTS`
+ *  token and so the keyword-based flush can't see the boundary. The inline year
+ *  is exactly what the old whole-chunk date scan would bleed onto the preceding
+ *  school; splitting here keeps it with its own program. Requires ALL of:
+ *   - a Title-case / digit lead (a program label, not lowercase prose), and
+ *   - NOT a `GPA:` / `Minor` / `Major` note, and
+ *   - a 4-digit year token present, and
+ *   - real program TEXT besides the date — once the year(s) and connective date
+ *     words are stripped, a non-trivial remainder must survive. This rejects a
+ *     bare date range on its own line ("Fall 2013 – Spring 2014", an honors-block
+ *     date) while keeping "MIT Applied Data Science (2023)" (the "MIT Applied
+ *     Data Science" remainder survives). `isDateOnlyLine` at the call site is the
+ *     first such guard; this is the stricter companion that also rejects a
+ *     season-qualified range whose only words ARE date words. */
+function isInlineDatedProgram(line: string): boolean {
+  const t = line.trim();
+  if (!t) return false;
+  if (/^(GPA[:\s]|Minor\b|Major\b)/i.test(t)) return false;
+  if (!/^[A-Z0-9]/.test(t)) return false;
+  if (!/\b(19|20)\d{2}\b/.test(t)) return false;
+  // A graduation-date line ("Grad. May 2011 | Kolkata, India", "Expected
+  // Graduation: 2026", "Class of 2025") is the DATE of an existing school, not a
+  // new program — it leads with a graduation/date-context word. Reject so a
+  // school's own grad-date line never splits off as a phantom entry.
+  if (/^(grad(?:\.|uat\w*)?|expected|anticipated|class of|completed)\b/i.test(t))
+    return false;
+  // Drop a trailing "| City, Region" location segment before measuring the
+  // program remainder — a date+location line ("… 2011 | Kolkata, India") must
+  // not pass on the strength of its city words.
+  const noLocation = t.replace(/[|,]\s*[A-Z][A-Za-z.\-]+(?:\s*,\s*[A-Za-z.\-]+)*$/, "");
+  // Strip years and date connective words (seasons / months / range words); a
+  // real program name leaves substantive text, a bare date line leaves nothing.
+  const remainder = noLocation
+    .replace(/\b(19|20)\d{2}\b/g, "")
+    .replace(
+      /\b(?:spring|summer|fall|autumn|winter|present|jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b/gi,
+      "",
+    )
+    .replace(/[\s,–\-—|/().:]+/g, "")
+    .trim();
+  return remainder.length >= 3;
+}
+
 /** Map one education chunk (the degree + institution + date lines of a single
  *  qualification) to a `ResumeEducation` and its confidence. */
 function educationFromChunk(chunk: string[]): {
@@ -306,8 +353,15 @@ export function extractEducation(
       hasDegree &&
       hasInstitution &&
       !isDateOnlyLine(text) &&
-      next !== undefined &&
-      DEGREE_RE.test(next);
+      ((next !== undefined && DEGREE_RE.test(next)) ||
+        // …or the boundary line is itself a hint-less, degree-less PROGRAM NAME
+        // carrying its own graduation year inline ("MIT Applied Data Science
+        // (2023)", #219). The inline year is what the old code would bleed onto
+        // the preceding school; splitting here keeps it with its own program.
+        // Requires a Title-case program lead (not a `GPA:`/`Minor` note, not a
+        // bare "Fall 2013 – Spring 2014" date range — which `isDateOnlyLine`
+        // already excluded above) so an honors/awards line never splits.
+        isInlineDatedProgram(text));
     if ((isDeg && hasDegree) || (isInst && hasInstitution) || startsHintlessEntry)
       flush();
     current.push(lines[li]);

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -193,6 +193,19 @@ function isInlineDatedProgram(line: string): boolean {
   // school's own grad-date line never splits off as a phantom entry.
   if (/^(grad(?:\.|uat\w*)?|expected|anticipated|class of|completed)\b/i.test(t))
     return false;
+  // An honors / awards / activity annotation that happens to carry a year
+  // ("Dean's List 2021", "Honors Thesis: … (2024)", "Teaching Assistant for …
+  // (2022 - 2023)", "Study Abroad, Florence 2021") is a sub-field of the current
+  // school, NOT a new program — it must not split off a phantom degree-less
+  // entry (#219). These read as annotations, not program names, so an exact
+  // keyword denylist is safe: a real second program ("MIT Applied Data Science
+  // (2023)", "Google Data Analytics Certificate 2022") carries none of them.
+  if (
+    /\b(dean'?s? list|awards?|honou?rs?|thesis|teaching assistant|research assistant|study abroad|coursework|scholarships?|fellowships?|cum laude)\b/i.test(
+      t,
+    )
+  )
+    return false;
   // Drop a trailing "| City, Region" location segment before measuring the
   // program remainder — a date+location line ("… 2011 | Kolkata, India") must
   // not pass on the strength of its city words.

--- a/src/lib/heuristics/extract/experience.location.test.ts
+++ b/src/lib/heuristics/extract/experience.location.test.ts
@@ -2,10 +2,9 @@
 // Copyright 2026 The resumelint Authors
 
 /**
- * Regression tests for role location extraction (#218).
+ * Regression tests for role location extraction (#218, #229).
  *
- * Covers two header shapes where `City, ST` was previously swallowed or
- * mis-routed:
+ * Covers header shapes where location was previously swallowed or mis-routed:
  *
  *   1. Two-line header: "Company  DATE" / "Title  City, ST"
  *      — city and state were split at the comma, city glued to title,
@@ -13,6 +12,11 @@
  *
  *   2. Single-line `·`-delimited header: "Title · Company, City, ST · Team"
  *      — location embedded in company; `location` stayed null.
+ *
+ *   3. International "City, Country" in `·`-delimited header (#229):
+ *      "Title · Company, City, Country · Team"
+ *      — country is not a 2-letter USPS code so Pass A/B missed it;
+ *        Pass C (COUNTRY_GAZETTEER) now strips it.
  *
  * Synthetic personas only, per the fixtures PII policy.
  */
@@ -209,6 +213,104 @@ describe("role location extraction (#218)", () => {
       // Company must not contain location text
       expect(role.company).toBe("MegaCorp");
       expect(role.location).toBe("Austin, TX");
+    });
+  });
+
+  describe("international City, Country extraction (Pass C, #229)", () => {
+    it("extracts 'Hyderabad, India' from mid-dot header (primary AC)", () => {
+      // "Regional Engineering Lead · Globex, Hyderabad, India · Platform Group"
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        {
+          text: "Regional Engineering Lead · Globex, Hyderabad, India · Platform Group",
+          fontSize: 11,
+        },
+        { text: "03/2021 - 12/2023", fontSize: 11 },
+        { text: "• Led platform reliability for 5M daily active users.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      const role = roles[0];
+
+      expect(role.title?.toLowerCase()).toContain("engineering lead");
+      expect(role.company).toBe("Globex");
+      expect(role.company).not.toContain("Hyderabad");
+      expect(role.team).toBe("Platform Group");
+      expect(role.location).toBe("Hyderabad, India");
+    });
+
+    it("extracts 'London, United Kingdom' (multi-word country) from mid-dot header", () => {
+      // "Staff Engineer · Meridian Systems, London, United Kingdom · Infrastructure"
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        {
+          text: "Staff Engineer · Meridian Systems, London, United Kingdom · Infrastructure",
+          fontSize: 11,
+        },
+        { text: "06/2019 - 08/2022", fontSize: 11 },
+        { text: "• Reduced build times by 40%.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      const role = roles[0];
+
+      expect(role.company).toBe("Meridian Systems");
+      expect(role.company).not.toContain("London");
+      expect(role.team).toBe("Infrastructure");
+      expect(role.location).toBe("London, United Kingdom");
+    });
+
+    it("extracts 'Berlin, Germany' (no team) from mid-dot header", () => {
+      // "Backend Engineer · Sigma Analytics, Berlin, Germany"
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        {
+          text: "Backend Engineer · Sigma Analytics, Berlin, Germany",
+          fontSize: 11,
+        },
+        { text: "01/2020 - 05/2023", fontSize: 11 },
+        { text: "• Built streaming data pipeline processing 10M events/day.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      const role = roles[0];
+
+      expect(role.company).toBe("Sigma Analytics");
+      expect(role.company).not.toContain("Berlin");
+      expect(role.team).toBeUndefined();
+      expect(role.location).toBe("Berlin, Germany");
+    });
+
+    it("US City, ST still wins over Pass C (Mountain View, CA not mis-read as intl)", () => {
+      // Regression: Pass A must fire before Pass C for US locations.
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        { text: "Engineering Lead · Google, Mountain View, CA", fontSize: 11 },
+        { text: "01/2018 - 12/2020", fontSize: 11 },
+        { text: "• Led the GFiber platform team.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      const role = roles[0];
+      expect(role.company).toBe("Google");
+      expect(role.location).toBe("Mountain View, CA");
+    });
+
+    it("non-empty-remainder guard: does not consume entire string into location", () => {
+      // If company = "Hyderabad, India" (no company name before city), the guard
+      // must block stripping and leave the string intact rather than setting
+      // company = "" and location = "Hyderabad, India".
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        {
+          text: "Software Engineer · Hyderabad, India",
+          fontSize: 11,
+        },
+        { text: "05/2022 - Present", fontSize: 11 },
+        { text: "• Built microservices for e-commerce platform.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      const role = roles[0];
+      // Either the location is extracted with a non-empty company, or the
+      // entire "Hyderabad, India" remains as company — either way company must
+      // be non-empty and we must not have eaten all text into location.
+      expect(role.company).toBeTruthy();
     });
   });
 });

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -5,7 +5,7 @@ import type { ResumeExperience } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
-import { US_LOCATION_RE, INTL_LOCATION_RE, US_STATE_CODE_RE } from "../regex.ts";
+import { US_LOCATION_RE, INTL_LOCATION_RE, US_STATE_CODE_RE, COUNTRY_GAZETTEER } from "../regex.ts";
 import { looksLikeTitle, looksLikeCompany, finalizeEntries } from "./shared.ts";
 
 // ── Experience ──────────────────────────────────────────────────────────────
@@ -104,31 +104,26 @@ function looksLikeLocationTail(after: string): boolean {
 }
 
 /**
- * Strip a trailing US "City, ST" location segment from a header string and
- * return both the cleaned string and the extracted location.
+ * Strip a trailing location segment from a header string and return both the
+ * cleaned string and the extracted location.
  *
- * Two separator shapes are supported:
- *   - Comma-prefixed: "Acme Corp, Springfield, IL"           → strips ", Springfield, IL"
- *   - Space-only:     "Senior Engineer Bellevue, WA"          → strips " Bellevue, WA"
+ * Three passes, tried in order (US state first — tighter closed vocabulary):
  *
- * Two separator shapes, each with its own city rule:
- *   - Comma-delimited ("Acme Corp, Mountain View, CA"): the comma before the
- *     city is a clean boundary, so the city may be MULTI-WORD ("Mountain View",
- *     "Santa Clara") — a single-token rule here truncated the city and glued its
- *     leading word(s) onto the company ("Google, Mountain" / "View, CA").
- *   - Space-delimited ("…Risk Team Bellevue, WA"): no comma marks where the role
- *     text ends, so the city is the SINGLE token before ", ST" — a greedy
- *     multi-word match would consume role keywords ("Engineer Portland, OR" must
- *     extract "Portland", not "Engineer Portland").
+ *   Pass A — comma-delimited US "…, City, ST": comma boundary lets the city be
+ *     multi-word ("Mountain View", "Santa Clara").
+ *   Pass B — space-delimited US "Role … City, ST": single-token city only (no
+ *     comma boundary means greedy multi-word would consume role keywords).
+ *   Pass C — comma-delimited international "…, City, Country": validates the
+ *     trailing token against `COUNTRY_GAZETTEER` (closed ~249-entry ISO set +
+ *     colloquial aliases) to avoid false-matching any capitalized word.
+ *     Space-delimited intl is NOT attempted here — multi-word countries make
+ *     space boundaries too ambiguous (deferred to a follow-up issue).
  *
- * Conservative design choices to avoid false positives:
- *   - The state must be a valid 2-letter USPS abbreviation.
- *   - Stripping must leave a non-empty remainder so the entire string is
- *     never consumed.
- *
- * International "City, Country" tails (e.g. "Google, Hyderabad, India") are NOT
- * stripped here — this is the US-state complement; the intl case is covered by
- * `INTL_LOCATION_RE`/`BARE_LOCATION_RE` full-string checks used elsewhere.
+ * Conservative design choices shared by all passes:
+ *   - The state/country suffix must be in a closed vocabulary (US_STATE_CODE_RE
+ *     for A/B; COUNTRY_GAZETTEER for C) — open-shape regex is not enough.
+ *   - Stripping must leave a non-empty remainder so the entire string is never
+ *     consumed into location.
  */
 function stripLocationSuffix(s: string): {
   text: string;
@@ -140,18 +135,35 @@ function stripLocationSuffix(s: string): {
     /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})$/;
   // Pass B — space-delimited "Role … City, ST": single-token city only.
   const SPACE_LOCATION_RE = /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
-  const m = s.match(COMMA_LOCATION_RE) ?? s.match(SPACE_LOCATION_RE);
-  if (!m) return { text: s, location: undefined };
-  // Validate the 2-letter suffix is a real USPS state code, not a random abbrev.
-  if (!US_STATE_CODE_RE.test(m[2])) return { text: s, location: undefined };
-  // Guard: stripping must leave a non-empty remainder. Drop any dangling comma
-  // left when the city was the only thing after a "Company," boundary.
-  const before = s
-    .slice(0, m.index)
-    .replace(/,\s*$/, "")
-    .trim();
-  if (!before) return { text: s, location: undefined };
-  return { text: before, location: `${m[1]}, ${m[2]}` };
+
+  const mUS = s.match(COMMA_LOCATION_RE) ?? s.match(SPACE_LOCATION_RE);
+  if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
+    // Guard: stripping must leave a non-empty remainder.
+    const before = s
+      .slice(0, mUS.index)
+      .replace(/,\s*$/, "")
+      .trim();
+    if (before) return { text: before, location: `${mUS[1]}, ${mUS[2]}` };
+  }
+
+  // Pass C — comma-delimited "…, City, Country" (international). Only fires
+  // when the COUNTRY_GAZETTEER is non-empty (graceful fallback when Intl APIs
+  // are unavailable keeps this a no-op rather than a false-positive risk).
+  if (COUNTRY_GAZETTEER.size > 0) {
+    // Country may be multi-word ("United Kingdom", "New Zealand", "South Korea").
+    const INTL_SUFFIX_RE =
+      /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
+    const mIntl = s.match(INTL_SUFFIX_RE);
+    if (mIntl && COUNTRY_GAZETTEER.has(mIntl[2].toLowerCase())) {
+      const before = s
+        .slice(0, mIntl.index)
+        .replace(/,\s*$/, "")
+        .trim();
+      if (before) return { text: before, location: `${mIntl[1]}, ${mIntl[2]}` };
+    }
+  }
+
+  return { text: s, location: undefined };
 }
 
 /**
@@ -191,8 +203,8 @@ function splitRoleComma(h: string): [string, string] | null {
  * Single-line `·`-delimited headers ("Title · Company, City, ST · Team", #217)
  * are tokenized here into up to three segments before the tiebreaker runs, so
  * the title and company are extracted rather than staying glued together. The
- * location embedded in the company segment ("Company, City, ST") is left for
- * #218 to strip.
+ * location embedded in the company segment ("Company, City, ST" or intl
+ * "Company, City, Country") is stripped by `stripLocationSuffix`.
  */
 function disambiguateCompanyTitle(headers: string[]): {
   company?: string;
@@ -282,12 +294,42 @@ function disambiguateCompanyTitle(headers: string[]): {
   //     looksLikeLocationTail was fixed, or a "City, ST" segment from a ·-split),
   //     rescue it as location and clear team.  Only fire when we have no location yet.
   if (!location && team) {
-    if (
+    // (3a) Try stripping a trailing location suffix from team — handles the case
+    //      where `looksLikeCompany` mis-routed a "Group"/"Systems"/"Labs" segment
+    //      as company (e.g. "Platform Group" in
+    //      "Title · Globex, Hyderabad, India · Platform Group"), pushing
+    //      "Globex, Hyderabad, India" into the team slot. If strip succeeds and
+    //      the team isn't itself a bare whole-string location (which the step-3b
+    //      check below handles), rotate: remainder → company, old company → team.
+    //
+    //      Bare-location guard: a string like "Mountain View, CA" would also
+    //      satisfy stripLocationSuffix (Pass B yields "Mountain" + "View, CA"),
+    //      but it IS already a bare location (US_LOCATION_RE covers the whole
+    //      string). Exclude these by checking whether any location regex matches
+    //      the FULL string (not just a substring), so "Mountain View, CA"
+    //      (full match) vs. "Globex, Hyderabad, India" (INTL_LOCATION_RE only
+    //      matches "Globex, Hyderabad", not the full "…India" tail) are
+    //      distinguished correctly.
+    const teamStrip = stripLocationSuffix(team);
+    const _usLoc = US_LOCATION_RE.exec(team);
+    const _intlLoc = INTL_LOCATION_RE.exec(team);
+    const teamIsBareLocation =
+      US_STATE_CODE_RE.test(team) ||
+      BARE_LOCATION_RE.test(team) ||
+      (_usLoc !== null && _usLoc[0].length === team.length) ||
+      (_intlLoc !== null && _intlLoc[0].length === team.length);
+    if (teamStrip.location && !teamIsBareLocation) {
+      location = teamStrip.location;
+      // Rotate: real-company (strip remainder) → company, old company → team.
+      team = company;
+      company = teamStrip.text;
+    } else if (
       US_STATE_CODE_RE.test(team) ||
       US_LOCATION_RE.test(team) ||
       INTL_LOCATION_RE.test(team) ||
       BARE_LOCATION_RE.test(team)
     ) {
+      // (3b) Whole-string bare location check (original behavior).
       location = team;
       team = undefined;
     }

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -12,8 +12,12 @@ describe("tokenizeSkillLine", () => {
   it("splits a bare comma-separated list into skill tokens", () => {
     const result = tokenizeSkillLine("SQL, PHP, Javascript, HTML/CSS");
     expect(result).toEqual(expect.arrayContaining(["SQL", "PHP", "Javascript"]));
-    // HTML/CSS splits on the slash — both tokens must survive isSkillToken
-    expect(result).toEqual(expect.arrayContaining(["HTML", "CSS"]));
+    // HTML/CSS has word chars on both sides of the slash — the fix (issue #220)
+    // keeps it as one token rather than splitting. "HTML" and "CSS" do NOT
+    // appear as separate tokens.
+    expect(result).toEqual(expect.arrayContaining(["HTML/CSS"]));
+    expect(result).not.toContain("HTML");
+    expect(result).not.toContain("CSS");
   });
 
   it("strips an inline Label: prefix before tokenizing", () => {
@@ -133,10 +137,11 @@ describe("parseHeuristic — ADDITIONAL section inline-label skills re-route (#1
 
     // Skills must be populated from the ADDITIONAL inline-labeled line
     expect(result.parsed.skills.length).toBeGreaterThan(0);
-    // The SKILL_SPLIT_RE splits on comma/semicolon, giving multi-word phrases:
-    //   "Advanced in SQL", "PHP", "Javascript", "HTML", "CSS",
+    // Splitting on comma/semicolon gives multi-word phrases:
+    //   "Advanced in SQL", "PHP", "Javascript", "HTML/CSS" (kept whole — #220
+    //   fix: slash between word chars no longer splits),
     //   "Proficient in MATLAB", "Python"
-    // Assert on the tokens that actually survive isSkillToken (≤4 words each).
+    // Assert on the tokens that actually survive isSkillToken (≤6 words each).
     expect(result.parsed.skills).toEqual(
       expect.arrayContaining(["PHP", "Python", "Proficient in MATLAB"]),
     );
@@ -167,5 +172,118 @@ describe("parseHeuristic — ADDITIONAL section inline-label skills re-route (#1
       expect.arrayContaining(["Leadership", "Agile", "Scrum", "Docker", "Kubernetes"]),
     );
     expect(result.fieldConfidence.skills).toBe(0.65);
+  });
+});
+
+// ── Issue #220: comma-in-parens, AI/ML slash, 5-word skill, soft-wrap ────────
+
+describe("tokenizeSkillLine — issue #220 fixes", () => {
+  it("does not split on a comma inside balanced parentheses", () => {
+    // "Cloud Infrastructure (GCP, Hybrid Cloud)" must be ONE token, not two.
+    const result = tokenizeSkillLine(
+      "Distributed Systems Architecture, Cloud Infrastructure (GCP, Hybrid Cloud), AI/ML Orchestration",
+    );
+    expect(result).toContain("Cloud Infrastructure (GCP, Hybrid Cloud)");
+    expect(result).toContain("Distributed Systems Architecture");
+    expect(result).toContain("AI/ML Orchestration");
+    // The in-parens comma must NOT produce orphan tokens
+    expect(result).not.toContain("Cloud Infrastructure (GCP");
+    expect(result).not.toContain("Hybrid Cloud)");
+  });
+
+  it("keeps AI/ML, CI/CD, TCP/IP as single tokens (slash between word chars)", () => {
+    const result = tokenizeSkillLine("AI/ML Orchestration, CI/CD Pipelines, TCP/IP Networking");
+    expect(result).toContain("AI/ML Orchestration");
+    expect(result).toContain("CI/CD Pipelines");
+    expect(result).toContain("TCP/IP Networking");
+    // Must NOT split any of them on the slash
+    expect(result).not.toContain("AI");
+    expect(result).not.toContain("ML Orchestration");
+    expect(result).not.toContain("CI");
+    expect(result).not.toContain("CD Pipelines");
+  });
+
+  it("still splits on a standalone slash flanked by spaces (e.g. Python / JavaScript)", () => {
+    // A slash that is NOT flanked by word chars (spaces on both sides) IS a
+    // separator — this is intentional and must not regress.
+    const result = tokenizeSkillLine("Python / JavaScript");
+    expect(result).toEqual(expect.arrayContaining(["Python", "JavaScript"]));
+    expect(result).not.toContain("Python / JavaScript");
+  });
+
+  it("allows 5-word skill phrases through the word-count filter", () => {
+    // "LLM Architectures & Prompt Engineering" is 5 words — the old >4 filter
+    // dropped it; the new >6 filter retains it.
+    const result = tokenizeSkillLine(
+      "LLM Architectures & Prompt Engineering, Cloud Infrastructure (GCP, Hybrid Cloud)",
+    );
+    expect(result).toContain("LLM Architectures & Prompt Engineering");
+    expect(result).toContain("Cloud Infrastructure (GCP, Hybrid Cloud)");
+  });
+
+  it("still rejects obvious sentence fragments (7+ words)", () => {
+    // The word-count cap moved from >4 to >6. A 7-word sentence fragment must
+    // still be rejected.
+    const result = tokenizeSkillLine(
+      "Python, Over 200 technical interviews for senior engineering roles, SQL",
+    );
+    // "Over 200 technical interviews for senior engineering roles" is 8 words →
+    // dropped. The short tokens survive.
+    expect(result).toContain("Python");
+    expect(result).toContain("SQL");
+    expect(result).not.toContain("Over 200 technical interviews for senior engineering roles");
+  });
+});
+
+describe("parseHeuristic — soft-wrapped skills lines rejoined (#220)", () => {
+  it("rejoins a skill name that pdfjs broke across two lines", () => {
+    // Simulates: "..., ISP Network" on line N and "Engineering, ..." on line N+1.
+    // After rejoin: "ISP Network Engineering" is one token.
+    // Synthetic resume persona: Jordan Lee, jordan.lee@example.com, (415) 555-0147
+    const items = mkItems([
+      { text: "Jordan Lee", fontSize: 18 },
+      { text: "jordan.lee@example.com  (415) 555-0147  San Francisco, CA", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      { text: "SKILLS", fontSize: 13 },
+      // Line 1 of a comma list that wraps: ends mid-skill-name "ISP Network"
+      { text: "Distributed Systems Architecture, Cloud Infrastructure (GCP, Hybrid Cloud), ISP Network", fontSize: 10 },
+      // Line 2: continuation — "Engineering" completes "ISP Network Engineering"
+      { text: "Engineering, AI/ML Orchestration, LLM Architectures & Prompt Engineering", fontSize: 10 },
+    ]);
+    const pages = mkDefaultPages(items);
+    const result = parseHeuristic(items, pages);
+
+    // The rejoined skill must appear
+    expect(result.parsed.skills).toContain("ISP Network Engineering");
+    // The parenthetical form must not be split
+    expect(result.parsed.skills).toContain("Cloud Infrastructure (GCP, Hybrid Cloud)");
+    // AI/ML slash stays together
+    expect(result.parsed.skills).toContain("AI/ML Orchestration");
+    // 5-word skill survives the word filter
+    expect(result.parsed.skills).toContain("LLM Architectures & Prompt Engineering");
+    // Orphan half-tokens must NOT appear
+    expect(result.parsed.skills).not.toContain("ISP Network");
+    expect(result.parsed.skills).not.toContain("Engineering");
+  });
+
+  it("does not merge label-prefixed sub-lines into a continuation", () => {
+    // "Databases: MySQL" must NOT be joined to the previous "Languages: Python, JS" line.
+    const items = mkItems([
+      { text: "Casey Kim", fontSize: 18 },
+      { text: "casey.kim@example.com  (312) 555-0182  Chicago, IL", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      { text: "SKILLS", fontSize: 13 },
+      { text: "Languages: Python, JavaScript", fontSize: 10 },
+      { text: "Databases: MySQL, PostgreSQL", fontSize: 10 },
+    ]);
+    const pages = mkDefaultPages(items);
+    const result = parseHeuristic(items, pages);
+
+    // Each label group is a separate logical cell — tokens from both survive
+    expect(result.parsed.skills).toEqual(
+      expect.arrayContaining(["Python", "JavaScript", "MySQL", "PostgreSQL"]),
+    );
+    // "JavaScript Databases" must NOT appear (it would if the lines were naively joined)
+    expect(result.parsed.skills).not.toContain("JavaScript Databases");
   });
 });

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -233,6 +233,18 @@ describe("tokenizeSkillLine — issue #220 fixes", () => {
     expect(result).toContain("SQL");
     expect(result).not.toContain("Over 200 technical interviews for senior engineering roles");
   });
+
+  it("does not swallow items after an unbalanced open paren (OCR artifact)", () => {
+    // "C++ (advanced" never closes its paren, so depth-tracked comma-splitting
+    // would suppress every comma after it and absorb the trailing items into one
+    // token. The unbalanced-paren fallback re-splits paren-blind so "Node" is
+    // still recovered as its own token.
+    const result = tokenizeSkillLine("React, C++ (advanced, Node");
+    expect(result).toContain("React");
+    expect(result).toContain("Node");
+    // The whole tail is not glued into one swallowed token.
+    expect(result).not.toContain("C++ (advanced, Node");
+  });
 });
 
 describe("parseHeuristic — soft-wrapped skills lines rejoined (#220)", () => {
@@ -285,5 +297,27 @@ describe("parseHeuristic — soft-wrapped skills lines rejoined (#220)", () => {
     );
     // "JavaScript Databases" must NOT appear (it would if the lines were naively joined)
     expect(result.parsed.skills).not.toContain("JavaScript Databases");
+  });
+
+  it("does not merge a comma-less standalone skill into a following comma-list", () => {
+    // A single-skill line with no comma ("Machine Learning") followed by an
+    // independent comma-list ("Data Analysis, Python, SQL") must NOT be treated
+    // as a soft-wrap continuation — the old Condition B merged them into
+    // "Machine Learning Data Analysis", losing both as standalone skills.
+    const items = mkItems([
+      { text: "Riley Park", fontSize: 18 },
+      { text: "riley.park@example.com  (206) 555-0133  Seattle, WA", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      { text: "SKILLS", fontSize: 13 },
+      { text: "Machine Learning", fontSize: 10 },
+      { text: "Data Analysis, Python, SQL", fontSize: 10 },
+    ]);
+    const pages = mkDefaultPages(items);
+    const result = parseHeuristic(items, pages);
+
+    expect(result.parsed.skills).toEqual(
+      expect.arrayContaining(["Machine Learning", "Data Analysis", "Python", "SQL"]),
+    );
+    expect(result.parsed.skills).not.toContain("Machine Learning Data Analysis");
   });
 });

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -8,7 +8,57 @@ import { stripBullet } from "../line-primitives.ts";
 
 // ── Skills ──────────────────────────────────────────────────────────────────
 
-const SKILL_SPLIT_RE = /[,;·•|/]+|\s{2,}/;
+/**
+ * Delimiter regex for skill splitting.
+ *
+ * Intentionally excludes `/` from the character class — `AI/ML`, `CI/CD`,
+ * `TCP/IP`, `HTML/CSS` etc. are single skill tokens, not two. A standalone
+ * `/` (not flanked by word chars, e.g. `Python / JavaScript`) IS a separator
+ * and is matched by the third alternative.
+ *
+ * Comma (`,`) is handled separately in `splitRespectingParens` — commas inside
+ * balanced parentheses (e.g. `Cloud Infrastructure (GCP, Hybrid Cloud)`) must
+ * not split the token. Only commas OUTSIDE parens are delimiters.
+ */
+const SKILL_SPLIT_RE = /[;·•|]+|\s{2,}|(?<!\w)\/+(?!\w)/;
+
+/**
+ * Split `text` on skill delimiters while ignoring commas that appear inside
+ * balanced parentheses, e.g. `Cloud Infrastructure (GCP, Hybrid Cloud)` →
+ * one token, not two.
+ *
+ * Algorithm: scan the string one character at a time, tracking paren depth.
+ * When depth === 0, a comma terminates the current segment. The remaining
+ * delimiters (semicolon, bullet chars, wide whitespace, standalone slash) are
+ * applied to each segment afterwards via `SKILL_SPLIT_RE`.
+ */
+function splitRespectingParens(text: string): string[] {
+  // Step 1: split on commas that are outside balanced parens.
+  const commaParts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "(") {
+      depth++;
+    } else if (ch === ")") {
+      if (depth > 0) depth--;
+    } else if (ch === "," && depth === 0) {
+      commaParts.push(text.slice(start, i));
+      start = i + 1;
+    }
+  }
+  commaParts.push(text.slice(start));
+
+  // Step 2: apply the remaining delimiters inside each comma-segment.
+  const parts: string[] = [];
+  for (const segment of commaParts) {
+    for (const sub of segment.split(SKILL_SPLIT_RE)) {
+      parts.push(sub);
+    }
+  }
+  return parts;
+}
 
 /**
  * True if a skill token is plausibly a real skill.
@@ -16,8 +66,10 @@ const SKILL_SPLIT_RE = /[,;·•|/]+|\s{2,}/;
  * Defends against bleed-in from neighboring sections when the section-boundary
  * fix did not catch a given token. Filters:
  *   - date-range runs ("1985 - 1989 Riverton", "04/2021 - Present")
- *   - tokens with more than 4 whitespace-delimited words (sentence fragments
- *     like "Over 200+ interviews for engineering" — real skills are terse)
+ *   - tokens with more than 6 whitespace-delimited words (sentence fragments
+ *     like "Over 200+ interviews for engineering" — real skills are terse, but
+ *     legitimate 5–6 word skill names like "LLM Architectures & Prompt
+ *     Engineering" must survive)
  *
  * Note: trailing punctuation is stripped by the caller before this check, so
  * "AWS." → "AWS" passes without special-casing single-word tokens.
@@ -54,8 +106,10 @@ function isSkillToken(tok: string): boolean {
   if (looksLikeContactLink(tok)) return false;
   // Reject date-range runs: "1985 - 1989", "04/2021 - Present" etc.
   if (/\d{4}\s*[-–]\s*(\d{4}|present)/i.test(tok)) return false;
-  // Reject tokens that span more than 4 words — real skills are terse.
-  if (tok.split(/\s+/).length > 4) return false;
+  // Reject tokens that span more than 6 words — real skills are terse, but
+  // legitimate 5–6 word names like "LLM Architectures & Prompt Engineering"
+  // must survive the filter.
+  if (tok.split(/\s+/).length > 6) return false;
   return true;
 }
 
@@ -98,16 +152,16 @@ function splitColumnCells(line: { text: string; items: PdfTextItem[] }): string[
 /**
  * Tokenizes a single column cell into valid skill tokens and adds them to
  * `out`. Drops the cell entirely when it looks like a contact/profile link —
- * this must happen before `SKILL_SPLIT_RE` (which splits on `/`) would shred
- * the URL and leave its path segment as a spurious token.
+ * this must happen before splitting would shred the URL and leave its path
+ * segment as a spurious token.
  */
 function tokenizeCell(cell: string, out: Set<string>): void {
   const clean = stripBullet(cell).replace(/^[A-Z][A-Za-z ]+:\s*/, "");
   // A whole cell that is a profile link ("github.com/janesmith") must be
-  // dropped before SKILL_SPLIT_RE — which splits on "/" (for "HTML/CSS") —
-  // shreds the URL and leaves its path segment ("janesmith") as a token.
+  // dropped before splitting — a path slash would otherwise leave the path
+  // segment ("janesmith") as a spurious token.
   if (looksLikeContactLink(clean)) return;
-  for (const raw of clean.split(SKILL_SPLIT_RE)) {
+  for (const raw of splitRespectingParens(clean)) {
     // Strip trailing sentence punctuation that can appear at line-end (e.g.
     // "Python, JavaScript, Git, SQL, Linux, AWS." → the period is a list
     // terminator, not part of the skill name).
@@ -129,16 +183,104 @@ export function tokenizeSkillLine(raw: string): string[] {
   return [...out];
 }
 
+/** Matches a line that starts a new logical sub-list (label prefix or bullet).
+ *  Used by collectSkillCells to decide whether a single-column line is a
+ *  continuation of the previous one or a fresh entry. */
+const SKILLS_NEW_ENTRY_RE = /^(?:[•\-–*]\s|[A-Z][A-Za-z ]+:\s)/;
+
+/**
+ * True when the pending accumulated text and `nextText` together indicate a
+ * soft-wrap: the line break happened mid-skill-name or mid-list, not between
+ * two independent items.
+ *
+ * Two conditions trigger a join:
+ *   A) The PENDING line ends with an explicit continuation character (`&`, `-`,
+ *      `–`, `+`) — e.g. `"Hiring &"` → clearly continues onto the next line.
+ *   B) The NEXT line contains a comma (meaning it is itself part of a longer
+ *      comma-separated list that wrapped) AND the pending line does NOT end
+ *      with a comma/semicolon (which would make the previous line a complete
+ *      entry followed by a new one).
+ *
+ * Both guards also reject standalone profile/contact links and new-sub-list
+ * patterns unconditionally.
+ */
+function isSoftWrapContinuation(pending: string, nextText: string): boolean {
+  // Always skip standalone profile/contact links — they are their own items.
+  if (looksLikeContactLink(nextText)) return false;
+  // Always skip if the next line starts a new sub-list (label or bullet).
+  if (SKILLS_NEW_ENTRY_RE.test(nextText)) return false;
+
+  // Condition A: pending ends with an explicit continuation glyph.
+  if (/[&\-–+]\s*$/.test(pending)) return true;
+
+  // Condition B: next line contains a comma (it's mid-list) AND pending doesn't
+  // end with a comma (which would mean a complete list item terminated cleanly).
+  if (nextText.includes(",") && !/[,;]\s*$/.test(pending)) return true;
+
+  return false;
+}
+
+/**
+ * Collect all skill "cells" from a skills section's lines, re-joining
+ * soft-wrapped continuation lines before returning.
+ *
+ * Two line shapes exist inside a skills section:
+ *   1. Multi-column rows — `splitColumnCells` returns 2+ cells. Each cell is
+ *      its own logical token group and must stay separate.
+ *   2. Single-column soft-wrapped lines — the comma-separated skill list was
+ *      wider than the column so pdfjs broke it across multiple PdfLines. These
+ *      consecutive single-cell lines must be rejoined with a space before
+ *      splitting so that `ISP Network\nEngineering` → `ISP Network Engineering`
+ *      and `Hiring &\nTalent Acquisition` → `Hiring & Talent Acquisition`.
+ *
+ * A single-column line that begins a NEW sub-list (bullet marker or label
+ * prefix like `Databases: …`), or that is a standalone contact/profile link
+ * like `"GitHub"`, is not a continuation — it flushes the pending accumulated
+ * text and starts fresh.
+ */
+function collectSkillCells(lines: PdfSection["lines"]): string[] {
+  const result: string[] = [];
+  let pending = "";
+
+  const flush = () => {
+    if (pending) {
+      result.push(pending);
+      pending = "";
+    }
+  };
+
+  for (const line of lines) {
+    const cells = splitColumnCells(line);
+    if (cells.length > 1) {
+      // Multi-column row: flush any pending single-col accumulation, then add
+      // each column cell individually (they are separate logical groups).
+      flush();
+      result.push(...cells);
+    } else {
+      // Single-column line — may be a soft-wrap continuation of the previous.
+      const text = (cells[0] ?? "").trim();
+      if (!text) continue;
+      if (pending && isSoftWrapContinuation(pending, text)) {
+        // Looks like a continuation — join with a space.
+        pending += " " + text;
+      } else {
+        flush();
+        pending = text;
+      }
+    }
+  }
+  flush();
+  return result;
+}
+
 export function extractSkills(
   skills: PdfSection | undefined,
 ): { value: string[]; confidence: number } {
   if (!skills || skills.lines.length === 0) return { value: [], confidence: 0 };
 
   const tokens = new Set<string>();
-  for (const line of skills.lines) {
-    for (const cell of splitColumnCells(line)) {
-      tokenizeCell(cell, tokens);
-    }
+  for (const cell of collectSkillCells(skills.lines)) {
+    tokenizeCell(cell, tokens);
   }
   const value = [...tokens];
   const confidence = value.length >= 5 ? 0.85 : value.length >= 2 ? 0.6 : 0.2;

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -50,6 +50,16 @@ function splitRespectingParens(text: string): string[] {
   }
   commaParts.push(text.slice(start));
 
+  // Unbalanced open paren (an OCR artifact like "C++ (advanced, Node"): depth
+  // never returned to 0, so every comma after the stray "(" was suppressed and
+  // the trailing items were swallowed into one token. Fall back to a paren-blind
+  // comma split so those items aren't lost — the malformed token keeps its stray
+  // glyph, but the items after it are recovered.
+  if (depth > 0) {
+    commaParts.length = 0;
+    for (const seg of text.split(",")) commaParts.push(seg);
+  }
+
   // Step 2: apply the remaining delimiters inside each comma-segment.
   const parts: string[] = [];
   for (const segment of commaParts) {
@@ -213,9 +223,18 @@ function isSoftWrapContinuation(pending: string, nextText: string): boolean {
   // Condition A: pending ends with an explicit continuation glyph.
   if (/[&\-–+]\s*$/.test(pending)) return true;
 
-  // Condition B: next line contains a comma (it's mid-list) AND pending doesn't
-  // end with a comma (which would mean a complete list item terminated cleanly).
-  if (nextText.includes(",") && !/[,;]\s*$/.test(pending)) return true;
+  // Condition B: a comma-separated list wrapped across two lines — the NEXT line
+  // is mid-list (has a comma) AND the PENDING line is itself an unterminated list
+  // fragment (already has a comma, and doesn't end on a clean comma). Requiring a
+  // comma in `pending` is what keeps a comma-less standalone skill ("Machine
+  // Learning") from being merged into a following independent list ("Data
+  // Analysis, Python, SQL") — only a line that is already part of a list rejoins.
+  if (
+    nextText.includes(",") &&
+    pending.includes(",") &&
+    !/[,;]\s*$/.test(pending)
+  )
+    return true;
 
   return false;
 }

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -51,6 +51,72 @@ export const INTL_LOCATION_RE =
 export const US_STATE_CODE_RE =
   /^(AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC|PR|GU|VI|AS|MP)$/;
 
+/**
+ * Closed country gazetteer for international suffix stripping (Pass C of
+ * `stripLocationSuffix`). Built from ISO 3166-1 alpha-2 names via
+ * `Intl.DisplayNames` when `Intl.supportedValuesOf('region')` is available;
+ * otherwise falls back to a hardcoded set of the ~50 most common country names
+ * on resumes so Pass C still works on Node versions that don't support that key.
+ *
+ * Colloquial aliases not in ISO English names (`uk`, `usa`, `uae`, …) are
+ * always included from the alias map.
+ *
+ * Graceful degradation guarantee: if both paths fail, the export is an empty
+ * set and Pass C simply never matches — it degrades to "no intl strip" rather
+ * than throwing at module load.
+ */
+const _COUNTRY_ALIASES: ReadonlyArray<string> = [
+  "uk",
+  "usa",
+  "us",
+  "uae",
+  "south korea",
+  "north korea",
+];
+
+// Hardcoded fallback covering the most common country names on resumes — used
+// when Intl.supportedValuesOf('region') is unavailable (e.g. Node ≤18 / v25).
+const _FALLBACK_COUNTRIES: ReadonlyArray<string> = [
+  "india", "germany", "france", "united kingdom", "canada", "australia",
+  "japan", "china", "brazil", "mexico", "singapore", "netherlands",
+  "sweden", "norway", "denmark", "finland", "switzerland", "austria",
+  "spain", "italy", "portugal", "poland", "ireland", "belgium",
+  "new zealand", "south africa", "nigeria", "kenya", "egypt",
+  "israel", "pakistan", "bangladesh", "indonesia", "malaysia",
+  "thailand", "philippines", "vietnam", "argentina", "chile",
+  "colombia", "ghana", "saudi arabia", "hong kong", "taiwan",
+  "ukraine", "russia", "turkey", "greece", "czech republic",
+  "hungary", "romania", "croatia", "serbia", "slovakia",
+];
+
+function _buildGazetteer(): Set<string> {
+  const out = new Set<string>(_COUNTRY_ALIASES);
+  try {
+    if (typeof Intl === "undefined" || !("DisplayNames" in Intl)) {
+      _FALLBACK_COUNTRIES.forEach((c) => out.add(c));
+      return out;
+    }
+    const region = new Intl.DisplayNames(["en"], { type: "region" });
+    const codes = (Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] })
+      .supportedValuesOf?.("region");
+    if (codes) {
+      codes
+        .filter((c) => /^[A-Z]{2}$/.test(c))
+        .forEach((c) => {
+          const name = region.of(c);
+          if (name) out.add(name.toLowerCase());
+        });
+    } else {
+      _FALLBACK_COUNTRIES.forEach((c) => out.add(c));
+    }
+  } catch {
+    _FALLBACK_COUNTRIES.forEach((c) => out.add(c));
+  }
+  return out;
+}
+
+export const COUNTRY_GAZETTEER: ReadonlySet<string> = _buildGazetteer();
+
 // ── Date patterns ───────────────────────────────────────────────────────────
 
 const MONTH =

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
@@ -23,7 +23,7 @@
       "projects",
       "skills"
     ],
-    "skillsCount": 7,
+    "skillsCount": 6,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 1,

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.88,
+    "confidence": 0.86,
     "triggers": [],
     "tiers": [
       "t0_layout",
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 13,
+    "skillsCount": 4,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.86,
+    "confidence": 0.88,
     "triggers": [],
     "tiers": [
       "t0_layout",
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 4,
+    "skillsCount": 6,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -28,7 +28,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 21,
+    "skillsCount": 22,
     "experienceCount": 6,
     "educationCount": 3,
     "projectsCount": 0,

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -28,7 +28,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 21,
+    "skillsCount": 22,
     "experienceCount": 6,
     "educationCount": 3,
     "projectsCount": 0,

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -25,7 +25,7 @@
       "skills",
       "summary"
     ],
-    "skillsCount": 10,
+    "skillsCount": 9,
     "experienceCount": 3,
     "educationCount": 1,
     "projectsCount": 0,

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -27,7 +27,7 @@
       "skills",
       "summary"
     ],
-    "skillsCount": 18,
+    "skillsCount": 17,
     "experienceCount": 5,
     "educationCount": 1,
     "projectsCount": 3,

--- a/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
+++ b/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.9,
+    "confidence": 0.83,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "none",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -24,7 +24,7 @@
       "skills"
     ],
     "skillsCount": 20,
-    "experienceCount": 1,
+    "experienceCount": 3,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,
@@ -35,8 +35,8 @@
     "sectionSource": "regex"
   },
   "score": {
-    "overall": 84,
-    "preLayoutOverall": 84,
+    "overall": 81,
+    "preLayoutOverall": 81,
     "specificity": {
       "score": 40,
       "max": 40,
@@ -52,10 +52,11 @@
       "totalBullets": 8
     },
     "completeness": {
-      "score": 27,
+      "score": 24,
       "max": 30,
       "gradable": true,
       "missing": [
+        "role dates",
         "summary"
       ]
     },

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.88,
+    "confidence": 0.86,
     "triggers": [],
     "tiers": [
       "t0_layout",
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 13,
+    "skillsCount": 4,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.86,
+    "confidence": 0.88,
     "triggers": [],
     "tiers": [
       "t0_layout",
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 4,
+    "skillsCount": 6,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -22,7 +22,7 @@
       "skills",
       "summary"
     ],
-    "skillsCount": 7,
+    "skillsCount": 8,
     "experienceCount": 2,
     "educationCount": 1,
     "projectsCount": 0,


### PR DESCRIPTION
## Summary

Three independent **M1 · Parser Hardening** bugs, implemented onto one branch as a single accumulated commit.

- **#229 — Intl `City, Country` role location never extracted.** Added a closed `COUNTRY_GAZETTEER` (`Intl.DisplayNames`, zero-dep, hardcoded fallback when `Intl.supportedValuesOf` is unavailable) plus **Pass C** (comma-delimited) to `stripLocationSuffix`. Pass order A→B→C keeps US `City, ST` winning first. `Globex, Hyderabad, India` → `company="Globex"`, `location="Hyderabad, India"`.
- **#220 — Skills tokenizer over-splits + drops 5+ word skills.** No longer splits commas inside balanced parens, no longer splits `/` flanked by word chars (`AI/ML`, `CI/CD`), re-joins soft-wrapped skill lines, and raises the word-count cap 4→6 so a 5-word skill survives.
- **#219 — Page-2 entries dropped / year mis-attributed.** Anchors dateless trailing experience roles (header + bullets, no date range) and splits a hint-less education program carrying its own inline year so the year stops bleeding onto the wrong school. Page boundary ruled out — both triggers are structural, not page-gated.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 1068 pass (80 files)
- [x] `npm run lint` clean
- New unit tests: `skills.test.ts`, `experience.location.test.ts`, `dateless-entries.test.ts` (synthetic, PII-free)
- 9 corpus golden snapshots rebaked (more entries recovered, year correctly attributed — verified each diff is an improvement, not a regression)

Closes #229
Closes #220
Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)