### PR TITLE
fix(parser): stop institution name being eaten as a section header; surface the major

### DIFF
--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -62,6 +62,21 @@ describe("resolveEducationDisplay", () => {
     expect(d.institution).toBeUndefined();
   });
 
+  it("surfaces the major (field), passing it through and applying its override", () => {
+    const withMajor: ResumeEducation = {
+      ...base,
+      field: "Computer Science & Engineering",
+    };
+    expect(resolveEducationDisplay(withMajor, undefined).field).toBe(
+      "Computer Science & Engineering",
+    );
+    // Override replaces; an empty-string override clears the major.
+    expect(resolveEducationDisplay(withMajor, { field: "Data Science" }).field).toBe(
+      "Data Science",
+    );
+    expect(resolveEducationDisplay(withMajor, { field: "" }).field).toBeUndefined();
+  });
+
   it("collapses the dates string when both dates are cleared", () => {
     const noYear: ResumeEducation = { ...base, year: undefined };
     const d = resolveEducationDisplay(noYear, { start_date: "", end_date: "" });

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -31,9 +31,11 @@ import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
 import { Button, EditableField } from "@design-system";
 import { AddPill, RemoveButton } from "./ReconstructedAdd.tsx";
 
-/** Map an EducationEntry field name to the flat AddedEntry field it edits. */
+/** Map an EducationEntry field name to the flat AddedEntry field it edits.
+ *  `field` (major) is intentionally omitted — added entries carry no major slot,
+ *  so the major affordance renders on PARSED entries only and never routes here. */
 const EDUCATION_FIELD_MAP: Record<
-  keyof EducationFieldOverrides,
+  Exclude<keyof EducationFieldOverrides, "field">,
   AddedEntryField
 > = {
   degree: "title",
@@ -70,6 +72,9 @@ export function resolveEduValue(
 /** The resolved education fields an entry renders, after applying overrides. */
 export interface EducationDisplay {
   degree: string | undefined;
+  /** Subject of study ("Computer Science & Engineering"); for a degree-less
+   *  program (#238) this holds the program title and degree is absent. */
+  field: string | undefined;
   institution: string | undefined;
   startDate: string | undefined;
   endDate: string | undefined;
@@ -93,6 +98,7 @@ export function resolveEducationDisplay(
   const endDate = resolveEduValue(edu.end_date, overrides?.end_date);
   return {
     degree: resolveEduValue(edu.degree, overrides?.degree),
+    field: resolveEduValue(edu.field, overrides?.field),
     institution: resolveEduValue(edu.institution, overrides?.institution),
     startDate,
     endDate,
@@ -106,15 +112,26 @@ function EducationEntry({
   overrides,
   onFieldChange,
   onRemove,
+  isAdded = false,
 }: {
   edu: ResumeEducation;
   overrides: EducationFieldOverrides | undefined;
   onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
   /** Remove this entry (only set for user-ADDED entries). */
   onRemove?: () => void;
+  /** User-added entries carry no `field` (major) slot, so the major affordance
+   *  renders on PARSED entries only. */
+  isAdded?: boolean;
 }) {
-  const { degree, institution, startDate, endDate, dates, coursework } =
+  const { degree, field, institution, startDate, endDate, dates, coursework } =
     resolveEducationDisplay(edu, overrides);
+
+  // A degree-less program (#238, e.g. "ACME Applied Robotics") keeps its
+  // title in `field`; promote it into the primary (semibold) slot so the entry
+  // doesn't read as an empty "degree not detected". Otherwise the major follows
+  // the degree after a comma ("Bachelor of Science, Mechanical Engineering & …").
+  const majorInPrimary = !degree && Boolean(field);
+  const showMajor = !isAdded && Boolean(field);
 
   // The editable start/end fields ARE the date display, so the compact `dates`
   // string would duplicate them. Show it ONLY in the legacy year-only fallback
@@ -126,13 +143,27 @@ function EducationEntry({
     <li className="flex flex-col gap-0.5 text-sm">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-          <EditableField
-            value={degree}
-            placeholder="degree not detected"
-            label="Degree"
-            textWeight="semibold"
-            onCommit={(v) => onFieldChange("degree", v)}
-          />
+          {!majorInPrimary && (
+            <EditableField
+              value={degree}
+              placeholder="degree not detected"
+              label="Degree"
+              textWeight="semibold"
+              onCommit={(v) => onFieldChange("degree", v)}
+            />
+          )}
+          {showMajor && (
+            <>
+              {degree && <span className="text-content-muted">,</span>}
+              <EditableField
+                value={field}
+                placeholder="major"
+                label="Field of study"
+                textWeight={majorInPrimary ? "semibold" : undefined}
+                onCommit={(v) => onFieldChange("field", v)}
+              />
+            </>
+          )}
           <span className="text-content-muted">—</span>
           <EditableField
             value={institution}
@@ -216,10 +247,12 @@ export function EducationSection({
                 overrides={added ? undefined : educationOverrides[i]}
                 onFieldChange={(field, value) =>
                   added
-                    ? onEntryField(added.id, EDUCATION_FIELD_MAP[field], value)
+                    ? field !== "field" &&
+                      onEntryField(added.id, EDUCATION_FIELD_MAP[field], value)
                     : onEducationFieldChange(i, field, value)
                 }
                 onRemove={added ? () => onRemoveEntry(added.id) : undefined}
+                isAdded={Boolean(added)}
               />
             );
           })}

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -245,12 +245,17 @@ export function EducationSection({
                 key={added ? added.id : i}
                 edu={edu}
                 overrides={added ? undefined : educationOverrides[i]}
-                onFieldChange={(field, value) =>
-                  added
-                    ? field !== "field" &&
-                      onEntryField(added.id, EDUCATION_FIELD_MAP[field], value)
-                    : onEducationFieldChange(i, field, value)
-                }
+                onFieldChange={(field, value) => {
+                  if (!added) {
+                    onEducationFieldChange(i, field, value);
+                    return;
+                  }
+                  // Added entries carry no major slot; the `field` edit can't
+                  // originate here (the major affordance is parsed-only), and
+                  // EDUCATION_FIELD_MAP has no "field" key — narrow it out.
+                  if (field !== "field")
+                    onEntryField(added.id, EDUCATION_FIELD_MAP[field], value);
+                }}
                 onRemove={added ? () => onRemoveEntry(added.id) : undefined}
                 isAdded={Boolean(added)}
               />

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -56,11 +56,14 @@ export type BulletOverrides = Record<number, string>;
 
 // ── Education overrides ───────────────────────────────────────────────────────
 
-/** Editable education fields (degree, institution, dates). Mirrors the
- *  experience-header override shape. An empty string clears the field
- *  (rendered as "not detected"); undefined means "no override". */
+/** Editable education fields (degree, field/major, institution, dates). Mirrors
+ *  the experience-header override shape. An empty string clears the field
+ *  (rendered as "not detected"); undefined means "no override". `field` is the
+ *  subject of study ("Computer Science & Engineering") parsed off the degree
+ *  line — editable only on PARSED entries; user-added entries carry no major. */
 export interface EducationFieldOverrides {
   degree?: string;
+  field?: string;
   institution?: string;
   start_date?: string;
   end_date?: string;

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -387,6 +387,32 @@ describe("applyOverrides — education", () => {
     expect(out.education[1].institution).toBe("");
   });
 
+  it("writes the major (field) override, and a clear drops it to undefined", () => {
+    const { parsed: set } = applyOverrides(
+      eduParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 0: { field: "Computer Science & Engineering" } },
+    );
+    expect(set.education[0].field).toBe("Computer Science & Engineering");
+
+    const { parsed: cleared } = applyOverrides(
+      eduParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      { 0: { field: "" } },
+    );
+    expect(cleared.education[0].field).toBeUndefined();
+  });
+
   it("ignores an education override for an out-of-range index", () => {
     const parsed = eduParsed();
     const { parsed: out } = applyOverrides(

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -374,6 +374,9 @@ export function applyOverrides(
     const edu = nextParsed.education[idx];
     if (!edu) continue;
     if (fields.degree !== undefined) edu.degree = fields.degree;
+    // `field` (major) is optional; a clear ("") drops it so render/PDF treat it
+    // as absent rather than emitting an empty subject after the degree comma.
+    if (fields.field !== undefined) edu.field = fields.field || undefined;
     if (fields.institution !== undefined) edu.institution = fields.institution;
     if (fields.start_date !== undefined) edu.start_date = fields.start_date;
     if (fields.end_date !== undefined) edu.end_date = fields.end_date;

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -92,6 +92,19 @@ describe("matchSectionHeader — head-noun anchor fallback (#108 / #111)", () =>
     expect(matchSectionHeader("20% Experience")).toBeNull();
   });
 
+  it("rejects an institution name ending in an anchor word (acronym + Title-case)", () => {
+    // FP #8: "ACME Professional Education" is a SCHOOL name, not an education
+    // header. A mixed ALL-CAPS-acronym + Title-case line reads as an org entity
+    // whose trailing anchor word is part of the name; eating it as a header drops
+    // the whole entry. ALL-CAPS headers and plain Title-case headers still match.
+    expect(matchSectionHeader("ACME Professional Education")).toBeNull();
+    // Trailing anchor is "Academics" — would match without Guard 8.
+    expect(matchSectionHeader("QSU Graduate Academics")).toBeNull();
+    // Genuine headers are unaffected: wholly ALL CAPS, or wholly Title-case.
+    expect(matchSectionHeader("PROFESSIONAL EXPERIENCE")).toBe("experience");
+    expect(matchSectionHeader("Professional Experience")).toBe("experience");
+  });
+
   it("rejects a header-shaped line ending in terminal punctuation", () => {
     // FP #4: terminal sentence punctuation marks prose, not a heading.
     expect(matchSectionHeader("Gained Relevant Experience.")).toBeNull();

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -103,6 +103,10 @@ describe("matchSectionHeader — head-noun anchor fallback (#108 / #111)", () =>
     // Genuine headers are unaffected: wholly ALL CAPS, or wholly Title-case.
     expect(matchSectionHeader("PROFESSIONAL EXPERIENCE")).toBe("experience");
     expect(matchSectionHeader("Professional Experience")).toBe("experience");
+    // A domain-qualified header pairs the acronym DIRECTLY with the head noun
+    // (no proper-noun modifier between) and is a real heading, not an org name.
+    expect(matchSectionHeader("IT Experience")).toBe("experience");
+    expect(matchSectionHeader("HR Experience")).toBe("experience");
   });
 
   it("rejects a header-shaped line ending in terminal punctuation", () => {

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -298,6 +298,17 @@ function matchAnchorFallback(
     const first = w[0];
     if (!/[A-Z]/.test(first)) return null;
   }
+  // Guard 8: an organization / institution name, not a heading. A line that
+  // mixes an ALL-CAPS acronym token (an org initialism — "ACME", "QSU", "ZTU")
+  // with Title-case words reads as a proper-noun entity whose trailing category
+  // word is part of the NAME, not a section header — "ACME Professional
+  // Education", "QSU School of Law". A genuine qualified header is either wholly
+  // Title-case ("Relevant Experience") or wholly ALL CAPS ("PROFESSIONAL
+  // EXPERIENCE"); only the mixed acronym+Title-case shape is an entity, so an
+  // institution line ending in an anchor word ("Education") is no longer eaten
+  // as a header and dropped (its whole entry with it).
+  const allCaps = rawWords.every((w) => w === w.toUpperCase());
+  if (!allCaps && rawWords.some((w) => /^[A-Z]{2,}$/.test(w))) return null;
   const last = tokens[tokens.length - 1];
   // Guard 3 + 6: last token must be an anchor of a fallback-enabled section.
   for (const [name, anchors] of Object.entries(SECTION_ANCHORS) as Array<

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -299,16 +299,27 @@ function matchAnchorFallback(
     if (!/[A-Z]/.test(first)) return null;
   }
   // Guard 8: an organization / institution name, not a heading. A line that
-  // mixes an ALL-CAPS acronym token (an org initialism — "ACME", "QSU", "ZTU")
-  // with Title-case words reads as a proper-noun entity whose trailing category
-  // word is part of the NAME, not a section header — "ACME Professional
-  // Education", "QSU School of Law". A genuine qualified header is either wholly
-  // Title-case ("Relevant Experience") or wholly ALL CAPS ("PROFESSIONAL
-  // EXPERIENCE"); only the mixed acronym+Title-case shape is an entity, so an
-  // institution line ending in an anchor word ("Education") is no longer eaten
-  // as a header and dropped (its whole entry with it).
+  // pairs an ALL-CAPS acronym token (an org initialism — "ACME", "QSU", "ZTU")
+  // with a Title-case proper-noun word BEFORE the head noun reads as an entity
+  // whose trailing category word is part of the NAME, not a section header —
+  // "ACME Professional Education", "QSU Graduate Academics" (the "Professional"
+  // / "Graduate" modifier is the tell). The acronym alone is NOT enough: a
+  // domain-qualified header pairs an acronym directly with the head noun and IS
+  // a real heading — "IT Experience", "QA Qualifications" — so reject only when
+  // a non-acronym Title-case word sits between the acronym and the trailing
+  // anchor. Wholly ALL CAPS ("PROFESSIONAL EXPERIENCE") and wholly Title-case
+  // ("Relevant Experience") headers carry no acronym and never reach this test.
+  const isAcronym = (w: string) => /^[A-Z]{2,}$/.test(w);
   const allCaps = rawWords.every((w) => w === w.toUpperCase());
-  if (!allCaps && rawWords.some((w) => /^[A-Z]{2,}$/.test(w))) return null;
+  if (!allCaps && rawWords.some(isAcronym)) {
+    // Modifier words = everything before the trailing head noun. A Title-case
+    // non-acronym modifier ("Professional", "Graduate") marks a proper-noun
+    // entity; an acronym-only prefix ("IT", "QA") is a domain qualifier.
+    const hasProperNounModifier = rawWords
+      .slice(0, -1)
+      .some((w) => !isAcronym(w) && /^[A-Z]/.test(w));
+    if (hasProperNounModifier) return null;
+  }
   const last = tokens[tokens.length - 1];
   // Guard 3 + 6: last token must be an anchor of a fallback-enabled section.
   for (const [name, anchors] of Object.entries(SECTION_ANCHORS) as Array<

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -107,6 +107,33 @@ describe("buildAtsResumeModel", () => {
     expect(skills.headerLine).toContain("TypeScript");
   });
 
+  it("surfaces the major (field) joined to the degree, and a degree-less program's title alone", () => {
+    const result = makeResult({
+      education: [
+        {
+          degree: "Bachelor of Science",
+          field: "Mechanical Engineering",
+          institution: "Riverside College Of Engineering",
+        },
+        {
+          // Degree-less program (#238): title lives in `field`, no credential.
+          degree: "",
+          field: "Applied Robotics Program",
+          institution: "ACME Professional Education",
+          year: "2024",
+        },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const edu = model.sections.find((s) => s.heading === "Education")!;
+    expect(edu.entries[0].headerLine).toBe(
+      "Bachelor of Science, Mechanical Engineering — Riverside College Of Engineering",
+    );
+    expect(edu.entries[1].headerLine).toBe(
+      "Applied Robotics Program — ACME Professional Education",
+    );
+  });
+
   it("falls back to description split when no graded bullets are attributed", () => {
     const result = makeResult();
     const model = buildAtsResumeModel(result, makeScore([]));

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -265,8 +265,12 @@ export function buildAtsResumeModel(
     if (edu.coursework && edu.coursework.length > 0) {
       bullets.push(`Coursework: ${edu.coursework.join(", ")}`);
     }
+    // Degree + major share the primary slot ("Bachelor of Science, Mechanical
+    // Engineering"); a degree-less program (#238) shows its title (in
+    // `field`) alone. Then " — institution".
+    const degreeField = [edu.degree, edu.field].filter(Boolean).join(", ");
     return {
-      headerLine: joinHeader([edu.degree, edu.institution], " — ") ||
+      headerLine: joinHeader([degreeField, edu.institution], " — ") ||
         "Education",
       subLine: buildEducationDates(edu) || undefined,
       bullets,


### PR DESCRIPTION
## Summary

Fixes two distinct education-surfacing bugs that share one real-world résumé shape (a degree-less program entry plus an institution line whose name ends in a section-anchor word, e.g. `… Education`):

1. **Parser — root cause.** `matchAnchorFallback` misclassified an institution name ending in an anchor word (`"ACME Professional Education"`) as an education *section header*. The section splitter then consumed the line as a section boundary and dropped the whole entry **upstream of `education.ts`**, orphaning its graduation year onto a surviving entry. **Guard 8** rejects a line that mixes an ALL-CAPS acronym token with Title-case words — that shape is a proper-noun org entity, not a heading. Wholly-ALL-CAPS (`PROFESSIONAL EXPERIENCE`) and wholly-Title-case (`Relevant Experience`) headers still match.
   - This is the **section-splitter-layer recurrence** of #238's symptom. #238's extractor-layer fix (degree-less program recognition) was correct but masked: under real `pdfjs` extraction the line was eaten before the extractor ever saw it. Sibling to the epic #235 children (#238/#239/#215), at a layer they don't cover.

2. **Render.** `ResumeEducation.field` (the major / program title) was parsed but never rendered in the reconstructed view **or** the exported PDF. Now surfaced in both — comma-joined after the degree (`Degree, Major`), or alone in the primary slot for a degree-less program — and editable end-to-end (override type, `apply-overrides` write/clear, display resolver).

Refs #238
Refs #235

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (1152 passed)
- [x] New regression tests: section-header guard (`regex.test.ts`), degree+major / degree-less header line (`ats-resume-model.test.ts`), `field` override write/clear (`apply-overrides.test.ts`), display resolver (`ReconstructedEducationSkills.test.ts`)
- [x] Verified on the originating PDF: two education entries recovered, full (non-truncated) program title shown, year no longer orphaned

## Notes

- Test data is fully synthetic (`ACME`/`QSU`/`Riverside`, `Applied Robotics Program`) — no real PII in this diff.
