### PR TITLE
feat(resume-library): save, reload, rename, delete resumes locally (#322)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -11,15 +11,7 @@
   "entry": [
     "jd-spike.html",
     "eval-rewrite.html",
-    "parse-eval.html",
-
-    // Local-first storage foundation (#321) is infrastructure shipped AHEAD of
-    // its UI — the resume-library and job-tracker follow-ups are its first
-    // in-repo consumers. Until they land, the public barrel has no importer, so
-    // register it as an intentional root; without this fallow flags the whole
-    // module (barrel + its export/import/persist surface) as unreachable dead
-    // code. Remove this line once a follow-up imports `@/lib/storage`.
-    "src/lib/storage/index.ts"
+    "parse-eval.html"
   ],
 
   // `@design-tokens` is a Vite CSS-import alias (vite.config.ts resolve.alias),

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ under disk pressure, and Safari clears script-writable storage after 7 days
 without a visit — so the module ships a JSON **export/import** backup path (resume
 bytes base64-encoded in the export file) as the user's own recovery route.
 
+The **resume library** (save a parsed resume, reload it later without re-uploading,
+rename/delete) is the first surface built on this store; it shows the persistence
+state and the eviction note inline, with the export backup reachable from there.
+
 ### GitHub star count
 
 The footer shows the live repo star count via an unauthenticated call to

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,10 @@ import { ReconstructedResume } from "./components/features/ReconstructedResume.t
 import { AtsScoreReadout } from "./components/features/AtsScoreReadout.tsx";
 import { PageShell } from "./components/features/PageShell.tsx";
 import { ReplaceResumeDropOverlay } from "./components/features/ReplaceResumeDropOverlay.tsx";
+import { ResumeLibrary } from "./components/features/ResumeLibrary.tsx";
+import { SaveResumeBar } from "./components/features/SaveResumeBar.tsx";
 import { useAnalyzedResume } from "./hooks/useAnalyzedResume.ts";
+import { useResumeLibrary } from "./hooks/useResumeLibrary.ts";
 import { useReplaceResumeOnDrop } from "./hooks/useReplaceResumeOnDrop.ts";
 import { writeJdFitHandoff } from "./lib/jd-fit-handoff.ts";
 import { isScoreRevealed } from "./lib/contact.ts";
@@ -26,7 +29,24 @@ export default function App() {
     startBlank,
     resumeDraft,
     startOverBlank,
+    loadSavedResume,
   } = useAnalyzedResume();
+
+  // Local-first resume library (#322) — save/reload parsed resumes without
+  // re-uploading. Loading hydrates the "done" state from the cached parse.
+  const library = useResumeLibrary();
+  const onLoadSavedResume = async (id: string) => {
+    const loaded = await library.load(id);
+    if (loaded === undefined) return;
+    loadSavedResume({
+      fileName: loaded.filename,
+      fileSize: loaded.fileSize,
+      bytes: loaded.bytes,
+      sourceKind: loaded.sourceKind,
+      result: loaded.result,
+      score: loaded.score,
+    });
+  };
 
   // Once a parse is done the inline DropZone is gone; this restores drag-and-
   // drop so a new resume can replace the current one (confirm-gated, since it
@@ -138,6 +158,13 @@ export default function App() {
           />
 
           {(state.phase === "idle" || state.phase === "error") && (
+            // Saved-resumes picker (#322) — self-hides when the library is
+            // empty. Sits directly beneath the drop zone; loading one restores
+            // the results view from its cached parse (no re-upload).
+            <ResumeLibrary library={library} onLoad={onLoadSavedResume} />
+          )}
+
+          {(state.phase === "idle" || state.phase === "error") && (
             // "Start from scratch" entry point (#313) — a clearly-secondary
             // CTA for a user with no resume yet (or who wants a clean start).
             // Reuses the existing editor/exporter surface (ReconstructedResume
@@ -196,6 +223,16 @@ export default function App() {
               sourceKind={state.sourceKind}
               onReset={reset}
               edit={edit}
+            />
+            {/* Save-to-library affordance (#322) — saves the edited parse +
+                source bytes so this resume can be reloaded without re-uploading. */}
+            <SaveResumeBar
+              library={library}
+              fileName={state.fileName}
+              bytes={state.bytes}
+              sourceKind={state.sourceKind}
+              result={displayResult}
+              score={edited.score}
             />
             {jdFitEnabled && (
               // Cross-sell sits *below* the result as a quiet follow-on, not a

--- a/src/components/features/ResumeLibrary.tsx
+++ b/src/components/features/ResumeLibrary.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ResumeLibrary — the saved-resumes picker on the landing view (#322). Lists
+ * saved resumes, surfaces the storage-persistence state + eviction transparency
+ * copy with a one-click export as the backup path, and shows approximate space
+ * used. All local: resume bytes never leave the browser. Row rendering + the
+ * delete confirm live in ResumeLibraryEntry; storage access is the
+ * `useResumeLibrary` hook. Renders nothing when the library is empty.
+ */
+
+import { Card, Button, StatusBadge } from "@design-system";
+import { formatBytes } from "../../lib/format-bytes.ts";
+import { EVICTION_NOTICE } from "../../lib/storage/index.ts";
+import type { ResumeLibrary as Library } from "../../hooks/useResumeLibrary.ts";
+import { ResumeLibraryEntry } from "./ResumeLibraryEntry.tsx";
+
+interface ResumeLibraryProps {
+  library: Library;
+  onLoad: (id: string) => void;
+}
+
+export function ResumeLibrary({ library, onLoad }: ResumeLibraryProps) {
+  const { entries, ready, persisted, usageBytes, rename, remove, exportBackup } =
+    library;
+
+  // Nothing to show until at least one resume is saved.
+  if (!ready || entries.length === 0) return null;
+
+  return (
+    <Card className="flex flex-col gap-4">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-content-primary">
+            Saved resumes
+          </h2>
+          <span className="text-xs text-content-muted">
+            {entries.length}
+            {usageBytes !== null && <> · {formatBytes(usageBytes)} used</>}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusBadge tone={persisted ? "ok" : "warning"}>
+            {persisted ? "Persistent" : "Best-effort"}
+          </StatusBadge>
+          <Button variant="ghost" size="sm" onClick={() => void exportBackup()}>
+            Export backup
+          </Button>
+        </div>
+      </header>
+
+      <p className="text-xs text-content-tertiary">
+        Saved only in this browser — no account, no sync.{" "}
+        {!persisted && EVICTION_NOTICE}
+      </p>
+
+      <ul className="flex flex-col gap-2">
+        {entries.map((entry) => (
+          <ResumeLibraryEntry
+            key={entry.id}
+            entry={entry}
+            onLoad={onLoad}
+            onRename={(id, filename) => void rename(id, filename)}
+            onDelete={(id) => void remove(id)}
+          />
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/src/components/features/ResumeLibraryEntry.tsx
+++ b/src/components/features/ResumeLibraryEntry.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * ResumeLibraryEntry — one saved-resume row in the library (#322): editable
+ * filename, saved-time + score-at-save metadata, and load / delete actions.
+ * Delete is confirm-gated (a load-bearing, data-losing action). Composed from
+ * design-system primitives per the 3-tier rules; the list container and its
+ * storage wiring live in ResumeLibrary.tsx.
+ */
+
+import { useState } from "react";
+import { Button, EditableField, Dialog } from "@design-system";
+import { timeAgo } from "../../lib/date-utils.ts";
+import type { ResumeLibraryEntry as Entry } from "../../lib/resume-library.ts";
+
+interface ResumeLibraryEntryProps {
+  entry: Entry;
+  onLoad: (id: string) => void;
+  onRename: (id: string, filename: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function ResumeLibraryEntry({
+  entry,
+  onLoad,
+  onRename,
+  onDelete,
+}: ResumeLibraryEntryProps) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  return (
+    <li className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border border-border-light bg-surface-subtle px-3 py-2.5">
+      <div className="min-w-0 flex-1">
+        <EditableField
+          value={entry.filename}
+          placeholder="Untitled resume"
+          label="Resume name"
+          onCommit={(next) => {
+            const trimmed = next.trim();
+            if (trimmed && trimmed !== entry.filename) onRename(entry.id, trimmed);
+          }}
+        />
+        <p className="mt-0.5 flex items-center gap-2 text-xs text-content-muted">
+          <span className="uppercase tracking-wider">{entry.sourceKind}</span>
+          <span aria-hidden>·</span>
+          <span>score {entry.scoreOverall}</span>
+          <span aria-hidden>·</span>
+          <span>saved {timeAgo(new Date(entry.savedAt).toISOString())}</span>
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button variant="primary" size="sm" onClick={() => onLoad(entry.id)}>
+          Load
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setConfirmingDelete(true)}
+        >
+          Delete
+        </Button>
+      </div>
+
+      <Dialog
+        open={confirmingDelete}
+        onClose={() => setConfirmingDelete(false)}
+        title="Delete this saved resume?"
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-content-secondary">
+            <span className="font-medium text-content-primary">
+              {entry.filename}
+            </span>{" "}
+            will be removed from this browser. This can&apos;t be undone.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setConfirmingDelete(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {
+                onDelete(entry.id);
+                setConfirmingDelete(false);
+              }}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </li>
+  );
+}

--- a/src/components/features/SaveResumeBar.tsx
+++ b/src/components/features/SaveResumeBar.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * SaveResumeBar — the "save this resume to your library" affordance shown under
+ * a parsed result (#322). Saves the current (edited) parse + source bytes to
+ * local storage so it can be reloaded later without re-uploading. A second save
+ * updates the same record rather than minting a duplicate. Quiet, secondary
+ * styling — the page's primary action stays the parse/score, not this.
+ */
+
+import { useState } from "react";
+import { Button } from "@design-system";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../../lib/score/score.ts";
+import type { ResumeLibrary } from "../../hooks/useResumeLibrary.ts";
+
+interface SaveResumeBarProps {
+  library: ResumeLibrary;
+  fileName: string;
+  bytes?: ArrayBuffer;
+  sourceKind: "pdf" | "docx";
+  result: CascadeResult;
+  score: AnonymousAtsScore;
+}
+
+export function SaveResumeBar({
+  library,
+  fileName,
+  bytes,
+  sourceKind,
+  result,
+  score,
+}: SaveResumeBarProps) {
+  const [savedId, setSavedId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const id = await library.save({
+        id: savedId ?? undefined,
+        filename: fileName,
+        bytes,
+        sourceKind,
+        result,
+        score,
+      });
+      setSavedId(id);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border-light bg-surface-subtle px-4 py-3">
+      <p className="text-sm text-content-secondary">
+        {savedId === null
+          ? "Keep this resume to reload later — saved only in this browser."
+          : "Saved to your library on this browser."}
+      </p>
+      <Button variant="ghost" size="sm" disabled={saving} onClick={() => void save()}>
+        {saving
+          ? "Saving…"
+          : savedId === null
+            ? "Save to library"
+            : "Update saved copy"}
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -33,6 +33,7 @@ import {
   clearBlankDraft,
   type ParseState,
   type BlankDraftSnapshot,
+  type LoadedDoneState,
 } from "./useResumeAnalysis.ts";
 import {
   useEditableParse,
@@ -79,6 +80,8 @@ export interface AnalyzedResume {
   /** Discard a previously-detected draft and start a fresh blank resume.
    *  No-op outside an unresolved draft prompt. */
   startOverBlank: () => void;
+  /** Hydrate the results view from a saved resume (#322) — no re-parse. */
+  loadSavedResume: (saved: LoadedDoneState) => void;
 }
 
 export function useAnalyzedResume(): AnalyzedResume {
@@ -90,6 +93,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     startBlank,
     resolveDraftPrompt,
     startOverBlank,
+    loadSavedResume,
   } = useResumeAnalysis();
 
   // Lifted edit state (#82): overrides live ABOVE the scorer so a corrected
@@ -324,5 +328,6 @@ export function useAnalyzedResume(): AnalyzedResume {
     startBlank,
     resumeDraft,
     startOverBlank,
+    loadSavedResume,
   };
 }

--- a/src/hooks/useResumeAnalysis.ts
+++ b/src/hooks/useResumeAnalysis.ts
@@ -106,6 +106,20 @@ export interface ResumeAnalysis {
   /** Start a genuinely fresh blank session (used by "start over"): clears
    *  `pendingDraft` AND bumps `generation` so the reset-edits effect fires. */
   startOverBlank: () => void;
+  /** Hydrate the "done" state directly from a saved resume (#322) — restores
+   *  the results view from a cached parse without re-running the cascade. */
+  loadSavedResume: (saved: LoadedDoneState) => void;
+}
+
+/** The pieces the resume library replays into the "done" state (#322). Mirrors
+ *  the `done` phase fields the parse pipeline produces. */
+export interface LoadedDoneState {
+  fileName: string;
+  fileSize: number;
+  bytes?: ArrayBuffer;
+  sourceKind: SourceKind;
+  result: CascadeResult;
+  score: AnonymousAtsScore;
 }
 
 // ── Draft persistence (#313) ─────────────────────────────────────────────────
@@ -256,6 +270,12 @@ export function useResumeAnalysis(): ResumeAnalysis {
     setState({ phase: "idle" });
   }, []);
 
+  const loadSavedResume = useCallback((saved: LoadedDoneState) => {
+    // Restore the results view straight from the cached parse (#322) — same
+    // shape `handleFile` would set after a live parse, minus the re-run.
+    setState({ phase: "done", ...saved });
+  }, []);
+
   // Monotonic source of "fresh authoring generation" ids. A ref (not state)
   // because minting one must not itself trigger a render — only the
   // `generation` value stored on `ParseState` does that. Never reset, even
@@ -313,5 +333,6 @@ export function useResumeAnalysis(): ResumeAnalysis {
     startBlank,
     resolveDraftPrompt,
     startOverBlank,
+    loadSavedResume,
   };
 }

--- a/src/hooks/useResumeLibrary.ts
+++ b/src/hooks/useResumeLibrary.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * useResumeLibrary — UI-facing state over the resume-library domain layer
+ * (#322). Owns the reactive list, the storage-persistence signal, and the
+ * approximate space-used figure; delegates all persistence to
+ * `src/lib/resume-library.ts` and `src/lib/storage`. Mutations refresh the list
+ * so the picker stays in sync without the caller re-fetching.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  listLibrary,
+  saveResumeToLibrary,
+  loadResumeFromLibrary,
+  renameLibraryResume,
+  removeLibraryResume,
+  estimateStorageUsage,
+  type ResumeLibraryEntry,
+  type LoadedResume,
+} from "../lib/resume-library.ts";
+import {
+  requestStoragePersistence,
+  isStoragePersisted,
+  exportToJson,
+} from "../lib/storage/index.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../lib/score/score.ts";
+
+export interface SaveResumeParams {
+  id?: string;
+  filename: string;
+  bytes?: ArrayBuffer;
+  sourceKind: "pdf" | "docx";
+  result: CascadeResult;
+  score: AnonymousAtsScore;
+}
+
+export interface ResumeLibrary {
+  entries: ResumeLibraryEntry[];
+  /** True once the initial list load has resolved. */
+  ready: boolean;
+  /** IndexedDB persistence grant: true = exempt from eviction, false =
+   *  best-effort (surface the eviction notice). */
+  persisted: boolean;
+  /** Approximate bytes used by this origin's storage, or null if unknown. */
+  usageBytes: number | null;
+  save: (params: SaveResumeParams) => Promise<string>;
+  load: (id: string) => Promise<LoadedResume | undefined>;
+  rename: (id: string, filename: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  /** Download the full storage export as a JSON backup file. */
+  exportBackup: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useResumeLibrary(): ResumeLibrary {
+  const [entries, setEntries] = useState<ResumeLibraryEntry[]>([]);
+  const [ready, setReady] = useState(false);
+  const [persisted, setPersisted] = useState(false);
+  const [usageBytes, setUsageBytes] = useState<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    const [list, usage] = await Promise.all([
+      listLibrary(),
+      estimateStorageUsage(),
+    ]);
+    setEntries(list);
+    setUsageBytes(usage);
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    void isStoragePersisted().then(setPersisted);
+  }, [refresh]);
+
+  const save = useCallback(
+    async (params: SaveResumeParams) => {
+      // Ask for durable storage on first save; reflect the grant so the UI can
+      // drop the eviction warning when it's granted.
+      const granted = await requestStoragePersistence();
+      setPersisted((prev) => prev || granted);
+      const id = await saveResumeToLibrary(params);
+      await refresh();
+      return id;
+    },
+    [refresh],
+  );
+
+  const load = useCallback((id: string) => loadResumeFromLibrary(id), []);
+
+  const rename = useCallback(
+    async (id: string, filename: string) => {
+      await renameLibraryResume(id, filename);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await removeLibraryResume(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const exportBackup = useCallback(async () => {
+    const json = await exportToJson();
+    const url = URL.createObjectURL(
+      new Blob([json], { type: "application/json" }),
+    );
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "resumelint-backup.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  return {
+    entries,
+    ready,
+    persisted,
+    usageBytes,
+    save,
+    load,
+    rename,
+    remove,
+    exportBackup,
+    refresh,
+  };
+}

--- a/src/lib/resume-library.test.ts
+++ b/src/lib/resume-library.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Resume-library domain tests (#322): save → list → load → rename → delete
+ * against `fake-indexeddb`, exercising the real storage foundation. Asserts the
+ * cached parse round-trips losslessly (including a `Map`, which IndexedDB
+ * structured clone preserves) and that source bytes reload byte-identically.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DB_NAME, closeDB } from "./storage/index.ts";
+import {
+  saveResumeToLibrary,
+  listLibrary,
+  loadResumeFromLibrary,
+  renameLibraryResume,
+  removeLibraryResume,
+} from "./resume-library.ts";
+import type { CascadeResult } from "./heuristics/types.ts";
+import type { AnonymousAtsScore } from "./score/score.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+const bytes = () => new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x00, 0xff]); // %PDF + binary
+
+// Minimal stand-ins — the library treats `result` opaquely and only reads
+// `score.overall`. The `sections.byName` Map proves structured clone survives.
+const result = () =>
+  ({
+    marker: "cascade-42",
+    sections: { byName: new Map([["skills", 3]]) },
+  }) as unknown as CascadeResult;
+const score = (overall: number) => ({ overall }) as AnonymousAtsScore;
+
+async function save(filename: string, overall = 72) {
+  return saveResumeToLibrary({
+    filename,
+    bytes: bytes().buffer,
+    sourceKind: "pdf",
+    result: result(),
+    score: score(overall),
+  });
+}
+
+describe("resume-library: save + list", () => {
+  it("lists saved resumes newest-first with score + kind", async () => {
+    await save("general.pdf", 71);
+    await save("tailored.pdf", 84);
+    const list = await listLibrary();
+    expect(list).toHaveLength(2);
+    expect(list.map((e) => e.filename)).toEqual(["tailored.pdf", "general.pdf"]);
+    expect(list[0]).toMatchObject({ scoreOverall: 84, sourceKind: "pdf" });
+  });
+});
+
+describe("resume-library: load", () => {
+  it("restores the cached parse (Map intact) and byte-identical bytes", async () => {
+    const id = await save("cv.pdf", 66);
+    const loaded = await loadResumeFromLibrary(id);
+    expect(loaded).toBeDefined();
+    expect(loaded!.score.overall).toBe(66);
+    expect(loaded!.sourceKind).toBe("pdf");
+    // Opaque cached parse round-trips, including the sections Map.
+    const r = loaded!.result as unknown as {
+      marker: string;
+      sections: { byName: Map<string, number> };
+    };
+    expect(r.marker).toBe("cascade-42");
+    expect(r.sections.byName.get("skills")).toBe(3);
+    // Source bytes reload byte-identically.
+    expect([...new Uint8Array(loaded!.bytes!)]).toEqual([...bytes()]);
+  });
+
+  it("returns undefined for a missing id", async () => {
+    expect(await loadResumeFromLibrary("nope")).toBeUndefined();
+  });
+});
+
+describe("resume-library: rename + delete", () => {
+  it("renames in place, preserving bytes and score", async () => {
+    const id = await save("draft.pdf", 55);
+    await renameLibraryResume(id, "final.pdf");
+    const list = await listLibrary();
+    expect(list).toHaveLength(1);
+    expect(list[0].filename).toBe("final.pdf");
+    expect(list[0].scoreOverall).toBe(55);
+    expect((await loadResumeFromLibrary(id))!.bytes).toBeDefined();
+  });
+
+  it("deletes an entry", async () => {
+    const id = await save("cv.pdf");
+    await removeLibraryResume(id);
+    expect(await listLibrary()).toHaveLength(0);
+  });
+});
+
+describe("resume-library: DOCX (no source bytes)", () => {
+  it("saves without bytes and reloads with bytes undefined", async () => {
+    const id = await saveResumeToLibrary({
+      filename: "cv.docx",
+      sourceKind: "docx",
+      result: result(),
+      score: score(60),
+    });
+    const loaded = await loadResumeFromLibrary(id);
+    expect(loaded!.sourceKind).toBe("docx");
+    expect(loaded!.bytes).toBeUndefined();
+    expect(loaded!.score.overall).toBe(60);
+  });
+});

--- a/src/lib/resume-library.ts
+++ b/src/lib/resume-library.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Resume library (#322) — the domain layer between the parse pipeline and the
+ * local-first storage foundation (#321). Maps a parsed resume to a saved
+ * `resumes` record and back, so a saved resume reloads straight into the results
+ * view from its cached parse (no re-run of the cascade).
+ *
+ * This is the first in-repo consumer of `@/lib/storage`, and the place the
+ * CascadeResult ↔ storage coupling lives — the foundation itself stays parser-
+ * agnostic (it holds the parse as an opaque `parse` payload). The cached parse
+ * round-trips via IndexedDB structured clone (which preserves the `sections`
+ * Map), so loading is lossless; only the JSON export path (backup.ts) is lossy,
+ * which is fine — export is a backup, not the reload path.
+ */
+
+import {
+  saveResume,
+  getResume,
+  getAllResumes,
+  deleteResume,
+} from "./storage/index.ts";
+import type { CascadeResult } from "./heuristics/types.ts";
+import type { AnonymousAtsScore } from "./score/score.ts";
+
+type SourceKind = "pdf" | "docx";
+
+const MIME: Record<SourceKind, string> = {
+  pdf: "application/pdf",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+};
+
+/** What we stash in the record's opaque `parse` slot: enough to restore the
+ *  results view without re-parsing. Internal to this module — callers go through
+ *  the save/load functions, not the raw snapshot. */
+interface SavedResumeSnapshot {
+  result: CascadeResult;
+  score: AnonymousAtsScore;
+  sourceKind: SourceKind;
+}
+
+/** A row in the library list — the light metadata the picker renders. */
+export interface ResumeLibraryEntry {
+  id: string;
+  filename: string;
+  /** Epoch ms of the last save (record `updatedAt`). */
+  savedAt: number;
+  /** Overall ATS score captured at save time. */
+  scoreOverall: number;
+  sourceKind: SourceKind;
+}
+
+/** Everything App needs to hydrate the "done" state from a saved resume. */
+export interface LoadedResume {
+  id: string;
+  filename: string;
+  fileSize: number;
+  /** Source bytes for the PDF preview; absent for DOCX (no preview, as live). */
+  bytes?: ArrayBuffer;
+  sourceKind: SourceKind;
+  result: CascadeResult;
+  score: AnonymousAtsScore;
+}
+
+function readSnapshot(parse: unknown): SavedResumeSnapshot | null {
+  const snap = parse as Partial<SavedResumeSnapshot> | undefined;
+  if (snap?.result == null || snap.score == null) return null;
+  return {
+    result: snap.result,
+    score: snap.score,
+    sourceKind: snap.sourceKind ?? "pdf",
+  };
+}
+
+/** Save (or overwrite, when `id` is given) a resume. Bytes are stored as a Blob
+ *  at rest; for DOCX (no source bytes kept in the done state) the blob is empty
+ *  and reload restores from the cached parse alone. Returns the record id. */
+export async function saveResumeToLibrary(input: {
+  id?: string;
+  filename: string;
+  bytes?: ArrayBuffer;
+  sourceKind: SourceKind;
+  result: CascadeResult;
+  score: AnonymousAtsScore;
+}): Promise<string> {
+  const blob = new Blob(input.bytes ? [input.bytes] : [], {
+    type: MIME[input.sourceKind],
+  });
+  const snapshot: SavedResumeSnapshot = {
+    result: input.result,
+    score: input.score,
+    sourceKind: input.sourceKind,
+  };
+  const record = await saveResume({
+    id: input.id,
+    filename: input.filename,
+    blob,
+    parse: snapshot,
+  });
+  return record.id;
+}
+
+/** List saved resumes, newest first. Records with a malformed snapshot are kept
+ *  in the list (score 0) rather than hidden — the user can still delete them. */
+export async function listLibrary(): Promise<ResumeLibraryEntry[]> {
+  const records = await getAllResumes();
+  return records
+    .map((r) => {
+      const snap = readSnapshot(r.parse);
+      return {
+        id: r.id,
+        filename: r.filename,
+        savedAt: r.updatedAt,
+        scoreOverall: snap?.score.overall ?? 0,
+        sourceKind: snap?.sourceKind ?? "pdf",
+      };
+    })
+    .sort((a, b) => b.savedAt - a.savedAt);
+}
+
+/** Load a saved resume for hydration into the results view. Returns `undefined`
+ *  when the record is gone or its cached parse is unreadable. */
+export async function loadResumeFromLibrary(
+  id: string,
+): Promise<LoadedResume | undefined> {
+  const record = await getResume(id);
+  if (record === undefined) return undefined;
+  const snap = readSnapshot(record.parse);
+  if (snap === null) return undefined;
+  const bytes =
+    record.blob.size > 0 ? await record.blob.arrayBuffer() : undefined;
+  return {
+    id: record.id,
+    filename: record.filename,
+    fileSize: record.blob.size,
+    bytes,
+    sourceKind: snap.sourceKind,
+    result: snap.result,
+    score: snap.score,
+  };
+}
+
+/** Rename a saved resume, preserving its bytes and cached parse. */
+export async function renameLibraryResume(
+  id: string,
+  filename: string,
+): Promise<void> {
+  const record = await getResume(id);
+  if (record === undefined) return;
+  await saveResume({ id, filename, blob: record.blob, parse: record.parse });
+}
+
+/** Delete a saved resume. */
+export function removeLibraryResume(id: string): Promise<void> {
+  return deleteResume(id);
+}
+
+/** Approximate bytes used by this origin's storage (for the "space used" note),
+ *  or null when the API is unavailable. */
+export async function estimateStorageUsage(): Promise<number | null> {
+  if (typeof navigator === "undefined" || !navigator.storage?.estimate) {
+    return null;
+  }
+  try {
+    const { usage } = await navigator.storage.estimate();
+    return usage ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What & why

Closes #322. Builds on the #321 IndexedDB storage foundation.

Users iterating on a resume (or juggling a general + a role-tailored version) had no way to keep more than one around, or to come back tomorrow and pick up where they left off. This adds a **local-first resume library**: save a parsed resume, list saved resumes, reload one **without re-uploading**, rename/delete. All local — resume bytes never leave the browser.

## How it works

- **`src/lib/resume-library.ts`** — the domain layer between the parse pipeline and storage, and the **first in-repo consumer of `@/lib/storage`** (so this PR drops the temporary fallow `entry` registered in #321). It maps a parse ↔ a `resumes` record: the cached parse rides in the record's opaque `parse` slot and round-trips **losslessly via IndexedDB structured clone** (which preserves the `sections` Map), so a reload is exact; source bytes reload **byte-identically**.
- **`useResumeLibrary`** — reactive list, persistence-grant signal, approximate space used, `save`/`load`/`rename`/`remove`, and a JSON **export-backup** download.
- **`useResumeAnalysis.loadSavedResume()`** — hydrates the `done` state directly from a cached parse (same shape a live parse produces, minus the cascade run). Threaded through `useAnalyzedResume`.
- **Feature components** (design-system primitives only, per the 3-tier rules):
  - `ResumeLibrary` — the picker beneath the drop zone; persistence `StatusBadge` + eviction transparency copy + **Export backup** + approx space used. Self-hides when empty.
  - `ResumeLibraryEntry` — rename via `EditableField`, **confirm-gated delete** via `Dialog`.
  - `SaveResumeBar` — the save affordance under a result; a second save updates the same record rather than minting a duplicate.
- **App** wires the picker (landing view) and the save bar (done view).

## Privacy

No network calls introduced; nothing leaves the browser. Loading restores from the local cached parse; the eviction notice + export path make the local-only, best-effort nature honest (per #321).

## Tests (`fake-indexeddb`)

save → list → load → rename → delete; cached-parse (Map intact) + byte-identical bytes round-trip; DOCX no-source-bytes path; missing-id guard.

## Acceptance criteria

- [x] Save, list, load, rename, delete work end-to-end offline.
- [x] Loading a saved resume restores the results view without re-uploading.
- [x] Persistence state + eviction copy visible in the library view; export reachable there.
- [x] Feature components under `src/components/features/` composed from `@design-system`; storage hook in `src/hooks/`.
- [x] `npm run verify` green (typecheck, eslint, build; new tests pass).

## Notes for the reviewer

- **fallow complexity (report-only):** `App.tsx` is flagged CRITICAL, but that's **inherited** — App was already a large CRITICAL wiring component; this PR adds ~40 lines and the diff-scoped gate excludes it as inherited. `ResumeLibrary` (display conditionals) and `estimateStorageUsage` (guard-heavy, 0% tested) are minor and report-only.
- **Flaky full-suite run:** one unrelated pre-existing test (`render-roundtrip.repro.test.ts`) hit a 10s `beforeAll` timeout under machine load in one `verify` run; it passes in isolation (766ms) and doesn't touch storage. Typecheck, lint, build, and all storage/library tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)