### PR TITLE
feat(m5-positioning): hero card, static chrome, and image-PDF verdict

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>resumelint — PDF parser stress test for resumes</title>
+    <title>ResumeLint — see what a resume parser reads from your PDF</title>
     <meta
       name="description"
-      content="Drop a resume PDF; see what a generic text extractor reads back."
+      content="Drop a resume PDF and see what a generic parser pulls out of it. Free, private, open-source — your PDF never leaves your browser."
     />
     <meta name="color-scheme" content="light dark" />
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,13 +61,12 @@ export default function App() {
                   nearly half of job seekers
                 </span>{" "}
                 say they&apos;ve lost trust in a process they can&apos;t see into.
-                <a
-                  href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
-                  target="_blank"
-                  rel="nofollow noopener noreferrer"
-                  className="align-super text-[0.7em] text-brand-amber hover:underline"
-                  aria-label="Source: Greenhouse 2025 AI in Hiring Report"
-                >1</a>
+                <span
+                  aria-hidden="true"
+                  className="align-super text-xs text-brand-amber"
+                >
+                  1
+                </span>
               </p>
               <p className="max-w-prose border-l-2 border-brand-amber pl-4 text-base font-medium text-content-primary sm:text-lg">
                 ResumeLint shows you what a generic parser reads back from your

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-import { Chip, ErrorState, ErrorBoundary, Button } from "@design-system";
+import { Card, Chip, ErrorState, ErrorBoundary, Button } from "@design-system";
 import { DropZone } from "./components/DropZone";
 import { Result } from "./components/Result";
 import { PageShell } from "./components/features/PageShell.tsx";
@@ -40,16 +40,53 @@ export default function App() {
           <Chip icon="⚡">A few seconds</Chip>
           <Chip icon="🔒">Runs in your browser</Chip>
           <Chip icon="✓">No signup required</Chip>
+          <Chip icon="✉️">No email collected</Chip>
+          <Chip icon="📊">Score, not a verdict</Chip>
         </>
       }
     >
       {state.phase !== "done" && (
-        <section className="flex flex-col gap-3">
-          <p className="max-w-prose text-sm text-content-secondary">
-            Drop a resume PDF below to see what a generic text extractor reads
-            back. This is a diagnostic — not a verdict from any specific
-            applicant tracking system.
-          </p>
+        <section className="flex flex-col gap-6">
+          {(state.phase === "idle" || state.phase === "error") && (
+            <Card className="flex flex-col gap-5 bg-surface-card-warm">
+              <h2 className="max-w-prose text-2xl font-semibold leading-snug tracking-tight text-content-primary sm:text-3xl">
+                Screeners don&apos;t read your PDF.{" "}
+                <span className="font-normal text-content-secondary">
+                  They read what a parser pulls out of it.
+                </span>
+              </h2>
+              <p className="max-w-prose text-sm text-content-muted">
+                AI is now part of most hiring pipelines — and{" "}
+                <span className="font-medium text-content-secondary">
+                  nearly half of job seekers
+                </span>{" "}
+                say they&apos;ve lost trust in a process they can&apos;t see into.
+                <a
+                  href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                  className="align-super text-[0.7em] text-brand-amber hover:underline"
+                  aria-label="Source: Greenhouse 2025 AI in Hiring Report"
+                >1</a>
+              </p>
+              <p className="max-w-prose border-l-2 border-brand-amber pl-4 text-base font-medium text-content-primary sm:text-lg">
+                ResumeLint shows you what a generic parser reads back from your
+                resume — free, private, open-source.
+              </p>
+              <p className="text-xs text-content-muted">
+                Source:{" "}
+                <a
+                  href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                  className="hover:underline"
+                >
+                  Greenhouse, 2025 AI in Hiring Report (4,100+ job seekers and hiring managers)
+                </a>
+              </p>
+            </Card>
+          )}
+
           <DropZone
             onFile={handleFile}
             disabled={state.phase === "parsing"}

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -288,26 +288,34 @@ function LimitedParsingCard({
   const links = result.linkAnnotations;
   const uniqueUrls = Array.from(new Set(links.map((l) => l.url)));
 
+  const pages = result.diagnostics.pages;
+
   return (
     <Card className="flex flex-col gap-5 shadow-xs">
+      {/* 1. Header row */}
       <header className="flex items-center justify-between">
-        <StatusBadge tone="limited">Limited parsing</StatusBadge>
+        <span className="flex items-center gap-3">
+          <StatusBadge tone="limited">Not machine-readable</StatusBadge>
+          <span className="text-xs text-content-muted">
+            {pages} page{pages === 1 ? "" : "s"}
+          </span>
+        </span>
         <Button variant="link" className="text-content-primary" onClick={onReset}>
           Try a different PDF
         </Button>
       </header>
 
-      <div>
-        <h2 className="text-base font-semibold">
-          Some text wasn't readable in this PDF
+      {/* 2. Verdict block */}
+      <div role="status">
+        <h2 className="text-lg font-semibold">
+          A generic parser read almost nothing from this PDF.
         </h2>
-        <p className="mt-1 text-sm text-content-tertiary">
-          {result.diagnostics.pages} page
-          {result.diagnostics.pages === 1 ? "" : "s"} scanned. Below is what we
-          could recover.
+        <p className="mt-2 text-sm text-content-secondary">
+          Most text-based résumé screeners face the same challenge — they see almost nothing.
         </p>
       </div>
 
+      {/* 3. Recovered links — visually primary content */}
       <section className="flex flex-col gap-2">
         <h3 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
           Recovered links
@@ -334,16 +342,21 @@ function LimitedParsingCard({
         )}
       </section>
 
-      <hr className="border-border-light" />
+      {/* 4. Fix hint — plain text, no second CTA button */}
+      <p className="text-sm text-content-tertiary">
+        Fix: re-export as a text-based PDF — not a scanned image or &ldquo;print to image&rdquo;.
+      </p>
 
-      <section className="flex flex-col gap-2">
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-          What happened
-        </h3>
-        <p className="text-sm text-content-secondary">
+      {/* 5. "Why did this happen?" disclosure — collapsed by default */}
+      <hr className="border-border-light" />
+      <details className="text-sm">
+        <summary className="cursor-pointer text-content-secondary hover:text-content-primary">
+          Why did this happen?
+        </summary>
+        <p className="mt-2 text-content-secondary">
           {FONTS_UNMAPPABLE_BLURB}
         </p>
-      </section>
+      </details>
     </Card>
   );
 }

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -311,7 +311,7 @@ function LimitedParsingCard({
           A generic parser read almost nothing from this PDF.
         </h2>
         <p className="mt-2 text-sm text-content-secondary">
-          Most text-based résumé screeners face the same challenge — they see almost nothing.
+          Most text-based resume screeners face the same challenge — they see almost nothing.
         </p>
       </div>
 

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -85,7 +85,7 @@ export function PageShell({
       {children}
 
       <footer className="mt-auto flex flex-col gap-2 border-t border-border-light pt-6 text-xs text-content-tertiary">
-        <p>Your PDF stays in this browser tab.</p>
+        <p>Your PDF stays in this browser tab — it never enters an AI training pipeline.</p>
         <div className="flex flex-wrap gap-x-4 gap-y-1">
           <a
             href="https://github.com/resumelint-org/resumelint/blob/main/LICENSE"


### PR DESCRIPTION
## Summary

M5 Launch Readiness positioning epic — three locked-spec issues landed as one accumulated commit. Leads every surface with the **parsing mechanic**, holds the privacy stance plainly, no fear-mongering, no competitor language.

- **#264** — sourced positioning hero card on the parser-audit landing page (`src/App.tsx`). Mechanic-led headline + independently-cited (Greenhouse) trust stat; shows only on `idle`/`error`, collapses on drop.
- **#265** — carry the positioning into static chrome: `<title>`/meta (`index.html`), two header chips ("No email collected", "Score, not a verdict"), footer AI-training line (`PageShell.tsx`).
- **#266** — elevate the image-PDF (`fonts_unmappable`) case as a loud verdict headline in `LimitedParsingCard` (`src/components/Result.tsx`); recovered links stay visually primary, "Why did this happen?" collapsed into `<details>`.

Closes #264
Closes #265
Closes #266

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (style guard)
- [x] `npm run test` green (1279 tests)
- [x] `npm run verify` gate passed on push
- [x] Manually verify hero phase-gating + dark mode in `npm run preview`

## Adversarial review

**Round 1 — converged clean (0 blocking).** Independent adversarial reviewer (opus) traced the full accumulated diff.

**Verified (most-likely-to-break, all hold):**
- Phase-gating: `ParseState = "idle"|"parsing"|"done"|"error"`; hero gate `(idle||error)` correct, DropZone parsing status preserved.
- All semantic tokens resolve (`bg-surface-card-warm` → `#f1f5f9`/`#1e293b`); `Card` bg-override precedent confirmed.
- `result.diagnostics.pages` is a required `number` — never renders `undefined`.
- No heading-level skip (h1 wordmark → h2 hero/verdict → h3 links).
- **Greenhouse citation verified against the live report**: "nearly half" ↔ 46% job-seeker trust decline. Sourced, not invented.
- No prevalence figure (#266); external anchors all `rel="nofollow noopener noreferrer"`; only external domain is the cited Greenhouse source (no competitor).
- Footer AI-training claim holds for `/jd-fit` too (resume bytes never leave the browser).

**Blocking:** none.

**Nits (non-blocking, human eyeball):**
1. `role="status"` on the static verdict block (`Result.tsx`) — reviewer flags as no-op/possible double-announce; **kept intentionally** per #266 locked spec ("so screen readers announce it").
2. Five chips — "No signup required" + "No email collected" read close; technically distinct (account vs contact capture), meets AC.
3. `résumé`/`resume` spelling drift between hero and `Result.tsx` consequence line.
4. Footer "never enters an AI training pipeline" — true by construction but an unprovable negative.
