### PR TITLE
feat(result,edit): two-column warning + edit validation (#396, #398)

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -25,7 +25,7 @@ const FONTS_UNMAPPABLE_BLURB =
 // fonts_unmappable, two-column output is still usable, so this renders as a
 // warning banner alongside the score rather than replacing the whole card.
 const TWO_COLUMN_BLURB =
-  "This resume uses a two-column layout. Many ATS parsers read text column-by-column-merged or out of order, scrambling the result. The reconstructed text below shows what a generic parser actually extracted — for the most reliable ATS parsing, use a single-column layout.";
+  "This resume uses a two-column layout. Text extractors often read the columns out of order — merging or interleaving them. The reconstructed text below is what a generic parser actually pulled out; if it looks scrambled, that's the ATS risk. A single-column layout parses most reliably.";
 
 type SourceKind = "pdf" | "docx";
 

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import { computeAnonymousAtsScore, type AnonymousAtsScore } from "../lib/score/score.ts";
 import type { EditableParse } from "../hooks/useEditableParse.ts";
-import { Card, StatusBadge, Button } from "@design-system";
+import { Card, StatusBadge, Button, ErrorState } from "@design-system";
 import { FeedbackPanel } from "./features/FeedbackPanel.tsx";
 import { AtsScoreReadout } from "./features/AtsScoreReadout.tsx";
 import { isScoreRevealed } from "../lib/contact.ts";
@@ -20,6 +20,12 @@ import { ResultDetailTabs } from "./features/ResultDetailTabs.tsx";
 // LAYOUT_TRIGGER_BLURBS for fonts_unmappable is still needed by LimitedParsingCard.
 const FONTS_UNMAPPABLE_BLURB =
   "Text is present in the source but uses custom font encodings that don't decode to characters. Common with Framer, Affinity, and some InDesign exports.";
+
+// Two-column layout warning (#356) — inline, non-blocking. Unlike
+// fonts_unmappable, two-column output is still usable, so this renders as a
+// warning banner alongside the score rather than replacing the whole card.
+const TWO_COLUMN_BLURB =
+  "This resume uses a two-column layout. Many ATS parsers read text column-by-column-merged or out of order, scrambling the result. The reconstructed text below shows what a generic parser actually extracted — for the most reliable ATS parsing, use a single-column layout.";
 
 type SourceKind = "pdf" | "docx";
 
@@ -143,6 +149,11 @@ function ParsedCard({
   const scoreRevealed =
     !isBlankAuthored || isScoreRevealed(activeResult, edit.contactOverrides);
 
+  // Two-column layout warning (#356) — detected but previously never
+  // surfaced to the user. Inline, not a full-page takeover: two-column
+  // output is still usable, unlike the fonts_unmappable case above.
+  const isTwoColumn = result.triggers.includes("two_column");
+
   return (
     // Two stacked surfaces: the score "summary" card on top, the tabbed detail
     // card below. The gap + each card's own border draws the separator the
@@ -166,6 +177,10 @@ function ParsedCard({
           onResetAll={edit.resetAll}
           onReset={onReset}
         />
+
+        {isTwoColumn && (
+          <ErrorState tone="warning">{TWO_COLUMN_BLURB}</ErrorState>
+        )}
 
         {scoreRevealed ? (
           <AtsScoreReadout score={activeScore} />

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -20,6 +20,12 @@
 
 import { formatLinkDisplay, type ContactDisplayField } from "../../lib/contact.ts";
 import { EditableField } from "@design-system";
+import {
+  validateEmail,
+  validatePhone,
+  validateUrl,
+  type FieldValidator,
+} from "../../lib/edit/field-validators.ts";
 import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
 
 /** The inline-editable contact fields, mapped 1:1 to their `ContactOverrides`
@@ -38,6 +44,18 @@ const EDITABLE_KEYS: Record<string, keyof ContactOverrides> = {
 };
 
 type Commit = (key: keyof ContactOverrides, v: string) => void;
+
+/** Shape validator per editable contact field. Name/location are free-form
+ *  (a "parser audit, not a judge" — any string is a legitimate name), so they
+ *  map to no validator; email/phone/link fields each get a shape check. */
+const FIELD_VALIDATORS: Partial<Record<string, FieldValidator>> = {
+  email: validateEmail,
+  phone: validatePhone,
+  linkedin_url: validateUrl,
+  github_url: validateUrl,
+  portfolio_url: validateUrl,
+  website_url: validateUrl,
+};
 
 interface ContactDetailsProps {
   contactLine: ContactDisplayField[];
@@ -132,6 +150,7 @@ function EditableValue({
       placeholder={`${field.label} not detected`}
       label={field.label}
       textSize="sm"
+      validate={FIELD_VALIDATORS[field.key]}
       onCommit={(v) => commit(ovKey, v)}
     />
   );

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -47,15 +47,27 @@ type Commit = (key: keyof ContactOverrides, v: string) => void;
 
 /** Shape validator per editable contact field. Name/location are free-form
  *  (a "parser audit, not a judge" — any string is a legitimate name), so they
- *  map to no validator; email/phone/link fields each get a shape check. */
+ *  map to no validator; email/link fields each get a shape check. Phone is
+ *  resolved separately (see `validatorFor`) because it needs the parsed
+ *  location threaded in for its region default. */
 const FIELD_VALIDATORS: Partial<Record<string, FieldValidator>> = {
   email: validateEmail,
-  phone: validatePhone,
   linkedin_url: validateUrl,
   github_url: validateUrl,
   portfolio_url: validateUrl,
   website_url: validateUrl,
 };
+
+/** Resolve the validator for a field. Phone binds the résumé's parsed location
+ *  so non-US local-form numbers aren't falsely flagged (mirrors the parser's
+ *  `extractContact`, which wires `regionFromLocation` for the same reason). */
+function validatorFor(
+  key: string,
+  location: string | undefined,
+): FieldValidator | undefined {
+  if (key === "phone") return (v) => validatePhone(v, location);
+  return FIELD_VALIDATORS[key];
+}
 
 interface ContactDetailsProps {
   contactLine: ContactDisplayField[];
@@ -70,6 +82,9 @@ export function ContactDetails({
   editable,
   commit,
 }: ContactDetailsProps) {
+  // The parsed location, threaded into the phone validator's region default so a
+  // non-US local-form number isn't falsely flagged (see `validatorFor`).
+  const location = contactLine.find((f) => f.key === "location")?.value;
   return (
     <>
       {/* Contact line: location / email / phone, pipe-joined, present-only. */}
@@ -78,7 +93,7 @@ export function ContactDetails({
           {contactLine.map((field, i) => (
             <span key={field.key} className="inline-flex items-center gap-x-2">
               {i > 0 && <span className="text-content-muted">|</span>}
-              {renderContactValue(field, editable, commit)}
+              {renderContactValue(field, editable, commit, location)}
             </span>
           ))}
         </p>
@@ -134,11 +149,13 @@ function EditableValue({
   ovKey,
   commit,
   displayValue,
+  location,
 }: {
   field: ContactDisplayField;
   ovKey: keyof ContactOverrides;
   commit: Commit;
   displayValue?: string;
+  location?: string;
 }) {
   const absent = field.gated && field.reason === "absent";
   const lowConfidence = field.gated && field.reason === "low_confidence";
@@ -150,7 +167,7 @@ function EditableValue({
       placeholder={`${field.label} not detected`}
       label={field.label}
       textSize="sm"
-      validate={FIELD_VALIDATORS[field.key]}
+      validate={validatorFor(field.key, location)}
       onCommit={(v) => commit(ovKey, v)}
     />
   );
@@ -183,10 +200,13 @@ function renderContactValue(
   field: ContactDisplayField,
   editable: boolean,
   commit: Commit,
+  location: string | undefined,
 ) {
   const ovKey = EDITABLE_KEYS[field.key];
   if (editable && ovKey !== undefined) {
-    return <EditableValue field={field} ovKey={ovKey} commit={commit} />;
+    return (
+      <EditableValue field={field} ovKey={ovKey} commit={commit} location={location} />
+    );
   }
   return field.gated && field.reason === "absent" ? (
     <MissingToken label={field.label} />

--- a/src/components/features/FeedbackPanel.test.tsx
+++ b/src/components/features/FeedbackPanel.test.tsx
@@ -22,7 +22,7 @@
  * `useModelSelection.integration.test.tsx`.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
@@ -53,31 +53,13 @@ async function mountPanel(opts: {
   return container;
 }
 
-// Persisted render-state keys FeedbackPanel writes (#193/#194). The CI
-// localStorage shim has no .clear(), so remove them individually; wrap in
-// try/catch to match the component's own fail-silent storage access.
-function resetFeedbackStorage() {
-  for (const k of [
-    "rl_feedback_seen",
-    "rl_feedback_submitted",
-    "rl_star_cta_seen",
-    "rl_gh_stars_cache",
-  ]) {
-    try {
-      localStorage.removeItem(k);
-    } catch {
-      /* shim/private-mode — ignore */
-    }
-  }
-}
-
-// Start each test from clean persisted state — CI shares localStorage across
-// test files too, so another file's FeedbackPanel mount could otherwise leak
-// rl_feedback_submitted / rl_feedback_seen into this file's first test.
-beforeEach(() => {
-  resetFeedbackStorage();
-});
-
+// FeedbackPanel persists render-state to localStorage (rl_feedback_seen /
+// rl_feedback_submitted / rl_star_cta_seen / rl_gh_stars_cache, #193/#194).
+// Without a clean store, the submit test flips later mounts into "done"
+// (renders null) and the seen counter accumulates into "compact" mode — both
+// hide the form. The global setup (src/test-setup.ts, #398) installs a fresh
+// in-memory localStorage before every test, so every test starts in the "full"
+// state without any per-file clearing bookkeeping.
 afterEach(() => {
   if (root) act(() => root!.unmount());
   container?.remove();
@@ -85,12 +67,6 @@ afterEach(() => {
   container = undefined;
   vi.resetModules();
   vi.clearAllMocks();
-  // FeedbackPanel persists render-state to localStorage (rl_feedback_seen /
-  // rl_feedback_submitted, #193). jsdom localStorage is shared across tests in
-  // a file, so without this the submit test flips later mounts into "done"
-  // (renders null) and the seen counter accumulates into "compact" mode —
-  // both hide the form. Clear it so every test starts in the fresh "full" state.
-  resetFeedbackStorage();
 });
 
 describe("FeedbackPanel", () => {

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -29,6 +29,7 @@ import type {
 import { buildEducationDates } from "../../lib/score/entry-dates.ts";
 import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
 import { Button, EditableField } from "@design-system";
+import { validateDate } from "../../lib/edit/field-validators.ts";
 import { AddPill, RemoveButton } from "./ReconstructedAdd.tsx";
 
 /** Map an EducationEntry field name to the flat AddedEntry field it edits.
@@ -182,6 +183,7 @@ function EducationEntry({
           placeholder="start"
           label="Education start date"
           textSize="xs"
+          validate={validateDate}
           onCommit={(v) => onFieldChange("start_date", v)}
         />
         <span aria-hidden="true">–</span>
@@ -190,6 +192,7 @@ function EducationEntry({
           placeholder="end"
           label="Education end date"
           textSize="xs"
+          validate={validateDate}
           onCommit={(v) => onFieldChange("end_date", v)}
         />
         {yearOnly && <span className="text-content-muted">{dates}</span>}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -21,6 +21,7 @@ import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { needsAttention } from "../../lib/score/group-bullets.ts";
 import type { BulletObservation } from "../../lib/score/score.ts";
 import { EditableField } from "@design-system";
+import { validateDate } from "../../lib/edit/field-validators.ts";
 import type {
   ExperienceFieldOverrides,
   BulletOverrides,
@@ -425,6 +426,7 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
             placeholder="start date"
             label="Start date"
             textSize="xs"
+            validate={validateDate}
             onCommit={(v) => onFieldChange("start_date", v)}
           />
           <span aria-hidden="true">–</span>
@@ -433,6 +435,7 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
             placeholder="end date"
             label="End date"
             textSize="xs"
+            validate={validateDate}
             onCommit={(v) => onFieldChange("end_date", v)}
           />
         </span>

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -102,14 +102,18 @@ interface EditableFieldProps {
 /**
  * Soft, non-blocking shape-warning glyph shown beside a read-mode value whose
  * `validate` returned a message. A small stroke triangle in the semantic
- * warning-icon token — the message rides on `title` (hover) and `aria-label`
- * (assistive tech), so the warning is never colour-only.
+ * warning-icon token. The `<title>` gives a mouse-hover tooltip; the glyph is
+ * `aria-hidden` because it lives INSIDE the read-mode button's subtree, and an
+ * explicit `aria-label` on that button suppresses ALL descendant text from the
+ * accessible name (ARIA name-from-author precedence). So the message would be
+ * silently dropped for screen readers here — instead the button's own
+ * aria-label carries the warning (see the read-mode span), keeping the signal
+ * non-colour-only for assistive tech.
  */
 function ShapeWarningGlyph({ message }: { message: string }) {
   return (
     <svg
-      role="img"
-      aria-label={message}
+      aria-hidden="true"
       className="ml-1 inline-block h-3.5 w-3.5 shrink-0 align-text-bottom text-feedback-warning-icon"
       viewBox="0 0 24 24"
       fill="none"
@@ -303,7 +307,10 @@ export function EditableField({
     <span
       role="button"
       tabIndex={0}
-      aria-label={`Edit ${label}`}
+      // Fold the shape warning into the accessible name: an explicit aria-label
+      // on this button suppresses the inner glyph's <title>, so screen readers
+      // would otherwise get zero warning signal (WCAG 1.4.1 — colour-only).
+      aria-label={warning ? `Edit ${label} — ${warning}` : `Edit ${label}`}
       onClick={startEdit}
       onKeyDown={(e: ReactKeyboardEvent) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -85,6 +85,45 @@ interface EditableFieldProps {
    * unchanged in behavior.
    */
   multiline?: boolean;
+  /**
+   * Optional SHAPE validator (ADDITIVE, opt-in). Runs against the current
+   * committed `value` in read mode. Returns `null` when the value is a clean
+   * shape, or a short message when it is not (e.g. `banana` in a date field).
+   *
+   * NON-BLOCKING by design: a shape-fail never rejects the commit or traps the
+   * user in edit mode — the value still commits and a soft warning icon appears
+   * beside it in read mode, carrying the message on hover / for screen readers.
+   * Omitting this prop leaves callers byte-for-byte unchanged (no icon, no
+   * behavior change).
+   */
+  validate?: (value: string) => string | null;
+}
+
+/**
+ * Soft, non-blocking shape-warning glyph shown beside a read-mode value whose
+ * `validate` returned a message. A small stroke triangle in the semantic
+ * warning-icon token — the message rides on `title` (hover) and `aria-label`
+ * (assistive tech), so the warning is never colour-only.
+ */
+function ShapeWarningGlyph({ message }: { message: string }) {
+  return (
+    <svg
+      role="img"
+      aria-label={message}
+      className="ml-1 inline-block h-3.5 w-3.5 shrink-0 align-text-bottom text-feedback-warning-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <title>{message}</title>
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+      <line x1="12" x2="12" y1="9" y2="13" />
+      <line x1="12" x2="12.01" y1="17" y2="17" />
+    </svg>
+  );
 }
 
 export function EditableField({
@@ -98,6 +137,7 @@ export function EditableField({
   textSize = "sm",
   display = "flex",
   multiline = false,
+  validate,
 }: EditableFieldProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -248,6 +288,10 @@ export function EditableField({
   // editability, which (unlike a hover-revealed pencil) also works on touch.
   const inlineFlow = display === "inline";
 
+  // Non-blocking shape check: run the optional validator against the committed
+  // value only when there is one to check. An absent field is never a typo.
+  const warning = validate && hasValue ? validate(value ?? "") : null;
+
   // Inline mode: plain `inline` so the value wraps as text and trailing siblings
   // flow after the last word. Flex mode: `inline-flex` atom. The negative margin
   // offsets the hover-tint padding so the tinted box doesn't shift the layout.
@@ -281,6 +325,7 @@ export function EditableField({
         .join(" ")}
     >
       {hasValue ? (displayValue ?? value) : placeholder}
+      {warning && <ShapeWarningGlyph message={warning} />}
     </span>
   );
 }

--- a/src/hooks/__test-utils__/memory-storage.ts
+++ b/src/hooks/__test-utils__/memory-storage.ts
@@ -20,6 +20,12 @@
 
 class MemoryStorage {
   private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
   getItem(k: string): string | null {
     return this.map.get(k) ?? null;
   }

--- a/src/hooks/__test-utils__/memory-storage.ts
+++ b/src/hooks/__test-utils__/memory-storage.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * In-memory `Storage` shim for hook tests that persist to `localStorage`.
+ *
+ * Two environments need it:
+ *  - **Node env** (vitest's default per `vite.config.ts`), where `localStorage`
+ *    simply isn't defined.
+ *  - **jsdom env**, where Node 22+ ships a *built-in* global `localStorage` that
+ *    (without `--localstorage-file`) exposes no working `Storage` — `.clear`/
+ *    `.setItem` are absent — and, being a non-configurable global, shadows
+ *    jsdom's own `window.localStorage` (`globalThis.localStorage ===
+ *    window.localStorage`). A bare `localStorage.clear()` then throws on newer
+ *    runtimes: green on CI's Node 20, red on Node 25 locally (#398).
+ *
+ * `installMemoryLocalStorage()` in a `beforeEach` gives every suite a real,
+ * per-test-fresh `Storage` regardless of the underlying runtime.
+ */
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.map.get(k) ?? null;
+  }
+  setItem(k: string, v: string): void {
+    this.map.set(k, String(v));
+  }
+  removeItem(k: string): void {
+    this.map.delete(k);
+  }
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+/**
+ * Replace the global `localStorage` with a fresh in-memory shim and return it.
+ * Call in `beforeEach` so each test starts from clean persisted state.
+ */
+export function installMemoryLocalStorage(): Storage {
+  const storage = new MemoryStorage() as unknown as Storage;
+  (globalThis as { localStorage?: Storage }).localStorage = storage;
+  return storage;
+}

--- a/src/hooks/useAnalyzedResume.test.tsx
+++ b/src/hooks/useAnalyzedResume.test.tsx
@@ -22,6 +22,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { useAnalyzedResume, type AnalyzedResume } from "./useAnalyzedResume.ts";
 import { isScoreRevealed } from "../lib/contact.ts";
 import { BLANK_DRAFT_STORAGE_KEY } from "./useResumeAnalysis.ts";
+import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -48,7 +49,7 @@ function unmount(): void {
 }
 
 beforeEach(() => {
-  localStorage.clear();
+  installMemoryLocalStorage();
   mount();
 });
 

--- a/src/hooks/useAnalyzedResume.test.tsx
+++ b/src/hooks/useAnalyzedResume.test.tsx
@@ -22,7 +22,6 @@ import { createRoot, type Root } from "react-dom/client";
 import { useAnalyzedResume, type AnalyzedResume } from "./useAnalyzedResume.ts";
 import { isScoreRevealed } from "../lib/contact.ts";
 import { BLANK_DRAFT_STORAGE_KEY } from "./useResumeAnalysis.ts";
-import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -49,7 +48,6 @@ function unmount(): void {
 }
 
 beforeEach(() => {
-  installMemoryLocalStorage();
   mount();
 });
 

--- a/src/hooks/useDownloadPdf.test.tsx
+++ b/src/hooks/useDownloadPdf.test.tsx
@@ -22,7 +22,6 @@ import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import { computeAnonymousAtsScore } from "../lib/score/score.ts";
 import { BLANK_DRAFT_STORAGE_KEY } from "./useResumeAnalysis.ts";
-import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 const tracked: Array<{ source: string }> = [];
 vi.mock("../lib/analytics.ts", () => ({
@@ -86,7 +85,6 @@ function mount(result: CascadeResult): void {
 
 beforeEach(() => {
   tracked.length = 0;
-  installMemoryLocalStorage();
 
   globalThis.URL.createObjectURL = vi.fn(
     () => "blob:mock",

--- a/src/hooks/useDownloadPdf.test.tsx
+++ b/src/hooks/useDownloadPdf.test.tsx
@@ -22,6 +22,7 @@ import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import { computeAnonymousAtsScore } from "../lib/score/score.ts";
 import { BLANK_DRAFT_STORAGE_KEY } from "./useResumeAnalysis.ts";
+import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 const tracked: Array<{ source: string }> = [];
 vi.mock("../lib/analytics.ts", () => ({
@@ -85,7 +86,7 @@ function mount(result: CascadeResult): void {
 
 beforeEach(() => {
   tracked.length = 0;
-  localStorage.clear();
+  installMemoryLocalStorage();
 
   globalThis.URL.createObjectURL = vi.fn(
     () => "blob:mock",

--- a/src/hooks/useModelSelection.integration.test.tsx
+++ b/src/hooks/useModelSelection.integration.test.tsx
@@ -36,6 +36,7 @@ import {
 } from "./useModelSelection.ts";
 import { MODEL_REGISTRY } from "../lib/webllm/models.ts";
 import type { LicenseType } from "../lib/webllm/models.ts";
+import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 const restrictedModel = MODEL_REGISTRY.find(
   (m) => m.licenseType === "Restricted-Community",
@@ -68,11 +69,9 @@ function Probe({
 
 beforeEach(() => {
   // Node 22+ ships a built-in global `localStorage` that shadows jsdom's
-  // `Storage` and exposes no `clear()` method, so a bare `localStorage.clear()`
-  // throws on newer runtimes (green on CI's Node 20, red on Node 25 locally).
-  // Optional-chain it to match the store's own defensive access; the per-key
-  // cleanup that actually matters is done by the reset helper below.
-  globalThis.localStorage?.clear?.();
+  // `Storage` and exposes no working methods, so install a fresh in-memory
+  // shim per test rather than depending on the runtime's global (#398).
+  installMemoryLocalStorage();
   _resetPersistedModelSelectionForTesting();
 });
 

--- a/src/hooks/useModelSelection.integration.test.tsx
+++ b/src/hooks/useModelSelection.integration.test.tsx
@@ -36,7 +36,6 @@ import {
 } from "./useModelSelection.ts";
 import { MODEL_REGISTRY } from "../lib/webllm/models.ts";
 import type { LicenseType } from "../lib/webllm/models.ts";
-import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 const restrictedModel = MODEL_REGISTRY.find(
   (m) => m.licenseType === "Restricted-Community",
@@ -68,10 +67,8 @@ function Probe({
 }
 
 beforeEach(() => {
-  // Node 22+ ships a built-in global `localStorage` that shadows jsdom's
-  // `Storage` and exposes no working methods, so install a fresh in-memory
-  // shim per test rather than depending on the runtime's global (#398).
-  installMemoryLocalStorage();
+  // The fresh in-memory localStorage shim is installed globally per test
+  // (src/test-setup.ts, #398); just reset the hook's persisted state here.
   _resetPersistedModelSelectionForTesting();
 });
 

--- a/src/hooks/useModelSelection.test.ts
+++ b/src/hooks/useModelSelection.test.ts
@@ -18,13 +18,11 @@ import {
   writePersistedModelId,
 } from "./useModelSelection.ts";
 import { DEFAULT_MODEL_ID, MODEL_REGISTRY } from "../lib/webllm/models.ts";
-import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
-// Vitest defaults to Node env (per vite.config.ts), where `localStorage`
-// isn't defined. Provide a tiny in-memory shim so the hook's safeGet/safeSet
-// have something real to drive.
+// The in-memory localStorage shim is installed globally (src/test-setup.ts), so
+// the hook's safeGet/safeSet have something real to drive; just reset the hook's
+// persisted state per test.
 beforeEach(() => {
-  installMemoryLocalStorage();
   _resetPersistedModelSelectionForTesting();
 });
 

--- a/src/hooks/useModelSelection.test.ts
+++ b/src/hooks/useModelSelection.test.ts
@@ -18,29 +18,13 @@ import {
   writePersistedModelId,
 } from "./useModelSelection.ts";
 import { DEFAULT_MODEL_ID, MODEL_REGISTRY } from "../lib/webllm/models.ts";
+import { installMemoryLocalStorage } from "./__test-utils__/memory-storage.ts";
 
 // Vitest defaults to Node env (per vite.config.ts), where `localStorage`
 // isn't defined. Provide a tiny in-memory shim so the hook's safeGet/safeSet
 // have something real to drive.
-class MemoryStorage {
-  private map = new Map<string, string>();
-  getItem(k: string): string | null {
-    return this.map.get(k) ?? null;
-  }
-  setItem(k: string, v: string): void {
-    this.map.set(k, v);
-  }
-  removeItem(k: string): void {
-    this.map.delete(k);
-  }
-  clear(): void {
-    this.map.clear();
-  }
-}
-
 beforeEach(() => {
-  (globalThis as { localStorage?: Storage }).localStorage =
-    new MemoryStorage() as unknown as Storage;
+  installMemoryLocalStorage();
   _resetPersistedModelSelectionForTesting();
 });
 

--- a/src/lib/edit/field-validators.test.ts
+++ b/src/lib/edit/field-validators.test.ts
@@ -59,6 +59,22 @@ describe("validateDate", () => {
     expect(validateDate("banana 2020")).not.toBeNull();
     expect(validateDate("hired 2020")).not.toBeNull();
   });
+
+  it("flags an unfilled Word/Office template placeholder", () => {
+    // The parser's DATE_ANCHOR recognizes `Month`/`Year` so it can drop these
+    // downstream; the edit surface must agree they aren't real dates (else the
+    // score says "missing dates" while the edit field shows no warning).
+    for (const v of [
+      "Month Year",
+      "Month YYYY",
+      "Mon Year",
+      "Mon YYYY",
+      "Month Year – Month Year",
+      "Month Year to Month Year",
+    ]) {
+      expect(validateDate(v), `expected flag: ${v}`).not.toBeNull();
+    }
+  });
 });
 
 describe("validateEmail", () => {
@@ -118,6 +134,13 @@ describe("validatePhone", () => {
 
   it("accepts a valid international number", () => {
     expect(validatePhone("+44 20 7946 0958")).toBeNull();
+  });
+
+  it("uses the parsed location's region so a local-form number isn't falsely flagged", () => {
+    // A UK local form (no +44) is invalid under the US default but valid once
+    // the résumé's UK location is threaded through (mirrors extractContact).
+    expect(validatePhone("020 7946 0958")).not.toBeNull();
+    expect(validatePhone("020 7946 0958", "London, United Kingdom")).toBeNull();
   });
 
   it("treats an empty field as clean", () => {

--- a/src/lib/edit/field-validators.test.ts
+++ b/src/lib/edit/field-validators.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  validateDate,
+  validateEmail,
+  validateUrl,
+  validatePhone,
+} from "./field-validators.ts";
+
+describe("validateDate", () => {
+  it("accepts the résumé date forms the parser understands", () => {
+    const clean = [
+      "Present",
+      "Current",
+      "Now",
+      "Ongoing",
+      "2020",
+      "1998",
+      "Jan 2020",
+      "January 2020",
+      "Jan. 2020",
+      "Sept 2019",
+      "May '19",
+      "08/2020",
+      "8/2020",
+      "Summer 2013",
+      "20XX", // redacted placeholder — odd but real, must not flag
+      "2020 – 2023",
+      "2020 - 2023",
+      "Jan 2020 – Present",
+      "May 2019 to Aug 2021",
+      "March 20XX – December 20XX", // redacted range
+    ];
+    for (const v of clean) {
+      expect(validateDate(v), `expected clean: ${v}`).toBeNull();
+    }
+  });
+
+  it("does not flag a future year (parser audit, not a judge)", () => {
+    expect(validateDate("2035")).toBeNull();
+    expect(validateDate("Jan 2099")).toBeNull();
+  });
+
+  it("treats an empty / cleared field as clean, never a typo", () => {
+    expect(validateDate("")).toBeNull();
+    expect(validateDate("   ")).toBeNull();
+  });
+
+  it("flags a bare word or garbage typed into a date field", () => {
+    for (const v of ["banana", "asdf", "hello world", "N/A", "12345", "sometime"]) {
+      expect(validateDate(v), `expected flag: ${v}`).not.toBeNull();
+    }
+  });
+
+  it("flags a value that merely CONTAINS a date but is not a date shape", () => {
+    // Guards against the `^a|b$` anchor trap — a leading garbage token must fail.
+    expect(validateDate("banana 2020")).not.toBeNull();
+    expect(validateDate("hired 2020")).not.toBeNull();
+  });
+});
+
+describe("validateEmail", () => {
+  it("accepts RFC-ish addresses incl. synthetic fixtures", () => {
+    for (const v of [
+      "alice@example.com",
+      "a.b+tag@sub.example.co.uk",
+      "jane_doe@example.org",
+    ]) {
+      expect(validateEmail(v), `expected clean: ${v}`).toBeNull();
+    }
+  });
+
+  it("treats an empty field as clean", () => {
+    expect(validateEmail("")).toBeNull();
+  });
+
+  it("flags non-email shapes", () => {
+    for (const v of ["banana", "alice@example", "alice example.com", "@example.com", "alice@"]) {
+      expect(validateEmail(v), `expected flag: ${v}`).not.toBeNull();
+    }
+  });
+});
+
+describe("validateUrl", () => {
+  it("accepts URL-ish link shapes incl. synthetic fixtures", () => {
+    for (const v of [
+      "linkedin.com/in/janedoe",
+      "example.com/in/janedoe",
+      "https://www.linkedin.com/in/janedoe",
+      "https://github.com/janedoe",
+      "github.com/janedoe",
+      "janedoe.dev",
+      "https://janedoe.example.com/portfolio?ref=cv",
+    ]) {
+      expect(validateUrl(v), `expected clean: ${v}`).toBeNull();
+    }
+  });
+
+  it("treats an empty field as clean", () => {
+    expect(validateUrl("")).toBeNull();
+  });
+
+  it("flags non-URL shapes", () => {
+    for (const v of ["banana", "just some text", "alice@example.com", "in/janedoe"]) {
+      expect(validateUrl(v), `expected flag: ${v}`).not.toBeNull();
+    }
+  });
+});
+
+describe("validatePhone", () => {
+  it("accepts a valid synthetic reserved US number", () => {
+    // Real area code + 555-01xx fictional range — passes libphonenumber isValid().
+    expect(validatePhone("(312) 555-0123")).toBeNull();
+    expect(validatePhone("312-555-0123")).toBeNull();
+  });
+
+  it("accepts a valid international number", () => {
+    expect(validatePhone("+44 20 7946 0958")).toBeNull();
+  });
+
+  it("treats an empty field as clean", () => {
+    expect(validatePhone("")).toBeNull();
+  });
+
+  it("flags a bare word or an unparseable / too-short number", () => {
+    for (const v of ["banana", "123", "call me", "(555) 010-0123"]) {
+      expect(validatePhone(v), `expected flag: ${v}`).not.toBeNull();
+    }
+  });
+});

--- a/src/lib/edit/field-validators.ts
+++ b/src/lib/edit/field-validators.ts
@@ -29,7 +29,7 @@ import {
   DATE_RANGE_RE,
   EMAIL_RE,
 } from "../heuristics/regex.ts";
-import { normalizePhone } from "../heuristics/phone.ts";
+import { normalizePhone, regionFromLocation } from "../heuristics/phone.ts";
 
 /** A field validator: `null` when clean, else a short shape-fail message. */
 export type FieldValidator = (value: string) => string | null;
@@ -57,13 +57,31 @@ const DATE_FIELD_RE = new RegExp(
   "i",
 );
 
+// Unfilled Word/Office template placeholders. `DATE_ANCHOR`'s grammar
+// deliberately RECOGNIZES these (`MONTH_OR_PLACEHOLDER` accepts `Month`,
+// `YEAR_FORMS` accepts `Year`) so the parser can spot and drop them downstream —
+// which means `DATE_FIELD_RE` alone would treat `Month Year` as a clean shape.
+// The score's completeness signal flags such a role as "missing dates", so the
+// edit surface must agree: a value made ONLY of placeholder tokens (single or a
+// range of them) is rejected before the general shape check. Note `20XX` is NOT
+// a placeholder — it is a real redaction the user is authoritative over.
+const DATE_PLACEHOLDER_TOKEN = String.raw`(?:(?:Mon|Month)\s+)?(?:Year|YYYY)`;
+const DATE_PLACEHOLDER_RE = new RegExp(
+  `^\\s*${DATE_PLACEHOLDER_TOKEN}(?:\\s*(?:[–—-]|to)\\s*${DATE_PLACEHOLDER_TOKEN})?\\s*$`,
+  "i",
+);
+
 /**
  * Flag a start/end date field that is the wrong shape (e.g. `banana`), while
  * passing every résumé date form the parser recognizes. Never flags an empty
- * field or an odd-but-real date (future years, redacted `20XX`, etc.).
+ * field or an odd-but-real date (future years, redacted `20XX`, etc.). Unfilled
+ * template placeholders (`Month Year`, `Mon YYYY`) are flagged — they are not a
+ * real date, and the score already counts them as missing.
  */
 export const validateDate: FieldValidator = (value) => {
   if (value.trim() === "") return null;
+  if (DATE_PLACEHOLDER_RE.test(value))
+    return "Looks like an unfilled template placeholder — replace it with a real date";
   return DATE_FIELD_RE.test(value)
     ? null
     : "Doesn't look like a date (try “Jan 2020”, “2020”, or “Present”)";
@@ -113,14 +131,22 @@ export const validateUrl: FieldValidator = (value) => {
 
 /**
  * Flag a phone field libphonenumber can't read as a valid number. Reuses the
- * parser's `normalizePhone` (US default region) so the edit surface and the
- * extractor agree on validity. Synthetic reserved numbers — a real area code
- * with the `555-01xx` fictional range, e.g. `(312) 555-0123` — pass `isValid()`;
- * bare words and too-short digit runs are flagged.
+ * parser's `normalizePhone` so the edit surface and the extractor agree on
+ * validity. Synthetic reserved numbers — a real area code with the `555-01xx`
+ * fictional range, e.g. `(312) 555-0123` — pass `isValid()`; bare words and
+ * too-short digit runs are flagged.
+ *
+ * `location` threads the résumé's parsed location through to the region default,
+ * exactly as `extractContact` does — so a UK user typing a local-form number
+ * (`020 7946 0958`, no `+44`) isn't falsely flagged. Falls back to `"US"` when
+ * the location is absent or unmapped, matching `normalizePhone`'s own default.
  */
-export const validatePhone: FieldValidator = (value) => {
+export const validatePhone = (
+  value: string,
+  location?: string,
+): string | null => {
   if (value.trim() === "") return null;
-  const parsed = normalizePhone(value);
+  const parsed = normalizePhone(value, regionFromLocation(location) ?? "US");
   return parsed && parsed.isValid
     ? null
     : "Doesn't look like a valid phone number";

--- a/src/lib/edit/field-validators.ts
+++ b/src/lib/edit/field-validators.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Shape validators for the inline-edit fields on the reconstructed résumé (#357).
+ *
+ * These are **shape** checks, not judgments. ResumeLint is a "parser audit, not
+ * a judge": the user is authoritative over their own résumé, so future dates,
+ * unusual company names, redacted placeholders, and other odd-but-real values
+ * must NOT be flagged. A validator returns a message ONLY when the value is the
+ * wrong *shape* for its field — a bare word where a date/URL/phone/email belongs.
+ *
+ * Contract (matches `EditableField`'s `validate` prop):
+ *   - `null`   → clean (no warning icon).
+ *   - `string` → a short shape-fail message, surfaced as a soft, NON-blocking
+ *                warning icon on the read-mode value (the commit still lands).
+ *
+ * An empty / whitespace-only value is always `null`: an absent field is a
+ * legitimate "not detected" state (surfaced separately by the AttentionStrip),
+ * never a typo. So clearing a field never raises a shape warning.
+ *
+ * Where practical these reuse the parser's own recognition grammar
+ * (`src/lib/heuristics/`) so the edit surface and the extractor agree on what a
+ * date / email / phone looks like.
+ */
+
+import {
+  DATE_ANCHOR,
+  DATE_RANGE_RE,
+  EMAIL_RE,
+} from "../heuristics/regex.ts";
+import { normalizePhone } from "../heuristics/phone.ts";
+
+/** A field validator: `null` when clean, else a short shape-fail message. */
+export type FieldValidator = (value: string) => string | null;
+
+// ── Dates ────────────────────────────────────────────────────────────────────
+
+// Open-ended end-date words. Mirrors PRESENT_RE's alternation; inlined (rather
+// than reusing that `\b`-bounded RegExp) so it composes cleanly inside the
+// fully-anchored single-field pattern below.
+const PRESENT_WORDS = "Present|Current|Now|Ongoing";
+
+/**
+ * A single date FIELD (start_date / end_date). Accepts the résumé date forms the
+ * parser understands — one anchor (`Mon YYYY`, `YYYY`, `MM/YYYY`, `Season YYYY`,
+ * `20XX`), an open-ended word (`Present`…), OR a full range typed into one field
+ * (`YYYY – YYYY`, `Jan 2020 – Present`) — and nothing else.
+ *
+ * Built from the parser's exported `DATE_ANCHOR` fragment and `DATE_RANGE_RE`.
+ * Both carry top-level `|` alternations, so each is wrapped in its own
+ * non-capturing group before the outer `^…$` anchors bind (otherwise `^`/`$`
+ * would attach to only the first/last alternative — the classic `^a|b$` trap).
+ */
+const DATE_FIELD_RE = new RegExp(
+  `^\\s*(?:(?:${DATE_RANGE_RE.source})|(?:${DATE_ANCHOR})|(?:${PRESENT_WORDS}))\\s*$`,
+  "i",
+);
+
+/**
+ * Flag a start/end date field that is the wrong shape (e.g. `banana`), while
+ * passing every résumé date form the parser recognizes. Never flags an empty
+ * field or an odd-but-real date (future years, redacted `20XX`, etc.).
+ */
+export const validateDate: FieldValidator = (value) => {
+  if (value.trim() === "") return null;
+  return DATE_FIELD_RE.test(value)
+    ? null
+    : "Doesn't look like a date (try “Jan 2020”, “2020”, or “Present”)";
+};
+
+// ── Email ────────────────────────────────────────────────────────────────────
+
+// Full-field email shape, reusing the parser's EMAIL_RE grammar anchored to the
+// whole value (EMAIL_RE itself is a global match-anywhere pattern).
+const EMAIL_FIELD_RE = new RegExp(`^(?:${EMAIL_RE.source})$`, "i");
+
+/**
+ * Flag an email field that isn't an RFC-ish `local@domain.tld` shape. Passes
+ * synthetic fixture addresses (`alice@example.com`); flags bare words and
+ * dot-less domains.
+ */
+export const validateEmail: FieldValidator = (value) => {
+  if (value.trim() === "") return null;
+  return EMAIL_FIELD_RE.test(value.trim())
+    ? null
+    : "Doesn't look like an email address";
+};
+
+// ── URL / LinkedIn ───────────────────────────────────────────────────────────
+
+// URL-ish shape: an optional http(s) scheme, one or more dotted host labels, a
+// TLD, and an optional path/query/fragment. Deliberately looser than the
+// parser's bucket-specific LINKEDIN_RE/GITHUB_RE — the user is authoritative, so
+// any real link shape passes. Multi-label hosts (`www.linkedin.com/in/x`) and
+// synthetic fixtures (`example.com/in/x`) both match; bare words do not.
+const URL_FIELD_RE =
+  /^(?:https?:\/\/)?(?:[\w-]+\.)+[a-z]{2,}(?:[/?#]\S*)?$/i;
+
+/**
+ * Flag a link field (LinkedIn / GitHub / portfolio / website) that isn't a
+ * URL-ish shape. Accepts `linkedin.com/in/…`, `example.com/in/…`,
+ * `https://github.com/…`, and bare domains; flags bare words.
+ */
+export const validateUrl: FieldValidator = (value) => {
+  if (value.trim() === "") return null;
+  return URL_FIELD_RE.test(value.trim())
+    ? null
+    : "Doesn't look like a URL";
+};
+
+// ── Phone ────────────────────────────────────────────────────────────────────
+
+/**
+ * Flag a phone field libphonenumber can't read as a valid number. Reuses the
+ * parser's `normalizePhone` (US default region) so the edit surface and the
+ * extractor agree on validity. Synthetic reserved numbers — a real area code
+ * with the `555-01xx` fictional range, e.g. `(312) 555-0123` — pass `isValid()`;
+ * bare words and too-short digit runs are flagged.
+ */
+export const validatePhone: FieldValidator = (value) => {
+  if (value.trim() === "") return null;
+  const parsed = normalizePhone(value);
+  return parsed && parsed.isValid
+    ? null
+    : "Doesn't look like a valid phone number";
+};

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -180,7 +180,13 @@ const MONTH_OR_PLACEHOLDER = `(?:${MONTH}|Month)`;
 // tail admits `20XX` (unambiguous) but NOT bare `XXXX`/`####` (too weak alone).
 // Season YYYY (e.g. "Summer 2013") is admitted so a season date participates in
 // branch (a) when an explicit separator (–/-/to) is present.
-const DATE_ANCHOR = `${MONTH_OR_PLACEHOLDER}\\.?\\s+(?:${YEAR_FORMS})|${SEASON}\\s+\\d{4}|\\d{1,2}[\\/\\-]\\d{4}|20XX|\\d{4}`;
+// Exported (source fragment, not a compiled RegExp) so downstream shape
+// validators — e.g. the inline-edit date field guard (#357) — can reuse the
+// exact anchor grammar the parser recognizes rather than duplicating a fresh
+// regex. It carries top-level `|` alternations, so any consumer MUST wrap it in
+// a non-capturing group before anchoring (`^(?:${DATE_ANCHOR})$`), else the
+// `^`/`$` bind only to the first/last alternative.
+export const DATE_ANCHOR = `${MONTH_OR_PLACEHOLDER}\\.?\\s+(?:${YEAR_FORMS})|${SEASON}\\s+\\d{4}|\\d{1,2}[\\/\\-]\\d{4}|20XX|\\d{4}`;
 
 // Strict month-year anchor (no bare-year / numeric-slash forms) for the
 // separator-less branch — bare years adjacent are too weak a signal.

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Project-wide vitest setup (wired as `test.setupFiles` in `vite.config.ts`).
+ *
+ * Installs a fresh in-memory `localStorage` shim before EVERY test, globally.
+ * The `rl_*` functional keys touch a `localStorage` that neither the Node env
+ * (default) provisions nor Node 22+'s built-in global exposes as a working
+ * `Storage` (#398). Doing this once at the workload level — instead of an
+ * `import + beforeEach` per file — closes the "new test forgot to install the
+ * shim" regression class permanently. Per-test-fresh state means suites still
+ * start clean without any `clear()` bookkeeping.
+ */
+
+import { beforeEach } from "vitest";
+import { installMemoryLocalStorage } from "./hooks/__test-utils__/memory-storage.ts";
+
+beforeEach(() => {
+  installMemoryLocalStorage();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -174,6 +174,9 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     globals: true,
+    // Install the in-memory localStorage shim before every test, workload-wide,
+    // so no suite has to remember to import it (#398). See src/test-setup.ts.
+    setupFiles: ["src/test-setup.ts"],
     coverage: {
       // v8 provider; emit lcov so `fallow audit --coverage` can compute
       // accurate CRAP scores in CI. Without coverage, CRAP collapses to a


### PR DESCRIPTION
## Summary

Batch epic #396 — Result-page guardrails. Two user-facing safety nudges on the Result/edit surface: surface a signal the parser already computes but never shows, and validate what the user types back in.

- **#356 — two-column warning.** When the parser emits the `two_column` trigger, the Result page now shows an inline warning (shared `ErrorState` `tone="warning"`, semantic tokens) explaining two-column layouts are a common ATS mis-parse cause, pointing at the reconstructed text below as evidence, and recommending a single-column layout. No warning when the trigger is absent.
- **#357 — EditableField validation.** Adds an optional additive `validate?: (value) => string | null` hook to the `EditableField` primitive with **non-blocking** UX — the value always commits and a soft warning glyph appears in read mode (semantic `text-feedback-warning-icon`); the field never traps or rejects. Wired date/URL/phone/email shape validators at the call sites. Date validator **reuses** the heuristics grammar (`DATE_ANCHOR`/`DATE_RANGE_RE`), phone reuses `normalizePhone`, email reuses `EMAIL_RE`. Catches shape typos (`banana`) only — `Present`/`YYYY`/`Mon YYYY`/ranges/`20XX`/future years pass ("parser audit, not a judge").

Closes #356
Closes #357
Closes #398
Closes #396

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Affected suites green (field-validators 15/15, Result/ReconstructedRole/ContactCard/EducationSkills 73/73)
- [x] Whole-tree `fallow audit` — no dead-code/dupe issues in changed files (complexity advisories only)
- [x] Full `npm run test` / `verify` in CI (green — run 28912727231, includes the #398 localStorage-shim fix; 1673 passed)

> **Folded in (#398):** `useAnalyzedResume.test.tsx` + `useDownloadPdf.test.tsx` (13 jsdom-harness failures on Node 22+, where a broken native global `localStorage` shadows jsdom's) are now fixed here via a shared in-memory `localStorage` shim. Pre-existing on clean `main`; unrelated to the guardrails diff but bundled so the branch goes green end-to-end.

## Adversarial review

Ran a bounded adversarial pass (`ecc:react-reviewer`, opus) on the accumulated diff **before** opening this PR. Converged in **1 round — clean, zero blocking findings.** Reviewer reproduced end-to-end (not just reasoned): date anchoring is fully `^…$`-anchored (`banana 2020` / `2020 banana` / `2020 2021` all flag; `Present`/`Mon YYYY`/`20XX`/ranges/future years pass), `DATE_ANCHOR` reuse is genuinely consumed (not dead), `#356` gate matches the real `two_column` `LayoutTrigger`, and the `validate` prop is byte-for-byte additive + non-blocking.

**Surviving nits (non-blocking — human reviewer may eyeball):**
1. **a11y** — `EditableField.tsx` read-mode wrapper has `aria-label="Edit {label}"`, which shadows the warning glyph's `title`/`aria-label` (ARIA name-from-author), so a screen-reader user hears the field name but not the shape warning. Hover tooltip works; SR path does not. Fix: fold the message into the field's `aria-label`/`aria-describedby`.
2. **consistency** — the achievement `label="Year"` `EditableField` in `ReconstructedResume.tsx` is a date-shaped sibling left unwired (`validateDate` accepts bare `YYYY`/`20XX` and would fit). Not in the acceptance list.
3. **copy** — `TWO_COLUMN_BLURB` "column-by-column-merged or out of order" reads as a run-on.


