### PR TITLE
fix(agy): skills.json object root so agy discovers project skills

### DIFF
--- a/.agents/skills.json
+++ b/.agents/skills.json
@@ -1,3 +1,1 @@
-[
-  { "path": ".claude/skills" }
-]
+{ "entries": [{ "path": ".claude/skills" }] }


### PR DESCRIPTION
## Summary

`.agents/skills.json` (added in #447) used a top-level JSON **array**:
`[ { "path": ".claude/skills" } ]`. agy's `skills.json` schema requires an
**object** root — `{ "entries": [...] }` / `{ "inherits": [...] }`, or the bare
`{ "path": ... }` shortcut. The array form fails agy's `ScanSkillsConfigFile`, so
a fresh agy scan discovers **zero** project skills ("No skills found") — the exact
regression #447 was meant to fix. It appeared to work until an agy restart
re-scanned the config strictly.

Fix: `{ "entries": [{ "path": ".claude/skills" }] }`. `.claude/skills` stays the
canonical single source; no skill files duplicated.

Refs #447

## Test plan

- [ ] `.agents/skills.json` is valid JSON with an object root
- [ ] Restart agy in the repo → all 12 `.claude/skills` project skills appear