### PR TITLE
fix: de-track letter-spaced name headings before parsing

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -127,17 +127,6 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   //     asymmetry, not the swap. (The #299/#E skills split is fixed by #301.)
   "unknown/openresume-react-pdf.pdf": ["experience"],
 
-  //   - letter-spaced-name-heading (#330): the name heading is rendered with wide
-  //     letter-spacing, so pdfjs explodes it to per-glyph tokens
-  //     ("J O R D A N R E Y E S") and `mergeItemText` inserts a space between
-  //     every glyph; the name heuristic's `>5 words` guard then rejects it, so
-  //     parse1 has NO `full_name`. On round-trip the reconstructed single-column
-  //     PDF re-parses a nearby line as the name, so `contact` diverges
-  //     (undefined → "Software Engineer II"). This is the letter-spacing artifact
-  //     itself, tracked in #330 — remove this line when the collapse-single-char-
-  //     run fix lands and parse1 recovers the real name.
-  "unknown/letter-spaced-name-heading.pdf": ["contact"],
-
   // Experience SWAP cleared by #298 (removed from these lines). The skills-line
   // token split (#299/#E) is fixed by #301, so google-docs-skia-proxy-role-first-
   // experience and -programs-skills-software round-trip clean; no line remains

--- a/src/lib/heuristics/sections.test.ts
+++ b/src/lib/heuristics/sections.test.ts
@@ -19,11 +19,14 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import {
+  collapseLetterSpacing,
   groupIntoLines,
+  mergeItemText,
   splitIntoSections,
   toSectionedResume,
   type PdfSection,
 } from "./sections.ts";
+import type { PdfTextItem } from "./types.ts";
 import { runCascade } from "./cascade.ts";
 import { mkItems } from "./__test-utils__/mkItem.ts";
 
@@ -684,5 +687,80 @@ describe("PdfSection.rawHeading — verbatim source heading capture (#285)", () 
     const resume = toSectionedResume(sections, "regex");
     expect(resume.sectionHeadings?.get("experience")).toBe("Work History");
     expect(resume.sectionHeadings?.size).toBe(1);
+  });
+});
+
+describe("collapseLetterSpacing — de-track tracked-out runs (#330)", () => {
+  it("collapses a letter-spaced word to one token", () => {
+    expect(collapseLetterSpacing("J O R D A N")).toBe("JORDAN");
+    expect(collapseLetterSpacing("r e s u m e")).toBe("resume");
+  });
+
+  it("leaves runs shorter than the min (< 4 letters) alone", () => {
+    // Initials, roman numerals, short spaced acronyms stay untouched.
+    expect(collapseLetterSpacing("J R R")).toBe("J R R");
+    expect(collapseLetterSpacing("I V X")).toBe("I V X");
+    expect(collapseLetterSpacing("A B C")).toBe("A B C");
+  });
+
+  it("collapses each word but preserves a trailing multi-char token", () => {
+    // The run anchors on a non-letter, so "Reyes" isn't swallowed.
+    expect(collapseLetterSpacing("J O R D A N Reyes")).toBe("JORDAN Reyes");
+  });
+
+  it("de-tracks accented (non-ASCII) letters", () => {
+    expect(collapseLetterSpacing("A N D R É S")).toBe("ANDRÉS");
+    expect(collapseLetterSpacing("J O S É")).toBe("JOSÉ");
+  });
+
+  it("preserves a >=2-space word gap as a boundary within one item", () => {
+    // A wider inter-word gap ends the single-space run, so the two words
+    // survive even when the whole heading is one item. collapseLetterSpacing
+    // itself only strips intra-run spaces; the surrounding gap is left as-is
+    // (mergeItemText's trailing \s+ collapse normalizes it to one space).
+    expect(collapseLetterSpacing("J O R D A N  R E Y E S")).toBe(
+      "JORDAN  REYES",
+    );
+  });
+
+  it("does not touch normal prose or digits", () => {
+    expect(collapseLetterSpacing("Globex Financial | New York, NY")).toBe(
+      "Globex Financial | New York, NY",
+    );
+    expect(collapseLetterSpacing("1 2 3 4 5")).toBe("1 2 3 4 5");
+  });
+});
+
+describe("mergeItemText — letter-spaced heading recovery (#330)", () => {
+  const line = (str: string, x: number, width: number): PdfTextItem => ({
+    page: 1,
+    str,
+    x,
+    y: 72,
+    width,
+    height: 24,
+    fontSize: 24,
+    fontName: "font-24",
+    hasEOL: true,
+  });
+
+  it("recovers a two-word name from per-glyph items, keeping the word break", () => {
+    // pdfjs emits each tracked-out word as one space-joined item and the real
+    // word boundary as a separate " " item. Per-item de-tracking must keep the
+    // boundary so the two words survive.
+    const items = [
+      line("J O R D A N", 100, 90),
+      line(" ", 195, 8),
+      line("R E Y E S", 205, 75),
+    ];
+    expect(mergeItemText(items)).toBe("JORDAN REYES");
+  });
+
+  it("leaves an un-tracked line unchanged", () => {
+    const items = [
+      line("Jordan Reyes", 100, 90),
+      line("Engineer", 205, 60),
+    ];
+    expect(mergeItemText(items)).toBe("Jordan Reyes Engineer");
   });
 });

--- a/src/lib/heuristics/sections.ts
+++ b/src/lib/heuristics/sections.ts
@@ -487,6 +487,47 @@ function groupLinesSingle(bandItems: PdfTextItem[]): PdfLine[] {
 }
 
 /**
+ * Minimum single-letter run length that reads as letter-spacing (tracked-out
+ * type) rather than genuine single-char tokens. Four keeps initials ("J R R"),
+ * roman numerals ("I V X"), and short spaced acronyms out of the collapse.
+ */
+const LETTER_SPACING_MIN_RUN = 4;
+
+/**
+ * Regex for a maximal run of ≥`LETTER_SPACING_MIN_RUN` single letters each
+ * separated by exactly one space (`J O R D A N`). `\p{L}` (Unicode letter, `u`
+ * flag) so accented names de-track too (`A N D R É S` → `ANDRÉS`), not just
+ * ASCII. Anchored on both sides by a non-letter (or string edge) so a trailing
+ * multi-char word isn't swallowed ("J O R D A N Reyes" → only "J O R D A N"
+ * collapses). Requiring exactly one space per pair means a wider (≥2-space)
+ * inter-word gap ends the run, preserving that word boundary even inside one
+ * item (`"J O R D A N  R E Y E S"` → `"JORDAN REYES"`).
+ */
+const LETTER_SPACED_RUN = new RegExp(
+  `(?<!\\p{L})(?:\\p{L} ){${LETTER_SPACING_MIN_RUN - 1},}\\p{L}(?!\\p{L})`,
+  "gu",
+);
+
+/**
+ * Collapse letter-spaced (tracked-out) runs inside one pdfjs item string.
+ * A heading rendered with wide `letter-spacing` reaches us as glyphs joined by
+ * spaces *within a single item* (`"J O R D A N"`), while genuine word breaks
+ * arrive as separate items — so collapsing per item de-tracks each word yet
+ * preserves the real word boundary between items (#330). Every downstream
+ * extractor (name, contact, sections) then sees `"JORDAN"`, not `"J O R D A N"`.
+ *
+ * Scope: this recovers the word boundary when it surfaces as a separate item
+ * (the observed pdfjs shape) or as a ≥2-space gap within an item. The one case
+ * it cannot resolve is a whole multi-word heading emitted as a *single* item
+ * with a *single*-space word gap — then intra- and inter-word gaps are
+ * indistinguishable from the string alone and the words would weld. Not
+ * observed for pdfjs on the #330 corpus; a gap-magnitude split would be needed.
+ */
+export function collapseLetterSpacing(str: string): string {
+  return str.replace(LETTER_SPACED_RUN, (run) => run.replace(/ /g, ""));
+}
+
+/**
  * Concatenate items on a line, inserting a space when the horizontal gap
  * between runs is large enough to imply a word boundary. pdfjs emits each
  * glyph run as a separate item, so naively joining with spaces over-pads
@@ -494,7 +535,11 @@ function groupLinesSingle(bandItems: PdfTextItem[]): PdfLine[] {
  */
 export function mergeItemText(items: PdfTextItem[]): string {
   if (items.length === 0) return "";
-  let out = items[0].str;
+  // De-track each item first (geometry left untouched — gap math below still
+  // uses the original item widths). Collapsing per item keeps the word-boundary
+  // items intact, so `"J O R D A N"` + `" "` + `"R E Y E S"` → `"JORDAN REYES"`.
+  const strs = items.map((it) => collapseLetterSpacing(it.str));
+  let out = strs[0];
   for (let i = 1; i < items.length; i++) {
     const prev = items[i - 1];
     const cur = items[i];
@@ -502,10 +547,10 @@ export function mergeItemText(items: PdfTextItem[]): string {
     const avgCharW = prev.width / Math.max(prev.str.length, 1);
     // Gap wider than ~half a character triggers an inserted space.
     // Also always insert a space if either side already has trailing/leading ws.
-    const prevEndsWs = /\s$/.test(prev.str);
-    const curStartsWs = /^\s/.test(cur.str);
+    const prevEndsWs = /\s$/.test(strs[i - 1]);
+    const curStartsWs = /^\s/.test(strs[i]);
     const needSpace = !prevEndsWs && !curStartsWs && gap > avgCharW * 0.4;
-    out += (needSpace ? " " : "") + cur.str;
+    out += (needSpace ? " " : "") + strs[i];
   }
   return out.replace(/\s+/g, " ").trim();
 }

--- a/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
+++ b/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
@@ -1,20 +1,22 @@
 {
   "schemaVersion": 3,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.91,
     "triggers": [],
     "tiers": [
       "t0_layout",
-      "t1_openresume",
-      "t1_5_regex"
+      "t1_openresume"
     ],
-    "suggestedEscalation": "llm",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
       "current_company",
       "current_title",
       "education",
       "email",
       "experience",
+      "family_name",
+      "full_name",
+      "given_name",
       "location",
       "phone",
       "phoneIsValid"
@@ -24,15 +26,15 @@
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,
-    "rawTextCharCount": 951,
+    "rawTextCharCount": 942,
     "pageCount": 1,
     "linkAnnotationCount": 0,
     "hasMarkdown": true,
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 41,
-    "preLayoutOverall": 41,
+    "overall": 44,
+    "preLayoutOverall": 44,
     "specificity": {
       "score": 0,
       "max": 40,
@@ -48,12 +50,11 @@
       "totalBullets": 4
     },
     "completeness": {
-      "score": 18,
+      "score": 21,
       "max": 30,
       "gradable": true,
       "missing": [
         "LinkedIn",
-        "name",
         "skills",
         "summary"
       ]


### PR DESCRIPTION
## Summary

A résumé whose name heading uses wide `letter-spacing` reaches the parser as
single-letter runs joined by spaces inside one pdfjs text item
(`"J O R D A N"`), so the `full_name` heuristic reads per-glyph tokens and drops
the name. This de-tracks such runs before parsing.

- add `collapseLetterSpacing()` in `sections.ts`: collapses a maximal run of
  ≥4 single letters (Unicode `\p{L}`, so accented names de-track too) separated
  by exactly one space back into one word, anchored so a trailing multi-char
  word isn't swallowed
- apply it per-item in `mergeItemText()` so real word boundaries (separate
  items, or a ≥2-space gap within an item) are preserved while each tracked-out
  word de-tracks; item geometry is untouched
- unit tests for the collapse + its boundary/accent/threshold cases
- remove the now-fixed `KNOWN_FAILURES` round-trip baseline for this case and
  re-bake the `letter-spaced-name-heading` fixture snapshot (`full_name` now
  populated)

Known scope limit (commented in code): a whole multi-word heading emitted as a
*single* item with a *single*-space word gap can't be split from the string
alone — not observed for pdfjs on the corpus.

Closes #330

## Test plan

- [ ] `npm run typecheck` clean
- [ ] `npm run test` green
- [ ] `npm run verify` green (ran locally: EXIT=0, 1506 passed)

## Adversarial review

One skeptic pass (opus) on the diff, pre-PR. 2 blocking findings, both fixed; 2 nits accepted with scoping.

- **blocking (fixed)** — ASCII-only `[A-Za-z]` corrupted accented names (`A N D R É S` → `ANDR É S`). Switched the run regex to Unicode `\p{L}` + `u` flag; added accented-name tests.
- **blocking (downgraded on verification)** — claimed a single-item single-space heading welds both words. True only for the pure single-item + single-space-word-gap shape; the regex requires exactly one space per pair, so a ≥2-space word gap already ends the run and is preserved. Added a boundary test + a scoping comment for the genuinely-ambiguous residual (not observed for pdfjs on the corpus).
- **nit (accepted)** — double-space *intra-word* tracking won't collapse; and a genuine ≥4 single-letter run (e.g. musical notes `C D E F G`) welds. Threshold 4 is a defensible precision/recall tradeoff; documented.