### PR TITLE
fix: page-furniture strip on experience path, preserve source headings, PDF round-trip

### DIFF
--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -204,6 +204,7 @@ function EducationEntry({
 }
 
 export function EducationSection({
+  heading,
   education,
   educationOverrides,
   onEducationFieldChange,
@@ -213,6 +214,8 @@ export function EducationSection({
   onRemoveEntry,
   onEntryField,
 }: {
+  /** Verbatim source heading (#285); falls back to "Education" when absent. */
+  heading?: string;
   education: ResumeEducation[];
   educationOverrides: Record<number, EducationFieldOverrides>;
   onEducationFieldChange: (
@@ -230,7 +233,7 @@ export function EducationSection({
 }) {
   return (
     <section className="flex flex-col gap-2">
-      <SectionHeading>Education</SectionHeading>
+      <SectionHeading>{heading ?? "Education"}</SectionHeading>
       {education.length === 0 ? (
         <NotDetected what="education" />
       ) : (
@@ -408,10 +411,13 @@ function AddSkillInput({
 }
 
 export function SkillsSection({
+  heading,
   skills,
   onAddSkill,
   onRemoveSkill,
 }: {
+  /** Verbatim source heading (#285); falls back to "Skills" when absent. */
+  heading?: string;
   /** The edited skills list (parsed minus removed, plus added) — what renders.
    *  App already folds skillsOverride into this via applyOverrides, so the
    *  section renders the resolved list directly. */
@@ -421,7 +427,7 @@ export function SkillsSection({
 }) {
   return (
     <section className="flex flex-col gap-2">
-      <SectionHeading>Skills</SectionHeading>
+      <SectionHeading>{heading ?? "Skills"}</SectionHeading>
       {skills.length === 0 ? (
         <NotDetected what="skills" />
       ) : (

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -341,6 +341,7 @@ const EXPERIENCE_FIELD_MAP: Record<
 };
 
 function ExperienceSection({
+  heading,
   groups,
   resumeSections,
   jdContext,
@@ -357,6 +358,8 @@ function ExperienceSection({
   onEntryField,
   onAddBullet,
 }: {
+  /** Verbatim source heading (#285); falls back to "Experience" when absent. */
+  heading?: string;
   /** Pre-built experience groups + the shared "Other" group appended last. */
   groups: BulletGroup[];
   /** Chain-of-sections input for the whole-résumé rewrite CTA (#67). */
@@ -422,7 +425,7 @@ function ExperienceSection({
           where the inline glyphs actually appear), not at the top of the
           section where it reads as detached. */}
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
-        <SectionHeading>Experience</SectionHeading>
+        <SectionHeading>{heading ?? "Experience"}</SectionHeading>
         {hasBullets && <BulletFlagLegend />}
       </div>
       {/* Picker + whole-résumé CTA mounted at the top of Experience —
@@ -497,6 +500,7 @@ function ExperienceSection({
  * bullets grade and export like any other.
  */
 function ProjectsSection({
+  heading,
   projects,
   groups,
   bulletOverrides,
@@ -507,6 +511,8 @@ function ProjectsSection({
   onEntryField,
   onAddBullet,
 }: {
+  /** Verbatim source heading (#285); falls back to "Projects" when absent. */
+  heading?: string;
   projects: ResumeProject[];
   /** Pre-built project groups, index-aligned with `projects`. */
   groups: BulletGroup[];
@@ -520,7 +526,7 @@ function ProjectsSection({
 }) {
   return (
     <section className="flex flex-col gap-3">
-      <SectionHeading>Projects</SectionHeading>
+      <SectionHeading>{heading ?? "Projects"}</SectionHeading>
       <div className="flex flex-col gap-4">
         {projects.map((project, i) => {
           const group = groups[i];
@@ -592,6 +598,7 @@ function ProjectsSection({
  * `buildProjectDates` is just the year string.
  */
 function AchievementsSection({
+  heading,
   achievements,
   groups,
   bulletOverrides,
@@ -602,6 +609,8 @@ function AchievementsSection({
   onEntryField,
   onAddBullet,
 }: {
+  /** Verbatim source heading (#285); falls back to "Achievements" when absent. */
+  heading?: string;
   achievements: HeuristicAchievement[];
   /** Pre-built achievement groups, index-aligned with `achievements`. */
   groups: BulletGroup[];
@@ -615,7 +624,7 @@ function AchievementsSection({
 }) {
   return (
     <section className="flex flex-col gap-3">
-      <SectionHeading>Achievements</SectionHeading>
+      <SectionHeading>{heading ?? "Achievements"}</SectionHeading>
       <div className="flex flex-col gap-4">
         {achievements.map((achievement, i) => {
           const group = groups[i];
@@ -863,6 +872,7 @@ export function ReconstructedResume({
   // Skills, which also render an add affordance unconditionally.
   const achievementsSection = (
     <AchievementsSection
+      heading={result.sections?.sectionHeadings?.get("achievements")}
       achievements={achievements}
       groups={achievementGroups}
       bulletOverrides={bulletOverrides}
@@ -914,6 +924,7 @@ export function ReconstructedResume({
       />
       {achievementsAbove && achievementsSection}
       <ExperienceSection
+        heading={result.sections?.sectionHeadings?.get("experience")}
         groups={experienceRenderGroups}
         resumeSections={resumeSections}
         jdContext={jdContext}
@@ -933,6 +944,7 @@ export function ReconstructedResume({
         onAddBullet={addBullet}
       />
       <ProjectsSection
+        heading={result.sections?.sectionHeadings?.get("projects")}
         projects={projects}
         groups={projectGroups}
         bulletOverrides={bulletOverrides}
@@ -945,6 +957,7 @@ export function ReconstructedResume({
       />
       {!achievementsAbove && achievementsSection}
       <EducationSection
+        heading={result.sections?.sectionHeadings?.get("education")}
         education={parsed.education}
         educationOverrides={educationOverrides}
         onEducationFieldChange={(index, field, value) =>
@@ -957,6 +970,7 @@ export function ReconstructedResume({
         onEntryField={setEntryField}
       />
       <SkillsSection
+        heading={result.sections?.sectionHeadings?.get("skills")}
         skills={parsed.skills}
         onAddSkill={addSkill}
         onRemoveSkill={removeSkill}

--- a/src/lib/heuristics/entry-blocks.test.ts
+++ b/src/lib/heuristics/entry-blocks.test.ts
@@ -266,6 +266,44 @@ describe("parseEntryBlocks — first_line anchor (projects / date-optional secti
     expect(blocks[0].headerLines.some((h) => /\d{4}/.test(h))).toBe(false);
   });
 
+  // #283 false-positive guard: a legit project/role header that CONTAINS the
+  // word "Resume"/"CV" AND a pipe/mid-dot separator (a common "Name | Stack" or
+  // "Title · Company" shape) must NOT be mistaken for a "Name · Résumé N"
+  // footer and silently stripped — that dropped the whole entry. The positional
+  // guard now requires the separator ADJACENT to the résumé/CV keyword, which
+  // this header does not have ("Resume" is not next to the "|").
+  it("keeps a legit 'Resume Parser | Stack  <dates>' header — not footer furniture (#283)", () => {
+    const blocks = parseEntryBlocks(
+      section([
+        { text: "Resume Parser | Python, React  Jan 2024 - Present" },
+        { text: "• Built a browser-side PDF extraction cascade." },
+      ]),
+      { anchor: "first_line", collectBody: true },
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].headerLines.some((h) => h.includes("Resume Parser"))).toBe(
+      true,
+    );
+    expect(blocks[0].body).toContain("extraction cascade");
+  });
+
+  it("still strips a real 'Name · Résumé N' footer that lands mid-section (#283)", () => {
+    const blocks = parseEntryBlocks(
+      section([
+        { text: "June 3, 2026  Jane Smith · Résumé 1" }, // footer — stripped
+        { text: "Trip Planner" },
+        { text: "• Added the itinerary view." },
+      ]),
+      { anchor: "first_line", collectBody: true },
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].headerLines).toContain("Trip Planner");
+    for (const b of blocks) {
+      expect(b.headerLines.join(" ")).not.toContain("Résumé");
+      expect(b.headerLines.join(" ")).not.toContain("Jane Smith");
+    }
+  });
+
   // x-aware builder: a long bullet wraps onto a marker-less second line that
   // aligns with the bullet *text* (indented past the header margin).
   function sectionX(lines: Array<{ text: string; x: number }>): PdfSection {

--- a/src/lib/heuristics/entry-blocks.test.ts
+++ b/src/lib/heuristics/entry-blocks.test.ts
@@ -287,6 +287,22 @@ describe("parseEntryBlocks — first_line anchor (projects / date-optional secti
     expect(blocks[0].body).toContain("extraction cascade");
   });
 
+  // #286 review: the positional tell must be ADJACENT to the résumé/CV keyword.
+  // A real bullet that merely mentions our own domain ("resume") AND happens to
+  // carry an "N of M" ratio must NOT be stripped as furniture — the bare
+  // "N of M" / "page N" alternatives were dropped so this bullet survives.
+  it("keeps a real bullet mentioning 'resume' + an 'N of M' ratio (#286 review)", () => {
+    const blocks = parseEntryBlocks(
+      section([
+        { text: "Resume Linter" },
+        { text: "• Rebuilt the resume parser, improving 3 of 5 core metrics." },
+      ]),
+      { anchor: "first_line", collectBody: true },
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].body).toContain("3 of 5 core metrics");
+  });
+
   it("still strips a real 'Name · Résumé N' footer that lands mid-section (#283)", () => {
     const blocks = parseEntryBlocks(
       section([

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -40,6 +40,7 @@ import {
   parseDateRange,
   stripDateRange,
   isBulletLine,
+  isPageFurniture,
   isProseLine,
   stripBullet,
 } from "./line-primitives.ts";
@@ -98,6 +99,39 @@ export function isDateOnlyLine(text: string): boolean {
  *     "Minor in Economics", "Relevant Coursework: …" are properties of the entry
  *     above, not a new entry head.
  */
+/**
+ * A running-header/footer POSITION signal, required on the entry paths in
+ * addition to the {@link isPageFurniture} keyword before a line is stripped as
+ * furniture (#283). The keyword test alone over-matches on entry sections, where
+ * a legitimate project or role title routinely CONTAINS "Resume"/"CV" — "Resume
+ * Linter", "CV Toolkit", even "Resume Linter 2024 - 2025". A genuine page footer
+ * carries a structural tell such a title never does: a name↔label separator
+ * ("Jane Smith · Résumé"), the résumé/CV keyword immediately followed by a page
+ * number ("Résumé 1", "Resume 2"), or a "Page N" / "N of M" counter. The
+ * achievements path (#225) keeps the bare keyword test — an award line is far
+ * less likely to embed the word — so its behavior is unchanged.
+ */
+const FURNITURE_KEYWORD = "(?:r[ée]sum[ée]|resume|cv|curriculum\\s+vitae)";
+const FURNITURE_POSITION_RE = new RegExp(
+  // separator ADJACENT to the résumé/CV keyword ("Jane Smith · Résumé",
+  // "Résumé | Jane Smith") — a bare separator anywhere is NOT enough, or a
+  // legit "Resume Parser | Python" / "Company · Title" header would be stripped.
+  `${FURNITURE_KEYWORD}\\s*[·•‣|]|[·•‣|]\\s*${FURNITURE_KEYWORD}` +
+    // the résumé/CV keyword immediately followed by a page number ("Résumé 1")
+    `|${FURNITURE_KEYWORD}\\s+\\d` +
+    // an explicit page counter ("Page 2", "1 of 3", "2/5")
+    `|\\bpage\\s+\\d|\\b\\d+\\s*(?:\\/|of)\\s*\\d+\\b`,
+  "i",
+);
+
+/** True when a line is page running-header/footer furniture on an ENTRY path —
+ *  it carries both the résumé/CV keyword ({@link isPageFurniture}) AND a footer
+ *  position signal ({@link FURNITURE_POSITION_RE}), so a real project/role title
+ *  that merely contains "Resume"/"CV" is not stripped (#283). */
+function isEntryPageFurniture(line: PdfLine): boolean {
+  return isPageFurniture(line) && FURNITURE_POSITION_RE.test(line.text);
+}
+
 export function isEntryHeaderShape(text: string): boolean {
   const t = text.trim();
   if (!t) return false;
@@ -756,6 +790,18 @@ export function parseEntryBlocks(
 ): EntryBlock[] {
   if (!section || section.lines.length === 0) return [];
 
+  // Strip page running-header/footer furniture (a repeated "Name · Résumé N"
+  // line a continuation page carries) BEFORE any anchor detection or header
+  // folding (#283, generalizing the achievements-only strip of #225). When an
+  // entry section spans a page break, that footer lands in reading order between
+  // the last role on one page and the first on the next; left in, it becomes the
+  // company/title of that first page-2 role (or mints a spurious dateless role),
+  // dropping the real title. Every entry path (experience `date_range`, projects
+  // / achievements `first_line`) filters here at once. Achievements already
+  // pre-filters its lines, so this is idempotent there.
+  const furnitureFiltered = section.lines.filter((l) => !isEntryPageFurniture(l));
+  if (furnitureFiltered.length === 0) return [];
+
   // Fold wrapped multi-line role headers (an org/date that spilled onto extra
   // physical rows) back into one logical header BEFORE anchor detection, so a
   // header whose closing date-year wrapped still opens a `date_range` entry
@@ -763,8 +809,8 @@ export function parseEntryBlocks(
   // hint / first line, not a date range that can wrap incomplete.
   const lines =
     cfg.anchor === "date_range"
-      ? mergeWrappedHeaderRows(section.lines, cfg.headerLookback || 2)
-      : section.lines;
+      ? mergeWrappedHeaderRows(furnitureFiltered, cfg.headerLookback || 2)
+      : furnitureFiltered;
   const anchors = collectAnchors(lines, cfg.anchor);
   if (anchors.length === 0) {
     // A `first_line` section with no anchorable header line is a flat bullet

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -106,8 +106,11 @@ export function isDateOnlyLine(text: string): boolean {
  * a legitimate project or role title routinely CONTAINS "Resume"/"CV" — "Resume
  * Linter", "CV Toolkit", even "Resume Linter 2024 - 2025". A genuine page footer
  * carries a structural tell such a title never does: a name↔label separator
- * ("Jane Smith · Résumé"), the résumé/CV keyword immediately followed by a page
- * number ("Résumé 1", "Resume 2"), or a "Page N" / "N of M" counter. The
+ * ("Jane Smith · Résumé"), or the résumé/CV keyword immediately followed by a
+ * page number ("Résumé 1", "Resume 2"). The positional tell must sit ADJACENT to
+ * the keyword — a bare "Page N" / "N of M" counter anywhere on the line is NOT
+ * enough, or a real bullet that merely mentions our own domain would be dropped
+ * ("Rebuilt the resume parser, improving 3 of 5 core metrics", #286 review). The
  * achievements path (#225) keeps the bare keyword test — an award line is far
  * less likely to embed the word — so its behavior is unchanged.
  */
@@ -118,9 +121,7 @@ const FURNITURE_POSITION_RE = new RegExp(
   // legit "Resume Parser | Python" / "Company · Title" header would be stripped.
   `${FURNITURE_KEYWORD}\\s*[·•‣|]|[·•‣|]\\s*${FURNITURE_KEYWORD}` +
     // the résumé/CV keyword immediately followed by a page number ("Résumé 1")
-    `|${FURNITURE_KEYWORD}\\s+\\d` +
-    // an explicit page counter ("Page 2", "1 of 3", "2/5")
-    `|\\bpage\\s+\\d|\\b\\d+\\s*(?:\\/|of)\\s*\\d+\\b`,
+    `|${FURNITURE_KEYWORD}\\s+\\d`,
   "i",
 );
 

--- a/src/lib/heuristics/extract/achievements.ts
+++ b/src/lib/heuristics/extract/achievements.ts
@@ -6,42 +6,20 @@ import type { PdfLine, PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
 import { YEAR_RE } from "../regex.ts";
-import { isBulletLine, parseDateRange, stripDateRange } from "../line-primitives.ts";
+import {
+  isBulletLine,
+  isPageFurniture,
+  parseDateRange,
+  stripDateRange,
+} from "../line-primitives.ts";
 import { firstMatch, finalizeEntries } from "./shared.ts";
 import { liftHeaderLabel } from "./projects.ts";
 
 // ── Achievements ──────────────────────────────────────────────────────────────
 
-/**
- * A page running-header / footer line — the candidate's own name + "Resume" /
- * "Résumé" / "CV" / "Curriculum Vitae" furniture a continuation page repeats at
- * its top (often beside a date and a page number, e.g. "June 10, 2026 Jane Doe
- * Resume 2" / "Jane Doe · Résumé"). When an Honors/Awards (or any
- * achievements-family) section spans a page break, that furniture line lands
- * mid-section and would otherwise become an award title or contaminate an
- * award's description blob (#225). A genuine award line never carries the word
- * résumé/CV, so keying on it is a safe, content-free strip. Matched
- * case-insensitively and accent-tolerantly (`Résumé`/`Resume`).
- */
-// NB: `\b` is unreliable around the accented `é` (not a `\w` char in JS regex),
-// so we anchor on the ASCII-letter side only: `(?<![A-Za-z])` … `(?![A-Za-z])`.
-// These spelled-out forms are rare inside an award title, so a letter boundary
-// is a safe key.
-const PAGE_FURNITURE_RE =
-  /(?<![A-Za-z])(r[ée]sum[ée]|curriculum\s+vitae)(?![A-Za-z])/i;
-
-// The bare two-letter "CV" is far easier to hit by accident inside content — a
-// parenthesised domain acronym ("Cardiovascular (CV) Fellowship"), a hyphenated
-// code ("CV-204"), a journal short-name — so it strips a real entry if keyed on
-// a letter boundary alone. Require it to stand alone between whitespace / line
-// ends, which the running-header form ("Jane Doe · CV", "Name CV 2") satisfies
-// but a punctuation-adjacent in-content "CV" does not.
-const CV_FURNITURE_RE = /(?:^|\s)cv(?:$|\s)/i;
-
-/** True when the line is page running-header/footer furniture, not content. */
-function isPageFurniture(line: PdfLine): boolean {
-  return PAGE_FURNITURE_RE.test(line.text) || CV_FURNITURE_RE.test(line.text);
-}
+// Page running-header/footer furniture detection (`isPageFurniture`) lives in
+// `line-primitives.ts` (#283) so the achievements path and the entry-block
+// parser share one copy — see that module for the regex rationale.
 
 /**
  * Extract an Achievements / Accomplishments / Awards / Activities section into

--- a/src/lib/heuristics/extract/experience.location.test.ts
+++ b/src/lib/heuristics/extract/experience.location.test.ts
@@ -370,5 +370,15 @@ describe("role location extraction (#218)", () => {
       expect(role.company).toContain("Acme");
       expect(role.location).toBeUndefined();
     });
+
+    it("defers a multi-word city with a locality-generic tail ('Mexico City') (#286 review)", () => {
+      // Single-token Pass D would grab "City" as the city and mis-split into
+      // company "Google Mexico" + location "City, Mexico". "City" is a locality
+      // generic (never a standalone city), so LOCALITY_SUFFIX_RE defers: the
+      // whole string stays with the company rather than fragmenting the city.
+      const role = roleFromTwoLine("Google Mexico City, Mexico");
+      expect(role.company).toContain("Mexico City");
+      expect(role.location).not.toBe("City, Mexico");
+    });
   });
 });

--- a/src/lib/heuristics/extract/experience.location.test.ts
+++ b/src/lib/heuristics/extract/experience.location.test.ts
@@ -313,4 +313,62 @@ describe("role location extraction (#218)", () => {
       expect(role.company).toBeTruthy();
     });
   });
+
+  describe("two-column fold — space-delimited 'Company City, Country' (Pass D, #287)", () => {
+    function roleFromTwoLine(company: string) {
+      // Two-column templates (Awesome-CV) fold the right-column location onto the
+      // company line with no comma before the city: "Company City, Country".
+      return roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        { text: company, fontSize: 11 },
+        { text: "Jun. 2018 - Jan. 2021", fontSize: 11 },
+        { text: "Director of Infrastructure", fontSize: 11 },
+        { text: "• Built the platform team from scratch.", fontSize: 11 },
+      ])[0];
+    }
+
+    it("splits abbreviated country 'City, S.Korea' off the company (primary AC)", () => {
+      const role = roleFromTwoLine("Kasa Seoul, S.Korea");
+      expect(role.company).toBe("Kasa");
+      expect(role.company).not.toContain("Seoul");
+      expect(role.location).toBe("Seoul, S.Korea");
+    });
+
+    it("splits a folded location off a legal-suffix company", () => {
+      const role = roleFromTwoLine("Dunamu Inc. Seoul, S.Korea");
+      expect(role.company).toBe("Dunamu Inc.");
+      expect(role.location).toBe("Seoul, S.Korea");
+    });
+
+    it("keeps a legal-suffix tail with the company, not the location (Co., Ltd.)", () => {
+      // "Omnious. Co., Ltd. Seoul, S.Korea" — the comma after "Co." is
+      // company-internal ("Co., Ltd."), not a company/city boundary; only
+      // " Seoul, S.Korea" is the fold.
+      const role = roleFromTwoLine("Omnious. Co., Ltd. Seoul, S.Korea");
+      expect(role.company).toBe("Omnious. Co., Ltd.");
+      expect(role.location).toBe("Seoul, S.Korea");
+    });
+
+    it("splits a folded location past an internal comma in the company", () => {
+      // "R.O.K Cyber Command, MND Seoul, S.Korea" — the company itself has a
+      // comma; Pass D must peel only the trailing " Seoul, S.Korea".
+      const role = roleFromTwoLine("R.O.K Cyber Command, MND Seoul, S.Korea");
+      expect(role.company).toBe("R.O.K Cyber Command, MND");
+      expect(role.location).toBe("Seoul, S.Korea");
+    });
+
+    it("splits a full ISO-name country 'City, Germany' folded onto company", () => {
+      const role = roleFromTwoLine("Sigma Analytics Berlin, Germany");
+      expect(role.company).toBe("Sigma Analytics");
+      expect(role.location).toBe("Berlin, Germany");
+    });
+
+    it("no-regression: does not strip a non-country comma tail ('Acme, Systems')", () => {
+      // "Systems" is not in COUNTRY_GAZETTEER, so Pass D must not fire and the
+      // company stays intact.
+      const role = roleFromTwoLine("Acme, Systems");
+      expect(role.company).toContain("Acme");
+      expect(role.location).toBeUndefined();
+    });
+  });
 });

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -150,6 +150,19 @@ function cityStartsWithCompanyText(city: string): boolean {
   return LEGAL_SUFFIX_RE.test(first) || /^[A-Z]{2,}$/.test(first);
 }
 
+/** A single-token Pass-D "city" that is a locality-TYPE generic ("City", "Beach",
+ *  "Springs", "Heights", "Town", …) is never a standalone city — it is the
+ *  truncated tail of a multi-word place ("Mexico City", "Long Beach", "Cape
+ *  Town") whose earlier words the single-token space-fold regex left glued to the
+ *  company. Peeling it would mis-split "Google Mexico City, Mexico" into company
+ *  "Google Mexico" + location "City, Mexico" — both wrong (#286 review). Defer:
+ *  leave the whole string as company rather than fragment a real multi-word city.
+ *  (A proper-noun compound like "Buenos Aires" has no generic tell and stays a
+ *  known limitation — distinguishing it from a real company+city fold needs a
+ *  city gazetteer we don't carry.) */
+const LOCALITY_SUFFIX_RE =
+  /^(?:city|town|beach|springs?|heights|falls|hills|park|bay|harbou?r|grove|gardens?|valley|shores?)$/i;
+
 function stripLocationSuffix(s: string): {
   text: string;
   location: string | undefined;
@@ -191,9 +204,11 @@ function stripLocationSuffix(s: string): {
     // so Pass C (which needs a comma before the city) misses it. This is the
     // space-delimited intl case Pass C deferred: it's admissible here only under
     // the same tight guards Pass B uses for US "City, ST" —
-    //   - single-token city (space boundary; a multi-word space-fold city like
-    //     "Google Mexico City" is genuinely ambiguous with a subsidiary name and
-    //     stays deferred), and
+    //   - single-token city (space boundary). A multi-word space-fold city whose
+    //     last token is a locality generic ("…City", "…Beach") would otherwise be
+    //     truncated to that generic tail and mis-split, so LOCALITY_SUFFIX_RE
+    //     defers it ("Google Mexico City, Mexico" stays company, not fragmented),
+    //     and
     //   - a closed-vocabulary country (COUNTRY_GAZETTEER), not any capitalized
     //     word — so it fires on a real "City, Country" fold, not on a company
     //     that merely ends in a comma tail.
@@ -204,7 +219,11 @@ function stripLocationSuffix(s: string): {
     const SPACE_INTL_RE =
       /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
     const mSpaceIntl = s.match(SPACE_INTL_RE);
-    if (mSpaceIntl && COUNTRY_GAZETTEER.has(mSpaceIntl[2].toLowerCase())) {
+    if (
+      mSpaceIntl &&
+      COUNTRY_GAZETTEER.has(mSpaceIntl[2].toLowerCase()) &&
+      !LOCALITY_SUFFIX_RE.test(mSpaceIntl[1])
+    ) {
       const before = stripDanglingSeparator(s.slice(0, mSpaceIntl.index));
       if (before)
         return { text: before, location: `${mSpaceIntl[1]}, ${mSpaceIntl[2]}` };

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -116,8 +116,11 @@ function looksLikeLocationTail(after: string): boolean {
  *   Pass C — comma-delimited international "…, City, Country": validates the
  *     trailing token against `COUNTRY_GAZETTEER` (closed ~249-entry ISO set +
  *     colloquial aliases) to avoid false-matching any capitalized word.
- *     Space-delimited intl is NOT attempted here — multi-word countries make
- *     space boundaries too ambiguous (deferred to a follow-up issue).
+ *   Pass D — space-delimited international "…Company City, Country" (#287): the
+ *     two-column fold where the location is glued onto the company line with no
+ *     comma before the city ("Kasa Seoul, S.Korea"). Single-token city only and
+ *     a closed-vocabulary country, mirroring Pass B's US guards; tried last so
+ *     the comma-delimited passes win first.
  *
  * Conservative design choices shared by all passes:
  *   - The state/country suffix must be in a closed vocabulary (US_STATE_CODE_RE
@@ -133,6 +136,18 @@ function looksLikeLocationTail(after: string): boolean {
  *  artifact, never real company text. */
 function stripDanglingSeparator(s: string): string {
   return s.replace(/[\s,–—\-|·]+$/, "").trim();
+}
+
+/** A comma-delimited intl "city" (Pass C group 1) whose FIRST token is a legal
+ *  suffix ("Ltd.") or an all-caps org acronym ("MND") is company text carried
+ *  past a company-internal comma — not a city — so that comma is not the
+ *  company/city boundary. Reject it in Pass C so the space-delimited Pass D
+ *  peels only the real trailing single-token city:
+ *  "Omnious. Co., Ltd. Seoul, S.Korea" → company "Omnious. Co., Ltd." +
+ *  "Seoul, S.Korea", not company "Omnious. Co." + "Ltd. Seoul, S.Korea" (#287). */
+function cityStartsWithCompanyText(city: string): boolean {
+  const first = city.split(/\s+/)[0];
+  return LEGAL_SUFFIX_RE.test(first) || /^[A-Z]{2,}$/.test(first);
 }
 
 function stripLocationSuffix(s: string): {
@@ -161,9 +176,38 @@ function stripLocationSuffix(s: string): {
     const INTL_SUFFIX_RE =
       /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
     const mIntl = s.match(INTL_SUFFIX_RE);
-    if (mIntl && COUNTRY_GAZETTEER.has(mIntl[2].toLowerCase())) {
+    if (
+      mIntl &&
+      COUNTRY_GAZETTEER.has(mIntl[2].toLowerCase()) &&
+      !cityStartsWithCompanyText(mIntl[1])
+    ) {
       const before = stripDanglingSeparator(s.slice(0, mIntl.index));
       if (before) return { text: before, location: `${mIntl[1]}, ${mIntl[2]}` };
+    }
+
+    // Pass D — space-delimited international "…Company City, Country" (#287).
+    // Two-column templates (Awesome-CV) fold the right-column location onto the
+    // company line with no comma between company and city ("Kasa Seoul, S.Korea"),
+    // so Pass C (which needs a comma before the city) misses it. This is the
+    // space-delimited intl case Pass C deferred: it's admissible here only under
+    // the same tight guards Pass B uses for US "City, ST" —
+    //   - single-token city (space boundary; a multi-word space-fold city like
+    //     "Google Mexico City" is genuinely ambiguous with a subsidiary name and
+    //     stays deferred), and
+    //   - a closed-vocabulary country (COUNTRY_GAZETTEER), not any capitalized
+    //     word — so it fires on a real "City, Country" fold, not on a company
+    //     that merely ends in a comma tail.
+    // Tried after Pass C so a genuine comma-delimited multi-word city
+    // ("…, Mexico City, Mexico") is still captured whole; Pass D then peels the
+    // single-token fold Pass C skipped (including the company-internal-comma case
+    // "…Co., Ltd. Seoul, S.Korea" that Pass C's guard rejected).
+    const SPACE_INTL_RE =
+      /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
+    const mSpaceIntl = s.match(SPACE_INTL_RE);
+    if (mSpaceIntl && COUNTRY_GAZETTEER.has(mSpaceIntl[2].toLowerCase())) {
+      const before = stripDanglingSeparator(s.slice(0, mSpaceIntl.index));
+      if (before)
+        return { text: before, location: `${mSpaceIntl[1]}, ${mSpaceIntl[2]}` };
     }
   }
 

--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -53,6 +53,41 @@ export function isProseLine(text: string): boolean {
   return trimmed.split(/\s+/).filter(Boolean).length >= PROSE_MIN_WORDS;
 }
 
+/**
+ * A page running-header / footer line — the candidate's own name + "Resume" /
+ * "Résumé" / "CV" / "Curriculum Vitae" furniture a continuation page repeats at
+ * its top or bottom (often beside a date and a page number, e.g. "June 10, 2026
+ * Jane Doe Resume 2" / "Jane Doe · Résumé 1"). When an entry-style section
+ * (experience, projects, education, or an achievements-family section) spans a
+ * page break, that furniture line lands mid-section and would otherwise become
+ * an entry header (a role's company/title) or contaminate a description blob
+ * (#225, generalized #283). A genuine entry line never carries the word
+ * résumé/CV, so keying on it is a safe, content-free strip. Matched
+ * case-insensitively and accent-tolerantly (`Résumé`/`Resume`).
+ *
+ * NB: `\b` is unreliable around the accented `é` (not a `\w` char in JS regex),
+ * so we anchor on the ASCII-letter side only: `(?<![A-Za-z])` … `(?![A-Za-z])`.
+ * These spelled-out forms are rare inside an entry title, so a letter boundary
+ * is a safe key.
+ */
+const PAGE_FURNITURE_RE =
+  /(?<![A-Za-z])(r[ée]sum[ée]|curriculum\s+vitae)(?![A-Za-z])/i;
+
+// The bare two-letter "CV" is far easier to hit by accident inside content — a
+// parenthesised domain acronym ("Cardiovascular (CV) Fellowship"), a hyphenated
+// code ("CV-204"), a journal short-name — so it strips a real entry if keyed on
+// a letter boundary alone. Require it to stand alone between whitespace / line
+// ends, which the running-header form ("Jane Doe · CV", "Name CV 2") satisfies
+// but a punctuation-adjacent in-content "CV" does not.
+const CV_FURNITURE_RE = /(?:^|\s)cv(?:$|\s)/i;
+
+/** True when the line is page running-header/footer furniture, not content.
+ *  Shared by the achievements extractor and the entry-block parser so a footer
+ *  that lands mid-section on a page break is stripped on every entry path. */
+export function isPageFurniture(line: PdfLine): boolean {
+  return PAGE_FURNITURE_RE.test(line.text) || CV_FURNITURE_RE.test(line.text);
+}
+
 /** Collapse internal whitespace and trim — the canonical date-token normalizer. */
 export function normalizeDate(raw: string): string {
   return raw.replace(/\s+/g, " ").trim();

--- a/src/lib/heuristics/markdown-lines.test.ts
+++ b/src/lib/heuristics/markdown-lines.test.ts
@@ -74,3 +74,35 @@ describe("sectionizeMarkdown — institution name ending in a section anchor (#2
     expect(edu!.lines.some((l) => l.text.includes("Mentor"))).toBe(false);
   });
 });
+
+describe("sectionizeMarkdown — rawHeading capture (#285)", () => {
+  it("captures the verbatim heading text, stripped of markdown decoration, for a synonym", () => {
+    const markdown = [
+      "**Dana Lopez**",
+      "",
+      "dana.lopez@example.com | (312) 555-0123",
+      "",
+      "**Work History**",
+      "",
+      "Engineer, Globex  2019 - 2021",
+    ].join("\n");
+
+    const { sections } = sectionizeMarkdown(markdown);
+
+    const experience = sections.find((s) => s.name === "experience");
+    expect(experience?.rawHeading).toBe("Work History");
+  });
+
+  it("leaves rawHeading undefined for the profile section", () => {
+    const markdown = [
+      "**Dana Lopez**",
+      "",
+      "dana.lopez@example.com | (312) 555-0123",
+    ].join("\n");
+
+    const { sections } = sectionizeMarkdown(markdown);
+
+    const profile = sections.find((s) => s.name === "profile");
+    expect(profile?.rawHeading).toBeUndefined();
+  });
+});

--- a/src/lib/heuristics/markdown-lines.ts
+++ b/src/lib/heuristics/markdown-lines.ts
@@ -344,7 +344,7 @@ export function sectionizeMarkdownLines(lines: PdfLine[]): PdfSection[] {
         ? null
         : (detailed?.section ?? matchLeadingSectionKeyword(line.text));
     if (header) {
-      sections.push({ name: header, lines: [] });
+      sections.push({ name: header, rawHeading: line.text.trim(), lines: [] });
       continue;
     }
     sections[sections.length - 1].lines.push(line);

--- a/src/lib/heuristics/page-furniture-experience.repro.test.ts
+++ b/src/lib/heuristics/page-furniture-experience.repro.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Repro regression for #283 — a page running-header/footer line
+ * ("June 3, 2026  Jane Smith · Résumé 1") that falls on a page break INSIDE the
+ * Work Experience section used to be absorbed as the company/title of the first
+ * role on the next page, dropping that role's real title.
+ *
+ * The furniture strip already existed for the achievements path (#225); #283
+ * promotes `isPageFurniture` to `line-primitives.ts` and filters it centrally in
+ * `parseEntryBlocks`, so every entry path (experience/projects/achievements)
+ * drops the footer before anchor detection.
+ *
+ * Reproduces on the in-tree synthetic fixture
+ * `tests/fixtures/pdfs/latex/awesome-cv-resume.pdf` (persona: Jane Smith /
+ * jane.smith@example.com, a `Jane Smith · Résumé N` running footer). No new PDF
+ * and no real-person PII — the fixture is synthetic. The lossy `*.expected.json`
+ * golden records only counts and cannot catch a title/company swap, so this
+ * asserts the exact field mapping directly.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "./cascade.ts";
+import type { HeuristicParsedResume } from "./types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/latex/awesome-cv-resume.pdf",
+);
+
+// Footer tokens that must never leak into any experience field once furniture is
+// stripped: the running-footer date, name, "Résumé", and the page number tail.
+const FOOTER_TOKENS = ["Résumé", "Resume", "Jane Smith", "June 3, 2026"];
+
+describe("#283 — page footer bleeds into experience roles across page breaks", () => {
+  let parsed: HeuristicParsedResume;
+
+  beforeAll(async () => {
+    const bytes = readFileSync(FIXTURE);
+    const c = await runCascade(new Uint8Array(bytes));
+    parsed = c.parsed;
+  });
+
+  it("parses the first page-2 role (Kasa) with its real title, footer stripped", () => {
+    const exp = parsed.experience ?? [];
+    // The footer corrupted an existing role rather than minting one, so the
+    // count is unchanged — no spurious dateless role.
+    expect(exp).toHaveLength(8);
+
+    const kasa = exp[3];
+    expect(kasa.title).toBe(
+      "Founding Member & Director of Infrastructure Division",
+    );
+    // Company leads with the real org "Kasa" (this two-column fixture folds the
+    // right-column location onto the company line for every role; the #283 fix
+    // is about the footer no longer displacing it, not about location splitting).
+    expect(kasa.company?.startsWith("Kasa")).toBe(true);
+    expect(kasa.start_date).toBe("Jun. 2018");
+    expect(kasa.end_date).toBe("Jan. 2021");
+  });
+
+  it("leaves no footer text in any experience field", () => {
+    const exp = parsed.experience ?? [];
+    for (const role of exp) {
+      const blob = [role.title, role.company, role.location, role.description]
+        .filter(Boolean)
+        .join(" ");
+      for (const token of FOOTER_TOKENS) {
+        expect(blob).not.toContain(token);
+      }
+    }
+  });
+});

--- a/src/lib/heuristics/page-furniture-experience.repro.test.ts
+++ b/src/lib/heuristics/page-furniture-experience.repro.test.ts
@@ -58,10 +58,12 @@ describe("#283 — page footer bleeds into experience roles across page breaks",
     expect(kasa.title).toBe(
       "Founding Member & Director of Infrastructure Division",
     );
-    // Company leads with the real org "Kasa" (this two-column fixture folds the
-    // right-column location onto the company line for every role; the #283 fix
-    // is about the footer no longer displacing it, not about location splitting).
-    expect(kasa.company?.startsWith("Kasa")).toBe(true);
+    // This two-column fixture folds the right-column location onto the company
+    // line for every role. #283 stopped the footer from displacing it; #287 then
+    // split the folded location off, so company is the clean org and the folded
+    // "Seoul, S.Korea" lands in `location` (Pass D of stripLocationSuffix).
+    expect(kasa.company).toBe("Kasa");
+    expect(kasa.location).toBe("Seoul, S.Korea");
     expect(kasa.start_date).toBe("Jun. 2018");
     expect(kasa.end_date).toBe("Jan. 2021");
   });

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -72,6 +72,13 @@ const _COUNTRY_ALIASES: ReadonlyArray<string> = [
   "uae",
   "south korea",
   "north korea",
+  // Abbreviated colloquial forms that appear as a folded right-column country in
+  // two-column templates (e.g. Awesome-CV's "City, S.Korea") — the ISO English
+  // name "South Korea" never matches these, so admit the abbreviations directly.
+  "s.korea",
+  "s. korea",
+  "n.korea",
+  "n. korea",
 ];
 
 // Hardcoded fallback covering the most common country names on resumes — used

--- a/src/lib/heuristics/sections.test.ts
+++ b/src/lib/heuristics/sections.test.ts
@@ -18,7 +18,12 @@ import { promises as fsp } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
-import { groupIntoLines, splitIntoSections, type PdfSection } from "./sections.ts";
+import {
+  groupIntoLines,
+  splitIntoSections,
+  toSectionedResume,
+  type PdfSection,
+} from "./sections.ts";
 import { runCascade } from "./cascade.ts";
 import { mkItems } from "./__test-utils__/mkItem.ts";
 
@@ -631,5 +636,53 @@ describe("splitIntoSections — institution name ending in a section anchor (#25
     expect(edu!.lines.some((l) => l.text.includes("Relevant Experience"))).toBe(
       false,
     );
+  });
+});
+
+describe("PdfSection.rawHeading — verbatim source heading capture (#285)", () => {
+  it("captures the original heading text for a synonym mapped to a canonical section", () => {
+    // "Work History" is an alias for the canonical "experience" section —
+    // scoring stays keyed on "experience", but the section retains the user's
+    // own wording for display.
+    const sections = build([
+      { text: "Dana Lopez", fontSize: 18 },
+      { text: "dana.lopez@example.com | (312) 555-0123", fontSize: 11 },
+      { text: "Work History", fontSize: 13 },
+      { text: "Engineer, Globex  2019 - 2021", fontSize: 11 },
+    ]);
+    const experience = sections.find((s) => s.name === "experience");
+    expect(experience?.rawHeading).toBe("Work History");
+  });
+
+  it("captures the original heading text for a skills synonym", () => {
+    const sections = build([
+      { text: "Dana Lopez", fontSize: 18 },
+      { text: "dana.lopez@example.com | (312) 555-0123", fontSize: 11 },
+      { text: "Technical Skills", fontSize: 13 },
+      { text: "TypeScript, SQL, React", fontSize: 11 },
+    ]);
+    const skills = sections.find((s) => s.name === "skills");
+    expect(skills?.rawHeading).toBe("Technical Skills");
+  });
+
+  it("leaves rawHeading undefined for the profile section", () => {
+    const sections = build([
+      { text: "Dana Lopez", fontSize: 18 },
+      { text: "dana.lopez@example.com | (312) 555-0123", fontSize: 11 },
+    ]);
+    const profile = sections.find((s) => s.name === "profile");
+    expect(profile?.rawHeading).toBeUndefined();
+  });
+
+  it("threads rawHeading into SectionedResume.sectionHeadings for the display layer", () => {
+    const sections = build([
+      { text: "Dana Lopez", fontSize: 18 },
+      { text: "dana.lopez@example.com | (312) 555-0123", fontSize: 11 },
+      { text: "Work History", fontSize: 13 },
+      { text: "Engineer, Globex  2019 - 2021", fontSize: 11 },
+    ]);
+    const resume = toSectionedResume(sections, "regex");
+    expect(resume.sectionHeadings?.get("experience")).toBe("Work History");
+    expect(resume.sectionHeadings?.size).toBe(1);
   });
 });

--- a/src/lib/heuristics/sections.ts
+++ b/src/lib/heuristics/sections.ts
@@ -57,6 +57,10 @@ export interface PdfLine {
 export interface PdfSection {
   /** "profile" covers anything above the first recognized header. */
   name: SectionName | "profile";
+  /** Verbatim heading text as it appeared in the source document, when this
+   *  section was opened by a recognized/other header (issue #285). Absent for
+   *  "profile" (content above the first header) and synthesized sections. */
+  rawHeading?: string;
   lines: PdfLine[];
 }
 
@@ -82,6 +86,13 @@ export interface SectionedResume {
    *  policy order. A convenience accessor over `byName` for the scorer; not yet
    *  consumed by the pool sourcing (that is the next issue — see #132 Notes). */
   readonly accomplishmentSections: readonly SectionName[];
+  /** Section name → verbatim source heading text, when the section was opened
+   *  by a recognized/other header (issue #285). Display-layer only — scoring
+   *  stays keyed on canonical `SectionName`; this is purely for the UI/export
+   *  to render the user's own wording instead of the hardcoded canonical word.
+   *  Absent entries — and an absent map entirely, for hand-built test fixtures
+   *  predating this field — fall back to the canonical word at the call site. */
+  readonly sectionHeadings?: ReadonlyMap<SectionName, string>;
   /** Which splitter produced the section boundaries — provenance for
    *  confidence tuning / telemetry. */
   readonly source: "markdown" | "regex";
@@ -112,6 +123,10 @@ export function toSectionedResume(
   // all matches' lines in document order. Mirroring that here keeps
   // `byName.get("skills")` byte-identical to the retired `skillsSectionLines`.
   const byName = new Map<SectionName | "profile", string[]>();
+  // First occurrence wins — a resume can split one logical section across
+  // continuation headers (e.g. "EXPERIENCE" repeated across a page break); the
+  // first header's wording is the representative one for display.
+  const sectionHeadings = new Map<SectionName, string>();
   for (const section of sections) {
     // Fold wrapped-continuation lines (a long bullet that wrapped onto a
     // second, marker-less line indented past the bullet marker) into the line
@@ -127,11 +142,19 @@ export function toSectionedResume(
     const existing = byName.get(section.name);
     if (existing) existing.push(...lines);
     else byName.set(section.name, lines);
+    if (
+      section.name !== "profile" &&
+      section.rawHeading &&
+      !sectionHeadings.has(section.name)
+    ) {
+      sectionHeadings.set(section.name, section.rawHeading);
+    }
   }
   return {
     byName,
     accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
     source,
+    sectionHeadings,
   };
 }
 
@@ -869,7 +892,11 @@ export function splitIntoSections(
       sections[sections.length - 1].name,
     );
     if (action.kind === "open") {
-      sections.push({ name: action.name, lines: [] });
+      sections.push({
+        name: action.name,
+        rawHeading: line.text.trim(),
+        lines: [],
+      });
       openedRealSection = true;
       prevLineOpenedBoundary = true;
       continue;
@@ -996,7 +1023,11 @@ export function findSection(
   const matches = sections.filter((s) => s.name === name);
   if (matches.length === 0) return undefined;
   if (matches.length === 1) return matches[0];
-  return { name, lines: matches.flatMap((s) => s.lines) };
+  return {
+    name,
+    rawHeading: matches.find((s) => s.rawHeading)?.rawHeading,
+    lines: matches.flatMap((s) => s.lines),
+  };
 }
 
 // ── Markdown-anchored section splitting ──────────────────────────
@@ -1040,7 +1071,11 @@ export function splitIntoSectionsWithMarkdown(
     const key = normalizeHeaderText(line.text);
     const section = headerTexts.get(key);
     if (section && matchSectionHeader(line.text) === section) {
-      sections.push({ name: section, lines: [] });
+      sections.push({
+        name: section,
+        rawHeading: line.text.trim(),
+        lines: [],
+      });
       continue;
     }
     sections[sections.length - 1].lines.push(line);

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -19,8 +19,12 @@ function bullet(text: string, index: number): BulletObservation {
 
 function makeResult(
   parsed: Partial<CascadeResult["parsed"]> = {},
+  sectionHeadings?: Partial<Record<string, string>>,
 ): CascadeResult {
   return {
+    ...(sectionHeadings
+      ? { sections: { sectionHeadings: new Map(Object.entries(sectionHeadings)) } }
+      : {}),
     parsed: {
       full_name: "Jane Candidate",
       email: "jane@example.com",
@@ -92,8 +96,11 @@ describe("buildAtsResumeModel", () => {
     expect(headings).toEqual(["Experience", "Education", "Skills"]);
 
     const exp = model.sections[0].entries[0];
-    expect(exp.headerLine).toBe("Senior PM · Acme");
-    expect(exp.subLine).toBe("2020 – 2024");
+    // Stacked round-trip shape (#284): title leads the bold header, the
+    // "Company · Location  Dates" line (carrying the parser's date anchor) sits
+    // on the sub-line so the emitted role re-segments back to one entry.
+    expect(exp.headerLine).toBe("Senior PM");
+    expect(exp.subLine).toBe("Acme  2020 – 2024");
     expect(exp.bullets).toEqual([
       "Led migration of legacy auth system to OAuth",
       "Drove 30% revenue growth across the platform",
@@ -191,5 +198,25 @@ describe("buildAtsResumeModel", () => {
     const model = buildAtsResumeModel(result, makeScore([]));
     expect(model.sections).toEqual([]);
     expect(model.summary).toBeUndefined();
+  });
+
+  it("uses the verbatim source heading when present, falling back to canonical otherwise (#285)", () => {
+    const result = makeResult({}, { experience: "Work History" });
+    const model = buildAtsResumeModel(result, makeScore([]));
+
+    const experienceSection = model.sections.find(
+      (s) => s.heading === "Work History",
+    );
+    expect(experienceSection).toBeDefined();
+    // Education had no rawHeading recorded — falls back to the canonical word.
+    expect(model.sections.some((s) => s.heading === "Education")).toBe(true);
+    // Summary heading falls back too when no rawHeading was recorded for it.
+    expect(model.summaryHeading).toBeUndefined();
+  });
+
+  it("uses the verbatim source heading for Summary when present", () => {
+    const result = makeResult({}, { summary: "Profile" });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    expect(model.summaryHeading).toBe("Profile");
   });
 });

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -64,6 +64,10 @@ export interface AtsSection {
 export interface AtsResumeModel {
   contact: AtsContact;
   summary?: string;
+  /** Verbatim source heading for the Summary section (#285); falls back to
+   *  "Summary" at draw time when absent. Only meaningful when `summary` is
+   *  set — the Summary heading is drawn separately from `sections`. */
+  summaryHeading?: string;
   sections: AtsSection[];
 }
 
@@ -226,16 +230,36 @@ export function buildAtsResumeModel(
   const sections: AtsSection[] = [];
 
   // ── Experience ──
-  const experienceEntries: AtsEntry[] = experiences.map((exp, i) => ({
-    headerLine:
-      joinHeader([exp.title, exp.company, exp.location], " · ") || "Experience",
-    subLine: experienceDateRange(exp) || undefined,
-    bullets: resolveBullets(
-      bulletsByIndex.get(expOffset + i),
-      bulletOverrides,
-      exp.description,
-    ),
-  }));
+  // Round-trip layout (#284): emit the STACKED shape the text-only parser is
+  // tuned to re-segment — the role TITLE on the bold header line, and
+  // "Company · Location · Dates" on the sub-line. The date lives on the sub-line
+  // so that line becomes the parser's `date_range` anchor (one anchor per role),
+  // with the title one line above it (within the 2-line header lookback). The
+  // old single combined "Title · Company · Location" header line (with the date
+  // on a separate bare line below) did NOT round-trip: a "Company Inc. Location"
+  // header trips the description-prose detector (an "Inc. Seoul"-style internal
+  // sentence break), so the parser folded the header into the previous role's
+  // body and dropped the role — and a bulletless role had no anchor at all.
+  const experienceEntries: AtsEntry[] = experiences.map((exp, i) => {
+    const title = (exp.title ?? "").trim();
+    // Company · Location joined with the dot; the date range is appended after a
+    // whitespace gap (the natural right-aligned-date shape) rather than another
+    // " · ", so stripping the date anchor leaves a clean "Company · Location"
+    // with no dangling separator leaking into the parsed company field.
+    const org = joinHeader([exp.company, exp.location], " · ");
+    const orgLine = [org, experienceDateRange(exp)].filter(Boolean).join("  ");
+    return {
+      // Title alone leads (bold); when a role has no title, the org/date line
+      // leads so it still carries the date anchor on the header line itself.
+      headerLine: title || orgLine || "Experience",
+      subLine: title ? orgLine || undefined : undefined,
+      bullets: resolveBullets(
+        bulletsByIndex.get(expOffset + i),
+        bulletOverrides,
+        exp.description,
+      ),
+    };
+  });
 
   // ── Projects ──
   const projectEntries: AtsEntry[] = projects.map((proj, i) => ({
@@ -286,27 +310,47 @@ export function buildAtsResumeModel(
 
   const achievementsAbove =
     parsed.achievements_placement === "above_experience";
+  // Verbatim source headings (#285) — display-only; scoring stays canonical-
+  // keyed. Falls back to the canonical word when a section wasn't opened by a
+  // recognized/other header (e.g. synthesized or profile-only content).
+  const headings = result.sections?.sectionHeadings;
   const achievementsSection: AtsSection | null =
     achievementEntries.length > 0
-      ? { heading: "Achievements", entries: achievementEntries }
+      ? {
+          heading: headings?.get("achievements") ?? "Achievements",
+          entries: achievementEntries,
+        }
       : null;
 
   if (achievementsAbove && achievementsSection)
     sections.push(achievementsSection);
   if (experienceEntries.length > 0)
-    sections.push({ heading: "Experience", entries: experienceEntries });
+    sections.push({
+      heading: headings?.get("experience") ?? "Experience",
+      entries: experienceEntries,
+    });
   if (projectEntries.length > 0)
-    sections.push({ heading: "Projects", entries: projectEntries });
+    sections.push({
+      heading: headings?.get("projects") ?? "Projects",
+      entries: projectEntries,
+    });
   if (!achievementsAbove && achievementsSection)
     sections.push(achievementsSection);
   if (educationEntries.length > 0)
-    sections.push({ heading: "Education", entries: educationEntries });
+    sections.push({
+      heading: headings?.get("education") ?? "Education",
+      entries: educationEntries,
+    });
   if (skillsEntries.length > 0)
-    sections.push({ heading: "Skills", entries: skillsEntries });
+    sections.push({
+      heading: headings?.get("skills") ?? "Skills",
+      entries: skillsEntries,
+    });
 
   return {
     contact,
     summary: parsed.summary?.trim() || undefined,
+    summaryHeading: headings?.get("summary"),
     sections,
   };
 }

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -232,7 +232,8 @@ export function buildAtsResumeModel(
   // ── Experience ──
   // Round-trip layout (#284): emit the STACKED shape the text-only parser is
   // tuned to re-segment — the role TITLE on the bold header line, and
-  // "Company · Location · Dates" on the sub-line. The date lives on the sub-line
+  // "Company · Location" followed by the dates after a whitespace gap (not a
+  // third " · " — see the join below) on the sub-line. The date lives there
   // so that line becomes the parser's `date_range` anchor (one anchor per role),
   // with the title one line above it (within the 2-line header lookback). The
   // old single combined "Title · Company · Location" header line (with the date

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -33,7 +33,21 @@ const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
 const CONTENT_BOTTOM = MARGIN;
 
 // ── Type scale (points) ───────────────────────────────────────────────────────
-
+//
+// Font-signal stance (#284, Part 2 — documented limitation, not a fix here).
+// This engine DOES emit bold (Helvetica-Bold) and a real type scale — a role
+// header is bold at SIZE_HEADER, its date muted at SIZE_SUB, bullets at SIZE_BODY.
+// Those signals are, however, invisible to the round-trip: our own text-only
+// parser classifies role title / company / bullet purely from text shape and
+// x/y geometry — `groupIntoLines` collapses per-glyph `fontSize`/`fontName` away
+// before `parseEntryBlocks` runs, so re-introducing bold buys re-segmentation
+// nothing. That is why round-trip fidelity (#284) is carried entirely by the
+// TEXT LAYOUT the model emits (the stacked "Title" / "Company · Location  Dates"
+// shape in `ats-resume-model.ts`), not by these weights/sizes. Teaching the
+// parser to consume font weight/size as a role-header signal is a larger,
+// separate change (it would touch `groupIntoLines` retention + `entry-blocks`
+// anchoring) and is intentionally out of scope here; if we later want
+// font-aware parsing, file it as its own follow-up.
 const SIZE_NAME = 18;
 const SIZE_CONTACT = 9;
 const SIZE_SECTION = 11;
@@ -206,7 +220,7 @@ export async function renderAtsResumePdf(
 
   // ── Summary ──
   if (model.summary) {
-    drawSectionHeading(layout, "Summary");
+    drawSectionHeading(layout, model.summaryHeading ?? "Summary");
     layout.drawText(model.summary, { size: SIZE_BODY });
     layout.advance(GAP_BETWEEN_ENTRIES);
   }

--- a/src/lib/pdf/render-roundtrip.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip.repro.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Round-trip regression for #284 — the "Download PDF" reconstructed résumé must
+ * re-segment cleanly through our own text-only parser.
+ *
+ * Pipeline exercised end to end: parse a multi-role résumé → `buildAtsResumeModel`
+ * → `renderAtsResumePdf` → RE-parse the rendered bytes with `runCascade`. Before
+ * the fix, the re-parse LOST work-experience roles (8 → 5): the renderer emitted
+ * each role header as a single combined `Title · Company · Location` line above a
+ * bare date line, and a "Company Inc. Location" header trips the description-prose
+ * detector (an "Inc. Seoul"-style internal sentence break), so the parser folded
+ * the header into the previous role's body and dropped the role — while a
+ * bulletless role had no date anchor at all.
+ *
+ * The fix (`ats-resume-model.ts`) emits the STACKED shape the parser is tuned for:
+ * the role TITLE on the bold header line, and "Company · Location  Dates" on the
+ * sub-line — the date lives on the sub-line so it becomes the `date_range` anchor
+ * (one anchor per role), title one line above within the header lookback.
+ *
+ * Uses the in-tree synthetic fixture `tests/fixtures/pdfs/latex/awesome-cv-resume.pdf`
+ * (persona: Jane Smith, 8 roles) as the round-trip input — no new PDF and no
+ * real-person PII. The lossy `*.expected.json` goldens record only counts and
+ * cannot catch a title/company swap, so this asserts the field mapping directly.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/latex/awesome-cv-resume.pdf",
+);
+
+/** Grade a parsed résumé exactly the way the app's surfaces do (#133): the scorer
+ *  pools bullets from `sections`, so the model's bullet attribution mirrors what
+ *  the reconstructed surface shows. */
+function scoreFor(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: {
+      full_name: cascade.parsed.full_name,
+      email: cascade.parsed.email,
+      phone: cascade.parsed.phone,
+      location: cascade.parsed.location,
+      linkedin_url: cascade.parsed.linkedin_url,
+      summary: cascade.parsed.summary,
+      skills: cascade.parsed.skills,
+      experience: cascade.parsed.experience,
+      education: cascade.parsed.education,
+    },
+    fieldConfidence: cascade.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.sections,
+  });
+}
+
+describe("#284 — Download-PDF reconstructed résumé round-trips through the parser", () => {
+  let original: CascadeResult;
+  let reparsed: CascadeResult;
+
+  beforeAll(async () => {
+    original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const model = buildAtsResumeModel(original, scoreFor(original));
+    const bytes = await renderAtsResumePdf(model);
+    reparsed = await runCascade(bytes);
+  });
+
+  it("preserves the work-experience role count end to end (AC#1)", () => {
+    const origExp = original.parsed.experience ?? [];
+    const reExp = reparsed.parsed.experience ?? [];
+    // Baseline sanity: the fixture parses to 8 roles.
+    expect(origExp.length).toBe(8);
+    expect(reExp.length).toBe(origExp.length);
+  });
+
+  it("re-parses each role's title / company back into the right fields (AC#3)", () => {
+    const origExp = original.parsed.experience ?? [];
+    const reExp = reparsed.parsed.experience ?? [];
+    origExp.forEach((orig, i) => {
+      expect(reExp[i]?.title).toBe(orig.title);
+      expect(reExp[i]?.company).toBe(orig.company);
+      expect(reExp[i]?.start_date).toBe(orig.start_date);
+      expect(reExp[i]?.end_date).toBe(orig.end_date);
+    });
+  });
+
+  it("leaves no role description ending with the NEXT role's header (AC#2)", () => {
+    const reExp = reparsed.parsed.experience ?? [];
+    // A swallowed next-role header manifests as a trailing description line that
+    // reads "Title · Company …". Assert no role's description tail matches any
+    // other role's rendered header signature (title token + the "·" join).
+    const titles = reExp.map((e) => e.title).filter(Boolean) as string[];
+    for (const role of reExp) {
+      const tail = (role.description ?? "").split("\n").pop()?.trim() ?? "";
+      for (const otherTitle of titles) {
+        if (otherTitle === role.title) continue;
+        // The next role's header would appear as "<otherTitle> · <company>".
+        expect(tail.startsWith(`${otherTitle} ·`)).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Epic across four M1 · Parser Hardening issues, accumulated on one branch:

- **#283 (fix)** — Generalize the page running-header/footer furniture strip from the achievements-only path to the shared experience/entry path. `isPageFurniture` promoted to `line-primitives.ts`; a **separator-adjacent-to-keyword** positional guard keeps legit `Company | Title` / `Resume Parser | …` headers while stripping `Name · Résumé N` footers. Fixes the footer bleeding into the first page-2 role's title/company.
- **#285 (feat)** — Preserve verbatim source section headings (`rawHeading` on `PdfSection`, `sectionHeadings` map on `SectionedResume`); render them in the reconstructed résumé + Download PDF, falling back to canonical words. Scoring stays canonical-keyed — no score drift.
- **#284 (fix)** — Make the Download-PDF reconstructed résumé round-trip through the parser by emitting role headers in the stacked `title` / `company·location + dates` shape (role count was **8→5**, now **8→8**). Font-signal blindness documented as an out-of-scope limitation.
- **#287 (fix)** — Split a two-column folded right-column location off the company on the experience path. Awesome-CV folds the location onto the company line with no comma before the city (`Kasa Seoul, S.Korea`), so it landed wholesale in `company`. Adds **Pass D** to `stripLocationSuffix` (space-delimited intl `…Company City, Country`, single-token city + closed-gazetteer country, mirroring Pass B's US guards) and a Pass C guard so a company-internal comma (`Co., Ltd.`, `Command, MND`) is not mistaken for the city boundary. Follow-up to #283, surfaced during this PR's review. All 8 fixture roles now split cleanly.

Resolves #283
Resolves #285
Resolves #284
Resolves #287

## Location-fold behavior (Pass C vs Pass D)

The two-column split is boundary-driven — where the company ends and the city begins is only knowable from a **comma** or a **city gazetteer** (we carry a *country* gazetteer, not a city one):

| Input shape | Handler | Result |
|---|---|---|
| `Google, Mexico City, Mexico` (comma before city) | Pass C | `company: Google` + `location: Mexico City, Mexico` ✅ |
| `Kasa Seoul, S.Korea` (space-fold, single-token city) | Pass D | `company: Kasa` + `location: Seoul, S.Korea` ✅ |
| `Google Mexico City, Mexico` (space-fold, **multi-word** city) | Pass D | **deferred** — stays `company: Google Mexico City`, no location |

The last row is the deliberate limitation: with no comma, `Google Mexico City` is structurally ambiguous (company `Google` + city `Mexico City`, vs. subsidiary `Google Mexico` + city `City`). Pass D captures a single token, so a locality-generic tail (`City`, `Beach`, `Town`, …) is the truncated end of a multi-word place — `LOCALITY_SUFFIX_RE` **defers** those rather than emit a wrong split. Not tracked as an issue; will revisit if it shows up on a real résumé. Comma-delimited multi-word cities (`…, Mexico City, Mexico`) are unaffected — Pass C handles them.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1390 tests)
- [x] `npm run verify` green (typecheck → lint → coverage → build → fallow) — passed in pre-push hook
- [x] New regression tests: page-furniture footer strip, furniture false-positive guards, full build→render→re-parse round-trip, two-column location split (Pass D), Pass D locality-tail deferral
- [ ] Manually spot-check reconstructed résumé + Download PDF headings in `npm run dev`

No new fixture binaries — existing synthetic `awesome-cv-resume.pdf` reused; no PII added.

## Adversarial review

Bounded pre-PR adversarial review (independent reviewer → fix → re-verify → re-review), **2 rounds, converged** (covered #283/#284/#285).

**Round 1 — 1 blocking, fixed.** `FURNITURE_POSITION_RE` (#283) over-matched ordinary `Company | Title` / `Company · Location` headers that merely contain "Resume"/"CV": a bare `|`/`·`/`•`/`‣` alternative combined with the bare-keyword `isPageFurniture` silently deleted the whole entry before anchor detection. Concretely reproduced — `Resume Parser | Python, React  Jan 2024 - Present` → **0** experience entries (vs 1 for `Task Tracker | …`). Real hazard given this tool's own audience (résumé-tooling names: "Resume Parser", "CV Builder", …).
  - **Fix:** the positional guard now requires the separator **adjacent** to the résumé/CV/page-number token (rebuilt from a shared `FURNITURE_KEYWORD` fragment). Legit headers survive; the real `Jane Smith · Résumé 1` footer is still stripped (satisfies both the `· Résumé` adjacency and the `Résumé 1` keyword+digit tell). +2 regression tests (false-positive survives, footer still dropped).

**Round 2 — clean.** Over-match closed (4 legit headers verified surviving), footer still stripped, regex construction sound (`i` flag, escaped metacharacters, correct interpolation), tests non-vacuous. `#285` (score stays canonical-keyed, fallbacks correct, no injection surface) and `#284` (stacked-shape composes with #285's heading logic; anchor still matches) cleared. Fallow's 3 "unused exports" in `markdown-lines.ts` confirmed a pre-existing diff-attribution artifact (not new dead code); duplication clones are pre-existing structural parallelism.

**#287 addendum (added after the 2-round review).** Implementation self-review caught the real hazard: once the abbreviated `s.korea` alias makes Pass C's country match, Pass C's greedy multi-word city over-captured across a company-internal comma (`Omnious. Co., Ltd. Seoul, S.Korea` → city `Ltd. Seoul`, `R.O.K Cyber Command, MND Seoul, S.Korea` → city `MND Seoul`). Fixed with the `cityStartsWithCompanyText` guard (reject a "city" whose first token is a legal suffix or all-caps acronym) so Pass D peels only the real single-token city. Verified against all 8 fixture roles; comma-delimited multi-word cities (`…, Mexico City, Mexico`) still handled by Pass C. Full suite green; corpus golden unchanged.

## PR #286 review (Rohith) — 2 findings, both fixed in `3c698ee`

**1. Pass D mis-split a multi-word city with a locality-generic tail.** `Google Mexico City, Mexico` → `company: "Google Mexico"` + `location: "City, Mexico"` — both wrong. The `#287` addendum *claimed* these stayed deferred, but nothing enforced it: `SPACE_INTL_RE` grabbed `City` as the single-token city. Rohith's literal guard (defer when the remainder ends in a capitalized non-legal-suffix word) would also kill the shipped `Kasa Seoul` / `Sigma Analytics Berlin` cases — structurally a company's last word and a multi-word-city lead are indistinguishable. **Fix:** added `LOCALITY_SUFFIX_RE` to defer specifically the locality-*generic* tails (`City`/`Beach`/`Town`/…) that are never standalone cities, so `Google Mexico City` stays whole while single-token folds still split. Proper-noun compounds (`Buenos Aires`) remain a documented gazetteer-bound limitation. +1 regression test.

**2. Furniture strip dropped real bullets mentioning "resume"/"CV".** `isEntryPageFurniture` combined the bare résumé/CV keyword with `FURNITURE_POSITION_RE`, whose **keyword-independent** `\bpage\s+\d` and `\b\d+\s*(?:/|of)\s*\d+\b` alternatives fire on real content — e.g. `• Rebuilt the resume parser, improving 3 of 5 core metrics` was silently deleted. Especially likely on this project's own domain and on recruiting résumés. **Fix (Rohith's lever 2):** dropped those two keyword-independent alternatives; the positional tell must now sit adjacent to the résumé/CV keyword. Genuine footers keep matching (the #283 fixture `Jane Smith · Résumé 1` hits the separator-adjacency and keyword+digit branches; no test relied on the bare counters). +1 regression test.

**Surviving nit (LOW, no action):** a separator-less footer like `Jane Smith Resume` (no `·`, no page digit) escapes the entry-path guard — a documented, deliberate precision-over-recall tradeoff of the furniture filter.
