### PR TITLE
fix(parser): standalone-URL guard, degree-less education, dateless role

### DIFF
--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -34,6 +34,7 @@ import {
   MONTH_YEAR_RE,
   NUMERIC_MONTH_YEAR_RE,
   YEAR_RE,
+  PROGRAM_NOTE_RE,
 } from "./regex.ts";
 import {
   parseDateRange,
@@ -42,6 +43,70 @@ import {
   isProseLine,
   stripBullet,
 } from "./line-primitives.ts";
+
+// ── Shared entry-header shape recognition ───────────────────────────────────
+//
+// The anchor-on-shape family (#238 education, #239 experience; cf #31, #145):
+// a valid entry is missed when it lacks the field the section anchors on — a
+// degree keyword for education, a date range for experience. The fix is to
+// recognize an entry by the SHAPE of its header line rather than requiring that
+// one field. `isEntryHeaderShape` is that shared, field-agnostic shape test:
+// "does this line read like the LEAD of an entry (a role title, an org/program
+// name, an institution) — as opposed to body prose, a bare date, or a sub-field
+// note?" Geometry signals (indent past the bullet margin, a dangling wrapped
+// tail) stay in the callers, which own the layout; this predicate is pure text
+// shape so education (no geometry) and experience (full geometry) share it.
+
+/** True when the whole trimmed line is essentially JUST a date / date-range — a
+ *  bare year, a month-year, or a season/graduation-qualified range — so it must
+ *  not be mistaken for an entry header or an institution. Strips date tokens and
+ *  connective/season/graduation words; an empty remainder means the line carried
+ *  nothing but a date. Shared by education chunking and {@link isEntryHeaderShape}. */
+export function isDateOnlyLine(text: string): boolean {
+  const stripped = text
+    .replace(/\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\.?/gi, "")
+    .replace(/\b(?:spring|summer|fall|autumn|winter)\b/gi, "")
+    .replace(/\b\d{4}\b/g, "")
+    .replace(/\b(?:present|current|expected|graduation|graduated|anticipated)\b/gi, "")
+    .replace(/[\s,–\-—|/().:]+/g, "")
+    .trim();
+  return stripped.length === 0;
+}
+
+/**
+ * True when `text` reads like the HEADER LEAD of a resume entry — a role title,
+ * an organization, a program/certificate name, or an institution — rather than
+ * description prose, a bare date line, or a sub-field note (GPA / Minor / etc.).
+ *
+ * This is the shared "entry-boundary shape" predicate behind the anchor-on-shape
+ * fixes: education recognizes a degree-keyword-less program entry by it (#238),
+ * and experience recognizes a dateless role header by it (#239). It is
+ * intentionally TEXT-ONLY — it makes no use of x/y geometry — so a section with
+ * no layout data (education chunking runs on flattened strings) and one with full
+ * geometry (experience) can both rely on it; each caller layers its own geometry
+ * guards (wrapped-tail indent, dangling-connective predecessor) on top.
+ *
+ * A line qualifies when ALL hold:
+ *   - it carries substantive text (non-empty after trim), and
+ *   - it LEADS WITH A CAPITAL OR DIGIT — a proper-noun / numbered entry lead, not
+ *     a lowercase-led sentence fragment (a wrapped bullet tail), and
+ *   - it does NOT read as a date-only line ({@link isDateOnlyLine}) — a bare
+ *     graduation year / attendance range is the date OF an entry, not a new one, and
+ *   - it does NOT read as prose ({@link isProseLine}) — a mid-thought description
+ *     sentence, and
+ *   - it is NOT a sub-field note ({@link PROGRAM_NOTE_RE}) — "GPA: 3.8",
+ *     "Minor in Economics", "Relevant Coursework: …" are properties of the entry
+ *     above, not a new entry head.
+ */
+export function isEntryHeaderShape(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  if (!/^[A-Z0-9]/.test(t)) return false;
+  if (isDateOnlyLine(t)) return false;
+  if (isProseLine(t)) return false;
+  if (PROGRAM_NOTE_RE.test(t)) return false;
+  return true;
+}
 
 /**
  * How a section's entry blocks are anchored — i.e. what marks the start of a
@@ -249,6 +314,38 @@ function introducesBulletBody(
   return false;
 }
 
+/** Whether the line at `i-1` closes the previous role's BULLET BODY — i.e. the
+ *  candidate header at `i` genuinely follows a bullet run, not a header/lead line.
+ *  True when the predecessor is a bullet, OR a wrapped-bullet continuation
+ *  (marker-less line indented past `markerX`) whose run traces back to a bullet
+ *  with no intervening header-level line. A real role's last bullet often wraps
+ *  onto a marker-less continuation ("…used by / millions of users."), so the
+ *  next role's dateless header sits below that wrap, not below the bullet marker
+ *  itself (#239). Walking back over wrapped continuations recovers that case
+ *  without loosening the gate to allow a header to follow a non-bullet header
+ *  line (which would re-split a multi-line dateless header). A no-op for the
+ *  glyphless x=0 path (markerX = Infinity ⇒ no line is a wrapped continuation),
+ *  where the predecessor must still be a bullet outright — the dangling-tail and
+ *  shape gates carry phantom-split protection there. */
+function precededByBulletBody(
+  lines: PdfLine[],
+  i: number,
+  markerX: number,
+): boolean {
+  let j = i - 1;
+  while (j >= 0) {
+    if (isBulletLine(lines[j])) return true;
+    // A marker-less line indented past the bullet text margin is the wrap of the
+    // bullet above it — keep walking back through the wrapped run.
+    if (isWrappedContinuation(lines[j], markerX)) {
+      j--;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
 function collectDatelessAnchors(lines: PdfLine[], dateAnchors: number[]): number[] {
   const isDate = new Set(dateAnchors);
   const markerX = bulletMarkerX(lines);
@@ -256,17 +353,24 @@ function collectDatelessAnchors(lines: PdfLine[], dateAnchors: number[]): number
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i];
     if (isBulletLine(line) || isDate.has(i)) continue;
-    // First non-bullet line of a header run: predecessor must be a bullet.
-    if (!isBulletLine(lines[i - 1])) continue;
+    // First non-bullet line of a header run: it must follow the previous role's
+    // bullet body — a bullet, or a wrapped continuation of one (#239). A header
+    // following another non-bullet header line is the 2nd line of a multi-line
+    // header, not a new entry, and is skipped (mirrors the first_line run rule).
+    if (!precededByBulletBody(lines, i, markerX)) continue;
     // A predecessor bullet that ends on a dangling conjunction/article/prep has
     // wrapped — this line is its tail, not a header. Decisive when geometry is
     // degenerate (all x=0), where the indent filter below can't tell them apart.
     if (DANGLING_BULLET_TAIL_RE.test(lines[i - 1].text.trim())) continue;
-    // Reject a wrapped-bullet tail (indented past the marker) or sentence prose.
-    if (isWrappedContinuation(line, markerX) || isProseLine(line.text)) continue;
-    // A role header is a proper noun (capital/digit lead); a bullet tail that
-    // slipped past the geometry/prose filters is lowercase-led sentence prose.
-    if (!/^[A-Z0-9]/.test(line.text.trim())) continue;
+    // Reject a wrapped-bullet tail (indented past the marker) — a geometry
+    // signal this caller owns.
+    if (isWrappedContinuation(line, markerX)) continue;
+    // The remaining content gates — capital/digit lead, not prose, not a bare
+    // date, not a sub-field note — are the shared entry-header SHAPE test, the
+    // same one education uses to recognize a degree-less program entry (#238).
+    // A bullet tail that slipped past the geometry filter is lowercase-led
+    // sentence prose and fails the shape test here.
+    if (!isEntryHeaderShape(line.text)) continue;
     // Must introduce a bullet body before the next header/anchor line.
     if (introducesBulletBody(lines, i, isDate)) out.push(i);
   }

--- a/src/lib/heuristics/extract/achievements.test.ts
+++ b/src/lib/heuristics/extract/achievements.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { liftHeaderLabel } from "./projects.ts";
+
+// liftHeaderLabel is defined in projects.ts and shared by achievementFromBlock
+// (achievements.ts imports it from there). These tests cover the URL-lift
+// behavior from the achievements surface — the same function handles both.
+
+describe("liftHeaderLabel — mid-sentence domain is NOT lifted (#237)", () => {
+  it("leaves return2india.com in title when mid-sentence", () => {
+    // Source: "Exit · Founded and sold return2india.com to Satyam Infoway …"
+    const header =
+      "Exit · Founded and sold return2india.com to Satyam Infoway (NASDAQ: SIFY). 200K monthly visits. [2000]";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBeUndefined();
+    expect(label).toContain("return2india.com");
+  });
+
+  it("leaves domain in title when preceded and followed by words", () => {
+    const header = "Launched mysite.com for enterprise clients";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBeUndefined();
+    expect(label).toContain("mysite.com");
+  });
+});
+
+describe("liftHeaderLabel — standalone URL IS lifted", () => {
+  it("lifts a bare standalone domain at the end of a header", () => {
+    // "My OSS Library | github.com/user/repo" — domain is at end, no word after it
+    const header = "My OSS Library | github.com/user/repo";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBe("github.com/user/repo");
+    expect(label).toBe("My OSS Library");
+  });
+
+  it("lifts an https:// URL regardless of position", () => {
+    const header =
+      "Founded and sold https://return2india.com to Satyam Infoway";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBe("https://return2india.com");
+    // label should have the URL removed and cleaned up
+    expect(label).not.toContain("https://return2india.com");
+  });
+
+  it("lifts a domain-only header line", () => {
+    const { label, url } = liftHeaderLabel(["janedoe.dev"]);
+    expect(url).toBe("janedoe.dev");
+    expect(label).toBe("");
+  });
+
+  it("lifts a www. URL always (standalone)", () => {
+    // URL_RE matches the first domain segment: www.janedoe — the trailing .com
+    // is a known URL_RE limitation (three-part domains). The key behavior under
+    // test is that www. prefix triggers standalone promotion regardless of
+    // surrounding text context.
+    const header = "Portfolio | www.janedoe.com";
+    const { url } = liftHeaderLabel([header]);
+    expect(url).toBeDefined();
+    expect(url).toMatch(/^www\./);
+  });
+
+  it("lifts a later standalone link past a leading mid-prose domain", () => {
+    // A prose domain (acme.example) appears BEFORE a genuine standalone link
+    // (github.com/me/repo). The first URL_RE hit is the prose domain, which
+    // isStandaloneUrl correctly rejects — so the parser must keep scanning and
+    // lift the real link, not give up on the first match.
+    const header = "Sold acme.example to buyer | github.com/me/repo";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBe("github.com/me/repo");
+    // The lifted link is stripped; the leading prose domain stays in the label.
+    expect(label).toContain("acme.example");
+    expect(label).not.toContain("github.com/me/repo");
+  });
+});

--- a/src/lib/heuristics/extract/contact.test.ts
+++ b/src/lib/heuristics/extract/contact.test.ts
@@ -65,3 +65,66 @@ describe("extractContact — email domain is not a website", () => {
     expect(result.website_url).toBe("https://janedoe.com");
   });
 });
+
+describe("extractContact — mid-sentence domain is not promoted to website_url (#237)", () => {
+  // Regression: a bare domain embedded in achievement/body prose (e.g. "sold
+  // return2india.com to Satyam Infoway") was being picked up by the full-doc
+  // fallback scan and promoted to website_url. The standalone check in
+  // extractOtherUrls now rejects domains that appear mid-sentence.
+
+  it("does not promote a domain mid-sentence to website_url", () => {
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | (312) 555-0123",
+      0,
+    );
+    // Body line that contains a domain mid-sentence
+    const bodyLine = mkLine(
+      "Exit · Founded and sold return2india.com to Satyam Infoway (NASDAQ: SIFY). 200K monthly visits.",
+      100,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const allLines: PdfLine[] = [contactLine, bodyLine];
+
+    const result = extractContact(profile, allLines);
+
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("does not promote a domain with surrounding words to website_url", () => {
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
+    const bodyLine = mkLine("Launched mysite.com for 10K users in 2023", 100);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const allLines: PdfLine[] = [contactLine, bodyLine];
+
+    const result = extractContact(profile, allLines);
+
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("still promotes a standalone domain on its own line to website_url", () => {
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | janedoe.com",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+
+    const result = extractContact(profile, [contactLine]);
+
+    expect(result.website_url).toBe("https://janedoe.com");
+  });
+
+  it("still promotes an https:// URL even when mid-sentence text surrounds it", () => {
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
+    // An explicit https:// URL is always a link regardless of surrounding text
+    const bodyLine = mkLine(
+      "Sold https://return2india.com to Satyam Infoway",
+      100,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const allLines: PdfLine[] = [contactLine, bodyLine];
+
+    const result = extractContact(profile, allLines);
+
+    expect(result.website_url).toBe("https://return2india.com");
+  });
+});

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -13,7 +13,7 @@ import {
 } from "../regex.ts";
 import { escapeRegex } from "../../jd-match/regex-utils.ts";
 import { findFirstPhone, regionFromLocation } from "../phone.ts";
-import { firstMatch, allMatches } from "./shared.ts";
+import { firstMatch, allMatches, isStandaloneUrl } from "./shared.ts";
 
 // ── Contact (email, phone, urls, location) ──────────────────────────────────
 
@@ -214,6 +214,12 @@ function looksLikeRealWebsite(u: string): boolean {
  * "Other URLs" are those whose lowercased form does not include `linkedin.com`
  * or `github.com`. Portfolio wins if the URL matches a portfolio-indicator
  * pattern; the first remaining URL becomes the website candidate.
+ *
+ * A bare domain is only accepted as a contact link when it is positionally
+ * standalone in the text — not flanked by word characters on both sides. A
+ * domain mid-sentence ("sold return2india.com to Satyam") is prose, not a
+ * contact URL (#237). URLs with an explicit scheme or `www.` are always
+ * accepted regardless of position.
  */
 function extractOtherUrls(joined: string): {
   portfolio: string | undefined;
@@ -230,7 +236,10 @@ function extractOtherUrls(joined: string): {
       return false;
     }
     // Reject `token.token` false positives (skills like `Node.js`, `etc.`).
-    return looksLikeRealWebsite(u);
+    if (!looksLikeRealWebsite(u)) return false;
+    // Reject a bare domain mid-sentence in prose (e.g. "sold return2india.com
+    // to Satyam"). A URL with an explicit scheme or www. is always standalone.
+    return isStandaloneUrl(u, withoutEmails);
   });
   const portfolio = others.find((u) =>
     /(portfolio|\.me\b|\.io\b|\.dev\b|behance|dribbble|medium)/i.test(u),

--- a/src/lib/heuristics/extract/dateless-entries.test.ts
+++ b/src/lib/heuristics/extract/dateless-entries.test.ts
@@ -124,6 +124,84 @@ describe("dateless trailing experience role (#219)", () => {
     expect(value[0].description).toContain("Reduced cloud spend by 30%");
   });
 
+  it("opens a single-line mid-dot dateless trailing role as its own entry (#239)", () => {
+    // #239's exact shape: a trailing role whose ONE-LINE header carries the org
+    // inline (`Title · Org, Location`) but no date range, after a dated role
+    // whose header puts everything on one line. Pre-fix the dateless header and
+    // its bullets were absorbed into the AOL/Netscape role's description (6 of 7
+    // roles parsed); it must now open its own entry with empty dates.
+    const { value } = extractExperience(
+      mkSection("experience", [
+        [
+          "Sr. Software Engineer · America Online / Netscape, MV, CA            07/2004 - 11/2006",
+          0,
+          100,
+        ],
+        ["• Architected the foundational accessibility layer for Boxely UI", 10, 90],
+        [
+          "Early Career: IC & Consultant · Microsoft, Aksharamala, Siemens ICN, HCL R&D, E-Z Data",
+          0,
+          70,
+        ],
+        ["• Pioneered Indian-language input on Windows through Aksharamala", 10, 60],
+        ["• Developed an innovative point-and-click tool", 10, 50],
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value[0]).toMatchObject({
+      title: "Sr. Software Engineer",
+      company: "America Online / Netscape",
+      start_date: "07/2004",
+      end_date: "11/2006",
+    });
+    // The dateless role opens its own entry with its two bullets and no dates.
+    expect(value[1].title).toBe("Early Career: IC & Consultant");
+    expect(value[1].start_date).toBeUndefined();
+    expect(value[1].end_date).toBeUndefined();
+    expect(value[1].description).toBe(
+      "Pioneered Indian-language input on Windows through Aksharamala\nDeveloped an innovative point-and-click tool",
+    );
+  });
+
+  it("opens a dateless role whose predecessor bullet WRAPPED onto a continuation line (#239)", () => {
+    // The previous role's last bullet wraps onto a marker-less continuation line
+    // ("millions of users…") that ends on a period — so the dateless header sits
+    // below that wrap, not below the bullet marker. The new-entry boundary must
+    // still fire: a header following a wrapped-bullet body still closes the prior
+    // role. (A loose rule must NOT split the wrap itself off — it's lowercase-led
+    // prose indented past the marker, caught by the geometry + shape gates.)
+    const { value } = extractExperience(
+      mkSection("experience", [
+        [
+          "Sr. Software Engineer · America Online / Netscape, MV, CA   07/2004 - 11/2006",
+          0,
+          100,
+        ],
+        [
+          "• Architected the foundational accessibility layer for AOL's Boxely UI used by",
+          10,
+          90,
+        ],
+        ["millions of users across the product suite.", 14, 83],
+        [
+          "Early Career: IC & Consultant · Microsoft, Aksharamala, Siemens ICN, HCL R&D",
+          0,
+          70,
+        ],
+        ["• Pioneered Indian-language input on Windows through Aksharamala", 10, 60],
+        ["• Developed an innovative point-and-click tool", 10, 50],
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value[0].title).toBe("Sr. Software Engineer");
+    // The wrap stays inside the prior role's body — not promoted to a phantom.
+    expect(value[0].description).toContain("millions of users across the product suite.");
+    expect(value[1].title).toBe("Early Career: IC & Consultant");
+    expect(value[1].description).toBe(
+      "Pioneered Indian-language input on Windows through Aksharamala\nDeveloped an innovative point-and-click tool",
+    );
+  });
+
   it("returns no entries for a section with bullets but zero dated anchors", () => {
     // The "no date range ⇒ []" contract for the date_range anchor still holds:
     // a fully dateless section routes through the first_line anchor elsewhere,
@@ -205,4 +283,59 @@ describe("education year mis-attribution across entries (#219)", () => {
       expect(value[0].institution).toContain("Stanford");
     },
   );
+});
+
+describe("degree-less program entry dropped + year orphaned (#238)", () => {
+  // The issue's exact reproducer: a program/certificate entry whose first line is
+  // a program TITLE with an inline year (no degree keyword) followed by its own
+  // institution line, sitting ABOVE a normal degree entry that has NO date of its
+  // own. Pre-fix, the program entry was dropped (it lacked the degree keyword the
+  // chunker anchored on) and its 2023 leaked onto the JNTU degree below it.
+  it("keeps the degree-less program entry AND binds its year to itself, not the next entry", () => {
+    const { value } = extractEducation(
+      mkSection("education", [
+        "Applied Data Science Program: Leveraging AI for Effective Decision-Making        2023",
+        "MIT Professional Education",
+        "Bachelor of Technology in Computer Science & Engineering",
+        "JNTU College Of Engineering, Hyderabad",
+      ]),
+    );
+    // Both entries survive — the program entry is no longer dropped.
+    expect(value).toHaveLength(2);
+
+    const mit = value.find((e) => e.institution.includes("MIT"));
+    const jntu = value.find((e) => e.institution.includes("JNTU"));
+    expect(mit).toBeDefined();
+    expect(jntu).toBeDefined();
+
+    // The program entry: institution is its OWN school, the program title lands in
+    // `field` (no credential keyword), and the inline 2023 stays with it.
+    expect(mit?.institution).toBe("MIT Professional Education");
+    expect(mit?.degree).toBe("");
+    expect(mit?.field).toContain("Applied Data Science Program");
+    expect(mit?.year).toBe("2023");
+
+    // The JNTU degree keeps its own degree/field and — crucially (C2) — does NOT
+    // inherit the program's 2023; it genuinely has no date.
+    expect(jntu?.degree).toBe("Bachelor of Technology");
+    expect(jntu?.field).toBe("Computer Science & Engineering");
+    expect(jntu?.year).toBeUndefined();
+  });
+
+  it("works regardless of order — program entry BELOW the dated-less degree entry", () => {
+    const { value } = extractEducation(
+      mkSection("education", [
+        "Bachelor of Technology in Computer Science & Engineering",
+        "JNTU College Of Engineering, Hyderabad",
+        "Applied Data Science Program: Leveraging AI for Effective Decision-Making        2023",
+        "MIT Professional Education",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    const mit = value.find((e) => e.institution.includes("MIT"));
+    const jntu = value.find((e) => e.institution.includes("JNTU"));
+    expect(mit?.year).toBe("2023");
+    expect(mit?.field).toContain("Applied Data Science Program");
+    expect(jntu?.year).toBeUndefined();
+  });
 });

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -17,6 +17,7 @@ import {
   normalizeDate,
   stripBullet,
 } from "../line-primitives.ts";
+import { isDateOnlyLine, isEntryHeaderShape } from "../entry-blocks.ts";
 import { avgScore } from "./shared.ts";
 
 // ── Education ───────────────────────────────────────────────────────────────
@@ -132,19 +133,6 @@ function educationDateFields(
   };
 }
 
-/** A line that is essentially just a date / date-range (a bare year or
- *  month-year), so it must not be mistaken for the institution inside an
- *  education chunk. */
-function isDateOnlyLine(text: string): boolean {
-  const stripped = text
-    .replace(/\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\.?/gi, "")
-    .replace(/\b\d{4}\b/g, "")
-    .replace(/\b(?:present|current|expected|graduation|graduated|anticipated)\b/gi, "")
-    .replace(/[\s,–\-—|/().:]+/g, "")
-    .trim();
-  return stripped.length === 0;
-}
-
 /** Whether `line` reads as a *wrapped continuation* of the preceding coursework
  *  bullet (e.g. the `Business` half of `● Global Dimensions of` + `Business`)
  *  rather than a standalone field that merely follows the bullet. The recovery
@@ -223,6 +211,43 @@ function isInlineDatedProgram(line: string): boolean {
     .replace(/[\s,–\-—|/().:]+/g, "")
     .trim();
   return remainder.length >= 3;
+}
+
+/** Whether `text` reads as an INSTITUTION line for a degree-less program entry —
+ *  an explicit institution-hint line ("MIT Sloan School of Management") OR a
+ *  hint-less proper-noun line that is the school's own name ("MIT Professional
+ *  Education"). It must be entry-header-shaped (proper-noun lead, not prose, not a
+ *  bare date, not a GPA/Minor note) and must NOT itself be a degree line — a
+ *  following degree opens a NEW entry, it is not the program's institution. Used
+ *  only to confirm a program-title lead is followed by its own school, so the
+ *  pair forms one entry that splits cleanly off the next (#238). */
+function isInstitutionLine(text: string): boolean {
+  if (DEGREE_RE.test(text)) return false;
+  if (INSTITUTION_HINTS.test(text)) return true;
+  return isEntryHeaderShape(text);
+}
+
+/** Whether the lines at [`i`, `i+1`] form a DEGREE-LESS PROGRAM ENTRY — a
+ *  program/certificate title carrying its own inline graduation year
+ *  ("Applied Data Science Program: … 2023"), immediately followed by its own
+ *  institution line ("MIT Professional Education"). This is the #238 shape: an
+ *  education entry recognized by entry-boundary SHAPE (a header-like program line
+ *  + an institution line) rather than a degree keyword. The lead reuses the
+ *  well-tested {@link isInlineDatedProgram} (a real program name with an inline
+ *  year, not an honors/GPA/grad-date annotation); the partner reuses
+ *  {@link isInstitutionLine}. Recognizing this pair lets the chunker bind the
+ *  program's year to the program's own entry and stops it bleeding onto a
+ *  neighbouring degree that has no date of its own (C2). */
+function isProgramLeadAt(
+  lines: { text: string }[],
+  i: number,
+): boolean {
+  const lead = lines[i]?.text;
+  const partner = lines[i + 1]?.text;
+  if (lead === undefined || partner === undefined) return false;
+  if (DEGREE_RE.test(lead) || INSTITUTION_HINTS.test(lead)) return false;
+  if (!isInlineDatedProgram(lead)) return false;
+  return isInstitutionLine(partner);
 }
 
 /** Trim a parsed field string down to the subject, cutting any trailing date,
@@ -349,28 +374,43 @@ function educationFromChunk(chunk: string[]): {
   // joined chunk, whose " | " separators would confuse the field tail).
   const degreeLine = chunk.find((l) => DEGREE_RE.test(l));
   const degreeMatch = DEGREE_RE.exec(joined);
-  const { degree, field } = degreeLine
+  let { degree, field } = degreeLine
     ? parseDegreeAndField(degreeLine)
-    : { degree: "", field: undefined };
+    : { degree: "", field: undefined as string | undefined };
 
-  // Institution: an explicit institution-hint line first; else the first line
-  // that is neither the degree-bearing line nor a bare date — this recovers
-  // acronym schools ("MIT", "UC Berkeley") that carry no "University"/"College"
-  // word; else strip the degree off its own line (degree + school on one line).
+  // Degree-less PROGRAM ENTRY (#238): a program/certificate title carrying its
+  // own inline year, followed by its institution line — recognized by SHAPE, not
+  // a degree keyword. The program title is the subject (`field`); the institution
+  // is the following line; there is no credential, so `degree` stays empty. Done
+  // before the generic institution scan so the program title is NOT mistaken for
+  // the institution (the first non-degree, non-date line). Scoped to a chunk with
+  // no degree line so a normal degree entry is untouched.
   let institution = "";
-  const instLine = chunk.find((l) => INSTITUTION_HINTS.test(l));
-  if (instLine) {
-    institution = instLine.trim();
+  if (!degreeLine && chunk.length >= 2 && isProgramLeadAt(
+    chunk.map((text) => ({ text })),
+    0,
+  )) {
+    field = cleanField(chunk[0]) ?? field;
+    institution = chunk[1].trim();
   } else {
-    const cand = chunk.find((l) => !DEGREE_RE.test(l) && !isDateOnlyLine(l));
-    if (cand) {
-      institution = cand.trim();
-    } else if (degreeMatch) {
-      institution = joined
-        .replace(degreeMatch[0], "")
-        .replace(/\s*\|\s*/g, " ")
-        .replace(/[,|]+$/, "")
-        .trim();
+    // Institution: an explicit institution-hint line first; else the first line
+    // that is neither the degree-bearing line nor a bare date — this recovers
+    // acronym schools ("MIT", "UC Berkeley") that carry no "University"/"College"
+    // word; else strip the degree off its own line (degree + school on one line).
+    const instLine = chunk.find((l) => INSTITUTION_HINTS.test(l));
+    if (instLine) {
+      institution = instLine.trim();
+    } else {
+      const cand = chunk.find((l) => !DEGREE_RE.test(l) && !isDateOnlyLine(l));
+      if (cand) {
+        institution = cand.trim();
+      } else if (degreeMatch) {
+        institution = joined
+          .replace(degreeMatch[0], "")
+          .replace(/\s*\|\s*/g, " ")
+          .replace(/[,|]+$/, "")
+          .trim();
+      }
     }
   }
 
@@ -474,16 +514,29 @@ export function extractEducation(
   let current: { text: string; idx: number }[] = [];
   let hasDegree = false;
   let hasInstitution = false;
+  // True once the current chunk holds a complete DEGREE-LESS PROGRAM ENTRY
+  // (a program-title lead + its institution line, #238). It becomes the
+  // boundary signal a degree-keyword-less entry otherwise lacks: a following
+  // degree / institution-hint / new program-lead then opens a fresh chunk,
+  // instead of merging in and dragging the program's inline year onto the next
+  // (dateless) school. Set only AFTER the program's own institution line is
+  // consumed (`programLeadInstIdx`), so that institution line is not itself
+  // mistaken for the start of a new entry.
+  let hasProgramLead = false;
+  let programLeadInstIdx = -1;
   const flush = () => {
     if (current.length > 0) chunks.push(current);
     current = [];
     hasDegree = false;
     hasInstitution = false;
+    hasProgramLead = false;
+    programLeadInstIdx = -1;
   };
   for (let li = 0; li < lines.length; li++) {
     const text = lines[li].text;
     const isDeg = DEGREE_RE.test(text);
     const isInst = INSTITUTION_HINTS.test(text);
+    const isProgramLead = isProgramLeadAt(lines, li);
     // A bare line (no degree/institution-hint, not a date) that arrives once the
     // current chunk already holds BOTH a degree and an institution, AND is
     // immediately followed by a degree, begins a new entry whose school is
@@ -508,11 +561,26 @@ export function extractEducation(
         // bare "Fall 2013 – Spring 2014" date range — which `isDateOnlyLine`
         // already excluded above) so an honors/awards line never splits.
         isInlineDatedProgram(text));
-    if ((isDeg && hasDegree) || (isInst && hasInstitution) || startsHintlessEntry)
+    // Once the current chunk is a complete degree-less program entry (#238), a
+    // new entry lead — a degree, an institution-hint, or another program lead —
+    // closes it. The program's own institution line (`programLeadInstIdx`) is
+    // excluded because `hasProgramLead` is not yet set when it arrives.
+    const startsAfterProgramLead =
+      hasProgramLead && (isDeg || isInst || isProgramLead);
+    if (
+      (isDeg && hasDegree) ||
+      (isInst && hasInstitution) ||
+      startsHintlessEntry ||
+      startsAfterProgramLead
+    )
       flush();
     current.push(lines[li]);
     if (isDeg) hasDegree = true;
     if (isInst) hasInstitution = true;
+    // A program lead claims the NEXT line as its institution; mark the chunk a
+    // complete program entry only once that institution line has been consumed.
+    if (isProgramLead) programLeadInstIdx = li + 1;
+    if (li === programLeadInstIdx) hasProgramLead = true;
   }
   flush();
 

--- a/src/lib/heuristics/extract/projects.ts
+++ b/src/lib/heuristics/extract/projects.ts
@@ -6,7 +6,7 @@ import type { PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
 import { URL_RE } from "../regex.ts";
-import { firstMatch, finalizeEntries } from "./shared.ts";
+import { allMatches, finalizeEntries, isStandaloneUrl } from "./shared.ts";
 
 // ── Projects ────────────────────────────────────────────────────────────────
 
@@ -45,15 +45,33 @@ export function extractProjects(
  * (repo / live demo / publication link) may appear anywhere in the header; it
  * is removed from the first line and trailing separators are trimmed. Shared by
  * `projectFromBlock` and `achievementFromBlock` — the SAME header shape (#96).
+ *
+ * A URL is only lifted when it is positionally a link — standalone on the
+ * line, or at a word boundary (adjacent to whitespace / separators, not
+ * flanked by word characters on BOTH sides). A bare domain mid-sentence (e.g.
+ * "sold return2india.com to Satyam") is left in the label text and not
+ * promoted to the `url` field (#237).
  */
 export function liftHeaderLabel(headerLines: string[]): {
   label: string;
   url?: string;
 } {
   const headerJoined = headerLines.join(" ");
-  const url = firstMatch(URL_RE, headerJoined);
+  // Lift the FIRST positionally-standalone URL — not merely the first URL_RE
+  // hit. A header can carry a bare domain mid-prose BEFORE a genuine link
+  // ("Sold acme.com to buyer | github.com/me/repo"); gating only firstMatch on
+  // isStandaloneUrl would reject the prose domain and never examine the real
+  // link. Mirror contact.ts::extractOtherUrls — scan all hits, keep the first
+  // standalone one. A URL with an explicit scheme or www. prefix is always
+  // standalone (#237).
+  const url = allMatches(URL_RE, headerJoined).find((u) =>
+    isStandaloneUrl(u, headerJoined),
+  );
   const raw = headerLines[0] ?? "";
-  const label = (url ? raw.replace(URL_RE, "") : raw)
+  // Strip THAT specific lifted url's occurrence — not the first URL_RE match —
+  // so a single prose-domain header (nothing lifted) keeps the domain in its
+  // label (#237).
+  const label = (url ? raw.replace(url, "") : raw)
     .replace(/[\s|•·\-–—]+$/g, "")
     .trim();
   URL_RE.lastIndex = 0;

--- a/src/lib/heuristics/extract/shared.ts
+++ b/src/lib/heuristics/extract/shared.ts
@@ -24,6 +24,41 @@ export function allMatches(re: RegExp, text: string): string[] {
 }
 
 /**
+ * True when `url` is positionally a link in `sourceText` — not embedded as a
+ * bare domain mid-sentence in prose.
+ *
+ * A URL is treated as standalone when it does NOT have a word character
+ * immediately before AND a word character immediately after its occurrence in
+ * the source text. Mid-sentence prose embeds a domain between words on both
+ * sides ("sold return2india.com to Satyam"), while a genuine link line or a
+ * header URL sits at a boundary (start/end of line, or adjacent to separators
+ * like ` | `, `·`, `—`).
+ *
+ * A URL with an explicit scheme (`https?://`) or `www.` prefix is always
+ * treated as standalone — the scheme is unambiguous intent.
+ *
+ * @param url        - The URL string as matched (e.g. "return2india.com").
+ * @param sourceText - The text to search within for positional context.
+ */
+export function isStandaloneUrl(url: string, sourceText: string): boolean {
+  // An explicit scheme or www. is always intentional — treat as standalone.
+  if (/^https?:\/\//i.test(url) || /^www\./i.test(url)) return true;
+  const idx = sourceText.indexOf(url);
+  if (idx === -1) return true; // can't find it — assume standalone
+  // Trim surrounding whitespace to look at the nearest non-space char on each
+  // side. "sold return2india.com to" has a space immediately before/after, but
+  // the nearest non-space chars are word chars — so it is mid-sentence prose.
+  const before = sourceText.slice(0, idx).trimEnd();
+  const after = sourceText.slice(idx + url.length).trimStart();
+  // Mid-sentence: word chars on BOTH sides (after trimming whitespace) →
+  // embedded in prose. A domain at start/end of text, or adjacent to
+  // separators (|, ·, —), has no word char on at least one side.
+  const wordBefore = /\w$/.test(before);
+  const wordAfter = /^\w/.test(after);
+  return !(wordBefore && wordAfter);
+}
+
+/**
  * Keywords that commonly appear in a job title. Used as a tiebreaker when
  * neither header line carries a company suffix:
  * modern resumes often flip the "Company first, then Title" convention

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -380,6 +380,17 @@ export const DEGREE_RE =
 export const INSTITUTION_HINTS =
   /\b(University|College|Institute|School|Academy|Polytechnic)s?\b/i;
 
+/** A sub-field NOTE line that rides under an entry — a GPA / Minor / Major /
+ *  concentration / coursework annotation — rather than a new entry header. Used
+ *  by the shared {@link isEntryHeaderShape} predicate (entry-blocks.ts) to reject
+ *  such a line as an entry-boundary lead: "GPA: 3.8", "Minor in Economics",
+ *  "Relevant Coursework: …" are properties of the school/role above them, not a
+ *  new title/program/institution. Anchored to the line start so a legitimate
+ *  program named with one of these words mid-line ("Major League Operations
+ *  Program") is unaffected. */
+export const PROGRAM_NOTE_RE =
+  /^(?:GPA[:\s]|Minor\b|Major\b|Concentration\b|Relevant Coursework\b|Coursework\b)/i;
+
 // ── Company suffix hints ────────────────────────────────────────────────────
 
 export const COMPANY_SUFFIX_RE =

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.87,
+    "confidence": 0.84,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume",
       "t1_5_regex"
     ],
-    "suggestedEscalation": "none",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
       "current_company",
       "current_title",
@@ -23,7 +23,7 @@
       "summary"
     ],
     "skillsCount": 8,
-    "experienceCount": 2,
+    "experienceCount": 3,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,


### PR DESCRIPTION
## Summary

Three anchor-on-shape parser fixes accumulated on one branch (children of the #31/#145 family):

- **#237** — a bare domain sitting mid-prose (e.g. `… sold return2india.com to Satyam …`) was mis-promoted to a URL / `website_url`. New `isStandaloneUrl` positional guard (`shared.ts`); `liftHeaderLabel` (`projects.ts`) and `extractOtherUrls` (`contact.ts`) gate on it. `liftHeaderLabel` now scans all URL matches and lifts the first *standalone* one, so a genuine link after a prose domain still surfaces.
- **#238** — a degree-keyword-less education entry (`… Program:` + institution line) was dropped and its year orphaned onto an adjacent entry. Education entries now recognized by header **shape** (new exported `isEntryHeaderShape`/`isDateOnlyLine` in `entry-blocks.ts`, `PROGRAM_NOTE_RE` in `regex.ts`); the year binds to the correct entry.
- **#239** — a dateless `Title · Org, Location` experience header was folded into the previous role. Extends #238's shared shape seam (`precededByBulletBody` relaxes the predecessor gate in `collectDatelessAnchors`) so a dateless header following a (possibly wrapped) bullet opens its own entry. One corpus golden rebaked (`laverne-word-quartz`: a previously-dropped role now recovered).

Closes #237
Closes #238
Closes #239

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1130 tests)
- [x] `npm run lint` clean
- [ ] Manually verified in `npm run dev` / `npm run preview`

## Adversarial review

Bounded pre-PR adversarial review loop (independent `code-reviewer`, opus), 2 rounds, converged clean.

**Round 1 — 1 blocking, fixed in place:**
- `liftHeaderLabel` (`projects.ts`) used `firstMatch(URL_RE)` then gated on `isStandaloneUrl` — a mid-prose domain *preceding* a genuine standalone link on the same header would consume the first match, get rejected, and the real link was never examined → no URL lifted (missed the #237 "standalone still populates" criterion). **Fixed:** now `allMatches(URL_RE).find(isStandaloneUrl)` + strips the lifted URL's occurrence; regression test added.
- **Corpus rebake verified legitimate:** reviewer confirmed against the real PDF that `laverne-word-quartz` `experienceCount 2→3` is a genuinely *recovered* role (YMCA / Volunteer Swim Coach, previously dropped outright), not a masked regression. `confidence 0.87→0.84` + `escalation none→llm` correctly reflect a recovered-but-dateless entry.
- #238/#239 anchor-on-shape relaxations verified: no phantom-split / over-recognition regression (multi-line-header + wrapped-tail guards hold live).

**Round 2 — 0 blocking, converged (`clean: true`).**

**Surviving nits (non-blocking, follow-up issues recommended):**
- `isStandaloneUrl` `indexOf` + `raw.replace(url,"")` locate a URL by first textual occurrence — aliases when one matched URL is a substring/duplicate of another on the same header line (narrow, label-only). Fix by carrying the match index through `allMatches`.
- Recovered YMCA role silently drops its source date `"Summer 2013, 2014"` — pre-existing `Season YYYY, YYYY` date-format gap, not introduced here.
- `isInlineDatedProgram` denylist catches `thesis`/`coursework` but not `project`/`capstone` (pre-existing).
