### PR TITLE
fix(parser): URL index carry-through, Season-YYYY dates, capstone denylist (#249 #250 #251)

### DIFF
--- a/src/lib/heuristics/extract/achievements.test.ts
+++ b/src/lib/heuristics/extract/achievements.test.ts
@@ -74,3 +74,30 @@ describe("liftHeaderLabel — standalone URL IS lifted", () => {
     expect(label).not.toContain("github.com/me/repo");
   });
 });
+
+describe("liftHeaderLabel — substring/duplicate URL aliasing (#249)", () => {
+  it("lifts standalone site.com even when mysite.com precedes it in prose", () => {
+    // Class 1 aliasing: indexOf("site.com") lands inside "mysite.com" (position 2)
+    // rather than at the genuine standalone occurrence after the separator.
+    // With the index-passing fix, isStandaloneUrl receives the regex match index
+    // (position of the real standalone "site.com"), not a re-derived indexOf.
+    const header = "Built mysite.com for client | site.com";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBe("site.com");
+    // The prose-embedded mysite.com stays in the label; only the standalone
+    // site.com is stripped.
+    expect(label).toContain("mysite.com");
+    expect(label).not.toContain("| site.com");
+  });
+
+  it("strips a duplicated link cleanly with no dangling separator or raw URL", () => {
+    // Class 2 aliasing: raw.replace(url, "") only removes the first occurrence.
+    // The second copy of github.com/a/b would be left in the label as a raw URL.
+    // With the slice-based strip, ALL regex-matched occurrences are removed.
+    const header = "Repo | github.com/a/b | github.com/a/b";
+    const { label, url } = liftHeaderLabel([header]);
+    expect(url).toBe("github.com/a/b");
+    // Label must not contain a raw URL or a dangling separator run.
+    expect(label).toBe("Repo");
+  });
+});

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -117,6 +117,66 @@ describe("extractEducation — coursework loop must not over-consume (#184)", ()
   });
 });
 
+describe("extractEducation — capstone/project sub-line stays annotation, not sibling entry (#251)", () => {
+  it("does NOT split a capstone project sub-line into a phantom education entry", () => {
+    // A line like "Capstone Project: Real-time Sentiment Analysis (2023)" sits
+    // under a degree and must remain an annotation, not become a second entry.
+    const { value } = extractEducation(
+      mkEduSection([
+        "University of Example",
+        "B.S. Computer Science   2020 - 2024",
+        "Capstone Project: Real-time Sentiment Analysis (2023)",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].institution).toBe("University of Example");
+    expect(value[0].degree).toBe("B.S.");
+  });
+
+  it("does NOT split a 'Senior Project' sub-line into a phantom education entry", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Lakeside Institute of Technology",
+        "Bachelor of Science in Electrical Engineering   2019 - 2023",
+        "Senior Project: Autonomous Drone Navigation (2023)",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].institution).toBe("Lakeside Institute of Technology");
+  });
+
+  it("still recognizes a genuine program entry that carries no capstone/project keyword", () => {
+    // "Applied Data Science Program" carries no denylist word, so a genuine
+    // certificate/program entry on its own line must still be recognized.
+    const { value } = extractEducation(
+      mkEduSection([
+        "Massachusetts Institute of Technology",
+        "B.S. Computer Science   2018 - 2022",
+        "Applied Data Science (2023)",
+      ]),
+    );
+    // The inline-dated program "Applied Data Science (2023)" should produce a
+    // second entry since it carries no denylist keyword and has a year.
+    expect(value).toHaveLength(2);
+    expect(value[0].institution).toBe("Massachusetts Institute of Technology");
+  });
+
+  it("still splits a credential title that merely contains the word 'project'", () => {
+    // "Project Management Certificate" is a genuine standalone credential, not an
+    // annotation — the denylist must not swallow it just because it contains
+    // "project" (bare-word breadth was a #251 adversarial-review blocking finding).
+    const { value } = extractEducation(
+      mkEduSection([
+        "Cornell University",
+        "B.S. Information Science   2017 - 2021",
+        "Project Management Certificate 2022",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value[0].institution).toBe("Cornell University");
+  });
+});
+
 describe("extractEducation — degree/field split + location peel (#222)", () => {
   it("splits 'B.S. in Computer Science' into bare degree + field and peels City, ST", () => {
     // The issue's exact reproducer: degree+field+dates on the second line,

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -200,15 +200,21 @@ function isInlineDatedProgram(line: string): boolean {
     return false;
   // An honors / awards / activity annotation that happens to carry a year
   // ("Dean's List 2021", "Honors Thesis: … (2024)", "Teaching Assistant for …
-  // (2022 - 2023)", "Study Abroad, Florence 2021") is a sub-field of the current
-  // school, NOT a new program — it must not split off a phantom degree-less
-  // entry (#219). These read as annotations, not program names, so an exact
-  // keyword denylist is safe: a real second program ("MIT Applied Data Science
-  // (2023)", "Google Data Analytics Certificate 2022") carries none of them.
+  // (2022 - 2023)", "Study Abroad, Florence 2021", "Capstone Project: Sentiment
+  // Analysis (2023)") is a sub-field of the current school, NOT a new program —
+  // it must not split off a phantom degree-less entry (#219, #251). These read as
+  // annotations, not program names, so an exact keyword denylist is safe: a real
+  // second program ("MIT Applied Data Science (2023)", "Google Data Analytics
+  // Certificate 2022") carries none of them. NOTE: "project" is denied only in its
+  // annotation shape — a qualifier-led "Senior/Final/… Project" or a "Project: …"
+  // sub-line — NOT bare anywhere, so a genuine credential title that merely contains
+  // the word ("Project Management Certificate 2022", PMP) still splits into its own
+  // program entry (#251 adversarial review).
   if (
-    /\b(dean'?s? list|awards?|honou?rs?|thesis|teaching assistant|research assistant|study abroad|coursework|scholarships?|fellowships?|cum laude)\b/i.test(
+    /\b(dean'?s? list|awards?|honou?rs?|thesis|teaching assistant|research assistant|study abroad|coursework|scholarships?|fellowships?|cum laude|capstone|(?:senior|final|independent|group|team)\s+project)\b/i.test(
       t,
-    )
+    ) ||
+    /\bproject\s*:/i.test(t)
   )
     return false;
   // Drop a trailing "| City, Region" location segment before measuring the

--- a/src/lib/heuristics/extract/projects.ts
+++ b/src/lib/heuristics/extract/projects.ts
@@ -6,7 +6,11 @@ import type { PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
 import { URL_RE } from "../regex.ts";
-import { allMatches, finalizeEntries, isStandaloneUrl } from "./shared.ts";
+import {
+  allMatchesWithIndex,
+  finalizeEntries,
+  isStandaloneUrl,
+} from "./shared.ts";
 
 // ── Projects ────────────────────────────────────────────────────────────────
 
@@ -64,16 +68,42 @@ export function liftHeaderLabel(headerLines: string[]): {
   // link. Mirror contact.ts::extractOtherUrls — scan all hits, keep the first
   // standalone one. A URL with an explicit scheme or www. prefix is always
   // standalone (#237).
-  const url = allMatches(URL_RE, headerJoined).find((u) =>
-    isStandaloneUrl(u, headerJoined),
+  //
+  // Use allMatchesWithIndex so we pass the exact regex match position to
+  // isStandaloneUrl — avoids the substring-aliasing bug where indexOf("site.com")
+  // lands inside "mysite.com" instead of at the genuine standalone occurrence
+  // (#249, Class 1).
+  const liftedMatch = allMatchesWithIndex(URL_RE, headerJoined).find((m) =>
+    isStandaloneUrl(m.text, headerJoined, m.index),
   );
+  const url = liftedMatch?.text;
   const raw = headerLines[0] ?? "";
-  // Strip THAT specific lifted url's occurrence — not the first URL_RE match —
-  // so a single prose-domain header (nothing lifted) keeps the domain in its
-  // label (#237).
-  const label = (url ? raw.replace(url, "") : raw)
-    .replace(/[\s|•·\-–—]+$/g, "")
-    .trim();
+  // Strip ALL occurrences of the lifted URL from the first header line (#249,
+  // Class 2). Use the regex to locate each occurrence by position rather than
+  // string.replace(url, …), which only removes the first textual occurrence and
+  // may corrupt a different token that contains url as a substring
+  // (e.g. "mysite.com" when url = "site.com").
+  //
+  // Strategy: re-scan raw with URL_RE, collect positions of every hit whose
+  // trimmed text equals the lifted url, then splice them out right-to-left so
+  // earlier offsets remain valid.
+  let stripped = raw;
+  if (url) {
+    URL_RE.lastIndex = 0;
+    const positions: { start: number; end: number }[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = URL_RE.exec(raw)) !== null) {
+      if (m[0].trim() === url) {
+        positions.push({ start: m.index, end: m.index + m[0].length });
+      }
+    }
+    // Remove right-to-left so each splice doesn't shift earlier offsets.
+    for (let i = positions.length - 1; i >= 0; i--) {
+      const { start, end } = positions[i]!;
+      stripped = stripped.slice(0, start) + stripped.slice(end);
+    }
+  }
+  const label = stripped.replace(/[\s|•·\-–—]+$/g, "").trim();
   URL_RE.lastIndex = 0;
   return { label, ...(url ? { url } : {}) };
 }

--- a/src/lib/heuristics/extract/shared.ts
+++ b/src/lib/heuristics/extract/shared.ts
@@ -24,6 +24,27 @@ export function allMatches(re: RegExp, text: string): string[] {
 }
 
 /**
+ * All regex hits with their match positions. Unlike `allMatches`, this does NOT
+ * deduplicate — every occurrence is returned in order, so callers can reason
+ * about which specific occurrence of a repeated token they are dealing with.
+ *
+ * Use this instead of `allMatches` when you need to pass the match index to
+ * `isStandaloneUrl` (avoids substring aliasing — see #249).
+ */
+export function allMatchesWithIndex(
+  re: RegExp,
+  text: string,
+): { text: string; index: number }[] {
+  re.lastIndex = 0;
+  const out: { text: string; index: number }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.push({ text: m[0].trim(), index: m.index });
+  }
+  return out;
+}
+
+/**
  * True when `url` is positionally a link in `sourceText` — not embedded as a
  * bare domain mid-sentence in prose.
  *
@@ -39,11 +60,25 @@ export function allMatches(re: RegExp, text: string): string[] {
  *
  * @param url        - The URL string as matched (e.g. "return2india.com").
  * @param sourceText - The text to search within for positional context.
+ * @param knownIndex - The exact byte-offset of `url` within `sourceText` as
+ *                     returned by `RegExp.exec` (i.e. `match.index`). When
+ *                     provided, it is used directly instead of `indexOf`, which
+ *                     eliminates the substring-aliasing bug where
+ *                     `"site.com".indexOf("site.com")` would land inside
+ *                     `"mysite.com"` rather than at the genuine standalone
+ *                     occurrence (#249).
  */
-export function isStandaloneUrl(url: string, sourceText: string): boolean {
+export function isStandaloneUrl(
+  url: string,
+  sourceText: string,
+  knownIndex?: number,
+): boolean {
   // An explicit scheme or www. is always intentional — treat as standalone.
   if (/^https?:\/\//i.test(url) || /^www\./i.test(url)) return true;
-  const idx = sourceText.indexOf(url);
+  // Use the caller-supplied regex match index when available — avoids the
+  // substring-aliasing problem of indexOf (see #249). Fall back to indexOf
+  // only for backward-compat with callers that don't supply the index.
+  const idx = knownIndex ?? sourceText.indexOf(url);
   if (idx === -1) return true; // can't find it — assume standalone
   // Trim surrounding whitespace to look at the nearest non-space char on each
   // side. "sold return2india.com to" has a space immediately before/after, but

--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -67,7 +67,8 @@ function isPlaceholderDate(token: string): boolean {
   return /^(?:month(?:\s+year)?|year)$/i.test(token.trim());
 }
 
-/** Parse a date range (start/end) from a line. Tolerates M/YYYY, Mmm YYYY, YYYY. */
+/** Parse a date range (start/end) from a line. Tolerates M/YYYY, Mmm YYYY, YYYY,
+ *  and Season YYYY[, YYYY] (branch (c) of DATE_RANGE_RE). */
 export function parseDateRange(text: string): {
   start_date?: string;
   end_date?: string;
@@ -77,6 +78,10 @@ export function parseDateRange(text: string): {
   const m = DATE_RANGE_RE.exec(text);
   DATE_RANGE_RE.lastIndex = 0;
   if (m) {
+    // Branch (c): Season YYYY, YYYY — m[5] is start ("Summer 2013"), m[6] is end year.
+    if (m[5] !== undefined) {
+      return { start_date: normalizeDate(m[5]), end_date: normalizeDate(m[6]) };
+    }
     const start = normalizeDate(m[1] ?? m[3]);
     // An unfilled template range ("Month Year - ...") matched only to anchor and
     // strip the role header — it carries no real date, so report none. (A real

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -280,3 +280,53 @@ describe("stripDateRange — bracket/paren residue (#236)", () => {
     );
   });
 });
+
+describe("parseDateRange — season-comma dates (#250)", () => {
+  // "Summer 2013, 2014" = branch (c): Season YYYY, YYYY.
+  it("recognises 'Summer 2013, 2014' as a date range", () => {
+    expect(DATE_RANGE_RE.test("Summer 2013, 2014")).toBe(true);
+    DATE_RANGE_RE.lastIndex = 0;
+  });
+
+  it("parses 'Summer 2013, 2014' — start is season+year, end is second year", () => {
+    const result = parseDateRange("Summer 2013, 2014");
+    expect(result.start_date).toBe("Summer 2013");
+    expect(result.end_date).toBe("2014");
+    expect(result.is_current).toBeUndefined();
+  });
+
+  it("parses a role line containing 'Summer 2013, 2014'", () => {
+    const result = parseDateRange("Volunteer Swim Coach Summer 2013, 2014");
+    expect(result.start_date).toBe("Summer 2013");
+    expect(result.end_date).toBe("2014");
+  });
+
+  it("recognises other season words (Spring, Fall, Winter, Autumn)", () => {
+    for (const season of ["Spring", "Fall", "Winter", "Autumn"]) {
+      const text = `${season} 2022, 2023`;
+      expect(DATE_RANGE_RE.test(text)).toBe(true);
+      DATE_RANGE_RE.lastIndex = 0;
+      const result = parseDateRange(text);
+      expect(result.start_date).toBe(`${season} 2022`);
+      expect(result.end_date).toBe("2023");
+    }
+  });
+
+  it("recognises 'Summer 2013 – 2014' via the classic dash separator (branch a)", () => {
+    // Season YYYY is now in DATE_ANCHOR, so branch (a) fires too.
+    const result = parseDateRange("Summer 2013 – 2014");
+    expect(result.start_date).toBe("Summer 2013");
+    expect(result.end_date).toBe("2014");
+  });
+
+  it("does NOT match a bare season word without a year", () => {
+    expect(DATE_RANGE_RE.test("Summer internship")).toBe(false);
+    DATE_RANGE_RE.lastIndex = 0;
+  });
+
+  it("strips a season-comma date from a role line", () => {
+    expect(stripDateRange("Volunteer Swim Coach Summer 2013, 2014")).toBe(
+      "Volunteer Swim Coach",
+    );
+  });
+});

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -122,6 +122,9 @@ export const COUNTRY_GAZETTEER: ReadonlySet<string> = _buildGazetteer();
 const MONTH =
   "(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*";
 
+/** Academic / seasonal period words. Case-insensitive at use site. */
+const SEASON = "(?:Spring|Summer|Fall|Autumn|Winter)";
+
 /** "Jan 2020", "January 2020", "Jan. 2020", "Jan '20". 2-digit apostrophe
  *  form (`'20`) covers older resumes that use AP-style short dates. */
 export const MONTH_YEAR_RE = new RegExp(
@@ -164,11 +167,13 @@ const YEAR_FORMS = `\\d{4}|'\\d{2}|20XX|XXXX|####|Year`;
 // detection keep requiring a real month name.
 const MONTH_OR_PLACEHOLDER = `(?:${MONTH}|Month)`;
 
-// Shared fragment for one date anchor (Mmm YYYY | 'YY, mm/yyyy, YYYY).
+// Shared fragment for one date anchor (Mmm YYYY | 'YY, mm/yyyy, YYYY, Season YYYY).
 // Reused by DATE_RANGE_RE's start and end groups. Apostrophe-year keeps
 // DOCX parsing compatible with older resumes that use "Dec '00". The bare-year
 // tail admits `20XX` (unambiguous) but NOT bare `XXXX`/`####` (too weak alone).
-const DATE_ANCHOR = `${MONTH_OR_PLACEHOLDER}\\.?\\s+(?:${YEAR_FORMS})|\\d{1,2}[\\/\\-]\\d{4}|20XX|\\d{4}`;
+// Season YYYY (e.g. "Summer 2013") is admitted so a season date participates in
+// branch (a) when an explicit separator (–/-/to) is present.
+const DATE_ANCHOR = `${MONTH_OR_PLACEHOLDER}\\.?\\s+(?:${YEAR_FORMS})|${SEASON}\\s+\\d{4}|\\d{1,2}[\\/\\-]\\d{4}|20XX|\\d{4}`;
 
 // Strict month-year anchor (no bare-year / numeric-slash forms) for the
 // separator-less branch — bare years adjacent are too weak a signal.
@@ -178,18 +183,23 @@ const MONTH_YEAR_ANCHOR = `${MONTH_OR_PLACEHOLDER}\\.?\\s+(?:${YEAR_FORMS})`;
  * Date range between two anchors. Captures both halves. Tolerant of spacing,
  * dashes (—, –, -, to, through).
  *
- * Two branches:
+ * Three branches:
  *   (a) classic — any anchor, explicit separator (–/—/-/to/through), any anchor or Present.
  *       Groups: m[1] = start, m[2] = end.
  *   (b) separator-less — month-year WS month-year (or Present), no dash.
  *       Covers LaTeX/Awesome-CV where pdfjs drops the dash glyph.
  *       Groups: m[3] = start, m[4] = end.
+ *   (c) season-comma — "Season YYYY, YYYY" (e.g. "Summer 2013, 2014").
+ *       Comma is the range separator; season + first year is start, second year is end.
+ *       Groups: m[5] = start ("Summer 2013"), m[6] = end ("2014").
  */
 export const DATE_RANGE_RE = new RegExp(
   // (a) classic: any anchor, explicit separator, any anchor|Present
   `(?:(${DATE_ANCHOR})\\s*(?:–|—|-|to|through)\\s*(${DATE_ANCHOR}|Present|Current|Now|Ongoing))` +
     // (b) separator-less: month-year WS month-year (or Present)
-    `|(?:(${MONTH_YEAR_ANCHOR})\\s+(${MONTH_YEAR_ANCHOR}|Present|Current|Now|Ongoing))`,
+    `|(?:(${MONTH_YEAR_ANCHOR})\\s+(${MONTH_YEAR_ANCHOR}|Present|Current|Now|Ongoing))` +
+    // (c) season-comma: "Season YYYY, YYYY" (e.g. "Summer 2013, 2014")
+    `|(?:(${SEASON}\\s+\\d{4}),\\s*(\\d{4}))`,
   "i",
 );
 

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0.84,
+    "confidence": 0.8,
     "triggers": [],
     "tiers": [
       "t0_layout",


### PR DESCRIPTION
## Summary

Three M1 Parser-Hardening fixes, all follow-ups surfaced by the adversarial review of PR #248. Independent fixes, no shared source files — bundled as one branch.

- **#249 — substring/duplicate URL on a header line corrupts label or drops the link.** `liftHeaderLabel`/`isStandaloneUrl` aliased URLs by first textual occurrence. Now carries the regex match **index** (new `allMatchesWithIndex`, optional `knownIndex?` on `isStandaloneUrl`) and strips **all** occurrences of the lifted URL right-to-left via slice. Lifts a genuine standalone `site.com` even when `mysite.com` precedes it in prose; strips a duplicated link cleanly (no dangling `|  |`, no raw URL left in the name).
- **#250 — `Season YYYY, YYYY` dates dropped.** Taught the date matcher the season-comma shape (new `SEASON` const, `DATE_ANCHOR` alternative, `DATE_RANGE_RE` branch c, `parseDateRange` binding). `Summer 2013, 2014` now parses as the entry's date instead of being silently dropped. `laverne-word-quartz` golden updated (confidence 0.84→0.80 — the YMCA role now extracts a typed date).
- **#251 — `isInlineDatedProgram` denylist over-split.** Narrowed to deny `capstone`, qualifier-led `Senior/Final/Independent/Group/Team Project`, and `Project:` sub-lines **only** — not bare `project`. Capstone/project sub-lines stay annotations under their degree; genuine credential titles like `Project Management Certificate 2022` (PMP) still split into their own entry.

Resolves #249
Resolves #250
Resolves #251

## Adversarial review

Pre-PR adversarial review — **2 rounds, converged clean**:
- **Blocking (fixed):** #251's initial `\bproject\b` was matched bare anywhere on the line, swallowing legit credential titles (`Project Management Certificate`, PMP, Google PM Certificate). Narrowed to the annotation shape only; added a regression test asserting `Project Management Certificate 2022` splits into its own entry.
- **Verified clean:** #249 multi-strip is gated on exact full-token equality (never over-strips a substring); #250 season alternatives do not broaden/regress existing date forms (`MM/YYYY`, `Mon YYYY`, `20XX`, bare year), and the laverne confidence drop is a legitimate extraction-ratio shift, not a masked regression.
- **Nits (deferred):** ~81-line test-helper clone between `education.test.ts` ↔ `extract-fields.test.ts`; pre-existing multi-distinct-URL dangling-separator behavior in `projects.ts` (not introduced here).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (82 files, 1148/1148)
- [x] `npm run lint` clean
- [x] `fallow audit --changed-since main` — no new blocking (complexity findings inherited)
- [ ] Manually verified in `npm run dev` / `npm run preview`

**Round 2 (re-review):** `clean: true`, zero blocking. The #251 narrowing verified correct (credential titles split; capstone / qualified-project / `Project:` sub-lines stay annotations); #249 and #250 independently re-confirmed. New low-value nit only: season date `Summer 2013 , 2014` (space before comma) won't match — realistic PDFs rarely insert it; deferred.