### PR TITLE
fix(experience): map "Title, Team" over "Company | …" to the right fields

### DIFF
--- a/src/lib/heuristics/extract/experience.title-team-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.title-team-comma.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression for #372 — a "Title, Team" role header over a
+ * "Company | Location Dates" anchor line.
+ *
+ *   Software Engineer II, Business Credit Journey
+ *   Globex Financial | New York, NY  August 2024 - Present
+ *
+ * The comma suffix "Business Credit Journey" is an internal TEAM, and the real
+ * employer "Globex Financial" sits on the next (date-anchor) line. Neither reads
+ * as a company by `looksLikeCompany` (no legal suffix), so disambiguation fell to
+ * the title-keyword tiebreak, which blindly assigned the post-comma segment as
+ * the company (`company = "Business Credit Journey"`) and demoted the real
+ * employer to `team`. The fix routes the post-comma segment to `team` and takes
+ * the company from the delimited anchor line's leading segment.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("'Title, Team' over 'Company | Location Dates' (#372)", () => {
+  it("maps the post-comma segment to team and the anchor-line org to company", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Software Engineer II, Business Credit Journey", fontSize: 11 },
+      {
+        text: "Globex Financial | New York, NY August 2024 - Present",
+        fontSize: 11,
+      },
+      { text: "• Ran Cassandra design sessions with technical leads.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title).toBe("Software Engineer II");
+    expect(role.company).toBe("Globex Financial");
+    expect(role.team).toBe("Business Credit Journey");
+    // The team must not be mislabeled as the company.
+    expect(role.company).not.toContain("Business Credit Journey");
+  });
+
+  it("still maps a genuine 'Title, Company' with a plain date line below (no regression)", () => {
+    // Pure-date anchor line (no delimiter → no company segment), so the fix must
+    // NOT fire: the comma suffix stays the company.
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Office manager, Nod Publishing", fontSize: 11 },
+      { text: "March 2023 - December 2024", fontSize: 11 },
+      { text: "• Ran the front office for a 40-person team.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title.toLowerCase()).toContain("office manager");
+    expect(role.company).toBe("Nod Publishing");
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -534,8 +534,32 @@ function disambiguateCompanyTitle(
     const secondLooksTitle = splits[1] ? looksLikeTitle(splits[1].text) : false;
     if (firstLooksTitle && !secondLooksTitle) {
       title = splits[0]?.text;
-      company = splits[1]?.text;
-      team = splits[2]?.text;
+      // #372 — "Title, Team" over "Company | Location Dates": splits[0]/splits[1]
+      // are a role-comma split of ONE header line (same source), so the
+      // post-comma splits[1] is a team/sub-org suffix, not the company. When the
+      // anchor (date) line below was delimiter-split into "Company | Location
+      // Dates", its leading segment is the real company — take it and demote the
+      // post-comma segment to team. Additive: fires only for the comma-split +
+      // delimited-anchor shape; every other case keeps the "Title, Company"
+      // default below.
+      const isRoleCommaSplit =
+        splits[1] !== undefined && splits[0]?.source === splits[1].source;
+      const anchorSplits =
+        anchorIdx !== undefined
+          ? splits.filter((s) => s.source === anchorIdx)
+          : [];
+      const anchorCompany =
+        anchorSplits.length >= 2 &&
+        !looksLikeLocationTail(anchorSplits[0].text)
+          ? anchorSplits[0].text
+          : undefined;
+      if (isRoleCommaSplit && anchorCompany) {
+        company = anchorCompany;
+        team = splits[1]?.text;
+      } else {
+        company = splits[1]?.text;
+        team = splits[2]?.text;
+      }
     } else if (!firstLooksTitle && secondLooksTitle) {
       // Older convention ("Company / Title"): leave as default.
       company = splits[0]?.text;


### PR DESCRIPTION
## Summary

A role header of shape **`Title, Team`** over a **`Company | Location Dates`** anchor line mislabeled the post-comma team as the company and demoted the real employer to `team`:

```
Software Engineer II, Business Credit Journey
Globex Financial | New York, NY  August 2024 - Present
```

| field | before | after |
|---|---|---|
| title | Software Engineer II | Software Engineer II |
| company | **Business Credit Journey** ✗ | **Globex Financial** ✓ |
| team | Globex Financial ✗ | Business Credit Journey ✓ |

**Root cause:** neither `Business Credit Journey` nor `Globex Financial` reads as a company via `looksLikeCompany` (no legal suffix), so disambiguation fell through to the title-keyword tiebreak, whose `firstLooksTitle && !secondLooksTitle` branch blindly assigns `company = splits[1]` (the post-comma segment) — treating a `Title, Team` header as a `Title, Company` one.

**Fix:** when `splits[0]/splits[1]` are a role-comma split of one line (same source) *and* the date-anchor line below was delimiter-split into `Company | …`, route the post-comma segment to `team` and take the company from the anchor line's leading segment (guarded so a location-first anchor is rejected). Additive — fires only for that shape; a genuine `Title, Company` over a plain date line is unchanged.

`columnBoundaries` is empty on this fixture — a single-column field-mapping bug, not the two-column reader.

Closes #372

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — full heuristics suite (632 passed), no regressions on the `disambiguateCompanyTitle` hot path
- [x] `npm run build` clean
- [x] New `experience.title-team-comma.test.ts` (fix case + `Title, Company` no-regression); confirmed red without the fix
- [x] Verified on real fixture `tests/fixtures/pdfs/unknown/letter-spaced-name-heading.pdf`: both roles now `company = Globex Financial`, `team = Business Credit Journey` / `Import Aggregation`

## Note

The sibling location bug on the same header line (`New York, NY` dropped) is **#373**, handled separately — this PR intentionally does not touch location extraction.