### PR TITLE
chore(skills): current milestones in triage-issue + zsh-safe dep wiring in batch-issues

### DIFF
--- a/.claude/skills/batch-issues/SKILL.md
+++ b/.claude/skills/batch-issues/SKILL.md
@@ -179,7 +179,9 @@ LINKED=$(gh api "repos/$REPO/issues/$PARENT/sub_issues" --jq '.[].number' 2>/dev
 for N in "${CHILDREN[@]}"; do
   grep -qx "$N" <<<"$LINKED" && { echo "#$N already linked — skip"; continue; }
   CHILD_ID=$(gh api "repos/$REPO/issues/$N" --jq .id)
-  gh api -X POST "repos/$REPO/issues/$PARENT/sub_issues" -F sub_issue_id="$CHILD_ID"
+  [[ "$CHILD_ID" =~ ^[0-9]+$ ]] || { echo "✗ can't resolve id for #$N — skipping link"; continue; }
+  gh api -X POST "repos/$REPO/issues/$PARENT/sub_issues" -F sub_issue_id="$CHILD_ID" >/dev/null 2>&1 \
+    && echo "linked #$N"
 done
 ```
 **Verify by diffing the readback against the input set** — never assume the loop
@@ -217,19 +219,72 @@ done
 
 If `--order A,B,C` given (already validated in Step 2), wire `blocked_by` so B is
 blocked by A, C by B — each edge uses the **blocking** issue's internal id, typed `-F`.
-Mirror Step 4's idempotency: preflight the child's existing `blocked_by` set and skip
-an edge that's already there (a bare re-POST 422s on re-run), then verify the edge
-landed:
+
+Four failure modes bit real runs — the loop below defends against all four:
+
+1. **`${ARR[i]}` index math breaks under zsh (THE load-bearing one).** resumelint's
+   shell is **zsh, whose arrays are 1-indexed**; a `for ((i=1; i<${#ORDER[@]}; i++))`
+   loop written for **bash's 0-indexing** silently wires the *wrong* pairs — the first
+   edge gets an empty blocker and the last edge (which needs `i==len`) never runs.
+   **Never index the array.** Iterate values with a `PREV` cursor — identical in bash
+   and zsh — as below. (This is why an earlier version half-wired every chain.)
+2. **Unsuppressed POST output scrambles the log.** `gh api -X POST` prints the full
+   dependency JSON to stdout; interleaved with your `echo`s it becomes unreadable and
+   *looks* like edges wired to the wrong issue. Always `>/dev/null` the POST, stderr → tmpfile.
+3. **An unguarded blocker-id feeds garbage into the next POST.** If `gh api …/issues/$BLOCKER --jq .id`
+   errors, `$BLOCKER_ID` becomes an error-JSON blob and the POST 422s with
+   `not of type integer`. Numeric-guard the id before POSTing (same guard as `$PARENT`).
+4. **A half-wired chain reported as success.** GitHub does **not** materialize
+   transitive edges (`C blocked_by B` never adds `C blocked_by A`), so end with a
+   **full-chain audit** that prints each child's entire stored `blocked_by` set —
+   missing edges *and* stray extras both show.
+
+Each edge uses the **blocking** issue's internal id, typed `-F`. Mirror Step 4's
+idempotency (preflight the existing set; a bare re-POST 422s on re-run) and swallow
+only the benign "already been taken" dup error:
 ```bash
-for ((i=1; i<${#ORDER[@]}; i++)); do
-  BLOCKED="${ORDER[i]}"; BLOCKER="${ORDER[i-1]}"
-  EXISTING=$(gh api "repos/$REPO/issues/$BLOCKED/dependencies/blocked_by" --jq '.[].number' 2>/dev/null)
-  grep -qx "$BLOCKER" <<<"$EXISTING" && { echo "#$BLOCKED already blocked by #$BLOCKER — skip"; continue; }
-  BLOCKER_ID=$(gh api "repos/$REPO/issues/$BLOCKER" --jq .id)
-  gh api -X POST "repos/$REPO/issues/$BLOCKED/dependencies/blocked_by" -F issue_id="$BLOCKER_ID"
-  gh api "repos/$REPO/issues/$BLOCKED/dependencies/blocked_by" --jq '.[].number' | grep -qx "$BLOCKER" \
-    || echo "✗ #$BLOCKED → blocked_by #$BLOCKER did not land — check before reporting success"
-done
+wire_edge() {   # $1 = blocked issue, $2 = blocker issue
+  local BLOCKED="$1" BLOCKER="$2"
+  local EXISTING; EXISTING=$(gh api "repos/$REPO/issues/$BLOCKED/dependencies/blocked_by" --jq '.[].number' 2>/dev/null)
+  grep -qx "$BLOCKER" <<<"$EXISTING" && { echo "#$BLOCKED already blocked_by #$BLOCKER — skip"; return; }
+  local BID; BID=$(gh api "repos/$REPO/issues/$BLOCKER" --jq .id 2>/dev/null)
+  [[ "$BID" =~ ^[0-9]+$ ]] || { echo "✗ can't resolve id for #$BLOCKER — skipping edge #$BLOCKED←#$BLOCKER"; return; }
+  if ! gh api -X POST "repos/$REPO/issues/$BLOCKED/dependencies/blocked_by" \
+         -F issue_id="$BID" >/dev/null 2>/tmp/dep.err; then
+    grep -q "already been taken" /tmp/dep.err || { echo "✗ POST #$BLOCKED←#$BLOCKER failed:"; cat /tmp/dep.err; }
+  fi
+}
+
+if (( ${#ORDER[@]} > 1 )); then
+  # Value iteration with a PREV cursor — NO array indexing (zsh-safe).
+  PREV=""
+  for CUR in "${ORDER[@]}"; do
+    [[ -n $PREV ]] && wire_edge "$CUR" "$PREV"    # CUR blocked_by PREV
+    PREV="$CUR"
+  done
+  # Full-chain audit — stored set must equal exactly the consecutive pairs.
+  echo "── dependency audit (expected chain: ${ORDER[*]}) ──"
+  PREV=""
+  for CUR in "${ORDER[@]}"; do
+    if [[ -n $PREV ]]; then
+      HAVE=$(gh api "repos/$REPO/issues/$CUR/dependencies/blocked_by" --jq '[.[].number]|sort|join(",")' 2>/dev/null)
+      if grep -qx "$PREV" < <(printf '%s\n' "${HAVE//,/$'\n'}"); then
+        echo "✓ #$CUR blocked_by #$PREV   (stored: ${HAVE:-none})"
+      else
+        echo "✗ #$CUR MISSING blocked_by #$PREV   (stored: ${HAVE:-none}) — fix before reporting success"
+      fi
+      for h in ${HAVE//,/ }; do
+        [[ "$h" == "$PREV" ]] || echo "⚠ #$CUR also blocked_by #$h — not in the intended chain; remove if spurious"
+      done
+    fi
+    PREV="$CUR"
+  done
+fi
+```
+Remove a stray edge (id from the readback, not the issue number):
+```bash
+DEP_ID=$(gh api "repos/$REPO/issues/<BLOCKED>/dependencies/blocked_by" --jq '.[]|select(.number==<STRAY>)|.id')
+gh api -X DELETE "repos/$REPO/issues/<BLOCKED>/dependencies/blocked_by/$DEP_ID"
 ```
 
 ### Step 6 — Place the parent on the board
@@ -267,6 +322,19 @@ Implement it:  /implement-batch <PARENT>   ⚠ executor lands in #387 — not ru
   incoherent batch produces an unreviewable PR.
 - **Typed `-F` for every id.** Sub-issue and dependency links use the child's
   internal REST `id` with `-F` (integer), never the number, never `-f`.
+- **Never index a bash array — resumelint's shell is zsh (1-indexed).** A
+  `for ((i=1;…)); ${ORDER[i-1]}` loop written for bash's 0-indexing wires the wrong
+  dependency pairs under zsh (empty first blocker, last edge skipped). Iterate values
+  with a `PREV` cursor instead; it behaves identically in both shells.
+- **Numeric-guard every resolved id + suppress POST output.** Guard `CHILD_ID` /
+  `BLOCKER_ID` with `[[ … =~ ^[0-9]+$ ]]` before POSTing (a failed `--jq .id`
+  returns an error-JSON that 422s the POST), and `>/dev/null` every `gh api -X POST`
+  — its JSON response interleaves with your echoes and makes a run look like it
+  wired edges to the wrong issue.
+- **Audit the whole dependency chain, not each edge in isolation.** GitHub does not
+  add transitive edges, so end Step 5 by printing each child's full stored
+  `blocked_by` set — that catches a missing edge *and* a stray extra edge (both hit
+  real runs); remove strays with the `DELETE …/blocked_by/<dep_id>` call.
 - **Don't clobber good child metadata.** Add the batch label; set a child's
   milestone only when it has none (warn on conflict); add the assignee only when the
   child is unowned (warn if already assigned — `--add-assignee` co-assigns).

--- a/.claude/skills/batch-issues/SKILL.md
+++ b/.claude/skills/batch-issues/SKILL.md
@@ -180,8 +180,11 @@ for N in "${CHILDREN[@]}"; do
   grep -qx "$N" <<<"$LINKED" && { echo "#$N already linked — skip"; continue; }
   CHILD_ID=$(gh api "repos/$REPO/issues/$N" --jq .id)
   [[ "$CHILD_ID" =~ ^[0-9]+$ ]] || { echo "✗ can't resolve id for #$N — skipping link"; continue; }
-  gh api -X POST "repos/$REPO/issues/$PARENT/sub_issues" -F sub_issue_id="$CHILD_ID" >/dev/null 2>&1 \
-    && echo "linked #$N"
+  if gh api -X POST "repos/$REPO/issues/$PARENT/sub_issues" -F sub_issue_id="$CHILD_ID" >/dev/null 2>/tmp/link.err; then
+    echo "linked #$N"
+  else
+    grep -q "already" /tmp/link.err || { echo "✗ link #$N failed:"; cat /tmp/link.err; }
+  fi
 done
 ```
 **Verify by diffing the readback against the input set** — never assume the loop
@@ -268,14 +271,18 @@ if (( ${#ORDER[@]} > 1 )); then
   for CUR in "${ORDER[@]}"; do
     if [[ -n $PREV ]]; then
       HAVE=$(gh api "repos/$REPO/issues/$CUR/dependencies/blocked_by" --jq '[.[].number]|sort|join(",")' 2>/dev/null)
-      if grep -qx "$PREV" < <(printf '%s\n' "${HAVE//,/$'\n'}"); then
+      # Split on comma with `tr`, NOT `${HAVE//,/$'\n'}` — zsh leaves the ANSI-C
+      # `$'\n'` literal in the replacement (bash expands it), so that idiom is itself
+      # not zsh-safe; `tr` behaves identically in both shells.
+      if grep -qx "$PREV" < <(printf '%s\n' "$HAVE" | tr ',' '\n'); then
         echo "✓ #$CUR blocked_by #$PREV   (stored: ${HAVE:-none})"
       else
         echo "✗ #$CUR MISSING blocked_by #$PREV   (stored: ${HAVE:-none}) — fix before reporting success"
       fi
-      for h in ${HAVE//,/ }; do
-        [[ "$h" == "$PREV" ]] || echo "⚠ #$CUR also blocked_by #$h — not in the intended chain; remove if spurious"
-      done
+      while IFS= read -r h; do
+        [[ -z $h || $h == "$PREV" ]] && continue
+        echo "⚠ #$CUR also blocked_by #$h — not in the intended chain; remove if spurious"
+      done < <(printf '%s\n' "$HAVE" | tr ',' '\n')
     fi
     PREV="$CUR"
   done

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -48,15 +48,24 @@ gh issue view <N> --json number,title,body,labels,milestone
 ```
 
 Match the issue to a milestone by **what it delivers**, using the milestone
-descriptions from Step 0. Rules of thumb for this repo:
+descriptions from Step 0. The roadmap is an **audience-gated** scheme (`P1`…`P4`) —
+each milestone is "who can use it next," not a subsystem. Read the live
+descriptions from Step 0; the current buckets are:
 
-- Parser accuracy / extraction / scoring correctness / corpus / CI-quality-gate
-  → the **parser-hardening** milestone (the trust foundation).
-- UI / visual / component-parity work → the **UI-parity** milestone (gates launch).
-- A net-new user-facing feature → its own feature milestone.
-- Anything explicitly deferred past the next launch → the **post-launch** milestone.
+- **`P1 · Friends & Family`** — core loop trustworthy on normal resumes (drop →
+  correct parse + score → safe download). Parser/score/edit correctness that keeps a
+  well-formatted single-column resume from visibly breaking lands here.
+- **`P2 · Design Partner`** — differentiators (semantic JD-match, AI rewrite),
+  reliability across diverse/edge PDFs (two-column, round-trip), and score
+  transparency, for partners who commit structured feedback.
+- **`P3 · Public Launch`** — polish, standards compliance, positioning (JSON Resume
+  export, profiles model, JD-match v2 eval/telemetry/docs close-out).
+- **`P4 · Post-Public`** — work deliberately deferred past launch (job-search lane,
+  local-first storage, resume library, job tracker, blank-resume authoring,
+  code-health cleanup).
 
-If the fit is genuinely ambiguous, ask the user rather than guessing.
+These titles change — **always match against the live Step 0 list, never this
+snapshot.** If the fit is genuinely ambiguous, ask the user rather than guessing.
 
 ```bash
 gh issue edit <N> --milestone "<exact milestone title>"
@@ -86,23 +95,35 @@ ITEM_ID="$(gh project item-add "$PROJ_NUM" --owner "$OWNER" \
 `item-add` is idempotent-ish: re-adding an existing item returns its id, so this
 is safe to re-run.
 
-### Step 4: Set the Phase field to match the milestone
+### Step 4: Set the Phase field to match the milestone (only if an option corresponds)
 
-Read the `Phase` field id and its option ids live, then set the option whose name
-corresponds to the milestone chosen in Step 1:
+Read the `Phase` field id and its option ids live:
 
 ```bash
 gh project field-list "$PROJ_NUM" --owner "$OWNER" --format json \
   --jq '.fields[] | select(.name=="Phase") | {fieldId:.id, opts:[.options[]|{name,id}]}'
 ```
 
+**The Phase options and the milestones can drift out of sync** — the board's `Phase`
+field currently carries an older subsystem scheme (`M1 Parser Hardening`, `M2 UI
+Parity`, …) while milestones are the audience-gated `P1`…`P4`. Set Phase **only when
+a listed option clearly corresponds** to the chosen milestone. If none does, **leave
+Phase blank** — that is the current convention (existing `P3`/`P4` items sit on the
+board with an empty Phase), and the milestone is the load-bearing signal regardless.
+Do **not** force a wrong Phase to fill the column, and do **not** invent a Phase
+option here (option edits are a maintainer decision — see First-time setup).
+
+When an option does correspond, set it (match on the meaningful part, not
+punctuation):
+
 ```bash
 gh project item-edit --project-id "$PROJ_ID" --id "$ITEM_ID" \
   --field-id "<Phase field id>" --single-select-option-id "<matching option id>"
 ```
 
-Phase option names mirror milestone titles (e.g. milestone `M1 · Parser Hardening`
-↔ Phase `M1 Parser Hardening`). Match on the meaningful part, not punctuation.
+> **Maintainer note:** if the Phase options should track the `P1`…`P4` milestones,
+> realign them once in the web UI (or via `gh project field-*`) so future triage can
+> set a Phase instead of leaving it blank. Until then, blank-when-no-match is correct.
 
 ### Step 5: Report
 
@@ -132,9 +153,12 @@ Create the board + the Phase field, with one option per milestone:
 
 ```bash
 gh project create --owner "$OWNER" --title "ResumeLint v1"
+# Phase options should mirror the CURRENT milestone titles so triage can set a
+# matching Phase (Step 4). Read them live first, don't paste a stale list:
+#   gh api "repos/$REPO/milestones?state=open" --jq '[.[].title]|join(",")'
 gh project field-create <PROJ_NUM> --owner "$OWNER" --name "Phase" \
   --data-type SINGLE_SELECT \
-  --single-select-options "M1 Parser Hardening,M2 UI Parity,M3 JD Matching,M4 AI Rewrite,v1.1 Post-Launch"
+  --single-select-options "P1 Friends & Family,P2 Design Partner,P3 Public Launch,P4 Post-Public"
 ```
 
 Then add a **Board** view in the web UI grouped by **Phase** (view layout/grouping


### PR DESCRIPTION
## Summary

Two skill-file fixes surfaced while batching parentless issues (epics #400, #401):

- **`triage-issue`** — its milestone rules of thumb referenced a stale subsystem scheme (`parser-hardening`, `UI-parity`). Replaced with the live audience-gated `P1 · Friends & Family` … `P4 · Post-Public` buckets and their roles (still matched against the live Step 0 list, not the snapshot). Step 4 now handles the fact that the board's `Phase` field still carries the old M-scheme and no longer maps 1:1 to milestones — set Phase only when an option corresponds, else leave it blank (the current convention), never force a wrong Phase. First-time-setup Phase example mirrors P1–P4.
- **`batch-issues`** — fixed the dependency-order wiring. The `for ((i=1;…)); ${ORDER[i-1]}` loop assumed **bash 0-indexed** arrays, but resumelint's shell is **zsh (1-indexed)**, so it wired the wrong pairs: empty first blocker, last edge skipped. This is why the two batches above half-wired their chains and needed manual repair. Rewrote with a `PREV` value cursor (shell-agnostic), numeric-guarded resolved ids before POST, suppressed `gh api` POST output, swallowed the benign "already been taken" dup, and added a full-chain audit that surfaces missing **and** stray edges.

Docs/skill-only change — no product code touched.

## Test plan

- [x] zsh-safe dependency loop verified against live epic #400 chain (334←335, 343←334)
- [x] `npm run typecheck` clean; `npm run test` = 1645 passed / 13 failed — the 13 are the pre-existing #398 `localStorage.clear is not a function` shim failures (`useAnalyzedResume`/`useDownloadPdf`, shim fix lives on the #397 branch), unrelated to this docs-only diff
