### PR TITLE
fix(experience): strip stray '·' separators from role fields (#348, #347)

### DIFF
--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -1104,7 +1104,17 @@ function buildEntryBlock(
   // structural signal (#298). Each group is trimmed and de-blanked
   // independently so the anchor index stays accurate after empties drop.
   const aboveTexts = aboveLines.map((l) => l.text.trim()).filter(Boolean);
-  const anchorText = anchorTextWithoutDates.trim();
+  // A "Date · Location" sub-line (two-column Google-Docs export, #347) leaves a
+  // dangling LEADING separator once the date range is stripped off the front:
+  // "Jan 2022 – Present · Springfield, IL" → "· Springfield, IL". Peel that
+  // orphaned leading "·"/"|"/dash so the residual location routes cleanly in
+  // disambiguateCompanyTitle — otherwise the leading "·" survives the
+  // whitespace-both-sides split, clobbers the company/team assignment, and (for
+  // a multi-word city) mis-splits the location. Only the LEADING run is peeled:
+  // a TRAILING "·" is the reconstructed-export org-signature marker
+  // (anchorCarriesOrgSignal) and an INTERNAL " · " is a real segment separator,
+  // both of which must survive.
+  const anchorText = anchorTextWithoutDates.replace(/^[\s·•‣|—–-]+/, "").trim();
   const belowTexts = belowHeaderLines.map((l) => l.text.trim()).filter(Boolean);
   const headerLines = [
     ...aboveTexts,

--- a/src/lib/heuristics/extract/experience.date-location.test.ts
+++ b/src/lib/heuristics/extract/experience.date-location.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression tests for a `Date · Location` experience sub-line (#347).
+ *
+ * When a role's date anchor line carries a trailing " · Location" (two-column
+ * Google-Docs exports write "Jan 2022 – Present · Springfield, IL"), stripping
+ * the date range off the front leaves a dangling LEADING "·" ("· Springfield,
+ * IL"). Before the fix that orphaned "·" survived the whitespace-both-sides
+ * header split, clobbered the company/team assignment, and — for a multi-word
+ * city — mis-split the location ("Initech" lost; company="· Pacific";
+ * location="Coast, CA"). The location must route cleanly and the company must
+ * survive intact.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("date · location experience sub-line (#347)", () => {
+  it("routes a single-word city to location, not team", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Acme Corp — Senior Software Engineer", fontSize: 11 },
+      { text: "Jan 2022 – Present · Springfield, IL", fontSize: 11 },
+      { text: "• Led migration of core services to Kubernetes.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Acme Corp");
+    expect(roles[0].title).toBe("Senior Software Engineer");
+    expect(roles[0].location).toBe("Springfield, IL");
+    expect(roles[0].team).toBeUndefined();
+  });
+
+  it("keeps company intact and location whole for a multi-word city", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Initech — Junior Engineer", fontSize: 11 },
+      { text: "Aug 2017 – Feb 2019 · Pacific Coast, CA", fontSize: 11 },
+      { text: "• Built internal tooling used across three teams.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    // Before the fix: company="· Pacific", location="Coast, CA", "Initech" lost.
+    expect(roles[0].company).toBe("Initech");
+    expect(roles[0].title).toBe("Junior Engineer");
+    expect(roles[0].location).toBe("Pacific Coast, CA");
+    expect(roles[0].company).not.toContain("·");
+  });
+});

--- a/src/lib/heuristics/extract/experience.mid-dot.test.ts
+++ b/src/lib/heuristics/extract/experience.mid-dot.test.ts
@@ -128,4 +128,21 @@ describe("mid-dot (·) single-line experience headers (#217)", () => {
     expect(roles[0].title.toLowerCase()).toContain("office manager");
     expect(roles[0].company).toContain("Nod Publishing");
   });
+
+  it("strips a trailing `·` left dangling on a two-line title header (#348)", () => {
+    // WeasyPrint-Cairo shape: the title line ends in a bare trailing "·" with the
+    // company on the NEXT line, so the " · " (whitespace-both-sides) split never
+    // fires and the glyph would otherwise stay glued to the title.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Vice President ·", fontSize: 11 },
+      { text: "Computer Science Society, Springfield State University", fontSize: 11 },
+      { text: "01/2022 - 05/2024", fontSize: 11 },
+      { text: "• Led the executive board and doubled active membership.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].title).toBe("Vice President");
+    expect(roles[0].title).not.toContain("·");
+    expect(roles[0].company).toContain("Computer Science Society");
+  });
 });

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -584,6 +584,15 @@ function disambiguateCompanyTitle(
   //     never ends in a bare middot, so this only ever removes the marker.
   if (company) company = company.replace(/\s*·\s*$/, "").trim() || undefined;
 
+  // (4b) Strip a field-separator glyph left dangling on the TITLE after header
+  //      splitting. The `·`/`|`/`—`-split above only fires on a separator with
+  //      whitespace on BOTH sides, so a two-line "Title ·" / "Company … Dates"
+  //      header (WeasyPrint-Cairo, #348) — where the title line ends in a bare
+  //      trailing "·" (no company on the same row to split against) — keeps the
+  //      glyph glued to the title. A real title never ends in a bare separator,
+  //      so `stripDanglingSeparator` only ever removes the residue.
+  if (title) title = stripDanglingSeparator(title) || undefined;
+
   // (5) A title that is ENTIRELY a bare location string is a title-less role, not
   //     a real title. Our own empty-title-role export (ats-resume-model.ts) emits
   //     "Company · City, ST" on a SINGLE header line for a role with no title (the


### PR DESCRIPTION
## Summary

Two related `·`-separator parse bugs where the mid-dot glyph gets absorbed into a field value instead of acting as a separator.

**#348 — trailing `·` on role title (WeasyPrint-Cairo).** The title/company split only fires on a `" · "` with whitespace on *both* sides, so a two-line header whose title line ends in a bare trailing `·` (company on the next line) never splits and the glyph stays glued to the title. Company already had a trailing-`·` strip; mirrored it for the title.

```
before: title="Vice President ·"      after: title="Vice President"
before: title="Volunteer Engineer ·"  after: title="Volunteer Engineer"
```

**#347 — `Date · Location` sub-line (two-column Google-Docs).** Stripping the date range off the front of `"Jan 2022 – Present · Springfield, IL"` leaves a dangling *leading* `"· Springfield, IL"`, whose orphaned `·` survives the split, clobbers the company/team assignment, and mis-splits a multi-word city. Peel the leading separator run off the anchor text (leaving trailing/internal `·` — the export org-signature and real segment separators — intact).

```
role 3 before: company="· Pacific", location="Coast, CA"   (Initech lost)
role 3 after:  company="Initech",   location="Pacific Coast, CA"
roles 1–2:     location now "Springfield, IL" / "Remote" (was empty)
```

Closes #348
Closes #347

## Test plan

- [x] `npm run verify` green (typecheck + lint + 1576 tests + build)
- [x] #348: regression case in `experience.mid-dot.test.ts` (`Title ·` two-line header → no trailing `·`)
- [x] #347: new `experience.date-location.test.ts` asserts field *values* directly (single- and multi-word city) — the corpus gate can't catch this class since snapshots are lossy (keys/counts, not values)
- [x] Two-column Google-Docs fixture now parses all three roles' company/location cleanly; classic single-column fixture unchanged
- [x] Corpus snapshots unchanged — lossy by design, no re-bake needed