### PR TITLE
fix(roundtrip): education + summary fixes + corpus round-trip gate (#291, #292, #293)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Corpus round-trip invariant gate (#293).
+ *
+ * For every fixture PDF, assert that our own reconstructed-PDF output re-parses
+ * back to the same structured résumé:
+ *
+ *   parse1 = runCascade(fixture)
+ *   model  = buildAtsResumeModel(parse1, score(parse1))
+ *   bytes  = renderAtsResumePdf(model)          // the "Download PDF" surface
+ *   parse3 = runCascade(bytes)
+ *   assert invariants(parse1, parse3)
+ *
+ * This is a SELF-CONSISTENCY check — the renderer must emit shapes our own
+ * parser round-trips — fully in our control on both ends, no dependency on
+ * quirky source PDFs. It generalizes the single-fixture `render-roundtrip.repro`
+ * test (#284/#291/#292) to the whole corpus so future renderer or parser
+ * changes can't silently regress a round-trip that works today.
+ *
+ * Only the parse1-vs-parse3 diff carries signal. The original 5-step idea also
+ * diffed rendered PDF bytes against a re-render; `renderAtsResumePdf` is
+ * deterministic, so those bytes are identical and prove only render determinism,
+ * never parse quality. That step is intentionally omitted (#293 scope note).
+ *
+ * `triggers` are deliberately NOT an invariant: reconstruction normalizes layout
+ * to a single-column ATS-clean shape on purpose, so layout triggers (two_column,
+ * etc.) legitimately drop on re-parse. Asserting trigger equality would flag the
+ * intended normalization as a regression.
+ *
+ * PII-free: this asserts field mapping (counts, degree/title/company strings that
+ * are synthetic-persona by policy), never dumps a snapshot of values.
+ *
+ * ── Known-failure baseline (ratchet) ──
+ * The round-trip is NOT yet clean across the whole corpus — the audit that
+ * motivated this gate surfaced a batch of latent renderer/parser bugs (education
+ * count inflation, experience header re-segmentation in dense/two-column layouts,
+ * skills token splits, one total re-parse collapse). Those are tracked as
+ * follow-up issues, not fixed here. `KNOWN_FAILURES` lists, per fixture, which
+ * invariant CATEGORIES are currently allowed to fail. The gate therefore:
+ *   - fails if a NON-baselined category regresses on any fixture (the ratchet's
+ *     teeth — protects every invariant that passes today), and
+ *   - fails if a BASELINED category now PASSES (stale entry — a bug got fixed,
+ *     so its baseline line must be deleted, tightening the gate).
+ * Net effect: the baseline can only shrink. Fix a bug → delete its line.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { runCascade } from "./cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "./types.ts";
+import { buildAtsResumeModel } from "../pdf/ats-resume-model.ts";
+import { renderAtsResumePdf } from "../pdf/render-ats-pdf.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(HERE, "../../..", "tests/fixtures/pdfs");
+
+type Category =
+  | "contact"
+  | "experience"
+  | "education"
+  | "skills"
+  | "summary"
+  // `render` = renderAtsResumePdf threw before any re-parse could run. A crash in
+  // the Download-PDF path is more severe than a field swap; it's baselined the
+  // same way so the gate stays green while the fix is tracked separately.
+  | "render";
+
+/**
+ * Per-fixture invariant categories currently allowed to fail. Keyed by the
+ * fixture path relative to `tests/fixtures/pdfs/`. Shrink this as the follow-up
+ * round-trip bugs are fixed — a fixed bug makes its category pass, which trips
+ * the stale-entry check below and forces the line's removal.
+ *
+ * Grouped by the likely shared root cause so follow-up issues map cleanly:
+ */
+const KNOWN_FAILURES: Record<string, Category[]> = {
+  // renderAtsResumePdf crashes on a non-WinAnsi glyph in the parsed text
+  // (pdf-lib StandardFonts only encode WinAnsi): "→" (0x2192), "‐" (0x2010).
+  // A hard crash in the Download-PDF path — highest-severity of the round-trip
+  // finds. Tracked as its own follow-up.
+  "google-docs/google-docs-skia-proxy-classic.pdf": ["render"],
+  "unknown/weasyprint-cairo-classic.pdf": ["render"],
+  "word/openresume-laverne-word-quartz.pdf": ["render"],
+
+  // Education count inflation: reconstructed education emits a phantom extra
+  // entry (1→2, 2→3) on re-parse.
+  "google-docs/google-docs-skia-proxy-achievements-oneline.pdf": ["education"],
+  "google-docs/google-docs-skia-proxy-additional-skills.pdf": ["education"],
+  "google-docs/google-docs-skia-proxy-honors-subheadings.pdf": ["education"],
+  "latex/header-as-name-functional-resume.pdf": ["education"],
+  "unknown/chromium-qualified-experience-headers.pdf": ["education"],
+  "word/chanchal-sharma-bulleted-skills.pdf": ["education"],
+  "word/chanchal-sharma-sample.pdf": ["education"],
+
+  // Experience header re-segmentation: title/company (and sometimes dates) swap
+  // or shift on re-parse in denser / multi-role / two-column layouts.
+  "google-docs/google-docs-skia-proxy-certifications.pdf": ["experience"],
+  "latex/awesome-cv-cv.pdf": ["experience"],
+  "unknown/chromium-two-column-sidebar.pdf": ["experience"],
+  "unknown/two-column-achievements-sidebar.pdf": ["experience"],
+
+  // Experience header re-segmentation + a skills-line token split (+1 skill).
+  "google-docs/google-docs-skia-proxy-role-first-experience.pdf": [
+    "experience",
+    "skills",
+  ],
+  "latex/deedy-resume-macfonts.pdf": ["experience", "skills"],
+  "latex/deedy-resume-openfonts.pdf": ["experience", "skills"],
+  "unknown/openresume-react-pdf.pdf": ["experience", "skills"],
+
+  // Multiple: experience swap, education institution pollution
+  // ("University of California" → "… · Berkeley Berkeley, CA"), skills +1.
+  "google-docs/google-docs-skia-proxy-programs-skills-software.pdf": [
+    "experience",
+    "education",
+    "skills",
+  ],
+
+  // Total re-parse collapse: the reconstructed PDF reads back empty (contact,
+  // experience, and education all drop out).
+  "google-docs/google-docs-skia-proxy-coursework-dup.pdf": [
+    "contact",
+    "experience",
+    "education",
+  ],
+};
+
+function walkPdfs(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkPdfs(p));
+    else if (e.isFile() && e.name.toLowerCase().endsWith(".pdf")) out.push(p);
+  }
+  return out.sort();
+}
+
+function scoreFor(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: { ...cascade.parsed },
+    fieldConfidence: cascade.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.sections,
+  });
+}
+
+const same = (a: unknown, b: unknown) =>
+  JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+
+/** Collect per-category failure messages for one round-trip. Empty array for a
+ *  category ⇒ that invariant holds. */
+function invariantFailures(
+  p1: CascadeResult,
+  p3: CascadeResult,
+): Record<Exclude<Category, "render">, string[]> {
+  const c1 = p1.parsed;
+  const c3 = p3.parsed;
+  const fails: Record<Exclude<Category, "render">, string[]> = {
+    contact: [],
+    experience: [],
+    education: [],
+    skills: [],
+    summary: [],
+  };
+
+  for (const k of [
+    "full_name",
+    "email",
+    "phone",
+    "location",
+    "linkedin_url",
+  ] as const) {
+    if (!same(c1[k], c3[k]))
+      fails.contact.push(
+        `${k}: ${JSON.stringify(c1[k])} → ${JSON.stringify(c3[k])}`,
+      );
+  }
+
+  const e1 = c1.experience ?? [];
+  const e3 = c3.experience ?? [];
+  if (e1.length !== e3.length) {
+    fails.experience.push(`role count ${e1.length} → ${e3.length}`);
+  } else {
+    e1.forEach((r, i) => {
+      for (const k of ["title", "company", "start_date", "end_date"] as const)
+        if (!same(r[k], e3[i]?.[k])) fails.experience.push(`role[${i}].${k}`);
+    });
+  }
+
+  const d1 = c1.education ?? [];
+  const d3 = c3.education ?? [];
+  if (d1.length !== d3.length) {
+    fails.education.push(`entry count ${d1.length} → ${d3.length}`);
+  } else {
+    d1.forEach((r, i) => {
+      for (const k of ["degree", "field", "institution"] as const)
+        if (!same(r[k], d3[i]?.[k])) fails.education.push(`entry[${i}].${k}`);
+    });
+  }
+
+  const sk1 = (c1.skills ?? []).length;
+  const sk3 = (c3.skills ?? []).length;
+  if (sk1 !== sk3) fails.skills.push(`count ${sk1} → ${sk3}`);
+
+  const s1 = c1.summary ?? "";
+  const s3 = c3.summary ?? "";
+  if (s1.length > 0) {
+    const deltaPct = (100 * Math.abs(s1.length - s3.length)) / s1.length;
+    if (deltaPct >= 5)
+      fails.summary.push(
+        `|Δ| ${deltaPct.toFixed(1)}% (${s1.length} → ${s3.length})`,
+      );
+  }
+
+  return fails;
+}
+
+const CATEGORIES: Category[] = [
+  "contact",
+  "experience",
+  "education",
+  "skills",
+  "summary",
+  "render",
+];
+
+describe("corpus round-trip invariants (#293)", () => {
+  const fixtures = walkPdfs(FIXTURE_ROOT);
+
+  it("finds fixtures to round-trip", () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+  });
+
+  it("every KNOWN_FAILURES key names a real fixture", () => {
+    const rel = new Set(fixtures.map((f) => relative(FIXTURE_ROOT, f)));
+    for (const key of Object.keys(KNOWN_FAILURES))
+      expect(rel.has(key), `stale KNOWN_FAILURES key: ${key}`).toBe(true);
+  });
+
+  for (const fixture of fixtures) {
+    const rel = relative(FIXTURE_ROOT, fixture);
+    it(`round-trips: ${rel}`, async () => {
+      const p1 = await runCascade(new Uint8Array(readFileSync(fixture)));
+      const model = buildAtsResumeModel(p1, scoreFor(p1));
+
+      let fails: Record<Category, string[]>;
+      try {
+        const p3 = await runCascade(await renderAtsResumePdf(model));
+        fails = { ...invariantFailures(p1, p3), render: [] };
+      } catch (err) {
+        // A render crash pre-empts every field invariant; record it as the
+        // single `render` failure so the baseline/ratchet logic below handles it
+        // uniformly.
+        fails = {
+          contact: [],
+          experience: [],
+          education: [],
+          skills: [],
+          summary: [],
+          render: [`renderAtsResumePdf threw: ${(err as Error).message}`],
+        };
+      }
+      const baseline = new Set(KNOWN_FAILURES[rel] ?? []);
+
+      for (const cat of CATEGORIES) {
+        const failing = fails[cat].length > 0;
+        if (baseline.has(cat)) {
+          // Ratchet: a baselined category that now passes means the underlying
+          // bug was fixed — delete its line from KNOWN_FAILURES to tighten the
+          // gate. (This intentionally fails until the stale entry is removed.)
+          expect(
+            failing,
+            `${rel}: '${cat}' now round-trips — remove it from KNOWN_FAILURES`,
+          ).toBe(true);
+        } else {
+          // The teeth: any non-baselined category must round-trip cleanly.
+          expect(
+            fails[cat],
+            `${rel}: '${cat}' regressed:\n  ${fails[cat].join("\n  ")}`,
+          ).toEqual([]);
+        }
+      }
+    });
+  }
+});
+
+/**
+ * Dev triage harness — inert in CI, runs ONLY when `RL_RT_PDF=<path>` is set:
+ *
+ *   RL_RT_PDF=/path/to/real-resume.pdf npx vitest run \
+ *     src/lib/heuristics/corpus-roundtrip.test.ts
+ *
+ * Dumps the per-category parse1-vs-parse3 diff for one arbitrary PDF, so a
+ * real (uncommitted, possibly PII-bearing) résumé can be round-trip-audited
+ * WITHOUT being committed as a fixture. This is how the education (#291) and
+ * summary (#292) regressions were originally localized. Kept out of the corpus
+ * gate above precisely because the input may carry PII.
+ */
+describe.runIf(process.env.RL_RT_PDF)("round-trip dev harness (RL_RT_PDF)", () => {
+  it("dumps the parse1-vs-parse3 diff for RL_RT_PDF", async () => {
+    const path = process.env.RL_RT_PDF!;
+    const p1 = await runCascade(new Uint8Array(readFileSync(path)));
+    const model = buildAtsResumeModel(p1, scoreFor(p1));
+    const p3 = await runCascade(await renderAtsResumePdf(model));
+    const fails = invariantFailures(p1, p3);
+    const summary = Object.fromEntries(
+      (Object.keys(fails) as Exclude<Category, "render">[])
+        .filter((c) => fails[c].length > 0)
+        .map((c) => [c, fails[c]]),
+    );
+    console.log(
+      `RL_RT_PDF round-trip diff for ${path}:\n` +
+        (Object.keys(summary).length
+          ? JSON.stringify(summary, null, 2)
+          : "clean — all invariants round-trip"),
+    );
+    // Informational only: never fails, so a PII résumé with known bugs doesn't
+    // redden the suite.
+    expect(true).toBe(true);
+  });
+});

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -114,11 +114,12 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   "latex/deedy-resume-openfonts.pdf": ["experience", "skills"],
   "unknown/openresume-react-pdf.pdf": ["experience", "skills"],
 
-  // Multiple: experience swap, education institution pollution
-  // ("University of California" → "… · Berkeley Berkeley, CA"), skills +1.
+  // Multiple: experience swap, skills +1. (The education "institution
+  // pollution" — "University of California" → "… · Berkeley, CA" glued — was
+  // fixed by teaching `stripInstitutionLocation` the " · " middot boundary the
+  // reconstructed education sub-line emits, #294; education now round-trips.)
   "google-docs/google-docs-skia-proxy-programs-skills-software.pdf": [
     "experience",
-    "education",
     "skills",
   ],
 
@@ -154,22 +155,12 @@ function scoreFor(cascade: CascadeResult) {
 const same = (a: unknown, b: unknown) =>
   JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
 
-/** Collect per-category failure messages for one round-trip. Empty array for a
- *  category ⇒ that invariant holds. */
-function invariantFailures(
-  p1: CascadeResult,
-  p3: CascadeResult,
-): Record<Exclude<Category, "render">, string[]> {
-  const c1 = p1.parsed;
-  const c3 = p3.parsed;
-  const fails: Record<Exclude<Category, "render">, string[]> = {
-    contact: [],
-    experience: [],
-    education: [],
-    skills: [],
-    summary: [],
-  };
-
+/** Contact scalar-field diffs (name/email/phone/location/linkedin). */
+function contactFails(
+  c1: CascadeResult["parsed"],
+  c3: CascadeResult["parsed"],
+): string[] {
+  const out: string[] = [];
   for (const k of [
     "full_name",
     "email",
@@ -178,48 +169,65 @@ function invariantFailures(
     "linkedin_url",
   ] as const) {
     if (!same(c1[k], c3[k]))
-      fails.contact.push(
-        `${k}: ${JSON.stringify(c1[k])} → ${JSON.stringify(c3[k])}`,
-      );
+      out.push(`${k}: ${JSON.stringify(c1[k])} → ${JSON.stringify(c3[k])}`);
   }
+  return out;
+}
 
-  const e1 = c1.experience ?? [];
-  const e3 = c3.experience ?? [];
-  if (e1.length !== e3.length) {
-    fails.experience.push(`role count ${e1.length} → ${e3.length}`);
-  } else {
-    e1.forEach((r, i) => {
-      for (const k of ["title", "company", "start_date", "end_date"] as const)
-        if (!same(r[k], e3[i]?.[k])) fails.experience.push(`role[${i}].${k}`);
-    });
-  }
+/** Ordered-entry-list diff (shared by experience and education): a count
+ *  mismatch, else per-field inequality at each index. */
+function entryListFails<T>(
+  a1: readonly T[],
+  a3: readonly T[],
+  keys: readonly (keyof T)[],
+  label: string,
+): string[] {
+  if (a1.length !== a3.length)
+    return [`${label} count ${a1.length} → ${a3.length}`];
+  const out: string[] = [];
+  a1.forEach((r, i) => {
+    for (const k of keys)
+      if (!same(r[k], a3[i]?.[k])) out.push(`${label}[${i}].${String(k)}`);
+  });
+  return out;
+}
 
-  const d1 = c1.education ?? [];
-  const d3 = c3.education ?? [];
-  if (d1.length !== d3.length) {
-    fails.education.push(`entry count ${d1.length} → ${d3.length}`);
-  } else {
-    d1.forEach((r, i) => {
-      for (const k of ["degree", "field", "institution"] as const)
-        if (!same(r[k], d3[i]?.[k])) fails.education.push(`entry[${i}].${k}`);
-    });
-  }
+/** Summary length drift ≥ 5% (the round-trip truncation signal, #292). */
+function summaryFails(s1: string, s3: string): string[] {
+  if (s1.length === 0) return [];
+  const deltaPct = (100 * Math.abs(s1.length - s3.length)) / s1.length;
+  return deltaPct >= 5
+    ? [`|Δ| ${deltaPct.toFixed(1)}% (${s1.length} → ${s3.length})`]
+    : [];
+}
 
+/** Collect per-category failure messages for one round-trip. Empty array for a
+ *  category ⇒ that invariant holds. */
+function invariantFailures(
+  p1: CascadeResult,
+  p3: CascadeResult,
+): Record<Exclude<Category, "render">, string[]> {
+  const c1 = p1.parsed;
+  const c3 = p3.parsed;
   const sk1 = (c1.skills ?? []).length;
   const sk3 = (c3.skills ?? []).length;
-  if (sk1 !== sk3) fails.skills.push(`count ${sk1} → ${sk3}`);
-
-  const s1 = c1.summary ?? "";
-  const s3 = c3.summary ?? "";
-  if (s1.length > 0) {
-    const deltaPct = (100 * Math.abs(s1.length - s3.length)) / s1.length;
-    if (deltaPct >= 5)
-      fails.summary.push(
-        `|Δ| ${deltaPct.toFixed(1)}% (${s1.length} → ${s3.length})`,
-      );
-  }
-
-  return fails;
+  return {
+    contact: contactFails(c1, c3),
+    experience: entryListFails(
+      c1.experience ?? [],
+      c3.experience ?? [],
+      ["title", "company", "start_date", "end_date"] as const,
+      "role",
+    ),
+    education: entryListFails(
+      c1.education ?? [],
+      c3.education ?? [],
+      ["degree", "field", "institution"] as const,
+      "entry",
+    ),
+    skills: sk1 !== sk3 ? [`count ${sk1} → ${sk3}`] : [],
+    summary: summaryFails(c1.summary ?? "", c3.summary ?? ""),
+  };
 }
 
 const CATEGORIES: Category[] = [

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -260,3 +260,51 @@ describe("extractEducation — degree/field split + location peel (#222)", () =>
     expect(value[0].field).toBe("Data Science");
   });
 });
+
+describe("extractEducation — trailing date peeled cleanly off one-line institution (#294)", () => {
+  // The reconstructed-résumé sub-line emits "Institution  Dates" on one line.
+  // `stripInstitutionDate` must peel the WHOLE date, not just its trailing year —
+  // a half-strip ("… Fall 2013 – Spring") corrupts the institution field.
+  it("peels a season-qualified range whole (not just the trailing year)", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "B.S. Computer Science",
+        "Some University  Fall 2013 – Spring 2014",
+      ]),
+    );
+    expect(value[0].institution).toBe("Some University");
+    expect(value[0].institution).not.toMatch(/Fall|Spring|\d{4}/);
+  });
+
+  it("peels a single season-qualified year whole", () => {
+    const { value } = extractEducation(
+      mkEduSection(["B.A. History", "Some University  Fall 2014"]),
+    );
+    expect(value[0].institution).toBe("Some University");
+  });
+
+  it("peels a numeric MM/YYYY range", () => {
+    const { value } = extractEducation(
+      mkEduSection(["B.S. Biology", "Example College  01/2020 – 05/2020"]),
+    );
+    expect(value[0].institution).toBe("Example College");
+  });
+
+  it("peels an open-ended '… – Current' range", () => {
+    const { value } = extractEducation(
+      mkEduSection(["B.S. Physics", "Example College  2015 – Current"]),
+    );
+    expect(value[0].institution).toBe("Example College");
+  });
+
+  it("strips a ' · City, ST' middot location off the institution", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "B.S. Computer Science",
+        "University of Example · Seattle, WA  Sep 2020 – May 2024",
+      ]),
+    );
+    expect(value[0].institution).toBe("University of Example");
+    expect(value[0].location).toBe("Seattle, WA");
+  });
+});

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -357,7 +357,13 @@ function stripInstitutionLocation(s: string): {
   // "Stanford University, CA" (state-only, no city) wrongly yields
   // institution "Stanford" + location "University, CA".
   const SPACE_US_RE = /\s{2,}([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
-  const mUS = s.match(COMMA_US_RE) ?? s.match(SPACE_US_RE);
+  // " · City, ST" middot boundary — the shape the reconstructed education
+  // sub-line emits ("Institution · City, ST", #291/#294). `stripInstitutionDate`
+  // has already peeled any trailing dates by the time this runs.
+  const MIDDOT_US_RE =
+    /\s*·\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})$/;
+  const mUS =
+    s.match(COMMA_US_RE) ?? s.match(SPACE_US_RE) ?? s.match(MIDDOT_US_RE);
   if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
     const before = s
       .slice(0, mUS.index)
@@ -370,7 +376,11 @@ function stripInstitutionLocation(s: string): {
   if (COUNTRY_GAZETTEER.size > 0) {
     const INTL_RE =
       /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
-    const mIntl = s.match(INTL_RE);
+    // " · City, Country" middot boundary — the international counterpart of the
+    // reconstructed education sub-line (#294).
+    const MIDDOT_INTL_RE =
+      /\s*·\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*)$/;
+    const mIntl = s.match(INTL_RE) ?? s.match(MIDDOT_INTL_RE);
     if (mIntl && COUNTRY_GAZETTEER.has(mIntl[2].toLowerCase())) {
       const before = s
         .slice(0, mIntl.index)
@@ -393,10 +403,20 @@ function stripInstitutionLocation(s: string): {
  *  range (or "… – Present"); requires leading whitespace and never consumes the
  *  whole string. */
 function stripInstitutionDate(s: string): string {
-  const DATE = `(?:${MONTH_YEAR_RE.source}|\\b\\d{4}\\b)`;
+  // A single date token: a month-year ("Mar. 2010"), a numeric "MM/YYYY", or a
+  // bare year optionally season-qualified ("Fall 2013"). The season prefix and
+  // the numeric form matter: without them a `$`-anchored strip lands on only the
+  // trailing YEAR of a "Fall 2013 – Spring 2014" range and leaves a corrupted
+  // "… Fall 2013 – Spring" glued onto the institution (#294 review) — worse than
+  // leaving the whole range intact.
+  const SEASON = `(?:spring|summer|fall|autumn|winter)`;
+  const DATE = `(?:${MONTH_YEAR_RE.source}|${NUMERIC_MONTH_YEAR_RE.source}|(?:${SEASON}\\s+)?\\b\\d{4}\\b)`;
+  // Open-ended range tail: "Present"/"Current"/"Ongoing"/"Now" as well as a
+  // second date — so "… 2015 – Current" peels whole, not nothing.
+  const OPEN = `(?:present|current|ongoing|now)`;
   const SEP = `\\s*[–—-]\\s*`;
   const TRAILING_DATE_RE = new RegExp(
-    `\\s+${DATE}(?:${SEP}(?:${DATE}|Present))?\\s*$`,
+    `\\s+${DATE}(?:${SEP}(?:${DATE}|${OPEN}))?\\s*$`,
     "i",
   );
   const stripped = s.replace(TRAILING_DATE_RE, "").trim();

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -384,6 +384,25 @@ function stripInstitutionLocation(s: string): {
   return { institution: s };
 }
 
+/** Peel a trailing date range / single date off an institution string. When the
+ *  institution and its dates land on ONE line — as the Download-PDF reconstructed
+ *  résumé emits them ("… University, S.Korea  Mar. 2010 – Aug. 2017") — the date
+ *  is still captured separately via `parseEducationDates(joined)`, but without
+ *  this strip it stayed glued onto `institution` and even blocked the trailing
+ *  location strip (#291). Matches a month-year or bare year, optionally as a
+ *  range (or "… – Present"); requires leading whitespace and never consumes the
+ *  whole string. */
+function stripInstitutionDate(s: string): string {
+  const DATE = `(?:${MONTH_YEAR_RE.source}|\\b\\d{4}\\b)`;
+  const SEP = `\\s*[–—-]\\s*`;
+  const TRAILING_DATE_RE = new RegExp(
+    `\\s+${DATE}(?:${SEP}(?:${DATE}|Present))?\\s*$`,
+    "i",
+  );
+  const stripped = s.replace(TRAILING_DATE_RE, "").trim();
+  return stripped || s;
+}
+
 /** Map one education chunk (the degree + institution + date lines of a single
  *  qualification) to a `ResumeEducation` and its confidence. */
 function educationFromChunk(chunk: string[]): {
@@ -434,6 +453,11 @@ function educationFromChunk(chunk: string[]): {
       }
     }
   }
+
+  // Peel a trailing date range off the institution first (a one-line
+  // "Institution  Dates" shape, e.g. the reconstructed-résumé emitter, #291),
+  // otherwise the date blocks the $-anchored location strip below.
+  institution = stripInstitutionDate(institution);
 
   // Peel a trailing "City, ST" / "City, Country" off the institution so it isn't
   // glued on ("University of Example, …   Seattle, WA" → institution without the

--- a/src/lib/heuristics/extract/summary.test.ts
+++ b/src/lib/heuristics/extract/summary.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { extractSummary } from "./summary.ts";
+import type { PdfLine, PdfSection } from "../sections.ts";
+
+/** extractSummary only reads `line.text`; build minimal lines. */
+function line(text: string): PdfLine {
+  return { text } as unknown as PdfLine;
+}
+function summarySection(...texts: string[]): PdfSection {
+  return { name: "summary", lines: texts.map(line) } as PdfSection;
+}
+
+describe("extractSummary", () => {
+  it("keeps an en/em-dash-led continuation line as prose (#292)", () => {
+    // A prose summary wraps such that a sentence-level em dash lands at the
+    // START of a continuation line — exactly how the reconstructed-résumé
+    // renderer re-wraps a parenthetical. isBulletLine would drop it as a bullet,
+    // silently truncating the summary on round-trip.
+    const section = summarySection(
+      "Seasoned SRE/DevOps leader with 15+ years of expertise",
+      "— proven in scaling infrastructure teams at two fintech companies.",
+      "Delivered technical advisory for DeFi, AI, and B2B SaaS startups.",
+    );
+    const { value } = extractSummary(section);
+    expect(value).toContain("proven in scaling infrastructure teams");
+    // Nothing dropped: all three lines are joined into one prose paragraph.
+    expect(value).toBe(
+      "Seasoned SRE/DevOps leader with 15+ years of expertise " +
+        "— proven in scaling infrastructure teams at two fintech companies. " +
+        "Delivered technical advisory for DeFi, AI, and B2B SaaS startups.",
+    );
+  });
+
+  it("also keeps an en-dash-led line", () => {
+    const section = summarySection(
+      "Platform engineer focused on reliability",
+      "– driving multi-region rollouts across AWS and GCP.",
+    );
+    expect(extractSummary(section).value).toContain("driving multi-region");
+  });
+
+  it("still drops genuine glyph / hyphen / asterisk bullets", () => {
+    const section = summarySection(
+      "Core strengths:",
+      "• Kubernetes and Terraform at scale",
+      "- Incident response and on-call leadership",
+      "* Cost optimization",
+    );
+    const { value } = extractSummary(section);
+    expect(value).toBe("Core strengths:");
+  });
+
+  it("returns confidence 0 for an empty or missing section", () => {
+    expect(extractSummary(undefined).confidence).toBe(0);
+    expect(extractSummary(summarySection()).confidence).toBe(0);
+  });
+});

--- a/src/lib/heuristics/extract/summary.ts
+++ b/src/lib/heuristics/extract/summary.ts
@@ -1,10 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-import type { PdfSection } from "../sections.ts";
-import { isBulletLine } from "../line-primitives.ts";
+import type { PdfLine, PdfSection } from "../sections.ts";
 
 // ── Summary ─────────────────────────────────────────────────────────────────
+
+/**
+ * A summary bullet uses a glyph or hyphen/asterisk marker. Deliberately NARROWER
+ * than the shared `isBulletLine`: it OMITS the en/em dashes (`–` `—`). A prose
+ * summary can wrap such that a sentence-level dash lands at the start of a
+ * continuation line (e.g. "…security engineering\n— proven in scaling…" — how
+ * our own reconstructed-résumé renderer re-wraps a parenthetical). Treating that
+ * line as a bullet silently truncates the summary on round-trip (#292); here we
+ * keep it as prose. `isBulletLine` still owns dash-bulleted experience lines —
+ * this stricter set is summary-local on purpose.
+ */
+const SUMMARY_BULLET_RE = /^\s*[•‣▪●◦⁃*\-]/;
 
 /**
  * Summary is a prose paragraph, usually 2–6 lines, right after the "Summary"
@@ -16,7 +27,7 @@ export function extractSummary(
 ): { value?: string; confidence: number } {
   if (!summary || summary.lines.length === 0) return { confidence: 0 };
   const prose = summary.lines
-    .filter((l) => !isBulletLine(l))
+    .filter((l: PdfLine) => !SUMMARY_BULLET_RE.test(l.text))
     .map((l) => l.text.trim())
     .join(" ")
     .replace(/\s+/g, " ")

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -107,7 +107,10 @@ describe("buildAtsResumeModel", () => {
     ]);
 
     const edu = model.sections[1].entries[0];
-    expect(edu.headerLine).toBe("BS Computer Science — State University");
+    // Stacked shape (#291): degree leads the header, institution moves to the
+    // sub-line (mirroring experience) so it round-trips back through the parser.
+    expect(edu.headerLine).toBe("BS Computer Science");
+    expect(edu.subLine).toBe("State University  2016");
     expect(edu.bullets[0]).toMatch(/Coursework: Algorithms, Databases/);
 
     const skills = model.sections[2].entries[0];
@@ -133,12 +136,14 @@ describe("buildAtsResumeModel", () => {
     });
     const model = buildAtsResumeModel(result, makeScore([]));
     const edu = model.sections.find((s) => s.heading === "Education")!;
+    // Stacked shape (#291): degree(+field) on the header, institution on the
+    // sub-line (with the date anchor appended after a whitespace gap).
     expect(edu.entries[0].headerLine).toBe(
-      "Bachelor of Science, Mechanical Engineering — Riverside College Of Engineering",
+      "Bachelor of Science, Mechanical Engineering",
     );
-    expect(edu.entries[1].headerLine).toBe(
-      "Applied Robotics Program — ACME Professional Education",
-    );
+    expect(edu.entries[0].subLine).toBe("Riverside College Of Engineering");
+    expect(edu.entries[1].headerLine).toBe("Applied Robotics Program");
+    expect(edu.entries[1].subLine).toBe("ACME Professional Education  2024");
   });
 
   it("falls back to description split when no graded bullets are attributed", () => {

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -29,7 +29,7 @@ import {
   groupBulletsByExperience,
   type BulletExperience,
 } from "../score/group-bullets.ts";
-import { buildEducationDates, buildProjectDates } from "../score/entry-dates.ts";
+import { buildProjectDates } from "../score/entry-dates.ts";
 import { buildContactFields } from "../contact.ts";
 import type {
   ContactOverrides,
@@ -292,13 +292,30 @@ export function buildAtsResumeModel(
       bullets.push(`Coursework: ${edu.coursework.join(", ")}`);
     }
     // Degree + major share the primary slot ("Bachelor of Science, Mechanical
-    // Engineering"); a degree-less program (#238) shows its title (in
-    // `field`) alone. Then " — institution".
+    // Engineering"); a degree-less program (#238) shows its title (in `field`)
+    // alone. Stacked shape (mirrors the experience fix in #284, and #291): the
+    // degree leads the (bold) header line, and "Institution · Location  Dates"
+    // sits on the sub-line — institution on the sub-line, the date after a
+    // whitespace gap so it becomes the entry's date anchor. Emitting the old
+    // glued "Degree — Institution" one-liner did not round-trip: re-parsing
+    // collapsed degree/field/institution into each other (#291).
     const degreeField = [edu.degree, edu.field].filter(Boolean).join(", ");
+    const org = joinHeader([edu.institution, edu.location], " · ");
+    // Spaced " – " range (the experience shape) so the re-parser recognizes and
+    // strips the date anchor off the institution line; `buildEducationDates`'
+    // unspaced en-dash was left glued into `institution` on round-trip (#291).
+    // Fall back to the bare year when only a single year is known.
+    const eduDates =
+      experienceDateRange({
+        start_date: edu.start_date,
+        end_date: edu.end_date,
+      }) ||
+      edu.year ||
+      "";
+    const orgLine = [org, eduDates].filter(Boolean).join("  ");
     return {
-      headerLine: joinHeader([degreeField, edu.institution], " — ") ||
-        "Education",
-      subLine: buildEducationDates(edu) || undefined,
+      headerLine: degreeField || orgLine || "Education",
+      subLine: degreeField ? orgLine || undefined : undefined,
       bullets,
     };
   });

--- a/src/lib/pdf/render-roundtrip.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip.repro.test.ts
@@ -96,6 +96,36 @@ describe("#284 — Download-PDF reconstructed résumé round-trips through the p
     });
   });
 
+  it("re-parses education degree / field / institution back into the right fields (#291)", () => {
+    const origEdu = original.parsed.education ?? [];
+    const reEdu = reparsed.parsed.education ?? [];
+    // Baseline: the fixture parses to at least one education entry.
+    expect(origEdu.length).toBeGreaterThan(0);
+    expect(reEdu.length).toBe(origEdu.length);
+    origEdu.forEach((orig, i) => {
+      expect(reEdu[i]?.degree).toBe(orig.degree);
+      expect(reEdu[i]?.field).toBe(orig.field);
+      // Institution must round-trip clean — before the fix the reconstructed
+      // "Institution  Dates" one-liner glued the date range onto `institution`.
+      expect(reEdu[i]?.institution).toBe(orig.institution);
+      expect(reEdu[i]?.institution ?? "").not.toMatch(/\b\d{4}\s*$/);
+      expect(reEdu[i]?.start_date).toBe(orig.start_date);
+      expect(reEdu[i]?.end_date).toBe(orig.end_date);
+    });
+  });
+
+  it("preserves the summary text end to end (#292)", () => {
+    const s1 = original.parsed.summary ?? "";
+    const s3 = reparsed.parsed.summary ?? "";
+    expect(s1.length).toBeGreaterThan(0);
+    // The reconstructed-résumé renderer re-wraps prose, which can push a
+    // sentence-level en/em dash to the start of a line; the summary extractor
+    // used to drop that line as a "bullet" (#292), shrinking the summary.
+    // Round-trip must now preserve it within whitespace-normalization noise.
+    const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+    expect(norm(s3)).toBe(norm(s1));
+  });
+
   it("leaves no role description ending with the NEXT role's header (AC#2)", () => {
     const reExp = reparsed.parsed.experience ?? [];
     // A swallowed next-role header manifests as a trailing description line that


### PR DESCRIPTION
## Summary

Fixes + a CI gate from a **round-trip audit** of the Download-PDF reconstructed résumé: parse → `buildAtsResumeModel` → `renderAtsResumePdf` → **re-parse the rendered bytes**, then diff parse-1 vs parse-3.

Lands **#291 (education)**, **#292 (summary)**, and **#293 (corpus round-trip gate)**.

## #291 — education entry collapsed on round-trip

Reconstructed résumé emitted each education entry as a glued `Degree — Institution` one-liner the text-only re-parser couldn't re-split: **degree/field/institution collapsed** and the **date range welded onto `institution`**.

- `ats-resume-model.ts` — emit the **stacked** shape (mirrors the #284 experience fix): degree(+field) on the bold header; `Institution · Location  Dates` on the sub-line (date → parser's `date_range` anchor).
- `extract/education.ts` — new `stripInstitutionDate` peels a trailing date off the institution line before the location strip.

## #292 — summary lost ~11% of its text on round-trip

The renderer re-wraps prose so a sentence-level **en/em dash lands at a continuation-line start** (`…engineering\n— proven in scaling…`). `extractSummary` filtered via the shared `isBulletLine` (marker set includes `– —`) → **dropped that line as a "bullet"** → 104 of 957 chars gone.

- `extract/summary.ts` — summary-local `SUMMARY_BULLET_RE` that **omits en/em dashes** (glyph/hyphen/asterisk still count). Shared `isBulletLine` untouched. Verified **957 → 957 (0.0% Δ)**.

## #293 — corpus round-trip invariant gate

New `corpus-roundtrip.test.ts` round-trips **every fixture** and asserts contact/experience/education/skills/summary field mapping is preserved (auto-wired into `npm run test`). `triggers` deliberately excluded — reconstruction normalizes layout to single-column on purpose.

**The corpus is not yet clean.** The audit surfaced ~17 latent bugs, held in a per-fixture `KNOWN_FAILURES` baseline that **ratchets** (a regression in any passing invariant fails the gate; fixing a baselined bug makes its entry go stale-red until removed — so the baseline can only shrink). Grouped for follow-up issues:

| Pattern | Fixtures | Likely root cause |
|---|---|---|
| **render crash** (highest severity) | 3 | `renderAtsResumePdf` throws on non-WinAnsi glyphs (`→` 0x2192, `‐` 0x2010) — kills Download-PDF entirely |
| education count inflation (1→2, 2→3) | 8 | reconstructed education emits a phantom extra entry |
| experience title/company swap | ~10 | header re-segmentation in dense/two-column layouts |
| skills count +1 | 5 | reconstructed skills line splits one extra token |
| institution pollution | 1 | `#291` strip edge on a two-part institution+location |
| total re-parse collapse | 1 (coursework-dup) | reconstructed PDF reads back empty |

Also ships an env-gated **dev harness** (`RL_RT_PDF=<path>`) for one-off triage of real, uncommitted (possibly PII-bearing) résumés — how #291/#292 were localized — kept out of the committed corpus for that reason.

## Tests

- `corpus-roundtrip.test.ts` (new) — the gate + baseline + dev harness.
- `render-roundtrip.repro.test.ts` — education field-mapping + summary-preservation assertions (synthetic `awesome-cv-resume.pdf`, no PII).
- `extract/summary.test.ts` (new) — dash-led continuation kept; real bullets dropped.
- `ats-resume-model.test.ts` — 2 assertions updated to the stacked shape.

Both content fixes verified end-to-end on a real résumé locally (dev harness reports it **"clean — all invariants round-trip"**).

## Gate

`npm run verify` green: typecheck ✓, lint ✓, **1438** tests (+1 skipped harness) ✓, build ✓. Fallow diff gate clean on the changed files; the complexity/duplication findings it reports are **inherited** (`buildAtsResumeModel` CRAP 30.6 at 91% tested; the pre-existing `toBulletExperience` clone) — report-only, not introduced here.

## Follow-ups

The ~17 baselined round-trip bugs above are the next round of squashing — file per-pattern issues off the table (the render crash first — it's a hard crash). Each fix deletes its `KNOWN_FAILURES` line and the ratchet keeps it fixed.

Refs #291, #292, #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fXd19rsShrHyhiMeoQBDy
