### PR TITLE
fix(score): drop parser blame from content-only verdict copy (#214)

### DIFF
--- a/src/lib/score/recommendation.test.ts
+++ b/src/lib/score/recommendation.test.ts
@@ -110,7 +110,7 @@ describe("getScoreRecommendation", () => {
       }),
     );
     expect(msg).toMatch(/add metrics/i);
-    expect(msg).toContain("A generic parser gets most of this"); // overall 70 → medium tier
+    expect(msg).toContain("This is close"); // overall 70 → medium tier
   });
 
   it("points at Structure when it is the weakest gradable dimension", () => {
@@ -177,20 +177,62 @@ describe("getScoreRecommendation", () => {
       }),
     );
     expect(msg).toMatch(/add a few quantified bullets/i);
-    expect(msg).toContain("A generic extractor struggles here");
+    expect(msg).toContain("This has clear gaps to close");
   });
 
   it("uses the matching band opener for each tier", () => {
     const weakSpec = { specificity: { score: 8, max: 40 } };
     expect(
       getScoreRecommendation(makeScore({ overall: 85, ...weakSpec })),
-    ).toContain("Most generic parsers should read this cleanly");
+    ).toContain("This is in solid shape");
     expect(
       getScoreRecommendation(makeScore({ overall: 65, ...weakSpec })),
-    ).toContain("A generic parser gets most of this");
+    ).toContain("This is close");
     expect(
       getScoreRecommendation(makeScore({ overall: 40, ...weakSpec })),
-    ).toContain("A generic extractor struggles here");
+    ).toContain("This has clear gaps to close");
+  });
+
+  it("keeps content-only messages free of parser/extractor language on the no-layout-flag path (issue #214)", () => {
+    // Regression guard: earlier BAND_OPENER wording ("A generic extractor
+    // struggles here" etc.) misattributed pure content weakness to a parser
+    // failure — see #214. The layout-penalty branch of getScoreRecommendation
+    // legitimately mentions parsers ("scramble it for many parsers"); this
+    // test only exercises the content-only path (multiplier === 1, scanned
+    // false, no triggers — all defaults from makeScore) and asserts the
+    // returned sentence never mentions the parser or the extractor.
+    //
+    // Parametrized over every tier × every weakest-dimension path so a future
+    // edit reintroducing "parser" vocabulary in any BAND_OPENER value OR any
+    // dimensionStep() branch is caught on the same test.
+    const weakestBy: Record<
+      "specificity" | "structure" | "completeness",
+      Parameters<typeof makeScore>[0]
+    > = {
+      specificity: {
+        specificity: { score: 8, max: 40 },
+        structure: { score: 27, max: 30 },
+        completeness: { score: 27, max: 30, missing: [] },
+      },
+      structure: {
+        specificity: { score: 36, max: 40 },
+        structure: { score: 6, max: 30 },
+        completeness: { score: 27, max: 30, missing: [] },
+      },
+      completeness: {
+        specificity: { score: 36, max: 40 },
+        structure: { score: 27, max: 30 },
+        completeness: { score: 3, max: 30, missing: ["phone", "location"] },
+      },
+    };
+    for (const overall of [85, 65, 40]) {
+      for (const weakest of ["specificity", "structure", "completeness"] as const) {
+        const msg = getScoreRecommendation(makeScore({ overall, ...weakestBy[weakest] }));
+        expect(msg, `tier=${overall}, weakest=${weakest}`).not.toMatch(
+          /parser|extractor/i,
+        );
+      }
+    }
   });
 
   it("is deterministic — same input yields the same sentence", () => {

--- a/src/lib/score/recommendation.ts
+++ b/src/lib/score/recommendation.ts
@@ -21,11 +21,21 @@ import type { AnonymousAtsScore } from "./score.ts";
 import { getScoreTier } from "./score.ts";
 import type { ScoreTier } from "./types.ts";
 
-/** Band-opening clause (no trailing punctuation — the caller appends the step). */
+/**
+ * Band-opening clause (no trailing punctuation — the caller appends the step).
+ *
+ * These openers land on the CONTENT-ONLY path — the scanned and layout-penalty
+ * branches upstream short-circuit before reaching here. So copy must speak to
+ * content quality only and never blame a parser: a low score under this
+ * constant is always a real content weakness (missing metrics, weak verbs,
+ * missing fields), not a parsing failure. Copy is kept dimension-agnostic so
+ * every opener composes cleanly with every downstream step, and tab-agnostic
+ * so it doesn't couple to the tab-strip vocabulary.
+ */
 const BAND_OPENER: Record<ScoreTier, string> = {
-  high: "Most generic parsers should read this cleanly",
-  medium: "A generic parser gets most of this",
-  low: "A generic extractor struggles here",
+  high: "This is in solid shape",
+  medium: "This is close",
+  low: "This has clear gaps to close",
 };
 
 /** Short, friendly names for the layout triggers we penalize. Kept terse for


### PR DESCRIPTION
## Summary

The score verdict's band-opening copy (`BAND_OPENER` in `src/lib/score/recommendation.ts`) blamed parsers/extractors on the **content-only** code path — i.e. when the resume parsed cleanly, no layout flags fired, and the low score was purely a content-quality issue like weak metrics or missing sections. A 50/100 resume with a clean parse read *"A generic extractor struggles here — add metrics…"*, misattributing a real content weakness to a parsing failure and misleading users into thinking their resume was breaking ATSs when it actually parsed fine.

Reworded all three tiers to speak to content only. Deliberately scoped: the scanned short-circuit and the layout-penalty branch still name parsers where the parser really is the problem.

Closes #214.

## Before / after

| Tier | Before (misleading on content-only path) | After |
| --- | --- | --- |
| `high` | "Most generic parsers should read this cleanly" | **"This is in solid shape"** |
| `medium` | "A generic parser gets most of this" | **"This is close"** |
| `low` | "A generic extractor struggles here" | **"This has clear gaps to close"** |

Each opener composes with the concrete dimension step after the em-dash:

- `— add metrics like numbers, %, or $ to more bullets so each one shows measurable impact.`
- `— tighten each bullet to a single line that opens with an action verb.`
- `— check that phone and location extract as plain text.`
- `— use real 4-digit years on your roles — the dates currently read as redaction stubs.`
- `— round out the remaining contact and section fields.`

All 15 opener × step permutations were sanity-checked to read naturally.

## Scope discipline — what was intentionally NOT touched

Every other place that mentions parsers/extractors was reviewed and left alone because the mention is correct in that context:

| Path | Copy left as-is | Reason |
| --- | --- | --- |
| Scanned short-circuit in `getScoreRecommendation` | *"This reads as a scanned image, not selectable text — export a real text-based PDF before anything else."* | Text really is unreadable; parser mention is accurate. |
| Layout-penalty branch (`multiplier < 1`) | *"Your content scored X/100, but a `<trigger>` will scramble it for many parsers — fix that layout first."* | The layout really is causing a parse problem; parser mention is accurate. |
| `TRIGGER_PHRASE.fonts_unmappable` | *"font encoding the parser can't read"* | Same as above. |
| LLM escape-hatch banner (`useLlmEscapeHatch`) | *"We couldn't read much of this resume. Try a local AI pass?"* | Different feature (#243), different code path, out of scope per #214. |

## Reviewer notes

**(a) Low-tier wording choice.** The issue's clarification suggested `low` → "This reads thin on impact" ("e.g., final wording is the implementer's call"). I tried that first and switched to **"This has clear gaps to close"** because "thin on impact" is specificity-flavored and composes awkwardly with the structure / redacted-dates / missing-fields / round-out steps — e.g. *"This reads thin on impact — check that phone extracts as plain text"*. The neutral phrasing reads uniformly across all five downstream steps. All three openers are dimension-agnostic and tab-agnostic by construction.

**(b) Doc comment discipline.** The new comment on `BAND_OPENER` explains the WHY (content-only path, no parser blame, dimension-agnostic, tab-agnostic) but does NOT reference #214 — per CLAUDE.md's rule that fix references belong in the PR description rather than in code comments where they rot.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — **1297/1297 tests pass**, including:
  - 5 existing assertions updated to expect the new strings.
  - New regression guard `keeps content-only messages free of parser/extractor language on the no-layout-flag path (issue #214)` — parametrizes **3 tiers × 3 weakest-dimension paths** (9 combinations) and asserts the rendered sentence never matches `/parser|extractor/i` on the content-only path. Locks the fix against a future edit reintroducing parser vocabulary in either `BAND_OPENER` or any `dimensionStep()` branch.
  - Existing `flags a scanned PDF as the hard blocker` and `leads with the layout penalty` tests still pass — confirming the untouched branches still emit their (correct) parser mentions.
- [x] Manually verified in `npm run dev` using the exact `music_resume25.pdf` from the issue report. The score renders 50/100 (Needs Work band), no layout flags, and the sentence beneath the ring now reads *"This has clear gaps to close — add metrics like numbers, %, or $ to more bullets so each one shows measurable impact."* — the old *"A generic extractor struggles here"* wording is gone.

## Diff size

Two files, +61 / −9 lines total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)