### PR TITLE
chore(roundtrip): link KNOWN_FAILURES comments to tracking issues (#324/#325/#326)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -92,19 +92,23 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   // distinct, separately-rooted round-trip bugs that the swap fix does not (and
   // should not) touch; each warrants its own follow-up:
   //
-  //   - chromium-two-column-sidebar: count 5 → 7. A stray "20%" token renders
-  //     glued onto the "PROJECTS" section heading ("20% PROJECTS"), so section
-  //     recognition misses it and the projects block leaks into EXPERIENCE as
-  //     phantom roles. A RENDER-side heading-pollution bug, not segmentation.
+  //   - chromium-two-column-sidebar (#324): count 5 → 7. A stray "20%" token
+  //     renders glued onto the "PROJECTS" section heading ("20% PROJECTS"), so
+  //     section recognition misses it and the projects block leaks into
+  //     EXPERIENCE as phantom roles. A RENDER-side heading-pollution bug, not
+  //     segmentation (distinct layer from the parse-side fix in closed #117).
   "unknown/chromium-two-column-sidebar.pdf": ["experience"],
 
-  //   - classic / weasyprint: the ONLY diff is a Unicode glyph the #295
-  //     `toWinAnsi` sanitizer rewrites lossily — a role title "… Intern → Junior
-  //     Engineer" round-trips as "… Intern -> Junior Engineer" (→ U+2192 → "->").
-  //     A #295 render-sanitizer artifact, not the header swap.
-  //   - word-quartz: p1 has a role with an EMPTY title; the emit puts
+  //   - classic / weasyprint (#326, wontfix by-design): the ONLY diff is a
+  //     Unicode glyph the #295 `toWinAnsi` sanitizer rewrites lossily — a role
+  //     title "… Intern → Junior Engineer" round-trips as "… Intern -> Junior
+  //     Engineer" (→ U+2192 → "->"). A #295 render-sanitizer artifact, not the
+  //     header swap. Accepted tradeoff (no-crash > glyph fidelity); a real fix
+  //     needs a Unicode-capable embedded font. See #326 for the decision record.
+  //   - word-quartz (#325): p1 has a role with an EMPTY title; the emit puts
   //     "Company · Location  Dates" on the header line and re-parse assigns the
-  //     bare "City, ST" location as the title. An empty-title-role emit edge.
+  //     bare "City, ST" location as the title. An empty-title-role emit edge
+  //     (distinct from the score-path filter in closed #145).
   "google-docs/google-docs-skia-proxy-classic.pdf": ["experience"],
   "unknown/weasyprint-cairo-classic.pdf": ["experience"],
   "word/openresume-laverne-word-quartz.pdf": ["experience"],


### PR DESCRIPTION
## Summary

Comment-only follow-up to the round-trip work. The `KNOWN_FAILURES` baseline block in `corpus-roundtrip.test.ts` now cites the GitHub issue tracking each still-baselined fixture, so no baseline line is silent debt.

| Baselined fixture | Issue | Kind |
|---|---|---|
| `unknown/chromium-two-column-sidebar.pdf` | #324 | bug — render-side `20% PROJECTS` heading pollution |
| `word/openresume-laverne-word-quartz.pdf` | #325 | bug — empty-title role emit, location mis-read as title |
| `google-docs-skia-proxy-classic` + `weasyprint-cairo-classic` | #326 | wontfix decision-record — #295 `toWinAnsi` `→`→`->` artifact |

Also notes the distinction from the prior closed issues (#117 parse-side, #145 score-path) inline.

## Scope

- **Comment-only.** No logic, no baseline change, no snapshot change.
- `npx vitest run src/lib/heuristics/corpus-roundtrip.test.ts` → 37 passed / 1 skipped.

## Test plan

- [x] `npm run test -- corpus-roundtrip` green
- [ ] `npm run verify` (CI)

Refs #324
Refs #325
Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HXweW998LS7xc4MunjXz9
