### PR TITLE
feat(probe): add probe-education skill + RL_EDUCATION_PDF vitest harness

### DIFF
--- a/.claude/skills/probe-education/SKILL.md
+++ b/.claude/skills/probe-education/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: probe-education
+description: Extract + verify the EDUCATION section (entries, degree, field, institution, location, dates, coursework) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/merged/under-chunked entry to the exact layer (header routing vs chunker vs field heuristic). Prints the header candidates the router saw and the education region it scanned next to the parsed entries, plus an independent header-recognition oracle that flags an education-like header the strict router rejected (leading-glyph, out-of-alias wording, two-line wrap) and a DEGREE_RE token count over the routed region as a lower-bound oracle for chunker under-segmentation. One of the `probe-*` parser probes (see also `probe-contact`, `probe-experience`, `probe-roundtrip`, `probe-skills`). Use when the user says "probe education", "/probe-education", "why is the degree/institution/coursework wrong", "education section isn't parsing", "why are two degrees showing as one entry", or hands you a résumé whose education entries parse wrong.
+---
+
+# Probe: Education
+
+> One of the `probe-*` parser-probe family (siblings: `probe-contact`,
+> `probe-experience`, `probe-roundtrip`, `probe-skills`). Type `probe-` to list
+> them all.
+
+Drop in **any** résumé PDF and see exactly what the parser reads for the
+education section — the parsed entries (degree, field, institution, location,
+dates, coursework), the education region the extractor scanned, and the header
+candidates the section router saw — and, when entries come back wrong, which
+layer is responsible. This is the tooling lane for the three education failure
+classes: a routing miss (`Academics` / `Qualifications` / `Education & Training`
+wording, leading decorative glyph, two-line-wrapped header), a chunker collapse
+(two degrees fold into one entry — the pattern that seeded #364 and its
+follow-ups), or a field heuristic drop (a specific field like `location` or
+`field` blanks even though the chunk looks right — the shape that seeded #366 /
+#367).
+
+It reuses a dev harness in `src/lib/heuristics/probe-education.test.ts` (the
+`RL_EDUCATION_PDF` block) — there is **no standalone script and you should not
+write one**: the pdfjs worker uses Vite's `?url` import, which resolves only
+under the Vite/vitest transform, so plain `tsx`/node breaks. The vitest run
+**is** the execution vehicle (same constraint as the sibling probes).
+
+## ⚠️ PII guardrail — read first
+
+This probe is meant to run on **real résumés with real candidate PII**. Same two
+hard rules as the sibling probes, non-negotiable:
+
+1. **The input PDF is local-only. NEVER commit it.** It is not a fixture. The
+   public repo's `tests/fixtures/pdfs/` is **synthetic-personas-only by policy**
+   (`tests/fixtures/pdfs/README.md`). A real résumé must never land there.
+2. **The output prints entry VALUES → scratch only.** The full JSON report
+   (including the dropped education content under a rejected header) is written
+   to the **gitignored** `internal/education/` dir; the console prints the
+   per-entry values so a value-level defect is visible. Do not paste raw
+   candidate values into an issue, PR, commit, or Slack — cite the corruption
+   by **category** ("education count 2 → 1; two-degree section collapsed into
+   one entry", "field dropped though present in the degree line"), never the
+   value.
+
+If you are ever unsure whether a path is committed, stop and check `git status` /
+`.gitignore` before running.
+
+## Run it
+
+```bash
+RL_EDUCATION_PDF=/abs/path/to/real-resume.pdf \
+  npx vitest run src/lib/heuristics/probe-education.test.ts
+```
+
+Use an **absolute path** for `RL_EDUCATION_PDF`.
+
+### Env vars
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RL_EDUCATION_PDF` | *(unset)* | Absolute path to the résumé PDF. When unset the harness is **inert** (skipped) — CI never runs it. |
+| `RL_EDUCATION_OUT` | `internal/education/` | Directory for the full JSON report. The default lives under `internal/`, which is **gitignored**. Override only with another gitignored/out-of-repo path. |
+
+## What you get
+
+Six blocks, printed to the console (full JSON mirrored to the gitignored dir):
+
+1. **Score** — `overall` (+ pre-layout and the layout multiplier/triggers), so
+   a parse failure's score impact is visible in the same run.
+2. **Sections detected** — every routed region with its line count
+   (`profile(3) experience(17) education(6) …`). **No `education(...)` entry**
+   here is the first signal the section never routed.
+3. **Parsed education entries** — one row per entry with `degree`, `field`,
+   `institution`, `location`, `start_date → end_date`, `year`, and coursework
+   count. This is the OUTPUT. `(none)` means zero entries reached the model.
+4. **Education region scanned** — the `sections.byName.get("education")` lines
+   the chunker actually saw, plus a count of `DEGREE_RE` tokens inside them.
+   This is the INPUT on the routed path. `(empty)` means the router never
+   handed an education region to the chunker → the failure is upstream, at
+   header routing.
+5. **Education-like headers the router REJECTED** — the independent oracle.
+   Header candidates from the ordered markdown whose text loosely reads as
+   education but which `matchSectionHeader` did **not** map to education, each
+   with the reason the strict matcher missed it (leading-glyph prefix,
+   out-of-alias wording). When a header is rejected, the dropped education
+   content beneath it (up to the next header) is captured to the JSON and its
+   line count shown.
+6. **Per-entry field presence** — for each parsed entry, which of
+   `institution`, `degree`, `date` came back empty. Catches silent per-entry
+   drops even when the count is right.
+
+The **Verify** verdict is the fast triage:
+- `ok (N education entries parsed)` — entries came through; no count mismatch.
+- `EXTRACTION-MISS` — an `education` region WAS routed but 0 entries parsed →
+  the bug is in the chunker or field heuristics, not routing.
+- `HEADER-UNRECOGNIZED` — no region routed, but an education-like header exists
+  that the strict router rejected → the routing class (leading glyph / alias
+  miss / two-line wrap); the reason names why the strict matcher missed it.
+- `UNDER-CHUNKED (N entries < M DEGREE_RE tokens in region)` — the region has
+  more degree tokens than entries → two degrees likely collapsed into one entry.
+  This is the #364-class shape: fix belongs in the `flush` / boundary logic in
+  `educationFromChunk`.
+- `NO-EDUCATION-SECTION` — no routed region and no education-like header
+  candidate → the résumé likely has no education section, or its header is
+  entirely outside the recognized surface.
+
+The oracle is deliberately a **lower** bound: a degree-less program entry
+(`MIT Applied Data Science Program (2023) — MIT Professional Education`, #238)
+legitimately contributes an entry with no `DEGREE_RE` match, so `entries >
+regionDegrees` is never flagged — only the reverse direction is.
+
+## Reading the result — localize the layer
+
+An education error can drop at three layers. The probe's routed-region-vs-
+header-candidate split + the per-entry presence block together point at which
+one:
+
+- **Section routing** (`matchSectionHeaderDetailed` in
+  `src/lib/heuristics/regex.ts`) — the header exists in the document but the
+  exact-match router rejected it (leading glyph, wording not in
+  `SECTION_KEYWORDS.education` aliases, two-line wrap), so no education region
+  was ever handed downstream. Verdict `HEADER-UNRECOGNIZED`; block 4 shows an
+  empty region and block 5 names the rejected header.
+- **Chunker** (`extractEducation`'s per-entry grouper in
+  `src/lib/heuristics/extract/education.ts`) — the region routed fine but the
+  entry count is wrong. Verdict `UNDER-CHUNKED` (region has more `DEGREE_RE`
+  tokens than entries) or `EXTRACTION-MISS` (region routed with N lines but
+  0 entries — every line was rejected by the chunker's shape guards). Fix
+  lives in the `flush()` / `startsHintlessEntry` / `isDupDegreeSubLine`
+  boundary logic.
+- **Field heuristic** (`educationFromChunk`, `parseDegreeAndField`,
+  `stripInstitutionLocation`, `stripInstitutionDate`, `parseEducationDates` in
+  the same file) — the count is right but a specific field is empty or
+  corrupted. Per-entry presence block (block 6) will flag `institution`
+  (acronym-only school the entry-header shape rejected), `degree` (chunker
+  matched a stray "BA" outside a real degree), or `date` (letter-spaced or
+  redacted `20XX` year the date primitive missed). Fix lives in the specific
+  per-field helper.
+
+## Filing what you find (gated auto-file)
+
+Once you've localized the layer, you can turn the finding into a
+`resumelint-org/resumelint` issue **without leaving the probe** — via the
+in-repo [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is
+**gated**: draft, show, confirm, then write. Never blast-file.
+
+**PII guardrail carries over unchanged.** The issue body must describe the
+corruption **by category with a synthetic repro** — never the candidate's real
+values. The category is what you cite in the console ("education count 2 → 1;
+two-degree section collapsed", "institution bled with trailing location string
+`University … Seattle, WA`"); the values stay in the gitignored scratch dir.
+If you can't restate the defect without a real value, you can't file it yet —
+build the synthetic repro first.
+
+### 1. Dedup first (required)
+
+Before drafting, search open issues for the same **layer + symptom** so you
+don't pile onto existing open education parser bugs (e.g. #364-class chunker
+collapses, #366-class institution/location gluing, #371-class annotation-date
+mis-selection):
+
+```bash
+gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+  --search "education <symptom keyword>"   # e.g. "education chunker collapse"
+```
+
+If a match already covers this layer+symptom, **stop** — link the existing
+issue instead of filing. Only file when nothing matches.
+
+### 2. Draft by category
+
+Build a self-contained finding from the probe's six blocks, values scrubbed to
+categories:
+
+- **Title** — the defect + localized layer, e.g. `[parser] education —
+  degree line reused as institution when the two share one line`.
+- **Body** — sections detected (region names + line counts, not values), the
+  entry count vs `DEGREE_RE` region-token count (`2 → 1`), the `verify`
+  verdict (`UNDER-CHUNKED` / `EXTRACTION-MISS` / `HEADER-UNRECOGNIZED`), and
+  the localized layer (routing / chunker / field heuristic) with the specific
+  file + function (`matchSectionHeaderDetailed` in `regex.ts`,
+  `educationFromChunk` / `parseDegreeAndField` / `stripInstitutionLocation` in
+  `extract/education.ts`).
+- **Synthetic repro** — a synthetic-persona PDF (fake name, `@example.com`, a
+  `555`-exchange phone on a real area code, subscriber `0100`–`0199`) that
+  reproduces the same category of corruption. See
+  `tests/fixtures/pdfs/README.md` for the add-fixture workflow.
+
+### 3. Show + confirm, then write
+
+Print the drafted title + body and the labels you'll use, and **wait for an
+explicit human confirm**. On confirm, write via the `create-gh-issue` skill
+(which owns the `scripts/create-gh-issue.sh` write path, label handling, and
+body-file escaping) — do **not** hand-roll a parallel `gh issue create` here.
+`bug` is the default type label; add `testing` when the fix seeds a corpus
+fixture.
+
+## Boundaries
+
+- This is a **dev/triage tool**, not a CI gate. It is informational: the
+  harness never reddens the suite, so a PII résumé with a known bug won't fail
+  the run.
+- The PII-free enforcement lane is the corpus gate (`corpus.test.ts`) over
+  **synthetic fixtures** — this probe is the manual lane over **real** ones.
+  Don't confuse the two.

--- a/src/lib/heuristics/probe-education.test.ts
+++ b/src/lib/heuristics/probe-education.test.ts
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Education-section dev probe — inert in CI, runs ONLY when
+ * `RL_EDUCATION_PDF=<path>` is set:
+ *
+ *   RL_EDUCATION_PDF=/abs/path/to/resume.pdf npx vitest run \
+ *     src/lib/heuristics/probe-education.test.ts
+ *
+ * Extracts + VERIFIES the education section of one arbitrary PDF so a real
+ * (uncommitted, possibly PII-bearing) résumé can be triaged WITHOUT being
+ * committed as a fixture. This is the execution vehicle for the
+ * `probe-education` skill — sibling of `probe-contact` / `probe-experience` /
+ * `probe-roundtrip` / `probe-skills`; the pattern is identical: run the real
+ * parser via runCascade (the pdfjs worker only resolves under the vitest
+ * transform — no standalone script), then show the section router's INPUT (the
+ * header candidates + the education region it scanned) next to its OUTPUT
+ * (the parsed entries) so a dropped / merged / mis-chunked entry is
+ * localizable to a layer.
+ *
+ * ── PII guardrail (same rules as the sibling probes) ──
+ * 1. The input PDF is local-only. NEVER commit it. `tests/fixtures/pdfs/` is
+ *    synthetic-personas-only by policy.
+ * 2. The console + JSON output prints degree / institution / field / date
+ *    VALUES so the corruption is visible → scratch only. The full JSON goes to
+ *    the gitignored `internal/education/` dir. Do not paste raw values into an
+ *    issue / PR / Slack — cite the corruption by CATEGORY ("education count
+ *    2 → 1; two-degree section collapsed into one entry", "field dropped
+ *    though present in the degree line").
+ *
+ * ── The "verify" pass ──
+ * There is no ground truth for a real résumé, so verification is an
+ * independent scan of the document's header candidates + a `DEGREE_RE`-token
+ * count over the ROUTED region. The oracle:
+ *   - parsed entries > 0, no count mismatch          → ok
+ *   - 0 entries, education region WAS routed         → EXTRACTION-MISS (region
+ *     found; the chunker or field heuristic rejected every candidate line)
+ *   - 0 entries, NO region, but a header candidate loosely reads as education
+ *     that the strict matcher rejected                → HEADER-UNRECOGNIZED
+ *     (leading glyph, out-of-alias wording, two-line wrap — the routing class)
+ *   - entries > 0 AND region has MORE `DEGREE_RE` tokens than entries
+ *                                                     → UNDER-CHUNKED (two
+ *     degrees collapsed into one entry, or a section-routing bug narrowed the
+ *     region so a degree line landed outside it)
+ *   - 0 parsed, nothing education-like anywhere      → NO-EDUCATION-SECTION
+ *
+ * A degree-less program entry (e.g. "MIT Applied Data Science Program (2023) —
+ * MIT Professional Education", #238) legitimately contributes an entry with
+ * NO `DEGREE_RE` match, so `entries > regionDegrees` is intentionally NOT
+ * flagged — the oracle is a lower bound, not an upper bound.
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { runCascade } from "./cascade.ts";
+import { matchSectionHeader, SECTION_KEYWORDS, DEGREE_RE } from "./regex.ts";
+import { SECTION_ANCHORS } from "./sections.config.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const EDUCATION_ALIASES: readonly string[] = SECTION_KEYWORDS.education ?? [];
+const EDUCATION_ANCHORS: ReadonlySet<string> =
+  SECTION_ANCHORS.education ?? new Set<string>();
+
+/**
+ * Loose education-header oracle. Mirrors the strict normalizer in
+ * `matchSectionHeaderDetailed` (trim + lowercase + trailing-punct strip) but
+ * ALSO strips a leading run of non-letter / non-number glyphs — the exact gap
+ * the routing miss classes (leading decorative glyph, out-of-alias wording)
+ * exploit. Returns the reason a strict match would have failed, or null if
+ * the line doesn't read as education at all.
+ */
+function looseEducationReason(raw: string): string | null {
+  const trimmedLower = raw.trim().toLowerCase().replace(/[:·•]+$/, "").trim();
+  const glyphStripped = trimmedLower.replace(/^[^\p{L}\p{N}]+/u, "").trim();
+  if (glyphStripped.length === 0 || glyphStripped.length > 40) return null;
+  if (EDUCATION_ALIASES.includes(glyphStripped)) {
+    return glyphStripped === trimmedLower
+      ? "alias match (would route — not a miss)"
+      : `leading-glyph prefix (${JSON.stringify(trimmedLower)} → ${JSON.stringify(glyphStripped)})`;
+  }
+  const tokens = glyphStripped.split(/\s+/).filter(Boolean);
+  if (tokens.some((t) => EDUCATION_ANCHORS.has(t)))
+    return `contains education anchor token but wording not in aliases (${JSON.stringify(glyphStripped)})`;
+  return null;
+}
+
+/** Count `DEGREE_RE` matches in `text` via a fresh global clone. `DEGREE_RE`
+ *  is non-global to keep `lastIndex` state out of the field heuristics, so
+ *  cloning here is the safe way to count without mutating the shared
+ *  instance. */
+function countDegrees(text: string): number {
+  const flags = DEGREE_RE.flags.includes("g")
+    ? DEGREE_RE.flags
+    : `${DEGREE_RE.flags}g`;
+  return (text.match(new RegExp(DEGREE_RE.source, flags)) ?? []).length;
+}
+
+describe.runIf(process.env.RL_EDUCATION_PDF)(
+  "education dev probe (RL_EDUCATION_PDF)",
+  () => {
+    // Deliberate monolithic diagnostic harness (mirrors probe-skills /
+    // probe-experience): one linear read-out of parse → verdict so the whole
+    // triage is visible in a single scroll. Not production logic.
+    // fallow-ignore-next-line complexity
+    it("extracts + verifies the education section for RL_EDUCATION_PDF", async () => {
+      const path = process.env.RL_EDUCATION_PDF!;
+      const outDir =
+        process.env.RL_EDUCATION_OUT ??
+        join(HERE, "../../..", "internal/education");
+
+      const cascade = await runCascade(new Uint8Array(readFileSync(path)));
+      const p = cascade.parsed;
+
+      const score = computeAnonymousAtsScore({
+        parsed: { ...p },
+        fieldConfidence: cascade.fieldConfidence,
+        triggers: cascade.triggers,
+        rawText: cascade.rawText,
+        sections: cascade.sections,
+      });
+
+      // OUTPUT: the parsed education entries.
+      const entries = (p.education ?? []).map((e) => ({
+        institution: e.institution || null,
+        degree: e.degree || null,
+        field: e.field ?? null,
+        location: e.location ?? null,
+        start_date: e.start_date ?? null,
+        end_date: e.end_date ?? null,
+        year: e.year ?? null,
+        coursework: e.coursework?.length ?? 0,
+      }));
+
+      // INPUT (routed): the education region the chunker scanned, if any.
+      const educationRegion = [
+        ...(cascade.sections.byName.get("education") ?? []),
+      ];
+      const regionPresent = educationRegion.length > 0;
+
+      // Section-detection overview (all regions, line counts only).
+      const sectionOverview = [...cascade.sections.byName.entries()].map(
+        ([name, lines]) => `${name}(${lines.length})`,
+      );
+
+      // Header candidates from the ordered markdown (`#`/`##`/`###` lines).
+      // The markdown header heuristic is looser than the router, so a rejected
+      // education header still shows up here — that is exactly what localizes
+      // a routing miss.
+      const md = cascade.markdown ?? "";
+      const mdLines = md.split("\n");
+      const headerCandidates = mdLines
+        .map((l, i) => ({
+          text: l.replace(/^#{1,3}\s+/, "").trim(),
+          i,
+          isHeader: /^#{1,3}\s+/.test(l),
+        }))
+        .filter((h) => h.isHeader && h.text.length > 0);
+
+      // An education-like header the strict router did NOT map to education.
+      const missedEducationHeaders = headerCandidates
+        .map((h) => ({
+          ...h,
+          strict: matchSectionHeader(h.text),
+          reason: looseEducationReason(h.text),
+        }))
+        .filter(
+          (h) =>
+            h.strict !== "education" &&
+            h.reason !== null &&
+            !h.reason.startsWith("alias match"),
+        );
+
+      // The markdown block under the first missed header (its dropped
+      // content), up to the next markdown header. Scrubbed to a line count in
+      // the console; full text only in the gitignored JSON.
+      const orphanBlock: string[] = [];
+      if (missedEducationHeaders.length > 0) {
+        const start = missedEducationHeaders[0].i + 1;
+        for (let i = start; i < mdLines.length; i++) {
+          if (/^#{1,3}\s+/.test(mdLines[i])) break;
+          if (mdLines[i].trim()) orphanBlock.push(mdLines[i].trim());
+        }
+      }
+
+      // Count `DEGREE_RE` tokens inside the routed region — a LOWER-BOUND
+      // oracle for entry count. `entries < regionDegrees` flags UNDER-CHUNKED
+      // (two degrees collapsed into one). `entries > regionDegrees` is NOT
+      // flagged — a degree-less program (#238) legitimately produces an entry
+      // with no `DEGREE_RE` match.
+      const regionDegrees = countDegrees(educationRegion.join("\n"));
+
+      // Per-entry field-presence sanity check. Not a wrong-value oracle (no
+      // ground truth for a real résumé) — just a presence gate that catches
+      // silent per-entry drops even when the count is right.
+      const perEntry = entries.map((e, i) => {
+        const missing: string[] = [];
+        if (!e.institution) missing.push("institution");
+        if (!e.degree) missing.push("degree");
+        if (!e.start_date && !e.end_date) missing.push("date");
+        return { i, missing };
+      });
+
+      let verdict: string;
+      if (entries.length === 0 && regionPresent) {
+        verdict = `EXTRACTION-MISS (education region routed with ${educationRegion.length} lines but 0 entries)`;
+      } else if (entries.length === 0 && missedEducationHeaders.length > 0) {
+        verdict = `HEADER-UNRECOGNIZED (education-like header rejected by the strict router → ${missedEducationHeaders[0].reason})`;
+      } else if (entries.length === 0) {
+        verdict =
+          "NO-EDUCATION-SECTION (no routed region and no education-like header candidate)";
+      } else if (regionDegrees > entries.length) {
+        verdict = `UNDER-CHUNKED (${entries.length} entries < ${regionDegrees} DEGREE_RE tokens in region — a degree line likely merged with a neighbour)`;
+      } else {
+        verdict = `ok (${entries.length} education entries parsed)`;
+      }
+
+      const report = {
+        path,
+        score: {
+          overall: score.overall,
+          preLayoutOverall: score.preLayoutOverall,
+          layoutTriggers: [...score.layout.triggers],
+          layoutMultiplier: score.layout.multiplier,
+        },
+        sectionOverview,
+        entries,
+        perEntry,
+        educationRegion,
+        regionDegrees,
+        headerCandidates: headerCandidates.map((h) => ({
+          text: h.text,
+          strict: matchSectionHeader(h.text),
+        })),
+        missedEducationHeaders: missedEducationHeaders.map((h) => ({
+          text: h.text,
+          reason: h.reason,
+        })),
+        orphanBlock,
+        verdict,
+        triggers: [...cascade.triggers],
+      };
+
+      mkdirSync(outDir, { recursive: true });
+      const outFile = join(
+        outDir,
+        `education-${basename(path).replace(/\.[^.]+$/, "")}.json`,
+      );
+      writeFileSync(outFile, JSON.stringify(report, null, 2));
+
+      const entryLines = entries.length
+        ? entries
+            .map(
+              (e, i) =>
+                `    ${i + 1}. degree=${JSON.stringify(e.degree)}  field=${JSON.stringify(e.field)}\n` +
+                `       institution=${JSON.stringify(e.institution)}  location=${JSON.stringify(e.location)}\n` +
+                `       dates=${JSON.stringify(e.start_date)} → ${JSON.stringify(e.end_date)}  year=${JSON.stringify(e.year)}  coursework=${e.coursework}`,
+            )
+            .join("\n")
+        : "    (none)";
+
+      const perEntryLines = perEntry
+        .map(
+          (p) =>
+            `    ${p.i + 1}. ${
+              p.missing.length === 0
+                ? "all present"
+                : `MISSING: ${p.missing.join(", ")}`
+            }`,
+        )
+        .join("\n");
+
+      console.log(
+        `RL_EDUCATION_PDF education probe for ${path}:\n` +
+          `\n  Score: overall ${score.overall} (pre-layout ${score.preLayoutOverall}, ` +
+          `layout ×${score.layout.multiplier} [${score.layout.triggers.join(", ") || "none"}])\n` +
+          `\n  Sections detected: ${sectionOverview.join("  ")}\n` +
+          `\n  Parsed education entries (${entries.length}):\n` +
+          entryLines +
+          `\n\n  Education region scanned (${educationRegion.length} lines, ` +
+          `${regionDegrees} DEGREE_RE tokens):\n` +
+          (educationRegion.length
+            ? educationRegion.map((l) => `    | ${l}`).join("\n")
+            : "    (empty — no education region routed)") +
+          `\n\n  Education-like headers the router REJECTED (${missedEducationHeaders.length}):\n` +
+          (missedEducationHeaders.length
+            ? missedEducationHeaders
+                .map((h) => `    | ${JSON.stringify(h.text)} — ${h.reason}`)
+                .join("\n")
+            : "    (none)") +
+          (orphanBlock.length
+            ? `\n\n  Dropped education content under that header (${orphanBlock.length} lines — values in JSON):`
+            : "") +
+          (entries.length
+            ? `\n\n  Per-entry field presence:\n${perEntryLines}`
+            : "") +
+          `\n\n  Verify: ${verdict}` +
+          `\n\n  Full JSON → ${outFile}  ⚠️ gitignored; may carry PII, do NOT commit.`,
+      );
+
+      // Informational only: never fails the suite.
+      expect(true).toBe(true);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Adds `probe-education`, the fifth `probe-*` parser probe (siblings: `probe-contact` / `probe-experience` / `probe-roundtrip` / `probe-skills`) — the triage tooling lane for the **education-section extraction failure classes**.

It runs the real `runCascade` parser over an arbitrary, uncommitted résumé PDF and prints the section router's **INPUT** (the header candidates it saw + the routed education region + `DEGREE_RE` token count in the region) next to its **OUTPUT** (the parsed entries — degree / field / institution / location / dates / coursework), plus an independent header-recognition oracle and per-entry field-presence check. The verdict localizes a dropped / wrong / mis-chunked entry to its layer:

- `ok` — entries parsed, no count mismatch
- `EXTRACTION-MISS` — an education region **was** routed but 0 entries parsed → bug in `educationFromChunk` (chunker or field heuristics), not routing
- `HEADER-UNRECOGNIZED` — no region routed, but an education-like header was rejected by the exact-match router (leading-glyph class, out-of-alias wording); the reason names *why* the strict match failed
- `UNDER-CHUNKED` — region has more `DEGREE_RE` tokens than entries → the #364-class shape (two degrees collapsed into one entry, or a section-routing bug narrowed the region)
- `NO-EDUCATION-SECTION` — no routed region and no education-like header candidate

The `DEGREE_RE`-in-region count is a deliberate **lower** bound: a degree-less program entry (#238, e.g. `MIT Applied Data Science Program (2023)`) legitimately contributes an entry with no `DEGREE_RE` match, so `entries > regionDegrees` is intentionally **not** flagged — only the reverse direction is.

**Tooling:**
- `src/lib/heuristics/probe-education.test.ts` — the `RL_EDUCATION_PDF`-gated dev harness. Inert in CI (skipped unless the env var is set), so it never reddens the suite. Follows the monolithic-diagnostic-harness pattern established by `probe-skills` / `probe-experience` — a single linear read-out of parse → verdict.
- `.claude/skills/probe-education/SKILL.md` — the skill, with the same PII guardrail as its siblings (real PDF never committed; values → gitignored `internal/education/`) and the gated-auto-file workflow via the `create-gh-issue` skill.

Refs #364, #366, #367, #371, #375 (the education-parser bugs the initial version of this probe helped surface during the F&F QC — all closed in the #392 → #417 batch). This class of tooling stays as the triage lane for future education failure classes.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Harness inert (`1 test | 1 skipped`) when `RL_EDUCATION_PDF` unset — CI-safe
- [x] `npm run verify` green (fallow report-only warning noted below)
- [x] Spot-checked against 3 corpus fixtures with distinct verdicts:
  - `synthetic-degreeless-two-programs.pdf` → `ok (2 entries)` — the previous version's OVER-SPLIT false-positive on this shape is fixed by dropping the upper-bound check
  - `latex/multi-degree-coursework.pdf` → `ok (2 entries, 2 DEGREE_RE tokens)`
  - `google-docs/google-docs-skia-proxy-achievements-oneline.pdf` → `ok (1 entry)` — with the #364 fix landed on main, `institution="State University"` now reads clean
- [x] Bash / `gh` commands in SKILL.md validated (both blocks: the run invocation and the dedup search)

## Notes

**Fallow duplication warning (report-only, not blocking):** fallow reports 10 clone groups (~282 lines total, ~71 lines with `probe-skills.test.ts`) that this diff introduces with the sibling probe test files. Groups cover the `looseXHeaderReason` helper shape, the `describe.runIf` + score-compute scaffold, the markdown-header-candidate + orphan-block extraction, and the JSON write + console output template.

This mirrors the intentional monolithic-diagnostic-harness pattern the sibling probes already ship (matches the same "test-scaffold shared with the sibling probes by design" acknowledgement in #416 for probe-skills). Deferring extraction to a follow-up refactor PR that touches all `probe-*.test.ts` files together, so the shape of the shared helper module can be decided in one place rather than piecemeal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)