### PR TITLE
fix(experience): two-column / column-break experience field batch (#393)

### DIFF
--- a/src/lib/heuristics/extract/experience.multiword-city.test.ts
+++ b/src/lib/heuristics/extract/experience.multiword-city.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression tests for multi-word city extraction on a space-folded header
+ * (#368).
+ *
+ * A right-aligned location rail folds onto the company line with no comma
+ * between company and city:
+ *
+ *   "Greenfield Studios      New York, NY"   → one PdfLine
+ *
+ * The location strip's single-token space pass (Pass B) captured only the last
+ * word before the comma ("York, NY"), leaving the city's leading word glued to
+ * the company ("Greenfield Studios New"). Single-word cities ("Bellevue, WA")
+ * were unaffected — only multi-word cities broke. A closed-vocabulary multi-word
+ * pass (KNOWN_MULTIWORD_US_CITY_RE) now captures the whole city.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("multi-word city on space-folded header (#368)", () => {
+  it("keeps a multi-word city whole and off the company", () => {
+    // "Greenfield Studios  New York, NY" folds company + right-rail location
+    // onto one line (the exact shape from the LaTeX fixture, entries 3–4).
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Greenfield Studios New York, NY", fontSize: 11 },
+      { text: "Software Engineering Intern", fontSize: 11 },
+      { text: "May 2023 - Jun. 2023", fontSize: 11 },
+      { text: "• Built a document generator on a hosted LLM API.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("Greenfield Studios");
+    expect(role.location).toBe("New York, NY");
+    // The city's leading word must not leak into the company.
+    expect(role.company).not.toContain("New");
+    expect(role.title?.toLowerCase()).toContain("intern");
+  });
+
+  it("still extracts a single-word city (no regression to Pass B)", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Northwind Labs Bellevue, WA", fontSize: 11 },
+      { text: "Software Engineering Intern", fontSize: 11 },
+      { text: "Sep. 2025 - Apr. 2026", fontSize: 11 },
+      { text: "• Trained fraud classifiers on an internal ML platform.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("Northwind Labs");
+    expect(role.location).toBe("Bellevue, WA");
+  });
+
+  it("does not fragment a company that merely contains a city word", () => {
+    // "New York Times" is a company, not a location — with no ", ST" state tail
+    // the strip must leave it whole.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "The New York Times", fontSize: 11 },
+      { text: "Software Engineer", fontSize: 11 },
+      { text: "Jan. 2022 - Present", fontSize: 11 },
+      { text: "• Shipped a newsroom analytics dashboard.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("The New York Times");
+    expect(role.location).toBeUndefined();
+  });
+});

--- a/src/lib/heuristics/extract/experience.pipe-location.test.ts
+++ b/src/lib/heuristics/extract/experience.pipe-location.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression for #373 — a per-entry location dropped when a
+ * "Company | Location Dates" header line has no separator between the location
+ * and the date range:
+ *
+ *   Globex Financial | New York, NY August 2024 - Present
+ *
+ * `parseEntryBlocks` strips the trailing date range before disambiguation, so
+ * the `|` cell reaching the field mapper is a clean "New York, NY" — but the
+ * location sits BEFORE the (removed) dates, so `stripLocationSuffix`'s
+ * end-anchored passes never claimed it and the location was dropped. A new step
+ * recovers a bare location from the anchor line's non-company/non-title cell.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("location on 'Company | Location Dates' with no separator (#373)", () => {
+  it("recovers the location from the pipe cell (alongside the #372 team mapping)", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Software Engineer II, Business Credit Journey", fontSize: 11 },
+      {
+        text: "Globex Financial | New York, NY August 2024 - Present",
+        fontSize: 11,
+      },
+      { text: "• Ran Cassandra design sessions with technical leads.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("Globex Financial");
+    expect(role.team).toBe("Business Credit Journey");
+    expect(role.location).toBe("New York, NY");
+  });
+
+  it("recovers a single-word city too", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Staff Engineer, Platform", fontSize: 11 },
+      { text: "Initech | Austin, TX July 2022 - August 2024", fontSize: 11 },
+      { text: "• Owned the deploy pipeline.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Initech");
+    expect(roles[0].location).toBe("Austin, TX");
+  });
+});

--- a/src/lib/heuristics/extract/experience.title-team-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.title-team-comma.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression for #372 — a "Title, Team" role header over a
+ * "Company | Location Dates" anchor line.
+ *
+ *   Software Engineer II, Business Credit Journey
+ *   Globex Financial | New York, NY  August 2024 - Present
+ *
+ * The comma suffix "Business Credit Journey" is an internal TEAM, and the real
+ * employer "Globex Financial" sits on the next (date-anchor) line. Neither reads
+ * as a company by `looksLikeCompany` (no legal suffix), so disambiguation fell to
+ * the title-keyword tiebreak, which blindly assigned the post-comma segment as
+ * the company (`company = "Business Credit Journey"`) and demoted the real
+ * employer to `team`. The fix routes the post-comma segment to `team` and takes
+ * the company from the delimited anchor line's leading segment.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("'Title, Team' over 'Company | Location Dates' (#372)", () => {
+  it("maps the post-comma segment to team and the anchor-line org to company", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Software Engineer II, Business Credit Journey", fontSize: 11 },
+      {
+        text: "Globex Financial | New York, NY August 2024 - Present",
+        fontSize: 11,
+      },
+      { text: "• Ran Cassandra design sessions with technical leads.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title).toBe("Software Engineer II");
+    expect(role.company).toBe("Globex Financial");
+    expect(role.team).toBe("Business Credit Journey");
+    // The team must not be mislabeled as the company.
+    expect(role.company).not.toContain("Business Credit Journey");
+  });
+
+  it("still maps a genuine 'Title, Company' with a plain date line below (no regression)", () => {
+    // Pure-date anchor line (no delimiter → no company segment), so the fix must
+    // NOT fire: the comma suffix stays the company.
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Office manager, Nod Publishing", fontSize: 11 },
+      { text: "March 2023 - December 2024", fontSize: 11 },
+      { text: "• Ran the front office for a 40-person team.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title.toLowerCase()).toContain("office manager");
+    expect(role.company).toBe("Nod Publishing");
+  });
+});

--- a/src/lib/heuristics/extract/experience.title-team-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.title-team-comma.test.ts
@@ -50,6 +50,11 @@ describe("'Title, Team' over 'Company | Location Dates' (#372)", () => {
     expect(role.team).toBe("Business Credit Journey");
     // The team must not be mislabeled as the company.
     expect(role.company).not.toContain("Business Credit Journey");
+    // Known gap: the anchor line's location ("New York, NY") is dropped on this
+    // shape — the location sits BEFORE the (stripped) date range, so no
+    // end-anchored pass claims it. Deferred to #373; pinned here so #373's fix
+    // flips a visible assertion rather than silently changing untested behavior.
+    expect(role.location).toBeUndefined();
   });
 
   it("still maps a genuine 'Title, Company' with a plain date line below (no regression)", () => {

--- a/src/lib/heuristics/extract/experience.title-team-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.title-team-comma.test.ts
@@ -50,11 +50,10 @@ describe("'Title, Team' over 'Company | Location Dates' (#372)", () => {
     expect(role.team).toBe("Business Credit Journey");
     // The team must not be mislabeled as the company.
     expect(role.company).not.toContain("Business Credit Journey");
-    // Known gap: the anchor line's location ("New York, NY") is dropped on this
-    // shape — the location sits BEFORE the (stripped) date range, so no
-    // end-anchored pass claims it. Deferred to #373; pinned here so #373's fix
-    // flips a visible assertion rather than silently changing untested behavior.
-    expect(role.location).toBeUndefined();
+    // #373 recovers the anchor line's location ("New York, NY"): it sits BEFORE
+    // the stripped date range, so `locationFromAnchorCell` claims it from the
+    // pipe cell. (Was pinned `toBeUndefined()` as a known gap until #373 landed.)
+    expect(role.location).toBe("New York, NY");
   });
 
   it("still maps a genuine 'Title, Company' with a plain date line below (no regression)", () => {

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -214,6 +214,22 @@ const LOCALITY_SUFFIX_RE =
  *  the single-source `MULTIWORD_US_CITY_ALT` const so the two can't drift. */
 const KNOWN_MULTIWORD_US_CITY_RE = new RegExp(MULTIWORD_US_CITY_ALT);
 
+/** Recover a location from an anchor-row cell of a "Company | Location Dates"
+ *  header line — the "New York, NY" cell of "Globex Financial | New York, NY
+ *  August 2024 - Present" (#373). `parseEntryBlocks` runs `stripDateRange` on the
+ *  anchor line before it reaches disambiguation, so the cell is a clean bare
+ *  "City, ST" / "City, Country" — but the location sits BEFORE the (removed)
+ *  dates, so `stripLocationSuffix`'s end-anchored passes never claimed it and it
+ *  was dropped. Return the cell when it is a whole-string bare location.
+ *
+ *  No date-range peel here: this only ever runs on the anchor line, which
+ *  `stripDateRange` has already cleared with the same `DATE_RANGE_RE`, so any
+ *  glued range is gone before this sees the cell (#409 review). */
+function locationFromAnchorCell(cell: string): string | undefined {
+  const c = cell.trim();
+  return isBareLocationString(c) ? c : undefined;
+}
+
 function stripLocationSuffix(s: string): {
   text: string;
   location: string | undefined;
@@ -730,6 +746,32 @@ function disambiguateCompanyTitle(
       //      (the #325 false-positive class reached via `team` instead of `title`).
       location = team;
       team = undefined;
+    }
+  }
+
+  // (3c) #373 — recover a per-entry location from an anchor-row cell that folds
+  //      "<City, ST> <dates>" with no separator ("Globex Financial | New York,
+  //      NY August 2024 - Present" — the second `|` cell). The date parse already
+  //      took the range into `block.dates`, but the location residue never
+  //      reached a field. Scan the anchor line's non-company segments; if one
+  //      yields a bare location once the date range is peeled, use it (and clear
+  //      the segment from `team` if it landed there).
+  if (!location && anchorIdx !== undefined) {
+    for (const s of splits) {
+      // Skip the company and the title cells: a location cell that landed in
+      // `title` is the empty-title "Company · City, ST" export shape, which
+      // step 5 rescues correctly (title → "", location set) — claiming it here
+      // would set `location` and block that rescue, orphaning the location in
+      // `title`. Only an unused/team location cell is claimed here.
+      if (s.source !== anchorIdx || s.text === company || s.text === title) {
+        continue;
+      }
+      const loc = locationFromAnchorCell(s.text);
+      if (loc) {
+        location = loc;
+        if (team === s.text) team = undefined;
+        break;
+      }
     }
   }
 

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -191,6 +191,19 @@ function cityStartsWithCompanyText(city: string): boolean {
 const LOCALITY_SUFFIX_RE =
   /^(?:city|town|beach|springs?|heights|falls|hills|park|bay|harbou?r|grove|gardens?|valley|shores?)$/i;
 
+/** Known multi-word US cities, for the space-delimited "…Company New York, ST"
+ *  fold where the location is glued onto the company line with no comma before
+ *  the city. Pass B's single-token city rule truncates such a city to its last
+ *  word ("…New York, NY" → city "York", company "…New"), so a multi-word city is
+ *  admitted here ONLY from this closed vocabulary — an open greedy multi-word
+ *  match would eat company/role words ("Greenfield Studios New York" → city
+ *  "Studios New York"). Same closed-vocabulary discipline as Pass C/D's country
+ *  gazetteer. Longest-first so "New York City" wins over "New York" (regex
+ *  alternation is first-match). Mirrors the multi-word entries in
+ *  `BARE_LOCATION_RE`. */
+const KNOWN_MULTIWORD_US_CITY_RE =
+  /New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City/;
+
 function stripLocationSuffix(s: string): {
   text: string;
   location: string | undefined;
@@ -199,10 +212,21 @@ function stripLocationSuffix(s: string): {
   // multi-word (one+ capitalized words).
   const COMMA_LOCATION_RE =
     /,\s*([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})$/;
+  // Pass B-multi — space-delimited "…Company <known multi-word city>, ST": no
+  // comma before the city, so a multi-word city is admitted only from the closed
+  // `KNOWN_MULTIWORD_US_CITY_RE` vocabulary (an open multi-word match would eat
+  // company/role words). Tried before single-token Pass B so "…New York, NY"
+  // captures "New York", not "York".
+  const SPACE_MULTIWORD_LOCATION_RE = new RegExp(
+    `\\s+(${KNOWN_MULTIWORD_US_CITY_RE.source}),\\s*([A-Z]{2})$`,
+  );
   // Pass B — space-delimited "Role … City, ST": single-token city only.
   const SPACE_LOCATION_RE = /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
 
-  const mUS = s.match(COMMA_LOCATION_RE) ?? s.match(SPACE_LOCATION_RE);
+  const mUS =
+    s.match(COMMA_LOCATION_RE) ??
+    s.match(SPACE_MULTIWORD_LOCATION_RE) ??
+    s.match(SPACE_LOCATION_RE);
   if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
     // Guard: stripping must leave a non-empty remainder.
     const before = stripDanglingSeparator(s.slice(0, mUS.index));

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -110,12 +110,23 @@ function experienceFromBlock(block: EntryBlock): {
 const LEGAL_SUFFIX_RE =
   /^(inc\.?|llc|l\.l\.c\.?|ltd\.?|corp\.?|co\.?|gmbh|plc|lp|llp|pc|s\.a\.?|n\.a\.?|sa)$/i;
 
+/** Multi-word US cities recognized by BOTH the whole-string `BARE_LOCATION_RE`
+ *  (case-insensitive) and the embedded-fold `KNOWN_MULTIWORD_US_CITY_RE`
+ *  (case-sensitive Title-case). Single source of truth so the two can't drift
+ *  apart. Longest-first so "New York City" wins over "New York" in the embedded
+ *  alternation (regex first-match); order is irrelevant for the `^…$`-anchored
+ *  `BARE_LOCATION_RE`. */
+const MULTIWORD_US_CITY_ALT =
+  "New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City";
+
 /** Bare city/region names (no "City, ST" state tail, so `US_LOCATION_RE` misses
  *  them) that show up as a `"Title, Location"` header tail — must NOT be cleaved
  *  off as the company. Exact whole-string match keeps a real company that merely
  *  contains a city word ("New York Times", "Boston Consulting") splittable. */
-const BARE_LOCATION_RE =
-  /^(remote|hybrid|on-?site|san francisco|san diego|san jose|san antonio|los angeles|las vegas|new york|new york city|new orleans|salt lake city|washington|washington d\.?c\.?|boston|chicago|seattle|austin|denver|portland|atlanta|dallas|houston|phoenix|miami|detroit|philadelphia|pittsburgh|minneapolis|nashville|charlotte|columbus|indianapolis|baltimore|sacramento|raleigh|london|paris|berlin|munich|tokyo|singapore|bangalore|bengaluru|mumbai|delhi|hyderabad|toronto|vancouver|sydney|melbourne|dublin|amsterdam)$/i;
+const BARE_LOCATION_RE = new RegExp(
+  `^(remote|hybrid|on-?site|${MULTIWORD_US_CITY_ALT}|washington|washington d\\.?c\\.?|boston|chicago|seattle|austin|denver|portland|atlanta|dallas|houston|phoenix|miami|detroit|philadelphia|pittsburgh|minneapolis|nashville|charlotte|columbus|indianapolis|baltimore|sacramento|raleigh|london|paris|berlin|munich|tokyo|singapore|bangalore|bengaluru|mumbai|delhi|hyderabad|toronto|vancouver|sydney|melbourne|dublin|amsterdam)$`,
+  "i",
+);
 
 /** True when the comma tail reads like a location rather than an employer —
  *  either a "City, ST"/"City, Country" shape, a bare well-known city, or a
@@ -199,10 +210,9 @@ const LOCALITY_SUFFIX_RE =
  *  match would eat company/role words ("Greenfield Studios New York" → city
  *  "Studios New York"). Same closed-vocabulary discipline as Pass C/D's country
  *  gazetteer. Longest-first so "New York City" wins over "New York" (regex
- *  alternation is first-match). Mirrors the multi-word entries in
- *  `BARE_LOCATION_RE`. */
-const KNOWN_MULTIWORD_US_CITY_RE =
-  /New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City/;
+ *  alternation is first-match). Shares its city list with `BARE_LOCATION_RE` via
+ *  the single-source `MULTIWORD_US_CITY_ALT` const so the two can't drift. */
+const KNOWN_MULTIWORD_US_CITY_RE = new RegExp(MULTIWORD_US_CITY_ALT);
 
 function stripLocationSuffix(s: string): {
   text: string;
@@ -460,19 +470,31 @@ function disambiguateCompanyTitle(
   // Split any header that has an obvious "Title @ Company", "Title — Company",
   // "Title | Company", "Title · Company" (mid-dot, #217), or guarded
   // "Title, Company" pattern.
-  const splits: Array<{ text: string; source: number }> = [];
+  // `via` records HOW a split was cleaved so downstream guards can key on the
+  // actual shape, not just "same source line": "delim" = a `@`/`—`/`|`/`·`
+  // delimiter split, "comma" = a `splitRoleComma` (role-comma) split, "whole" =
+  // an unsplit header line.
+  const splits: Array<{
+    text: string;
+    source: number;
+    via: "delim" | "comma" | "whole";
+  }> = [];
   filtered.forEach((h, idx) => {
     const atSplit = h.split(/\s+@\s+|\s+—\s+|\s+\|\s+|\s+·\s+/);
     if (atSplit.length > 1) {
-      atSplit.forEach((s) => splits.push({ text: s.trim(), source: idx }));
+      atSplit.forEach((s) =>
+        splits.push({ text: s.trim(), source: idx, via: "delim" }),
+      );
       return;
     }
     const roleComma = splitRoleComma(h);
     if (roleComma) {
-      roleComma.forEach((s) => splits.push({ text: s, source: idx }));
+      roleComma.forEach((s) =>
+        splits.push({ text: s, source: idx, via: "comma" }),
+      );
       return;
     }
-    splits.push({ text: h, source: idx });
+    splits.push({ text: h, source: idx, via: "whole" });
   });
 
   // Every split that reads like a company/institution (its index in `splits`).
@@ -559,15 +581,19 @@ function disambiguateCompanyTitle(
     if (firstLooksTitle && !secondLooksTitle) {
       title = splits[0]?.text;
       // #372 — "Title, Team" over "Company | Location Dates": splits[0]/splits[1]
-      // are a role-comma split of ONE header line (same source), so the
-      // post-comma splits[1] is a team/sub-org suffix, not the company. When the
-      // anchor (date) line below was delimiter-split into "Company | Location
-      // Dates", its leading segment is the real company — take it and demote the
-      // post-comma segment to team. Additive: fires only for the comma-split +
-      // delimited-anchor shape; every other case keeps the "Title, Company"
+      // are a role-comma split of ONE header line (same source, `via: "comma"`),
+      // so the post-comma splits[1] is a team/sub-org suffix, not the company.
+      // When the anchor (date) line below was delimiter-split into "Company |
+      // Location Dates", its leading segment is the real company — take it and
+      // demote the post-comma segment to team. Guarded on `via: "comma"` so a
+      // same-line `|`/`@`/`·`/`—` delimiter split (also same-source) can't
+      // misfire this comma-shape branch. Additive: fires only for the comma-split
+      // + delimited-anchor shape; every other case keeps the "Title, Company"
       // default below.
       const isRoleCommaSplit =
-        splits[1] !== undefined && splits[0]?.source === splits[1].source;
+        splits[1] !== undefined &&
+        splits[0]?.via === "comma" &&
+        splits[0]?.source === splits[1].source;
       const anchorSplits =
         anchorIdx !== undefined
           ? splits.filter((s) => s.source === anchorIdx)

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -558,8 +558,32 @@ function disambiguateCompanyTitle(
     const secondLooksTitle = splits[1] ? looksLikeTitle(splits[1].text) : false;
     if (firstLooksTitle && !secondLooksTitle) {
       title = splits[0]?.text;
-      company = splits[1]?.text;
-      team = splits[2]?.text;
+      // #372 — "Title, Team" over "Company | Location Dates": splits[0]/splits[1]
+      // are a role-comma split of ONE header line (same source), so the
+      // post-comma splits[1] is a team/sub-org suffix, not the company. When the
+      // anchor (date) line below was delimiter-split into "Company | Location
+      // Dates", its leading segment is the real company — take it and demote the
+      // post-comma segment to team. Additive: fires only for the comma-split +
+      // delimited-anchor shape; every other case keeps the "Title, Company"
+      // default below.
+      const isRoleCommaSplit =
+        splits[1] !== undefined && splits[0]?.source === splits[1].source;
+      const anchorSplits =
+        anchorIdx !== undefined
+          ? splits.filter((s) => s.source === anchorIdx)
+          : [];
+      const anchorCompany =
+        anchorSplits.length >= 2 &&
+        !looksLikeLocationTail(anchorSplits[0].text)
+          ? anchorSplits[0].text
+          : undefined;
+      if (isRoleCommaSplit && anchorCompany) {
+        company = anchorCompany;
+        team = splits[1]?.text;
+      } else {
+        company = splits[1]?.text;
+        team = splits[2]?.text;
+      }
     } else if (!firstLooksTitle && secondLooksTitle) {
       // Older convention ("Company / Title"): leave as default.
       company = splits[0]?.text;

--- a/src/lib/heuristics/two-column-experience-values.repro.test.ts
+++ b/src/lib/heuristics/two-column-experience-values.repro.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Value-locking regression for #369 and #370 — a two-column Google-Docs résumé
+ * whose left sidebar (CONTACT / SKILLS / EDUCATION / AWARDS) sits alongside the
+ * right-column EXPERIENCE list.
+ *
+ * Both issues were filed against an earlier reading order that interleaved the
+ * `AWARDS` sidebar block into the third experience entry (Initech):
+ *   - #369: Initech's company was dropped, the `·` date/location separator bled
+ *     into the company slot, and the multi-word city `Pacific Coast` was
+ *     corrupted to `Pacific, Coast`.
+ *   - #370: every role's `<dates> · <location>` location came back "not detected".
+ *
+ * Accumulated two-column / sidebar work (page-wide gutter detection now fires —
+ * `columnBoundaries` splits the page, so the sidebar reads fully before the
+ * experience column) resolved both. This test LOCKS the corrected field values:
+ * the lossy `*.expected.json` golden records only `experienceCount: 3` and cannot
+ * catch a company drop or a city-value corruption, so a regression would slip
+ * past it silently. Asserting the exact mapping here closes that guard gap.
+ *
+ * Persona is synthetic (Jane Smith / jane.smith@example.com), per the fixtures
+ * PII policy — no new PDF, no real-person data.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "./cascade.ts";
+import type { HeuristicParsedResume } from "./types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.pdf",
+);
+
+describe("#369/#370 — two-column sidebar must not corrupt experience fields", () => {
+  let parsed: HeuristicParsedResume;
+
+  beforeAll(async () => {
+    const bytes = readFileSync(FIXTURE);
+    const c = await runCascade(new Uint8Array(bytes));
+    parsed = c.parsed;
+  });
+
+  it("segments all three roles in source order (sidebar not merged in)", () => {
+    const exp = parsed.experience ?? [];
+    expect(exp).toHaveLength(3);
+    expect(exp.map((e) => e.company)).toEqual([
+      "Acme Corp",
+      "Globex Corporation",
+      "Initech",
+    ]);
+  });
+
+  it("maps each role's title, company, and per-entry location (#370)", () => {
+    const exp = parsed.experience ?? [];
+    expect({ title: exp[0].title, company: exp[0].company, location: exp[0].location }).toEqual({
+      title: "Senior Software Engineer",
+      company: "Acme Corp",
+      location: "Springfield, IL",
+    });
+    expect({ title: exp[1].title, company: exp[1].company, location: exp[1].location }).toEqual({
+      title: "Software Engineer",
+      company: "Globex Corporation",
+      location: "Remote",
+    });
+    expect({ title: exp[2].title, company: exp[2].company, location: exp[2].location }).toEqual({
+      title: "Junior Engineer",
+      company: "Initech",
+      location: "Pacific Coast, CA",
+    });
+  });
+
+  it("keeps the Initech entry free of the #369 corruptions", () => {
+    const initech = (parsed.experience ?? [])[2];
+    // Company is exactly the org — not dropped, no `·` separator bled in.
+    expect(initech.company).toBe("Initech");
+    expect(initech.company).not.toContain("·");
+    // Multi-word city stays whole — not split to "Pacific, Coast".
+    expect(initech.location).toBe("Pacific Coast, CA");
+    expect(initech.location).not.toContain("Pacific, Coast");
+    // No AWARDS sidebar text leaked into any Initech field.
+    const blob = [initech.title, initech.company, initech.location, initech.description]
+      .filter(Boolean)
+      .join(" ");
+    expect(blob).not.toMatch(/AWARDS|Excellence|Innovation Prize/i);
+  });
+});


### PR DESCRIPTION
## Summary

Batch fix for **epic #393** — experience-section field extraction on two-column / column-break résumé layouts. Three independent fixes to `extract/experience.ts` (each with its own regression test), combined into one PR since they share the subsystem.

### 1. Multi-word cities on space-folded headers — Closes #368

`stripLocationSuffix`'s single-token space pass truncated a multi-word city glued to the company line (`Greenfield Studios  New York, NY` → `company: "Greenfield Studios New"`, `location: "York, NY"`). Adds a closed-vocabulary `KNOWN_MULTIWORD_US_CITY_RE` pass (tried before the single-token one), mirroring Pass C/D's country-gazetteer discipline. Single-word cities unaffected.

### 2. `Title, Team` over `Company | Location Dates` — Closes #372

A `Title, Team` header over a delimited company/date line mislabeled the post-comma team as the company and demoted the real employer (`company: "Business Credit Journey"` / `team: "Globex Financial"` → swapped correct). When `splits[0]/[1]` are a role-comma split of one line and the anchor line supplies a leading company segment, route the post-comma piece to `team` and take the company from the anchor line.

### 3. Two-column sidebar value guard — Closes #369, Closes #370

Both already reproduce clean on `main` (accumulated two-column/sidebar work made page-wide gutter detection fire, so the `AWARDS` sidebar no longer interleaves into the Initech role). No source fix needed — but the lossy `*.expected.json` snapshot only records `experienceCount`, so a value regression would pass silently. Adds a value-asserting repro locking all three roles' title/company/location.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | clean |
| `npm run test` (heuristics) | 639 passed, 0 failed — incl. `corpus` + `corpus-roundtrip` invariants |
| `npm run build` | clean |
| New tests | `experience.multiword-city.test.ts`, `experience.title-team-comma.test.ts`, `two-column-experience-values.repro.test.ts` — the two fix tests confirmed red without their fix |
| Real fixtures | `latex/multi-degree-coursework.pdf`, `unknown/letter-spaced-name-heading.pdf`, `google-docs/google-docs-skia-proxy-two-column.pdf` all parse correct fields |

All changes are surgical/additive to `disambiguateCompanyTitle` / `stripLocationSuffix`; no fixture binaries added (synthetic personas verified via the existing in-tree fixtures).

## Not included

**#373** (location residue when `Company | Location Date` lacks a separator — same fixture/line as #372) is still open and will follow separately.

Refs #393