### PR TITLE
feat: job-search lane — resume-driven discovery (#318, #319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,30 @@ and the rest of the UI is unaffected. Because the request originates in your
 browser, **your IP address is seen by GitHub** (a US third party) as a result
 of loading the app.
 
+### Job-search feeds (Find jobs tab)
+
+The **Find jobs** tab can fetch a sample of live postings from free, keyless,
+CORS-open job feeds and rank them against your parsed résumé. These requests
+fire **only when you click "Search jobs"** — never on drop, tab open, or query
+edit — and carry **only the derived search keywords** (the editable title/skills
+in the query block), never your résumé text. Each shipped feed is contacted
+directly from your browser, so **your IP address is seen by that third party**
+(same class of disclosure as the GitHub star-count call above):
+
+| Provider | Endpoint | Notes |
+| --- | --- | --- |
+| Remotive | `https://remotive.com/api/remote-jobs?search=<keywords>` | remote-only, tech-skewed; the feed ignores `search=`, so results are keyword-filtered client-side after fetch |
+| Arbeitnow | `https://www.arbeitnow.com/api/job-board-api?search=<keywords>` | EU-heavy board; the feed ignores `search=`, so results are keyword-filtered client-side after fetch |
+| Jobicy | `https://jobicy.com/api/v2/remote-jobs?tag=<keyword>` | remote-only, tech-skewed; `tag=` filters server-side |
+
+All three verified CORS-open (`Access-Control-Allow-Origin: *`) from a browser
+origin. Regardless of what each feed does with its query param, every fetched
+posting is keyword-filtered in your browser against the query title/skills
+before ranking, so only query-relevant postings are shown. A feed that fails
+(network, CORS, malformed response) degrades silently
+— its results are simply absent and the UI notes the missing source. Results are
+labeled in-app as a remote/tech-heavy **sample, not every job**.
+
 ## Theming
 
 Colors are plain CSS custom properties split into two layers:

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * FindJobsPanel — first slice of the job-search lane (#318). Builds a search
+ * query from the parsed resume, lets the user edit it, and renders inert
+ * deep-link buttons to major job boards. Zero network calls: deep links open
+ * in a new tab under the user's own navigation; nothing here fetches.
+ *
+ * This is the STABLE SKELETON for the whole "Find Jobs" panel arc (epic
+ * #317): header + Query block + Actions row (see the UX spec at
+ * `find-jobs-ux-spec.md`). Slice #319 appends a Search button + Results
+ * region below the Actions row; slice #320 appends a BYOK footer. Neither
+ * restructures what this slice ships — only append here.
+ *
+ * The query is local, scratch-editable state seeded once from the parse; it
+ * intentionally does NOT write back into the résumé override model
+ * (useEditableParse) — editing the search query is not editing the résumé.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button, EditableField } from "@design-system";
+import { buildJobQuery, type JobQuery } from "../../lib/job-search/query-builder.ts";
+import { buildDeepLinks } from "../../lib/job-search/deep-links.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+import {
+  JobSearchResults,
+  type SearchPhase,
+} from "./JobSearchResults.tsx";
+
+interface FindJobsPanelProps {
+  /** The live cascade's parsed résumé. `buildJobQuery` reads only title/skills;
+   *  the fit-ranking (via `searchJobs`) needs the fuller shape (summary,
+   *  education) for accurate coverage, so we take the whole `HeuristicParsedResume`
+   *  rather than the narrow query-only Pick. */
+  parsed: HeuristicParsedResume;
+}
+
+function RemoveIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="10"
+      height="10"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <path d="M3 3l10 10M13 3L3 13" />
+    </svg>
+  );
+}
+
+function RemovableSkillChip({
+  skill,
+  onRemove,
+}: {
+  skill: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-surface-subtle py-1 pl-2.5 pr-1 text-xs text-content-secondary">
+      {skill}
+      <Button
+        variant="icon"
+        aria-label={`Remove ${skill}`}
+        onClick={onRemove}
+        className="shrink-0 text-content-muted hover:text-content-secondary"
+      >
+        <RemoveIcon />
+      </Button>
+    </span>
+  );
+}
+
+export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
+  // Seed local query state from the parse once (lazy initializer — runs only
+  // on mount); the user edits it from here.
+  const [query, setQuery] = useState<JobQuery>(() => buildJobQuery(parsed));
+  const [skillDraft, setSkillDraft] = useState("");
+
+  const links = useMemo(() => buildDeepLinks(query), [query]);
+  const isDegenerate = !query.title.trim() && query.skills.length === 0;
+
+  const addSkill = () => {
+    const trimmed = skillDraft.trim();
+    if (!trimmed) return;
+    const alreadyPresent = query.skills.some(
+      (s) => s.toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (!alreadyPresent) {
+      setQuery((q) => ({ ...q, skills: [...q.skills, trimmed] }));
+    }
+    setSkillDraft("");
+  };
+
+  const removeSkill = (skill: string) => {
+    setQuery((q) => ({ ...q, skills: q.skills.filter((s) => s !== skill) }));
+  };
+
+  // In-app search state. The fetch fires ONLY from runSearch (the Search
+  // click) — never on drop, tab open, or query edit. searchJobs dynamic-imports
+  // the provider/rank tiers, so nothing job-fetch-related is in the entry chunk.
+  const [phase, setPhase] = useState<SearchPhase>({ kind: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+  const isLoading = phase.kind === "loading";
+
+  // Abort any in-flight search on unmount so a late response can't try to
+  // update state on an unmounted component.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const runSearch = () => {
+    // Supersede any in-flight search so its results can't land after this one.
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setPhase({ kind: "loading" });
+    void (async () => {
+      try {
+        const { searchJobs } = await import("../../lib/job-search/search.ts");
+        const result = await searchJobs(query, parsed, ctrl.signal);
+        if (ctrl.signal.aborted) return;
+        setPhase({ kind: "loaded", result });
+      } catch {
+        if (ctrl.signal.aborted) return;
+        setPhase({ kind: "failed" });
+      }
+    })();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            Find jobs
+          </h2>
+          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
+            alpha
+          </span>
+        </div>
+        <p className="max-w-prose text-xs text-content-tertiary">
+          We built this search from your parsed resume. Edit it, then search
+          job boards. Your resume text never leaves this browser — only the
+          keywords below are sent.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+          <span className="text-xs text-content-tertiary">Title</span>
+          <EditableField
+            value={query.title}
+            placeholder="title not detected"
+            label="Job title"
+            textWeight="semibold"
+            onCommit={(v) => setQuery((q) => ({ ...q, title: v }))}
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+          <span className="text-xs text-content-tertiary">Seniority</span>
+          <EditableField
+            value={query.seniority}
+            placeholder="not detected"
+            label="Seniority"
+            onCommit={(v) =>
+              setQuery((q) => ({ ...q, seniority: v || undefined }))
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-content-tertiary">Skills</span>
+          {query.skills.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {query.skills.map((skill) => (
+                <RemovableSkillChip
+                  key={skill}
+                  skill={skill}
+                  onRemove={() => removeSkill(skill)}
+                />
+              ))}
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={skillDraft}
+              aria-label="Add skill"
+              placeholder="Add a skill…"
+              onChange={(e) => setSkillDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addSkill();
+                }
+              }}
+              className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-xs text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={addSkill}
+              disabled={skillDraft.trim().length === 0}
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+        {isDegenerate && (
+          <p className="text-xs text-content-tertiary">
+            We couldn&apos;t derive a search from this resume — add a title or
+            skills above to search.
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs text-content-tertiary">
+          Search external boards
+        </span>
+        <div className="flex flex-wrap gap-2">
+          {links.map((link) => (
+            <a
+              key={link.label}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber"
+            >
+              {link.label}
+              <span aria-hidden="true">↗</span>
+            </a>
+          ))}
+        </div>
+        <p className="text-xs text-content-tertiary">
+          Only your search keywords are sent, and only when you click a link
+          above.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={runSearch}
+            disabled={isDegenerate || isLoading}
+          >
+            {isLoading ? "Searching…" : "Search jobs"}
+          </Button>
+        </div>
+        <p className="text-xs text-content-tertiary">
+          Only your search keywords are sent, and only when you click Search.
+        </p>
+      </div>
+
+      <JobSearchResults phase={phase} onRetry={runSearch} />
+    </div>
+  );
+}

--- a/src/components/features/JobResultCard.test.tsx
+++ b/src/components/features/JobResultCard.test.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for JobResultCard (#319). Drives the card with a real
+ * `RankedJob` built through `rankPostings` (no hand-mocked coverage) so the
+ * fit-% headline, matched/missing chips, external link, and the "View match
+ * detail" toggle → inline `<JdMatch>` all exercise. Raw createRoot + act,
+ * matching the other feature render tests (no @testing-library in this repo).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { JobResultCard } from "./JobResultCard.tsx";
+import { rankPostings } from "../../lib/job-search/rank.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+import type { JobPosting } from "../../lib/job-search/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [
+    { title: "Frontend Engineer", company: "Acme", description: "Built React apps" },
+  ],
+  education: [],
+};
+
+const posting: JobPosting = {
+  id: "remotive:1",
+  title: "Senior Frontend Engineer",
+  company: "Globex",
+  location: "Remote",
+  url: "https://example.com/jobs/1",
+  description:
+    "We want a React and TypeScript engineer. Rust and Kubernetes are a plus.",
+  source: "Remotive",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  const [job] = rankPostings(parsed, [posting]);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(JobResultCard, { job }));
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("JobResultCard", () => {
+  it("renders title, source line, fit %, and a safe external link", () => {
+    const el = render();
+    expect(el.textContent).toContain("Senior Frontend Engineer");
+    expect(el.textContent).toContain("Globex");
+    expect(el.textContent).toContain("Remotive");
+    expect(el.textContent).toContain("Remote");
+    expect(el.textContent).toContain("/100");
+    expect(el.textContent).toContain("fit");
+
+    const link = el.querySelector("a") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("https://example.com/jobs/1");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("toggles the inline JdMatch detail via View match detail", () => {
+    const el = render();
+    const toggle = [...el.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("View match detail"),
+    ) as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(el.textContent).not.toContain("JD match");
+
+    act(() => toggle.click());
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(el.textContent).toContain("Hide match detail");
+    // Reused JdMatch detail is now inline.
+    expect(el.textContent).toContain("JD match");
+  });
+});

--- a/src/components/features/JobResultCard.tsx
+++ b/src/components/features/JobResultCard.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * JobResultCard — one ranked posting in the Find Jobs results list (#319).
+ *
+ * Split out of FindJobsPanel to keep that file under the ~200 LOC gate (UX spec
+ * §4). The whole card is NOT a link (avoids the nested-interactive a11y trap):
+ * two explicit affordances — "View match detail" toggles the reused `<JdMatch>`
+ * detail inline, "Open posting" is a plain external anchor.
+ *
+ * Ranking parity: the card's fit % (`job.score`) and the expanded `<JdMatch>`
+ * are fed from the SAME `job.jdMatch` object computed once in `rank.ts`, so the
+ * headline number can never disagree with the detail view.
+ */
+
+import { useState } from "react";
+import { Button, Chip } from "@design-system";
+import { JdMatch } from "./JdMatch.tsx";
+import type { RankedJob } from "../../lib/job-search/rank.ts";
+
+/** Top matched/missing terms shown on the card face before expansion. */
+const CHIP_CAP = 4;
+
+export function JobResultCard({ job }: { job: RankedJob }) {
+  const [open, setOpen] = useState(false);
+  const { posting, jdMatch, score } = job;
+  const matched = jdMatch.coverage.covered.slice(0, CHIP_CAP);
+  const missing = jdMatch.coverage.missing.slice(0, CHIP_CAP);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border-light p-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-sm font-semibold text-content-primary">
+          {posting.title}
+        </h3>
+        <span className="shrink-0 whitespace-nowrap text-xs text-content-tertiary">
+          <span className="font-mono text-content-secondary">{score}/100</span> fit
+        </span>
+      </div>
+
+      <p className="text-xs text-content-tertiary">
+        {[posting.company, posting.source].filter(Boolean).join(" · ")}
+        {posting.location ? ` · ${posting.location}` : ""}
+      </p>
+
+      {(matched.length > 0 || missing.length > 0) && (
+        <div className="flex flex-wrap gap-1.5">
+          {matched.map((term) => (
+            <Chip key={`m:${term.source}:${term.id}`} tone="success">
+              {term.display}
+            </Chip>
+          ))}
+          {missing.map((term) => (
+            <Chip key={`x:${term.source}:${term.id}`} tone="neutral">
+              {term.display}
+            </Chip>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <Button
+          variant="link"
+          size="sm"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          {open ? "Hide match detail" : "View match detail"}
+        </Button>
+        <a
+          href={posting.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-medium text-content-secondary transition-colors hover:text-content-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber"
+        >
+          Open posting <span aria-hidden="true">↗</span>
+        </a>
+      </div>
+
+      {open && <JdMatch result={jdMatch} />}
+    </div>
+  );
+}

--- a/src/components/features/JobSearchResults.test.tsx
+++ b/src/components/features/JobSearchResults.test.tsx
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for JobSearchResults (#319) — the five-state Results region.
+ * Drives each SearchPhase directly (idle / loading / failed / loaded) plus the
+ * loaded sub-branches inside `Loaded` (results, capped list, empty, partial
+ * degrade, total degrade → hard error) so every state from UX spec §2 renders.
+ * Real `RankedJob`s built via `rankPostings`; raw createRoot + act.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  JobSearchResults,
+  type SearchPhase,
+} from "./JobSearchResults.tsx";
+import { rankPostings } from "../../lib/job-search/rank.ts";
+import type { JobSearchResult } from "../../lib/job-search/search.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+import type { JobPosting } from "../../lib/job-search/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [],
+  education: [],
+};
+
+function posting(id: string): JobPosting {
+  return {
+    id,
+    title: `React Engineer ${id}`,
+    company: `Co ${id}`,
+    location: "Remote",
+    url: `https://example.com/${id}`,
+    description: "React and TypeScript role.",
+    source: "Remotive",
+  };
+}
+
+function loaded(
+  count: number,
+  degradedProviders: string[] = [],
+  providerCount = 3,
+): JobSearchResult {
+  const jobs = rankPostings(
+    parsed,
+    Array.from({ length: count }, (_, i) => posting(String(i))),
+  );
+  return { jobs, degradedProviders, providerCount };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(phase: SearchPhase) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(JobSearchResults, { phase, onRetry: () => {} }),
+    );
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("JobSearchResults", () => {
+  it("idle renders nothing", () => {
+    expect(render({ kind: "idle" }).textContent).toBe("");
+  });
+
+  it("loading renders skeleton + status line", () => {
+    const el = render({ kind: "loading" });
+    expect(el.textContent).toContain("Searching remote/tech boards");
+  });
+
+  it("failed renders the hard error with a retry", () => {
+    const el = render({ kind: "failed" });
+    expect(el.textContent).toContain("Couldn't reach any of the job feeds");
+    expect(el.textContent).toContain("Retry search");
+  });
+
+  it("loaded with results renders the sample label + cards", () => {
+    const el = render({ kind: "loaded", result: loaded(2) });
+    expect(el.textContent).toContain("sample");
+    expect(el.textContent).toContain("2 matches ranked by fit");
+    expect(el.querySelectorAll("h3").length).toBe(2);
+  });
+
+  it("caps the rendered list at 20 and notes the cap", () => {
+    const el = render({ kind: "loaded", result: loaded(25) });
+    expect(el.querySelectorAll("h3").length).toBe(20);
+    expect(el.textContent).toContain("Showing the top 20 of 25");
+  });
+
+  it("loaded with a partial degrade notes the missing feed", () => {
+    const el = render({
+      kind: "loaded",
+      result: loaded(1, ["Jobicy"]),
+    });
+    expect(el.textContent).toContain("Couldn't reach Jobicy");
+  });
+
+  it("loaded with zero jobs (no degrade) renders the empty state", () => {
+    const el = render({ kind: "loaded", result: loaded(0) });
+    expect(el.textContent).toContain("No matching postings");
+  });
+
+  it("all providers degraded → hard error with retry", () => {
+    const el = render({
+      kind: "loaded",
+      result: loaded(0, ["Remotive", "Arbeitnow", "Jobicy"], 3),
+    });
+    expect(el.textContent).toContain("Couldn't reach any of the job feeds");
+    expect(el.textContent).toContain("Retry search");
+  });
+});

--- a/src/components/features/JobSearchResults.tsx
+++ b/src/components/features/JobSearchResults.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * JobSearchResults — the Results region of the Find Jobs panel (#319).
+ *
+ * Presentational: renders the five result states from the UX spec §2
+ * (loading / results / degraded / empty / error) off a phase computed by
+ * FindJobsPanel, which owns the fetch + abort. Split out to keep FindJobsPanel
+ * under the ~200 LOC gate.
+ *
+ * The whole region is `aria-live="polite"` so a screen reader hears
+ * "N jobs found" / "search failed" without stealing focus.
+ */
+
+import { Button, ErrorState, StatusBadge } from "@design-system";
+import { JobResultCard } from "./JobResultCard.tsx";
+import type { JobSearchResult } from "../../lib/job-search/search.ts";
+
+/** Cap on rendered cards — the sample is a taster, not a firehose (spec §4). */
+const RENDER_CAP = 20;
+
+export type SearchPhase =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; result: JobSearchResult }
+  | { kind: "failed" };
+
+const SAMPLE_LABEL =
+  "These come from a few free, keyless job feeds that skew remote and tech — " +
+  "a sample, not every job. Use the external board links above for broader coverage.";
+
+export function JobSearchResults({
+  phase,
+  onRetry,
+}: {
+  phase: SearchPhase;
+  onRetry: () => void;
+}) {
+  return (
+    <div aria-live="polite" className="flex flex-col gap-3 empty:hidden">
+      {phase.kind === "loading" && <LoadingState />}
+      {phase.kind === "failed" && <HardError onRetry={onRetry} />}
+      {phase.kind === "loaded" && <Loaded result={phase.result} onRetry={onRetry} />}
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-content-tertiary">
+        Searching remote/tech boards…
+      </p>
+      <div className="flex flex-col gap-2">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="h-16 rounded-lg border border-border-light bg-surface-subtle motion-safe:animate-pulse"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HardError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <ErrorState tone="error">
+        Couldn&apos;t reach any of the job feeds. This is usually a transient
+        network hiccup — try again in a moment.
+      </ErrorState>
+      <Button variant="ghost" size="sm" onClick={onRetry}>
+        Retry search
+      </Button>
+    </div>
+  );
+}
+
+function Loaded({
+  result,
+  onRetry,
+}: {
+  result: JobSearchResult;
+  onRetry: () => void;
+}) {
+  const { jobs, degradedProviders, providerCount } = result;
+
+  // Every provider rejected → hard error (with retry). Guarded on a non-zero
+  // provider count so an empty registry (possible once #320 makes the set
+  // variable) reads as "no matches", not a network failure.
+  if (providerCount > 0 && degradedProviders.length === providerCount) {
+    return <HardError onRetry={onRetry} />;
+  }
+
+  // Some providers succeeded but nothing matched.
+  if (jobs.length === 0) {
+    return (
+      <ErrorState tone="warning">
+        No matching postings on the feeds we can search. Broaden the query above
+        or try the external board links.
+      </ErrorState>
+    );
+  }
+
+  const shown = jobs.slice(0, RENDER_CAP);
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge tone="info">sample</StatusBadge>
+          <span className="text-xs text-content-tertiary">
+            {jobs.length} match{jobs.length === 1 ? "" : "es"} ranked by fit
+          </span>
+        </div>
+        <p className="max-w-prose text-xs text-content-tertiary">{SAMPLE_LABEL}</p>
+        {degradedProviders.length > 0 && (
+          <p className="text-xs text-content-tertiary">
+            Couldn&apos;t reach {degradedProviders.join(", ")} — showing results
+            from the other feeds.
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {shown.map((job) => (
+          <JobResultCard key={job.posting.id} job={job} />
+        ))}
+      </div>
+
+      {jobs.length > RENDER_CAP && (
+        <p className="text-xs text-content-muted">
+          Showing the top {RENDER_CAP} of {jobs.length} matches. Narrow the query
+          above for a tighter set.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/ResultDetailTabs.test.tsx
+++ b/src/components/features/ResultDetailTabs.test.tsx
@@ -30,9 +30,14 @@ import type { ResumeCritique } from "../../lib/webllm/critique-resume.ts";
 
 const EMPTY_CRITIQUE: ResumeCritique = { bulletFindings: [], missingSections: [] };
 
-function result(summary?: string): CascadeResult {
+function result(summary?: string, title?: string): CascadeResult {
   return {
-    parsed: { skills: [], experience: [], education: [], ...(summary ? { summary } : {}) },
+    parsed: {
+      skills: [],
+      experience: title ? [{ title }] : [],
+      education: [],
+      ...(summary ? { summary } : {}),
+    },
     confidence: 0.6,
     fieldConfidence: {},
     triggers: ["two_column"],
@@ -123,6 +128,45 @@ describe("ResultDetailTabs", () => {
     expect(labels[1]).toContain("Find jobs");
     expect(labels[2]).toContain("Resume Quality");
     expect(labels[3]).toContain("Source & diagnostics");
+  });
+
+  it("reseeds the Find jobs query when the LLM escape hatch swaps activeResult (keyed remount)", () => {
+    // Original heuristic parse and a distinct recovered parse — same `result`
+    // (the pre-LLM cascade), different `activeResult` once recovery lands. The
+    // Find jobs panel seeds its query once from the parse; without the parse-
+    // identity key it would keep the heuristic title while runSearch ranks the
+    // recovered parse (PR #337 review). Keyed remount reseeds it.
+    const heuristic = result(undefined, "Heuristic Engineer");
+    const recovered = result(undefined, "Recovered Architect");
+    const opts: ControllerOpts = { isAvailable: false };
+
+    function RecoveryHost({ recover }: { recover: boolean }) {
+      const edit = useEditableParse();
+      return createElement(ResultDetailTabs, {
+        activeResult: recover ? recovered : heuristic,
+        activeScore: score,
+        result: heuristic,
+        sourceKind: "pdf",
+        edit,
+        analysis: controller(opts),
+        triggerCount: heuristic.triggers.length,
+      });
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(createElement(RecoveryHost, { recover: false }));
+    });
+    expect(container.textContent).toContain("Heuristic Engineer");
+
+    // Escape hatch recovers a better parse: activeResult now !== result.
+    act(() => {
+      root.render(createElement(RecoveryHost, { recover: true }));
+    });
+    expect(container.textContent).toContain("Recovered Architect");
+    expect(container.textContent).not.toContain("Heuristic Engineer");
   });
 
   it("keeps the Resume Quality tab (warn-marked) with the notice when WebGPU is unavailable", () => {

--- a/src/components/features/ResultDetailTabs.test.tsx
+++ b/src/components/features/ResultDetailTabs.test.tsx
@@ -103,6 +103,7 @@ describe("ResultDetailTabs", () => {
   it("hides the Resume Quality tab while capability is still detecting / no text", () => {
     const el = render({ isAvailable: false });
     expect(el.textContent).toContain("Reconstructed resume");
+    expect(el.textContent).toContain("Find jobs");
     expect(el.textContent).toContain("Source & diagnostics");
     expect(el.textContent).not.toContain("Resume Quality");
   });
@@ -115,11 +116,13 @@ describe("ResultDetailTabs", () => {
     const labels = Array.from(el.querySelectorAll('[role="tab"]')).map(
       (t) => t.textContent ?? "",
     );
-    // Exactly three tabs, Resume Quality in the middle (2nd), diagnostics last.
-    expect(labels).toHaveLength(3);
+    // Exactly four tabs: reconstructed, Find jobs (#318, always present),
+    // Resume Quality, diagnostics last.
+    expect(labels).toHaveLength(4);
     expect(labels[0]).toContain("Reconstructed resume");
-    expect(labels[1]).toContain("Resume Quality");
-    expect(labels[2]).toContain("Source & diagnostics");
+    expect(labels[1]).toContain("Find jobs");
+    expect(labels[2]).toContain("Resume Quality");
+    expect(labels[3]).toContain("Source & diagnostics");
   });
 
   it("keeps the Resume Quality tab (warn-marked) with the notice when WebGPU is unavailable", () => {

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -92,7 +92,16 @@ export function ResultDetailTabs({
             />
           </TabPanel>
           <TabPanel id="find-jobs">
-            <FindJobsPanel parsed={activeResult.parsed} />
+            {/* Key on parse identity so the LLM escape hatch (activeResult !==
+                result) remounts the panel and reseeds its once-seeded local
+                query from the recovered parse. Without this the panel keeps the
+                garbage-derived query while runSearch ranks against the fresh
+                parse — result set and fit scores would answer different
+                questions (PR #337 review). */}
+            <FindJobsPanel
+              key={activeResult === result ? "heuristic" : "recovered"}
+              parsed={activeResult.parsed}
+            />
           </TabPanel>
           {showQualityTab && (
             <TabPanel id="quality">

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { Card, Tabs, TabList, Tab, TabPanel } from "@design-system";
 import { ReconstructedResume } from "./ReconstructedResume.tsx";
+import { FindJobsPanel } from "./FindJobsPanel.tsx";
 import { ResumeQualityPanel } from "./ResumeQualityPanel.tsx";
 import { SourceDiagnosticsPanel } from "./SourceDiagnosticsPanel.tsx";
 import { WebGpuUnavailableNotice } from "./WebGpuUnavailableNotice.tsx";
@@ -70,6 +71,7 @@ export function ResultDetailTabs({
             without opening it. */}
         <TabList aria-label="Parsed result views">
           <Tab id="reconstructed">Reconstructed resume</Tab>
+          <Tab id="find-jobs">Find jobs</Tab>
           {showQualityTab && (
             <Tab id="quality" warn={!analysis.isAvailable}>
               Resume Quality
@@ -88,6 +90,9 @@ export function ResultDetailTabs({
               edit={edit}
               jdContext={jdContext}
             />
+          </TabPanel>
+          <TabPanel id="find-jobs">
+            <FindJobsPanel parsed={activeResult.parsed} />
           </TabPanel>
           {showQualityTab && (
             <TabPanel id="quality">

--- a/src/lib/job-search/deep-links.test.ts
+++ b/src/lib/job-search/deep-links.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { buildDeepLinks } from "./deep-links.ts";
+import type { JobQuery } from "./query-builder.ts";
+
+function query(overrides: Partial<JobQuery> = {}): JobQuery {
+  return { title: "", skills: [], ...overrides };
+}
+
+describe("buildDeepLinks", () => {
+  it("returns one link each for LinkedIn, Indeed, and Google Jobs", () => {
+    const links = buildDeepLinks(query({ title: "Software Engineer" }));
+    expect(links.map((l) => l.label)).toEqual(["LinkedIn", "Indeed", "Google Jobs"]);
+    for (const link of links) {
+      expect(() => new URL(link.url)).not.toThrow();
+    }
+  });
+
+  it("prefills keywords from seniority + title + skills, space-joined", () => {
+    const links = buildDeepLinks(
+      query({ title: "Backend Engineer", seniority: "Senior", skills: ["python", "go"] }),
+    );
+    const linkedin = new URL(links[0].url);
+    expect(linkedin.searchParams.get("keywords")).toBe(
+      "Senior Backend Engineer python go",
+    );
+    const indeed = new URL(links[1].url);
+    expect(indeed.searchParams.get("q")).toBe("Senior Backend Engineer python go");
+  });
+
+  it("skips seniority when the title already contains it (no 'Senior Senior …')", () => {
+    const links = buildDeepLinks(
+      query({ title: "Senior Backend Engineer", seniority: "Senior", skills: ["go"] }),
+    );
+    const linkedin = new URL(links[0].url);
+    expect(linkedin.searchParams.get("keywords")).toBe("Senior Backend Engineer go");
+  });
+
+  it("URL-encodes special characters in title/skills", () => {
+    const links = buildDeepLinks(
+      query({ title: "C++ Engineer & Architect", skills: ["c#", "R&D"] }),
+    );
+    const linkedin = new URL(links[0].url);
+    // Round-trips through URLSearchParams decoding back to the original string.
+    expect(linkedin.searchParams.get("keywords")).toBe("C++ Engineer & Architect c# R&D");
+    // The raw query string must actually be percent/plus-encoded, not literal.
+    expect(links[0].url).not.toContain("C++ Engineer & Architect");
+    expect(links[0].url).toMatch(/keywords=/);
+  });
+
+  it("Google Jobs appends the word 'jobs' to the keyword string", () => {
+    const links = buildDeepLinks(query({ title: "Data Scientist" }));
+    const google = new URL(links[2].url);
+    expect(google.searchParams.get("q")).toBe("Data Scientist jobs");
+  });
+
+  it("still produces valid URLs for a fully degenerate query (no title, no skills)", () => {
+    const links = buildDeepLinks(query());
+    const linkedin = new URL(links[0].url);
+    const indeed = new URL(links[1].url);
+    const google = new URL(links[2].url);
+    expect(linkedin.searchParams.get("keywords")).toBeNull();
+    expect(indeed.searchParams.get("q")).toBeNull();
+    expect(google.searchParams.get("q")).toBe("jobs");
+  });
+});

--- a/src/lib/job-search/deep-links.ts
+++ b/src/lib/job-search/deep-links.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * buildDeepLinks — maps a `JobQuery` to prefilled search URLs on major job
+ * boards (#318, slice 1 of the job-search epic). Pure function, no I/O; the
+ * resulting URLs are rendered as inert `<a target="_blank" rel="noopener
+ * noreferrer">` — nothing here fetches anything.
+ *
+ * Keyword composition: seniority + title + skills, space-joined — with the
+ * seniority skipped when the title already contains it (the usual case, since
+ * seniority is derived from a title word; see query-builder.ts), so "Senior
+ * Backend Engineer" never becomes "Senior Senior Backend Engineer". A fully
+ * degenerate query (no title, no skills) still
+ * produces valid URLs — LinkedIn/Indeed get an empty query string, Google
+ * Jobs falls back to the bare word "jobs" — so the deep-link row never
+ * breaks even before the user has typed anything.
+ */
+
+import type { JobQuery } from "./query-builder.ts";
+
+export interface JobBoardLink {
+  label: string;
+  url: string;
+}
+
+function buildKeywords(query: JobQuery): string {
+  // Seniority is usually DERIVED from a word in the title (query-builder.ts),
+  // so prepending it blindly doubles it ("Senior Senior Backend Engineer").
+  // Only add it when the title doesn't already carry it (e.g. a user-typed
+  // seniority, or an abbreviated title like "Sr. Engineer" with the expanded
+  // "Senior" label).
+  const seniority =
+    query.seniority &&
+    !query.title.toLowerCase().includes(query.seniority.toLowerCase())
+      ? query.seniority
+      : undefined;
+  const parts = [seniority, query.title, ...query.skills].filter(
+    (part): part is string => Boolean(part && part.trim()),
+  );
+  return parts.join(" ");
+}
+
+export function buildDeepLinks(query: JobQuery): JobBoardLink[] {
+  const keywords = buildKeywords(query);
+
+  const linkedinParams = new URLSearchParams();
+  if (keywords) linkedinParams.set("keywords", keywords);
+
+  const indeedParams = new URLSearchParams();
+  if (keywords) indeedParams.set("q", keywords);
+
+  const googleParams = new URLSearchParams();
+  googleParams.set("q", keywords ? `${keywords} jobs` : "jobs");
+
+  return [
+    {
+      label: "LinkedIn",
+      url: `https://www.linkedin.com/jobs/search/?${linkedinParams.toString()}`,
+    },
+    {
+      label: "Indeed",
+      url: `https://www.indeed.com/jobs?${indeedParams.toString()}`,
+    },
+    {
+      label: "Google Jobs",
+      url: `https://www.google.com/search?${googleParams.toString()}`,
+    },
+  ];
+}

--- a/src/lib/job-search/providers/arbeitnow.test.ts
+++ b/src/lib/job-search/providers/arbeitnow.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { arbeitnowProvider } from "./arbeitnow.ts";
+import type { JobQuery } from "../query-builder.ts";
+
+const query: JobQuery = { title: "Frontend Engineer", skills: ["React"] };
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok,
+    status,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("arbeitnowProvider", () => {
+  it("maps the data[] shape and converts the unix created_at to ISO", async () => {
+    mockFetch({
+      data: [
+        {
+          slug: "frontend-berlin-289280",
+          title: "Frontend Engineer",
+          company_name: "Think3DDD",
+          location: "Berlin",
+          url: "https://www.arbeitnow.com/jobs/frontend-berlin-289280",
+          description: "<p>React &amp; TypeScript</p>",
+          created_at: 1783287031,
+        },
+      ],
+    });
+
+    const [job] = await arbeitnowProvider.search(query, new AbortController().signal);
+    expect(job.id).toBe("arbeitnow:frontend-berlin-289280");
+    expect(job.company).toBe("Think3DDD");
+    expect(job.location).toBe("Berlin");
+    expect(job.source).toBe("Arbeitnow");
+    expect(job.description).toBe("React & TypeScript");
+    expect(job.postedAt).toBe(new Date(1783287031 * 1000).toISOString());
+  });
+
+  it("sends the title as the search keyword", async () => {
+    const fetchMock = mockFetch({ data: [] });
+    await arbeitnowProvider.search(query, new AbortController().signal);
+    expect(fetchMock.mock.calls[0][0]).toContain("search=Frontend%20Engineer");
+  });
+
+  it("rejects on a non-ok response", async () => {
+    mockFetch({}, false, 500);
+    await expect(
+      arbeitnowProvider.search(query, new AbortController().signal),
+    ).rejects.toThrow(/Arbeitnow responded 500/);
+  });
+
+  it("tolerates a missing data array", async () => {
+    mockFetch({});
+    await expect(
+      arbeitnowProvider.search(query, new AbortController().signal),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/lib/job-search/providers/arbeitnow.ts
+++ b/src/lib/job-search/providers/arbeitnow.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Arbeitnow adapter — https://www.arbeitnow.com/api/job-board-api?search=<kw>
+ *
+ * Keyless, CORS-open (`access-control-allow-origin: *`, verified from a browser
+ * origin). EU-heavy board (many Germany-based listings); a sample, not a
+ * census. Postings arrive under a top-level `data` array with a UNIX
+ * `created_at` timestamp.
+ */
+
+import type { JobProvider, JobPosting } from "../types.ts";
+import type { JobQuery } from "../query-builder.ts";
+import { htmlToPlaintext } from "../../jd-match/fetch-jd.ts";
+import { searchPhrase } from "./keywords.ts";
+
+const ENDPOINT = "https://www.arbeitnow.com/api/job-board-api";
+const ID = "arbeitnow";
+const LABEL = "Arbeitnow";
+
+interface ArbeitnowJob {
+  slug?: string;
+  title?: string;
+  company_name?: string;
+  location?: string;
+  url?: string;
+  description?: string;
+  created_at?: number;
+}
+
+interface ArbeitnowResponse {
+  data?: ArbeitnowJob[];
+}
+
+function mapJob(job: ArbeitnowJob): JobPosting {
+  return {
+    id: `${ID}:${job.slug ?? job.url ?? ""}`,
+    title: (job.title ?? "").trim(),
+    company: (job.company_name ?? "").trim(),
+    location: (job.location ?? "").trim(),
+    url: job.url ?? "",
+    description: htmlToPlaintext(job.description ?? ""),
+    // Feed gives a UNIX seconds timestamp; normalize to ISO when present.
+    postedAt:
+      typeof job.created_at === "number"
+        ? new Date(job.created_at * 1000).toISOString()
+        : undefined,
+    source: LABEL,
+  };
+}
+
+export const arbeitnowProvider: JobProvider = {
+  id: ID,
+  label: LABEL,
+  async search(query: JobQuery, signal: AbortSignal): Promise<JobPosting[]> {
+    const kw = searchPhrase(query);
+    const url = `${ENDPOINT}?search=${encodeURIComponent(kw)}`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`${LABEL} responded ${res.status}`);
+    const data = (await res.json()) as ArbeitnowResponse;
+    return (data.data ?? []).map(mapJob).filter((p) => p.title && p.url);
+  },
+};

--- a/src/lib/job-search/providers/index.test.ts
+++ b/src/lib/job-search/providers/index.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Registry contract for the keyless provider set (#319).
+ *
+ * `getProviders` / `KEYLESS_PROVIDERS` are consumed by `search.ts` through a
+ * dynamic `await import()` (the cascade-tier chunk-splitting pattern), which the
+ * static dead-code graph can't follow — so this suite is also their first
+ * static importer, pinning the shipped registry: the three CORS-verified
+ * keyless feeds, in display order, each satisfying the `JobProvider` contract.
+ */
+
+import { describe, it, expect } from "vitest";
+import { KEYLESS_PROVIDERS, getProviders } from "./index.ts";
+
+describe("keyless provider registry", () => {
+  it("ships the three CORS-verified feeds in display order", () => {
+    expect(KEYLESS_PROVIDERS.map((p) => p.id)).toEqual([
+      "remotive",
+      "arbeitnow",
+      "jobicy",
+    ]);
+  });
+
+  it("every provider satisfies the JobProvider contract", () => {
+    for (const provider of KEYLESS_PROVIDERS) {
+      expect(typeof provider.id).toBe("string");
+      expect(provider.id.length).toBeGreaterThan(0);
+      expect(typeof provider.label).toBe("string");
+      expect(provider.label.length).toBeGreaterThan(0);
+      expect(typeof provider.search).toBe("function");
+    }
+  });
+
+  it("getProviders resolves the keyless set today (the #320 seam)", () => {
+    expect(getProviders()).toEqual(KEYLESS_PROVIDERS);
+  });
+});

--- a/src/lib/job-search/providers/index.ts
+++ b/src/lib/job-search/providers/index.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Provider registry for the in-app job search.
+ *
+ * Only keyless, CORS-open feeds verified reachable from a browser origin ship
+ * here (Remotive, Arbeitnow, Jobicy — all return
+ * `access-control-allow-origin: *`). A candidate that fails CORS is dropped
+ * rather than added, so the fan-out never hangs on an unreachable feed.
+ *
+ * This module is dynamic-imported by `search.ts` (same chunk-splitting pattern
+ * as the cascade tiers) so the provider adapters + their HTML-strip dependency
+ * stay out of the entry chunk until the user actually searches.
+ *
+ * #320 (BYOK) will append its keyed adapter to the returned list ONLY when a
+ * key is present — `getProviders()` is the single seam that decides who
+ * participates in the fan-out.
+ */
+
+import type { JobProvider } from "../types.ts";
+import { remotiveProvider } from "./remotive.ts";
+import { arbeitnowProvider } from "./arbeitnow.ts";
+import { jobicyProvider } from "./jobicy.ts";
+
+/** The always-on keyless providers, in display order. */
+export const KEYLESS_PROVIDERS: readonly JobProvider[] = [
+  remotiveProvider,
+  arbeitnowProvider,
+  jobicyProvider,
+];
+
+/**
+ * Resolve the providers that participate in the next fan-out. Today this is
+ * just the keyless set; #320 folds in a keyed provider here when a stored key
+ * is present.
+ */
+export function getProviders(): readonly JobProvider[] {
+  return KEYLESS_PROVIDERS;
+}

--- a/src/lib/job-search/providers/jobicy.test.ts
+++ b/src/lib/job-search/providers/jobicy.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { jobicyProvider } from "./jobicy.ts";
+import type { JobQuery } from "../query-builder.ts";
+
+const query: JobQuery = { title: "Senior Software Engineer", skills: ["Kubernetes", "Go"] };
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok,
+    status,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("jobicyProvider", () => {
+  it("maps the camelCase jobs[] shape to JobPosting", async () => {
+    mockFetch({
+      jobs: [
+        {
+          id: 145290,
+          jobTitle: "Senior Software Engineer",
+          companyName: "Datadog",
+          jobGeo: "France, Germany",
+          url: "https://jobicy.com/jobs/145290",
+          jobDescription: "<p>Own the <em>graph engine</em></p>",
+          pubDate: "2026-07-05T12:10:02+00:00",
+        },
+      ],
+    });
+
+    const [job] = await jobicyProvider.search(query, new AbortController().signal);
+    expect(job.id).toBe("jobicy:145290");
+    expect(job.title).toBe("Senior Software Engineer");
+    expect(job.company).toBe("Datadog");
+    expect(job.source).toBe("Jobicy");
+    expect(job.description).toBe("Own the graph engine");
+    expect(job.postedAt).toBe("2026-07-05T12:10:02+00:00");
+  });
+
+  it("sends the first skill as the tag keyword (tag-style feed)", async () => {
+    const fetchMock = mockFetch({ jobs: [] });
+    await jobicyProvider.search(query, new AbortController().signal);
+    expect(fetchMock.mock.calls[0][0]).toContain("tag=Kubernetes");
+  });
+
+  it("falls back to the title when there are no skills", async () => {
+    const fetchMock = mockFetch({ jobs: [] });
+    await jobicyProvider.search(
+      { title: "Data Analyst", skills: [] },
+      new AbortController().signal,
+    );
+    expect(fetchMock.mock.calls[0][0]).toContain("tag=Data%20Analyst");
+  });
+
+  it("rejects on a non-ok response", async () => {
+    mockFetch({}, false, 429);
+    await expect(
+      jobicyProvider.search(query, new AbortController().signal),
+    ).rejects.toThrow(/Jobicy responded 429/);
+  });
+});

--- a/src/lib/job-search/providers/jobicy.ts
+++ b/src/lib/job-search/providers/jobicy.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Jobicy adapter — https://jobicy.com/api/v2/remote-jobs?tag=<kw>
+ *
+ * Keyless, CORS-open (`access-control-allow-origin: *`, verified from a browser
+ * origin). Remote-only, tech-skewed. Tag-style query (single keyword), postings
+ * under a top-level `jobs` array with camelCase fields.
+ */
+
+import type { JobProvider, JobPosting } from "../types.ts";
+import type { JobQuery } from "../query-builder.ts";
+import { htmlToPlaintext } from "../../jd-match/fetch-jd.ts";
+import { primaryKeyword } from "./keywords.ts";
+
+const ENDPOINT = "https://jobicy.com/api/v2/remote-jobs";
+const ID = "jobicy";
+const LABEL = "Jobicy";
+
+interface JobicyJob {
+  id?: number | string;
+  jobTitle?: string;
+  companyName?: string;
+  jobGeo?: string;
+  url?: string;
+  jobDescription?: string;
+  pubDate?: string;
+}
+
+interface JobicyResponse {
+  jobs?: JobicyJob[];
+}
+
+function mapJob(job: JobicyJob): JobPosting {
+  return {
+    // Fall back to the url (guaranteed non-empty by the post-map filter) so
+    // two id-less postings never collide on `jobicy:undefined` — the id doubles
+    // as the React key and cross-provider dedup id.
+    id: `${ID}:${job.id ?? job.url ?? ""}`,
+    title: (job.jobTitle ?? "").trim(),
+    company: (job.companyName ?? "").trim(),
+    location: (job.jobGeo ?? "").trim(),
+    url: job.url ?? "",
+    description: htmlToPlaintext(job.jobDescription ?? ""),
+    postedAt: job.pubDate,
+    source: LABEL,
+  };
+}
+
+export const jobicyProvider: JobProvider = {
+  id: ID,
+  label: LABEL,
+  async search(query: JobQuery, signal: AbortSignal): Promise<JobPosting[]> {
+    const kw = primaryKeyword(query);
+    // Jobicy requires a non-empty tag; a bare skills-less query falls back to
+    // the title in primaryKeyword, so kw is empty only for a degenerate query
+    // (which the UI gates the Search button on anyway).
+    const url = `${ENDPOINT}?tag=${encodeURIComponent(kw)}`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`${LABEL} responded ${res.status}`);
+    const data = (await res.json()) as JobicyResponse;
+    return (data.jobs ?? []).map(mapJob).filter((p) => p.title && p.url);
+  },
+};

--- a/src/lib/job-search/providers/keywords.ts
+++ b/src/lib/job-search/providers/keywords.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Derive the outbound search keyword(s) from a `JobQuery`.
+ *
+ * Privacy note: this is the ONLY resume-derived data that leaves the browser —
+ * a short keyword string built from the (user-editable) query title/skills.
+ * Never the resume text. Kept in one shared helper so every adapter sends the
+ * same derivation and there is a single place to audit what goes out.
+ */
+
+import type { JobQuery } from "../query-builder.ts";
+
+/**
+ * Full-text search phrase for feeds with a `search=` param (Remotive,
+ * Arbeitnow). Prefers the title; falls back to the top few skills when the
+ * résumé had no derivable title.
+ */
+export function searchPhrase(query: JobQuery): string {
+  const title = query.title.trim();
+  const parts = title ? [title] : query.skills.slice(0, 3);
+  return parts.join(" ").trim();
+}
+
+/**
+ * A single keyword for tag-style feeds (Jobicy's `tag=`). Prefers the first
+ * skill (feed tags are skill/tech-shaped), falls back to the title.
+ */
+export function primaryKeyword(query: JobQuery): string {
+  return (query.skills[0] ?? query.title).trim();
+}

--- a/src/lib/job-search/providers/remotive.test.ts
+++ b/src/lib/job-search/providers/remotive.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { remotiveProvider } from "./remotive.ts";
+import type { JobQuery } from "../query-builder.ts";
+
+const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok,
+    status,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("remotiveProvider", () => {
+  it("maps the feed shape to JobPosting and strips HTML from the description", async () => {
+    mockFetch({
+      jobs: [
+        {
+          id: 1185979,
+          title: "Backend Engineer",
+          company_name: "Acme",
+          candidate_required_location: "Worldwide",
+          url: "https://remotive.com/remote-jobs/backend-1185979",
+          description: "<p>Build <strong>APIs</strong> in Go</p>",
+          publication_date: "2026-07-04T16:53:04",
+        },
+      ],
+    });
+
+    const [job] = await remotiveProvider.search(query, new AbortController().signal);
+    expect(job.id).toBe("remotive:1185979");
+    expect(job.title).toBe("Backend Engineer");
+    expect(job.company).toBe("Acme");
+    expect(job.location).toBe("Worldwide");
+    expect(job.source).toBe("Remotive");
+    expect(job.description).not.toContain("<");
+    expect(job.description).toContain("Build APIs in Go");
+    expect(job.postedAt).toBe("2026-07-04T16:53:04");
+  });
+
+  it("sends the title as the search keyword and threads the abort signal", async () => {
+    const fetchMock = mockFetch({ jobs: [] });
+    const signal = new AbortController().signal;
+    await remotiveProvider.search(query, signal);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("search=Backend%20Engineer");
+    expect((init as RequestInit).signal).toBe(signal);
+  });
+
+  it("drops entries missing a title or url", async () => {
+    mockFetch({
+      jobs: [
+        { id: 1, title: "", url: "https://x", description: "" },
+        { id: 2, title: "Real Job", url: "", description: "" },
+        { id: 3, title: "Keeper", company_name: "Co", url: "https://y", description: "" },
+      ],
+    });
+    const jobs = await remotiveProvider.search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual(["remotive:3"]);
+  });
+
+  it("rejects on a non-ok response so the orchestrator can degrade it", async () => {
+    mockFetch({}, false, 503);
+    await expect(
+      remotiveProvider.search(query, new AbortController().signal),
+    ).rejects.toThrow(/Remotive responded 503/);
+  });
+
+  it("tolerates a missing jobs array", async () => {
+    mockFetch({});
+    await expect(
+      remotiveProvider.search(query, new AbortController().signal),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/lib/job-search/providers/remotive.ts
+++ b/src/lib/job-search/providers/remotive.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Remotive adapter — https://remotive.com/api/remote-jobs?search=<kw>
+ *
+ * Keyless, CORS-open (`access-control-allow-origin: *`, verified from a browser
+ * origin). Remote-only feed skewed toward tech, so results are a sample, not a
+ * census — the panel labels them as such.
+ */
+
+import type { JobProvider, JobPosting } from "../types.ts";
+import type { JobQuery } from "../query-builder.ts";
+import { htmlToPlaintext } from "../../jd-match/fetch-jd.ts";
+import { searchPhrase } from "./keywords.ts";
+
+const ENDPOINT = "https://remotive.com/api/remote-jobs";
+const ID = "remotive";
+const LABEL = "Remotive";
+
+interface RemotiveJob {
+  id?: number | string;
+  title?: string;
+  company_name?: string;
+  candidate_required_location?: string;
+  url?: string;
+  description?: string;
+  publication_date?: string;
+}
+
+interface RemotiveResponse {
+  jobs?: RemotiveJob[];
+}
+
+function mapJob(job: RemotiveJob): JobPosting {
+  return {
+    // Fall back to the url (guaranteed non-empty by the post-map filter) so
+    // two id-less postings never collide on `remotive:undefined` — the id
+    // doubles as the React key and cross-provider dedup id.
+    id: `${ID}:${job.id ?? job.url ?? ""}`,
+    title: (job.title ?? "").trim(),
+    company: (job.company_name ?? "").trim(),
+    location: (job.candidate_required_location ?? "").trim(),
+    url: job.url ?? "",
+    description: htmlToPlaintext(job.description ?? ""),
+    postedAt: job.publication_date,
+    source: LABEL,
+  };
+}
+
+export const remotiveProvider: JobProvider = {
+  id: ID,
+  label: LABEL,
+  async search(query: JobQuery, signal: AbortSignal): Promise<JobPosting[]> {
+    const kw = searchPhrase(query);
+    const url = `${ENDPOINT}?search=${encodeURIComponent(kw)}`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`${LABEL} responded ${res.status}`);
+    const data = (await res.json()) as RemotiveResponse;
+    return (data.jobs ?? []).map(mapJob).filter((p) => p.title && p.url);
+  },
+};

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { buildJobQuery, MAX_SKILLS } from "./query-builder.ts";
+import type { ParsedResume, ResumeExperience } from "../score/types.ts";
+
+function baseParsed(overrides: Partial<ParsedResume> = {}): ParsedResume {
+  return {
+    full_name: "Jamie Rivera",
+    skills: [],
+    experience: [],
+    education: [],
+    skills_explicit: [],
+    skills_inferred: [],
+    ...overrides,
+  };
+}
+
+function experience(overrides: Partial<ResumeExperience> = {}): ResumeExperience {
+  return {
+    title: "Software Engineer",
+    company: "Acme Corp",
+    ...overrides,
+  };
+}
+
+describe("buildJobQuery", () => {
+  it("returns an empty query for a fully empty resume", () => {
+    const query = buildJobQuery(baseParsed());
+    expect(query).toEqual({ title: "", skills: [], seniority: undefined });
+  });
+
+  it("derives title from the most recent (first) experience entry", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "Staff Software Engineer" }),
+        experience({ title: "Software Engineer II" }),
+      ],
+    });
+    const query = buildJobQuery(parsed);
+    expect(query.title).toBe("Staff Software Engineer");
+  });
+
+  it("falls back to current_title when there is no experience", () => {
+    const parsed = baseParsed({ current_title: "Product Manager" });
+    const query = buildJobQuery(parsed);
+    expect(query.title).toBe("Product Manager");
+  });
+
+  it("falls back to skills-only query when there is no experience and no current_title", () => {
+    const parsed = baseParsed({ skills: ["Python", "SQL"] });
+    const query = buildJobQuery(parsed);
+    expect(query.title).toBe("");
+    expect(query.skills).toEqual(["python", "sql"]);
+    expect(query.seniority).toBeUndefined();
+  });
+
+  it("derives seniority from a keyword in the title", () => {
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Senior Backend Engineer" })] }),
+      ).seniority,
+    ).toBe("Senior");
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Staff Platform Engineer" })] }),
+      ).seniority,
+    ).toBe("Staff");
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Junior Developer" })] }),
+      ).seniority,
+    ).toBe("Junior");
+  });
+
+  it("leaves seniority undefined when the title carries no seniority keyword", () => {
+    const parsed = baseParsed({
+      experience: [experience({ title: "Software Engineer" })],
+    });
+    expect(buildJobQuery(parsed).seniority).toBeUndefined();
+  });
+
+  it("canonicalizes and dedupes skills via the shared SKILLS index", () => {
+    const parsed = baseParsed({ skills: ["JS", "Javascript", "React.js", "python3"] });
+    const query = buildJobQuery(parsed);
+    // "JS" and "Javascript" both canonicalize to the same skill id and collapse.
+    expect(query.skills).toEqual(["javascript", "react", "python"]);
+  });
+
+  it("passes through an unrecognized skill verbatim (title-cased)", () => {
+    const parsed = baseParsed({ skills: ["underwater basket weaving"] });
+    const query = buildJobQuery(parsed);
+    expect(query.skills).toEqual(["Underwater Basket Weaving"]);
+  });
+
+  it("caps skills at MAX_SKILLS", () => {
+    const parsed = baseParsed({
+      skills: ["python", "java", "go", "rust", "ruby", "php", "swift"],
+    });
+    const query = buildJobQuery(parsed);
+    expect(query.skills).toHaveLength(MAX_SKILLS);
+  });
+
+  it("ignores blank/whitespace-only skill entries", () => {
+    const parsed = baseParsed({ skills: ["  ", "", "python"] });
+    const query = buildJobQuery(parsed);
+    expect(query.skills).toEqual(["python"]);
+  });
+});

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * buildJobQuery — derives a job-search query from a parsed resume (#318,
+ * slice 1 of the job-search epic). Pure function, no I/O.
+ *
+ * Title: prefers the most recent experience entry's title (experience[0] —
+ * the cascade parses roles most-recent-first, mirroring the résumé's own
+ * reverse-chronological order); falls back to the top-level `current_title`
+ * when there's no experience at all. A résumé with no experience and no
+ * current title naturally falls back to a skills-only query (empty title,
+ * populated skills) — the degenerate-query UI state handles the rest.
+ *
+ * Seniority: derived from keywords in the title itself (senior/staff/lead/
+ * principal/junior/intern), not from `ParsedResume.seniority_level` — the
+ * issue asks for a title-keyword derivation so the seniority shown always
+ * traces back to a word the user can see in their own title.
+ *
+ * Skills: reuses the shared SKILLS canonical index (`getSkillIndex` from
+ * jd-match) to canonicalize + dedupe `parsed.skills` — two raw entries that
+ * alias the same canonical skill (e.g. "JS" and "Javascript") collapse into
+ * one. Skills that don't match a known canonical alias pass through verbatim
+ * (title-cased raw string) rather than being dropped, so an unusual but real
+ * skill still surfaces. Capped at MAX_SKILLS for URL-length sanity.
+ */
+
+import type { ParsedResume } from "../score/types.ts";
+import { getSkillIndex } from "../jd-match/skills.ts";
+
+export interface JobQuery {
+  /** Most recent role title, or "" when none could be derived. */
+  title: string;
+  /** Top-ranked skills, canonicalized + deduped, capped at MAX_SKILLS. */
+  skills: string[];
+  /** Seniority keyword found in the title (Staff/Principal/Lead/Senior/
+   *  Junior/Intern), or undefined when the title carries no such keyword. */
+  seniority?: string;
+}
+
+/**
+ * Structural subset of `ParsedResume` this module actually reads. The live
+ * caller (`ResultDetailTabs`) holds a `HeuristicParsedResume`
+ * (`Partial<ParsedResume> & { skills, experience, education }` —
+ * src/lib/heuristics/types.ts), which lacks `ParsedResume`'s other required
+ * fields (`full_name`, `skills_explicit`, `skills_inferred`). Picking just the
+ * fields we use keeps `buildJobQuery` callable with either shape without a
+ * cast, while still reading naturally as "takes a parsed resume".
+ */
+export type ResumeQueryInput = Pick<
+  ParsedResume,
+  "skills" | "experience" | "current_title"
+>;
+
+/** Cap on skills surfaced in the query — keeps deep-link URLs a sane length. */
+export const MAX_SKILLS = 5;
+
+const SENIORITY_PATTERNS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
+  // Order matters: check the more specific/senior keywords before "senior"
+  // itself so "Senior Staff Engineer" reads as Staff, not Senior.
+  { label: "Staff", pattern: /\bstaff\b/i },
+  { label: "Principal", pattern: /\bprincipal\b/i },
+  { label: "Lead", pattern: /\blead\b/i },
+  { label: "Senior", pattern: /\bsenior\b|\bsr\.?\b/i },
+  { label: "Junior", pattern: /\bjunior\b|\bjr\.?\b/i },
+  { label: "Intern", pattern: /\bintern(?:ship)?\b/i },
+];
+
+function deriveTitle(parsed: ResumeQueryInput): string {
+  const mostRecent = parsed.experience?.[0]?.title?.trim();
+  if (mostRecent) return mostRecent;
+  return parsed.current_title?.trim() ?? "";
+}
+
+function deriveSeniority(title: string): string | undefined {
+  for (const { label, pattern } of SENIORITY_PATTERNS) {
+    if (pattern.test(title)) return label;
+  }
+  return undefined;
+}
+
+function titleCase(raw: string): string {
+  return raw
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function deriveSkills(parsed: ResumeQueryInput): string[] {
+  const index = getSkillIndex();
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of parsed.skills ?? []) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const canonicalId = index.aliasToId.get(trimmed.toLowerCase());
+    const dedupeKey = canonicalId ?? trimmed.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    out.push(
+      canonicalId ? (index.idToLabel.get(canonicalId) ?? trimmed) : titleCase(trimmed),
+    );
+    if (out.length >= MAX_SKILLS) break;
+  }
+  return out;
+}
+
+export function buildJobQuery(parsed: ResumeQueryInput): JobQuery {
+  const title = deriveTitle(parsed);
+  const seniority = title ? deriveSeniority(title) : undefined;
+  const skills = deriveSkills(parsed);
+  return { title, skills, seniority };
+}

--- a/src/lib/job-search/rank.test.ts
+++ b/src/lib/job-search/rank.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { rankPostings } from "./rank.ts";
+import { extractJdTerms } from "../jd-match/extract-jd-terms.ts";
+import { computeCoverage } from "../jd-match/coverage.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobPosting } from "./types.ts";
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [
+    { title: "Frontend Engineer", company: "Acme", description: "Built React apps" },
+  ],
+  education: [],
+};
+
+function posting(id: string, description: string): JobPosting {
+  return {
+    id,
+    title: `Job ${id}`,
+    company: "Co",
+    location: "Remote",
+    url: `https://x/${id}`,
+    description,
+    source: "Test",
+  };
+}
+
+describe("rankPostings", () => {
+  it("sorts by fit descending", () => {
+    const strong = posting("strong", "We need React and TypeScript experts.");
+    const weak = posting("weak", "We need Rust and Kubernetes and Terraform experts.");
+    const ranked = rankPostings(parsed, [weak, strong]);
+    expect(ranked[0].posting.id).toBe("strong");
+    expect(ranked[0].score).toBeGreaterThanOrEqual(ranked[1].score);
+  });
+
+  it("guarantees card fit parity: job.score === job.jdMatch.coverage.score, and both equal a fresh computeCoverage", () => {
+    const p = posting("p1", "Seeking a React and TypeScript developer.");
+    const [job] = rankPostings(parsed, [p]);
+
+    // Card reads job.score; detail view reads job.jdMatch.coverage.score.
+    expect(job.score).toBe(job.jdMatch.coverage.score);
+
+    // Independent recomputation over the same description must match exactly —
+    // proves there is one coverage computation, not two divergent paths.
+    const fresh = computeCoverage(parsed, extractJdTerms(p.description).all);
+    expect(job.jdMatch.coverage.score).toBe(fresh.score);
+    expect(job.jdMatch.path).toBe("keyword");
+  });
+});

--- a/src/lib/job-search/rank.ts
+++ b/src/lib/job-search/rank.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Rank fetched postings against the parsed résumé, reusing the jd-match
+ * machinery verbatim.
+ *
+ * Ranking parity (acceptance criterion): the fit % on a job card MUST equal
+ * what the reused `JdMatch` detail view computes for the SAME posting. We
+ * guarantee that by computing coverage ONCE per posting here — `extractJdTerms`
+ * + `computeCoverage` — and packaging it into the exact `JdMatchResult` object
+ * the `JdMatch` renderer consumes. The card reads `job.jdMatch.coverage` (score
+ * + covered/missing) and the detail view is fed that same `job.jdMatch`, so the
+ * two can never diverge (there is only one coverage computation).
+ *
+ * Dynamic-imported by `search.ts` so jd-match's skill dictionary stays out of
+ * the entry chunk.
+ */
+
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JdMatchResult } from "../jd-match/types.ts";
+import { extractJdTerms } from "../jd-match/extract-jd-terms.ts";
+import { computeCoverage } from "../jd-match/coverage.ts";
+import type { JobPosting } from "./types.ts";
+
+/** The keyword arm of `JdMatchResult` — the only shape produced here. */
+export type KeywordJdMatch = Extract<JdMatchResult, { path: "keyword" }>;
+
+/** A posting paired with its (single) coverage computation. */
+export interface RankedJob {
+  posting: JobPosting;
+  /** The exact object handed to `<JdMatch result={...} />` for detail. */
+  jdMatch: KeywordJdMatch;
+  /** Weighted coverage 0..100 — the card's "fit %". Mirror of
+   *  `jdMatch.coverage.score`; surfaced flat for sort + card convenience. */
+  score: number;
+}
+
+/**
+ * Score every posting against `parsed` and return them sorted by fit
+ * descending. Ties keep input order (stable sort), which preserves the
+ * provider/dedup order from the fan-out.
+ */
+export function rankPostings(
+  parsed: HeuristicParsedResume,
+  postings: readonly JobPosting[],
+): RankedJob[] {
+  const ranked = postings.map((posting): RankedJob => {
+    const extracted = extractJdTerms(posting.description);
+    const coverage = computeCoverage(parsed, extracted.all);
+    const jdMatch: KeywordJdMatch = {
+      path: "keyword",
+      coverage,
+      terms: extracted.all,
+      nounsDropped: extracted.nounsDropped,
+    };
+    return { posting, jdMatch, score: coverage.score };
+  });
+  return ranked.sort((a, b) => b.score - a.score);
+}

--- a/src/lib/job-search/search.test.ts
+++ b/src/lib/job-search/search.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { JobProvider, JobPosting } from "./types.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobQuery } from "./query-builder.ts";
+
+// Mutable holder so each test can install its own provider set. rank.ts is NOT
+// mocked — it runs the real jd-match coverage, exercising ranking parity.
+const holder = vi.hoisted(() => ({ providers: [] as JobProvider[] }));
+
+vi.mock("./providers/index.ts", () => ({
+  getProviders: () => holder.providers,
+}));
+
+import { searchJobs } from "./search.ts";
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [],
+  education: [],
+};
+const query: JobQuery = { title: "Frontend Engineer", skills: ["React"] };
+
+function posting(overrides: Partial<JobPosting>): JobPosting {
+  return {
+    id: "x:1",
+    title: "Frontend Engineer",
+    company: "Acme",
+    location: "Remote",
+    url: "https://x/1",
+    description: "We need React and TypeScript.",
+    source: "Test",
+    ...overrides,
+  };
+}
+
+function provider(id: string, impl: JobProvider["search"]): JobProvider {
+  return { id, label: id[0].toUpperCase() + id.slice(1), search: impl };
+}
+
+beforeEach(() => {
+  holder.providers = [];
+});
+
+describe("searchJobs", () => {
+  it("merges results across providers and dedups by normalized title+company", async () => {
+    holder.providers = [
+      provider("alpha", async () => [posting({ id: "alpha:1" })]),
+      provider("beta", async () => [
+        // Same title+company but different casing/spacing → deduped away.
+        posting({ id: "beta:1", title: "  frontend   ENGINEER ", company: "acme" }),
+        posting({ id: "beta:2", title: "Backend Engineer", company: "Other" }),
+      ]),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.degradedProviders).toEqual([]);
+    expect(res.providerCount).toBe(2);
+    const ids = res.jobs.map((j) => j.posting.id).sort();
+    expect(ids).toEqual(["alpha:1", "beta:2"]);
+  });
+
+  it("degrades gracefully: one provider rejecting still yields the others' results", async () => {
+    holder.providers = [
+      provider("alpha", async () => [posting({ id: "alpha:1" })]),
+      provider("beta", async () => {
+        throw new Error("network down");
+      }),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.degradedProviders).toEqual(["Beta"]);
+    expect(res.jobs).toHaveLength(1);
+    expect(res.jobs[0].posting.id).toBe("alpha:1");
+  });
+
+  it("flags a total failure when every provider rejects", async () => {
+    holder.providers = [
+      provider("alpha", async () => {
+        throw new Error("boom");
+      }),
+      provider("beta", async () => {
+        throw new Error("boom");
+      }),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.degradedProviders).toHaveLength(res.providerCount);
+    expect(res.jobs).toEqual([]);
+  });
+
+  it("drops off-query postings client-side (feeds that ignore search= get filtered here)", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        // No query term in title or description → dropped before ranking.
+        posting({
+          id: "alpha:off",
+          title: "Forklift Operator",
+          description: "Operate warehouse machinery on the night shift.",
+        }),
+        // Title token match ("engineer" from "Frontend Engineer").
+        posting({ id: "alpha:title", title: "Platform Engineer" }),
+        // Skills-only match: no title-token hit, but the description mentions
+        // a query SKILL — proves skill chips participate in the filter.
+        posting({
+          id: "alpha:skill",
+          title: "UI Developer",
+          description: "You will build React components all day.",
+        }),
+      ]),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    const ids = res.jobs.map((j) => j.posting.id).sort();
+    expect(ids).toEqual(["alpha:skill", "alpha:title"]);
+  });
+
+  it("drops postings whose url is not http(s) — javascript: urls never render", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({ id: "alpha:evil", url: "javascript:alert(document.cookie)" }),
+        posting({
+          id: "alpha:data",
+          title: "Frontend Engineer II",
+          url: "data:text/html,<script>1</script>",
+        }),
+        posting({ id: "alpha:ok", url: "https://example.com/job/1" }),
+      ]),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.jobs.map((j) => j.posting.id)).toEqual(["alpha:ok"]);
+  });
+
+  it("threads the abort signal into each provider", async () => {
+    const signal = new AbortController().signal;
+    const seen: AbortSignal[] = [];
+    holder.providers = [
+      provider("alpha", async (_q, s) => {
+        seen.push(s);
+        return [];
+      }),
+    ];
+    await searchJobs(query, parsed, signal);
+    expect(seen[0]).toBe(signal);
+  });
+
+  it("ranks the merged set and preserves card fit parity", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        // Both mention a query term ("frontend"/"React") so they clear the
+        // client-side keyword filter; only strong covers the résumé skills.
+        posting({ id: "alpha:weak", title: "A", description: "Frontend role. Rust and Kubernetes only." }),
+        posting({ id: "alpha:strong", title: "B", description: "React and TypeScript expert." }),
+      ]),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.jobs[0].posting.id).toBe("alpha:strong");
+    for (const job of res.jobs) {
+      expect(job.score).toBe(job.jdMatch.coverage.score);
+    }
+  });
+});

--- a/src/lib/job-search/search.ts
+++ b/src/lib/job-search/search.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Job-search orchestrator — fan out enabled providers, filter, dedup, rank.
+ *
+ * Client-side keyword filter: Remotive and Arbeitnow ignore their `search=`
+ * param (live-verified — the response is the same unfiltered latest-jobs feed
+ * with or without it), so the honest backstop lives HERE: a posting survives
+ * only if its title or description contains at least one significant query
+ * term (title tokens + skills). Applied uniformly to every provider — harmless
+ * for Jobicy (whose `tag=` does filter server-side), corrective for the rest —
+ * so editing the query, including skill chips, actually changes the result set.
+ *
+ * URL trust boundary: feed JSON is untrusted input and `posting.url` is
+ * rendered as an `<a href>`, so any posting whose url is not http(s) (e.g. a
+ * `javascript:` url) is dropped here, covering every current and future
+ * provider in one place.
+ *
+ * Graceful degradation: providers run through `Promise.allSettled`, so one feed
+ * failing (network, CORS, malformed JSON) never rejects the whole search — its
+ * postings are simply absent and its label is reported in `degradedProviders`
+ * so the UI can note the missing source. A search only counts as a hard error
+ * when EVERY provider rejected (`degradedProviders.length === providerCount`);
+ * the panel derives that state from this result rather than a thrown error.
+ *
+ * The providers registry and the ranking tier are BOTH dynamic-imported (the
+ * cascade-tier pattern) so the entry chunk stays small — adapters, their
+ * HTML-strip helper, and jd-match's skill dictionary load only when the user
+ * actually clicks Search.
+ *
+ * AbortSignal is threaded into every provider's `search()` so an in-flight
+ * search can be cancelled or superseded by a newer one.
+ */
+
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobQuery } from "./query-builder.ts";
+import type { JobPosting } from "./types.ts";
+import type { RankedJob } from "./rank.ts";
+
+export interface JobSearchResult {
+  /** Postings ranked by fit descending (deduped across providers). */
+  jobs: RankedJob[];
+  /** Display labels of providers that failed — surfaced as a degraded notice.
+   *  When this equals every provider, the search is a hard error. */
+  degradedProviders: string[];
+  /** How many providers were attempted (denominator for the error state). */
+  providerCount: number;
+}
+
+/** Normalized dedup key: each of title/company lowercased and
+ *  whitespace-collapsed independently, then joined — so trailing/among-word
+ *  spacing differences between feeds collapse to the same key. */
+function normalizeField(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function dedupKey(posting: JobPosting): string {
+  return `${normalizeField(posting.title)}::${normalizeField(posting.company)}`;
+}
+
+/** Only ever render feed-supplied urls that are plain web links. */
+function isSafeUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+/** Tokens too generic to carry query intent on their own. */
+const STOPWORDS = new Set([
+  "and", "or", "the", "of", "for", "with", "in", "at", "to", "on", "an", "a",
+]);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Significant query terms as whole-word-ish case-insensitive patterns:
+ * the query title's tokens (minus stopwords/short tokens) plus every skill
+ * verbatim. Lookarounds instead of `\b` so symbol-bearing skills ("C++",
+ * "Node.js") still match on word-ish edges.
+ */
+function buildQueryTermPatterns(query: JobQuery): RegExp[] {
+  const terms = new Set<string>();
+  for (const token of query.title.toLowerCase().split(/[^a-z0-9+#.]+/)) {
+    const term = token.replace(/^\.+|\.+$/g, "");
+    if (term.length < 3 || STOPWORDS.has(term)) continue;
+    terms.add(term);
+  }
+  for (const skill of query.skills) {
+    const term = skill.trim().toLowerCase();
+    if (term) terms.add(term);
+  }
+  return [...terms].map(
+    (term) => new RegExp(`(?<![a-z0-9])${escapeRegExp(term)}(?![a-z0-9])`),
+  );
+}
+
+/** True when the posting's title or description contains ≥1 query term.
+ *  A query with no significant terms (degenerate) filters nothing. */
+function matchesQuery(posting: JobPosting, patterns: RegExp[]): boolean {
+  if (patterns.length === 0) return true;
+  const haystack = `${posting.title}\n${posting.description}`.toLowerCase();
+  return patterns.some((pattern) => pattern.test(haystack));
+}
+
+/**
+ * Run the search. Never rejects on a provider failure — inspect the returned
+ * `degradedProviders` / `providerCount` for partial or total failure. May
+ * reject only if the dynamic chunk import itself fails (offline first-load);
+ * the caller treats that as a hard error too.
+ */
+export async function searchJobs(
+  query: JobQuery,
+  parsed: HeuristicParsedResume,
+  signal: AbortSignal,
+): Promise<JobSearchResult> {
+  const [{ getProviders }, { rankPostings }] = await Promise.all([
+    import("./providers/index.ts"),
+    import("./rank.ts"),
+  ]);
+
+  const providers = getProviders();
+  const settled = await Promise.allSettled(
+    providers.map((p) => p.search(query, signal)),
+  );
+
+  const degradedProviders: string[] = [];
+  const seen = new Set<string>();
+  const merged: JobPosting[] = [];
+  const termPatterns = buildQueryTermPatterns(query);
+
+  settled.forEach((outcome, i) => {
+    if (outcome.status === "rejected") {
+      degradedProviders.push(providers[i].label);
+      return;
+    }
+    for (const posting of outcome.value) {
+      if (!isSafeUrl(posting.url)) continue;
+      if (!matchesQuery(posting, termPatterns)) continue;
+      const key = dedupKey(posting);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(posting);
+    }
+  });
+
+  return {
+    jobs: rankPostings(parsed, merged),
+    degradedProviders,
+    providerCount: providers.length,
+  };
+}

--- a/src/lib/job-search/types.ts
+++ b/src/lib/job-search/types.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Provider adapter contract for the in-app job search (#319, slice 2 of the
+ * job-search epic).
+ *
+ * A `JobProvider` fetches postings from one keyless, CORS-open job feed and
+ * maps its response shape into the normalized `JobPosting` below. The fan-out
+ * orchestrator (`search.ts`) runs every enabled provider through
+ * `Promise.allSettled`, so one provider failing (network, CORS, malformed
+ * JSON) never rejects the whole search — its results are simply absent and the
+ * UI notes the degraded source.
+ *
+ * The keyed BYOK adapter (#320) implements this same interface and joins the
+ * registry only when a key is present — nothing about this contract changes for
+ * that slice.
+ */
+
+import type { JobQuery } from "./query-builder.ts";
+
+/** A single normalized job posting, provider-agnostic. */
+export interface JobPosting {
+  /** Provider-prefixed for cross-provider dedup, e.g. `"remotive:1185979"`. */
+  id: string;
+  title: string;
+  company: string;
+  /** Often "Remote" / "Worldwide"; "" when the feed omits it. */
+  location: string;
+  /** Canonical external listing URL. */
+  url: string;
+  /** Plaintext (HTML stripped via `htmlToPlaintext`) — the corpus we rank on. */
+  description: string;
+  /** ISO date if the provider supplies one. */
+  postedAt?: string;
+  /** Provider display name, shown on the card to reinforce the honest-sample
+   *  framing ("Remotive"). */
+  source: string;
+}
+
+/** One keyless job feed, adapted to the normalized shape. */
+export interface JobProvider {
+  /** Stable slug, also the dedup id prefix (e.g. `"remotive"`). */
+  id: string;
+  /** Human display name shown in degraded notices + card source line. */
+  label: string;
+  /**
+   * Fetch + map postings for `query`. MUST thread `signal` into `fetch` so an
+   * in-flight or superseded search can be cancelled. Rejects on transport /
+   * parse failure — the orchestrator catches it per-provider via allSettled.
+   */
+  search(query: JobQuery, signal: AbortSignal): Promise<JobPosting[]>;
+}


### PR DESCRIPTION
## Summary

Adds a **job-search lane** to the results view (epic #317): drop a resume → derive a query → discover jobs. Ships the first two slices of the epic.

- **#318 — Query builder + deep-links.** A new **"Find jobs"** tab derives an *editable* query (title, top ~5 skills, seniority) from the parsed resume and renders prefilled deep-link buttons to LinkedIn / Indeed / Google Jobs. Zero network.
- **#319 — Provider interface + keyless feeds + ranking.** `JobProvider` adapter interface; three CORS-verified keyless feeds (Remotive, Arbeitnow, Jobicy) fanned out via `Promise.allSettled` with per-provider graceful degrade, dedup, and fit-ranking that **reuses** the existing jd-match `extractJdTerms` + `computeCoverage`. Ranked cards reuse the `JdMatch` detail renderer. README Telemetry documents every feed endpoint.

**Privacy:** no resume text or PDF bytes leave the browser — only derived keywords, and only on an explicit **Search** click (never on drop). The keyless feeds are labeled a remote/tech-heavy **sample**, not "all jobs."

Resolves #318
Resolves #319
Refs #317

> **#320 (BYOK keyed provider) deferred / left open** — all keyed candidates (Adzuna, Jooble, USAJobs) block browser-origin CORS (no `Access-Control-Allow-Origin`; Cloudflare/Akamai challenge on preflight). No proxy fallback per the epic's constraints; #320 stays open pending a keyed feed that permits browser calls.

## Adversarial review

An independent adversarial reviewer attacked the accumulated diff before this PR opened; two rounds ran to convergence (`clean: true`).

**Round 1 — 2 blocking findings, both fixed:**
- **B1 (query-driven contract + honest labeling):** live-probing showed Remotive & Arbeitnow *ignore* the `?search=` param and return an unfiltered latest-jobs feed. Fixed with a **client-side keyword filter** (title tokens + skills, regex-escaped) applied to all providers before ranking, so query edits — including skill chips — actually change results. README Telemetry corrected to disclose the client-side filtering.
- **B2 (security, feed trust boundary):** untrusted `posting.url` was rendered as `<a href>` with no scheme check → a `javascript:`/`data:` URL from a compromised feed could execute in the app origin (where resume text lives). Fixed with a single fail-closed `http(s)`-only guard at the merge boundary, covering all current + future providers.

**Round 2 — `clean: true`.** Verified the regex is properly escaped (`C++`, `a.b`, `(` are safe, no crash/ReDoS), the degenerate/empty query fails open (filters nothing), and B2 has no bypass. Ranking parity, abort-race safety, no-auto-fetch, and privacy all re-confirmed clean. 3 LOW nits noted, no action.

## Test plan

- [x] `npm run verify` green (typecheck + lint + coverage + build + fallow report-only) — 1552 tests pass
- [x] Provider adapters unit-tested against mocked responses (no live network)
- [x] Card fit % == jd-match detail (ranking-parity test)
- [x] Client-side filter drops off-query + `javascript:`/`data:` URL postings (tests added)
- [x] Manually verify Find-jobs tab in `npm run dev` (drop resume → edit query → deep links + Search)
