### PR TITLE
docs(test): point awesome-cv-cv KNOWN_FAILURES follow-up to #383

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -128,8 +128,8 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   //     "Company. City" prose false-positive had swallowed). Net +1 real role
   //     (16 → 17). That recovered role's header packs inline abbreviated dates
   //     ("Researcher … Mar. 2016 Exp. Jun. 2017"), so its title/start_date don't
-  //     round-trip cleanly yet — a SEPARATE header-shape weakness tracked as a
-  //     follow-up (#386). Recovering the role beats dropping it, so the experience
+  //     round-trip cleanly yet — a SEPARATE header-shape weakness tracked as
+  //     #383. Recovering the role beats dropping it, so the experience
   //     round-trip is baselined here rather than blocking the #341 fix.
   "latex/awesome-cv-cv.pdf": ["experience"],
 


### PR DESCRIPTION
Small doc-only follow-up to the merged #361.

#361's merge linked the `awesome-cv-cv` `KNOWN_FAILURES` baseline comment to **#386**, but **#383** was filed specifically as the follow-up for that comment ("this issue is that follow-up"). #383 and #386 are duplicates (same author, same awesome-cv-cv abbreviated-date round-trip bug); this makes **#383** canonical in the comment. #386 closed as a duplicate of #383.

Comment-only change in `corpus-roundtrip.test.ts` — no behavior change, no snapshot movement.

Refs #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)