### PR TITLE
fix(parser): exclude non-skill sub-labels + split education degree/field

### DIFF
--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -179,4 +179,24 @@ describe("extractEducation — degree/field split + location peel (#222)", () =>
     expect(value[0].field).toBeUndefined();
     expect(value[0].location).toBeUndefined();
   });
+
+  it("does not split a state-only 'Institution, ST' (no city) at a normal word space", () => {
+    // A single space inside the institution name must not be read as a city
+    // boundary — only a 2+ space column gap separates a city. #222 follow-up.
+    const { value } = extractEducation(
+      mkEduSection(["Stanford University, CA", "M.S. in Statistics   2021 - 2023"]),
+    );
+    expect(value[0].institution).toBe("Stanford University, CA");
+    expect(value[0].location).toBeUndefined();
+  });
+
+  it("parses an 'M.Sc.' credential without stranding 'c.' into the field", () => {
+    // DEGREE_RE must prefer the longer 'M.Sc.' over 'M.S.' so the credential
+    // isn't truncated to 'M.S' with 'c. in Data Science' bleeding into field.
+    const { value } = extractEducation(
+      mkEduSection(["University of Example", "M.Sc. in Data Science, 2021 - 2023"]),
+    );
+    expect(value[0].degree).toBe("M.Sc.");
+    expect(value[0].field).toBe("Data Science");
+  });
 });

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -116,3 +116,67 @@ describe("extractEducation — coursework loop must not over-consume (#184)", ()
     ]);
   });
 });
+
+describe("extractEducation — degree/field split + location peel (#222)", () => {
+  it("splits 'B.S. in Computer Science' into bare degree + field and peels City, ST", () => {
+    // The issue's exact reproducer: degree+field+dates on the second line,
+    // institution+location on the first (column gap before the city).
+    const { value } = extractEducation(
+      mkEduSection([
+        "University of Example, Allen School of CS and Engineering   Seattle, WA",
+        "B.S. in Computer Science   Sep. 2024 - Jun. 2027",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBe("Computer Science");
+    expect(value[0].institution).toBe(
+      "University of Example, Allen School of CS and Engineering",
+    );
+    expect(value[0].location).toBe("Seattle, WA");
+  });
+
+  it("keeps an ampersand subject when DEGREE_RE's 'of' branch swallows the 'in' tail", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Indian Institute of Technology",
+        "Bachelor of Technology in Computer Science & Engineering, 2018 - 2022",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("Bachelor of Technology");
+    expect(value[0].field).toBe("Computer Science & Engineering");
+  });
+
+  it("recovers a connective-less '<credential> <Field>' subject without the trailing date", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Stanford University",
+        "M.S. Computer Science, 2022 - 2024",
+      ]),
+    );
+    expect(value[0].degree).toBe("M.S.");
+    expect(value[0].field).toBe("Computer Science");
+  });
+
+  it("peels an international 'City, Country' off the institution", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "University of Example, London, United Kingdom",
+        "M.S. in Data Science   2021",
+      ]),
+    );
+    expect(value[0].institution).toBe("University of Example");
+    expect(value[0].location).toBe("London, United Kingdom");
+    expect(value[0].field).toBe("Data Science");
+  });
+
+  it("leaves field/location absent when the degree line carries neither", () => {
+    const { value } = extractEducation(
+      mkEduSection(["Massachusetts Institute of Technology", "Bachelor of Science, 2020"]),
+    );
+    expect(value[0].degree).toBe("Bachelor of Science");
+    expect(value[0].field).toBeUndefined();
+    expect(value[0].location).toBeUndefined();
+  });
+});

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -306,7 +306,11 @@ function stripInstitutionLocation(s: string): {
   // (column-gap/space boundary → single-token city).
   const COMMA_US_RE =
     /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})$/;
-  const SPACE_US_RE = /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
+  // Require a 2+ space column gap (not a single word-space) so a normal space
+  // inside the institution name isn't read as a city boundary — otherwise
+  // "Stanford University, CA" (state-only, no city) wrongly yields
+  // institution "Stanford" + location "University, CA".
+  const SPACE_US_RE = /\s{2,}([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
   const mUS = s.match(COMMA_US_RE) ?? s.match(SPACE_US_RE);
   if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
     const before = s

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -8,6 +8,8 @@ import {
   INSTITUTION_HINTS,
   MONTH_YEAR_RE,
   NUMERIC_MONTH_YEAR_RE,
+  US_STATE_CODE_RE,
+  COUNTRY_GAZETTEER,
 } from "../regex.ts";
 import {
   isBulletLine,
@@ -223,6 +225,115 @@ function isInlineDatedProgram(line: string): boolean {
   return remainder.length >= 3;
 }
 
+/** Trim a parsed field string down to the subject, cutting any trailing date,
+ *  column break, pipe, or GPA/Minor/Major note that rode along on the degree
+ *  line ("Computer Science   Sep. 2024 - Jun. 2027" → "Computer Science").
+ *  Returns undefined when nothing substantive survives. */
+function cleanField(raw: string): string | undefined {
+  let f = raw
+    // A column break (2+ spaces from the PDF grid) or an explicit pipe ends the
+    // field — the date / location column starts after it.
+    .split(/\s{2,}|\s*\|\s*/)[0]
+    .trim();
+  // Cut a trailing graduation / attendance date ("— May 2027", ", 2022 - 2024",
+  // "Expected 2026", "Class of 2025") — the date belongs to the entry, not the
+  // field.
+  f = f.replace(
+    /\s*[-–—,;]?\s*(?:(?:expected|anticipated|graduat\w*|class of|present|current)\b\s*)*(?:(?:jan|feb|mar|apr|may|jun|jul|aug|sept?|oct|nov|dec)[a-z]*\.?\s*)?\(?(?:19|20)\d{2}\b.*$/i,
+    "",
+  );
+  // Cut a trailing "… , Minor in Economics" / "… , GPA: 3.8" note — a sub-field,
+  // not part of the subject.
+  f = f.replace(/[,;]\s*(?:minor|major|gpa|concentration)\b.*$/i, "");
+  // Strip leftover edge punctuation.
+  f = f.replace(/^[\s,;:–\-—]+|[\s,;:–\-—]+$/g, "").trim();
+  return f.length > 0 ? f : undefined;
+}
+
+/** Parse a degree-bearing line into a bare credential + its subject field.
+ *
+ * `DEGREE_RE` either matches just the credential ("B.S.") or — via its optional
+ * `of <subject>` branch — greedily swallows an "… in <field>" tail
+ * ("Bachelor of Science in Biology"). Either way the field is recovered from the
+ * ORIGINAL line (not the truncated match) so an ampersand/comma in the subject
+ * ("Computer Science & Engineering") is never lost. The credential is split off
+ * at the " in " connective when the match swallowed it; otherwise the field is
+ * whatever text follows the credential, with dates/notes stripped by
+ * `cleanField`. Connective-less shapes ("M.S. Computer Science", "B.S. Business
+ * Administration — May 2027") are handled too: the field is the post-credential
+ * remainder. */
+function parseDegreeAndField(line: string): {
+  degree: string;
+  field?: string;
+} {
+  const dm = DEGREE_RE.exec(line);
+  if (!dm) return { degree: "" };
+  const matched = dm[0];
+  // If the `of`-branch swallowed an " in <field>", the credential ends at that
+  // " in " — split it there and let the field be read from the original line so
+  // characters DEGREE_RE can't match (e.g. "&") aren't truncated.
+  const inIdx = matched.search(/\s+in\s+/i);
+  let degree: string;
+  let fieldStart: number;
+  if (inIdx >= 0) {
+    degree = matched.slice(0, inIdx).trim();
+    fieldStart = dm.index + inIdx;
+  } else {
+    degree = matched.trim();
+    fieldStart = dm.index + matched.length;
+  }
+  const fieldRaw = line
+    .slice(fieldStart)
+    // Drop a leading "in "/"of " connective or a "-"/"—"/":"/"," separator.
+    .replace(/^\s*(?:in|of)\s+/i, "")
+    .replace(/^\s*[-–—,:]\s*/, "")
+    .replace(/^\s*(?:in|of)\s+/i, "");
+  return { degree, field: cleanField(fieldRaw) };
+}
+
+/** Peel a trailing "City, ST" (US) or "City, Country" (international) location
+ *  off an institution string, returning the cleaned institution and the
+ *  location. Mirrors experience's `stripLocationSuffix` (same closed-vocabulary
+ *  guards: `US_STATE_CODE_RE` for US, `COUNTRY_GAZETTEER` for intl), specialized
+ *  for the institution line where the city is usually separated by a column gap
+ *  ("… Engineering   Seattle, WA") rather than a comma. Stripping must leave a
+ *  non-empty institution, so the whole string is never consumed. */
+function stripInstitutionLocation(s: string): {
+  institution: string;
+  location?: string;
+} {
+  // US "…, City, ST" (comma boundary → multi-word city) or "… City, ST"
+  // (column-gap/space boundary → single-token city).
+  const COMMA_US_RE =
+    /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})$/;
+  const SPACE_US_RE = /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
+  const mUS = s.match(COMMA_US_RE) ?? s.match(SPACE_US_RE);
+  if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
+    const before = s
+      .slice(0, mUS.index)
+      .replace(/,\s*$/, "")
+      .trim();
+    if (before) return { institution: before, location: `${mUS[1]}, ${mUS[2]}` };
+  }
+
+  // International "…, City, Country" — country validated against the gazetteer.
+  if (COUNTRY_GAZETTEER.size > 0) {
+    const INTL_RE =
+      /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
+    const mIntl = s.match(INTL_RE);
+    if (mIntl && COUNTRY_GAZETTEER.has(mIntl[2].toLowerCase())) {
+      const before = s
+        .slice(0, mIntl.index)
+        .replace(/,\s*$/, "")
+        .trim();
+      if (before)
+        return { institution: before, location: `${mIntl[1]}, ${mIntl[2]}` };
+    }
+  }
+
+  return { institution: s };
+}
+
 /** Map one education chunk (the degree + institution + date lines of a single
  *  qualification) to a `ResumeEducation` and its confidence. */
 function educationFromChunk(chunk: string[]): {
@@ -230,8 +341,13 @@ function educationFromChunk(chunk: string[]): {
   score: number;
 } {
   const joined = chunk.join(" | ");
+  // Parse degree + field off the specific degree-bearing line (cleaner than the
+  // joined chunk, whose " | " separators would confuse the field tail).
+  const degreeLine = chunk.find((l) => DEGREE_RE.test(l));
   const degreeMatch = DEGREE_RE.exec(joined);
-  const degree = degreeMatch ? degreeMatch[0].trim() : "";
+  const { degree, field } = degreeLine
+    ? parseDegreeAndField(degreeLine)
+    : { degree: "", field: undefined };
 
   // Institution: an explicit institution-hint line first; else the first line
   // that is neither the degree-bearing line nor a bare date — this recovers
@@ -254,6 +370,13 @@ function educationFromChunk(chunk: string[]): {
     }
   }
 
+  // Peel a trailing "City, ST" / "City, Country" off the institution so it isn't
+  // glued on ("University of Example, …   Seattle, WA" → institution without the
+  // location, location surfaced separately).
+  const { institution: instClean, location } =
+    stripInstitutionLocation(institution);
+  institution = instClean;
+
   // Shared date primitive (via the education wrapper) so a range like
   // "Sep 2024 - July 2025" keeps both halves and a lone graduation date lands in
   // `end_date` (#97).
@@ -266,7 +389,13 @@ function educationFromChunk(chunk: string[]): {
   if (hasDate) score += 0.3;
 
   return {
-    entry: { institution, degree, ...educationDateFields(dates) },
+    entry: {
+      institution,
+      degree,
+      ...(field ? { field } : {}),
+      ...(location ? { location } : {}),
+      ...educationDateFields(dates),
+    },
     score: Math.min(score, 1),
   };
 }

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -321,3 +321,89 @@ describe("parseHeuristic — soft-wrapped skills lines rejoined (#220)", () => {
     expect(result.parsed.skills).not.toContain("Machine Learning Data Analysis");
   });
 });
+
+// ── Issue #221: Interests/Hobbies sub-labels must not bleed into skills ───────
+
+describe("tokenizeSkillLine — issue #221 non-skill sub-labels", () => {
+  it("drops an Interests: sub-label cell entirely", () => {
+    const result = tokenizeSkillLine(
+      "Interests: Science Fiction Novels, Weightlifting, Gardening, Tennis",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("drops a Hobbies: sub-label cell entirely", () => {
+    expect(tokenizeSkillLine("Hobbies: Reading, Cooking, Hiking")).toEqual([]);
+  });
+
+  it("drops an Activities: sub-label cell entirely", () => {
+    expect(tokenizeSkillLine("Activities: Basketball, Chess")).toEqual([]);
+  });
+
+  it("drops a qualified 'Personal Interests:' / 'Other Hobbies:' cell", () => {
+    expect(tokenizeSkillLine("Personal Interests: Eating, Travel")).toEqual([]);
+    expect(tokenizeSkillLine("Other Hobbies: Painting")).toEqual([]);
+  });
+
+  it("keeps skill sub-labels (Languages/Technologies/Tools/Frameworks)", () => {
+    expect(tokenizeSkillLine("Languages: Python, Go, C++, Java")).toEqual(
+      expect.arrayContaining(["Python", "Go", "C++", "Java"]),
+    );
+    expect(tokenizeSkillLine("Technologies: Linux, AWS, Docker, iOS")).toEqual(
+      expect.arrayContaining(["Linux", "AWS", "Docker", "iOS"]),
+    );
+    expect(tokenizeSkillLine("Tools: Git, Vim")).toEqual(
+      expect.arrayContaining(["Git", "Vim"]),
+    );
+    expect(tokenizeSkillLine("Frameworks: React, Vue")).toEqual(
+      expect.arrayContaining(["React", "Vue"]),
+    );
+  });
+
+  it("does not catch a real skill that merely starts with a denylist word", () => {
+    // "Interest Rate Modeling" is a legitimate skill, not an "Interests:" label
+    // — the denylist matches the WHOLE label phrase, so this survives.
+    const result = tokenizeSkillLine("Interest Rate Modeling, Risk Analysis");
+    expect(result).toEqual(
+      expect.arrayContaining(["Interest Rate Modeling", "Risk Analysis"]),
+    );
+  });
+});
+
+describe("parseHeuristic — issue #221 Interests sub-label in SKILLS section", () => {
+  it("excludes Interests items while keeping Languages/Technologies skills", () => {
+    // Repro from the issue: a Technical Skills section internally sub-labeled
+    // with Languages / Technologies / Interests. Only the genuine skill
+    // sub-labels should reach parsed.skills.
+    const items = mkItems([
+      { text: "Jordan Lee", fontSize: 18 },
+      { text: "jordan.lee@example.com  (312) 555-0123  Chicago, IL", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      { text: "TECHNICAL SKILLS", fontSize: 13 },
+      { text: "Languages: Python, Go, C++, Java, JavaScript", fontSize: 10 },
+      { text: "Technologies: Linux, AWS, Docker, iOS", fontSize: 10 },
+      {
+        text: "Interests: Science Fiction Novels, Weightlifting, Gardening, Eating, Tennis, Basketball",
+        fontSize: 10,
+      },
+    ]);
+    const pages = mkDefaultPages(items);
+    const result = parseHeuristic(items, pages);
+
+    // Genuine skills survive.
+    expect(result.parsed.skills).toEqual(
+      expect.arrayContaining(["Python", "Go", "Java", "Linux", "AWS", "Docker"]),
+    );
+    // Hobbies must NOT be scored/displayed as professional skills.
+    for (const hobby of [
+      "Science Fiction Novels",
+      "Weightlifting",
+      "Gardening",
+      "Eating",
+      "Tennis",
+      "Basketball",
+    ]) {
+      expect(result.parsed.skills).not.toContain(hobby);
+    }
+  });
+});

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -159,6 +159,19 @@ function splitColumnCells(line: { text: string; items: PdfTextItem[] }): string[
     .filter((t) => t.length > 0);
 }
 
+/** A Skills-section sub-label whose contents are NOT professional skills — a
+ *  hobbies/interests list that must never flow into `skills`. Matched against
+ *  the captured `Label` of a leading `Label:` cell prefix, so it sees only the
+ *  label phrase (never the items). An optional leading qualifier ("Personal",
+ *  "Other") is allowed so "Personal Interests:" / "Other Hobbies:" are caught;
+ *  a real skill sub-label like "Languages:" / "Frameworks:" never matches. */
+const NON_SKILL_SUBLABEL_RE =
+  /^(?:personal\s+|other\s+)?(?:interests?|hobbies|hobby|activities|pastimes)\s*$/i;
+
+/** Leading `Label:` prefix of a skills cell — captures the label phrase so it
+ *  can be checked against the non-skill denylist before being stripped. */
+const SUBLABEL_PREFIX_RE = /^([A-Z][A-Za-z ]+):\s*/;
+
 /**
  * Tokenizes a single column cell into valid skill tokens and adds them to
  * `out`. Drops the cell entirely when it looks like a contact/profile link —
@@ -166,7 +179,14 @@ function splitColumnCells(line: { text: string; items: PdfTextItem[] }): string[
  * segment as a spurious token.
  */
 function tokenizeCell(cell: string, out: Set<string>): void {
-  const clean = stripBullet(cell).replace(/^[A-Z][A-Za-z ]+:\s*/, "");
+  const debulleted = stripBullet(cell);
+  // A non-skill sub-label inside a Skills section (e.g. "Interests: Tennis,
+  // Gardening" or "Hobbies: Reading") must NOT bleed into `skills`. Inspect the
+  // leading `Label:` prefix and drop the whole cell when it names a
+  // hobbies/interests list — before the label is stripped and the items split.
+  const labelMatch = debulleted.match(SUBLABEL_PREFIX_RE);
+  if (labelMatch && NON_SKILL_SUBLABEL_RE.test(labelMatch[1])) return;
+  const clean = debulleted.replace(SUBLABEL_PREFIX_RE, "");
   // A whole cell that is a profile link ("github.com/janesmith") must be
   // dropped before splitting — a path slash would otherwise leave the path
   // segment ("janesmith") as a spurious token.

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -372,7 +372,10 @@ export function matchSectionHeader(text: string): SectionName | null {
 // ── Degree patterns ─────────────────────────────────────────────────────────
 
 export const DEGREE_RE =
-  /\b(B\.?A\.?|B\.?S\.?|B\.?Sc\.?|B\.?E\.?|B\.?Eng\.?|B\.?Tech\.?|M\.?A\.?|M\.?S\.?|M\.?Sc\.?|M\.?Eng\.?|M\.?B\.?A\.?|Ph\.?D\.?|M\.?D\.?|J\.?D\.?|Bachelor|Master|Doctor|Associate)(?:\s+of\s+[A-Za-z ]{2,40})?/;
+  // NOTE: longer credential variants precede their prefixes (`B.Sc.` before
+  // `B.S.`, `M.Sc.` before `M.S.`) so alternation picks the full token — else
+  // `M.Sc.` matches only `M.S`, stranding `c.` to bleed into the parsed field.
+  /\b(B\.?A\.?|B\.?Sc\.?|B\.?S\.?|B\.?Eng\.?|B\.?E\.?|B\.?Tech\.?|M\.?A\.?|M\.?Sc\.?|M\.?S\.?|M\.?Eng\.?|M\.?B\.?A\.?|Ph\.?D\.?|M\.?D\.?|J\.?D\.?|Bachelor|Master|Doctor|Associate)(?:\s+of\s+[A-Za-z ]{2,40})?/;
 
 export const INSTITUTION_HINTS =
   /\b(University|College|Institute|School|Academy|Polytechnic)s?\b/i;

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -129,7 +129,18 @@ export interface ResumeExperience {
 export interface ResumeEducation {
   id?: string;
   degree: string;
+  /** Subject / field of study parsed from the degree line — the "Computer
+   *  Science" in "B.S. in Computer Science" or "Bachelor of Technology in
+   *  Computer Science & Engineering". `degree` keeps only the bare credential
+   *  ("B.S.", "Bachelor of Technology"); the subject lives here. Absent when the
+   *  degree line carries no parseable field. */
+  field?: string;
   institution: string;
+  /** Institution location ("City, ST" / "City, Country") peeled off the
+   *  institution line so `institution` is free of trailing location text.
+   *  Mirrors `ResumeExperience.location`; distinct from top-level candidate
+   *  address. */
+  location?: string;
   /**
    * Lead year of the education entry, kept for back-compat with consumers that
    * only show a single year (`looksLikeStudent`, the reconstructed view). When a

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -23,7 +23,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 24,
+    "skillsCount": 17,
     "experienceCount": 4,
     "educationCount": 2,
     "projectsCount": 3,


### PR DESCRIPTION
## Summary

Two parser extraction fixes, landed together on one branch.

**#221 — Interests/Hobbies no longer scored as skills.** When a Technical Skills section is internally sub-labeled (`Languages:`, `Technologies:`, `Interests:`), every sub-label's contents were flattened into `skills` — hobbies included. `tokenizeCell` now inspects the leading `Label:` prefix and drops the whole cell when it names a non-skill list (`interests`/`hobbies`/`activities`/`pastimes`, with optional `personal`/`other` qualifier), before splitting. Skill sub-labels (`Languages`, `Technologies`, `Tools`, `Frameworks`, ...) flow through unchanged. A real skill that merely starts with a denylist word ("Interest Rate Modeling") is not caught.

**#222 — education degree/field split + institution location peeled.** Degree was truncated at the credential token (`B.S.`), `field` was never populated, and the trailing `City, ST` stayed glued to the institution. Now `degree` = bare credential, `field` = subject (`Computer Science`, `Computer Science & Engineering`), and a trailing `City, ST` / `City, Country` is peeled off the institution into a separate `location`. `ResumeEducation` gains optional `field` / `location`.

Closes #221
Closes #222

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1088 tests)
- [x] `npm run lint` clean
- [x] No new fixture binaries — #221 reproduces against the existing `multi-degree-coursework.pdf` corpus fixture; both fixes covered by unit + integration tests (zero new PII surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)