### PR TITLE
fix(roundtrip): render hardening, experience swap, skills word-wrap + scanned false-positive

### DIFF
--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -40,6 +40,7 @@ import {
   groupBulletsByExperience,
   needsAttention,
   suppressTitleOwnedBullets,
+  toBulletExperience,
 } from "../../lib/score/group-bullets.ts";
 import { ContactCard } from "./ContactCard.tsx";
 import {
@@ -244,25 +245,6 @@ function NotDetected({ what }: { what: string }) {
  * We do NOT rely on groupBulletsByExperience's output alone: it omits entries
  * with no matched bullet, which would silently drop those roles/projects/items.
  */
-function toBulletExperience(
-  entries: ReadonlyArray<{
-    title?: string;
-    name?: string;
-    description?: string;
-    start_date?: string;
-    end_date?: string;
-    is_current?: boolean;
-  }>,
-): BulletExperience[] {
-  return entries.map((e) => ({
-    title: e.title ?? e.name,
-    description: e.description,
-    start_date: e.start_date,
-    end_date: e.end_date,
-    is_current: e.is_current,
-  }));
-}
-
 function buildEntryGroups(
   experiences: BulletExperience[],
   projects: ResumeProject[],

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -80,38 +80,56 @@ type Category =
  * Grouped by the likely shared root cause so follow-up issues map cleanly:
  */
 const KNOWN_FAILURES: Record<string, Category[]> = {
-  // renderAtsResumePdf crashes on a non-WinAnsi glyph in the parsed text
-  // (pdf-lib StandardFonts only encode WinAnsi): "→" (0x2192), "‐" (0x2010).
-  // A hard crash in the Download-PDF path — highest-severity of the round-trip
-  // finds. Tracked as its own follow-up.
-  "google-docs/google-docs-skia-proxy-classic.pdf": ["render"],
-  "unknown/weasyprint-cairo-classic.pdf": ["render"],
-  "word/openresume-laverne-word-quartz.pdf": ["render"],
-
-  // Experience header re-segmentation: title/company (and sometimes dates) swap
-  // or shift on re-parse in denser / multi-role / two-column layouts.
-  "google-docs/google-docs-skia-proxy-certifications.pdf": ["experience"],
-  "latex/awesome-cv-cv.pdf": ["experience"],
+  // The experience header title/company SWAP (#298) — title and company traded
+  // places on re-parse in denser / multi-role / two-column layouts — is FIXED:
+  // `disambiguateCompanyTitle` now uses the date-anchor line position as a
+  // tiebreak (anchor line = company, line above = title) when text-content
+  // heuristics can't decide, so the reconstructed stacked shape re-segments to
+  // the same title/company it was built from. Fixtures cleared by that fix have
+  // had their `experience` line removed here (the ratchet forces it).
+  //
+  // The `experience` entries that REMAIN below are NOT the swap — they are
+  // distinct, separately-rooted round-trip bugs that the swap fix does not (and
+  // should not) touch; each warrants its own follow-up:
+  //
+  //   - chromium-two-column-sidebar: count 5 → 7. A stray "20%" token renders
+  //     glued onto the "PROJECTS" section heading ("20% PROJECTS"), so section
+  //     recognition misses it and the projects block leaks into EXPERIENCE as
+  //     phantom roles. A RENDER-side heading-pollution bug, not segmentation.
   "unknown/chromium-two-column-sidebar.pdf": ["experience"],
-  "unknown/two-column-achievements-sidebar.pdf": ["experience"],
 
-  // Experience header re-segmentation + a skills-line token split (+1 skill).
-  "google-docs/google-docs-skia-proxy-role-first-experience.pdf": [
-    "experience",
-    "skills",
-  ],
-  "latex/deedy-resume-macfonts.pdf": ["experience", "skills"],
-  "latex/deedy-resume-openfonts.pdf": ["experience", "skills"],
+  //   - classic / weasyprint: the ONLY diff is a Unicode glyph the #295
+  //     `toWinAnsi` sanitizer rewrites lossily — a role title "… Intern → Junior
+  //     Engineer" round-trips as "… Intern -> Junior Engineer" (→ U+2192 → "->").
+  //     A #295 render-sanitizer artifact, not the header swap.
+  //   - word-quartz: p1 has a role with an EMPTY title; the emit puts
+  //     "Company · Location  Dates" on the header line and re-parse assigns the
+  //     bare "City, ST" location as the title. An empty-title-role emit edge.
+  "google-docs/google-docs-skia-proxy-classic.pdf": ["experience"],
+  "unknown/weasyprint-cairo-classic.pdf": ["experience"],
+  "word/openresume-laverne-word-quartz.pdf": ["experience"],
+
+  //   - deedy macfonts/openfonts: experience now round-trips (all 6 roles, same
+  //     company/title P1↔P3) after the Phase 4b middot-only anchor gate — the old
+  //     location/keyword org-signal disjuncts were inverting a reconstructed role
+  //     differently from the first parse, breaking fidelity; dropping them fixed
+  //     it. Only the skills-line token split remains, tracked in #299/#E.
+  "latex/deedy-resume-macfonts.pdf": ["skills"],
+  "latex/deedy-resume-openfonts.pdf": ["skills"],
+
+  //   - openresume-react-pdf: a dateless role whose title carries an inline year
+  //     ("Software Engineer Intern Summer 2022") round-trips with the year split
+  //     out as `start_date` ("… Summer" + 2022) — an inline-year-in-title
+  //     asymmetry, not the swap. (Plus the #299/#E skills split.)
   "unknown/openresume-react-pdf.pdf": ["experience", "skills"],
 
-  // Multiple: experience swap, skills +1. (The education "institution
-  // pollution" — "University of California" → "… · Berkeley, CA" glued — was
-  // fixed by teaching `stripInstitutionLocation` the " · " middot boundary the
-  // reconstructed education sub-line emits, #294; education now round-trips.)
-  "google-docs/google-docs-skia-proxy-programs-skills-software.pdf": [
-    "experience",
-    "skills",
-  ],
+  // Experience SWAP cleared by #298 (removed from these lines); only the
+  // skills-line token split remains, tracked in #299/#E. (For
+  // programs-skills-software the education "institution pollution" was already
+  // fixed in #294 — "University of California" → "… · Berkeley, CA" glued —
+  // via the " · " middot boundary; education round-trips.)
+  "google-docs/google-docs-skia-proxy-role-first-experience.pdf": ["skills"],
+  "google-docs/google-docs-skia-proxy-programs-skills-software.pdf": ["skills"],
 
   // Total re-parse collapse: the reconstructed PDF reads back empty (contact,
   // experience, and education all drop out).

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -113,31 +113,30 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   //     company/title P1↔P3) after the Phase 4b middot-only anchor gate — the old
   //     location/keyword org-signal disjuncts were inverting a reconstructed role
   //     differently from the first parse, breaking fidelity; dropping them fixed
-  //     it. Only the skills-line token split remains, tracked in #299/#E.
-  "latex/deedy-resume-macfonts.pdf": ["skills"],
-  "latex/deedy-resume-openfonts.pdf": ["skills"],
+  //     it. The skills-line token split (#299/#E) is ALSO fixed now (#301 —
+  //     `wrap()` keeps each " · "-delimited skill atomic instead of breaking mid-
+  //     word), so these fixtures round-trip clean; no line remains here.
 
   //   - openresume-react-pdf: a dateless role whose title carries an inline year
   //     ("Software Engineer Intern Summer 2022") round-trips with the year split
   //     out as `start_date` ("… Summer" + 2022) — an inline-year-in-title
-  //     asymmetry, not the swap. (Plus the #299/#E skills split.)
-  "unknown/openresume-react-pdf.pdf": ["experience", "skills"],
+  //     asymmetry, not the swap. (The #299/#E skills split is fixed by #301.)
+  "unknown/openresume-react-pdf.pdf": ["experience"],
 
-  // Experience SWAP cleared by #298 (removed from these lines); only the
-  // skills-line token split remains, tracked in #299/#E. (For
-  // programs-skills-software the education "institution pollution" was already
-  // fixed in #294 — "University of California" → "… · Berkeley, CA" glued —
-  // via the " · " middot boundary; education round-trips.)
-  "google-docs/google-docs-skia-proxy-role-first-experience.pdf": ["skills"],
-  "google-docs/google-docs-skia-proxy-programs-skills-software.pdf": ["skills"],
+  // Experience SWAP cleared by #298 (removed from these lines). The skills-line
+  // token split (#299/#E) is fixed by #301, so google-docs-skia-proxy-role-first-
+  // experience and -programs-skills-software round-trip clean; no line remains
+  // for either. (For programs-skills-software the education "institution
+  // pollution" was already fixed in #294 — "University of California" → "… ·
+  // Berkeley, CA" glued — via the " · " middot boundary; education round-trips.)
 
-  // Total re-parse collapse: the reconstructed PDF reads back empty (contact,
-  // experience, and education all drop out).
-  "google-docs/google-docs-skia-proxy-coursework-dup.pdf": [
-    "contact",
-    "experience",
-    "education",
-  ],
+  // Total re-parse collapse (#296) — FIXED: the reconstructed PDF read back
+  // empty because the compact single-role + single-degree résumé rendered as
+  // only ~11 line-granular text items, tripping the `avgItems < 15` arm of the
+  // scanned probe despite 439 real characters. That arm short-circuited the
+  // whole cascade (contact, experience, and education all dropped). Removing the
+  // spurious item-count arm from `probeScanned` (character sparsity is the
+  // reliable scanned signal) restores the full round-trip; no line remains.
 };
 
 function walkPdfs(dir: string): string[] {
@@ -182,22 +181,37 @@ function contactFails(
   return out;
 }
 
-/** Ordered-entry-list diff (shared by experience and education): a count
- *  mismatch, else per-field inequality at each index. */
-function entryListFails<T>(
+/** Ordered-entry-list diff skeleton: a count mismatch short-circuits, else each
+ *  index/key inequality is rendered by `formatMismatch`. The two callers below
+ *  differ ONLY in that formatter — the PII-free corpus gate prints field names,
+ *  the harness prints before → after values. */
+function entryListDiff<T>(
   a1: readonly T[],
   a3: readonly T[],
   keys: readonly (keyof T)[],
   label: string,
+  formatMismatch: (i: number, k: keyof T, v1: T[keyof T], v3: T[keyof T] | undefined) => string,
 ): string[] {
   if (a1.length !== a3.length)
     return [`${label} count ${a1.length} → ${a3.length}`];
   const out: string[] = [];
   a1.forEach((r, i) => {
     for (const k of keys)
-      if (!same(r[k], a3[i]?.[k])) out.push(`${label}[${i}].${String(k)}`);
+      if (!same(r[k], a3[i]?.[k])) out.push(formatMismatch(i, k, r[k], a3[i]?.[k]));
   });
   return out;
+}
+
+/** Ordered-entry-list diff (shared by experience and education): a count
+ *  mismatch, else per-field inequality at each index. Prints field NAMES only,
+ *  so it stays PII-free (used by the corpus gate). */
+function entryListFails<T>(
+  a1: readonly T[],
+  a3: readonly T[],
+  keys: readonly (keyof T)[],
+  label: string,
+): string[] {
+  return entryListDiff(a1, a3, keys, label, (i, k) => `${label}[${i}].${String(k)}`);
 }
 
 /** Summary length drift ≥ 5% (the round-trip truncation signal, #292). */
@@ -344,17 +358,14 @@ function entryValueFails<T>(
   keys: readonly (keyof T)[],
   label: string,
 ): string[] {
-  if (a1.length !== a3.length)
-    return [`${label} count ${a1.length} → ${a3.length}`];
-  const out: string[] = [];
-  a1.forEach((r, i) => {
-    for (const k of keys)
-      if (!same(r[k], a3[i]?.[k]))
-        out.push(
-          `${label}[${i}].${String(k)}: ${JSON.stringify(r[k])} → ${JSON.stringify(a3[i]?.[k])}`,
-        );
-  });
-  return out;
+  return entryListDiff(
+    a1,
+    a3,
+    keys,
+    label,
+    (i, k, v1, v3) =>
+      `${label}[${i}].${String(k)}: ${JSON.stringify(v1)} → ${JSON.stringify(v3)}`,
+  );
 }
 
 /** Skills value diff: the count delta plus the added/removed tokens. */

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -195,6 +195,19 @@ export interface EntryBlock {
    * line is title / company / institution / project name.
    */
   headerLines: string[];
+  /**
+   * Index into {@link headerLines} of the line that carried the date anchor
+   * (the anchor line with its dates stripped), or -1 when that line reduced to
+   * empty (date-only anchor) or the block came from a non-date anchor path.
+   * A structural signal the caller can use to disambiguate title vs company:
+   * in a stacked "Title \n Company Dates" header the anchor line is the
+   * company/org line and the line(s) above it are the title. Lets a caller
+   * (experience) recover the right mapping when text-content heuristics can't
+   * decide — notably our own reconstructed "Download PDF" export, whose
+   * experience sub-line is `Company · Location  Dates` under a bare title
+   * header (#298).
+   */
+  anchorHeaderIndex?: number;
   /** Parsed start/end/is_current off the anchor line (empty object if none). */
   dates: ReturnType<typeof parseDateRange>;
   /**
@@ -1085,13 +1098,20 @@ function buildEntryBlock(
     belowHeaderLines.push(lines[i]);
   }
 
+  // Assemble header lines in document order — above lines, the anchor line
+  // (dates stripped), then below lines — tracking where the anchor line lands
+  // in the trimmed/filtered array so the caller can use it as a title/company
+  // structural signal (#298). Each group is trimmed and de-blanked
+  // independently so the anchor index stays accurate after empties drop.
+  const aboveTexts = aboveLines.map((l) => l.text.trim()).filter(Boolean);
+  const anchorText = anchorTextWithoutDates.trim();
+  const belowTexts = belowHeaderLines.map((l) => l.text.trim()).filter(Boolean);
   const headerLines = [
-    ...aboveLines.map((l) => l.text),
-    anchorTextWithoutDates,
-    ...belowHeaderLines.map((l) => l.text),
-  ]
-    .map((t) => t.trim())
-    .filter(Boolean);
+    ...aboveTexts,
+    ...(anchorText ? [anchorText] : []),
+    ...belowTexts,
+  ];
+  const anchorHeaderIndex = anchorText ? aboveTexts.length : -1;
 
   // Body: every bullet or prose paragraph from where the body began to the next
   // anchor. Bullet glyphs are stripped; a wrapped tail folds onto its bullet.
@@ -1160,5 +1180,5 @@ function buildEntryBlock(
   }
   const body = cfg.collectBody ? bodyUnits.join("\n").trim() || undefined : undefined;
 
-  return { headerLines, dates, body, bulletCount: bodyUnits.length };
+  return { headerLines, anchorHeaderIndex, dates, body, bulletCount: bodyUnits.length };
 }

--- a/src/lib/heuristics/extract/experience.anchor-tiebreak.test.ts
+++ b/src/lib/heuristics/extract/experience.anchor-tiebreak.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression tests for the anchor-position company/title tiebreak in
+ * `disambiguateCompanyTitle` (#298 review).
+ *
+ * The tiebreak treats the date-anchor line as the COMPANY and the line above it
+ * as the TITLE — but ONLY when the anchor line carries the reconstructed-export
+ * signature: an edge/whitespace-bounded " · " middot marker (`anchorCarriesOrgSignal`).
+ * Our own "Download PDF" emit always appends it to the company sub-line
+ * ("Company · Location  Dates" or "Company · Dates"). Location- and title-keyword
+ * signals were removed (Phase 4b): on a genuinely ambiguous two-line header the
+ * anchor line's shape alone can't disambiguate company from title, so every
+ * location/comma/keyword heuristic created a symmetric company↔title inversion on
+ * generic real résumés. A genuine "Company (top) / Title + Dates (bottom)" résumé
+ * whose anchor has no middot must NOT invert; it falls through to the pre-#298
+ * default (company = first line) — exactly as it behaved before #298.
+ *
+ * Exercised through `extractExperience` (the real caller) rather than the
+ * un-exported helper. Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("anchor-position tiebreak gate (#298)", () => {
+  it("does NOT invert a genuine 'Company top / Title + Dates bottom' résumé with no lexical tell", () => {
+    // Neither line carries a company suffix, a title keyword, a location, or a
+    // " · " separator — a fully neutral two-line stack. The anchor line (the
+    // TITLE, carrying the dates) must stay the title; the top line stays the
+    // company. (Old #298 behavior inverted this: company="Relationship Banking".)
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Northern Trust", fontSize: 11 },
+      { text: "Relationship Banking   Jan 2019 - Mar 2021", fontSize: 11 },
+      { text: "• Managed a portfolio of client relationships.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBe(1);
+    expect(roles[0].company).toBe("Northern Trust");
+    expect(roles[0].title).toBe("Relationship Banking");
+  });
+
+  it("still fires the tiebreak on the reconstructed 'Title / Company · Location Dates' shape", () => {
+    // Our own "Download PDF" export shape: a bare title header over a
+    // "Company · Location  Dates" anchor. The " · " signals the anchor is the
+    // company, so the tiebreak assigns company=Company, title=Title (round-trip).
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Relationship Banking", fontSize: 11 },
+      { text: "Northern Trust · Chicago, IL   Jan 2019 - Mar 2021", fontSize: 11 },
+      { text: "• Managed a portfolio of client relationships.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBe(1);
+    expect(roles[0].title).toBe("Relationship Banking");
+    expect(roles[0].company).toBe("Northern Trust");
+    expect(roles[0].location).toBe("Chicago, IL");
+  });
+
+  it("does NOT invert when the anchor TITLE ends in an embedded (comma-attached) location [case a]", () => {
+    // A genuine two-line entry whose title carries a comma-attached location tail
+    // ("Field Sales, Austin, TX"). The anchor line has no middot, so the tiebreak
+    // does not fire and the top line stays the company. Under the earlier
+    // location-based gates this "Austin, TX" tail was read as an org signal and
+    // inverted the roles to company="Field Sales"; the middot-only gate never
+    // looks at the location, so it cannot invert here (Phase 4b).
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Salesforce", fontSize: 11 },
+      { text: "Field Sales, Austin, TX   Jan 2020 - Mar 2022", fontSize: 11 },
+      { text: "• Closed enterprise deals.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBe(1);
+    expect(roles[0].company).toBe("Salesforce");
+    expect(roles[0].title).toBe("Field Sales");
+    expect(roles[0].location).toBe("Austin, TX");
+  });
+
+  it("leaves the pre-existing 'Company, City, ST anchor under a non-keyword title' ambiguity unchanged [case b]", () => {
+    // A genuine two-line entry where the REAL company ("Acme Widgets, Austin, TX")
+    // is on the date-anchor line and a non-keyword TITLE ("Customer Success") is on
+    // top. With no middot, no company suffix, and no title keyword, nothing in the
+    // content distinguishes which line is the company — so the pre-#298 default
+    // (company = first line) applies and mis-labels "Customer Success" as the
+    // company. This is a PRE-EXISTING content ambiguity: main (no anchor tiebreak
+    // at all) produces the identical mapping. The middot-only gate neither fixes
+    // nor worsens it — asserted here so no future gate silently re-inverts it in a
+    // direction that diverges from main. (#298 only ever aimed to round-trip our
+    // OWN reconstructed export, which always carries the middot.)
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Customer Success", fontSize: 11 },
+      { text: "Acme Widgets, Austin, TX   Jan 2020 - Mar 2022", fontSize: 11 },
+      { text: "• Ran the customer success org.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBe(1);
+    // Pre-existing default (== main): company = first line. Documented, not desired.
+    expect(roles[0].company).toBe("Customer Success");
+    expect(roles[0].title).toBe("Acme Widgets");
+    expect(roles[0].location).toBe("Austin, TX");
+  });
+
+  it("fires on the reconstructed location-less shape via the ' ·' org-signature marker", () => {
+    // A location-less reconstructed role emits "Company · Dates" (the " · "
+    // org-signature marker before the date, ats-resume-model.ts). The anchor line
+    // is then recognizably the company; the marker is stripped back off so the
+    // company field is clean.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Relationship Banking", fontSize: 11 },
+      { text: "Northern Trust · Jan 2019 - Mar 2021", fontSize: 11 },
+      { text: "• Managed a portfolio of client relationships.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBe(1);
+    expect(roles[0].title).toBe("Relationship Banking");
+    expect(roles[0].company).toBe("Northern Trust");
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -51,7 +51,10 @@ function experienceFromBlock(block: EntryBlock): {
   score: number;
 } {
   const { dates } = block;
-  const { title, company, team, location } = disambiguateCompanyTitle(block.headerLines);
+  const { title, company, team, location } = disambiguateCompanyTitle(
+    block.headerLines,
+    block.anchorHeaderIndex,
+  );
   const description = block.body;
 
   // Score the entry.
@@ -255,6 +258,36 @@ function splitRoleComma(h: string): [string, string] | null {
 }
 
 /**
+ * True when a date-anchor line carries the reconstructed-export org signature —
+ * used to gate the anchor-is-company positional tiebreak in
+ * {@link disambiguateCompanyTitle} so it fires ONLY on our own reconstructed
+ * "Download PDF" export shape, never on a genuine two-line real-résumé header.
+ *
+ * The ONLY signal is an edge/whitespace-bounded " · " middot marker. Our emit
+ * (ats-resume-model.ts) ALWAYS appends it to the company sub-line whenever a role
+ * has a title and a date anchor: "Company · Location  Dates" for the with-location
+ * case and "Company · Dates" for the location-less case. That middot is a
+ * sufficient and unambiguous round-trip signature.
+ *
+ * Location- and title-keyword-based signals were REMOVED (Phase 4b, #298): on a
+ * genuinely ambiguous two-line header ("Company (top) / Title + Dates (bottom)")
+ * the anchor line's shape alone can't disambiguate company from title, so every
+ * location/comma/keyword heuristic created a symmetric company↔title inversion on
+ * generic real résumés (three review rounds). None of them are needed for the
+ * round-trip goal — the middot marker covers every reconstructed/corpus case.
+ *
+ * A neutral anchor (no middot — e.g. "Relationship Banking" or "Acme Widgets,
+ * Austin, TX") returns false, so control falls through to the pre-#298 default
+ * (company = first line): generic real résumés behave exactly as they did before.
+ */
+function anchorCarriesOrgSignal(text: string): boolean {
+  // A " · " mid-dot (Company · Location) or a trailing " ·" marker (the
+  // reconstructed-export signature our own emit appends to a location-less
+  // company sub-line, ats-resume-model.ts) — either bounded by whitespace/edge.
+  return /(?:^|\s)·(?:\s|$)/.test(text);
+}
+
+/**
  * Given 1..3 header lines, decide which is the company and which is the title.
  * Heuristics (in priority order):
  *   - If one looks like a company/institution (legal suffix OR "University",
@@ -272,8 +305,27 @@ function splitRoleComma(h: string): [string, string] | null {
  * the title and company are extracted rather than staying glued together. The
  * location embedded in the company segment ("Company, City, ST" or intl
  * "Company, City, Country") is stripped by `stripLocationSuffix`.
+ *
+ * `anchorIdx` (optional) is the index within `headers` of the line that carried
+ * the date anchor — the company/org line in a stacked "Title \n Company Dates"
+ * header (see {@link EntryBlock.anchorHeaderIndex}). It is used ONLY as a
+ * structural TIEBREAK when the text-content heuristics above can't decide (the
+ * default `first-line-is-company` path, and the case where MORE THAN ONE header
+ * line reads as a company): the anchor line is the company and the line above it
+ * is the title. This is what lets our own reconstructed "Download PDF" export —
+ * whose experience block is a bare title header over a `Company · Location Dates`
+ * sub-line — re-segment back to the SAME title/company it was built from, even
+ * when neither content heuristic fires (both lines look like a company, e.g. a
+ * "Solutions Engineer" title carrying the soft company-suffix word "Solutions";
+ * or both look like a title, e.g. a two-column source parse that assigned the
+ * org name as the title). A decisive content signal (exactly one company suffix,
+ * or exactly one title keyword) still wins, so genuine source layouts are
+ * unaffected (#298).
  */
-function disambiguateCompanyTitle(headers: string[]): {
+function disambiguateCompanyTitle(
+  headers: string[],
+  anchorIdx?: number,
+): {
   company?: string;
   title?: string;
   team?: string;
@@ -300,10 +352,59 @@ function disambiguateCompanyTitle(headers: string[]): {
     splits.push({ text: h, source: idx });
   });
 
-  const companyIdx = splits.findIndex((s) => looksLikeCompany(s.text));
+  // Every split that reads like a company/institution (its index in `splits`).
+  const companyMatchIdxs = splits
+    .map((s, i) => (looksLikeCompany(s.text) ? i : -1))
+    .filter((i) => i >= 0);
+  // The stacked-header positional tiebreak is available only when the anchor
+  // (date) line is known AND at least one split sits ABOVE it (a title line) —
+  // i.e. a real two-line "Title \n Company Dates" shape, not a single header
+  // line where everything shares the anchor row.
+  const hasAbove =
+    anchorIdx !== undefined &&
+    anchorIdx > 0 &&
+    splits.some((s) => s.source < anchorIdx);
+
+  // The anchor-is-company positional tiebreak below (else-if) must NOT fire on a
+  // genuine "Company (top) / Title + Dates (bottom)" résumé where the anchor line
+  // is the TITLE and neither line carries any lexical tell — e.g. "Northern Trust"
+  // over "Relationship Banking  Jan 2019 – Mar 2021". There, treating the anchor
+  // as the company inverts the roles (company↔title swap, #298 review). Gate it on
+  // the anchor line carrying a positive "this line is the org/company" signal
+  // ({@link anchorCarriesOrgSignal}): a " · " reconstructed-export separator, an
+  // embedded location / country, or a role/title keyword (the anchor of the
+  // stacked shapes our own reconstructed export and dense/two-column source
+  // layouts produce). A fully neutral anchor (no separator, no location, no title
+  // keyword) has no such corroboration, so we fall through to the old default
+  // (company = first line) — the only case this narrows, and one no corpus fixture
+  // exercises, so every round-trip that relied on the tiebreak stays intact.
+  const anchorHasReconstructedSignature =
+    anchorIdx !== undefined &&
+    anchorIdx >= 0 &&
+    anchorIdx < filtered.length &&
+    anchorCarriesOrgSignal(filtered[anchorIdx]);
+
   let company: string | undefined;
   let title: string | undefined;
   let team: string | undefined;
+
+  // Choose which split is the company. A single company-suffix match is a
+  // decisive content signal (rule 1). When MULTIPLE splits look like a company,
+  // the plain findIndex would pick the topmost — which mis-labels the title line
+  // as the company whenever the title carries a soft company-suffix word
+  // ("Solutions Engineer"). Break that tie with the anchor position: the
+  // date-bearing line is the company (#298). No above line ⇒ keep findIndex.
+  const chooseCompanyIdx = (): number => {
+    if (companyMatchIdxs.length <= 1) return companyMatchIdxs[0] ?? -1;
+    if (hasAbove) {
+      const anchorMatch = companyMatchIdxs.find(
+        (i) => splits[i].source === anchorIdx,
+      );
+      if (anchorMatch !== undefined) return anchorMatch;
+    }
+    return companyMatchIdxs[0];
+  };
+  const companyIdx = chooseCompanyIdx();
 
   if (companyIdx !== -1) {
     company = splits[companyIdx].text;
@@ -324,8 +425,25 @@ function disambiguateCompanyTitle(headers: string[]): {
       company = splits[0]?.text;
       title = splits[1]?.text;
       team = splits[2]?.text;
+    } else if (hasAbove && anchorHasReconstructedSignature) {
+      // No title-keyword signal either way, but the anchor line carries the
+      // reconstructed-export signature (a " · " on the date line) — so this is
+      // our own "Title \n Company · Location Dates" export shape: the anchor
+      // (date) line is the company and the line(s) above it are the title. This
+      // preserves the mapping our reconstructed export was built from, WITHOUT
+      // the old blind "anchor line is company" swap that inverted a genuine
+      // "Company \n Title Dates" résumé lacking the signature (#298 review).
+      const anchorSplit = splits.find((s) => s.source === anchorIdx);
+      const titleSplit = splits.find((s) => s.source < anchorIdx!);
+      company = anchorSplit?.text;
+      title = titleSplit?.text;
+      // A leftover split (an extra anchor-row segment such as a location, or a
+      // second above line) becomes team — rescued to `location` below if it is
+      // one.
+      team = splits.find((s) => s !== anchorSplit && s !== titleSplit)?.text;
     } else {
-      // No title-keyword signal either way — assume top line is company.
+      // No title-keyword signal and no stacked-shape anchor — assume top line is
+      // company (single-line header default).
       company = splits[0]?.text;
       title = splits[1]?.text;
       team = splits[2]?.text;
@@ -401,6 +519,15 @@ function disambiguateCompanyTitle(headers: string[]): {
       team = undefined;
     }
   }
+
+  // (4) Strip the reconstructed-export " ·" org-signature marker that our own
+  //     "Download PDF" appends to a location-less company sub-line so the anchor
+  //     re-parses as the company (see `anchorCarriesOrgSignal` and the emit in
+  //     ats-resume-model.ts). It survives as a trailing dangling middot on an
+  //     otherwise clean company ("Leadership Experience ·"); peel it back off so
+  //     the round-tripped company field matches the source. A genuine company
+  //     never ends in a bare middot, so this only ever removes the marker.
+  if (company) company = company.replace(/\s*·\s*$/, "").trim() || undefined;
 
   return { company, title, team, location };
 }

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -249,8 +249,22 @@ function isSoftWrapContinuation(pending: string, nextText: string): boolean {
   // Always skip if the next line starts a new sub-list (label or bullet).
   if (SKILLS_NEW_ENTRY_RE.test(nextText)) return false;
 
-  // Condition A: pending ends with an explicit continuation glyph.
-  if (/[&\-–+]\s*$/.test(pending)) return true;
+  // Condition A: pending ends with an explicit continuation glyph — the glyph
+  // must be its OWN whitespace-separated token ("Hiring &", "Data -"), not the
+  // tail of a compact skill name like "C++" or "PHP7+" (#301: our own
+  // middot-atomic wrap can legitimately end a rendered line on such a skill,
+  // and a false continuation match there merges it with the next line's first
+  // skill into one bogus multi-word token).
+  //
+  // The leading `\s` is deliberate and load-bearing: it is what distinguishes a
+  // standalone continuation glyph ("Hiring &") from a glyph glued to a word
+  // ("C++", "PHP7+"). Accepted symmetric hole: a real continuation glyph glued
+  // to a word with NO preceding space (a source line ending "Development&") is
+  // now NOT joined. This is a knowingly accepted tradeoff — the C++/PHP7+
+  // false-positive fix is more valuable and no corpus fixture regresses on the
+  // glued-continuation case. Do not drop the `\s` to close this hole without
+  // re-guarding the compact-skill false positive.
+  if (/\s[&\-–+]\s*$/.test(pending)) return true;
 
   // Condition B: a comma-separated list wrapped across two lines — the NEXT line
   // is mid-list (has a comma) AND the PENDING line is itself an unterminated list

--- a/src/lib/heuristics/pdf-layout.test.ts
+++ b/src/lib/heuristics/pdf-layout.test.ts
@@ -47,10 +47,26 @@ const singlePage: PdfPageInfo[] = [
 ];
 
 describe("analyzeLayout", () => {
-  it("flags scanned PDFs when item count is near zero", () => {
+  it("flags scanned PDFs when average characters per page is below the threshold", () => {
     const items = [mkItemAt(1, 100, 100, "logo")];
     const pages: PdfPageInfo[] = [
       { page: 1, width: 612, height: 792, charCount: 4 },
+    ];
+    const probes = analyzeLayout(items, pages);
+    expect(probes.isScanned).toBe(true);
+    expect(probes.triggers).toContain("scanned");
+  });
+
+  it("still flags scanned when item count is HIGH but characters are sparse (garbage/partial-glyph)", () => {
+    // A fonts-unmappable / partial-glyph page can shatter into many text items
+    // (one per stray glyph fragment) while yielding almost no real characters.
+    // The removed item-count arm would have treated this as text-bearing; the
+    // surviving avgChars arm must still catch it. Item count 200, but the page
+    // holds only 40 chars total — well under SCANNED_MIN_CHARS_PER_PAGE (80).
+    const items: PdfTextItem[] = [];
+    for (let i = 0; i < 200; i++) items.push(mkItemAt(1, 72 + i, 100, "."));
+    const pages: PdfPageInfo[] = [
+      { page: 1, width: 612, height: 792, charCount: 40 },
     ];
     const probes = analyzeLayout(items, pages);
     expect(probes.isScanned).toBe(true);

--- a/src/lib/heuristics/pdf-layout.ts
+++ b/src/lib/heuristics/pdf-layout.ts
@@ -23,7 +23,6 @@ import type {
 // ── Thresholds (tuneable) ───────────────────────────────────────────────────
 
 const SCANNED_MIN_CHARS_PER_PAGE = 80;
-const SCANNED_MIN_ITEMS_PER_PAGE = 15;
 
 /**
  * Maximum share of a page's text *rows* that may paint ink at the gutter strip
@@ -36,7 +35,7 @@ const SCANNED_MIN_ITEMS_PER_PAGE = 15;
  * drop below 6.3% (their wide wrapped body text inks straight through the
  * would-be gutter). Set in the gap between those populations.
  */
-export const TWO_COLUMN_MAX_GUTTER_COVERAGE = 0.04;
+const TWO_COLUMN_MAX_GUTTER_COVERAGE = 0.04;
 
 /**
  * The gutter's center must fall inside this central band of the page
@@ -75,7 +74,7 @@ export function analyzeLayout(
   pages: PdfPageInfo[],
   extractionFailureReason?: ExtractionFailureReason,
 ): LayoutProbes {
-  const isScanned = probeScanned(items, pages);
+  const isScanned = probeScanned(pages);
   // If scanned, two-column probe is meaningless (no positional signal).
   const isTwoColumn = isScanned
     ? false
@@ -101,15 +100,21 @@ export function analyzeLayout(
   return { isScanned, isTwoColumn, triggers };
 }
 
-function probeScanned(items: PdfTextItem[], pages: PdfPageInfo[]): boolean {
+function probeScanned(pages: PdfPageInfo[]): boolean {
   if (pages.length === 0) return true;
   const avgChars =
     pages.reduce((s, p) => s + p.charCount, 0) / pages.length;
-  const avgItems = items.length / pages.length;
-  return (
-    avgChars < SCANNED_MIN_CHARS_PER_PAGE ||
-    avgItems < SCANNED_MIN_ITEMS_PER_PAGE
-  );
+  // Character sparsity is the reliable scanned/no-extractable-text signal: an
+  // image-only or fonts-unmappable page yields ~0 characters. Item count is NOT
+  // an independent scanned signal — item granularity is a property of how the
+  // producer laid out text, not of whether text exists. Our own reconstructed
+  // "Download PDF" emits one text item per line, so a short-but-real résumé
+  // (e.g. a compact single-role + single-degree doc) has only a handful of
+  // items yet hundreds of real characters. Gating on `avgItems` there
+  // false-positived as `scanned`, short-circuiting the cascade and zeroing an
+  // otherwise fully parseable document (#296). A page with real characters is
+  // real text regardless of how few items it split into.
+  return avgChars < SCANNED_MIN_CHARS_PER_PAGE;
 }
 
 /**

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -98,9 +98,12 @@ describe("buildAtsResumeModel", () => {
     const exp = model.sections[0].entries[0];
     // Stacked round-trip shape (#284): title leads the bold header, the
     // "Company · Location  Dates" line (carrying the parser's date anchor) sits
-    // on the sub-line so the emitted role re-segments back to one entry.
+    // on the sub-line so the emitted role re-segments back to one entry. With no
+    // location the company is bare, so the date is joined with a " · " org-signature
+    // marker (#298 review) — "Company · Dates" — so the re-parse anchor is
+    // recognizably the company, not the title.
     expect(exp.headerLine).toBe("Senior PM");
-    expect(exp.subLine).toBe("Acme  2020 – 2024");
+    expect(exp.subLine).toBe("Acme · 2020 – 2024");
     expect(exp.bullets).toEqual([
       "Led migration of legacy auth system to OAuth",
       "Drove 30% revenue growth across the platform",

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -27,7 +27,7 @@ import type {
 } from "../score/types.ts";
 import {
   groupBulletsByExperience,
-  type BulletExperience,
+  toBulletExperience,
 } from "../score/group-bullets.ts";
 import { buildProjectDates } from "../score/entry-dates.ts";
 import { buildContactFields } from "../contact.ts";
@@ -147,25 +147,6 @@ function resolveBullets(
   return bulletsFromDescription(description);
 }
 
-function asBulletExperience(
-  entries: ReadonlyArray<{
-    title?: string;
-    name?: string;
-    description?: string;
-    start_date?: string;
-    end_date?: string;
-    is_current?: boolean;
-  }>,
-): BulletExperience[] {
-  return entries.map((e) => ({
-    title: e.title ?? e.name,
-    description: e.description,
-    start_date: e.start_date,
-    end_date: e.end_date,
-    is_current: e.is_current,
-  }));
-}
-
 function experienceDateRange(exp: {
   start_date?: string;
   end_date?: string;
@@ -213,9 +194,9 @@ export function buildAtsResumeModel(
   // One grouping pass over experiences + projects + achievements, mirroring the
   // surface, so bullets are attributed to their own entry.
   const combined = [
-    ...asBulletExperience(experiences),
-    ...asBulletExperience(projects),
-    ...asBulletExperience(achievements),
+    ...toBulletExperience(experiences),
+    ...toBulletExperience(projects),
+    ...toBulletExperience(achievements),
   ];
   const grouped = groupBulletsByExperience([...bulletPool], combined);
   const bulletsByIndex = new Map<number, BulletObservation[]>();

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -248,12 +248,31 @@ export function buildAtsResumeModel(
     // " · ", so stripping the date anchor leaves a clean "Company · Location"
     // with no dangling separator leaking into the parsed company field.
     const org = joinHeader([exp.company, exp.location], " · ");
-    const orgLine = [org, experienceDateRange(exp)].filter(Boolean).join("  ");
+    // Re-parse company/title tiebreak signature (#298 round-trip). When this role
+    // has a TITLE, the org+date line becomes the parser's date-anchor sub-line, and
+    // the re-parser only treats a bare, neutral anchor as the company (rather than
+    // the title) when the line carries a positive org signal. A `Company · Location`
+    // org already carries the " · " tell; a location-less `Company` does NOT, so a
+    // neutral company ("Leadership Experience", "Books for Life") would re-parse
+    // inverted (company↔title swap). Emit the " · " signature on the sub-line for
+    // that location-less-with-title case so the anchor is recognizably the company;
+    // the re-parser strips the trailing marker back to a clean company field.
+    const dateRange = experienceDateRange(exp);
+    const needsOrgSignature =
+      Boolean(title) && Boolean(org) && Boolean(dateRange) && !org.includes(" · ");
+    // Location-less-with-title: put the date after a " · " so the re-parse anchor
+    // carries the org signature (reads "Company · Dates"). Otherwise keep the date
+    // after the whitespace gap so a "Company · Location" org stays clean on strip.
+    const subLine = needsOrgSignature
+      ? [org, dateRange].filter(Boolean).join(" · ") || undefined
+      : [org, dateRange].filter(Boolean).join("  ") || undefined;
+    const headerOrgLine = [org, dateRange].filter(Boolean).join("  ") || undefined;
     return {
       // Title alone leads (bold); when a role has no title, the org/date line
-      // leads so it still carries the date anchor on the header line itself.
-      headerLine: title || orgLine || "Experience",
-      subLine: title ? orgLine || undefined : undefined,
+      // leads so it still carries the date anchor on the header line itself (and
+      // needs no signature — a title-less header is not disambiguated).
+      headerLine: title || headerOrgLine || "Experience",
+      subLine: title ? subLine : undefined,
       bullets: resolveBullets(
         bulletsByIndex.get(expOffset + i),
         bulletOverrides,

--- a/src/lib/pdf/render-ats-pdf.test.ts
+++ b/src/lib/pdf/render-ats-pdf.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 The resumelint Authors
 
 import { describe, expect, it } from "vitest";
-import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+import { renderAtsResumePdf, toWinAnsi } from "./render-ats-pdf.ts";
 import type { AtsResumeModel } from "./ats-resume-model.ts";
 
 const MODEL: AtsResumeModel = {
@@ -96,5 +96,129 @@ describe("renderAtsResumePdf", () => {
       useSystemFonts: false,
     }).promise;
     expect(doc.numPages).toBeGreaterThan(1);
+  });
+
+  // #295 — drawText must never throw on non-WinAnsi glyphs parsed résumé text
+  // routinely contains (arrows, unicode hyphens/dashes, smart quotes, bullets,
+  // NBSP, ligatures, emoji, CJK).
+  describe("non-WinAnsi glyph safety (#295)", () => {
+    const glyphModel = (text: string): AtsResumeModel => ({
+      contact: { name: "Jane Candidate", links: [] },
+      summary: text,
+      sections: [
+        {
+          heading: "Experience",
+          entries: [
+            {
+              headerLine: text,
+              subLine: text,
+              bullets: [text],
+            },
+          ],
+        },
+      ],
+    });
+
+    const crashingGlyphs: Array<[string, string]> = [
+      ["rightwards arrow (U+2192)", "Migrated auth → OAuth"],
+      ["Unicode hyphen (U+2010)", "co‐founder of the initiative"],
+      ["leftwards arrow (U+2190)", "Rolled back v2 ← v1"],
+      ["smart quotes", "Shipped the “v2” engine, called it ‘Atlas’"],
+      ["NBSP", "Chicago, IL"],
+      ["ligatures", "ﬁnance ﬂow efﬁciency"],
+      ["ellipsis", "Led a team of engineers…"],
+      ["emoji / astral plane", "Shipped it 🚀 on time"],
+      ["CJK", "领导团队完成项目"],
+    ];
+
+    it.each(crashingGlyphs)("does not throw on %s", async (_label, text) => {
+      await expect(renderAtsResumePdf(glyphModel(text))).resolves.toBeInstanceOf(
+        Uint8Array,
+      );
+    });
+
+    // #298 review — a section heading is drawn with `uppercase: true`, and
+    // `.toUpperCase()` can map a WinAnsi-native lowercase glyph to one with NO
+    // WinAnsi representation (µ U+00B5 → Μ U+039C Greek Capital Mu). Sanitizing
+    // BEFORE the case transform let that Μ reach pdf-lib and throw "WinAnsi cannot
+    // encode Μ". Headings come from verbatim résumé section-heading text, so this
+    // must never throw. Sanitize is now the LAST step (after toUpperCase).
+    const headingModel = (heading: string): AtsResumeModel => ({
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [
+        { heading, entries: [{ headerLine: "Role", subLine: "Co", bullets: ["x"] }] },
+      ],
+    });
+
+    const caseExpandingHeadings: Array<[string, string]> = [
+      ["µ MICRO SIGN → Greek Μ", "µ-services architecture"],
+      ["ß sharp-s → SS", "Groß­projekte & Straße"],
+      ["ﬁ ligature → FI", "ﬁnance ﬂow"],
+      ["Turkish dotless-i expander", "i̇stanbul ﬁeld work"],
+    ];
+
+    it.each(caseExpandingHeadings)(
+      "does not throw on an uppercased heading with %s",
+      async (_label, heading) => {
+        await expect(
+          renderAtsResumePdf(headingModel(heading)),
+        ).resolves.toBeInstanceOf(Uint8Array);
+      },
+    );
+
+    it("sanitizes AFTER uppercasing so a case-expanded glyph can't reach the encoder", () => {
+      // µ → Μ (Greek, no WinAnsi) must degrade to "?", never survive to drawText.
+      expect(toWinAnsi("µ".toUpperCase())).toBe("?");
+      // ß → SS and ﬁ → FI are both encodable once uppercased-then-sanitized.
+      expect(toWinAnsi("straße".toUpperCase())).toBe("STRASSE");
+      expect(toWinAnsi("ﬁnance".toUpperCase())).toBe("FINANCE");
+    });
+
+    it("fuzzes a wide range of code points without throwing", async () => {
+      // Sample code points across many Unicode blocks (Latin-1, general
+      // punctuation, arrows, CJK, emoji, control chars) to make sure no
+      // single glyph anywhere reaches pdf-lib's encoder unsanitized.
+      const codePoints = [
+        0x09, 0x0a, 0x20, 0x7e, 0x7f, 0x9f, 0xa0, 0xff, 0x100, 0x2010, 0x2013,
+        0x2014, 0x2018, 0x2019, 0x201c, 0x201d, 0x2022, 0x2026, 0x2190, 0x2192,
+        0x2600, 0x4e2d, 0xfb01, 0x1f680,
+      ];
+      const text = codePoints.map((cp) => String.fromCodePoint(cp)).join(" X ");
+      await expect(renderAtsResumePdf(glyphModel(text))).resolves.toBeInstanceOf(
+        Uint8Array,
+      );
+    });
+  });
+
+  describe("toWinAnsi", () => {
+    it("transliterates glyphs with no WinAnsi representation", () => {
+      expect(toWinAnsi("a → b")).toBe("a -> b");
+      expect(toWinAnsi("co‐founder")).toBe("co-founder");
+      expect(toWinAnsi("a b")).toBe("a b");
+      expect(toWinAnsi("ﬁnance")).toBe("finance");
+    });
+
+    it("passes ASCII, Latin-1, and native WinAnsi-upper-range glyphs through unchanged", () => {
+      expect(toWinAnsi("Jane Candidate")).toBe("Jane Candidate");
+      expect(toWinAnsi("café")).toBe("café");
+      // en dash, em dash, curly quotes, bullet, ellipsis are all valid
+      // WinAnsi (cp1252 0x80-0x9F) -- must round-trip unchanged (#284).
+      expect(toWinAnsi("2020 – 2024")).toBe("2020 – 2024");
+      expect(toWinAnsi("scaling — infra")).toBe("scaling — infra");
+      expect(toWinAnsi("“quoted”")).toBe("“quoted”");
+      expect(toWinAnsi("‘quoted’")).toBe("‘quoted’");
+      expect(toWinAnsi("• item")).toBe("• item");
+      expect(toWinAnsi("done…")).toBe("done…");
+    });
+
+    it("replaces unmappable code points with '?' instead of throwing", () => {
+      expect(toWinAnsi("🚀")).toBe("?");
+      expect(toWinAnsi("中文")).toBe("??");
+    });
+
+    it("handles empty and whitespace-only input", () => {
+      expect(toWinAnsi("")).toBe("");
+      expect(toWinAnsi("   ")).toBe("   ");
+    });
   });
 });

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -67,6 +67,138 @@ const GAP_AFTER_HEADER = 2;
 const BULLET_MARKER = "• ";
 const BULLET_INDENT = 12; // hanging-indent width for wrapped bullet lines
 
+// ── WinAnsi sanitization (#295) ───────────────────────────────────────────────
+//
+// pdf-lib's StandardFonts (Helvetica et al.) only encode WinAnsi (Windows-1252).
+// `PDFPage.drawText` throws `WinAnsi cannot encode "…"` on any code point
+// outside that codec — e.g. U+2192 (→) or U+2010 (the *Unicode* hyphen,
+// distinct from ASCII "-"). Parsed résumé text is arbitrary and routinely
+// contains such glyphs, so every string must be sanitized before it reaches
+// `drawText`.
+//
+// Windows-1252's upper range (0x80-0x9F) already assigns real Unicode code
+// points to en/em dash, curly quotes, bullet, and ellipsis (e.g. U+2014 em
+// dash IS valid WinAnsi) — those must pass through unchanged, not get
+// transliterated, or round-trip fidelity (#284) regresses. Only glyphs with
+// NO WinAnsi representation (arrows, the Unicode hyphen variants, ligatures,
+// exotic whitespace, zero-width marks) get transliterated to a safe ASCII
+// equivalent; anything left over is replaced with "?". Never throws.
+
+/** Code points WinAnsi (cp1252 0x80-0x9F) assigns to real Unicode glyphs. */
+const WINANSI_UPPER_RANGE = new Set([
+  0x20ac, // € euro
+  0x201a, // ‚ low single quote
+  0x0192, // ƒ florin
+  0x201e, // „ low double quote
+  0x2026, // … ellipsis
+  0x2020, // † dagger
+  0x2021, // ‡ double dagger
+  0x02c6, // ˆ circumflex
+  0x2030, // ‰ per mille
+  0x0160, // Š
+  0x2039, // ‹ single left angle quote
+  0x0152, // Œ
+  0x017d, // Ž
+  0x2018, // ‘ left single quote
+  0x2019, // ’ right single quote
+  0x201c, // “ left double quote
+  0x201d, // ” right double quote
+  0x2022, // • bullet
+  0x2013, // – en dash
+  0x2014, // — em dash
+  0x02dc, // ˜ small tilde
+  0x2122, // ™ trademark
+  0x0161, // š
+  0x203a, // › single right angle quote
+  0x0153, // œ
+  0x017e, // ž
+  0x0178, // Ÿ
+]);
+
+const WINANSI_TRANSLITERATIONS: Record<string, string> = {
+  "→": "->", // rightwards arrow (not in WinAnsi)
+  "←": "<-", // leftwards arrow
+  "↔": "<->", // left-right arrow
+  "‐": "-", // Unicode hyphen (distinct from ASCII "-", not in WinAnsi)
+  "‑": "-", // non-breaking hyphen
+  "‒": "-", // figure dash
+  "―": "-", // horizontal bar
+  "‣": "-", // triangular bullet
+  "◦": "-", // white bullet
+  " ": " ", // figure space
+  " ": " ", // en quad
+  " ": " ", // em quad
+  " ": " ", // en space
+  " ": " ", // em space
+  " ": " ", // three-per-em space
+  " ": " ", // four-per-em space
+  " ": " ", // six-per-em space
+  " ": " ", // punctuation space
+  " ": " ", // thin space
+  " ": " ", // hair space
+  " ": " ", // narrow NBSP
+  " ": " ", // medium math space
+  "　": " ", // ideographic space
+  "​": "", // zero-width space
+  "‌": "", // zero-width non-joiner
+  "‍": "", // zero-width joiner
+  "﻿": "", // BOM / zero-width no-break space
+  "ﬀ": "ff", // ff ligature
+  "ﬁ": "fi", // fi ligature
+  "ﬂ": "fl", // fl ligature
+  "ﬃ": "ffi", // ffi ligature
+  "ﬄ": "ffl", // ffl ligature
+};
+
+/**
+ * Sanitize `text` to the WinAnsi (Windows-1252) subset that pdf-lib's
+ * StandardFonts can encode. Glyphs WinAnsi already supports (en/em dash,
+ * curly quotes, bullet, ellipsis, NBSP, ...) pass through unchanged; glyphs
+ * with no WinAnsi representation are transliterated to a safe ASCII
+ * equivalent (see `WINANSI_TRANSLITERATIONS`); anything left is replaced
+ * with "?". Never throws.
+ */
+export function toWinAnsi(text: string): string {
+  if (!text) return text;
+  let out = "";
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+
+    // Printable ASCII + Latin-1 supplement: WinAnsi covers this range as-is
+    // (includes NBSP at U+00A0).
+    if (code >= 0x20 && code <= 0x7e) {
+      out += ch;
+      continue;
+    }
+    if (code >= 0xa0 && code <= 0xff) {
+      out += ch;
+      continue;
+    }
+    // Tab/newline/carriage-return: keep as-is (whitespace, harmless to draw).
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      out += ch;
+      continue;
+    }
+    // Real WinAnsi upper-range glyphs (en/em dash, curly quotes, bullet, ...)
+    // -- pass through unchanged so round-trip fidelity is preserved.
+    if (WINANSI_UPPER_RANGE.has(code)) {
+      out += ch;
+      continue;
+    }
+    const replacement = WINANSI_TRANSLITERATIONS[ch];
+    if (replacement !== undefined) {
+      out += replacement;
+      continue;
+    }
+    // Other C0/C1 control characters: drop silently.
+    if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) continue;
+    // Anything else (other Unicode blocks, emoji, CJK, etc.) has no WinAnsi
+    // representation -- degrade the glyph instead of crashing.
+    out += "?";
+  }
+  return out;
+}
+
 type RGB = ReturnType<PdfLibParts["rgb"]>;
 type Doc = Awaited<ReturnType<PdfLibParts["PDFDocument"]["create"]>>;
 type Page = ReturnType<Doc["addPage"]>;
@@ -149,7 +281,14 @@ class Layout {
     const color = opts.color ?? this.black;
     const x = opts.x ?? MARGIN;
     const hanging = opts.hangingIndent ?? 0;
-    const value = opts.uppercase ? text.toUpperCase() : text;
+    // Sanitize LAST — after the case transform — so a case-expansion can never
+    // produce an un-encodable glyph downstream. `toUpperCase()` maps some
+    // WinAnsi-native lowercase letters to glyphs with NO WinAnsi representation
+    // (e.g. µ U+00B5 → Μ U+039C Greek Capital Mu, ſ → S, ﬁ ligature → FI), so
+    // uppercasing BEFORE toWinAnsi would let `drawText` throw `WinAnsi cannot
+    // encode "Μ"` and reintroduce the #295 crash. Uppercase the raw text, then
+    // sanitize the result — toWinAnsi is the final step before measure/draw.
+    const value = toWinAnsi(opts.uppercase ? text.toUpperCase() : text);
     const maxWidth = CONTENT_WIDTH - (x - MARGIN);
 
     const lines = this.wrap(value, font, size, maxWidth);

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -67,6 +67,11 @@ const GAP_AFTER_HEADER = 2;
 const BULLET_MARKER = "• ";
 const BULLET_INDENT = 12; // hanging-indent width for wrapped bullet lines
 
+// The middot list/org-line join separator emitted by ats-resume-model.ts
+// (skills, "Company · Location", "Institution · Location", ...). Wrap logic
+// treats each middot-delimited segment as atomic — see `wrap()` (#301).
+const MIDDOT_SEGMENT_SEP = " · ";
+
 // ── WinAnsi sanitization (#295) ───────────────────────────────────────────────
 //
 // pdf-lib's StandardFonts (Helvetica et al.) only encode WinAnsi (Windows-1252).
@@ -205,6 +210,80 @@ type Page = ReturnType<Doc["addPage"]>;
 type PdfFont = Awaited<ReturnType<Doc["embedFont"]>>;
 
 /**
+ * Plain `\s+`-word wrap — never breaks a word apart, just packs words up to
+ * `maxWidth`. A single word wider than `maxWidth` is emitted as its own line
+ * (never split mid-word), so this always terminates.
+ */
+function wrapWordsToLines(
+  words: string[],
+  font: PdfFont,
+  size: number,
+  maxWidth: number,
+): string[] {
+  if (words.length === 0) return [];
+  const lines: string[] = [];
+  let current = words[0];
+  for (let i = 1; i < words.length; i++) {
+    const candidate = `${current} ${words[i]}`;
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      current = candidate;
+    } else {
+      lines.push(current);
+      current = words[i];
+    }
+  }
+  lines.push(current);
+  return lines;
+}
+
+/**
+ * Wrap a list of middot-delimited segments, keeping each segment intact.
+ * The wrap point only falls between segments (rejoined with
+ * `MIDDOT_SEGMENT_SEP`); a segment wider than `maxWidth` on its own falls
+ * back to `wrapWordsToLines` for that segment only. Exported for testing.
+ */
+export function wrapSegmentsToLines(
+  segments: string[],
+  font: PdfFont,
+  size: number,
+  maxWidth: number,
+): string[] {
+  if (segments.length === 0) return [];
+  const lines: string[] = [];
+  // Seed `current` from the empty string and run EVERY segment — including
+  // segments[0] — through the same width check + word-wrap fallback, so an
+  // overlong first segment (e.g. a long "Company · Location" org line whose
+  // company name alone exceeds maxWidth) is wrapped rather than emitted verbatim.
+  let current = "";
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const candidate =
+      current === "" ? seg : `${current}${MIDDOT_SEGMENT_SEP}${seg}`;
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      current = candidate;
+      continue;
+    }
+    if (current !== "") lines.push(current);
+    if (font.widthOfTextAtSize(seg, size) > maxWidth) {
+      // `wrapWordsToLines` never loops on a single word wider than maxWidth
+      // (it emits it as its own line), so this terminates.
+      const subLines = wrapWordsToLines(
+        seg.split(/\s+/).filter(Boolean),
+        font,
+        size,
+        maxWidth,
+      );
+      lines.push(...subLines.slice(0, -1));
+      current = subLines[subLines.length - 1] ?? "";
+    } else {
+      current = seg;
+    }
+  }
+  lines.push(current);
+  return lines;
+}
+
+/**
  * Mutable cursor + page state threaded through the draw routines. We keep one
  * "current page" and append new pages as the cursor overflows.
  */
@@ -236,28 +315,39 @@ class Layout {
     this.y -= points;
   }
 
-  /** Word-wrap `text` to `maxWidth` using the given font/size. */
+  /**
+   * Word-wrap `text` to `maxWidth` using the given font/size.
+   *
+   * When `text` contains the middot segment separator (`" · "` — used to join
+   * skills, and "Company · Location" / "Institution · Location" org lines,
+   * see `ats-resume-model.ts`), each middot-delimited segment is wrapped as an
+   * ATOMIC unit: the wrap point can only fall BETWEEN segments, never inside
+   * one. Plain `\s+`-word wrapping used to let the break land mid-segment
+   * (e.g. inside the multi-word skill "Cloud Data Warehousing"), which
+   * re-parsed as two skills instead of one (#301). A single segment that
+   * alone exceeds `maxWidth` still falls back to per-word wrapping so a
+   * pathologically long segment doesn't overflow the page width.
+   */
   private wrap(
     text: string,
     font: PdfFont,
     size: number,
     maxWidth: number,
   ): string[] {
-    const words = text.split(/\s+/).filter(Boolean);
-    if (words.length === 0) return [];
-    const lines: string[] = [];
-    let current = words[0];
-    for (let i = 1; i < words.length; i++) {
-      const candidate = `${current} ${words[i]}`;
-      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
-        current = candidate;
-      } else {
-        lines.push(current);
-        current = words[i];
-      }
+    if (text.includes(MIDDOT_SEGMENT_SEP)) {
+      return wrapSegmentsToLines(
+        text.split(MIDDOT_SEGMENT_SEP).filter((s) => s.length > 0),
+        font,
+        size,
+        maxWidth,
+      );
     }
-    lines.push(current);
-    return lines;
+    return wrapWordsToLines(
+      text.split(/\s+/).filter(Boolean),
+      font,
+      size,
+      maxWidth,
+    );
   }
 
   /**

--- a/src/lib/pdf/skills-wrap-roundtrip.test.ts
+++ b/src/lib/pdf/skills-wrap-roundtrip.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Round-trip regression for #301 — a multi-word skill token must not split
+ * across the line-wrap boundary on the parse → "Download PDF" → re-parse
+ * cycle.
+ *
+ * Mechanism (see `ats-resume-model.ts:361` and `render-ats-pdf.ts`):
+ *   - Reconstruction joins all skills into ONE middot-delimited header line
+ *     (`skills.join(" · ")`).
+ *   - The renderer word-wraps that line. Before the fix, the wrap split on
+ *     ANY whitespace (`text.split(/\s+/)`), so a wrap point could fall INSIDE
+ *     a multi-word skill (e.g. between "Data" and "Warehousing" in "Cloud
+ *     Data Warehousing"), breaking it across two rendered PDF lines.
+ *   - On re-parse the skills tokenizer then reads the wrapped continuation as
+ *     a brand-new token, so one skill became two (count N → N+1).
+ *
+ * The fix makes `Layout.wrap()` treat each " · "-delimited segment (a whole
+ * skill) as an atomic wrap unit — the wrap point can only fall BETWEEN
+ * skills, never inside one.
+ *
+ * No new binary PDF fixture is needed: this test reuses an in-tree synthetic
+ * fixture purely to get a legitimate `CascadeResult` (satisfying
+ * `buildAtsResumeModel`'s full input contract), then overrides `parsed.skills`
+ * with a long, deliberately multi-word-heavy list engineered to force at
+ * least one wrap boundary inside a 2-4 word skill under the old
+ * `\s+`-only wrap. Round-trip correctness is asserted as an exact set/count
+ * match, independent of exactly where any given line wraps.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf, wrapSegmentsToLines } from "./render-ats-pdf.ts";
+import { loadPdfLibOnce } from "./load-pdf-lib.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/latex/awesome-cv-resume.pdf",
+);
+
+function scoreFor(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: { ...cascade.parsed },
+    fieldConfidence: cascade.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.sections,
+  });
+}
+
+// A long, multi-word-heavy skill list. Several 2-4 word skills interleaved
+// with single-word ones so the joined " · " line spans multiple wrapped
+// lines at the renderer's header size/width — under the pre-fix `\s+`-only
+// wrap, at least one of these multi-word skills is virtually guaranteed to
+// straddle a wrap boundary.
+const SYNTHETIC_SKILLS = [
+  "Python",
+  "Kubernetes",
+  "Cloud Data Warehousing",
+  "Terraform",
+  "Site Reliability Engineering",
+  "Docker",
+  "Machine Learning Operations",
+  "SQL",
+  "Customer Relationship Management",
+  "AWS",
+  "Distributed Systems Design",
+  "Golang",
+  "Continuous Integration Pipelines",
+  "React",
+  "Infrastructure As Code",
+  "Redis",
+  "Data Warehouse Modeling",
+  "Linux",
+  "Security Incident Response",
+  "GraphQL",
+];
+
+describe("#301 — multi-word skill does not split at the line-wrap boundary", () => {
+  let reparsedSkills: string[];
+
+  beforeAll(async () => {
+    const original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const withSyntheticSkills: CascadeResult = {
+      ...original,
+      parsed: { ...original.parsed, skills: SYNTHETIC_SKILLS },
+    };
+    const model = buildAtsResumeModel(
+      withSyntheticSkills,
+      scoreFor(withSyntheticSkills),
+    );
+    const bytes = await renderAtsResumePdf(model);
+    const reparsed = await runCascade(bytes);
+    reparsedSkills = reparsed.parsed.skills ?? [];
+  });
+
+  it("round-trips the same skill count (AC)", () => {
+    expect(reparsedSkills.length).toBe(SYNTHETIC_SKILLS.length);
+  });
+
+  it("round-trips every multi-word skill intact — none split at a wrap point", () => {
+    const reparsedSet = new Set(reparsedSkills);
+    for (const skill of SYNTHETIC_SKILLS) {
+      expect(reparsedSet.has(skill)).toBe(true);
+    }
+  });
+});
+
+/**
+ * Regression for the `wrapSegmentsToLines` first-segment bug: `segments[0]`
+ * used to be assigned to `current` before the loop and never measured, so an
+ * overlong FIRST segment (a "Company · Location" org line whose company name
+ * alone exceeds maxWidth) was emitted verbatim and overflowed the right margin.
+ * Proven repro (Helvetica, size 10, maxWidth 468): the 104-char company string
+ * measures 476.46pt > 468. Every returned line must now fit within maxWidth.
+ */
+describe("wrapSegmentsToLines — overlong FIRST segment is wrapped, not overflowed", () => {
+  const SIZE = 10;
+  const MAX_WIDTH = 468;
+
+  it("no rendered line exceeds maxWidth when segments[0] is too wide", async () => {
+    const { PDFDocument, StandardFonts } = await loadPdfLibOnce();
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+
+    const segments = [
+      "International Business Machines Corporation Yorktown Heights Thomas J Watson Research Center Division",
+      "Yorktown Heights NY",
+    ];
+    // Sanity-check the repro precondition: the first segment alone overflows.
+    expect(font.widthOfTextAtSize(segments[0], SIZE)).toBeGreaterThan(MAX_WIDTH);
+
+    const lines = wrapSegmentsToLines(segments, font, SIZE, MAX_WIDTH);
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(font.widthOfTextAtSize(line, SIZE)).toBeLessThanOrEqual(MAX_WIDTH);
+    }
+  });
+});

--- a/src/lib/score/group-bullets.ts
+++ b/src/lib/score/group-bullets.ts
@@ -63,6 +63,31 @@ export interface BulletExperience {
   description?: string;
 }
 
+/**
+ * Coerce a list of parsed entries (experiences, projects, achievements) into
+ * the `BulletExperience` shape: `name` falls back to `title`, and the date /
+ * currency fields pass through verbatim. Shared by the reconstruction surface
+ * and the ATS render-model builder so both derive the entry shape identically.
+ */
+export function toBulletExperience(
+  entries: ReadonlyArray<{
+    title?: string;
+    name?: string;
+    description?: string;
+    start_date?: string;
+    end_date?: string;
+    is_current?: boolean;
+  }>,
+): BulletExperience[] {
+  return entries.map((e) => ({
+    title: e.title ?? e.name,
+    description: e.description,
+    start_date: e.start_date,
+    end_date: e.end_date,
+    is_current: e.is_current,
+  }));
+}
+
 /** A group of flagged bullets under one parsed experience role (or "Other"). */
 export interface BulletGroup {
   /** Index into the experiences array, or null for unmatched bullets. */


### PR DESCRIPTION
## Summary

Round-trip audit epic — parse → export ("Download PDF") → re-parse fidelity. Two batches, one PR.

### Batch 1 — render hardening + experience swap
- **#295** — `renderAtsResumePdf` (the Download-PDF surface) hard-crashed on any non-WinAnsi glyph (`→`, `‐`, or a `µ` that case-expands to `Μ` under uppercasing). Added a `toWinAnsi()` sanitizer applied **after** uppercasing, so `drawText` can never throw — worst case degrades a glyph, never crashes.
- **#298** — experience title/company swap on re-parse. The reconstructed experience emit now always carries a ` · ` middot org-signature on the company sub-line, and the re-parse anchor-tiebreak gates on that signature **only** — fixing the swap for the round-trip target without regressing generic-résumé shapes (proven `fixed == main` on the ambiguous cases).

### Batch 2 — skills word-wrap + scanned false-positive
- **#301** — a multi-word skill (`Cloud Data Warehousing`) or a `Company · Location` line word-wrapped **inside** a segment → +1 token on re-parse. `wrap()` now wraps `" · "` middot segments atomically (`wrapSegmentsToLines`, incl. an overlong `segments[0]`), never breaking mid-segment. Companion: `isSoftWrapContinuation` tightened to `/\s[&\-–+]\s*$/` so `C++`/`PHP7+` aren't mistaken for wrap continuations.
- **#299** — skills +1 delimiter split — **same root cause as #301**, fixed by the same change; all 5 skills fixtures cleared.
- **#296** — reconstructed PDF re-parsed nearly empty (contact + experience + education all dropped). Root cause: `probeScanned`'s `avgItems < 15` arm false-positived on compact reconstructions → cascade short-circuited to "scanned". Scanned detection is now `avgChars`-only.
- **Fallow cleanup** — extracted a shared `toBulletExperience` helper (removed an 83-line `ReconstructedResume ↔ ats-resume-model` dup), collapsed a corpus-roundtrip self-dup, dropped an unused export.

Corpus round-trip gate (#293) stays green; **13 fixtures newly cleared** from `KNOWN_FAILURES` across both batches, none re-baselined to hide a regression.

Resolves #295
Resolves #296
Resolves #298
Resolves #299
Resolves #301

## Adversarial review

Pre-PR adversarial review loop, both batches, converged clean.

**Batch 1 (3 rounds):** fixed `toWinAnsi` being defeated by a later `.toUpperCase()`; then three successive anchor-tiebreak inversions, resolved structurally by gating the tiebreak on the reconstructed middot signature **only** (proven `fixed == main` on generic shapes → no regression).

**Batch 2 (2 rounds):** Round 1 caught 1 blocking bug the fix introduced — `wrapSegmentsToLines` never measured `segments[0]`, so an overlong first segment overflowed the page margin (fixed + regression-tested). 2 mediums accepted + documented in code (`probeScanned` avgChars-only tradeoff; `isSoftWrapContinuation` symmetric hole). Round 2 clean (1 nit).

## Known-honest remainder

Still baselined in `KNOWN_FAILURES`, each a **distinct** root cause (not the fixes above): render heading pollution (`chromium-two-column-sidebar`), the by-design `→`→`->` transliteration artifact (2 fixtures), an empty-title emit edge (`openresume-laverne-word-quartz`). Candidates for follow-up.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1482 passed / 1 skipped)
- [x] `npm run verify` green (typecheck → lint → coverage → build; fallow report-only)
- [x] Corpus round-trip gate (#293) green; 13 fixtures newly cleared, none re-baselined
- [ ] Manual spot-check in `npm run preview` (Download-PDF on a résumé with `→`/`µ` headers + a multi-word skill)
