### PR TITLE
fix(test): posix-normalize corpus-roundtrip fixture keys on Windows

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -47,7 +47,7 @@
  */
 
 import { readFileSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, basename } from "node:path";
+import { dirname, join, relative, basename, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
@@ -59,6 +59,14 @@ import { renderAtsResumePdf } from "../pdf/render-ats-pdf.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = join(HERE, "../../..", "tests/fixtures/pdfs");
+
+/** Fixture path relative to `FIXTURE_ROOT`, posix-separated on every platform.
+ *  `KNOWN_FAILURES` is keyed with `/`; Windows `relative()` yields `\`, which
+ *  both failed the stale-key check and silently voided every known-failure
+ *  exemption there (the three documented fixtures reported as regressions). */
+function relKey(fixture: string): string {
+  return relative(FIXTURE_ROOT, fixture).split(sep).join("/");
+}
 
 type Category =
   | "contact"
@@ -261,13 +269,13 @@ describe("corpus round-trip invariants (#293)", () => {
   });
 
   it("every KNOWN_FAILURES key names a real fixture", () => {
-    const rel = new Set(fixtures.map((f) => relative(FIXTURE_ROOT, f)));
+    const rel = new Set(fixtures.map(relKey));
     for (const key of Object.keys(KNOWN_FAILURES))
       expect(rel.has(key), `stale KNOWN_FAILURES key: ${key}`).toBe(true);
   });
 
   for (const fixture of fixtures) {
-    const rel = relative(FIXTURE_ROOT, fixture);
+    const rel = relKey(fixture);
     it(`round-trips: ${rel}`, async () => {
       const p1 = await runCascade(new Uint8Array(readFileSync(fixture)));
       const model = buildAtsResumeModel(p1, scoreFor(p1));


### PR DESCRIPTION
## Summary

On any **Windows checkout**, `corpus-roundtrip.test.ts` fails 4 tests: `relative()` yields `\`-separated paths while `KNOWN_FAILURES` is keyed with `/`, so

1. the stale-key check (`every KNOWN_FAILURES key names a real fixture`) fails, and
2. every known-failure exemption is silently voided — the three documented fixtures (`google-docs-skia-proxy-classic`, `openresume-react-pdf`, `weasyprint-cairo-classic`) report as `experience` regressions.

Fix: one `relKey()` helper that posix-normalizes the relative path (`split(sep).join("/")`), used by both the stale-key check and the per-fixture gate. No behavior change on macOS/Linux (where `sep` is already `/`).

## Test plan

- [x] `corpus-roundtrip.test.ts` on Windows: 4 failed → **39 passed / 1 skipped**
- [x] Full suite on Windows: **1514 passed, 0 failed**
- [x] `tsc -b --noEmit` + `eslint .` clean; `vite build` OK; fallow: no issues in the changed file

## Note: a second Windows tooling gap (not fixed here)

The `verify` npm script itself cannot run on Windows — its `(fallow audit … || echo '…')` subshell is POSIX syntax, and npm's default script shell on Windows is cmd.exe, which dies with `') was unexpected at this time.'` before anything runs. That also breaks the pre-push hook. This PR's gate was run step-by-step manually and the push used the documented `RESUMELINT_SKIP_HOOKS=1` bypass. Happy to follow up making `verify` cross-platform (e.g. move the fallow fallback into a small node script) if wanted — flagging rather than scope-creeping it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
