### PR TITLE
chore(agy): make all resumelint skills available to agy

### DIFF
--- a/.agents/skills.json
+++ b/.agents/skills.json
@@ -1,0 +1,3 @@
+[
+  { "path": ".claude/skills" }
+]


### PR DESCRIPTION
## Summary

Adds `.agents/skills.json` so [agy](https://antigravity.google) (the Antigravity CLI) discovers this repo's 12 project skills. It points agy at the existing `.claude/skills/` directory via agy's documented shared-directory mechanism, so the skills stay single-sourced in `.claude/skills` (no duplication, no drift) and are available in both Claude Code and agy.

Verified locally: local skills load in an agy session in this workspace.

```json
[
  { "path": ".claude/skills" }
]
```

## Test plan

- [x] `agy` discovers the resumelint skills in this workspace (verified in an agy session)
- [x] `npm run typecheck` clean (no source touched — config-only)
- [x] `npm run test` green (no source touched — config-only)