### PR TITLE
feat(probe): add probe-experience skill + RL_EXPERIENCE_PDF vitest harness

### DIFF
--- a/.claude/skills/probe-experience/SKILL.md
+++ b/.claude/skills/probe-experience/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: probe-experience
+description: Extract + verify the EXPERIENCE section (roles — title, company, location, dates, bullets) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/merged role to the exact layer (line-assembly vs section-routing vs entry segmentation). Prints the experience region the segmenter scanned next to the role entries it produced, plus an independent date-range re-scan that separates "dateless-in-pdf" from "parser-miss". One of the `probe-*` parser probes (see also `probe-contact`, `probe-roundtrip`). Use when the user says "probe experience", "/probe-experience", "why is a role missing/merged", "employment history isn't parsing", or hands you a résumé whose roles extract wrong.
+---
+
+# Probe: Experience
+
+> One of the `probe-*` parser-probe family (siblings: `probe-contact`,
+> `probe-roundtrip`). Type `probe-` to list them all.
+
+Drop in **any** résumé PDF and see exactly what the parser reads for the
+experience section — every role's title, company, location, date range, and
+bullet count — and, when a role comes back missing, merged into a neighbor, or
+with swapped fields, which layer dropped it. This is the tooling lane for the
+two-column entry-collapse (#341) and role-title-miss (#342) failure classes.
+
+It reuses a dev harness in `src/lib/heuristics/probe-experience.test.ts` (the
+`RL_EXPERIENCE_PDF` block) — there is **no standalone script and you should not
+write one**: the pdfjs worker uses Vite's `?url` import, which resolves only
+under the Vite/vitest transform, so plain `tsx`/node breaks. The vitest run
+**is** the execution vehicle (same constraint as the sibling probes).
+
+## ⚠️ PII guardrail — read first
+
+This probe is meant to run on **real résumés with real candidate PII**. Same two
+hard rules as the sibling probes, non-negotiable:
+
+1. **The input PDF is local-only. NEVER commit it.** It is not a fixture. The
+   public repo's `tests/fixtures/pdfs/` is **synthetic-personas-only by policy**
+   (`tests/fixtures/pdfs/README.md`). A real résumé must never land there.
+2. **The output prints field VALUES → scratch only.** The console and JSON
+   report print role titles/companies/locations so the corruption is visible.
+   The full JSON is written to the **gitignored** `internal/experience/` dir.
+   Do not paste raw candidate values into an issue, PR, commit, or Slack —
+   cite the corruption by **category** ("second role's header demoted to a
+   bullet under the first role"), never the value.
+
+If you are ever unsure whether a path is committed, stop and check `git status` /
+`.gitignore` before running.
+
+## Run it
+
+```bash
+RL_EXPERIENCE_PDF=/abs/path/to/real-resume.pdf \
+  npx vitest run src/lib/heuristics/probe-experience.test.ts
+```
+
+Use an **absolute path** for `RL_EXPERIENCE_PDF`.
+
+### Env vars
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RL_EXPERIENCE_PDF` | *(unset)* | Absolute path to the résumé PDF. When unset the harness is **inert** (skipped) — CI never runs it. |
+| `RL_EXPERIENCE_OUT` | `internal/experience/` | Directory for the full JSON report. The default lives under `internal/`, which is **gitignored**. Override only with another gitignored/out-of-repo path. |
+
+## What you get
+
+Five blocks, printed to the console (full JSON mirrored to the gitignored dir):
+
+1. **Score** — `overall` (+ pre-layout and the layout multiplier/triggers), so
+   a parse failure's score impact is visible in the same run.
+2. **Sections detected** — every segmented region with its line count
+   (`profile(4) experience(18) education(3) …`). A missing/short `experience`
+   region means the failure is upstream of entry segmentation.
+3. **Parsed experience entries** — each role as
+   `title @ company  start – end  loc=…  bullets=N`, straight off
+   `runCascade(...).parsed.experience`. This is the OUTPUT.
+4. **Experience region scanned** — the `sections.byName.get("experience")`
+   lines the entry segmenter actually saw, with the date-range line count.
+   This is the INPUT. When a role is missing, this is where you see *why*:
+   the role's header line never landed in the region (routing), or it is there
+   but glued to a neighbor line (assembly), or it is there and intact but no
+   entry anchored on it (segmentation).
+5. **Verify (independent date-range re-scan)** — date-range lines inside the
+   region are a lower-bound oracle for the role count:
+   - `ok` — entry count ≥ date-range lines (dateless roles can exceed it).
+   - `UNDER-SEGMENTED` — fewer entries than date-range lines → a role likely
+     **merged into a neighbor** (the #341/#239 failure class).
+   - `PARSER-MISS` — zero entries but the region has date-range lines →
+     entry segmentation dropped everything.
+
+## Reading the result — localize the layer
+
+A role can drop at three layers. The probe's INPUT-vs-OUTPUT split points at
+which one:
+
+- **Line assembly** (`sections.ts` `mergeItemText`) — the region lines are
+  mangled (two-column text glued, header split mid-role, sidebar interleaved).
+  Fix belongs in item→line joining, not the extractor.
+- **Section routing** (`sections.ts` segmentation) — the role's lines are fine
+  but landed outside the `experience` band (unrecognized header, second
+  experience-category section swallowed — the #310/#311 class).
+- **Entry segmentation / header mapping**
+  (`extract/experience.ts` `parseEntryBlocks` / `disambiguateCompanyTitle`) —
+  the lines are in the region and intact, but no entry anchored on the role's
+  header (dateless header, wrapped header), or title/company mapped wrong.
+
+The `verify` block is the fast triage: `UNDER-SEGMENTED` with an intact region
+means the bug is in entry segmentation; a short/empty region means routing or
+assembly.
+
+## Filing what you find
+
+Localize the layer, then file a **public** `resumelint-org/resumelint` issue
+describing the corruption **by category, using a synthetic repro** — never the
+candidate's real values. Reproduce with a synthetic-persona PDF (fake name,
+`@example.com`, a `555-01xx` phone on a real area code) so the fixture is
+PII-free; see `tests/fixtures/pdfs/README.md` for the add-fixture workflow.
+
+## Boundaries
+
+- This is a **dev/triage tool**, not a CI gate. It is informational: the
+  harness never reddens the suite, so a PII résumé with a known bug won't fail
+  the run.
+- The PII-free enforcement lane is the corpus gate (`corpus.test.ts`) over
+  **synthetic fixtures** — this probe is the manual lane over **real** ones.
+  Don't confuse the two.

--- a/src/lib/heuristics/probe-experience.test.ts
+++ b/src/lib/heuristics/probe-experience.test.ts
@@ -64,17 +64,7 @@ describe.runIf(process.env.RL_EXPERIENCE_PDF)(
       const p = cascade.parsed;
 
       const score = computeAnonymousAtsScore({
-        parsed: {
-          full_name: p.full_name,
-          email: p.email,
-          phone: p.phone,
-          location: p.location,
-          linkedin_url: p.linkedin_url,
-          summary: p.summary,
-          skills: p.skills,
-          experience: p.experience,
-          education: p.education,
-        },
+        parsed: { ...p },
         fieldConfidence: cascade.fieldConfidence,
         triggers: cascade.triggers,
         rawText: cascade.rawText,

--- a/src/lib/heuristics/probe-experience.test.ts
+++ b/src/lib/heuristics/probe-experience.test.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Experience-section dev probe — inert in CI, runs ONLY when
+ * `RL_EXPERIENCE_PDF=<path>` is set:
+ *
+ *   RL_EXPERIENCE_PDF=/abs/path/to/resume.pdf npx vitest run \
+ *     src/lib/heuristics/probe-experience.test.ts
+ *
+ * Extracts + VERIFIES the experience section of one arbitrary PDF so a real
+ * (uncommitted, possibly PII-bearing) résumé can be triaged WITHOUT being
+ * committed as a fixture. This is the execution vehicle for the
+ * `probe-experience` skill — sibling of `probe-contact` / `probe-roundtrip`;
+ * the pattern is: run the real parser via runCascade (the pdfjs worker only
+ * resolves under the vitest transform — no standalone script), then show the
+ * section extractor's INPUT (the experience region it scanned) next to its
+ * OUTPUT (the parsed role entries) so a dropped/merged role is localizable.
+ *
+ * ── PII guardrail (same rules as probe-contact) ──
+ * 1. The input PDF is local-only. NEVER commit it. `tests/fixtures/pdfs/` is
+ *    synthetic-personas-only by policy.
+ * 2. The console + JSON output prints role field VALUES (titles/companies/…)
+ *    so the corruption is visible → scratch only. The full JSON goes to the
+ *    gitignored `internal/` dir. Do not paste raw values into an
+ *    issue/PR/Slack; cite the corruption by CATEGORY ("second role's header
+ *    demoted to a bullet under the first role").
+ *
+ * ── The "verify" pass ──
+ * There is no ground truth for a real résumé, so verification is a second,
+ * independent scan with the date-range regex. Date ranges are the strongest
+ * role-header signal, so the count of distinct date-range lines inside the
+ * experience region is a lower-bound oracle for how many roles SHOULD have
+ * segmented. The split localizes the failure:
+ *   - entries == 0 AND region has date-range lines → PARSER bug (roles are in
+ *     the region; entry segmentation dropped them)
+ *   - entries  <  date-range lines                → UNDER-SEGMENTED (a role
+ *     was likely merged into its neighbor — #341/#239 failure class)
+ *   - entries >=  date-range lines                → ok (dateless roles can
+ *     legitimately exceed the oracle)
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { runCascade } from "./cascade.ts";
+import { DATE_RANGE_RE } from "./regex.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe.runIf(process.env.RL_EXPERIENCE_PDF)(
+  "experience dev probe (RL_EXPERIENCE_PDF)",
+  () => {
+    it("extracts + verifies the experience section for RL_EXPERIENCE_PDF", async () => {
+      const path = process.env.RL_EXPERIENCE_PDF!;
+      const outDir =
+        process.env.RL_EXPERIENCE_OUT ??
+        join(HERE, "../../..", "internal/experience");
+
+      const cascade = await runCascade(new Uint8Array(readFileSync(path)));
+      const p = cascade.parsed;
+
+      const score = computeAnonymousAtsScore({
+        parsed: {
+          full_name: p.full_name,
+          email: p.email,
+          phone: p.phone,
+          location: p.location,
+          linkedin_url: p.linkedin_url,
+          summary: p.summary,
+          skills: p.skills,
+          experience: p.experience,
+          education: p.education,
+        },
+        fieldConfidence: cascade.fieldConfidence,
+        triggers: cascade.triggers,
+        rawText: cascade.rawText,
+        sections: cascade.sections,
+      });
+
+      // OUTPUT: the parsed role entries.
+      const entries = (p.experience ?? []).map((e) => ({
+        title: e.title || null,
+        company: e.company || null,
+        location: e.location ?? null,
+        start_date: e.start_date ?? null,
+        end_date: e.end_date ?? (e.is_current ? "Present" : null),
+        bullets: e.description
+          ? e.description.split("\n").filter((l) => l.trim()).length
+          : 0,
+      }));
+
+      // INPUT: the experience region the entry segmenter scanned.
+      const regionLines = [
+        ...(cascade.sections.byName.get("experience") ?? []),
+      ];
+
+      // Section-detection overview (all regions, line counts only).
+      const sectionOverview = [...cascade.sections.byName.entries()].map(
+        ([name, lines]) => `${name}(${lines.length})`,
+      );
+
+      // VERIFY: date-range lines inside the region are a lower-bound oracle
+      // for the role count. DATE_RANGE_RE is non-global; test per line.
+      const dateRangeLines = regionLines.filter((l) => DATE_RANGE_RE.test(l));
+      let verdict: string;
+      if (entries.length === 0 && dateRangeLines.length > 0)
+        verdict = `PARSER-MISS (0 entries; region has ${dateRangeLines.length} date-range lines)`;
+      else if (entries.length < dateRangeLines.length)
+        verdict = `UNDER-SEGMENTED (${entries.length} entries < ${dateRangeLines.length} date-range lines — a role likely merged into a neighbor)`;
+      else verdict = "ok";
+
+      const report = {
+        path,
+        score: {
+          overall: score.overall,
+          preLayoutOverall: score.preLayoutOverall,
+          layoutTriggers: [...score.layout.triggers],
+          layoutMultiplier: score.layout.multiplier,
+        },
+        sectionOverview,
+        entries,
+        regionLines,
+        dateRangeLines,
+        verdict,
+        triggers: [...cascade.triggers],
+      };
+
+      mkdirSync(outDir, { recursive: true });
+      const outFile = join(
+        outDir,
+        `experience-${basename(path).replace(/\.[^.]+$/, "")}.json`,
+      );
+      writeFileSync(outFile, JSON.stringify(report, null, 2));
+
+      console.log(
+        `RL_EXPERIENCE_PDF experience probe for ${path}:\n` +
+          `\n  Score: overall ${score.overall} (pre-layout ${score.preLayoutOverall}, ` +
+          `layout ×${score.layout.multiplier} [${score.layout.triggers.join(", ") || "none"}])\n` +
+          `\n  Sections detected: ${sectionOverview.join("  ")}\n` +
+          `\n  Parsed experience entries (${entries.length}):\n` +
+          (entries.length
+            ? entries
+                .map(
+                  (e, i) =>
+                    `    ${i + 1}. ${JSON.stringify(e.title)} @ ${JSON.stringify(
+                      e.company,
+                    )}  ${e.start_date ?? "?"} – ${e.end_date ?? "?"}  ` +
+                    `loc=${JSON.stringify(e.location)}  bullets=${e.bullets}`,
+                )
+                .join("\n")
+            : "    (none)") +
+          `\n\n  Experience region scanned (${regionLines.length} lines, ` +
+          `${dateRangeLines.length} with date ranges):\n` +
+          (regionLines.length
+            ? regionLines.map((l) => `    | ${l}`).join("\n")
+            : "    (empty — no experience region segmented)") +
+          `\n\n  Verify: ${verdict}` +
+          `\n\n  Full JSON → ${outFile}  ⚠️ gitignored; may carry PII, do NOT commit.`,
+      );
+
+      // Informational only: never fails the suite.
+      expect(true).toBe(true);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Adds `probe-experience`, the third `probe-*` parser probe (siblings: `probe-contact`, `probe-roundtrip`): a `RL_EXPERIENCE_PDF`-gated vitest harness (`src/lib/heuristics/probe-experience.test.ts`) plus its skill doc (`.claude/skills/probe-experience/SKILL.md`). It runs any résumé PDF — including a real, PII-bearing one — through the real cascade and prints the score, section overview, parsed role entries (title/company/location/dates/bullets), the experience region the segmenter scanned (INPUT vs OUTPUT), and an `ok / UNDER-SEGMENTED / PARSER-MISS` verdict from a date-range lower-bound oracle, so a dropped/merged role is localizable to line-assembly vs section-routing vs entry segmentation.

Same guardrails as the sibling probes: inert in CI (env-gated, never reddens the suite), JSON report written to the gitignored `internal/experience/`, PII rules documented in the SKILL.md.

Proven in use: this harness ran the 10-fixture parse-accuracy sweep that filed #346–#349 and produced the committed-fixture repro comment on #342.

Refs #341, #342 (triage tooling for those lanes; does not resolve them).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (probe skips when `RL_EXPERIENCE_PDF` unset — verified inert)
- [x] `npm run build` clean
- [x] Harness exercised end-to-end against 10 corpus fixtures across 4 provenance categories (reports in gitignored `internal/experience/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
