### PR TITLE
fix(experience): keep multi-word cities whole on space-folded headers

### DIFF
--- a/src/lib/heuristics/extract/experience.multiword-city.test.ts
+++ b/src/lib/heuristics/extract/experience.multiword-city.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression tests for multi-word city extraction on a space-folded header
+ * (#368).
+ *
+ * A right-aligned location rail folds onto the company line with no comma
+ * between company and city:
+ *
+ *   "Greenfield Studios      New York, NY"   → one PdfLine
+ *
+ * The location strip's single-token space pass (Pass B) captured only the last
+ * word before the comma ("York, NY"), leaving the city's leading word glued to
+ * the company ("Greenfield Studios New"). Single-word cities ("Bellevue, WA")
+ * were unaffected — only multi-word cities broke. A closed-vocabulary multi-word
+ * pass (KNOWN_MULTIWORD_US_CITY_RE) now captures the whole city.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("multi-word city on space-folded header (#368)", () => {
+  it("keeps a multi-word city whole and off the company", () => {
+    // "Greenfield Studios  New York, NY" folds company + right-rail location
+    // onto one line (the exact shape from the LaTeX fixture, entries 3–4).
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Greenfield Studios New York, NY", fontSize: 11 },
+      { text: "Software Engineering Intern", fontSize: 11 },
+      { text: "May 2023 - Jun. 2023", fontSize: 11 },
+      { text: "• Built a document generator on a hosted LLM API.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("Greenfield Studios");
+    expect(role.location).toBe("New York, NY");
+    // The city's leading word must not leak into the company.
+    expect(role.company).not.toContain("New");
+    expect(role.title?.toLowerCase()).toContain("intern");
+  });
+
+  it("still extracts a single-word city (no regression to Pass B)", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Northwind Labs Bellevue, WA", fontSize: 11 },
+      { text: "Software Engineering Intern", fontSize: 11 },
+      { text: "Sep. 2025 - Apr. 2026", fontSize: 11 },
+      { text: "• Trained fraud classifiers on an internal ML platform.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("Northwind Labs");
+    expect(role.location).toBe("Bellevue, WA");
+  });
+
+  it("does not fragment a company that merely contains a city word", () => {
+    // "New York Times" is a company, not a location — with no ", ST" state tail
+    // the strip must leave it whole.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "The New York Times", fontSize: 11 },
+      { text: "Software Engineer", fontSize: 11 },
+      { text: "Jan. 2022 - Present", fontSize: 11 },
+      { text: "• Shipped a newsroom analytics dashboard.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("The New York Times");
+    expect(role.location).toBeUndefined();
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -191,6 +191,19 @@ function cityStartsWithCompanyText(city: string): boolean {
 const LOCALITY_SUFFIX_RE =
   /^(?:city|town|beach|springs?|heights|falls|hills|park|bay|harbou?r|grove|gardens?|valley|shores?)$/i;
 
+/** Known multi-word US cities, for the space-delimited "…Company New York, ST"
+ *  fold where the location is glued onto the company line with no comma before
+ *  the city. Pass B's single-token city rule truncates such a city to its last
+ *  word ("…New York, NY" → city "York", company "…New"), so a multi-word city is
+ *  admitted here ONLY from this closed vocabulary — an open greedy multi-word
+ *  match would eat company/role words ("Greenfield Studios New York" → city
+ *  "Studios New York"). Same closed-vocabulary discipline as Pass C/D's country
+ *  gazetteer. Longest-first so "New York City" wins over "New York" (regex
+ *  alternation is first-match). Mirrors the multi-word entries in
+ *  `BARE_LOCATION_RE`. */
+const KNOWN_MULTIWORD_US_CITY_RE =
+  /New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City/;
+
 function stripLocationSuffix(s: string): {
   text: string;
   location: string | undefined;
@@ -199,10 +212,21 @@ function stripLocationSuffix(s: string): {
   // multi-word (one+ capitalized words).
   const COMMA_LOCATION_RE =
     /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})$/;
+  // Pass B-multi — space-delimited "…Company <known multi-word city>, ST": no
+  // comma before the city, so a multi-word city is admitted only from the closed
+  // `KNOWN_MULTIWORD_US_CITY_RE` vocabulary (an open multi-word match would eat
+  // company/role words). Tried before single-token Pass B so "…New York, NY"
+  // captures "New York", not "York".
+  const SPACE_MULTIWORD_LOCATION_RE = new RegExp(
+    `\\s+(${KNOWN_MULTIWORD_US_CITY_RE.source}),\\s*([A-Z]{2})$`,
+  );
   // Pass B — space-delimited "Role … City, ST": single-token city only.
   const SPACE_LOCATION_RE = /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
 
-  const mUS = s.match(COMMA_LOCATION_RE) ?? s.match(SPACE_LOCATION_RE);
+  const mUS =
+    s.match(COMMA_LOCATION_RE) ??
+    s.match(SPACE_MULTIWORD_LOCATION_RE) ??
+    s.match(SPACE_LOCATION_RE);
   if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
     // Guard: stripping must leave a non-empty remainder.
     const before = stripDanglingSeparator(s.slice(0, mUS.index));


### PR DESCRIPTION
## Summary

On a header line where a right-aligned location rail folds onto the company line with no comma before the city (`Greenfield Studios  New York, NY` → one line), `stripLocationSuffix`'s single-token space pass (**Pass B**) captured only the last word before the comma — leaving `company = "Greenfield Studios New"`, `location = "York, NY"`. Single-word cities (`Bellevue, WA`) were unaffected, so only **multi-word** cities broke.

This adds a **Pass B-multi** that admits a multi-word city only from a closed `KNOWN_MULTIWORD_US_CITY_RE` vocabulary (`New York`, `San Francisco`, `Los Angeles`, …), tried before the single-token pass. An open greedy multi-word match would eat company/role words (`Greenfield Studios New York` → city `Studios New York`) — which is exactly why Pass B was single-token. Same closed-vocabulary discipline as Pass C/D's country gazetteer.

**Root cause note:** the issue localized this to the two-column line assembler (`pdf-extract.ts`). Reproducing through the real parser showed raw extraction is correct (`columnBoundaries` empty; the line assembles as `Greenfield Studios New York, NY`) — the corruption is one layer down, in the experience field extractor's location strip. Fix is `+25/−1`, fully additive.

Closes #368

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — full heuristics suite (634 passed), incl. `corpus` + `corpus-roundtrip` invariants
- [x] `npm run build` clean
- [x] New regression test `experience.multiword-city.test.ts` (multi-word fixed, single-word no-regression, `The New York Times` not fragmented); confirmed red without the fix
- [x] Verified on real fixture `tests/fixtures/pdfs/latex/multi-degree-coursework.pdf`: entries 3–4 now parse `Greenfield Studios` / `New York, NY` and `Meridian Analytics` / `New York, NY`