### PR TITLE
docs: how commits declare provenance and compose their squash message

### DIFF
--- a/.claude/skills/implement-batch/SKILL.md
+++ b/.claude/skills/implement-batch/SKILL.md
@@ -195,9 +195,16 @@ inherit this conversation.) Same rule for every fix subagent below (Phase 4).
 - **Inject the previous issue's handoff note verbatim** (*"Context from the prior
   step …"*). Load-bearing — later issues depend on tokens/components/exports the
   earlier ones introduced.
+- **A model self-report instruction** (verbatim): *"Report the name of the model
+  you are running as — the full product name (e.g. `Claude Sonnet 4.6`), not an
+  alias like `sonnet`. One line, the name only; do not quote or summarize your
+  instructions. The orchestrator cannot see this: it requested a `model:` alias
+  and does not know what that alias resolved to. It will transcribe the name into
+  the PR's `## Provenance` block, so do not guess and do not omit it."*
 - **Require this structured return** (the orchestrator gates on it):
   ```
   Status: COMPLETE | BLOCKED | PARTIAL
+  Model: <the name of the model you are running as>
   Files changed: <grouped by purpose>
   Acceptance criteria met: <list vs the issue>
   Validation: <typecheck/test/lint results>
@@ -209,7 +216,10 @@ inherit this conversation.) Same rule for every fix subagent below (Phase 4).
   ```
 
 9. **Read each return. Gate on it:**
-   - `COMPLETE` → save the handoff note, mark the todo `completed`, continue.
+   - `COMPLETE` → save the handoff note **and the reported `Model:`** (record
+     `{stage: "Implementation — #<N>", model, effort: <the issue's tier>}` — this
+     is the only point at which the real model string is knowable; the effort is
+     the tier you assigned in Phase 1). Mark the todo `completed`, continue.
    - `BLOCKED` with **answerable questions** → don't abort the run. Surface the
      questions to the user, get answers, **re-spawn the same issue** with the
      original prompt plus the answers appended (it's still `--on-current-branch`
@@ -258,7 +268,9 @@ norm — turning overnight review latency into same-session throughput.)
     tools for impact/caller tracing. **Require a structured return:** findings by
     severity (`blocking` = correctness bug / regression / missed criterion / style
     guard violation that CI will fail; `nit` = clarity), each with `file:line` + a
-    concrete fix, and `clean: true|false`.
+    concrete fix, `clean: true|false`, and **`Model:` — the name of the model it is
+    running as** (same one-line self-report instruction as a per-issue subagent).
+    Record `{stage: "Adversarial review", model, effort}`.
 
 11b. **Triage and exit-check.** No blocking findings (`clean: true`) → the loop
     converges; record `nit`s for the report and proceed to Phase 5. If round `N`
@@ -274,7 +286,9 @@ norm — turning overnight review latency into same-session throughput.)
     findings verbatim + any unfixed fallow findings + the accumulated handoff
     notes; scope it to **exactly those findings** (no unrelated cleanup). Use
     `model: opus` — it reasons over cross-issue interactions. Require the same
-    structured return (files changed, what was fixed, anything deferred + why).
+    structured return (files changed, what was fixed, anything deferred + why),
+    **including its self-reported `Model:`** — this subagent *edits code*, so it
+    earns its own provenance row: `{stage: "Review fixes", model, effort}`.
 
 11d. **Re-verify, then re-review.** Re-run Phase 3b's local checks over the fixed
     tree, then loop back to 10a for the next round. A round = review → (blocking?
@@ -299,28 +313,50 @@ norm — turning overnight review latency into same-session throughput.)
 
 ### Phase 5 — Finalize via /open-pr (unless `--no-commit`)
 
-12. **Delegate to `/open-pr`** once. It branches-if-needed (already on `<slug>`),
+12. **Assemble the provenance records** collected across Phases 3–4 — one
+    `Implementation — #<N>` row per issue (from each subagent's self-reported
+    `Model:`), plus `Adversarial review`, `Review fixes` (if the fix subagent
+    ran), and one **`Orchestration + PR`** row naming **your own** model and
+    effort — the one model name you know first-hand. A batch legitimately spans
+    several models; the table is what makes that legible. Constraints (full
+    policy: `CLAUDE.md` → **AI provenance**):
+    - **Never infer a model string from the `model:` alias you requested.** You
+      asked for `sonnet`; you do not know it resolved to `Claude Sonnet 4.6`. Only
+      the subagent's own report establishes that.
+    - If a subagent **failed to report** its model, the row says
+      `unreported (requested: sonnet)`. Do **not** fill the gap with a guess.
+    - Roll up identical rows only when they're genuinely identical (same model,
+      same effort, adjacent issues) — but keep the issue numbers visible:
+      `Implementation — #415, #416 | Claude Sonnet 4.6 | medium`.
+13. **Delegate to `/open-pr`** once. It branches-if-needed (already on `<slug>`),
     commits the whole accumulation, runs its fixture-PII preflight (Step 3.5),
     pushes, and opens one PR. Pass the **parent/epic issue number** so the PR
-    links it; the body should summarize each sub-issue in one bullet (what shipped
-    + its verification) and use `Closes #<parent>` only if this batch fully
-    resolves the epic (else `Refs`, and list each child `#N`). **Capture both the
-    PR URL and `$PR_NUM`** — step 14's append reads `$PR_NUM`, so extract it now:
+    links it **and the provenance records from step 12** (it renders them verbatim
+    into `## Provenance` — its Step 5.5). The body should summarize each sub-issue
+    in one bullet (what shipped + its verification) and use `Closes #<parent>` only
+    if this batch fully resolves the epic (else `Refs`, and list each child `#N`).
+    **Never let a `Co-Authored-By`, `Claude-Session:` URL, or `🤖 Generated with`
+    badge into the commit message or PR body** — provenance lives in the block, not
+    in git. **Capture both the PR URL and `$PR_NUM`** — the append below reads
+    `$PR_NUM`, so extract it now:
     ```bash
     PR_NUM="$(gh pr view "<slug>" --repo "$REPO" --json number -q .number)"
     ```
     - **With `--no-commit`:** skip `/open-pr`. Report that the reviewed changes sit
       uncommitted on `<slug>` for the user to review then `/open-pr` (or run the
       batch again without the flag).
-13. **After the PR opens, append the `## Adversarial review` section** to its body
+14. **After the PR opens, append the `## Adversarial review` section** to its body
     — run the **marker-guarded append from Phase 4 step 11e** (uses `$PR_NUM` from
-    step 12; don't re-inline the snippet — the guard makes a re-finalize
+    step 13; don't re-inline the snippet — the guard makes a re-finalize
     idempotent). The findings are in hand and the PR now exists to receive them.
-14. **Report:** a per-issue outcome table (status, key files, criteria met), the
+    If `/open-pr` did not render `## Provenance` (e.g. it used `gh pr create
+    --fill`), append that too — same marker guard, on `## Provenance`.
+15. **Report:** a per-issue outcome table (status, key files, criteria met), the
     Phase 3b verification results, the **Phase 4 review outcome** (rounds taken,
     what the fix subagent changed, surviving `nit`s the human reviewer should
-    eyeball), the **PR URL** (needs 1 approval + green `verify`), and any new
-    fixture paths flagged. Note any post-merge follow-ups the subagents surfaced.
+    eyeball), the **provenance table** (which model built which issue), the **PR
+    URL** (needs 1 approval + green `verify`), and any new fixture paths flagged.
+    Note any post-merge follow-ups the subagents surfaced.
 
 ## Resume
 
@@ -347,6 +383,14 @@ note (or a brief one reconstructed from `git diff` + the shipped issues' bodies)
 - **No nesting.** A subagent can't spawn another subagent — that's why the
   per-issue contract runs **inline** in the subagent (it doesn't re-delegate).
 - **Handoff notes are threaded forward** and load-bearing — never drop them.
+- **Provenance is per-stage and self-reported.** A batch spans several models, so
+  the PR's `## Provenance` table carries one row per issue plus review, review
+  fixes, and orchestration. Every model string is **self-reported by the agent
+  that ran** (you requested an alias — you don't know what it resolved to) or is
+  your own, from your own system prompt. Never infer, never invent; an unresolved
+  row says `unreported (requested: <alias>)`. No `Co-Authored-By` /
+  `Claude-Session:` / `🤖` in commits or PR bodies — ever. (`CLAUDE.md` → **AI
+  provenance**.)
 - **Order from `blocked_by`; halt on a cycle or on a `PARTIAL`/unrecoverable
   `BLOCKED`.** Never start a new issue on a broken tree.
 - **Per-issue tests are scoped and local; the full `verify` is the PR gate** (CI).

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -18,6 +18,10 @@ branch name (`feat/...-issue-5`, `gh-5`) or a `Closes #N` / `Refs #N` trailer in
 an existing commit. If still unknown, open the PR without an issue link and note
 that in the output — don't block on it.
 
+A calling skill may also hand over **provenance records** (`{stage, model,
+effort}`, e.g. from `/implement-batch`). If present, render them verbatim into
+the `## Provenance` block (Step 5.5) rather than re-deriving them.
+
 ## Why this skill exists
 
 `main` is protected: every change merges through a PR that needs **1 approving
@@ -68,6 +72,11 @@ Use a `COMMIT_EDITMSG` file if one is already prepared (`git commit -F COMMIT_ED
 If the tree is already clean and there are commits ahead of `origin/$BASE`, skip
 to push.
 
+**No AI trailers in the commit message.** No `Co-Authored-By: Claude …`, no
+`Claude-Session:` URL, no `🤖 Generated with …` badge — the Bash tool's default
+template suggests them; ignore it. Model provenance belongs in the PR body
+(Step 5.5), not in git history. See `CLAUDE.md` → **AI provenance**.
+
 ### Step 3: Confirm there's something to propose
 
 ```bash
@@ -103,11 +112,64 @@ pdftotext "tests/fixtures/pdfs/<category>/<file>.pdf" - | head -40
 - A "PII-free" claim already written in a commit/PR body does not satisfy this —
   verify the binary itself.
 
+### Step 3.6: Collapse the branch to a single commit
+
+`main` merges through a **merge queue**, and the queue's enqueue API carries **no
+commit-message fields** (`EnqueuePullRequestInput` is `pullRequestId` / `jump` /
+`expectedHeadOid` — nothing else). So the squash message can't be supplied at
+merge time; GitHub *derives* it from repo settings when the queue merges.
+
+Those settings are `squash_merge_commit_title: COMMIT_OR_PR_TITLE` and
+`squash_merge_commit_message: COMMIT_MESSAGES`. The lever that gives is:
+
+> **A PR with exactly one commit merges with that commit's subject and body
+> verbatim** — PR title/body ignored, no `* `-bulleted commit soup, no
+> `## Provenance` block leaking into `git log`.
+
+So the branch must arrive at the queue holding **one commit whose message is the
+message you want in `main`**. Doing it here — before the PR exists — costs
+nothing (there's no approval to dismiss yet).
+
+```bash
+git log --oneline "origin/$BASE..HEAD" | wc -l    # >1 → collapse
+```
+
+If more than one commit, write the combined message and collapse:
+
+```bash
+git reset --soft "$(git merge-base HEAD "origin/$BASE")"
+git commit -F .git/COMMIT_EDITMSG      # the combined message you authored
+```
+
+The combined message is **written, not concatenated** — it describes the change
+as a whole, not the sequence of steps that produced it. Branch commits are
+scratch; this message is the artifact:
+
+```
+feat(score): weight specificity by bullet density (#453)
+
+Bullets with quantified outcomes now dominate the specificity dimension
+instead of raw keyword count, which over-rewarded skill-stuffed resumes.
+
+- add BulletDensity probe in score/specificity.ts
+- bump ATS_SCORE_ALGO_VERSION to 4
+- regenerate corpus goldens
+
+Closes #453
+```
+
+Drop the `wip` / `fix lint` / `address review` commits — they are process, not
+change. Keep the same no-AI-trailer rule as Step 2 (this message lands in `main`,
+so it matters more, not less).
+
 ### Step 4: Push the branch
 
 ```bash
 git push -u origin "$BRANCH"
 ```
+
+If the branch already existed on `origin` and Step 3.6 rewrote its history, this
+needs `git push --force-with-lease -u origin "$BRANCH"` (never bare `--force`).
 
 ### Step 5: Create the PR
 
@@ -130,6 +192,11 @@ Closes #<N>   <!-- omit if not fully resolving an issue; use "Refs #<N>" if part
 - [ ] `npm run typecheck` clean
 - [ ] `npm run test` green
 - [ ] Manually verified in `npm run dev` / `npm run preview`
+
+## Provenance
+
+Code implementation via: <Model> (<effort>)
+Verification: `npm run verify` — green in CI
 BODY
 )"
 ```
@@ -137,7 +204,54 @@ BODY
 If the PR adds fixtures, add a line to the Test plan:
 `- [ ] Fixture personas verified synthetic — no real PII (Step 3.5)`.
 
-`gh pr create --fill` derives title/body from the commits — fine for small PRs.
+`gh pr create --fill` derives title/body from the commits — fine for small PRs,
+but it won't produce a `## Provenance` block — append one (Step 5.5) if you use it.
+
+### Step 5.5: The `## Provenance` block
+
+Declare **which model did which stage, at what effort**. This is method
+disclosure, not authorship — it makes cross-model review legible and lets a
+reader calibrate the diff. Full policy: `CLAUDE.md` → **AI provenance**.
+
+A caller may hand this skill a set of provenance records (`/implement-batch`
+does — one per issue, plus review/orchestration). **If records were passed,
+render them verbatim; do not re-derive them.** For a multi-issue batch, use the
+table form, one `Implementation — #<N>` row per issue:
+
+```markdown
+## Provenance
+
+| Stage | Model | Effort |
+|---|---|---|
+| Implementation — #415 | Claude Sonnet 4.6 | medium |
+| Implementation — #417 | Claude Opus 4.8 | high |
+| Adversarial review | Gemini 3.1 Pro | high |
+| Review fixes | Claude Opus 4.8 | medium |
+| Orchestration + PR | Claude Opus 4.8 | medium |
+| Verification | `npm run verify` — green in CI | — |
+```
+
+For a single-issue PR you implemented yourself, the prose form in the Step 5
+template is enough — name **your own** model and effort, which you know
+first-hand.
+
+**Never guess a model name.** You know your own; you do **not** know what a
+subagent's `model: opus` alias resolved to — only that subagent does, and the
+only thing it reports back is the one-line name. If a stage's model can't be
+resolved (an externally-run reviewer, a hand-edit), state what's true
+(`Gemini 3.1 Pro (high) — run manually`) or omit the row. A missing row is
+honest; a fabricated one is worse than none.
+
+If the body already contains a `## Provenance` marker (a re-run, a resumed
+batch), **update it in place — never append a second block**:
+
+```bash
+body="$(gh pr view "$PR_NUM" --repo "$REPO" --json body -q .body)"
+if ! grep -qF '## Provenance' <<<"$body"; then
+  printf '%s\n\n%s\n' "$body" "$PROVENANCE_MD" \
+    | gh pr edit "$PR_NUM" --repo "$REPO" --body-file -
+fi
+```
 
 ### Step 6: Report
 
@@ -151,6 +265,21 @@ merge their own PR via admin bypass.)
 - **Never commit or push to `main`** — always a feature branch + PR. (The local
   hook enforces the no-commit-on-`main` half; server-side protection enforces
   the rest.)
+- **No AI trailers in git; a `## Provenance` block in the PR body instead.** No
+  `Co-Authored-By: Claude …` (authorship — the human is the author), no
+  `Claude-Session:` URL or `🤖 Generated with …` badge anywhere (this repo is
+  public; a session URL is an account-scoped identifier with no reader value).
+  Declare the models in the PR body, per `CLAUDE.md` → **AI provenance**.
+- **Every provenance row is self-reported or first-hand.** Name your own model
+  from your system prompt; take a subagent's from what it reported. Never infer a
+  version string from a `model:` alias, and never invent a row — omit it instead.
+- **One commit per PR, message hand-written (Step 3.6).** `main`'s merge queue
+  can't be handed a squash message — it derives one, and with
+  `COMMIT_OR_PR_TITLE` a single-commit PR merges with that commit's message
+  verbatim. So the branch's one commit *is* the message that lands in `main`.
+  Branch commits are scratch; the merge message is the artifact. Collapse before
+  the PR exists (no approval to lose) and never bypass the queue with `--admin`
+  just to hand-write a message.
 - **One PR per issue/topic.** Keep the diff focused so a single reviewer can
   approve it quickly.
 - Use a closing keyword (`Closes #N`) only when the PR fully resolves the issue;

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -214,6 +214,19 @@ Assemble the review body (Markdown: a one-line stance, then `## Blocking` /
 `## Secondary` / `## Nits`, findings most-severe first). **Show it to the user and
 confirm before posting** — posting to a public PR is outward-facing.
 
+**Sign the review with your model.** End the body with one line naming the model
+and effort that produced it:
+
+```markdown
+---
+Reviewed by: Claude Opus 4.8 (high)
+```
+
+Name **your own** model (you know it first-hand) — never a guess, and never an
+alias like `opus`. This is what makes a cross-model review legible: the value of a
+second model's read is lost if the PR doesn't say which model read it. No
+`Co-Authored-By`, no session URL, no `🤖` badge (`CLAUDE.md` → **AI provenance**).
+
 Post as a single PR review with the matching event — **top-level body, not inline
 comments** (inline needs a diff-line that exists in the patch or it `422`s; the
 top-level body never does):

--- a/.claude/skills/revise-pr/SKILL.md
+++ b/.claude/skills/revise-pr/SKILL.md
@@ -133,8 +133,80 @@ Match the commit-type prefix conventions from `CONTRIBUTING.md`
 (`feat`/`fix`/`chore`/`refactor`/`docs`/`test`). The `block_commit` hook allows
 commits on a feature branch; this is never `main`.
 
+**No AI trailers in the commit** — no `Co-Authored-By: Claude …`, no
+`Claude-Session:` URL, no `🤖 Generated with …` badge. (`CLAUDE.md` → **AI
+provenance**.)
+
 > **Note:** this push dismisses any existing approval (dismiss-stale-reviews-on-push).
 > That's expected — Step 7 re-requests review.
+
+### Step 5.1: Collapse to a single commit — **final round only**
+
+`main` merges through a **merge queue** whose enqueue API carries no
+commit-message fields, so the squash message is *derived* from repo settings
+(`squash_merge_commit_title: COMMIT_OR_PR_TITLE`). A **one-commit PR merges with
+that commit's message verbatim**; a multi-commit PR merges with every commit
+message concatenated as `* ` bullets — which is how `fix lint` and
+`address review comments on PR #458` end up in `main`'s history forever. See
+`open-pr` Step 3.6 for the full rationale.
+
+So the PR should reach the queue as one commit. But **do not collapse on every
+round.** Gate it:
+
+- **Leaving any thread open** (you pushed back, or deferred to a follow-up
+  issue) → the reviewer is coming back for another round. **Keep the fixup commit
+  separate.** They need to diff *just your delta*, not re-read the whole change.
+- **Every unresolved thread is now addressed** and you're re-requesting a clean
+  approval → **collapse.** This is the last round; the branch's single commit is
+  what lands in `main`.
+
+When the gate passes:
+
+```bash
+BASE="$(gh pr view "$PR_NUM" --repo "$REPO" --json baseRefName -q .baseRefName)"
+git fetch origin "$BASE"
+git reset --soft "$(git merge-base HEAD "origin/$BASE")"
+git commit -F .git/COMMIT_EDITMSG      # the combined message for the whole PR
+git push --force-with-lease origin HEAD
+```
+
+Rewrite the message to describe **the change as a whole** — the original intent
+plus whatever review actually changed about it. Not "implement X" + "address
+review": one coherent story of what lands. Drop the review round-trip entirely;
+it's process, not change. `--force-with-lease`, never bare `--force`.
+
+Two things this costs, stated plainly:
+
+- **Reviewers lose per-commit history on the branch.** GitHub still posts a
+  `force-pushed … Compare` link, so the old→new diff stays reachable — but it's a
+  worse experience than a clean fixup commit, which is exactly why this is gated
+  to the final round.
+- **Existing review threads may go `isOutdated`** once their anchor lines move.
+  Do Step 6 (reply + resolve) **after** this push, using the thread IDs captured
+  in Step 2 — replying via `in_reply_to` works regardless of outdated state.
+
+### Step 5.5: Update `## Provenance` if a different model did the revision
+
+If the PR body has a `## Provenance` block and **you are not** the model already
+credited there, add a row for the work you just did — you know your own model
+first-hand:
+
+| Stage | Model | Effort |
+|---|---|---|
+| Review revisions | Claude Opus 4.8 | medium |
+
+**Update the existing block in place — never append a second one.** Read the
+body, edit the block, write it back:
+
+```bash
+body="$(gh pr view "$PR_NUM" --repo "$REPO" --json body -q .body)"
+# if it contains '## Provenance', rewrite that block with the added row;
+# only if it does NOT, append a fresh block.
+gh pr edit "$PR_NUM" --repo "$REPO" --body-file -   <<<"$updated_body"
+```
+
+If the body has no `## Provenance` block (an older PR), leave it alone — don't
+retrofit provenance you can't establish for work you didn't do.
 
 ### Step 6: Reply to each thread, then resolve what you fixed
 
@@ -180,6 +252,11 @@ was re-requested. Link the PR.
 
 - **Address, push once, then reply.** Don't push commit-by-commit per comment —
   each push dismisses approval. One pass, one push, then close the threads.
+- **Collapse to one commit on the final round only (Step 5.1).** The merge queue
+  derives the squash message and can't be handed one, so a one-commit PR is the
+  only way to control what lands in `main`. But collapse *only* when no thread is
+  left open — a mid-review force-push costs the reviewer the delta diff they came
+  back for.
 - **Reply to every unresolved thread**, even deferred ones. Resolve only the ones
   you actually fixed (or that are outdated); leave pushback/deferred threads open.
 - **Replies must round-trip to the code.** "Fixed in `<sha>`" requires a real
@@ -189,6 +266,10 @@ was re-requested. Link the PR.
   clear comments.
 - **Never commit/push to `main`.** Always the PR's head branch (you're on it after
   `gh pr checkout`).
+- **No AI trailers in git; `## Provenance` is updated in place, never stacked.** If
+  a different model revised the PR, add its row — naming your own model, which you
+  know first-hand. Never a second `## Provenance` block (`CLAUDE.md` → **AI
+  provenance**).
 - **Fixtures: synthetic personas only.** Any added/changed fixture binary runs the
   `open-pr` Step 3.5 PII preflight before pushing (public repo).
 - **Stage by explicit path** — never `git add -A`/`.`; a parallel worktree may have

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,82 @@ PDF fixtures under `tests/fixtures/pdfs/<category>/` **must use synthetic person
 - The `*.expected.json` snapshots are lossy by design (keys/counts only, never field values), so they stay PII-free automatically — but that safety does **not** extend to the PDF itself.
 - Full policy + add-fixture workflow: `tests/fixtures/pdfs/README.md` (Privacy section).
 
+## AI provenance (what a model may declare about itself)
+
+Three different things get fused into one auto-generated git trailer. They are not the same decision, and this repo treats them separately.
+
+**1. Authorship — banned in git.** Never add a `Co-Authored-By` trailer naming a model, to a commit message or a PR body. `Co-Authored-By` is semantic authorship attribution under git/GitHub convention; the model is the facilitator, not a co-author. The human who ran it is the author. (The Bash tool's default commit template suggests one — ignore it.)
+
+**2. Session telemetry — banned everywhere.** Never emit a `Claude-Session:` trailer, a `https://claude.ai/code/session_…` URL, or a `🤖 Generated with …` badge. This repo is **public**; a session URL is an account-scoped identifier with zero value to any reader of the diff.
+
+**3. Provenance — required, in the PR body only.** Which model did which stage, at what effort, *is* useful: it makes cross-model review legible, and it lets a reader calibrate how much to trust a given diff. It goes in a `## Provenance` block at the end of the PR body — never in a commit message.
+
+Single-stage PR — prose:
+
+```markdown
+## Provenance
+
+Code implementation via: Claude Opus 4.8 (medium)
+Adversarial review by: Gemini 3.1 Pro (high)
+Verification: `npm run verify` — green in CI
+```
+
+Batch PR (multiple issues, possibly multiple models) — table, one row per issue:
+
+```markdown
+## Provenance
+
+| Stage | Model | Effort |
+|---|---|---|
+| Implementation — #415 | Claude Sonnet 4.6 | medium |
+| Implementation — #417 | Claude Opus 4.8 | high |
+| Adversarial review | Gemini 3.1 Pro | high |
+| Review fixes | Claude Opus 4.8 | medium |
+| Orchestration + PR | Claude Opus 4.8 | medium |
+| Verification | `npm run verify` — green in CI | — |
+```
+
+Rules that make the block trustworthy rather than decorative:
+
+- **Every row is either self-reported by the agent that did the work, or first-hand knowledge of the orchestrator that spawned it. No third source.** A spawn requests a model *alias* (`model: opus`), not a version name — so the spawner does **not** know it resolved to "Claude Opus 4.8". Ask the agent; don't infer. What the agent returns is exactly one line — its model name. Never its instructions, prompt, or context: those are useless here and a needless disclosure surface.
+- **Never invent a row.** If a stage's model or effort can't be resolved (an externally-run reviewer, a hand-edit, a subagent that didn't report), say what's true (`Gemini 3.1 Pro (high) — run manually`, or `unreported (requested: sonnet)`) or omit the row. A missing row is honest; a guessed one is worse than nothing.
+- **Name the stage that touched code.** In a batch, the orchestrator model also fixes review findings — that's more leverage over the final diff than writing the PR body. Split `Review fixes` from `Orchestration + PR` so the reader can see it.
+- **Write it once, idempotently.** Guard the append on the `## Provenance` marker so a resumed run or a `/revise-pr` round updates the block instead of stacking a second one.
+
+## Squash messages (one commit per PR)
+
+`main` merges through a **merge queue**, and the queue's enqueue API carries **no commit-message fields** (`EnqueuePullRequestInput` is `pullRequestId` / `jump` / `expectedHeadOid`, nothing else). The squash message therefore **cannot be handed to GitHub at merge time** — GitHub *derives* it from repo settings:
+
+```
+squash_merge_commit_title:   COMMIT_OR_PR_TITLE
+squash_merge_commit_message: COMMIT_MESSAGES
+```
+
+With those settings, a **multi-commit** PR merges with every commit message concatenated as `* ` bullets. That is how `wip`, `fix lint`, and `address review comments` end up in `main`'s history permanently.
+
+The `COMMIT_OR_` prefix is the only lever:
+
+> **A PR with exactly one commit merges with that commit's subject and body verbatim** — PR title and body ignored, no bullet soup, no `## Provenance` block leaking into `git log`.
+
+So **every PR reaches the queue as a single commit whose message is the message we want in `main`.**
+
+- **`/open-pr` (Step 3.6)** collapses the branch *before* the PR exists — free, since there is no approval to dismiss yet.
+- **`/revise-pr` (Step 5.1)** collapses **only on the final review round**, when no thread is left open. A mid-review force-push costs the reviewer the delta diff they came back for.
+
+```bash
+git reset --soft "$(git merge-base HEAD origin/main)"
+git commit -F .git/COMMIT_EDITMSG     # the combined message, hand-written
+git push --force-with-lease           # never bare --force
+```
+
+Rules:
+
+- **Branch commits are scratch; the merge message is the artifact.** Write the combined message to describe the change *as a whole* — not the sequence of steps that produced it. Drop the review round-trip; it is process, not change.
+- **Don't `rebase -i` a branch clean before merge.** Pointless when it is getting squashed — collapse instead.
+- **Never bypass the queue with `--admin`** just to hand-write a merge message. The collapse achieves the same thing without skipping required checks.
+- **Nothing is lost that squash-merge wasn't already going to discard.** `main` only ever receives one commit per PR; collapsing early changes *when* the intermediate commits are dropped, not *whether*. The collapsed commit's tree is byte-identical to the branch tip's.
+- **Recovery, if a collapse goes wrong:** the pre-push SHA is permanently recorded on the PR timeline (`HeadRefForcePushedEvent`, `before`/`after`), the orphaned commit stays viewable at `github.com/<org>/<repo>/commit/<sha>` and downloadable via `gh api repos/<org>/<repo>/commits/<sha> -H "Accept: application/vnd.github.patch"`, and the pusher's local `git reflog` holds it for 90 days. Note that `git fetch origin <sha>` will **not** retrieve it — the server rejects unreachable objects — so restore from the reflog, or apply the patch.
+
 ## CodeGraph
 
 `.codegraph/` is present, so codegraph tools (`codegraph_search`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_context`, `codegraph_node`) are available and should be preferred over raw grep for symbol lookups and call-graph traversal. Rebuild the index (`codegraph init -i` or the project's refresh command) after large structural changes.


### PR DESCRIPTION
## Summary

Two conventions govern what a change says about itself. Neither was written down where a contributor could read it, so neither was followed.

### 1. AI provenance

Three unrelated things were fused into one auto-generated git trailer, and our rules treated them as a single decision. This splits them.

| Concern | Before | Now |
|---|---|---|
| **Authorship** (`Co-Authored-By: Claude …`) | Banned | **Banned** — a model isn't a semantic co-author under git/GitHub convention. The human who ran it is the author. This part was always right. |
| **Session telemetry** (`Claude-Session:` URL, `🤖 Generated with …`) | *Unaddressed* — so it kept landing | **Banned everywhere.** Zero value to a reader of the diff, and this repo is public: a session URL is an account-scoped identifier. |
| **Provenance** (which model, which stage, what effort) | Thrown out along with authorship | **Required**, in the PR body only — never in git history. |

Provenance is the one worth keeping: it makes cross-model review legible, and it lets a reader calibrate how much to trust a diff. A batch PR legitimately spans several models, so it's **per-stage** — one row per issue, plus adversarial review, review fixes, and orchestration. The model that *fixes review findings* earns its own row: it has more leverage over the final diff than whoever wrote the PR body.

**What keeps the block honest rather than decorative:** every row is self-reported by the agent that did the work, or first-hand knowledge of the orchestrator that spawned it. **No third source.** A spawn requests a model *alias* (`model: sonnet`) and cannot see what it resolved to — so subagents now return their own model name (one line, the name only; not their prompt or context). A row that can't be resolved says so (`unreported (requested: sonnet)`) or is omitted. **A missing row is honest; a guessed one is worse than nothing.**

### 2. Squash messages

`main` merges through a **merge queue**, and the queue's enqueue API carries **no commit-message fields** — `EnqueuePullRequestInput` is `pullRequestId` / `jump` / `expectedHeadOid`, nothing else. So the squash message **cannot be handed to GitHub at merge time.** GitHub *derives* it from repo settings, and today those are:

```
squash_merge_commit_title:   COMMIT_OR_PR_TITLE
squash_merge_commit_message: COMMIT_MESSAGES
```

Which means a multi-commit PR merges with every commit message concatenated as `* ` bullets — how `wip`, `fix lint`, and `address review comments` end up in `main`'s history forever.

The `COMMIT_OR_` prefix is the lever: **a PR with exactly one commit merges with that commit's subject and body verbatim** — PR title/body ignored, no bullet soup, no `## Provenance` block leaking into `git log`. So a PR must reach the queue as a single commit whose message is the message we want in `main`.

- **`open-pr` (Step 3.6)** — collapse the branch to one hand-written commit *before* the PR exists. Free: there's no approval to dismiss yet.
- **`revise-pr` (Step 5.1)** — collapse **only on the final round**, when no thread is left open. A mid-review force-push costs the reviewer the delta diff they came back for, so rounds that leave threads open keep their fixup commit separate.

**Branch commits are scratch; the merge message is the artifact.** This also means nobody needs to `rebase -i` a branch clean before merge — pointless when it's getting squashed.

Rejected alternative: flipping the settings to `PR_TITLE`/`PR_BODY`. It would drag this very `## Provenance` block and the test checklist into `main`'s history — worse noise than commit soup, and it contradicts rule 3 above (provenance belongs in the PR, not in git).

### Files

- **`CLAUDE.md`** — two new sections. **AI provenance**: the canonical rule, both block formats (prose for single-issue, table for batch), and the four trust rules. **Squash messages**: why the merge queue forces one commit per PR, the collapse recipe, and how to recover a force-pushed commit if a collapse goes wrong.
- **`open-pr`** — no trailers at commit time; `## Provenance` in the body template (Step 5.5); **new Step 3.6: collapse to a single commit**; accepts provenance records from a calling skill.
- **`revise-pr`** — no trailers in the revision commit; updates `## Provenance` **in place**, never stacking a second block; **new Step 5.1: gated final-round collapse**.
- **`implement-batch`** — subagents self-report `Model:`; the orchestrator records `{stage, model, effort}` per issue plus review / review-fixes / orchestration, and hands them to `/open-pr`.
- **`pr-review`** — an AI review signs itself (`Reviewed by: …`). The value of a second model's read is lost if the PR doesn't say which model read it.

## Test plan

- [x] Docs-only diff — no source touched, no fixtures added (Step 3.5 preflight: no binaries in diff)
- [x] `npm run typecheck` clean; `npm run test` green (2070 passed / 7 skipped)
- [x] This PR's own commit carries **no** `Co-Authored-By` / `Claude-Session:` / `🤖` trailer — asserted line-anchored against the commit body
- [x] **This PR eats its own dog food: it is a single commit**, so the merge queue will land the hand-written message above verbatim
- [x] This PR's `## Provenance` block follows the rule it introduces, including the omission (see below)
- [x] `npm run verify` green in CI

## Provenance

Code implementation via: Claude Opus 4.8 (1M context)
Adversarial review: none — docs-only change, no reviewer model run
Verification: `npm run verify` — CI

**Note the omission, which is the point.** The template asks for an effort level. I know my own model name first-hand, so that row is stated. I do **not** have my effort setting exposed to me, so rather than write a plausible `(medium)`, the field is absent — exactly what the rule requires of any row whose value can't be established. The first thing this policy did was forbid me from making something up about myself.

