### PR TITLE
fix(parser): stop institution name ending in a section anchor being eaten as a header (#258)

### DIFF
--- a/src/lib/heuristics/markdown-lines.test.ts
+++ b/src/lib/heuristics/markdown-lines.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Unit tests for the markdown/DOCX section path (`sectionizeMarkdown`).
+ *
+ * Focus: the #258 Layer B parity port. The PDF splitter (`classifyLine`) and
+ * this markdown path share the same invariant — an L2 head-noun-anchor line
+ * that re-matches the CURRENTLY open section is an institution entry under its
+ * own header, not a new boundary, and must be retained as content. This file
+ * pins that behavior on the markdown path so the two never drift.
+ */
+
+import { sectionizeMarkdown } from "./markdown-lines.ts";
+
+describe("sectionizeMarkdown — institution name ending in a section anchor (#258 Layer B)", () => {
+  it("retains an all-caps institution line under an open education section instead of eating it as a 2nd header", () => {
+    const markdown = [
+      "**Dana Lopez**",
+      "",
+      "dana.lopez@example.com | (312) 555-0123",
+      "",
+      "**EDUCATION**",
+      "",
+      "ACME PROFESSIONAL EDUCATION",
+      "",
+      "M.S. Data Science  2018 - 2020",
+    ].join("\n");
+
+    const { sections } = sectionizeMarkdown(markdown);
+
+    // The institution line is retained as content inside an education section,
+    // not consumed as a boundary label (which would drop the institution name).
+    const inst = sections.find((s) =>
+      s.lines.some((l) => l.text.includes("ACME PROFESSIONAL EDUCATION")),
+    );
+    expect(inst).toBeDefined();
+    expect(inst!.name).toBe("education");
+
+    // Exactly one education section — the institution line did NOT open a second.
+    expect(sections.filter((s) => s.name === "education").length).toBe(1);
+  });
+
+  it("still opens a genuine L2 header for a DIFFERENT section than the one currently open", () => {
+    // Suppression is gated on the CURRENTLY-open section, not "ever opened": a
+    // real "Relevant Experience" (L2) header after an EDUCATION block must open
+    // its own experience section, not bleed into education.
+    const markdown = [
+      "**Dana Lopez**",
+      "",
+      "dana.lopez@example.com | (312) 555-0123",
+      "",
+      "**EDUCATION**",
+      "",
+      "B.S. Computer Science, MIT  2019",
+      "",
+      "Relevant Experience",
+      "",
+      "Mentor, Local Shelter  2022 - Present",
+    ].join("\n");
+
+    const { sections } = sectionizeMarkdown(markdown);
+
+    const mentor = sections.find((s) =>
+      s.lines.some((l) => l.text.includes("Mentor, Local Shelter")),
+    );
+    expect(mentor).toBeDefined();
+    expect(mentor!.name).toBe("experience");
+
+    const edu = sections.find((s) =>
+      s.lines.some((l) => l.text.includes("B.S. Computer Science")),
+    );
+    expect(edu!.name).toBe("education");
+    expect(edu!.lines.some((l) => l.text.includes("Mentor"))).toBe(false);
+  });
+});

--- a/src/lib/heuristics/markdown-lines.ts
+++ b/src/lib/heuristics/markdown-lines.ts
@@ -40,7 +40,7 @@
 
 import type { PdfLine, PdfSection } from "./sections.ts";
 import {
-  matchSectionHeader,
+  matchSectionHeaderDetailed,
   SECTION_KEYWORDS,
   SPLIT_LETTER_NORMALIZABLE_SECTIONS,
   SPLIT_LETTER_RE,
@@ -332,9 +332,17 @@ export function sectionizeMarkdownLines(lines: PdfLine[]): PdfSection[] {
   const sections: PdfSection[] = [{ name: "profile", lines: [] }];
 
   for (const line of lines) {
+    const detailed = matchSectionHeaderDetailed(line.text);
+    const current = sections[sections.length - 1].name;
+    // #258 Layer B (markdown/DOCX path): an L2 anchor-fallback line that
+    // re-matches the CURRENTLY open section is an institution entry under its
+    // own header ("ACME PROFESSIONAL EDUCATION" under EDUCATION), not a new
+    // boundary — retain it as content. Mirrors the PDF `classifyLine` gate;
+    // same current-section safety (a DIFFERENT-section L2 header still opens).
     const header =
-      matchSectionHeader(line.text) ??
-      matchLeadingSectionKeyword(line.text);
+      detailed && detailed.viaAnchorFallback && detailed.section === current
+        ? null
+        : (detailed?.section ?? matchLeadingSectionKeyword(line.text));
     if (header) {
       sections.push({ name: header, lines: [] });
       continue;

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -109,6 +109,28 @@ describe("matchSectionHeader — head-noun anchor fallback (#108 / #111)", () =>
     expect(matchSectionHeader("HR Experience")).toBe("experience");
   });
 
+  it("rejects a wholly-Title-case institution name ending in an anchor word (#258)", () => {
+    // #258 residual hole 1: a wholly Title-case institution whose trailing word
+    // is a section anchor carries NO acronym, so Guard 8 never fires — yet the
+    // line is an org entity ("Harvard University Education"), not a header. The
+    // institution-type word ("University"/"College") sitting BEFORE the head noun
+    // is the line-local tell a genuine header never carries.
+    expect(matchSectionHeader("Harvard University Education")).toBeNull();
+    expect(matchSectionHeader("Riverside College Academics")).toBeNull();
+    // Genuine qualified headers carry no institution-type *name* word and still
+    // match, including a real L2 education header ("Academic Qualifications").
+    expect(matchSectionHeader("Relevant Experience")).toBe("experience");
+    expect(matchSectionHeader("Academic Qualifications")).toBe("education");
+    expect(matchSectionHeader("IT Experience")).toBe("experience");
+    // "School" is an interior header *qualifier*, not an org-name tell — Guard 9
+    // must not reject these common student-résumé headers (it uses the narrower
+    // INSTITUTION_NAME_HINTS set that drops "School").
+    expect(matchSectionHeader("High School Coursework")).toBe("education");
+    expect(matchSectionHeader("Business School Experience")).toBe("experience");
+    expect(matchSectionHeader("Law School Experience")).toBe("experience");
+    expect(matchSectionHeader("Summer School Projects")).toBe("projects");
+  });
+
   it("rejects a header-shaped line ending in terminal punctuation", () => {
     // FP #4: terminal sentence punctuation marks prose, not a heading.
     expect(matchSectionHeader("Gained Relevant Experience.")).toBeNull();

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -320,6 +320,28 @@ function matchAnchorFallback(
       .some((w) => !isAcronym(w) && /^[A-Z]/.test(w));
     if (hasProperNounModifier) return null;
   }
+  // Guard 9: an institution name, not a heading — the wholly-Title-case case
+  // Guard 8 cannot reach (no acronym). An institution NAME pairs a proper noun
+  // with an institution-TYPE word ("University", "College", "Institute", …)
+  // before the trailing anchor — "Harvard University Education", "Riverside
+  // College Academics" — where the anchor is part of the org's name. The tell is
+  // an institution-type word in a NON-FIRST, non-final slot: something (the
+  // proper-noun name, "Harvard"/"Riverside") sits before it. When the
+  // institution-type word is itself the FIRST token it is a category qualifier
+  // of a genuine header, not a name — "University Projects", "College Athletics"
+  // — so those still classify. The head noun is the LAST token, so we scan the
+  // interior slots (index 1 .. second-to-last). A real L2 header like "Academic
+  // Qualifications" carries no institution-type word and is unaffected.
+  //
+  // Uses INSTITUTION_NAME_HINTS, a deliberately NARROWER set than
+  // INSTITUTION_HINTS: it drops "School", which routinely serves as an interior
+  // header qualifier ("High School Coursework", "Business School Experience",
+  // "Law School Experience") rather than an org-name tell. The remaining words
+  // (University / College / Institute / Academy / Polytechnic) do not pattern
+  // that way as header qualifiers, so an interior occurrence reliably marks a
+  // proper-noun institution name.
+  if (rawWords.slice(1, -1).some((w) => INSTITUTION_NAME_HINTS.test(w)))
+    return null;
   const last = tokens[tokens.length - 1];
   // Guard 3 + 6: last token must be an anchor of a fallback-enabled section.
   for (const [name, anchors] of Object.entries(SECTION_ANCHORS) as Array<
@@ -370,14 +392,26 @@ export function matchSectionAnchorToken(text: string): SectionName | null {
   return null;
 }
 
-/** True if the normalized line text matches any known section header. */
-export function matchSectionHeader(text: string): SectionName | null {
+/**
+ * Match a section header AND report which tier produced the match.
+ *
+ * `viaAnchorFallback` is true ONLY when the match came from the head-noun
+ * anchor-fallback (L2) path — the prose-adjacent tier whose qualified headers
+ * ("Relevant Experience") are a softer signal than an exact alias. It is false
+ * for the L1 exact-alias and split-letter matches, which are unambiguous header
+ * text. The splitter (sections.ts) uses this tier flag to suppress a SECOND L2
+ * open of an already-open section — that repeat is an institution entry sitting
+ * under its real header, not a new boundary (#258 Layer B).
+ */
+export function matchSectionHeaderDetailed(
+  text: string,
+): { section: SectionName; viaAnchorFallback: boolean } | null {
   const normalized = text.trim().toLowerCase().replace(/[:·•]+$/, "").trim();
   if (normalized.length === 0 || normalized.length > 40) return null;
   for (const [name, keywords] of Object.entries(SECTION_KEYWORDS) as Array<
     [SectionName, readonly string[]]
   >) {
-    if (keywords.includes(normalized)) return name;
+    if (keywords.includes(normalized)) return { section: name, viaAnchorFallback: false };
   }
   // Split-letter headers: pdfjs reads a tracked/decorated `EXPERIENCE` as
   // `E XPERIENCE`. Rejoin single split letters and retry, gated to the
@@ -388,7 +422,7 @@ export function matchSectionHeader(text: string): SectionName | null {
       [SectionName, readonly string[]]
     >) {
       if (keywords.includes(rejoined) && SPLIT_LETTER_NORMALIZABLE_SECTIONS.has(name))
-        return name;
+        return { section: name, viaAnchorFallback: false };
     }
   }
   // Head-noun anchor fallback for qualified headers ("Relevant Experience").
@@ -396,9 +430,16 @@ export function matchSectionHeader(text: string): SectionName | null {
   // bullet glyph is normalized away. See matchAnchorFallback for the rest.
   if (!LEADING_BULLET_RE.test(text)) {
     const anchored = matchAnchorFallback(text, normalized);
-    if (anchored) return anchored;
+    if (anchored) return { section: anchored, viaAnchorFallback: true };
   }
   return null;
+}
+
+/** True if the normalized line text matches any known section header. Thin
+ *  wrapper over {@link matchSectionHeaderDetailed} that discards the tier flag —
+ *  signature and behavior are byte-identical to the pre-#258 function. */
+export function matchSectionHeader(text: string): SectionName | null {
+  return matchSectionHeaderDetailed(text)?.section ?? null;
 }
 
 // ── Degree patterns ─────────────────────────────────────────────────────────
@@ -411,6 +452,14 @@ export const DEGREE_RE =
 
 export const INSTITUTION_HINTS =
   /\b(University|College|Institute|School|Academy|Polytechnic)s?\b/i;
+
+// Narrower than INSTITUTION_HINTS: drops "School" (a common interior header
+// qualifier — "High School Coursework", "Law School Experience"). Used ONLY by
+// Guard 9 in matchAnchorFallback to tell a proper-noun institution name from a
+// genuine qualified header by an INTERIOR institution-type word. Not exported —
+// Guard 9 is its only consumer.
+const INSTITUTION_NAME_HINTS =
+  /\b(University|College|Institute|Academy|Polytechnic)s?\b/i;
 
 /** A sub-field NOTE line that rides under an entry — a GPA / Minor / Major /
  *  concentration / coursework annotation — rather than a new entry header. Used

--- a/src/lib/heuristics/sections.test.ts
+++ b/src/lib/heuristics/sections.test.ts
@@ -573,3 +573,63 @@ describe("splitIntoSections — corpus section-count regression (#112)", () => {
     }, 15_000);
   }
 });
+
+describe("splitIntoSections — institution name ending in a section anchor (#258)", () => {
+  // #258 residual hole 2: a wholly ALL-CAPS institution whose trailing word is a
+  // section anchor ("ACME PROFESSIONAL EDUCATION") carries no institution-type
+  // word and no Title-case modifier, so it is shape-indistinguishable from a real
+  // header line-locally (the `allCaps` escape needed by real "PROFESSIONAL
+  // EXPERIENCE" headers lets Guard 8 NOT fire). When it appears UNDER an
+  // already-open `education` section, the second anchor-fallback open is the
+  // context tell: the line is an institution entry, not a header. It must be
+  // retained as content, not consumed as a boundary (which drops the name).
+  it("retains an institution line under an open education section instead of eating it as a 2nd header", () => {
+    const sections = build([
+      { text: "Dana Lopez", fontSize: 18 }, // name
+      { text: "dana.lopez@example.com | (312) 555-0123", fontSize: 11 }, // contact
+      { text: "EDUCATION", fontSize: 13 }, // real header (L1 exact alias)
+      { text: "ACME PROFESSIONAL EDUCATION", fontSize: 11 }, // institution entry (wholly ALL-CAPS — Guard 8 cannot fire)
+      { text: "M.S. Data Science  2018 - 2020", fontSize: 11 }, // degree + date
+    ]);
+
+    // The institution line is retained as content inside the education section,
+    // not consumed as a boundary label (which would drop the institution name).
+    const inst = sectionContaining(sections, "ACME PROFESSIONAL EDUCATION");
+    expect(inst).toBeDefined();
+    expect(inst!.name).toBe("education");
+
+    // Exactly one education section — the institution line did NOT open a second.
+    expect(names(sections).filter((n) => n === "education").length).toBe(1);
+  });
+
+  it("still opens a genuine L2 header for a DIFFERENT section than the one currently open", () => {
+    // The suppression is gated on the CURRENTLY-open section, not "ever opened":
+    // a real "Relevant Experience" (L2) header appearing while EDUCATION is the
+    // open section must open its own experience section — its content must NOT
+    // bleed into education. (Regression guard for the cross-section bleed a naive
+    // "ever-opened" gate would cause.)
+    const sections = build([
+      { text: "Dana Lopez", fontSize: 18 }, // name
+      { text: "dana.lopez@example.com | (312) 555-0123", fontSize: 11 }, // contact
+      { text: "PROFESSIONAL EXPERIENCE", fontSize: 13 }, // L1 — opens experience
+      { text: "Engineer, Globex  2019 - 2021", fontSize: 11 },
+      { text: "EDUCATION", fontSize: 13 }, // L1 — opens education (now current)
+      { text: "B.S. Computer Science, MIT  2019", fontSize: 11 },
+      { text: "Relevant Experience", fontSize: 11 }, // L2 experience ≠ current
+      { text: "Mentor, Local Shelter  2022 - Present", fontSize: 11 },
+    ]);
+
+    // The Mentor role landed in an experience section, not in education.
+    const mentor = sectionContaining(sections, "Mentor, Local Shelter");
+    expect(mentor).toBeDefined();
+    expect(mentor!.name).toBe("experience");
+
+    // Education holds only the degree line — no experience bleed.
+    const edu = sectionContaining(sections, "B.S. Computer Science");
+    expect(edu!.name).toBe("education");
+    expect(edu!.lines.some((l) => l.text.includes("Mentor"))).toBe(false);
+    expect(edu!.lines.some((l) => l.text.includes("Relevant Experience"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/heuristics/sections.ts
+++ b/src/lib/heuristics/sections.ts
@@ -18,6 +18,7 @@ import type { PdfTextItem } from "./types.ts";
 import { mergeWrappedContinuations } from "./entry-blocks.ts";
 import {
   matchSectionHeader,
+  matchSectionHeaderDetailed,
   matchSectionAnchorToken,
   EMAIL_RE,
   PHONE_RE,
@@ -865,6 +866,7 @@ export function splitIntoSections(
       seenContactInProfile,
       prevLineOpenedBoundary,
       columnSplitX,
+      sections[sections.length - 1].name,
     );
     if (action.kind === "open") {
       sections.push({ name: action.name, lines: [] });
@@ -901,9 +903,35 @@ function classifyLine(
   seenContactInProfile: boolean,
   prevLineOpenedBoundary: boolean,
   columnSplitX: number | undefined,
+  currentSection: SectionName | "profile",
 ): LineAction {
-  const header = matchSectionHeader(line.text);
-  if (header) return { kind: "open", name: header };
+  const header = matchSectionHeaderDetailed(line.text);
+  if (header) {
+    // #258 Layer B: a head-noun-anchor (L2) line that re-matches the CURRENTLY
+    // open section is an institution entry sitting under its own real header
+    // ("ACME PROFESSIONAL EDUCATION" directly under an open EDUCATION header) —
+    // shape-indistinguishable from a real header line-locally (the wholly-ALL-
+    // CAPS case Guard 8/9 in regex.ts cannot reach). Suppress the boundary so
+    // the line is RETAINED as content, not consumed as a label.
+    // SAFETY — gated on the CURRENT section, not "ever opened": only an L2 repeat
+    // of the section that is still open folds in, which is unambiguously correct
+    // (the line stays in the section it already belongs to). An L2 header for a
+    // DIFFERENT section than the current one still opens — so a genuine "Relevant
+    // Experience" appearing after an EDUCATION block opens its own experience
+    // section rather than bleeding into education. L1 exact-alias / split-letter
+    // headers (incl. multi-page "EXPERIENCE" continuation headers) are not
+    // viaAnchorFallback and always open.
+    if (!(header.viaAnchorFallback && header.section === currentSection)) {
+      return { kind: "open", name: header.section };
+    }
+    // Suppressed: retain the institution line as content. Return append
+    // directly rather than falling through to the visual-header path, which
+    // would re-promote a clean multi-word ALL-CAPS institution name ("ACME
+    // PROFESSIONAL EDUCATION") to an `other` boundary via isTextPatternHeader —
+    // re-dropping the very line this guard exists to keep. A section is already
+    // open here, so this line is never the contact line that ends a name block.
+    return { kind: "append", marksContactEnd: false };
+  }
 
   const contactShaped = hasContactShape(line.text);
 


### PR DESCRIPTION
## Summary

The section splitter over-recognized a header: an institution name whose trailing word is a section anchor (`Harvard University Education`, `ACME PROFESSIONAL EDUCATION`) was eaten as an `education` header in `matchAnchorFallback`, splitting the document there and **dropping the institution line**. Splitter-layer recurrence of #238, past #257's Guard 8.

Two complementary layers:

- **Layer A — line-local Guard 9 (`regex.ts`).** Reject the anchor-fallback match when an institution-type word sits in an **interior** slot (a proper-noun name precedes it) — `Harvard University Education`, `Riverside College Academics`. Uses a narrower `INSTITUTION_NAME_HINTS` set that drops `School` (a common interior header *qualifier* — `High School Coursework`, `Law School Experience` — not an org-name tell).
- **Layer B — splitter context (`sections.ts` + `markdown-lines.ts`).** New `matchSectionHeaderDetailed` exposes the L1-exact vs L2-anchor-fallback tier; the splitter suppresses an L2 open that re-matches the **currently-open** section (an institution entry under its own header — the wholly-ALL-CAPS case the line-local guards can't reach), retaining the line as content. Gated on the *current* section (not "ever opened"), so a genuine L2 header for a different section than the open one still opens — no cross-section bleed. Ported to the markdown/DOCX path for parity.

**Scoped out:** an all-caps institution ending in an anchor with no preceding section header of that type stays line-locally indistinguishable from a real first-occurrence header (documented in the issue's Non-goals spirit).

Closes #258

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1156 passed; full corpus snapshot unchanged — no rebake)
- [x] `npm run lint` clean
- [x] New reproduction + regression tests: `regex.test.ts` (Title-case institution + `School`-qualifier headers), `sections.test.ts` (ALL-CAPS institution retained; cross-section L2 header still opens)

## Adversarial review (1 round + fix, converged)

An independent reviewer attacked the first implementation and surfaced **2 BLOCKING** regressions, both fixed here before the PR:

1. **Guard 9 over-fired on `… School …` headers** — `INSTITUTION_HINTS` includes `School`, so `High School Coursework` / `Law School Experience` wrongly returned `null`. Fixed with the narrower `INSTITUTION_NAME_HINTS` set + regression tests.
2. **Layer B cross-section bleed** — the first cut gated suppression on "ever opened", so a real `Relevant Experience` (L2) appearing after an `EDUCATION` block was suppressed and bled into `education`. Fixed by gating on the **currently-open** section + a regression test.

Non-blocking: fallow flags 3 `markdown-lines.ts` exports as "unused" — pre-existing exports re-attributed because the diff touched the file (known fallow false-attribution), plus pre-existing advisory complexity findings. Not introduced here.