### PR TITLE
fix(experience): attribute a shared employer banner to "Title, Team" roles (#382)

### DIFF
--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -242,7 +242,7 @@ function stripLocationSuffix(s: string): {
  * before the comma), and "Marketing Manager, San Francisco" (location tail) do
  * not. Returns null when no guarded split applies.
  */
-function splitRoleComma(h: string): [string, string] | null {
+export function splitRoleComma(h: string): [string, string] | null {
   const comma = h.indexOf(",");
   if (comma <= 0) return null;
   const before = h.slice(0, comma).trim();
@@ -533,8 +533,16 @@ function mapTitleFirst(splits: Split[], anchorIdx: number | undefined): Fields {
     splits[1] !== undefined &&
     splits[0]?.via === "comma" &&
     splits[0]?.source === splits[1].source;
+  // The real company lives on a SEPARATE delimited anchor line below the comma
+  // header ("Company | Location Dates"). When the comma header IS itself the
+  // anchor line (a single-line "Title, Team  Dates" role, source === anchorIdx),
+  // its leading segment is the title — not a company — so there is no anchor
+  // company to borrow and we must not treat splits[0] as one (that would set
+  // company = the title, #382). Require the anchor to be a different source line.
   const anchorSplits =
-    anchorIdx !== undefined ? splits.filter((s) => s.source === anchorIdx) : [];
+    anchorIdx !== undefined && anchorIdx !== splits[0]?.source
+      ? splits.filter((s) => s.source === anchorIdx)
+      : [];
   const anchorCompany =
     anchorSplits.length >= 2 && !looksLikeLocationTail(anchorSplits[0].text)
       ? anchorSplits[0].text

--- a/src/lib/heuristics/extract/experience.shared-banner.test.ts
+++ b/src/lib/heuristics/extract/experience.shared-banner.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Regression for #382 — a single employer banner heading a run of roles, each
+ * role header a bare "Title, Team" with the employer named ONCE above the group
+ * (not repeated per role):
+ *
+ *   Acme Corporation
+ *     Staff Engineer, Platform Infrastructure    Aug 2024 - Present
+ *     Senior Engineer, Payments Core             Jul 2022 - Aug 2024
+ *     Engineer, Identity Services                Aug 2020 - Jul 2022
+ *
+ * The employer banner sits above the group and is out of each follower role's
+ * header window (`headerLookback: 2` reaches only the first role), so roles 2..N
+ * had no company at all — and the "Title, Team" comma split mislabeled the
+ * team/sub-org as the company. Every role must map to `company = "Acme
+ * Corporation"`, `title = <role>`, `team = <post-comma segment>`.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function rolesFrom(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("shared employer banner over 'Title, Team' roles (#382)", () => {
+  it("attributes the banner employer to every role under it", () => {
+    const roles = rolesFrom([
+      { text: "Experience", fontSize: 13 },
+      { text: "Acme Corporation", fontSize: 12 },
+      { text: "Staff Engineer, Platform Infrastructure  Aug 2024 - Present", fontSize: 11 },
+      { text: "• Led platform work.", fontSize: 11 },
+      { text: "Senior Engineer, Payments Core  Jul 2022 - Aug 2024", fontSize: 11 },
+      { text: "• Ran payments.", fontSize: 11 },
+      { text: "Engineer, Identity Services  Aug 2020 - Jul 2022", fontSize: 11 },
+      { text: "• Built identity.", fontSize: 11 },
+    ]);
+
+    expect(roles.length).toBe(3);
+    for (const role of roles) {
+      expect(role.company).toBe("Acme Corporation");
+    }
+    expect(roles[0]).toMatchObject({
+      title: "Staff Engineer",
+      company: "Acme Corporation",
+      team: "Platform Infrastructure",
+    });
+    expect(roles[1]).toMatchObject({
+      title: "Senior Engineer",
+      company: "Acme Corporation",
+      team: "Payments Core",
+    });
+    expect(roles[2]).toMatchObject({
+      title: "Engineer",
+      company: "Acme Corporation",
+      team: "Identity Services",
+    });
+    // The team/sub-org must never be mislabeled as the company.
+    expect(roles.map((r) => r.company)).not.toContain("Payments Core");
+    expect(roles.map((r) => r.company)).not.toContain("Identity Services");
+  });
+
+  it("does NOT propagate to a role that names its own employer (no false positive)", () => {
+    // Same banner + two followers, then a role whose header carries its OWN
+    // employer ("Consultant, Globex LLC" — post-comma reads as a company). The
+    // run stops at it: it keeps its own company, not the banner.
+    const roles = rolesFrom([
+      { text: "Experience", fontSize: 13 },
+      { text: "Acme Corporation", fontSize: 12 },
+      { text: "Staff Engineer, Platform Infrastructure  Aug 2024 - Present", fontSize: 11 },
+      { text: "• Led platform work.", fontSize: 11 },
+      { text: "Senior Engineer, Payments Core  Jul 2022 - Aug 2024", fontSize: 11 },
+      { text: "• Ran payments.", fontSize: 11 },
+      { text: "Consultant, Globex LLC  Aug 2020 - Jul 2022", fontSize: 11 },
+      { text: "• Advised on architecture.", fontSize: 11 },
+    ]);
+
+    expect(roles.length).toBe(3);
+    expect(roles[0].company).toBe("Acme Corporation");
+    expect(roles[1].company).toBe("Acme Corporation");
+    // The self-employed role keeps its own employer, NOT the banner.
+    expect(roles[2].company).toBe("Globex LLC");
+    expect(roles[2].company).not.toBe("Acme Corporation");
+  });
+
+  it("leaves a single standalone 'Title, Company' role unchanged (no banner)", () => {
+    // No banner above → no propagation. A lone comma role keeps its prior
+    // mapping (regression guard on the isolated comma-split path).
+    const roles = rolesFrom([
+      { text: "Experience", fontSize: 13 },
+      { text: "Office manager, Nod Publishing  March 2023 - December 2024", fontSize: 11 },
+      { text: "• Ran the front office.", fontSize: 11 },
+    ]);
+
+    expect(roles.length).toBe(1);
+    expect(roles[0].title.toLowerCase()).toContain("office manager");
+    expect(roles[0].company).toBe("Nod Publishing");
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -5,8 +5,11 @@ import type { ResumeExperience } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
-import { finalizeEntries } from "./shared.ts";
-import { disambiguateCompanyTitle } from "./experience-disambiguate.ts";
+import { finalizeEntries, looksLikeCompany } from "./shared.ts";
+import {
+  disambiguateCompanyTitle,
+  splitRoleComma,
+} from "./experience-disambiguate.ts";
 
 // ── Experience ──────────────────────────────────────────────────────────────
 
@@ -54,25 +57,117 @@ export function extractExperience(
       collectBody: true,
     });
   }
+  // Detect a shared employer banner heading a run of "Title, Team" roles (#382):
+  // one employer stated once above a group, each role below carrying only its
+  // "Title, Team" header. The per-role blocks lack the banner (it sits above the
+  // group, out of each follower's header window), so attribute it here before
+  // mapping.
+  const banners = detectSharedBanners(blocks);
   // Drop a date-only phantom — a block with neither title nor company (#145).
   // Experience has no single title axis, so we keep a role that has either.
   return finalizeEntries(
-    blocks.map(experienceFromBlock),
+    blocks.map((block, i) => experienceFromBlock(block, banners.get(i))),
     (e) => e.title !== "" || e.company !== "",
   );
 }
 
+/**
+ * The employer named by a block that HEADS a shared-employer banner group
+ * (#382): its first header line is a standalone org (`looksLikeCompany`) sitting
+ * ABOVE the date anchor (`anchorHeaderIndex >= 1`), and its own role header (the
+ * anchor line) is itself a "Title, Team" comma shape — so the whole group is the
+ * homogeneous "one banner over N × `Title, Team`" layout, not a coincidental
+ * stacked "Company / Title" role above an unrelated comma role. Returns the
+ * banner employer, or undefined when the block is not such a head.
+ */
+function bannerEmployerOf(block: EntryBlock): string | undefined {
+  const idx = block.anchorHeaderIndex ?? -1;
+  if (idx < 1) return undefined;
+  const lead = block.headerLines[0];
+  if (!lead || !looksLikeCompany(lead)) return undefined;
+  const anchorLine = block.headerLines[idx];
+  if (!anchorLine || !splitRoleComma(anchorLine)) return undefined;
+  return lead;
+}
+
+/**
+ * True when a block is a FOLLOWER under a shared employer banner (#382): a single
+ * "Title, Team" header line (the anchor), where the post-comma segment is NOT
+ * itself an employer (`!looksLikeCompany`) — i.e. the role names no company of
+ * its own, so the group banner above supplies it. A role whose header carries its
+ * own employer ("Engineer, Globex Inc") reads as `looksLikeCompany` on the
+ * post-comma segment and is left alone (the issue's "last role maps correctly"
+ * case).
+ */
+function isCommaFollower(block: EntryBlock): boolean {
+  if (block.headerLines.length !== 1) return false;
+  const rc = splitRoleComma(block.headerLines[0]);
+  return rc !== null && !looksLikeCompany(rc[1]);
+}
+
+/**
+ * Map each block index to its shared-employer banner (#382). A banner head
+ * (`bannerEmployerOf`) claims the contiguous run of comma-follower blocks
+ * (`isCommaFollower`) directly below it; the run stops at the first block that is
+ * not a follower (its own employer, a differently-shaped role, or a new banner).
+ * Only activates when at least one follower exists, so a lone banner-shaped role
+ * is untouched.
+ */
+function detectSharedBanners(blocks: EntryBlock[]): Map<number, string> {
+  const out = new Map<number, string>();
+  for (let i = 0; i < blocks.length; i++) {
+    const employer = bannerEmployerOf(blocks[i]);
+    if (!employer) continue;
+    const followers: number[] = [];
+    for (let j = i + 1; j < blocks.length; j++) {
+      if (!isCommaFollower(blocks[j])) break;
+      followers.push(j);
+    }
+    for (const j of followers) out.set(j, employer);
+  }
+  return out;
+}
+
+/** Resolve a block's title/company/team/location. Runs the shared header
+ *  disambiguation, then — for a shared-banner follower (#382) — overrides: the
+ *  lone "Title, Team" header names no company of its own, so route the pre-comma
+ *  segment to title, the post-comma segment to team, and take the company from
+ *  the group banner. */
+function resolveBlockFields(
+  block: EntryBlock,
+  bannerEmployer: string | undefined,
+): { title?: string; company?: string; team?: string; location?: string } {
+  const mapped = disambiguateCompanyTitle(
+    block.headerLines,
+    block.anchorHeaderIndex,
+  );
+  if (!bannerEmployer) return mapped;
+  const rc = splitRoleComma(block.headerLines[0] ?? "");
+  return {
+    title: rc ? rc[0] : mapped.title,
+    company: bannerEmployer,
+    team: rc ? rc[1] : mapped.team,
+    location: mapped.location,
+  };
+}
+
 /** Map one dated entry block to a `ResumeExperience` and its confidence score.
  *  Extracted from `extractExperience` to keep each function below the
- *  complexity threshold; mirrors `projectFromBlock` / `achievementFromBlock`. */
-function experienceFromBlock(block: EntryBlock): {
+ *  complexity threshold; mirrors `projectFromBlock` / `achievementFromBlock`.
+ *  `bannerEmployer` (set for a shared-banner follower, #382) overrides the
+ *  employer: the role's single "Title, Team" header supplies title + team and the
+ *  group banner supplies the company. */
+function experienceFromBlock(
+  block: EntryBlock,
+  bannerEmployer?: string,
+): {
   entry: ResumeExperience;
   score: number;
 } {
   const { dates } = block;
-  const { title, company, team, location } = disambiguateCompanyTitle(
-    block.headerLines,
-    block.anchorHeaderIndex,
+  const { title, company, team, location } = resolveBlockFields(
+    block,
+    bannerEmployer,
   );
   const description = block.body;
 


### PR DESCRIPTION
Closes #382. **Stacked on #419** (`refactor/412-decompose-disambiguate`) — base auto-retargets to `main` when #419 merges; rebase to drop #419's commits then.

## Problem

A résumé that names an employer **once as a banner** over a group of roles, each header a bare `Title, Team`:

```
Acme Corporation
  Staff Engineer, Platform Infrastructure   Aug 2024 – Present
  Senior Engineer, Payments Core            Jul 2022 – Aug 2024
  Engineer, Identity Services               Aug 2020 – Jul 2022
```

dropped the employer on every role but the first. The banner sits above the group (out of each follower's `headerLookback: 2` window), and the `Title, Team` comma split mislabeled the team/sub-org as the company.

**Before → After**

| Role | company (before) | company (after) |
|------|------------------|-----------------|
| Staff Engineer | Acme Corporation ✅ | Acme Corporation |
| Senior Engineer | **Senior Engineer** ❌ | **Acme Corporation** |
| Engineer | **Engineer** ❌ | **Acme Corporation** |

## Fix (two coupled parts)

1. **`mapTitleFirst` self-anchor guard** (`experience-disambiguate.ts`) — the #372 "borrow the company from a delimited anchor line" path must fire only when that anchor is a *separate* line below the comma header. When the comma header **is** the anchor (single-line `Title, Team  Dates`), its leading segment is the title — treating it as the company set `company = title`. Now requires `anchorIdx !== splits[0].source`.

2. **Shared-banner propagation** (`experience.ts`) — `detectSharedBanners` finds a block heading a homogeneous "one employer banner over N × `Title, Team`" group and attributes its employer to the contiguous run of comma-follower roles. Pre-comma → title, post-comma → team, banner → company.

**Conservative gates (no false positives):**
- banner must be a standalone `looksLikeCompany` line **above** the anchor;
- the group head's own role must share the `Title, Team` comma shape (rules out a stacked `Company / Title` role above an unrelated comma role);
- a follower that names its **own** employer (post-comma `looksLikeCompany`) stops the run and keeps its company (the issue's "last role maps correctly" case).

`splitRoleComma` is now exported from `experience-disambiguate.ts` for the follower re-map (consumed by `experience.ts` — no unconsumed export).

## Tests

Value-asserting regression (`experience.shared-banner.test.ts`, per the repo's parser-fix style over lossy snapshots):
- 3 roles under one banner → all map to the banner employer + correct title/team;
- a role with its own employer → **not** propagated (false-positive guard);
- a lone standalone comma role → unchanged.

## Verify

typecheck · eslint · full suite **1701 passed / 4 skipped** · build — green. **Zero `*.expected.json` edits**; #372 title-team test still green.

## Follow-up

A synthetic-persona PDF fixture (per `tests/fixtures/pdfs/README.md`) exercising the banner shape end-to-end is a natural add; the value-asserting unit test is the primary regression anchor here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)