### PR TITLE
feat(edit): full edit fidelity for the Achievements section (#454, #455)

### DIFF
--- a/.claude/skills/probe-achievements/SKILL.md
+++ b/.claude/skills/probe-achievements/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: probe-achievements
+description: Extract + verify the ACHIEVEMENTS section (patents, awards, publications, talks — type label, description, year, bullets) of any résumé PDF, including a real PII-bearing one, via the real parser, and localize a dropped/merged/mis-split achievement to the exact layer (line-assembly vs section-routing vs entry segmentation vs the type/description split). Prints the achievements region the segmenter scanned next to the entries it produced, with each title decomposed into the bold "type" run and the description. One of the `probe-*` parser probes (see also `probe-experience`, `probe-contact`, `probe-roundtrip`). Use when the user says "probe achievements", "/probe-achievements", "an award/patent is missing", "the achievement type is wrong", or hands you a résumé whose achievements extract wrong.
+---
+
+# Probe: Achievements
+
+> One of the `probe-*` parser-probe family (siblings: `probe-experience`,
+> `probe-contact`, `probe-skills`, `probe-education`, `probe-roundtrip`). Type
+> `probe-` to list them all.
+
+Drop in **any** résumé PDF and see exactly what the parser reads for the
+achievements section — each entry's **type** label, **description**, **year**, and
+**bullet count** — and, when an achievement comes back missing, merged into a
+neighbor, or split at the wrong place, which layer did it.
+
+It reuses a dev harness in `src/lib/heuristics/probe-achievements.test.ts` (the
+`RL_ACHIEVEMENTS_PDF` block) — there is **no standalone script and you should not
+write one**: the pdfjs worker uses Vite's `?url` import, which resolves only under
+the Vite/vitest transform, so plain `tsx`/node breaks. The vitest run **is** the
+execution vehicle (same constraint as the sibling probes).
+
+## ⚠️ PII guardrail — read first
+
+This probe is meant to run on **real résumés with real candidate PII**. Same two
+hard rules as the sibling probes, non-negotiable:
+
+1. **The input PDF is local-only. NEVER commit it.** It is not a fixture. The
+   public repo's `tests/fixtures/pdfs/` is **synthetic-personas-only by policy**
+   (`tests/fixtures/pdfs/README.md`). A real résumé must never land there.
+2. **The output prints field VALUES → scratch only.** The console and JSON report
+   print achievement titles and years so the corruption is visible. The full JSON
+   is written to the **gitignored** `internal/achievements/` dir. Do not paste raw
+   candidate values into an issue, PR, commit, or Slack — cite the defect by
+   **category** ("the year was glued to the front of the description"), never the
+   value.
+
+If you are ever unsure whether a path is committed, stop and check `git status` /
+`.gitignore` before running.
+
+## Run it
+
+```bash
+RL_ACHIEVEMENTS_PDF=/abs/path/to/real-resume.pdf \
+  npx vitest run src/lib/heuristics/probe-achievements.test.ts
+```
+
+Use an **absolute path** for `RL_ACHIEVEMENTS_PDF`.
+
+### Env vars
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RL_ACHIEVEMENTS_PDF` | *(unset)* | Absolute path to the résumé PDF. When unset the harness is **inert** (skipped) — CI never runs it. |
+| `RL_ACHIEVEMENTS_OUT` | `internal/achievements/` | Directory for the full JSON report. The default lives under `internal/`, which is **gitignored**. Override only with another gitignored/out-of-repo path. |
+
+## What you get
+
+Five blocks, printed to the console (full JSON mirrored to the gitignored dir):
+
+1. **Score** — `overall` (+ pre-layout and the layout multiplier/triggers), so a
+   parse failure's score impact is visible in the same run.
+2. **Sections detected** — every segmented region with its line count
+   (`profile(1) experience(27) achievements(14) …`). **No `achievements` region
+   means the failure is upstream of entry segmentation** — the block was never
+   routed here (unrecognized heading, or swallowed by a neighbor section).
+3. **Parsed achievements** — each entry as `type=… / description=… / year=… /
+   bullets=N`, straight off `runCascade(...)`. This is the OUTPUT.
+4. **Achievements region scanned** — the `sections.byName.get("achievements")`
+   lines the entry segmenter actually saw. This is the INPUT.
+5. **Verify (independent header-line re-scan)** — every non-bullet line in the
+   region is a candidate entry header, a lower-bound oracle for the entry count:
+   - `ok` — entries ≥ header-shaped lines (a wrapped header can exceed it).
+   - `UNDER-SEGMENTED` — fewer entries than header-shaped lines → an achievement
+     likely **merged into a neighbor**.
+   - `PARSER-MISS` — zero entries but the region has lines → entry segmentation
+     dropped everything.
+
+### The type / description split
+
+The type label ("Patent", "Best Paper Award") is a **stored `type` field** on the
+entry (#456). The parser lifts it off the header's leading `" · "` run exactly
+once, at parse, leaving `title` holding only the description. That stored `type`
+is the run the reconstructed view and the Download PDF render **bold** (#452), and
+the field the inline editor commits against (#454). The probe reads both halves
+straight off the entry — no re-split — and prints whether a type label was lifted
+at all (`no type label — whole header renders bold`), so a mis-emphasized header is
+visible as the parse defect it is rather than a styling mystery.
+
+## Reading the result — localize the layer
+
+An achievement can go wrong at four layers. The INPUT-vs-OUTPUT split points at
+which one:
+
+- **Line assembly** (`sections.ts` `mergeItemText`) — the region lines are mangled
+  (superscript fragments orphaned on their own line, two-column text glued, a
+  following section's heading swallowed into the last entry).
+- **Section routing** (`sections.ts` segmentation) — the entries are fine but
+  landed outside the `achievements` band (an unrecognized "Honors & Awards" /
+  "Publications" heading, or the block absorbed into `experience`).
+- **Entry segmentation** — the lines are in the region and intact, but the entry
+  boundaries are wrong (two awards merged, one award split across two entries).
+- **Type/description split** — the entry is right but the bold run isn't: the
+  title carries no `" · "` (so the whole header bolds), or a prose lead longer
+  than `ACHIEVEMENT_TYPE_MAX_LEN` (`src/lib/score/entry-dates.ts`) correctly
+  refuses to read as a label.
+
+## Filing what you find (gated auto-file)
+
+Once you've localized the layer, you can turn the finding into a
+`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+[`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
+show, confirm, then write. Never blast-file.
+
+**PII guardrail carries over unchanged.** The issue body must describe the defect
+**by category with a synthetic repro** — never the candidate's real award titles,
+employers, or years. If you can't restate the defect without a real value, you
+can't file it yet — build the synthetic repro first.
+
+### 1. Dedup first (required)
+
+```bash
+gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+  --search "achievements <symptom keyword>"   # e.g. "achievements award merged"
+```
+
+If a match already covers this layer+symptom, **stop** — link the existing issue
+instead of filing.
+
+### 2. Draft by category
+
+- **Title** — the defect + localized layer, e.g. `Achievements: superscript rank
+  fragment orphaned into its own entry at line assembly`.
+- **Body** — sections detected (region names + line counts, not values), parsed
+  entry count vs. what was expected, the `verify` verdict, and the localized layer
+  with the specific file + function.
+- **Synthetic repro** — a synthetic-persona PDF (fake name, `@example.com`, a
+  `555`-exchange phone on a real area code, subscriber `0100`–`0199`) reproducing
+  the same category of corruption. See `tests/fixtures/pdfs/README.md`.
+
+### 3. Show + confirm, then write
+
+Print the drafted title + body and the labels, and **wait for an explicit human
+confirm**. On confirm, write via the `create-gh-issue` skill — do not hand-roll a
+parallel `gh issue create`.
+
+## Boundaries
+
+- This is a **dev/triage tool**, not a CI gate. It is informational: the harness
+  never reddens the suite, so a PII résumé with a known bug won't fail the run.
+- The PII-free enforcement lane is the corpus gate (`corpus.test.ts`) over
+  **synthetic fixtures** — this probe is the manual lane over **real** ones.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,13 +66,15 @@ export default function App() {
   // re-parsing, then navigate to the base-aware /jd-fit URL — works under both
   // the custom-domain "/" base and the "/resumelint/" Pages-fallback base.
   const goToJdFit = () => {
-    if (state.phase === "done" && edited) {
+    if (state.phase === "done") {
+      // The PRISTINE parse + score and the edit state as SEPARATE payloads —
+      // /jd-fit re-applies the overrides through its own edit layer (#456).
+      // Handing it `edited.parsed` instead baked the edits in irreversibly:
+      // added entries arrived indistinguishable from parsed ones.
       writeJdFitHandoff({
-        result: {
-          ...state.result,
-          canonical: { ...state.result.canonical, fields: edited.parsed },
-        },
-        score: edited.score,
+        result: state.result,
+        score: state.score,
+        edit: edit.snapshot,
       });
     }
     window.location.href = `${import.meta.env.BASE_URL}jd-fit/`;

--- a/src/components/features/AchievementTypePicker.test.tsx
+++ b/src/components/features/AchievementTypePicker.test.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * AchievementTypePicker (issue 456). The property that matters: the picker offers a
+ * closed grid of presets WITHOUT closing the model — `type` is free text lifted
+ * from a real PDF, so a label no preset covers must survive being shown and stay
+ * editable. A picker that silently normalized it to the nearest preset would
+ * rewrite what the résumé actually said.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { AchievementTypePicker } from "./AchievementTypePicker.tsx";
+import { matchAchievementPreset } from "../../lib/achievements/presets.ts";
+
+/** Read the glyph from the catalog rather than repeating it as an escape — the
+ *  test then can't drift from the presets it is asserting about. */
+function emojiFor(label: string): string {
+  const preset = matchAchievementPreset(label);
+  if (!preset) throw new Error(`no preset "${label}"`);
+  return preset.emoji;
+}
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+let committed: string[];
+
+function mount(value: string | undefined) {
+  committed = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() =>
+    root.render(
+      <AchievementTypePicker
+        value={value}
+        onSelect={(v) => committed.push(v)}
+      />,
+    ),
+  );
+}
+
+/** The popover only exists once the trigger is clicked. */
+function openMenu() {
+  const trigger = container.querySelector("button");
+  act(() => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+function menu(): HTMLElement | null {
+  return container.querySelector('[role="menu"]');
+}
+
+function menuItem(label: string): HTMLButtonElement {
+  const items = [
+    ...container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+  ];
+  const found = items.find((el) => el.textContent?.includes(label));
+  if (!found) throw new Error(`no menu item "${label}"`);
+  return found;
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("AchievementTypePicker (issue 456)", () => {
+  it("shows the preset emoji beside a recognized label", () => {
+    mount("Patent");
+    expect(container.textContent).toContain("Patent");
+    expect(container.textContent).toContain(emojiFor("Patent"));
+  });
+
+  it("shows a parser-lifted label that matches no preset, verbatim and emoji-less", () => {
+    mount("Best Paper Award");
+    // Rendered as-is — NOT normalized to the "Award" preset.
+    expect(container.textContent).toContain("Best Paper Award");
+    expect(container.textContent).not.toContain(emojiFor("Award"));
+  });
+
+  it("falls back to a 'type' placeholder when the achievement has no label", () => {
+    mount(undefined);
+    expect(container.textContent).toContain("type");
+  });
+
+  it("commits the preset label — not a slug — when one is picked", () => {
+    mount(undefined);
+    openMenu();
+    act(() =>
+      menuItem("Talk").dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    // The label string is what lands on `HeuristicAchievement.type` and what the
+    // exporter bolds, so it must be "Talk", not "talk".
+    expect(committed).toEqual(["Talk"]);
+  });
+
+  it("closes the menu after a pick", () => {
+    mount(undefined);
+    openMenu();
+    expect(menu()).not.toBeNull();
+    act(() =>
+      menuItem("Book").dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    expect(menu()).toBeNull();
+  });
+
+  it("marks the current label as the checked option", () => {
+    mount("Award");
+    openMenu();
+    expect(menuItem("Award").getAttribute("aria-checked")).toBe("true");
+    expect(menuItem("Talk").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("closes on Escape without committing", () => {
+    mount("Patent");
+    openMenu();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(menu()).toBeNull();
+    expect(committed).toEqual([]);
+  });
+
+  it("closes on an outside click without committing", () => {
+    mount("Patent");
+    openMenu();
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    expect(menu()).toBeNull();
+    expect(committed).toEqual([]);
+  });
+});

--- a/src/components/features/AchievementTypePicker.tsx
+++ b/src/components/features/AchievementTypePicker.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * AchievementTypePicker — pick an achievement's `type` label (#456).
+ *
+ * A labelled trigger that opens a grid of presets (`lib/achievements/presets.ts`).
+ * Typing the label by hand invites a typo the exporter would then bold, so the
+ * common vocabulary is one tap.
+ *
+ * The picker must never be a cage, though: `type` is FREE TEXT lifted from a
+ * real PDF, so the "Custom label" field below the grid commits any string —
+ * including whatever the parser found. A parsed label that matches no preset
+ * shows as-is (no emoji) and survives untouched unless the user changes it.
+ *
+ * Committing "" clears the type, which is meaningful: the achievement then has
+ * no label run, and the exporter bolds the whole header instead.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button, EditableField } from "@design-system";
+import {
+  ACHIEVEMENT_PRESETS,
+  matchAchievementPreset,
+} from "../../lib/achievements/presets.ts";
+
+export function AchievementTypePicker({
+  value,
+  onSelect,
+}: {
+  /** Current free-text label, or undefined when the achievement has none. */
+  value: string | undefined;
+  /** Commit a new label. "" clears it. */
+  onSelect: (type: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const label = value?.trim();
+  const preset = matchAchievementPreset(label);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  // Dismiss on outside click / Escape — the popover is the only thing holding
+  // focus, so leaving it any other way would strand it open behind the résumé.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) close();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, close]);
+
+  const pick = (next: string) => {
+    onSelect(next);
+    close();
+  };
+
+  return (
+    <div ref={rootRef} className="relative inline-flex">
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={
+          label ? `Achievement type: ${label}. Change it.` : "Set achievement type"
+        }
+        onClick={() => setOpen((o) => !o)}
+        className="font-semibold text-content-primary"
+      >
+        {preset && <span aria-hidden="true">{preset.emoji}</span>}
+        <span>{label || "type"}</span>
+        <span aria-hidden="true" className="text-content-muted">
+          ▾
+        </span>
+      </Button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Achievement type"
+          className="absolute left-0 top-full z-20 mt-1 w-72 rounded-lg border border-border-light bg-surface-card p-2 shadow-lg"
+        >
+          <div className="grid grid-cols-2 gap-1">
+            {ACHIEVEMENT_PRESETS.map((p) => {
+              const selected =
+                p.label.toLowerCase() === (label ?? "").toLowerCase();
+              return (
+                <Button
+                  key={p.label}
+                  role="menuitemradio"
+                  aria-checked={selected}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => pick(p.label)}
+                  className={`justify-start ${
+                    selected
+                      ? "bg-surface-subtle font-semibold text-content-primary"
+                      : ""
+                  }`}
+                >
+                  <span aria-hidden="true">{p.emoji}</span>
+                  <span className="truncate">{p.label}</span>
+                </Button>
+              );
+            })}
+          </div>
+
+          <div className="mt-2 flex items-center gap-2 border-t border-border-light pt-2">
+            {/* The free-text escape hatch. A label the parser lifted from a real
+                résumé ("Best Paper Award") usually matches no preset — it has to
+                stay editable, or the picker would silently overwrite what the
+                PDF actually said. */}
+            <EditableField
+              value={label || undefined}
+              placeholder="Custom label"
+              label="Custom achievement type"
+              textSize="xs"
+              onCommit={(v) => pick(v)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -73,13 +73,13 @@ import type {
   BulletOverrides,
   AddedEntry,
   AddedEntryField,
+  AchievementFieldOverrides,
 } from "../../hooks/useEditableParse.ts";
 import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
 import { AddPill, RemoveButton, InlineBulletAdd } from "./ReconstructedAdd.tsx";
-import {
-  buildProjectDates,
-  splitAchievementType,
-} from "../../lib/score/entry-dates.ts";
+import { AchievementTypePicker } from "./AchievementTypePicker.tsx";
+import { buildProjectDates } from "../../lib/score/entry-dates.ts";
+import { validateDate } from "../../lib/edit/field-validators.ts";
 import {
   EducationSection,
   SkillsSection,
@@ -643,44 +643,79 @@ function ProjectsSection({
 }
 
 /**
- * Read-only achievement header. Emphasizes ONLY the leading "type" label (e.g.
- * "Patent", "Publication") when the title carries the canonical "Type ·
- * description" shape, matching the Download PDF, which bolds just that run
- * (#452). The rest of the header — description + year — renders regular weight.
- * When there is no qualifying type segment the whole header stays bold, as the
- * PDF keeps the whole line bold in that case.
+ * An achievement's header, inline-editable (#454) — used for BOTH a parsed
+ * achievement and a user-ADDED one, which render identically and differ only in
+ * which override map the commit lands in (the caller supplies `onFieldChange`).
+ *
+ * `type` and `title` are REAL fields on the achievement (#456), and the props
+ * here are the OVERRIDE-APPLIED values — so the header just renders them. It
+ * used to derive the two from a composed `title`, which is not a round-trip and
+ * needed a pinning layer to stay honest; storing the label deletes both.
+ *
+ * `type` is a PICKER, not a free text field: it is a small, mostly-closed
+ * vocabulary ("Patent", "Talk", "Award"), so typing it out invites the typo the
+ * exporter would then bold. The picker still commits free text for the labels a
+ * real résumé used that no preset covers — see `AchievementTypePicker`.
  */
 function AchievementHeader({
+  type,
   title,
   year,
-  fallback,
+  onFieldChange,
 }: {
+  type?: string;
   title?: string;
   year?: string;
-  fallback: string;
+  onFieldChange: (field: keyof AchievementFieldOverrides, value: string) => void;
 }) {
-  const split = title ? splitAchievementType(title) : null;
-  if (!split) {
-    return (
-      <h3 className="text-sm font-semibold text-content-primary">{fallback}</h3>
-    );
-  }
-  const tail = [split.rest, year].filter(Boolean).join(" · ");
   return (
-    <h3 className="text-sm font-normal text-content-primary">
-      <span className="font-semibold">{split.type}</span>
-      {` · ${tail}`}
-    </h3>
+    <div className="flex min-w-0 grow flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+      <AchievementTypePicker
+        value={type || undefined}
+        onSelect={(v) => onFieldChange("type", v)}
+      />
+      <span className="text-content-muted" aria-hidden="true">
+        ·
+      </span>
+      <EditableField
+        value={title || undefined}
+        placeholder="achievement not detected"
+        label="Achievement description"
+        textSize="sm"
+        // With no type label there is no run to single out, so the exporter
+        // bolds the whole header (`ats-resume-model.ts`, headerBold). Match it
+        // here, or the view and the PDF disagree on emphasis for the common
+        // type-less "Best Paper Award" shape.
+        textWeight={type ? undefined : "semibold"}
+        multiline
+        onCommit={(v) => onFieldChange("title", v)}
+      />
+      <span className="text-content-muted" aria-hidden="true">
+        ·
+      </span>
+      <EditableField
+        value={year || undefined}
+        placeholder="year"
+        label="Year"
+        textSize="xs"
+        validate={validateDate}
+        onCommit={(v) => onFieldChange("year", v)}
+      />
+    </div>
   );
 }
 
 /**
  * Achievements render as their OWN section (#96), mirroring ProjectsSection: a
  * title-led header + the same graded `ResumeBulletRow`s used everywhere else, so
- * achievement bullets are checked and flagged identically. Read-only — the edit
- * affordances target experience/contact, not achievements. Achievements carry a
+ * achievement bullets are checked and flagged identically. Achievements carry a
  * single `year`, not a date range, so the header equivalent of
  * `buildProjectDates` is just the year string.
+ *
+ * Both branches are editable: a PARSED achievement's type / title / year through
+ * `AchievementHeader` (#454, overrides keyed by parsed index and already folded
+ * into `achievements` by `applyOverrides`), a user-ADDED one through the flat
+ * `AddedEntry` fields (#455).
  */
 function AchievementsSection({
   heading,
@@ -692,6 +727,7 @@ function AchievementsSection({
   onAddEntry,
   onRemoveEntry,
   onEntryField,
+  onAchievementField,
   onAddBullet,
 }: {
   /** Verbatim source heading (#285); falls back to "Achievements" when absent. */
@@ -705,6 +741,11 @@ function AchievementsSection({
   onAddEntry: () => void;
   onRemoveEntry: (id: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  onAchievementField: (
+    index: number,
+    field: keyof AchievementFieldOverrides,
+    value: string,
+  ) => void;
   onAddBullet: (entryKey: string, text: string) => void;
 }) {
   return (
@@ -717,37 +758,33 @@ function AchievementsSection({
             i >= originalCount
               ? addedAchievements[i - originalCount]
               : undefined;
-          const header = [achievement.title, achievement.year]
-            .filter(Boolean)
-            .join(" · ");
           return (
             <div key={added ? added.id : i} className="flex flex-col gap-1.5">
               <div className="flex items-start justify-between gap-2">
                 {added ? (
-                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-                    <EditableField
-                      value={achievement.title || undefined}
-                      placeholder="achievement title"
-                      label="Achievement title"
-                      textWeight="semibold"
-                      textSize="sm"
-                      multiline
-                      onCommit={(v) => onEntryField(added.id, "title", v)}
-                    />
-                    <span className="text-content-muted">·</span>
-                    <EditableField
-                      value={achievement.year || undefined}
-                      placeholder="year"
-                      label="Year"
-                      textSize="xs"
-                      onCommit={(v) => onEntryField(added.id, "year", v)}
-                    />
-                  </div>
+                  // Same header as a parsed achievement — an added entry stores
+                  // its label under `achievementType` on the flat AddedEntry, so
+                  // only the commit target differs.
+                  <AchievementHeader
+                    type={added.achievementType}
+                    title={added.title}
+                    year={added.year}
+                    onFieldChange={(field, value) =>
+                      onEntryField(
+                        added.id,
+                        field === "type" ? "achievementType" : field,
+                        value,
+                      )
+                    }
+                  />
                 ) : (
                   <AchievementHeader
+                    type={achievement.type}
                     title={achievement.title}
                     year={achievement.year}
-                    fallback={header || "Untitled achievement"}
+                    onFieldChange={(field, value) =>
+                      onAchievementField(i, field, value)
+                    }
                   />
                 )}
                 {added && (
@@ -889,6 +926,7 @@ export function ReconstructedResume({
     removeBullet,
     educationOverrides,
     setEducationField,
+    setAchievementField,
     addEntry,
     removeEntry,
     setEntryField,
@@ -1030,6 +1068,7 @@ export function ReconstructedResume({
       onAddEntry={() => addEntry("achievements")}
       onRemoveEntry={removeEntry}
       onEntryField={setEntryField}
+      onAchievementField={setAchievementField}
       onAddBullet={addBullet}
     />
   );

--- a/src/hooks/useAnalyzedResume.test.tsx
+++ b/src/hooks/useAnalyzedResume.test.tsx
@@ -215,6 +215,42 @@ describe("useAnalyzedResume — draft persistence across reload (#313)", () => {
     ).toBe(true);
   });
 
+  it("restore keeps every added-entry field — including team (#425) and achievementType (#455)", () => {
+    vi.useFakeTimers();
+    act(() => api.startBlank());
+    let roleId = "";
+    let achId = "";
+    act(() => {
+      api.edit.setContactField("full_name", "Jane Doe");
+      roleId = api.edit.addEntry("experience");
+      api.edit.setEntryField(roleId, "title", "Engineer");
+      api.edit.setEntryField(roleId, "subtitle", "Acme");
+      api.edit.setEntryField(roleId, "team", "Platform Infrastructure");
+      achId = api.edit.addEntry("achievements");
+      api.edit.setEntryField(achId, "achievementType", "Patent");
+      api.edit.setEntryField(achId, "title", "US 11,123,456");
+      api.edit.setEntryField(achId, "year", "2023");
+    });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    unmount();
+    vi.useRealTimers();
+    mount();
+    act(() => api.startBlank());
+    act(() => api.resumeDraft());
+
+    // Before the fix, the replay tuple omitted both fields: the snapshot carried
+    // them and the restore threw them away.
+    expect(api.edited?.parsed.experience[0].team).toBe("Platform Infrastructure");
+    const achievements = api.edited?.parsed.heuristic_achievements ?? [];
+    expect(achievements).toHaveLength(1);
+    expect(achievements[0].type).toBe("Patent");
+    expect(achievements[0].title).toBe("US 11,123,456");
+    expect(achievements[0].year).toBe("2023");
+  });
+
   it("startOverBlank() discards the saved draft and starts fresh (blank, empty)", () => {
     vi.useFakeTimers();
     act(() => api.startBlank());

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -32,16 +32,9 @@ import {
   writeBlankDraft,
   clearBlankDraft,
   type ParseState,
-  type BlankDraftSnapshot,
   type LoadedDoneState,
 } from "./useResumeAnalysis.ts";
-import {
-  useEditableParse,
-  type EditableParse,
-  type ContactOverrides,
-  type ExperienceFieldOverrides,
-  type EducationFieldOverrides,
-} from "./useEditableParse.ts";
+import { useEditableParse, type EditableParse } from "./useEditableParse.ts";
 import {
   applyOverrides,
   applyProfileOverrides,
@@ -119,22 +112,11 @@ export function useAnalyzedResume(): AnalyzedResume {
     bulletOverrides,
     removedBullets,
     educationOverrides,
+    achievementOverrides,
     skillsOverride,
     addedEntries,
     addedBullets,
     profileOverrides,
-    setContactField,
-    setExperienceField,
-    setBulletField,
-    removeBullet,
-    setEducationField,
-    addEntry,
-    setEntryField,
-    addBullet,
-    addSkill,
-    removeSkill,
-    setLegacyLink,
-    addProfile,
   } = edit;
 
   // The base CascadeResult overrides fold onto: the original parse in "done",
@@ -179,6 +161,7 @@ export function useAnalyzedResume(): AnalyzedResume {
       removedBullets,
       profileOverrides,
       base.canonical.fieldConfidence,
+      achievementOverrides,
     );
   }, [
     base,
@@ -187,6 +170,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     experienceOverrides,
     bulletOverrides,
     educationOverrides,
+    achievementOverrides,
     skillsOverride,
     addedEntries,
     addedBullets,
@@ -267,6 +251,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     experienceOverrides,
     bulletOverrides,
     educationOverrides,
+    achievementOverrides,
     skillsOverride,
     addedEntries,
     addedBullets,
@@ -334,121 +319,22 @@ export function useAnalyzedResume(): AnalyzedResume {
       clearBlankDraft();
       return;
     }
-    const snapshot: BlankDraftSnapshot = {
-      contactOverrides,
-      experienceOverrides,
-      bulletOverrides,
-      removedBullets: [...removedBullets],
-      educationOverrides,
-      skillsOverride,
-      addedEntries,
-      addedBullets,
-      profileOverrides,
-    };
-    const timer = setTimeout(() => writeBlankDraft(snapshot), 500);
+    const timer = setTimeout(() => writeBlankDraft(edit.snapshot), 500);
     return () => clearTimeout(timer);
+    // `edit.snapshot` is memoized on every override map, so it is the one dep
+    // that stands for all of them — it changes exactly when the draft does.
   }, [
     state.phase,
     state.phase === "authoring" ? state.pendingDraft : null,
     edit.hasEdits,
-    contactOverrides,
-    experienceOverrides,
-    bulletOverrides,
-    removedBullets,
-    educationOverrides,
-    skillsOverride,
-    addedEntries,
-    addedBullets,
-    profileOverrides,
+    edit.snapshot,
   ]);
-
-  // Replay a saved draft snapshot through `useEditableParse`'s own public
-  // setters, rather than reaching into its internals. `addEntry` mints a
-  // fresh id per call, so added entries (and any bullets keyed by their id)
-  // are remapped old-id → new-id as they're replayed.
-  const replayDraft = useCallback(
-    (snapshot: BlankDraftSnapshot) => {
-      (
-        Object.entries(snapshot.contactOverrides) as [
-          keyof ContactOverrides,
-          string,
-        ][]
-      ).forEach(([key, value]) => setContactField(key, value));
-
-      Object.entries(snapshot.experienceOverrides).forEach(
-        ([index, fields]) => {
-          (
-            Object.entries(fields) as [keyof ExperienceFieldOverrides, string][]
-          ).forEach(([field, value]) =>
-            setExperienceField(Number(index), field, value),
-          );
-        },
-      );
-
-      Object.entries(snapshot.bulletOverrides).forEach(([index, value]) =>
-        setBulletField(Number(index), value),
-      );
-
-      snapshot.removedBullets.forEach((index) => removeBullet(index));
-
-      Object.entries(snapshot.educationOverrides).forEach(
-        ([index, fields]) => {
-          (
-            Object.entries(fields) as [keyof EducationFieldOverrides, string][]
-          ).forEach(([field, value]) =>
-            setEducationField(Number(index), field, value),
-          );
-        },
-      );
-
-      snapshot.skillsOverride.added.forEach((skill) => addSkill(skill));
-      snapshot.skillsOverride.removed.forEach((skill) => removeSkill(skill));
-
-      const idMap = new Map<string, string>();
-      for (const entry of snapshot.addedEntries) {
-        const newId = addEntry(entry.section);
-        idMap.set(entry.id, newId);
-        (
-          ["title", "subtitle", "location", "start_date", "end_date", "year"] as const
-        ).forEach((field) => {
-          const value = entry[field];
-          if (value !== undefined) setEntryField(newId, field, value);
-        });
-      }
-      for (const [entryKey, bullets] of Object.entries(snapshot.addedBullets)) {
-        const mappedKey = idMap.get(entryKey) ?? entryKey;
-        bullets.forEach((text) => addBullet(mappedKey, text));
-      }
-
-      // Contact-link overrides (#427): corrections (carrying a legacyKey) replay
-      // through `setLegacyLink`; extras replay through `addProfile`. Fresh ids
-      // are minted on replay — the old per-session ids are never reused.
-      for (const ov of snapshot.profileOverrides ?? []) {
-        if (ov.legacyKey !== undefined) setLegacyLink(ov.legacyKey, ov.url);
-        else addProfile(ov.url);
-      }
-    },
-    [
-      setContactField,
-      setExperienceField,
-      setBulletField,
-      removeBullet,
-      setEducationField,
-      addSkill,
-      removeSkill,
-      addEntry,
-      setEntryField,
-      addBullet,
-      setLegacyLink,
-      addProfile,
-    ],
-  );
 
   const resumeDraft = useCallback(() => {
     if (state.phase !== "authoring" || !state.pendingDraft) return;
-    replayDraft(state.pendingDraft);
+    edit.replay(state.pendingDraft);
     resolveDraftPrompt();
-  }, [state, replayDraft, resolveDraftPrompt]);
+  }, [state, edit, resolveDraftPrompt]);
 
   return {
     state,

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -77,6 +77,66 @@ export interface EducationFieldOverrides {
   end_date?: string;
 }
 
+// ── Achievement overrides (#454) ──────────────────────────────────────────────
+
+/**
+ * Editable fields on a PARSED achievement. Every key names a REAL field on
+ * `HeuristicAchievement` (#456) — `applyOverrides` copies it straight across, so
+ * each field is independent and an edit round-trips verbatim.
+ *
+ * This was briefly two halves of a composed `title` (#454, design model (a)),
+ * which forced the edit surface to pin both halves on the first edit just to
+ * avoid re-decomposing a title it had itself recomposed. Storing `type` on the
+ * model deletes that whole mechanism, and with it the two surfaces (the PDF's
+ * bold run, `/jd-fit`'s field halves) that re-split the title and got it wrong.
+ *
+ * An empty string clears the field (clearing `type` leaves the bare title;
+ * clearing `year` drops it, mirroring `location`/`team` on experience).
+ * `undefined` means "no override" — the parsed value shows through.
+ */
+export interface AchievementFieldOverrides {
+  /** Leading type label ("Patent", "Best Paper Award") — the run rendered bold. */
+  type?: string;
+  /** Item title, without the type label. */
+  title?: string;
+  /** Lead year (achievements carry a single year, not a range). */
+  year?: string;
+}
+
+// ── Edit snapshot (serializable edit state) ──────────────────────────────────
+
+/**
+ * The hook's complete override state as a plain, JSON-safe value — every map,
+ * nothing derived. Two consumers need edit state to cross a boundary, and both
+ * go through this ONE shape:
+ *
+ *   - the from-scratch draft (#313), persisted to localStorage and replayed on
+ *     reload (`BlankDraftSnapshot` is this type);
+ *   - the `/` → `/jd-fit` handoff (#456), which hands over the PRISTINE parse
+ *     plus this snapshot, so `/jd-fit` re-applies the edits itself rather than
+ *     inheriting an already-applied result it can no longer take apart.
+ *
+ * `removedBullets` is an array, not a `Set` — a `Set` isn't JSON-safe.
+ *
+ * Every override map must appear here. A silently-absent one is exactly how
+ * `team` (#425) and `achievementType` (#455) got dropped on restore.
+ */
+export interface EditSnapshot {
+  contactOverrides: ContactOverrides;
+  experienceOverrides: Record<number, ExperienceFieldOverrides>;
+  bulletOverrides: BulletOverrides;
+  removedBullets: number[];
+  educationOverrides: Record<number, EducationFieldOverrides>;
+  /** Optional: drafts persisted before #454 carry no such key. */
+  achievementOverrides?: Record<number, AchievementFieldOverrides>;
+  skillsOverride: SkillsOverride;
+  addedEntries: AddedEntry[];
+  addedBullets: AddedBullets;
+  /** Optional: drafts persisted before #427 carry link edits on
+   *  `contactOverrides.{...}_url` instead — `migrateBlankDraft` upconverts. */
+  profileOverrides?: ProfileOverride[];
+}
+
 // ── Added entries + bullets ─────────────────────────────────────────────────
 // Edit overrides above CORRECT what the parser found; these ADD what it missed
 // entirely — a whole role/degree/project/achievement, or a bullet under any
@@ -98,7 +158,9 @@ export type AddableSection =
  *   - experience:   title, subtitle (company), start_date, end_date
  *   - education:    title (degree), subtitle (institution), start_date, end_date
  *   - projects:     title (name)
- *   - achievements: title, year
+ *   - achievements: achievementType, title, year — mapped straight onto the
+ *                   achievement's real `type` / `title` / `year` fields, matching
+ *                   the parsed-achievement edit model (#455, #456)
  * `id` is a stable per-session key (`"added:<n>"`) so the entry's bullets (in
  * `addedBullets`) and inline header edits track it without relying on array
  * position.
@@ -106,7 +168,8 @@ export type AddableSection =
 export interface AddedEntry {
   id: string;
   section: AddableSection;
-  /** Primary header: job title / degree / project name / achievement title. */
+  /** Primary header: job title / degree / project name / achievement title. For
+   *  achievements this excludes the type label — see {@link achievementType}. */
   title: string;
   /** Secondary header: company / institution. Unused for projects/achievements. */
   subtitle?: string;
@@ -119,17 +182,34 @@ export interface AddedEntry {
   end_date?: string;
   /** Achievement year (achievements carry a single year, not a range). */
   year?: string;
+  /** Achievement type label ("Patent", "Best Paper Award") — the bold run, and
+   *  the pushed achievement's `type` field (#456). Achievements only; ignored by
+   *  other sections. */
+  achievementType?: string;
 }
 
+/**
+ * Editable header fields on an added entry, as a value — {@link EditableParse.replay}
+ * iterates this to rehydrate a snapshot, so the list must stay exhaustive or a
+ * field persists into the snapshot and is silently dropped on replay (`team`
+ * (#425) and `achievementType` (#455) were both lost that way). Deriving
+ * {@link AddedEntryField} FROM the tuple is what keeps the two in lockstep: a
+ * new field can only join the union by joining the replay. Not exported — replay
+ * lives in this module now, so nothing outside it needs the tuple.
+ */
+const ADDED_ENTRY_FIELDS = [
+  "title",
+  "subtitle",
+  "location",
+  "team",
+  "start_date",
+  "end_date",
+  "year",
+  "achievementType",
+] as const;
+
 /** Editable header fields on an added entry. */
-export type AddedEntryField =
-  | "title"
-  | "subtitle"
-  | "location"
-  | "team"
-  | "start_date"
-  | "end_date"
-  | "year";
+export type AddedEntryField = (typeof ADDED_ENTRY_FIELDS)[number];
 
 /**
  * Bullet lines a user appended to an entry, keyed by entry key. A PARSED entry's
@@ -231,6 +311,18 @@ export interface EditableParse {
     field: keyof EducationFieldOverrides,
     value: string | undefined,
   ) => void;
+  /** Override map for parsed achievements, keyed by `heuristic_achievements`
+   *  array index. */
+  achievementOverrides: Record<number, AchievementFieldOverrides>;
+  /** Update one field on a specific parsed achievement by its array index.
+   *  Every field maps 1:1 onto `HeuristicAchievement` (#456), so this is a plain
+   *  per-field setter — no pairing, no recomposition. Pass undefined to clear
+   *  that single field's override. */
+  setAchievementField: (
+    index: number,
+    field: keyof AchievementFieldOverrides,
+    value: string | undefined,
+  ) => void;
   /** User-added entries across all sections, in insertion order. */
   addedEntries: AddedEntry[];
   /** Append a new (empty-header) entry to a section. Returns its stable id. */
@@ -275,6 +367,15 @@ export interface EditableParse {
    *  parse (records its key in `removed`) or from a prior add (drops it from
    *  `added`). */
   removeSkill: (skill: string) => void;
+  /** The complete override state as a JSON-safe value (#456) — the one shape
+   *  every consumer that must carry edits across a boundary uses (draft
+   *  persistence, the `/` → `/jd-fit` handoff). */
+  snapshot: EditSnapshot;
+  /** Replay a snapshot through this hook's own public setters, rather than
+   *  reaching into its internals. `addEntry` mints a fresh id per call, so added
+   *  entries (and any bullets keyed by their id) are remapped old-id → new-id.
+   *  Additive: replaying onto a non-empty state merges rather than replaces. */
+  replay: (snapshot: EditSnapshot) => void;
   /** True when any contact, experience, bullet, education, or skills override is set. */
   hasEdits: boolean;
   /** Clear every override, reverting to the original parse. */
@@ -294,6 +395,9 @@ export function useEditableParse(): EditableParse {
   );
   const [educationOverrides, setEducationOverrides] = useState<
     Record<number, EducationFieldOverrides>
+  >({});
+  const [achievementOverrides, setAchievementOverrides] = useState<
+    Record<number, AchievementFieldOverrides>
   >({});
   const [skillsOverride, setSkillsOverride] = useState<SkillsOverride>(
     EMPTY_SKILLS_OVERRIDE,
@@ -379,6 +483,22 @@ export function useEditableParse(): EditableParse {
         } else {
           entry[field] = value;
         }
+        return { ...prev, [index]: entry };
+      });
+    },
+    [],
+  );
+
+  const setAchievementField = useCallback(
+    (
+      index: number,
+      field: keyof AchievementFieldOverrides,
+      value: string | undefined,
+    ) => {
+      setAchievementOverrides((prev) => {
+        const entry = { ...prev[index] };
+        if (value === undefined) delete entry[field];
+        else entry[field] = value;
         return { ...prev, [index]: entry };
       });
     },
@@ -512,11 +632,131 @@ export function useEditableParse(): EditableParse {
     setBulletOverrides({});
     setRemovedBullets(new Set());
     setEducationOverrides({});
+    setAchievementOverrides({});
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
     setAddedEntries([]);
     setAddedBullets({});
     setProfileOverrides([]);
   }, []);
+
+  const snapshot = useMemo<EditSnapshot>(
+    () => ({
+      contactOverrides,
+      experienceOverrides,
+      bulletOverrides,
+      removedBullets: [...removedBullets],
+      educationOverrides,
+      achievementOverrides,
+      skillsOverride,
+      addedEntries,
+      addedBullets,
+      profileOverrides,
+    }),
+    [
+      contactOverrides,
+      experienceOverrides,
+      bulletOverrides,
+      removedBullets,
+      educationOverrides,
+      achievementOverrides,
+      skillsOverride,
+      addedEntries,
+      addedBullets,
+      profileOverrides,
+    ],
+  );
+
+  const replay = useCallback(
+    (snap: EditSnapshot) => {
+      (
+        Object.entries(snap.contactOverrides) as [
+          keyof ContactOverrides,
+          string,
+        ][]
+      ).forEach(([key, value]) => setContactField(key, value));
+
+      Object.entries(snap.experienceOverrides).forEach(([index, fields]) => {
+        (
+          Object.entries(fields) as [keyof ExperienceFieldOverrides, string][]
+        ).forEach(([field, value]) =>
+          setExperienceField(Number(index), field, value),
+        );
+      });
+
+      Object.entries(snap.bulletOverrides).forEach(([index, value]) =>
+        setBulletField(Number(index), value),
+      );
+
+      snap.removedBullets.forEach((index) => removeBullet(index));
+
+      Object.entries(snap.educationOverrides).forEach(([index, fields]) => {
+        (
+          Object.entries(fields) as [keyof EducationFieldOverrides, string][]
+        ).forEach(([field, value]) =>
+          setEducationField(Number(index), field, value),
+        );
+      });
+
+      // Each achievement override key is a real field (#456), so replaying them
+      // one by one rebuilds the map exactly.
+      Object.entries(snap.achievementOverrides ?? {}).forEach(
+        ([index, fields]) => {
+          (
+            Object.entries(fields) as [
+              keyof AchievementFieldOverrides,
+              string,
+            ][]
+          ).forEach(([field, value]) =>
+            setAchievementField(Number(index), field, value),
+          );
+        },
+      );
+
+      snap.skillsOverride.added.forEach((skill) => addSkill(skill));
+      snap.skillsOverride.removed.forEach((skill) => removeSkill(skill));
+
+      const idMap = new Map<string, string>();
+      for (const entry of snap.addedEntries) {
+        const newId = addEntry(entry.section);
+        idMap.set(entry.id, newId);
+        // Iterates the field tuple AddedEntryField is derived from, so a new
+        // editable field cannot be added to the union without also being
+        // replayed here — `team` (#425) and `achievementType` (#455) were both
+        // silently dropped on restore by a hand-synced list.
+        ADDED_ENTRY_FIELDS.forEach((field) => {
+          const value = entry[field];
+          if (value !== undefined) setEntryField(newId, field, value);
+        });
+      }
+      for (const [entryKey, bullets] of Object.entries(snap.addedBullets)) {
+        const mappedKey = idMap.get(entryKey) ?? entryKey;
+        bullets.forEach((text) => addBullet(mappedKey, text));
+      }
+
+      // Contact-link overrides (#427): corrections (carrying a legacyKey) replay
+      // through `setLegacyLink`; extras replay through `addProfile`. Fresh ids
+      // are minted on replay — the old per-session ids are never reused.
+      for (const ov of snap.profileOverrides ?? []) {
+        if (ov.legacyKey !== undefined) setLegacyLink(ov.legacyKey, ov.url);
+        else addProfile(ov.url);
+      }
+    },
+    [
+      setContactField,
+      setExperienceField,
+      setBulletField,
+      removeBullet,
+      setEducationField,
+      setAchievementField,
+      addSkill,
+      removeSkill,
+      addEntry,
+      setEntryField,
+      addBullet,
+      setLegacyLink,
+      addProfile,
+    ],
+  );
 
   const hasEdits = useMemo(() => {
     if (Object.keys(contactOverrides).length > 0) return true;
@@ -533,6 +773,12 @@ export function useEditableParse(): EditableParse {
       )
     )
       return true;
+    if (
+      Object.values(achievementOverrides).some(
+        (entry) => Object.keys(entry).length > 0,
+      )
+    )
+      return true;
     return Object.values(experienceOverrides).some(
       (entry) => Object.keys(entry).length > 0,
     );
@@ -542,6 +788,7 @@ export function useEditableParse(): EditableParse {
     bulletOverrides,
     removedBullets,
     educationOverrides,
+    achievementOverrides,
     skillsOverride,
     addedEntries,
     addedBullets,
@@ -559,6 +806,8 @@ export function useEditableParse(): EditableParse {
     removeBullet,
     educationOverrides,
     setEducationField,
+    achievementOverrides,
+    setAchievementField,
     addedEntries,
     addEntry,
     removeEntry,
@@ -573,6 +822,8 @@ export function useEditableParse(): EditableParse {
     skillsOverride,
     addSkill,
     removeSkill,
+    snapshot,
+    replay,
     hasEdits,
     resetAll,
   };

--- a/src/hooks/useResumeAnalysis.ts
+++ b/src/hooks/useResumeAnalysis.ts
@@ -29,12 +29,7 @@ import {
 import { formatBytes } from "../lib/format-bytes.ts";
 import type {
   ContactOverrides,
-  ExperienceFieldOverrides,
-  EducationFieldOverrides,
-  BulletOverrides,
-  SkillsOverride,
-  AddedEntry,
-  AddedBullets,
+  EditSnapshot,
   ProfileOverride,
 } from "./useEditableParse.ts";
 import { classifyProfile } from "../lib/contact/profile-registry.ts";
@@ -45,27 +40,14 @@ import { LEGACY_LINK_KEYS } from "../lib/contact/contact-profiles.ts";
 type SourceKind = "pdf" | "docx";
 
 /**
- * A serializable snapshot of the from-scratch draft's edit-override state
- * (#313) — the SAME shape `useEditableParse` exposes, persisted verbatim so
- * a restore can replay it through the hook's own public setters (in
- * `useAnalyzedResume.ts`) rather than reaching into its internals.
- * `removedBullets` is serialized as an array — a `Set` isn't JSON-safe.
+ * The persisted from-scratch draft (#313) is exactly `useEditableParse`'s own
+ * {@link EditSnapshot} — the hook produces it (`edit.snapshot`) and replays it
+ * (`edit.replay`) through its public setters. This alias names the persistence
+ * ROLE; the shape is defined once, at the hook, so a new override map cannot be
+ * added without joining the snapshot (which is how `team` and `achievementType`
+ * were once silently dropped on restore).
  */
-export interface BlankDraftSnapshot {
-  contactOverrides: ContactOverrides;
-  experienceOverrides: Record<number, ExperienceFieldOverrides>;
-  bulletOverrides: BulletOverrides;
-  removedBullets: number[];
-  educationOverrides: Record<number, EducationFieldOverrides>;
-  skillsOverride: SkillsOverride;
-  addedEntries: AddedEntry[];
-  addedBullets: AddedBullets;
-  /** Consolidated contact-link overrides (#427). Optional in the persisted
-   *  shape for back-compat: a draft saved before #427 has no `profileOverrides`
-   *  key and instead carries link edits under `contactOverrides.{...}_url` —
-   *  `migrateBlankDraft` upconverts those on read. */
-  profileOverrides: ProfileOverride[];
-}
+export type BlankDraftSnapshot = EditSnapshot;
 
 /** A pre-#427 persisted draft: link edits lived on `contactOverrides` under the
  *  four legacy `*_url` keys, and there was no `profileOverrides` list. */

--- a/src/jd-fit/useJdFitResume.test.tsx
+++ b/src/jd-fit/useJdFitResume.test.tsx
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Behavioral tests for the `/` → `/jd-fit` handoff (#456), exercised through a
+ * probe component (the project has no @testing-library/react — same pattern as
+ * `useAnalyzedResume.test.tsx`).
+ *
+ * The handoff hands over the PRISTINE parse plus the user's edit SNAPSHOT, and
+ * /jd-fit replays the snapshot into its own edit layer. These tests pin the two
+ * properties that made the previous design (hand over the override-APPLIED
+ * result, start /jd-fit with an empty edit layer) wrong:
+ *
+ *   - the user's edits arrive, AND stay edits — an entry they added is still an
+ *     added entry here, so it keeps its Remove button and its bullets;
+ *   - replay is additive, so it must run exactly once — a naive re-seed appended
+ *     every added entry a second time on the next render.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useJdFitResume, type JdFitResume } from "./useJdFitResume.ts";
+import type { AnalyzedResume } from "../hooks/useAnalyzedResume.ts";
+import type { EditSnapshot } from "../hooks/useEditableParse.ts";
+import {
+  JDFIT_HANDOFF_KEY,
+  writeJdFitHandoff,
+  type JdFitHandoff,
+} from "../lib/jd-fit-handoff.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.map.get(k) ?? null;
+  }
+  setItem(k: string, v: string): void {
+    this.map.set(k, v);
+  }
+  removeItem(k: string): void {
+    this.map.delete(k);
+  }
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+const EMPTY_EDIT: EditSnapshot = {
+  contactOverrides: {},
+  experienceOverrides: {},
+  bulletOverrides: {},
+  removedBullets: [],
+  educationOverrides: {},
+  achievementOverrides: {},
+  skillsOverride: { removed: [], added: [] },
+  addedEntries: [],
+  addedBullets: {},
+  profileOverrides: [],
+};
+
+/** A pristine parse carrying one mis-typed achievement — the correction below
+ *  is exactly the kind of edit that has to survive the navigation. */
+function pristineResult(): CascadeResult {
+  return {
+    canonical: {
+      fields: {
+        full_name: "Jane Candidate",
+        skills: [],
+        experience: [],
+        education: [],
+        heuristic_achievements: [
+          { type: "Pantent", title: "Bulk catalog editor" },
+        ],
+      },
+      sections: {
+        byName: new Map<string, readonly string[]>(),
+        accomplishmentSections: ["experience", "projects", "achievements"],
+        source: "regex",
+      },
+      fieldConfidence: {},
+    },
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+/** The local-DropZone lane, idle — so the handoff lane is the one under test. */
+const IDLE_ANALYZED = {
+  state: { phase: "idle" },
+  edit: {},
+  edited: null,
+  reset: () => {},
+} as unknown as AnalyzedResume;
+
+let container: HTMLDivElement;
+let root: Root;
+let api: JdFitResume | null;
+
+function Probe() {
+  api = useJdFitResume(IDLE_ANALYZED);
+  return null;
+}
+
+/** Mount under `<StrictMode>` — both entry points do (`jd-fit/main.tsx`), and
+ *  the effects here are one-shot and NOT idempotent: the handoff read clears
+ *  sessionStorage, and replay appends. StrictMode's dev-only double-invoke is
+ *  precisely what surfaces a guard that doesn't hold, so the tests have to run
+ *  the way the app does. Mounting bare hid a real bug (#456 review). */
+function mount(): void {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() =>
+    root.render(
+      <StrictMode>
+        <Probe />
+      </StrictMode>,
+    ),
+  );
+}
+
+function seedHandoff(edit: EditSnapshot): void {
+  writeJdFitHandoff({
+    result: pristineResult(),
+    score: { overall: 60, bullets: [] },
+    edit,
+  } as unknown as JdFitHandoff);
+}
+
+beforeEach(() => {
+  (globalThis as { sessionStorage?: Storage }).sessionStorage =
+    new MemoryStorage() as unknown as Storage;
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useJdFitResume — the handoff carries edit STATE (#456)", () => {
+  it("replays a field correction from `/` onto the pristine parse", () => {
+    seedHandoff({
+      ...EMPTY_EDIT,
+      contactOverrides: { full_name: "Jane Q. Candidate" },
+      achievementOverrides: { 0: { type: "Patent" } },
+    });
+    mount();
+
+    expect(api?.parsed.full_name).toBe("Jane Q. Candidate");
+    // The achievement override lands on the real `type` field — the title is
+    // untouched, and nothing re-derived either from a composed string.
+    expect(api?.parsed.heuristic_achievements?.[0]).toMatchObject({
+      type: "Patent",
+      title: "Bulk catalog editor",
+    });
+  });
+
+  it("keeps a user-ADDED entry editable here — it does not arrive baked in", () => {
+    seedHandoff({
+      ...EMPTY_EDIT,
+      addedEntries: [
+        {
+          id: "added:0",
+          section: "achievements",
+          achievementType: "Talk",
+          title: "KubeCon",
+          year: "2024",
+        },
+      ],
+    });
+    mount();
+
+    // It shows up in the résumé...
+    const achievements = api?.parsed.heuristic_achievements ?? [];
+    expect(achievements).toHaveLength(2);
+    expect(achievements[1]).toMatchObject({ type: "Talk", title: "KubeCon" });
+    // ...AND it is still an ADDED entry, not a parsed one. This is what the
+    // old applied-result handoff destroyed: /jd-fit saw two parsed achievements
+    // and no way to remove the one the user had added.
+    expect(api?.edit.addedEntries).toHaveLength(1);
+    expect(api?.edit.addedEntries[0].section).toBe("achievements");
+  });
+
+  it("replays exactly once — editing here does not re-append the added entry", () => {
+    seedHandoff({
+      ...EMPTY_EDIT,
+      addedEntries: [
+        { id: "added:0", section: "achievements", title: "KubeCon" },
+      ],
+    });
+    mount();
+    expect(api?.edit.addedEntries).toHaveLength(1);
+
+    // Replay is ADDITIVE — `addEntry` mints a fresh id per call, so replaying a
+    // second time would append a DUPLICATE rather than converge. Drive the
+    // renders a real session drives: edits on /jd-fit, each re-running the
+    // apply memo and the replay effect's dependency check.
+    act(() => api!.edit.setContactField("full_name", "Jane Q. Candidate"));
+    act(() => api!.edit.setAchievementField(0, "type", "Patent"));
+
+    expect(api?.edit.addedEntries).toHaveLength(1);
+    expect(api?.parsed.heuristic_achievements).toHaveLength(2);
+    // The local edits still apply on top of the replayed ones.
+    expect(api?.parsed.full_name).toBe("Jane Q. Candidate");
+    expect(api?.parsed.heuristic_achievements?.[0].type).toBe("Patent");
+  });
+
+  it("survives StrictMode's double effect invoke — the handoff lands, once", () => {
+    // Both one-shot effects here are non-idempotent, and StrictMode runs an
+    // effect setup→cleanup→setup in one commit with no re-render between, so a
+    // `useState` guard captures the same stale closure in both setups and does
+    // not short-circuit. Two distinct failures if the guards aren't refs:
+    //   - the handoff READ clears sessionStorage → the second read returns null
+    //     → `setHandoff(null)` wins → the résumé vanishes and /jd-fit shows the
+    //     DropZone (dev only, but the feature is simply broken there);
+    //   - REPLAY appends → the added entry lands twice.
+    seedHandoff({
+      ...EMPTY_EDIT,
+      addedEntries: [
+        { id: "added:0", section: "achievements", title: "KubeCon" },
+      ],
+    });
+    mount();
+
+    expect(api).not.toBeNull();
+    expect(api?.edit.addedEntries).toHaveLength(1);
+    expect(api?.parsed.heuristic_achievements).toHaveLength(2);
+  });
+
+  it("consumes the handoff — the key is cleared so a reload falls back to the DropZone", () => {
+    seedHandoff(EMPTY_EDIT);
+    mount();
+    expect(api).not.toBeNull();
+    expect(globalThis.sessionStorage.getItem(JDFIT_HANDOFF_KEY)).toBeNull();
+  });
+
+  it("returns null with no handoff and an idle local lane", () => {
+    mount();
+    expect(api).toBeNull();
+  });
+});

--- a/src/jd-fit/useJdFitResume.ts
+++ b/src/jd-fit/useJdFitResume.ts
@@ -7,10 +7,11 @@
  * Two sources collapse to ONE `{ result, score, edit, parsed, ... }` shape that
  * `<Result>` and the JD coverage memo consume identically:
  *
- *  1. Handoff from `/` — the parser-audit surface stashed an already-parsed +
- *     edited résumé in sessionStorage (read once on mount). JD-fit re-grades it
- *     live through its OWN edit layer so inline edits here move the score + JD
- *     coverage, exactly as on `/`.
+ *  1. Handoff from `/` — the parser-audit surface stashed the PRISTINE parse
+ *     plus the user's edit snapshot in sessionStorage (read once on mount).
+ *     JD-fit replays those edits into its OWN edit layer and applies them here,
+ *     so inline edits move the score + JD coverage exactly as on `/` and the
+ *     edits stay editable (#456).
  *  2. Local DropZone parse — when there's no handoff, the user drops a PDF here
  *     and `useAnalyzedResume` drives the parse → edit → re-grade pipeline.
  *
@@ -18,7 +19,7 @@
  * /jd-fit falls back to the DropZone rather than re-showing a stale résumé.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { AnalyzedResume } from "../hooks/useAnalyzedResume.ts";
 import { useEditableParse, type EditableParse } from "../hooks/useEditableParse.ts";
 import { applyOverrides } from "../lib/edit/apply-overrides.ts";
@@ -50,9 +51,18 @@ export interface JdFitResume {
 }
 
 export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
-  // Read the one-shot handoff exactly once, on mount.
+  // Read the one-shot handoff exactly once, on mount. The guard is a REF, not
+  // state: `consumeJdFitHandoff` reads AND clears sessionStorage, so it is not
+  // idempotent, and StrictMode (dev) runs an effect setup→cleanup→setup within
+  // one commit with no re-render between. A state guard cannot short-circuit
+  // the second setup — it captures the same pre-update closure — so the second
+  // read would find the key already cleared and `setHandoff(null)` would win,
+  // dropping the whole handoff. A ref flips synchronously and survives it.
+  const consumedRef = useRef(false);
   const [handoff, setHandoff] = useState<JdFitHandoff | null>(null);
   useEffect(() => {
+    if (consumedRef.current) return;
+    consumedRef.current = true;
     setHandoff(consumeJdFitHandoff());
   }, []);
 
@@ -60,6 +70,21 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
   // mirroring useAnalyzedResume's `edited` memo but seeded from the rehydrated
   // result rather than a fresh parse.
   const handoffEdit = useEditableParse();
+
+  // Replay the edits the user made on `/` into THIS layer, once, when the
+  // handoff lands (#456). The payload carries the PRISTINE parse, so replaying
+  // is what reproduces their edited résumé here — and it stays edit STATE, so an
+  // added entry is still an added entry (it keeps its Remove button) instead of
+  // arriving baked into the parsed arrays. Replay is additive — `addEntry` mints
+  // a fresh id per call — so running it twice would append every added entry a
+  // second time. Ref guard for the same reason as the consume above.
+  const { replay } = handoffEdit;
+  const replayedRef = useRef(false);
+  useEffect(() => {
+    if (!handoff || replayedRef.current) return;
+    replayedRef.current = true;
+    replay(handoff.edit);
+  }, [handoff, replay]);
   const handoffEdited = useMemo(() => {
     if (!handoff) return null;
     const base = handoff.result;
@@ -78,6 +103,8 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
       handoffEdit.addedBullets,
       handoffEdit.removedBullets,
       handoffEdit.profileOverrides,
+      base.canonical.fieldConfidence,
+      handoffEdit.achievementOverrides,
     );
     const parsed = applied.fields;
     const score = computeAnonymousAtsScore({
@@ -99,6 +126,7 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
     handoffEdit.experienceOverrides,
     handoffEdit.bulletOverrides,
     handoffEdit.educationOverrides,
+    handoffEdit.achievementOverrides,
     handoffEdit.skillsOverride,
     handoffEdit.addedEntries,
     handoffEdit.addedBullets,

--- a/src/lib/achievements/presets.test.ts
+++ b/src/lib/achievements/presets.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  ACHIEVEMENT_PRESETS,
+  matchAchievementPreset,
+} from "./presets.ts";
+
+describe("matchAchievementPreset (issue 456)", () => {
+  it("matches a preset label case-insensitively", () => {
+    expect(matchAchievementPreset("Patent")?.label).toBe("Patent");
+    expect(matchAchievementPreset("patent")?.label).toBe("Patent");
+    expect(matchAchievementPreset("  PATENT  ")?.label).toBe("Patent");
+  });
+
+  it("returns undefined for a label no preset covers — the normal parsed case", () => {
+    // `type` is free text lifted from a real résumé. A miss is expected, not a
+    // failure: the label still renders and still round-trips, just without an
+    // emoji. It must NOT fuzzy-match onto "Award".
+    expect(matchAchievementPreset("Best Paper Award")).toBeUndefined();
+  });
+
+  it("returns undefined for an absent or empty label", () => {
+    expect(matchAchievementPreset(undefined)).toBeUndefined();
+    expect(matchAchievementPreset("   ")).toBeUndefined();
+  });
+
+  it("carries a non-empty label and emoji on every preset, with unique labels", () => {
+    const labels = ACHIEVEMENT_PRESETS.map((p) => p.label);
+    for (const p of ACHIEVEMENT_PRESETS) {
+      expect(p.label.trim()).not.toBe("");
+      expect(p.emoji.trim()).not.toBe("");
+    }
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});

--- a/src/lib/achievements/presets.ts
+++ b/src/lib/achievements/presets.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Achievement type presets — the catalog behind the type picker (#456).
+ *
+ * {@link HeuristicAchievement.type} is FREE TEXT: the verbatim label a real
+ * résumé happened to carry, lifted at parse (`splitAchievementType`). It cannot
+ * be narrowed to an enum without losing every label a résumé actually used
+ * ("Best Paper Award", "Keynote", …) — so these presets are SUGGESTIONS layered
+ * over free text, not a closed set:
+ *
+ *   – the picker offers them as one-tap choices, and
+ *   – any other string a user types (or the parser lifted) stays valid and
+ *     round-trips untouched.
+ *
+ * Matching is therefore by LABEL, case-insensitively, and a miss is normal —
+ * an unrecognized label simply has no emoji.
+ *
+ * The emoji is a UI affordance ONLY. It is never written into the exported PDF:
+ * the export bolds the `type` label as text, and the parser reads text back, so
+ * injecting a glyph would put a character in the résumé that no ATS asked for
+ * and that re-parses as part of the label.
+ */
+
+export interface AchievementPreset {
+  /** The label written to `HeuristicAchievement.type` when picked. */
+  label: string;
+  /** Displayed next to the label in the picker. UI-only — never exported. */
+  emoji: string;
+}
+
+export const ACHIEVEMENT_PRESETS: readonly AchievementPreset[] = [
+  { label: "Patent", emoji: "\u{1F4DC}" },
+  { label: "Book", emoji: "\u{1F4D8}" },
+  { label: "Publication", emoji: "\u{1F4C4}" },
+  { label: "Founded", emoji: "\u{1F680}" },
+  { label: "Exit", emoji: "\u{1F3C1}" },
+  { label: "Acquired", emoji: "\u{1F91D}" },
+  { label: "Award", emoji: "\u{1F3C6}" },
+  { label: "Talk", emoji: "\u{1F3A4}" },
+  { label: "Fellowship", emoji: "\u{1F393}" },
+  { label: "Press", emoji: "\u{1F4F0}" },
+  { label: "Open Source", emoji: "\u{1F9EA}" },
+  { label: "Certification", emoji: "\u{1F4CB}" },
+];
+
+const BY_LABEL = new Map(
+  ACHIEVEMENT_PRESETS.map((p) => [p.label.toLowerCase(), p]),
+);
+
+/**
+ * The preset a free-text label corresponds to, or `undefined` when it matches
+ * none — the expected case for a label the parser lifted verbatim from a PDF.
+ */
+export function matchAchievementPreset(
+  type: string | undefined,
+): AchievementPreset | undefined {
+  const key = type?.trim().toLowerCase();
+  return key ? BY_LABEL.get(key) : undefined;
+}

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -766,6 +766,60 @@ describe("applyOverrides — added entries + bullets", () => {
     });
   });
 
+  it("maps an added achievement's type + title onto the real fields (#455, #456)", () => {
+    const { fields: out } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [
+        {
+          id: "added:0",
+          section: "achievements",
+          achievementType: "Patent",
+          title: "Issued US10275736B1; bulk catalog editor",
+          year: "2021",
+        },
+      ],
+      {},
+    );
+    expect(out.heuristic_achievements?.[0]).toMatchObject({
+      type: "Patent",
+      title: "Issued US10275736B1; bulk catalog editor",
+      year: "2021",
+    });
+  });
+
+  it("adds an achievement with no type as a bare description (#455)", () => {
+    const { fields: out } = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [
+        {
+          id: "added:0",
+          section: "achievements",
+          title: "Ran the local 10k for charity",
+        },
+      ],
+      {},
+    );
+    expect(out.heuristic_achievements?.[0].title).toBe(
+      "Ran the local 10k for charity",
+    );
+  });
+
   it("folds an added bullet on an existing role into description AND the pool", () => {
     const parsed = baseParsed();
     const { fields: out, sections } = applyOverrides(
@@ -1129,5 +1183,182 @@ describe("applyOverrides — profiles[] (#335)", () => {
     expect(linkedinEdits).toHaveLength(1);
     expect(linkedinEdits[0].confidence).toBe(1); // present, not the stale clear
     expect(probe.linkedin_url).toBe("https://linkedin.com/in/new");
+  });
+});
+
+// ── Achievements (#454) ─────────────────────────────────────────────────────
+//
+// `title` is the canonical field: the UI edits its two halves (the leading type
+// label and the description) as separate fields and applyOverrides recomposes
+// them, so these tests pin the decompose → edit → recompose loop, including the
+// degenerate shapes (no type segment, a cleared type, an over-long type).
+
+/** A parse carrying two parsed achievements — one typed, one prose-only. */
+function achParsed(): HeuristicParsedResume {
+  return {
+    ...baseParsed(),
+    heuristic_achievements: [
+      {
+        type: "Patent",
+        title: "Issued US10275736B1; bulk catalog editor",
+        year: "2019",
+        description: "Cut editor latency 40%",
+      },
+      { title: "Best Paper Award", year: "2021" },
+    ],
+  };
+}
+
+/** applyOverrides with only the achievement overrides (+ optional added entries)
+ *  set — the rest defaulted, so the calls below stay readable. */
+function applyAch(
+  parsed: HeuristicParsedResume,
+  achievements: Parameters<typeof applyOverrides>[14],
+  addedEntries: Parameters<typeof applyOverrides>[9] = [],
+) {
+  return applyOverrides(
+    parsed,
+    "raw",
+    makeSections(),
+    {},
+    {},
+    {},
+    [],
+    {},
+    undefined,
+    addedEntries,
+    {},
+    undefined,
+    undefined,
+    undefined,
+    achievements,
+  );
+}
+
+describe("applyOverrides — achievements", () => {
+  it("writes the title override onto the title field, leaving the type alone", () => {
+    const parsed = achParsed();
+    const { fields: out } = applyAch(parsed, {
+      0: { title: "Issued US10275736B1; bulk catalog editor v2" },
+    });
+    expect(out.heuristic_achievements?.[0]).toMatchObject({
+      type: "Patent",
+      title: "Issued US10275736B1; bulk catalog editor v2",
+    });
+    // The original parse is not mutated.
+    expect(parsed.heuristic_achievements?.[0].title).toBe(
+      "Issued US10275736B1; bulk catalog editor",
+    );
+  });
+
+  it("writes the type override onto the type field (the bold run tracks it)", () => {
+    const { fields: out } = applyAch(achParsed(), { 0: { type: "Publication" } });
+    expect(out.heuristic_achievements?.[0]).toMatchObject({
+      type: "Publication",
+      title: "Issued US10275736B1; bulk catalog editor",
+    });
+  });
+
+  it("clearing the type drops the field, keeping the title intact", () => {
+    const { fields: out } = applyAch(achParsed(), { 0: { type: "" } });
+    expect(out.heuristic_achievements?.[0].type).toBeUndefined();
+    expect(out.heuristic_achievements?.[0].title).toBe(
+      "Issued US10275736B1; bulk catalog editor",
+    );
+  });
+
+  it("adds a type to a previously type-less achievement", () => {
+    const { fields: out } = applyAch(achParsed(), { 1: { type: "Award" } });
+    expect(out.heuristic_achievements?.[1]).toMatchObject({
+      type: "Award",
+      title: "Best Paper Award",
+    });
+  });
+
+  it("edits the title of a type-less achievement without inventing a type", () => {
+    const { fields: out } = applyAch(achParsed(), {
+      1: { title: "Best Paper Award, ACL" },
+    });
+    expect(out.heuristic_achievements?.[1].type).toBeUndefined();
+    expect(out.heuristic_achievements?.[1].title).toBe("Best Paper Award, ACL");
+  });
+
+  it("sets the year, and an empty year clears it", () => {
+    const { fields: set } = applyAch(achParsed(), { 1: { year: "2022" } });
+    expect(set.heuristic_achievements?.[1].year).toBe("2022");
+
+    const { fields: cleared } = applyAch(achParsed(), { 1: { year: "" } });
+    expect(cleared.heuristic_achievements?.[1].year).toBeUndefined();
+  });
+
+  it("clearing both fields empties the header without cross-contamination", () => {
+    const { fields: out } = applyAch(achParsed(), { 0: { type: "", title: "" } });
+    expect(out.heuristic_achievements?.[0].type).toBeUndefined();
+    expect(out.heuristic_achievements?.[0].title).toBe("");
+  });
+
+  it("keeps the achievement's bullets (description body) across a header edit", () => {
+    const { fields: out } = applyAch(achParsed(), { 0: { type: "Publication" } });
+    expect(out.heuristic_achievements?.[0].description).toBe(
+      "Cut editor latency 40%",
+    );
+  });
+
+  // ── The two shapes the old composed-title model (#454) got wrong ────────────
+  // Both used to survive as a `title` STRING but re-split into a different pair,
+  // so the PDF bolded the wrong run and /jd-fit showed the wrong fields. With
+  // `type` a real field there is nothing to re-split (#456).
+
+  it("keeps an over-long type as the type — it is not folded into the title", () => {
+    const longType = "Recognized across the org for sustained impact";
+    const { fields: out } = applyAch(achParsed(), { 1: { type: longType } });
+    expect(out.heuristic_achievements?.[1]).toMatchObject({
+      type: longType,
+      title: "Best Paper Award",
+    });
+  });
+
+  it("keeps a title carrying its own separator out of the type", () => {
+    const { fields: out } = applyAch(achParsed(), {
+      1: { type: "Talk", title: "KubeCon · Amsterdam" },
+    });
+    expect(out.heuristic_achievements?.[1]).toMatchObject({
+      type: "Talk",
+      title: "KubeCon · Amsterdam",
+    });
+  });
+
+  it("ignores an achievement override for an out-of-range index", () => {
+    const { fields: out } = applyAch(achParsed(), { 5: { type: "Patent" } });
+    expect(out.heuristic_achievements).toHaveLength(2);
+    expect(out.heuristic_achievements?.[0].type).toBe("Patent");
+  });
+
+  it("is a no-op when there are no achievement overrides", () => {
+    const { fields: out } = applyAch(achParsed(), {});
+    expect(out.heuristic_achievements).toEqual(achParsed().heuristic_achievements);
+  });
+
+  it("survives an override against a parse with no achievements at all", () => {
+    const { fields: out } = applyAch(baseParsed(), { 0: { type: "Patent" } });
+    expect(out.heuristic_achievements).toBeUndefined();
+  });
+
+  it("keys overrides against the PARSED indices — an added achievement never collides", () => {
+    const { fields: out } = applyAch(
+      achParsed(),
+      { 0: { type: "Publication" } },
+      [{ id: "added:0", section: "achievements", title: "Talk", year: "2024" }],
+    );
+    expect(out.heuristic_achievements).toHaveLength(3);
+    expect(out.heuristic_achievements?.[0]).toMatchObject({
+      type: "Publication",
+      title: "Issued US10275736B1; bulk catalog editor",
+    });
+    // The appended entry sits past the parsed ones, untouched by the override.
+    expect(out.heuristic_achievements?.[2]).toMatchObject({
+      title: "Talk",
+      year: "2024",
+    });
   });
 });

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -35,6 +35,7 @@ import type {
 import type { CanonicalResume } from "../heuristics/canonical.ts";
 import { toCanonicalResume } from "../heuristics/canonical.ts";
 import type { BulletObservation } from "../score/score.ts";
+import type { HeuristicAchievement } from "../score/types.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 import type { SectionName } from "../heuristics/regex.ts";
 import { normalizeBulletText } from "../score/group-bullets.ts";
@@ -44,6 +45,7 @@ import type {
   ContactOverrides,
   ExperienceFieldOverrides,
   EducationFieldOverrides,
+  AchievementFieldOverrides,
   SkillsOverride,
   AddedEntry,
   AddedBullets,
@@ -294,6 +296,53 @@ function applyEducationFieldOverrides(
     if (fields.start_date !== undefined) edu.start_date = fields.start_date;
     if (fields.end_date !== undefined) edu.end_date = fields.end_date;
   }
+}
+
+// ── Achievements (#454) ─────────────────────────────────────────────────────
+
+/**
+ * Fold `achievements` field overrides into the parsed achievements, keyed by
+ * array index. Each override key names a REAL field on `HeuristicAchievement`
+ * (`type`, `title`, `year`) and is copied straight onto it (#456) — there is no
+ * compose/decompose step, so an edit to one field can never perturb another.
+ *
+ * An empty `type` or `year` drops the key (mirroring the optional
+ * `location`/`team` clears on experience); an empty `title` is kept verbatim,
+ * since `title` is required and its empty string is the parser's own
+ * no-usable-header value.
+ *
+ * `heuristic_achievements` is cloned here (the entry point pre-clones only
+ * experience / education / skills). A later re-clone by
+ * {@link applyAddedEntriesAndBullets} preserves these edits.
+ *
+ * Achievement overrides are keyed against the PARSED array, and added entries
+ * are appended AFTER this runs, so the two index spaces never collide.
+ */
+function applyAchievementOverrides(
+  nextParsed: HeuristicParsedResume,
+  overrides: Record<number, AchievementFieldOverrides>,
+): void {
+  if (Object.keys(overrides).length === 0) return;
+  const parsedAchievements = nextParsed.heuristic_achievements;
+  if (!parsedAchievements || parsedAchievements.length === 0) return;
+
+  const achievements = parsedAchievements.map((a) => ({ ...a }));
+  for (const [idxStr, fields] of Object.entries(overrides)) {
+    const ach = achievements[Number(idxStr)];
+    if (!ach) continue;
+    mergeAchievementFields(ach, fields);
+  }
+  nextParsed.heuristic_achievements = achievements;
+}
+
+/** Fold one achievement's field overrides into the (already cloned) entry. */
+function mergeAchievementFields(
+  ach: HeuristicAchievement,
+  fields: AchievementFieldOverrides,
+): void {
+  if (fields.type !== undefined) ach.type = fields.type || undefined;
+  if (fields.title !== undefined) ach.title = fields.title;
+  if (fields.year !== undefined) ach.year = fields.year || undefined;
 }
 
 // ── Skills (add / remove) ───────────────────────────────────────────────────
@@ -637,7 +686,12 @@ function pushAddedEntry(
   } else if (entry.section === "projects") {
     nextParsed.projects!.push({ name: entry.title, description });
   } else {
+    // The added entry's flat header fields map straight onto the achievement's
+    // real fields (#456) — `achievementType` is the bold label, `title` the rest
+    // — so an added achievement is indistinguishable from a parsed-then-edited
+    // one (#455) without any recomposition.
     nextParsed.heuristic_achievements!.push({
+      type: entry.achievementType || undefined,
       title: entry.title,
       year: entry.year,
       description,
@@ -774,6 +828,11 @@ function applyAddedBulletsToExistingEntries(
  *                  clear), so a typed-in / picker-added contact link scores +
  *                  displays as present rather than as low-confidence against the
  *                  frozen base parse (#421 Blocking #1 / #3). Default `{}`.
+ * @param achievements achievement-field overrides keyed by
+ *                  `heuristic_achievements` array index (#454). `type`, `title`
+ *                  and `year` are copied straight onto the entry — `type` is a
+ *                  stored field, not a run of `title`, so nothing is recomposed
+ *                  (#456). An empty `type` or `year` clears it. Default `{}`.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -790,6 +849,7 @@ export function applyOverrides(
   removedBullets: ReadonlySet<number> = new Set(),
   profileOverrides: readonly ProfileOverride[] = [],
   fieldConfidence: FieldConfidence = {},
+  achievements: Record<number, AchievementFieldOverrides> = {},
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -826,6 +886,9 @@ export function applyOverrides(
   );
 
   applyEducationFieldOverrides(nextParsed.education, education);
+  // Before the added-entry append below, so the override keys stay aligned with
+  // the PARSED achievement indices they were captured against.
+  applyAchievementOverrides(nextParsed, achievements);
   applySkillOverrides(nextParsed, skills);
 
   const nextSections = applyAddedEntriesAndBullets(

--- a/src/lib/heuristics/extract-fields.test.ts
+++ b/src/lib/heuristics/extract-fields.test.ts
@@ -1242,6 +1242,30 @@ describe("extractProjects", () => {
 });
 
 describe("extractAchievements", () => {
+  it("lifts the leading 'Patent · …' label into the type field (#456)", () => {
+    const section = mkSection("achievements", [
+      { text: "Patent · Bulk catalog editor 2019" },
+      { text: "• Cut editor latency 40%" },
+    ]);
+    const { value } = extractAchievements(section);
+    expect(value).toHaveLength(1);
+    // The label is STORED, not left embedded in the title for a downstream
+    // consumer to re-split — the split happens exactly once, here.
+    expect(value[0].type).toBe("Patent");
+    expect(value[0].title).toBe("Bulk catalog editor");
+    expect(value[0].year).toBe("2019");
+  });
+
+  it("leaves a prose header with no qualifying label type-less (#456)", () => {
+    const section = mkSection("achievements", [
+      { text: "Best Paper Award" },
+      { text: "• Cited 100+ times" },
+    ]);
+    const { value } = extractAchievements(section);
+    expect(value[0].type).toBeUndefined();
+    expect(value[0].title).toBe("Best Paper Award");
+  });
+
   it("maps title + lead year + url, dropping the date range to a year", () => {
     const section = mkSection("achievements", [
       { text: "Best Paper Award 2021 https://conf.example.com/paper" },

--- a/src/lib/heuristics/extract/achievements.ts
+++ b/src/lib/heuristics/extract/achievements.ts
@@ -6,6 +6,7 @@ import type { PdfLine, PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
 import { YEAR_RE } from "../regex.ts";
+import { splitAchievementType } from "../../score/entry-dates.ts";
 import {
   isBulletLine,
   isPageFurniture,
@@ -47,10 +48,11 @@ import { liftHeaderLabel } from "./projects.ts";
  * continuation page carries) is stripped first, so it never becomes a title or
  * leaks into an award's description.
  *
- * Honest-by-construction (#96, option (a)): we emit only what a regex parser can
- * truthfully assert — a title, an optional year/url, and a bullet body. We do
- * NOT guess an `AchievementType`; the structured `Achievement[]` is the LLM
- * path's job.
+ * Honest-by-construction (#96): we emit only what a regex parser can truthfully
+ * assert — a title, an optional verbatim type label, year/url, and a bullet
+ * body. The label is lifted off the header, never invented, and stays free text:
+ * we do NOT guess the closed `AchievementType` enum; the structured
+ * `Achievement[]` is the LLM path's job.
  */
 export function extractAchievements(
   achievements: PdfSection | undefined,
@@ -147,7 +149,15 @@ function achievementFromBlock(block: EntryBlock): {
   const cleanedHeader = block.dates.start_date
     ? block.headerLines
     : [stripDateRange(headerText), ...block.headerLines.slice(1)];
-  const { label: title, url } = liftHeaderLabel(cleanedHeader);
+  const { label, url } = liftHeaderLabel(cleanedHeader);
+
+  // Lift the leading "Patent · …" type label off the header into its own field
+  // — the ONE place that split happens (#456). Storing it here is what lets the
+  // edit surface and the PDF exporter agree on the emphasized run without
+  // re-splitting a composed string (which is not a round-trip).
+  const split = splitAchievementType(label);
+  const type = split?.type;
+  const title = split ? split.rest : label;
 
   // Reduce any date range the header carried to a single lead year.
   const year = dates.start_date
@@ -164,6 +174,7 @@ function achievementFromBlock(block: EntryBlock): {
 
   return {
     entry: {
+      ...(type ? { type } : {}),
       title,
       ...(year ? { year } : {}),
       ...(url ? { url } : {}),

--- a/src/lib/heuristics/probe-achievements.test.ts
+++ b/src/lib/heuristics/probe-achievements.test.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Achievements-section dev probe — inert in CI, runs ONLY when
+ * `RL_ACHIEVEMENTS_PDF=<path>` is set:
+ *
+ *   RL_ACHIEVEMENTS_PDF=/abs/path/to/resume.pdf npx vitest run \
+ *     src/lib/heuristics/probe-achievements.test.ts
+ *
+ * Extracts + VERIFIES the achievements section of one arbitrary PDF so a real
+ * (uncommitted, possibly PII-bearing) résumé can be triaged WITHOUT being
+ * committed as a fixture. This is the execution vehicle for the
+ * `probe-achievements` skill — sibling of `probe-experience` / `probe-contact` /
+ * `probe-roundtrip`; the pattern is identical: run the real parser via
+ * runCascade (the pdfjs worker only resolves under the vitest transform — no
+ * standalone script), then show the section extractor's INPUT (the achievements
+ * region it scanned) next to its OUTPUT (the parsed achievement entries) so a
+ * dropped/merged/mis-split achievement is localizable.
+ *
+ * ── PII guardrail (same rules as the sibling probes) ──
+ * 1. The input PDF is local-only. NEVER commit it. `tests/fixtures/pdfs/` is
+ *    synthetic-personas-only by policy.
+ * 2. The console + JSON output prints achievement VALUES (titles, years) so the
+ *    corruption is visible → scratch only. The full JSON goes to the gitignored
+ *    `internal/` dir. Do not paste raw values into an issue/PR/Slack; cite the
+ *    defect by CATEGORY ("the type label was split at the wrong middot").
+ *
+ * ── type / description ──
+ * The parser stores the type label in its own `type` field, lifted off the
+ * header's leading " · " run once at parse (#456); `title` carries only the
+ * description. That stored `type` is the run the reconstructed view and the
+ * Download PDF render bold (#452), and the field the inline editor commits
+ * against (#454). The probe prints both halves as stored — no re-split — so a
+ * mis-emphasized header ("the whole prose title bolded", "the type swallowed the
+ * description") is visible as a parse defect, not just a styling one.
+ *
+ * ── The "verify" pass ──
+ * There is no ground truth for a real résumé, so verification is a second,
+ * independent scan of the region: every line that is NOT bullet-marked is a
+ * candidate achievement HEADER, so the count of such lines is a lower-bound
+ * oracle for how many entries SHOULD have segmented. The split localizes the
+ * failure:
+ *   - entries == 0 AND the region is non-empty  → PARSER-MISS (the block is in
+ *     the region; entry segmentation dropped it)
+ *   - entries  <  header-shaped lines           → UNDER-SEGMENTED (achievements
+ *     merged into a neighbor entry)
+ *   - entries >=  header-shaped lines           → ok (a wrapped header can
+ *     legitimately exceed the oracle)
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { runCascade } from "./cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Bullet/numbered lead markers — a line carrying one is a BODY line, not a
+ *  candidate entry header (mirrors group-bullets' LEADING_MARKER_RE). */
+const BULLET_LINE_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·]|\d+[.)])\s/;
+
+describe.runIf(process.env.RL_ACHIEVEMENTS_PDF)(
+  "achievements dev probe (RL_ACHIEVEMENTS_PDF)",
+  () => {
+    it("extracts + verifies the achievements section for RL_ACHIEVEMENTS_PDF", async () => {
+      const path = process.env.RL_ACHIEVEMENTS_PDF!;
+      const outDir =
+        process.env.RL_ACHIEVEMENTS_OUT ??
+        join(HERE, "../../..", "internal/achievements");
+
+      const cascade = await runCascade(new Uint8Array(readFileSync(path)));
+      const p = cascade.canonical.fields;
+
+      const score = computeAnonymousAtsScore({
+        parsed: { ...p },
+        fieldConfidence: cascade.canonical.fieldConfidence,
+        triggers: cascade.triggers,
+        rawText: cascade.rawText,
+        sections: cascade.canonical.sections,
+      });
+
+      // OUTPUT: the parsed achievement entries. `type` and `title` are the two
+      // stored halves the view/PDF/editor all read — no re-splitting here, the
+      // split happened once at parse (#456).
+      const entries = (p.heuristic_achievements ?? []).map((a) => {
+        const type = a.type ?? null;
+        return {
+          type,
+          description: a.title,
+          // Whether the header carried a LABEL — i.e. whether the export bolds
+          // just the type (true) or the whole header line (false).
+          typeIsLabel: type !== null,
+          year: a.year ?? null,
+          url: a.url ?? null,
+          bullets: a.description
+            ? a.description.split("\n").filter((l) => l.trim()).length
+            : 0,
+        };
+      });
+
+      // INPUT: the achievements region the entry segmenter scanned.
+      const regionLines = [
+        ...(cascade.canonical.sections.byName.get("achievements") ?? []),
+      ];
+
+      // Section-detection overview (all regions, line counts only). A missing
+      // `achievements` region means the failure is upstream of entry
+      // segmentation — the block was never routed here (heading unrecognized,
+      // or swallowed by a neighbor section).
+      const sectionOverview = [
+        ...cascade.canonical.sections.byName.entries(),
+      ].map(([name, lines]) => `${name}(${lines.length})`);
+
+      // VERIFY: non-bullet lines in the region are candidate entry headers —
+      // a lower-bound oracle for the entry count.
+      const headerLines = regionLines.filter((l) => !BULLET_LINE_RE.test(l));
+      let verdict: string;
+      if (entries.length === 0 && regionLines.length > 0)
+        verdict = `PARSER-MISS (0 entries; the achievements region has ${regionLines.length} lines)`;
+      else if (entries.length < headerLines.length)
+        verdict = `UNDER-SEGMENTED (${entries.length} entries < ${headerLines.length} header-shaped lines — an achievement likely merged into a neighbor)`;
+      else if (entries.length === 0 && regionLines.length === 0)
+        verdict =
+          "no achievements region segmented (the résumé may carry none — check `Sections detected` for a mis-routed block)";
+      else verdict = "ok";
+
+      const report = {
+        path,
+        score: {
+          overall: score.overall,
+          preLayoutOverall: score.preLayoutOverall,
+          layoutTriggers: [...score.layout.triggers],
+          layoutMultiplier: score.layout.multiplier,
+        },
+        sectionOverview,
+        achievementsPlacement: p.achievements_placement ?? null,
+        entries,
+        regionLines,
+        headerLines,
+        verdict,
+        triggers: [...cascade.triggers],
+      };
+
+      mkdirSync(outDir, { recursive: true });
+      const outFile = join(
+        outDir,
+        `achievements-${basename(path).replace(/\.[^.]+$/, "")}.json`,
+      );
+      writeFileSync(outFile, JSON.stringify(report, null, 2));
+
+      console.log(
+        `RL_ACHIEVEMENTS_PDF achievements probe for ${path}:\n` +
+          `\n  Score: overall ${score.overall} (pre-layout ${score.preLayoutOverall}, ` +
+          `layout ×${score.layout.multiplier} [${score.layout.triggers.join(", ") || "none"}])\n` +
+          `\n  Sections detected: ${sectionOverview.join("  ")}\n` +
+          `\n  Parsed achievements (${entries.length}):\n` +
+          (entries.length
+            ? entries
+                .map(
+                  (e, i) =>
+                    `    ${i + 1}. type=${JSON.stringify(e.type)}` +
+                    `${e.typeIsLabel ? "" : " (no type label — whole header renders bold)"}\n` +
+                    `       description=${JSON.stringify(e.description)}\n` +
+                    `       year=${e.year ?? "?"}  bullets=${e.bullets}`,
+                )
+                .join("\n")
+            : "    (none)") +
+          `\n\n  Achievements region scanned (${regionLines.length} lines, ` +
+          `${headerLines.length} header-shaped):\n` +
+          (regionLines.length
+            ? regionLines.map((l) => `    | ${l}`).join("\n")
+            : "    (empty — no achievements region segmented)") +
+          `\n\n  Verify: ${verdict}` +
+          `\n\n  Full JSON → ${outFile}  ⚠️ gitignored; may carry PII, do NOT commit.`,
+      );
+
+      // Informational only: never fails the suite.
+      expect(true).toBe(true);
+    });
+  },
+);

--- a/src/lib/jd-fit-handoff.test.ts
+++ b/src/lib/jd-fit-handoff.test.ts
@@ -8,6 +8,7 @@ import {
   consumeJdFitHandoff,
   type JdFitHandoff,
 } from "./jd-fit-handoff.ts";
+import type { EditSnapshot } from "../hooks/useEditableParse.ts";
 
 // Vitest defaults to Node env (per vite.config.ts), where `sessionStorage`
 // isn't defined. Provide a tiny in-memory shim so the handoff read/write/clear
@@ -33,6 +34,20 @@ beforeEach(() => {
     new MemoryStorage() as unknown as Storage;
 });
 
+/** An untouched edit layer — what crosses when the user edited nothing. */
+const EMPTY_EDIT: EditSnapshot = {
+  contactOverrides: {},
+  experienceOverrides: {},
+  bulletOverrides: {},
+  removedBullets: [],
+  educationOverrides: {},
+  achievementOverrides: {},
+  skillsOverride: { removed: [], added: [] },
+  addedEntries: [],
+  addedBullets: {},
+  profileOverrides: [],
+};
+
 // Minimal handoff payload — only the fields the shape-guard checks need to be
 // present; the rest round-trips opaquely through JSON. `canonical.sections`
 // carries the `byName` / `sectionHeadings` Maps the scorer reads, so the sample
@@ -55,6 +70,7 @@ const samplePayload = {
     rawText: "x",
   },
   score: { overall: 72 },
+  edit: EMPTY_EDIT,
 } as unknown as JdFitHandoff;
 
 describe("jd-fit handoff round-trip (#226)", () => {
@@ -87,6 +103,50 @@ describe("jd-fit handoff round-trip (#226)", () => {
       JDFIT_HANDOFF_KEY,
       JSON.stringify({
         result: { canonical: { sections: { byName: {} } } },
+        score: { overall: 50 },
+      }),
+    );
+    expect(consumeJdFitHandoff()).toBeNull();
+  });
+
+  it("carries the user's edit STATE, not an override-applied résumé (#456)", () => {
+    // The payload must hand over the pristine parse + the edits separately, so
+    // /jd-fit can re-apply them through its own edit layer. An added entry has
+    // to survive as an ADDED entry — baked into `result.canonical.fields` it
+    // would arrive indistinguishable from a parsed one (and lose its Remove
+    // button), and re-seeding from an applied payload would append it twice.
+    const edited: JdFitHandoff = {
+      ...samplePayload,
+      edit: {
+        ...EMPTY_EDIT,
+        contactOverrides: { full_name: "Corrected Persona" },
+        achievementOverrides: { 0: { type: "Patent", title: "Catalog editor" } },
+        addedEntries: [
+          { id: "added:0", section: "achievements", title: "Talk", year: "2024" },
+        ],
+      },
+    };
+    writeJdFitHandoff(edited);
+    const got = consumeJdFitHandoff();
+
+    expect(got?.edit.contactOverrides.full_name).toBe("Corrected Persona");
+    expect(got?.edit.achievementOverrides?.[0]).toEqual({
+      type: "Patent",
+      title: "Catalog editor",
+    });
+    expect(got?.edit.addedEntries).toHaveLength(1);
+    // The parse itself crosses UNTOUCHED — the correction is not folded in.
+    expect(got?.result.canonical.fields.full_name).toBe("Synthetic Persona");
+  });
+
+  it("rejects a payload with no edit snapshot (#456)", () => {
+    // A pre-#456 payload carried an override-APPLIED result and no `edit` key.
+    // Consuming it would silently show an un-edited résumé, so the guard rejects
+    // and /jd-fit falls back to its DropZone.
+    globalThis.sessionStorage.setItem(
+      JDFIT_HANDOFF_KEY,
+      JSON.stringify({
+        result: { canonical: { sections: { byName: { __rlMap: [] } } } },
         score: { overall: 50 },
       }),
     );

--- a/src/lib/jd-fit-handoff.ts
+++ b/src/lib/jd-fit-handoff.ts
@@ -5,12 +5,19 @@
  * One-shot resume handoff from `/` (parser audit) to `/jd-fit` (issue #226).
  *
  * When a user parses a résumé on `/` and clicks "Check fit against a job", the
- * already-parsed + edited result is stashed here so `/jd-fit` can rehydrate it
- * without re-parsing the PDF. We hand off the PARSED JSON (the edited
- * CascadeResult shape `<Result>` receives, plus its re-graded score), not the
- * PDF bytes — JD-fit doesn't show the source-PDF pane, and JSON survives the
- * navigation cheaply. PDF bytes are intentionally dropped (they don't serialize
- * to JSON and the source-PDF pane isn't shown on /jd-fit).
+ * parse is stashed here so `/jd-fit` can rehydrate it without re-parsing the
+ * PDF. We hand off the PARSED JSON, not the PDF bytes — JD-fit doesn't show the
+ * source-PDF pane, and JSON survives the navigation cheaply.
+ *
+ * What crosses is the PRISTINE parse + score and the user's EDIT STATE as a
+ * separate `edit` snapshot (#456) — never the override-APPLIED result. `/jd-fit`
+ * runs its own edit layer, so it must receive the same two inputs `/` had and
+ * re-apply them itself. Handing over an applied result instead made the edits
+ * unrecoverable on the far side: they had already been baked into the fields, so
+ * `/jd-fit` could not tell a user-ADDED entry from a parsed one (it lost its
+ * Remove button) and its fresh, empty edit layer re-derived achievement fields
+ * from the applied ones. Re-seeding the far side from an applied payload is NOT
+ * a fix — the entries would be appended a second time.
  *
  * Stored under sessionStorage (not localStorage) because this is a
  * within-session, within-tab handoff — it must not leak a parsed résumé into a
@@ -22,6 +29,7 @@
 
 import type { CascadeResult } from "./heuristics/types.ts";
 import type { AnonymousAtsScore } from "./score/score.ts";
+import type { EditSnapshot } from "../hooks/useEditableParse.ts";
 
 /** sessionStorage key for the parser-audit → JD-fit handoff payload (#226). */
 export const JDFIT_HANDOFF_KEY = "rl_jdfit_handoff";
@@ -59,10 +67,17 @@ function reviveMaps(_key: string, value: unknown): unknown {
 }
 
 export interface JdFitHandoff {
-  /** The edited CascadeResult `<Result>` receives ({ ...result, parsed }). */
+  /** The PRISTINE CascadeResult — the parse as it came off the cascade, with NO
+   *  overrides applied. `/jd-fit` folds `edit` onto this itself. */
   result: CascadeResult;
-  /** The re-graded anonymous ATS score for that edited result. */
+  /** The PRISTINE anonymous ATS score for that parse. Its `bullets` pool is the
+   *  one `edit.bulletOverrides` / `removedBullets` are keyed against, so it must
+   *  be the un-edited pool, not a re-graded one. */
   score: AnonymousAtsScore;
+  /** The user's edit state from `/`, replayed into `/jd-fit`'s own edit layer so
+   *  their corrections carry over AND stay editable (an added entry is still an
+   *  added entry). Absent/empty when they made no edits. */
+  edit: EditSnapshot;
 }
 
 /** Write the one-shot handoff payload before navigating to /jd-fit. */
@@ -96,6 +111,7 @@ export function consumeJdFitHandoff(): JdFitHandoff | null {
     // Minimal shape guard: a malformed/partial payload falls back to DropZone.
     if (!parsed || typeof parsed !== "object") return null;
     if (!parsed.result || !parsed.result.canonical || !parsed.score) return null;
+    if (!parsed.edit) return null;
     // The scorer/section reads require a revived `byName` Map, not a plain
     // object (#450). Reject a payload where it failed to round-trip as a Map.
     if (!(parsed.result.canonical.sections?.byName instanceof Map)) return null;

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -215,7 +215,8 @@ describe("buildAtsResumeModel", () => {
     const result = makeResult({
       heuristic_achievements: [
         {
-          title: "Patent · Issued US10275736B1; bulk catalog editor",
+          type: "Patent",
+          title: "Issued US10275736B1; bulk catalog editor",
           year: "2019",
         },
       ],
@@ -223,8 +224,8 @@ describe("buildAtsResumeModel", () => {
     const model = buildAtsResumeModel(result, makeScore([]));
     const ach = model.sections.find((s) => s.kind === "achievements");
     const entry = ach!.entries[0];
-    // The type ("Patent") is wrapped in the PUA emphasis sentinels; the rest of
-    // the header — description and year — stays outside them (regular weight).
+    // The `type` field ("Patent") is wrapped in the PUA emphasis sentinels; the
+    // rest of the header — title and year — stays outside them (regular weight).
     expect(entry.headerLine).toBe(
       `${EMPHASIS_OPEN}Patent${EMPHASIS_CLOSE} · ` +
         "Issued US10275736B1; bulk catalog editor · 2019",

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -31,7 +31,7 @@ import {
   groupBulletsByExperience,
   toBulletExperience,
 } from "../score/group-bullets.ts";
-import { buildProjectDates, splitAchievementType } from "../score/entry-dates.ts";
+import { buildProjectDates } from "../score/entry-dates.ts";
 import { isLoneDateRange } from "../heuristics/line-primitives.ts";
 import { projectDisplay } from "../heuristics/projections.ts";
 import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
@@ -363,31 +363,44 @@ export function isDatedEntry(entry: {
 }
 
 /**
- * Build an achievement's header string, emphasizing ONLY the leading "type"
- * label (e.g. "Patent", "Publication") when the title carries the canonical
- * "Type · description" shape — the rest of the header stays regular weight.
+ * Build an achievement's header string, emphasizing ONLY its `type` label (e.g.
+ * "Patent", "Publication") — the rest of the header stays regular weight.
  *
- * The type run (see {@link splitAchievementType}) is wrapped in the renderer's
- * PUA emphasis sentinels (`EMPHASIS_OPEN`/`CLOSE`) so `drawEntry` draws just that
- * run bold; the sentinels are stripped before drawing, so the round-trip text is
- * unchanged (display-only weight, #284/#425). When there is no such type segment
- * the header is returned plain (no sentinels) and the caller keeps the whole line
- * bold. The reconstructed-résumé view shares `splitAchievementType` so its header
- * emphasizes the identical run (#452).
+ * The label is read from the stored `type` field, never re-derived by splitting
+ * the title (#456): the emphasized run is exactly the label the parser lifted or
+ * the user typed, whatever its length or punctuation. The run is wrapped in the
+ * renderer's PUA emphasis sentinels (`EMPHASIS_OPEN`/`CLOSE`) so `drawEntry`
+ * draws just it bold; the sentinels are stripped before drawing, so the
+ * round-trip TEXT is unchanged (display-only weight, #284/#425). With no label
+ * (or no title to set it off against) the header is returned plain and the
+ * caller keeps the whole line bold. `ReconstructedResume` reads the same field,
+ * so the on-screen header and the Download PDF emphasize the identical run
+ * (#452).
+ *
+ * Round-trip caveat: the exported text is `"Type · Title"`, and re-parsing it
+ * recovers `type` only when the label still passes `splitAchievementType` — a
+ * label over `ACHIEVEMENT_TYPE_MAX_LEN`, or a title carrying its own `" · "`,
+ * re-parses into a different split. The bold run is the PDF's only other
+ * encoding of the label and the parser does not read font weight, so this is
+ * inherent to the format, not to the model.
  */
 function buildAchievementHeader(
+  type: string | undefined,
   title: string,
   year: string | undefined,
 ): { headerLine: string; emphasized: boolean } {
-  const split = splitAchievementType(title);
-  if (split) {
-    const emphasizedTitle = `${EMPHASIS_OPEN}${split.type}${EMPHASIS_CLOSE} · ${split.rest}`;
+  const label = type?.trim();
+  if (label && title) {
+    const emphasizedTitle = `${EMPHASIS_OPEN}${label}${EMPHASIS_CLOSE} · ${title}`;
     return {
       headerLine: joinHeader([emphasizedTitle, year], " · "),
       emphasized: true,
     };
   }
-  return { headerLine: joinHeader([title, year], " · "), emphasized: false };
+  return {
+    headerLine: joinHeader([label || title, year], " · "),
+    emphasized: false,
+  };
 }
 
 /**
@@ -575,13 +588,14 @@ export function buildAtsResumeModel(
 
   // ── Achievements ──
   const achievementEntries: AtsEntry[] = achievements.map((ach, i) => {
-    // Bold only the leading "type" label ("Patent", "Publication") when the
-    // title carries the canonical "Type · description" shape; the rest of the
-    // header stays regular. A type-less title keeps the whole header bold.
+    // Bold only the `type` label ("Patent", "Publication"); the rest of the
+    // header stays regular. A type-less achievement keeps the whole header bold.
     const { headerLine, emphasized } = buildAchievementHeader(
+      ach.type,
       ach.title,
       ach.year,
     );
+    const awardTitle = [ach.type?.trim(), ach.title].filter(Boolean).join(" · ");
     return {
       headerLine: headerLine || "Achievement",
       // The emphasized header carries its own per-run weight (via the sentinels),
@@ -595,8 +609,12 @@ export function buildAtsResumeModel(
       ),
       // Structured source for the JSON Resume `awards[]` export (#421). Display
       // code never reads `fields`; it renders `headerLine`/`bullets` above.
+      //
+      // JSON Resume has no slot for a type label, so `title` carries the FULL
+      // "Patent · Foo" line (#456) — dropping the label to match the narrowed
+      // `HeuristicAchievement.title` would silently lose it from the export.
       fields: {
-        ...(ach.title ? { title: ach.title } : {}),
+        ...(awardTitle ? { title: awardTitle } : {}),
         ...(ach.year ? { startDate: ach.year } : {}),
       },
     };

--- a/src/lib/pdf/render-roundtrip-achievement-add.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-achievement-add.repro.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Round-trip guard for #455 — a user-ADDED achievement (type / description /
+ * year fields) survives the export exactly like a parsed-then-edited one (#454).
+ *
+ * `AddedEntry` carries the type + description split raw (`achievementType` +
+ * `title`); `pushAddedEntry` recomposes "type · description" into the pushed
+ * achievement's canonical `title` via `joinAchievementTitle` — the same
+ * recomposition `applyAchievementOverrides` does for a parsed edit. This proves
+ * the loop is closed end to end for the ADD path — reconstructed add →
+ * applyOverrides → ats-resume-model → PDF → re-parse yields the same
+ * type / description / year, and the type is the run the PDF bolds (#452).
+ *
+ * PII-free: synthetic persona, all fields fabricated.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { applyOverrides } from "../edit/apply-overrides.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult, HeuristicParsedResume } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+const PARSED: HeuristicParsedResume = {
+  full_name: "Jane Candidate",
+  email: "jane@example.com",
+  phone: "(312) 555-0123",
+  location: "Chicago, IL",
+  summary: "Platform engineer with a decade of distributed-systems experience.",
+  skills: ["TypeScript", "Go", "PostgreSQL"],
+  experience: [
+    {
+      title: "Staff Engineer",
+      company: "Acme",
+      location: "Chicago, IL",
+      start_date: "2021",
+      end_date: "2024",
+      description:
+        "Led migration of legacy auth to OAuth for 50K users\nCut p99 checkout latency by 38%",
+    },
+  ],
+  education: [],
+  heuristic_achievements: [],
+};
+
+const EMPTY_SECTIONS: SectionedResume = {
+  byName: new Map() as SectionedResume["byName"],
+  accomplishmentSections: ["experience", "projects", "achievements"],
+  source: "regex",
+};
+
+function makeResult(fields: HeuristicParsedResume): CascadeResult {
+  return {
+    canonical: { fields, sections: EMPTY_SECTIONS, fieldConfidence: {} },
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+const fakeScore = { bullets: [] } as unknown as AnonymousAtsScore;
+
+describe("#455 — an added achievement round-trips through the export", () => {
+  let model: ReturnType<typeof buildAtsResumeModel>;
+  let reparsed: CascadeResult;
+
+  beforeAll(async () => {
+    // The user adds an achievement with distinct type / description / year.
+    const edited = applyOverrides(
+      PARSED,
+      "",
+      EMPTY_SECTIONS,
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [
+        {
+          id: "added:0",
+          section: "achievements",
+          achievementType: "Patent",
+          title: "Bulk catalog editor for marketplaces",
+          year: "2019",
+        },
+      ],
+      {},
+    );
+    model = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
+    reparsed = await runCascade(await renderAtsResumePdf(model));
+  });
+
+  it("composes the added type + description into the canonical title", () => {
+    const entry = model.sections.find((s) => s.kind === "achievements")!
+      .entries[0];
+    // Only the type is wrapped in the emphasis sentinels — the run drawn bold.
+    // The description + year ride outside them at regular weight.
+    expect(entry.headerLine).toBe(
+      `${EMPHASIS_OPEN}Patent${EMPHASIS_CLOSE} · ` +
+        "Bulk catalog editor for marketplaces · 2019",
+    );
+    expect(entry.headerBold).toBe(false);
+  });
+
+  it("re-parses the added type / title / year back off the rendered PDF", () => {
+    const achievements = reparsed.canonical.fields.heuristic_achievements ?? [];
+    expect(achievements).toHaveLength(1);
+    expect(achievements[0].type).toBe("Patent");
+    expect(achievements[0].title).toBe("Bulk catalog editor for marketplaces");
+    expect(achievements[0].year).toBe("2019");
+  });
+});

--- a/src/lib/pdf/render-roundtrip-achievement-edit.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-achievement-edit.repro.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Round-trip guard for #454 — an inline-edited achievement survives the export.
+ *
+ * The reconstructed view edits a parsed achievement as three REAL fields (type /
+ * title / year, #456). This proves the loop is closed end to end — reconstructed
+ * edit → applyOverrides → ats-resume-model → PDF → re-parse yields the EDITED
+ * type / title / year, and the edited type is the run the PDF bolds (the
+ * emphasis sentinels wrap it, per #452).
+ *
+ * The last case is the one the old composed-title model (#454, design model (a))
+ * got wrong: it re-derived the bold run by re-splitting the recomposed title, so
+ * clearing the type promoted the title's first segment to the bold run. With
+ * `type` a real field there is nothing to re-split.
+ *
+ * PII-free: synthetic persona, all fields fabricated.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { applyOverrides } from "../edit/apply-overrides.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult, HeuristicParsedResume } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+const PARSED: HeuristicParsedResume = {
+  full_name: "Jane Candidate",
+  email: "jane@example.com",
+  phone: "(312) 555-0123",
+  location: "Chicago, IL",
+  summary: "Platform engineer with a decade of distributed-systems experience.",
+  skills: ["TypeScript", "Go", "PostgreSQL"],
+  experience: [
+    {
+      title: "Staff Engineer",
+      company: "Acme",
+      location: "Chicago, IL",
+      start_date: "2021",
+      end_date: "2024",
+      description:
+        "Led migration of legacy auth to OAuth for 50K users\nCut p99 checkout latency by 38%",
+    },
+  ],
+  education: [],
+  heuristic_achievements: [
+    // Mis-parsed on purpose: the type label is wrong and the year is missing —
+    // exactly the correction #454 exists to make possible.
+    { type: "Pantent", title: "Bulk catalog editor for large marketplaces" },
+  ],
+};
+
+const EMPTY_SECTIONS: SectionedResume = {
+  byName: new Map() as SectionedResume["byName"],
+  accomplishmentSections: ["experience", "projects", "achievements"],
+  source: "regex",
+};
+
+function makeResult(fields: HeuristicParsedResume): CascadeResult {
+  return {
+    canonical: { fields, sections: EMPTY_SECTIONS, fieldConfidence: {} },
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+const fakeScore = { bullets: [] } as unknown as AnonymousAtsScore;
+
+describe("#454 — an edited achievement round-trips through the export", () => {
+  let model: ReturnType<typeof buildAtsResumeModel>;
+  let reparsed: CascadeResult;
+
+  beforeAll(async () => {
+    // The user fixes the type typo, tightens the description, and adds the year.
+    const edited = applyOverrides(
+      PARSED,
+      "",
+      EMPTY_SECTIONS,
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [],
+      {},
+      undefined,
+      undefined,
+      undefined,
+      {
+        0: {
+          type: "Patent",
+          title: "Bulk catalog editor for marketplaces",
+          year: "2019",
+        },
+      },
+    );
+    model = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
+    reparsed = await runCascade(await renderAtsResumePdf(model));
+  });
+
+  it("bolds exactly the edited type label, and nothing else", () => {
+    const entry = model.sections.find((s) => s.kind === "achievements")!
+      .entries[0];
+    // Only the EDITED type is wrapped in the emphasis sentinels — the run drawn
+    // bold. The title + year ride outside them at regular weight.
+    expect(entry.headerLine).toBe(
+      `${EMPHASIS_OPEN}Patent${EMPHASIS_CLOSE} · ` +
+        "Bulk catalog editor for marketplaces · 2019",
+    );
+    expect(entry.headerBold).toBe(false);
+  });
+
+  it("re-parses the edited type / title / year back off the rendered PDF", () => {
+    const achievements = reparsed.canonical.fields.heuristic_achievements ?? [];
+    expect(achievements).toHaveLength(1);
+    expect(achievements[0].type).toBe("Patent");
+    expect(achievements[0].title).toBe("Bulk catalog editor for marketplaces");
+    expect(achievements[0].year).toBe("2019");
+    // The typo the user fixed is gone from the exported document.
+    expect(achievements[0].type).not.toContain("Pantent");
+  });
+
+  it("clearing the type bolds the whole header — it does not promote the title's first segment (#456)", async () => {
+    // The #454 failure case: with the label modelled as the leading run of a
+    // composed title, clearing it left "Deep Learning · NeurIPS 2023", whose
+    // leading run re-split as the TYPE — so the PDF bolded "Deep Learning", a
+    // label the user never typed. The label is a real field now, so an empty
+    // one means exactly that: no bold run.
+    const edited = applyOverrides(
+      PARSED,
+      "",
+      EMPTY_SECTIONS,
+      {},
+      {},
+      {},
+      [],
+      {},
+      undefined,
+      [],
+      {},
+      undefined,
+      undefined,
+      undefined,
+      { 0: { type: "", title: "Deep Learning · NeurIPS 2023" } },
+    );
+    const cleared = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
+    const entry = cleared.sections.find((s) => s.kind === "achievements")!
+      .entries[0];
+    expect(entry.headerLine).not.toContain(EMPHASIS_OPEN);
+    expect(entry.headerLine).toBe("Deep Learning · NeurIPS 2023");
+    expect(entry.headerBold).toBe(true);
+  });
+});

--- a/src/lib/score/entry-dates.test.ts
+++ b/src/lib/score/entry-dates.test.ts
@@ -108,3 +108,25 @@ describe("splitAchievementType", () => {
     expect(splitAchievementType(" · orphan description")).toBeNull();
   });
 });
+
+describe("splitAchievementType — parse-time only (#456)", () => {
+  // The split runs exactly once, in `extractAchievements`, and its result is
+  // STORED as `HeuristicAchievement.type`. These cases are the reason nothing
+  // downstream may re-derive the label from a composed string: re-splitting
+  // "Type · Title" does not always return the pair it was built from.
+  it("does not round-trip a label over the length cap", () => {
+    const type = "x".repeat(ACHIEVEMENT_TYPE_MAX_LEN + 1);
+    // Composing is lossless as a STRING, but the label no longer reads back —
+    // a consumer that re-split would emphasize the whole line instead.
+    expect(splitAchievementType(`${type} · runner-up`)).toBeNull();
+  });
+
+  it("does not round-trip a title that carries its own separator", () => {
+    // Built from ("", "KubeCon · Amsterdam") — no type at all. Re-splitting the
+    // composed string promotes the title's first segment to the type.
+    expect(splitAchievementType("KubeCon · Amsterdam")).toEqual({
+      type: "KubeCon",
+      rest: "Amsterdam",
+    });
+  });
+});

--- a/src/lib/score/entry-dates.ts
+++ b/src/lib/score/entry-dates.ts
@@ -43,14 +43,19 @@ export function buildEducationDates(edu: ResumeEducation): string {
 export const ACHIEVEMENT_TYPE_MAX_LEN = 28;
 
 /**
- * Split an achievement title into its leading "type" label + the rest, when the
- * title carries the canonical "Type · description" shape and the type is short
+ * Split a raw achievement header into its leading "type" label + the rest, when
+ * the header carries the canonical "Type · title" shape and the label is short
  * enough to read as a label (see {@link ACHIEVEMENT_TYPE_MAX_LEN}). Returns null
- * when there is no qualifying type segment (the whole title is prose).
+ * when there is no qualifying type segment (the whole header is prose).
  *
- * Shared by the PDF header builder (which bolds just the type run via emphasis
- * sentinels) and the reconstructed-résumé view, so both emphasize the identical
- * run — the on-screen header must match the Download PDF (#452).
+ * PARSE-TIME ONLY. This runs exactly once, in `extractAchievements`, and its
+ * result is stored as `HeuristicAchievement.type` (#456). Nothing downstream may
+ * re-derive the label by re-splitting a composed string: the split is lossy in
+ * the direction that matters (a label over the length cap, or a title carrying
+ * its own `" · "`, re-splits into a DIFFERENT pair), so a consumer that re-split
+ * emphasized the wrong run in the PDF and showed the wrong halves on `/jd-fit`.
+ * The edit surface, the export projection, and the canonical model all read the
+ * stored field.
  */
 export function splitAchievementType(
   title: string,

--- a/src/lib/score/group-bullets.test.ts
+++ b/src/lib/score/group-bullets.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 import {
   groupBulletsByExperience,
   suppressTitleOwnedBullets,
+  toBulletExperience,
   formatExperienceHeader,
   normalizeBulletText,
   type BulletExperience,
@@ -303,6 +304,51 @@ describe("multi-line bullet pool is fully merged and correctly attributed (#162)
       expect(otherText.has(t)).toBe(false);
     }
   }, 20000);
+});
+
+// ── Achievement-label-tolerant ownership (issue 456) ──────────────────────────
+
+describe("suppressTitleOwnedBullets — achievement type labels (issue 456)", () => {
+  // The pooled bullet is raw PDF text, so the achievement's header arrives as ONE
+  // composed line, while the parsed entry holds the halves apart (type + title).
+  const RAW_LINE = "Patent · Ranking e-commerce catalogs. [2019]";
+  const PARSED = { type: "Patent", title: "Ranking e-commerce catalogs. []" };
+
+  it("suppresses a title-only achievement's own composed source line", () => {
+    const kept = suppressTitleOwnedBullets(
+      [makeBullet(RAW_LINE, 0)],
+      toBulletExperience([PARSED]),
+    );
+    expect(kept).toEqual([]);
+  });
+
+  it("REGRESSION: retyping the achievement does not resurrect the duplicate", () => {
+    // `type` is user-editable; the raw PDF line is not. Keying ownership on a
+    // recomposed `type · title` rebuilt the key out of the editable half, so
+    // retyping "Patent" as "Book" moved the key off the line it had to match and
+    // stranded that line in "Other bullets". Ownership keys on the canonical
+    // title, so the retype is inert.
+    const retyped = { ...PARSED, type: "Book" };
+    const entries = toBulletExperience([retyped]);
+    expect(entries[0].title).toBe(PARSED.title); // no label folded in
+    const kept = suppressTitleOwnedBullets([makeBullet(RAW_LINE, 0)], entries);
+    expect(kept).toEqual([]);
+  });
+
+  it("leaves an unrelated bullet that merely carries a ' · ' run alone", () => {
+    const bullet = makeBullet("Led team · shipped an unrelated thing", 0);
+    const kept = suppressTitleOwnedBullets([bullet], toBulletExperience([PARSED]));
+    expect(kept).toEqual([bullet]);
+  });
+
+  it("coerces entries without folding any label into the title", () => {
+    const [exp, proj] = toBulletExperience([
+      { title: "Senior PM", description: "• Shipped it" },
+      { name: "Revenue Forecasting" },
+    ]);
+    expect(exp.title).toBe("Senior PM");
+    expect(proj.title).toBe("Revenue Forecasting");
+  });
 });
 
 // ── suppressTitleOwnedBullets (#224) ────────────────────────────────────────────

--- a/src/lib/score/group-bullets.ts
+++ b/src/lib/score/group-bullets.ts
@@ -13,6 +13,7 @@
  */
 
 import type { BulletObservation } from "./score.ts";
+import { splitAchievementType } from "./entry-dates.ts";
 
 // ── Normalization ─────────────────────────────────────────────────────────────
 
@@ -72,6 +73,15 @@ export interface BulletExperience {
  * the `BulletExperience` shape: `name` falls back to `title`, and the date /
  * currency fields pass through verbatim. Shared by the reconstruction surface
  * and the ATS render-model builder so both derive the entry shape identically.
+ *
+ * An achievement's `type` label is deliberately NOT folded into the title here.
+ * The title must stay the entry's CANONICAL text — the one thing a `type` edit
+ * cannot change — because it is the ownership key {@link suppressTitleOwnedBullets}
+ * matches against. Composing `type · title` instead would rebuild the key out of
+ * a user-editable field, so retyping a "Patent" as a "Book" would move the key
+ * off the raw PDF line it has to match and strand that line in "Other bullets"
+ * (#456). The label tolerance lives on the bullet side instead, where the text is
+ * immutable.
  */
 export function toBulletExperience(
   entries: ReadonlyArray<{
@@ -198,6 +208,27 @@ function normalizeTitleKey(s: string): string {
 }
 
 /**
+ * The bullet key with a leading achievement-type run removed, or null when it
+ * carries none.
+ *
+ * A pooled bullet is raw PDF text, so an achievement's line arrives COMPOSED
+ * (`"Patent · Issued US10275736B1"`) while the parsed entry holds the two halves
+ * apart — `type: "Patent"`, `title: "Issued US10275736B1"`. Ownership therefore
+ * has to compare the bullet's post-label remainder against the bare title.
+ *
+ * This reuses the parser's own {@link splitAchievementType} rather than
+ * re-deriving the split: it IS the inverse of the parse-time cut, so the two stay
+ * in lockstep on the separator and the type-length bound. Rolling a second regex
+ * here would let the two drift, which is exactly how the label run stopped
+ * matching in the first place.
+ */
+function stripAchievementLabel(key: string): string | null {
+  const split = splitAchievementType(key);
+  const rest = split?.rest.trim();
+  return rest ? rest : null;
+}
+
+/**
  * Drop from a bullet list every bullet whose content is already OWNED by a
  * title-only entry — i.e. a `• Label … [year]` achievement/project that renders
  * its whole line as a header and carries no `description` for the grouper to
@@ -205,6 +236,12 @@ function normalizeTitleKey(s: string): string {
  * the same content twice. We suppress it from "Other" rather than re-attributing
  * it to the entry: the entry's own title already IS that content, so rendering it
  * again as the entry's bullet would just move the duplicate, not remove it.
+ *
+ * A bullet matches on EITHER its whole key or its key minus a leading achievement
+ * type run (#456) — the composed-vs-split reconciliation described on
+ * {@link stripAchievementLabel}. The second candidate is additive: it only ever
+ * suppresses more, and it is keyed on the entry's canonical `title`, so editing an
+ * achievement's `type` cannot move the key off the raw line it has to match.
  *
  * Ownership is exact on the residue-tolerant {@link normalizeTitleKey} — a tight
  * key, not substring containment — so a genuinely-unmatched bullet that merely
@@ -223,7 +260,12 @@ export function suppressTitleOwnedBullets(
     if (key) ownedKeys.add(key);
   }
   if (ownedKeys.size === 0) return [...bullets];
-  return bullets.filter((b) => !ownedKeys.has(normalizeTitleKey(b.text)));
+  return bullets.filter((b) => {
+    const key = normalizeTitleKey(b.text);
+    if (ownedKeys.has(key)) return false;
+    const unlabelled = stripAchievementLabel(key);
+    return !(unlabelled && ownedKeys.has(unlabelled));
+  });
 }
 
 // ── Header formatting ─────────────────────────────────────────────────────────

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -240,17 +240,28 @@ export interface Achievement {
 export type AchievementsPlacement = "default" | "above_experience";
 
 // ── Heuristic achievements ──────────────────────────────────────────────────
-// The deterministic parser cannot classify an achievement's TYPE (patent vs.
-// award vs. talk) — that requires the LLM path, which populates the structured
-// `Achievement[]` above. Rather than fabricate a `type` (and the
-// `custom_emoji`/`custom_label` that `type: "custom"` mandates), the heuristic
-// path emits this honest, structure-free shape: a name-led item with optional
-// year/url and a bullet body, mirroring `ResumeProject`. A name-led item is the
-// most a regex parser can truthfully assert about an Achievements / Activities
-// / Awards block. Issue #96, design option (a).
+// The deterministic parser cannot CLASSIFY an achievement into the closed
+// `AchievementType` enum (patent vs. award vs. talk) — that requires the LLM
+// path, which populates the structured `Achievement[]` above. Rather than
+// fabricate a classification (and the `custom_emoji`/`custom_label` that
+// `type: "custom"` mandates), the heuristic path emits this honest,
+// structure-free shape: a title-led item with an optional VERBATIM type label,
+// year, url, and a bullet body, mirroring `ResumeProject`. Issue #96.
 
 export interface HeuristicAchievement {
-  /** Item title — the header line that leads the entry. Empty string only when
+  /** The verbatim leading label the header carried before its first `" · "`
+   *  ("Patent", "Best Paper Award"), when short enough to read as a label
+   *  rather than prose — see `splitAchievementType`. NOT the classified
+   *  `AchievementType` enum: free text, exactly as written.
+   *
+   *  A real field, not a run of `title` (#456). It was briefly modelled as the
+   *  leading `" · "` segment of a composed `title` (#454, design model (a)),
+   *  but `decompose ∘ join` is not the identity — every consumer holding only
+   *  the composed title re-split it differently from what the user typed (the
+   *  PDF bolded the wrong run; `/jd-fit` showed the wrong halves). Storing the
+   *  label makes the split happen exactly once, at parse. */
+  type?: string;
+  /** Item title, WITHOUT the leading {@link type} label. Empty string only when
    *  the block carried no usable header line. */
   title: string;
   /** Lead year when the header carried a date (achievements show a single year,


### PR DESCRIPTION
## Summary

Achievements were the only reconstructed-résumé section a user could not fully edit — parsed entries were read-only, and the add flow collapsed the achievement's *type* and *description* into one title blob. This brings the section to parity with experience / education / skills.

**Design decision — `type` is a real field.** This PR originally shipped model (a): `title` stayed the only canonical parsed field and the type label was merely its leading `" · "` run, decomposed for editing and recomposed on commit. That model is **reversed here** (see below). `HeuristicAchievement` now carries `type`, populated once at parse.

- **#454 — edit existing achievements inline.** Type / title / year are each independently editable (three `EditableField`s, mirroring the experience role header). Each override key names a real field, so `applyOverrides` copies it straight across. The achievement-override map is folded in *before* the added-entry append, so parsed-index keys never collide with appended entries. **Verified:** `render-roundtrip-achievement-edit.repro.test.ts` drives edit → `apply-overrides` → `ats-resume-model` → real PDF → `runCascade` re-parse, asserting the same type/title/year and that the emphasis sentinels wrap exactly the type run.
- **#455 — structured add-achievement flow.** Same three fields on the add path. `AddedEntry.achievementType` maps onto the pushed achievement's `type`, so an added achievement is indistinguishable from a parsed-then-edited one. **Verified:** its own `render-roundtrip-achievement-add.repro.test.ts`, same end-to-end shape.
- **`probe-achievements` skill + harness** (epic #453), sibling of the existing `probe-*` parser probes: prints each parsed achievement's type / title / year / bullet count straight off `runCascade`, plus the region the segmenter saw. Inert without `RL_ACHIEVEMENTS_PDF`; output goes to the gitignored `internal/`. No fixture PDFs added — no PII surface.

## Reversing model (a) — the composed title was not re-splittable

Model (a) made `decompose ∘ join` load-bearing, and **it is not the identity**. Every consumer holding only the composed title re-split it differently from what the user typed. Two surfaces were confirmed broken:

- the **PDF exporter** bolded the wrong run — a title carrying its own `" · "`, or a cleared type, promoted the title's first segment to the bold label;
- **`/jd-fit`** re-decomposed the recomposed title and showed the wrong halves.

The in-app patch (pin both halves into the override map on first edit, `lib/edit/achievement-fields.ts`) held on `/` only. It could not cross the jd-fit handoff, and its docstring understated the blast radius as *"only the PDF's bold run is wrong"* — which was false.

Storing the label deletes the whole class rather than patching each surface:

- the split runs **exactly once**, in `extractAchievements`, into a real `type` field; `title` is the header without the label;
- the exporter bolds `ach.type` verbatim — any length, any punctuation;
- the edit surface renders the override-applied fields directly, so the pinning layer *and* `decomposeAchievementTitle` / `joinAchievementTitle` are **deleted**, not reworked.

**Round-trip caveat, documented where it lives** (`buildAchievementHeader`): the exported *text* is still `"Type · Title"`, so re-parsing recovers `type` only when the label passes `splitAchievementType`. The bold run is the PDF's only other encoding of the label and the parser does not read font weight — inherent to the format, not to the model. JSON Resume has no type slot either, so `awards[].title` keeps carrying the full `"Patent · Foo"` line; narrowing it would have silently dropped the label from the export.

## The `/jd-fit` handoff carried an applied result

Same root cause, second surface — and it exposed a **pre-existing** bug the achievements work only made visible.

The handoff serialized the override-**applied** `CascadeResult`, and `/jd-fit` then started a fresh, **empty** edit layer over it. The edits were baked into the parsed fields and unrecoverable on the far side: a user-**added** entry arrived indistinguishable from a parsed one — shown, but with no Remove button and its bullets no longer attributed to it. That hit experience, education, projects, and achievements alike, and **predates this PR**.

Naively re-seeding the far side from the applied payload is *not* the fix — it would append every added entry a second time. The handoff has to carry the same two inputs `/` itself had: the **pristine parse + score**, and the **edit state**.

So edit state gets one serializable shape, `EditSnapshot`, owned by the hook that owns the state. `useEditableParse` now exposes `snapshot` and `replay`. The from-scratch draft (#313) already needed exactly this and had hand-rolled it in `useAnalyzedResume` — that copy is deleted and `BlankDraftSnapshot` is now an alias. One shape, one replay, so a new override map cannot be added without joining both (which is how `team` and `achievementType` were once silently dropped on restore). `/jd-fit` replays once on mount, guarded, since replay is additive; `consumeJdFitHandoff` rejects a payload with no `edit` key so a stale one falls back to the DropZone instead of silently showing an un-edited résumé.

## Incidental fixes (same class, in code this epic touched)

- Added-entry **draft restore dropped `achievementType`** on reload — and, in pre-existing code, **`team` (#425)** — because the replay iterated a hand-synced field list. `AddedEntryField` is now derived *from* that tuple, so a new field cannot join the union without joining the replay. (Confirmed the old `satisfies` guard was inert; the new one fails the build.)
- `useJdFitResume` was **omitting the `fieldConfidence` argument** to `applyOverrides`. Inert in practice, now passed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (style guards: no raw `<button>`, hex, palette classes, or manual `dark:`)
- [x] `npm run test` green — **2103 passed**, 8 skipped, 0 failed
- [x] `npm run build` clean
- [x] `fallow audit --base origin/main` — no dead code, **no unused exports**, no new duplication
- [x] Manually verified in `npm run dev`

New coverage for the reversal: the parser lifts the label; the two shapes the old model got wrong (over-long type, separator-bearing title) now survive `applyOverrides` intact; a cleared type bolds the whole header instead of promoting the title's first segment; and a new `useJdFitResume.test.tsx` pins the handoff — a correction replays onto the pristine parse, an added entry stays an **added** entry on the far side, and editing on `/jd-fit` does not re-append it.

Closes #453
Closes #454
Closes #455

## Adversarial review

Two rounds of independent adversarial review (`ecc:react-reviewer`) ran on the accumulated diff **before** this PR was opened. A third-party review on the open PR then found the two surfaces that pushed the model (a) reversal above. Recorded here as an audit artifact.

**Round 1 — 2 blocking, `clean: false`.**

1. **`decompose ∘ join` is not idempotent, and the header re-decomposed the already-recomposed title every render.** Reproduced with three failing assertions: a cleared type swallowed the description; an over-long type dumped the whole title into the description field and doubled itself on re-commit; a cleared description reverted the type field to its placeholder while the PDF still emitted it. Fixed *at the time* by pinning both halves into the override map — **since superseded**: the real fix was to stop composing the title at all.
2. **Added achievements lost their type label on blank-draft restore** (`achievementType` missing from the hand-synced replay tuple). The reviewer found a **sibling in untouched code** — `team` (#425) was dropped the same way. **Fixed** both, and made the tuple exhaustive at the type level so the class can't recur.

**Round 2 — `clean: true`.** Both blockers verified fixed by live repro against the real `applyOverrides` loop (the reviewer distrusted the unit tests' simulated apply step and drove production code instead).

**Post-open review — the model (a) reversal.** A review on the open PR argued the pinned-halves patch treated a symptom: it stabilized the edit surface on `/` but every *other* consumer still re-split the composed title. Verified against the code — the mechanism checked out on both surfaces it named (`jd-fit-handoff.ts` + `useJdFitResume.ts` for the re-decompose; the exporter for the bold run), and its "added entries baked in" finding was real but **pre-existing** and not attributable to this PR. Rather than defer, both are fixed here: `type` is now a real field and the handoff carries edit state. `lib/edit/achievement-fields.ts` — the entire pinning mechanism — is **deleted**.

**Nits surfaced, then fixed before opening this PR** (not deferred):
- A type-less achievement (`"Best Paper Award"` — the common shape) rendered regular-weight in the view but whole-line bold in the PDF. Reclassified from nit to fix.
- The `satisfies readonly AddedEntryField[]` guard gave **zero** exhaustiveness protection — the reviewer proved it by deleting `"team"` and watching `tsc` still exit 0. Replaced with a derived-union tuple; deleting a field now fails the build in two places.

**Surviving nits for the human reviewer's eye** (non-blocking):
- `AchievementHeader` trips fallow's CRAP threshold at 0% direct component coverage (it is exercised end-to-end through the round-trip and hook tests, not in isolation). `App`, `buildAtsResumeModel`, `educationEntries`, and `applyExperienceHeaderOverrides` also trip complexity — all pre-existing, all report-only in CI.
