### PR TITLE
chore(ci): run verify on merge_group events (enable merge queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue entries run on a temporary `gh-readonly-queue/*` branch and
+  # emit a `merge_group` event, not `pull_request`/`push`. Without this the
+  # required `verify` check never runs on the queue branch and every queued PR
+  # stalls forever. Keep this in lockstep with the "Require merge queue" branch
+  # protection on `main`.
+  merge_group:
 
 jobs:
   verify:


### PR DESCRIPTION
## Why

Step 1 of enabling GitHub **merge queue** on `main`. The queue runs each entry on a temporary `gh-readonly-queue/*` branch that emits a **`merge_group`** event — not `pull_request`/`push`. Our `ci.yml` only listens for the latter two, so the required `verify` check would never run on a queued PR and **every queued PR would stall forever**.

This PR adds the `merge_group` trigger so `verify` runs on the queue branch. It must land on `main` **before** "Require merge queue" is turned on.

## Change

```yaml
on:
  pull_request:
    branches: [main]
  push:
    branches: [main]
  merge_group:        # ← new
```

fallow's diff gate resolves its `origin/main` merge-base fine on `merge_group` — `fetch-depth: 0` is already set on the checkout.

## Sequence

1. **This PR** → merge under current rules.
2. Then enable "Require merge queue" on `main` protection.

## Context

Follow-on to the branch-protection change that set `required_status_checks.strict = false` (stop forcing "Update branch", which was dismissing approvals). Merge queue restores the up-to-date-at-merge guarantee without the manual update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)