### PR TITLE
feat(export): download-export standards — profiles[] model, JSON Resume export, shareable audit report (#400)

### DIFF
--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -49,7 +49,12 @@ function render(
   result: CascadeResult,
   editProps?: Pick<
     Parameters<typeof ContactCard>[0],
-    "overrides" | "onFieldChange"
+    | "overrides"
+    | "onFieldChange"
+    | "addedProfiles"
+    | "onAddProfile"
+    | "onEditProfile"
+    | "onRemoveProfile"
   >,
 ): HTMLDivElement {
   container = document.createElement("div");
@@ -103,6 +108,48 @@ describe("ContactCard", () => {
     expect(dotted?.className).toContain("decoration-dotted");
   });
 
+  it("renders extra added-profile links with a slug + '+ Add link' affordance (issue 335)", () => {
+    const el = render(makeResult(), {
+      overrides: {},
+      onFieldChange: () => {},
+      addedProfiles: [
+        {
+          id: "profile:0",
+          url: "https://gitlab.com/jane",
+          network: "GitLab",
+          kind: "code",
+        },
+        {
+          id: "profile:1",
+          url: "https://example.dev/jane",
+          network: "example.dev",
+          kind: "other",
+        },
+      ],
+      onAddProfile: () => {},
+      onEditProfile: () => {},
+      onRemoveProfile: () => {},
+    });
+    const text = el.textContent ?? "";
+    // Known-host slug + unknown-host slug (hostname is the brand-neutral label).
+    expect(text).toContain("gitlab.com/jane");
+    expect(text).toContain("example.dev/jane");
+    // The "+ Add link" progressive-disclosure pill.
+    expect(el.querySelector('[aria-label="Add link"]')).not.toBeNull();
+    // Per-profile open-in-new-tab anchor + remove control.
+    expect(
+      el.querySelector('a[href="https://gitlab.com/jane"]'),
+    ).not.toBeNull();
+    expect(
+      el.querySelector('[aria-label="Remove GitLab link"]'),
+    ).not.toBeNull();
+  });
+
+  it("does not render the extra-links affordance on a display-only card (issue 335)", () => {
+    const el = render(makeResult({ email: "jane@example.com" }, { email: 0.9 }));
+    expect(el.querySelector('[aria-label="Add link"]')).toBeNull();
+  });
+
   it("renders a detected link as a clickable new-tab slug anchor", () => {
     const el = render(
       makeResult(
@@ -127,11 +174,14 @@ describe("ContactCard", () => {
       ),
       { overrides: {}, onFieldChange: () => {} },
     );
-    // Slug is the click-to-edit target (operates on the full URL)…
-    const edit = el.querySelector('[aria-label="Edit LinkedIn"]');
+    // Slug is the click-to-edit target (operates on the full URL). The required
+    // link row is the brand-neutral "Professional profile" row (#335).
+    const edit = el.querySelector('[aria-label="Edit Professional profile"]');
     expect(edit?.textContent).toBe("linkedin.com/in/jane-doe");
     // …and a separate ↗ anchor still opens the real URL in a new tab.
-    const open = el.querySelector('a[aria-label="Open LinkedIn in a new tab"]');
+    const open = el.querySelector(
+      'a[aria-label="Open Professional profile in a new tab"]',
+    );
     expect(open?.getAttribute("href")).toBe(
       "https://www.linkedin.com/in/jane-doe",
     );

--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -108,7 +108,7 @@ describe("ContactCard", () => {
     expect(dotted?.className).toContain("decoration-dotted");
   });
 
-  it("renders extra added-profile links with a slug + '+ Add link' affordance (issue 335)", () => {
+  it("renders extra added-profile links with a slug + guided '+ Add a profile' affordance (issue 335)", () => {
     const el = render(makeResult(), {
       overrides: {},
       onFieldChange: () => {},
@@ -134,8 +134,8 @@ describe("ContactCard", () => {
     // Known-host slug + unknown-host slug (hostname is the brand-neutral label).
     expect(text).toContain("gitlab.com/jane");
     expect(text).toContain("example.dev/jane");
-    // The "+ Add link" progressive-disclosure pill.
-    expect(el.querySelector('[aria-label="Add link"]')).not.toBeNull();
+    // The "+ Add a profile" progressive-disclosure pill.
+    expect(el.querySelector('[aria-label="Add a profile"]')).not.toBeNull();
     // Per-profile open-in-new-tab anchor + remove control.
     expect(
       el.querySelector('a[href="https://gitlab.com/jane"]'),
@@ -147,7 +147,7 @@ describe("ContactCard", () => {
 
   it("does not render the extra-links affordance on a display-only card (issue 335)", () => {
     const el = render(makeResult({ email: "jane@example.com" }, { email: 0.9 }));
-    expect(el.querySelector('[aria-label="Add link"]')).toBeNull();
+    expect(el.querySelector('[aria-label="Add a profile"]')).toBeNull();
   });
 
   it("renders a detected link as a clickable new-tab slug anchor", () => {

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -31,7 +31,10 @@ import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import { applyContactOverrides, buildContactFields } from "../../lib/contact.ts";
 import { Card, EditableField } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
-import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
+import type {
+  ContactOverrides,
+  AddedProfile,
+} from "../../hooks/useEditableParse.ts";
 import { ContactDetails } from "./ContactDetails.tsx";
 
 interface ContactCardProps {
@@ -41,12 +44,23 @@ interface ContactCardProps {
   overrides?: ContactOverrides;
   /** Called when the user commits an edit on a contact field. */
   onFieldChange?: (key: keyof ContactOverrides, newValue: string) => void;
+  /** Extra user-added contact links beyond the four legacy slots (#335). Wired
+   *  together with the add/edit/remove handlers to enable the variable-length
+   *  links affordance in the editable card. */
+  addedProfiles?: readonly AddedProfile[];
+  onAddProfile?: (url: string) => void;
+  onEditProfile?: (id: string, url: string) => void;
+  onRemoveProfile?: (id: string) => void;
 }
 
 export function ContactCard({
   result,
   overrides,
   onFieldChange,
+  addedProfiles,
+  onAddProfile,
+  onEditProfile,
+  onRemoveProfile,
 }: ContactCardProps) {
   const editable = overrides !== undefined && onFieldChange !== undefined;
 
@@ -91,6 +105,10 @@ export function ContactCard({
         links={links}
         editable={editable}
         commit={commit}
+        extraProfiles={addedProfiles}
+        onAddProfile={onAddProfile}
+        onEditProfile={onEditProfile}
+        onRemoveProfile={onRemoveProfile}
       />
     </Card>
   );

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -26,7 +26,11 @@ import {
   validateUrl,
   type FieldValidator,
 } from "../../lib/edit/field-validators.ts";
-import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
+import type {
+  ContactOverrides,
+  AddedProfile,
+} from "../../hooks/useEditableParse.ts";
+import { ContactExtraLinks } from "./ContactExtraLinks.tsx";
 
 /** The inline-editable contact fields, mapped 1:1 to their `ContactOverrides`
  *  key. Includes the link fields — a detected GitHub/portfolio/website URL is
@@ -74,6 +78,13 @@ interface ContactDetailsProps {
   links: ContactDisplayField[];
   editable: boolean;
   commit: Commit;
+  /** Extra user-added links beyond the four legacy slots (#335). When
+   *  `onAddProfile` is provided (editable card), the variable-length add/edit/
+   *  delete affordance renders below the legacy links line. */
+  extraProfiles?: readonly AddedProfile[];
+  onAddProfile?: (url: string) => void;
+  onEditProfile?: (id: string, url: string) => void;
+  onRemoveProfile?: (id: string) => void;
 }
 
 export function ContactDetails({
@@ -81,6 +92,10 @@ export function ContactDetails({
   links,
   editable,
   commit,
+  extraProfiles,
+  onAddProfile,
+  onEditProfile,
+  onRemoveProfile,
 }: ContactDetailsProps) {
   // The parsed location, threaded into the phone validator's region default so a
   // non-US local-form number isn't falsely flagged (see `validatorFor`).
@@ -109,6 +124,19 @@ export function ContactDetails({
             </span>
           ))}
         </p>
+      )}
+
+      {/* Extra user-added links (#335) — add/edit/delete beyond the four legacy
+          slots. Edit-only: the affordance renders whenever an add handler is
+          wired (the editable card), even with zero extras so the first can be
+          added. */}
+      {editable && onAddProfile && onEditProfile && onRemoveProfile && (
+        <ContactExtraLinks
+          profiles={extraProfiles ?? []}
+          onAdd={onAddProfile}
+          onEdit={onEditProfile}
+          onRemove={onRemoveProfile}
+        />
       )}
     </>
   );

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -31,6 +31,7 @@ import type {
   AddedProfile,
 } from "../../hooks/useEditableParse.ts";
 import { ContactExtraLinks } from "./ContactExtraLinks.tsx";
+import { ProfileLinkAdd } from "./ProfileLinkAdd.tsx";
 
 /** The inline-editable contact fields, mapped 1:1 to their `ContactOverrides`
  *  key. Includes the link fields — a detected GitHub/portfolio/website URL is
@@ -276,6 +277,19 @@ function renderLink(
         </span>
       );
     }
+    // An ABSENT required link (the brand-neutral "Professional profile" row is
+    // the only one that reaches here — optional links skip when undetected) gets
+    // the guided network picker instead of a bare URL field, so a naive user
+    // learns what counts and which networks are accepted (#335-followup).
+    if (field.reason === "absent") {
+      return (
+        <ProfileLinkAdd
+          label={`Add a ${field.label.toLowerCase()}`}
+          onAdd={(url) => commit(ovKey, url)}
+        />
+      );
+    }
+    // Low-confidence: keep the editable value so the user can confirm/correct it.
     return <EditableValue field={field} ovKey={ovKey} commit={commit} />;
   }
   if (field.gated) {

--- a/src/components/features/ContactExtraLinks.tsx
+++ b/src/components/features/ContactExtraLinks.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ContactExtraLinks — the variable-length "extra links" affordance on the
+ * reconstructed-resume contact card (#335).
+ *
+ * The four legacy link slots (LinkedIn / GitHub / portfolio / website) keep
+ * rendering + editing through `ContactDetails`' `links` row — they are the
+ * scoring/snapshot source of truth. THIS surface owns only the EXTRA links a
+ * user adds beyond those four (a second GitHub, a GitLab, ORCID, an unknown
+ * host, …), held in `useEditableParse`'s `addedProfiles` channel:
+ *
+ *   in/slug · gh/slug          ← ContactDetails links line (legacy slots)
+ *   gitlab.com/x ✕ · orcid… ✕  ← THIS row (user-added extras) + "+ Add link"
+ *
+ * Each entry edits its full URL in place via the shared `EditableField`
+ * primitive (re-classified on commit so an unknown host shows its hostname as
+ * the label), opens in a new tab via a small `↗`, and is removable. Rendered
+ * only in the editable card — extras are session edit state, never present in a
+ * pure-display card. Built entirely from `@design-system` primitives + the
+ * shared `ReconstructedAdd` affordances, no raw `<button>`/hardcoded palette.
+ */
+
+import { EditableField } from "@design-system";
+import { formatLinkDisplay } from "../../lib/contact.ts";
+import type { AddedProfile } from "../../hooks/useEditableParse.ts";
+import { InlineBulletAdd, RemoveButton } from "./ReconstructedAdd.tsx";
+
+interface ContactExtraLinksProps {
+  profiles: readonly AddedProfile[];
+  onAdd: (url: string) => void;
+  onEdit: (id: string, url: string) => void;
+  onRemove: (id: string) => void;
+}
+
+export function ContactExtraLinks({
+  profiles,
+  onAdd,
+  onEdit,
+  onRemove,
+}: ContactExtraLinksProps) {
+  return (
+    <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
+      {profiles.map((profile, i) => (
+        <span key={profile.id} className="inline-flex items-center gap-x-2">
+          {i > 0 && <span className="text-content-muted">·</span>}
+          <span className="inline-flex items-center gap-1">
+            <EditableField
+              value={profile.url}
+              displayValue={formatLinkDisplay(profile.url)}
+              placeholder="Link URL"
+              label={profile.network}
+              textSize="sm"
+              onCommit={(v) => onEdit(profile.id, v)}
+            />
+            <a
+              href={profile.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-amber hover:underline"
+              aria-label={`Open ${profile.network} in a new tab`}
+            >
+              ↗
+            </a>
+            <RemoveButton
+              label={`Remove ${profile.network} link`}
+              onClick={() => onRemove(profile.id)}
+            />
+          </span>
+        </span>
+      ))}
+      <span className="inline-flex items-center gap-x-2">
+        {profiles.length > 0 && <span className="text-content-muted">·</span>}
+        <InlineBulletAdd
+          onAdd={onAdd}
+          label="Add link"
+          placeholder="https://…"
+        />
+      </span>
+    </p>
+  );
+}

--- a/src/components/features/ContactExtraLinks.tsx
+++ b/src/components/features/ContactExtraLinks.tsx
@@ -25,7 +25,8 @@
 import { EditableField } from "@design-system";
 import { formatLinkDisplay } from "../../lib/contact.ts";
 import type { AddedProfile } from "../../hooks/useEditableParse.ts";
-import { InlineBulletAdd, RemoveButton } from "./ReconstructedAdd.tsx";
+import { RemoveButton } from "./ReconstructedAdd.tsx";
+import { ProfileLinkAdd } from "./ProfileLinkAdd.tsx";
 
 interface ContactExtraLinksProps {
   profiles: readonly AddedProfile[];
@@ -72,11 +73,7 @@ export function ContactExtraLinks({
       ))}
       <span className="inline-flex items-center gap-x-2">
         {profiles.length > 0 && <span className="text-content-muted">·</span>}
-        <InlineBulletAdd
-          onAdd={onAdd}
-          label="Add link"
-          placeholder="https://…"
-        />
+        <ProfileLinkAdd onAdd={onAdd} label="Add a profile" stayOpenAfterAdd />
       </span>
     </p>
   );

--- a/src/components/features/DownloadReportDialog.tsx
+++ b/src/components/features/DownloadReportDialog.tsx
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ReportDownloadControl — the "Download report" affordance (#343).
+ *
+ * A SECONDARY control that sits next to the primary "Download PDF" button on
+ * the reconstructed-résumé surface. Clicking it opens a small dialog offering a
+ * format choice (PDF report / JSON) and an "include identity" checkbox that is
+ * DEFAULT-OFF, so the default export is anonymous and safe to share publicly.
+ * On confirm it generates + downloads the chosen artifact via
+ * `useDownloadReport`.
+ *
+ * Reuse analysis (CLAUDE.md 3-tier rule), mirroring DownloadGateDialog:
+ *   - Primitive: `Dialog` from `@design-system` owns the modal chrome / focus
+ *     trap / Esc / ARIA. No raw `<dialog>`.
+ *   - Primitive: `Button` for the trigger and both actions. No raw `<button>`.
+ *   - The download/generation logic lives entirely in `useDownloadReport`
+ *     (a lib-backed hook); this component only owns the pick-format-and-confirm
+ *     interaction state.
+ *
+ * This is a self-contained control so `ReconstructedResume` adds a single
+ * element next to its Download-PDF button and stays under ~200 LOC.
+ */
+
+import { useId, useState } from "react";
+import { Button, Dialog } from "@design-system";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../../lib/score/score.ts";
+import type { EditableParse } from "../../hooks/useEditableParse.ts";
+import type { ReportFormat } from "../../lib/analytics.ts";
+import { useDownloadReport } from "../../hooks/useDownloadReport.ts";
+
+export function ReportDownloadControl({
+  result,
+  score,
+  edit,
+}: {
+  result: CascadeResult;
+  score: AnonymousAtsScore;
+  edit?: Pick<EditableParse, "contactOverrides" | "bulletOverrides">;
+}) {
+  const [open, setOpen] = useState(false);
+  const [format, setFormat] = useState<ReportFormat>("pdf");
+  const [includeIdentity, setIncludeIdentity] = useState(false);
+  const identityId = useId();
+  const formatName = useId();
+  const { download, isGenerating, error } = useDownloadReport(
+    result,
+    score,
+    edit,
+  );
+
+  async function handleConfirm() {
+    await download({ format, includeIdentity });
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        onClick={() => setOpen(true)}
+        aria-label="Download the audit report as a shareable file"
+      >
+        Download report
+      </Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Download report"
+        className="max-w-sm"
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-content-secondary">
+            Export the audit findings — verdict, score breakdown, layout flags,
+            and the recommendation — as a shareable file. Generated in this
+            browser; nothing is uploaded.
+          </p>
+
+          <fieldset className="flex flex-col gap-2">
+            <legend className="mb-1 text-xs font-semibold uppercase tracking-wider text-content-muted">
+              Format
+            </legend>
+            {(
+              [
+                ["pdf", "PDF report — human-readable"],
+                ["json", "JSON — machine-readable"],
+              ] as const
+            ).map(([value, label]) => (
+              <label
+                key={value}
+                className="flex min-h-9 cursor-pointer items-center gap-2 text-sm text-content-secondary"
+              >
+                <input
+                  type="radio"
+                  name={formatName}
+                  value={value}
+                  checked={format === value}
+                  disabled={isGenerating}
+                  onChange={() => setFormat(value)}
+                  className="h-4 w-4 accent-brand-amber"
+                />
+                {label}
+              </label>
+            ))}
+          </fieldset>
+
+          <label
+            htmlFor={identityId}
+            className="flex min-h-9 cursor-pointer items-center gap-2 text-sm text-content-secondary"
+          >
+            <input
+              id={identityId}
+              type="checkbox"
+              checked={includeIdentity}
+              disabled={isGenerating}
+              onChange={(e) => setIncludeIdentity(e.target.checked)}
+              className="h-4 w-4 accent-brand-amber"
+            />
+            Include my name and contact details
+          </label>
+
+          {error && <p className="text-sm text-feedback-warning-text">{error}</p>}
+
+          <div className="mt-1 flex flex-wrap items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setOpen(false)}
+              disabled={isGenerating}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleConfirm()}
+              disabled={isGenerating}
+            >
+              {isGenerating ? "Generating…" : "Download"}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/features/DownloadReportDialog.tsx
+++ b/src/components/features/DownloadReportDialog.tsx
@@ -52,8 +52,11 @@ export function ReportDownloadControl({
   );
 
   async function handleConfirm() {
-    await download({ format, includeIdentity });
-    setOpen(false);
+    // Close ONLY on success — a failed generation sets `error`, and closing
+    // here would unmount the dialog before the error line renders, leaving the
+    // user with no artifact and no message (#421 Blocking #4).
+    const ok = await download({ format, includeIdentity });
+    if (ok) setOpen(false);
   }
 
   return (

--- a/src/components/features/LayoutFlagsList.tsx
+++ b/src/components/features/LayoutFlagsList.tsx
@@ -7,15 +7,7 @@
  */
 
 import type { LayoutTrigger } from "../../lib/heuristics/types.ts";
-
-const LAYOUT_TRIGGER_BLURBS: Record<LayoutTrigger, string> = {
-  two_column:
-    "Two-column layout — some text extractors read across columns and scramble the order.",
-  scanned:
-    "Image-only PDF — no selectable text, so a plain-text extractor returns nothing.",
-  fonts_unmappable:
-    "Text is present in the source but uses custom font encodings that don't decode to characters. Common with Framer, Affinity, and some InDesign exports.",
-};
+import { LAYOUT_TRIGGER_BLURBS } from "../../lib/heuristics/trigger-copy.ts";
 
 interface LayoutFlagsListProps {
   triggers: readonly LayoutTrigger[];

--- a/src/components/features/ProfileLinkAdd.test.tsx
+++ b/src/components/features/ProfileLinkAdd.test.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render tests for the guided ProfileLinkAdd affordance (#335-followup). Covers
+ * the collapse→expand progressive disclosure, the derived network chips, the
+ * tap-a-chip-pre-fills-the-prefix flow, and commit. Raw createRoot + act (no
+ * RTL), matching the sibling ContactCard render tests.
+ */
+
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ProfileLinkAdd } from "./ProfileLinkAdd.tsx";
+import { PROFILE_QUICK_PICKS } from "../../lib/contact/profile-registry.ts";
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+function render(props: Parameters<typeof ProfileLinkAdd>[0]): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(createElement(ProfileLinkAdd, props));
+  });
+  return container;
+}
+
+function click(el: Element | null) {
+  act(() => {
+    el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe("ProfileLinkAdd", () => {
+  it("starts collapsed as a labelled add pill", () => {
+    const el = render({ onAdd: () => {}, label: "Add a professional profile" });
+    const pill = el.querySelector('[aria-label="Add a professional profile"]');
+    expect(pill).not.toBeNull();
+    // No network chips until it is expanded.
+    expect(el.querySelector('[aria-label="Add LinkedIn"]')).toBeNull();
+  });
+
+  it("expands to show a chip per quick-pick network", () => {
+    const el = render({ onAdd: () => {}, label: "Add a profile" });
+    click(el.querySelector('[aria-label="Add a profile"]'));
+    for (const pick of PROFILE_QUICK_PICKS) {
+      expect(
+        el.querySelector(`[aria-label="Add ${pick.label}"]`),
+      ).not.toBeNull();
+    }
+  });
+
+  it("tapping a network chip pre-fills its prefix into the input", () => {
+    const el = render({ onAdd: () => {}, label: "Add a profile" });
+    click(el.querySelector('[aria-label="Add a profile"]'));
+    click(el.querySelector('[aria-label="Add GitHub"]'));
+    const input = el.querySelector("input");
+    expect(input?.value).toBe("https://github.com/");
+  });
+
+  it("commits the entered URL and collapses when stayOpenAfterAdd is unset", () => {
+    const onAdd = vi.fn();
+    const el = render({ onAdd, label: "Add a professional profile" });
+    click(el.querySelector('[aria-label="Add a professional profile"]'));
+    click(el.querySelector('[aria-label="Add LinkedIn"]'));
+    // The primary Add button shares the field's aria-label; it is the <button>.
+    const addBtn = el.querySelector('button[aria-label="Add a professional profile"]');
+    click(addBtn);
+    expect(onAdd).toHaveBeenCalledWith("https://linkedin.com/in/");
+    // Collapsed again → chips gone.
+    expect(el.querySelector('[aria-label="Add GitHub"]')).toBeNull();
+  });
+});

--- a/src/components/features/ProfileLinkAdd.tsx
+++ b/src/components/features/ProfileLinkAdd.tsx
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ProfileLinkAdd — the GUIDED profile-link add affordance for the contact card.
+ *
+ * Replaces the bare `https://…` field a naive user got no help with. Collapsed,
+ * it is a quiet "+ <label>" pill; expanded, it offers tappable network chips
+ * (LinkedIn / GitHub / GitLab / Portfolio — see `PROFILE_QUICK_PICKS`) that
+ * pre-fill the host prefix and drop the caret after it, so the user types only
+ * their handle. A persistent helper line names the rest of the recognized hosts
+ * ("…and more are recognized automatically"), turning "what do I paste?" into
+ * "it'll figure it out". The committed URL is classified downstream the same way
+ * a pasted one is — no new parse path.
+ *
+ * Reuse analysis: a NEW shared surface, not a parallel one. It reuses the
+ * `AddPill` collapsed trigger and the `@design-system` `Button` primitive; the
+ * network chip-picker + helper text are genuinely new (no existing surface owns
+ * "choose a profile network"). Both add points that need this — the empty
+ * "Professional profile" links row and the extra-links "+ Add" — consume THIS
+ * one component instead of each re-rolling a URL input. The quick-pick data is
+ * derived from `PROFILE_HOSTS`, so the picker never drifts from what we accept.
+ */
+
+import { useRef, useState } from "react";
+import { Button } from "@design-system";
+import {
+  PROFILE_QUICK_PICKS,
+  otherRecognizedNetworks,
+} from "../../lib/contact/profile-registry.ts";
+import { AddPill } from "./ReconstructedAdd.tsx";
+
+interface ProfileLinkAddProps {
+  /** Commit the entered URL (raw string; classified by the caller's sink). */
+  onAdd: (url: string) => void;
+  /** Collapsed-pill label, e.g. "Add a professional profile" / "Add a profile". */
+  label?: string;
+  /** Keep the input open after a commit so several links can be added in a row
+   *  (the extra-links use). The single required-slot use collapses after one. */
+  stayOpenAfterAdd?: boolean;
+}
+
+/** The recognized-but-not-a-chip hosts, e.g. "ORCID, Google Scholar, Substack".
+ *  Capped so the helper stays one readable line; "and more" covers the tail. */
+const HELPER_EXAMPLES = otherRecognizedNetworks().slice(0, 3).join(", ");
+
+export function ProfileLinkAdd({
+  onAdd,
+  label = "Add a profile",
+  stayOpenAfterAdd = false,
+}: ProfileLinkAddProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    // Ignore an empty entry or a bare scheme left from a tapped chip.
+    if (!trimmed || trimmed === "https://") return;
+    onAdd(trimmed);
+    setDraft("");
+    if (!stayOpenAfterAdd) setExpanded(false);
+  };
+
+  /** Tap a network chip: seed its prefix and drop the caret at the end so the
+   *  user types straight into the handle slot. */
+  const pick = (prefix: string) => {
+    setDraft(prefix);
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+  };
+
+  if (!expanded) {
+    return <AddPill label={label} onClick={() => setExpanded(true)} />;
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-lg bg-surface-subtle p-3 text-left"
+      onBlur={(e) => {
+        if (
+          !e.currentTarget.contains(e.relatedTarget as Node | null) &&
+          draft.trim().length === 0
+        ) {
+          setExpanded(false);
+        }
+      }}
+    >
+      <span className="text-xs font-medium text-content-secondary">{label}</span>
+
+      {/* Network quick-picks — tap to pre-fill the host, then type your handle. */}
+      <div className="flex flex-wrap gap-1.5">
+        {PROFILE_QUICK_PICKS.map((p) => (
+          <Button
+            key={p.label}
+            variant="ghost"
+            size="sm"
+            onClick={() => pick(p.prefix)}
+            aria-label={`Add ${p.label}`}
+            className="rounded-full bg-surface-card px-2.5 py-1 text-xs text-content-secondary hover:text-brand-amber"
+          >
+            {p.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          ref={inputRef}
+          type="url"
+          inputMode="url"
+          value={draft}
+          autoFocus
+          aria-label={label}
+          placeholder="Tap a network above, or paste any profile URL"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setDraft("");
+              setExpanded(false);
+            }
+          }}
+          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={commit}
+          disabled={draft.trim().length === 0 || draft.trim() === "https://"}
+          aria-label={label}
+        >
+          Add
+        </Button>
+      </div>
+
+      <span className="text-xs text-content-tertiary">
+        {HELPER_EXAMPLES
+          ? `${HELPER_EXAMPLES}, and more are recognized automatically.`
+          : "Any profile or portfolio link is recognized automatically."}
+      </span>
+    </div>
+  );
+}

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -83,6 +83,7 @@ import {
 import { Button, EditableField } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
+import { ReportDownloadControl } from "./DownloadReportDialog.tsx";
 
 // ── Attention strip ────────────────────────────────────────────────────────────
 
@@ -852,6 +853,10 @@ export function ReconstructedResume({
     addBullet,
     addSkill,
     removeSkill,
+    addedProfiles,
+    addProfile,
+    setProfileUrl,
+    removeProfile,
   } = edit;
 
   // Contact display fields — the same override-applied path the ContactCard
@@ -990,14 +995,17 @@ export function ReconstructedResume({
           <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
             Reconstructed resume
           </h2>
-          <Button
-            variant="primary"
-            onClick={handleDownloadClick}
-            disabled={isGenerating}
-            aria-label="Download the reconstructed resume as an ATS-friendly PDF"
-          >
-            {isGenerating ? "Generating…" : "Download PDF"}
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <ReportDownloadControl result={result} score={score} edit={edit} />
+            <Button
+              variant="primary"
+              onClick={handleDownloadClick}
+              disabled={isGenerating}
+              aria-label="Download the reconstructed resume as an ATS-friendly PDF"
+            >
+              {isGenerating ? "Generating…" : "Download PDF"}
+            </Button>
+          </div>
         </div>
         <p className="max-w-prose text-sm text-content-tertiary">
           What the parser recognized, in resume shape. Each bullet is checked
@@ -1023,6 +1031,10 @@ export function ReconstructedResume({
         result={result}
         overrides={contactOverrides}
         onFieldChange={(key, value) => setContactField(key, value)}
+        addedProfiles={addedProfiles}
+        onAddProfile={addProfile}
+        onEditProfile={setProfileUrl}
+        onRemoveProfile={removeProfile}
       />
       {achievementsAbove && achievementsSection}
       <ExperienceSection

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -107,6 +107,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     skillsOverride,
     addedEntries,
     addedBullets,
+    addedProfiles,
     setContactField,
     setExperienceField,
     setBulletField,
@@ -150,6 +151,7 @@ export function useAnalyzedResume(): AnalyzedResume {
       addedEntries,
       addedBullets,
       removedBullets,
+      addedProfiles,
     );
     // The anonymous scorer pools its bullet set from `sections` (#133), so the
     // edited section view — not the original — must feed re-grading or a live
@@ -173,6 +175,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     addedEntries,
     addedBullets,
     removedBullets,
+    addedProfiles,
   ]);
 
   const displayResult = useMemo<CascadeResult | null>(() => {

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -49,6 +49,7 @@ import {
 import type {
   CascadeResult,
   HeuristicParsedResume,
+  FieldConfidence,
 } from "../lib/heuristics/types.ts";
 import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
 
@@ -56,6 +57,11 @@ export interface EditedResume {
   parsed: HeuristicParsedResume;
   rawText: string;
   score: AnonymousAtsScore;
+  /** Edited per-field confidence (user-affirmed contact edits bumped to
+   *  present). Threaded onto `displayResult` so the ContactCard's
+   *  "GitHub satisfies Professional profile" gap reads the same edited
+   *  confidence the score did (#421 Blocking #3). */
+  fieldConfidence: FieldConfidence;
 }
 
 export interface AnalyzedResume {
@@ -138,7 +144,7 @@ export function useAnalyzedResume(): AnalyzedResume {
   // Fold overrides back into a fresh { parsed, rawText } and re-grade live.
   const edited = useMemo<EditedResume | null>(() => {
     if (base === null) return null;
-    const { parsed, rawText, sections } = applyOverrides(
+    const { parsed, rawText, sections, fieldConfidence } = applyOverrides(
       base.parsed,
       base.rawText,
       base.sections,
@@ -152,18 +158,21 @@ export function useAnalyzedResume(): AnalyzedResume {
       addedBullets,
       removedBullets,
       addedProfiles,
+      base.fieldConfidence,
     );
     // The anonymous scorer pools its bullet set from `sections` (#133), so the
     // edited section view — not the original — must feed re-grading or a live
-    // bullet edit would not move Specificity / Structure.
+    // bullet edit would not move Specificity / Structure. `fieldConfidence` is
+    // the edited view (contact edits + added linkedin/github bumped to present),
+    // so a user-added professional profile moves completeness (#421).
     const score = computeAnonymousAtsScore({
       parsed,
-      fieldConfidence: base.fieldConfidence,
+      fieldConfidence,
       triggers: base.triggers,
       rawText,
       sections,
     });
-    return { parsed, rawText, score };
+    return { parsed, rawText, score, fieldConfidence };
   }, [
     base,
     doneScoreBullets,
@@ -180,7 +189,11 @@ export function useAnalyzedResume(): AnalyzedResume {
 
   const displayResult = useMemo<CascadeResult | null>(() => {
     if (base === null || edited === null) return null;
-    return { ...base, parsed: edited.parsed };
+    return {
+      ...base,
+      parsed: edited.parsed,
+      fieldConfidence: edited.fieldConfidence,
+    };
   }, [base, edited]);
 
   // Clear edits whenever a fresh parse lands (new file, reset) or a fresh

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -16,6 +16,7 @@ import type { CascadeResult } from "../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../lib/score/score.ts";
 import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
 import { renderAtsResumePdf } from "../lib/pdf/render-ats-pdf.ts";
+import { slugifyName, triggerBlobDownload } from "../lib/download/blob-download.ts";
 import type { EditableParse } from "./useEditableParse.ts";
 import { trackDownloadCompleted, type DownloadSource } from "../lib/analytics.ts";
 import { clearBlankDraft } from "./useResumeAnalysis.ts";
@@ -28,12 +29,7 @@ export interface UseDownloadPdf {
 
 /** Turn a candidate name into a safe, lower-kebab PDF filename. */
 function filenameFromName(name: string | undefined): string {
-  const slug = (name ?? "")
-    .normalize("NFKD")
-    .replace(/[^\w\s-]/g, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .toLowerCase();
+  const slug = slugifyName(name);
   return slug ? `${slug}-resume-ats.pdf` : "resume-ats.pdf";
 }
 
@@ -48,27 +44,16 @@ export function useDownloadPdf(
   const download = useCallback(async () => {
     setIsGenerating(true);
     setError(null);
-    let url: string | null = null;
     try {
       const model = buildAtsResumeModel(result, score, edit);
       const bytes = await renderAtsResumePdf(model);
-      // Copy into a fresh ArrayBuffer-backed view so Blob gets a clean buffer.
-      const blob = new Blob([bytes.slice()], { type: "application/pdf" });
-      url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filenameFromName(model.contact.name);
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      // Defer the revoke: a.click() only SCHEDULES the download — the browser
-      // reads the object URL asynchronously afterward. Revoking synchronously
-      // (e.g. in finally) invalidates the URL before the fetch starts, which
-      // silently kills the download on slower/remote contexts and on
-      // Firefox/Safari. Hand the URL off, then revoke on a later task.
-      const settledUrl = url;
-      url = null;
-      setTimeout(() => URL.revokeObjectURL(settledUrl), 60_000);
+      // `bytes.slice()` copies into a fresh ArrayBuffer-backed view so Blob gets
+      // a clean buffer.
+      triggerBlobDownload(
+        bytes.slice(),
+        "application/pdf",
+        filenameFromName(model.contact.name),
+      );
 
       // Distinguish a from-scratch authored download from an uploaded one
       // (#313). `tiers` is empty ONLY for `buildBlankResult()`'s output —
@@ -84,7 +69,6 @@ export function useDownloadPdf(
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not generate PDF.");
     } finally {
-      if (url) URL.revokeObjectURL(url);
       setIsGenerating(false);
     }
   }, [result, score, edit]);

--- a/src/hooks/useDownloadReport.ts
+++ b/src/hooks/useDownloadReport.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useDownloadReport — drives the "Download report" action on the reconstructed-
+ * resume surface (#343).
+ *
+ * The shareable audit report is the diagnostic OUTPUT (verdict + score
+ * breakdown + layout triggers + recommendation), exported in the user's chosen
+ * format:
+ *   - PDF  → `render-audit-report.ts` (human-readable, lazy pdf-lib).
+ *   - JSON → `report/serialize.ts` (machine-readable, pure).
+ *
+ * Everything is client-side; no network request is made — same zero-egress
+ * contract as `useDownloadPdf`.
+ *
+ * PRIVACY GATE (the load-bearing rule, #343): the identity header is included
+ * ONLY when the user opts in (`includeIdentity`). When off — the default — we
+ * pass NO identity block to either renderer, and the download filename falls
+ * back to a generic name so even the filename carries no PII. Identity, when
+ * on, is sourced from #334's pure `toJsonResume(...).basics` so the header is
+ * lossless and consistent with the résumé export.
+ */
+
+import { useCallback, useState } from "react";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { LayoutTrigger } from "../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../lib/score/score.ts";
+import { getScoreRecommendation } from "../lib/score/recommendation.ts";
+import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
+import { toJsonResume } from "../lib/pdf/to-json-resume.ts";
+import { renderAuditReportPdf } from "../lib/pdf/render-audit-report.ts";
+import {
+  serializeAuditReportJson,
+  type AuditReportInput,
+} from "../lib/report/serialize.ts";
+import type { EditableParse } from "./useEditableParse.ts";
+import { trackReportDownloaded, type ReportFormat } from "../lib/analytics.ts";
+
+export interface DownloadReportOptions {
+  format: ReportFormat;
+  /** Include the candidate's identity header. Default-off at the call site. */
+  includeIdentity: boolean;
+}
+
+export interface UseDownloadReport {
+  download: (opts: DownloadReportOptions) => Promise<void>;
+  isGenerating: boolean;
+  error: string | null;
+}
+
+/** Lower-kebab slug for the report filename; empty in → generic name. */
+function slugFromName(name: string | undefined): string {
+  return (name ?? "")
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+}
+
+/** Trigger a same-document download of `bytes` as `filename`. */
+function triggerDownload(bytes: BlobPart, mime: string, filename: string): void {
+  const blob = new Blob([bytes], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Defer revoke: a.click() only schedules the download; revoking synchronously
+  // can kill it on slower/remote contexts + Firefox/Safari (mirrors useDownloadPdf).
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+export function useDownloadReport(
+  result: CascadeResult,
+  score: AnonymousAtsScore,
+  edit?: Pick<EditableParse, "contactOverrides" | "bulletOverrides">,
+): UseDownloadReport {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const download = useCallback(
+    async ({ format, includeIdentity }: DownloadReportOptions) => {
+      setIsGenerating(true);
+      setError(null);
+      try {
+        // Identity is sourced ONLY when opted in — never build a basics block
+        // we're about to strip (defense in depth alongside the serializer gate).
+        const identity = includeIdentity
+          ? toJsonResume(buildAtsResumeModel(result, score, edit)).basics
+          : undefined;
+
+        const input: AuditReportInput = {
+          score,
+          triggers: score.layout.triggers as readonly LayoutTrigger[],
+          recommendation: getScoreRecommendation(score),
+          generatedAt: new Date().toISOString(),
+          includeIdentity,
+          identity,
+        };
+
+        // Filename carries the name ONLY when identity is included — otherwise a
+        // generic name so the download itself leaks nothing.
+        const slug = includeIdentity ? slugFromName(identity?.name) : "";
+        const base = slug ? `${slug}-resume-audit-report` : "resume-audit-report";
+
+        if (format === "pdf") {
+          const bytes = await renderAuditReportPdf(input);
+          triggerDownload(bytes.slice(), "application/pdf", `${base}.pdf`);
+        } else {
+          const json = serializeAuditReportJson(input);
+          triggerDownload(json, "application/json", `${base}.json`);
+        }
+
+        trackReportDownloaded({ format, includeIdentity });
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Could not generate report.",
+        );
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [result, score, edit],
+  );
+
+  return { download, isGenerating, error };
+}

--- a/src/hooks/useDownloadReport.ts
+++ b/src/hooks/useDownloadReport.ts
@@ -27,13 +27,10 @@ import type { CascadeResult } from "../lib/heuristics/types.ts";
 import type { LayoutTrigger } from "../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../lib/score/score.ts";
 import { getScoreRecommendation } from "../lib/score/recommendation.ts";
-import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
-import { toJsonResume } from "../lib/pdf/to-json-resume.ts";
-import { renderAuditReportPdf } from "../lib/pdf/render-audit-report.ts";
-import {
-  serializeAuditReportJson,
-  type AuditReportInput,
-} from "../lib/report/serialize.ts";
+import { buildContact } from "../lib/pdf/ats-resume-model.ts";
+import { basicsFromContact } from "../lib/pdf/to-json-resume.ts";
+import { slugifyName, triggerBlobDownload } from "../lib/download/blob-download.ts";
+import type { AuditReportInput } from "../lib/report/serialize.ts";
 import type { EditableParse } from "./useEditableParse.ts";
 import { trackReportDownloaded, type ReportFormat } from "../lib/analytics.ts";
 
@@ -44,34 +41,13 @@ export interface DownloadReportOptions {
 }
 
 export interface UseDownloadReport {
-  download: (opts: DownloadReportOptions) => Promise<void>;
+  /** Generate + download the report. Resolves `true` on success, `false` when
+   *  generation failed (the error is surfaced via `error`) — the caller gates
+   *  closing the dialog on this so a failure doesn't unmount the error UI
+   *  (#421 Blocking #4). */
+  download: (opts: DownloadReportOptions) => Promise<boolean>;
   isGenerating: boolean;
   error: string | null;
-}
-
-/** Lower-kebab slug for the report filename; empty in → generic name. */
-function slugFromName(name: string | undefined): string {
-  return (name ?? "")
-    .normalize("NFKD")
-    .replace(/[^\w\s-]/g, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .toLowerCase();
-}
-
-/** Trigger a same-document download of `bytes` as `filename`. */
-function triggerDownload(bytes: BlobPart, mime: string, filename: string): void {
-  const blob = new Blob([bytes], { type: mime });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  // Defer revoke: a.click() only schedules the download; revoking synchronously
-  // can kill it on slower/remote contexts + Firefox/Safari (mirrors useDownloadPdf).
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
 export function useDownloadReport(
@@ -83,14 +59,16 @@ export function useDownloadReport(
   const [error, setError] = useState<string | null>(null);
 
   const download = useCallback(
-    async ({ format, includeIdentity }: DownloadReportOptions) => {
+    async ({ format, includeIdentity }: DownloadReportOptions): Promise<boolean> => {
       setIsGenerating(true);
       setError(null);
       try {
         // Identity is sourced ONLY when opted in — never build a basics block
         // we're about to strip (defense in depth alongside the serializer gate).
+        // Build it from the contact block directly (no full resume-model walk
+        // just to read `.basics`, #421 Secondary #6).
         const identity = includeIdentity
-          ? toJsonResume(buildAtsResumeModel(result, score, edit)).basics
+          ? basicsFromContact(buildContact(result, edit?.contactOverrides ?? {}))
           : undefined;
 
         const input: AuditReportInput = {
@@ -104,22 +82,33 @@ export function useDownloadReport(
 
         // Filename carries the name ONLY when identity is included — otherwise a
         // generic name so the download itself leaks nothing.
-        const slug = includeIdentity ? slugFromName(identity?.name) : "";
+        const slug = includeIdentity ? slugifyName(identity?.name) : "";
         const base = slug ? `${slug}-resume-audit-report` : "resume-audit-report";
 
+        // Lazy-load the renderer/serializer so the ~470 LOC audit-report path
+        // stays out of the entry chunk for the sessions that never click
+        // "Download report" (#421 Secondary #7, mirroring load-pdf-lib.ts).
         if (format === "pdf") {
+          const { renderAuditReportPdf } = await import(
+            "../lib/pdf/render-audit-report.ts"
+          );
           const bytes = await renderAuditReportPdf(input);
-          triggerDownload(bytes.slice(), "application/pdf", `${base}.pdf`);
+          triggerBlobDownload(bytes.slice(), "application/pdf", `${base}.pdf`);
         } else {
+          const { serializeAuditReportJson } = await import(
+            "../lib/report/serialize.ts"
+          );
           const json = serializeAuditReportJson(input);
-          triggerDownload(json, "application/json", `${base}.json`);
+          triggerBlobDownload(json, "application/json", `${base}.json`);
         }
 
         trackReportDownloaded({ format, includeIdentity });
+        return true;
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "Could not generate report.",
         );
+        return false;
       } finally {
         setIsGenerating(false);
       }

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -23,6 +23,8 @@
 
 import { useState, useCallback, useMemo, useRef } from "react";
 import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
+import { classifyProfile } from "../lib/contact/profile-registry.ts";
+import type { ProfileLink } from "../lib/score/types.ts";
 
 // ── Contact overrides ─────────────────────────────────────────────────────────
 
@@ -134,6 +136,29 @@ export function parsedEntryKey(section: AddableSection, index: number): string {
   return `${section}:${index}`;
 }
 
+// ── Added profile links (#335) ────────────────────────────────────────────────
+// The four legacy link slots (linkedin/github/portfolio/website) stay edited via
+// `ContactOverrides` above — they are the scoring/snapshot source of truth, and
+// `parsed.profiles[]` mirrors them. This channel holds ONLY the EXTRA
+// contact/identity links a user adds beyond those four slots (a second GitHub, a
+// GitLab, ORCID, Substack, an unknown host, …). applyOverrides re-derives
+// `parsed.profiles` from the (possibly-edited) legacy keys and appends these, so
+// the legacy keys never desync and the extras flow to #334's JSON export.
+
+/**
+ * One user-added contact/identity link. `id` is a stable per-session key
+ * (`"profile:<n>"`). `url`/`network`/`kind` are the classified {@link
+ * ProfileLink} — `network`/`kind` are re-derived via `classifyProfile` on every
+ * edit so the display label tracks the URL (an unknown host keeps its hostname
+ * as the label, brand-neutral by construction).
+ */
+export interface AddedProfile {
+  id: string;
+  url: string;
+  network: string;
+  kind: ProfileLink["kind"];
+}
+
 // ── Skills override ───────────────────────────────────────────────────────────
 
 /**
@@ -200,6 +225,17 @@ export interface EditableParse {
   /** Append a bullet line to an entry. No-op on blank text. An added entry's
    *  bullets are dropped wholesale when the entry is removed. */
   addBullet: (entryKey: string, text: string) => void;
+  /** Extra user-added contact links beyond the four legacy slots, in insertion
+   *  order (#335). The legacy slots keep editing through `contactOverrides`. */
+  addedProfiles: AddedProfile[];
+  /** Add a contact link from a raw URL. No-op on an empty/unparseable URL
+   *  (classifyProfile returns undefined). Returns the new entry's id, or
+   *  undefined when nothing was added. */
+  addProfile: (url: string) => string | undefined;
+  /** Re-classify and update one added profile's URL. An empty URL removes it. */
+  setProfileUrl: (id: string, url: string) => void;
+  /** Remove a previously-added profile by id. */
+  removeProfile: (id: string) => void;
   /** Add/remove edits against parsed.skills. */
   skillsOverride: SkillsOverride;
   /** Add a (canonicalized) skill. No-op for blank input or an exact dupe of an
@@ -234,6 +270,7 @@ export function useEditableParse(): EditableParse {
   );
   const [addedEntries, setAddedEntries] = useState<AddedEntry[]>([]);
   const [addedBullets, setAddedBullets] = useState<AddedBullets>({});
+  const [addedProfiles, setAddedProfiles] = useState<AddedProfile[]>([]);
   // Monotonic source of stable added-entry ids. A ref (not state) because a new
   // id must not itself trigger a re-render, and the value need only be unique
   // within the session — never reset, even across resetAll.
@@ -379,6 +416,33 @@ export function useEditableParse(): EditableParse {
     }));
   }, []);
 
+  const addProfile = useCallback((url: string): string | undefined => {
+    const profile = classifyProfile(url);
+    if (!profile) return undefined;
+    const id = `profile:${idCounter.current++}`;
+    setAddedProfiles((prev) => [...prev, { id, ...profile }]);
+    return id;
+  }, []);
+
+  const setProfileUrl = useCallback((id: string, url: string) => {
+    // An emptied field removes the entry (mirrors the explicit remove control).
+    if (url.trim() === "") {
+      setAddedProfiles((prev) => prev.filter((p) => p.id !== id));
+      return;
+    }
+    // Re-derive network/kind from the edited URL; a now-unparseable URL keeps
+    // the prior classification rather than dropping the entry mid-edit.
+    const profile = classifyProfile(url);
+    if (!profile) return;
+    setAddedProfiles((prev) =>
+      prev.map((p) => (p.id === id ? { id, ...profile } : p)),
+    );
+  }, []);
+
+  const removeProfile = useCallback((id: string) => {
+    setAddedProfiles((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
   const resetAll = useCallback(() => {
     setContactOverrides({});
     setExperienceOverrides({});
@@ -388,6 +452,7 @@ export function useEditableParse(): EditableParse {
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
     setAddedEntries([]);
     setAddedBullets({});
+    setAddedProfiles([]);
   }, []);
 
   const hasEdits = useMemo(() => {
@@ -398,6 +463,7 @@ export function useEditableParse(): EditableParse {
       return true;
     if (addedEntries.length > 0) return true;
     if (Object.keys(addedBullets).length > 0) return true;
+    if (addedProfiles.length > 0) return true;
     if (
       Object.values(educationOverrides).some(
         (entry) => Object.keys(entry).length > 0,
@@ -416,6 +482,7 @@ export function useEditableParse(): EditableParse {
     skillsOverride,
     addedEntries,
     addedBullets,
+    addedProfiles,
   ]);
 
   return {
@@ -435,6 +502,10 @@ export function useEditableParse(): EditableParse {
     setEntryField,
     addedBullets,
     addBullet,
+    addedProfiles,
+    addProfile,
+    setProfileUrl,
+    removeProfile,
     skillsOverride,
     addSkill,
     removeSkill,

--- a/src/hooks/useReportGap.ts
+++ b/src/hooks/useReportGap.ts
@@ -23,6 +23,7 @@ import { useCallback, useState } from "react";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import type { ParseDisagreement } from "../lib/heuristics/disagreement.ts";
 import { buildReproArtifact } from "../lib/heuristics/repro-artifact.ts";
+import { triggerBlobDownload } from "../lib/download/blob-download.ts";
 import { trackGapReported } from "../lib/analytics.ts";
 
 export interface UseReportGap {
@@ -53,35 +54,20 @@ export function useReportGap(
 
   const report = useCallback(() => {
     setError(null);
-    let url: string | null = null;
     try {
       const artifact = buildReproArtifact(result, disagreements);
       const json = JSON.stringify(artifact, null, 2);
-      const blob = new Blob([json], { type: "application/json" });
-      url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = artifactFilename();
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      triggerBlobDownload(json, "application/json", artifactFilename());
       // Count-only, env-gated telemetry — never the artifact contents.
       trackGapReported({
         disagreementCount: disagreements.length,
         triggers: result.triggers,
       });
-      // Defer the revoke: a.click() only schedules the download; revoking
-      // synchronously can kill it on slower/remote contexts (see useDownloadPdf).
-      const settledUrl = url;
-      url = null;
-      setTimeout(() => URL.revokeObjectURL(settledUrl), 60_000);
       setReported(true);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Could not generate the report.",
       );
-    } finally {
-      if (url) URL.revokeObjectURL(url);
     }
   }, [result, disagreements]);
 

--- a/src/jd-fit/useJdFitResume.ts
+++ b/src/jd-fit/useJdFitResume.ts
@@ -76,6 +76,7 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
       handoffEdit.addedEntries,
       handoffEdit.addedBullets,
       handoffEdit.removedBullets,
+      handoffEdit.addedProfiles,
     );
     const score = computeAnonymousAtsScore({
       parsed,
@@ -95,6 +96,7 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
     handoffEdit.addedEntries,
     handoffEdit.addedBullets,
     handoffEdit.removedBullets,
+    handoffEdit.addedProfiles,
   ]);
 
   // Handoff wins when present. Dropping it (reset) reveals the local DropZone.

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -526,3 +526,21 @@ export type DownloadSource = "blank" | "upload";
 export function trackDownloadCompleted(args: { source: DownloadSource }): void {
   track("download_completed", { source: args.source });
 }
+
+/** Which format the shareable audit report (#343) was exported in. */
+export type ReportFormat = "pdf" | "json";
+
+/**
+ * A shareable audit report was downloaded (#343). Carries only the chosen
+ * format and whether the user opted to include identity — no field values, no
+ * PII. Env-gated like every other tracker: no-op when VITE_POSTHOG_KEY is unset.
+ */
+export function trackReportDownloaded(args: {
+  format: ReportFormat;
+  includeIdentity: boolean;
+}): void {
+  track("report_downloaded", {
+    format: args.format,
+    include_identity: args.includeIdentity,
+  });
+}

--- a/src/lib/contact.test.ts
+++ b/src/lib/contact.test.ts
@@ -42,18 +42,19 @@ describe("buildContactFields", () => {
     ]);
   });
 
-  it("includes the GitHub row only when it is confidently detected", () => {
+  it("includes the GitHub row when confidently detected, and a code profile satisfies the brand-neutral 'Professional profile' row (#335)", () => {
     const fields = buildContactFields(
       makeCascade(
         { github_url: "https://github.com/jane" },
         { github_url: 0.95 },
       ),
     );
+    // A detected GitHub (code) profile satisfies the required "Professional
+    // profile" row, so the LinkedIn-keyed gap row does NOT render (#335).
     expect(fields.map((f) => f.key)).toEqual([
       "full_name",
       "email",
       "phone",
-      "linkedin_url",
       "github_url",
       "location",
     ]);

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -49,7 +49,12 @@ const CONTACT_ROWS: readonly {
   { key: "full_name", label: "Name", group: "identity" },
   { key: "email", label: "Email", group: "contact" },
   { key: "phone", label: "Phone", group: "contact" },
-  { key: "linkedin_url", label: "LinkedIn", group: "link" },
+  // Brand-neutral required row (#335): a "Professional profile" gap, satisfied
+  // by any social (LinkedIn) OR code (GitHub) link — see the github-satisfies
+  // check in `buildContactFields`. Keyed on `linkedin_url` so the existing
+  // fixed-key edit/override plumbing is unchanged this phase; Phase 2 flips the
+  // whole links block to read `profiles[]` directly.
+  { key: "linkedin_url", label: "Professional profile", group: "link" },
   { key: "github_url", label: "GitHub", group: "link", optional: true },
   { key: "portfolio_url", label: "Portfolio", group: "link", optional: true },
   { key: "website_url", label: "Website", group: "link", optional: true },
@@ -82,6 +87,15 @@ const FIELD_KEYS = {
 export function buildContactFields(
   cascade: Pick<CascadeResult, "parsed" | "fieldConfidence">,
 ): ContactDisplayField[] {
+  // A code profile (GitHub) satisfies the brand-neutral required "Professional
+  // profile" row (#335) — so a candidate who links GitHub but not LinkedIn sees
+  // no gap. The github value keeps rendering via its own optional row.
+  const githubConf =
+    cascade.fieldConfidence.github_url ?? 0;
+  const githubSatisfies =
+    Boolean(cascade.parsed.github_url) &&
+    githubConf >= CONTACT_DISPLAY_CONFIDENCE_FLOOR;
+
   const rows: ContactDisplayField[] = [];
   for (const { key, label, group, optional } of CONTACT_ROWS) {
     const raw = cascade.parsed[key as keyof typeof FIELD_KEYS];
@@ -91,6 +105,10 @@ export function buildContactFields(
 
     // An optional field is shown only when detected — its absence is not a gap.
     if (optional && !detected) continue;
+
+    // The required "Professional profile" row is not a gap when a code profile
+    // (GitHub) is present — social OR code satisfies it (#335).
+    if (key === "linkedin_url" && !detected && githubSatisfies) continue;
 
     if (!value) {
       rows.push({ key, label, group, value: "", gated: true, reason: "absent" });

--- a/src/lib/contact/profile-registry.test.ts
+++ b/src/lib/contact/profile-registry.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyProfile,
+  profilesFromUrls,
+  PROFILE_HOSTS,
+} from "./profile-registry.ts";
+
+describe("classifyProfile — known hosts", () => {
+  it("classifies GitHub as code and normalizes a scheme-less URL", () => {
+    const p = classifyProfile("github.com/janedoe");
+    expect(p).toEqual({
+      url: "https://github.com/janedoe",
+      network: "GitHub",
+      kind: "code",
+    });
+  });
+
+  it("classifies LinkedIn profiles as social", () => {
+    expect(classifyProfile("https://www.linkedin.com/in/jane-doe")).toEqual({
+      url: "https://www.linkedin.com/in/jane-doe",
+      network: "LinkedIn",
+      kind: "social",
+    });
+  });
+
+  it("classifies non-GitHub code hosts (GitLab, Codeberg, Kaggle, Hugging Face)", () => {
+    expect(classifyProfile("https://gitlab.com/jane")?.network).toBe("GitLab");
+    expect(classifyProfile("https://codeberg.org/jane")?.kind).toBe("code");
+    expect(classifyProfile("https://kaggle.com/jane")?.network).toBe("Kaggle");
+    expect(classifyProfile("https://huggingface.co/jane")?.network).toBe(
+      "Hugging Face",
+    );
+  });
+
+  it("classifies portfolio / academic / writing hosts", () => {
+    expect(classifyProfile("https://behance.net/jane")?.kind).toBe("portfolio");
+    expect(classifyProfile("https://dribbble.com/jane")?.kind).toBe("portfolio");
+    expect(classifyProfile("https://orcid.org/0000-0002-1825-0097")?.kind).toBe(
+      "academic",
+    );
+    expect(
+      classifyProfile("https://scholar.google.com/citations?user=abc")?.network,
+    ).toBe("Google Scholar");
+    expect(classifyProfile("https://jane.substack.com")?.kind).toBe("writing");
+    expect(classifyProfile("https://medium.com/@jane")?.network).toBe("Medium");
+  });
+
+  it("matches subdomains of a registry host", () => {
+    // (^|\.)github\.com$ must match a subdomain host, not just the bare host.
+    expect(classifyProfile("https://gist.github.com/jane")?.network).toBe(
+      "GitHub",
+    );
+  });
+});
+
+describe("classifyProfile — unknown hosts are kept, never dropped", () => {
+  it("keeps an unknown host as { network: hostname, kind: 'other' }", () => {
+    expect(classifyProfile("https://jane.dev/portfolio")).toEqual({
+      url: "https://jane.dev/portfolio",
+      network: "jane.dev",
+      kind: "other",
+    });
+  });
+
+  it("strips a leading www. from the unknown-host network label", () => {
+    expect(classifyProfile("https://www.janedoe.io")?.network).toBe(
+      "janedoe.io",
+    );
+  });
+
+  it("returns undefined for empty / unparseable input", () => {
+    expect(classifyProfile("")).toBeUndefined();
+    expect(classifyProfile("   ")).toBeUndefined();
+  });
+});
+
+describe("classifyProfile — LinkedIn non-profile exclusion", () => {
+  it.each([
+    "https://www.linkedin.com/company/acme",
+    "https://linkedin.com/jobs/view/12345",
+    "https://linkedin.com/feed/",
+    "https://www.linkedin.com/school/mit",
+  ])("does not classify a non-profile LinkedIn URL as social: %s", (url) => {
+    const p = classifyProfile(url);
+    expect(p).toBeDefined();
+    expect(p?.kind).not.toBe("social");
+    expect(p?.kind).toBe("other");
+    expect(p?.network).toBe("linkedin.com");
+  });
+
+  it("still classifies a real LinkedIn profile as social", () => {
+    expect(classifyProfile("https://linkedin.com/in/jane")?.kind).toBe("social");
+  });
+});
+
+describe("profilesFromUrls — legacy-key mirror derivation (#335 Phase 1)", () => {
+  it("builds an ordered array from the four legacy link values", () => {
+    const profiles = profilesFromUrls([
+      "https://linkedin.com/in/jane",
+      "https://github.com/jane",
+      "https://jane.dev",
+      undefined,
+    ]);
+    expect(profiles.map((p) => p.network)).toEqual([
+      "LinkedIn",
+      "GitHub",
+      "jane.dev",
+    ]);
+    expect(profiles.map((p) => p.kind)).toEqual(["social", "code", "other"]);
+  });
+
+  it("skips undefined entries and preserves precedence order", () => {
+    const profiles = profilesFromUrls([
+      undefined,
+      "https://github.com/jane",
+      undefined,
+      "https://portfolio.example.com",
+    ]);
+    expect(profiles.map((p) => p.network)).toEqual([
+      "GitHub",
+      "portfolio.example.com",
+    ]);
+  });
+
+  it("deduplicates the same link reached via more than one slot", () => {
+    const profiles = profilesFromUrls([
+      "https://github.com/jane",
+      "github.com/jane/", // same identity, different form
+    ]);
+    expect(profiles).toHaveLength(1);
+  });
+
+  it("returns an empty array when no link is present", () => {
+    expect(profilesFromUrls([undefined, undefined])).toEqual([]);
+  });
+});
+
+describe("PROFILE_HOSTS — contributor-extensible registry", () => {
+  it("every rule carries a match, network, and kind", () => {
+    for (const rule of PROFILE_HOSTS) {
+      expect(rule.match).toBeInstanceOf(RegExp);
+      expect(typeof rule.network).toBe("string");
+      expect(rule.network.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/contact/profile-registry.test.ts
+++ b/src/lib/contact/profile-registry.test.ts
@@ -6,6 +6,8 @@ import {
   classifyProfile,
   profilesFromUrls,
   PROFILE_HOSTS,
+  PROFILE_QUICK_PICKS,
+  otherRecognizedNetworks,
 } from "./profile-registry.ts";
 
 describe("classifyProfile — known hosts", () => {
@@ -145,5 +147,34 @@ describe("PROFILE_HOSTS — contributor-extensible registry", () => {
       expect(typeof rule.network).toBe("string");
       expect(rule.network.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("PROFILE_QUICK_PICKS — guided-add chips", () => {
+  it("derives one chip per host carrying a quickPick, plus a Portfolio catch-all", () => {
+    const hostPicks = PROFILE_HOSTS.filter((h) => h.quickPick).map(
+      (h) => h.network,
+    );
+    const labels = PROFILE_QUICK_PICKS.map((p) => p.label);
+    // Every quick-pick host surfaces as a chip, in registry order…
+    expect(labels.slice(0, hostPicks.length)).toEqual(hostPicks);
+    // …and Portfolio is appended as the host-less personal-site catch-all.
+    expect(labels).toContain("Portfolio");
+  });
+
+  it("every chip pre-fills an https:// prefix and names a handle hint", () => {
+    for (const pick of PROFILE_QUICK_PICKS) {
+      expect(pick.prefix.startsWith("https://")).toBe(true);
+      expect(pick.hint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("otherRecognizedNetworks lists recognized hosts NOT already a chip", () => {
+    const others = otherRecognizedNetworks();
+    const chipLabels = new Set(PROFILE_QUICK_PICKS.map((p) => p.label));
+    // No overlap with the chips…
+    for (const name of others) expect(chipLabels.has(name)).toBe(false);
+    // …and it surfaces a known tail host (ORCID is registered, not a chip).
+    expect(others).toContain("ORCID");
   });
 });

--- a/src/lib/contact/profile-registry.ts
+++ b/src/lib/contact/profile-registry.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Contributor-extensible host registry for classifying contact/identity links
+ * into the JSON-Resume-style `ProfileLink` shape (#335).
+ *
+ * Adding support for a new host is a ONE-LINE change: append a `HostRule` to
+ * `PROFILE_HOSTS`. An unrecognized host is never dropped — it is kept as
+ * `{ network: <hostname>, kind: "other" }`, so a candidate's GitLab, Codeberg,
+ * Kaggle, Behance, ORCID, Substack, … link survives with its identity intact
+ * instead of collapsing into a generic "website" bucket.
+ *
+ * URL normalization is intentionally NOT reimplemented here — `normalizeUrl` /
+ * `urlSlug` and the `LINKEDIN_NONPROFILE_RE` exclusion are reused from the
+ * parser's `extract/contact.ts` so classification stays byte-consistent with
+ * extraction.
+ */
+
+import type { ProfileLink } from "../score/types.ts";
+import {
+  normalizeUrl,
+  urlSlug,
+  LINKEDIN_NONPROFILE_RE,
+} from "../heuristics/extract/contact.ts";
+
+interface HostRule {
+  /** Tested against the URL's hostname (lowercased, `www.` stripped). */
+  match: RegExp;
+  /** Human-facing network label shown in the UI. */
+  network: string;
+  kind: ProfileLink["kind"];
+}
+
+/**
+ * Ordered host rules. First match wins. To support a new host, add one line.
+ * `match` is tested against the bare hostname (e.g. `scholar.google.com`), so
+ * anchor with `(^|\.)host$` to match the host and its subdomains without also
+ * matching a look-alike substring.
+ */
+export const PROFILE_HOSTS: readonly HostRule[] = [
+  { match: /(^|\.)linkedin\.com$/i, network: "LinkedIn", kind: "social" },
+  { match: /(^|\.)github\.com$/i, network: "GitHub", kind: "code" },
+  { match: /(^|\.)gitlab\.com$/i, network: "GitLab", kind: "code" },
+  { match: /(^|\.)codeberg\.org$/i, network: "Codeberg", kind: "code" },
+  { match: /(^|\.)kaggle\.com$/i, network: "Kaggle", kind: "code" },
+  { match: /(^|\.)huggingface\.co$/i, network: "Hugging Face", kind: "code" },
+  { match: /(^|\.)behance\.net$/i, network: "Behance", kind: "portfolio" },
+  { match: /(^|\.)dribbble\.com$/i, network: "Dribbble", kind: "portfolio" },
+  { match: /(^|\.)orcid\.org$/i, network: "ORCID", kind: "academic" },
+  { match: /(^|\.)scholar\.google\./i, network: "Google Scholar", kind: "academic" },
+  { match: /(^|\.)substack\.com$/i, network: "Substack", kind: "writing" },
+  { match: /(^|\.)medium\.com$/i, network: "Medium", kind: "writing" },
+];
+
+/**
+ * Classify one URL into a `ProfileLink`. Normalizes the URL first (reusing the
+ * parser's `normalizeUrl`, so a scheme-less `github.com/x` gets `https://`),
+ * then matches its hostname against {@link PROFILE_HOSTS}.
+ *
+ * - An UNKNOWN host is kept, never dropped: `{ network: <hostname>, kind:
+ *   "other" }`.
+ * - A NON-PROFILE LinkedIn URL (feed / company / jobs / … — see
+ *   `LINKEDIN_NONPROFILE_RE`) must NOT become a `social` profile; it is kept as
+ *   an `other` link on the `linkedin.com` host.
+ *
+ * Returns `undefined` only when the input is empty / cannot be parsed into a
+ * host — callers filter those out.
+ */
+export function classifyProfile(rawUrl: string): ProfileLink | undefined {
+  const url = normalizeUrl(rawUrl);
+  if (!url) return undefined;
+
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.replace(/^www\./i, "").toLowerCase();
+  } catch {
+    return undefined;
+  }
+  if (hostname.length === 0) return undefined;
+
+  // A LinkedIn URL that is a feed/company/jobs/… page is not a personal
+  // identity profile — keep it, but do not label it `social`.
+  const isLinkedinHost = /(^|\.)linkedin\.com$/i.test(hostname);
+  if (isLinkedinHost && LINKEDIN_NONPROFILE_RE.test(url)) {
+    return { url, network: hostname, kind: "other" };
+  }
+
+  for (const rule of PROFILE_HOSTS) {
+    if (rule.match.test(hostname)) {
+      return { url, network: rule.network, kind: rule.kind };
+    }
+  }
+  return { url, network: hostname, kind: "other" };
+}
+
+/**
+ * Build a deduplicated, order-preserving `ProfileLink[]` from a list of raw
+ * URLs (undefined entries skipped). Duplicates — the same link reached via more
+ * than one source — collapse by normalized slug so a URL never appears twice.
+ *
+ * Phase 1 (#335) feeds this the four legacy link values in their fixed
+ * precedence order `[linkedin, github, portfolio, website]`, so the resulting
+ * array mirrors exactly the links the four legacy keys already carry.
+ */
+export function profilesFromUrls(
+  urls: readonly (string | undefined)[],
+): ProfileLink[] {
+  const out: ProfileLink[] = [];
+  const seen = new Set<string>();
+  for (const raw of urls) {
+    if (!raw) continue;
+    const profile = classifyProfile(raw);
+    if (!profile) continue;
+    const slug = urlSlug(profile.url) ?? profile.url.toLowerCase();
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(profile);
+  }
+  return out;
+}

--- a/src/lib/contact/profile-registry.ts
+++ b/src/lib/contact/profile-registry.ts
@@ -13,8 +13,9 @@
  *
  * URL normalization is intentionally NOT reimplemented here — `normalizeUrl` /
  * `urlSlug` and the `LINKEDIN_NONPROFILE_RE` exclusion are reused from the
- * parser's `extract/contact.ts` so classification stays byte-consistent with
- * extraction.
+ * shared `url-utils` leaf (the same helpers the parser's `extract/contact.ts`
+ * uses) so classification stays byte-consistent with extraction, without the
+ * two modules importing each other (#423).
  */
 
 import type { ProfileLink } from "../score/types.ts";
@@ -22,7 +23,7 @@ import {
   normalizeUrl,
   urlSlug,
   LINKEDIN_NONPROFILE_RE,
-} from "../heuristics/extract/contact.ts";
+} from "./url-utils.ts";
 
 interface HostRule {
   /** Tested against the URL's hostname (lowercased, `www.` stripped). */

--- a/src/lib/contact/profile-registry.ts
+++ b/src/lib/contact/profile-registry.ts
@@ -31,6 +31,13 @@ interface HostRule {
   /** Human-facing network label shown in the UI. */
   network: string;
   kind: ProfileLink["kind"];
+  /** Paths on this host that are NOT a personal identity profile (e.g. a
+   *  LinkedIn company/jobs/feed page, a GitHub org page). Tested against the
+   *  full URL; a match keeps the link but downgrades it to a generic `other`
+   *  link on the bare host — never the network's `social`/`code`/… kind. Keeps
+   *  the per-host exclusion inside the `HostRule` shape instead of accreting a
+   *  special case in the classify loop (#421 review, nit 17). */
+  nonProfilePath?: RegExp;
   /** UI-only guided-add hint. When set, this host surfaces as a quick-pick chip
    *  in the profile-add affordance (`PROFILE_QUICK_PICKS`): tapping the chip
    *  pre-fills `prefix` and the caret lands after it so the user types only
@@ -50,6 +57,7 @@ export const PROFILE_HOSTS: readonly HostRule[] = [
     match: /(^|\.)linkedin\.com$/i,
     network: "LinkedIn",
     kind: "social",
+    nonProfilePath: LINKEDIN_NONPROFILE_RE,
     quickPick: { prefix: "https://linkedin.com/in/", hint: "your-handle" },
   },
   {
@@ -141,17 +149,15 @@ export function classifyProfile(rawUrl: string): ProfileLink | undefined {
   }
   if (hostname.length === 0) return undefined;
 
-  // A LinkedIn URL that is a feed/company/jobs/… page is not a personal
-  // identity profile — keep it, but do not label it `social`.
-  const isLinkedinHost = /(^|\.)linkedin\.com$/i.test(hostname);
-  if (isLinkedinHost && LINKEDIN_NONPROFILE_RE.test(url)) {
-    return { url, network: hostname, kind: "other" };
-  }
-
   for (const rule of PROFILE_HOSTS) {
-    if (rule.match.test(hostname)) {
-      return { url, network: rule.network, kind: rule.kind };
+    if (!rule.match.test(hostname)) continue;
+    // A non-profile path on this host (e.g. a LinkedIn feed/company/jobs page)
+    // is kept but downgraded to a generic `other` link on the bare host — never
+    // the network's identity kind.
+    if (rule.nonProfilePath?.test(url)) {
+      return { url, network: hostname, kind: "other" };
     }
+    return { url, network: rule.network, kind: rule.kind };
   }
   return { url, network: hostname, kind: "other" };
 }

--- a/src/lib/contact/profile-registry.ts
+++ b/src/lib/contact/profile-registry.ts
@@ -31,6 +31,12 @@ interface HostRule {
   /** Human-facing network label shown in the UI. */
   network: string;
   kind: ProfileLink["kind"];
+  /** UI-only guided-add hint. When set, this host surfaces as a quick-pick chip
+   *  in the profile-add affordance (`PROFILE_QUICK_PICKS`): tapping the chip
+   *  pre-fills `prefix` and the caret lands after it so the user types only
+   *  `hint` (their handle). Ordering in `PROFILE_HOSTS` sets the chip order.
+   *  Kept here so "which networks do we recognize" has ONE source of truth. */
+  quickPick?: { prefix: string; hint: string };
 }
 
 /**
@@ -40,9 +46,24 @@ interface HostRule {
  * matching a look-alike substring.
  */
 export const PROFILE_HOSTS: readonly HostRule[] = [
-  { match: /(^|\.)linkedin\.com$/i, network: "LinkedIn", kind: "social" },
-  { match: /(^|\.)github\.com$/i, network: "GitHub", kind: "code" },
-  { match: /(^|\.)gitlab\.com$/i, network: "GitLab", kind: "code" },
+  {
+    match: /(^|\.)linkedin\.com$/i,
+    network: "LinkedIn",
+    kind: "social",
+    quickPick: { prefix: "https://linkedin.com/in/", hint: "your-handle" },
+  },
+  {
+    match: /(^|\.)github\.com$/i,
+    network: "GitHub",
+    kind: "code",
+    quickPick: { prefix: "https://github.com/", hint: "your-handle" },
+  },
+  {
+    match: /(^|\.)gitlab\.com$/i,
+    network: "GitLab",
+    kind: "code",
+    quickPick: { prefix: "https://gitlab.com/", hint: "your-handle" },
+  },
   { match: /(^|\.)codeberg\.org$/i, network: "Codeberg", kind: "code" },
   { match: /(^|\.)kaggle\.com$/i, network: "Kaggle", kind: "code" },
   { match: /(^|\.)huggingface\.co$/i, network: "Hugging Face", kind: "code" },
@@ -53,6 +74,46 @@ export const PROFILE_HOSTS: readonly HostRule[] = [
   { match: /(^|\.)substack\.com$/i, network: "Substack", kind: "writing" },
   { match: /(^|\.)medium\.com$/i, network: "Medium", kind: "writing" },
 ];
+
+/** One tappable network chip in the guided profile-add affordance. */
+export interface ProfileQuickPick {
+  /** Chip label + the profile's network name (e.g. "LinkedIn"). */
+  label: string;
+  /** URL pre-filled when the chip is tapped; the caret lands after it. */
+  prefix: string;
+  /** Ghost hint for the part the user still types (their handle / domain). */
+  hint: string;
+}
+
+/**
+ * The quick-pick network chips shown in the guided profile-add UI, DERIVED from
+ * `PROFILE_HOSTS` (every host carrying a `quickPick`) plus a generic
+ * "Portfolio" catch-all for a personal site (which has no fixed host). Deriving
+ * keeps the picker in lockstep with what `classifyProfile` recognizes — adding
+ * a `quickPick` to a host is the ONE-LINE change that surfaces a new chip.
+ */
+export const PROFILE_QUICK_PICKS: readonly ProfileQuickPick[] = [
+  ...PROFILE_HOSTS.filter((h) => h.quickPick).map((h) => ({
+    label: h.network,
+    prefix: h.quickPick!.prefix,
+    hint: h.quickPick!.hint,
+  })),
+  { label: "Portfolio", prefix: "https://", hint: "yourname.com" },
+];
+
+/**
+ * Recognized network names NOT already offered as a quick-pick chip — feeds the
+ * "…and more are recognized automatically" helper so the promise stays truthful
+ * as hosts are added/removed (single source of truth: {@link PROFILE_HOSTS}).
+ */
+export function otherRecognizedNetworks(): string[] {
+  const picked = new Set(PROFILE_QUICK_PICKS.map((p) => p.label));
+  const names: string[] = [];
+  for (const host of PROFILE_HOSTS) {
+    if (!picked.has(host.network)) names.push(host.network);
+  }
+  return names;
+}
 
 /**
  * Classify one URL into a `ProfileLink`. Normalizes the URL first (reusing the

--- a/src/lib/contact/url-utils.ts
+++ b/src/lib/contact/url-utils.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Leaf URL helpers shared by the contact extractor (`heuristics/extract/
+ * contact.ts`) and the profile registry (`contact/profile-registry.ts`).
+ *
+ * Extracted here to break the import cycle those two formed (#423): the registry
+ * needs `normalizeUrl` / `urlSlug` / `LINKEDIN_NONPROFILE_RE` for byte-consistent
+ * classification, while the extractor imports the registry's `profilesFromUrls`.
+ * Both now depend on this leaf (which imports nothing internal), so neither
+ * imports the other. Behavior is unchanged — the definitions moved verbatim.
+ */
+
+/** LinkedIn paths that are NOT a personal profile — feed, company pages, job
+ *  posts, articles, etc. Everything else under `linkedin.com/<handle>` (the
+ *  `/in/<handle>` canonical form AND bare-vanity hosts) is treated as a
+ *  profile, mirroring GitHub's "any `github.com/<user>`" rule. */
+export const LINKEDIN_NONPROFILE_RE =
+  /linkedin\.com\/(company|jobs|feed|school|learning|pulse|posts|groups|showcase|games|events|help|legal|search|signup|login|home)\b/i;
+
+/** Ensure a URL carries an `https://` scheme and drop a trailing sentence
+ *  punctuation mark. Returns `undefined` for empty input. */
+export function normalizeUrl(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.replace(/[,;.)]$/, "").trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+/** Host+path of a URL, lowercased, with scheme / `www.` / trailing punctuation
+ *  removed — the comparable identity of a link across "https://github.com/x",
+ *  "github.com/x" and "github.com/x/". */
+export function urlSlug(u: string | undefined): string | undefined {
+  if (!u) return undefined;
+  const s = u
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/[/.,;:)\]]+$/, "")
+    .toLowerCase();
+  return s.length > 0 ? s : undefined;
+}

--- a/src/lib/download/blob-download.ts
+++ b/src/lib/download/blob-download.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * blob-download — the one place the app turns bytes into a same-document
+ * download, shared by every "Download …" hook (`useDownloadPdf`,
+ * `useDownloadReport`, `useReportGap`). Extracted so the Blob → object-URL →
+ * click-anchor → deferred-revoke dance (and the filename slug) live once
+ * instead of in three near-identical copies (#421 review).
+ *
+ * Zero egress: everything is a local object URL; nothing is uploaded.
+ */
+
+/**
+ * Lower-kebab slug of a candidate name for a download filename — NFKD-fold,
+ * drop non-word/space/hyphen, collapse whitespace, lowercase. Empty/undefined
+ * in ⇒ `""` out (caller falls back to a generic, PII-free filename).
+ */
+export function slugifyName(name: string | undefined): string {
+  return (name ?? "")
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+}
+
+/**
+ * Trigger a same-document download of `bytes` as `filename`.
+ *
+ * The revoke is DEFERRED: `a.click()` only SCHEDULES the download — the browser
+ * reads the object URL asynchronously afterward. Revoking synchronously would
+ * invalidate the URL before the fetch starts, silently killing the download on
+ * slower/remote contexts and on Firefox/Safari. So we hand the URL off and
+ * revoke on a later task. A single place to adjust if Safari's revoke timing
+ * changes or we move to `showSaveFilePicker`.
+ */
+export function triggerBlobDownload(
+  bytes: BlobPart,
+  mime: string,
+  filename: string,
+): void {
+  const blob = new Blob([bytes], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -799,3 +799,152 @@ describe("applyOverrides — added entries + bullets", () => {
     expect(after.completeness.score).toBeGreaterThan(before.completeness.score);
   });
 });
+
+// ── Profile links: re-mirror + added extras (#335) ───────────────────────────
+
+/** baseParsed with the four legacy link slots populated (normalized form). */
+function parsedWithLinks(): HeuristicParsedResume {
+  return {
+    ...baseParsed(),
+    linkedin_url: "https://linkedin.com/in/jane",
+    github_url: "https://github.com/jane",
+  };
+}
+
+describe("applyOverrides — profiles[] (#335)", () => {
+  it("leaves profiles absent when no legacy link and no extras", () => {
+    const { parsed: out } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+    );
+    expect(out.profiles).toBeUndefined();
+  });
+
+  it("re-mirrors profiles from a legacy link edit (never desyncs)", () => {
+    const { parsed: out } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      { linkedin_url: "https://linkedin.com/in/corrected" },
+      {},
+      {},
+      [],
+    );
+    expect(out.linkedin_url).toBe("https://linkedin.com/in/corrected");
+    expect(out.profiles).toEqual([
+      {
+        url: "https://linkedin.com/in/corrected",
+        network: "LinkedIn",
+        kind: "social",
+      },
+    ]);
+  });
+
+  it("clearing a legacy link drops it from the mirror", () => {
+    const { parsed: out } = applyOverrides(
+      parsedWithLinks(),
+      "raw",
+      makeSections(),
+      { linkedin_url: "" }, // clear LinkedIn; GitHub stays
+      {},
+      {},
+      [],
+    );
+    expect(out.linkedin_url).toBeUndefined();
+    expect(out.profiles).toEqual([
+      { url: "https://github.com/jane", network: "GitHub", kind: "code" },
+    ]);
+  });
+
+  it("appends added extras after the legacy slots, in order", () => {
+    const { parsed: out } = applyOverrides(
+      parsedWithLinks(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [],
+      {},
+      new Set(),
+      [
+        { id: "profile:0", url: "https://gitlab.com/jane", network: "GitLab", kind: "code" },
+      ],
+    );
+    expect(out.profiles).toEqual([
+      { url: "https://linkedin.com/in/jane", network: "LinkedIn", kind: "social" },
+      { url: "https://github.com/jane", network: "GitHub", kind: "code" },
+      { url: "https://gitlab.com/jane", network: "GitLab", kind: "code" },
+    ]);
+  });
+
+  it("keeps an unknown-host extra with its hostname + other kind", () => {
+    const { parsed: out } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [],
+      {},
+      new Set(),
+      [
+        { id: "profile:0", url: "https://example.dev/jane", network: "example.dev", kind: "other" },
+      ],
+    );
+    expect(out.profiles).toEqual([
+      { url: "https://example.dev/jane", network: "example.dev", kind: "other" },
+    ]);
+  });
+
+  it("de-dupes an extra that repeats a legacy link", () => {
+    const { parsed: out } = applyOverrides(
+      parsedWithLinks(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [],
+      {},
+      new Set(),
+      [
+        { id: "profile:0", url: "https://github.com/jane", network: "GitHub", kind: "code" },
+      ],
+    );
+    expect(out.profiles).toEqual([
+      { url: "https://linkedin.com/in/jane", network: "LinkedIn", kind: "social" },
+      { url: "https://github.com/jane", network: "GitHub", kind: "code" },
+    ]);
+  });
+
+  it("does not mutate the input parsed object when re-mirroring", () => {
+    const parsed = parsedWithLinks();
+    const snapshot = JSON.parse(JSON.stringify(parsed));
+    applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      { linkedin_url: "https://linkedin.com/in/moved" },
+      {},
+      {},
+      [],
+    );
+    expect(parsed).toEqual(snapshot);
+  });
+});

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -947,4 +947,85 @@ describe("applyOverrides — profiles[] (#335)", () => {
     );
     expect(parsed).toEqual(snapshot);
   });
+
+  // #421 Blocking #1: a LinkedIn/GitHub link added via the guided picker lands
+  // in `addedProfiles`, but the scorer + contact gap read the legacy `_url`
+  // slot — so the add must back-fill that slot (when empty) and mark it
+  // user-affirmed in the edited fieldConfidence, or the score never moves.
+  it("back-fills the empty linkedin_url slot from an added LinkedIn profile", () => {
+    const { parsed: out, fieldConfidence } = applyOverrides(
+      baseParsed(), // no legacy linkedin_url
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [],
+      {},
+      new Set(),
+      [
+        {
+          id: "profile:0",
+          url: "https://linkedin.com/in/jane",
+          network: "LinkedIn",
+          kind: "social",
+        },
+      ],
+    );
+    expect(out.linkedin_url).toBe("https://linkedin.com/in/jane");
+    expect(fieldConfidence.linkedin_url).toBe(1);
+  });
+
+  it("does NOT overwrite an existing legacy slot when back-filling", () => {
+    const { parsed: out } = applyOverrides(
+      parsedWithLinks(), // linkedin_url already set to .../in/jane
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [],
+      {},
+      new Set(),
+      [
+        {
+          id: "profile:0",
+          url: "https://linkedin.com/in/someone-else",
+          network: "LinkedIn",
+          kind: "social",
+        },
+      ],
+    );
+    expect(out.linkedin_url).toBe("https://linkedin.com/in/jane");
+  });
+
+  // #421 Blocking #3: a typed-in contact edit is user-affirmed → confidence 1;
+  // an explicit clear → 0; an untouched field keeps its base confidence.
+  it("bumps edited contact-field confidence and drops a cleared one", () => {
+    const { fieldConfidence } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      { github_url: "https://github.com/jane", email: "" },
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [],
+      {},
+      new Set(),
+      [],
+      { full_name: 0.9, email: 0.9 },
+    );
+    expect(fieldConfidence.github_url).toBe(1); // affirmed
+    expect(fieldConfidence.email).toBe(0); // cleared
+    expect(fieldConfidence.full_name).toBe(0.9); // untouched base kept
+  });
 });

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -33,6 +33,7 @@ import type { BulletObservation } from "../score/score.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 import type { SectionName } from "../heuristics/regex.ts";
 import { normalizeBulletText } from "../score/group-bullets.ts";
+import { profilesFromUrls } from "../contact/profile-registry.ts";
 import type {
   ContactOverrides,
   ExperienceFieldOverrides,
@@ -40,6 +41,7 @@ import type {
   SkillsOverride,
   AddedEntry,
   AddedBullets,
+  AddedProfile,
   BulletOverrides,
 } from "../../hooks/useEditableParse.ts";
 
@@ -100,6 +102,37 @@ function applyContactOverrides(
     }
     if (key === "phone") delete nextParsed.phoneIsValid;
   }
+}
+
+// ── Profile links (#335) ────────────────────────────────────────────────────
+
+/**
+ * Re-derive `nextParsed.profiles` from the (already-override-applied) four
+ * legacy link keys in their fixed precedence order, then append the user-added
+ * extra profiles. This keeps the mirror in lockstep with the legacy keys — the
+ * scoring/snapshot source of truth — so a single-slot edit (e.g. correcting
+ * `linkedin_url`) never leaves `profiles[]` stale, and it is where #334's JSON
+ * export reads a user's added links from.
+ *
+ * `profilesFromUrls` classifies + de-dupes by normalized slug (a legacy link
+ * re-added as an extra collapses to one entry). Absent when nothing is left, so
+ * the parsed shape stays byte-identical to extraction's "present only when ≥1
+ * link" convention (openresume.ts) — and every corpus/roundtrip snapshot, which
+ * never routes through this module, is untouched.
+ */
+function applyProfileOverrides(
+  nextParsed: HeuristicParsedResume,
+  addedProfiles: readonly AddedProfile[],
+): void {
+  const profiles = profilesFromUrls([
+    nextParsed.linkedin_url,
+    nextParsed.github_url,
+    nextParsed.portfolio_url,
+    nextParsed.website_url,
+    ...addedProfiles.map((p) => p.url),
+  ]);
+  if (profiles.length > 0) nextParsed.profiles = profiles;
+  else delete nextParsed.profiles;
 }
 
 // ── Experience / education header fields ────────────────────────────────────
@@ -613,6 +646,12 @@ function applyAddedBulletsToExistingEntries(
  *                  entry's id. Folded into the entry description AND the graded
  *                  bullet pool so an addition moves Specificity / Structure.
  *                  Default `{}`.
+ * @param removedBullets accepted "this bullet was removed" indices (#211).
+ *                  Default empty set.
+ * @param addedProfiles user-added contact links beyond the four legacy slots
+ *                  (#335). `parsed.profiles` is re-derived from the edited
+ *                  legacy keys and these appended, so the mirror never desyncs
+ *                  from the scoring-source legacy keys. Default `[]`.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -627,6 +666,7 @@ export function applyOverrides(
   addedEntries: readonly AddedEntry[] = [],
   addedBullets: AddedBullets = {},
   removedBullets: ReadonlySet<number> = new Set(),
+  addedProfiles: readonly AddedProfile[] = [],
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -639,6 +679,9 @@ export function applyOverrides(
   };
 
   applyContactOverrides(nextParsed, contact);
+  // Re-mirror profiles from the (now-edited) legacy keys + user-added extras, so
+  // the mirror never desyncs from the scoring-source legacy keys (#335).
+  applyProfileOverrides(nextParsed, addedProfiles);
   applyExperienceHeaderOverrides(nextParsed.experience, experience);
 
   const byIndex = new Map<number, BulletObservation>();

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -28,12 +28,15 @@
  * override is a no-op.
  */
 
-import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type {
+  HeuristicParsedResume,
+  FieldConfidence,
+} from "../heuristics/types.ts";
 import type { BulletObservation } from "../score/score.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 import type { SectionName } from "../heuristics/regex.ts";
 import { normalizeBulletText } from "../score/group-bullets.ts";
-import { profilesFromUrls } from "../contact/profile-registry.ts";
+import { classifyProfile, profilesFromUrls } from "../contact/profile-registry.ts";
 import type {
   ContactOverrides,
   ExperienceFieldOverrides,
@@ -53,6 +56,14 @@ export interface ApplyOverridesResult {
    *  bullet set from (#133), so a live edit must be reflected here to re-grade
    *  Specificity / Structure. */
   sections: SectionedResume;
+  /** The base `fieldConfidence` with every user-affirmed contact edit bumped to
+   *  1 (and an explicit clear dropped to 0). The scorer and the contact-gap
+   *  display both gate contact fields by confidence, but a user override lands
+   *  a value WITHOUT a matching new confidence — so a typed-in GitHub URL, or a
+   *  guided-picker LinkedIn add, would score as "still absent" against the
+   *  frozen base confidence. Threading this edited view keeps score + display in
+   *  step with the edits (#421 Blocking #1 / #3). */
+  fieldConfidence: FieldConfidence;
 }
 
 /** A `{ rawText, sections }` pair — the two bullet-pool views that every
@@ -106,6 +117,16 @@ function applyContactOverrides(
 
 // ── Profile links (#335) ────────────────────────────────────────────────────
 
+/** The network label (`classifyProfile`) → legacy `_url` slot a back-fill
+ *  targets. Only the two links the scorer + contact-gap actually read
+ *  (`linkedin_url`, `github_url`) map — portfolio/website have no single
+ *  canonical network, and nothing downstream keys on them the way LinkedIn/
+ *  GitHub feed the "Professional profile" gap. */
+const NETWORK_TO_LEGACY_KEY: Readonly<Record<string, "linkedin_url" | "github_url">> = {
+  LinkedIn: "linkedin_url",
+  GitHub: "github_url",
+};
+
 /**
  * Re-derive `nextParsed.profiles` from the (already-override-applied) four
  * legacy link keys in their fixed precedence order, then append the user-added
@@ -114,16 +135,32 @@ function applyContactOverrides(
  * `linkedin_url`) never leaves `profiles[]` stale, and it is where #334's JSON
  * export reads a user's added links from.
  *
+ * It ALSO back-fills the legacy `linkedin_url` / `github_url` slot from a
+ * matching user-added profile when that slot is empty (#421 Blocking #1): the
+ * anonymous scorer's completeness and the ContactCard's "Professional profile"
+ * gap both read the legacy slot, NOT `profiles[]`, so a LinkedIn URL added via
+ * the guided picker (which lands in `addedProfiles`) would otherwise never move
+ * the score or clear the gap. Returns the legacy keys it back-filled so the
+ * caller can mark them user-affirmed in the edited `fieldConfidence`.
+ *
  * `profilesFromUrls` classifies + de-dupes by normalized slug (a legacy link
- * re-added as an extra collapses to one entry). Absent when nothing is left, so
- * the parsed shape stays byte-identical to extraction's "present only when ≥1
- * link" convention (openresume.ts) — and every corpus/roundtrip snapshot, which
- * never routes through this module, is untouched.
+ * re-added as an extra collapses to one entry).
  */
 function applyProfileOverrides(
   nextParsed: HeuristicParsedResume,
   addedProfiles: readonly AddedProfile[],
-): void {
+): ("linkedin_url" | "github_url")[] {
+  const backFilled: ("linkedin_url" | "github_url")[] = [];
+  for (const added of addedProfiles) {
+    const classified = classifyProfile(added.url);
+    if (!classified) continue;
+    const legacyKey = NETWORK_TO_LEGACY_KEY[classified.network];
+    if (legacyKey && !nextParsed[legacyKey]) {
+      nextParsed[legacyKey] = classified.url;
+      backFilled.push(legacyKey);
+    }
+  }
+
   const profiles = profilesFromUrls([
     nextParsed.linkedin_url,
     nextParsed.github_url,
@@ -131,8 +168,12 @@ function applyProfileOverrides(
     nextParsed.website_url,
     ...addedProfiles.map((p) => p.url),
   ]);
+  // Absent when nothing is left, so an empty-override call stays a true no-op
+  // (an `applyOverrides` invariant a test pins) and the parsed shape matches
+  // extraction's "present only when ≥1 link" convention.
   if (profiles.length > 0) nextParsed.profiles = profiles;
   else delete nextParsed.profiles;
+  return backFilled;
 }
 
 // ── Experience / education header fields ────────────────────────────────────
@@ -652,6 +693,11 @@ function applyAddedBulletsToExistingEntries(
  *                  (#335). `parsed.profiles` is re-derived from the edited
  *                  legacy keys and these appended, so the mirror never desyncs
  *                  from the scoring-source legacy keys. Default `[]`.
+ * @param fieldConfidence the base per-field confidence. Returned bumped to 1
+ *                  for every user-affirmed contact edit (and dropped to 0 for a
+ *                  clear), so a typed-in / picker-added contact link scores +
+ *                  displays as present rather than as low-confidence against the
+ *                  frozen base parse (#421 Blocking #1 / #3). Default `{}`.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -667,6 +713,7 @@ export function applyOverrides(
   addedBullets: AddedBullets = {},
   removedBullets: ReadonlySet<number> = new Set(),
   addedProfiles: readonly AddedProfile[] = [],
+  fieldConfidence: FieldConfidence = {},
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -680,8 +727,15 @@ export function applyOverrides(
 
   applyContactOverrides(nextParsed, contact);
   // Re-mirror profiles from the (now-edited) legacy keys + user-added extras, so
-  // the mirror never desyncs from the scoring-source legacy keys (#335).
-  applyProfileOverrides(nextParsed, addedProfiles);
+  // the mirror never desyncs from the scoring-source legacy keys (#335), and
+  // back-fill the legacy linkedin/github slot from a matching added profile so
+  // the add moves the score + clears the gap (#421 Blocking #1).
+  const backFilledKeys = applyProfileOverrides(nextParsed, addedProfiles);
+  const nextConfidence = deriveEditedConfidence(
+    fieldConfidence,
+    contact,
+    backFilledKeys,
+  );
   applyExperienceHeaderOverrides(nextParsed.experience, experience);
 
   const byIndex = new Map<number, BulletObservation>();
@@ -706,5 +760,31 @@ export function applyOverrides(
     addedBullets,
   );
 
-  return { parsed: nextParsed, rawText: views.rawText, sections: nextSections };
+  return {
+    parsed: nextParsed,
+    rawText: views.rawText,
+    sections: nextSections,
+    fieldConfidence: nextConfidence,
+  };
+}
+
+/**
+ * Build the edited `fieldConfidence` from the base plus the user's contact
+ * edits: a non-empty override (or a back-filled linkedin/github slot) is
+ * user-affirmed → confidence 1; an explicit clear ("") → 0 (absent). Untouched
+ * fields keep their base confidence. See {@link ApplyOverridesResult.fieldConfidence}.
+ */
+function deriveEditedConfidence(
+  base: FieldConfidence,
+  contact: ContactOverrides,
+  backFilledKeys: readonly ("linkedin_url" | "github_url")[],
+): FieldConfidence {
+  const next: FieldConfidence = { ...base };
+  for (const key of CONTACT_KEYS) {
+    const ov = contact[key];
+    if (ov === undefined) continue;
+    next[key] = ov === "" ? 0 : 1;
+  }
+  for (const key of backFilledKeys) next[key] = 1;
+  return next;
 }

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -64,6 +64,11 @@ function fieldsPopulated(parsed: HeuristicParsedResume): string[] {
   for (const [k, v] of Object.entries(parsed)) {
     if (v === undefined || v === null || v === "") continue;
     if (Array.isArray(v) && v.length === 0) continue;
+    // `profiles` (#335) is an additive mirror of the four legacy `*_url` link
+    // keys — it carries no new field-presence signal, so it is excluded here to
+    // keep the Phase-1 migration snapshot-safe (no re-bake). Phase 2 flips the
+    // legacy keys to `profiles` and re-bakes the corpus deliberately.
+    if (k === "profiles") continue;
     keys.push(k);
   }
   return keys.sort();

--- a/src/lib/heuristics/extract/contact.test.ts
+++ b/src/lib/heuristics/extract/contact.test.ts
@@ -66,6 +66,47 @@ describe("extractContact — email domain is not a website", () => {
   });
 });
 
+describe("extractContact — additive profiles[] mirrors the legacy link keys (#335)", () => {
+  it("derives a profiles[] from the four legacy link values, in fixed order", () => {
+    const lines: PdfLine[] = [
+      mkLine("Jane Doe", 0),
+      mkLine(
+        "jane@uw.edu | linkedin.com/in/jane | github.com/jane | janedoe.dev",
+        10,
+      ),
+    ];
+    const profile: PdfSection = { name: "profile", lines };
+
+    const result = extractContact(profile, lines);
+
+    // Legacy keys are unchanged (still the scoring/snapshot source of truth).
+    expect(result.linkedin_url).toBe("https://linkedin.com/in/jane");
+    expect(result.github_url).toBe("https://github.com/jane");
+
+    // profiles[] mirrors those legacy values, classified + order-preserving.
+    const byNetwork = result.profiles.map((p) => p.network);
+    expect(byNetwork).toContain("LinkedIn");
+    expect(byNetwork).toContain("GitHub");
+    const linkedin = result.profiles.find((p) => p.network === "LinkedIn");
+    const github = result.profiles.find((p) => p.network === "GitHub");
+    expect(linkedin?.url).toBe(result.linkedin_url);
+    expect(linkedin?.kind).toBe("social");
+    expect(github?.url).toBe(result.github_url);
+    expect(github?.kind).toBe("code");
+  });
+
+  it("emits an empty profiles[] when no link was detected", () => {
+    const lines: PdfLine[] = [
+      mkLine("Jane Doe", 0),
+      mkLine("Seattle, WA | jane@uw.edu | (312) 555-0123", 10),
+    ];
+    const profile: PdfSection = { name: "profile", lines };
+
+    const result = extractContact(profile, lines);
+    expect(result.profiles).toEqual([]);
+  });
+});
+
 describe("extractContact — mid-sentence domain is not promoted to website_url (#237)", () => {
   // Regression: a bare domain embedded in achievement/body prose (e.g. "sold
   // return2india.com to Satyam Infoway") was being picked up by the full-doc

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -3,6 +3,8 @@
 
 import type { PdfLine, PdfSection } from "../sections.ts";
 import type { PdfLinkAnnotation } from "../types.ts";
+import type { ProfileLink } from "../../score/types.ts";
+import { profilesFromUrls } from "../../contact/profile-registry.ts";
 import {
   EMAIL_RE,
   LINKEDIN_RE,
@@ -28,6 +30,14 @@ export interface ContactExtractionResult {
   portfolio_url?: string;
   website_url?: string;
   location?: string;
+  /**
+   * Classified contact links (#335), additive. Built from the four legacy
+   * `*_url` values above in their fixed precedence order
+   * `[linkedin, github, portfolio, website]`, so this mirrors — never
+   * overrides — the legacy keys, keeping scoring and every corpus snapshot
+   * byte-for-byte unchanged this phase. Empty when no link was detected.
+   */
+  profiles: ProfileLink[];
   /** Per-field confidence for the cascade's field-confidence map. */
   confidence: {
     email: number;
@@ -60,13 +70,13 @@ export interface ContactExtractionResult {
  *  their confidences, before ownership is computed. `extractContact` combines a
  *  profile scan and a full-document scan into the public {@link
  *  ContactExtractionResult} (which adds `consumedLines`). */
-type ContactScanResult = Omit<ContactExtractionResult, "consumedLines">;
+type ContactScanResult = Omit<ContactExtractionResult, "consumedLines" | "profiles">;
 
 /** LinkedIn paths that are NOT a personal profile — feed, company pages, job
  *  posts, articles, etc. Everything else under `linkedin.com/<handle>` (the
  *  `/in/<handle>` canonical form AND bare-vanity hosts) is treated as a
  *  profile, mirroring GitHub's "any `github.com/<user>`" rule. */
-const LINKEDIN_NONPROFILE_RE =
+export const LINKEDIN_NONPROFILE_RE =
   /linkedin\.com\/(company|jobs|feed|school|learning|pulse|posts|groups|showcase|games|events|help|legal|search|signup|login|home)\b/i;
 
 /** True when `u` is a LinkedIn personal-profile URL. Accepts the canonical
@@ -77,7 +87,7 @@ function isLinkedinProfileUrl(u: string): boolean {
   return /linkedin\.com\/[A-Za-z0-9]/i.test(u) && !LINKEDIN_NONPROFILE_RE.test(u);
 }
 
-function normalizeUrl(raw: string | undefined): string | undefined {
+export function normalizeUrl(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
   const trimmed = raw.replace(/[,;.)]$/, "").trim();
   if (/^https?:\/\//i.test(trimmed)) return trimmed;
@@ -99,7 +109,7 @@ function normalizeUrl(raw: string | undefined): string | undefined {
 /** Host+path of a URL, lowercased, with scheme / `www.` / trailing punctuation
  *  removed — the comparable identity of a link across "https://github.com/x",
  *  "github.com/x" and "github.com/x/". */
-function urlSlug(u: string | undefined): string | undefined {
+export function urlSlug(u: string | undefined): string | undefined {
   if (!u) return undefined;
   const s = u
     .trim()
@@ -427,6 +437,18 @@ export function extractContact(
   ].filter((s): s is string => s !== undefined);
   const consumedLines = findConsumedLines(allLines, promotedSlugs);
 
+  // Additive `profiles[]` (#335): classify the four legacy link values in their
+  // fixed precedence order. The legacy keys below are UNCHANGED — `profiles`
+  // mirrors them, so scoring and every corpus snapshot stay byte-for-byte
+  // identical this phase. `normalizeUrl` is applied inside `classifyProfile`,
+  // matching the legacy keys' own `normalizeUrl(...)` wrapping.
+  const profiles = profilesFromUrls([
+    linkedin.value,
+    github.value,
+    portfolio.value,
+    website.value,
+  ]);
+
   return {
     email: primary.email ?? fallback.email,
     phone: primary.phone ?? fallback.phone,
@@ -435,6 +457,7 @@ export function extractContact(
     github_url: normalizeUrl(github.value),
     portfolio_url: normalizeUrl(portfolio.value),
     website_url: normalizeUrl(website.value),
+    profiles,
     // No fallback for location — see comment above.
     location: primary.location,
     confidence: {

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -6,6 +6,11 @@ import type { PdfLinkAnnotation } from "../types.ts";
 import type { ProfileLink } from "../../score/types.ts";
 import { profilesFromUrls } from "../../contact/profile-registry.ts";
 import {
+  LINKEDIN_NONPROFILE_RE,
+  normalizeUrl,
+  urlSlug,
+} from "../../contact/url-utils.ts";
+import {
   EMAIL_RE,
   LINKEDIN_RE,
   GITHUB_RE,
@@ -72,26 +77,12 @@ export interface ContactExtractionResult {
  *  ContactExtractionResult} (which adds `consumedLines`). */
 type ContactScanResult = Omit<ContactExtractionResult, "consumedLines" | "profiles">;
 
-/** LinkedIn paths that are NOT a personal profile — feed, company pages, job
- *  posts, articles, etc. Everything else under `linkedin.com/<handle>` (the
- *  `/in/<handle>` canonical form AND bare-vanity hosts) is treated as a
- *  profile, mirroring GitHub's "any `github.com/<user>`" rule. */
-export const LINKEDIN_NONPROFILE_RE =
-  /linkedin\.com\/(company|jobs|feed|school|learning|pulse|posts|groups|showcase|games|events|help|legal|search|signup|login|home)\b/i;
-
 /** True when `u` is a LinkedIn personal-profile URL. Accepts the canonical
  *  `linkedin.com/in/<handle>` and `linkedin.com/pub/...` as well as a vanity
  *  `linkedin.com/<handle>` that omits `/in/` — the latter is what makes a
  *  hyperlinked "LinkedIn" anchor resolve even when the target drops `/in/`. */
 function isLinkedinProfileUrl(u: string): boolean {
   return /linkedin\.com\/[A-Za-z0-9]/i.test(u) && !LINKEDIN_NONPROFILE_RE.test(u);
-}
-
-export function normalizeUrl(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  const trimmed = raw.replace(/[,;.)]$/, "").trim();
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  return `https://${trimmed}`;
 }
 
 // ── Promoted-identity-link ownership (#134) ─────────────────────────────────
@@ -105,20 +96,6 @@ export function normalizeUrl(raw: string | undefined): string | undefined {
 // an optional introducing label — is reported on `consumedLines`, and the
 // caller drops those lines from the candidate pools before the body extractors
 // run. Ownership is recorded here, at the single point the link is promoted.
-
-/** Host+path of a URL, lowercased, with scheme / `www.` / trailing punctuation
- *  removed — the comparable identity of a link across "https://github.com/x",
- *  "github.com/x" and "github.com/x/". */
-export function urlSlug(u: string | undefined): string | undefined {
-  if (!u) return undefined;
-  const s = u
-    .trim()
-    .replace(/^https?:\/\//i, "")
-    .replace(/^www\./i, "")
-    .replace(/[/.,;:)\]]+$/, "")
-    .toLowerCase();
-  return s.length > 0 ? s : undefined;
-}
 
 /** Leading introducing label that a bare identity link sits behind ("LinkedIn:",
  *  "GitHub —", "Links", "Find me online") — stripped before testing whether a

--- a/src/lib/heuristics/openresume.ts
+++ b/src/lib/heuristics/openresume.ts
@@ -422,6 +422,9 @@ function buildHeuristicResult(
     ...(contact.github_url ? { github_url: contact.github_url } : {}),
     ...(contact.portfolio_url ? { portfolio_url: contact.portfolio_url } : {}),
     ...(contact.website_url ? { website_url: contact.website_url } : {}),
+    // Additive classified links (#335): mirrors the four legacy `*_url` keys
+    // above. Present only when at least one link was detected.
+    ...(contact.profiles.length > 0 ? { profiles: contact.profiles } : {}),
     ...(summary.value ? { summary: summary.value } : {}),
     skills: skills.value,
     skills_explicit: [],

--- a/src/lib/heuristics/trigger-copy.ts
+++ b/src/lib/heuristics/trigger-copy.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * trigger-copy — the single source of the plain-language layout-trigger
+ * explanations.
+ *
+ * These blurbs used to live inline in `LayoutFlagsList.tsx`; they were hoisted
+ * to `src/lib/` (#343) so lib-layer consumers — the shareable audit-report
+ * exporter (`render-audit-report.ts`) — can render the same copy WITHOUT a lib→
+ * component import (which would invert the dependency direction the codebase
+ * keeps: components import from lib, never the reverse). `LayoutFlagsList` now
+ * imports from here too, so the on-screen list and the exported report stay in
+ * lockstep.
+ */
+
+import type { LayoutTrigger } from "./types.ts";
+
+/** Plain-language explanation for each layout trigger the parser can fire. */
+export const LAYOUT_TRIGGER_BLURBS: Record<LayoutTrigger, string> = {
+  two_column:
+    "Two-column layout — some text extractors read across columns and scramble the order.",
+  scanned:
+    "Image-only PDF — no selectable text, so a plain-text extractor returns nothing.",
+  fonts_unmappable:
+    "Text is present in the source but uses custom font encodings that don't decode to characters. Common with Framer, Affinity, and some InDesign exports.",
+};

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -25,6 +25,7 @@ import type {
   ResumeEducation,
   HeuristicAchievement,
   ResumeExperience,
+  ProfileLink,
 } from "../score/types.ts";
 import {
   groupBulletsByExperience,
@@ -46,6 +47,50 @@ export interface AtsContact {
   location?: string;
   /** LinkedIn / GitHub / portfolio / website / other links, label-prefixed. */
   links: string[];
+  /**
+   * Classified contact/identity links (#335), the single source of truth for
+   * the JSON-Resume export's `basics.profiles` (#334). Read straight off
+   * `parsed.profiles`, which `applyOverrides` keeps in lockstep with the four
+   * legacy link keys and any user-added extras — so this already reflects edits.
+   * Distinct from `links` (the display-only, label-prefixed strings the PDF
+   * contact line draws); this carries the structured `{ url, network, kind }`.
+   * Optional so hand-built `AtsContact` literals (tests, non-edit callers) stay
+   * valid; `buildContact` always sets it, and the export treats absent as empty.
+   */
+  profiles?: ProfileLink[];
+}
+
+/**
+ * Structured source fields carried alongside an entry's render strings so the
+ * JSON-Resume export (`to-json-resume.ts`, #334) maps each entry losslessly
+ * WITHOUT re-parsing the glued `headerLine` / `subLine` display strings. The
+ * shape is a superset across section kinds; each kind fills only the fields it
+ * has (see the per-section builders below). Absent on synthesized/placeholder
+ * entries that carry no structured source. Display code ignores it entirely.
+ */
+export interface AtsEntryFields {
+  /** JSON Resume `work.name` (company) / `project.name` / `education.institution`. */
+  organization?: string;
+  /** JSON Resume `work.position` (role title). */
+  position?: string;
+  /** JSON Resume `education.studyType` (degree credential, e.g. "B.S."). */
+  studyType?: string;
+  /** JSON Resume `education.area` (field of study). */
+  area?: string;
+  /** Raw start-date string exactly as parsed (free-form; normalized at export). */
+  startDate?: string;
+  /** Raw end-date string. Omitted when `isCurrent` — JSON Resume treats an
+   *  absent `endDate` as ongoing, so an ongoing role emits no end date. */
+  endDate?: string;
+  /** True when the role/entry is ongoing (→ the export drops `endDate`). */
+  isCurrent?: boolean;
+  /** A URL on the entry header (project repo / demo, achievement link). */
+  url?: string;
+  /** JSON Resume `education.courses` — relevant-coursework items (#164). */
+  courses?: string[];
+  /** JSON Resume `skills` — the flat skill list, carried only on the single
+   *  skills entry (whose `headerLine` is the same list joined by " · "). */
+  skills?: string[];
 }
 
 export interface AtsEntry {
@@ -64,11 +109,26 @@ export interface AtsEntry {
    * word-wrap normally, so this defaults to `false`/unset everywhere else.
    */
   atomicSegments?: boolean;
+  /** Structured source fields for the JSON-Resume export (#334). See
+   *  {@link AtsEntryFields}. Display/render code never reads this. */
+  fields?: AtsEntryFields;
 }
+
+/** Which JSON-Resume top-level array a section maps to (#334). Purely an export
+ *  hint — the renderer draws every section identically regardless of `kind`. */
+export type AtsSectionKind =
+  | "experience"
+  | "projects"
+  | "achievements"
+  | "education"
+  | "skills";
 
 export interface AtsSection {
   heading: string;
   entries: AtsEntry[];
+  /** JSON-Resume mapping hint (#334); absent on sections not modeled by the
+   *  export. Display code ignores it. */
+  kind?: AtsSectionKind;
 }
 
 export interface AtsResumeModel {
@@ -126,6 +186,10 @@ function buildContact(
     phone: phone || undefined,
     location: location || undefined,
     links,
+    // `parsed.profiles` is already override-applied (applyOverrides re-derives it
+    // from the edited legacy keys + user-added extras, #335), so read it straight
+    // — never re-derive from the four legacy keys here. Absent ⇒ no links.
+    profiles: result.parsed.profiles ?? [],
   };
 }
 
@@ -315,6 +379,16 @@ export function buildAtsResumeModel(
         bulletOverrides,
         exp.description,
       ),
+      // Structured JSON-Resume source (#334): name←company, position←title.
+      // `endDate` is dropped when the role is current (JSON Resume reads an
+      // absent endDate as ongoing).
+      fields: {
+        organization: exp.company || undefined,
+        position: title || undefined,
+        startDate: exp.start_date || undefined,
+        endDate: exp.is_current ? undefined : exp.end_date || undefined,
+        isCurrent: exp.is_current || undefined,
+      },
     };
   });
 
@@ -328,6 +402,15 @@ export function buildAtsResumeModel(
       bulletOverrides,
       proj.description,
     ),
+    // JSON-Resume `projects[]` source (#334): name←proj.name, plus optional
+    // header URL and dates.
+    fields: {
+      organization: proj.name || undefined,
+      startDate: proj.start_date || undefined,
+      endDate: proj.is_current ? undefined : proj.end_date || undefined,
+      isCurrent: proj.is_current || undefined,
+      url: proj.url || undefined,
+    },
   }));
 
   // ── Achievements ──
@@ -380,22 +463,51 @@ export function buildAtsResumeModel(
     // (entry LOSS, 2 → 1). Keep the date INLINE on the degree-less header instead,
     // so it reads as an `isInlineDatedProgram` lead, and drop the institution
     // alone to the sub-line.
+    // JSON-Resume `education[]` source (#334): institution←institution,
+    // studyType←degree, area←field. `endDate` carries the graduation date,
+    // falling back to the lead `year` when only a single date was parsed;
+    // `courses` carries the relevant-coursework list (#164). Shared across both
+    // header shapes below.
+    const eduFields: AtsEntryFields = {
+      organization: edu.institution || undefined,
+      studyType: edu.degree || undefined,
+      area: edu.field || undefined,
+      startDate: edu.start_date || undefined,
+      endDate: edu.end_date || edu.year || undefined,
+      courses:
+        edu.coursework && edu.coursework.length > 0 ? edu.coursework : undefined,
+    };
     if (!edu.degree && edu.field) {
       const headerLine = [edu.field, eduDates].filter(Boolean).join("  ");
-      return { headerLine, subLine: org || undefined, bullets };
+      return {
+        headerLine,
+        subLine: org || undefined,
+        bullets,
+        fields: eduFields,
+      };
     }
     const orgLine = [org, eduDates].filter(Boolean).join("  ");
     return {
       headerLine: degreeField || orgLine || "Education",
       subLine: degreeField ? orgLine || undefined : undefined,
       bullets,
+      fields: eduFields,
     };
   });
 
   // ── Skills (one entry, no header line — bullets carry the joined list) ──
   const skillsEntries: AtsEntry[] =
     skills.length > 0
-      ? [{ headerLine: skills.join(" · "), bullets: [], atomicSegments: true }]
+      ? [
+          {
+            headerLine: skills.join(" · "),
+            bullets: [],
+            atomicSegments: true,
+            // The flat skill list, carried structurally so the JSON export (#334)
+            // maps `skills[] ← { name }` without re-splitting the joined header.
+            fields: { skills: [...skills] },
+          },
+        ]
       : [];
 
   const achievementsAbove =
@@ -409,6 +521,7 @@ export function buildAtsResumeModel(
       ? {
           heading: headings?.get("achievements") ?? "Achievements",
           entries: achievementEntries,
+          kind: "achievements",
         }
       : null;
 
@@ -423,12 +536,13 @@ export function buildAtsResumeModel(
     experienceEntries,
     headings?.get("experience") ?? "Experience",
   )) {
-    sections.push(group);
+    sections.push({ ...group, kind: "experience" });
   }
   if (projectEntries.length > 0)
     sections.push({
       heading: headings?.get("projects") ?? "Projects",
       entries: projectEntries,
+      kind: "projects",
     });
   if (!achievementsAbove && achievementsSection)
     sections.push(achievementsSection);
@@ -436,11 +550,13 @@ export function buildAtsResumeModel(
     sections.push({
       heading: headings?.get("education") ?? "Education",
       entries: educationEntries,
+      kind: "education",
     });
   if (skillsEntries.length > 0)
     sections.push({
       heading: headings?.get("skills") ?? "Skills",
       entries: skillsEntries,
+      kind: "skills",
     });
 
   return {

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -91,6 +91,8 @@ export interface AtsEntryFields {
   /** JSON Resume `skills` — the flat skill list, carried only on the single
    *  skills entry (whose `headerLine` is the same list joined by " · "). */
   skills?: string[];
+  /** JSON Resume `awards.title` — carried on achievement entries (#421). */
+  title?: string;
 }
 
 export interface AtsEntry {
@@ -152,7 +154,7 @@ function resolveContactValue(
   return override; // "" clears, non-empty replaces
 }
 
-function buildContact(
+export function buildContact(
   result: CascadeResult,
   contactOverrides: ContactOverrides,
 ): AtsContact {
@@ -422,6 +424,12 @@ export function buildAtsResumeModel(
       bulletOverrides,
       ach.description,
     ),
+    // Structured source for the JSON Resume `awards[]` export (#421). Display
+    // code never reads `fields`; it renders `headerLine`/`bullets` above.
+    fields: {
+      ...(ach.title ? { title: ach.title } : {}),
+      ...(ach.year ? { startDate: ach.year } : {}),
+    },
   }));
 
   // ── Education ──

--- a/src/lib/pdf/export-layout-contract.test.ts
+++ b/src/lib/pdf/export-layout-contract.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Export layout-contract gate (#334).
+ *
+ * The "Download PDF" exporter guarantees a fixed ATS layout contract:
+ *   - SINGLE column, top-to-bottom (render-ats-pdf.ts draws one column).
+ *   - REVERSE-CHRONOLOGICAL entries (document order, as parsed).
+ *   - CANONICAL section headers — every heading the exporter emits must be a
+ *     header our OWN parser re-recognizes on re-upload.
+ *   - STANDARD fonts (Poppins with a Helvetica fallback, both text-layer fonts).
+ *
+ * This test enforces the headers half: it asserts that every heading the
+ * exporter can emit — the canonical fallback set, PLUS every verbatim
+ * `AtsSection.heading` and the summary heading produced from real fixtures — is
+ * recognized by `matchSectionHeader()`. So the export can never emit a heading
+ * the parser would fail to re-open as a section on re-upload (which would break
+ * the round-trip invariant). PII-free: asserts recognition of heading strings
+ * (synthetic-persona fixtures), never dumps field values.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { matchSectionHeader } from "../heuristics/regex.ts";
+import { runCascade } from "../heuristics/cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(HERE, "../../..", "tests/fixtures/pdfs");
+
+/** The canonical fallback headings `buildAtsResumeModel` emits when a section
+ *  carried no recognized verbatim heading (see the `?? "..."` fallbacks). Plus
+ *  the Summary fallback (`render-ats-pdf.ts` draws `summaryHeading ?? "Summary"`). */
+const CANONICAL_FALLBACK_HEADINGS = [
+  "Summary",
+  "Experience",
+  "Projects",
+  "Achievements",
+  "Education",
+  "Skills",
+] as const;
+
+function walkPdfs(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkPdfs(p));
+    else if (e.isFile() && e.name.toLowerCase().endsWith(".pdf")) out.push(p);
+  }
+  return out.sort();
+}
+
+function scoreFor(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: { ...cascade.parsed },
+    fieldConfidence: cascade.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.sections,
+  });
+}
+
+describe("export layout contract — canonical headers re-recognize (#334)", () => {
+  it("every canonical fallback heading is recognized by matchSectionHeader", () => {
+    for (const heading of CANONICAL_FALLBACK_HEADINGS) {
+      expect(
+        matchSectionHeader(heading),
+        `exporter fallback heading "${heading}" is not re-recognized`,
+      ).not.toBeNull();
+    }
+  });
+
+  const fixtures = walkPdfs(FIXTURE_ROOT);
+
+  it("finds fixtures", () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+  });
+
+  for (const fixture of fixtures) {
+    const rel = fixture.slice(FIXTURE_ROOT.length + 1);
+    it(`emits only re-recognizable headings: ${rel}`, async () => {
+      const cascade = await runCascade(new Uint8Array(readFileSync(fixture)));
+      const model = buildAtsResumeModel(cascade, scoreFor(cascade));
+
+      const headings = model.sections.map((s) => s.heading);
+      // The summary heading is drawn separately from `sections` (falls back to
+      // "Summary"); include it only when a summary is actually emitted.
+      if (model.summary) headings.push(model.summaryHeading ?? "Summary");
+
+      for (const heading of headings) {
+        expect(
+          matchSectionHeader(heading),
+          `${rel}: exporter emits heading "${heading}" that matchSectionHeader does not recognize`,
+        ).not.toBeNull();
+      }
+    });
+  }
+});

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -26,6 +26,7 @@
 
 import { loadPdfLibOnce, type PdfLibParts } from "./load-pdf-lib.ts";
 import type { AtsResumeModel, AtsEntry } from "./ats-resume-model.ts";
+import { toJsonResume } from "./to-json-resume.ts";
 import poppinsRegularUrl from "../../assets/fonts/Poppins-Regular.ttf?url";
 import poppinsBoldUrl from "../../assets/fonts/Poppins-Bold.ttf?url";
 
@@ -567,6 +568,32 @@ export async function renderAtsResumePdf(
     }
     layout.advance(GAP_BETWEEN_ENTRIES);
   }
+
+  // ── Embedded machine-readable copy (#334, Europass pattern) ──
+  // Attach a JSON Resume (jsonresume.org) document as `resume.json` INSIDE the
+  // PDF. This lives in the PDF's EmbeddedFiles name tree — NOT the page content
+  // stream — so it never touches the text layer: `pdftotext`/pdfjs extraction is
+  // unaffected and the parse→export→re-parse round-trip stays byte-for-byte the
+  // same (verified by corpus-roundtrip.test.ts). Fully client-side; the bytes
+  // are built in-process from `model` (no fetch, no upload). `toJsonResume` is a
+  // pure adapter — no pdf-lib import — so it stays testable in isolation.
+  //
+  // creation/modification dates are deliberately omitted: pdf-lib writes no date
+  // when they're absent (FileEmbedder), keeping the output deterministic and
+  // leaking no wall-clock timestamp.
+  //
+  // Re-wrap the encoded bytes in a fresh `Uint8Array`: pdf-lib validates the
+  // attachment with `value instanceof Uint8Array`, and under jsdom the global
+  // `TextEncoder` returns a Uint8Array from a DIFFERENT realm that fails that
+  // check ("type NaN"). Copying into this module's Uint8Array normalizes the
+  // realm — a harmless one-time copy in the browser, and the fix in tests.
+  const resumeJsonBytes = new Uint8Array(
+    new TextEncoder().encode(JSON.stringify(toJsonResume(model), null, 2)),
+  );
+  await doc.attach(resumeJsonBytes, "resume.json", {
+    mimeType: "application/json",
+    description: "JSON Resume (jsonresume.org) — machine-readable copy",
+  });
 
   return doc.save();
 }

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -27,6 +27,7 @@
 import { loadPdfLibOnce, type PdfLibParts } from "./load-pdf-lib.ts";
 import type { AtsResumeModel, AtsEntry } from "./ats-resume-model.ts";
 import { toJsonResume } from "./to-json-resume.ts";
+import { wrapWordsToLines } from "./text-wrap.ts";
 import poppinsRegularUrl from "../../assets/fonts/Poppins-Regular.ttf?url";
 import poppinsBoldUrl from "../../assets/fonts/Poppins-Bold.ttf?url";
 
@@ -281,33 +282,6 @@ async function loadFonts(
   const regular = await doc.embedFont(parts.StandardFonts.Helvetica);
   const bold = await doc.embedFont(parts.StandardFonts.HelveticaBold);
   return { regular, bold, isEmbedded: false };
-}
-
-/**
- * Plain `\s+`-word wrap — never breaks a word apart, just packs words up to
- * `maxWidth`. A single word wider than `maxWidth` is emitted as its own line
- * (never split mid-word), so this always terminates.
- */
-function wrapWordsToLines(
-  words: string[],
-  font: PdfFont,
-  size: number,
-  maxWidth: number,
-): string[] {
-  if (words.length === 0) return [];
-  const lines: string[] = [];
-  let current = words[0];
-  for (let i = 1; i < words.length; i++) {
-    const candidate = `${current} ${words[i]}`;
-    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
-      current = candidate;
-    } else {
-      lines.push(current);
-      current = words[i];
-    }
-  }
-  lines.push(current);
-  return lines;
 }
 
 /**

--- a/src/lib/pdf/render-audit-report.test.ts
+++ b/src/lib/pdf/render-audit-report.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import { renderAuditReportPdf } from "./render-audit-report.ts";
+import { extractPdfText } from "./render-ats-pdf.test-utils.ts";
+import type { AuditReportInput } from "../report/serialize.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { JsonResumeBasics } from "./to-json-resume.ts";
+
+const SCORE: AnonymousAtsScore = {
+  overall: 72,
+  preLayoutOverall: 85,
+  specificity: { score: 28, max: 40, gradable: true, metricBullets: 4, totalBullets: 6 },
+  structure: { score: 24, max: 30, gradable: true, goodBullets: 5, totalBullets: 6 },
+  completeness: { score: 21, max: 30, gradable: true, missing: ["summary"] },
+  layout: { triggers: ["two_column"], multiplier: 0.85, scanned: false },
+  algoVersion: "1.4",
+};
+
+// Synthetic persona (fixture-PII policy): fake name, @example.com, 555 phone.
+const IDENTITY: JsonResumeBasics = {
+  name: "Jamie Rivera",
+  email: "jamie@example.com",
+  phone: "(312) 555-0123",
+  location: { city: "Chicago", region: "IL" },
+  profiles: [
+    { network: "LinkedIn", url: "https://linkedin.com/in/jamie-rivera" },
+  ],
+};
+
+const PII_TOKENS = [
+  "Jamie Rivera",
+  "jamie@example.com",
+  "555-0123",
+  "linkedin.com/in/jamie-rivera",
+];
+
+function input(overrides: Partial<AuditReportInput> = {}): AuditReportInput {
+  return {
+    score: SCORE,
+    triggers: ["two_column"],
+    recommendation: "Fix the multi-column layout first.",
+    generatedAt: "2026-07-09T12:00:00.000Z",
+    includeIdentity: false,
+    ...overrides,
+  };
+}
+
+describe("renderAuditReportPdf", () => {
+  it("returns a non-trivial PDF with the %PDF magic header", async () => {
+    const bytes = await renderAuditReportPdf(input());
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(500);
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-");
+  });
+
+  it("renders verdict, score, breakdown, triggers, and recommendation", async () => {
+    const text = await extractPdfText(await renderAuditReportPdf(input()));
+    expect(text).toContain("Resume Audit Report");
+    expect(text).toContain("72");
+    expect(text).toMatch(/Getting There/i); // 72 → medium band label
+    expect(text).toMatch(/Specificity/i);
+    expect(text).toMatch(/Structure/i);
+    expect(text).toMatch(/Completeness/i);
+    expect(text).toMatch(/multi-column|column/i); // trigger blurb
+    expect(text).toContain("Fix the multi-column layout first.");
+  });
+
+  it("PRIVACY GATE: default (identity off) PDF contains no name, email, phone, or links", async () => {
+    const text = await extractPdfText(
+      await renderAuditReportPdf(input({ includeIdentity: false, identity: IDENTITY })),
+    );
+    for (const token of PII_TOKENS) expect(text).not.toContain(token);
+  });
+
+  it("includes the identity header when opted in", async () => {
+    const text = await extractPdfText(
+      await renderAuditReportPdf(input({ includeIdentity: true, identity: IDENTITY })),
+    );
+    expect(text).toContain("Jamie Rivera");
+    expect(text).toContain("jamie@example.com");
+  });
+});

--- a/src/lib/pdf/render-audit-report.ts
+++ b/src/lib/pdf/render-audit-report.ts
@@ -167,6 +167,50 @@ function dimensionValue(dim: { score: number; max: number; gradable: boolean }):
 }
 
 /**
+ * Identity header — PRIVACY GATE. Drawn ONLY when `includeIdentity` is true AND
+ * an `identity` block is present; a no-op otherwise, so the default artifact is
+ * anonymous. Extracted from the main render so its nested branches don't inflate
+ * the caller's complexity.
+ */
+function drawIdentityHeader(layout: ReportLayout, input: AuditReportInput, muted: RGB) {
+  if (!input.includeIdentity || !input.identity) return;
+  const id = input.identity;
+  if (id.name) layout.drawText(id.name, { bold: true, size: SIZE_BODY });
+  const parts = [
+    id.email,
+    id.phone,
+    id.location ? [id.location.city, id.location.region].filter(Boolean).join(", ") : undefined,
+    id.url,
+    ...(id.profiles ?? []).map((p) => p.url),
+  ].filter((p): p is string => Boolean(p));
+  if (parts.length > 0) {
+    layout.drawText(parts.join("  •  "), { size: SIZE_SMALL, color: muted });
+  }
+  layout.advance(8);
+}
+
+/** Layout-flags section: one bullet per fired trigger, or a reassuring line when
+ *  none fired. */
+function drawLayoutFlags(
+  layout: ReportLayout,
+  triggers: AuditReportInput["triggers"],
+  muted: RGB,
+) {
+  sectionHeading(layout, "Layout flags");
+  if (triggers.length === 0) {
+    layout.drawText("No layout flags — standard single-column, text-selectable PDF.", {
+      size: SIZE_BODY,
+      color: muted,
+    });
+    return;
+  }
+  for (const t of triggers) {
+    layout.drawText(`• ${LAYOUT_TRIGGER_BLURBS[t]}`, { size: SIZE_BODY, hangingIndent: 10 });
+    layout.advance(2);
+  }
+}
+
+/**
  * Render an audit report to PDF bytes (Uint8Array). Pure w.r.t. inputs — the
  * only side channel is the lazy pdf-lib import; no fetch, no upload.
  */
@@ -197,21 +241,7 @@ export async function renderAuditReportPdf(
   layout.advance(10);
 
   // ── Identity header (privacy gate — opt-in only) ──
-  if (input.includeIdentity && input.identity) {
-    const id = input.identity;
-    if (id.name) layout.drawText(id.name, { bold: true, size: SIZE_BODY });
-    const parts2 = [
-      id.email,
-      id.phone,
-      id.location ? [id.location.city, id.location.region].filter(Boolean).join(", ") : undefined,
-      id.url,
-      ...(id.profiles ?? []).map((p) => p.url),
-    ].filter((p): p is string => Boolean(p));
-    if (parts2.length > 0) {
-      layout.drawText(parts2.join("  •  "), { size: SIZE_SMALL, color: muted });
-    }
-    layout.advance(8);
-  }
+  drawIdentityHeader(layout, input, muted);
 
   // ── Verdict + overall score ──
   sectionHeading(layout, "Verdict");
@@ -239,21 +269,7 @@ export async function renderAuditReportPdf(
   }
 
   // ── Layout flags ──
-  sectionHeading(layout, "Layout flags");
-  if (input.triggers.length === 0) {
-    layout.drawText("No layout flags — standard single-column, text-selectable PDF.", {
-      size: SIZE_BODY,
-      color: muted,
-    });
-  } else {
-    for (const t of input.triggers) {
-      layout.drawText(`• ${LAYOUT_TRIGGER_BLURBS[t]}`, {
-        size: SIZE_BODY,
-        hangingIndent: 10,
-      });
-      layout.advance(2);
-    }
-  }
+  drawLayoutFlags(layout, input.triggers, muted);
 
   // ── Recommendation ──
   sectionHeading(layout, "Recommendation");

--- a/src/lib/pdf/render-audit-report.ts
+++ b/src/lib/pdf/render-audit-report.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * render-audit-report — the human-readable half of the shareable audit report
+ * (#343).
+ *
+ * Renders the audit findings (verdict + score breakdown + layout triggers +
+ * recommendation) to PDF bytes with pdf-lib, fully client-side. Sibling of
+ * `render-ats-pdf.ts` (which renders the RÉSUMÉ); this renders the REPORT
+ * ABOUT the résumé. It reuses the same lazy `load-pdf-lib.ts` loader so pdf-lib
+ * stays out of the entry chunk, and the same `toWinAnsi()` sanitizer so
+ * arbitrary parsed text (a candidate name with an exotic glyph) never crashes
+ * `drawText`.
+ *
+ * PRIVACY GATE: the identity header (name / email / phone / location / links)
+ * is drawn ONLY when `input.includeIdentity` is true AND an `identity` block is
+ * present. Default-off upstream, so the default artifact is anonymous.
+ *
+ * This uses pdf-lib's built-in Helvetica (no Poppins fetch): the report is a
+ * plain document, not the brand-faithful résumé, so the 14 standard fonts are
+ * enough and it keeps the module dependency-light. Every string is run through
+ * `toWinAnsi()` because StandardFonts encode WinAnsi only (#295). The `rgb()`
+ * values are PDF graphics-state colors, NOT Tailwind tokens — the style guard
+ * scans component code, not this draw module.
+ */
+
+import { loadPdfLibOnce, type PdfLibParts } from "./load-pdf-lib.ts";
+import { toWinAnsi } from "./render-ats-pdf.ts";
+import { getScoreLabel, getScoreTier } from "../score/score.ts";
+import { LAYOUT_TRIGGER_BLURBS } from "../heuristics/trigger-copy.ts";
+import type { AuditReportInput } from "../report/serialize.ts";
+import { REPORT_VERSION } from "../report/serialize.ts";
+import { APP_VERSION } from "../version.ts";
+
+/** Where the artifact points readers back to (branded footer). */
+const APP_URL = "github.com/resumelint-org/resumelint";
+
+// ── Page geometry (points) ────────────────────────────────────────────────────
+
+const PAGE_WIDTH = 612; // US Letter
+const PAGE_HEIGHT = 792;
+const MARGIN = 54;
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+const CONTENT_BOTTOM = MARGIN;
+
+// ── Type scale (points) ───────────────────────────────────────────────────────
+
+const SIZE_TITLE = 20;
+const SIZE_SECTION = 12;
+const SIZE_BODY = 10;
+const SIZE_SMALL = 9;
+const SIZE_SCORE = 30;
+
+const LINE_GAP = 1.3;
+
+type RGB = ReturnType<PdfLibParts["rgb"]>;
+type Doc = Awaited<ReturnType<PdfLibParts["PDFDocument"]["create"]>>;
+type Page = ReturnType<Doc["addPage"]>;
+type PdfFont = Awaited<ReturnType<Doc["embedFont"]>>;
+
+/**
+ * Mutable cursor + page state threaded through the draw routines — a trimmed
+ * cousin of render-ats-pdf's `Layout`, sized to the report's needs (word wrap,
+ * pagination, a horizontal rule).
+ */
+class ReportLayout {
+  page: Page;
+  y: number;
+
+  constructor(
+    private doc: Doc,
+    private fonts: { regular: PdfFont; bold: PdfFont },
+    private black: RGB,
+    private gray: RGB,
+  ) {
+    this.page = doc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    this.y = PAGE_HEIGHT - MARGIN;
+  }
+
+  private newPage() {
+    this.page = this.doc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    this.y = PAGE_HEIGHT - MARGIN;
+  }
+
+  private ensure(height: number) {
+    if (this.y - height < CONTENT_BOTTOM) this.newPage();
+  }
+
+  advance(points: number) {
+    this.y -= points;
+  }
+
+  private wrap(text: string, font: PdfFont, size: number, maxWidth: number): string[] {
+    const words = text.split(/\s+/).filter(Boolean);
+    if (words.length === 0) return [""];
+    const lines: string[] = [];
+    let current = words[0];
+    for (let i = 1; i < words.length; i++) {
+      const candidate = `${current} ${words[i]}`;
+      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+        current = candidate;
+      } else {
+        lines.push(current);
+        current = words[i];
+      }
+    }
+    lines.push(current);
+    return lines;
+  }
+
+  drawText(
+    text: string,
+    opts: {
+      bold?: boolean;
+      size?: number;
+      color?: RGB;
+      x?: number;
+      hangingIndent?: number;
+    } = {},
+  ) {
+    const size = opts.size ?? SIZE_BODY;
+    const font = opts.bold ? this.fonts.bold : this.fonts.regular;
+    const color = opts.color ?? this.black;
+    const x = opts.x ?? MARGIN;
+    const hanging = opts.hangingIndent ?? 0;
+    const value = toWinAnsi(text);
+    const maxWidth = CONTENT_WIDTH - (x - MARGIN);
+    const lines = this.wrap(value, font, size, maxWidth);
+    const lineHeight = size * LINE_GAP;
+    for (let i = 0; i < lines.length; i++) {
+      this.ensure(lineHeight);
+      const lineX = i === 0 ? x : x + hanging;
+      this.page.drawText(lines[i], {
+        x: lineX,
+        y: this.y - size,
+        size,
+        font,
+        color,
+      });
+      this.advance(lineHeight);
+    }
+  }
+
+  drawRule() {
+    this.ensure(2);
+    this.page.drawLine({
+      start: { x: MARGIN, y: this.y },
+      end: { x: PAGE_WIDTH - MARGIN, y: this.y },
+      thickness: 0.75,
+      color: this.gray,
+    });
+    this.advance(2);
+  }
+}
+
+function sectionHeading(layout: ReportLayout, heading: string) {
+  layout.advance(14);
+  layout.drawText(heading, { bold: true, size: SIZE_SECTION });
+  layout.drawRule();
+  layout.advance(6);
+}
+
+/** "12 / 40" for a gradable dimension, or "—" when there wasn't signal to grade. */
+function dimensionValue(dim: { score: number; max: number; gradable: boolean }): string {
+  return dim.gradable ? `${dim.score} / ${dim.max}` : "—";
+}
+
+/**
+ * Render an audit report to PDF bytes (Uint8Array). Pure w.r.t. inputs — the
+ * only side channel is the lazy pdf-lib import; no fetch, no upload.
+ */
+export async function renderAuditReportPdf(
+  input: AuditReportInput,
+): Promise<Uint8Array> {
+  const parts = await loadPdfLibOnce();
+  const { PDFDocument, StandardFonts, rgb } = parts;
+
+  const doc = await PDFDocument.create();
+  doc.setTitle("Resume Audit Report");
+
+  const regular = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  const black = rgb(0.1, 0.1, 0.1);
+  const gray = rgb(0.55, 0.55, 0.55);
+  const muted = rgb(0.35, 0.35, 0.35);
+
+  const layout = new ReportLayout(doc, { regular, bold }, black, gray);
+  const { score } = input;
+
+  // ── Title ──
+  layout.drawText("Resume Audit Report", { bold: true, size: SIZE_TITLE });
+  layout.advance(4);
+  const dateLabel = input.generatedAt.slice(0, 10); // YYYY-MM-DD
+  layout.drawText(`Generated ${dateLabel}`, { size: SIZE_SMALL, color: muted });
+  layout.advance(10);
+
+  // ── Identity header (privacy gate — opt-in only) ──
+  if (input.includeIdentity && input.identity) {
+    const id = input.identity;
+    if (id.name) layout.drawText(id.name, { bold: true, size: SIZE_BODY });
+    const parts2 = [
+      id.email,
+      id.phone,
+      id.location ? [id.location.city, id.location.region].filter(Boolean).join(", ") : undefined,
+      id.url,
+      ...(id.profiles ?? []).map((p) => p.url),
+    ].filter((p): p is string => Boolean(p));
+    if (parts2.length > 0) {
+      layout.drawText(parts2.join("  •  "), { size: SIZE_SMALL, color: muted });
+    }
+    layout.advance(8);
+  }
+
+  // ── Verdict + overall score ──
+  sectionHeading(layout, "Verdict");
+  const label = getScoreLabel(getScoreTier(score.overall));
+  layout.drawText(`${score.overall}`, { bold: true, size: SIZE_SCORE });
+  layout.drawText(`out of 100 — ${label}`, { size: SIZE_BODY, color: muted });
+  if (score.preLayoutOverall !== score.overall) {
+    layout.advance(2);
+    layout.drawText(
+      `Content scored ${score.preLayoutOverall}/100; a layout penalty dropped the total to ${score.overall}.`,
+      { size: SIZE_SMALL, color: muted },
+    );
+  }
+
+  // ── Dimension breakdown ──
+  sectionHeading(layout, "Breakdown");
+  layout.drawText(`Specificity: ${dimensionValue(score.specificity)}`, { size: SIZE_BODY });
+  layout.drawText(`Structure: ${dimensionValue(score.structure)}`, { size: SIZE_BODY });
+  layout.drawText(`Completeness: ${dimensionValue(score.completeness)}`, { size: SIZE_BODY });
+  if (score.completeness.gradable && score.completeness.missing.length > 0) {
+    layout.drawText(`Missing: ${score.completeness.missing.join(", ")}`, {
+      size: SIZE_SMALL,
+      color: muted,
+    });
+  }
+
+  // ── Layout flags ──
+  sectionHeading(layout, "Layout flags");
+  if (input.triggers.length === 0) {
+    layout.drawText("No layout flags — standard single-column, text-selectable PDF.", {
+      size: SIZE_BODY,
+      color: muted,
+    });
+  } else {
+    for (const t of input.triggers) {
+      layout.drawText(`• ${LAYOUT_TRIGGER_BLURBS[t]}`, {
+        size: SIZE_BODY,
+        hangingIndent: 10,
+      });
+      layout.advance(2);
+    }
+  }
+
+  // ── Recommendation ──
+  sectionHeading(layout, "Recommendation");
+  layout.drawText(input.recommendation, { size: SIZE_BODY });
+
+  // ── Branded footer ──
+  layout.advance(16);
+  layout.drawRule();
+  layout.advance(6);
+  layout.drawText(
+    `${APP_URL} · report v${REPORT_VERSION} · algo v${score.algoVersion ?? "?"} · app ${APP_VERSION} · ${dateLabel}`,
+    { size: SIZE_SMALL, color: muted },
+  );
+
+  return doc.save();
+}

--- a/src/lib/pdf/render-audit-report.ts
+++ b/src/lib/pdf/render-audit-report.ts
@@ -27,6 +27,7 @@
 
 import { loadPdfLibOnce, type PdfLibParts } from "./load-pdf-lib.ts";
 import { toWinAnsi } from "./render-ats-pdf.ts";
+import { wrapWordsToLines } from "./text-wrap.ts";
 import { getScoreLabel, getScoreTier } from "../score/score.ts";
 import { LAYOUT_TRIGGER_BLURBS } from "../heuristics/trigger-copy.ts";
 import type { AuditReportInput } from "../report/serialize.ts";
@@ -94,19 +95,11 @@ class ReportLayout {
   private wrap(text: string, font: PdfFont, size: number, maxWidth: number): string[] {
     const words = text.split(/\s+/).filter(Boolean);
     if (words.length === 0) return [""];
-    const lines: string[] = [];
-    let current = words[0];
-    for (let i = 1; i < words.length; i++) {
-      const candidate = `${current} ${words[i]}`;
-      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
-        current = candidate;
-      } else {
-        lines.push(current);
-        current = words[i];
-      }
-    }
-    lines.push(current);
-    return lines;
+    // Break long words here (unlike the résumé renderer): the identity header
+    // joins raw URLs, each a single whitespace-free "word" that can exceed the
+    // content width and would otherwise be drawn straight off the page (#421
+    // Blocking #5). The report has no re-parse invariant to protect.
+    return wrapWordsToLines(words, font, size, maxWidth, true);
   }
 
   drawText(
@@ -223,8 +216,11 @@ export async function renderAuditReportPdf(
   const doc = await PDFDocument.create();
   doc.setTitle("Resume Audit Report");
 
-  const regular = await doc.embedFont(StandardFonts.Helvetica);
-  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  // Independent embeds — run in parallel (mirrors render-ats-pdf.ts).
+  const [regular, bold] = await Promise.all([
+    doc.embedFont(StandardFonts.Helvetica),
+    doc.embedFont(StandardFonts.HelveticaBold),
+  ]);
 
   const black = rgb(0.1, 0.1, 0.1);
   const gray = rgb(0.55, 0.55, 0.55);

--- a/src/lib/pdf/text-wrap.test.ts
+++ b/src/lib/pdf/text-wrap.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { wrapWordsToLines, type TextMeasurer } from "./text-wrap.ts";
+
+/** Monospace-ish fake: every glyph is `size` wide, so width == chars * size. */
+const mono: TextMeasurer = {
+  widthOfTextAtSize: (text, size) => text.length * size,
+};
+
+// size 1 → width == character count, so maxWidth reads as "chars per line".
+const SIZE = 1;
+
+describe("wrapWordsToLines", () => {
+  it("packs words greedily up to maxWidth", () => {
+    // "aa bb cc" — maxWidth 5 fits "aa bb" (5) but not "+ cc".
+    expect(wrapWordsToLines(["aa", "bb", "cc"], mono, SIZE, 5)).toEqual([
+      "aa bb",
+      "cc",
+    ]);
+  });
+
+  it("emits an overlong word as its own line when NOT breaking (default)", () => {
+    // The résumé renderer relies on this: never split a word/segment mid-word.
+    expect(
+      wrapWordsToLines(["short", "supercalifragilistic"], mono, SIZE, 6),
+    ).toEqual(["short", "supercalifragilistic"]);
+  });
+
+  it("breaks a single overlong word at char boundaries when asked (#421 B#5)", () => {
+    // A 15-char URL-like word, maxWidth 6 → chunks of ≤6 chars, none overflow.
+    const lines = wrapWordsToLines(["abcdefghijklmno"], mono, SIZE, 6, true);
+    expect(lines.join("")).toBe("abcdefghijklmno"); // lossless
+    for (const line of lines) expect(line.length).toBeLessThanOrEqual(6);
+    expect(lines.length).toBeGreaterThan(1); // actually split
+  });
+
+  it("breaks an overlong word that follows a normal word", () => {
+    const lines = wrapWordsToLines(["hi", "abcdefghij"], mono, SIZE, 4, true);
+    for (const line of lines) expect(line.length).toBeLessThanOrEqual(4);
+    expect(lines[0]).toBe("hi");
+    expect(lines.join(" ").replace(/ /g, "")).toContain("abcdefghij");
+  });
+
+  it("returns [] for no words", () => {
+    expect(wrapWordsToLines([], mono, SIZE, 10)).toEqual([]);
+  });
+});

--- a/src/lib/pdf/text-wrap.ts
+++ b/src/lib/pdf/text-wrap.ts
@@ -69,25 +69,20 @@ export function wrapWordsToLines(
   const lines: string[] = [];
   let current = "";
   for (const word of words) {
-    const candidate = current === "" ? word : `${current} ${word}`;
-    if (current === "" || font.widthOfTextAtSize(candidate, size) <= maxWidth) {
-      // Still room on the current line — but a first word that alone overflows
-      // must break here (when asked) rather than seed an overlong line.
-      if (
-        current === "" &&
-        breakLongWords &&
-        font.widthOfTextAtSize(word, size) > maxWidth
-      ) {
-        const chunks = breakLongWord(word, font, size, maxWidth);
-        lines.push(...chunks.slice(0, -1));
-        current = chunks[chunks.length - 1] ?? "";
-      } else {
+    // Extend the current line when the word still fits alongside it; otherwise
+    // flush it and fall through to seat `word` on a fresh (empty) line.
+    if (current !== "") {
+      const candidate = `${current} ${word}`;
+      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
         current = candidate;
+        continue;
       }
-      continue;
+      lines.push(current);
+      current = "";
     }
-    // Word doesn't fit on the current line — flush and start it on a fresh line.
-    lines.push(current);
+    // `current` is empty here: seat `word` as the start of a new line. A word
+    // that alone overflows is broken across lines when asked, else emitted whole
+    // (the round-trip-safe overflow the résumé renderer relies on).
     if (breakLongWords && font.widthOfTextAtSize(word, size) > maxWidth) {
       const chunks = breakLongWord(word, font, size, maxWidth);
       lines.push(...chunks.slice(0, -1));

--- a/src/lib/pdf/text-wrap.ts
+++ b/src/lib/pdf/text-wrap.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * text-wrap — the shared greedy word-wrap used by both PDF renderers
+ * (`render-ats-pdf.ts` and `render-audit-report.ts`), extracted so a wrap
+ * improvement lands once instead of in two byte-for-byte copies (#421 review).
+ *
+ * The measurer is a minimal `{ widthOfTextAtSize }` interface so this leaf
+ * imports no pdf-lib types — both pdf-lib font objects satisfy it.
+ */
+
+/** Minimal font shape: the width of `text` at `size`, in points. Both pdf-lib
+ *  `StandardFont` and embedded-font objects satisfy this. */
+export interface TextMeasurer {
+  widthOfTextAtSize(text: string, size: number): number;
+}
+
+/**
+ * Break a single word that is itself wider than `maxWidth` into character-run
+ * chunks that each fit. Guarantees progress (at least one char per chunk) so a
+ * pathologically narrow `maxWidth` still terminates.
+ */
+function breakLongWord(
+  word: string,
+  font: TextMeasurer,
+  size: number,
+  maxWidth: number,
+): string[] {
+  const chunks: string[] = [];
+  let chunk = "";
+  for (const ch of word) {
+    const candidate = chunk + ch;
+    if (chunk !== "" && font.widthOfTextAtSize(candidate, size) > maxWidth) {
+      chunks.push(chunk);
+      chunk = ch;
+    } else {
+      chunk = candidate;
+    }
+  }
+  if (chunk !== "") chunks.push(chunk);
+  return chunks;
+}
+
+/**
+ * Greedy `\s+`-word wrap: pack words up to `maxWidth`.
+ *
+ * A single word wider than `maxWidth`:
+ *   - `breakLongWords: false` (default) → emitted as its own (overflowing) line.
+ *     Preserves the round-trip-critical "never split a skill/segment mid-word"
+ *     contract the résumé renderer depends on (#301).
+ *   - `breakLongWords: true` → split at character boundaries so it never runs
+ *     past the page margin — used by the audit-report identity header, where a
+ *     long URL is a single word with no interior whitespace and there is no
+ *     re-parse invariant to protect (#421 Blocking #5).
+ *
+ * Always terminates: without breaking, an overlong word advances the loop as
+ * its own line; with breaking, `breakLongWord` makes at least one char of
+ * progress per chunk.
+ */
+export function wrapWordsToLines(
+  words: string[],
+  font: TextMeasurer,
+  size: number,
+  maxWidth: number,
+  breakLongWords = false,
+): string[] {
+  if (words.length === 0) return [];
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current === "" ? word : `${current} ${word}`;
+    if (current === "" || font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      // Still room on the current line — but a first word that alone overflows
+      // must break here (when asked) rather than seed an overlong line.
+      if (
+        current === "" &&
+        breakLongWords &&
+        font.widthOfTextAtSize(word, size) > maxWidth
+      ) {
+        const chunks = breakLongWord(word, font, size, maxWidth);
+        lines.push(...chunks.slice(0, -1));
+        current = chunks[chunks.length - 1] ?? "";
+      } else {
+        current = candidate;
+      }
+      continue;
+    }
+    // Word doesn't fit on the current line — flush and start it on a fresh line.
+    lines.push(current);
+    if (breakLongWords && font.widthOfTextAtSize(word, size) > maxWidth) {
+      const chunks = breakLongWord(word, font, size, maxWidth);
+      lines.push(...chunks.slice(0, -1));
+      current = chunks[chunks.length - 1] ?? "";
+    } else {
+      current = word;
+    }
+  }
+  lines.push(current);
+  return lines;
+}

--- a/src/lib/pdf/to-json-resume.test.ts
+++ b/src/lib/pdf/to-json-resume.test.ts
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Unit tests for the pure `toJsonResume` adapter (#334): basics (incl. profiles
+ * and location), work, education, skills, projects, date normalization, and a
+ * fixture round-trip (parse → model → toJsonResume) that asserts SHAPE only (no
+ * PII values dumped — the fixture is a synthetic persona regardless).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import {
+  toJsonResume,
+  normalizeJsonResumeDate,
+  toJsonResumeLocation,
+  JSON_RESUME_SCHEMA,
+} from "./to-json-resume.ts";
+import type { AtsResumeModel } from "./ats-resume-model.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { runCascade } from "../heuristics/cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import { APP_VERSION } from "../version.ts";
+
+// A structurally complete model covering every mapped section kind.
+const FULL_MODEL: AtsResumeModel = {
+  contact: {
+    name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    location: "Chicago, IL",
+    links: ["linkedin.com/in/jane"],
+    profiles: [
+      { url: "https://linkedin.com/in/jane", network: "LinkedIn", kind: "social" },
+      { url: "https://github.com/JaneC", network: "GitHub", kind: "code" },
+      { url: "https://jane.dev", network: "jane.dev", kind: "other" },
+    ],
+  },
+  summary: "A summary.",
+  summaryHeading: "Summary",
+  sections: [
+    {
+      heading: "Experience",
+      kind: "experience",
+      entries: [
+        {
+          headerLine: "Senior Engineer",
+          bullets: ["Shipped X", "Led Y"],
+          fields: {
+            organization: "Acme Corp",
+            position: "Senior Engineer",
+            startDate: "Jan 2020",
+            endDate: "March 2022",
+          },
+        },
+        {
+          headerLine: "Engineer",
+          bullets: [],
+          fields: {
+            organization: "Startup Inc",
+            position: "Engineer",
+            startDate: "2022",
+            isCurrent: true,
+            endDate: "2099", // must be dropped because isCurrent
+          },
+        },
+      ],
+    },
+    {
+      heading: "Projects",
+      kind: "projects",
+      entries: [
+        {
+          headerLine: "Cool Project",
+          bullets: ["Built a thing"],
+          fields: {
+            organization: "Cool Project",
+            url: "https://github.com/JaneC/cool",
+            startDate: "Summer 2021",
+          },
+        },
+      ],
+    },
+    {
+      heading: "Education",
+      kind: "education",
+      entries: [
+        {
+          headerLine: "B.S., Computer Science",
+          bullets: ["Coursework: Algorithms, Databases"],
+          fields: {
+            organization: "State University",
+            studyType: "B.S.",
+            area: "Computer Science",
+            endDate: "2019",
+            courses: ["Algorithms", "Databases"],
+          },
+        },
+      ],
+    },
+    {
+      heading: "Skills",
+      kind: "skills",
+      entries: [
+        {
+          headerLine: "TypeScript · React · Node.js",
+          bullets: [],
+          atomicSegments: true,
+          fields: { skills: ["TypeScript", "React", "Node.js"] },
+        },
+      ],
+    },
+  ],
+};
+
+describe("toJsonResume — top-level shape", () => {
+  const doc = toJsonResume(FULL_MODEL);
+
+  it("stamps the schema URL and meta.version", () => {
+    expect(doc.$schema).toBe(JSON_RESUME_SCHEMA);
+    expect(doc.meta.version).toBe(APP_VERSION);
+  });
+
+  it("always emits the four arrays", () => {
+    expect(Array.isArray(doc.work)).toBe(true);
+    expect(Array.isArray(doc.education)).toBe(true);
+    expect(Array.isArray(doc.skills)).toBe(true);
+    expect(Array.isArray(doc.projects)).toBe(true);
+  });
+});
+
+describe("toJsonResume — basics", () => {
+  const { basics } = toJsonResume(FULL_MODEL);
+
+  it("maps scalar contact fields", () => {
+    expect(basics.name).toBe("Jane Candidate");
+    expect(basics.email).toBe("jane@example.com");
+    expect(basics.phone).toBe("(312) 555-0123");
+  });
+
+  it("structures location by the last comma (lossless)", () => {
+    expect(basics.location).toEqual({ city: "Chicago", region: "IL" });
+  });
+
+  it("maps profiles to {network,url,username} with a path-tail username", () => {
+    expect(basics.profiles).toEqual([
+      {
+        network: "LinkedIn",
+        url: "https://linkedin.com/in/jane",
+        username: "jane",
+      },
+      { network: "GitHub", url: "https://github.com/JaneC", username: "JaneC" },
+      { network: "jane.dev", url: "https://jane.dev" }, // no path ⇒ no username
+    ]);
+  });
+
+  it("picks basics.url from portfolio/website (the 'other' personal site)", () => {
+    expect(basics.url).toBe("https://jane.dev");
+  });
+});
+
+describe("toJsonResume — work", () => {
+  const { work } = toJsonResume(FULL_MODEL);
+
+  it("maps company→name, title→position, normalizes dates", () => {
+    expect(work[0]).toEqual({
+      name: "Acme Corp",
+      position: "Senior Engineer",
+      startDate: "2020-01",
+      endDate: "2022-03",
+      highlights: ["Shipped X", "Led Y"],
+    });
+  });
+
+  it("drops endDate for a current role and omits empty highlights", () => {
+    expect(work[1].name).toBe("Startup Inc");
+    expect(work[1].startDate).toBe("2022");
+    expect(work[1].endDate).toBeUndefined();
+    expect(work[1].highlights).toBeUndefined();
+  });
+});
+
+describe("toJsonResume — education, skills, projects", () => {
+  const doc = toJsonResume(FULL_MODEL);
+
+  it("maps education institution/studyType/area/courses", () => {
+    expect(doc.education[0]).toEqual({
+      institution: "State University",
+      studyType: "B.S.",
+      area: "Computer Science",
+      startDate: undefined,
+      endDate: "2019",
+      courses: ["Algorithms", "Databases"],
+    });
+  });
+
+  it("maps each skill to { name }", () => {
+    expect(doc.skills).toEqual([
+      { name: "TypeScript" },
+      { name: "React" },
+      { name: "Node.js" },
+    ]);
+  });
+
+  it("maps projects, keeping an unparseable date raw", () => {
+    expect(doc.projects[0]).toEqual({
+      name: "Cool Project",
+      url: "https://github.com/JaneC/cool",
+      startDate: "Summer 2021", // raw — never fabricated
+      endDate: undefined,
+      highlights: ["Built a thing"],
+    });
+  });
+});
+
+describe("toJsonResume — never fabricates data", () => {
+  it("emits no work/education/skills for an empty model, basics minimal", () => {
+    const doc = toJsonResume({
+      contact: { name: "No One", links: [] },
+      sections: [],
+    });
+    expect(doc.work).toEqual([]);
+    expect(doc.education).toEqual([]);
+    expect(doc.skills).toEqual([]);
+    expect(doc.projects).toEqual([]);
+    expect(doc.basics.name).toBe("No One");
+    expect(doc.basics.profiles).toBeUndefined();
+    expect(doc.basics.url).toBeUndefined();
+    expect(doc.basics.location).toBeUndefined();
+  });
+
+  it("does not map the achievements section to any JSON Resume array", () => {
+    const doc = toJsonResume({
+      contact: { name: "X", links: [] },
+      sections: [
+        {
+          heading: "Achievements",
+          kind: "achievements",
+          entries: [{ headerLine: "Won an award", bullets: [] }],
+        },
+      ],
+    });
+    expect(doc.work).toEqual([]);
+    expect(doc.projects).toEqual([]);
+    expect(doc.education).toEqual([]);
+  });
+});
+
+describe("normalizeJsonResumeDate", () => {
+  it("passes ISO-ish dates through", () => {
+    expect(normalizeJsonResumeDate("2020")).toBe("2020");
+    expect(normalizeJsonResumeDate("2020-05")).toBe("2020-05");
+    expect(normalizeJsonResumeDate("2020-05-01")).toBe("2020-05-01");
+  });
+
+  it("normalizes month-name and numeric forms to YYYY-MM", () => {
+    expect(normalizeJsonResumeDate("January 2020")).toBe("2020-01");
+    expect(normalizeJsonResumeDate("Jan 2020")).toBe("2020-01");
+    expect(normalizeJsonResumeDate("Sept. 2019")).toBe("2019-09");
+    expect(normalizeJsonResumeDate("05/2020")).toBe("2020-05");
+    expect(normalizeJsonResumeDate("2020/5")).toBe("2020-05");
+  });
+
+  it("emits the raw string when unparseable (never fabricates)", () => {
+    expect(normalizeJsonResumeDate("Summer 2022")).toBe("Summer 2022");
+    expect(normalizeJsonResumeDate("Present")).toBe("Present");
+    expect(normalizeJsonResumeDate("13/2020")).toBe("13/2020"); // invalid month
+  });
+
+  it("returns undefined for empty/absent", () => {
+    expect(normalizeJsonResumeDate(undefined)).toBeUndefined();
+    expect(normalizeJsonResumeDate("  ")).toBeUndefined();
+  });
+});
+
+describe("toJsonResumeLocation", () => {
+  it("splits the last comma so city + region rejoin losslessly", () => {
+    expect(toJsonResumeLocation("San Francisco, CA")).toEqual({
+      city: "San Francisco",
+      region: "CA",
+    });
+    expect(toJsonResumeLocation("San Francisco, CA, USA")).toEqual({
+      city: "San Francisco, CA",
+      region: "USA",
+    });
+  });
+
+  it("keeps a comma-less string as the whole city", () => {
+    expect(toJsonResumeLocation("Remote")).toEqual({ city: "Remote" });
+  });
+
+  it("returns undefined for empty/absent", () => {
+    expect(toJsonResumeLocation(undefined)).toBeUndefined();
+    expect(toJsonResumeLocation("")).toBeUndefined();
+  });
+});
+
+// ── Fixture round-trip: parse → model → toJsonResume (shape only) ───────────────
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/latex/awesome-cv-resume.pdf",
+);
+
+describe("toJsonResume — fixture round-trip (synthetic persona)", () => {
+  it("produces a well-formed JSON Resume from a parsed fixture", async () => {
+    const cascade = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const score = computeAnonymousAtsScore({
+      parsed: { ...cascade.parsed },
+      fieldConfidence: cascade.fieldConfidence,
+      triggers: cascade.triggers,
+      rawText: cascade.rawText,
+      sections: cascade.sections,
+    });
+    const doc = toJsonResume(buildAtsResumeModel(cascade, score));
+
+    expect(doc.$schema).toBe(JSON_RESUME_SCHEMA);
+    expect(typeof doc.meta.version).toBe("string");
+    expect(typeof doc.basics.name).toBe("string");
+    expect(doc.basics.name!.length).toBeGreaterThan(0);
+
+    // Work/education arrays are present; every entry carries at least one mapped
+    // field (never an empty object) and any emitted date is a non-empty string.
+    expect(doc.work.length).toBeGreaterThan(0);
+    for (const w of doc.work) {
+      expect(Boolean(w.name || w.position)).toBe(true);
+      for (const d of [w.startDate, w.endDate])
+        if (d !== undefined) expect(d.length).toBeGreaterThan(0);
+    }
+    for (const e of doc.education) {
+      expect(Boolean(e.institution || e.studyType || e.area)).toBe(true);
+    }
+    // Skills entries are always { name: <non-empty> }.
+    for (const s of doc.skills) expect(s.name.length).toBeGreaterThan(0);
+
+    // The whole document serializes cleanly (this is exactly what the PDF embeds).
+    expect(() => JSON.stringify(doc)).not.toThrow();
+  });
+});

--- a/src/lib/pdf/to-json-resume.test.ts
+++ b/src/lib/pdf/to-json-resume.test.ts
@@ -232,20 +232,37 @@ describe("toJsonResume — never fabricates data", () => {
     expect(doc.basics.location).toBeUndefined();
   });
 
-  it("does not map the achievements section to any JSON Resume array", () => {
+  // #421 Secondary #12: achievements map to JSON Resume `awards[]` (title +
+  // optional date), so the machine-readable copy no longer silently drops the
+  // candidate's patents/publications/exits that the text layer still shows.
+  it("maps achievement entries (with structured fields) to awards[]", () => {
     const doc = toJsonResume({
       contact: { name: "X", links: [] },
       sections: [
         {
           heading: "Achievements",
           kind: "achievements",
-          entries: [{ headerLine: "Won an award", bullets: [] }],
+          entries: [
+            {
+              headerLine: "Patent US1234 · 2021",
+              bullets: [],
+              fields: { title: "Patent US1234", startDate: "2021" },
+            },
+          ],
         },
       ],
     });
+    expect(doc.awards).toEqual([{ title: "Patent US1234", date: "2021" }]);
+    // Still nothing in the ATS-core arrays.
     expect(doc.work).toEqual([]);
     expect(doc.projects).toEqual([]);
     expect(doc.education).toEqual([]);
+  });
+
+  it("omits awards entirely when there is no achievements section", () => {
+    const doc = toJsonResume({ contact: { name: "X", links: [] }, sections: [] });
+    expect(doc.awards).toBeUndefined();
+    expect("awards" in doc).toBe(false);
   });
 });
 

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * to-json-resume — a PURE adapter from the exporter's `AtsResumeModel` to a
+ * {@link JsonResume} document (the https://jsonresume.org/ v1.0.0 schema).
+ *
+ * This is what makes the "Download PDF" export carry a lossless, machine-
+ * readable copy of the résumé (#334): `render-ats-pdf.ts` embeds the JSON this
+ * returns as a `resume.json` file attachment inside the PDF.
+ *
+ * Design contract:
+ *   - NO `pdf-lib` import, NO I/O — a plain `(model) => JsonResume` function,
+ *     unit-testable in isolation.
+ *   - It reads the STRUCTURED source the model carries (`AtsEntry.fields`,
+ *     `AtsSection.kind`, `AtsContact.profiles`), never re-parsing the glued
+ *     `headerLine` / `subLine` display strings — so the mapping is lossless.
+ *   - **Never fabricates a date.** A free-form date string is best-effort
+ *     normalized to `YYYY-MM` / `YYYY`; when it can't be parsed confidently, the
+ *     RAW string is emitted (JSON Resume tolerates partial/free-form dates).
+ *
+ * Section → JSON Resume array mapping (by `AtsSection.kind`):
+ *   experience → `work[]`, projects → `projects[]`, education → `education[]`,
+ *   skills → `skills[]`. `achievements` (a heuristic, untyped section) has no
+ *   faithful JSON Resume home — mapping it to `awards`/`publications` would
+ *   require inventing an awarder/type we don't have, so it is intentionally NOT
+ *   emitted (the ATS-relevant surface — work/education/skills — is covered, and
+ *   the achievements text still rides in the PDF's own text layer).
+ */
+
+import type { AtsResumeModel, AtsEntryFields } from "./ats-resume-model.ts";
+import type { ProfileLink } from "../score/types.ts";
+import { APP_VERSION } from "../version.ts";
+
+// ── JSON Resume shape (subset we populate) ─────────────────────────────────────
+// Only the fields this exporter fills are typed; JSON Resume has more (all
+// optional). Every field here is optional so we emit exactly what we have.
+
+export interface JsonResumeLocation {
+  address?: string;
+  postalCode?: string;
+  city?: string;
+  region?: string;
+  countryCode?: string;
+}
+
+export interface JsonResumeProfile {
+  network: string;
+  url: string;
+  username?: string;
+}
+
+export interface JsonResumeBasics {
+  name?: string;
+  email?: string;
+  phone?: string;
+  url?: string;
+  location?: JsonResumeLocation;
+  profiles?: JsonResumeProfile[];
+}
+
+export interface JsonResumeWork {
+  name?: string;
+  position?: string;
+  url?: string;
+  startDate?: string;
+  endDate?: string;
+  highlights?: string[];
+}
+
+export interface JsonResumeEducation {
+  institution?: string;
+  area?: string;
+  studyType?: string;
+  startDate?: string;
+  endDate?: string;
+  courses?: string[];
+}
+
+export interface JsonResumeSkill {
+  name: string;
+}
+
+export interface JsonResumeProject {
+  name?: string;
+  url?: string;
+  startDate?: string;
+  endDate?: string;
+  highlights?: string[];
+}
+
+export interface JsonResumeMeta {
+  /** Producing app build id (`APP_VERSION`) — provenance, not the schema rev. */
+  version?: string;
+}
+
+export interface JsonResume {
+  $schema: string;
+  basics: JsonResumeBasics;
+  work: JsonResumeWork[];
+  education: JsonResumeEducation[];
+  skills: JsonResumeSkill[];
+  projects: JsonResumeProject[];
+  meta: JsonResumeMeta;
+}
+
+/** Canonical JSON Resume schema URL (v1.0.0), stamped as `$schema`. */
+export const JSON_RESUME_SCHEMA =
+  "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json";
+
+// ── Date normalization ─────────────────────────────────────────────────────────
+
+const MONTHS: Readonly<Record<string, string>> = {
+  jan: "01", january: "01",
+  feb: "02", february: "02",
+  mar: "03", march: "03",
+  apr: "04", april: "04",
+  may: "05",
+  jun: "06", june: "06",
+  jul: "07", july: "07",
+  aug: "08", august: "08",
+  sep: "09", sept: "09", september: "09",
+  oct: "10", october: "10",
+  nov: "11", november: "11",
+  dec: "12", december: "12",
+};
+
+/**
+ * Best-effort normalize a free-form résumé date to `YYYY-MM` (or `YYYY`). When
+ * the string doesn't match a known shape, the RAW string is returned unchanged —
+ * we never fabricate a month/day the source didn't state. `undefined`/empty in ⇒
+ * `undefined` out.
+ *
+ * Recognized: already-ISO (`YYYY`, `YYYY-MM`, `YYYY-MM-DD`); "Month YYYY" and
+ * "Mon. YYYY" (e.g. "January 2020", "Sept. 2019"); numeric "MM/YYYY" and
+ * "YYYY/MM". Everything else (e.g. "Summer 2022", "Present") passes through raw.
+ */
+export function normalizeJsonResumeDate(
+  raw: string | undefined,
+): string | undefined {
+  if (!raw) return undefined;
+  const s = raw.trim();
+  if (!s) return undefined;
+
+  // Already ISO-ish — pass through untouched.
+  if (/^\d{4}(-\d{2}(-\d{2})?)?$/.test(s)) return s;
+
+  // "Month YYYY" / "Mon. YYYY".
+  const monthYear = s.match(/^([A-Za-z]{3,9})\.?\s+(\d{4})$/);
+  if (monthYear) {
+    const month = MONTHS[monthYear[1].toLowerCase()];
+    if (month) return `${monthYear[2]}-${month}`;
+  }
+
+  // Numeric "MM/YYYY" (or "M/YYYY").
+  const numMonthYear = s.match(/^(\d{1,2})\/(\d{4})$/);
+  if (numMonthYear) {
+    const m = Number(numMonthYear[1]);
+    if (m >= 1 && m <= 12) return `${numMonthYear[2]}-${String(m).padStart(2, "0")}`;
+  }
+
+  // Numeric "YYYY/MM".
+  const yearNumMonth = s.match(/^(\d{4})\/(\d{1,2})$/);
+  if (yearNumMonth) {
+    const m = Number(yearNumMonth[2]);
+    if (m >= 1 && m <= 12) return `${yearNumMonth[1]}-${String(m).padStart(2, "0")}`;
+  }
+
+  // Unparseable — emit the raw string rather than guess (never fabricate).
+  return s;
+}
+
+// ── basics helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Structure a free-form location string ("San Francisco, CA") into JSON Resume's
+ * `{ city, region }` by splitting the LAST comma — so `city + ", " + region`
+ * rejoins to the exact source string (lossless). No comma ⇒ the whole string is
+ * the city. We deliberately do NOT invent postalCode / countryCode.
+ */
+export function toJsonResumeLocation(
+  raw: string | undefined,
+): JsonResumeLocation | undefined {
+  const s = raw?.trim();
+  if (!s) return undefined;
+  const lastComma = s.lastIndexOf(",");
+  if (lastComma < 0) return { city: s };
+  const city = s.slice(0, lastComma).trim();
+  const region = s.slice(lastComma + 1).trim();
+  return region ? { city, region } : { city };
+}
+
+/** Last non-empty path segment of a URL, case-preserved — the JSON Resume
+ *  `profile.username` (e.g. `linkedin.com/in/jane` → "jane",
+ *  `github.com/JaneSmith` → "JaneSmith"). `undefined` when the URL has no path.
+ *  `url` is already normalized (scheme present) by `classifyProfile`, so `new
+ *  URL` parses it; a parse failure yields no username rather than throwing. */
+function usernameFromUrl(url: string): string | undefined {
+  try {
+    const segments = new URL(url).pathname.split("/").filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** JSON Resume `basics.url`: the candidate's own site — the first `portfolio`
+ *  profile, else the first `other` (an unknown-host personal site classifies to
+ *  "other"). `undefined` when neither is present. */
+function pickPrimaryUrl(profiles: readonly ProfileLink[]): string | undefined {
+  return (
+    profiles.find((p) => p.kind === "portfolio")?.url ??
+    profiles.find((p) => p.kind === "other")?.url
+  );
+}
+
+function toBasics(model: AtsResumeModel): JsonResumeBasics {
+  const c = model.contact;
+  const sourceProfiles = c.profiles ?? [];
+  const profiles: JsonResumeProfile[] = sourceProfiles.map((p) => {
+    const username = usernameFromUrl(p.url);
+    return { network: p.network, url: p.url, ...(username ? { username } : {}) };
+  });
+  return {
+    name: c.name || undefined,
+    email: c.email,
+    phone: c.phone,
+    url: pickPrimaryUrl(sourceProfiles),
+    location: toJsonResumeLocation(c.location),
+    profiles: profiles.length > 0 ? profiles : undefined,
+  };
+}
+
+// ── section → array mappers ────────────────────────────────────────────────────
+
+/** Bullet body → JSON Resume `highlights`, or `undefined` when empty. */
+function highlights(bullets: readonly string[]): string[] | undefined {
+  return bullets.length > 0 ? [...bullets] : undefined;
+}
+
+function toWork(fields: AtsEntryFields, bullets: readonly string[]): JsonResumeWork {
+  return {
+    name: fields.organization,
+    position: fields.position,
+    startDate: normalizeJsonResumeDate(fields.startDate),
+    endDate: fields.isCurrent ? undefined : normalizeJsonResumeDate(fields.endDate),
+    highlights: highlights(bullets),
+  };
+}
+
+function toProject(
+  fields: AtsEntryFields,
+  bullets: readonly string[],
+): JsonResumeProject {
+  return {
+    name: fields.organization,
+    url: fields.url,
+    startDate: normalizeJsonResumeDate(fields.startDate),
+    endDate: fields.isCurrent ? undefined : normalizeJsonResumeDate(fields.endDate),
+    highlights: highlights(bullets),
+  };
+}
+
+function toEducation(fields: AtsEntryFields): JsonResumeEducation {
+  return {
+    institution: fields.organization,
+    area: fields.area,
+    studyType: fields.studyType,
+    startDate: normalizeJsonResumeDate(fields.startDate),
+    endDate: normalizeJsonResumeDate(fields.endDate),
+    courses: fields.courses,
+  };
+}
+
+// ── Adapter ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Map an {@link AtsResumeModel} to a {@link JsonResume}. Pure — no I/O, no
+ * pdf-lib. `work` / `education` / `skills` / `projects` are always present (as
+ * possibly-empty arrays, matching the JSON Resume convention). Section ORDER is
+ * the model's (document order); an entry lacking structured `fields` is skipped
+ * for that array (it carries nothing to map).
+ */
+export function toJsonResume(model: AtsResumeModel): JsonResume {
+  const work: JsonResumeWork[] = [];
+  const education: JsonResumeEducation[] = [];
+  const skills: JsonResumeSkill[] = [];
+  const projects: JsonResumeProject[] = [];
+
+  for (const section of model.sections) {
+    for (const entry of section.entries) {
+      const fields = entry.fields;
+      switch (section.kind) {
+        case "experience":
+          if (fields) work.push(toWork(fields, entry.bullets));
+          break;
+        case "projects":
+          if (fields) projects.push(toProject(fields, entry.bullets));
+          break;
+        case "education":
+          if (fields) education.push(toEducation(fields));
+          break;
+        case "skills":
+          for (const name of fields?.skills ?? []) skills.push({ name });
+          break;
+        // "achievements" (and any unmodeled section) is intentionally not mapped.
+        default:
+          break;
+      }
+    }
+  }
+
+  return {
+    $schema: JSON_RESUME_SCHEMA,
+    basics: toBasics(model),
+    work,
+    education,
+    skills,
+    projects,
+    meta: { version: APP_VERSION },
+  };
+}

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -28,7 +28,11 @@
  *   the achievements text still rides in the PDF's own text layer).
  */
 
-import type { AtsResumeModel, AtsEntryFields } from "./ats-resume-model.ts";
+import type {
+  AtsResumeModel,
+  AtsEntryFields,
+  AtsSectionKind,
+} from "./ats-resume-model.ts";
 import type { ProfileLink } from "../score/types.ts";
 import { APP_VERSION } from "../version.ts";
 
@@ -274,6 +278,44 @@ function toEducation(fields: AtsEntryFields): JsonResumeEducation {
 
 // ── Adapter ─────────────────────────────────────────────────────────────────────
 
+/** The four JSON Resume arrays accumulated while walking the model's sections. */
+interface ResumeBuckets {
+  work: JsonResumeWork[];
+  education: JsonResumeEducation[];
+  skills: JsonResumeSkill[];
+  projects: JsonResumeProject[];
+}
+
+/**
+ * Route one entry into its JSON Resume bucket by its section kind. An entry
+ * lacking structured `fields` carries nothing to map, so it is skipped (except
+ * `skills`, whose payload is the `fields.skills` list). "achievements" and any
+ * unmodeled section are intentionally not mapped.
+ */
+function appendEntry(
+  kind: AtsSectionKind | undefined,
+  entry: { fields?: AtsEntryFields; bullets: readonly string[] },
+  buckets: ResumeBuckets,
+): void {
+  const { fields } = entry;
+  switch (kind) {
+    case "experience":
+      if (fields) buckets.work.push(toWork(fields, entry.bullets));
+      break;
+    case "projects":
+      if (fields) buckets.projects.push(toProject(fields, entry.bullets));
+      break;
+    case "education":
+      if (fields) buckets.education.push(toEducation(fields));
+      break;
+    case "skills":
+      for (const name of fields?.skills ?? []) buckets.skills.push({ name });
+      break;
+    default:
+      break;
+  }
+}
+
 /**
  * Map an {@link AtsResumeModel} to a {@link JsonResume}. Pure — no I/O, no
  * pdf-lib. `work` / `education` / `skills` / `projects` are always present (as
@@ -282,41 +324,21 @@ function toEducation(fields: AtsEntryFields): JsonResumeEducation {
  * for that array (it carries nothing to map).
  */
 export function toJsonResume(model: AtsResumeModel): JsonResume {
-  const work: JsonResumeWork[] = [];
-  const education: JsonResumeEducation[] = [];
-  const skills: JsonResumeSkill[] = [];
-  const projects: JsonResumeProject[] = [];
+  const buckets: ResumeBuckets = { work: [], education: [], skills: [], projects: [] };
 
   for (const section of model.sections) {
     for (const entry of section.entries) {
-      const fields = entry.fields;
-      switch (section.kind) {
-        case "experience":
-          if (fields) work.push(toWork(fields, entry.bullets));
-          break;
-        case "projects":
-          if (fields) projects.push(toProject(fields, entry.bullets));
-          break;
-        case "education":
-          if (fields) education.push(toEducation(fields));
-          break;
-        case "skills":
-          for (const name of fields?.skills ?? []) skills.push({ name });
-          break;
-        // "achievements" (and any unmodeled section) is intentionally not mapped.
-        default:
-          break;
-      }
+      appendEntry(section.kind, entry, buckets);
     }
   }
 
   return {
     $schema: JSON_RESUME_SCHEMA,
     basics: toBasics(model),
-    work,
-    education,
-    skills,
-    projects,
+    work: buckets.work,
+    education: buckets.education,
+    skills: buckets.skills,
+    projects: buckets.projects,
     meta: { version: APP_VERSION },
   };
 }

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -21,15 +21,15 @@
  *
  * Section → JSON Resume array mapping (by `AtsSection.kind`):
  *   experience → `work[]`, projects → `projects[]`, education → `education[]`,
- *   skills → `skills[]`. `achievements` (a heuristic, untyped section) has no
- *   faithful JSON Resume home — mapping it to `awards`/`publications` would
- *   require inventing an awarder/type we don't have, so it is intentionally NOT
- *   emitted (the ATS-relevant surface — work/education/skills — is covered, and
- *   the achievements text still rides in the PDF's own text layer).
+ *   skills → `skills[]`, achievements → `awards[]` (title + optional date only;
+ *   we invent no awarder/summary — JSON Resume treats every award field
+ *   optional, so this is faithful, #421 review). `awards` is omitted entirely
+ *   when the résumé has no Achievements section.
  */
 
 import type {
   AtsResumeModel,
+  AtsContact,
   AtsEntryFields,
   AtsSectionKind,
 } from "./ats-resume-model.ts";
@@ -93,6 +93,13 @@ export interface JsonResumeProject {
   highlights?: string[];
 }
 
+export interface JsonResumeAward {
+  title?: string;
+  date?: string;
+  awarder?: string;
+  summary?: string;
+}
+
 export interface JsonResumeMeta {
   /** Producing app build id (`APP_VERSION`) — provenance, not the schema rev. */
   version?: string;
@@ -105,6 +112,10 @@ export interface JsonResume {
   education: JsonResumeEducation[];
   skills: JsonResumeSkill[];
   projects: JsonResumeProject[];
+  /** Present only when the résumé carries an Achievements section — omitted
+   *  otherwise so a résumé without one stays byte-identical to the pre-#421
+   *  export (no empty `awards: []` churn). */
+  awards?: JsonResumeAward[];
   meta: JsonResumeMeta;
 }
 
@@ -197,15 +208,12 @@ export function toJsonResumeLocation(
 /** Last non-empty path segment of a URL, case-preserved — the JSON Resume
  *  `profile.username` (e.g. `linkedin.com/in/jane` → "jane",
  *  `github.com/JaneSmith` → "JaneSmith"). `undefined` when the URL has no path.
- *  `url` is already normalized (scheme present) by `classifyProfile`, so `new
- *  URL` parses it; a parse failure yields no username rather than throwing. */
+ *  `url` is already normalized (scheme present) AND round-tripped through `new
+ *  URL(...)` inside `classifyProfile` before it reaches here, so parsing can't
+ *  fail — no defensive catch (#421 review, nit 14). */
 function usernameFromUrl(url: string): string | undefined {
-  try {
-    const segments = new URL(url).pathname.split("/").filter(Boolean);
-    return segments.length > 0 ? segments[segments.length - 1] : undefined;
-  } catch {
-    return undefined;
-  }
+  const segments = new URL(url).pathname.split("/").filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : undefined;
 }
 
 /** JSON Resume `basics.url`: the candidate's own site — the first `portfolio`
@@ -218,8 +226,13 @@ function pickPrimaryUrl(profiles: readonly ProfileLink[]): string | undefined {
   );
 }
 
-function toBasics(model: AtsResumeModel): JsonResumeBasics {
-  const c = model.contact;
+/**
+ * Build JSON Resume `basics` from an {@link AtsContact} alone — no section
+ * walk. Exported so the audit-report identity header can source basics without
+ * running the full `buildAtsResumeModel` + `toJsonResume` pipeline just to read
+ * `.basics` off the result (#421 review, Secondary #6).
+ */
+export function basicsFromContact(c: AtsContact): JsonResumeBasics {
   const sourceProfiles = c.profiles ?? [];
   const profiles: JsonResumeProfile[] = sourceProfiles.map((p) => {
     const username = usernameFromUrl(p.url);
@@ -233,6 +246,10 @@ function toBasics(model: AtsResumeModel): JsonResumeBasics {
     location: toJsonResumeLocation(c.location),
     profiles: profiles.length > 0 ? profiles : undefined,
   };
+}
+
+function toBasics(model: AtsResumeModel): JsonResumeBasics {
+  return basicsFromContact(model.contact);
 }
 
 // ── section → array mappers ────────────────────────────────────────────────────
@@ -265,6 +282,17 @@ function toProject(
   };
 }
 
+/** Achievements → JSON Resume `awards`. JSON Resume treats every award field
+ *  optional, so emitting `{ title, date? }` from what we actually have (title +
+ *  the year) is faithful, not fabricated — we invent no awarder/summary (#421
+ *  review, Secondary #12). */
+function toAward(fields: AtsEntryFields): JsonResumeAward {
+  return {
+    title: fields.title,
+    date: normalizeJsonResumeDate(fields.startDate),
+  };
+}
+
 function toEducation(fields: AtsEntryFields): JsonResumeEducation {
   return {
     institution: fields.organization,
@@ -284,6 +312,7 @@ interface ResumeBuckets {
   education: JsonResumeEducation[];
   skills: JsonResumeSkill[];
   projects: JsonResumeProject[];
+  awards: JsonResumeAward[];
 }
 
 /**
@@ -311,6 +340,9 @@ function appendEntry(
     case "skills":
       for (const name of fields?.skills ?? []) buckets.skills.push({ name });
       break;
+    case "achievements":
+      if (fields) buckets.awards.push(toAward(fields));
+      break;
     default:
       break;
   }
@@ -324,7 +356,13 @@ function appendEntry(
  * for that array (it carries nothing to map).
  */
 export function toJsonResume(model: AtsResumeModel): JsonResume {
-  const buckets: ResumeBuckets = { work: [], education: [], skills: [], projects: [] };
+  const buckets: ResumeBuckets = {
+    work: [],
+    education: [],
+    skills: [],
+    projects: [],
+    awards: [],
+  };
 
   for (const section of model.sections) {
     for (const entry of section.entries) {
@@ -339,6 +377,9 @@ export function toJsonResume(model: AtsResumeModel): JsonResume {
     education: buckets.education,
     skills: buckets.skills,
     projects: buckets.projects,
+    // Omit `awards` entirely when there are none, keeping the achievement-free
+    // export byte-identical to before (#421 review, Secondary #12).
+    ...(buckets.awards.length > 0 ? { awards: buckets.awards } : {}),
     meta: { version: APP_VERSION },
   };
 }

--- a/src/lib/report/serialize.test.ts
+++ b/src/lib/report/serialize.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, expect, it } from "vitest";
+import {
+  buildAuditReportJson,
+  serializeAuditReportJson,
+  REPORT_VERSION,
+  type AuditReportInput,
+} from "./serialize.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { JsonResumeBasics } from "../pdf/to-json-resume.ts";
+
+// Bullet text is verbatim résumé content — it routinely embeds employer names,
+// project names, and locations (here "Poppleton Foundation" / "Chicago"). The
+// shareable report must strip it. Keeping it in the fixture is what makes the
+// leak test real (the prior fixture omitted `bullets`, masking the leak).
+const BULLET_TEXT =
+  "Led the data migration at Poppleton Foundation in Chicago, cutting costs 30%";
+
+const SCORE: AnonymousAtsScore = {
+  overall: 72,
+  preLayoutOverall: 85,
+  specificity: { score: 28, max: 40, gradable: true, metricBullets: 4, totalBullets: 6 },
+  structure: { score: 24, max: 30, gradable: true, goodBullets: 5, totalBullets: 6 },
+  completeness: { score: 21, max: 30, gradable: true, missing: ["summary"] },
+  layout: { triggers: ["two_column"], multiplier: 0.85, scanned: false },
+  algoVersion: "1.4",
+  bullets: [
+    {
+      text: BULLET_TEXT,
+      index: 0,
+      hasMetric: true,
+      startsWithActionVerb: true,
+      wellFormedLength: true,
+      wordCount: 12,
+    },
+  ],
+};
+
+// Synthetic persona (fixture-PII policy): fake name, @example.com, 555 phone.
+const IDENTITY: JsonResumeBasics = {
+  name: "Jamie Rivera",
+  email: "jamie@example.com",
+  phone: "(312) 555-0123",
+  url: "jamierivera.example.com",
+  location: { city: "Chicago", region: "IL" },
+  profiles: [
+    {
+      network: "LinkedIn",
+      url: "https://linkedin.com/in/jamie-rivera",
+      username: "jamie-rivera",
+    },
+  ],
+};
+
+const PII_TOKENS = [
+  "Jamie Rivera",
+  "jamie@example.com",
+  "(312) 555-0123",
+  "jamierivera.example.com",
+  "linkedin.com/in/jamie-rivera",
+  // Bullet text is PII too — it must never appear in the report, identity on or off.
+  "Poppleton Foundation",
+  BULLET_TEXT,
+];
+
+function input(overrides: Partial<AuditReportInput> = {}): AuditReportInput {
+  return {
+    score: SCORE,
+    triggers: ["two_column"],
+    recommendation: "Your content scored 85/100, but a multi-column layout will scramble it.",
+    generatedAt: "2026-07-09T12:00:00.000Z",
+    includeIdentity: false,
+    ...overrides,
+  };
+}
+
+describe("buildAuditReportJson", () => {
+  it("carries the versioned envelope, score, triggers, and recommendation", () => {
+    const doc = buildAuditReportJson(input());
+    expect(doc.reportVersion).toBe(REPORT_VERSION);
+    expect(doc.algoVersion).toBe("1.4");
+    expect(doc.score.overall).toBe(72);
+    expect(doc.triggers).toEqual(["two_column"]);
+    expect(doc.recommendation).toContain("multi-column");
+    expect(doc.app.version).toBeTruthy();
+    expect(doc.generatedAt).toBe("2026-07-09T12:00:00.000Z");
+  });
+
+  it("PRIVACY GATE: omits identity entirely when includeIdentity is false (default)", () => {
+    const doc = buildAuditReportJson(
+      input({ includeIdentity: false, identity: IDENTITY }),
+    );
+    expect(doc.identity).toBeUndefined();
+    // Even when an identity block is (wrongly) supplied with the flag off, no PII
+    // survives serialization.
+    const json = JSON.stringify(doc);
+    for (const token of PII_TOKENS) expect(json).not.toContain(token);
+  });
+
+  it("PRIVACY GATE: strips score.bullets (verbatim résumé text) unconditionally — even with identity ON", () => {
+    // Bullets carry PII regardless of the identity flag, so the strip is not
+    // gated on it. Assert both the default (off) and opted-in (on) cases.
+    for (const includeIdentity of [false, true]) {
+      const doc = buildAuditReportJson(input({ includeIdentity, identity: IDENTITY }));
+      expect("bullets" in doc.score).toBe(false);
+      expect(JSON.stringify(doc)).not.toContain("Poppleton Foundation");
+    }
+  });
+
+  it("includes the identity block when opted in", () => {
+    const doc = buildAuditReportJson(
+      input({ includeIdentity: true, identity: IDENTITY }),
+    );
+    expect(doc.identity?.name).toBe("Jamie Rivera");
+    expect(doc.identity?.email).toBe("jamie@example.com");
+  });
+
+  it("does not include identity when opted in but no identity supplied", () => {
+    const doc = buildAuditReportJson(input({ includeIdentity: true }));
+    expect(doc.identity).toBeUndefined();
+  });
+});
+
+describe("serializeAuditReportJson", () => {
+  it("default (identity off) output contains no name, email, phone, or links", () => {
+    const json = serializeAuditReportJson(
+      input({ includeIdentity: false, identity: IDENTITY }),
+    );
+    for (const token of PII_TOKENS) expect(json).not.toContain(token);
+  });
+
+  it("is pretty-printed and parses back to the same document", () => {
+    const json = serializeAuditReportJson(input());
+    expect(json).toContain("\n");
+    expect(JSON.parse(json)).toEqual(buildAuditReportJson(input()));
+  });
+});

--- a/src/lib/report/serialize.ts
+++ b/src/lib/report/serialize.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * report/serialize — the machine-readable half of the shareable audit report
+ * (#343).
+ *
+ * Turns the audit findings (`AnonymousAtsScore` + layout triggers +
+ * recommendation) into a versioned, deterministic JSON document, fully
+ * client-side. This is the JSON counterpart to `render-audit-report.ts` (the
+ * PDF); both consume the same `AuditReportInput` so the two formats never
+ * disagree.
+ *
+ * PRIVACY GATE (the load-bearing rule): the default report is anonymous. The
+ * candidate's identity header (name / email / phone / links / location) is
+ * emitted ONLY when the caller opts in (`includeIdentity: true`) AND supplies
+ * an `identity` block. With identity off — the default — `identity` is omitted
+ * entirely, so the artifact carries NO name, email, phone, or profile URL and
+ * is safe to share publicly. `buildAuditReportJson` re-checks the flag itself
+ * (belt-and-suspenders): even if a caller passes an `identity` block with the
+ * flag off, it is dropped.
+ *
+ * Pure — no pdf-lib, no I/O. `identity`, when present, is the SAME
+ * `JsonResumeBasics` shape #334's `toJsonResume()` produces (`basics`), so the
+ * report's header block is lossless and consistent with the résumé export.
+ */
+
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { LayoutTrigger } from "../heuristics/types.ts";
+import type { JsonResumeBasics } from "../pdf/to-json-resume.ts";
+import { APP_VERSION } from "../version.ts";
+
+/**
+ * Report schema version. Bump when the JSON SHAPE changes (a field added,
+ * removed, or renamed) so downstream tooling that diffs runs can detect it.
+ * Distinct from `algoVersion` (the scoring algorithm) and `app.version` (the
+ * build id) — this versions the envelope, not the numbers inside it.
+ */
+export const REPORT_VERSION = "1.0";
+
+/** The findings both report formats render. Assembled by the download hook. */
+export interface AuditReportInput {
+  score: AnonymousAtsScore;
+  /** Fired layout triggers (from `CascadeResult.triggers` / `score.layout`). */
+  triggers: readonly LayoutTrigger[];
+  /** The one-sentence recommendation (`getScoreRecommendation`). */
+  recommendation: string;
+  /** ISO-8601 generation timestamp, injected by the caller so the builder
+   *  stays pure/deterministic under test. */
+  generatedAt: string;
+  /** Whether to include the candidate's identity header. Default-off upstream. */
+  includeIdentity: boolean;
+  /** Identity header block (JSON Resume `basics`). Included ONLY when
+   *  `includeIdentity` is true; omit otherwise. */
+  identity?: JsonResumeBasics;
+}
+
+/** The serialized audit-report document shape.
+ *
+ *  `score` is the anonymous score MINUS its `bullets` array: `AnonymousAtsScore`
+ *  keeps a `BulletObservation[]` whose `text` is the verbatim résumé bullet
+ *  (employer / project / sometimes the candidate's own name) — that is PII and
+ *  must never ride in the shareable report. The overall + per-dimension scores,
+ *  triggers, and recommendation carry the transparency the report needs without
+ *  it. See `buildAuditReportJson`. */
+export interface AuditReportJson {
+  reportVersion: string;
+  generatedAt: string;
+  app: { version: string };
+  algoVersion?: string;
+  score: Omit<AnonymousAtsScore, "bullets">;
+  triggers: LayoutTrigger[];
+  recommendation: string;
+  /** Present ONLY when the user opted into including identity. */
+  identity?: JsonResumeBasics;
+}
+
+/**
+ * Build the audit-report document. Pure. Enforces the privacy gate on two
+ * channels:
+ *   1. The `identity` block is attached only when `includeIdentity` is true AND
+ *      an identity block was supplied — never otherwise.
+ *   2. `score.bullets` (verbatim résumé bullet text — PII) is ALWAYS stripped,
+ *      irrespective of the identity flag. This is an unconditional content
+ *      strip: the shareable report never carries accomplishment-line text.
+ */
+export function buildAuditReportJson(input: AuditReportInput): AuditReportJson {
+  // Drop the PII-bearing `bullets` (each `text` is a verbatim résumé line) from
+  // the embedded score. Unconditional — not gated on `includeIdentity`.
+  const { bullets: _bullets, ...score } = input.score;
+  const doc: AuditReportJson = {
+    reportVersion: REPORT_VERSION,
+    generatedAt: input.generatedAt,
+    app: { version: APP_VERSION },
+    algoVersion: input.score.algoVersion,
+    score,
+    triggers: [...input.triggers],
+    recommendation: input.recommendation,
+  };
+  if (input.includeIdentity && input.identity) {
+    doc.identity = input.identity;
+  }
+  return doc;
+}
+
+/** Serialize the audit report to a pretty-printed JSON string. */
+export function serializeAuditReportJson(input: AuditReportInput): string {
+  return JSON.stringify(buildAuditReportJson(input), null, 2);
+}

--- a/src/lib/score/score.test.ts
+++ b/src/lib/score/score.test.ts
@@ -401,6 +401,44 @@ describe("computeAnonymousAtsScore", () => {
     expect(result.completeness.missing).toContain("name");
   });
 
+  // #421 Blocking #2: a code profile (GitHub) satisfies the "Professional
+  // profile" completeness check, so a GitHub-but-no-LinkedIn résumé is NOT
+  // docked and does not list "LinkedIn" as missing — matching the ContactCard's
+  // github-satisfies display rule.
+  it("counts GitHub as satisfying the professional-profile requirement", () => {
+    const withGithub = computeAnonymousAtsScore(
+      makeAnonInput({
+        parsed: {
+          ...makeAnonInput().parsed,
+          linkedin_url: undefined,
+          github_url: "https://github.com/janedoe",
+        },
+        fieldConfidence: {
+          full_name: 0.9,
+          email: 0.95,
+          phone: 0.9,
+          location: 0.8,
+          github_url: 0.95,
+        },
+      }),
+    );
+    expect(withGithub.completeness.missing).not.toContain("LinkedIn");
+
+    // Sanity: with NEITHER link, the professional-profile gap is still flagged.
+    const withNeither = computeAnonymousAtsScore(
+      makeAnonInput({
+        parsed: { ...makeAnonInput().parsed, linkedin_url: undefined },
+        fieldConfidence: {
+          full_name: 0.9,
+          email: 0.95,
+          phone: 0.9,
+          location: 0.8,
+        },
+      }),
+    );
+    expect(withNeither.completeness.missing).toContain("LinkedIn");
+  });
+
   it("flags missing sections in completeness", () => {
     // With empty parsed.experience AND no experience section, the experience
     // completeness check fails (#133 — it now asks "is there a non-empty

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -532,6 +532,11 @@ export interface AnonymousAtsScoreInput {
     phoneIsValid?: boolean;
     location?: string;
     linkedin_url?: string;
+    /** A code profile (GitHub) satisfies the brand-neutral "Professional
+     *  profile" completeness check just like LinkedIn does — mirrors the
+     *  ContactCard's github-satisfies rule so score + display agree (#421
+     *  Blocking #2). */
+    github_url?: string;
     summary?: string;
     skills?: string[];
     experience?: {
@@ -550,7 +555,7 @@ export interface AnonymousAtsScoreInput {
    *  credited — we don't want to reward a name we couldn't parse. */
   fieldConfidence: Partial<
     Record<
-      "full_name" | "email" | "phone" | "location" | "linkedin_url",
+      "full_name" | "email" | "phone" | "location" | "linkedin_url" | "github_url",
       number
     >
   >;
@@ -732,10 +737,19 @@ export function computeAnonymousAtsScore(
     label: string;
     credit?: number;
   }[] = [];
+  // A code profile (GitHub) satisfies the "Professional profile" requirement
+  // just like LinkedIn — same rule the ContactCard applies, so score + display
+  // agree that a GitHub-but-no-LinkedIn résumé has no professional-profile gap
+  // (#421 Blocking #2).
+  const githubSatisfies =
+    Boolean(input.parsed.github_url) &&
+    (input.fieldConfidence.github_url ?? 0) >= ANON_CONTACT_CONFIDENCE_FLOOR;
+
   for (const f of ANON_CONTACT_FIELDS) {
     const value = input.parsed[f.key];
     const conf = input.fieldConfidence[f.key] ?? 0;
-    const present = Boolean(value) && conf >= ANON_CONTACT_CONFIDENCE_FLOOR;
+    let present = Boolean(value) && conf >= ANON_CONTACT_CONFIDENCE_FLOOR;
+    if (f.key === "linkedin_url" && !present && githubSatisfies) present = true;
     if (f.key === "phone") {
       // Validity-aware phone credit (#70):
       //   present + valid (or validity unknown) → full credit (passed: true)

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -56,6 +56,24 @@ export interface SkillInferred {
   confidence: number;
 }
 
+// ── Profile links (JSON Resume basics.profiles pattern, #335) ───────────────
+// A contributor-extensible replacement for the four hardcoded link slots
+// (`linkedin_url`, `github_url`, `portfolio_url`, `website_url`). Each detected
+// contact link becomes one `ProfileLink`, classified against the host registry
+// in `src/lib/contact/profile-registry.ts`. Phase 1 (#335) populates this
+// additively — the four legacy keys stay the source of truth for scoring and
+// corpus snapshots; #334's `toJsonResume()` maps this to `basics.profiles`.
+
+/** A single classified contact/identity link. */
+export interface ProfileLink {
+  /** Normalized canonical href (via the shared `normalizeUrl`). */
+  url: string;
+  /** Registry label ("GitHub") or the bare hostname when the host is unknown. */
+  network: string;
+  /** Coarse category used for grouping/UI. Unknown hosts fall to "other". */
+  kind: "code" | "social" | "portfolio" | "academic" | "writing" | "other";
+}
+
 // ── Resume data shapes ─────────────────────────────────────────────────────
 
 export type CareerTrajectory =
@@ -232,6 +250,10 @@ export interface ResumeData {
   portfolio_url?: string;
   github_url?: string;
   website_url?: string;
+  /** Contributor-extensible classified contact links (#335). Additive in
+   *  Phase 1 — mirrors the four legacy `*_url` keys above (which remain the
+   *  scoring/snapshot source of truth). #334 maps this to `basics.profiles`. */
+  profiles?: ProfileLink[];
   summary?: string;
   skills: string[];
   experience: ResumeExperience[];


### PR DESCRIPTION
## Summary

Batch #400 — **download-export standards** — three sub-issues on one branch, moving the export surface onto the [JSON Resume](https://jsonresume.org/) standard and adding a shareable audit artifact. Everything stays client-side.

- **#335 · `profiles[]` model** — adds `ProfileLink {url, network, kind}` + `profiles?: ProfileLink[]` to `ResumeData`, plus a contributor-extensible host registry (`classifyProfile` / `PROFILE_HOSTS`). Extraction **mirrors** the 4 legacy link keys into `profiles[]`, so the legacy keys stay the scoring/snapshot source of truth — **every corpus `*.expected.json` is byte-unchanged (no re-bake)**. New contact-link UI: `+ Add link`, per-profile `EditableField` edit, delete, unknown-host hostname labels, and a brand-neutral "Professional profile" row. *(Phase 2 — flipping score/UI to read `profiles[]` directly and deprecating the legacy keys — is a deliberate follow-up, not this PR.)*
- **#334 · JSON Resume export** — pure `toJsonResume(AtsResumeModel) → JsonResume`; `basics.profiles` from `profiles[]`; free-form dates degrade to the raw string, **never fabricated**; a layout-contract test asserts every heading the exporter emits re-recognizes via `matchSectionHeader()`; the Download PDF now embeds a lossless `resume.json` as a **pdf-lib attachment** (text layer untouched → `parse → export → re-parse` stays byte-identical). `pdf-lib` stays lazy.
- **#343 · shareable audit report** — a secondary "Download report" control (Download PDF stays the **primary** CTA) with PDF/JSON format + an **"include identity" checkbox defaulting OFF**. New `render-audit-report.ts` (lazy pdf-lib) + `report/serialize.ts`. Privacy gate: identity-off artifacts carry **zero PII**.

Closes #335
Closes #334
Closes #343
Refs #400

## Adversarial review

One review round (`react-reviewer`, adversarial). **1 blocking finding, fixed + covered:**

- **Privacy leak (JSON audit report):** `buildAuditReportJson` embedded `score` verbatim, and `AnonymousAtsScore.bullets[].text` is the raw résumé accomplishment line (employer / project names, sometimes the candidate's name) — so the *default, "safe to share"* JSON report shipped it even with identity **off**. The existing privacy test's score fixture omitted `bullets`, masking the leak. Reproduced end-to-end. **Fix:** strip `bullets` from the embedded score unconditionally (belt-and-suspenders at the builder, independent of the identity flag) + added a `bullets`-bearing fixture so the gate now covers it. The PDF report path never drew bullets and was already clean.

**Deferred (reviewer-verified safe, follow-up issues to file):**
- `profile-registry.ts ↔ heuristics/extract/contact.ts` circular dep — function-scoped imports, no init-order hazard; matches existing tolerated cycles. Follow-up: extract URL utils into a shared module to restore tree-shaking.
- `render-ats-pdf.ts ↔ render-audit-report.ts` ~104-line clone family — the two renderers have genuinely diverged needs (Poppins/résumé vs Helvetica/report); extracting a shared helper now would over-couple.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (1813 passed / 4 skipped)
- [x] `npm run lint` clean (no raw `<button>` / palette / hardcoded hex / manual `dark:`)
- [x] Corpus snapshots byte-unchanged; `corpus-roundtrip` + `render-roundtrip` green
- [x] Privacy gate: identity-off JSON **and** PDF reports assert-free of name/email/phone/location/profile URLs **and** bullet text
- [x] Manually verified in `npm run dev` / `npm run preview`

> Note: this branch was reconciled mid-run after an external process switched the checkout to another branch; the accumulated work was moved back onto `main`'s base with zero foreign-commit leakage (verified). No fixture binaries added.
