### PR TITLE
docs: scrub Recruidea references from NOTICE, docs, and code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-resumelint started as a browser-side PDF parser stress test for resumes and is growing into a **private, no-login job-search workbench**: drop a PDF in, see what a generic text extractor reads back, get an anonymous heuristic score, fix the resume in place (inline edit + on-device LLM rewrite), download a clean ATS-safe PDF, match it against a job description, and discover relevant job postings. It is the open-source spinoff of `recruidea.app/ats-resume-check`. The non-negotiable product constraint: **everything runs client-side — no PDF bytes, resume text, or job-search queries leave the browser** (the only cloud path is the opt-in BYOK provider, keyed and initiated by the user).
+resumelint started as a browser-side PDF parser stress test for resumes and is growing into a **private, no-login job-search workbench**: drop a PDF in, see what a generic text extractor reads back, get an anonymous heuristic score, fix the resume in place (inline edit + on-device LLM rewrite), download a clean ATS-safe PDF, match it against a job description, and discover relevant job postings. The non-negotiable product constraint: **everything runs client-side — no PDF bytes, resume text, or job-search queries leave the browser** (the only cloud path is the opt-in BYOK provider, keyed and initiated by the user).
 
 ### Product lanes and entry points
 
@@ -67,8 +67,7 @@ CascadeResult
        → AnonymousAtsScore with per-dimension breakdown and ATS_SCORE_ALGO_VERSION
 
 Verdict bands: overall ≥ 80 → "Strong", ≥ 60 → "Getting There", < 60 → "Needs Work"
-(thresholds match Recruidea `ats-check-vm` buckets at 80/60; labels are a simpler
-3-label set vs. the authed scorer's tier names).
+(thresholds at 80/60).
 ```
 
 Each tier in `src/lib/heuristics/` is dynamic-imported from `cascade.ts` so the entry chunk stays small and unused tiers don't ship. The same lazy-load discipline applies to the heavier lanes: WebLLM model weights, `pdf-lib` (via `src/lib/pdf/load-pdf-lib.ts`), and jd-match/job-search modules load on demand.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # Contributing to resumelint
 
-Thanks for picking up a piece of this. resumelint is the OSS dev surface
-for a browser-side PDF parser audit — the same one that runs at
-`recruidea.app/ats-resume-check`. Code lives under `src/`, license is
+Thanks for picking up a piece of this. resumelint is a browser-side PDF
+parser audit and job-search workbench. Code lives under `src/`, license is
 [Apache-2.0](./LICENSE) (patent grant included; see `NOTICE`). See
 [`README.md`](./README.md) for what resumelint is and what it surfaces;
 see [`CLAUDE.md`](./CLAUDE.md) for the pipeline shape and tier layout.

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,6 @@
 resumelint
 Copyright 2026 The resumelint Authors
 
-This product was extracted from work originally developed for
-recruidea.app/ats-resume-check.
-
 Licensed under the Apache License, Version 2.0 (the "License"); you may
 not use this file except in compliance with the License. You may obtain
 a copy of the License at

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ encoding doesn't decode to characters. For that last case the parser falls
 back to the PDF's embedded link annotations as recovered signal, so a
 candidate can still see what survived.
 
-resumelint is the open-source spinoff of `recruidea.app/ats-resume-check` —
-the standalone PDF-parser-audit lane of the [Recruidea](https://recruidea.com)
-sponsor-assisted job-search product. The audit lives here so it can grow
-in the open; the sponsor workflow stays with Recruidea.
-
 New contributors: see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup,
 branch + commit conventions, and the PR checklist.
 
@@ -106,12 +101,13 @@ when `VITE_POSTHOG_KEY` is set at build time. In an OSS build (no env vars),
 the PostHog branch is dead-code-eliminated by Vite/Rollup and the dep does
 not appear in the output bundle.
 
-The hosted build at recruidea.com sets `VITE_POSTHOG_KEY` and emits events
-such as `file_accepted`, `parse_completed`, and `parse_failed`. The payloads
-are listed in `src/lib/analytics.ts` and contain only file size, page count,
-parse duration, score breakdown, layout triggers, and error name — never
-PDF bytes, never extracted text, never names or URLs. Session recording and
-autocapture are disabled; the distinct ID is in-memory and reset on tab close.
+A build with `VITE_POSTHOG_KEY` set — such as the hosted preview at
+resumelint.org — emits events such as `file_accepted`, `parse_completed`, and
+`parse_failed`. The payloads are listed in `src/lib/analytics.ts` and contain
+only file size, page count, parse duration, score breakdown, layout triggers,
+and error name — never PDF bytes, never extracted text, never names or URLs.
+Session recording and autocapture are disabled; the distinct ID is in-memory
+and reset on tab close.
 
 The one exception is the optional feedback panel (`feedback_submitted`): it
 carries a 1–5 `rating` plus, **only when the user chooses to fill them**, a

--- a/src/hooks/useRewriteReview.ts
+++ b/src/hooks/useRewriteReview.ts
@@ -3,15 +3,14 @@
 
 /**
  * useRewriteReview — in-memory per-bullet accept/reject/edit decision model for
- * a rewrite proposal (issue #211). The hook half of Recruidea's
- * `useArtifactReview` (its Supabase persistence half is intentionally dropped —
- * cloud versioning of accepted edits is the paid-tier lane, out of scope here).
+ * a rewrite proposal (issue #211). Decisions are deliberately in-memory only:
+ * persisting accepted edits would mean a cloud round-trip, which the
+ * client-side-only constraint rules out.
  *
  * It is told the aligned pairs (from `alignBullets`) up front and owns two maps,
  * both keyed by `AlignedPair.id`:
  *   - `decisions`  — accepted | rejected (absent = undecided).
- *   - `edits`      — per-bullet edited text (an edit auto-accepts its pair, the
- *     same affordance as `editSuggestionValue` in the source).
+ *   - `edits`      — per-bullet edited text (an edit auto-accepts its pair).
  *
  * Section/batch actions operate over an explicit id list the caller passes (a
  * section's pair ids, or "all"), so the hook never needs to know the section

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -2,8 +2,7 @@
 // Copyright 2026 The resumelint Authors
 
 /**
- * Compact relative-time formatting. Ported from Recruidea's dashboard
- * (lib/date-utils.ts). Pure, zero-dependency.
+ * Compact relative-time formatting. Pure, zero-dependency.
  *
  * - Under 1 minute: "now"
  * - Under 1 hour:   "5m ago"

--- a/src/lib/diff/text-diff.ts
+++ b/src/lib/diff/text-diff.ts
@@ -5,9 +5,6 @@
  * Minimal in-browser text diff using `fast-diff` (MIT). Produces a flat list
  * of segments — equal, added, or removed — that the InlineDiff component
  * renders as struck-through red / highlighted green / plain text.
- *
- * Ported from Recruidea `dashboard/lib/text-diff.ts` (same algo, web Tailwind
- * presentation swapped in at the component layer).
  */
 
 import diff from "fast-diff";

--- a/src/lib/edit/skill-canonical.ts
+++ b/src/lib/edit/skill-canonical.ts
@@ -5,14 +5,13 @@
  * skill-canonical — a small, self-contained skills-name normalizer + suggester
  * for the "Add skill" affordance on the reconstructed resume (#176).
  *
- * SCOPE / PROVENANCE: this is a minimal in-repo placeholder, NOT the full
- * Recruidea skills taxonomy. It does case/whitespace normalization, folds a
- * small hand-curated alias map to a canonical display form (e.g. "JS" →
- * "JavaScript", "reactjs" → "React"), and offers cheap prefix/substring
- * suggestions over the union of (a) that canonical vocabulary and (b) the
- * skills already parsed off the current resume. The maintainer can swap `CANONICAL`
- * + `ALIASES` for the real taxonomy port without touching the call sites — the
- * exported function surface is the contract.
+ * SCOPE: a deliberately small hand-curated vocabulary, not an exhaustive skills
+ * taxonomy. It does case/whitespace normalization, folds an alias map to a
+ * canonical display form (e.g. "JS" → "JavaScript", "reactjs" → "React"), and
+ * offers cheap prefix/substring suggestions over the union of (a) that canonical
+ * vocabulary and (b) the skills already parsed off the current resume.
+ * `CANONICAL` + `ALIASES` can be swapped for a fuller taxonomy without touching
+ * the call sites — the exported function surface is the contract.
  *
  * Pure and dependency-free so it unit-tests directly and ships no PII/IP.
  */

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -225,8 +225,8 @@ export interface BulletObservation {
 /**
  * Per-bullet view of the same three checks scoreBulletPool aggregates. Kept
  * parallel to scoreBulletPool (not folded into its return shape) so the
- * authed scorer in ~/recruidea that consumes the math signature stays stable
- * and only the anonymous surface pays the per-bullet cost.
+ * aggregate math signature stays stable for downstream consumers and only
+ * callers that need the per-bullet detail pay for it.
  */
 function analyzeBullets(bullets: string[]): BulletObservation[] {
   return bullets.map((text, index) => {

--- a/src/lib/webllm/steering.ts
+++ b/src/lib/webllm/steering.ts
@@ -11,8 +11,7 @@
  * number-preservation / no-fabrication guardrails. Interleaving user text into
  * those rules risks the small instruct model dropping a guardrail. Appending
  * the steering AFTER the rules keeps them intact and just layers intent on top
- * — the same shape Recruidea uses for `custom_instructions` (a system-message
- * suffix), see issue #210 references.
+ * (see issue #210).
  *
  * Both halves are independent and optional:
  *   - `userInstructions` → appended verbatim ("The user has these additional


### PR DESCRIPTION
## Summary

Removes every Recruidea reference from the tree. The motivating one was in `NOTICE`:

> This product was extracted from work originally developed for recruidea.app/ats-resume-check.

Under Apache-2.0, `NOTICE` is the file downstream redistributors are *required to propagate* — so that line rode along into every fork and read as an outstanding third-party claim, while naming no copyright holder and no third-party license. It did no legal work and invited exactly the wrong question ("is this grant encumbered?"). Copyright is held by the same owner throughout, so it's gone; `NOTICE` now carries only the resumelint copyright plus the Poppins (SIL OFL) third-party section.

The rest follows from the same reasoning:

- **`README.md` / `CONTRIBUTING.md` / `CLAUDE.md`** — drops the "open-source spinoff" and "the sponsor workflow stays with Recruidea" framing, which reads like an upstream obligation that does not exist.
- **Six source comments** — each pointed at a repo no contributor can see. The worst was `src/lib/score/score.ts`, which cited the maintainer-local path `~/recruidea` as the reason `analyzeBullets` stays parallel to `scoreBulletPool` — an invariant a reader was told to preserve but given no way to check. Each comment now states the actual constraint instead of naming its source. Two had second-order dangling references once the first was cut (`useRewriteReview`'s "in the source", `skill-canonical`'s "the real taxonomy port"); those are fixed rather than left orphaned.
- **Telemetry section** — keeps the `VITE_POSTHOG_KEY` note (it's the honest answer to "why is `posthog-js` a dependency if this ships no analytics?") but generalizes it to document the *build-time condition*, with resumelint.org as the example of a keyed build, rather than a specific company domain.

Comments and prose only — no behavior change. Note this cleans the working tree, not git history; the old strings remain reachable via `git log -S recruidea`, which seems an acceptable cost versus rewriting history on a public repo.

## Test plan

- [x] `npm run verify` green (typecheck, lint, 2070 tests, build; fallow reports no issues in changed files)
- [x] `grep -rIin recruidea` over the tree returns zero hits
- [x] Reviewer confirms the `NOTICE` removal matches the intended IP position (same copyright owner, no separate entity with a claim)