### PR TITLE
fix(ci): exclude per-surface main.tsx from coverage so fallow gate stays live

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -125,7 +125,12 @@ export default defineConfig({
         "src/**/*.test.ts",
         "src/**/__test-utils__/**",
         "src/**/*.d.ts",
-        "src/main.tsx",
+        // App entry points (root + per-surface, e.g. src/jd-fit/main.tsx). These
+        // are untested boot shims, and v8 instrumentation has emitted bogus
+        // source-map columns for them (negative `end.column`) that crash
+        // `fallow audit`'s u32 coverage parser, silently zeroing the whole
+        // fallow report. The glob excludes every `main.tsx` so the gate stays live.
+        "src/**/main.tsx",
       ],
     },
     // Force pdfjs-dist to its legacy build during tests so the Node 20+


### PR DESCRIPTION
## Summary

The `fallow` static-analysis gate (#15) has been **silently inert**: `fallow audit --coverage` crashes on every CI run while parsing the Istanbul coverage JSON, so it uploads an empty SARIF and the code-scanning check sits at a neutral *"configurations not found"*.

Root cause: v8 coverage instrumented `src/jd-fit/main.tsx` (the jd-fit entry added in #228) and emitted a bogus **negative** source-map column (`end.column = -773`) in its `fnMap`/`branchMap`. fallow's coverage parser expects `u32` and rejects it:

```
coverage: failed to parse coverage data from coverage-final.json:
invalid value: integer `-773`, expected u32 at line 56 column 2203
fallow audit exited non-zero (report-only, ignored)
```

Because the CI step is report-only (`|| echo ... ignored`), nobody noticed the gate was dead.

`src/main.tsx` was already coverage-excluded; this generalizes the exclude to `src/**/main.tsx` so every app-entry boot shim (root + per-surface) is skipped — entry points are untested boot code with no meaningful coverage.

## Verification (local)

- `coverage-final.json` now has **0** negative columns (was 4, all in `jd-fit/main.tsx`).
- `npx fallow audit --format sarif --base origin/main --coverage coverage/coverage-final.json` → **exit 0** (was non-zero).
- `npm run typecheck` clean, `npm run lint` clean.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:coverage` green; no negative coverage columns
- [x] `fallow audit` exits 0 and emits a real report
- [x] CI `verify` green; `fallow` check no longer neutral

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)