### PR TITLE
docs(skills): don't hard-wrap GitHub issue bodies (create-gh-issue step 9b)

### DIFF
--- a/.claude/skills/create-gh-issue/SKILL.md
+++ b/.claude/skills/create-gh-issue/SKILL.md
@@ -111,6 +111,21 @@ the full plan back for line-by-line approval.
    the path collided — pick another suffix. Use the exact same path in the next
    step.
 
+9b. **Do NOT hard-wrap the body.** Write each paragraph, list item, and table row
+   as ONE physical line, however long, and let GitHub soft-wrap it to the reader's
+   viewport. Nothing in this skill or in `create-gh-issue.sh` reflows text — a
+   manual ~80-column wrap survives verbatim into the issue and into every later
+   `gh issue edit` / `/clarify` round, where it turns a one-word change into a
+   whole-paragraph reflow diff. It is also self-inconsistent: tables and fenced
+   code blocks can't be wrapped, so a hard-wrapped body wraps some content and not
+   the rest.
+
+   Hard line breaks are meaningful in exactly three places — keep them there:
+   - **inside fenced code blocks** (` ``` `), where they are the content;
+   - **between** block elements (the blank line separating paragraphs, list items,
+     headings);
+   - a deliberate **two-space** or `\` line break, if you actually want a `<br>`.
+
 10. **Run the writer** (from the repo root):
 
     ```bash


### PR DESCRIPTION
## Summary

Adds step 9b to the `/create-gh-issue` skill: write issue-body paragraphs, list items, and table rows as one physical line each and let GitHub soft-wrap them.

A manual ~80-column wrap survives verbatim into the issue and into every later `gh issue edit` / `/clarify` round, where it turns a one-word change into a whole-paragraph reflow diff. It is also self-inconsistent — tables and fenced code blocks can't be wrapped, so a hard-wrapped body wraps some content and not the rest. The step names the three places a hard break *is* meaningful (inside fenced code blocks, between block elements, a deliberate two-space/backslash break) so they're preserved.

Skill-doc only — no source, no test, no fixture changes.

## Test plan

- [x] Docs-only change to `.claude/skills/create-gh-issue/SKILL.md`; no code surface touched
- [x] `verify` green in CI

## Provenance

Code implementation via: Claude Opus 4.8 (medium)
Verification: `npm run verify` — green in CI