### PR TITLE
feat(webllm): disagreement detection, LLM escape hatch, critique + gap-report

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { CascadeResult, LayoutTrigger } from "../lib/heuristics/types.ts";
-import type { AnonymousAtsScore } from "../lib/score/score.ts";
+import { computeAnonymousAtsScore, type AnonymousAtsScore } from "../lib/score/score.ts";
 import type { EditableParse } from "../hooks/useEditableParse.ts";
 import { Card, StatusBadge, Button, Tabs, TabList, Tab, TabPanel } from "@design-system";
 import { FeedbackPanel } from "./features/FeedbackPanel.tsx";
@@ -14,6 +14,13 @@ import {
   SourcePdfPanel,
   ExtractedTextPanel,
 } from "./features/EvidencePanel.tsx";
+import { DisagreementPanel } from "./features/DisagreementPanel.tsx";
+import { CritiquePanel } from "./features/CritiquePanel.tsx";
+import { useParseDisagreement } from "../hooks/useParseDisagreement.ts";
+import { useLlmEscapeHatch } from "../hooks/useLlmEscapeHatch.ts";
+import { useResumeCritique } from "../hooks/useResumeCritique.ts";
+import { LlmEscapeHatchBanner } from "./features/LlmEscapeHatchBanner.tsx";
+import type { LlmParsedResume } from "../lib/webllm/parse-resume.ts";
 
 // LAYOUT_TRIGGER_BLURBS for fonts_unmappable is still needed by LimitedParsingCard.
 const FONTS_UNMAPPABLE_BLURB =
@@ -82,16 +89,111 @@ function ParsedCard({
 }) {
   const [tab, setTab] = useState("reconstructed");
   const triggerCount = result.triggers.length;
+
+  // Opt-in WebLLM "what an ATS misses" comparison (#242). The controller is
+  // lifted here so the tab is only advertised on WebGPU-capable browsers with
+  // extractable text; on everything else the tab (and panel) are silently
+  // absent. The panel itself drives the opt-in run + diff.
+  const disagreement = useParseDisagreement(result);
+
+  // Characterized gaps to fold into a "Report a parsing gap" download (#245) —
+  // available only once the opt-in WebLLM comparison has completed. Kinds/fields
+  // only enter the artifact (never the recovered values); see repro-artifact.ts.
+  const reportableDisagreements =
+    disagreement.status.kind === "done"
+      ? disagreement.status.disagreements
+      : undefined;
+
+  // Degenerate-case LLM escape hatch (#243). Only available when
+  // `result.suggestedEscalation === "llm"` AND WebGPU is available AND there is
+  // text. When the user opts in and the pass completes, `llmOverride` is set and
+  // the entire result surface re-renders from the LLM-parsed fields.
+  const escapeHatch = useLlmEscapeHatch(result);
+  const [llmOverride, setLlmOverride] = useState<LlmParsedResume | null>(null);
+  const handleRecovered = useCallback((llmParsed: LlmParsedResume) => {
+    setLlmOverride(llmParsed);
+  }, []);
+
+  // When `llmOverride` is set, build a synthetic CascadeResult that merges the
+  // LLM-parsed fields into the original result. `rawText` / `markdown` / layout
+  // fields stay original — the override is parse-field only. `suggestedEscalation`
+  // is cleared to "none" since we've recovered. Score is re-derived from the
+  // overridden parse so the readout reflects the LLM result.
+  const activeResult: CascadeResult = useMemo(() => {
+    if (llmOverride === null) return result;
+    return {
+      ...result,
+      suggestedEscalation: "none",
+      parsed: {
+        ...result.parsed,
+        full_name: llmOverride.full_name ?? result.parsed.full_name,
+        email: llmOverride.email ?? result.parsed.email,
+        phone: llmOverride.phone ?? result.parsed.phone,
+        location: llmOverride.location ?? result.parsed.location,
+        summary: llmOverride.summary ?? result.parsed.summary,
+        skills: llmOverride.skills.length > 0 ? llmOverride.skills : result.parsed.skills,
+        experience: llmOverride.experience.length > 0
+          ? llmOverride.experience.map((e) => ({
+              company: e.company,
+              title: e.title,
+              description: e.description,
+              is_current: false,
+            }))
+          : result.parsed.experience,
+        education: llmOverride.education.length > 0
+          ? llmOverride.education.map((e) => ({
+              institution: e.institution,
+              degree: e.degree,
+            }))
+          : result.parsed.education,
+      },
+    };
+  }, [result, llmOverride]);
+
+  const activeScore: AnonymousAtsScore = useMemo(() => {
+    if (llmOverride === null) return score;
+    return computeAnonymousAtsScore({
+      parsed: activeResult.parsed,
+      fieldConfidence: activeResult.fieldConfidence,
+      triggers: activeResult.triggers,
+      rawText: activeResult.rawText,
+      sections: activeResult.sections,
+    });
+  }, [activeResult, llmOverride, score]);
+
+  const isLlmRecovered = llmOverride !== null;
+
+  // Opt-in WebLLM content-quality critique (#244). Runs on the active parsed
+  // result so that when the #243 escape hatch has recovered the parse, the
+  // critique judges the improved fields rather than the raw heuristic output.
+  // Must be called AFTER activeResult is computed (hooks ordering is stable
+  // because activeResult is a useMemo, not a conditional render path).
+  const critique = useResumeCritique(activeResult.parsed, activeResult.rawText);
+
   return (
     // Two stacked surfaces: the score "summary" card on top, the tabbed detail
     // card below. The gap + each card's own border draws the separator the
     // single-card layout lacked (the tab strip reads as its own section).
     <div className="flex flex-col gap-4">
+      {/* Escape hatch banner — shown above the score card when the cascade
+          flagged a degenerate result and WebGPU is available (#243). */}
+      {escapeHatch.isAvailable && (
+        <LlmEscapeHatchBanner
+          controller={escapeHatch}
+          onRecovered={handleRecovered}
+        />
+      )}
+
       <Card className="flex flex-col gap-6 shadow-xs">
         <header className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <StatusBadge tone="ok">Parsed</StatusBadge>
-            {edit.hasEdits && <StatusBadge tone="warning">Edited</StatusBadge>}
+            {isLlmRecovered && (
+              <StatusBadge tone="info">Recovered with on-device AI</StatusBadge>
+            )}
+            {!isLlmRecovered && edit.hasEdits && (
+              <StatusBadge tone="warning">Edited</StatusBadge>
+            )}
             <span className="text-xs text-content-muted">
               {result.diagnostics.pages} page
               {result.diagnostics.pages === 1 ? "" : "s"} ·{" "}
@@ -99,7 +201,7 @@ function ParsedCard({
             </span>
           </div>
           <div className="flex items-center gap-3">
-            {edit.hasEdits && (
+            {!isLlmRecovered && edit.hasEdits && (
               <Button variant="link" onClick={edit.resetAll}>
                 Reset to parsed
               </Button>
@@ -110,8 +212,15 @@ function ParsedCard({
           </div>
         </header>
 
-        <AtsScoreReadout score={score} />
-        <FeedbackPanel />
+        <AtsScoreReadout score={activeScore} />
+        {/* Feedback surface (#51) + "Report a parsing gap" (#245). The gap
+            report builds a structure-only repro artifact from the active parse;
+            when the user ran the opt-in WebLLM comparison (#242), the
+            characterized disagreements ride along (kinds only, never values). */}
+        <FeedbackPanel
+          result={activeResult}
+          disagreements={reportableDisagreements}
+        />
       </Card>
 
       {/* Detail sits behind tabs in its own card so only one panel shows at a
@@ -128,13 +237,19 @@ function ParsedCard({
             <Tab id="flags" count={triggerCount}>
               Layout flags
             </Tab>
+            {disagreement.isAvailable && (
+              <Tab id="disagreement">What an ATS misses</Tab>
+            )}
+            {critique.isAvailable && (
+              <Tab id="critique">Resume quality</Tab>
+            )}
           </TabList>
 
           <div className="pt-4">
             <TabPanel id="reconstructed">
               <ReconstructedResume
-                result={result}
-                score={score}
+                result={activeResult}
+                score={activeScore}
                 edit={edit}
                 jdContext={jdContext}
               />
@@ -150,6 +265,23 @@ function ParsedCard({
                 triggers={result.triggers as readonly LayoutTrigger[]}
               />
             </TabPanel>
+            {disagreement.isAvailable && (
+              <TabPanel id="disagreement">
+                <DisagreementPanel controller={disagreement} />
+              </TabPanel>
+            )}
+            {critique.isAvailable && (
+              <TabPanel id="critique">
+                {/* onGoToRewrite: switch back to reconstructed tab where the
+                    per-role wand button (#3 / useSectionRewrite) already lives.
+                    The critique panel links each flagged bullet to this affordance
+                    instead of building a parallel rewrite UI (issue #244). */}
+                <CritiquePanel
+                  controller={critique}
+                  onGoToRewrite={() => setTab("reconstructed")}
+                />
+              </TabPanel>
+            )}
           </div>
         </Tabs>
       </Card>

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -21,6 +21,7 @@ import { useLlmEscapeHatch } from "../hooks/useLlmEscapeHatch.ts";
 import { useResumeCritique } from "../hooks/useResumeCritique.ts";
 import { LlmEscapeHatchBanner } from "./features/LlmEscapeHatchBanner.tsx";
 import type { LlmParsedResume } from "../lib/webllm/parse-resume.ts";
+import { mergeLlmParse } from "../lib/webllm/merge-override.ts";
 
 // LAYOUT_TRIGGER_BLURBS for fonts_unmappable is still needed by LimitedParsingCard.
 const FONTS_UNMAPPABLE_BLURB =
@@ -119,36 +120,10 @@ function ParsedCard({
   // fields stay original — the override is parse-field only. `suggestedEscalation`
   // is cleared to "none" since we've recovered. Score is re-derived from the
   // overridden parse so the readout reflects the LLM result.
-  const activeResult: CascadeResult = useMemo(() => {
-    if (llmOverride === null) return result;
-    return {
-      ...result,
-      suggestedEscalation: "none",
-      parsed: {
-        ...result.parsed,
-        full_name: llmOverride.full_name ?? result.parsed.full_name,
-        email: llmOverride.email ?? result.parsed.email,
-        phone: llmOverride.phone ?? result.parsed.phone,
-        location: llmOverride.location ?? result.parsed.location,
-        summary: llmOverride.summary ?? result.parsed.summary,
-        skills: llmOverride.skills.length > 0 ? llmOverride.skills : result.parsed.skills,
-        experience: llmOverride.experience.length > 0
-          ? llmOverride.experience.map((e) => ({
-              company: e.company,
-              title: e.title,
-              description: e.description,
-              is_current: false,
-            }))
-          : result.parsed.experience,
-        education: llmOverride.education.length > 0
-          ? llmOverride.education.map((e) => ({
-              institution: e.institution,
-              degree: e.degree,
-            }))
-          : result.parsed.education,
-      },
-    };
-  }, [result, llmOverride]);
+  const activeResult: CascadeResult = useMemo(
+    () => (llmOverride === null ? result : mergeLlmParse(result, llmOverride)),
+    [result, llmOverride],
+  );
 
   const activeScore: AnonymousAtsScore = useMemo(() => {
     if (llmOverride === null) return score;

--- a/src/components/features/CritiquePanel.test.tsx
+++ b/src/components/features/CritiquePanel.test.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for CritiquePanel (#244) — display-only "Resume quality" tab.
+ * Drives a fake controller through each status so every branch of CritiquePanel
+ * and CritiqueDonePanel (summary feedback, flagged bullets, missing sections,
+ * all-ok) executes. Raw createRoot, matching the other feature render tests.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CritiquePanel } from "./CritiquePanel.tsx";
+import type { CritiqueController } from "../../hooks/useResumeCritique.ts";
+import type { ResumeCritique } from "../../lib/webllm/critique-resume.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function controller(status: CritiqueController["status"]): CritiqueController {
+  return { status, isAvailable: true, isBusy: false, run: () => Promise.resolve() };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(status: CritiqueController["status"]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(CritiquePanel, { controller: controller(status), onGoToRewrite: () => {} }),
+    );
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("CritiquePanel", () => {
+  it("renders flagged bullets, summary feedback, and missing sections", () => {
+    const critique: ResumeCritique = {
+      bulletFindings: [
+        { bullet: "Was responsible for stuff", issue: "weak_verb", suggestion: "Led stuff" },
+        { bullet: "Did things", issue: "vague" },
+        { bullet: "Shipped X with metric", issue: "ok" },
+      ],
+      missingSections: ["skills"],
+      summaryFeedback: "Tighten the summary.",
+    };
+    const el = render({ kind: "done", critique });
+    expect(el.textContent).toContain("Weak verb");
+    expect(el.textContent).toContain("Suggestion:");
+    expect(el.textContent).toContain("Tighten the summary");
+    expect(el.textContent).toContain("Possibly missing sections");
+    expect(el.textContent).toContain("skills");
+  });
+
+  it("renders the all-ok done state", () => {
+    const el = render({
+      kind: "done",
+      critique: { bulletFindings: [{ bullet: "x", issue: "ok" }], missingSections: [] },
+    });
+    expect(el.textContent).toContain("All bullets look strong");
+  });
+
+  it("renders loading, running, and error states", () => {
+    expect(render({ kind: "loading", progress: { progress: 0.2, text: "…" } }).textContent).toBeTruthy();
+    act(() => root.unmount());
+    container.remove();
+    expect(render({ kind: "running" }).textContent).toContain("Judging");
+    act(() => root.unmount());
+    container.remove();
+    expect(render({ kind: "error", message: "nope" }).textContent).toContain("nope");
+  });
+});

--- a/src/components/features/CritiquePanel.tsx
+++ b/src/components/features/CritiquePanel.tsx
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * CritiquePanel — the "Resume quality" tab panel (issue #244).
+ *
+ * Shows the results of the on-device LLM content-quality critique, one row
+ * per flagged bullet and a list of missing sections.
+ *
+ * Bullet finding rows include a "Suggest a rewrite" nudge that navigates the
+ * user to the "Reconstructed resume" tab, where the per-role wand button
+ * (useSectionRewrite) already lives. This ties the critique finding to the
+ * existing affordance (#3) without duplicating any rewrite UI here.
+ *
+ * Design rules (CLAUDE.md):
+ *   - Semantic tokens only; no hardcoded hex or raw palette classes.
+ *   - All interactive elements via <Button> from "@design-system".
+ *   - No raw <button> in this file.
+ */
+
+import { Button, Card, ModelLoadProgress, StatusBadge } from "@design-system";
+import type { BulletFinding, ResumeCritique } from "../../lib/webllm/critique-resume.ts";
+import type { CritiqueController } from "../../hooks/useResumeCritique.ts";
+import { labelForCritique } from "../../hooks/useResumeCritique.ts";
+
+// ── Issue labels ──────────────────────────────────────────────────────────────
+
+const ISSUE_LABEL: Record<BulletFinding["issue"], string> = {
+  no_quantification: "No metric",
+  weak_verb: "Weak verb",
+  vague: "Vague",
+  ok: "OK",
+};
+
+const ISSUE_TONE: Record<BulletFinding["issue"], "warning" | "ok" | "info"> = {
+  no_quantification: "warning",
+  weak_verb: "warning",
+  vague: "warning",
+  ok: "ok",
+};
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function BulletFindingRow({
+  finding,
+  onGoToRewrite,
+}: {
+  finding: BulletFinding;
+  /** Switch to the "Reconstructed resume" tab where the rewrite affordance lives. */
+  onGoToRewrite?: () => void;
+}) {
+  const { issue, bullet, suggestion } = finding;
+  const isFlagged = issue !== "ok";
+
+  if (!isFlagged) return null;
+
+  return (
+    <li className="flex flex-col gap-1.5 rounded border border-border-light bg-surface-subtle p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <StatusBadge tone={ISSUE_TONE[issue]}>{ISSUE_LABEL[issue]}</StatusBadge>
+          <p className="text-sm text-content-secondary leading-snug">
+            {bullet}
+          </p>
+        </div>
+      </div>
+      {suggestion && (
+        <p className="text-xs text-content-tertiary">
+          <span className="font-medium text-content-secondary">Suggestion: </span>
+          {suggestion}
+        </p>
+      )}
+      {onGoToRewrite && (
+        <Button
+          variant="link"
+          size="sm"
+          onClick={onGoToRewrite}
+          className="self-start text-[11px] font-medium text-brand-amber"
+          aria-label="Go to Reconstructed resume tab to rewrite this bullet"
+        >
+          Rewrite this section →
+        </Button>
+      )}
+    </li>
+  );
+}
+
+function MissingSectionRow({ section }: { section: string }) {
+  return (
+    <li className="flex items-center gap-2 rounded border border-border-light bg-surface-subtle p-3">
+      <StatusBadge tone="warning">Missing</StatusBadge>
+      <span className="text-sm text-content-secondary capitalize">{section}</span>
+    </li>
+  );
+}
+
+function CritiqueDonePanel({
+  critique,
+  onGoToRewrite,
+}: {
+  critique: ResumeCritique;
+  onGoToRewrite: () => void;
+}) {
+  const flaggedBullets = critique.bulletFindings.filter((f) => f.issue !== "ok");
+  const allOk =
+    flaggedBullets.length === 0 && critique.missingSections.length === 0;
+
+  if (allOk) {
+    return (
+      <p className="text-sm text-content-secondary">
+        All bullets look strong — strong verbs, metrics present, and no missing
+        sections detected.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {critique.summaryFeedback && (
+        <Card className="flex flex-col gap-1 p-3">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+            Summary
+          </span>
+          <p className="text-sm text-content-secondary">{critique.summaryFeedback}</p>
+        </Card>
+      )}
+
+      {flaggedBullets.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            Bullet findings ({flaggedBullets.length} flagged)
+          </h3>
+          <ul className="flex flex-col gap-2 list-none">
+            {flaggedBullets.map((f, i) => (
+              <BulletFindingRow
+                key={`${f.issue}-${i}`}
+                finding={f}
+                onGoToRewrite={onGoToRewrite}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {critique.missingSections.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            Possibly missing sections
+          </h3>
+          <ul className="flex flex-col gap-2 list-none">
+            {critique.missingSections.map((s) => (
+              <MissingSectionRow key={s} section={s} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Public component ──────────────────────────────────────────────────────────
+
+/**
+ * The full critique tab panel. The controller is owned by `ParsedCard` (lifted
+ * so the tab label can be gated on availability), and the parent only mounts
+ * this when `controller.isAvailable`.
+ *
+ * `onGoToRewrite` is a callback that switches the parent's tab state to
+ * "reconstructed", where the existing per-role rewrite wand button lives.
+ */
+export function CritiquePanel({
+  controller,
+  onGoToRewrite,
+}: {
+  controller: CritiqueController;
+  /** Navigate to the "Reconstructed resume" tab so the user can use the wand. */
+  onGoToRewrite: () => void;
+}) {
+  const { status } = controller;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            Resume quality
+          </h2>
+          <p className="max-w-prose text-sm text-content-tertiary">
+            Run a small on-device model to judge bullet quality — weak verbs,
+            missing metrics, vague language — and flag absent sections. Nothing
+            leaves this tab.
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => void controller.run()}
+          disabled={controller.isBusy}
+          aria-label="Run on-device LLM content quality critique"
+        >
+          {labelForCritique(status)}
+        </Button>
+      </div>
+
+      {status.kind === "loading" && (
+        <ModelLoadProgress
+          progress={status.progress.progress}
+          text={status.progress.text}
+          label="Loading the critique model (one-time download)"
+          showExplainer
+        />
+      )}
+
+      {status.kind === "running" && (
+        <p className="text-sm text-content-secondary" role="status">
+          Judging content…
+        </p>
+      )}
+
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-feedback-error-text">
+          {status.message}
+        </p>
+      )}
+
+      {status.kind === "done" && (
+        <CritiqueDonePanel
+          critique={status.critique}
+          onGoToRewrite={onGoToRewrite}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/components/features/DisagreementPanel.test.tsx
+++ b/src/components/features/DisagreementPanel.test.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for DisagreementPanel (#242) — the display-only "what an ATS
+ * misses" surface. Drives a fake controller through each status so every render
+ * branch plus the per-kind copy builders (`headlineFor`, `sideValues`) execute.
+ * Raw createRoot, matching the other feature render tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { DisagreementPanel } from "./DisagreementPanel.tsx";
+import type { DisagreementController } from "../../hooks/useParseDisagreement.ts";
+import type { ParseDisagreement } from "../../lib/heuristics/disagreement.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const allKinds: ParseDisagreement[] = [
+  { kind: "dropped_role", field: "experience", heuristicValue: "2", llmValue: "4", likelyCause: "two_column" },
+  { kind: "merged_roles", field: "experience", heuristicValue: "1", llmValue: "3" },
+  { kind: "dropped_section", field: "skills", heuristicValue: null, llmValue: "5" },
+  { kind: "missing_field", field: "email", heuristicValue: null, llmValue: "jane@example.com" },
+];
+
+function controller(status: DisagreementController["status"]): DisagreementController {
+  return { status, isAvailable: true, isBusy: false, run: () => Promise.resolve() };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(status: DisagreementController["status"]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(DisagreementPanel, { controller: controller(status) }));
+  });
+  return container;
+}
+
+beforeEach(() => {});
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("DisagreementPanel", () => {
+  it("renders all kinds in the done state", () => {
+    const el = render({ kind: "done", disagreements: allKinds });
+    expect(el.textContent).toContain("An ATS likely drops");
+    expect(el.textContent).toContain("An ATS likely merges");
+    expect(el.textContent).toContain("section");
+    expect(el.textContent).toContain("Likely cause");
+    // sideValues pluralization + missing-field side.
+    expect(el.textContent).toContain("role");
+  });
+
+  it("renders the empty done state", () => {
+    const el = render({ kind: "done", disagreements: [] });
+    expect(el.textContent).toContain("No gaps found");
+  });
+
+  it("renders loading, running, and error states", () => {
+    expect(render({ kind: "loading", progress: { progress: 0.3, text: "…" } }).textContent).toBeTruthy();
+    act(() => root.unmount());
+    container.remove();
+    expect(render({ kind: "running" }).textContent).toContain("Comparing");
+    act(() => root.unmount());
+    container.remove();
+    expect(render({ kind: "error", message: "boom" }).textContent).toContain("boom");
+  });
+});

--- a/src/components/features/DisagreementPanel.tsx
+++ b/src/components/features/DisagreementPanel.tsx
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * DisagreementPanel — the headline "what an ATS misses" surface (issue #242).
+ *
+ * Shows, on the opt-in WebLLM pass, the gap between what the deterministic
+ * heuristic parse (a generic ATS text extractor) recovered and what the LLM
+ * recovered — and names the likely layout cause. Detection is the pure
+ * `diffParses` in `lib/heuristics/disagreement.ts`; engine + state glue is
+ * `useParseDisagreement`. This file is display only.
+ *
+ * Reuse analysis (CLAUDE.md 3-tier rule):
+ *   - Primitive: `Button` (the opt-in CTA) — no raw `<button>`.
+ *   - Shared: `StatusBadge` (per-gap kind pill), `ModelLoadProgress` (download
+ *     bar). No hand-rolled banners; no hardcoded colors — semantic tokens only.
+ *
+ * Returns `null` when the controller flags the feature unavailable (no WebGPU,
+ * or no extractable text). Silent absence — matches the rewrite paths.
+ */
+
+import { Button, StatusBadge, ModelLoadProgress } from "@design-system";
+import {
+  labelForDisagreement,
+  type DisagreementController,
+} from "../../hooks/useParseDisagreement.ts";
+import type { ParseDisagreement } from "../../lib/heuristics/disagreement.ts";
+import type { LayoutTrigger } from "../../lib/heuristics/types.ts";
+
+/** Human-readable cause copy, keyed off the layout trigger. */
+const CAUSE_COPY: Record<LayoutTrigger, string> = {
+  two_column:
+    "your two-column layout — extractors read across columns and interleave the content",
+  scanned: "the PDF is image-only, so a text extractor sees nothing",
+  fonts_unmappable:
+    "the custom font encoding doesn't decode to characters for a generic extractor",
+};
+
+/** Short headline per disagreement kind + field. */
+function headlineFor(d: ParseDisagreement): string {
+  switch (d.kind) {
+    case "dropped_role":
+      return `An ATS likely drops ${dropCount(d)} of your ${d.llmValue} roles`;
+    case "merged_roles":
+      return `An ATS likely merges your ${d.llmValue} roles into ${d.heuristicValue}`;
+    case "dropped_section":
+      return `An ATS likely drops your entire ${sectionLabel(d.field)} section`;
+    case "missing_field":
+      return `An ATS likely misses your ${fieldLabel(d.field)}`;
+  }
+}
+
+/** How many roles were lost: LLM count minus heuristic count. */
+function dropCount(d: ParseDisagreement): string {
+  const llm = Number(d.llmValue);
+  const heuristic = Number(d.heuristicValue ?? 0);
+  return String(Math.max(0, llm - heuristic));
+}
+
+const SECTION_LABELS: Record<string, string> = {
+  experience: "experience",
+  education: "education",
+  skills: "skills",
+};
+function sectionLabel(field: string): string {
+  return SECTION_LABELS[field] ?? field;
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  full_name: "name",
+  email: "email",
+  phone: "phone number",
+  location: "location",
+  summary: "summary",
+};
+function fieldLabel(field: string): string {
+  return FIELD_LABELS[field] ?? field;
+}
+
+const KIND_BADGE: Record<ParseDisagreement["kind"], string> = {
+  dropped_role: "Dropped roles",
+  merged_roles: "Merged roles",
+  dropped_section: "Dropped section",
+  missing_field: "Missing field",
+};
+
+/**
+ * The panel body. The controller is owned by the parent (`Result.tsx` lifts the
+ * hook so the tab strip can gate its label on availability), and the parent only
+ * mounts this when `controller.isAvailable` — so no internal availability guard
+ * is needed here.
+ */
+export function DisagreementPanel({
+  controller,
+}: {
+  controller: DisagreementController;
+}) {
+  const { status } = controller;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            What an ATS misses
+          </h2>
+          <p className="max-w-prose text-sm text-content-tertiary">
+            Run a small on-device model to compare what a generic ATS extractor
+            reads against what's actually on the page. Nothing leaves this tab.
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => void controller.run()}
+          disabled={controller.isBusy}
+          aria-label="Compare the heuristic parse against an on-device LLM parse"
+        >
+          {labelForDisagreement(status)}
+        </Button>
+      </div>
+
+      {status.kind === "loading" && (
+        <ModelLoadProgress
+          progress={status.progress.progress}
+          text={status.progress.text}
+          label="Loading the comparison model (one-time download)"
+          showExplainer
+        />
+      )}
+
+      {status.kind === "running" && (
+        <p className="text-sm text-content-secondary" role="status">
+          Comparing parses…
+        </p>
+      )}
+
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-feedback-error-text">
+          {status.message}
+        </p>
+      )}
+
+      {status.kind === "done" &&
+        (status.disagreements.length === 0 ? (
+          <p className="text-sm text-content-secondary">
+            No gaps found — a generic ATS extractor reads this résumé the same
+            way the on-device model does.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2 list-none">
+            {status.disagreements.map((d, i) => (
+              <DisagreementRow key={`${d.kind}-${d.field}-${i}`} d={d} />
+            ))}
+          </ul>
+        ))}
+    </section>
+  );
+}
+
+function DisagreementRow({ d }: { d: ParseDisagreement }) {
+  return (
+    <li className="flex flex-col gap-2 rounded border border-border-light bg-surface-subtle p-3">
+      <div className="flex items-center gap-2">
+        <StatusBadge tone="warning">{KIND_BADGE[d.kind]}</StatusBadge>
+        <span className="text-sm font-medium text-content-primary">
+          {headlineFor(d)}
+        </span>
+      </div>
+      {d.likelyCause && (
+        <p className="text-xs text-content-tertiary">
+          Likely cause: {CAUSE_COPY[d.likelyCause]}.
+        </p>
+      )}
+      {/* Inline side-by-side heuristic-vs-LLM diff (#245). In-browser display
+          only — these recovered values stay in this tab and never enter the
+          downloadable repro artifact (which is structure-only). Lets the user
+          confirm a *characterized* gap before reporting it. */}
+      <HeuristicVsLlm d={d} />
+    </li>
+  );
+}
+
+/** Copy for the two sides of the diff, tuned per kind so a count gap reads as
+ *  "2 roles | 4 roles" and a missing scalar reads "(not found) | jane@…". */
+function sideValues(d: ParseDisagreement): { heuristic: string; llm: string } {
+  const llm = d.llmValue ?? "—";
+  switch (d.kind) {
+    case "dropped_role":
+    case "merged_roles":
+      return {
+        heuristic: `${d.heuristicValue ?? "0"} role${d.heuristicValue === "1" ? "" : "s"}`,
+        llm: `${llm} role${llm === "1" ? "" : "s"}`,
+      };
+    case "dropped_section":
+      return {
+        heuristic: "(not found)",
+        llm: `${llm} item${llm === "1" ? "" : "s"}`,
+      };
+    case "missing_field":
+      return { heuristic: "(not found)", llm };
+  }
+}
+
+/**
+ * Two-column "what an ATS read | what's on the page" comparison. Renders the
+ * heuristic side muted/struck and the LLM side highlighted so the recovered
+ * content stands out. Purely presentational; the values come straight off the
+ * disagreement (in-browser only).
+ */
+function HeuristicVsLlm({ d }: { d: ParseDisagreement }) {
+  const { heuristic, llm } = sideValues(d);
+  return (
+    <div className="grid grid-cols-2 gap-2 text-xs">
+      <div className="flex flex-col gap-0.5 rounded border border-border-light bg-feedback-error-bg p-2">
+        <span className="font-semibold uppercase tracking-wide text-content-muted">
+          Generic ATS reads
+        </span>
+        <span className="font-mono text-feedback-error-text">{heuristic}</span>
+      </div>
+      <div className="flex flex-col gap-0.5 rounded border border-border-light bg-feedback-success-bg p-2">
+        <span className="font-semibold uppercase tracking-wide text-content-muted">
+          On the page
+        </span>
+        <span className="font-mono text-feedback-success-text">{llm}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/DisagreementPanel.tsx
+++ b/src/components/features/DisagreementPanel.tsx
@@ -36,18 +36,23 @@ const CAUSE_COPY: Record<LayoutTrigger, string> = {
     "the custom font encoding doesn't decode to characters for a generic extractor",
 };
 
+/** Headline copy builder per disagreement kind. */
+const HEADLINE_FOR: Record<
+  ParseDisagreement["kind"],
+  (d: ParseDisagreement) => string
+> = {
+  dropped_role: (d) =>
+    `An ATS likely drops ${dropCount(d)} of your ${d.llmValue} roles`,
+  merged_roles: (d) =>
+    `An ATS likely merges your ${d.llmValue} roles into ${d.heuristicValue}`,
+  dropped_section: (d) =>
+    `An ATS likely drops your entire ${sectionLabel(d.field)} section`,
+  missing_field: (d) => `An ATS likely misses your ${fieldLabel(d.field)}`,
+};
+
 /** Short headline per disagreement kind + field. */
 function headlineFor(d: ParseDisagreement): string {
-  switch (d.kind) {
-    case "dropped_role":
-      return `An ATS likely drops ${dropCount(d)} of your ${d.llmValue} roles`;
-    case "merged_roles":
-      return `An ATS likely merges your ${d.llmValue} roles into ${d.heuristicValue}`;
-    case "dropped_section":
-      return `An ATS likely drops your entire ${sectionLabel(d.field)} section`;
-    case "missing_field":
-      return `An ATS likely misses your ${fieldLabel(d.field)}`;
-  }
+  return HEADLINE_FOR[d.kind](d);
 }
 
 /** How many roles were lost: LLM count minus heuristic count. */
@@ -181,25 +186,42 @@ function DisagreementRow({ d }: { d: ParseDisagreement }) {
   );
 }
 
+interface DiffSides {
+  heuristic: string;
+  llm: string;
+}
+
+/** Pluralize `noun` against a string count ("1" → singular). */
+function pluralize(count: string, noun: string): string {
+  return `${count} ${noun}${count === "1" ? "" : "s"}`;
+}
+
+/** Role-count gap sides ("2 roles | 4 roles"). Shared by dropped/merged. */
+function roleSides(d: ParseDisagreement): DiffSides {
+  return {
+    heuristic: pluralize(d.heuristicValue ?? "0", "role"),
+    llm: pluralize(d.llmValue ?? "—", "role"),
+  };
+}
+
+/** Side-value builder per disagreement kind. */
+const SIDE_VALUES: Record<
+  ParseDisagreement["kind"],
+  (d: ParseDisagreement) => DiffSides
+> = {
+  dropped_role: roleSides,
+  merged_roles: roleSides,
+  dropped_section: (d) => ({
+    heuristic: "(not found)",
+    llm: pluralize(d.llmValue ?? "—", "item"),
+  }),
+  missing_field: (d) => ({ heuristic: "(not found)", llm: d.llmValue ?? "—" }),
+};
+
 /** Copy for the two sides of the diff, tuned per kind so a count gap reads as
  *  "2 roles | 4 roles" and a missing scalar reads "(not found) | jane@…". */
-function sideValues(d: ParseDisagreement): { heuristic: string; llm: string } {
-  const llm = d.llmValue ?? "—";
-  switch (d.kind) {
-    case "dropped_role":
-    case "merged_roles":
-      return {
-        heuristic: `${d.heuristicValue ?? "0"} role${d.heuristicValue === "1" ? "" : "s"}`,
-        llm: `${llm} role${llm === "1" ? "" : "s"}`,
-      };
-    case "dropped_section":
-      return {
-        heuristic: "(not found)",
-        llm: `${llm} item${llm === "1" ? "" : "s"}`,
-      };
-    case "missing_field":
-      return { heuristic: "(not found)", llm };
-  }
+function sideValues(d: ParseDisagreement): DiffSides {
+  return SIDE_VALUES[d.kind](d);
 }
 
 /**

--- a/src/components/features/FeedbackPanel.tsx
+++ b/src/components/features/FeedbackPanel.tsx
@@ -43,6 +43,9 @@ import {
   usePersistentCounter,
 } from "../../hooks/usePersistentFlag.ts";
 import { useGitHubStars } from "../../hooks/useGitHubStars.ts";
+import { useReportGap } from "../../hooks/useReportGap.ts";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+import type { ParseDisagreement } from "../../lib/heuristics/disagreement.ts";
 
 /**
  * StarCtaOnce — renders the `card` variant of `GitHubStarCta` and fires
@@ -69,13 +72,46 @@ function StarCtaOnce({
 const CATEGORIES = ["Parsing", "Scoring", "UI", "Other"] as const;
 type Category = (typeof CATEGORIES)[number];
 
-// localStorage key constants (exported so sibling features can reference the same keys).
-export const LS_KEY_SEEN = "rl_feedback_seen";
-export const LS_KEY_SUBMITTED = "rl_feedback_submitted";
+// localStorage key constants (internal — only used within this module).
+const LS_KEY_SEEN = "rl_feedback_seen";
+const LS_KEY_SUBMITTED = "rl_feedback_submitted";
 // One-time star CTA seen flag (set when shown after a 4–5★ submission).
 const LS_KEY_STAR_CTA_SEEN = "rl_star_cta_seen";
 
-export function FeedbackPanel() {
+interface FeedbackPanelProps {
+  /** The active parse result. When provided, the "Report a parsing gap"
+   *  affordance is rendered (it builds a structure-only repro artifact from it).
+   *  Absent on surfaces that have no parse (the gap report needs one). */
+  result?: CascadeResult;
+  /** Characterized disagreements from the opt-in WebLLM pass (#242/#245), so a
+   *  WebLLM user reports a *characterized* gap. Empty/omitted when the user
+   *  hasn't run the comparison — the report still works, just without them. */
+  disagreements?: readonly ParseDisagreement[];
+}
+
+/**
+ * FeedbackPanel — the one owning feedback surface. Composes two independent
+ * sections:
+ *   - the star-rating form (analytics-gated: no sink → no form)
+ *   - the "Report a parsing gap" affordance (#245), which is a LOCAL download
+ *     and works regardless of analytics (only its count-only telemetry is gated)
+ *
+ * Reuse-gate: the gap-report extends THIS surface rather than adding a parallel
+ * feedback component (CLAUDE.md). The two sections render independently so the
+ * gap report still appears in a keyless OSS build where the rating form does not.
+ */
+export function FeedbackPanel({ result, disagreements }: FeedbackPanelProps = {}) {
+  return (
+    <>
+      <FeedbackRatingForm />
+      {result && (
+        <ReportGapSection result={result} disagreements={disagreements} />
+      )}
+    </>
+  );
+}
+
+function FeedbackRatingForm() {
   // ── Persistent state ──────────────────────────────────────────────────────
   const [persistedSubmitted, setPersistedSubmitted] = usePersistentFlag(
     LS_KEY_SUBMITTED,
@@ -362,6 +398,114 @@ export function FeedbackPanel() {
           </div>
         )}
       </form>
+    </Card>
+  );
+}
+
+/**
+ * ReportGapSection — "Report a parsing gap" affordance (#245).
+ *
+ * Generates a structure-only, PII-redacted repro artifact (see
+ * `lib/heuristics/repro-artifact.ts`) and downloads it LOCALLY so the user can
+ * attach it to a GitHub issue by hand. NOTHING is uploaded — the copy says so,
+ * and the implementation has no network path. Renders regardless of analytics
+ * (the download is local); only `trackGapReported` (count-only) is env-gated.
+ *
+ * Progressive disclosure: a quiet one-line trigger that unfolds into the
+ * explainer + download button, mirroring the rating form's collapsed-first feel.
+ * Built from `Card`/`Button` primitives; semantic tokens only.
+ */
+function ReportGapSection({
+  result,
+  disagreements,
+}: {
+  result: CascadeResult;
+  disagreements?: readonly ParseDisagreement[];
+}) {
+  const [open, setOpen] = useState(false);
+  const { report, reported, error } = useReportGap(result, disagreements ?? []);
+  const headingId = useId();
+
+  if (!open) {
+    return (
+      <div className="flex items-center justify-end gap-2 -mt-2">
+        <Button
+          variant="link"
+          size="sm"
+          onClick={() => setOpen(true)}
+          aria-expanded={false}
+        >
+          Parser missed something? Report a parsing gap
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Card className="flex flex-col gap-3 border-l-4 border-l-brand-amber bg-accent-forward-bg shadow-sm">
+      <div className="flex flex-col gap-1">
+        <h2
+          id={headingId}
+          className="text-sm font-semibold text-content-primary"
+        >
+          Report a parsing gap
+        </h2>
+        <p className="max-w-prose text-sm text-content-tertiary">
+          Download a small, <strong>structure-only</strong> diagnostic file —
+          section boundaries, counts, and layout flags. It carries{" "}
+          <strong>none of your résumé text</strong> (no name, email, phone, or
+          bullet content), so it's safe to attach to a public issue. Nothing is
+          uploaded; the download stays in this browser until you attach it
+          yourself.
+        </p>
+      </div>
+
+      {reported ? (
+        <div
+          role="status"
+          className="flex flex-col gap-1 rounded border border-border-light bg-surface-subtle p-3"
+        >
+          <p className="text-sm font-medium text-content-primary">
+            Diagnostic file downloaded.
+          </p>
+          <p className="text-sm text-content-tertiary">
+            Attach it to a new issue at{" "}
+            <a
+              href="https://github.com/resumelint-org/resumelint/issues/new"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="underline decoration-dotted hover:decoration-solid"
+            >
+              github.com/resumelint-org/resumelint
+            </a>{" "}
+            describing what the parser got wrong.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={report}
+            aria-describedby={headingId}
+          >
+            Download diagnostic file
+          </Button>
+          {disagreements && disagreements.length > 0 && (
+            <span className="text-xs text-content-muted">
+              Includes {disagreements.length} characterized gap
+              {disagreements.length === 1 ? "" : "s"} from the on-device
+              comparison (kinds only — no recovered text).
+            </span>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="text-xs text-feedback-error-text">
+          {error}
+        </p>
+      )}
     </Card>
   );
 }

--- a/src/components/features/LlmEscapeHatchBanner.test.tsx
+++ b/src/components/features/LlmEscapeHatchBanner.test.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for LlmEscapeHatchBanner (#243) — the degenerate-case recovery
+ * CTA. Drives a fake controller through each status so every render branch plus
+ * the `ctaLabel` lookup executes, and asserts the done state fires `onRecovered`.
+ * Raw createRoot, matching the other feature render tests.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { LlmEscapeHatchBanner } from "./LlmEscapeHatchBanner.tsx";
+import type { EscapeHatchController } from "../../hooks/useLlmEscapeHatch.ts";
+import type { LlmParsedResume } from "../../lib/webllm/parse-resume.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const llmParsed: LlmParsedResume = {
+  full_name: "Recovered",
+  email: null,
+  phone: null,
+  location: null,
+  summary: null,
+  skills: [],
+  experience: [],
+  education: [],
+};
+
+function controller(status: EscapeHatchController["status"]): EscapeHatchController {
+  return { status, isAvailable: true, isBusy: false, run: () => Promise.resolve() };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(
+  status: EscapeHatchController["status"],
+  onRecovered: (p: LlmParsedResume) => void = () => {},
+) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(LlmEscapeHatchBanner, { controller: controller(status), onRecovered }),
+    );
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("LlmEscapeHatchBanner", () => {
+  it("renders the idle CTA", () => {
+    expect(render({ kind: "idle" }).textContent).toContain("Try a local AI pass");
+  });
+
+  it("renders loading, running, and error states", () => {
+    expect(render({ kind: "loading", progress: { progress: 0.4, text: "…" } }).textContent).toBeTruthy();
+    act(() => root.unmount());
+    container.remove();
+    expect(render({ kind: "running" }).textContent).toContain("Parsing");
+    act(() => root.unmount());
+    container.remove();
+    expect(render({ kind: "error", message: "fail" }).textContent).toContain("fail");
+  });
+
+  it("fires onRecovered when the pass completes", () => {
+    const onRecovered = vi.fn();
+    render({ kind: "done", llmParsed }, onRecovered);
+    expect(onRecovered).toHaveBeenCalledWith(llmParsed);
+  });
+});

--- a/src/components/features/LlmEscapeHatchBanner.tsx
+++ b/src/components/features/LlmEscapeHatchBanner.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * LlmEscapeHatchBanner — the degenerate-case recovery CTA (issue #243).
+ *
+ * Shown above the result tabs when the cascade returned a degenerate parse
+ * (`suggestedEscalation === "llm"`) and WebGPU is available. Offers the user
+ * an opt-in on-device LLM re-parse and renders the download progress while it
+ * runs.
+ *
+ * When the LLM pass completes, calls `onRecovered(llmParsed)` so the parent
+ * (`ParsedCard` in `Result.tsx`) can substitute the LLM-parsed fields into the
+ * result surface and show the "recovered with on-device AI" provenance badge.
+ *
+ * Reuse analysis (CLAUDE.md 3-tier rule):
+ *   - Primitive: `Button` (the opt-in CTA) — no raw `<button>`.
+ *   - Shared: `ModelLoadProgress` (download bar, same as DisagreementPanel #242
+ *     and SectionRewrite) — no parallel progress component.
+ *   - Semantic tokens only; no hardcoded hex or raw palette classes.
+ *
+ * Returns `null` when the controller flags the feature unavailable. Silent
+ * absence — matches the rewrite and disagreement paths.
+ */
+
+import { Button, ModelLoadProgress } from "@design-system";
+import type { EscapeHatchController, EscapeHatchStatus } from "../../hooks/useLlmEscapeHatch.ts";
+import type { LlmParsedResume } from "../../lib/webllm/parse-resume.ts";
+import { useEffect } from "react";
+
+function ctaLabel(status: EscapeHatchStatus): string {
+  switch (status.kind) {
+    case "loading":
+      return "Loading model…";
+    case "running":
+      return "Parsing with on-device AI…";
+    case "done":
+      return "Re-run AI recovery";
+    case "error":
+      return "Try again";
+    default:
+      return "Try a local AI pass";
+  }
+}
+
+interface LlmEscapeHatchBannerProps {
+  controller: EscapeHatchController;
+  /** Called with the LLM-parsed result once the pass completes. */
+  onRecovered: (llmParsed: LlmParsedResume) => void;
+}
+
+/**
+ * The banner is only mounted when `controller.isAvailable` (the parent gates
+ * on this), so no internal availability guard is needed.
+ */
+export function LlmEscapeHatchBanner({
+  controller,
+  onRecovered,
+}: LlmEscapeHatchBannerProps) {
+  const { status } = controller;
+
+  // Notify parent whenever a successful LLM pass completes.
+  useEffect(() => {
+    if (status.kind === "done") {
+      onRecovered(status.llmParsed);
+    }
+  }, [status, onRecovered]);
+
+  return (
+    <div
+      role="region"
+      aria-label="AI recovery suggestion"
+      className="flex flex-col gap-2 rounded-lg border border-feedback-info-border bg-feedback-info-bg px-4 py-3"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <p className="text-sm font-medium text-content-primary">
+            We couldn't read much of this resume.
+          </p>
+          <p className="text-xs text-content-tertiary">
+            Try a local AI pass? Runs entirely in your browser — nothing leaves
+            this tab. One-time ~1.2&nbsp;GB download, cached for next time.
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => void controller.run()}
+          disabled={controller.isBusy}
+          aria-label="Run an on-device AI pass to recover the resume parse"
+        >
+          {ctaLabel(status)}
+        </Button>
+      </div>
+
+      {status.kind === "loading" && (
+        <ModelLoadProgress
+          progress={status.progress.progress}
+          text={status.progress.text}
+          label="Loading the recovery model (one-time download)"
+          showExplainer
+        />
+      )}
+
+      {status.kind === "running" && (
+        <p className="text-xs text-content-secondary" role="status">
+          Parsing with on-device AI…
+        </p>
+      )}
+
+      {status.kind === "error" && (
+        <p role="alert" className="text-xs text-feedback-error-text">
+          {status.message}
+        </p>
+      )}
+
+      {status.kind === "done" && (
+        <p className="text-xs text-feedback-success-text">
+          Recovered with on-device AI — result updated below.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/LlmEscapeHatchBanner.tsx
+++ b/src/components/features/LlmEscapeHatchBanner.tsx
@@ -28,19 +28,17 @@ import type { EscapeHatchController, EscapeHatchStatus } from "../../hooks/useLl
 import type { LlmParsedResume } from "../../lib/webllm/parse-resume.ts";
 import { useEffect } from "react";
 
+/** CTA copy keyed off the status lifecycle (idle is the default fallback). */
+const CTA_LABELS: Record<EscapeHatchStatus["kind"], string> = {
+  idle: "Try a local AI pass",
+  loading: "Loading model…",
+  running: "Parsing with on-device AI…",
+  done: "Re-run AI recovery",
+  error: "Try again",
+};
+
 function ctaLabel(status: EscapeHatchStatus): string {
-  switch (status.kind) {
-    case "loading":
-      return "Loading model…";
-    case "running":
-      return "Parsing with on-device AI…";
-    case "done":
-      return "Re-run AI recovery";
-    case "error":
-      return "Try again";
-    default:
-      return "Try a local AI pass";
-  }
+  return CTA_LABELS[status.kind];
 }
 
 interface LlmEscapeHatchBannerProps {

--- a/src/components/features/ReportGapSection.test.tsx
+++ b/src/components/features/ReportGapSection.test.tsx
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for the ReportGapSection inside FeedbackPanel (#245). The
+ * existing FeedbackPanel test mounts the panel with no `result`, so the gap
+ * affordance renders nothing there; this file passes a `result` so the section
+ * mounts and exercises its branches: collapsed trigger → expand → local download
+ * → "downloaded" confirmation, plus the characterized-gap count line.
+ *
+ * Analytics is mocked DISABLED so the rating form returns null and this test
+ * isolates ReportGapSection. The download is intercepted (Blob/anchor/object
+ * URL) exactly as in useReportGap.test, and any network call fails the test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+import type { SectionedResume } from "../../lib/heuristics/sections.ts";
+import type { SectionName } from "../../lib/heuristics/regex.ts";
+import type { ParseDisagreement } from "../../lib/heuristics/disagreement.ts";
+
+vi.mock("../../lib/analytics.ts", () => ({
+  ANALYTICS_ENABLED: false,
+  trackFeedback: vi.fn(),
+  trackGapReported: vi.fn(),
+}));
+
+import { FeedbackPanel } from "./FeedbackPanel.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function sectioned(): SectionedResume {
+  const byName = new Map<SectionName | "profile", readonly string[]>([
+    ["experience", ["a bullet"]],
+  ]);
+  return { byName, accomplishmentSections: ["experience"], source: "regex" };
+}
+
+function result(): CascadeResult {
+  return {
+    parsed: {
+      full_name: "Jane",
+      email: "jane@example.com",
+      skills: ["s"],
+      experience: [{ company: "Co", title: "T", description: "d", is_current: false }],
+      education: [],
+    },
+    confidence: 0.6,
+    fieldConfidence: {},
+    triggers: ["two_column"],
+    suggestedEscalation: "none",
+    tiers: ["t0_layout", "t1_openresume"],
+    rawText: "text",
+    markdown: "text",
+    sections: sectioned(),
+    linkAnnotations: [],
+    diagnostics: { rawCharCount: 100, extractedCharCount: 50, pages: 1, elapsedMs: 10 },
+    timings: { t0_layout_ms: 1, t1_openresume_ms: 1 },
+  };
+}
+
+const disagreements: ParseDisagreement[] = [
+  { kind: "merged_roles", field: "experience", heuristicValue: "1", llmValue: "3", likelyCause: "two_column" },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let anchorClicked = false;
+
+beforeEach(() => {
+  anchorClicked = false;
+  const RealBlob = globalThis.Blob;
+  vi.spyOn(globalThis, "Blob").mockImplementation(
+    (parts?: BlobPart[], opts?: BlobPropertyBag) => new RealBlob(parts, opts),
+  );
+  globalThis.URL.createObjectURL = vi.fn(
+    () => "blob:mock",
+  ) as unknown as typeof URL.createObjectURL;
+  globalThis.URL.revokeObjectURL = vi.fn();
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    anchorClicked = true;
+  });
+  globalThis.fetch = vi.fn(() => {
+    throw new Error("ReportGapSection must not make a network request");
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function mount() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(<FeedbackPanel result={result()} disagreements={disagreements} />);
+  });
+}
+
+function clickButton(label: RegExp) {
+  const btn = Array.from(container.querySelectorAll("button")).find((b) =>
+    label.test(b.textContent ?? ""),
+  );
+  if (!btn) throw new Error(`button not found: ${label}`);
+  act(() => {
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("ReportGapSection", () => {
+  it("expands, downloads locally, and confirms — no network call", async () => {
+    mount();
+    // Collapsed trigger present.
+    expect(container.textContent).toContain("Report a parsing gap");
+
+    clickButton(/Report a parsing gap/);
+    // Expanded: explainer + characterized-gap count line.
+    expect(container.textContent).toContain("structure-only");
+    expect(container.textContent).toContain("characterized gap");
+
+    clickButton(/Download diagnostic file/);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(anchorClicked).toBe(true);
+    expect(container.textContent).toContain("Diagnostic file downloaded");
+  });
+});

--- a/src/design-system/shared/StatusBadge.tsx
+++ b/src/design-system/shared/StatusBadge.tsx
@@ -11,13 +11,14 @@
  *   ok      — green / success feedback tokens (e.g. "Parsed")
  *   limited — amber / warning feedback tokens (e.g. "Limited parsing")
  *   warning — alias for limited; kept for callsite clarity
+ *   info    — blue / informational feedback tokens (e.g. "Recovered with on-device AI")
  *
  * Design rules (CLAUDE.md): semantic tokens only.
  */
 
 import type { ReactNode } from "react";
 
-export type StatusBadgeTone = "ok" | "limited" | "warning";
+type StatusBadgeTone = "ok" | "limited" | "warning" | "info";
 
 interface StatusBadgeProps {
   tone: StatusBadgeTone;
@@ -28,6 +29,7 @@ const TONE_CLS: Record<StatusBadgeTone, string> = {
   ok: "bg-feedback-success-bg text-feedback-success-text",
   limited: "bg-feedback-warning-bg text-feedback-warning-text",
   warning: "bg-feedback-warning-bg text-feedback-warning-text",
+  info: "bg-feedback-info-bg text-feedback-info-text",
 };
 
 export function StatusBadge({ tone, children }: StatusBadgeProps) {

--- a/src/hooks/useLlmEscapeHatch.ts
+++ b/src/hooks/useLlmEscapeHatch.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useLlmEscapeHatch — drives the degenerate-case LLM recovery pass (issue #243).
+ *
+ * When the deterministic cascade returns a degenerate result
+ * (`suggestedEscalation === "llm"` — zero experiences, low extraction ratio, or
+ * similar hard failures on a text-layer PDF), this hook offers the user an opt-in
+ * WebLLM pass that re-parses the resume with an on-device model and returns the
+ * full `LlmParsedResume` for the caller to render in place of the heuristic parse.
+ *
+ * Mirrors `useParseDisagreement`'s shape (WebGPU-gated controller, `loadEngine` +
+ * inference guard, `ModelLoadProgress` progress UI). The key difference: instead
+ * of diffing against the heuristic parse, it returns the LLM result directly so
+ * the parent can re-render the full result surface with `final_source: "llm_fallback"`.
+ *
+ * Availability gate: `suggestedEscalation === "llm"` AND WebGPU available AND
+ * there is extractable text. Hidden (null) on everything else — silent absence.
+ *
+ * Pure parse logic lives in `lib/webllm/parse-resume.ts`; this hook is the
+ * React/engine glue only.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { detectWebGpu } from "../lib/webllm/capability.ts";
+import { loadEngine, acquireInference, releaseInference } from "../lib/webllm/web-llm.ts";
+import { parseResumeWithLlm, type LlmParsedResume } from "../lib/webllm/parse-resume.ts";
+import { trackLlmFallbackRan } from "../lib/analytics.ts";
+import { useModelSelection } from "./useModelSelection.ts";
+import type { ProgressUpdate, WebGpuCapability } from "../lib/webllm/types.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+
+export type EscapeHatchStatus =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "running" }
+  | { kind: "done"; llmParsed: LlmParsedResume }
+  | { kind: "error"; message: string };
+
+export interface EscapeHatchController {
+  status: EscapeHatchStatus;
+  /**
+   * `false` when the escape hatch should not be shown — either because
+   * `suggestedEscalation !== "llm"`, no WebGPU, or no extractable text.
+   * The feature component renders nothing in that case — silent absence.
+   */
+  isAvailable: boolean;
+  /** True while the model is loading or the parse is in flight. */
+  isBusy: boolean;
+  /** Start the opt-in LLM pass. No-op while already busy. */
+  run: () => Promise<void>;
+}
+
+export function useLlmEscapeHatch(result: CascadeResult): EscapeHatchController {
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [status, setStatus] = useState<EscapeHatchStatus>({ kind: "idle" });
+  const { selectedModelId } = useModelSelection();
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // A fresh parse (new file) resets the panel — keyed on the result identity.
+  useEffect(() => {
+    setStatus({ kind: "idle" });
+  }, [result]);
+
+  // Whether there is any text for the LLM to parse. A scanned/empty PDF has
+  // none, so the recovery pass would be vacuous — treat as unavailable.
+  const hasText = (result.markdown ?? result.rawText).trim().length > 0;
+
+  const run = useCallback(async () => {
+    if (status.kind === "loading" || status.kind === "running") return;
+    // Snapshot the model id so the same id is released that we acquired.
+    const modelId = selectedModelId;
+    acquireInference(modelId);
+    try {
+      setStatus({ kind: "loading", progress: { progress: 0, text: "Starting…" } });
+      const engine = await loadEngine(modelId, (progress) => {
+        setStatus({ kind: "loading", progress });
+      });
+      setStatus({ kind: "running" });
+      const llmParsed = await parseResumeWithLlm(
+        {
+          rawText: result.rawText,
+          ...(result.markdown ? { markdown: result.markdown } : {}),
+        },
+        engine,
+      );
+      // Report llm_ran: true + final_source: "llm_fallback" (#243).
+      trackLlmFallbackRan({ model: modelId });
+      setStatus({ kind: "done", llmParsed });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Couldn't load the recovery model",
+      });
+    } finally {
+      releaseInference(modelId);
+    }
+  }, [result, selectedModelId, status.kind]);
+
+  // Only advertise when the cascade flagged this as needing LLM recovery AND
+  // WebGPU is available AND there is text to parse.
+  const isAvailable =
+    result.suggestedEscalation === "llm" &&
+    capability === "available" &&
+    hasText;
+  const isBusy = status.kind === "loading" || status.kind === "running";
+
+  return { status, isAvailable, isBusy, run };
+}

--- a/src/hooks/useParseDisagreement.ts
+++ b/src/hooks/useParseDisagreement.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useParseDisagreement — drives the opt-in WebLLM parse pass and diffs it
+ * against the deterministic heuristic parse (issue #242, headline feature).
+ *
+ * Mirrors `useResumeRewrite`'s shape: a WebGPU-gated controller exposing a
+ * status discriminator the feature component renders off. The hook owns:
+ *   - WebGPU capability detection (silent absence when unavailable)
+ *   - loading the selected model (shared `loadEngine` + inference guard)
+ *   - running `parseResumeWithLlm` on the same rawText/markdown the cascade saw
+ *   - diffing via the pure `diffParses` and surfacing `ParseDisagreement[]`
+ *   - the telemetry contract: `llm_ran: true` on parse_completed + an
+ *     anonymized `disagreements_found` count event, fired once per run
+ *
+ * Pure detection logic lives in `lib/heuristics/disagreement.ts`; this hook is
+ * the React/engine glue only.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { detectWebGpu } from "../lib/webllm/capability.ts";
+import { loadEngine, acquireInference, releaseInference } from "../lib/webllm/web-llm.ts";
+import { parseResumeWithLlm } from "../lib/webllm/parse-resume.ts";
+import {
+  diffParses,
+  type ParseDisagreement,
+} from "../lib/heuristics/disagreement.ts";
+import {
+  trackDisagreementsFound,
+  trackLlmParseRan,
+} from "../lib/analytics.ts";
+import { useModelSelection } from "./useModelSelection.ts";
+import type { ProgressUpdate, WebGpuCapability } from "../lib/webllm/types.ts";
+import type {
+  CascadeResult,
+  LayoutTrigger,
+} from "../lib/heuristics/types.ts";
+
+export type DisagreementStatus =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "running" }
+  | { kind: "done"; disagreements: readonly ParseDisagreement[] }
+  | { kind: "error"; message: string };
+
+export interface DisagreementController {
+  status: DisagreementStatus;
+  /**
+   * `false` hides every surface (no WebGPU, or no text to parse). The feature
+   * component renders nothing in that case — silent absence, matching the
+   * rewrite paths.
+   */
+  isAvailable: boolean;
+  /** True while the model is loading or the parse is in flight. */
+  isBusy: boolean;
+  /** Start the opt-in LLM pass. No-op while already busy. */
+  run: () => Promise<void>;
+}
+
+/** Label for the CTA across the status lifecycle. */
+export function labelForDisagreement(status: DisagreementStatus): string {
+  switch (status.kind) {
+    case "loading":
+      return "Loading model…";
+    case "running":
+      return "Comparing parses…";
+    case "done":
+      return "Compare again";
+    case "error":
+      return "Try again";
+    default:
+      return "Check what an ATS misses";
+  }
+}
+
+/** Count disagreements per kind for the anonymized telemetry event. */
+function tallyKinds(disagreements: readonly ParseDisagreement[]): {
+  droppedRole: number;
+  droppedSection: number;
+  missingField: number;
+  mergedRoles: number;
+} {
+  let droppedRole = 0;
+  let droppedSection = 0;
+  let missingField = 0;
+  let mergedRoles = 0;
+  for (const d of disagreements) {
+    if (d.kind === "dropped_role") droppedRole++;
+    else if (d.kind === "dropped_section") droppedSection++;
+    else if (d.kind === "missing_field") missingField++;
+    else if (d.kind === "merged_roles") mergedRoles++;
+  }
+  return { droppedRole, droppedSection, missingField, mergedRoles };
+}
+
+export function useParseDisagreement(
+  result: CascadeResult,
+): DisagreementController {
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [status, setStatus] = useState<DisagreementStatus>({ kind: "idle" });
+  const { selectedModelId } = useModelSelection();
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // A fresh parse (new file) resets the panel — keyed on the result identity.
+  useEffect(() => {
+    setStatus({ kind: "idle" });
+  }, [result]);
+
+  // Whether there is any text for the LLM to parse. A scanned/empty PDF has
+  // none, so the comparison would be vacuous — treat as unavailable.
+  const hasText = (result.markdown ?? result.rawText).trim().length > 0;
+
+  const isBusy = status.kind === "loading" || status.kind === "running";
+
+  const run = useCallback(async () => {
+    if (isBusy) return;
+    // Snapshot the model id so the same id is released that we acquired.
+    const modelId = selectedModelId;
+    acquireInference(modelId);
+    try {
+      setStatus({ kind: "loading", progress: { progress: 0, text: "Starting…" } });
+      const engine = await loadEngine(modelId, (progress) => {
+        setStatus({ kind: "loading", progress });
+      });
+      setStatus({ kind: "running" });
+      const llm = await parseResumeWithLlm(
+        { rawText: result.rawText, ...(result.markdown ? { markdown: result.markdown } : {}) },
+        engine,
+      );
+      // The LLM pass ran — stamp the funnel (sets llm_ran:true downstream).
+      trackLlmParseRan({ model: modelId });
+
+      const triggers = result.triggers as LayoutTrigger[];
+      const disagreements = diffParses(result.parsed, llm, triggers);
+      const tally = tallyKinds(disagreements);
+      trackDisagreementsFound({
+        model: modelId,
+        count: disagreements.length,
+        triggers,
+        ...tally,
+      });
+      setStatus({ kind: "done", disagreements });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Couldn't load the comparison model",
+      });
+    } finally {
+      releaseInference(modelId);
+    }
+  }, [result, selectedModelId, isBusy]);
+
+  const isAvailable = capability === "available" && hasText;
+
+  return { status, isAvailable, isBusy, run };
+}

--- a/src/hooks/useParseDisagreement.ts
+++ b/src/hooks/useParseDisagreement.ts
@@ -58,40 +58,45 @@ export interface DisagreementController {
   run: () => Promise<void>;
 }
 
+/** CTA copy keyed off the status lifecycle (idle is the default fallback). */
+const DISAGREEMENT_LABELS: Record<DisagreementStatus["kind"], string> = {
+  idle: "Check what an ATS misses",
+  loading: "Loading model…",
+  running: "Comparing parses…",
+  done: "Compare again",
+  error: "Try again",
+};
+
 /** Label for the CTA across the status lifecycle. */
 export function labelForDisagreement(status: DisagreementStatus): string {
-  switch (status.kind) {
-    case "loading":
-      return "Loading model…";
-    case "running":
-      return "Comparing parses…";
-    case "done":
-      return "Compare again";
-    case "error":
-      return "Try again";
-    default:
-      return "Check what an ATS misses";
-  }
+  return DISAGREEMENT_LABELS[status.kind];
 }
 
-/** Count disagreements per kind for the anonymized telemetry event. */
-function tallyKinds(disagreements: readonly ParseDisagreement[]): {
+interface KindTally {
   droppedRole: number;
   droppedSection: number;
   missingField: number;
   mergedRoles: number;
-} {
-  let droppedRole = 0;
-  let droppedSection = 0;
-  let missingField = 0;
-  let mergedRoles = 0;
-  for (const d of disagreements) {
-    if (d.kind === "dropped_role") droppedRole++;
-    else if (d.kind === "dropped_section") droppedSection++;
-    else if (d.kind === "missing_field") missingField++;
-    else if (d.kind === "merged_roles") mergedRoles++;
-  }
-  return { droppedRole, droppedSection, missingField, mergedRoles };
+}
+
+/** Maps each disagreement kind to its tally field. */
+const TALLY_FIELD: Record<ParseDisagreement["kind"], keyof KindTally> = {
+  dropped_role: "droppedRole",
+  dropped_section: "droppedSection",
+  missing_field: "missingField",
+  merged_roles: "mergedRoles",
+};
+
+/** Count disagreements per kind for the anonymized telemetry event. */
+function tallyKinds(disagreements: readonly ParseDisagreement[]): KindTally {
+  const tally: KindTally = {
+    droppedRole: 0,
+    droppedSection: 0,
+    missingField: 0,
+    mergedRoles: 0,
+  };
+  for (const d of disagreements) tally[TALLY_FIELD[d.kind]]++;
+  return tally;
 }
 
 export function useParseDisagreement(

--- a/src/hooks/useReportGap.test.tsx
+++ b/src/hooks/useReportGap.test.tsx
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useReportGap behaviour (#245), exercised through a probe component (the
+ * project has no @testing-library/react — same pattern as the other hook tests).
+ *
+ * Covers: report() triggers a LOCAL download (anchor click, object URL) and
+ * NEVER a network upload; the count-only telemetry carries only a count + the
+ * trigger enum (no résumé text); and the downloaded Blob content is PII-free.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useReportGap, type UseReportGap } from "./useReportGap.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { SectionedResume } from "../lib/heuristics/sections.ts";
+import type { SectionName } from "../lib/heuristics/regex.ts";
+import type { ParseDisagreement } from "../lib/heuristics/disagreement.ts";
+
+// Capture telemetry without a PostHog stub.
+const tracked: Array<{ disagreementCount: number; triggers: readonly string[] }> =
+  [];
+vi.mock("../lib/analytics.ts", () => ({
+  trackGapReported: (args: {
+    disagreementCount: number;
+    triggers: readonly string[];
+  }) => tracked.push(args),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const PII_SENTINEL = "SENTINEL_PII_jane@leak.invalid";
+
+function result(): CascadeResult {
+  const byName = new Map<SectionName | "profile", readonly string[]>([
+    ["experience", [PII_SENTINEL, PII_SENTINEL]],
+  ]);
+  const sections: SectionedResume = {
+    byName,
+    accomplishmentSections: ["experience"],
+    source: "regex",
+  };
+  return {
+    parsed: {
+      full_name: PII_SENTINEL,
+      email: PII_SENTINEL,
+      skills: [PII_SENTINEL],
+      experience: [
+        { company: PII_SENTINEL, title: PII_SENTINEL, description: PII_SENTINEL },
+      ],
+      education: [],
+    },
+    confidence: 0.6,
+    fieldConfidence: {},
+    triggers: ["two_column"],
+    suggestedEscalation: "none",
+    tiers: ["t0_layout", "t1_openresume"],
+    rawText: PII_SENTINEL,
+    markdown: PII_SENTINEL,
+    sections,
+    linkAnnotations: [],
+    diagnostics: {
+      rawCharCount: 100,
+      extractedCharCount: 50,
+      pages: 1,
+      elapsedMs: 10,
+    },
+    timings: { t0_layout_ms: 1, t1_openresume_ms: 1 },
+  };
+}
+
+const disagreements: ParseDisagreement[] = [
+  {
+    kind: "merged_roles",
+    field: "experience",
+    heuristicValue: PII_SENTINEL,
+    llmValue: PII_SENTINEL,
+    likelyCause: "two_column",
+  },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let api: UseReportGap;
+let downloadedBlobText = "";
+let anchorClicked = false;
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+function Probe({ withGaps }: { withGaps: boolean }) {
+  api = useReportGap(result(), withGaps ? disagreements : []);
+  return null;
+}
+
+beforeEach(() => {
+  tracked.length = 0;
+  downloadedBlobText = "";
+  anchorClicked = false;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+
+  // Capture the JSON the hook serializes by spying on the Blob constructor —
+  // jsdom's Blob has no async .text(), so read the constructor parts directly.
+  const RealBlob = globalThis.Blob;
+  vi.spyOn(globalThis, "Blob").mockImplementation(
+    (parts?: BlobPart[], opts?: BlobPropertyBag) => {
+      if (parts && typeof parts[0] === "string") downloadedBlobText = parts[0];
+      return new RealBlob(parts, opts);
+    },
+  );
+  globalThis.URL.createObjectURL = vi.fn(
+    () => "blob:mock",
+  ) as unknown as typeof URL.createObjectURL;
+  globalThis.URL.revokeObjectURL = vi.fn();
+
+  // Intercept the anchor click so jsdom doesn't try to navigate.
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    anchorClicked = true;
+  });
+
+  // Any network call would be a violation — fail loudly if one happens.
+  fetchSpy = vi.fn(() => {
+    throw new Error("useReportGap must not make a network request");
+  });
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useReportGap", () => {
+  it("downloads locally, makes no network call, and tracks count-only", async () => {
+    root = createRoot(container);
+    act(() => {
+      root.render(<Probe withGaps={true} />);
+    });
+
+    act(() => {
+      api.report();
+    });
+    // Let the Blob.text() microtask settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(api.error).toBeNull();
+    expect(anchorClicked).toBe(true);
+    expect(api.reported).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Telemetry is count-only: a disagreement count + the trigger enum, no text.
+    expect(tracked).toHaveLength(1);
+    expect(tracked[0].disagreementCount).toBe(1);
+    expect(tracked[0].triggers).toEqual(["two_column"]);
+    expect(JSON.stringify(tracked[0])).not.toContain(PII_SENTINEL);
+
+    // The downloaded artifact carries no PII.
+    expect(downloadedBlobText.length).toBeGreaterThan(0);
+    expect(downloadedBlobText).not.toContain(PII_SENTINEL);
+  });
+
+  it("reports zero gaps when the WebLLM comparison was not run", async () => {
+    root = createRoot(container);
+    act(() => {
+      root.render(<Probe withGaps={false} />);
+    });
+    act(() => {
+      api.report();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(tracked[0].disagreementCount).toBe(0);
+    expect(downloadedBlobText).not.toContain(PII_SENTINEL);
+  });
+});

--- a/src/hooks/useReportGap.ts
+++ b/src/hooks/useReportGap.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useReportGap — drives the "Report a parsing gap" download (issue #245).
+ *
+ * Builds the structure-only repro artifact (`buildReproArtifact`), serializes it
+ * to JSON, and triggers a LOCAL, same-document download via a temporary object
+ * URL — exactly the zero-egress pattern `useDownloadPdf` uses. NOTHING is
+ * uploaded; the user attaches the file to a GitHub issue by hand.
+ *
+ * PII safety lives one layer down, in `buildReproArtifact`: the artifact is
+ * structure-only BY CONSTRUCTION (no name/email/phone/bullet text). This hook is
+ * just the React/Blob glue and must never reach past the artifact into
+ * `result.rawText`, `result.markdown`, or any value-bearing field to "enrich"
+ * the download — doing so would defeat the artifact's PII guarantee.
+ *
+ * Telemetry is COUNT ONLY (`trackGapReported`) and env-gated — the artifact
+ * contents never cross the analytics path.
+ */
+
+import { useCallback, useState } from "react";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { ParseDisagreement } from "../lib/heuristics/disagreement.ts";
+import { buildReproArtifact } from "../lib/heuristics/repro-artifact.ts";
+import { trackGapReported } from "../lib/analytics.ts";
+
+export interface UseReportGap {
+  /** Build + download the structure-only repro artifact. */
+  report: () => void;
+  /** True for a moment after a successful download (drives the thank-you copy). */
+  reported: boolean;
+  error: string | null;
+}
+
+/** Timestamped, PII-free filename for the repro artifact download. */
+function artifactFilename(): string {
+  // YYYYMMDD-HHMMSS from the local clock — no résumé-derived text.
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const stamp =
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+    `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `resumelint-repro-${stamp}.json`;
+}
+
+export function useReportGap(
+  result: CascadeResult,
+  disagreements: readonly ParseDisagreement[] = [],
+): UseReportGap {
+  const [reported, setReported] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const report = useCallback(() => {
+    setError(null);
+    let url: string | null = null;
+    try {
+      const artifact = buildReproArtifact(result, disagreements);
+      const json = JSON.stringify(artifact, null, 2);
+      const blob = new Blob([json], { type: "application/json" });
+      url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = artifactFilename();
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      // Count-only, env-gated telemetry — never the artifact contents.
+      trackGapReported({
+        disagreementCount: disagreements.length,
+        triggers: result.triggers,
+      });
+      // Defer the revoke: a.click() only schedules the download; revoking
+      // synchronously can kill it on slower/remote contexts (see useDownloadPdf).
+      const settledUrl = url;
+      url = null;
+      setTimeout(() => URL.revokeObjectURL(settledUrl), 60_000);
+      setReported(true);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Could not generate the report.",
+      );
+    } finally {
+      if (url) URL.revokeObjectURL(url);
+    }
+  }, [result, disagreements]);
+
+  return { report, reported, error };
+}

--- a/src/hooks/useResumeCritique.ts
+++ b/src/hooks/useResumeCritique.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useResumeCritique — drives the opt-in WebLLM content-quality critique pass
+ * (issue #244).
+ *
+ * Mirrors `useParseDisagreement` / `useLlmEscapeHatch` in shape:
+ *   - WebGPU-gated; hidden on unsupported browsers.
+ *   - Shared `loadEngine` + `acquireInference`/`releaseInference` engine guard.
+ *   - No network calls after the one-time model download.
+ *
+ * **Input:** the "active" parsed resume (`activeResult.parsed` in ParsedCard),
+ * which is either the raw heuristic parse or the LLM-recovered fields merged
+ * in by the #243 escape hatch. This means the critique always runs on the
+ * best available parse without needing its own LLM parse pass.
+ *
+ * **Availability:** WebGPU available AND the resume has extractable text AND
+ * at least one experience bullet OR a summary present. Hidden on scanned /
+ * empty PDFs where there is nothing to judge.
+ *
+ * Pure engine glue only — all critique logic lives in
+ * `lib/webllm/critique-resume.ts`.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { detectWebGpu } from "../lib/webllm/capability.ts";
+import {
+  loadEngine,
+  acquireInference,
+  releaseInference,
+} from "../lib/webllm/web-llm.ts";
+import {
+  critiqueResumeWithLlm,
+  type ResumeCritique,
+} from "../lib/webllm/critique-resume.ts";
+import { trackCritiqueRan } from "../lib/analytics.ts";
+import { useModelSelection } from "./useModelSelection.ts";
+import type { ProgressUpdate, WebGpuCapability } from "../lib/webllm/types.ts";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+
+// ── Status discriminator ──────────────────────────────────────────────────────
+
+export type CritiqueStatus =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "running" }
+  | { kind: "done"; critique: ResumeCritique }
+  | { kind: "error"; message: string };
+
+// ── Controller interface ──────────────────────────────────────────────────────
+
+export interface CritiqueController {
+  status: CritiqueStatus;
+  /**
+   * `false` when the feature should not be surfaced — either because WebGPU
+   * is unavailable, there is no text to judge (scanned PDF), or the parsed
+   * resume has neither bullets nor a summary. Silent absence, matching the
+   * other WebLLM controllers.
+   */
+  isAvailable: boolean;
+  /** True while the model is loading or the critique is in flight. */
+  isBusy: boolean;
+  /** Start the opt-in LLM critique pass. No-op while already busy. */
+  run: () => Promise<void>;
+}
+
+// ── CTA labels ────────────────────────────────────────────────────────────────
+
+/** CTA label for the run button across the status lifecycle. */
+export function labelForCritique(status: CritiqueStatus): string {
+  switch (status.kind) {
+    case "loading":
+      return "Loading model…";
+    case "running":
+      return "Judging content…";
+    case "done":
+      return "Run again";
+    case "error":
+      return "Try again";
+    default:
+      return "Judge resume quality";
+  }
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useResumeCritique(
+  parsed: HeuristicParsedResume,
+  rawText: string,
+): CritiqueController {
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [status, setStatus] = useState<CritiqueStatus>({ kind: "idle" });
+  const { selectedModelId } = useModelSelection();
+
+  // WebGPU probe (async, one-shot).
+  useEffect(() => {
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // A fresh parse (new file) resets the panel.
+  useEffect(() => {
+    setStatus({ kind: "idle" });
+  }, [parsed]);
+
+  // Availability: something worth judging must be present.
+  const hasBullets = (parsed.experience ?? []).some(
+    (e) => typeof e.description === "string" && e.description.trim().length > 0,
+  );
+  const hasSummary =
+    typeof parsed.summary === "string" && parsed.summary.trim().length > 0;
+  const hasText = rawText.trim().length > 0;
+
+  const isAvailable =
+    capability === "available" && hasText && (hasBullets || hasSummary);
+
+  const isBusy = status.kind === "loading" || status.kind === "running";
+
+  const run = useCallback(async () => {
+    if (isBusy) return;
+    // Snapshot the model id so the same id is released that we acquired.
+    const modelId = selectedModelId;
+    acquireInference(modelId);
+    try {
+      setStatus({
+        kind: "loading",
+        progress: { progress: 0, text: "Starting…" },
+      });
+      const engine = await loadEngine(modelId, (progress) => {
+        setStatus({ kind: "loading", progress });
+      });
+      setStatus({ kind: "running" });
+      const critique = await critiqueResumeWithLlm(parsed, engine);
+      // Anonymized telemetry — no bullet text, no PII.
+      const flaggedCount = critique.bulletFindings.filter(
+        (f) => f.issue !== "ok",
+      ).length;
+      trackCritiqueRan({
+        model: modelId,
+        bulletCount: critique.bulletFindings.length,
+        flaggedCount,
+        missingSectionCount: critique.missingSections.length,
+      });
+      setStatus({ kind: "done", critique });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : "Couldn't load the critique model",
+      });
+    } finally {
+      releaseInference(modelId);
+    }
+  }, [parsed, selectedModelId, isBusy]);
+
+  return { status, isAvailable, isBusy, run };
+}

--- a/src/hooks/useResumeCritique.ts
+++ b/src/hooks/useResumeCritique.ts
@@ -67,20 +67,18 @@ export interface CritiqueController {
 
 // ── CTA labels ────────────────────────────────────────────────────────────────
 
+/** CTA copy keyed off the status lifecycle (idle is the default fallback). */
+const CRITIQUE_LABELS: Record<CritiqueStatus["kind"], string> = {
+  idle: "Judge resume quality",
+  loading: "Loading model…",
+  running: "Judging content…",
+  done: "Run again",
+  error: "Try again",
+};
+
 /** CTA label for the run button across the status lifecycle. */
 export function labelForCritique(status: CritiqueStatus): string {
-  switch (status.kind) {
-    case "loading":
-      return "Loading model…";
-    case "running":
-      return "Judging content…";
-    case "done":
-      return "Run again";
-    case "error":
-      return "Try again";
-    default:
-      return "Judge resume quality";
-  }
+  return CRITIQUE_LABELS[status.kind];
 }
 
 // ── Hook ──────────────────────────────────────────────────────────────────────

--- a/src/hooks/webllm-controllers.test.tsx
+++ b/src/hooks/webllm-controllers.test.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Lifecycle coverage for the three WebGPU-gated WebLLM controllers (#242/#243/
+ * #244): useParseDisagreement, useLlmEscapeHatch, useResumeCritique.
+ *
+ * The engine layer (capability probe, loadEngine, the parse/critique passes,
+ * model selection, analytics) is mocked, so these tests exercise the React/
+ * state glue only — availability gating, the idle→loading→done happy path, and
+ * the error path — via a probe component (the project has no RTL; same pattern
+ * as the other hook tests).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { SectionedResume } from "../lib/heuristics/sections.ts";
+import type { SectionName } from "../lib/heuristics/regex.ts";
+
+// ── Mocks (engine layer only) ──────────────────────────────────────────────────
+
+let webgpu: "available" | "unavailable" = "available";
+let loadShouldThrow = false;
+
+vi.mock("../lib/webllm/capability.ts", () => ({
+  detectWebGpu: () => Promise.resolve(webgpu),
+}));
+
+vi.mock("../lib/webllm/web-llm.ts", () => ({
+  loadEngine: (_id: string, onProgress: (p: unknown) => void) => {
+    onProgress({ progress: 0.5, text: "Loading…" });
+    if (loadShouldThrow) return Promise.reject(new Error("load failed"));
+    return Promise.resolve({ chat: {} });
+  },
+  acquireInference: vi.fn(),
+  releaseInference: vi.fn(),
+}));
+
+vi.mock("../lib/webllm/parse-resume.ts", () => ({
+  parseResumeWithLlm: () =>
+    Promise.resolve({
+      full_name: "LLM Name",
+      email: null,
+      phone: null,
+      location: null,
+      summary: null,
+      skills: [],
+      experience: [],
+      education: [],
+    }),
+}));
+
+vi.mock("../lib/webllm/critique-resume.ts", () => ({
+  critiqueResumeWithLlm: () =>
+    Promise.resolve({
+      bulletFindings: [
+        { bullet: "x", issue: "weak_verb" },
+        { bullet: "y", issue: "ok" },
+      ],
+      missingSections: ["skills"],
+    }),
+}));
+
+vi.mock("./useModelSelection.ts", () => ({
+  useModelSelection: () => ({ selectedModelId: "test-model" }),
+}));
+
+vi.mock("../lib/analytics.ts", () => ({
+  trackLlmParseRan: vi.fn(),
+  trackDisagreementsFound: vi.fn(),
+  trackLlmFallbackRan: vi.fn(),
+  trackCritiqueRan: vi.fn(),
+}));
+
+import { useParseDisagreement } from "./useParseDisagreement.ts";
+import { useLlmEscapeHatch } from "./useLlmEscapeHatch.ts";
+import { useResumeCritique } from "./useResumeCritique.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function sectioned(): SectionedResume {
+  const byName = new Map<SectionName | "profile", readonly string[]>([
+    ["experience", ["a bullet"]],
+  ]);
+  return { byName, accomplishmentSections: ["experience"], source: "regex" };
+}
+
+function result(): CascadeResult {
+  return {
+    parsed: {
+      full_name: "Orig",
+      email: "orig@example.com",
+      skills: ["s"],
+      experience: [
+        { company: "Co", title: "T", description: "did a thing", is_current: false },
+      ],
+      education: [],
+    },
+    confidence: 0.4,
+    fieldConfidence: {},
+    triggers: ["two_column"],
+    suggestedEscalation: "llm",
+    tiers: ["t0_layout", "t1_openresume"],
+    rawText: "some extractable text",
+    markdown: "some extractable text",
+    sections: sectioned(),
+    linkAnnotations: [],
+    diagnostics: { rawCharCount: 100, extractedCharCount: 20, pages: 1, elapsedMs: 5 },
+    timings: { t0_layout_ms: 1, t1_openresume_ms: 1 },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+// Mount a probe that publishes the controller into `sink` on every render.
+async function mount<T>(useHook: () => T, sink: { current: T | null }) {
+  function Probe() {
+    sink.current = useHook();
+    return null;
+  }
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<Probe />);
+  });
+  // Let the async WebGPU probe settle so `isAvailable` reflects capability.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  webgpu = "available";
+  loadShouldThrow = false;
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("useParseDisagreement", () => {
+  it("runs the pass and reaches done", async () => {
+    const r = result();
+    const sink: { current: ReturnType<typeof useParseDisagreement> | null } = {
+      current: null,
+    };
+    await mount(() => useParseDisagreement(r), sink);
+    expect(sink.current!.isAvailable).toBe(true);
+    await act(async () => {
+      await sink.current!.run();
+    });
+    expect(sink.current!.status.kind).toBe("done");
+  });
+
+  it("is unavailable without WebGPU", async () => {
+    webgpu = "unavailable";
+    const r = result();
+    const sink: { current: ReturnType<typeof useParseDisagreement> | null } = {
+      current: null,
+    };
+    await mount(() => useParseDisagreement(r), sink);
+    expect(sink.current!.isAvailable).toBe(false);
+  });
+});
+
+describe("useLlmEscapeHatch", () => {
+  it("runs and reaches done", async () => {
+    const r = result();
+    const sink: { current: ReturnType<typeof useLlmEscapeHatch> | null } = {
+      current: null,
+    };
+    await mount(() => useLlmEscapeHatch(r), sink);
+    expect(sink.current!.isAvailable).toBe(true);
+    await act(async () => {
+      await sink.current!.run();
+    });
+    expect(sink.current!.status.kind).toBe("done");
+  });
+
+  it("surfaces an error when the engine fails to load", async () => {
+    loadShouldThrow = true;
+    const r = result();
+    const sink: { current: ReturnType<typeof useLlmEscapeHatch> | null } = {
+      current: null,
+    };
+    await mount(() => useLlmEscapeHatch(r), sink);
+    await act(async () => {
+      await sink.current!.run();
+    });
+    expect(sink.current!.status.kind).toBe("error");
+  });
+});
+
+describe("useResumeCritique", () => {
+  it("runs the critique and reaches done", async () => {
+    const sink: { current: ReturnType<typeof useResumeCritique> | null } = {
+      current: null,
+    };
+    const r = result();
+    await mount(() => useResumeCritique(r.parsed, r.rawText), sink);
+    expect(sink.current!.isAvailable).toBe(true);
+    await act(async () => {
+      await sink.current!.run();
+    });
+    expect(sink.current!.status.kind).toBe("done");
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
+import { CASCADE_VERSION } from "./heuristics/types";
 import type { LayoutTrigger, ParseEvent } from "./heuristics/types";
 import type { WebGpuCapability } from "./webllm/types";
 import type { AtsPlatform } from "./jd-match/fetch-jd";
@@ -229,11 +230,62 @@ export function trackCascadeEvent(event: ParseEvent): void {
   }
 }
 
+/**
+ * The opt-in WebLLM parse pass ran (#242). The cascade's
+ * `cascade_parse_completed` event always carries `llm_ran: false` because the
+ * LLM pass runs AFTER the cascade returns — by the time the user opts in, that
+ * event has already fired. So re-emit the completion signal with `llm_ran: true`
+ * (same event name, so PostHog correlates the two on the same person/session)
+ * to satisfy the "set `llm_ran: true` on parse_completed when the LLM pass runs"
+ * contract. Carries only the model id + the flag — no field values, no PII.
+ */
+export function trackLlmParseRan(args: { model: string }): void {
+  track("cascade_parse_completed", {
+    cascade_version: CASCADE_VERSION,
+    llm_ran: true,
+    model: args.model,
+  });
+}
+
+/**
+ * The degenerate-case LLM escape hatch ran (#243). Re-emits `cascade_parse_completed`
+ * with `llm_ran: true` AND `final_source: "llm_fallback"` to distinguish the
+ * recovery-pass from the comparison-pass (#242, which uses `trackLlmParseRan`).
+ * Carries only the model id — no field values, no PII.
+ */
+export function trackLlmFallbackRan(args: { model: string }): void {
+  track("cascade_parse_completed", {
+    cascade_version: CASCADE_VERSION,
+    llm_ran: true,
+    final_source: "llm_fallback",
+    model: args.model,
+  });
+}
+
 export function trackRenderError(args: { errorName: string }): void {
   // Never pass the error message — it can echo text fragments from the file
   // being parsed and would violate the footer's privacy claim.
   track("render_error", {
     error_name: args.errorName,
+  });
+}
+
+/**
+ * The on-device LLM content-quality critique ran (#244). Emits a single
+ * anonymized event carrying the model id, the total bullet count judged, and
+ * the count of non-ok findings. No bullet text, no field values, no PII.
+ */
+export function trackCritiqueRan(args: {
+  model: string;
+  bulletCount: number;
+  flaggedCount: number;
+  missingSectionCount: number;
+}): void {
+  track("llm_critique_ran", {
+    model: args.model,
+    bullet_count: args.bulletCount,
+    flagged_count: args.flaggedCount,
+    missing_section_count: args.missingSectionCount,
   });
 }
 
@@ -348,6 +400,58 @@ export function trackWebllmResumeRewriteCompleted(args: {
 
 export function trackWebllmFirstResumeRewrite(args: { model: string }): void {
   track("webllm_first_resume_rewrite", { model: args.model });
+}
+
+// Disagreement detector funnel (#242 — heuristic vs LLM parse, headline). Fires
+// once after the opt-in WebLLM pass completes and the two parses are diffed.
+// Anonymized BY CONSTRUCTION: only the count of gaps and per-kind tallies leave
+// the browser — never a field value, name, email, or recovered text. Matches the
+// privacy contract the rest of the parse funnel upholds; compiles away to a
+// no-op when VITE_POSTHOG_KEY is unset.
+export function trackDisagreementsFound(args: {
+  model: string;
+  /** Total gaps the diff surfaced (0 is a meaningful "LLM agreed" datapoint). */
+  count: number;
+  /** Per-kind tally so the funnel can split "which gap kind drives engagement". */
+  droppedRole: number;
+  droppedSection: number;
+  missingField: number;
+  mergedRoles: number;
+  /** Active layout triggers — already anonymized (a fixed enum, no PII). */
+  triggers: readonly LayoutTrigger[];
+}): void {
+  track("disagreements_found", {
+    model: args.model,
+    count: args.count,
+    dropped_role: args.droppedRole,
+    dropped_section: args.droppedSection,
+    missing_field: args.missingField,
+    merged_roles: args.mergedRoles,
+    triggers: [...args.triggers],
+  });
+}
+
+/**
+ * The user reported a parsing gap (#245) — i.e. they generated and downloaded
+ * the structure-only repro artifact to attach to an issue manually. COUNT ONLY:
+ * a `gap_disagreements` integer (how many characterized gaps the report
+ * carried, 0 when the reporter had not run the WebLLM comparison) plus the
+ * active layout triggers (a fixed enum). NEVER the artifact contents, the
+ * résumé text, or any field value — the artifact itself is PII-free by
+ * construction (see `lib/heuristics/repro-artifact.ts`), and this event carries
+ * even less. Env-gated like every other tracker: no-op when VITE_POSTHOG_KEY is
+ * unset.
+ */
+export function trackGapReported(args: {
+  /** How many characterized disagreements the report carried (0 if none). */
+  disagreementCount: number;
+  /** Active layout triggers — already anonymized (a fixed enum, no PII). */
+  triggers: readonly LayoutTrigger[];
+}): void {
+  track("gap_reported", {
+    gap_disagreements: args.disagreementCount,
+    triggers: [...args.triggers],
+  });
 }
 
 // JD URL ingestion funnel (#72 / #75). Fires on every user-initiated fetch

--- a/src/lib/heuristics/confidence.test.ts
+++ b/src/lib/heuristics/confidence.test.ts
@@ -103,7 +103,10 @@ describe("computeConfidence — hard failures force escalation", () => {
     expect(result.confidence).toBeGreaterThan(0);
   });
 
-  it("forces ocr escalation on low extraction ratio", () => {
+  it("forces llm escalation on low extraction ratio for non-scanned PDFs (#243)", () => {
+    // A text-layer PDF where the heuristic parser failed to capture most content
+    // (extraction ratio < EXTRACTION_RATIO_FLOOR) should suggest an on-device LLM
+    // recovery pass, not OCR — the bytes are extractable, just poorly structured.
     const result = computeConfidence({
       heuristic: mkHeuristic(),
       layout: cleanLayout,
@@ -111,7 +114,19 @@ describe("computeConfidence — hard failures force escalation", () => {
       extractedCharCount: 100,
     });
     expect(result.confidence).toBe(0);
-    expect(result.suggestedEscalation).toBe("ocr");
+    expect(result.suggestedEscalation).toBe("llm");
+  });
+
+  it("forces llm escalation when zero experience on non-student resume (#243)", () => {
+    const h = mkHeuristic({ experience: [], education: [] });
+    const result = computeConfidence({
+      heuristic: h,
+      layout: cleanLayout,
+      rawCharCount: 400,
+      extractedCharCount: 350,
+    });
+    expect(result.confidence).toBe(0);
+    expect(result.suggestedEscalation).toBe("llm");
   });
 });
 

--- a/src/lib/heuristics/confidence.ts
+++ b/src/lib/heuristics/confidence.ts
@@ -289,7 +289,10 @@ function chooseEscalation(
   confidence?: number,
 ): EscalationSuggestion {
   if (layout.isScanned) return "ocr";
-  if (hardReasons.includes("low_extraction_ratio")) return "ocr";
+  // `low_extraction_ratio` at this point means the PDF is NOT scanned (the
+  // isScanned guard above would have returned "ocr" first). A low extraction
+  // ratio on a text-layer PDF means the heuristic parser failed to capture the
+  // content — the right recovery is an on-device LLM pass, not OCR (#243).
   if (layout.isTwoColumn) return "ner";
   if (hardReasons.length > 0) return "llm";
   if (confidence != null && confidence < CANONICAL_CONFIDENCE_THRESHOLD) {

--- a/src/lib/heuristics/disagreement.test.ts
+++ b/src/lib/heuristics/disagreement.test.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Unit tests for diffParses (issue #242).
+ *
+ * Pure function — no engine, no DOM. Covers every disagreement kind and its
+ * edge cases:
+ *   - missing_field: each scalar (full_name/email/phone/location/summary),
+ *     null/undefined/blank on the heuristic side, reverse direction ignored
+ *   - dropped_section: experience / education / skills whole-section drop
+ *   - dropped_role vs merged_roles: partial experience gap, disambiguated by
+ *     the two_column trigger
+ *   - likelyCause correlation + kind-aware trigger priority
+ *   - no-disagreement cases (equal/heuristic-richer)
+ *   - ordering + the partial-education non-report rationale
+ */
+
+import { describe, it, expect } from "vitest";
+import { diffParses, type ParseDisagreement } from "./disagreement.ts";
+import type { HeuristicParsedResume, LayoutTrigger } from "./types.ts";
+import type { LlmParsedResume } from "../webllm/parse-resume.ts";
+
+// ── Builders ─────────────────────────────────────────────────────────────────
+
+function heuristic(
+  over: Partial<HeuristicParsedResume> = {},
+): HeuristicParsedResume {
+  return {
+    full_name: "Jane Example",
+    skills: ["TypeScript"],
+    experience: [],
+    education: [],
+    ...over,
+  };
+}
+
+function llm(over: Partial<LlmParsedResume> = {}): LlmParsedResume {
+  return {
+    full_name: "Jane Example",
+    email: null,
+    phone: null,
+    location: null,
+    summary: null,
+    skills: ["TypeScript"],
+    experience: [],
+    education: [],
+    ...over,
+  };
+}
+
+const exp = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    company: `Co ${i}`,
+    title: `Role ${i}`,
+    description: "",
+  }));
+
+const edu = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    institution: `School ${i}`,
+    degree: `Degree ${i}`,
+  }));
+
+function findKind(
+  results: ParseDisagreement[],
+  field: string,
+): ParseDisagreement | undefined {
+  return results.find((d) => d.field === field);
+}
+
+// ── missing_field ────────────────────────────────────────────────────────────
+
+describe("diffParses — missing_field (scalars)", () => {
+  const cases: Array<[string, Partial<HeuristicParsedResume>, Partial<LlmParsedResume>]> = [
+    ["email", { email: undefined }, { email: "jane@example.com" }],
+    ["phone", { phone: undefined }, { phone: "(312) 555-0123" }],
+    ["location", { location: undefined }, { location: "Chicago, IL" }],
+    ["summary", { summary: undefined }, { summary: "Engineer." }],
+    ["full_name", { full_name: "" }, { full_name: "Jane Example" }],
+  ];
+
+  it.each(cases)(
+    "reports %s missing on heuristic but present on LLM",
+    (field, hOver, lOver) => {
+      const r = diffParses(heuristic(hOver), llm(lOver), []);
+      const d = findKind(r, field);
+      expect(d).toBeDefined();
+      expect(d!.kind).toBe("missing_field");
+      expect(d!.heuristicValue).toBeNull();
+      expect(d!.llmValue).toBe((lOver as Record<string, string>)[field]);
+    },
+  );
+
+  it("treats null heuristic scalar the same as undefined", () => {
+    const r = diffParses(
+      heuristic({ email: null as unknown as string }),
+      llm({ email: "jane@example.com" }),
+      [],
+    );
+    expect(findKind(r, "email")?.kind).toBe("missing_field");
+  });
+
+  it("treats whitespace-only heuristic scalar as missing", () => {
+    const r = diffParses(
+      heuristic({ phone: "   " }),
+      llm({ phone: "(312) 555-0123" }),
+      [],
+    );
+    expect(findKind(r, "phone")?.kind).toBe("missing_field");
+  });
+
+  it("does NOT report when both sides have the field", () => {
+    const r = diffParses(
+      heuristic({ email: "jane@example.com" }),
+      llm({ email: "jane@example.com" }),
+      [],
+    );
+    expect(findKind(r, "email")).toBeUndefined();
+  });
+
+  it("does NOT report the reverse direction (heuristic has it, LLM null)", () => {
+    const r = diffParses(
+      heuristic({ email: "jane@example.com" }),
+      llm({ email: null }),
+      [],
+    );
+    expect(findKind(r, "email")).toBeUndefined();
+  });
+
+  it("ignores a blank LLM value (no recovery to report)", () => {
+    const r = diffParses(heuristic({ email: undefined }), llm({ email: "  " }), []);
+    expect(findKind(r, "email")).toBeUndefined();
+  });
+});
+
+// ── dropped_section ──────────────────────────────────────────────────────────
+
+describe("diffParses — dropped_section", () => {
+  it("reports experience when heuristic has 0 and LLM has roles", () => {
+    const r = diffParses(heuristic({ experience: [] }), llm({ experience: exp(3) }), []);
+    const d = findKind(r, "experience");
+    expect(d!.kind).toBe("dropped_section");
+    expect(d!.heuristicValue).toBeNull();
+    expect(d!.llmValue).toBe("3");
+  });
+
+  it("reports education whole-section drop", () => {
+    const r = diffParses(heuristic({ education: [] }), llm({ education: edu(2) }), []);
+    const d = findKind(r, "education");
+    expect(d!.kind).toBe("dropped_section");
+    expect(d!.llmValue).toBe("2");
+  });
+
+  it("reports skills whole-section drop", () => {
+    const r = diffParses(
+      heuristic({ skills: [] }),
+      llm({ skills: ["Go", "Rust"] }),
+      [],
+    );
+    const d = findKind(r, "skills");
+    expect(d!.kind).toBe("dropped_section");
+    expect(d!.llmValue).toBe("2");
+  });
+
+  it("does NOT report a section the heuristic also recovered", () => {
+    const r = diffParses(
+      heuristic({ education: edu(1) }),
+      llm({ education: edu(1) }),
+      [],
+    );
+    expect(findKind(r, "education")).toBeUndefined();
+  });
+
+  it("does NOT report a partial education gap (no kind for it by design)", () => {
+    // Heuristic got 1, LLM got 3 — intentionally NOT reported. Education has no
+    // partial-gap kind; only the whole-section vanish is honest to detect.
+    const r = diffParses(
+      heuristic({ education: edu(1) }),
+      llm({ education: edu(3) }),
+      [],
+    );
+    expect(findKind(r, "education")).toBeUndefined();
+  });
+});
+
+// ── dropped_role vs merged_roles ─────────────────────────────────────────────
+
+describe("diffParses — dropped_role vs merged_roles (partial experience gap)", () => {
+  it("reports dropped_role when LLM has more roles and NO two_column", () => {
+    const r = diffParses(
+      heuristic({ experience: [{ title: "x", company: "y" }] }),
+      llm({ experience: exp(4) }),
+      [],
+    );
+    const d = findKind(r, "experience");
+    expect(d!.kind).toBe("dropped_role");
+    expect(d!.heuristicValue).toBe("1");
+    expect(d!.llmValue).toBe("4");
+  });
+
+  it("reports merged_roles when two_column is active", () => {
+    const r = diffParses(
+      heuristic({ experience: [{ title: "x", company: "y" }] }),
+      llm({ experience: exp(4) }),
+      ["two_column"],
+    );
+    const d = findKind(r, "experience");
+    expect(d!.kind).toBe("merged_roles");
+    expect(d!.likelyCause).toBe("two_column");
+  });
+
+  it("does NOT report when counts are equal", () => {
+    const r = diffParses(
+      heuristic({ experience: exp(2) }),
+      llm({ experience: exp(2) }),
+      [],
+    );
+    expect(findKind(r, "experience")).toBeUndefined();
+  });
+
+  it("does NOT report when the heuristic recovered MORE roles than the LLM", () => {
+    const r = diffParses(
+      heuristic({ experience: exp(3) }),
+      llm({ experience: exp(1) }),
+      [],
+    );
+    expect(findKind(r, "experience")).toBeUndefined();
+  });
+});
+
+// ── likelyCause correlation ──────────────────────────────────────────────────
+
+describe("diffParses — likelyCause correlation", () => {
+  it("omits likelyCause when no triggers are active", () => {
+    const r = diffParses(heuristic({ experience: [] }), llm({ experience: exp(2) }), []);
+    expect(findKind(r, "experience")!.likelyCause).toBeUndefined();
+    expect("likelyCause" in findKind(r, "experience")!).toBe(false);
+  });
+
+  it("prefers two_column for an experience gap even when scanned is also set", () => {
+    const triggers: LayoutTrigger[] = ["scanned", "two_column"];
+    const r = diffParses(heuristic({ experience: exp(1) }), llm({ experience: exp(3) }), triggers);
+    expect(findKind(r, "experience")!.likelyCause).toBe("two_column");
+  });
+
+  it("prefers scanned over two_column for a scalar field gap", () => {
+    const triggers: LayoutTrigger[] = ["two_column", "scanned"];
+    const r = diffParses(heuristic({ email: undefined }), llm({ email: "a@example.com" }), triggers);
+    expect(findKind(r, "email")!.likelyCause).toBe("scanned");
+  });
+
+  it("falls back to fonts_unmappable when it is the only trigger", () => {
+    const r = diffParses(
+      heuristic({ skills: [] }),
+      llm({ skills: ["Go"] }),
+      ["fonts_unmappable"],
+    );
+    expect(findKind(r, "skills")!.likelyCause).toBe("fonts_unmappable");
+  });
+});
+
+// ── No disagreement / ordering ───────────────────────────────────────────────
+
+describe("diffParses — no disagreement & ordering", () => {
+  it("returns empty array when the two parses agree", () => {
+    const same = {
+      full_name: "Jane Example",
+      email: "jane@example.com",
+      skills: ["TS"],
+      experience: exp(2),
+      education: edu(1),
+    };
+    const r = diffParses(
+      heuristic(same),
+      llm({ ...same, phone: null, location: null, summary: null }),
+      [],
+    );
+    expect(r).toEqual([]);
+  });
+
+  it("returns scalar gaps before section gaps, in field order", () => {
+    const r = diffParses(
+      heuristic({ email: undefined, location: undefined, skills: [], experience: [] }),
+      llm({
+        email: "a@example.com",
+        location: "NYC",
+        skills: ["Go"],
+        experience: exp(1),
+      }),
+      [],
+    );
+    expect(r.map((d) => d.field)).toEqual([
+      "email",
+      "location",
+      "experience",
+      "skills",
+    ]);
+  });
+
+  it("is deterministic across repeated calls", () => {
+    const h = heuristic({ experience: exp(1), email: undefined });
+    const l = llm({ experience: exp(3), email: "a@example.com" });
+    const triggers: LayoutTrigger[] = ["two_column"];
+    expect(diffParses(h, l, triggers)).toEqual(diffParses(h, l, triggers));
+  });
+});

--- a/src/lib/heuristics/disagreement.ts
+++ b/src/lib/heuristics/disagreement.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Disagreement detector — heuristic vs LLM parse (issue #242, headline feature).
+ *
+ * The deterministic heuristic parser is what a *generic* ATS text extractor
+ * sees: drop columns, lose roles, miss contact fields. The opt-in WebLLM pass
+ * recovers what is actually on the page. Diffing the two surfaces the GAP — the
+ * exact thing a dumb extractor would silently miss — and, by correlating each
+ * gap with the layout trigger that caused it, names the *cause*:
+ *
+ *   "An ATS likely drops 2 of your 4 roles — your two-column layout
+ *    interleaves them."
+ *
+ * This module is PURE and lib-layer: it takes two parsed shapes plus the active
+ * layout triggers and returns a flat `ParseDisagreement[]`. No engine, no React,
+ * no I/O — every branch is unit-testable without WebGPU.
+ *
+ * ── Disagreement model ──────────────────────────────────────────────────────
+ * A disagreement is always framed as "the LLM recovered something the heuristic
+ * (the dumb extractor) did NOT." The reverse direction (heuristic richer than
+ * the LLM) is not a gap an ATS would miss, so it is never reported.
+ *
+ * Four kinds, each fired by a distinct, non-overlapping condition:
+ *
+ *   - `missing_field`   — a scalar contact/summary field is empty on the
+ *                         heuristic side but present on the LLM side.
+ *   - `dropped_section` — a whole section (experience / education / skills) is
+ *                         empty on the heuristic side but non-empty on the LLM
+ *                         side. The *entire* section vanished.
+ *   - `dropped_role`    — the heuristic recovered SOME experience entries but
+ *                         FEWER than the LLM, and no two-column interleave is
+ *                         implicated. Roles were lost, not glued together.
+ *   - `merged_roles`    — same partial-experience count gap as `dropped_role`,
+ *                         but a `two_column` trigger is active: the classic
+ *                         cause is two columns being read across, gluing
+ *                         adjacent roles into one entry. Distinguishing this
+ *                         from `dropped_role` lets the copy name the mechanism.
+ *
+ * The experience partition is total and exclusive:
+ *   heuristic 0,  llm ≥ 1            → dropped_section
+ *   heuristic ≥ 1, llm > heuristic   → merged_roles (if two_column) | dropped_role
+ *   llm ≤ heuristic                  → no experience disagreement
+ *
+ * Education and skills report only the whole-section case (`dropped_section`):
+ * neither has a dedicated partial-gap kind in the AC, and manufacturing one
+ * from differently-shaped entry objects would be fragile. A partial education
+ * gap is intentionally not reported (see the module test for the rationale).
+ */
+
+import type { LayoutTrigger, HeuristicParsedResume } from "./types.ts";
+import type { LlmParsedResume } from "../webllm/parse-resume.ts";
+
+/**
+ * One detected gap between the heuristic and LLM parse.
+ *
+ * `heuristicValue` / `llmValue` carry a short, human-displayable summary of the
+ * two sides — a count for collection kinds (`"2"` vs `"4"` roles), a scalar's
+ * text for `missing_field`, or `null` when that side recovered nothing. They are
+ * display fodder, not structured data; the UI renders them verbatim.
+ */
+export interface ParseDisagreement {
+  kind: "dropped_role" | "dropped_section" | "missing_field" | "merged_roles";
+  /** Which field/section the gap is about: a scalar name (`"email"`) or a
+   *  collection name (`"experience"`, `"education"`, `"skills"`). */
+  field: string;
+  /** What the dumb (heuristic) parser saw — `null` when it recovered nothing. */
+  heuristicValue: string | null;
+  /** What the LLM recovered — `null` only in the (unreached) reverse direction. */
+  llmValue: string | null;
+  /** The layout trigger that most plausibly caused this gap, when one applies. */
+  likelyCause?: LayoutTrigger;
+}
+
+// ── Scalar field plumbing ────────────────────────────────────────────────────
+
+/** Scalar fields compared one-for-one across the two parse shapes. `summary` is
+ *  included here (the AC groups it with "missing contact fields"); it is a field
+ *  on both shapes, not a section. */
+const SCALAR_FIELDS = [
+  "full_name",
+  "email",
+  "phone",
+  "location",
+  "summary",
+] as const;
+
+type ScalarField = (typeof SCALAR_FIELDS)[number];
+
+/** Normalize a scalar to a non-empty string, or `null` if absent/blank.
+ *  Treats `undefined`, `null`, and whitespace-only as "the parser found
+ *  nothing" so a heuristic field that is `""` is correctly read as missing. */
+function presentScalar(value: string | null | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+// ── Cause correlation ────────────────────────────────────────────────────────
+
+/**
+ * Pick the layout trigger that most plausibly explains a gap, or `undefined`
+ * when none is active. Priority is kind-aware:
+ *
+ *   - For experience gaps (dropped_role / merged_roles), `two_column` is the
+ *     most specific explanation — reading across columns interleaves and glues
+ *     adjacent roles. It leads; the page-wide failures follow.
+ *   - For everything else, the page-wide failures lead: `scanned` (no
+ *     selectable text at all) and `fonts_unmappable` (text present but
+ *     undecodable) wipe out whole sections/fields, so they out-explain a column
+ *     split when present.
+ *
+ * Only triggers actually in `triggers` are eligible, so the cause never claims
+ * a layout problem the probes didn't detect.
+ */
+function pickCause(
+  triggers: readonly LayoutTrigger[],
+  preferTwoColumn: boolean,
+): LayoutTrigger | undefined {
+  const order: LayoutTrigger[] = preferTwoColumn
+    ? ["two_column", "scanned", "fonts_unmappable"]
+    : ["scanned", "fonts_unmappable", "two_column"];
+  return order.find((t) => triggers.includes(t));
+}
+
+/** Spread helper: attach `likelyCause` only when a cause was found, so the
+ *  object never carries an explicit `likelyCause: undefined` key. */
+function withCause(
+  base: Omit<ParseDisagreement, "likelyCause">,
+  cause: LayoutTrigger | undefined,
+): ParseDisagreement {
+  return cause ? { ...base, likelyCause: cause } : base;
+}
+
+// ── Detector ─────────────────────────────────────────────────────────────────
+
+/**
+ * Diff a heuristic parse against an LLM parse and return every gap the dumb
+ * extractor would miss, in a stable order: missing scalar fields (in
+ * `SCALAR_FIELDS` order), then experience, education, and skills sections.
+ *
+ * Pure and deterministic — the same inputs always yield the same array.
+ */
+export function diffParses(
+  heuristic: HeuristicParsedResume,
+  llm: LlmParsedResume,
+  triggers: LayoutTrigger[],
+): ParseDisagreement[] {
+  const out: ParseDisagreement[] = [];
+
+  // ── Scalar contact + summary fields ──
+  for (const field of SCALAR_FIELDS) {
+    const h = presentScalar(heuristicScalar(heuristic, field));
+    const l = presentScalar(llm[field]);
+    // Gap only in the LLM-recovered direction: heuristic blank, LLM present.
+    if (h === null && l !== null) {
+      out.push(
+        withCause(
+          {
+            kind: "missing_field",
+            field,
+            heuristicValue: null,
+            llmValue: l,
+          },
+          pickCause(triggers, /* preferTwoColumn */ false),
+        ),
+      );
+    }
+  }
+
+  // ── Experience: dropped_section | merged_roles | dropped_role ──
+  const hExp = heuristic.experience.length;
+  const lExp = llm.experience.length;
+  if (hExp === 0 && lExp > 0) {
+    // The whole section vanished from the heuristic parse.
+    out.push(
+      withCause(
+        {
+          kind: "dropped_section",
+          field: "experience",
+          heuristicValue: null,
+          llmValue: String(lExp),
+        },
+        pickCause(triggers, /* preferTwoColumn */ true),
+      ),
+    );
+  } else if (hExp >= 1 && lExp > hExp) {
+    // Partial gap: the heuristic kept some roles but fewer than the LLM. A
+    // two-column layout interleaves columns and glues adjacent roles into one
+    // entry (merged_roles); absent that signal, roles were simply lost
+    // (dropped_role).
+    const twoColumn = triggers.includes("two_column");
+    out.push(
+      withCause(
+        {
+          kind: twoColumn ? "merged_roles" : "dropped_role",
+          field: "experience",
+          heuristicValue: String(hExp),
+          llmValue: String(lExp),
+        },
+        pickCause(triggers, /* preferTwoColumn */ true),
+      ),
+    );
+  }
+
+  // ── Education: whole-section drop only ──
+  if (heuristic.education.length === 0 && llm.education.length > 0) {
+    out.push(
+      withCause(
+        {
+          kind: "dropped_section",
+          field: "education",
+          heuristicValue: null,
+          llmValue: String(llm.education.length),
+        },
+        pickCause(triggers, /* preferTwoColumn */ false),
+      ),
+    );
+  }
+
+  // ── Skills: whole-section drop only ──
+  if (heuristic.skills.length === 0 && llm.skills.length > 0) {
+    out.push(
+      withCause(
+        {
+          kind: "dropped_section",
+          field: "skills",
+          heuristicValue: null,
+          llmValue: String(llm.skills.length),
+        },
+        pickCause(triggers, /* preferTwoColumn */ false),
+      ),
+    );
+  }
+
+  return out;
+}
+
+/** Read a scalar field off the heuristic shape. `full_name` is required on
+ *  `ResumeData`; the rest are optional. Centralized so the loop above stays a
+ *  single typed access point. */
+function heuristicScalar(
+  heuristic: HeuristicParsedResume,
+  field: ScalarField,
+): string | null | undefined {
+  switch (field) {
+    case "full_name":
+      return heuristic.full_name;
+    case "email":
+      return heuristic.email;
+    case "phone":
+      return heuristic.phone;
+    case "location":
+      return heuristic.location;
+    case "summary":
+      return heuristic.summary;
+  }
+}

--- a/src/lib/heuristics/repro-artifact.test.ts
+++ b/src/lib/heuristics/repro-artifact.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Tests for buildReproArtifact (issue #245).
+ *
+ * The LOAD-BEARING test is "carries no PII by construction": we plant a unique
+ * sentinel string in EVERY PII-bearing field a real résumé parse would hold
+ * (name, email, phone, location, summary, company/title/bullet text, skills,
+ * rawText, markdown, link URL, and the disagreement value fields), build the
+ * artifact, serialize it to JSON exactly as the download path does, and assert
+ * NOT ONE sentinel survives. If a future contributor "helpfully" widens the
+ * artifact to carry literal text, this fails — that is the whole point.
+ *
+ * The remaining tests pin the structure-only shape (counts, section boundaries,
+ * triggers, disagreement kinds) the maintainer needs to reproduce a gap.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildReproArtifact,
+  REPRO_ARTIFACT_VERSION,
+} from "./repro-artifact.ts";
+import type { CascadeResult } from "./types.ts";
+import type { SectionedResume } from "./sections.ts";
+import type { SectionName } from "./regex.ts";
+import type { ParseDisagreement } from "./disagreement.ts";
+
+// ── Sentinels ────────────────────────────────────────────────────────────────
+// Each is a distinctive, non-structural string that must NEVER appear in the
+// artifact. Keyed by the field it occupies so a failure names the leak.
+const PII = {
+  fullName: "SENTINEL_FULL_NAME_Aria_Q_Testperson",
+  email: "SENTINEL_EMAIL_aria@leak.invalid",
+  phone: "SENTINEL_PHONE_+1-202-555-0142",
+  location: "SENTINEL_LOCATION_Atlantis_Xy",
+  summary: "SENTINEL_SUMMARY_drove_a_thing",
+  company: "SENTINEL_COMPANY_AcmeLeak",
+  title: "SENTINEL_TITLE_ChiefLeak",
+  bullet: "SENTINEL_BULLET_did_a_thing_42pct",
+  institution: "SENTINEL_INSTITUTION_Leak_University",
+  degree: "SENTINEL_DEGREE_BS_Leakology",
+  skill: "SENTINEL_SKILL_LeakScript",
+  rawText: "SENTINEL_RAWTEXT_whole_resume_body",
+  markdown: "SENTINEL_MARKDOWN_# whole resume",
+  sectionLine: "SENTINEL_SECTION_LINE_a_real_bullet",
+  linkUrl: "https://SENTINEL.linkedin.example/in/aria-leak",
+  disagreementHeuristic: "SENTINEL_DISAGREE_HEURISTIC_value",
+  disagreementLlm: "SENTINEL_DISAGREE_LLM_value",
+} as const;
+
+const ALL_SENTINELS = Object.values(PII);
+
+function sectioned(): SectionedResume {
+  const byName = new Map<SectionName | "profile", readonly string[]>([
+    ["profile", [PII.fullName, PII.email]],
+    ["experience", [PII.company, PII.title, PII.bullet]],
+    ["education", [PII.institution]],
+    ["skills", [PII.skill]],
+  ]);
+  return { byName, accomplishmentSections: ["experience"], source: "markdown" };
+}
+
+/** A CascadeResult salted with PII in every value-bearing field. */
+function pollutedResult(): CascadeResult {
+  return {
+    parsed: {
+      full_name: PII.fullName,
+      email: PII.email,
+      phone: PII.phone,
+      location: PII.location,
+      summary: PII.summary,
+      skills: [PII.skill],
+      experience: [
+        {
+          company: PII.company,
+          title: PII.title,
+          description: PII.bullet,
+          is_current: false,
+        },
+      ],
+      education: [{ institution: PII.institution, degree: PII.degree }],
+    },
+    confidence: 0.7,
+    fieldConfidence: {},
+    triggers: ["two_column"],
+    suggestedEscalation: "none",
+    tiers: ["t0_layout", "t1_openresume"],
+    rawText: PII.rawText,
+    markdown: PII.markdown,
+    sections: sectioned(),
+    linkAnnotations: [
+      { page: 1, url: PII.linkUrl, rect: [0, 0, 1, 1], yTop: 0 },
+    ],
+    diagnostics: {
+      rawCharCount: 4000,
+      extractedCharCount: 2500,
+      pages: 2,
+      elapsedMs: 120,
+      sectionSource: "markdown",
+    },
+    timings: { t0_layout_ms: 10, t1_openresume_ms: 20 },
+  };
+}
+
+const pollutedDisagreements: ParseDisagreement[] = [
+  {
+    kind: "merged_roles",
+    field: "experience",
+    heuristicValue: PII.disagreementHeuristic,
+    llmValue: PII.disagreementLlm,
+    likelyCause: "two_column",
+  },
+  {
+    kind: "missing_field",
+    field: "email",
+    heuristicValue: null,
+    llmValue: PII.disagreementLlm,
+  },
+];
+
+// ── The load-bearing PII assertion ───────────────────────────────────────────
+
+describe("buildReproArtifact — PII-redacted by construction", () => {
+  it("carries no literal field value, anywhere, when serialized", () => {
+    const artifact = buildReproArtifact(pollutedResult(), pollutedDisagreements);
+    // Serialize exactly as the download path does.
+    const json = JSON.stringify(artifact);
+    for (const sentinel of ALL_SENTINELS) {
+      expect(json).not.toContain(sentinel);
+    }
+  });
+
+  it("also leaks nothing when no disagreements are supplied", () => {
+    const json = JSON.stringify(buildReproArtifact(pollutedResult()));
+    for (const sentinel of ALL_SENTINELS) {
+      expect(json).not.toContain(sentinel);
+    }
+  });
+});
+
+// ── Structure-only shape ─────────────────────────────────────────────────────
+
+describe("buildReproArtifact — structure-only shape", () => {
+  it("captures counts, boundaries, triggers, and disagreement kinds", () => {
+    const a = buildReproArtifact(pollutedResult(), pollutedDisagreements);
+
+    expect(a.artifactVersion).toBe(REPRO_ARTIFACT_VERSION);
+    expect(a.triggers).toEqual(["two_column"]);
+    expect(a.sectionSource).toBe("markdown");
+    expect(a.pageCount).toBe(2);
+    expect(a.rawCharCount).toBe(4000);
+    expect(a.extractedCharCount).toBe(2500);
+    expect(a.linkAnnotationCount).toBe(1);
+
+    // Section boundaries — names + line counts, no text.
+    const exp = a.sections.find((s) => s.name === "experience");
+    expect(exp?.lineCount).toBe(3);
+    const skills = a.sections.find((s) => s.name === "skills");
+    expect(skills?.lineCount).toBe(1);
+
+    // Parse cardinality — presence flags + counts.
+    expect(a.parsedCounts.hasEmail).toBe(true);
+    expect(a.parsedCounts.hasFullName).toBe(true);
+    expect(a.parsedCounts.experienceCount).toBe(1);
+    expect(a.parsedCounts.educationCount).toBe(1);
+    expect(a.parsedCounts.skillsCount).toBe(1);
+
+    // Disagreements — kind/field/cause only.
+    expect(a.disagreements).toHaveLength(2);
+    expect(a.disagreements[0]).toEqual({
+      kind: "merged_roles",
+      field: "experience",
+      likelyCause: "two_column",
+    });
+    expect(a.disagreements[1]).toEqual({
+      kind: "missing_field",
+      field: "email",
+    });
+    // No likelyCause key when none applied.
+    expect("likelyCause" in a.disagreements[1]).toBe(false);
+  });
+
+  it("reports presence=false for empty scalar fields", () => {
+    const r = pollutedResult();
+    r.parsed.email = undefined;
+    r.parsed.location = "   ";
+    const a = buildReproArtifact(r);
+    expect(a.parsedCounts.hasEmail).toBe(false);
+    expect(a.parsedCounts.hasLocation).toBe(false);
+  });
+});

--- a/src/lib/heuristics/repro-artifact.ts
+++ b/src/lib/heuristics/repro-artifact.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Repro artifact builder — a structure-only, PII-redacted-BY-CONSTRUCTION
+ * snapshot of a parse, for the "Report a parsing gap" loop (issue #245).
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ WHY THIS FILE NEVER CARRIES RÉSUMÉ TEXT — read before editing.            │
+ * │                                                                           │
+ * │ resumelint is a PUBLIC repo. A user reporting a parser gap is, by         │
+ * │ definition, sitting on top of their OWN résumé — real name, real email,   │
+ * │ real phone, real bullet text. If any of that literal text rode along in   │
+ * │ the downloadable repro artifact, the user would unknowingly publish their │
+ * │ PII the moment they attach the file to a public GitHub issue. The         │
+ * │ committed PDF binary is already the hard exposure surface (see CLAUDE.md   │
+ * │ "Test fixtures — PII policy"); a text artifact would be a SECOND, softer   │
+ * │ one that looks innocuous.                                                  │
+ * │                                                                           │
+ * │ So the artifact captures ONLY the *shape* of the parse — layout triggers, │
+ * │ section boundaries (names + line counts), parse cardinality, and          │
+ * │ disagreement KINDS — never a single literal field value. This mirrors the │
+ * │ `*.expected.json` corpus snapshots, which are lossy by design             │
+ * │ (keys/counts/structure, never values) and therefore PII-free             │
+ * │ automatically.                                                            │
+ * │                                                                           │
+ * │ PII-redacted BY CONSTRUCTION, not by filtering:                           │
+ * │   1. The exported `ReproArtifact` type admits ONLY numbers, booleans, and │
+ * │      values drawn from fixed enums (LayoutTrigger, section names,         │
+ * │      disagreement kinds, the splitter source). There is no free-form      │
+ * │      `string` slot a literal résumé value could occupy.                   │
+ * │   2. The builder reads counts/enums/booleans off the inputs and NEVER     │
+ * │      reads `rawText`, `markdown`, link URLs, parsed scalar VALUES, the    │
+ * │      section line text, or `ParseDisagreement.heuristicValue` / `llmValue`│
+ * │      (which MAY hold literal text). Those properties are simply untouched. │
+ * │                                                                           │
+ * │ DO NOT "helpfully" add raw-text capture here (a sample line, the failing  │
+ * │ bullet, the recovered email, a link URL, …). Adding it would force you to │
+ * │ widen `ReproArtifact` with a free `string` field — which breaks the       │
+ * │ load-bearing `repro-artifact.test.ts` PII assertion AND defeats this      │
+ * │ comment. If a maintainer needs the literal text to build a fixture, they  │
+ * │ re-export the template with a SYNTHETIC persona (CLAUDE.md); they do not  │
+ * │ harvest it from a user's report.                                          │
+ * │                                                                           │
+ * │ Likewise: this builder feeds a LOCAL download only. There is no upload    │
+ * │ path, silent or otherwise. Any future ingestion is a separate,           │
+ * │ explicitly-consented decision and out of scope here (issue #245).         │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * Pure and lib-layer: no React, no I/O. The component serializes the returned
+ * object to JSON and hands it to the browser's download path.
+ */
+
+import type { CascadeResult, LayoutTrigger } from "./types.ts";
+import { CASCADE_VERSION } from "./types.ts";
+import type { SectionName } from "./regex.ts";
+import type { ParseDisagreement } from "./disagreement.ts";
+
+/** Bump when the artifact field shape changes, so a maintainer triaging an old
+ *  attachment knows which builder produced it. Independent of CASCADE_VERSION. */
+export const REPRO_ARTIFACT_VERSION = "v1" as const;
+
+/**
+ * The structure-only, PII-free repro snapshot.
+ *
+ * Every field below is a number, a boolean, a fixed enum, or an array of those.
+ * There is deliberately NO free-form `string` slot — that is the type-level
+ * guarantee that no literal résumé text can ride along. See the file header.
+ */
+export interface ReproArtifact {
+  artifactVersion: typeof REPRO_ARTIFACT_VERSION;
+  cascadeVersion: typeof CASCADE_VERSION;
+  /** Active layout probes — a fixed enum, no PII. */
+  triggers: LayoutTrigger[];
+  /** Which splitter produced the section boundaries (provenance), no values. */
+  sectionSource: "markdown" | "regex";
+  /** Page-level counts — never any text. */
+  pageCount: number;
+  /** Raw vs. extracted character counts (numbers) — the density signal behind
+   *  the scanned/low-extraction triggers. Never the characters themselves. */
+  rawCharCount: number;
+  extractedCharCount: number;
+  /** Detected section boundaries by canonical name with line COUNTS only —
+   *  never the line text. This is the "where did the parser cut the document"
+   *  signal a maintainer needs to reproduce a mis-section. */
+  sections: ReproSection[];
+  /** Cardinality of the structured parse — counts/presence, never the values. */
+  parsedCounts: ReproParsedCounts;
+  /** Count of recovered link annotations — never the URLs themselves. */
+  linkAnnotationCount: number;
+  /** The reported disagreements as KIND/FIELD/CAUSE only — never the
+   *  heuristicValue/llmValue text. Empty when the reporter had not run the
+   *  opt-in WebLLM comparison. */
+  disagreements: ReproDisagreement[];
+}
+
+/** A detected section: its canonical name (enum) and how many lines it held. */
+export interface ReproSection {
+  name: SectionName | "profile";
+  lineCount: number;
+}
+
+/** Structured-parse cardinality. Presence flags + counts only — never the
+ *  parsed values. A boolean cannot leak an email; a count cannot leak a name. */
+export interface ReproParsedCounts {
+  hasFullName: boolean;
+  hasEmail: boolean;
+  hasPhone: boolean;
+  hasLocation: boolean;
+  hasSummary: boolean;
+  experienceCount: number;
+  educationCount: number;
+  skillsCount: number;
+}
+
+/** A disagreement reduced to its non-PII shape. The value fields
+ *  (`heuristicValue` / `llmValue`) of the source `ParseDisagreement` are
+ *  intentionally NOT copied — they may contain literal résumé text. */
+export interface ReproDisagreement {
+  kind: ParseDisagreement["kind"];
+  /** A section/field NAME (`"experience"`, `"email"`) — an enum-like key from
+   *  the detector, never a value. */
+  field: string;
+  likelyCause?: LayoutTrigger;
+}
+
+/**
+ * Build the structure-only repro artifact from a cascade result and, optionally,
+ * the disagreements the reporter had already characterized via the WebLLM pass.
+ *
+ * Reads ONLY counts, section names, presence flags, and enums. Never reads
+ * `rawText`, `markdown`, link URLs, parsed scalar values, section line text, or
+ * `ParseDisagreement.heuristicValue` / `llmValue`. See the file header for the
+ * PII contract this upholds.
+ */
+export function buildReproArtifact(
+  result: CascadeResult,
+  disagreements: readonly ParseDisagreement[] = [],
+): ReproArtifact {
+  return {
+    artifactVersion: REPRO_ARTIFACT_VERSION,
+    cascadeVersion: CASCADE_VERSION,
+    triggers: [...result.triggers],
+    sectionSource: result.sections.source,
+    pageCount: result.diagnostics.pages,
+    rawCharCount: result.diagnostics.rawCharCount,
+    extractedCharCount: result.diagnostics.extractedCharCount,
+    sections: buildSections(result),
+    parsedCounts: buildParsedCounts(result),
+    linkAnnotationCount: result.linkAnnotations.length,
+    disagreements: disagreements.map((d) => ({
+      kind: d.kind,
+      field: d.field,
+      ...(d.likelyCause ? { likelyCause: d.likelyCause } : {}),
+    })),
+  };
+}
+
+/** Section boundaries: canonical name + line count, in document order. Reads
+ *  the `byName` map's KEYS (enum names) and array LENGTHS — never the lines. */
+function buildSections(result: CascadeResult): ReproSection[] {
+  const out: ReproSection[] = [];
+  for (const [name, lines] of result.sections.byName) {
+    out.push({ name, lineCount: lines.length });
+  }
+  return out;
+}
+
+/** Presence flags + counts off the structured parse. `present` returns a
+ *  BOOLEAN — the scalar VALUE never enters the artifact. */
+function buildParsedCounts(result: CascadeResult): ReproParsedCounts {
+  const p = result.parsed;
+  const present = (v: string | null | undefined): boolean =>
+    v != null && v.trim().length > 0;
+  return {
+    hasFullName: present(p.full_name),
+    hasEmail: present(p.email),
+    hasPhone: present(p.phone),
+    hasLocation: present(p.location),
+    hasSummary: present(p.summary),
+    experienceCount: p.experience.length,
+    educationCount: p.education.length,
+    skillsCount: p.skills.length,
+  };
+}

--- a/src/lib/webllm/critique-resume.test.ts
+++ b/src/lib/webllm/critique-resume.test.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Unit tests for critiqueResumeWithLlm (issue #244).
+ *
+ * All tests mock the WebLlmEngine so no real model download happens.
+ * The mock controls `engine.chat.completions.create` to return deterministic
+ * JSON strings, verifying the coercion + shape of the returned `ResumeCritique`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  critiqueResumeWithLlm,
+  type ResumeCritique,
+} from "./critique-resume.ts";
+import type { WebLlmEngine } from "./types.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/** A minimal parsed resume with two experience bullets and a summary. */
+const PARSED_WITH_BULLETS: HeuristicParsedResume = {
+  full_name: "Jane Smith",
+  email: "jane@example.com",
+  phone: undefined,
+  location: undefined,
+  summary: "Experienced engineer with a passion for distributed systems.",
+  skills: ["Python", "Go", "Kubernetes"],
+  experience: [
+    {
+      company: "Acme Corp",
+      title: "Senior Engineer",
+      description: "Led migration to Kubernetes\nHelped the team with deployments",
+    },
+    {
+      company: "Beta Inc",
+      title: "Engineer",
+      description: "Worked on various features",
+    },
+  ],
+  education: [
+    { institution: "State University", degree: "B.S. Computer Science" },
+  ],
+};
+
+/** A parsed resume with no bullets, no summary, and no skills. */
+const PARSED_EMPTY: HeuristicParsedResume = {
+  full_name: "John Doe",
+  email: undefined,
+  phone: undefined,
+  location: undefined,
+  summary: undefined,
+  skills: [],
+  experience: [],
+  education: [],
+};
+
+// ── Mock engine builder ───────────────────────────────────────────────────────
+
+/**
+ * Build a mock WebLlmEngine that returns `responses` in call order.
+ * Each call to `engine.chat.completions.create` pops the next response.
+ * If responses run out, returns an empty content string.
+ */
+function makeMockEngine(responses: string[]): WebLlmEngine {
+  let callIndex = 0;
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockImplementation(async () => {
+          const content = responses[callIndex] ?? "";
+          callIndex++;
+          return { choices: [{ message: { content } }] };
+        }),
+      },
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("critiqueResumeWithLlm", () => {
+  it("returns correct finding shape for each bullet", async () => {
+    // Pass 1 response: one JSON object per line, covering the 3 bullets.
+    const bulletResponse = [
+      `{"bullet":"Led migration to Kubernetes","issue":"no_quantification","suggestion":"Led migration of 12 microservices to Kubernetes, reducing deploy time by 40%"}`,
+      `{"bullet":"Helped the team with deployments","issue":"weak_verb","suggestion":"Streamlined team deployment pipeline using Helm"}`,
+      `{"bullet":"Worked on various features","issue":"vague","suggestion":"Implemented user authentication feature reducing login latency by 200ms"}`,
+    ].join("\n");
+
+    // Pass 2 response: meta JSON.
+    const metaResponse = `{"missingSections":[],"summaryFeedback":"Summary is clear but could mention key technologies."}`;
+
+    const engine = makeMockEngine([bulletResponse, metaResponse]);
+    const result: ResumeCritique = await critiqueResumeWithLlm(
+      PARSED_WITH_BULLETS,
+      engine,
+    );
+
+    // Bullet findings shape
+    expect(result.bulletFindings).toHaveLength(3);
+
+    const [f0, f1, f2] = result.bulletFindings;
+
+    expect(f0!.issue).toBe("no_quantification");
+    expect(f0!.bullet).toBe("Led migration to Kubernetes");
+    expect(f0!.suggestion).toContain("microservices");
+
+    expect(f1!.issue).toBe("weak_verb");
+    expect(f1!.suggestion).toContain("Streamlined");
+
+    expect(f2!.issue).toBe("vague");
+    expect(f2!.suggestion).toBeDefined();
+
+    // Missing sections
+    expect(result.missingSections).toEqual([]);
+
+    // Summary feedback
+    expect(result.summaryFeedback).toContain("key technologies");
+  });
+
+  it("returns missing sections when the model flags them", async () => {
+    // Empty resume — no bullets, so bullet pass is SKIPPED and only the meta
+    // pass runs. The engine is only called once (meta only).
+    const metaResponse = `{"missingSections":["summary","skills","experience"],"summaryFeedback":null}`;
+
+    const engine = makeMockEngine([metaResponse]);
+    const result = await critiqueResumeWithLlm(PARSED_EMPTY, engine);
+
+    expect(result.bulletFindings).toHaveLength(0);
+    expect(result.missingSections).toEqual(["summary", "skills", "experience"]);
+    expect(result.summaryFeedback).toBeUndefined();
+  });
+
+  it("pads with 'ok' findings if model returns fewer lines than bullets", async () => {
+    // Only one finding returned for 3 bullets.
+    const bulletResponse = `{"bullet":"Led migration to Kubernetes","issue":"no_quantification","suggestion":"Add numbers"}`;
+    const metaResponse = `{"missingSections":[]}`;
+
+    const engine = makeMockEngine([bulletResponse, metaResponse]);
+    const result = await critiqueResumeWithLlm(PARSED_WITH_BULLETS, engine);
+
+    expect(result.bulletFindings).toHaveLength(3);
+    // Second + third padded to "ok"
+    expect(result.bulletFindings[1]!.issue).toBe("ok");
+    expect(result.bulletFindings[2]!.issue).toBe("ok");
+  });
+
+  it("degrades gracefully when engine throws on the bullet pass", async () => {
+    const engine: WebLlmEngine = {
+      chat: {
+        completions: {
+          create: vi.fn()
+            .mockRejectedValueOnce(new Error("OOM"))
+            .mockResolvedValueOnce({ choices: [{ message: { content: `{"missingSections":[]}` } }] }),
+        },
+      },
+    };
+
+    const result = await critiqueResumeWithLlm(PARSED_WITH_BULLETS, engine);
+
+    // All bullets padded to "ok" since engine threw on pass 1
+    expect(result.bulletFindings).toHaveLength(3);
+    for (const f of result.bulletFindings) {
+      expect(f.issue).toBe("ok");
+    }
+    // Meta pass still ran
+    expect(result.missingSections).toEqual([]);
+  });
+
+  it("degrades gracefully when engine throws on the meta pass", async () => {
+    const bulletResponse = [
+      `{"bullet":"Led migration to Kubernetes","issue":"ok"}`,
+      `{"bullet":"Helped the team with deployments","issue":"weak_verb"}`,
+      `{"bullet":"Worked on various features","issue":"vague"}`,
+    ].join("\n");
+
+    const engine: WebLlmEngine = {
+      chat: {
+        completions: {
+          create: vi.fn()
+            .mockResolvedValueOnce({ choices: [{ message: { content: bulletResponse } }] })
+            .mockRejectedValueOnce(new Error("timeout")),
+        },
+      },
+    };
+
+    const result = await critiqueResumeWithLlm(PARSED_WITH_BULLETS, engine);
+
+    // Bullet findings from pass 1
+    expect(result.bulletFindings[0]!.issue).toBe("ok");
+    expect(result.bulletFindings[1]!.issue).toBe("weak_verb");
+    // Meta pass failed — safe empty defaults
+    expect(result.missingSections).toEqual([]);
+    expect(result.summaryFeedback).toBeUndefined();
+  });
+
+  it("handles unknown issue values by coercing to 'ok'", async () => {
+    const bulletResponse = `{"bullet":"Led migration","issue":"unknown_thing","suggestion":"hmm"}`;
+    const metaResponse = `{"missingSections":[]}`;
+
+    const engine = makeMockEngine([bulletResponse, metaResponse]);
+    const result = await critiqueResumeWithLlm(PARSED_WITH_BULLETS, engine);
+
+    expect(result.bulletFindings[0]!.issue).toBe("ok");
+    // Other 2 bullets padded to ok
+    expect(result.bulletFindings[1]!.issue).toBe("ok");
+  });
+
+  it("returns empty bulletFindings when there are no bullets", async () => {
+    const metaResponse = `{"missingSections":["summary","skills"],"summaryFeedback":null}`;
+    // Only one call expected (meta pass); bullet pass skipped entirely.
+    const engine = makeMockEngine([metaResponse]);
+    const result = await critiqueResumeWithLlm(PARSED_EMPTY, engine);
+
+    expect(result.bulletFindings).toHaveLength(0);
+    expect(result.missingSections).toContain("summary");
+  });
+});

--- a/src/lib/webllm/critique-resume.ts
+++ b/src/lib/webllm/critique-resume.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * critique-resume.ts — on-device LLM quality judge (issue #244).
+ *
+ * Runs an on-device WebLLM pass to judge *content quality* rather than
+ * structural presence (which the heuristic scorer already covers). The LLM
+ * examines each bullet and the resume as a whole, returning:
+ *
+ *   - Per-bullet findings: weak verb, missing quantification, vague language.
+ *   - Missing section names (e.g. "summary", "skills") the LLM infers are
+ *     absent from the parsed content.
+ *   - Optional plain-text feedback on the summary section.
+ *
+ * **Design choice — runs on the heuristic parse, not the LLM parse:**
+ * The critique is available to every user immediately after the heuristic
+ * cascade completes, with no prerequisite LLM pass. If the #243 escape hatch
+ * has already run, `ParsedCard` merges the LLM fields into `activeResult` and
+ * passes that down — so the critique still sees the best available parse.
+ * Running critique on whichever parse is currently "active" means one crisp,
+ * well-typed input (`HeuristicParsedResume`) rather than a conditional union.
+ *
+ * **Prompt discipline:** the critique prompt targets a small on-device model
+ * (Qwen-2.5-1.5B). It asks for newline-delimited JSON *objects*, one per
+ * bullet, plus a final JSON object for section and summary findings — avoiding
+ * a single large JSON array that risks truncation mid-token.
+ *
+ * Pure logic only — no React, no hooks, no imports from src/hooks or
+ * src/components.
+ */
+
+import type { WebLlmEngine } from "./types.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface BulletFinding {
+  /** The original bullet text (trimmed). */
+  bullet: string;
+  /** The quality category the LLM assigned. */
+  issue: "no_quantification" | "weak_verb" | "vague" | "ok";
+  /**
+   * Optional short suggestion for `no_quantification`, `weak_verb`, or
+   * `vague` issues. Absent for `ok` findings and when the model omits it.
+   */
+  suggestion?: string;
+}
+
+export interface ResumeCritique {
+  /** One finding per non-blank bullet, in document order. */
+  bulletFindings: BulletFinding[];
+  /**
+   * Section names the LLM believes are missing from the resume.
+   * Examples: `["summary", "skills"]`. Empty when nothing is missing.
+   */
+  missingSections: string[];
+  /**
+   * Brief plain-text quality note on the summary paragraph, when one was
+   * found in the parsed content. Absent when there is no summary.
+   */
+  summaryFeedback?: string;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+const BULLET_SYSTEM_PROMPT = `You are a resume quality judge. For each bullet point below, classify it with one JSON object per line (no wrapping array). Each object must have:
+  "bullet": the original bullet text
+  "issue": one of "no_quantification", "weak_verb", "vague", or "ok"
+  "suggestion": a short improved version (omit for "ok")
+
+Rules:
+- "no_quantification": bullet lacks any number, metric, or measurable outcome
+- "weak_verb": starts with a passive or weak verb (was, helped, assisted, worked on, etc.)
+- "vague": too generic to be meaningful even if it has a verb and a number
+- "ok": bullet is clear, starts with a strong action verb, and has a metric or concrete outcome
+Output ONLY the JSON objects, one per line. No markdown, no explanation.`;
+
+const META_SYSTEM_PROMPT = `You are a resume quality judge. Given the resume content summary below, respond with a single JSON object:
+  "missingSections": array of section names absent from this resume (choose from: "summary", "skills", "experience", "education"); empty array if nothing is missing
+  "summaryFeedback": a 1-sentence plain-text note on the summary quality (omit key if no summary exists)
+
+Output ONLY the JSON object. No markdown, no explanation.`;
+
+/** Collect all non-blank bullet texts from the parsed resume. */
+function collectBullets(parsed: HeuristicParsedResume): string[] {
+  const bullets: string[] = [];
+  for (const exp of parsed.experience ?? []) {
+    if (!exp.description) continue;
+    for (const line of exp.description.split("\n")) {
+      const t = line.replace(/^[\s•\-–*]+/, "").trim();
+      if (t.length > 0) bullets.push(t);
+    }
+  }
+  return bullets;
+}
+
+/** Parse a single JSON object from a line, returning null on failure. */
+function tryParseJson(line: string): Record<string, unknown> | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const v = JSON.parse(trimmed) as unknown;
+    if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+      return v as Record<string, unknown>;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+const ISSUE_VALUES = new Set<string>([
+  "no_quantification",
+  "weak_verb",
+  "vague",
+  "ok",
+]);
+
+function coerceBulletFinding(
+  raw: Record<string, unknown>,
+  fallbackBullet: string,
+): BulletFinding {
+  const bullet =
+    typeof raw["bullet"] === "string" ? raw["bullet"].trim() : fallbackBullet;
+  const rawIssue = typeof raw["issue"] === "string" ? raw["issue"] : "";
+  const issue = ISSUE_VALUES.has(rawIssue)
+    ? (rawIssue as BulletFinding["issue"])
+    : "ok";
+  const suggestion =
+    typeof raw["suggestion"] === "string" && raw["suggestion"].trim()
+      ? raw["suggestion"].trim()
+      : undefined;
+  return { bullet, issue, suggestion };
+}
+
+function coerceMeta(raw: Record<string, unknown>): {
+  missingSections: string[];
+  summaryFeedback?: string;
+} {
+  const rawMissing = raw["missingSections"];
+  const missingSections = Array.isArray(rawMissing)
+    ? rawMissing.filter((s): s is string => typeof s === "string")
+    : [];
+  const summaryFeedback =
+    typeof raw["summaryFeedback"] === "string" && raw["summaryFeedback"].trim()
+      ? raw["summaryFeedback"].trim()
+      : undefined;
+  return { missingSections, summaryFeedback };
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/**
+ * Run an on-device LLM critique of the resume.
+ *
+ * Accepts the heuristic (or LLM-overridden) parsed resume and the already-
+ * loaded engine. Returns a `ResumeCritique` with per-bullet findings and
+ * missing-section flags. This function NEVER throws — on any engine or parse
+ * failure it returns a safe empty shape so the UI degrades gracefully.
+ *
+ * Two passes:
+ *   1. Bullet critique — one JSON object per line.
+ *   2. Meta critique — one JSON object covering missing sections + summary.
+ */
+export async function critiqueResumeWithLlm(
+  parsed: HeuristicParsedResume,
+  engine: WebLlmEngine,
+): Promise<ResumeCritique> {
+  const bullets = collectBullets(parsed);
+
+  // ── Pass 1: Per-bullet critique ─────────────────────────────────────────────
+  let bulletFindings: BulletFinding[] = [];
+  if (bullets.length > 0) {
+    const bulletUserPrompt = bullets
+      .map((b, i) => `${i + 1}. ${b}`)
+      .join("\n");
+    // Max tokens: ~60 per bullet (issue + suggestion) + headroom.
+    const bulletMaxTokens = Math.min(64 * bullets.length + 128, 1200);
+
+    let bulletRaw = "";
+    try {
+      const response = await engine.chat.completions.create({
+        messages: [
+          { role: "system", content: BULLET_SYSTEM_PROMPT },
+          { role: "user", content: `Bullets:\n${bulletUserPrompt}` },
+        ],
+        temperature: 0,
+        max_tokens: bulletMaxTokens,
+      });
+      bulletRaw = response.choices[0]?.message?.content ?? "";
+    } catch (err) {
+      console.warn("[critique-resume] bullet pass failed:", err);
+    }
+
+    if (bulletRaw.trim()) {
+      const lines = bulletRaw.split("\n");
+      // Try to match lines to bullets. Accept as many valid JSON lines as we
+      // get — partial output is still useful.
+      let bulletIdx = 0;
+      for (const line of lines) {
+        if (bulletIdx >= bullets.length) break;
+        const obj = tryParseJson(line);
+        if (obj === null) continue;
+        bulletFindings.push(coerceBulletFinding(obj, bullets[bulletIdx]!));
+        bulletIdx++;
+      }
+      // If the model returned fewer findings than bullets (truncation), pad
+      // with "ok" so the UI can still show all bullets without gaps.
+      for (let i = bulletFindings.length; i < bullets.length; i++) {
+        bulletFindings.push({ bullet: bullets[i]!, issue: "ok" });
+      }
+    } else {
+      // Engine returned nothing — treat all as ok, critique still renders
+      // the meta section.
+      bulletFindings = bullets.map((b) => ({ bullet: b, issue: "ok" as const }));
+    }
+  }
+
+  // ── Pass 2: Meta critique (missing sections + summary) ──────────────────────
+  let missingSections: string[] = [];
+  let summaryFeedback: string | undefined;
+
+  // Build a compact content summary for the meta pass.
+  const hasExperience = (parsed.experience ?? []).length > 0;
+  const hasEducation = (parsed.education ?? []).length > 0;
+  const hasSkills = (parsed.skills ?? []).length > 0;
+  const hasSummary = typeof parsed.summary === "string" && parsed.summary.trim().length > 0;
+  const summaryText = hasSummary ? (parsed.summary as string) : "";
+
+  const metaContent = [
+    `summary: ${hasSummary ? `"${summaryText.slice(0, 300)}"` : "absent"}`,
+    `skills: ${hasSkills ? `${(parsed.skills ?? []).length} listed` : "absent"}`,
+    `experience: ${hasExperience ? `${(parsed.experience ?? []).length} role(s)` : "absent"}`,
+    `education: ${hasEducation ? `${(parsed.education ?? []).length} entry` : "absent"}`,
+    `bullet count: ${bullets.length}`,
+  ].join("\n");
+
+  let metaRaw = "";
+  try {
+    const response = await engine.chat.completions.create({
+      messages: [
+        { role: "system", content: META_SYSTEM_PROMPT },
+        { role: "user", content: `Resume sections:\n${metaContent}` },
+      ],
+      temperature: 0,
+      max_tokens: 256,
+    });
+    metaRaw = response.choices[0]?.message?.content ?? "";
+  } catch (err) {
+    console.warn("[critique-resume] meta pass failed:", err);
+  }
+
+  if (metaRaw.trim()) {
+    // The meta response is a single JSON object — find the first `{…}` block.
+    const firstBrace = metaRaw.indexOf("{");
+    const lastBrace = metaRaw.lastIndexOf("}");
+    if (firstBrace !== -1 && lastBrace > firstBrace) {
+      const obj = tryParseJson(metaRaw.slice(firstBrace, lastBrace + 1));
+      if (obj !== null) {
+        const coerced = coerceMeta(obj);
+        missingSections = coerced.missingSections;
+        summaryFeedback = coerced.summaryFeedback;
+      }
+    }
+  }
+
+  return { bulletFindings, missingSections, summaryFeedback };
+}

--- a/src/lib/webllm/critique-resume.ts
+++ b/src/lib/webllm/critique-resume.ts
@@ -149,6 +149,140 @@ function coerceMeta(raw: Record<string, unknown>): {
   return { missingSections, summaryFeedback };
 }
 
+/**
+ * Call the engine with a system+user prompt, returning the raw text content.
+ * NEVER throws — on any engine failure it logs and returns an empty string so
+ * the caller's parse step degrades to safe defaults. `label` names the pass in
+ * the warning so failures stay diagnosable.
+ */
+async function callEngine(
+  engine: WebLlmEngine,
+  systemPrompt: string,
+  userPrompt: string,
+  maxTokens: number,
+  label: string,
+): Promise<string> {
+  try {
+    const response = await engine.chat.completions.create({
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      temperature: 0,
+      max_tokens: maxTokens,
+    });
+    return response.choices[0]?.message?.content ?? "";
+  } catch (err) {
+    console.warn(`[critique-resume] ${label} pass failed:`, err);
+    return "";
+  }
+}
+
+/**
+ * Parse the bullet-pass response into one finding per bullet, in order.
+ * Empty/partial output is padded with `ok` so every bullet renders without
+ * gaps.
+ */
+function parseBulletResponse(
+  bulletRaw: string,
+  bullets: string[],
+): BulletFinding[] {
+  // Engine returned nothing — treat all as ok; the meta section still renders.
+  if (!bulletRaw.trim()) {
+    return bullets.map((b) => ({ bullet: b, issue: "ok" as const }));
+  }
+  const findings: BulletFinding[] = [];
+  // Match lines to bullets. Accept as many valid JSON lines as we get —
+  // partial output is still useful.
+  let bulletIdx = 0;
+  for (const line of bulletRaw.split("\n")) {
+    if (bulletIdx >= bullets.length) break;
+    const obj = tryParseJson(line);
+    if (obj === null) continue;
+    findings.push(coerceBulletFinding(obj, bullets[bulletIdx]!));
+    bulletIdx++;
+  }
+  // If the model returned fewer findings than bullets (truncation), pad with
+  // "ok" so the UI can still show all bullets without gaps.
+  for (let i = findings.length; i < bullets.length; i++) {
+    findings.push({ bullet: bullets[i]!, issue: "ok" });
+  }
+  return findings;
+}
+
+/** Pass 1: per-bullet critique. Returns `[]` when there are no bullets. */
+async function runBulletPass(
+  bullets: string[],
+  engine: WebLlmEngine,
+): Promise<BulletFinding[]> {
+  if (bullets.length === 0) return [];
+  const userPrompt = bullets.map((b, i) => `${i + 1}. ${b}`).join("\n");
+  // Max tokens: ~60 per bullet (issue + suggestion) + headroom.
+  const maxTokens = Math.min(64 * bullets.length + 128, 1200);
+  const raw = await callEngine(
+    engine,
+    BULLET_SYSTEM_PROMPT,
+    `Bullets:\n${userPrompt}`,
+    maxTokens,
+    "bullet",
+  );
+  return parseBulletResponse(raw, bullets);
+}
+
+/** Build the compact content summary fed to the meta pass. */
+function buildMetaContent(
+  parsed: HeuristicParsedResume,
+  bulletCount: number,
+): string {
+  const hasExperience = (parsed.experience ?? []).length > 0;
+  const hasEducation = (parsed.education ?? []).length > 0;
+  const hasSkills = (parsed.skills ?? []).length > 0;
+  const hasSummary =
+    typeof parsed.summary === "string" && parsed.summary.trim().length > 0;
+  const summaryText = hasSummary ? (parsed.summary as string) : "";
+
+  return [
+    `summary: ${hasSummary ? `"${summaryText.slice(0, 300)}"` : "absent"}`,
+    `skills: ${hasSkills ? `${(parsed.skills ?? []).length} listed` : "absent"}`,
+    `experience: ${hasExperience ? `${(parsed.experience ?? []).length} role(s)` : "absent"}`,
+    `education: ${hasEducation ? `${(parsed.education ?? []).length} entry` : "absent"}`,
+    `bullet count: ${bulletCount}`,
+  ].join("\n");
+}
+
+/** Extract the first `{…}` JSON block from the meta response and coerce it. */
+function parseMetaResponse(metaRaw: string): {
+  missingSections: string[];
+  summaryFeedback?: string;
+} {
+  if (!metaRaw.trim()) return { missingSections: [] };
+  const firstBrace = metaRaw.indexOf("{");
+  const lastBrace = metaRaw.lastIndexOf("}");
+  if (firstBrace === -1 || lastBrace <= firstBrace) {
+    return { missingSections: [] };
+  }
+  const obj = tryParseJson(metaRaw.slice(firstBrace, lastBrace + 1));
+  if (obj === null) return { missingSections: [] };
+  return coerceMeta(obj);
+}
+
+/** Pass 2: meta critique (missing sections + summary feedback). */
+async function runMetaPass(
+  parsed: HeuristicParsedResume,
+  bulletCount: number,
+  engine: WebLlmEngine,
+): Promise<{ missingSections: string[]; summaryFeedback?: string }> {
+  const metaContent = buildMetaContent(parsed, bulletCount);
+  const raw = await callEngine(
+    engine,
+    META_SYSTEM_PROMPT,
+    `Resume sections:\n${metaContent}`,
+    256,
+    "meta",
+  );
+  return parseMetaResponse(raw);
+}
+
 // ── Public entry point ────────────────────────────────────────────────────────
 
 /**
@@ -168,102 +302,11 @@ export async function critiqueResumeWithLlm(
   engine: WebLlmEngine,
 ): Promise<ResumeCritique> {
   const bullets = collectBullets(parsed);
-
-  // ── Pass 1: Per-bullet critique ─────────────────────────────────────────────
-  let bulletFindings: BulletFinding[] = [];
-  if (bullets.length > 0) {
-    const bulletUserPrompt = bullets
-      .map((b, i) => `${i + 1}. ${b}`)
-      .join("\n");
-    // Max tokens: ~60 per bullet (issue + suggestion) + headroom.
-    const bulletMaxTokens = Math.min(64 * bullets.length + 128, 1200);
-
-    let bulletRaw = "";
-    try {
-      const response = await engine.chat.completions.create({
-        messages: [
-          { role: "system", content: BULLET_SYSTEM_PROMPT },
-          { role: "user", content: `Bullets:\n${bulletUserPrompt}` },
-        ],
-        temperature: 0,
-        max_tokens: bulletMaxTokens,
-      });
-      bulletRaw = response.choices[0]?.message?.content ?? "";
-    } catch (err) {
-      console.warn("[critique-resume] bullet pass failed:", err);
-    }
-
-    if (bulletRaw.trim()) {
-      const lines = bulletRaw.split("\n");
-      // Try to match lines to bullets. Accept as many valid JSON lines as we
-      // get — partial output is still useful.
-      let bulletIdx = 0;
-      for (const line of lines) {
-        if (bulletIdx >= bullets.length) break;
-        const obj = tryParseJson(line);
-        if (obj === null) continue;
-        bulletFindings.push(coerceBulletFinding(obj, bullets[bulletIdx]!));
-        bulletIdx++;
-      }
-      // If the model returned fewer findings than bullets (truncation), pad
-      // with "ok" so the UI can still show all bullets without gaps.
-      for (let i = bulletFindings.length; i < bullets.length; i++) {
-        bulletFindings.push({ bullet: bullets[i]!, issue: "ok" });
-      }
-    } else {
-      // Engine returned nothing — treat all as ok, critique still renders
-      // the meta section.
-      bulletFindings = bullets.map((b) => ({ bullet: b, issue: "ok" as const }));
-    }
-  }
-
-  // ── Pass 2: Meta critique (missing sections + summary) ──────────────────────
-  let missingSections: string[] = [];
-  let summaryFeedback: string | undefined;
-
-  // Build a compact content summary for the meta pass.
-  const hasExperience = (parsed.experience ?? []).length > 0;
-  const hasEducation = (parsed.education ?? []).length > 0;
-  const hasSkills = (parsed.skills ?? []).length > 0;
-  const hasSummary = typeof parsed.summary === "string" && parsed.summary.trim().length > 0;
-  const summaryText = hasSummary ? (parsed.summary as string) : "";
-
-  const metaContent = [
-    `summary: ${hasSummary ? `"${summaryText.slice(0, 300)}"` : "absent"}`,
-    `skills: ${hasSkills ? `${(parsed.skills ?? []).length} listed` : "absent"}`,
-    `experience: ${hasExperience ? `${(parsed.experience ?? []).length} role(s)` : "absent"}`,
-    `education: ${hasEducation ? `${(parsed.education ?? []).length} entry` : "absent"}`,
-    `bullet count: ${bullets.length}`,
-  ].join("\n");
-
-  let metaRaw = "";
-  try {
-    const response = await engine.chat.completions.create({
-      messages: [
-        { role: "system", content: META_SYSTEM_PROMPT },
-        { role: "user", content: `Resume sections:\n${metaContent}` },
-      ],
-      temperature: 0,
-      max_tokens: 256,
-    });
-    metaRaw = response.choices[0]?.message?.content ?? "";
-  } catch (err) {
-    console.warn("[critique-resume] meta pass failed:", err);
-  }
-
-  if (metaRaw.trim()) {
-    // The meta response is a single JSON object — find the first `{…}` block.
-    const firstBrace = metaRaw.indexOf("{");
-    const lastBrace = metaRaw.lastIndexOf("}");
-    if (firstBrace !== -1 && lastBrace > firstBrace) {
-      const obj = tryParseJson(metaRaw.slice(firstBrace, lastBrace + 1));
-      if (obj !== null) {
-        const coerced = coerceMeta(obj);
-        missingSections = coerced.missingSections;
-        summaryFeedback = coerced.summaryFeedback;
-      }
-    }
-  }
-
+  const bulletFindings = await runBulletPass(bullets, engine);
+  const { missingSections, summaryFeedback } = await runMetaPass(
+    parsed,
+    bullets.length,
+    engine,
+  );
   return { bulletFindings, missingSections, summaryFeedback };
 }

--- a/src/lib/webllm/merge-override.test.ts
+++ b/src/lib/webllm/merge-override.test.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * mergeLlmParse (#243) — folds an LLM-recovered parse into the cascade result.
+ *
+ * Covers: scalar fields fall back to the original when the LLM omitted them;
+ * list fields only replace when the LLM returned at least one entry;
+ * `suggestedEscalation` is cleared; non-parse fields (rawText/markdown/layout)
+ * stay original.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mergeLlmParse } from "./merge-override.ts";
+import type { LlmParsedResume } from "./parse-resume.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import type { SectionName } from "../heuristics/regex.ts";
+
+function sectioned(): SectionedResume {
+  const byName = new Map<SectionName | "profile", readonly string[]>([
+    ["experience", ["orig bullet"]],
+  ]);
+  return { byName, accomplishmentSections: ["experience"], source: "regex" };
+}
+
+function baseResult(): CascadeResult {
+  return {
+    parsed: {
+      full_name: "Orig Name",
+      email: "orig@example.com",
+      phone: "(312) 555-0123",
+      location: "Orig City",
+      summary: "orig summary",
+      skills: ["orig-skill"],
+      experience: [
+        {
+          company: "Orig Co",
+          title: "Orig Title",
+          description: "orig desc",
+          is_current: true,
+        },
+      ],
+      education: [{ institution: "Orig U", degree: "BS" }],
+    },
+    confidence: 0.4,
+    fieldConfidence: {},
+    triggers: ["two_column"],
+    suggestedEscalation: "llm",
+    tiers: ["t0_layout", "t1_openresume"],
+    rawText: "ORIG RAW",
+    markdown: "ORIG MD",
+    sections: sectioned(),
+    linkAnnotations: [],
+    diagnostics: {
+      rawCharCount: 100,
+      extractedCharCount: 20,
+      pages: 1,
+      elapsedMs: 5,
+    },
+    timings: { t0_layout_ms: 1, t1_openresume_ms: 1 },
+  };
+}
+
+function llm(over: Partial<LlmParsedResume> = {}): LlmParsedResume {
+  return {
+    full_name: null,
+    email: null,
+    phone: null,
+    location: null,
+    summary: null,
+    skills: [],
+    experience: [],
+    education: [],
+    ...over,
+  };
+}
+
+describe("mergeLlmParse", () => {
+  it("overrides scalar fields when the LLM provides them", () => {
+    const merged = mergeLlmParse(
+      baseResult(),
+      llm({ full_name: "LLM Name", email: "llm@example.com" }),
+    );
+    expect(merged.parsed.full_name).toBe("LLM Name");
+    expect(merged.parsed.email).toBe("llm@example.com");
+    // Untouched scalar falls back to original.
+    expect(merged.parsed.location).toBe("Orig City");
+  });
+
+  it("keeps original list fields when the LLM returns none", () => {
+    const merged = mergeLlmParse(baseResult(), llm());
+    expect(merged.parsed.skills).toEqual(["orig-skill"]);
+    expect(merged.parsed.experience).toHaveLength(1);
+    expect(merged.parsed.experience[0]!.company).toBe("Orig Co");
+    expect(merged.parsed.education[0]!.institution).toBe("Orig U");
+  });
+
+  it("replaces list fields when the LLM returns entries, normalizing shape", () => {
+    const merged = mergeLlmParse(
+      baseResult(),
+      llm({
+        skills: ["llm-skill"],
+        experience: [
+          { company: "LLM Co", title: "LLM Title", description: "llm desc" },
+        ],
+        education: [{ institution: "LLM U", degree: "MS" }],
+      }),
+    );
+    expect(merged.parsed.skills).toEqual(["llm-skill"]);
+    expect(merged.parsed.experience[0]).toEqual({
+      company: "LLM Co",
+      title: "LLM Title",
+      description: "llm desc",
+      is_current: false,
+    });
+    expect(merged.parsed.education[0]).toEqual({
+      institution: "LLM U",
+      degree: "MS",
+    });
+  });
+
+  it("clears the escalation flag and preserves non-parse fields", () => {
+    const merged = mergeLlmParse(baseResult(), llm({ full_name: "X" }));
+    expect(merged.suggestedEscalation).toBe("none");
+    expect(merged.rawText).toBe("ORIG RAW");
+    expect(merged.markdown).toBe("ORIG MD");
+    expect(merged.triggers).toEqual(["two_column"]);
+  });
+});

--- a/src/lib/webllm/merge-override.ts
+++ b/src/lib/webllm/merge-override.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * merge-override.ts — fold an LLM-recovered parse into the original cascade
+ * result (issue #243 escape hatch).
+ *
+ * When the degenerate-case escape hatch recovers a parse, the UI re-renders the
+ * full result surface from the LLM fields. This is the pure merge that produces
+ * the synthetic `CascadeResult`:
+ *   - parse fields are overridden field-by-field (LLM value wins when present),
+ *   - `rawText` / `markdown` / layout fields stay original — the override is
+ *     parse-field only,
+ *   - `suggestedEscalation` is cleared to `"none"` since we've recovered.
+ *
+ * Pure logic only — no React. Kept out of the component so it stays unit-tested
+ * and the `useMemo` in `Result.tsx` stays trivial.
+ */
+
+import type { CascadeResult } from "../heuristics/types.ts";
+import type { LlmParsedResume } from "./parse-resume.ts";
+
+/**
+ * Build a synthetic `CascadeResult` that merges the LLM-parsed fields into the
+ * original result. Scalar fields fall back to the original when the LLM omitted
+ * them; list fields (skills/experience/education) only replace the original when
+ * the LLM returned at least one entry.
+ */
+export function mergeLlmParse(
+  result: CascadeResult,
+  llmOverride: LlmParsedResume,
+): CascadeResult {
+  return {
+    ...result,
+    suggestedEscalation: "none",
+    parsed: {
+      ...result.parsed,
+      full_name: llmOverride.full_name ?? result.parsed.full_name,
+      email: llmOverride.email ?? result.parsed.email,
+      phone: llmOverride.phone ?? result.parsed.phone,
+      location: llmOverride.location ?? result.parsed.location,
+      summary: llmOverride.summary ?? result.parsed.summary,
+      skills:
+        llmOverride.skills.length > 0 ? llmOverride.skills : result.parsed.skills,
+      experience:
+        llmOverride.experience.length > 0
+          ? llmOverride.experience.map((e) => ({
+              company: e.company,
+              title: e.title,
+              description: e.description,
+              is_current: false,
+            }))
+          : result.parsed.experience,
+      education:
+        llmOverride.education.length > 0
+          ? llmOverride.education.map((e) => ({
+              institution: e.institution,
+              degree: e.degree,
+            }))
+          : result.parsed.education,
+    },
+  };
+}

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
@@ -7,7 +7,7 @@
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "ocr",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
       "current_company",
       "current_title",


### PR DESCRIPTION
## Summary

Builds the WebLLM-powered M1 parser-hardening layer (epic #240) on top of the foundation provider (#241). Four children land together on one branch:

- **#242 Disagreement detector** — pure `diffParses(heuristic, llm, triggers)` surfaces what a generic ATS misses (dropped/merged roles, dropped sections, missing fields), correlated to the existing layout triggers. New "What an ATS misses" tab.
- **#243 Degenerate-case LLM escape hatch** — wires `suggestedEscalation:"llm"` on zero-experience / low-extraction (non-scanned) parses; opt-in WebGPU recovery pass re-renders from the LLM parse with `final_source:"llm_fallback"` provenance.
- **#244 On-device content-quality critique** — `critiqueResumeWithLlm` judges *quality* (un-quantified bullets, weak verbs, vague phrasing, missing sections), reusing the existing engine + per-bullet rewrite affordance.
- **#245 Gap-report loop** — extends `FeedbackPanel` with a **PII-redacted-by-construction** structure-only repro artifact (local download, never auto-upload) + an inline heuristic-vs-LLM diff so users report a *characterized* gap into the parser-hardening corpus.

All four are opt-in, WebGPU-gated, and fully client-side (no network after model download). Telemetry is anonymized + env-gated (count-only).

Resolves #242
Resolves #243
Resolves #244
Resolves #245
Refs #240

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (1255 passing)
- [ ] Manually verified in `npm run dev` / `npm run preview`

## Adversarial review

Independent adversarial reviewer (opus, `ecc:code-reviewer`) attacked the accumulated diff before this PR existed. **1 round, converged clean — zero blocking findings.**

**Verified, could not break:**
- **PII-by-construction (#245):** `ReproArtifact` admits only numbers/booleans/fixed enums — no free `string` value slot; `buildReproArtifact` never copies `heuristicValue`/`llmValue`/`rawText`/`markdown`/link URLs. Both sentinel-sweep tests (`repro-artifact.test.ts`, `useReportGap.test.tsx`) pass for real.
- **No-network invariant:** zero `fetch`/XHR/beacon/`navigator.*` in the 10 new files; only egress is env-gated count-only telemetry.
- **`diffParses` correctness:** exclusive experience partition, correct `merged_roles` vs `dropped_role` disambiguation, kind-aware `pickCause`; full branch coverage.
- **Hook lifecycle:** all 3 controllers pair `acquireInference`/`releaseInference` in `try/finally`, snapshot `modelId` before await, reset on input change.
- **`Result.tsx` integration:** `activeResult`/`activeScore` memo deps correct; stable hook order; critique resets when escape hatch swaps the parse.

**Cleanup pass applied** (non-blocking nits): dropped 3 dead `export`s (fallow), added `isBusy` guard parity in `useParseDisagreement.run`, removed `statusLabel` no-op wrapper, removed unused `dismiss` surface from the 3 new hooks. Re-verified green (typecheck/lint/1255 tests; fallow dead-exports 0.0%).

**Remaining nits for the human reviewer (non-blocking):**
- `trackLlmParseRan`/`trackLlmFallbackRan` re-emit `cascade_parse_completed` → opt-in WebLLM users double-count in a parse-completion funnel (documented, deliberate).
- Recovered-parse `activeScore` scores against original section bullets + lacks role dates → understated date-completeness on the recovery pass. Acceptable; noted for future.
- 278-line clone groups across the 3 controller hooks — shared `useWebLlmPass<T>` abstraction deferred (per-hook telemetry contracts differ); follow-up when a 4th consumer appears.
