### PR TITLE
feat(job-tracker): local job tracker — data layer, tracker UI, JD-match seam (#323)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
+import { useCallback } from "react";
 import {
   Card,
   CapabilityStrip,
@@ -15,6 +16,7 @@ import { AtsScoreReadout } from "./components/features/AtsScoreReadout.tsx";
 import { PageShell } from "./components/features/PageShell.tsx";
 import { ReplaceResumeDropOverlay } from "./components/features/ReplaceResumeDropOverlay.tsx";
 import { ResumeLibrary } from "./components/features/ResumeLibrary.tsx";
+import { JobTrackerSection } from "./components/features/JobTracker.tsx";
 import { SaveResumeBar } from "./components/features/SaveResumeBar.tsx";
 import { useAnalyzedResume } from "./hooks/useAnalyzedResume.ts";
 import { useResumeLibrary } from "./hooks/useResumeLibrary.ts";
@@ -66,6 +68,19 @@ export default function App() {
   // Cross-sell to the `/jd-fit/` surface is gated (default off) — `/jd-fit/` is
   // alpha and not ready to promote from the parser result. See lib/flags.ts.
   const jdFitEnabled = useFlag("jd-fit-banner");
+
+  // Local job tracker (#323) — flag-gated (default off) while #323 sits at P4.
+  // `JobTrackerSection` owns `useJobTracker`, so with the flag off nothing here
+  // touches IndexedDB at all.
+  const jobTrackerEnabled = useFlag("job-tracker");
+  // Resolve a job's linked resume id to a display name, and offer the same
+  // library entries to the row's link picker. Both come from the library the
+  // page already loads, so the tracker never re-reads the resume store.
+  const resumeName = useCallback(
+    (resumeId: string) =>
+      library.entries.find((entry) => entry.id === resumeId)?.filename,
+    [library.entries],
+  );
 
   // Cross-link to /jd-fit (#226). On click we stash the edited parse in
   // sessionStorage (one-shot handoff) so JD-fit rehydrates it without
@@ -182,6 +197,17 @@ export default function App() {
             // empty. Sits directly beneath the drop zone; loading one restores
             // the results view from its cached parse (no re-upload).
             <ResumeLibrary library={library} onLoad={onLoadSavedResume} />
+          )}
+
+          {jobTrackerEnabled && (state.phase === "idle" || state.phase === "error") && (
+            // Tracked jobs (#323) — sits under the saved-resumes picker, the
+            // other local-first surface, so both persistence affordances live
+            // in one place. Unlike the library it does NOT self-hide when
+            // empty: its empty state carries the only "Add a job" entry point.
+            <JobTrackerSection
+              resumeName={resumeName}
+              resumeOptions={library.entries}
+            />
           )}
 
           {(state.phase === "idle" || state.phase === "error") && (

--- a/src/components/features/JobStatusPicker.tsx
+++ b/src/components/features/JobStatusPicker.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobStatusPicker — the application-status control for a tracked job (#323). A
+ * simple segmented picker over the linear lifecycle, not a workflow engine: the
+ * current status is the primary button, the rest are ghost buttons that switch
+ * to that status on click. Also exports the shared status → label / badge-tone
+ * maps so the row badge and the picker never disagree.
+ */
+
+import { Button, type StatusBadgeTone } from "@design-system";
+import { JOB_STATUS_ORDER } from "../../lib/storage/types.ts";
+import type { JobStatus } from "../../lib/storage/types.ts";
+
+const STATUS_LABEL: Record<JobStatus, string> = {
+  interested: "Interested",
+  applied: "Applied",
+  interviewing: "Interviewing",
+  offer: "Offer",
+  rejected: "Rejected",
+  archived: "Archived",
+};
+
+/** Badge tone per status — shared with the row's `StatusBadge` so display and
+ *  picker stay consistent. Module-private: consumers go through
+ *  {@link jobStatusTone}, which adds the unknown-status fallback. */
+const JOB_STATUS_TONE: Record<JobStatus, StatusBadgeTone> = {
+  interested: "info",
+  applied: "info",
+  interviewing: "ok",
+  offer: "ok",
+  rejected: "warning",
+  archived: "limited",
+};
+
+/** Display label for a status. Falls back to the raw string for a status that
+ *  isn't in the canonical lifecycle — a corrupt or future-version imported
+ *  record — so such a job renders with its literal status rather than a blank
+ *  badge. `JobTracker` relies on this to surface, not swallow, unknown statuses. */
+export function jobStatusLabel(status: string): string {
+  return STATUS_LABEL[status as JobStatus] ?? status;
+}
+
+/** Badge tone for a status, with a neutral fallback for an unknown one, so a
+ *  corrupt-status row still renders a valid badge instead of an empty class. */
+export function jobStatusTone(status: string): StatusBadgeTone {
+  return JOB_STATUS_TONE[status as JobStatus] ?? "info";
+}
+
+interface JobStatusPickerProps {
+  value: JobStatus;
+  onChange: (status: JobStatus) => void;
+}
+
+export function JobStatusPicker({ value, onChange }: JobStatusPickerProps) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1"
+      role="group"
+      aria-label="Application status"
+    >
+      {JOB_STATUS_ORDER.map((status) => (
+        <Button
+          key={status}
+          variant={status === value ? "primary" : "ghost"}
+          size="sm"
+          aria-pressed={status === value}
+          onClick={() => onChange(status)}
+        >
+          {STATUS_LABEL[status]}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/JobTracker.test.tsx
+++ b/src/components/features/JobTracker.test.tsx
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * JobTracker (#323). The properties that matter for the tracker surface: jobs
+ * render grouped by status, the manual add wires to the hook, a linked resume
+ * that no longer resolves degrades to "not linked" (never a dangling id) — the
+ * graceful-degrade AC as seen from the UI — and the link picker only offers
+ * resumes that actually exist.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { JobTracker } from "./JobTracker.tsx";
+import type { JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
+import type { JobRecord } from "../../lib/storage/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function job(over: Partial<JobRecord>): JobRecord {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    createdAt: 1,
+    updatedAt: 1,
+    title: "SWE",
+    company: "Acme",
+    status: "interested",
+    ...over,
+  };
+}
+
+function makeTracker(jobs: JobRecord[]): Tracker {
+  return {
+    jobs,
+    ready: true,
+    persisted: true,
+    usageBytes: null,
+    create: vi.fn(async () => "new-id"),
+    update: vi.fn(async () => {}),
+    setStatus: vi.fn(async () => {}),
+    link: vi.fn(async () => {}),
+    unlink: vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+    saveFromMatch: vi.fn(async () => "new-id"),
+    exportBackup: vi.fn(async () => {}),
+    refresh: vi.fn(async () => {}),
+  };
+}
+
+describe("JobTracker", () => {
+  it("still renders a job whose status isn't in the lifecycle, so the count can't lie", () => {
+    // A corrupt or future-version imported record can carry a status outside
+    // JOB_STATUS_ORDER. It must not vanish from the list while still being
+    // counted in the header total (rows < count) — it renders under its raw
+    // status label instead.
+    const tracker = makeTracker([
+      job({ title: "Real", status: "applied" }),
+      job({ title: "Weird", status: "ghosted" as JobRecord["status"] }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    const text = container.textContent ?? "";
+    expect(text).toContain("Real");
+    expect(text).toContain("Weird");
+    // The unknown status surfaces under its literal string, not a blank badge.
+    expect(text).toContain("ghosted");
+  });
+
+  it("groups jobs under their status headings", () => {
+    const tracker = makeTracker([
+      job({ title: "A", status: "interested" }),
+      job({ title: "B", status: "offer" }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    const text = container.textContent ?? "";
+    expect(text).toContain("Interested");
+    expect(text).toContain("Offer");
+    expect(text).toContain("Tracked jobs");
+  });
+
+  it("shows the empty-state prompt with no jobs", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker([])} />));
+    expect(container.textContent).toContain("No tracked jobs yet");
+  });
+
+  it("wires the manual add button to the hook", () => {
+    const tracker = makeTracker([]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    const add = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === "Add a job",
+    );
+    act(() => add?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(tracker.create).toHaveBeenCalledWith({ title: "New job" });
+  });
+
+  it("degrades a stale resume link to 'not linked' instead of a dangling id", () => {
+    const tracker = makeTracker([job({ resumeId: "deleted-resume" })]);
+    // resumeName resolver returns undefined — the linked resume is gone.
+    act(() =>
+      root.render(<JobTracker tracker={tracker} resumeName={() => undefined} />),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Not linked to a resume");
+    expect(text).not.toContain("deleted-resume");
+  });
+});
+
+describe("JobTracker: resume link picker", () => {
+  const RESUMES = [
+    { id: "r1", filename: "resume-v1.pdf" },
+    { id: "r2", filename: "resume-v2.pdf" },
+  ];
+
+  function clickButton(label: string) {
+    const button = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === label,
+    );
+    act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    return button;
+  }
+
+  it("offers the saved resumes and links the one picked", () => {
+    const tracker = makeTracker([job({ id: "j1" })]);
+    act(() =>
+      root.render(
+        <JobTracker tracker={tracker} resumeOptions={RESUMES} />,
+      ),
+    );
+    // Collapsed by default — a row shouldn't open with a list of every resume.
+    expect(container.textContent).not.toContain("resume-v2.pdf");
+
+    clickButton("Link a resume");
+    expect(container.textContent).toContain("resume-v1.pdf");
+    clickButton("resume-v2.pdf");
+
+    expect(tracker.link).toHaveBeenCalledWith("j1", "r2");
+  });
+
+  it("hides the picker when there are no saved resumes to link", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker([job({})])} />));
+    expect(container.textContent).toContain("Not linked to a resume");
+    expect(container.textContent).not.toContain("Link a resume");
+  });
+
+  it("offers unlink, not the picker, once a resume is linked", () => {
+    const tracker = makeTracker([job({ id: "j1", resumeId: "r1" })]);
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          resumeName={() => "resume-v1.pdf"}
+          resumeOptions={RESUMES}
+        />,
+      ),
+    );
+    expect(container.textContent).not.toContain("Link a resume");
+    clickButton("Unlink");
+    expect(tracker.unlink).toHaveBeenCalledWith("j1");
+  });
+});

--- a/src/components/features/JobTracker.tsx
+++ b/src/components/features/JobTracker.tsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobTracker — the saved-jobs surface (#323), sibling of ResumeLibrary. Lists
+ * tracked jobs grouped by application status, surfaces the same storage-
+ * persistence state + eviction transparency copy with a one-click backup export,
+ * and offers a manual add. All local: nothing leaves the browser, no account, no
+ * sync. Row rendering + status transitions live in JobTrackerEntry; storage
+ * access is the `useJobTracker` hook. Renders an empty-state prompt until the
+ * first job is added.
+ */
+
+import { useMemo } from "react";
+import { Card, Button, StatusBadge } from "@design-system";
+import { formatBytes } from "../../lib/format-bytes.ts";
+import { EVICTION_NOTICE } from "../../lib/storage/index.ts";
+import { JOB_STATUS_ORDER } from "../../lib/storage/types.ts";
+import type { JobRecord, JobStatus } from "../../lib/storage/types.ts";
+import { jobStatusLabel } from "./JobStatusPicker.tsx";
+import { JobTrackerEntry, type LinkableResume } from "./JobTrackerEntry.tsx";
+import { useJobTracker, type JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
+
+interface JobTrackerProps {
+  tracker: Tracker;
+  /** Resolve a linked resume id to its display name; returns undefined when the
+   *  resume no longer exists, so the row degrades to "not linked". */
+  resumeName?: (resumeId: string) => string | undefined;
+  /** Saved resumes a row's link picker offers. Omitted / empty hides the
+   *  picker, so the tracker still stands alone with an empty library. */
+  resumeOptions?: readonly LinkableResume[];
+}
+
+/**
+ * Flag-gated entry point that OWNS the hook, so `useJobTracker` mounts only
+ * where the tracker actually renders. A hook can't be called conditionally, so
+ * calling it in `App` above the flag check would open IndexedDB and list the
+ * jobs store on every visit for a feature nobody can see — this child is what
+ * makes "inert while the flag is off" true rather than aspirational.
+ * {@link JobTracker} stays tracker-injected so tests drive it with a fake.
+ */
+export function JobTrackerSection(props: Omit<JobTrackerProps, "tracker">) {
+  const tracker = useJobTracker();
+  return <JobTracker tracker={tracker} {...props} />;
+}
+
+export function JobTracker({ tracker, resumeName, resumeOptions }: JobTrackerProps) {
+  const { jobs, ready, persisted, usageBytes, update, setStatus, link, unlink, remove, create, exportBackup } =
+    tracker;
+
+  // One pass, bucketed by each job's ACTUAL status string — canonical lifecycle
+  // statuses in order first, then any status not in JOB_STATUS_ORDER (a corrupt
+  // or future-version imported record). Keying the render on JOB_STATUS_ORDER
+  // alone would silently drop such a job: it'd still count toward the header
+  // total but appear in no section, so the count would exceed the visible rows.
+  const groups = useMemo(() => {
+    const buckets = new Map<string, JobRecord[]>();
+    for (const job of jobs) {
+      const bucket = buckets.get(job.status);
+      if (bucket) bucket.push(job);
+      else buckets.set(job.status, [job]);
+    }
+    const known = JOB_STATUS_ORDER.filter((status) => buckets.has(status));
+    const unknown = [...buckets.keys()]
+      .filter((status) => !JOB_STATUS_ORDER.includes(status as JobStatus))
+      .sort();
+    return [...known, ...unknown].map((status) => ({
+      status,
+      jobs: buckets.get(status) ?? [],
+    }));
+  }, [jobs]);
+
+  if (!ready) return null;
+
+  return (
+    <Card className="flex flex-col gap-4">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-content-primary">
+            Tracked jobs
+          </h2>
+          <span className="text-xs text-content-muted">
+            {jobs.length}
+            {usageBytes !== null && <> · {formatBytes(usageBytes)} used</>}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusBadge tone={persisted ? "ok" : "warning"}>
+            {persisted ? "Persistent" : "Best-effort"}
+          </StatusBadge>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void create({ title: "New job" })}
+          >
+            Add a job
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => void exportBackup()}>
+            Export backup
+          </Button>
+        </div>
+      </header>
+
+      <p className="text-xs text-content-tertiary">
+        Saved only in this browser — no account, no sync.{" "}
+        {!persisted && EVICTION_NOTICE}
+      </p>
+
+      {jobs.length === 0 ? (
+        <p className="text-sm text-content-muted">
+          No tracked jobs yet. Add a job, or save one from a JD match.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map(({ status, jobs: group }) => (
+              <section key={status} className="flex flex-col gap-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+                  {jobStatusLabel(status)} · {group.length}
+                </h3>
+                <ul className="flex flex-col gap-2">
+                  {group.map((job) => (
+                    <JobTrackerEntry
+                      key={job.id}
+                      job={job}
+                      linkedResumeName={
+                        job.resumeId !== undefined
+                          ? resumeName?.(job.resumeId)
+                          : undefined
+                      }
+                      resumeOptions={resumeOptions}
+                      onUpdate={(id, patch) => void update(id, patch)}
+                      onStatusChange={(id, next) => void setStatus(id, next)}
+                      onLinkResume={(id, resumeId) => void link(id, resumeId)}
+                      onUnlinkResume={(id) => void unlink(id)}
+                      onRemove={(id) => void remove(id)}
+                    />
+                  ))}
+                </ul>
+              </section>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/features/JobTrackerEntry.tsx
+++ b/src/components/features/JobTrackerEntry.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobTrackerEntry — one row of the job tracker (#323). Title / company / URL /
+ * notes are inline-editable (`EditableField`); status switches via the shared
+ * JobStatusPicker; the linked resume shows its name (or "Not linked") and
+ * degrades to unlinked text if the resume was deleted. Picking a resume expands
+ * an inline list of saved resumes rather than a dropdown — the same
+ * button-list shape JobStatusPicker uses, so the row has one interaction
+ * vocabulary. Remove is a two-click inline confirm so a stray click can't drop
+ * a tracked application. All state access is the caller's `useJobTracker`
+ * handlers — this component is presentational.
+ */
+
+import { useState } from "react";
+import { Button, EditableField, StatusBadge } from "@design-system";
+import { JobStatusPicker, jobStatusTone, jobStatusLabel } from "./JobStatusPicker.tsx";
+import type { JobRecord, JobStatus } from "../../lib/storage/types.ts";
+import type { JobPatch } from "../../lib/job-tracker.ts";
+
+/** A saved resume the user can link this job to — the light shape the picker
+ *  renders, structurally satisfied by `ResumeLibraryEntry`. */
+export interface LinkableResume {
+  id: string;
+  filename: string;
+}
+
+interface JobTrackerEntryProps {
+  job: JobRecord;
+  /** Display name of the linked resume, or undefined when none is linked / the
+   *  linked resume no longer exists (graceful degrade). */
+  linkedResumeName?: string;
+  /** Saved resumes offered by the link picker. Empty (or omitted) hides it —
+   *  a user with no saved resumes has nothing to link. */
+  resumeOptions?: readonly LinkableResume[];
+  onUpdate: (id: string, patch: JobPatch) => void;
+  onStatusChange: (id: string, status: JobStatus) => void;
+  onLinkResume: (id: string, resumeId: string) => void;
+  onUnlinkResume: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function JobTrackerEntry({
+  job,
+  linkedResumeName,
+  resumeOptions = [],
+  onUpdate,
+  onStatusChange,
+  onLinkResume,
+  onUnlinkResume,
+  onRemove,
+}: JobTrackerEntryProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [picking, setPicking] = useState(false);
+
+  return (
+    <li className="flex flex-col gap-2 rounded-md border border-border-light p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <EditableField
+            value={job.title || undefined}
+            label="Job title"
+            textSize="sm"
+            onCommit={(v) => onUpdate(job.id, { title: v })}
+          />
+          <EditableField
+            value={job.company || undefined}
+            label="Company"
+            textSize="sm"
+            onCommit={(v) => onUpdate(job.id, { company: v })}
+          />
+        </div>
+        <StatusBadge tone={jobStatusTone(job.status)}>
+          {jobStatusLabel(job.status)}
+        </StatusBadge>
+      </div>
+
+      <JobStatusPicker
+        value={job.status}
+        onChange={(status) => onStatusChange(job.id, status)}
+      />
+
+      {job.url && (
+        <a
+          href={job.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="truncate text-xs text-accent-primary hover:underline"
+        >
+          {job.url}
+        </a>
+      )}
+
+      <EditableField
+        value={job.notes || undefined}
+        label="Notes"
+        textSize="sm"
+        onCommit={(v) => onUpdate(job.id, { notes: v })}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-content-muted">
+        <span>
+          {linkedResumeName ? (
+            <>
+              Resume: <span className="text-content-secondary">{linkedResumeName}</span>{" "}
+              <Button variant="link" size="sm" onClick={() => onUnlinkResume(job.id)}>
+                Unlink
+              </Button>
+            </>
+          ) : (
+            <>
+              Not linked to a resume
+              {resumeOptions.length > 0 && (
+                <>
+                  {" "}
+                  <Button
+                    variant="link"
+                    size="sm"
+                    aria-expanded={picking}
+                    onClick={() => setPicking((open) => !open)}
+                  >
+                    {picking ? "Cancel" : "Link a resume"}
+                  </Button>
+                </>
+              )}
+            </>
+          )}
+          {" · "}Updated {formatDate(job.updatedAt)}
+        </span>
+        {confirming ? (
+          <span className="flex items-center gap-1">
+            <span className="text-content-secondary">Remove?</span>
+            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" size="sm" onClick={() => onRemove(job.id)}>
+              Confirm
+            </Button>
+          </span>
+        ) : (
+          <Button variant="ghost" size="sm" onClick={() => setConfirming(true)}>
+            Remove
+          </Button>
+        )}
+      </div>
+
+      {picking && !linkedResumeName && resumeOptions.length > 0 && (
+        <div
+          className="flex flex-wrap items-center gap-1"
+          role="group"
+          aria-label="Link a saved resume"
+        >
+          {resumeOptions.map((resume) => (
+            <Button
+              key={resume.id}
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                onLinkResume(job.id, resume.id);
+                setPicking(false);
+              }}
+            >
+              {resume.filename}
+            </Button>
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/features/SaveJobFromMatch.test.tsx
+++ b/src/components/features/SaveJobFromMatch.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * SaveJobFromMatch (#323 AC, "JD-match flow offers 'save as tracked job' and
+ * carries the match result onto the job record"). Asserts the three things the
+ * seam promises: the click reaches `saveFromMatch`, the JD text and match
+ * result ride along with a title seeded from the JD, the button collapses to a
+ * confirmation so a second click can't double-save the same posting, that
+ * confirmation is keyed to its JD so a pasted-over posting is saveable, and a
+ * failed write says so instead of looking like a success.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SaveJobFromMatch } from "./SaveJobFromMatch.tsx";
+import type { JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
+import type { JdMatchResult } from "../../lib/jd-match";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const MATCH = {
+  path: "keyword",
+  coverage: { covered: [], missing: [] },
+  terms: ["typescript"],
+  nounsDropped: 0,
+} as unknown as JdMatchResult;
+
+const JD = "Staff Frontend Engineer\nAcme Inc\n\nWe are looking for...";
+
+function makeTracker(): Tracker {
+  return {
+    jobs: [],
+    ready: true,
+    persisted: true,
+    usageBytes: null,
+    create: vi.fn(async () => "new-id"),
+    update: vi.fn(async () => {}),
+    setStatus: vi.fn(async () => {}),
+    link: vi.fn(async () => {}),
+    unlink: vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+    saveFromMatch: vi.fn(async () => "new-id"),
+    exportBackup: vi.fn(async () => {}),
+    refresh: vi.fn(async () => {}),
+  };
+}
+
+async function clickSave() {
+  const button = [...container.querySelectorAll("button")].find((b) =>
+    b.textContent?.startsWith("Save as tracked job"),
+  );
+  await act(async () => {
+    button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  return button;
+}
+
+describe("SaveJobFromMatch", () => {
+  it("carries the JD text and match result onto the saved job", async () => {
+    const tracker = makeTracker();
+    await act(async () => {
+      root.render(
+        <SaveJobFromMatch tracker={tracker} jdText={JD} matchResult={MATCH} />,
+      );
+    });
+
+    await clickSave();
+
+    expect(tracker.saveFromMatch).toHaveBeenCalledWith({
+      title: "Staff Frontend Engineer",
+      jdText: JD,
+      matchResult: MATCH,
+    });
+  });
+
+  it("collapses to a confirmation so the same posting can't be double-saved", async () => {
+    const tracker = makeTracker();
+    await act(async () => {
+      root.render(
+        <SaveJobFromMatch tracker={tracker} jdText={JD} matchResult={MATCH} />,
+      );
+    });
+
+    await clickSave();
+
+    expect(container.textContent).toContain("Saved to your tracked jobs");
+    expect(
+      [...container.querySelectorAll("button")].some((b) =>
+        b.textContent?.startsWith("Save as tracked job"),
+      ),
+    ).toBe(false);
+    expect(tracker.saveFromMatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers Save again when the user pastes a different JD (no unmount)", async () => {
+    const tracker = makeTracker();
+    await act(async () => {
+      root.render(
+        <SaveJobFromMatch tracker={tracker} jdText={JD} matchResult={MATCH} />,
+      );
+    });
+    await clickSave();
+    expect(container.textContent).toContain("Saved to your tracked jobs");
+
+    // Select-all + paste takes jdText A -> B in one change event, so jdMatch
+    // never passes through null and JdFitApp never unmounts this component.
+    await act(async () => {
+      root.render(
+        <SaveJobFromMatch
+          tracker={tracker}
+          jdText={"Staff Backend Engineer\nGlobex\n\nDifferent posting..."}
+          matchResult={MATCH}
+        />,
+      );
+    });
+
+    const button = [...container.querySelectorAll("button")].find((b) =>
+      b.textContent?.startsWith("Save as tracked job"),
+    );
+    expect(button).toBeDefined();
+  });
+
+  it("surfaces a failed save instead of silently re-enabling the button", async () => {
+    const tracker = makeTracker();
+    tracker.saveFromMatch = vi.fn(async () => {
+      throw new Error("QuotaExceededError");
+    });
+    await act(async () => {
+      root.render(
+        <SaveJobFromMatch tracker={tracker} jdText={JD} matchResult={MATCH} />,
+      );
+    });
+
+    await clickSave();
+
+    expect(container.textContent).toContain("Couldn't save");
+    expect(container.textContent).not.toContain("Saved to your tracked jobs");
+    // Still offered, so the user can retry rather than being stuck.
+    expect(
+      [...container.querySelectorAll("button")].some((b) =>
+        b.textContent?.startsWith("Save as tracked job"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/features/SaveJobFromMatch.tsx
+++ b/src/components/features/SaveJobFromMatch.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * SaveJobFromMatch — the "save this job" affordance on `/jd-fit/` (#323 AC).
+ *
+ * Turns a moment-in-time JD match into a tracked job in one click: the pasted
+ * JD text and the match result ride onto the new record, so the tracker on `/`
+ * shows what was matched and how it scored without re-running anything. The
+ * title is seeded from the JD's first line (`deriveJobTitleFromJd`) and is
+ * inline-editable in the tracker — we never scrape the posting (#323 non-goal).
+ *
+ * Deliberately a button and a confirmation line, not a form: asking for
+ * title/company here would put a data-entry step between the user and the
+ * match they came for, and both fields are editable one surface over. The two
+ * surfaces are separate HTML entries sharing one IndexedDB origin, so the save
+ * lands in the same store `/` reads — hence the cross-surface pointer in the
+ * confirmation rather than an in-place list.
+ */
+
+import { useState } from "react";
+import { Button } from "@design-system";
+import { deriveJobTitleFromJd } from "../../lib/job-tracker.ts";
+import { useJobTracker, type JobTracker } from "../../hooks/useJobTracker.ts";
+import type { JdMatchResult } from "../../lib/jd-match";
+
+interface SaveJobFromMatchProps {
+  tracker: JobTracker;
+  /** The JD the user pasted — stored verbatim on the record. */
+  jdText: string;
+  /** The match the user just ran, carried onto the job record. */
+  matchResult: JdMatchResult;
+}
+
+/**
+ * Flag-gated entry point that OWNS the hook, mirroring `JobTrackerSection` on
+ * `/`. Calling `useJobTracker` in `JdFitApp` above the flag check would open
+ * IndexedDB on every `/jd-fit/` visit for a button nobody can see; a hook can't
+ * be called conditionally, so the gate has to be a component boundary.
+ */
+export function SaveJobFromMatchSection(
+  props: Omit<SaveJobFromMatchProps, "tracker">,
+) {
+  const tracker = useJobTracker();
+  return <SaveJobFromMatch tracker={tracker} {...props} />;
+}
+
+export function SaveJobFromMatch({
+  tracker,
+  jdText,
+  matchResult,
+}: SaveJobFromMatchProps) {
+  // Keyed to the JD it belongs to, NOT a bare boolean: the common way a user
+  // reaches a second posting is select-all + paste, which moves `jdText` from
+  // old to new in one change event. `jdMatch` recomputes truthy without ever
+  // passing through null, so this component never unmounts — a boolean would
+  // leave the confirmation up and the Save button gone for the rest of the
+  // session. Comparing against the current JD resets it for free.
+  const [savedFor, setSavedFor] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    setFailed(false);
+    try {
+      await tracker.saveFromMatch({
+        title: deriveJobTitleFromJd(jdText),
+        jdText,
+        matchResult,
+      });
+      setSavedFor(jdText);
+    } catch {
+      // A write can genuinely fail — quota exceeded, a blocked IndexedDB
+      // upgrade, a private-mode origin. Swallowing it would re-enable the
+      // button looking untouched and let the user believe the job was saved,
+      // so confirm the failure in place (the repo has no toast primitive).
+      setFailed(true);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (savedFor === jdText) {
+    return (
+      <p className="text-xs text-content-muted">
+        Saved to your tracked jobs — open the parser-audit page to rename it,
+        set a status, or link the resume you used. Stored in this browser only.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button variant="ghost" size="sm" disabled={saving} onClick={() => void save()}>
+        {saving ? "Saving…" : "Save as tracked job"}
+      </Button>
+      <span className="text-xs text-content-muted">
+        {failed
+          ? "Couldn't save — this browser may be out of storage or in private mode. Your JD match is unaffected."
+          : "Keeps this JD and its match result in your browser."}
+      </span>
+    </div>
+  );
+}

--- a/src/design-system/shared/StatusBadge.tsx
+++ b/src/design-system/shared/StatusBadge.tsx
@@ -18,7 +18,7 @@
 
 import type { ReactNode } from "react";
 
-type StatusBadgeTone = "ok" | "limited" | "warning" | "info";
+export type StatusBadgeTone = "ok" | "limited" | "warning" | "info";
 
 interface StatusBadgeProps {
   tone: StatusBadgeTone;

--- a/src/hooks/useJobTracker.ts
+++ b/src/hooks/useJobTracker.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useJobTracker — UI-facing state over the job-tracker domain layer (#323).
+ * Owns the reactive job list plus the storage-persistence signal and the
+ * approximate space-used figure; delegates all persistence to
+ * `src/lib/job-tracker.ts` and `src/lib/storage`. Every mutation refreshes the
+ * list so the view stays in sync without the caller re-fetching. Sibling of
+ * {@link useResumeLibrary}, and reuses the same persistence/eviction plumbing so
+ * the durability messaging is identical across both surfaces.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  listJobs,
+  createJob,
+  updateJob,
+  setJobStatus,
+  linkResume,
+  unlinkResume,
+  removeJob,
+  createTrackedJobFromMatch,
+  type NewJobInput,
+  type JobPatch,
+} from "../lib/job-tracker.ts";
+import {
+  requestStoragePersistence,
+  isStoragePersisted,
+  downloadStorageBackup,
+} from "../lib/storage/index.ts";
+import { estimateStorageUsage } from "../lib/resume-library.ts";
+import type { JobRecord, JobStatus } from "../lib/storage/types.ts";
+
+export interface JobTracker {
+  jobs: JobRecord[];
+  /** True once the initial list load has resolved. */
+  ready: boolean;
+  /** IndexedDB persistence grant: true = exempt from eviction, false =
+   *  best-effort (surface the eviction notice, same copy as the resume library). */
+  persisted: boolean;
+  /** Approximate bytes used by this origin's storage, or null if unknown. */
+  usageBytes: number | null;
+  create: (input: NewJobInput) => Promise<string>;
+  update: (id: string, patch: JobPatch) => Promise<void>;
+  setStatus: (id: string, status: JobStatus) => Promise<void>;
+  link: (id: string, resumeId: string) => Promise<void>;
+  unlink: (id: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  /** "Save this job" from the JD-match flow — carries JD text + match result. */
+  saveFromMatch: (
+    input: Parameters<typeof createTrackedJobFromMatch>[0],
+  ) => Promise<string>;
+  /** Download the full storage export as a JSON backup file. */
+  exportBackup: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useJobTracker(): JobTracker {
+  const [jobs, setJobs] = useState<JobRecord[]>([]);
+  const [ready, setReady] = useState(false);
+  const [persisted, setPersisted] = useState(false);
+  const [usageBytes, setUsageBytes] = useState<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    const [list, usage] = await Promise.all([
+      listJobs(),
+      estimateStorageUsage(),
+    ]);
+    setJobs(list);
+    setUsageBytes(usage);
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    void isStoragePersisted().then(setPersisted);
+  }, [refresh]);
+
+  /** Ask for durable storage on the first write and reflect the grant, so the
+   *  UI can drop the eviction warning — mirrors `useResumeLibrary.save`. */
+  const ensurePersistence = useCallback(async () => {
+    const granted = await requestStoragePersistence();
+    setPersisted((prev) => prev || granted);
+  }, []);
+
+  const create = useCallback(
+    async (input: NewJobInput) => {
+      await ensurePersistence();
+      const job = await createJob(input);
+      await refresh();
+      return job.id;
+    },
+    [ensurePersistence, refresh],
+  );
+
+  const update = useCallback(
+    async (id: string, patch: JobPatch) => {
+      await updateJob(id, patch);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const setStatus = useCallback(
+    async (id: string, status: JobStatus) => {
+      await setJobStatus(id, status);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const link = useCallback(
+    async (id: string, resumeId: string) => {
+      await linkResume(id, resumeId);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const unlink = useCallback(
+    async (id: string) => {
+      await unlinkResume(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await removeJob(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const saveFromMatch = useCallback(
+    async (input: Parameters<typeof createTrackedJobFromMatch>[0]) => {
+      await ensurePersistence();
+      const job = await createTrackedJobFromMatch(input);
+      await refresh();
+      return job.id;
+    },
+    [ensurePersistence, refresh],
+  );
+
+  const exportBackup = useCallback(() => downloadStorageBackup(), []);
+
+  return {
+    jobs,
+    ready,
+    persisted,
+    usageBytes,
+    create,
+    update,
+    setStatus,
+    link,
+    unlink,
+    remove,
+    saveFromMatch,
+    exportBackup,
+    refresh,
+  };
+}

--- a/src/hooks/useResumeLibrary.test.tsx
+++ b/src/hooks/useResumeLibrary.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useResumeLibrary — the one behaviour that lives in the hook rather than the
+ * domain layer: deleting a resume must also clear it from any tracked job that
+ * pointed at it (#323 AC, "deleting that resume degrades gracefully — link
+ * cleared, job kept").
+ *
+ * The lib-level `clearResumeLink` is covered in `job-tracker.test.ts`; what is
+ * asserted here is the *wiring* — that the resume-delete path actually calls
+ * it. Exercised through a probe component against `fake-indexeddb`, since the
+ * project has no @testing-library/react (same pattern as the other hook tests).
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { DB_NAME, closeDB, saveResume } from "../lib/storage/index.ts";
+import { createJob, listJobs } from "../lib/job-tracker.ts";
+import { useResumeLibrary, type ResumeLibrary } from "./useResumeLibrary.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** Render the hook and hand its value back through a ref-ish capture. */
+async function mountLibrary(): Promise<() => ResumeLibrary> {
+  let current: ResumeLibrary | undefined;
+  function Probe() {
+    current = useResumeLibrary();
+    return null;
+  }
+  await act(async () => {
+    root.render(<Probe />);
+  });
+  return () => {
+    if (!current) throw new Error("hook not mounted");
+    return current;
+  };
+}
+
+describe("useResumeLibrary: delete clears tracked-job links", () => {
+  it("keeps a job that pointed at the deleted resume, minus the link", async () => {
+    const resume = await saveResume({
+      filename: "resume-v1.pdf",
+      blob: new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+    });
+    const linked = await createJob({ title: "SWE", resumeId: resume.id });
+    const untouched = await createJob({ title: "PM", resumeId: "other-resume" });
+
+    const library = await mountLibrary();
+    await act(async () => {
+      await library().remove(resume.id);
+    });
+
+    const jobs = await listJobs();
+    // The job survives — only the dangling link is dropped.
+    expect(jobs).toHaveLength(2);
+    expect(jobs.find((j) => j.id === linked.id)?.title).toBe("SWE");
+    expect(jobs.find((j) => j.id === linked.id)?.resumeId).toBeUndefined();
+    // A link to a different resume is not collateral damage.
+    expect(jobs.find((j) => j.id === untouched.id)?.resumeId).toBe(
+      "other-resume",
+    );
+  });
+
+  it("deletes a resume with no tracked jobs at all without throwing", async () => {
+    const resume = await saveResume({
+      filename: "lonely.pdf",
+      blob: new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+    });
+    const library = await mountLibrary();
+    await act(async () => {
+      await library().remove(resume.id);
+    });
+    expect(library().entries).toHaveLength(0);
+  });
+});

--- a/src/hooks/useResumeLibrary.ts
+++ b/src/hooks/useResumeLibrary.ts
@@ -23,8 +23,9 @@ import {
 import {
   requestStoragePersistence,
   isStoragePersisted,
-  exportToJson,
+  downloadStorageBackup,
 } from "../lib/storage/index.ts";
+import { clearResumeLink } from "../lib/job-tracker.ts";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../lib/score/score.ts";
 
@@ -102,22 +103,24 @@ export function useResumeLibrary(): ResumeLibrary {
   const remove = useCallback(
     async (id: string) => {
       await removeLibraryResume(id);
+      try {
+        // Graceful degrade (#323 AC): a tracked job that pointed at this resume
+        // keeps its record and loses only the dangling link. Runs after the
+        // delete so a failure here can never leave the resume undeleted — and
+        // is caught so it can't skip the refresh below either, which would
+        // leave the just-deleted resume on screen until something re-lists.
+        // `reconcileResumeLinks` is the backstop for a link missed here.
+        await clearResumeLink(id);
+      } catch {
+        // Swallowed deliberately: the resume IS gone, and a stale link is a
+        // cosmetic "Not linked" degrade, not a failure worth blocking the UI.
+      }
       await refresh();
     },
     [refresh],
   );
 
-  const exportBackup = useCallback(async () => {
-    const json = await exportToJson();
-    const url = URL.createObjectURL(
-      new Blob([json], { type: "application/json" }),
-    );
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "offlinecv-backup.json";
-    a.click();
-    URL.revokeObjectURL(url);
-  }, []);
+  const exportBackup = useCallback(() => downloadStorageBackup(), []);
 
   return {
     entries,

--- a/src/jd-fit/JdFitApp.tsx
+++ b/src/jd-fit/JdFitApp.tsx
@@ -21,8 +21,10 @@ import { Result } from "../components/Result.tsx";
 import { PageShell } from "../components/features/PageShell.tsx";
 import { JdInput } from "../components/features/JdInput.tsx";
 import { JdMatch } from "../components/features/JdMatch.tsx";
+import { SaveJobFromMatchSection } from "../components/features/SaveJobFromMatch.tsx";
 import { useAnalyzedResume } from "../hooks/useAnalyzedResume.ts";
 import { useJdFitResume } from "./useJdFitResume.ts";
+import { useFlag } from "../lib/flags.ts";
 import { extractJdTerms, computeCoverage, type JdMatchResult } from "../lib/jd-match";
 import { buildJdRewriteContext } from "../lib/jd-match/rewrite-context.ts";
 
@@ -34,6 +36,11 @@ export default function JdFitApp() {
   // collapse to the SAME { result, score, edit, source } shape `<Result>` and
   // JD coverage consume.
   const resume = useJdFitResume(analyzed);
+
+  // "Save this job" (#323) — same flag as the tracker on `/`, since a saved
+  // job with nowhere to manage it is a dead end. The section child owns the
+  // hook, so a flag-off visit never opens IndexedDB.
+  const jobTrackerEnabled = useFlag("job-tracker");
 
   // JD coverage memo — moved verbatim from App (#226). Runs only when there's
   // both JD text and a parsed résumé.
@@ -113,6 +120,13 @@ export default function JdFitApp() {
       )}
 
       {jdMatch && <JdMatch result={jdMatch} />}
+
+      {jdMatch && jobTrackerEnabled && (
+        <SaveJobFromMatchSection
+          jdText={jdText}
+          matchResult={jdMatch}
+        />
+      )}
 
       <ErrorBoundary onReset={resume?.reset ?? analyzed.reset}>
         {resume && (

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -31,6 +31,12 @@ const envOn = (v: unknown): boolean => v === "true" || v === "1";
  *   cross-sell to the `/jd-fit/` surface. Off by default: `/jd-fit/` is alpha
  *   and not ready to promote from the parser result.
  *
+ * - `job-tracker` (`VITE_ENABLE_JOB_TRACKER`) — the local job tracker (#323)
+ *   on `/` and its "save this job" affordance on `/jd-fit/`. Off by default:
+ *   #323 is P4 (Post-Public), so the surface ships dark and is promoted from
+ *   PostHog rather than by a rebuild. The data layer is inert while off — the
+ *   hook only runs where the flag renders it.
+ *
  * - `llm` (`VITE_ENABLE_LLM`) — two-layer gate for all WebLLM-backed
  *   features: the disagreement detector (#242), escape hatch (#243), and
  *   gap-report (#245).
@@ -54,6 +60,7 @@ const envOn = (v: unknown): boolean => v === "true" || v === "1";
 // dead public export (fallow dead-code gate).
 const FLAG_DEFAULTS = {
   "jd-fit-banner": envOn(import.meta.env.VITE_ENABLE_JD_FIT),
+  "job-tracker": envOn(import.meta.env.VITE_ENABLE_JOB_TRACKER),
   "llm": envOn(import.meta.env.VITE_ENABLE_LLM),
 } as const;
 

--- a/src/lib/job-tracker.test.ts
+++ b/src/lib/job-tracker.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Job-tracker domain-layer tests (#323). Runs against `fake-indexeddb` (same
+ * harness as the storage foundation), so the real IndexedDB path is exercised
+ * offline. Covers the two headline acceptance criteria: CRUD + status
+ * transitions end-to-end, and graceful degrade when a linked resume is deleted
+ * (link cleared, job kept), plus the JD-match seam the `/jd-fit/` "save this
+ * job" button sits on.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DB_NAME, closeDB } from "./storage/db.ts";
+import {
+  createJob,
+  listJobs,
+  getJobById,
+  updateJob,
+  setJobStatus,
+  linkResume,
+  unlinkResume,
+  removeJob,
+  clearResumeLink,
+  reconcileResumeLinks,
+  createTrackedJobFromMatch,
+  deriveJobTitleFromJd,
+} from "./job-tracker.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+describe("job-tracker: CRUD + status", () => {
+  it("creates a job with a default status and managed id/timestamps", async () => {
+    const job = await createJob({ title: "Frontend Engineer", company: "Acme" });
+    expect(job.id).toBeTruthy();
+    expect(job.status).toBe("interested");
+    expect(job.createdAt).toBeGreaterThan(0);
+    expect(job.updatedAt).toBe(job.createdAt);
+    expect(await listJobs()).toHaveLength(1);
+  });
+
+  it("allows a blank company and optional fields", async () => {
+    const job = await createJob({ title: "SWE" });
+    expect(job.company).toBe("");
+    expect(job.url).toBeUndefined();
+    expect(job.resumeId).toBeUndefined();
+  });
+
+  it("updates fields without disturbing the rest, preserving createdAt", async () => {
+    const created = await createJob({ title: "SWE", company: "Acme" });
+    const updated = await updateJob(created.id, { notes: "referred by Dana" });
+    expect(updated.title).toBe("SWE");
+    expect(updated.company).toBe("Acme");
+    expect(updated.notes).toBe("referred by Dana");
+    expect(updated.createdAt).toBe(created.createdAt);
+    expect(updated.updatedAt).toBeGreaterThanOrEqual(created.updatedAt);
+  });
+
+  it("moves a job through the status lifecycle", async () => {
+    const job = await createJob({ title: "SWE" });
+    for (const status of ["applied", "interviewing", "offer"] as const) {
+      const next = await setJobStatus(job.id, status);
+      expect(next.status).toBe(status);
+    }
+    expect((await getJobById(job.id))?.status).toBe("offer");
+  });
+
+  it("lists every saved job (order is updatedAt-descending)", async () => {
+    // Timestamps are store-managed (`putRecord` stamps `Date.now()`), so exact
+    // tie-break order isn't controllable here; assert completeness, not the
+    // sub-millisecond order of the trivial `updatedAt` sort.
+    await createJob({ title: "A" });
+    await createJob({ title: "B" });
+    const titles = (await listJobs()).map((j) => j.title);
+    expect(titles).toHaveLength(2);
+    expect(titles).toEqual(expect.arrayContaining(["A", "B"]));
+  });
+
+  it("removes a job", async () => {
+    const job = await createJob({ title: "SWE" });
+    await removeJob(job.id);
+    expect(await listJobs()).toHaveLength(0);
+    expect(await getJobById(job.id)).toBeUndefined();
+  });
+
+  it("throws when updating a missing job", async () => {
+    await expect(updateJob("nope", { status: "applied" })).rejects.toThrow(
+      /no job/,
+    );
+  });
+});
+
+describe("job-tracker: resume linking + graceful degrade", () => {
+  it("links and unlinks a resume by id", async () => {
+    const job = await createJob({ title: "SWE" });
+    const linked = await linkResume(job.id, "resume-1");
+    expect(linked.resumeId).toBe("resume-1");
+    const unlinked = await unlinkResume(job.id);
+    expect(unlinked.resumeId).toBeUndefined();
+  });
+
+  it("clears the link when the linked resume is deleted, keeping the job", async () => {
+    const jobA = await createJob({ title: "A", resumeId: "resume-1" });
+    const jobB = await createJob({ title: "B", resumeId: "resume-2" });
+
+    const cleared = await clearResumeLink("resume-1");
+
+    expect(cleared).toBe(1);
+    // Job A survives, only its dangling link is gone.
+    expect((await getJobById(jobA.id))?.resumeId).toBeUndefined();
+    expect((await getJobById(jobA.id))?.title).toBe("A");
+    // Job B's unrelated link is untouched.
+    expect((await getJobById(jobB.id))?.resumeId).toBe("resume-2");
+    expect(await listJobs()).toHaveLength(2);
+  });
+
+  it("reconciles links orphaned by any delete path", async () => {
+    await createJob({ title: "A", resumeId: "gone" });
+    await createJob({ title: "B", resumeId: "stays" });
+    const repaired = await reconcileResumeLinks(new Set(["stays"]));
+    expect(repaired).toBe(1);
+    const jobs = await listJobs();
+    expect(jobs.find((j) => j.title === "A")?.resumeId).toBeUndefined();
+    expect(jobs.find((j) => j.title === "B")?.resumeId).toBe("stays");
+  });
+});
+
+describe("job-tracker: save-from-match", () => {
+  it("creates an interested job carrying the JD text + match result", async () => {
+    const match = { score: 82, missing: ["Rust"] };
+    const job = await createTrackedJobFromMatch({
+      title: "Platform Engineer",
+      company: "Globex",
+      jdText: "We are looking for...",
+      matchResult: match,
+    });
+    expect(job.status).toBe("interested");
+    expect(job.jdText).toContain("looking for");
+    expect(job.matchResult).toEqual(match);
+    // Survives a store round-trip (JSON-safe by contract).
+    expect((await getJobById(job.id))?.matchResult).toEqual(match);
+  });
+});
+
+describe("job-tracker: JD title seed", () => {
+  it("takes the JD's first non-empty line as the title seed", () => {
+    expect(deriveJobTitleFromJd("\n\n  Senior Frontend Engineer  \nAcme Inc\n"))
+      .toBe("Senior Frontend Engineer");
+  });
+
+  it("falls back to a placeholder when the first line is prose, not a title", () => {
+    const prose =
+      "We are a fast-growing company looking for someone who can own the " +
+      "entire frontend stack and mentor a team of engineers along the way.";
+    expect(deriveJobTitleFromJd(prose)).toBe("Untitled job");
+  });
+
+  it("falls back to a placeholder for blank input rather than an empty title", () => {
+    expect(deriveJobTitleFromJd("   \n\n  ")).toBe("Untitled job");
+    expect(deriveJobTitleFromJd("")).toBe("Untitled job");
+  });
+});
+
+describe("job-tracker: link cleanup is housekeeping, not a user edit", () => {
+  it("does not reorder the tracker when an unrelated resume is deleted", async () => {
+    const older = await createJob({ title: "Older", resumeId: "resume-1" });
+    // `updatedAt` is millisecond-resolution `Date.now()`, so two writes in the
+    // same tick tie and the sort order becomes arbitrary. Separate them
+    // explicitly — otherwise this test is a coin flip, not a check.
+    await new Promise((r) => setTimeout(r, 2));
+    const newer = await createJob({ title: "Newer" });
+    expect(newer.updatedAt).toBeGreaterThan(older.updatedAt);
+    expect((await listJobs()).map((j) => j.title)).toEqual(["Newer", "Older"]);
+
+    await clearResumeLink("resume-1");
+
+    // "Older" lost its dangling link but did not jump to the top.
+    expect((await listJobs()).map((j) => j.title)).toEqual(["Newer", "Older"]);
+    expect((await getJobById(older.id))?.resumeId).toBeUndefined();
+  });
+
+  it("still stamps updatedAt for a real user edit", async () => {
+    const job = await createJob({ title: "SWE" });
+    const before = job.updatedAt;
+    await new Promise((r) => setTimeout(r, 2));
+    const edited = await updateJob(job.id, { notes: "referred by Dana" });
+    expect(edited.updatedAt).toBeGreaterThan(before);
+  });
+});

--- a/src/lib/job-tracker.ts
+++ b/src/lib/job-tracker.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-tracker — domain layer over the IndexedDB job store (#323, `storage/jobs`).
+ *
+ * The store (#321) manages id + timestamps and treats the record as opaque; this
+ * module owns the tracked-job semantics the tracker UI needs: the pinned
+ * {@link JobRecord} shape, a sensible status default, and the resume-link
+ * lifecycle (link, unlink, and the graceful-degrade clear when a linked resume
+ * is deleted — the job is kept, only its dangling link is dropped).
+ *
+ * Sibling of `resume-library.ts`; both sit between their `src/hooks` façade and
+ * `src/lib/storage`, and neither imports the parser graph.
+ */
+
+import { saveJob, getJob, getAllJobs, deleteJob } from "./storage/jobs.ts";
+import type { JobRecord, JobStatus } from "./storage/types.ts";
+
+/** Fields a caller supplies when creating a tracked job. `status` defaults to
+ *  `"interested"`; id + timestamps are managed by the store. */
+export interface NewJobInput {
+  title: string;
+  company?: string;
+  url?: string;
+  notes?: string;
+  status?: JobStatus;
+  resumeId?: string;
+  jdText?: string;
+  matchResult?: unknown;
+}
+
+/**
+ * The editable subset of a job — everything a user can change from the tracker.
+ *
+ * An OMITTED key leaves the field untouched. An explicit `undefined` CLEARS it:
+ * `updateJob` spreads `{ ...existing, ...patch }`, and a spread copies an own
+ * property even when its value is `undefined`. That is not an accident to be
+ * tidied away — {@link unlinkResume} is built on it (`{ resumeId: undefined }`
+ * is how a link gets dropped). Pass an empty string to blank an optional text
+ * field.
+ */
+export type JobPatch = Partial<
+  Pick<
+    JobRecord,
+    "title" | "company" | "url" | "notes" | "status" | "resumeId"
+  >
+>;
+
+/** All tracked jobs, most-recently-updated first (the tracker's default order).
+ *  Grouping / filtering by status is a view concern left to the UI. */
+export async function listJobs(): Promise<JobRecord[]> {
+  const jobs = await getAllJobs();
+  return jobs.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export function getJobById(id: string): Promise<JobRecord | undefined> {
+  return getJob(id);
+}
+
+/** Create a tracked job. Blank company is allowed (the user can fill it later);
+ *  status defaults to `"interested"`. Returns the stored record (with id +
+ *  timestamps). */
+export function createJob(input: NewJobInput): Promise<JobRecord> {
+  return saveJob({
+    title: input.title,
+    company: input.company ?? "",
+    url: input.url,
+    notes: input.notes,
+    status: input.status ?? "interested",
+    resumeId: input.resumeId,
+    jdText: input.jdText,
+    matchResult: input.matchResult,
+  });
+}
+
+/** Apply a partial update to an existing job, preserving every field the patch
+ *  doesn't mention (and `createdAt`, via the store). Throws if the job is gone. */
+export async function updateJob(
+  id: string,
+  patch: JobPatch,
+): Promise<JobRecord> {
+  const existing = await getJob(id);
+  if (!existing) throw new Error(`job-tracker: no job with id ${id}`);
+  return saveJob({ ...existing, ...patch, id });
+}
+
+/** Move a job to a new lifecycle status. */
+export function setJobStatus(id: string, status: JobStatus): Promise<JobRecord> {
+  return updateJob(id, { status });
+}
+
+/** Link a job to the saved resume version used for it. */
+export function linkResume(id: string, resumeId: string): Promise<JobRecord> {
+  return updateJob(id, { resumeId });
+}
+
+/** Drop a job's resume link (user action), keeping the job. */
+export function unlinkResume(id: string): Promise<JobRecord> {
+  return updateJob(id, { resumeId: undefined });
+}
+
+export function removeJob(id: string): Promise<void> {
+  return deleteJob(id);
+}
+
+/**
+ * Graceful degrade for a deleted resume (#323 AC): clear the link from every
+ * job that pointed at `resumeId`, keeping the jobs. Idempotent and cheap — a
+ * no-op when nothing linked it. Returns the number of jobs whose link was
+ * cleared. Call this from the resume-delete path.
+ */
+export async function clearResumeLink(resumeId: string): Promise<number> {
+  const jobs = await getAllJobs();
+  const linked = jobs.filter((j) => j.resumeId === resumeId);
+  for (const job of linked) {
+    // `touch: false` — the user deleted a RESUME, not these jobs. Stamping
+    // `updatedAt` would float every job that merely referenced it to the top of
+    // a list sorted most-recently-updated-first.
+    await saveJob({ ...job, resumeId: undefined, id: job.id }, { touch: false });
+  }
+  return linked.length;
+}
+
+/**
+ * Sweep dangling resume links against the set of resume ids that still exist —
+ * a belt-and-suspenders reconcile for links orphaned by any delete path the
+ * explicit {@link clearResumeLink} call missed (e.g. a merge-mode import that
+ * dropped a resume). Returns the number of jobs repaired.
+ *
+ * NOTE: staged for #547 — no production caller yet. The delete path uses
+ * `clearResumeLink`, and the JSON import path (`storage/backup.ts`) that would
+ * orphan links isn't wired to any UI. This is called from the import flow once
+ * that lands; until then it's exercised only by its unit test.
+ */
+export async function reconcileResumeLinks(
+  existingResumeIds: ReadonlySet<string>,
+): Promise<number> {
+  const jobs = await getAllJobs();
+  const dangling = jobs.filter(
+    (j) => j.resumeId !== undefined && !existingResumeIds.has(j.resumeId),
+  );
+  for (const job of dangling) {
+    // Housekeeping, not a user edit — see `clearResumeLink`.
+    await saveJob({ ...job, resumeId: undefined, id: job.id }, { touch: false });
+  }
+  return dangling.length;
+}
+
+/** Longest derived title we keep — past this a JD's first line is prose, not a
+ *  title, and the row would just truncate. */
+const MAX_DERIVED_TITLE = 80;
+
+/**
+ * Best-effort job title for a pasted JD: its first non-empty line, which is the
+ * posting title in the overwhelming majority of copy-pasted descriptions.
+ *
+ * Deliberately dumb and never-fail: this is a *seed* for a field the user can
+ * rename inline in the tracker, not an extraction step. A too-long or empty
+ * first line falls back to `"Untitled job"` rather than guessing further — we
+ * never scrape or infer beyond what the user pasted (#323 non-goal).
+ */
+export function deriveJobTitleFromJd(jdText: string): string {
+  const firstLine = jdText
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (firstLine === undefined || firstLine.length > MAX_DERIVED_TITLE) {
+    return "Untitled job";
+  }
+  return firstLine;
+}
+
+/**
+ * "Save this job" from the JD-match flow (#323 AC): create a tracked job that
+ * carries the pasted JD text and the match result the user just ran, so a
+ * moment-in-time match becomes a tracked application in one step.
+ */
+export function createTrackedJobFromMatch(input: {
+  title: string;
+  company?: string;
+  url?: string;
+  jdText: string;
+  matchResult?: unknown;
+  resumeId?: string;
+}): Promise<JobRecord> {
+  return createJob({ ...input, status: "interested" });
+}

--- a/src/lib/storage/backup.ts
+++ b/src/lib/storage/backup.ts
@@ -96,3 +96,31 @@ export async function importFromJson(
 ): Promise<{ resumes: number; jobs: number }> {
   return importAll(JSON.parse(json) as StorageExport, mode);
 }
+
+/** Filename every backup download uses. Module-private: both surfaces reach it
+ *  through {@link downloadStorageBackup}, so there is nothing to export. */
+const BACKUP_FILENAME = "offlinecv-backup.json";
+
+/**
+ * Export everything and hand the user a JSON file.
+ *
+ * Shared by both local-first surfaces (`useResumeLibrary`, `useJobTracker`) —
+ * the export is origin-wide, not per-lane, so the two "Export backup" buttons
+ * produce the same document and there is no per-lane variant to justify two
+ * copies of the object-URL dance.
+ *
+ * Browser-only (touches `URL` and `document`); callers are hooks, never lib.
+ */
+export async function downloadStorageBackup(): Promise<void> {
+  const json = await exportToJson();
+  const url = URL.createObjectURL(new Blob([json], { type: "application/json" }));
+  try {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = BACKUP_FILENAME;
+    a.click();
+  } finally {
+    // In a `finally` so a click that throws can't leak the object URL.
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/lib/storage/crud.ts
+++ b/src/lib/storage/crud.ts
@@ -25,13 +25,20 @@ async function looseDB(): Promise<IDBPDatabase> {
 
 /** Upsert a record, stamping timestamps from a single `now`: `createdAt` comes
  *  from the existing row (update), else the record's own value (import restore),
- *  else `now`; `updatedAt` is always `now`. A brand-new record therefore has
- *  `createdAt === updatedAt`. Domain helpers omit the timestamps and let this own
- *  them; import passes them through to preserve `createdAt`. */
+ *  else `now`; `updatedAt` is `now` unless the write opts out. A brand-new record
+ *  therefore has `createdAt === updatedAt`. Domain helpers omit the timestamps and
+ *  let this own them; import passes them through to preserve `createdAt`.
+ *
+ *  `touch: false` keeps the existing `updatedAt` — for a write the USER did not
+ *  make. Clearing a job's dangling resume link when that resume is deleted (#323)
+ *  is the motivating case: stamping it would reshuffle a tracker sorted
+ *  most-recently-updated-first, so deleting one resume makes every job that
+ *  merely referenced it jump to the top. Never use it for a user edit. */
 export async function putRecord<T extends StoredRecord>(
   store: StoreName,
   record: Omit<T, "createdAt" | "updatedAt"> &
     Partial<Pick<T, "createdAt" | "updatedAt">>,
+  options: { touch?: boolean } = {},
 ): Promise<T> {
   const db = await looseDB();
   const now = Date.now();
@@ -39,7 +46,10 @@ export async function putRecord<T extends StoredRecord>(
   const written = {
     ...record,
     createdAt: existing?.createdAt ?? record.createdAt ?? now,
-    updatedAt: now,
+    updatedAt:
+      options.touch === false
+        ? (existing?.updatedAt ?? record.updatedAt ?? now)
+        : now,
   } as T;
   await db.put(store, written);
   return written;

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -29,6 +29,7 @@ export {
   exportToJson,
   importAll,
   importFromJson,
+  downloadStorageBackup,
 } from "./backup.ts";
 export type {
   StoredRecord,

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -17,14 +17,22 @@ import type { JobRecord } from "./types.ts";
 
 /** Save a job record. Generates a UUID when `id` is absent; timestamps managed
  *  by `putRecord`. Extra fields pass through (open shape until the tracker
- *  issue pins them). */
+ *  issue pins them). `touch: false` preserves `updatedAt` for a housekeeping
+ *  write the user did not make — see `putRecord`. */
 export async function saveJob(
   input: Partial<JobRecord> & { id?: string },
+  options: { touch?: boolean } = {},
 ): Promise<JobRecord> {
+  // The store is intentionally permissive — it writes whatever fields the caller
+  // supplies (the domain layer in `job-tracker.ts` owns completeness). Reads are
+  // typed as a full `JobRecord` because every production write goes through the
+  // domain layer with the required fields set; the cast bridges the permissive
+  // write shape to `putRecord`'s complete-record parameter.
   return putRecord<JobRecord>("jobs", {
     ...input,
     id: input.id ?? crypto.randomUUID(),
-  });
+  } as Omit<JobRecord, "createdAt" | "updatedAt"> &
+    Partial<Pick<JobRecord, "createdAt" | "updatedAt">>, options);
 }
 
 export function getJob(id: string): Promise<JobRecord | undefined> {

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -34,12 +34,55 @@ export interface ResumeRecord extends StoredRecord {
   parse?: unknown;
 }
 
-/** A tracked job. Shape is owned by the job-tracker follow-up; the store exists
- *  here so both stores version together under one migration path. Kept open
- *  beyond the common keys until that issue pins the fields. */
+/**
+ * Application status of a tracked job. A simple linear lifecycle
+ * (`interested → applied → interviewing → offer / rejected / archived`) — a
+ * status picker, not a workflow engine (#323).
+ */
+export type JobStatus =
+  | "interested"
+  | "applied"
+  | "interviewing"
+  | "offer"
+  | "rejected"
+  | "archived";
+
+/** A tracked job (#323). Field shape pinned here now that the tracker UI exists;
+ *  the store has lived in the foundation (#321) so both stores version together
+ *  under one migration path. Every field is JSON-safe so the whole record
+ *  survives the export/import round-trip (see backup.ts). */
 export interface JobRecord extends StoredRecord {
-  [field: string]: unknown;
+  /** Posting title, e.g. "Senior Frontend Engineer". */
+  title: string;
+  /** Hiring company. May be empty when the user hasn't filled it in yet. */
+  company: string;
+  /** Posting URL. Optional — the user pastes/types details; we never scrape. */
+  url?: string;
+  /** Free-text notes. */
+  notes?: string;
+  /** Where this job sits in the application lifecycle. */
+  status: JobStatus;
+  /** Optional link to a saved resume (`ResumeRecord.id`) — the version used for
+   *  this job. Cleared (not orphaned) if that resume is later deleted. */
+  resumeId?: string;
+  /** Optional pasted job description, when the job came from / ran a JD match. */
+  jdText?: string;
+  /** Optional JD-match result carried over from the JD-fit flow. Opaque +
+   *  JSON-safe by contract so it survives export/import. */
+  matchResult?: unknown;
 }
+
+/** The lifecycle order for display grouping and the "advance status" affordance
+ *  (#323). Terminal branches (`offer` / `rejected` / `archived`) all sit at the
+ *  end; there is no forced single path between them. */
+export const JOB_STATUS_ORDER: readonly JobStatus[] = [
+  "interested",
+  "applied",
+  "interviewing",
+  "offer",
+  "rejected",
+  "archived",
+];
 
 /** A cached company ATS board: the light-index postings one board returned,
  *  keyed `${ats}:${slug}` (#533). A pure CACHE — deliberately absent from the


### PR DESCRIPTION
## Summary

Local job tracker (#323) on top of the closed storage foundation (#321) and resume library (#322) — the last open child of the batch epic #401. Save postings, track application status, and link the resume version you used for each. All local: the records live in the same IndexedDB origin as saved resumes and ride the existing `StorageExport` round-trip unchanged.

**Flag-gated behind `job-tracker` (`VITE_ENABLE_JOB_TRACKER`), default off.** #323 is P4 · Post-Public, so the surface ships dark and is promoted from PostHog rather than by a rebuild — same posture as `jd-fit-banner`. The tracker on `/` and the "save this job" button on `/jd-fit/` share the one flag, since a saved job with nowhere to manage it is a dead end.

## What's here

- **Pinned `JobRecord` + `JobStatus`** (`storage/types.ts`). The store has shipped since #321 with an open shape "until the tracker issue pins the fields" — this issue owns them. Every field is JSON-safe, so the record survives export/import unchanged.
- **`lib/job-tracker.ts`** — domain layer over `storage/jobs`: CRUD, status transitions, resume link/unlink, and the graceful-degrade `clearResumeLink` + `reconcileResumeLinks`. Sibling of `resume-library.ts`; neither imports the parser graph.
- **`hooks/useJobTracker.ts`** — reactive façade mirroring `useResumeLibrary`, reusing the same persistence/eviction plumbing so the durability copy is identical across both surfaces.
- **UI** (`components/features/`, `@design-system` + semantic tokens only) — `JobTracker` (grouped by status, persistence badge, eviction copy, backup export, manual add, empty state), `JobTrackerEntry` (inline-edit, status picker, resume link picker + unlink, two-click remove), `JobStatusPicker`.
- **`SaveJobFromMatch`** on `/jd-fit/` — turns a JD match into a tracked job in one click, carrying the JD text and match result onto the record. The title is seeded from the JD's first line (`deriveJobTitleFromJd`) and renamed inline in the tracker; we never scrape the posting (#323 non-goal).
- **Resume delete clears tracked-job links** — `useResumeLibrary.remove` now calls `clearResumeLink`, so a tracked application survives the deletion of the resume it used.

## Acceptance criteria (#323)

- [x] CRUD + status transitions work end-to-end offline — domain layer + `fake-indexeddb` tests.
- [x] A job can link to a saved resume; deleting that resume degrades gracefully (link cleared, job kept) — `clearResumeLink` wired into the delete path, asserted at both the lib and hook level.
- [x] JD-match flow offers "save as tracked job" and carries the match result onto the job record.
- [x] Feature components under `src/components/features/` composed from `@design-system`; storage hooks in `src/hooks/`.

## Notes for review

- **`JobTracker` does not self-hide when empty**, unlike `ResumeLibrary`. Its empty state carries the only "Add a job" entry point, so hiding it would make the tracker reachable only via a JD match. The flag is what keeps the landing page clean until #323 is promoted.
- **The link picker is an inline button list, not a dropdown** — the same shape `JobStatusPicker` uses, so the row has one interaction vocabulary and no new primitive is introduced.
- **Placeholders were dropped from the row's `EditableField` call sites** so the primitive derives them from `label` — the repo-wide #376 sweep in `EditableField.test.tsx` requires add-affordance placeholders to be bare lowercase nouns, and the branch's original `"Job title"` / `"Company"` / `"Add notes"` failed it after the rebase onto main.
- Rebased onto current `main` (the branch predated the OfflineCV rename; stale `resumelint` copyright headers and the `resumelint-backup.json` download name are fixed).

## Test plan

- [x] `npm run verify` — full CI mirror green (typecheck → lint → fixture PII → coverage → build → fallow)
- [x] 2561 tests pass, 0 failures
- [x] The resume-delete wiring is mutation-tested: reverting the `clearResumeLink` call fails `useResumeLibrary.test.tsx`

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Data layer + tracker UI (original draft) | Claude Opus 4.8 (1M context) | high |
| Completion — mount, JD-match seam, link picker, delete wiring | Claude Opus 4.8 (1M context) | high |
| Verification | `npm run verify` — green locally and on the pre-push hook | — |

Closes #323
