### PR TITLE
refactor(export): move round-trip invariant onto canonical projection (#444, Stage C)

### DIFF
--- a/docs/canonical-resume-model.md
+++ b/docs/canonical-resume-model.md
@@ -171,7 +171,11 @@ if (cuts.length > 0 &&
 
 The *problem class* named in #438 is real — "is this line a category header or a dated entry?" is decided from **adjacent raw-line signals** (`isLoneDateRange` on the trailing segment) rather than from a structured field on a canonical model. The cited symbol is just wrong.
 
-**Acceptance test the canonical model must pass:** a one-line `Title  Dates` role under a section header routes as a **dated entry**, not a sub-section boundary, with the header-vs-entry call keyed off a structured `isDatedEntry` property on `CanonicalResume` — not off `isLoneDateRange`/`hasDateRange` re-scanning neighboring raw lines. Capture it as a fixture + assertion at Stage C (where the render+export projection takes over) and carry it green through Stage E.
+**Acceptance test the canonical model must pass:** a one-line `Title  Dates` role under a section header routes as a **dated entry**, not a sub-section boundary, with the header-vs-entry call keyed off a **derived** `isDatedEntry` predicate over the entry's structured dates — not off `isLoneDateRange`/`hasDateRange` re-scanning neighboring raw lines.
+
+> **§7 correction (folded in at Stage C, #444).** Earlier this read "keyed off a structured `isDatedEntry` **property** on `CanonicalResume`." That over-specified: the structure (`start_date` / `end_date` + precision) is **already** on the entry (`fields.experience[]` / `fields.education[]`). A stored `isDatedEntry` field would be a second entries representation parallel to the field core — exactly the parallel-shape lockstep cost this epic removes (considered and **rejected** via `/clarify`, 2026-07-11). So `isDatedEntry` is a **derived predicate** — `Boolean(start_date || end_date)` — over the dates the entry already holds (`isDatedEntry` in `pdf/ats-resume-model.ts`), never a new core or field. It answers §7's coarse "is this a dated entry at all"; the finer flush-right routing (`headerLineDate` / `subLineDate`) stays on `isLoneDateRange` over the *formatted* range, a render-shape concern Stage C keeps byte-identical.
+
+Capture it as a fixture + assertion at Stage C (where the render+export projection takes over) and carry it green through Stage E.
 
 ---
 

--- a/src/lib/heuristics/projections.ts
+++ b/src/lib/heuristics/projections.ts
@@ -23,11 +23,15 @@
  * recomputed from the canonical model, headings derived, etc.) without editing a
  * single call site.
  *
+ * Routed through {@link projectDisplay} as of Stage C (#444):
+ *   - `pdf/ats-resume-model.ts` — `buildAtsResumeModel` reads the field core and
+ *     `sectionHeadings` for the exported PDF through {@link projectDisplay} (the
+ *     render+export projection), not straight off `result.parsed` /
+ *     `result.sections`.
+ *
  * NOT yet routed through these projections (byte-identical today, but will drift
- * from the editor/scorer once Stage C+ makes a body re-derive — route them when
+ * from the editor/scorer once Stage D+ makes a body re-derive — route them when
  * that stage lands):
- *   - `pdf/ats-resume-model.ts` reads `result.sections?.sectionHeadings` for
- *     exported-PDF headings → fold into the render+export projection (Stage C).
  *   - `hooks/useResumeAnalysisLlm.ts` reads `result.sections.byName` for
  *     disagreement gating → fold into the llm-diff projection (Stage D).
  */

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -33,6 +33,8 @@ import {
 } from "../score/group-bullets.ts";
 import { buildProjectDates } from "../score/entry-dates.ts";
 import { isLoneDateRange } from "../heuristics/line-primitives.ts";
+import { canonicalFromCascade } from "../heuristics/canonical.ts";
+import { projectDisplay } from "../heuristics/projections.ts";
 import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
 import { buildContactFields, formatLinkDisplay } from "../contact.ts";
 import type {
@@ -332,6 +334,35 @@ function joinHeader(parts: Array<string | undefined>, sep: string): string {
   return parts.filter((p) => p && p.trim()).join(sep);
 }
 
+/**
+ * §7 header-vs-entry predicate (#444, `docs/canonical-resume-model.md` §7): an
+ * experience / education entry that carries any structured date **is** a dated
+ * entry by construction. The header-vs-entry classification the parser makes
+ * today from adjacent raw-line signals (`isLoneDateRange` on the trailing
+ * segment) has a structured answer already present on the canonical entry —
+ * `start_date` / `end_date` — so this reads that instead.
+ *
+ * DERIVED, not stored (locked via `/clarify`, 2026-07-11): `CanonicalResume`
+ * carries the dates on `fields.experience[]` / `fields.education[]`; adding an
+ * `isDatedEntry` field would be a second source of truth to keep in lockstep —
+ * the exact parallel-shape cost the epic (#441) removes. So it is a pure
+ * predicate over the dates the entry already holds.
+ *
+ * NOTE — this is NOT the flush-right routing discriminator. Whether a date draws
+ * flush-right (`headerLineDate` / `subLineDate`) still turns on
+ * {@link isLoneDateRange} over the *formatted* range, because that decision is a
+ * render-shape / re-parse concern (a lone `2020` or a season range stays glued;
+ * only a two-anchor range right-aligns), and Stage C keeps the rendered bytes
+ * byte-identical. `isDatedEntry` answers the coarser "is this a dated entry at
+ * all" question §7 names.
+ */
+export function isDatedEntry(entry: {
+  start_date?: string;
+  end_date?: string;
+}): boolean {
+  return Boolean(entry.start_date || entry.end_date);
+}
+
 /** Longest a leading achievement segment can be and still read as a "type"
  *  label ("Patent", "Publication", "Exit", "Best Paper Award") rather than a
  *  full sentence — guards against bolding an entire prose title that merely
@@ -417,7 +448,23 @@ function groupExperienceEntriesByLabel(
 // ── Builder ───────────────────────────────────────────────────────────────────
 
 /**
- * Build the flat ATS render model from the surface's own props.
+ * Build the flat ATS render model as a projection off the canonical résumé
+ * (#444, Stage C; `docs/canonical-resume-model.md` §4). `buildAtsResumeModel` is
+ * now `canonical → AtsResumeModel`: it lifts the `CascadeResult` façade into the
+ * {@link CanonicalResume} and reads its **field core** and **section headings**
+ * through {@link projectDisplay}, the same seam Stage B (#443) established and
+ * left tagged for this stage — so the render model no longer reaches straight
+ * into `result.parsed` / `result.sections.sectionHeadings`.
+ *
+ * Stage C is **additive** (§4): the output type is unchanged and `render-ats-pdf`
+ * is not re-pointed, so the rendered bytes stay byte-identical (the corpus +
+ * render round-trip goldens are the gate). The renderer's source flips and the
+ * type retires at Stage E.
+ *
+ * Stage-D remainder: the contact confidence gating still reads
+ * `result.fieldConfidence` (via {@link buildContact}), which `CanonicalResume`
+ * does not yet carry — `fieldConfidence` migrates to the canonical model at
+ * Stage D (§2.3). Field/heading reads route through the projection here.
  *
  * `edit` is optional — when omitted, no in-memory overrides are applied and the
  * model reflects the raw parse (used by tests / non-edit callers).
@@ -427,7 +474,8 @@ export function buildAtsResumeModel(
   score: AnonymousAtsScore,
   edit?: Pick<EditableParse, "contactOverrides" | "bulletOverrides">,
 ): AtsResumeModel {
-  const parsed = result.parsed;
+  const display = projectDisplay(canonicalFromCascade(result));
+  const parsed = display.parsed;
   const contactOverrides = edit?.contactOverrides ?? {};
   const bulletOverrides = edit?.bulletOverrides ?? {};
 
@@ -696,8 +744,10 @@ export function buildAtsResumeModel(
     parsed.achievements_placement === "above_experience";
   // Verbatim source headings (#285) — display-only; scoring stays canonical-
   // keyed. Falls back to the canonical word when a section wasn't opened by a
-  // recognized/other header (e.g. synthesized or profile-only content).
-  const headings = result.sections?.sectionHeadings;
+  // recognized/other header (e.g. synthesized or profile-only content). Routed
+  // through the display projection (#444, Stage C) — the read Stage B (#443) left
+  // tagged for this stage in `projections.ts`.
+  const headings = display.sectionHeadings;
   const achievementsSection: AtsSection | null =
     achievementEntries.length > 0
       ? {

--- a/src/lib/pdf/render-roundtrip-header-vs-entry.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-header-vs-entry.repro.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * §7 header-vs-entry acceptance test (#444, Stage C;
+ * `docs/canonical-resume-model.md` §7).
+ *
+ * The problem class #438 names is real: "is this line a category header or a
+ * dated entry?" is decided today from **adjacent raw-line signals** — the #425
+ * flush-right-date exemption in `columnGapCuts` pops a trailing lone-date segment
+ * when `isLoneDateRange` matches (`sections.ts:264`) — not from a structured
+ * field. Stage C's move is that the render+export projection reads the answer
+ * that is **already structured** on the canonical entry: an
+ * experience/education entry carrying `start_date` / `end_date` **is** a dated
+ * entry by construction, exposed as the derived {@link isDatedEntry} predicate
+ * (derived, not stored — locked via `/clarify`, 2026-07-11).
+ *
+ * Acceptance: a one-line `Title  Dates` role under a section header — with the
+ * degenerate shape where the flush-right date is the *only* signal the line is
+ * an entry and not a sub-section boundary (no company glued onto it) — must
+ * round-trip back to a **dated experience entry**, not fold into prose and not
+ * open a stray sub-section. Carries green through Stage E.
+ *
+ * PII-free: synthetic persona, all fields fabricated.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { buildAtsResumeModel, isDatedEntry } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+// A title-only role: the header line is "Title   <range>" with the date drawn
+// flush-right. With no company on the line, the flush-right date is the sole cue
+// that this is a dated ENTRY rather than a sub-section header — exactly the §7
+// case. Two such roles so "not a sub-section boundary" has teeth (a boundary
+// misread would collapse them).
+const ROLES = [
+  {
+    title: "Staff Engineer",
+    company: "",
+    start_date: "Jan 2020",
+    end_date: "Mar 2023",
+    description:
+      "Rebuilt the billing pipeline to cut latency by 40%\nMentored six engineers across two teams",
+  },
+  {
+    title: "Senior Engineer",
+    company: "",
+    start_date: "Jun 2016",
+    end_date: "Dec 2019",
+    description:
+      "Shipped the search-ranking service to 10M users\nCut infrastructure spend 25% year over year",
+  },
+];
+
+function makeResult(): CascadeResult {
+  return {
+    parsed: {
+      full_name: "Alex Candidate",
+      email: "alex@example.com",
+      phone: "(312) 555-0123",
+      location: "Chicago, IL",
+      summary: "Backend engineer with a decade building high-scale services.",
+      skills: ["Go", "Distributed Systems", "PostgreSQL"],
+      experience: ROLES,
+      education: [],
+      projects: [],
+      heuristic_achievements: [],
+    },
+    fieldConfidence: {},
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+const fakeScore = { bullets: [] } as unknown as AnonymousAtsScore;
+
+describe("§7 header-vs-entry — a one-line `Title  Dates` role routes as a dated entry (#444)", () => {
+  it("derives isDatedEntry from the entry's structured dates, not a raw-line re-scan", () => {
+    // The structured answer is already on the entry — no isLoneDateRange over a
+    // formatted string, no neighboring-line scan.
+    expect(isDatedEntry(ROLES[0])).toBe(true);
+    expect(isDatedEntry(ROLES[1])).toBe(true);
+    // Derivation only, never a stored field: a dateless entry derives false.
+    expect(isDatedEntry({ title: "Volunteer Lead" } as never)).toBe(false);
+  });
+
+  let model: ReturnType<typeof buildAtsResumeModel>;
+  let reparsed: CascadeResult;
+
+  beforeAll(async () => {
+    model = buildAtsResumeModel(makeResult(), fakeScore);
+    reparsed = await runCascade(await renderAtsResumePdf(model));
+  });
+
+  it("renders the title-only role with its range drawn flush-right on the header (the entry cue)", () => {
+    const exp = model.sections.find((s) => s.heading === "Experience");
+    const entries = exp?.entries ?? [];
+    // A dated entry with no org anchor puts the title on the header and routes
+    // the range to the flush-right `headerLineDate` slot — the exemption keeps it
+    // merged on re-parse so the line reads as an entry, not a boundary.
+    expect(entries[0]?.headerLine).toBe("Staff Engineer");
+    expect(entries[0]?.headerLineDate).toBe("Jan 2020 – Mar 2023");
+    expect(entries[1]?.headerLine).toBe("Senior Engineer");
+    expect(entries[1]?.headerLineDate).toBe("Jun 2016 – Dec 2019");
+  });
+
+  it("re-parses both one-line roles back as dated experience entries, not a folded boundary", () => {
+    const reExp = reparsed.parsed.experience ?? [];
+    // Both roles survive as distinct dated entries — neither collapsed into the
+    // other nor dropped into prose.
+    expect(reExp.length).toBe(ROLES.length);
+    ROLES.forEach((orig, i) => {
+      expect(reExp[i]?.title).toBe(orig.title);
+      expect(reExp[i]?.start_date).toBe(orig.start_date);
+      expect(reExp[i]?.end_date).toBe(orig.end_date);
+      // The structured predicate holds on the re-parsed entry too.
+      expect(isDatedEntry(reExp[i] ?? {})).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stage C of the canonical-résumé-model migration (#438 decision, #439 design). `buildAtsResumeModel` becomes `canonical → AtsResumeModel`: it reads the field core + section headings through `projectDisplay(canonicalFromCascade(result))` — the seam Stage B (#443) built and left tagged for this stage — instead of reaching straight into `result.parsed` / `result.sections.sectionHeadings`.

**Additive per design §4** — same output type, `render-ats-pdf.ts` **not** re-pointed, so rendered bytes stay **byte-identical**. The corpus + render round-trip goldens are the gate (all green, unchanged). The renderer flip + `AtsResumeModel` retirement stay at Stage E.

### The move — subtraction, read the structured entries (locked via `/clarify`, 2026-07-11)
- The render projection already reads `.title` / `.company` / `.start_date` / `.end_date` directly off the structured entry — no swap re-derivation.
- New **derived** `isDatedEntry(entry)` = `Boolean(start_date || end_date)` for the §7 header-vs-entry question. **Derived, never stored** — a stored field would be a second entries representation parallel to `fields.experience[]`, the exact parallel-shape cost the epic (#441) removes. **Not** the flush-right routing discriminator: `isLoneDateRange` over the *formatted* range still owns that (a render-shape concern kept byte-identical this stage).
- `#301` middot atomicity left untouched (separate skills-pool concern).

### §7 acceptance test
A one-line `Title  Dates` role under a section header round-trips back to a **dated experience entry**, not a sub-section boundary — via the real `buildAtsResumeModel → renderAtsResumePdf → runCascade` pipeline.

### Doc §7 correction (folded in)
"structured `isDatedEntry` **property** on `CanonicalResume`" → **derived predicate** over the entry's existing structured dates.

### Stage-D remainder (documented, not in scope)
Contact confidence gating still reads `result.fieldConfidence` — `CanonicalResume` does not yet carry it; migrates to the canonical model at Stage D (§2.3).

Closes #444. Refs #438, #439, #441.

## Stacking
Stacks on **#449** (Stages A+B), based on `gh-442-stage-a-export-projection`. GitHub auto-retargets this PR's base to `main` when #449 merges; then rebase:
```
git rebase --onto main gh-442-stage-a-export-projection gh-444-stage-c-roundtrip
```

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 2046 passed / 7 skipped
- [x] Corpus + render + multi-experience round-trip goldens green, byte-identical `AtsResumeModel`
- [x] New §7 header-vs-entry acceptance test green
- [x] `fallow` dead-exports 0.0%
- [x] Adversarial byte-identity review pass — sound (all three `sectionHeadings` branches + `.parsed` reference-identity traced)
