### PR TITLE
chore(fallow): tune out false positives + clean dead code (#15)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,74 @@
+{
+  // fallow static-analysis config (issue #15). Tunes out false positives so the
+  // diff-scoped `fallow audit` gate stays high-signal. See docs.fallow.tools.
+
+  // Dev-only browser harnesses (jd-spike.html / eval-rewrite.html / parse-eval.html)
+  // are real entry points kept in-repo but excluded from the production rollup
+  // `input` (vite.config.ts) so they never ship to dist/. Register them here so
+  // fallow follows them and stops reporting their browser `.ts` modules
+  // (jd-spike-browser.ts, run-eval-browser.ts, parse-eval-browser.ts and their
+  // spike/eval helpers) as unreachable dead code.
+  "entry": [
+    "jd-spike.html",
+    "eval-rewrite.html",
+    "parse-eval.html"
+  ],
+
+  // `@design-tokens` is a Vite CSS-import alias (vite.config.ts resolve.alias),
+  // not an npm package — it's `@import`ed from src/styles.css. Fallow's dependency
+  // scanner has no view of the Vite alias, so it reports an "unlisted dependency".
+  // Teach it the specifier is intentional.
+  "ignoreDependencies": [
+    "@design-tokens"
+  ],
+
+  // Complexity/CRAP thresholds only apply to shipped product code. The dev-only
+  // WebLLM harnesses (spike/eval/parse-eval, loaded via the dev HTML entries and
+  // never in the production rollup) score high CRAP purely because they carry no
+  // test coverage — that's not maintainability debt worth tracking.
+  "health": {
+    "ignore": [
+      "src/lib/webllm/spike/**",
+      "src/lib/webllm/eval/**",
+      "src/lib/webllm/parse-eval/**"
+    ]
+  },
+
+  "ignoreExports": [
+    // Design-system primitive variant types are the deliberate public surface of
+    // the `@design-system` seam (3-tier component architecture, CLAUDE.md). They
+    // are intended API for consumers even when no in-tree caller references the
+    // union type directly — not dead code.
+    { "file": "src/design-system/primitives/Button.tsx", "exports": ["ButtonVariant", "ButtonSize"] },
+    { "file": "src/design-system/primitives/Chip.tsx", "exports": ["ChipTone"] },
+    { "file": "src/design-system/shared/ErrorState.tsx", "exports": ["ErrorStateTone"] },
+
+    // Public-API barrels. Each file documents itself as THE consumer boundary
+    // for its module ("Public surface is intentionally small… Consumers should
+    // not import internals directly") and deliberately re-exports the result-shape
+    // types a caller needs to type `runCascade` / `extractJdTerms` — even where
+    // the in-tree app imports those types from deeper paths. Re-exports with no
+    // in-repo consumer are the intended external surface, not dead code.
+    { "file": "src/lib/heuristics/index.ts", "exports": ["*"] },
+    { "file": "src/lib/jd-match/index.ts", "exports": ["*"] },
+
+    // `ParseMetadata` is the telemetry metadata contract the heuristics barrel
+    // re-exports so a host can type the `ParseEvent` payloads it wires to the
+    // `onEvent` sink. It has no in-tree consumer (the app doesn't inspect
+    // metadata), and a barrel re-export whose barrel is itself ignored doesn't
+    // register as a consumer edge — so the source export must be marked here too.
+    { "file": "src/lib/heuristics/types.ts", "exports": ["ParseMetadata"] },
+
+    // `getThresholdsFor` is a deliberate extensibility stub (see its doc comment:
+    // "exists so we can diverge later without touching callers") re-exported by
+    // the heuristics barrel. Uncalled today by design; keep the seam.
+    { "file": "src/lib/heuristics/thresholds.ts", "exports": ["getThresholdsFor"] },
+
+    // Dev-only WebLLM spike/eval harnesses (loaded via the registered dev HTML
+    // entries above). Their type vocabulary documents the harness contract
+    // (README + prompt comments) even where no annotation consumes it; don't hold
+    // dev scaffolding to the production dead-surface bar.
+    { "file": "src/lib/webllm/spike/**", "exports": ["*"] },
+    { "file": "src/lib/webllm/eval/**", "exports": ["*"] }
+  ]
+}

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -49,8 +49,36 @@
     // types a caller needs to type `runCascade` / `extractJdTerms` — even where
     // the in-tree app imports those types from deeper paths. Re-exports with no
     // in-repo consumer are the intended external surface, not dead code.
-    { "file": "src/lib/heuristics/index.ts", "exports": ["*"] },
-    { "file": "src/lib/jd-match/index.ts", "exports": ["*"] },
+    //
+    // Enumerated (not `["*"]`) on purpose: `*` would silence the unused-export
+    // check for the whole file, so a *future* accidentally-dead re-export added
+    // here would go unreported. Listing the intended public names keeps that
+    // check live — a new `export { … }` that nothing consumes still trips fallow.
+    // The trade is upkeep when the surface churns; these barrels are stable, so
+    // it's cheap. Keep in sync with the `export`s in each barrel.
+    { "file": "src/lib/heuristics/index.ts", "exports": [
+      "runCascade", "runCascadeFromMarkdown",
+      "RunCascadeOptions", "RunCascadeFromMarkdownOptions",
+      "CANONICAL_CONFIDENCE_THRESHOLD", "EXTRACTION_RATIO_FLOOR",
+      "NAME_CONFIDENCE_FLOOR", "SOFT_PENALTY", "FIELD_CONFIDENCE_TARGETS",
+      "FIELD_WEIGHTS", "TWO_COLUMN_CONFIDENCE_CAP", "getThresholdsFor",
+      "CascadeBranch", "CascadeThresholds", "CASCADE_VERSION",
+      "emitMarkdown", "RenderLine",
+      "CascadeResult", "HeuristicResult", "HeuristicParsedResume",
+      "FieldConfidence", "LayoutProbes", "LayoutTrigger", "EscalationSuggestion",
+      "ExtractionFailureReason", "PdfExtractResult", "PdfLinkAnnotation",
+      "PdfTextItem", "PdfPageInfo", "ParseEvent", "ParseStartedEvent",
+      "TierEngagedEvent", "ParseCompletedEvent", "TierId", "TierEngagementReason",
+      "FinalSource", "FileSizeBucket", "ParseMetadata"
+    ] },
+    { "file": "src/lib/jd-match/index.ts", "exports": [
+      "extractJdTerms", "stripBoilerplate",
+      "ExtractedTerm", "ExtractJdTermsResult", "ExtractOptions",
+      "computeCoverage", "buildCorpus", "SKILL_WEIGHT", "NOUN_WEIGHT",
+      "CoverageResult", "SKILLS", "getSkillIndex", "skillCount", "SkillEntry",
+      "fetchJdFromUrl", "parseAtsUrl", "htmlToPlaintext", "AtsPlatform",
+      "JdMatchResult"
+    ] },
 
     // `ParseMetadata` is the telemetry metadata contract the heuristics barrel
     // re-exports so a host can type the `ParseEvent` payloads it wires to the

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -26,7 +26,7 @@ import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
  *  key. Includes the link fields — a detected GitHub/portfolio/website URL is
  *  editable too (only optional links that the parser actually found render, so
  *  there is nothing to edit when absent). */
-export const EDITABLE_KEYS: Record<string, keyof ContactOverrides> = {
+const EDITABLE_KEYS: Record<string, keyof ContactOverrides> = {
   full_name: "full_name",
   email: "email",
   phone: "phone",

--- a/src/lib/heuristics/__test-utils__/mkItem.ts
+++ b/src/lib/heuristics/__test-utils__/mkItem.ts
@@ -25,7 +25,7 @@ const LINE_HEIGHT = 14;
 const TOP_MARGIN = 72;
 
 /** Build a single `PdfTextItem` from a line spec (one text run per line). */
-export function mkItem(spec: LineSpec): PdfTextItem {
+function mkItem(spec: LineSpec): PdfTextItem {
   const fontSize = spec.fontSize ?? 11;
   const x = spec.x ?? 72;
   const y = TOP_MARGIN + spec.lineIndex * LINE_HEIGHT;
@@ -49,7 +49,7 @@ export function mkItems(
   return specs.map((s, i) => mkItem({ ...s, lineIndex: s.lineIndex ?? i }));
 }
 
-export function mkPage(
+function mkPage(
   page: number,
   items: PdfTextItem[],
   width = 612,

--- a/src/lib/heuristics/index.ts
+++ b/src/lib/heuristics/index.ts
@@ -37,7 +37,7 @@ export { CASCADE_VERSION } from "./types.ts";
 // Markdown emitter. Exported so callers can reuse it against locally
 // extracted `PdfTextItem[]` without re-running the cascade.
 export { emitMarkdown } from "./markdown-emit.ts";
-export type { PdfLine } from "./markdown-emit.ts";
+export type { RenderLine } from "./markdown-emit.ts";
 export type {
   CascadeResult,
   HeuristicResult,

--- a/src/lib/heuristics/markdown-emit.test.ts
+++ b/src/lib/heuristics/markdown-emit.test.ts
@@ -16,7 +16,7 @@ import {
   stripBulletPrefix,
 } from "./markdown-emit.ts";
 import { mkDefaultPages, mkItems } from "./__test-utils__/mkItem.ts";
-import type { PdfLine } from "./markdown-emit.ts";
+import type { RenderLine } from "./markdown-emit.ts";
 
 describe("markdown-emit: groupItemsIntoLines", () => {
   it("returns empty array on empty input", () => {
@@ -61,7 +61,7 @@ describe("markdown-emit: computeBodyFontSize", () => {
   it("picks the character-weighted mode, not the line-count mode", () => {
     // Two short 18pt header lines and three long 11pt body lines. Character
     // weighting should pick 11pt even though there are almost equal counts.
-    const lines: PdfLine[] = [
+    const lines: RenderLine[] = [
       { page: 1, y: 72, x: 72, text: "HEAD", fontSize: 18 },
       { page: 1, y: 100, x: 72, text: "HEAD2", fontSize: 18 },
       {
@@ -109,7 +109,7 @@ describe("markdown-emit: isBulletLine / stripBulletPrefix", () => {
 
 describe("markdown-emit: renderLine", () => {
   const bodySize = 10;
-  const line = (text: string, fontSize: number): PdfLine => ({
+  const line = (text: string, fontSize: number): RenderLine => ({
     page: 1, y: 100, x: 72, text, fontSize,
   });
 
@@ -140,7 +140,7 @@ describe("markdown-emit: renderLine", () => {
 
 describe("markdown-emit: needsParagraphBreak", () => {
   const body = 10;
-  const line = (page: number, y: number, fontSize = body): PdfLine => ({
+  const line = (page: number, y: number, fontSize = body): RenderLine => ({
     page, y, x: 72, text: "x", fontSize,
   });
 

--- a/src/lib/heuristics/markdown-emit.ts
+++ b/src/lib/heuristics/markdown-emit.ts
@@ -57,7 +57,7 @@ const LEADING_BULLET_RE =
 // ── Types ───────────────────────────────────────────────────────────────────
 
 /** A single logical line produced by grouping items at matching y-coords. */
-export interface PdfLine {
+export interface RenderLine {
   page: number;
   y: number;
   /** Leftmost x of any item in this line (for future indentation logic). */
@@ -84,13 +84,13 @@ export interface PdfLine {
 export function groupItemsIntoLines(
   items: PdfTextItem[],
   boundaries?: Map<number, number>,
-): PdfLine[] {
+): RenderLine[] {
   const bands = orderItemsByColumn(items, boundaries);
   return bands.flatMap(groupLinesSingle);
 }
 
 /** Single-pass line grouping over one band of items (no column awareness). */
-function groupLinesSingle(items: PdfTextItem[]): PdfLine[] {
+function groupLinesSingle(items: PdfTextItem[]): RenderLine[] {
   if (items.length === 0) return [];
 
   const sorted = [...items].sort((a, b) => {
@@ -99,8 +99,8 @@ function groupLinesSingle(items: PdfTextItem[]): PdfLine[] {
     return a.x - b.x;
   });
 
-  const lines: PdfLine[] = [];
-  let current: PdfLine | null = null;
+  const lines: RenderLine[] = [];
+  let current: RenderLine | null = null;
 
   for (const item of sorted) {
     if (!item.str) continue;
@@ -140,7 +140,7 @@ function groupLinesSingle(items: PdfTextItem[]): PdfLine[] {
  * Returns the default 10pt when given no lines. Bins sizes to 0.1pt to
  * collapse near-equal floats that pdfjs sometimes emits.
  */
-export function computeBodyFontSize(lines: PdfLine[]): number {
+export function computeBodyFontSize(lines: RenderLine[]): number {
   if (lines.length === 0) return 10;
 
   const bins = new Map<number, number>();
@@ -174,7 +174,7 @@ export function stripBulletPrefix(text: string): string {
  * Render a single line to markdown: heading by font-size ratio, bullet by
  * leading glyph, plain prose otherwise.
  */
-export function renderLine(line: PdfLine, bodySize: number): string {
+export function renderLine(line: RenderLine, bodySize: number): string {
   const ratio = line.fontSize / bodySize;
   if (ratio >= H1_RATIO) return `# ${line.text}`;
   if (ratio >= H2_RATIO) return `## ${line.text}`;
@@ -188,8 +188,8 @@ export function renderLine(line: PdfLine, bodySize: number): string {
  * page break, large vertical gap, or font-size change (header transition).
  */
 export function needsParagraphBreak(
-  prev: PdfLine,
-  next: PdfLine,
+  prev: RenderLine,
+  next: RenderLine,
   bodySize: number,
 ): boolean {
   if (prev.page !== next.page) return true;
@@ -228,7 +228,7 @@ export function emitMarkdown(
   const bodySize = computeBodyFontSize(lines);
 
   const output: string[] = [];
-  let prev: PdfLine | null = null;
+  let prev: RenderLine | null = null;
 
   for (const line of lines) {
     const rendered = renderLine(line, bodySize);

--- a/src/lib/heuristics/markdown-lines.ts
+++ b/src/lib/heuristics/markdown-lines.ts
@@ -152,7 +152,7 @@ function normalizeSplitLetterHeaders(markdown: string): string {
  * Pre-clean the raw markdown before line-by-line classification. Idempotent
  * and cheap — runs once per DOCX upload.
  */
-export function preprocessMarkdown(markdown: string): string {
+function preprocessMarkdown(markdown: string): string {
   let out = markdown;
   out = stripImages(out);
   out = unescapeBackslashes(out);
@@ -303,7 +303,7 @@ function buildLine(
  * Runs `preprocessMarkdown` first to strip base64 image blobs, undo
  * turndown escapes, and normalize split-letter section headers.
  */
-export function markdownToPseudoLines(markdown: string): PdfLine[] {
+function markdownToPseudoLines(markdown: string): PdfLine[] {
   const cleaned = preprocessMarkdown(markdown);
   const rawLines = cleaned.split(/\r?\n/);
   const out: PdfLine[] = [];
@@ -328,7 +328,7 @@ export function markdownToPseudoLines(markdown: string): PdfLine[] {
  * like `EXPERIENCE 04/2021 - Present` where the date run got joined into
  * the header line in mammoth output).
  */
-export function sectionizeMarkdownLines(lines: PdfLine[]): PdfSection[] {
+function sectionizeMarkdownLines(lines: PdfLine[]): PdfSection[] {
   const sections: PdfSection[] = [{ name: "profile", lines: [] }];
 
   for (const line of lines) {

--- a/src/lib/jd-match/extract-jd-terms.ts
+++ b/src/lib/jd-match/extract-jd-terms.ts
@@ -39,7 +39,7 @@ import { getSkillIndex } from "./skills.ts";
  * If you add an anchor, lowercase it and keep it phrase-shaped — we match
  * with `.includes()` after whitespace normalization, not regex.
  */
-export const BOILERPLATE_ANCHORS: readonly string[] = [
+const BOILERPLATE_ANCHORS: readonly string[] = [
   "equal opportunity employer",
   "equal employment opportunity",
   "without regard to race",
@@ -115,7 +115,7 @@ export interface ExtractJdTermsResult {
  * at <10 noun-phrase hits after the skill-overlap filter, so a 25-cap leaves
  * comfortable headroom while protecting the UI from outliers.
  */
-export const NOUN_PASS_CAP = 25;
+const NOUN_PASS_CAP = 25;
 
 /**
  * Lines that the noun-phrase regex would otherwise pick up but that almost
@@ -537,7 +537,7 @@ function countOccurrences(haystackLower: string, phraseLower: string): number {
  * The sort is stable: ties keep the input's document order, so a JD with no
  * repetition degrades gracefully to the prior first-N behavior.
  */
-export function rankNounHits(
+function rankNounHits(
   hits: readonly ExtractedTerm[],
   body: string,
 ): ExtractedTerm[] {

--- a/src/lib/jd-match/index.ts
+++ b/src/lib/jd-match/index.ts
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
 
-export {
-  extractJdTerms,
-  stripBoilerplate,
-  BOILERPLATE_ANCHORS,
-} from "./extract-jd-terms.ts";
+export { extractJdTerms, stripBoilerplate } from "./extract-jd-terms.ts";
 export type {
   ExtractedTerm,
   ExtractJdTermsResult,

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -10,7 +10,6 @@
 
 import type {
   AtsScore,
-  AtsScoreDimensions,
   ScoreTier,
   ResumeExperience,
   ResumeData,
@@ -18,11 +17,11 @@ import type {
 import type { SectionedResume } from "../heuristics/sections.ts";
 
 // Re-export types for convenience
-export type { AtsScore, AtsScoreDimensions, ScoreTier };
+export type { AtsScore, ScoreTier };
 
 // ── Scoring weights ─────────────────────────────────────────────────────────
 
-export const WEIGHTS = {
+const WEIGHTS = {
   specificity: 0.4,
   structure: 0.3,
   completeness: 0.3,
@@ -94,7 +93,7 @@ const BULLET_LENGTH_MIN_WORDS = 8;
 const BULLET_LENGTH_MAX_WORDS = 30;
 
 /** Ratio of metric-bearing bullets that earns full Specificity credit (100). */
-export const SPECIFICITY_TARGET_RATIO = 0.6;
+const SPECIFICITY_TARGET_RATIO = 0.6;
 
 /** Completeness sub-thresholds — match the authed scorer historically. */
 const COMPLETENESS_SUMMARY_MIN_CHARS = 20;

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -7,39 +7,6 @@
  * standalone — no DB or remote-store assumptions reach this layer.
  */
 
-// ── Ambiguity types ────────────────────────────────────────────────────────
-
-export type AmbiguityCategory =
-  | "employment_gap"
-  | "employment_overlap"
-  | "title_normalization"
-  | "date_unclear"
-  | "content_vague"
-  | "format_suggestion"
-  | "tenure_structure"
-  | "graduation_year_visible"
-  | "explicit_tenure_claim"
-  | "dated_summary_language"
-  | "early_career_date_leak";
-
-export type AmbiguitySeverity = "error" | "warning" | "info";
-
-export interface AmbiguityFieldRef {
-  company?: string;
-  team?: string;
-  title?: string;
-  start_date?: string;
-  field: string;
-}
-
-export interface StructuredAmbiguity {
-  category: AmbiguityCategory;
-  severity: AmbiguitySeverity;
-  description: string;
-  field_ref?: AmbiguityFieldRef;
-  suggested_value?: string;
-}
-
 // ── ATS score types ────────────────────────────────────────────────────────
 
 export interface AtsScoreDimensions {

--- a/src/lib/webllm/parse-eval/combined-report.ts
+++ b/src/lib/webllm/parse-eval/combined-report.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
-// fallow-ignore-file unused-file
 
 /**
  * Report renderers for the separate-vs-combined comparison eval (issue #262).
@@ -18,7 +17,6 @@ import type {
   CombinedFixtureComparison,
 } from "./combined-score.ts";
 
-// fallow-ignore-next-line unused-export
 export function renderCombinedJsonReport(report: CombinedEvalReport): string {
   return `${JSON.stringify(report, null, 2)}\n`;
 }
@@ -48,7 +46,6 @@ function tick(v: boolean): string {
   return v ? "PASS" : "fail";
 }
 
-// fallow-ignore-next-line unused-export
 export function renderCombinedMarkdownReport(report: CombinedEvalReport): string {
   const { separateMeans: sM, combinedMeans: cM } = report;
   const { separateCritiqueMeans: sC, combinedCritiqueMeans: cC } = report;

--- a/src/lib/webllm/parse-eval/fixtures.ts
+++ b/src/lib/webllm/parse-eval/fixtures.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
-// fallow-ignore-file unused-file
 
 /**
  * Inline eval fixtures for the parse-resume provider (issue #241).
@@ -250,7 +249,6 @@ B.S. Statistics — Westbrook University (Expected May 2025)`,
 // ---------------------------------------------------------------------------
 
 /** All eval fixtures, in run order. */
-// fallow-ignore-next-line unused-export
 export const PARSE_EVAL_FIXTURES: readonly ParseEvalFixture[] = [
   SOFTWARE_ENGINEER,
   MARKETING_COORDINATOR,

--- a/src/lib/webllm/parse-eval/parse-eval-browser.ts
+++ b/src/lib/webllm/parse-eval/parse-eval-browser.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
-// fallow-ignore-file unused-file
 
 /**
  * Browser entry for the parse-resume eval harness (issues #241 + #262).

--- a/src/lib/webllm/parse-eval/report.ts
+++ b/src/lib/webllm/parse-eval/report.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The resumelint Authors
-// fallow-ignore-file unused-file
 
 /**
  * Report renderers for the parse-resume eval harness (issue #241).
@@ -17,7 +16,6 @@
 
 import type { ParseEvalReport } from "./score.ts";
 
-// fallow-ignore-next-line unused-export
 export function renderJsonReport(report: ParseEvalReport): string {
   return `${JSON.stringify(report, null, 2)}\n`;
 }
@@ -30,7 +28,6 @@ function tick(v: boolean): string {
   return v ? "PASS" : "fail";
 }
 
-// fallow-ignore-next-line unused-export
 export function renderMarkdownReport(report: ParseEvalReport): string {
   const lines: string[] = [];
 


### PR DESCRIPTION
## Summary

No `.fallowrc` existed, so fallow ran on raw defaults — false positives never got tuned out and the reporting felt like noise. This adds `.fallowrc.jsonc` that models the project (dev HTML entries, the `@design-tokens` Vite alias, public-API barrels, dev-only harness dirs) and removes the genuine dead code fallow surfaced.

**Result:** `fallow dead-code` **93 issues → 0**, and the diff-scoped `fallow audit` gate passes with **zero introduced findings** (`✓ No issues in 15 changed files`). This PR also exists to confirm the **cloud fallow / code-scanning** run is green again on a real PR — the surfaced-but-unfixed warnings from #304 are what prompted it.

### Config (`.fallowrc.jsonc`)
- **entry** — register the 3 dev-only HTML harnesses (`jd-spike` / `eval-rewrite` / `parse-eval`) so their browser modules aren't flagged unreachable. They are real entries, just excluded from the production rollup (`vite.config.ts:152`), so fallow couldn't see them.
- **ignoreDependencies** — `@design-tokens` is a Vite CSS-import alias, not an npm package (false "unlisted dependency").
- **health.ignore** — webllm `spike`/`eval`/`parse-eval` dev dirs (high CRAP only from zero coverage by design, not shipped-code debt).
- **ignoreExports** — the two public-API barrels (`heuristics/index.ts`, `jd-match/index.ts`) that deliberately re-export result-shape types; the design-system primitive variant types; and two documented keep-alive seams (`ParseMetadata` telemetry contract, `getThresholdsFor` extensibility stub).

### Source cleanup
- Rename render-side `PdfLine` → `RenderLine` (`markdown-emit.ts`) — resolves a duplicate export colliding with the parse-side `PdfLine` in `sections.ts`.
- Drop `export` on internal-only symbols; delete genuinely-dead surface (`StructuredAmbiguity` cluster, unused `AtsScoreDimensions` re-export, `BOILERPLATE_ANCHORS` barrel leak).
- Remove 9 stale suppressions in `webllm/parse-eval` (redundant once the HTML entry is registered).

### Not in scope
Inherited complexity hotspots (`applyOverrides` cog 103, etc.) are **real** signal but don't block the new-only gate — tracked in **#305** rather than silently suppressed.

Refs #15, #304, #305

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1482 pass)
- [x] `npm run verify` green (full local CI mirror, incl. fallow audit)
- [x] Cloud fallow / code-scanning check green on this PR