### PR TITLE
feat(skills): project-specific create-gh-issue skill + writer

### DIFF
--- a/.claude/skills/create-gh-issue/SKILL.md
+++ b/.claude/skills/create-gh-issue/SKILL.md
@@ -43,7 +43,7 @@ If `gh` isn't installed or authenticated, stop and tell the user to run
    code areas involved, and any analysis already done.
 
 2. **If context is thin, investigate the codebase.** Prefer codegraph tools
-   (`codegraph_search`, `codegraph_explore`, `codegraph_callers/callees/impact`)
+   (`codegraph_search`, `codegraph_context`, `codegraph_callers/callees/impact`)
    over raw grep for symbol lookups and call-graph traversal — `.codegraph/` is
    present in this repo. Read the actual source to confirm current behavior;
    don't describe the code from memory.

--- a/.claude/skills/create-gh-issue/SKILL.md
+++ b/.claude/skills/create-gh-issue/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: create-gh-issue
+description: File a thorough, self-contained GitHub issue against resumelint-org/resumelint — full analysis, implementation plan, acceptance criteria — using the scripts/create-gh-issue.sh writer so backticks/tables/code blocks survive intact. Use when the user says "create an issue", "file an issue", "/create-gh-issue", or wants a well-scoped issue written from the current conversation.
+---
+
+# Create GitHub Issue (resumelint)
+
+File a comprehensive, **self-contained** issue against `resumelint-org/resumelint`.
+The issue must carry enough detail that someone with **no prior context** (a
+contributor after `/clear`, or another intern) can implement it start to finish.
+
+This skill is the intern-facing, in-repo version of the maintainer's private
+issue tooling. It depends on nothing outside this checkout: only `gh`
+(authenticated) and `scripts/create-gh-issue.sh`. No `~/tools`, no Linear,
+no machine-local `.env`. GitHub-only — resumelint has no Linear backend.
+
+## Input
+
+`$ARGUMENTS`, if present, is a free-form hint about the issue's subject — a topic,
+not an issue number or repo name.
+
+**The issue number is not yours to choose.** GitHub assigns it when the issue is
+created; the "next" number is not predictable (other people and automations file
+too). If the conversation or `$ARGUMENTS` names a specific number, treat it as an
+unverified guess: **strip it** from the title and body, and don't reference it
+anywhere (branch names, commits, cross-links) until the script reports the real
+`owner/repo#N` in the Create step.
+
+First, confirm the backend is reachable (one line, non-blocking):
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner   # → resumelint-org/resumelint
+```
+
+If `gh` isn't installed or authenticated, stop and tell the user to run
+`gh auth login` — don't try to work around it.
+
+## Process
+
+### Phase 1 — Gather and verify context
+
+1. **Review the conversation.** Identify: the problem or feature request, the
+   code areas involved, and any analysis already done.
+
+2. **If context is thin, investigate the codebase.** Prefer codegraph tools
+   (`codegraph_search`, `codegraph_explore`, `codegraph_callers/callees/impact`)
+   over raw grep for symbol lookups and call-graph traversal — `.codegraph/` is
+   present in this repo. Read the actual source to confirm current behavior;
+   don't describe the code from memory.
+
+3. **Build a root-cause analysis (bugs) or technical design (features):**
+   - Name ALL affected files with specific line numbers.
+   - Trace the data flow from entry point to symptom.
+   - For parser/scoring bugs, name the cascade tier and function (e.g.
+     `matchSectionHeader` in `src/lib/heuristics/regex.ts`) — see the Pipeline
+     shape section of `CLAUDE.md`.
+
+### Phase 2 — Draft the plan
+
+4. **Step-by-step implementation plan:** ordered steps, each naming specific
+   files and what changes, with short code snippets showing the approach (enough
+   to be unambiguous, not full implementations). Flag any new files.
+
+5. **Acceptance criteria as a checklist:** each independently testable. Include
+   regression checks (existing behavior must not break) and the edge cases found
+   during analysis. For parser/scoring changes, name the corpus/round-trip
+   invariant that must still hold (`corpus.test.ts`, `corpus-roundtrip.test.ts`).
+
+5b. **Reuse analysis — required when the issue adds a UI/workflow surface.**
+   resumelint enforces a Reuse Gate (see `CLAUDE.md` → "Workflow-surface Reuse").
+   Before finalizing a body that proposes a **new component, panel, dialog, or
+   page**, search for an existing surface that already owns that capability:
+   - Check the design-system (`src/design-system/`) for an existing primitive or
+     shared component before proposing any `<button>`, modal, dropzone, or banner.
+   - Check `src/components/features/` for a feature surface that already owns the
+     job (`codegraph_search` on the capability verb; grep fallback).
+   - Emit a **`### Reuse analysis`** section: **Capability** (what it does),
+     **Existing surfaces found** (`file:symbol`, or "none"), **Decision**
+     (`extend <surface>` — the default — or `build new because <reason>`). Soft
+     gate: a justified "build new" passes, but the section is mandatory.
+     "Faster to add a new one" is not a justification.
+
+### Phase 3 — Ask only if genuinely ambiguous
+
+By now the conversation usually holds enough to draft a complete issue. Don't echo
+the full plan back for line-by-line approval.
+
+6. **Decide whether anything material is ambiguous** — a scope boundary, which of
+   two reasonable approaches, an acceptance threshold. Stylistic polish doesn't
+   qualify. If nothing does, go straight to Phase 4.
+
+7. **If you must ask, ask narrowly** — AskUserQuestion, at most 1–2 focused
+   questions with concrete options. Never "does this look good?".
+
+### Phase 4 — Create the issue
+
+8. **State what you're about to file, in one line** — title + labels + milestone
+   (if any) — before the write. Informational, not an approval gate.
+
+9. **Write the body to a _unique_ tempfile.** Never a fixed path like
+   `/tmp/issue-body.md`: a stale file from an earlier session gets silently
+   re-filed, and the Write tool refuses to overwrite a file it hasn't read.
+   Generate a fresh suffix per call:
+
+   ```bash
+   date +%Y%m%d-%H%M%S        # e.g. 20260708-120000
+   ```
+
+   Use the Write tool to put the markdown body at
+   `/tmp/issue-body-<that-timestamp>.md`. If Write is rejected as already-existing,
+   the path collided — pick another suffix. Use the exact same path in the next
+   step.
+
+10. **Run the writer** (from the repo root):
+
+    ```bash
+    scripts/create-gh-issue.sh \
+      --title "<the issue title>" \
+      --body-file /tmp/issue-body-<timestamp>.md \
+      --labels bug,improvement \
+      [--assignee @me]            # optional; default = no assignee
+      [--milestone "P1 · Friends & Family"]   # optional; title or number
+    ```
+
+    - Body is passed as a file, so backticks / tables / fenced code blocks survive
+      shell escaping — write real markdown, don't flatten it.
+    - `--labels` are required and must already exist in the repo (see Labels
+      below). An unknown label makes `gh` fail with exit 1.
+    - No `--priority` / `--cycle` / `--blocked-by` — GitHub issues don't model
+      those. Record a blocker with a follow-up comment (`gh issue comment <N>
+      --body "Blocked by #M"`).
+
+11. **Capture stdout** — one tab-separated line: `<owner/repo>#<number>\t<URL>`.
+
+12. **Report to the user** the identifier, URL, labels, and milestone. Mention the
+    body can be revised with `gh issue edit <N> --body-file <file>` or via
+    `/clarify <N>`, and that `/triage-issue <N>` places it on the roadmap board if
+    it isn't there yet.
+
+**Error handling:**
+- Exit 2 = arg/env error (missing required arg, `gh` not on PATH, or no GitHub
+  remote detected). For the last, run from the repo root or pass `--repo
+  resumelint-org/resumelint`.
+- Exit 1 = `gh issue create` failed. Most common cause: a `--labels` value that
+  doesn't exist. Check `gh label list`; drop or correct the label and retry. If a
+  genuinely new label is needed, ask the user before `gh label create`.
+
+## Labels (required)
+
+Every issue needs at least one **type** label; add the domain labels that fit
+(most issues carry 2–3). These are the labels that exist in
+`resumelint-org/resumelint` today — check `gh label list` if unsure:
+
+### Type (pick at least one)
+| Label | When |
+|-------|------|
+| `bug` | Something is broken |
+| `feature` | New functionality |
+| `enhancement` | New feature or request (GitHub's default; overlaps `feature`) |
+| `improvement` | Enhancing existing functionality |
+| `refactor` | Code restructuring, no behavior change |
+| `chore` | Maintenance, deps, CI config, cleanup |
+
+### Domain / other (add all that match)
+| Label | When |
+|-------|------|
+| `testing` | Tests, test infrastructure, coverage, corpus fixtures |
+| `documentation` | READMEs, guides, docs |
+| `good first issue` | Well-scoped, low-context — good for a newcomer |
+| `help wanted` | Needs extra attention |
+
+If the exact label you want isn't in `gh label list`, either pick the closest
+existing one or ask the user before creating a new label — don't invent taxonomy.
+
+## Milestones (the roadmap)
+
+resumelint plans on four milestones (read live with
+`gh api repos/resumelint-org/resumelint/milestones --jq '.[] | "\(.number)\t\(.title)"'`).
+Pass `--milestone` by title or number when the issue's home is clear:
+
+| # | Title | Role |
+|---|-------|------|
+| 9 | `P1 · Friends & Family` | Core loop trustworthy on normal resumes (drop → correct parse + score → safe download) |
+| 10 | `P2 · Design Partner` | Differentiators live (semantic JD-match, AI rewrite), reliability, score transparency |
+| 11 | `P3 · Public Launch` | Polish + standards (JSON Resume export, profiles model, JD-match eval/docs) |
+| 12 | `P4 · Post-Public` | Job-search maturation, local-first storage, resume library, job tracker |
+
+If the milestone is genuinely ambiguous, leave it off and let `/triage-issue`
+place it — don't guess.
+
+## Quality standard
+
+The body must be **self-contained**. Someone reading it after `/clear` with zero
+prior context must be able to: understand the problem completely, know exactly
+which files to read and modify, follow the steps without ambiguity, and verify
+their work against the acceptance criteria. Avoid vague language ("update as
+needed", "handle appropriately") — every step must be specific.

--- a/.claude/skills/probe-contact/SKILL.md
+++ b/.claude/skills/probe-contact/SKILL.md
@@ -94,14 +94,56 @@ points at which one:
 The `verify` block is the fast triage: a `PARSER-MISS` means the data is in the
 PDF and the bug is ours; `absent-in-pdf` means stop — nothing to fix.
 
-## Filing what you find
+## Filing what you find (gated auto-file)
 
-Localize the layer, then file a **public** `resumelint-org/resumelint` issue
-describing the corruption **by category, using a synthetic repro** — never the
-candidate's real values. Reproduce with a synthetic-persona PDF (fake name,
-`@example.com`, a `555-01xx` phone on a real area code) so the fixture is
-PII-free; the letter-spaced-name repro fixture under
-`tests/fixtures/pdfs/unknown/` is the template.
+Once you've localized the layer, you can turn the finding into a
+`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+[`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
+show, confirm, then write. Never blast-file.
+
+**PII guardrail carries over unchanged.** The issue body must describe the
+corruption **by category with a synthetic repro** — never the candidate's real
+name / email / phone / location. The category is what you cite in the console
+("name dropped: letter-spaced heading"); the value stays in the gitignored scratch
+dir. If you can't restate the defect without a real value, you can't file it yet —
+build the synthetic repro first.
+
+### 1. Dedup first (required)
+
+Before drafting, search open issues for the same **layer + symptom** so you don't
+pile onto the existing open contact/parser bugs:
+
+```bash
+gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+  --search "contact <symptom keyword>"   # e.g. "contact letter-spaced name"
+```
+
+If a match already covers this layer+symptom, **stop** — link the existing issue
+instead of filing. Only file when nothing matches.
+
+### 2. Draft by category
+
+Build a self-contained finding from the probe's three blocks, values scrubbed to
+categories:
+
+- **Title** — the defect + localized layer, e.g. `Contact: letter-spaced name
+  heading dropped at the name field heuristic`.
+- **Body** — the region scanned (structure, not values), the fields produced
+  (`populated` / `empty`, not the values), the `verify` verdict
+  (`PARSER-MISS` vs `absent-in-pdf`), and the localized layer (line-assembly /
+  section-routing / field-heuristic) with the specific file + function.
+- **Synthetic repro** — a synthetic-persona PDF (fake name, `@example.com`, a
+  `555`-exchange phone on a real area code, subscriber `0100`–`0199`) that
+  reproduces the same category of corruption. The letter-spaced-name repro fixture
+  under `tests/fixtures/pdfs/unknown/` is the template.
+
+### 3. Show + confirm, then write
+
+Print the drafted title + body and the labels you'll use, and **wait for an
+explicit human confirm**. On confirm, write via the `create-gh-issue` skill (which
+owns the `scripts/create-gh-issue.sh` write path, label handling, and body-file
+escaping) — do **not** hand-roll a parallel `gh issue create` here. `bug` is the
+default type label; add `improvement` if it's a heuristic-tuning fix.
 
 ## Boundaries
 

--- a/.claude/skills/probe-experience/SKILL.md
+++ b/.claude/skills/probe-experience/SKILL.md
@@ -100,13 +100,57 @@ The `verify` block is the fast triage: `UNDER-SEGMENTED` with an intact region
 means the bug is in entry segmentation; a short/empty region means routing or
 assembly.
 
-## Filing what you find
+## Filing what you find (gated auto-file)
 
-Localize the layer, then file a **public** `resumelint-org/resumelint` issue
-describing the corruption **by category, using a synthetic repro** — never the
-candidate's real values. Reproduce with a synthetic-persona PDF (fake name,
-`@example.com`, a `555-01xx` phone on a real area code) so the fixture is
-PII-free; see `tests/fixtures/pdfs/README.md` for the add-fixture workflow.
+Once you've localized the layer, you can turn the finding into a
+`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+[`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
+show, confirm, then write. Never blast-file.
+
+**PII guardrail carries over unchanged.** The issue body must describe the
+corruption **by category with a synthetic repro** — never the candidate's real
+role titles / companies / locations. The category is what you cite in the console
+("second role's header demoted to a bullet under the first role"); the value stays
+in the gitignored scratch dir. If you can't restate the defect without a real
+value, you can't file it yet — build the synthetic repro first.
+
+### 1. Dedup first (required)
+
+Before drafting, search open issues for the same **layer + symptom** so you don't
+pile onto the existing open experience/parser bugs:
+
+```bash
+gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+  --search "experience <symptom keyword>"   # e.g. "experience role merged two-column"
+```
+
+If a match already covers this layer+symptom, **stop** — link the existing issue
+instead of filing. Only file when nothing matches.
+
+### 2. Draft by category
+
+Build a self-contained finding from the probe's five blocks, values scrubbed to
+categories:
+
+- **Title** — the defect + localized layer, e.g. `Experience: two-column second
+  role merged into the first at entry segmentation`.
+- **Body** — sections detected (region name + line counts, not values), parsed
+  entry count vs. what was expected, the `verify` verdict (`UNDER-SEGMENTED` /
+  `PARSER-MISS`), and the localized layer (line-assembly / section-routing /
+  entry-segmentation) with the specific file + function
+  (`parseEntryBlocks`, `disambiguateCompanyTitle`, …).
+- **Synthetic repro** — a synthetic-persona PDF (fake name, `@example.com`, a
+  `555`-exchange phone on a real area code, subscriber `0100`–`0199`) that
+  reproduces the same category of corruption. See
+  `tests/fixtures/pdfs/README.md` for the add-fixture workflow.
+
+### 3. Show + confirm, then write
+
+Print the drafted title + body and the labels you'll use, and **wait for an
+explicit human confirm**. On confirm, write via the `create-gh-issue` skill (which
+owns the `scripts/create-gh-issue.sh` write path, label handling, and body-file
+escaping) — do **not** hand-roll a parallel `gh issue create` here. `bug` is the
+default type label; add `improvement` if it's a segmentation-tuning fix.
 
 ## Boundaries
 

--- a/.claude/skills/probe-roundtrip/SKILL.md
+++ b/.claude/skills/probe-roundtrip/SKILL.md
@@ -78,13 +78,64 @@ Use an **absolute path** for `RL_RT_PDF`.
   Download-PDF path preserves what the parser read.
 - **A category regresses** (e.g. `education count 1 → 2`, a `role[i].company`
   value swap, a skills `added`/`removed` split) → that is a renderer or parser
-  bug. Localize it, then file a **public** `resumelint-org/resumelint` issue
-  describing the corruption **by category, using a synthetic repro** — never the
-  candidate's real values. The round-trip bugs this probe hunts are tracked at
+  bug. Localize it, then file it via **Filing what you find** below. The
+  round-trip bugs this probe hunts are tracked at
   resumelint-org/resumelint#295–#299.
 - **`renderError`** → `renderAtsResumePdf` crashed (e.g. a non-WinAnsi glyph the
   pdf-lib StandardFonts can't encode). Highest-severity find — the Download-PDF
   path throws for real users.
+
+## Filing what you find (gated auto-file)
+
+Once you've localized the corruption to a hop + layer, you can turn the finding
+into a `resumelint-org/resumelint` issue **without leaving the probe** — via the
+in-repo [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is
+**gated**: draft, show, confirm, then write. Never blast-file.
+
+**PII guardrail carries over unchanged.** The issue body must describe the
+corruption **by category with a synthetic repro** — never the candidate's real
+field values. The category is what you cite in the console ("education count
+inflated 1→2", "a `role[i].company` value swap"); the values stay in the
+gitignored JSON report. If you can't restate the defect without a real value, you
+can't file it yet — build the synthetic repro first.
+
+### 1. Dedup first (required)
+
+Before drafting, search open issues for the same **symptom** so you don't pile
+onto the tracked round-trip bugs (#295–#299) or the open parser backlog:
+
+```bash
+gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+  --search "round-trip <symptom keyword>"   # e.g. "round-trip education count"
+```
+
+If a match already covers this symptom, **stop** — link the existing issue instead
+of filing. Only file when nothing matches.
+
+### 2. Draft by category
+
+Build a self-contained finding from the probe's per-hop diff, values scrubbed to
+categories:
+
+- **Title** — the defect + where it regresses, e.g. `Round-trip: education entry
+  count inflated on re-parse of the reconstructed PDF`.
+- **Body** — the hop at which the category first regresses (`renderError` is the
+  highest-severity variant), the category of drift (`count inflated`, `field
+  swap`, `skills added/removed`, `summary length drift`), and whether it is a
+  renderer defect (`renderAtsResumePdf` / `ats-resume-model.ts`) or a re-parse
+  defect — no raw candidate values.
+- **Synthetic repro** — a synthetic-persona PDF (fake name, `@example.com`, a
+  `555`-exchange phone on a real area code, subscriber `0100`–`0199`) that
+  reproduces the same category of round-trip corruption, so it can seed a
+  `corpus-roundtrip.test.ts` case. See `tests/fixtures/pdfs/README.md`.
+
+### 3. Show + confirm, then write
+
+Print the drafted title + body and the labels you'll use, and **wait for an
+explicit human confirm**. On confirm, write via the `create-gh-issue` skill (which
+owns the `scripts/create-gh-issue.sh` write path, label handling, and body-file
+escaping) — do **not** hand-roll a parallel `gh issue create` here. `bug` is the
+default type label; add `testing` when the fix seeds a corpus round-trip case.
 
 ## Boundaries
 

--- a/scripts/create-gh-issue.sh
+++ b/scripts/create-gh-issue.sh
@@ -44,14 +44,24 @@ usage() {
     exit "${1:-0}"
 }
 
+# Abort with a friendly error if a value-taking flag is the last arg (no $2).
+# Runs in the current shell so `exit` aborts the script before `$2`/`shift 2`
+# trip `set -u` / a short `shift`.
+require_value() {
+    if [[ "$2" -lt 2 ]]; then
+        echo "[ERROR] $1 requires a value" >&2
+        exit 2
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --title)      TITLE="$2"; shift 2 ;;
-        --body-file)  BODY_FILE="$2"; shift 2 ;;
-        --labels)     LABELS="$2"; shift 2 ;;
-        --assignee)   ASSIGNEE="$2"; shift 2 ;;
-        --milestone)  MILESTONE="$2"; shift 2 ;;
-        --repo)       REPO="$2"; shift 2 ;;
+        --title)      require_value "$1" "$#"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$1" "$#"; BODY_FILE="$2"; shift 2 ;;
+        --labels)     require_value "$1" "$#"; LABELS="$2"; shift 2 ;;
+        --assignee)   require_value "$1" "$#"; ASSIGNEE="$2"; shift 2 ;;
+        --milestone)  require_value "$1" "$#"; MILESTONE="$2"; shift 2 ;;
+        --repo)       require_value "$1" "$#"; REPO="$2"; shift 2 ;;
         -h|--help)    usage 0 ;;
         *) echo "[ERROR] Unknown arg: $1" >&2; usage 2 ;;
     esac
@@ -74,7 +84,8 @@ fi
 LABEL_ARGS=()
 IFS=',' read -r -a LABEL_NAMES <<< "$LABELS"
 for label in "${LABEL_NAMES[@]}"; do
-    label_trimmed="$(echo "$label" | xargs)"
+    label_trimmed="${label#"${label%%[![:space:]]*}"}"   # strip leading whitespace
+    label_trimmed="${label_trimmed%"${label_trimmed##*[![:space:]]}"}"   # strip trailing
     [[ -z "$label_trimmed" ]] && continue
     LABEL_ARGS+=(--label "$label_trimmed")
 done

--- a/scripts/create-gh-issue.sh
+++ b/scripts/create-gh-issue.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# create-gh-issue.sh — Create a resumelint GitHub issue via `gh issue create`,
+# passing the body as a FILE so backticks, tables, and fenced code blocks survive
+# shell escaping intact.
+#
+# Self-contained: depends only on `gh` (authenticated) and `git`. No external
+# scripts, no ~/tools, no ~/.env — safe to run on any checkout of this repo,
+# including a contributor's fork. Driven by the `create-gh-issue` skill
+# (.claude/skills/create-gh-issue/); the intern-facing sibling of the
+# maintainer's private create-issue tooling.
+#
+# Surface:
+#   --title       (required)
+#   --body-file   (required; path to a markdown file holding the issue body)
+#   --labels      (required; comma-separated, must already exist in the repo)
+#   --assignee    (optional; GH username, e.g. @me to self-assign)
+#   --milestone   (optional; milestone title or number)
+#   --repo        (optional; default = current repo via `gh repo view`)
+#
+# GitHub issues don't model priority / cycles / blockers as fields. Express
+# priority via a label if the repo has one; record a blocker with a follow-up
+# comment like `Blocked by #N`.
+#
+# Stdout (success): <owner/repo>#<number>\t<URL>
+# Stderr (failure): [ERROR] ... ; exit 2 (arg/env error) or 1 (gh failure)
+#
+# Example:
+#   scripts/create-gh-issue.sh \
+#     --title "Skills under 'ADDITIONAL' header land in Other bucket" \
+#     --body-file /tmp/issue-body-20260708-120000.md \
+#     --labels bug,improvement
+
+set -euo pipefail
+
+TITLE=""
+BODY_FILE=""
+LABELS=""
+ASSIGNEE=""
+MILESTONE=""
+REPO=""
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)      TITLE="$2"; shift 2 ;;
+        --body-file)  BODY_FILE="$2"; shift 2 ;;
+        --labels)     LABELS="$2"; shift 2 ;;
+        --assignee)   ASSIGNEE="$2"; shift 2 ;;
+        --milestone)  MILESTONE="$2"; shift 2 ;;
+        --repo)       REPO="$2"; shift 2 ;;
+        -h|--help)    usage 0 ;;
+        *) echo "[ERROR] Unknown arg: $1" >&2; usage 2 ;;
+    esac
+done
+
+[[ -z "$TITLE"     ]] && { echo "[ERROR] --title required"     >&2; exit 2; }
+[[ -z "$BODY_FILE" ]] && { echo "[ERROR] --body-file required" >&2; exit 2; }
+[[ -z "$LABELS"    ]] && { echo "[ERROR] --labels required"    >&2; exit 2; }
+[[ -f "$BODY_FILE" ]] || { echo "[ERROR] body-file not found: $BODY_FILE" >&2; exit 2; }
+
+command -v gh >/dev/null || { echo "[ERROR] gh CLI not on PATH — install from https://cli.github.com and run 'gh auth login'" >&2; exit 2; }
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+        echo "[ERROR] Could not detect GitHub repo. Run from a repo with a github.com remote, or pass --repo owner/name." >&2
+        exit 2
+    }
+fi
+
+LABEL_ARGS=()
+IFS=',' read -r -a LABEL_NAMES <<< "$LABELS"
+for label in "${LABEL_NAMES[@]}"; do
+    label_trimmed="$(echo "$label" | xargs)"
+    [[ -z "$label_trimmed" ]] && continue
+    LABEL_ARGS+=(--label "$label_trimmed")
+done
+
+GH_ARGS=(
+    --repo "$REPO"
+    --title "$TITLE"
+    --body-file "$BODY_FILE"
+    "${LABEL_ARGS[@]}"
+)
+
+[[ -n "$ASSIGNEE"  ]] && GH_ARGS+=(--assignee "$ASSIGNEE")
+[[ -n "$MILESTONE" ]] && GH_ARGS+=(--milestone "$MILESTONE")
+
+URL=$(gh issue create "${GH_ARGS[@]}") || {
+    echo "[ERROR] gh issue create failed (most common cause: a --labels value that does not exist in the repo — check 'gh label list')" >&2
+    exit 1
+}
+
+NUMBER="${URL##*/}"
+[[ "$NUMBER" =~ ^[0-9]+$ ]] || {
+    echo "[ERROR] Could not parse issue number from gh output: $URL" >&2
+    exit 1
+}
+
+printf '%s#%s\t%s\n' "$REPO" "$NUMBER" "$URL"


### PR DESCRIPTION
## Summary

Two related changes that together give interns/contributors a self-contained issue-filing path — and wire the parser probes into it.

**1. `create-gh-issue` skill + writer.** A resumelint-specific way to file thorough, self-contained GitHub issues without any other custom tooling.

- `scripts/create-gh-issue.sh` — self-contained wrapper over `gh issue create` with body-as-file support (backticks/tables/fenced code survive shell escaping). Depends only on an authenticated `gh`; no `~/tools`, no Linear, no machine-local `.env`. Lives in `scripts/` alongside the other tracked repo scripts (skills stay prose-only, matching repo convention).
- `.claude/skills/create-gh-issue/SKILL.md` — GitHub-only workflow (gather → plan → acceptance criteria → reuse-gate → file), wired to resumelint's real labels, the four `P1–P4` milestones, and the codegraph/reuse-gate conventions from `CLAUDE.md`.

**2. Gated auto-file + dedup in the `probe-*` skills (`Resolves #408`).** `probe-roundtrip`, `probe-contact`, and `probe-experience` now document a gated flow that turns a localized defect into a filed issue **via the `create-gh-issue` skill above** — instead of stopping at the printed diagnosis:

- **Dedup first** — search open issues for the same layer+symptom before filing.
- **Draft by category** — build a self-contained finding with the PII guardrail intact (synthetic repro, never the candidate's real values).
- **Show + confirm** — the draft is shown; filing is gated behind an explicit human confirm.
- **Write via `create-gh-issue`** — no hand-rolled `gh issue create` in a probe.

This is the "file" step of the drop-PDF → probe → file → fix → PR loop.

Resolves #408

## Test plan

- [x] `scripts/create-gh-issue.sh` error/help paths exercised (missing `--title`/`--body-file`/`--labels`, absent body-file → exit 2; `--help` → usage) — no real issue created
- [x] `create-gh-issue.sh` verified end-to-end filing a real issue (#408, the issue this PR resolves)
- [x] `bash -n` syntax check clean; `verify` (lint + build) green on push
- [ ] Probe → `create-gh-issue` handoff exercised end-to-end on a real localized defect (manual, post-merge)