### PR TITLE
feat(jd-match): semantic orchestrator + keyword fallback; fix Windows corpus-test paths (#202)

### DIFF
--- a/src/components/features/JdMatch.test.ts
+++ b/src/components/features/JdMatch.test.ts
@@ -127,7 +127,7 @@ describe("JdMatch", () => {
     const result: JdMatchResult = {
       path: "semantic",
       verdicts: [],
-      summary: { matched: 0, total: 0 },
+      summary: { met: 0, partial: 0, missing: 0, total: 0 },
     };
     const html = renderToStaticMarkup(createElement(JdMatch, { result }));
     expect(html).toBe("");

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -47,7 +47,7 @@
  */
 
 import { readFileSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, basename } from "node:path";
+import { dirname, join, relative, basename, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
@@ -59,6 +59,14 @@ import { renderAtsResumePdf } from "../pdf/render-ats-pdf.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = join(HERE, "../../..", "tests/fixtures/pdfs");
+
+/** Fixture path relative to `FIXTURE_ROOT`, posix-separated on every platform.
+ *  `KNOWN_FAILURES` is keyed with `/`; Windows `relative()` yields `\`, which
+ *  both failed the stale-key check and silently voided every known-failure
+ *  exemption there (the three documented fixtures reported as regressions). */
+function relKey(fixture: string): string {
+  return relative(FIXTURE_ROOT, fixture).split(sep).join("/");
+}
 
 type Category =
   | "contact"
@@ -261,13 +269,13 @@ describe("corpus round-trip invariants (#293)", () => {
   });
 
   it("every KNOWN_FAILURES key names a real fixture", () => {
-    const rel = new Set(fixtures.map((f) => relative(FIXTURE_ROOT, f)));
+    const rel = new Set(fixtures.map(relKey));
     for (const key of Object.keys(KNOWN_FAILURES))
       expect(rel.has(key), `stale KNOWN_FAILURES key: ${key}`).toBe(true);
   });
 
   for (const fixture of fixtures) {
-    const rel = relative(FIXTURE_ROOT, fixture);
+    const rel = relKey(fixture);
     it(`round-trips: ${rel}`, async () => {
       const p1 = await runCascade(new Uint8Array(readFileSync(fixture)));
       const model = buildAtsResumeModel(p1, scoreFor(p1));

--- a/src/lib/jd-match/llm/run-llm-match.test.ts
+++ b/src/lib/jd-match/llm/run-llm-match.test.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Unit tests for runLlmMatch (#202) — the semantic orchestrator's two
+ * branches, driven by stubs (no WebGPU): the happy path assembles a
+ * `semantic` result from the collaborators' outputs, and EVERY failure mode
+ * (engine load error, extraction hard-failure, empty extraction, unexpected
+ * judge error) resolves to a keyword result that matches a fresh
+ * `extractJdTerms` + `computeCoverage` computation exactly — fallback parity,
+ * proven the same way rank parity is (#319-style independent recompute).
+ *
+ * `loadEngine` / `extractRequirements` / `judgeEvidence` are mocked at their
+ * module boundary; the keyword-path functions stay REAL so the fallback
+ * assertion exercises the actual deterministic pipeline.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the engine loader (and the inference-guard exports judge-evidence's
+// module-level imports resolve against, so importing it stays loadable).
+vi.mock("../../webllm/web-llm.ts", () => ({
+  loadEngine: vi.fn(),
+  acquireInference: vi.fn(),
+  releaseInference: vi.fn(),
+}));
+
+// Mock the two LLM calls; keep the real RequirementExtractionError class so
+// the thrown-error test uses the same type the production extractor throws.
+vi.mock("./extract-requirements.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./extract-requirements.ts")>();
+  return { ...actual, extractRequirements: vi.fn() };
+});
+vi.mock("./judge-evidence.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./judge-evidence.ts")>();
+  return { ...actual, judgeEvidence: vi.fn() };
+});
+
+import { runLlmMatch } from "./run-llm-match.ts";
+import { loadEngine } from "../../webllm/web-llm.ts";
+import {
+  extractRequirements,
+  RequirementExtractionError,
+  type JdRequirement,
+} from "./extract-requirements.ts";
+import { judgeEvidence, type RequirementVerdict } from "./judge-evidence.ts";
+import { extractJdTerms } from "../extract-jd-terms.ts";
+import { computeCoverage } from "../coverage.ts";
+import type { WebLlmEngine } from "../../webllm/types.ts";
+import type { HeuristicParsedResume } from "../../heuristics/types.ts";
+
+const loadEngineMock = vi.mocked(loadEngine);
+const extractMock = vi.mocked(extractRequirements);
+const judgeMock = vi.mocked(judgeEvidence);
+
+const MODEL = "test-model";
+const JD_TEXT =
+  "We are hiring a backend engineer. Requires TypeScript and Go. " +
+  "Kubernetes experience is a plus.";
+
+const engine: WebLlmEngine = {
+  chat: { completions: { create: vi.fn() } },
+};
+
+function parsed(): HeuristicParsedResume {
+  return {
+    full_name: "Jane Example",
+    skills: ["TypeScript", "Go"],
+    experience: [
+      {
+        company: "Acme",
+        title: "Backend Engineer",
+        description: "Built TypeScript services",
+        is_current: false,
+      },
+    ],
+    education: [],
+  };
+}
+
+function req(id: string, text: string): JdRequirement {
+  return { id, kind: "skill", text };
+}
+
+function verdict(
+  id: string,
+  status: RequirementVerdict["status"],
+): RequirementVerdict {
+  return {
+    requirement: req(id, `text for ${id}`),
+    status,
+    reason: `reason for ${id}`,
+  };
+}
+
+/** The exact keyword result the fallback must reproduce. */
+function freshKeywordResult(resume: HeuristicParsedResume) {
+  const extracted = extractJdTerms(JD_TEXT);
+  return {
+    path: "keyword" as const,
+    coverage: computeCoverage(resume, extracted.all),
+    terms: extracted.all,
+    nounsDropped: extracted.nounsDropped,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The fallback branch warns; keep test output clean and assertable.
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  loadEngineMock.mockResolvedValue(engine);
+});
+
+describe("runLlmMatch — happy path", () => {
+  it("assembles a semantic result: verdicts passed through, summary tallied", async () => {
+    const requirements = [req("req-1", "TypeScript"), req("req-2", "Go"), req("req-3", "Kubernetes"), req("req-4", "GraphQL")];
+    const verdicts = [
+      verdict("req-1", "met"),
+      verdict("req-2", "met"),
+      verdict("req-3", "partial"),
+      verdict("req-4", "missing"),
+    ];
+    extractMock.mockResolvedValue(requirements);
+    judgeMock.mockResolvedValue(verdicts);
+
+    const onProgress = vi.fn();
+    const result = await runLlmMatch(JD_TEXT, parsed(), MODEL, onProgress);
+
+    expect(result.path).toBe("semantic");
+    if (result.path !== "semantic") throw new Error("unreachable");
+    expect(result.verdicts).toBe(verdicts);
+    expect(result.summary).toEqual({ met: 2, partial: 1, missing: 1, total: 4 });
+  });
+
+  it("threads jdText, engine, modelId, and onProgress to the right collaborators", async () => {
+    const resume = parsed();
+    const requirements = [req("req-1", "TypeScript")];
+    extractMock.mockResolvedValue(requirements);
+    judgeMock.mockResolvedValue([verdict("req-1", "met")]);
+
+    const onProgress = vi.fn();
+    await runLlmMatch(JD_TEXT, resume, MODEL, onProgress);
+
+    expect(loadEngineMock).toHaveBeenCalledExactlyOnceWith(MODEL, onProgress);
+    expect(extractMock).toHaveBeenCalledExactlyOnceWith(JD_TEXT, engine);
+    expect(judgeMock).toHaveBeenCalledExactlyOnceWith(
+      requirements,
+      resume,
+      engine,
+      MODEL,
+    );
+  });
+});
+
+describe("runLlmMatch — fallback discipline (every failure → keyword, never a rejection)", () => {
+  it("falls back when the engine load fails (also the no-WebGPU manifestation)", async () => {
+    loadEngineMock.mockRejectedValue(new Error("WebGPU unavailable"));
+
+    const resume = parsed();
+    const result = await runLlmMatch(JD_TEXT, resume, MODEL, vi.fn());
+
+    expect(result).toEqual(freshKeywordResult(resume));
+    expect(extractMock).not.toHaveBeenCalled();
+    expect(judgeMock).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  it("falls back when extraction hard-fails (RequirementExtractionError)", async () => {
+    extractMock.mockRejectedValue(
+      new RequirementExtractionError("no parseable JSON array"),
+    );
+
+    const resume = parsed();
+    const result = await runLlmMatch(JD_TEXT, resume, MODEL, vi.fn());
+
+    expect(result).toEqual(freshKeywordResult(resume));
+    expect(judgeMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back on a valid-but-empty extraction (zero verdicts = blank panel)", async () => {
+    extractMock.mockResolvedValue([]);
+
+    const resume = parsed();
+    const result = await runLlmMatch(JD_TEXT, resume, MODEL, vi.fn());
+
+    expect(result.path).toBe("keyword");
+    expect(judgeMock).not.toHaveBeenCalled();
+    // Not an error — the extractor succeeded — so no warning is logged.
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back if the judge throws unexpectedly (defensive; its contract is never-throw)", async () => {
+    extractMock.mockResolvedValue([req("req-1", "TypeScript")]);
+    judgeMock.mockRejectedValue(new Error("engine evicted mid-batch"));
+
+    const resume = parsed();
+    const result = await runLlmMatch(JD_TEXT, resume, MODEL, vi.fn());
+
+    expect(result).toEqual(freshKeywordResult(resume));
+  });
+
+  it("fallback parity: the keyword result matches the JD-fit surface's own composition exactly", async () => {
+    loadEngineMock.mockRejectedValue(new Error("boom"));
+
+    const resume = parsed();
+    const result = await runLlmMatch(JD_TEXT, resume, MODEL, vi.fn());
+    const fresh = freshKeywordResult(resume);
+
+    if (result.path !== "keyword") throw new Error("expected keyword path");
+    expect(result.coverage.score).toBe(fresh.coverage.score);
+    expect(result.terms.length).toBeGreaterThan(0);
+    expect(result.terms).toEqual(fresh.terms);
+    expect(result.nounsDropped).toBe(fresh.nounsDropped);
+  });
+});

--- a/src/lib/jd-match/llm/run-llm-match.ts
+++ b/src/lib/jd-match/llm/run-llm-match.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * run-llm-match.ts — semantic JD-match orchestrator + path selection (#202).
+ *
+ * Chains the two LLM calls behind the stable `JdMatchResult` API:
+ * `loadEngine` → `extractRequirements` (#200) → `judgeEvidence` (#201) →
+ * `{ path: "semantic", verdicts, summary }`.
+ *
+ * Fallback discipline: ANY failure resolves to the deterministic keyword path
+ * (`{ path: "keyword" }`) — never a rejection, never a blank panel. That covers
+ * an engine load error (which is also how a missing-WebGPU environment
+ * manifests if the caller's `detectWebGpu` gate was stale), a requirement-
+ * extraction hard failure (`RequirementExtractionError`), and any unexpected
+ * inference error. A valid-but-EMPTY extraction also degrades: it is not a
+ * failure per #200's contract, but zero verdicts would render an empty
+ * semantic panel, and the keyword path always has something to show.
+ * `judgeEvidence` never throws by contract — its failure mode is per-batch
+ * `missing` verdicts, which stay on the semantic path by design.
+ *
+ * Caller contract: the `detectWebGpu` gate and the ConsentDialog gate for
+ * restricted models run BEFORE this is called — this module never prompts.
+ * `modelId` is the `useModelSelection` selected id; it is threaded both to
+ * `loadEngine` and to `judgeEvidence`'s inference guard. `onProgress` receives
+ * the engine download/load progress (first call on a cold cache is a large
+ * weight fetch).
+ *
+ * Chunk discipline: this module transitively imports `web-llm.ts` (via
+ * `judge-evidence.ts`), so it is NOT exported from the `jd-match` barrel
+ * (`index.ts`), which the JD-fit entry imports statically. Consumers
+ * dynamic-import this module (the cascade-tier pattern) so WebLLM stays out
+ * of the entry chunk until the user opts into the semantic match.
+ */
+
+import type { HeuristicParsedResume } from "../../heuristics/types.ts";
+import type { ProgressUpdate } from "../../webllm/types.ts";
+import { loadEngine } from "../../webllm/web-llm.ts";
+import { extractJdTerms } from "../extract-jd-terms.ts";
+import { computeCoverage } from "../coverage.ts";
+import type { JdMatchResult, SemanticMatchSummary } from "../types.ts";
+import { extractRequirements } from "./extract-requirements.ts";
+import type { RequirementVerdict } from "./judge-evidence.ts";
+import { judgeEvidence } from "./judge-evidence.ts";
+
+/**
+ * Run the semantic JD-match, degrading to the keyword path on any failure.
+ *
+ * Never rejects: the promise always resolves to a usable `JdMatchResult`.
+ */
+export async function runLlmMatch(
+  jdText: string,
+  parsed: HeuristicParsedResume,
+  modelId: string,
+  onProgress: (update: ProgressUpdate) => void,
+): Promise<JdMatchResult> {
+  try {
+    const engine = await loadEngine(modelId, onProgress);
+    const requirements = await extractRequirements(jdText, engine);
+    if (requirements.length === 0) {
+      // Legitimate empty extraction (#200: not a failure) — but a semantic
+      // result with no verdicts is a blank panel, so degrade anyway.
+      return keywordMatch(jdText, parsed);
+    }
+    const verdicts = await judgeEvidence(requirements, parsed, engine, modelId);
+    return { path: "semantic", verdicts, summary: summarize(verdicts) };
+  } catch (err) {
+    console.warn(
+      "[run-llm-match] semantic path failed; falling back to keyword:",
+      err,
+    );
+    return keywordMatch(jdText, parsed);
+  }
+}
+
+/** Tally verdict statuses once so the renderer never re-counts. */
+function summarize(
+  verdicts: readonly RequirementVerdict[],
+): SemanticMatchSummary {
+  let met = 0;
+  let partial = 0;
+  let missing = 0;
+  for (const verdict of verdicts) {
+    if (verdict.status === "met") met += 1;
+    else if (verdict.status === "partial") partial += 1;
+    else missing += 1;
+  }
+  return { met, partial, missing, total: verdicts.length };
+}
+
+/**
+ * The deterministic keyword path — the exact `extractJdTerms` +
+ * `computeCoverage` composition the JD-fit surface runs today
+ * (`JdFitApp.tsx`), wrapped in the keyword arm.
+ */
+function keywordMatch(
+  jdText: string,
+  parsed: HeuristicParsedResume,
+): JdMatchResult {
+  const extracted = extractJdTerms(jdText);
+  const coverage = computeCoverage(parsed, extracted.all);
+  return {
+    path: "keyword",
+    coverage,
+    terms: extracted.all,
+    nounsDropped: extracted.nounsDropped,
+  };
+}

--- a/src/lib/jd-match/types.ts
+++ b/src/lib/jd-match/types.ts
@@ -5,33 +5,35 @@
  * Path-agnostic JD-match result type (issue #199, anchor #156 — "JD Matching v2").
  *
  * One stable shape the renderer (`JdMatch.tsx`) can consume regardless of how the
- * match was produced. Today only the deterministic `keyword` path exists; M6 will
- * add a WebLLM `semantic` path. The `path` discriminant lets a consumer narrow
- * without branching on internals.
+ * match was produced. The `path` discriminant lets a consumer narrow without
+ * branching on internals.
  *
- * This first PR is tagging-only: the keyword arm wraps the existing
- * `extractJdTerms` + `computeCoverage` flow verbatim (no behavior change).
+ * The semantic arm carries the judge's verdicts verbatim (#201) — the
+ * `RequirementVerdict` import is TYPE-ONLY, so this module (reached statically
+ * through the `jd-match` barrel by the JD-fit entry) adds no runtime edge into
+ * the WebLLM chunk. The producer is `llm/run-llm-match.ts` (#202), which
+ * consumers dynamic-import.
  */
 
 import type { CoverageResult } from "./coverage.ts";
 import type { ExtractedTerm } from "./extract-jd-terms.ts";
+import type { RequirementVerdict } from "./llm/judge-evidence.ts";
 
-/**
- * Provisional M6 scaffolding for the semantic arm. Kept NON-exported: nothing
- * imports it yet, so exporting it would trip fallow's unused-export gate. The
- * semantic-path PR will flesh this out (and export it) when it adds a producer.
- */
-interface RequirementVerdict {
-  requirement: string;
-  met: boolean;
-  evidence?: string;
+/** Per-status verdict counts for the semantic arm — what a headline like
+ *  "6 met · 2 partial · 4 missing" renders from without re-tallying. */
+export interface SemanticMatchSummary {
+  met: number;
+  partial: number;
+  missing: number;
+  total: number;
 }
 
 /**
  * A JD-match result from either matching path.
  *
- * - `keyword`  — deterministic term coverage (the only path that exists today).
- * - `semantic` — WebLLM requirement matching (M6; no producer/UI yet).
+ * - `keyword`  — deterministic term coverage (also the semantic path's fallback).
+ * - `semantic` — WebLLM requirement matching (extract #200 → judge #201,
+ *                orchestrated by `runLlmMatch` #202).
  */
 export type JdMatchResult =
   | {
@@ -43,5 +45,5 @@ export type JdMatchResult =
   | {
       path: "semantic";
       verdicts: readonly RequirementVerdict[];
-      summary: { matched: number; total: number };
+      summary: SemanticMatchSummary;
     };


### PR DESCRIPTION
## Summary

Two changes on one branch (per review consolidation): the semantic JD-match **orchestrator** (#202) and the **Windows corpus-test fix** it surfaced (originally opened separately as #338, now folded in here).

### 1. Semantic orchestrator + path selection (#202)

Adds the semantic JD-match orchestrator behind the stable `JdMatchResult` API (M6 anchor #156; follows #200 extractor and #201 judge, whose first non-test consumer this is).

- **New `src/lib/jd-match/llm/run-llm-match.ts`** — `runLlmMatch(jdText, parsed, modelId, onProgress)`: `loadEngine` → `extractRequirements` (#200) → `judgeEvidence` (#201) → `{ path: "semantic", verdicts, summary }`. `modelId` is the `useModelSelection` selected id, threaded to both the loader and the judge's inference guard; the `detectWebGpu` and ConsentDialog gates are documented as the caller's job (this module never prompts). *Signature note:* the issue sketch wrote `engine` as the third param, but `loadEngine` is a step **inside** the orchestrator (that's what `onProgress` reports), and the judge needs the model id for its inference guard — so the param is `modelId`.
- **Fallback discipline** — never rejects, never a blank panel: engine-load failure (also how a missing-WebGPU environment manifests), `RequirementExtractionError`, an unexpected judge error, **and a valid-but-empty extraction** all resolve to `{ path: "keyword" }`, built with the same `extractJdTerms` + `computeCoverage` composition the JD-fit surface runs today. (`judgeEvidence` never throws by contract — its per-batch failures stay on the semantic path as `missing` verdicts, by design.)
- **`types.ts`** — fleshes out the provisional semantic arm exactly as its comment promised: real judge `RequirementVerdict` (type-only import → no runtime edge into the WebLLM chunk) and a new exported `SemanticMatchSummary` (`met/partial/missing/total` — per-status counts so the renderer never re-tallies; the provisional `matched/total` couldn't represent `partial`).
- **Chunk discipline** — deliberately NOT exported from the `jd-match` barrel (statically imported by the JD-fit entry); consumers dynamic-import this module (cascade-tier pattern) so WebLLM stays out of the entry chunk.

### 2. Windows corpus-roundtrip fix (was #338)

On any Windows checkout, `corpus-roundtrip.test.ts` failed 4 tests: `relative()` yields `\`-separated paths while `KNOWN_FAILURES` is keyed with `/`, so the stale-key check failed and every known-failure exemption was silently voided (the three documented fixtures reported as `experience` regressions). Fixed with one `relKey()` helper that posix-normalizes the relative path (`split(sep).join("/")`), used by both the stale-key check and the per-fixture gate. No behavior change on macOS/Linux.

Resolves #202

## Test plan

- [x] 7 new stub tests (`run-llm-match.test.ts`): happy-path assembly + summary tally, collaborator arg threading, all four failure modes → keyword (with judge-not-called assertions), and a **fallback-parity** test that independently recomputes the keyword result (#319-style)
- [x] One-line fixture update in `JdMatch.test.ts` (old provisional `{matched,total}` summary shape); renderer still renders nothing for the semantic path until its UI slice
- [x] `corpus-roundtrip.test.ts` on Windows: 4 failed → 39 passed / 1 skipped
- [x] **Full suite on Windows: 1521 passed / 0 failed** (fully green with both changes combined)
- [x] `tsc -b --noEmit` + `eslint .` clean; `vite build` OK; fallow report-only clean on changed files

## Note: a second Windows tooling gap (not fixed here)

The `verify` npm script itself cannot run on Windows — its `(fallow audit … || echo '…')` subshell is POSIX syntax, and npm's default script shell on Windows is cmd.exe, which dies with `') was unexpected at this time.'` before anything runs. That also breaks the pre-push hook. This PR's gate was run step-by-step manually and the push used the documented `RESUMELINT_SKIP_HOOKS=1` bypass. Happy to follow up making `verify` cross-platform (e.g. move the fallow fallback into a small node script) — flagging rather than scope-creeping it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
