### PR TITLE
test: scope 20s timeout to flaky fixture-read/roundtrip/render suites (#360)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -271,7 +271,10 @@ const CATEGORIES: Category[] = [
   "render",
 ];
 
-describe("corpus round-trip invariants (#293)", () => {
+// Fixture-read + full runCascade→render→runCascade round-trip per fixture is
+// slow under a coverage-instrumented full-suite `verify` run; scope a higher
+// timeout to just this suite rather than bumping vitest's global default (#360).
+describe("corpus round-trip invariants (#293)", { timeout: 20000 }, () => {
   const fixtures = walkPdfs(FIXTURE_ROOT);
 
   it("finds fixtures to round-trip", () => {

--- a/src/lib/heuristics/multi-experience-roundtrip.test.ts
+++ b/src/lib/heuristics/multi-experience-roundtrip.test.ts
@@ -39,7 +39,10 @@ function distinctLabels(exp: ReadonlyArray<{ section_label?: string }>): string[
   return out;
 }
 
-describe("#311 multiple experience sections — parse + round-trip", () => {
+// Fixture-read + runCascade/render round-trip is slow under a
+// coverage-instrumented full-suite `verify` run; scope a higher timeout to
+// just this suite rather than bumping vitest's global default (#360).
+describe("#311 multiple experience sections — parse + round-trip", { timeout: 20000 }, () => {
   it("parses two experience-category sections into labeled roles", async () => {
     const bytes = await fsp.readFile(FIXTURE);
     const cascade = await runCascade(new Uint8Array(bytes));

--- a/src/lib/pdf/render-ats-pdf.fonts.test.ts
+++ b/src/lib/pdf/render-ats-pdf.fonts.test.ts
@@ -79,7 +79,11 @@ const model = (text: string): AtsResumeModel => ({
   sections: [],
 });
 
-describe("Poppins font embed (#314)", () => {
+// Each case does a real fontkit Poppins-embed render (the failing glyph case
+// renders twice); slow under a coverage-instrumented full-suite `verify` run,
+// so scope a higher timeout to just this suite rather than bumping vitest's
+// global default (#360).
+describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetModules();

--- a/src/lib/pdf/skills-wrap-roundtrip.test.ts
+++ b/src/lib/pdf/skills-wrap-roundtrip.test.ts
@@ -89,6 +89,9 @@ const SYNTHETIC_SKILLS = [
 describe("#301 — multi-word skill does not split at the line-wrap boundary", () => {
   let reparsedSkills: string[];
 
+  // Fixture-read + runCascade/render round-trip is slow under a
+  // coverage-instrumented full-suite `verify` run; scope a higher timeout to
+  // just this hook rather than bumping vitest's global default (#360).
   beforeAll(async () => {
     const original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
     const withSyntheticSkills: CascadeResult = {
@@ -102,7 +105,7 @@ describe("#301 — multi-word skill does not split at the line-wrap boundary", (
     const bytes = await renderAtsResumePdf(model);
     const reparsed = await runCascade(bytes);
     reparsedSkills = reparsed.parsed.skills ?? [];
-  });
+  }, 20000);
 
   it("round-trips the same skill count (AC)", () => {
     expect(reparsedSkills.length).toBe(SYNTHETIC_SKILLS.length);

--- a/src/lib/score/group-bullets.test.ts
+++ b/src/lib/score/group-bullets.test.ts
@@ -236,6 +236,9 @@ describe("multi-line bullet pool is fully merged and correctly attributed (#162)
   // Merging wrapped continuations upstream (`mergeWrappedContinuations` in
   // `toSectionedResume`) makes the pool carry each bullet's full text, so it
   // matches its role by construction.
+  // Fixture-read + runCascade round-trip is slow under a coverage-instrumented
+  // full-suite `verify` run; scope a higher timeout to just this test rather
+  // than bumping vitest's global default (#360).
   it("recovers full wrapped-bullet text and attributes it to its role, not Other", async () => {
     const bytes = await fsp.readFile(
       join(
@@ -299,7 +302,7 @@ describe("multi-line bullet pool is fully merged and correctly attributed (#162)
     for (const t of fullText.slice(0, 3)) {
       expect(otherText.has(t)).toBe(false);
     }
-  });
+  }, 20000);
 });
 
 // ── suppressTitleOwnedBullets (#224) ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Several fixture-read + full `runCascade→render→re-parse` suites — plus the Poppins font-embed render suite — intermittently hit vitest's default **5000ms** per-test timeout under the coverage-instrumented full-suite `verify` run: worker-pool contention + coverage instrumentation, not assertion failure. A flaky infra timeout that reds the gate non-deterministically (surfaced during PR #359 / issue #355).

Scope a **20000ms** budget to just the heavy paths, leaving vitest's global default and all fast in-memory tests untouched — so a slow-but-correct run doesn't red `verify` while genuinely-slow regressions elsewhere stay caught.

Per file:
- `corpus-roundtrip.test.ts` — per-`describe` `{ timeout: 20000 }`
- `multi-experience-roundtrip.test.ts` — per-`describe` `{ timeout: 20000 }`
- `skills-wrap-roundtrip.test.ts` — per-`beforeAll` hook timeout (heavy render path only)
- `group-bullets.test.ts` — per-`it` trailing arg on the single fixture-read test
- `render-ats-pdf.fonts.test.ts` — per-`describe` `{ timeout: 20000 }` (fontkit Poppins-embed renders; caught by the Stop-hook `verify` run after the first four)

No assertions weakened or skipped — only timeout budgets change. The Poppins font-URL fallback log noise is left as a deferred follow-up per the issue.

Closes #360

## Test plan

- [x] `npm run typecheck` clean
- [x] The target suites pass in isolation
- [x] `npm run lint` clean
- [x] Pre-push `npm run verify` green (full coverage-instrumented suite)