### PR TITLE
fix(experience): recover location from separator-less "Company | Location Dates" cell (#373)

### DIFF
--- a/src/lib/heuristics/extract/experience.pipe-location.test.ts
+++ b/src/lib/heuristics/extract/experience.pipe-location.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression for #373 — a per-entry location dropped when a
+ * "Company | Location Dates" header line has no separator between the location
+ * and the date range:
+ *
+ *   Globex Financial | New York, NY August 2024 - Present
+ *
+ * `parseEntryBlocks` strips the trailing date range before disambiguation, so
+ * the `|` cell reaching the field mapper is a clean "New York, NY" — but the
+ * location sits BEFORE the (removed) dates, so `stripLocationSuffix`'s
+ * end-anchored passes never claimed it and the location was dropped. A new step
+ * recovers a bare location from the anchor line's non-company/non-title cell.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("location on 'Company | Location Dates' with no separator (#373)", () => {
+  it("recovers the location from the pipe cell (alongside the #372 team mapping)", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Software Engineer II, Business Credit Journey", fontSize: 11 },
+      {
+        text: "Globex Financial | New York, NY August 2024 - Present",
+        fontSize: 11,
+      },
+      { text: "• Ran Cassandra design sessions with technical leads.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.company).toBe("Globex Financial");
+    expect(role.team).toBe("Business Credit Journey");
+    expect(role.location).toBe("New York, NY");
+  });
+
+  it("recovers a single-word city too", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Staff Engineer, Platform", fontSize: 11 },
+      { text: "Initech | Austin, TX July 2022 - August 2024", fontSize: 11 },
+      { text: "• Owned the deploy pipeline.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Initech");
+    expect(roles[0].location).toBe("Austin, TX");
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -10,6 +10,7 @@ import {
   INTL_LOCATION_RE,
   US_STATE_CODE_RE,
   COUNTRY_GAZETTEER,
+  DATE_RANGE_RE,
   matchSectionHeader,
 } from "../regex.ts";
 import { looksLikeTitle, looksLikeCompany, finalizeEntries } from "./shared.ts";
@@ -203,6 +204,27 @@ const LOCALITY_SUFFIX_RE =
  *  `BARE_LOCATION_RE`. */
 const KNOWN_MULTIWORD_US_CITY_RE =
   /New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City/;
+
+/** Recover a location from an anchor-row cell of a "Company | Location Dates"
+ *  header line — the "New York, NY" cell of "Globex Financial | New York, NY
+ *  August 2024 - Present" (#373). `stripDateRange` in `parseEntryBlocks` peels
+ *  the trailing dates off the anchor line before it reaches disambiguation, so
+ *  the cell is normally a clean bare "City, ST" / "City, Country" — but the
+ *  location sits BEFORE the (now-removed) dates, so `stripLocationSuffix`'s
+ *  end-anchored passes never claimed it and it was dropped. Return the cell when
+ *  it is a whole-string bare location. Falls back to peeling a still-glued date
+ *  range (a format `stripDateRange` didn't catch) before the check, so the fold
+ *  is recovered whether or not the dates were pre-stripped. */
+function locationFromAnchorCell(cell: string): string | undefined {
+  const c = cell.trim();
+  if (isBareLocationString(c)) return c;
+  const peeled = stripDanglingSeparator(
+    c.replace(DATE_RANGE_RE, " ").replace(/\s{2,}/g, " "),
+  );
+  return peeled && peeled !== c && isBareLocationString(peeled)
+    ? peeled
+    : undefined;
+}
 
 function stripLocationSuffix(s: string): {
   text: string;
@@ -704,6 +726,32 @@ function disambiguateCompanyTitle(
       //      (the #325 false-positive class reached via `team` instead of `title`).
       location = team;
       team = undefined;
+    }
+  }
+
+  // (3c) #373 — recover a per-entry location from an anchor-row cell that folds
+  //      "<City, ST> <dates>" with no separator ("Globex Financial | New York,
+  //      NY August 2024 - Present" — the second `|` cell). The date parse already
+  //      took the range into `block.dates`, but the location residue never
+  //      reached a field. Scan the anchor line's non-company segments; if one
+  //      yields a bare location once the date range is peeled, use it (and clear
+  //      the segment from `team` if it landed there).
+  if (!location && anchorIdx !== undefined) {
+    for (const s of splits) {
+      // Skip the company and the title cells: a location cell that landed in
+      // `title` is the empty-title "Company · City, ST" export shape, which
+      // step 5 rescues correctly (title → "", location set) — claiming it here
+      // would set `location` and block that rescue, orphaning the location in
+      // `title`. Only an unused/team location cell is claimed here.
+      if (s.source !== anchorIdx || s.text === company || s.text === title) {
+        continue;
+      }
+      const loc = locationFromAnchorCell(s.text);
+      if (loc) {
+        location = loc;
+        if (team === s.text) team = undefined;
+        break;
+      }
     }
   }
 

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -10,7 +10,6 @@ import {
   INTL_LOCATION_RE,
   US_STATE_CODE_RE,
   COUNTRY_GAZETTEER,
-  DATE_RANGE_RE,
   matchSectionHeader,
 } from "../regex.ts";
 import { looksLikeTitle, looksLikeCompany, finalizeEntries } from "./shared.ts";
@@ -207,23 +206,18 @@ const KNOWN_MULTIWORD_US_CITY_RE =
 
 /** Recover a location from an anchor-row cell of a "Company | Location Dates"
  *  header line — the "New York, NY" cell of "Globex Financial | New York, NY
- *  August 2024 - Present" (#373). `stripDateRange` in `parseEntryBlocks` peels
- *  the trailing dates off the anchor line before it reaches disambiguation, so
- *  the cell is normally a clean bare "City, ST" / "City, Country" — but the
- *  location sits BEFORE the (now-removed) dates, so `stripLocationSuffix`'s
- *  end-anchored passes never claimed it and it was dropped. Return the cell when
- *  it is a whole-string bare location. Falls back to peeling a still-glued date
- *  range (a format `stripDateRange` didn't catch) before the check, so the fold
- *  is recovered whether or not the dates were pre-stripped. */
+ *  August 2024 - Present" (#373). `parseEntryBlocks` runs `stripDateRange` on the
+ *  anchor line before it reaches disambiguation, so the cell is a clean bare
+ *  "City, ST" / "City, Country" — but the location sits BEFORE the (removed)
+ *  dates, so `stripLocationSuffix`'s end-anchored passes never claimed it and it
+ *  was dropped. Return the cell when it is a whole-string bare location.
+ *
+ *  No date-range peel here: this only ever runs on the anchor line, which
+ *  `stripDateRange` has already cleared with the same `DATE_RANGE_RE`, so any
+ *  glued range is gone before this sees the cell (#409 review). */
 function locationFromAnchorCell(cell: string): string | undefined {
   const c = cell.trim();
-  if (isBareLocationString(c)) return c;
-  const peeled = stripDanglingSeparator(
-    c.replace(DATE_RANGE_RE, " ").replace(/\s{2,}/g, " "),
-  );
-  return peeled && peeled !== c && isBareLocationString(peeled)
-    ? peeled
-    : undefined;
+  return isBareLocationString(c) ? c : undefined;
 }
 
 function stripLocationSuffix(s: string): {


### PR DESCRIPTION
## Summary

Recovers a per-entry location that was dropped when a `Company | Location Dates` header cell folds the location and date range with **no separator** between them — e.g. `Globex Financial | New York, NY August 2024 - Present`. `parseEntryBlocks` strips the trailing dates before disambiguation, so the `|` cell reaching the field mapper is a clean `New York, NY`, but because the location sat *before* the removed dates, `stripLocationSuffix`'s end-anchored passes never claimed it and it was silently dropped.

Adds `locationFromAnchorCell()` and step **(3c)** in `disambiguateCompanyTitle`: scan the anchor line's non-company/non-title cells and, when one yields a bare location (peeling any still-glued date range first), use it — clearing it from `team` if it landed there. The title cell is skipped so the empty-title `Company · City, ST` export shape still routes through step 5's rescue.

Closes #373

> **Stacked on #406** (`fix/393-two-column-experience-batch`) — the fix builds on that batch's `disambiguateCompanyTitle` changes. GitHub will auto-retarget this PR to `main` once #406 merges; rebase to drop the shared commits then.

## Test plan

- [x] `npm run typecheck` clean
- [x] `eslint .` clean
- [x] `npm run test` green (1668 passed; new `experience.pipe-location.test.ts` covers multi-word + single-word city)
- [x] `vite build` succeeds