### PR TITLE
feat(probe): /probe-resume — one-drop résumé sweep + corpus-match engine (#469)

### DIFF
--- a/.claude/skills/probe-achievements/SKILL.md
+++ b/.claude/skills/probe-achievements/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: probe-achievements
-description: Extract + verify the ACHIEVEMENTS section (patents, awards, publications, talks — type label, description, year, bullets) of any résumé PDF, including a real PII-bearing one, via the real parser, and localize a dropped/merged/mis-split achievement to the exact layer (line-assembly vs section-routing vs entry segmentation vs the type/description split). Prints the achievements region the segmenter scanned next to the entries it produced, with each title decomposed into the bold "type" run and the description. One of the `probe-*` parser probes (see also `probe-experience`, `probe-contact`, `probe-roundtrip`). Use when the user says "probe achievements", "/probe-achievements", "an award/patent is missing", "the achievement type is wrong", or hands you a résumé whose achievements extract wrong.
+description: Extract + verify the ACHIEVEMENTS section (patents, awards, publications, talks — type label, description, year, bullets) of any résumé PDF, including a real PII-bearing one, via the real parser, and localize a dropped/merged/mis-split achievement to the exact layer (line-assembly vs section-routing vs entry segmentation vs the type/description split). Prints the achievements region the segmenter scanned next to the entries it produced, with each title decomposed into the bold "type" run and the description. One of the `probe-*` parser probes (see also `probe-experience`, `probe-contact`, `probe-roundtrip`, `probe-resume` — the whole-résumé sweep + corpus-coverage orchestrator over all six section probes). Use when the user says "probe achievements", "/probe-achievements", "an award/patent is missing", "the achievement type is wrong", or hands you a résumé whose achievements extract wrong.
 ---
 
 # Probe: Achievements
 
 > One of the `probe-*` parser-probe family (siblings: `probe-experience`,
-> `probe-contact`, `probe-skills`, `probe-education`, `probe-roundtrip`). Type
-> `probe-` to list them all.
+> `probe-contact`, `probe-skills`, `probe-education`, `probe-roundtrip`; see
+> also `probe-resume`, the whole-résumé sweep + corpus-coverage orchestrator
+> over all six section probes). Type `probe-` to list them all.
 
 Drop in **any** résumé PDF and see exactly what the parser reads for the
 achievements section — each entry's **type** label, **description**, **year**, and

--- a/.claude/skills/probe-contact/SKILL.md
+++ b/.claude/skills/probe-contact/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: probe-contact
-description: Extract + verify the CONTACT section (name, email, phone, location, links) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/wrong field to the exact layer (line-assembly vs section-routing vs the field heuristic). Prints the profile region the extractor scanned next to the fields it produced, plus an independent rawText re-scan that separates "absent-in-pdf" from "parser-miss". One of the `probe-*` parser probes (see also `probe-roundtrip`). Use when the user says "probe contact", "/probe-contact", "why is the name/email/phone wrong", "contact isn't parsing", or hands you a résumé whose header fields extract wrong.
+description: Extract + verify the CONTACT section (name, email, phone, location, links) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/wrong field to the exact layer (line-assembly vs section-routing vs the field heuristic). Prints the profile region the extractor scanned next to the fields it produced, plus an independent rawText re-scan that separates "absent-in-pdf" from "parser-miss". One of the `probe-*` parser probes (see also `probe-roundtrip`, `probe-resume` — the whole-résumé sweep + corpus-coverage orchestrator over all six section probes). Use when the user says "probe contact", "/probe-contact", "why is the name/email/phone wrong", "contact isn't parsing", or hands you a résumé whose header fields extract wrong.
 ---
 
 # Probe: Contact
 
 > One of the `probe-*` parser-probe family (sibling: `probe-roundtrip`, which
-> audits the parse→export→parse cycle). Type `probe-` to list them all.
+> audits the parse→export→parse cycle; see also `probe-resume`, the
+> whole-résumé sweep + corpus-coverage orchestrator over all six section
+> probes). Type `probe-` to list them all.
 
 Drop in **any** résumé PDF and see exactly what the parser reads for the contact
 block — name, email, phone, location, LinkedIn/GitHub/portfolio/website — and,

--- a/.claude/skills/probe-education/SKILL.md
+++ b/.claude/skills/probe-education/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: probe-education
-description: Extract + verify the EDUCATION section (entries, degree, field, institution, location, dates, coursework) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/merged/under-chunked entry to the exact layer (header routing vs chunker vs field heuristic). Prints the header candidates the router saw and the education region it scanned next to the parsed entries, plus an independent header-recognition oracle that flags an education-like header the strict router rejected (leading-glyph, out-of-alias wording, two-line wrap) and a DEGREE_RE token count over the routed region as a lower-bound oracle for chunker under-segmentation. One of the `probe-*` parser probes (see also `probe-contact`, `probe-experience`, `probe-roundtrip`, `probe-skills`). Use when the user says "probe education", "/probe-education", "why is the degree/institution/coursework wrong", "education section isn't parsing", "why are two degrees showing as one entry", or hands you a résumé whose education entries parse wrong.
+description: Extract + verify the EDUCATION section (entries, degree, field, institution, location, dates, coursework) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/merged/under-chunked entry to the exact layer (header routing vs chunker vs field heuristic). Prints the header candidates the router saw and the education region it scanned next to the parsed entries, plus an independent header-recognition oracle that flags an education-like header the strict router rejected (leading-glyph, out-of-alias wording, two-line wrap) and a DEGREE_RE token count over the routed region as a lower-bound oracle for chunker under-segmentation. One of the `probe-*` parser probes (see also `probe-contact`, `probe-experience`, `probe-roundtrip`, `probe-skills`, `probe-resume` — the whole-résumé sweep + corpus-coverage orchestrator over all six section probes). Use when the user says "probe education", "/probe-education", "why is the degree/institution/coursework wrong", "education section isn't parsing", "why are two degrees showing as one entry", or hands you a résumé whose education entries parse wrong.
 ---
 
 # Probe: Education
 
 > One of the `probe-*` parser-probe family (siblings: `probe-contact`,
-> `probe-experience`, `probe-roundtrip`, `probe-skills`). Type `probe-` to list
-> them all.
+> `probe-experience`, `probe-roundtrip`, `probe-skills`; see also
+> `probe-resume`, the whole-résumé sweep + corpus-coverage orchestrator over
+> all six section probes). Type `probe-` to list them all.
 
 Drop in **any** résumé PDF and see exactly what the parser reads for the
 education section — the parsed entries (degree, field, institution, location,

--- a/.claude/skills/probe-experience/SKILL.md
+++ b/.claude/skills/probe-experience/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: probe-experience
-description: Extract + verify the EXPERIENCE section (roles — title, company, location, dates, bullets) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/merged role to the exact layer (line-assembly vs section-routing vs entry segmentation). Prints the experience region the segmenter scanned next to the role entries it produced, plus an independent date-range re-scan that separates "dateless-in-pdf" from "parser-miss". One of the `probe-*` parser probes (see also `probe-contact`, `probe-roundtrip`). Use when the user says "probe experience", "/probe-experience", "why is a role missing/merged", "employment history isn't parsing", or hands you a résumé whose roles extract wrong.
+description: Extract + verify the EXPERIENCE section (roles — title, company, location, dates, bullets) of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped/merged role to the exact layer (line-assembly vs section-routing vs entry segmentation). Prints the experience region the segmenter scanned next to the role entries it produced, plus an independent date-range re-scan that separates "dateless-in-pdf" from "parser-miss". One of the `probe-*` parser probes (see also `probe-contact`, `probe-roundtrip`, `probe-resume` — the whole-résumé sweep + corpus-coverage orchestrator over all six section probes). Use when the user says "probe experience", "/probe-experience", "why is a role missing/merged", "employment history isn't parsing", or hands you a résumé whose roles extract wrong.
 ---
 
 # Probe: Experience
 
 > One of the `probe-*` parser-probe family (siblings: `probe-contact`,
-> `probe-roundtrip`). Type `probe-` to list them all.
+> `probe-roundtrip`; see also `probe-resume`, the whole-résumé sweep +
+> corpus-coverage orchestrator over all six section probes). Type `probe-` to
+> list them all.
 
 Drop in **any** résumé PDF and see exactly what the parser reads for the
 experience section — every role's title, company, location, date range, and

--- a/.claude/skills/probe-resume/SKILL.md
+++ b/.claude/skills/probe-resume/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: probe-resume
+description: One-drop, read-only sweep of ALL SIX section probes (contact, skills, experience, education, achievements, roundtrip) over any résumé PDF — including a real, PII-bearing one — off a SINGLE parse, then answers the question no single-section probe can — does a fixture already reproduce this defect? Matches each defect it finds against the 45 baked corpus fixtures via their ReproArtifact + DerivedSignals axes and prints `COVERED <fixture path>` or `NO FIXTURE COVERS THIS` per defect. One of the `probe-*` parser probes (see also `probe-contact`, `probe-skills`, `probe-experience`, `probe-education`, `probe-achievements`, `probe-roundtrip`). Use when the user says "probe resume", "/probe-resume", "sweep this résumé", "does a fixture already cover this defect", "should I mint a new fixture for this résumé", or hands you a real résumé and wants the full parser picture in one pass.
+---
+
+# Probe: Resume (whole-résumé sweep + corpus coverage)
+
+> The orchestrator of the `probe-*` parser-probe family (siblings:
+> `probe-contact`, `probe-skills`, `probe-experience`, `probe-education`,
+> `probe-achievements`, `probe-roundtrip`). Type `probe-` to list them all.
+
+Drop in **any** résumé PDF and get the full parser picture in one pass: every
+section localizer's defects, off a **single** `runCascade()` (plus one
+render→re-parse hop for round-trip classes), matched against the 45 baked
+corpus fixtures so you know — for each defect — whether a fixture already
+reproduces it.
+
+The six sibling probes each own **one section** and stop at localization. None
+of them answers *"is this defect new?"* — and running all six by hand, then
+holding six reports plus a 45-fixture corpus in your head, is the ergonomic
+wall this probe removes. It reuses each sibling's existing localization logic
+(`localize/{contact,skills,experience,education,achievements,roundtrip}.ts`)
+and `buildReproArtifact()` as-is — it is an orchestrator, not a
+reimplementation.
+
+It reuses a dev harness in `src/lib/heuristics/probe-resume.test.ts` (the
+`RL_RESUME_PDF` block) — there is **no standalone script and you should not
+write one**: the pdfjs worker uses Vite's `?url` import, which resolves only
+under the Vite/vitest transform, so plain `tsx`/node breaks. The vitest run
+**is** the execution vehicle (same constraint as the sibling probes).
+
+## ⚠️ PII guardrail — read first
+
+This probe is meant to run on **real résumés with real candidate PII**. It is
+stricter than its six siblings, non-negotiable:
+
+1. **The input PDF is local-only. NEVER commit it.** It is not a fixture. The
+   public repo's `tests/fixtures/pdfs/` is **synthetic-personas-only by
+   policy** (`tests/fixtures/pdfs/README.md`). A real résumé must never land
+   there.
+2. **The console prints NO résumé values at all** — only defect **classes**,
+   axis names, fixture paths, counts, and booleans. `ReproArtifact` and
+   `DerivedSignals` admit no free-form string, so this is PII-free by
+   construction, not by filtering. Cite a defect by **class**, never by value.
+3. **Additional leak paths this harness cannot close** — name them before you
+   share any output:
+   - **The résumé's filename** may itself carry the candidate's name, and it
+     is echoed verbatim in the console output and the report filename. Check
+     the filename before pasting console output anywhere, even though the
+     output itself carries no field values.
+   - **`RL_RESUME_OUT` pointed outside the repo (or into another git repo)**
+     is on you — the harness only guards paths inside *this* repo (see
+     below); it cannot see what you do with a report you send elsewhere.
+   - **The six sibling probes DO print field values**, unlike this one.
+     Running `probe-contact` / `probe-skills` / etc. on the same résumé after
+     this sweep re-opens the exact exposure this sweep exists to avoid — only
+     drop to a sibling probe when `probe-resume` tells you a defect is
+     `NO FIXTURE COVERS THIS` and you need that sibling's deeper INPUT/OUTPUT
+     detail to localize it.
+
+`RL_RESUME_OUT` pointed **inside** the repo at a path that is **not**
+gitignored is a **hard error by design** — the harness validates the target
+with `git check-ignore` and throws before writing anything, rather than
+degrading to "write it anyway." **Do not "fix" that error by un-ignoring the
+path.** Point `RL_RESUME_OUT` at the gitignored default, another gitignored
+path, or somewhere outside the repo.
+
+If you are ever unsure whether a path is committed, stop and check
+`git status` / `.gitignore` before running.
+
+## Run it
+
+```bash
+RL_RESUME_PDF=/abs/path/to/real-resume.pdf \
+  npx vitest run src/lib/heuristics/probe-resume.test.ts
+```
+
+Use an **absolute path** for `RL_RESUME_PDF`.
+
+### Env vars
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RL_RESUME_PDF` | *(unset)* | Absolute path to the résumé PDF. When unset the harness is **inert** (skipped) — CI never runs it. |
+| `RL_RESUME_OUT` | `internal/resume/` | Directory for the full JSON report. The default lives under `internal/`, which is **gitignored**. An override that resolves inside the repo and is NOT gitignored is a **hard error**, by design — see the guardrail above. |
+
+## What it does
+
+One `runCascade()` over the résumé, plus one render→re-parse hop
+(`runRoundtripHop`). Every section localizer — contact, skills, experience,
+education, achievements, and the round-trip diff — runs off that **single**
+parse, never re-parsing per section. Each localizer contributes its defect
+classes and a `DerivedSignals` slice (boolean-only, mirroring `ReproArtifact`'s
+PII-free discipline); together they build one `ReproArtifact` fingerprint for
+the résumé. `matchCorpus()` then diffs that fingerprint against the 45 baked
+`ReproArtifact`s in the corpus, one per fixture, on each defect's load-bearing
+axes.
+
+## What you get
+
+Printed to the console (full JSON mirrored to the gitignored out dir):
+
+- **`DEFECTS FOUND (n)`** — every **defect** class exhibited by this parse.
+  Advisory classes are excluded (see `INFORMATIONAL` below).
+- **Per defect, one of:**
+  - **`COVERED <fixture path>`** — a corpus fixture already exhibits the same
+    defect on the load-bearing axes. **This means STOP.** Go fix the parser
+    against the existing fixture and never open the real résumé again. The path
+    shown is the **closest** cover by whole-artifact divergence — presentation
+    only; every fixture in the JSON's `coveredBy` is an equally valid reproducer.
+  - **`NO FIXTURE COVERS THIS`** — no fixture reproduces it, plus
+    `nearest (showing N of M)`: the closest fixtures and the axes on which
+    each diverged, and the 4-step next-step instructions (mint a synthetic
+    fixture → `npm run bake-fixtures` → add a `*.repro.test.ts` pinning it →
+    re-run this sweep). This is the **only** case that justifies minting a
+    new fixture.
+- **`COVERAGE n/m defects already pinned by the corpus`** — the headline
+  number.
+- **`Sections detected`** — `name(lineCount)` for every region the section router
+  actually cut, printed next to `rawCharCount`/`extractedCharCount` (PII-free: a
+  section name is a fixed enum, counts are numbers). Printed immediately above
+  `INFORMATIONAL`, because it is what makes an advisory readable: a
+  `skills-no-section` on a résumé that plainly *has* a skills block shows up
+  here either as a **fat `profile` / `other` bucket that swallowed it**, or —
+  if the summed section line counts don't account for `extractedCharCount` —
+  as a block that **landed nowhere at all**. The char counts are what make a
+  vanished block visible instead of silently missing.
+- **`INFORMATIONAL (n)`** — the three **advisory** classes
+  (`skills-no-section`, `education-no-section`, `achievements-no-section`).
+  "This résumé has no Awards section" is **not a parser defect** — 34 of the 45
+  fixtures parse zero achievements, because those résumés genuinely have none.
+  Advisory classes are printed but never enter `DEFECTS FOUND` and never enter
+  `COVERAGE` — counting them would fire on nearly every résumé, corpus-match
+  trivially, and inflate the one number you actually act on. **`DEFECTS FOUND
+  (0)` with a non-empty `INFORMATIONAL` is not a clean bill of health**: check
+  `Sections detected` and decide whether the résumé really has no such section.
+  On the `⛔ PARSE UNREADABLE` path `INFORMATIONAL` is withheld outright (the
+  console and the JSON report agree: no oracle ran, so an advisory claim is as
+  undecidable as a defect claim).
+- **An `ORACLE UNAVAILABLE` banner + a `WITHHELD` class list** (only when it
+  applies). Every derived signal is read out of some *optional* input of the
+  parse, and when that input is absent the signal reads `false` — which means
+  **unknowable**, not "observed absent". Three inputs can go missing, so three
+  oracles can go blind, and each banner names **exactly which classes it
+  withheld**:
+  | Oracle | Blind when | Withholds |
+  |---|---|---|
+  | `text` | the parse produced **no readable text** (`scanned` trigger, or empty `rawText`) | every class but `roundtrip-render-crash` |
+  | `header` | the parse produced **no markdown** (scanned, or too sparse for the emitter) | the two `*-header-unrecognized` classes and their `*-no-section` advisories |
+  | `roundtrip` | the export → re-parse hop produced **no `after` parse** | the five `roundtrip-*-value-changed` classes |
+  A withheld class is **undecided, not clean**. Never read its silence as
+  coverage: a false `COVERED` would tell you to stop working on a defect no
+  fixture reproduces, which is the worst thing this tool could do.
+- **`⛔ PARSE UNREADABLE`** — when the text oracle is blind (or the parse
+  extracted **0 characters**), the harness **refuses to print `DEFECTS FOUND` or
+  `COVERAGE` at all**, and runs no corpus match. There is no honest defect report
+  over a document the parser never read, and an affirmative "no defect class is
+  exhibited by this parse" there would report resumelint's **single most severe
+  failure mode as clean**. What you get instead is the char counts, the layout
+  triggers, the withheld list, and a pointer at the real problem: this is a
+  **Tier-0 extraction failure** (scanned/OCR, unmappable fonts), not a
+  fixture-coverage question.
+- **A probe-per-defect line** — which sibling probe (`probe-contact`,
+  `probe-skills`, …) owns deeper localization for each defect class, in case
+  `NO FIXTURE COVERS THIS` sends you there.
+- **The full JSON report path** — gitignored; do not commit it.
+
+## The skill is read-only
+
+`/probe-resume` **commits nothing and mints nothing**. It prints the exact
+next-step invocation for minting a fixture; a human takes that step. Re-export
+a template with a synthetic persona is still a human act
+(`tests/fixtures/pdfs/README.md`) — this skill only tells you when it's
+needed and gives you the command.
+
+## Recovery — stale corpus snapshot
+
+`loadCorpus()` requires every `*.expected.json` to be at the current
+`schemaVersion` with a baked `reproArtifact` block. A **stale** snapshot makes
+the loader **throw**, not silently degrade to "nothing covers this" — so a
+crashed run here means the corpus is out of date, not that no fixture
+qualifies. Fix: `npm run bake-fixtures`, then re-run the probe.
+
+## Boundaries
+
+- This is a **dev/triage tool**, not a CI gate. It is informational: the
+  harness never reddens the suite, so a PII résumé with known bugs won't fail
+  the run.
+- The PII-free enforcement lane is the corpus gate (`corpus.test.ts`) over
+  **synthetic fixtures** — this probe is the manual lane over **real** ones.
+  Don't confuse the two.
+- This probe does not itself file issues. Once `NO FIXTURE COVERS THIS`
+  points you at a defect worth localizing further, drop to the owning sibling
+  probe (named on the "Probes per defect" line) for its deeper INPUT/OUTPUT
+  detail, then use that sibling's **Filing what you find** section to draft
+  and file via the gated `create-gh-issue` flow.

--- a/.claude/skills/probe-roundtrip/SKILL.md
+++ b/.claude/skills/probe-roundtrip/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: probe-roundtrip
-description: Round-trip-audit any résumé PDF — including a real, PII-bearing one — through the parse→export→parse cycle to surface where the reconstructed "Download PDF" corrupts the parse. Prints per-hop before→after field-value diffs. One of the `probe-*` parser probes (see also `probe-contact`). Use when the user says "probe roundtrip", "/probe-roundtrip", "round-trip probe", "/roundtrip-probe", "audit this résumé's round-trip", "why does the downloaded PDF re-parse wrong", or hands you a real résumé to triage.
+description: Round-trip-audit any résumé PDF — including a real, PII-bearing one — through the parse→export→parse cycle to surface where the reconstructed "Download PDF" corrupts the parse. Prints per-hop before→after field-value diffs. One of the `probe-*` parser probes (see also `probe-contact`, `probe-resume` — the whole-résumé sweep + corpus-coverage orchestrator over all six section probes). Use when the user says "probe roundtrip", "/probe-roundtrip", "round-trip probe", "/roundtrip-probe", "audit this résumé's round-trip", "why does the downloaded PDF re-parse wrong", or hands you a real résumé to triage.
 ---
 
 # Probe: Round-trip
 
 > One of the `probe-*` parser-probe family (sibling: `probe-contact`, which
-> isolates the contact section). Type `probe-` to list them all.
+> isolates the contact section; see also `probe-resume`, the whole-résumé
+> sweep + corpus-coverage orchestrator over all six section probes). Type
+> `probe-` to list them all.
 
 Drop in **any** résumé PDF and run the parse→export→parse cycle to see exactly
 where our own reconstructed "Download PDF" corrupts the parse on re-read. This is

--- a/.claude/skills/probe-skills/SKILL.md
+++ b/.claude/skills/probe-skills/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: probe-skills
-description: Extract + verify the SKILLS section of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped skills section to the exact layer (header routing vs extraction). Prints the header candidates the router saw and the skills region it scanned next to the parsed skills list, plus an independent header-recognition oracle that flags a skills-like header the strict router rejected (leading-glyph #414, out-of-alias wording, two-line wrap #374). One of the `probe-*` parser probes (see also `probe-contact`, `probe-experience`, `probe-roundtrip`). Use when the user says "probe skills", "/probe-skills", "why are skills missing/empty", "skills section not detected", or hands you a résumé whose skills extract wrong.
+description: Extract + verify the SKILLS section of any résumé PDF — including a real, PII-bearing one — via the real parser, and localize a dropped skills section to the exact layer (header routing vs extraction). Prints the header candidates the router saw and the skills region it scanned next to the parsed skills list, plus an independent header-recognition oracle that flags a skills-like header the strict router rejected (leading-glyph #414, out-of-alias wording, two-line wrap #374). One of the `probe-*` parser probes (see also `probe-contact`, `probe-experience`, `probe-roundtrip`, `probe-resume` — the whole-résumé sweep + corpus-coverage orchestrator over all six section probes). Use when the user says "probe skills", "/probe-skills", "why are skills missing/empty", "skills section not detected", or hands you a résumé whose skills extract wrong.
 ---
 
 # Probe: Skills
 
 > One of the `probe-*` parser-probe family (siblings: `probe-contact`,
-> `probe-experience`, `probe-roundtrip`). Type `probe-` to list them all.
+> `probe-experience`, `probe-roundtrip`; see also `probe-resume`, the
+> whole-résumé sweep + corpus-coverage orchestrator over all six section
+> probes). Type `probe-` to list them all.
 
 Drop in **any** résumé PDF and see exactly what the parser reads for the skills
 section — the parsed skill list, the skills region the extractor scanned, and

--- a/src/lib/heuristics/__test-utils__/corpus-snapshots.ts
+++ b/src/lib/heuristics/__test-utils__/corpus-snapshots.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The corpus loader (issue #469, step 6) — the sweep's I/O half.
+ *
+ * `fixture-match.ts` is pure by design: it takes `CorpusEntry[]` and never
+ * touches the disk. Somebody still has to READ the 45 baked snapshots, and that
+ * somebody is here. Kept out of `src/lib/heuristics/*.ts` proper because it
+ * imports `node:fs` and is test-only.
+ *
+ * Each `tests/fixtures/pdfs/<cat>/<name>.expected.json` is, at schemaVersion 5:
+ *
+ *   { schemaVersion: 5, cascade, score, reproArtifact, derived }
+ *
+ * where `reproArtifact` is exactly `ReproArtifact` and `derived` is the full
+ * `DerivedSignals` bag. Both are PII-free by type (numbers, booleans, fixed
+ * enums), which is why they are safe to commit at all.
+ *
+ * ── Why the schemaVersion guard FAILS LOUDLY ──
+ * A stale v4 snapshot has no `reproArtifact` and no `derived`. Silently skipping
+ * it — or defaulting it to an empty artifact — would quietly shrink the corpus,
+ * and a shrunken corpus does not report an error: it reports "NO FIXTURE COVERS
+ * THIS". That is the single worst failure mode of the whole tool, because it
+ * reads as a legitimate result and its remedy ("mint a fixture") duplicates one
+ * we already have. So: any snapshot that is not v5-with-both-blocks is a throw,
+ * naming the file and the fix (`npm run bake-fixtures`).
+ */
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { CorpusEntry } from "../fixture-match.ts";
+import type { DerivedSignals } from "../defect-classes.ts";
+import { DERIVED_SIGNAL_KEYS } from "../defect-classes.ts";
+import type { ReproArtifact } from "../repro-artifact.ts";
+
+/** The snapshot schema the loader (and `corpus.test.ts`'s bake) speaks. */
+export const CORPUS_SNAPSHOT_SCHEMA_VERSION = 5;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** `src/lib/heuristics/__test-utils__` → repo root. */
+export const REPO_ROOT = join(HERE, "../../../..");
+const FIXTURE_ROOT = join(REPO_ROOT, "tests/fixtures/pdfs");
+
+function walkSnapshots(dir: string): string[] {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkSnapshots(p));
+    else if (e.isFile() && e.name.endsWith(".expected.json")) out.push(p);
+  }
+  return out.sort();
+}
+
+/**
+ * Every baked fixture snapshot, as `CorpusEntry[]` ready for `matchCorpus()`.
+ *
+ * `path` is the repo-relative **PDF** path (not the snapshot's), because that is
+ * what a human is told to go open. Throws — never degrades — on a snapshot that
+ * is stale, malformed, or missing its PDF.
+ */
+export function loadCorpus(fixtureRoot: string = FIXTURE_ROOT): CorpusEntry[] {
+  const snapshots = walkSnapshots(fixtureRoot);
+  const problems: string[] = [];
+  const corpus: CorpusEntry[] = [];
+
+  for (const snap of snapshots) {
+    const rel = relative(REPO_ROOT, snap);
+    let json: Record<string, unknown>;
+    try {
+      json = JSON.parse(readFileSync(snap, "utf8")) as Record<string, unknown>;
+    } catch (err) {
+      problems.push(`${rel}: unparseable JSON (${(err as Error).message})`);
+      continue;
+    }
+
+    if (json.schemaVersion !== CORPUS_SNAPSHOT_SCHEMA_VERSION) {
+      problems.push(
+        `${rel}: schemaVersion ${String(json.schemaVersion)} — expected ${CORPUS_SNAPSHOT_SCHEMA_VERSION}`,
+      );
+      continue;
+    }
+    if (!json.reproArtifact || typeof json.reproArtifact !== "object") {
+      problems.push(`${rel}: missing the \`reproArtifact\` block`);
+      continue;
+    }
+    const derived = json.derived as Record<string, unknown> | undefined;
+    if (!derived || typeof derived !== "object") {
+      problems.push(`${rel}: missing the \`derived\` block`);
+      continue;
+    }
+    const missing = DERIVED_SIGNAL_KEYS.filter(
+      (k) => typeof derived[k] !== "boolean",
+    );
+    if (missing.length > 0) {
+      problems.push(
+        `${rel}: \`derived\` is missing/non-boolean for: ${missing.join(", ")}`,
+      );
+      continue;
+    }
+
+    const pdf = snap.replace(/\.expected\.json$/, ".pdf");
+    if (!existsSync(pdf)) {
+      problems.push(`${rel}: no sibling PDF at ${relative(REPO_ROOT, pdf)}`);
+      continue;
+    }
+
+    corpus.push({
+      path: relative(REPO_ROOT, pdf),
+      artifact: json.reproArtifact as ReproArtifact,
+      derived: derived as unknown as DerivedSignals,
+    });
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `loadCorpus: ${problems.length} unusable fixture snapshot(s). A stale snapshot ` +
+        `silently degrades coverage to "NO FIXTURE COVERS THIS", so this is fatal. ` +
+        `Re-bake with \`npm run bake-fixtures\`.\n  - ${problems.join("\n  - ")}`,
+    );
+  }
+  if (corpus.length === 0) {
+    throw new Error(`loadCorpus: no fixture snapshots found under ${fixtureRoot}`);
+  }
+
+  return corpus;
+}

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -52,10 +52,10 @@ import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
 import { runCascade } from "./cascade.ts";
-import { computeAnonymousAtsScore } from "../score/score.ts";
-import type { CascadeResult, HeuristicParsedResume } from "./types.ts";
-import { buildAtsResumeModel } from "../pdf/ats-resume-model.ts";
-import { renderAtsResumePdf } from "../pdf/render-ats-pdf.ts";
+import type { CascadeResult } from "./types.ts";
+import { runRoundtripHop } from "./roundtrip-hop.ts";
+import type { RoundtripCategory } from "./localize/roundtrip.ts";
+import { invariantFailures, harnessDiff } from "./localize/roundtrip.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = join(HERE, "../../..", "tests/fixtures/pdfs");
@@ -68,16 +68,10 @@ function relKey(fixture: string): string {
   return relative(FIXTURE_ROOT, fixture).split(sep).join("/");
 }
 
-type Category =
-  | "contact"
-  | "experience"
-  | "education"
-  | "skills"
-  | "summary"
-  // `render` = renderAtsResumePdf threw before any re-parse could run. A crash in
-  // the Download-PDF path is more severe than a field swap; it's baselined the
-  // same way so the gate stays green while the fix is tracked separately.
-  | "render";
+/** Re-exported for readability at this file's original name; the type itself
+ *  now lives at `./localize/roundtrip.ts` (issue #469 step 4) so the shared
+ *  detector logic and its category type travel together. */
+type Category = RoundtripCategory;
 
 /**
  * Per-fixture invariant categories currently allowed to fail. Keyed by the
@@ -191,109 +185,6 @@ function walkPdfs(dir: string): string[] {
   return out.sort();
 }
 
-function scoreFor(cascade: CascadeResult) {
-  return computeAnonymousAtsScore({
-    parsed: { ...cascade.canonical.fields },
-    fieldConfidence: cascade.canonical.fieldConfidence,
-    triggers: cascade.triggers,
-    rawText: cascade.rawText,
-    sections: cascade.canonical.sections,
-  });
-}
-
-const same = (a: unknown, b: unknown) =>
-  JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
-
-/** Contact scalar-field diffs (name/email/phone/location/linkedin). */
-function contactFails(
-  c1: HeuristicParsedResume,
-  c3: HeuristicParsedResume,
-): string[] {
-  const out: string[] = [];
-  for (const k of [
-    "full_name",
-    "email",
-    "phone",
-    "location",
-    "linkedin_url",
-  ] as const) {
-    if (!same(c1[k], c3[k]))
-      out.push(`${k}: ${JSON.stringify(c1[k])} → ${JSON.stringify(c3[k])}`);
-  }
-  return out;
-}
-
-/** Ordered-entry-list diff skeleton: a count mismatch short-circuits, else each
- *  index/key inequality is rendered by `formatMismatch`. The two callers below
- *  differ ONLY in that formatter — the PII-free corpus gate prints field names,
- *  the harness prints before → after values. */
-function entryListDiff<T>(
-  a1: readonly T[],
-  a3: readonly T[],
-  keys: readonly (keyof T)[],
-  label: string,
-  formatMismatch: (i: number, k: keyof T, v1: T[keyof T], v3: T[keyof T] | undefined) => string,
-): string[] {
-  if (a1.length !== a3.length)
-    return [`${label} count ${a1.length} → ${a3.length}`];
-  const out: string[] = [];
-  a1.forEach((r, i) => {
-    for (const k of keys)
-      if (!same(r[k], a3[i]?.[k])) out.push(formatMismatch(i, k, r[k], a3[i]?.[k]));
-  });
-  return out;
-}
-
-/** Ordered-entry-list diff (shared by experience and education): a count
- *  mismatch, else per-field inequality at each index. Prints field NAMES only,
- *  so it stays PII-free (used by the corpus gate). */
-function entryListFails<T>(
-  a1: readonly T[],
-  a3: readonly T[],
-  keys: readonly (keyof T)[],
-  label: string,
-): string[] {
-  return entryListDiff(a1, a3, keys, label, (i, k) => `${label}[${i}].${String(k)}`);
-}
-
-/** Summary length drift ≥ 5% (the round-trip truncation signal, #292). */
-function summaryFails(s1: string, s3: string): string[] {
-  if (s1.length === 0) return [];
-  const deltaPct = (100 * Math.abs(s1.length - s3.length)) / s1.length;
-  return deltaPct >= 5
-    ? [`|Δ| ${deltaPct.toFixed(1)}% (${s1.length} → ${s3.length})`]
-    : [];
-}
-
-/** Collect per-category failure messages for one round-trip. Empty array for a
- *  category ⇒ that invariant holds. */
-function invariantFailures(
-  p1: CascadeResult,
-  p3: CascadeResult,
-): Record<Exclude<Category, "render">, string[]> {
-  const c1 = p1.canonical.fields;
-  const c3 = p3.canonical.fields;
-  const sk1 = (c1.skills ?? []).length;
-  const sk3 = (c3.skills ?? []).length;
-  return {
-    contact: contactFails(c1, c3),
-    experience: entryListFails(
-      c1.experience ?? [],
-      c3.experience ?? [],
-      ["title", "company", "start_date", "end_date"] as const,
-      "role",
-    ),
-    education: entryListFails(
-      c1.education ?? [],
-      c3.education ?? [],
-      ["degree", "field", "institution"] as const,
-      "entry",
-    ),
-    skills: sk1 !== sk3 ? [`count ${sk1} → ${sk3}`] : [],
-    summary: summaryFails(c1.summary ?? "", c3.summary ?? ""),
-  };
-}
-
 const CATEGORIES: Category[] = [
   "contact",
   "experience",
@@ -323,25 +214,24 @@ describe("corpus round-trip invariants (#293)", { timeout: 20000 }, () => {
     const rel = relKey(fixture);
     it(`round-trips: ${rel}`, async () => {
       const p1 = await runCascade(new Uint8Array(readFileSync(fixture)));
-      const model = buildAtsResumeModel(p1, scoreFor(p1));
+      // The one shared render → re-parse hop (`./roundtrip-hop.ts`), also used
+      // by the corpus bake's `derived` block (#469 step 5).
+      const { after: p3, renderError } = await runRoundtripHop(p1);
 
-      let fails: Record<Category, string[]>;
-      try {
-        const p3 = await runCascade(await renderAtsResumePdf(model));
-        fails = { ...invariantFailures(p1, p3), render: [] };
-      } catch (err) {
-        // A render crash pre-empts every field invariant; record it as the
-        // single `render` failure so the baseline/ratchet logic below handles it
-        // uniformly.
-        fails = {
-          contact: [],
-          experience: [],
-          education: [],
-          skills: [],
-          summary: [],
-          render: [`renderAtsResumePdf threw: ${(err as Error).message}`],
-        };
-      }
+      // A render crash pre-empts every field invariant; record it as the single
+      // `render` failure so the baseline/ratchet logic below handles it
+      // uniformly.
+      const fails: Record<Category, string[]> =
+        p3 && !renderError
+          ? { ...invariantFailures(p1, p3), render: [] }
+          : {
+              contact: [],
+              experience: [],
+              education: [],
+              skills: [],
+              summary: [],
+              render: [renderError ?? "renderAtsResumePdf produced no parse"],
+            };
       const baseline = new Set(KNOWN_FAILURES[rel] ?? []);
 
       for (const cat of CATEGORIES) {
@@ -393,64 +283,10 @@ describe("corpus round-trip invariants (#293)", { timeout: 20000 }, () => {
  * ⚠️ Both the input PDF and this JSON carry PII — NEVER commit either.
  */
 
-/** Ordered-entry value diff (experience/education): a count mismatch, else the
- *  changed field VALUES `before → after` at each index. Unlike `entryListFails`
- *  above (mapping-only, prints field names) this prints values, so it is
- *  harness-only — never used by the PII-free corpus gate. */
-function entryValueFails<T>(
-  a1: readonly T[],
-  a3: readonly T[],
-  keys: readonly (keyof T)[],
-  label: string,
-): string[] {
-  return entryListDiff(
-    a1,
-    a3,
-    keys,
-    label,
-    (i, k, v1, v3) =>
-      `${label}[${i}].${String(k)}: ${JSON.stringify(v1)} → ${JSON.stringify(v3)}`,
-  );
-}
-
-/** Skills value diff: the count delta plus the added/removed tokens. */
-function skillsValueFails(s1: readonly string[], s3: readonly string[]): string[] {
-  const set1 = new Set(s1);
-  const set3 = new Set(s3);
-  const removed = s1.filter((s) => !set3.has(s));
-  const added = s3.filter((s) => !set1.has(s));
-  if (removed.length === 0 && added.length === 0) return [];
-  const out = [`count ${s1.length} → ${s3.length}`];
-  if (removed.length) out.push(`removed: ${JSON.stringify(removed)}`);
-  if (added.length) out.push(`added: ${JSON.stringify(added)}`);
-  return out;
-}
-
-/** Per-category before → after VALUE diff for one hop. */
-function harnessDiff(
-  before: CascadeResult,
-  after: CascadeResult,
-): Record<Exclude<Category, "render">, string[]> {
-  const c1 = before.canonical.fields;
-  const c3 = after.canonical.fields;
-  return {
-    contact: contactFails(c1, c3),
-    experience: entryValueFails(
-      c1.experience ?? [],
-      c3.experience ?? [],
-      ["title", "company", "start_date", "end_date"] as const,
-      "role",
-    ),
-    education: entryValueFails(
-      c1.education ?? [],
-      c3.education ?? [],
-      ["degree", "field", "institution"] as const,
-      "entry",
-    ),
-    skills: skillsValueFails(c1.skills ?? [], c3.skills ?? []),
-    summary: summaryFails(c1.summary ?? "", c3.summary ?? ""),
-  };
-}
+// `entryValueFails` / `skillsValueFails` / `harnessDiff` are imported from
+// `./localize/roundtrip.ts` (issue #469 step 4) — see that module's header
+// for why the value-level diffs live there alongside the mapping-only ones
+// the corpus gate above uses.
 
 describe.runIf(process.env.RL_RT_PDF)("round-trip dev harness (RL_RT_PDF)", () => {
   it("dumps per-hop field-value diffs for RL_RT_PDF", async () => {
@@ -467,13 +303,15 @@ describe.runIf(process.env.RL_RT_PDF)("round-trip dev harness (RL_RT_PDF)", () =
     let renderError: string | undefined;
     for (let hop = 1; hop <= rounds; hop++) {
       const prev = parses[parses.length - 1];
-      const model = buildAtsResumeModel(prev, scoreFor(prev));
-      try {
-        parses.push(await runCascade(await renderAtsResumePdf(model)));
-      } catch (err) {
-        renderError = `renderAtsResumePdf threw on hop ${hop}: ${(err as Error).message}`;
+      const res = await runRoundtripHop(prev);
+      if (!res.after || res.renderError) {
+        renderError = (res.renderError ?? "renderAtsResumePdf produced no parse").replace(
+          /^renderAtsResumePdf threw:/,
+          `renderAtsResumePdf threw on hop ${hop}:`,
+        );
         break;
       }
+      parses.push(res.after);
     }
 
     type HopReport = {

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -26,7 +26,12 @@ import { fileURLToPath } from "node:url";
 
 import { runCascade } from "./cascade.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
-import type { HeuristicParsedResume } from "./types.ts";
+import type { CascadeResult, HeuristicParsedResume } from "./types.ts";
+import { buildReproArtifact } from "./repro-artifact.ts";
+import type { DerivedSignals } from "./defect-classes.ts";
+import { sweepParse } from "./sweep.ts";
+import { runRoundtripHop } from "./roundtrip-hop.ts";
+import { CORPUS_SNAPSHOT_SCHEMA_VERSION } from "./__test-utils__/corpus-snapshots.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "../../..");
@@ -43,8 +48,37 @@ const UPDATE = process.env.UPDATE_FIXTURES === "1";
  *    include `heuristic_achievements`.
  *  - v4 (#425 follow-up): the parser now lifts a standalone header headline
  *    ("Engineering Lead") from the profile block via `extractHeadline`, so
- *    `fieldsPopulated` may include `headline` on résumés that carry one. */
-const SNAPSHOT_SCHEMA_VERSION = 4;
+ *    `fieldsPopulated` may include `headline` on résumés that carry one.
+ *  - v5 (#469): added the `reproArtifact` block (`buildReproArtifact`, the
+ *    structure-only parse fingerprint) and the `derived` block (the flat,
+ *    boolean-only `DerivedSignals` — the value-level signals the artifact is
+ *    structurally blind to, including the export → re-parse round-trip hop).
+ *    Together they make each fixture a `CorpusEntry` the `/probe-resume` sweep
+ *    (`fixture-match.ts`) can match a real résumé's defects against WITHOUT
+ *    re-parsing 45 PDFs. Both blocks are PII-free BY TYPE — numbers, booleans,
+ *    fixed enums, no free-form string slot — so the snapshots stay "lossy by
+ *    design, never field values". */
+const SNAPSHOT_SCHEMA_VERSION = CORPUS_SNAPSHOT_SCHEMA_VERSION;
+
+/**
+ * The full `DerivedSignals` bag for one fixture — every key in
+ * `DERIVED_SIGNAL_KEYS`, no more and no fewer (`loadCorpus()` rejects a snapshot
+ * missing any of them, so the count is pinned mechanically and this comment
+ * cannot rot into a wrong number).
+ *
+ * Computed by `sweepParse()` — the SAME function `/probe-resume` runs over the
+ * real résumé. That identity is not tidiness: it is what puts the résumé and the
+ * fixtures on the same axes, without which every coverage answer the sweep prints
+ * would be comparing two different things.
+ *
+ * A localizer never renders or re-parses — the caller performs the hop
+ * (`runRoundtripHop`), which NEVER throws: a crash in any of its four layers is
+ * DATA (`renderThrewOnRoundtrip: true` + `roundtripOracleUnavailable: true`),
+ * never a bake failure.
+ */
+async function bakeDerived(cascade: CascadeResult): Promise<DerivedSignals> {
+  return sweepParse(cascade, await runRoundtripHop(cascade)).derived;
+}
 
 function walkPdfs(dir: string): string[] {
   const out: string[] = [];
@@ -167,6 +201,10 @@ describe("corpus snapshots", () => {
               bulletCount: score.bullets?.length ?? 0,
               algoVersion: score.algoVersion ?? null,
             },
+            // #469: the fixture's `CorpusEntry` payload — the structure-only
+            // parse fingerprint plus the boolean-only value-level signals.
+            reproArtifact: buildReproArtifact(cascade),
+            derived: await bakeDerived(cascade),
           };
 
           if (UPDATE) {
@@ -188,12 +226,36 @@ describe("corpus snapshots", () => {
                 `and commit it alongside the PDF.`,
             );
           }
+          // ── The self-verifying bake. `derived` is RECOMPUTED here, per run,
+          // and diffed against the committed golden — deliberately: a bake that
+          // only ever writes and never checks would let a silently-changed
+          // signal ship. Know what that couples the goldens to:
+          //
+          //   The nine `*ChangedAcrossRoundtrip` bits come from the export →
+          //   re-parse hop, so they pin EXACT BITS of `pdf-lib`'s render output
+          //   AND of the font-fallback path (the current goldens were baked with
+          //   "Poppins font embed failed, falling back to Helvetica"). A pdf-lib
+          //   bump, a font-loading fix, or a change to `render-ats-pdf.ts` can
+          //   therefore turn corpus tests red WITHOUT any parser change.
+          //
+          // That is a FEATURE — the round-trip is a product invariant and a
+          // silent change to it should be visible — but it is a different
+          // contract from `corpus-roundtrip.test.ts`, which asserts round-trip
+          // INVARIANTS (nothing may be lost) rather than exact bits.
+          //
+          // When such a red is expected and understood: re-run
+          // `npm run bake-fixtures`, then diff the goldens and confirm the ONLY
+          // moved keys are the round-trip ones. A moved parse/score/artifact key
+          // in that diff is a real regression, not a re-bake artifact.
           const expected = JSON.parse(expectedRaw);
           expect(snapshot).toEqual(expected);
         },
         // PDF parse + score is fast for normal-sized resumes, but generous
         // ceiling so a slow CI runner doesn't false-fail on a 2MB LaTeX export.
-        15_000,
+        // Raised from 15s for #469: the snapshot's `derived` block needs the
+        // export → re-parse hop, so each fixture now costs parse + render +
+        // re-parse (the same budget `corpus-roundtrip.test.ts` runs on).
+        25_000,
       );
     });
   }

--- a/src/lib/heuristics/defect-classes.test.ts
+++ b/src/lib/heuristics/defect-classes.test.ts
@@ -1,0 +1,802 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Tests for the defect-class table (issue #469).
+ *
+ * Three load-bearing jobs, in order of importance:
+ *
+ *  1. **The PII contract.** `DerivedSignals` must admit no `string`, ever — it
+ *     is the escape hatch for value-level defects, so it sits closest to a real
+ *     résumé's real values, and (per #469 step 5) it gets BAKED into the
+ *     committed `*.expected.json` corpus snapshots. This mirrors the assertion
+ *     `repro-artifact.test.ts` makes for `ReproArtifact`: plant a sentinel where
+ *     a leak would land, serialize exactly as the persisting path does, and
+ *     assert not one survives. `ReproArtifact`'s leak surface is its BUILDER, so
+ *     that test salts the builder's inputs; `DerivedSignals`' leak surface is
+ *     its TYPE (a boolean-only mapped type — its builder lands in #469 step 6),
+ *     so the sentinel is planted through a deliberate cast and the shape guard
+ *     has to catch it. Both tests fail the moment someone widens the shape with
+ *     a free-form `string` — that is the whole point.
+ *
+ *  2. **No silent gap.** Every `DefectClass` has exactly one table entry.
+ *
+ *  3. **Every `exhibits()` predicate**, unit-tested against hand-built artifacts
+ *     — including the branch-order cases where two sibling classes would
+ *     otherwise both fire on one defect. No PDF I/O: the whole point of the
+ *     artifact seam is that it is testable without one.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFECT_CLASSES,
+  DEFECT_SPECS,
+  DERIVED_SIGNAL_KEYS,
+  EMPTY_DERIVED_SIGNALS,
+  ORACLES,
+  ORACLE_UNAVAILABLE_KEY,
+  PROBE_IDS,
+  defectClassesForProbe,
+  defectSpec,
+  exhibitedDefects,
+  isAdvisory,
+  isWithheld,
+  sectionLineCount,
+  unavailableOracles,
+  withheldClasses,
+  withheldOracles,
+  type DefectClass,
+  type DerivedSignalKey,
+  type DerivedSignals,
+  type ProbeId,
+} from "./defect-classes.ts";
+import { CONTACT_DEFECT_CLASSES, localizeContact } from "./localize/contact.ts";
+import { SKILLS_DEFECT_CLASSES, localizeSkills } from "./localize/skills.ts";
+import {
+  EXPERIENCE_DEFECT_CLASSES,
+  localizeExperience,
+} from "./localize/experience.ts";
+import {
+  EDUCATION_DEFECT_CLASSES,
+  localizeEducation,
+} from "./localize/education.ts";
+import {
+  ACHIEVEMENTS_DEFECT_CLASSES,
+  localizeAchievements,
+} from "./localize/achievements.ts";
+import {
+  ROUNDTRIP_CATEGORY_CLASS,
+  localizeRoundtripHop,
+} from "./localize/roundtrip.ts";
+import { mkCascade } from "./localize/__test-utils__.ts";
+import {
+  REPRO_ARTIFACT_VERSION,
+  type ReproArtifact,
+  type ReproParsedCounts,
+} from "./repro-artifact.ts";
+import type { SectionName } from "./sections.config.ts";
+import { CASCADE_VERSION } from "./types.ts";
+
+// ── Hand-built fixtures (no PDF I/O) ─────────────────────────────────────────
+
+/** A CLEAN parse: every section routed, every field parsed. Tests override only
+ *  the axes their defect lives on, so a predicate that fires on an untouched
+ *  axis shows up immediately as an unexpected extra class. */
+const CLEAN_SECTIONS: Partial<Record<SectionName | "profile", number>> = {
+  profile: 4,
+  summary: 3,
+  experience: 20,
+  education: 4,
+  skills: 3,
+  achievements: 3,
+};
+
+const CLEAN_COUNTS: ReproParsedCounts = {
+  hasFullName: true,
+  hasEmail: true,
+  hasPhone: true,
+  hasLocation: true,
+  hasSummary: true,
+  experienceCount: 3,
+  educationCount: 1,
+  skillsCount: 12,
+};
+
+/** A clean `ReproArtifact`, with the named section line-counts and parsed counts
+ *  overridden. A section overridden to `0` is treated as never routed — which is
+ *  how the probes read an empty region, and what `sectionLineCount` reports. */
+function artifact(over?: {
+  sections?: Partial<Record<SectionName | "profile", number>>;
+  counts?: Partial<ReproParsedCounts>;
+}): ReproArtifact {
+  const merged = { ...CLEAN_SECTIONS, ...over?.sections };
+  return {
+    artifactVersion: REPRO_ARTIFACT_VERSION,
+    cascadeVersion: CASCADE_VERSION,
+    triggers: [],
+    sectionSource: "markdown",
+    pageCount: 1,
+    rawCharCount: 2000,
+    extractedCharCount: 2000,
+    sections: (Object.entries(merged) as [SectionName | "profile", number][])
+      .filter(([, lineCount]) => lineCount > 0)
+      .map(([name, lineCount]) => ({ name, lineCount })),
+    parsedCounts: { ...CLEAN_COUNTS, ...over?.counts },
+    linkAnnotationCount: 0,
+    disagreements: [],
+  };
+}
+
+/** `DerivedSignals` with the named bits flipped on, everything else false. */
+function derived(...on: readonly DerivedSignalKey[]): DerivedSignals {
+  const d = { ...EMPTY_DERIVED_SIGNALS };
+  for (const k of on) d[k] = true;
+  return d;
+}
+
+/** No derived signal observed — i.e. a clean parse on every value-level axis. */
+const NONE = EMPTY_DERIVED_SIGNALS;
+
+/** Does this parse exhibit exactly `expected`, and nothing else? Stronger than
+ *  asserting one predicate: it also pins that sibling classes stay mutually
+ *  exclusive (a 0-entry experience region must NOT report as both a parser-miss
+ *  and under-segmented) and that no unrelated class leaks in. */
+function expectExactly(
+  a: ReproArtifact,
+  d: DerivedSignals,
+  expected: DefectClass[],
+): void {
+  expect(exhibitedDefects(a, d)).toEqual(expected);
+}
+
+// ── 1. The PII contract ──────────────────────────────────────────────────────
+
+describe("DerivedSignals — boolean-only by construction", () => {
+  // Compile-time half; `npm run typecheck` is the gate. Widen `DerivedSignals`
+  // to admit a `string` (or anything else) and `NonBoolean` stops being `never`,
+  // so this assignment stops compiling.
+  type NonBoolean = Exclude<DerivedSignals[DerivedSignalKey], boolean>;
+  const noNonBooleanMember: [NonBoolean] extends [never] ? true : false = true;
+
+  /** The runtime shape guard: a serialized `DerivedSignals` may hold nothing but
+   *  bare `true`/`false` literals — no string can occupy a value slot. */
+  const serializesToBooleansOnly = (v: unknown): boolean =>
+    /^\{"[A-Za-z]+":(?:true|false)(?:,"[A-Za-z]+":(?:true|false))*\}$/.test(
+      JSON.stringify(v),
+    );
+
+  it("compiles only while every member is a boolean", () => {
+    expect(noNonBooleanMember).toBe(true);
+  });
+
+  it("carries no literal field value, anywhere, when serialized", () => {
+    // Every signal on — the maximal payload the corpus bake will ever persist.
+    const all = derived(...DERIVED_SIGNAL_KEYS);
+    expect(Object.values(all).every((v) => typeof v === "boolean")).toBe(true);
+    expect(serializesToBooleansOnly(all)).toBe(true);
+    expect(serializesToBooleansOnly(EMPTY_DERIVED_SIGNALS)).toBe(true);
+  });
+
+  it("the guard has teeth — a smuggled string value fails it", () => {
+    // The leak this design exists to prevent: someone adds a "just the failing
+    // value, for context" slot. Only reachable through a cast today — which is
+    // exactly why the TYPE is the primary defence and this is the backstop.
+    const smuggled = {
+      ...EMPTY_DERIVED_SIGNALS,
+      emailChangedAcrossRoundtrip: "SENTINEL_EMAIL_aria@leak.invalid",
+    } as unknown as DerivedSignals;
+    expect(JSON.stringify(smuggled)).toContain("SENTINEL_EMAIL_aria@leak.invalid");
+    expect(serializesToBooleansOnly(smuggled)).toBe(false);
+  });
+
+  it("has no duplicate keys, and EMPTY_DERIVED_SIGNALS covers every one", () => {
+    expect(new Set(DERIVED_SIGNAL_KEYS).size).toBe(DERIVED_SIGNAL_KEYS.length);
+    expect(Object.keys(EMPTY_DERIVED_SIGNALS).sort()).toEqual(
+      [...DERIVED_SIGNAL_KEYS].sort(),
+    );
+    expect(Object.values(EMPTY_DERIVED_SIGNALS).every((v) => v === false)).toBe(true);
+  });
+});
+
+// ── 2. No silent gap ─────────────────────────────────────────────────────────
+
+describe("DEFECT_SPECS — one entry per class, no gaps", () => {
+  it("has no duplicate classes", () => {
+    expect(new Set(DEFECT_CLASSES).size).toBe(DEFECT_CLASSES.length);
+  });
+
+  it("has exactly one table entry per DefectClass", () => {
+    expect(Object.keys(DEFECT_SPECS).sort()).toEqual([...DEFECT_CLASSES].sort());
+    for (const c of DEFECT_CLASSES) {
+      expect(DEFECT_SPECS[c]).toBeDefined();
+      // The key and the spec's self-declared class must agree — a copy-paste slip
+      // here would silently mis-attribute a defect to another class.
+      expect(DEFECT_SPECS[c].class).toBe(c);
+      expect(defectSpec(c)).toBe(DEFECT_SPECS[c]);
+    }
+  });
+
+  it("names a known probe and at least one load-bearing axis for every class", () => {
+    for (const c of DEFECT_CLASSES) {
+      const spec = DEFECT_SPECS[c];
+      expect(PROBE_IDS).toContain(spec.probe);
+      expect(spec.loadBearingAxes.length).toBeGreaterThan(0);
+      expect(new Set(spec.loadBearingAxes).size).toBe(spec.loadBearingAxes.length);
+    }
+  });
+
+  it("covers all six probes", () => {
+    const covered = new Set(DEFECT_CLASSES.map((c) => DEFECT_SPECS[c].probe));
+    expect([...covered].sort()).toEqual([...PROBE_IDS].sort());
+  });
+
+  it("reports nothing on a clean parse", () => {
+    expectExactly(artifact(), NONE, []);
+  });
+
+  // ── The verdict↔class pin (#469's "a probe verdict with no table entry is a
+  // test failure, not a silent gap"). The `Record<DefectClass, DefectSpec>` above
+  // pins CLASS ↔ TABLE. This pins TABLE ↔ LOCALIZER: each localizer declares the
+  // exact tuple of classes its verdict chain can emit, and its `defect` variable
+  // is TYPED to that tuple — so a verdict branch cannot exist without naming a
+  // class (or an explicit `null`). If a class is added to the table for a probe
+  // and no localizer branch emits it, this fails. If a localizer names a class
+  // the table's `probe` column disagrees about, this fails too.
+  it("every table class is claimed by its localizer's declared class tuple", () => {
+    const declared: Record<ProbeId, readonly DefectClass[]> = {
+      "probe-contact": CONTACT_DEFECT_CLASSES,
+      "probe-skills": SKILLS_DEFECT_CLASSES,
+      "probe-experience": EXPERIENCE_DEFECT_CLASSES,
+      "probe-education": EDUCATION_DEFECT_CLASSES,
+      "probe-achievements": ACHIEVEMENTS_DEFECT_CLASSES,
+      // probe-roundtrip has no verdict string: a CATEGORY with a non-empty diff
+      // IS its verdict, so its pin is the total category→class map.
+      "probe-roundtrip": Object.values(ROUNDTRIP_CATEGORY_CLASS),
+    };
+    for (const probe of PROBE_IDS) {
+      expect([...declared[probe]].sort()).toEqual(
+        defectClassesForProbe(probe).sort(),
+      );
+    }
+  });
+
+  it("marks exactly the three *-no-section classes advisory", () => {
+    expect(DEFECT_CLASSES.filter(isAdvisory)).toEqual([
+      "skills-no-section",
+      "education-no-section",
+      "achievements-no-section",
+    ]);
+  });
+});
+
+// ── sectionLineCount ─────────────────────────────────────────────────────────
+
+describe("sectionLineCount", () => {
+  it("returns the routed line count, and 0 when no region was cut", () => {
+    const a = artifact({ sections: { skills: 4, education: 0 } });
+    expect(sectionLineCount(a, "skills")).toBe(4);
+    expect(sectionLineCount(a, "education")).toBe(0);
+  });
+
+  it("treats a routed-but-empty region as absent (as every probe does)", () => {
+    const a: ReproArtifact = {
+      ...artifact(),
+      sections: [{ name: "skills", lineCount: 0 }],
+    };
+    expect(sectionLineCount(a, "skills")).toBe(0);
+  });
+});
+
+// ── 3. The exhibits() predicates ─────────────────────────────────────────────
+
+describe("exhibits — probe-contact", () => {
+  it("flags a parser-miss only when the field is empty AND rawText has it", () => {
+    expectExactly(
+      artifact({ counts: { hasEmail: false } }),
+      derived("emailInRawTextButNotParsed"),
+      ["contact-email-parser-miss"],
+    );
+    expectExactly(
+      artifact({ counts: { hasPhone: false } }),
+      derived("phoneInRawTextButNotParsed"),
+      ["contact-phone-parser-miss"],
+    );
+    expectExactly(
+      artifact({ counts: { hasLocation: false } }),
+      derived("locationInRawTextButNotParsed"),
+      ["contact-location-parser-miss"],
+    );
+  });
+
+  it("does NOT flag a field that is simply absent from the PDF", () => {
+    // Field empty AND no rawText candidate → the probe says "absent-in-pdf",
+    // which is not a defect.
+    expectExactly(artifact({ counts: { hasEmail: false } }), NONE, []);
+  });
+
+  it("does NOT flag a field that parsed fine", () => {
+    expectExactly(artifact(), derived("emailInRawTextButNotParsed"), []);
+  });
+
+  it("keeps the three contact fields independent (no cross-field false cover)", () => {
+    // A fixture that drops the PHONE must never be reported as covering a résumé
+    // that drops the EMAIL.
+    expect(
+      DEFECT_SPECS["contact-email-parser-miss"].exhibits(
+        artifact({ counts: { hasEmail: false } }),
+        derived("phoneInRawTextButNotParsed"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("exhibits — probe-skills", () => {
+  it("EXTRACTION-MISS: region routed, 0 skills parsed", () => {
+    expectExactly(artifact({ counts: { skillsCount: 0 } }), NONE, [
+      "skills-extraction-miss",
+    ]);
+  });
+
+  it("HEADER-UNRECOGNIZED: no region, 0 skills, a rejected skills-like header", () => {
+    expectExactly(
+      artifact({ sections: { skills: 0 }, counts: { skillsCount: 0 } }),
+      derived("skillsHeaderCandidateRejected"),
+      ["skills-header-unrecognized"],
+    );
+  });
+
+  it("NO-SKILLS-SECTION: no region, 0 skills, no rejected header", () => {
+    expectExactly(artifact({ sections: { skills: 0 }, counts: { skillsCount: 0 } }), NONE, [
+      "skills-no-section",
+    ]);
+  });
+
+  it("separates the two structurally-identical no-region classes", () => {
+    // Same artifact; ONLY the derived bit differs. This is exactly the
+    // discrimination the DerivedSignals escape hatch exists for — the artifact
+    // cannot tell a rejected header from a résumé that has no skills section.
+    const a = artifact({ sections: { skills: 0 }, counts: { skillsCount: 0 } });
+    const unrecognized = DEFECT_SPECS["skills-header-unrecognized"];
+    const noSection = DEFECT_SPECS["skills-no-section"];
+    const d = derived("skillsHeaderCandidateRejected");
+    expect(unrecognized.exhibits(a, d)).toBe(true);
+    expect(noSection.exhibits(a, d)).toBe(false);
+    expect(unrecognized.exhibits(a, NONE)).toBe(false);
+    expect(noSection.exhibits(a, NONE)).toBe(true);
+  });
+
+  it("flags nothing once skills parsed, even with a rejected header candidate", () => {
+    expectExactly(artifact(), derived("skillsHeaderCandidateRejected"), []);
+  });
+
+  // The FALSE-COVER hazard this guard exists to kill: on a scanned/sparse parse
+  // there is no markdown, so `skillsHeaderCandidateRejected` is false because the
+  // oracle could not RUN — not because no header was rejected. Firing
+  // `skills-no-section` there would let 9 fixtures "cover" a header-rejection
+  // defect none of them reproduces.
+  it("withholds BOTH no-region classes when the header oracle could not run", () => {
+    const a = artifact({ sections: { skills: 0 }, counts: { skillsCount: 0 } });
+    expectExactly(a, derived("headerOracleUnavailable"), []);
+    expect(
+      DEFECT_SPECS["skills-no-section"].exhibits(
+        a,
+        derived("headerOracleUnavailable"),
+      ),
+    ).toBe(false);
+    expect(
+      DEFECT_SPECS["skills-header-unrecognized"].exhibits(
+        a,
+        derived("headerOracleUnavailable"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("exhibits — probe-experience", () => {
+  it("PARSER-MISS: 0 entries and the region holds date-range lines", () => {
+    expectExactly(
+      artifact({ counts: { experienceCount: 0 } }),
+      derived("experienceRegionHasDateRangeLines"),
+      ["experience-parser-miss"],
+    );
+  });
+
+  it("does NOT flag a 0-entry region with no date-range lines (the probe says ok)", () => {
+    expectExactly(artifact({ counts: { experienceCount: 0 } }), NONE, []);
+  });
+
+  it("UNDER-SEGMENTED: entries parsed, but fewer than the date-range lines", () => {
+    expectExactly(artifact(), derived("experienceEntriesFewerThanDateRangeLines"), [
+      "experience-under-segmented",
+    ]);
+  });
+
+  it("branch order holds: 0 entries + date-ranges is a MISS, never under-segmented", () => {
+    // With 0 entries and N > 0 date-range lines the probe's oracle also reads
+    // `entries < dateRangeLines`; its `else if` gives PARSER-MISS. Ours must too,
+    // or one defect would report as two.
+    expectExactly(
+      artifact({ counts: { experienceCount: 0 } }),
+      derived(
+        "experienceRegionHasDateRangeLines",
+        "experienceEntriesFewerThanDateRangeLines",
+      ),
+      ["experience-parser-miss"],
+    );
+  });
+});
+
+describe("exhibits — probe-education", () => {
+  it("EXTRACTION-MISS: region routed, 0 entries", () => {
+    expectExactly(artifact({ counts: { educationCount: 0 } }), NONE, [
+      "education-extraction-miss",
+    ]);
+  });
+
+  it("HEADER-UNRECOGNIZED: no region, 0 entries, a rejected education-like header", () => {
+    expectExactly(
+      artifact({ sections: { education: 0 }, counts: { educationCount: 0 } }),
+      derived("educationHeaderCandidateRejected"),
+      ["education-header-unrecognized"],
+    );
+  });
+
+  it("NO-EDUCATION-SECTION: no region, 0 entries, no rejected header", () => {
+    expectExactly(
+      artifact({ sections: { education: 0 }, counts: { educationCount: 0 } }),
+      NONE,
+      ["education-no-section"],
+    );
+  });
+
+  it("UNDER-CHUNKED: entries parsed, but fewer than the DEGREE_RE tokens", () => {
+    expectExactly(artifact(), derived("educationEntriesFewerThanDegreeTokens"), [
+      "education-under-chunked",
+    ]);
+  });
+
+  it("withholds BOTH no-region classes when the header oracle could not run", () => {
+    const a = artifact({
+      sections: { education: 0 },
+      counts: { educationCount: 0 },
+    });
+    expectExactly(a, derived("headerOracleUnavailable"), []);
+  });
+
+  it("branch order holds: 0 entries never reports as under-chunked", () => {
+    expectExactly(
+      artifact({ counts: { educationCount: 0 } }),
+      derived("educationEntriesFewerThanDegreeTokens"),
+      ["education-extraction-miss"],
+    );
+  });
+});
+
+describe("exhibits — probe-achievements", () => {
+  it("PARSER-MISS: region non-empty, 0 entries parsed", () => {
+    expectExactly(artifact(), derived("achievementsParsedEmpty"), [
+      "achievements-parser-miss",
+    ]);
+  });
+
+  it("no-section: 0 entries and no region segmented", () => {
+    expectExactly(
+      artifact({ sections: { achievements: 0 } }),
+      derived("achievementsParsedEmpty"),
+      ["achievements-no-section"],
+    );
+  });
+
+  it("UNDER-SEGMENTED: entries parsed, but fewer than the header-shaped lines", () => {
+    expectExactly(artifact(), derived("achievementsEntriesFewerThanHeaderLines"), [
+      "achievements-under-segmented",
+    ]);
+  });
+
+  it("parser-miss and no-section are mutually exclusive on the region axis", () => {
+    const withRegion = artifact();
+    const withoutRegion = artifact({ sections: { achievements: 0 } });
+    const d = derived("achievementsParsedEmpty");
+    expect(DEFECT_SPECS["achievements-parser-miss"].exhibits(withRegion, d)).toBe(true);
+    expect(DEFECT_SPECS["achievements-no-section"].exhibits(withRegion, d)).toBe(false);
+    expect(DEFECT_SPECS["achievements-parser-miss"].exhibits(withoutRegion, d)).toBe(
+      false,
+    );
+    expect(DEFECT_SPECS["achievements-no-section"].exhibits(withoutRegion, d)).toBe(true);
+  });
+});
+
+describe("exhibits — probe-roundtrip (value-level)", () => {
+  // The acceptance criterion #469 calls out by name: two parses with IDENTICAL
+  // ReproArtifacts must still be distinguished, because the corruption lives in
+  // the VALUES, which the artifact cannot see. Same clean `a` throughout — only
+  // the derived bag differs.
+  const a = artifact();
+
+  it("distinguishes a corrupted round-trip from a clean one on identical artifacts", () => {
+    expectExactly(a, NONE, []);
+    expectExactly(a, derived("emailChangedAcrossRoundtrip"), [
+      "roundtrip-contact-value-changed",
+    ]);
+  });
+
+  it("any of the five contact keys trips the contact class", () => {
+    const contact = DEFECT_SPECS["roundtrip-contact-value-changed"];
+    for (const k of [
+      "fullNameChangedAcrossRoundtrip",
+      "emailChangedAcrossRoundtrip",
+      "phoneChangedAcrossRoundtrip",
+      "locationChangedAcrossRoundtrip",
+      "linkedinUrlChangedAcrossRoundtrip",
+    ] as const) {
+      expect(contact.exhibits(a, derived(k))).toBe(true);
+    }
+    expect(contact.exhibits(a, NONE)).toBe(false);
+    // A non-contact round-trip change must NOT trip it.
+    expect(contact.exhibits(a, derived("skillsChangedAcrossRoundtrip"))).toBe(false);
+  });
+
+  it("maps each remaining harness category to its own class", () => {
+    expectExactly(a, derived("experienceChangedAcrossRoundtrip"), [
+      "roundtrip-experience-value-changed",
+    ]);
+    expectExactly(a, derived("educationChangedAcrossRoundtrip"), [
+      "roundtrip-education-value-changed",
+    ]);
+    expectExactly(a, derived("skillsChangedAcrossRoundtrip"), [
+      "roundtrip-skills-value-changed",
+    ]);
+    expectExactly(a, derived("summaryChangedAcrossRoundtrip"), [
+      "roundtrip-summary-value-changed",
+    ]);
+    expectExactly(a, derived("renderThrewOnRoundtrip"), ["roundtrip-render-crash"]);
+  });
+
+  it("reports every class a parse exhibits, in DEFECT_CLASSES order", () => {
+    expectExactly(
+      a,
+      derived(
+        "emailChangedAcrossRoundtrip",
+        "skillsChangedAcrossRoundtrip",
+        "renderThrewOnRoundtrip",
+      ),
+      [
+        "roundtrip-contact-value-changed",
+        "roundtrip-skills-value-changed",
+        "roundtrip-render-crash",
+      ],
+    );
+  });
+});
+
+// ── 4. The oracle gate ───────────────────────────────────────────────────────
+
+describe("the oracle gate — a blind oracle WITHHOLDS, it does not report clean", () => {
+  const clean = artifact();
+
+  it("declares each class's required oracles as load-bearing axes", () => {
+    for (const c of DEFECT_CLASSES) {
+      const s = DEFECT_SPECS[c];
+      for (const o of s.requires) {
+        expect(ORACLES).toContain(o);
+        // `spec()` appends it — so `exhibits()` can never read an axis the
+        // near-miss report is blind to.
+        expect(s.loadBearingAxes).toContain(`derived.${ORACLE_UNAVAILABLE_KEY[o]}`);
+      }
+    }
+  });
+
+  it("withholds EVERY text-derived class on a parse that produced no text", () => {
+    // The scanned/empty-rawText repro: all 20 non-oracle bits read false because
+    // there was nothing to read. Nothing may be reported as exhibited — and the
+    // withheld list must say so out loud.
+    const d = derived("textOracleUnavailable");
+    expect(exhibitedDefects(clean, d)).toEqual([]);
+    const withheld = withheldClasses(d);
+    expect(withheld).toEqual(
+      DEFECT_CLASSES.filter((c) => c !== "roundtrip-render-crash"),
+    );
+    // `roundtrip-render-crash` is an OBSERVED fact about the hop, not a reading
+    // of the document — it stays decidable, and stays reachable.
+    expect(isWithheld("roundtrip-render-crash", d)).toBe(false);
+    expect(exhibitedDefects(clean, derived("textOracleUnavailable", "renderThrewOnRoundtrip"))).toEqual([
+      "roundtrip-render-crash",
+    ]);
+  });
+
+  it("withholds the five roundtrip VALUE classes when the hop produced no `after`", () => {
+    // The render-crash repro: `renderThrewOnRoundtrip` is the only thing the hop
+    // observed. The nine `*ChangedAcrossRoundtrip` bits are false because the
+    // comparison never happened, so "no value changed" is not a finding.
+    const d = derived("renderThrewOnRoundtrip", "roundtripOracleUnavailable");
+    expect(exhibitedDefects(clean, d)).toEqual(["roundtrip-render-crash"]);
+    expect(withheldClasses(d)).toEqual([
+      "roundtrip-contact-value-changed",
+      "roundtrip-experience-value-changed",
+      "roundtrip-education-value-changed",
+      "roundtrip-skills-value-changed",
+      "roundtrip-summary-value-changed",
+    ]);
+    // And the gate has teeth: even with a value-change bit somehow set, the
+    // class stays withheld rather than claimed off an absent `after`.
+    expect(
+      DEFECT_SPECS["roundtrip-contact-value-changed"].exhibits(
+        clean,
+        derived("roundtripOracleUnavailable", "emailChangedAcrossRoundtrip"),
+      ),
+    ).toBe(false);
+  });
+
+  it("withholds nothing, and names no blind oracle, on a parse with all three oracles", () => {
+    expect(withheldClasses(NONE)).toEqual([]);
+    expect(unavailableOracles(NONE)).toEqual([]);
+    expect(unavailableOracles(derived("textOracleUnavailable", "roundtripOracleUnavailable"))).toEqual([
+      "text",
+      "roundtrip",
+    ]);
+    expect(withheldOracles("skills-no-section", derived("headerOracleUnavailable"))).toEqual([
+      "header",
+    ]);
+  });
+});
+
+// ── 5. Reachability: every table class is EMITTABLE by its localizer ─────────
+
+/**
+ * The verdict↔class pin, closed.
+ *
+ * `defectClassesForProbe` vs the localizers' declared tuples pins TABLE ↔ TUPLE.
+ * That alone has only partial teeth: a class in both the table AND the tuple but
+ * with NO verdict branch that emits it still passes — a class nobody can emit,
+ * silently pinned by nobody. So this drives hand-built `CascadeResult`s through
+ * the localizers themselves and asserts the union of what they ACTUALLY emit
+ * equals the table's class set for that probe. A class no branch can reach fails
+ * here; so does a branch that emits a class the table does not carry.
+ */
+describe("reachability — every table class is emittable by its localizer", () => {
+  const emitted = (probe: ProbeId, parses: DefectClass[][]): void => {
+    const union = [...new Set(parses.flat())].sort();
+    expect(union).toEqual(defectClassesForProbe(probe).sort());
+  };
+
+  it("probe-contact", () => {
+    emitted("probe-contact", [
+      localizeContact(
+        mkCascade({
+          fields: {},
+          rawText: "jordan@example.com · (312) 555-0100 · Austin, TX",
+          sections: { profile: [] },
+        }),
+      ).defects,
+    ]);
+  });
+
+  it("probe-skills", () => {
+    emitted("probe-skills", [
+      localizeSkills(
+        mkCascade({ fields: { skills: [] }, sections: { skills: ["Python, Go"] } }),
+      ).defects,
+      localizeSkills(
+        mkCascade({
+          fields: { skills: [] },
+          sections: {},
+          markdown: "# Skills Summary\nPython, Go\n# Experience\n",
+        }),
+      ).defects,
+      localizeSkills(
+        mkCascade({
+          fields: { skills: [] },
+          sections: {},
+          markdown: "# Experience\nSome role\n",
+        }),
+      ).defects,
+    ]);
+  });
+
+  it("probe-experience", () => {
+    emitted("probe-experience", [
+      localizeExperience(
+        mkCascade({
+          fields: { experience: [] },
+          sections: { experience: ["Engineer, Acme", "Jan 2020 – Jan 2022"] },
+        }),
+      ).defects,
+      localizeExperience(
+        mkCascade({
+          fields: {
+            experience: [{ title: "Engineer", company: "Acme" }],
+          },
+          sections: {
+            experience: ["Jan 2020 – Jan 2021", "Feb 2021 – Feb 2022"],
+          },
+        }),
+      ).defects,
+    ]);
+  });
+
+  it("probe-education", () => {
+    emitted("probe-education", [
+      localizeEducation(
+        mkCascade({
+          fields: { education: [] },
+          sections: { education: ["Bachelor of Science, State University"] },
+        }),
+      ).defects,
+      localizeEducation(
+        mkCascade({
+          fields: { education: [] },
+          sections: {},
+          markdown: "# education overview\nBachelor of Science\n# Skills\n",
+        }),
+      ).defects,
+      localizeEducation(
+        mkCascade({
+          fields: { education: [] },
+          sections: {},
+          markdown: "# Experience\nSome role\n",
+        }),
+      ).defects,
+      localizeEducation(
+        mkCascade({
+          fields: { education: [{ institution: "State University", degree: "BS" }] },
+          sections: {
+            education: [
+              "Bachelor of Science, State University",
+              "Master of Science, Other University",
+            ],
+          },
+        }),
+      ).defects,
+    ]);
+  });
+
+  it("probe-achievements", () => {
+    emitted("probe-achievements", [
+      localizeAchievements(
+        mkCascade({
+          fields: { heuristic_achievements: [] },
+          sections: { achievements: ["Award · Best Paper, 2022"] },
+        }),
+      ).defects,
+      localizeAchievements(
+        mkCascade({
+          fields: {
+            heuristic_achievements: [{ type: "Award", title: "Best Paper" }],
+          },
+          sections: {
+            achievements: ["Award · Best Paper", "- bullet", "Award · Second Prize"],
+          },
+        }),
+      ).defects,
+      localizeAchievements(
+        mkCascade({ fields: { heuristic_achievements: [] }, sections: {} }),
+      ).defects,
+    ]);
+  });
+
+  it("probe-roundtrip", () => {
+    const before = mkCascade({
+      fields: {
+        email: "a@example.com",
+        summary: "A".repeat(100),
+        skills: ["Go"],
+        experience: [{ title: "Engineer", company: "Acme" }],
+        education: [{ institution: "State University", degree: "BS" }],
+      },
+    });
+    const changed = mkCascade({
+      fields: {
+        email: "b@example.com",
+        summary: "A".repeat(50),
+        skills: ["Rust"],
+        experience: [{ title: "Senior Engineer", company: "Acme" }],
+        education: [{ institution: "Other University", degree: "BS" }],
+      },
+    });
+    emitted("probe-roundtrip", [
+      localizeRoundtripHop(before, changed).defects,
+      localizeRoundtripHop(before, undefined, "boom").defects,
+    ]);
+  });
+});

--- a/src/lib/heuristics/defect-classes.ts
+++ b/src/lib/heuristics/defect-classes.ts
@@ -1,0 +1,812 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Defect-class taxonomy + the load-bearing-axis table (issue #469).
+ *
+ * The six read-only parser probes each localize ONE section's defect to ONE
+ * parser layer, and each ends by printing a `verdict` string. Those verdict
+ * strings ARE the class taxonomy — they were just never named. This file names
+ * them, and pairs each with (a) the `ReproArtifact` / `DerivedSignals` axes the
+ * class actually lives on, and (b) a predicate that decides whether some OTHER
+ * parse — a corpus fixture's — exhibits the same defect.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ WHY `DerivedSignals` IS BOOLEAN-ONLY — read before editing.               │
+ * │                                                                           │
+ * │ This file exists to answer "does any fixture already reproduce the defect │
+ * │ this REAL résumé exposes?" — so it sits, by construction, one function    │
+ * │ call away from a real name, a real email, a real phone, real bullet text. │
+ * │ resumelint is a PUBLIC repo. Anything this layer can carry is one         │
+ * │ copy-paste from a public issue, and the `*.expected.json` corpus          │
+ * │ snapshots (which will bake a `DerivedSignals` per fixture, #469 step 5)   │
+ * │ are COMMITTED. A single free-form `string` slot here would turn both into │
+ * │ a PII surface that looks innocuous.                                       │
+ * │                                                                           │
+ * │ `repro-artifact.ts` already solved this for the STRUCTURAL half: its      │
+ * │ exported type admits only numbers, booleans, and fixed enums — PII-free   │
+ * │ BY CONSTRUCTION, not by filtering — and `repro-artifact.test.ts` pins it. │
+ * │ But `ReproArtifact` is structure-only, so it is BLIND to every defect      │
+ * │ where a field is *present but wrong*: a phone whose digits got mangled, a │
+ * │ name that absorbed a title, and all of the round-trip probe's domain.     │
+ * │ `hasPhone: true` before and after says nothing about whether the digits    │
+ * │ survived.                                                                  │
+ * │                                                                           │
+ * │ The fix is NOT to widen `ReproArtifact` with a string field — that breaks │
+ * │ its PII assertion and defeats its file header. Instead, value-level        │
+ * │ classes are expressed as DERIVED BOOLEANS: the predicate reads the real    │
+ * │ values in memory, and only the VERDICT — one bit — is ever returned,       │
+ * │ printed, or written. A boolean cannot leak an email.                       │
+ * │                                                                           │
+ * │ So: `DerivedSignals` is a flat, mapped, boolean-only type keyed off        │
+ * │ `DERIVED_SIGNAL_KEYS`. There is deliberately NO `string` slot, no          │
+ * │ `sample`, no `before`/`after`, no "just the failing bullet, for context".  │
+ * │ `defect-classes.test.ts` pins that. If you need the literal text to build  │
+ * │ a fixture, you re-export a template with a SYNTHETIC persona (CLAUDE.md);  │
+ * │ you do not harvest it from the résumé under probe.                         │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * ── Verdict-string → DefectClass map (the derivation; step 3 wires it 1:1) ──
+ *
+ * `probe-contact.test.ts` — verdict is emitted PER FIELD (email/phone/location):
+ *   "ok"                                    → (not a defect — no class)
+ *   "absent-in-pdf"                         → (not a defect — the field is
+ *                                              genuinely not in the document)
+ *   "PARSER-MISS (in rawText, not in field)"→ contact-{email,phone,location}-parser-miss
+ *
+ * `probe-skills.test.ts`:
+ *   "ok (N skill entries parsed)"           → (not a defect — no class)
+ *   "EXTRACTION-MISS (…)"                   → skills-extraction-miss
+ *   "HEADER-UNRECOGNIZED (…)"               → skills-header-unrecognized
+ *   "NO-SKILLS-SECTION (…)"                 → skills-no-section
+ *
+ * `probe-experience.test.ts`:
+ *   "ok"                                    → (not a defect — no class)
+ *   "PARSER-MISS (0 entries; …)"            → experience-parser-miss
+ *   "UNDER-SEGMENTED (…)"                   → experience-under-segmented
+ *
+ * `probe-education.test.ts`:
+ *   "ok (N education entries parsed)"       → (not a defect — no class)
+ *   "EXTRACTION-MISS (…)"                   → education-extraction-miss
+ *   "HEADER-UNRECOGNIZED (…)"               → education-header-unrecognized
+ *   "NO-EDUCATION-SECTION (…)"              → education-no-section
+ *   "UNDER-CHUNKED (…)"                     → education-under-chunked
+ *
+ * `probe-achievements.test.ts`:
+ *   "ok"                                    → (not a defect — no class)
+ *   "PARSER-MISS (0 entries; …)"            → achievements-parser-miss
+ *   "UNDER-SEGMENTED (…)"                   → achievements-under-segmented
+ *   "no achievements region segmented (…)"  → achievements-no-section
+ *
+ * `probe-roundtrip` — its harness is the `RL_RT_PDF` block of
+ * `corpus-roundtrip.test.ts` (there is no `probe-roundtrip.test.ts`). It does
+ * not print a single verdict string; it reports a per-hop diff keyed by its
+ * `Category` union, and a category with a non-empty diff IS its verdict. One
+ * class per category, at exactly that granularity — splitting finer would
+ * invent verdicts the probe cannot emit:
+ *   Category "contact"    non-empty         → roundtrip-contact-value-changed
+ *   Category "experience" non-empty         → roundtrip-experience-value-changed
+ *   Category "education"  non-empty         → roundtrip-education-value-changed
+ *   Category "skills"     non-empty         → roundtrip-skills-value-changed
+ *   Category "summary"    non-empty         → roundtrip-summary-value-changed
+ *   Category "render" (renderAtsResumePdf threw) → roundtrip-render-crash
+ *
+ * Pure and lib-layer: no React, no I/O, no PDF parsing. Every predicate here is
+ * a total function of two PII-free inputs.
+ */
+
+import type { SectionName } from "./sections.config.ts";
+import type { ReproArtifact, ReproParsedCounts } from "./repro-artifact.ts";
+
+// ── Probes ───────────────────────────────────────────────────────────────────
+
+/** The six probe skills. `probe-roundtrip`'s harness is the `RL_RT_PDF` block
+ *  of `corpus-roundtrip.test.ts`, not a `probe-roundtrip.test.ts`. */
+export const PROBE_IDS = [
+  "probe-contact",
+  "probe-skills",
+  "probe-experience",
+  "probe-education",
+  "probe-achievements",
+  "probe-roundtrip",
+] as const;
+
+export type ProbeId = (typeof PROBE_IDS)[number];
+
+// ── Derived signals ──────────────────────────────────────────────────────────
+
+/**
+ * The value-level signals `ReproArtifact` is structurally blind to.
+ *
+ * Each key is a PRIMITIVE FACT about a parse — never a verdict. (Verdicts are
+ * `DefectClass`es, composed from these facts plus artifact axes by the
+ * `exhibits()` predicates below. Keeping facts and verdicts apart is what stops
+ * the table from collapsing into a tautology, and is what makes the near-miss
+ * "why not" report legible.)
+ *
+ * Every key maps to a BOOLEAN. See the file header for why that is load-bearing
+ * and not merely tidy. The type is DERIVED from this tuple, so a new signal is
+ * added in exactly one place and cannot be added with a non-boolean type.
+ */
+export const DERIVED_SIGNAL_KEYS = [
+  // ── probe-contact: the independent rawText re-scan (the "is it anywhere in
+  // the doc?" oracle). True ⇒ the field is empty in the structured parse BUT a
+  // candidate for it exists in rawText ⇒ the regex saw it and a layer below
+  // dropped it. Distinguishes a PARSER-MISS from a field genuinely absent from
+  // the PDF — a distinction `parsedCounts.hasEmail: false` alone cannot make.
+  "emailInRawTextButNotParsed",
+  "phoneInRawTextButNotParsed",
+  "locationInRawTextButNotParsed",
+
+  // ── probe-skills: a skills-like header candidate that the STRICT section
+  // router rejected (leading decorative glyph #414, out-of-alias wording, or a
+  // two-line wrap #374). The rejection leaves no trace in the artifact — no
+  // `skills` section is routed, exactly as if the résumé had none — so this bit
+  // is the only thing separating skills-header-unrecognized from skills-no-section.
+  "skillsHeaderCandidateRejected",
+
+  // ── probe-education: same rejected-header oracle, plus the DEGREE_RE
+  // lower-bound oracle (more degree tokens inside the routed region than parsed
+  // entries ⇒ two degrees collapsed into one). The token count is not an
+  // artifact axis, so the COMPARISON is the boolean.
+  "educationHeaderCandidateRejected",
+  "educationEntriesFewerThanDegreeTokens",
+
+  // ── probe-experience: date-range lines inside the routed region are the
+  // lower-bound oracle for the role count. `…HasDateRangeLines` separates a
+  // real drop from a legitimately date-less region (the probe says "ok" when a
+  // region yields 0 entries AND holds 0 date-range lines); the comparison bit
+  // flags a role merged into a neighbour.
+  "experienceRegionHasDateRangeLines",
+  "experienceEntriesFewerThanDateRangeLines",
+
+  // ── probe-achievements: `ReproParsedCounts` has no achievements count at all
+  // (deliberately — widening it is out of scope for #469), so emptiness is a
+  // derived bit. Non-bullet lines in the region are the header-shaped
+  // lower-bound oracle for the entry count.
+  "achievementsParsedEmpty",
+  "achievementsEntriesFewerThanHeaderLines",
+
+  // ── probe-roundtrip (the `RL_RT_PDF` block of corpus-roundtrip.test.ts): the
+  // parse → export → re-parse hop. These are the classic invisible-to-the-
+  // artifact defects: `hasEmail` is `true` on both sides of a hop that mangled
+  // the address. Field granularity mirrors the harness's `contactFails`, which
+  // diffs exactly these five keys.
+  //
+  // NOTE the name is `phoneChanged…`, not `phoneDigitsChanged…`: the harness
+  // compares the FORMATTED phone value, so a pure re-formatting also trips it.
+  // Naming it after the digits would over-claim what the bit actually knows.
+  "fullNameChangedAcrossRoundtrip",
+  "emailChangedAcrossRoundtrip",
+  "phoneChangedAcrossRoundtrip",
+  "locationChangedAcrossRoundtrip",
+  "linkedinUrlChangedAcrossRoundtrip",
+  // The harness's remaining diff categories, at its own granularity.
+  "experienceChangedAcrossRoundtrip",
+  "educationChangedAcrossRoundtrip",
+  "skillsChangedAcrossRoundtrip",
+  "summaryChangedAcrossRoundtrip",
+  // Category "render": renderAtsResumePdf threw before any re-parse could run.
+  "renderThrewOnRoundtrip",
+
+  // ── cross-cutting: THE ORACLE-UNAVAILABLE BITS. ────────────────────────────
+  //
+  // ┌──────────────────────────────────────────────────────────────────────────┐
+  // │ THE BUG CLASS THESE THREE BITS EXIST TO KILL — read before adding a key.  │
+  // │                                                                           │
+  // │ Every OTHER key above is computed from some optional/nullable input of    │
+  // │ the parse: `cascade.rawText`, `cascade.markdown`, `cascade.canonical.     │
+  // │ sections`, or the round-trip hop's `after` parse. When that INPUT is      │
+  // │ ABSENT, the key computes to `false` — and `false` there does NOT mean     │
+  // │ "observed absent". It means UNKNOWABLE. A predicate reading it then       │
+  // │ silently does not fire, and the sweep affirmatively reports NO DEFECT     │
+  // │ over a parse whose oracles never ran. A false "clean" is strictly worse   │
+  // │ than no answer: it tells the maintainer to stop looking.                  │
+  // │                                                                           │
+  // │ So each ORACLE — each optional input a family of keys is derived from —   │
+  // │ carries its own `*Unavailable` bit, every `DefectSpec` DECLARES which     │
+  // │ oracles it `requires`, and `exhibits()` is GATED on them (see `spec()`    │
+  // │ below). A class whose oracle is blind is WITHHELD, never guessed, and the │
+  // │ harness prints the withheld list rather than an affirmative "no defects". │
+  // │ Adding a `DerivedSignals` key means answering: what input does it read,   │
+  // │ can that input be absent, and which oracle covers it?                     │
+  // └──────────────────────────────────────────────────────────────────────────┘
+  //
+  // TEXT oracle — the parse produced NO readable text (`triggers` includes
+  // `scanned`, so the cascade short-circuits before Tier 1; or `rawText` is
+  // empty). EVERY key above except the round-trip ones is derived from the
+  // extracted text or from the sections cut out of it, so on such a parse they
+  // are all false because there was nothing to read. This is resumelint's single
+  // most severe failure mode (zero characters extracted) and it must never be
+  // reported as "no defect class is exhibited by this parse".
+  "textOracleUnavailable",
+  // HEADER oracle — `cascade.markdown` is undefined (scanned PDF, or a document
+  // too sparse for `emitMarkdown()`). Both `skillsHeaderCandidateRejected` and
+  // `educationHeaderCandidateRejected` are derived EXCLUSIVELY from markdown
+  // headers, so on such a parse they are false because there was nothing to look
+  // at — NOT because no header was rejected.
+  //
+  // Without this bit, a real rejected skills header on a scanned/sparse PDF
+  // silently degrades to `skills-no-section`, which 9 corpus fixtures exhibit —
+  // so the sweep answers COVERED ("stop, the corpus already reproduces this")
+  // for a defect NO fixture reproduces.
+  "headerOracleUnavailable",
+  // ROUNDTRIP oracle — the hop produced no `after` parse (the model build, the
+  // render, or the re-parse threw). The nine `*ChangedAcrossRoundtrip` bits are
+  // a BEFORE→AFTER comparison, so with no `after` they are all false because
+  // there was nothing to compare — NOT because the values survived. Withholding
+  // the five `roundtrip-*-value-changed` classes is the only honest answer;
+  // `roundtrip-render-crash` (the observed fact) still fires.
+  "roundtripOracleUnavailable",
+] as const;
+
+export type DerivedSignalKey = (typeof DERIVED_SIGNAL_KEYS)[number];
+
+/**
+ * The flat, BOOLEAN-ONLY bag of value-level signals.
+ *
+ * A mapped type over `DERIVED_SIGNAL_KEYS`, so there is no syntactic way to add
+ * a `string` member without editing the tuple — which only ever yields booleans.
+ * That is the type-level PII guarantee, and `defect-classes.test.ts` pins it.
+ * See the file header.
+ */
+export type DerivedSignals = { [K in DerivedSignalKey]: boolean };
+
+/** All-false baseline. Callers (the localizers, and every hand-built test
+ *  artifact) start here and flip only what they observed, so a newly-added
+ *  signal defaults to "not observed" rather than to `undefined`. */
+export const EMPTY_DERIVED_SIGNALS: DerivedSignals = Object.freeze(
+  Object.fromEntries(DERIVED_SIGNAL_KEYS.map((k) => [k, false])) as DerivedSignals,
+);
+
+// ── Axis paths ───────────────────────────────────────────────────────────────
+
+/** A `ReproArtifact` axis, named by path. Template-literal-typed off the real
+ *  key sets, so a renamed `ReproParsedCounts` field or `SectionName` member
+ *  breaks every stale axis reference at compile time. */
+export type ArtifactAxis =
+  | "triggers"
+  | "sectionSource"
+  | "pageCount"
+  | "rawCharCount"
+  | "extractedCharCount"
+  | "linkAnnotationCount"
+  | "disagreements"
+  | `sections.${SectionName | "profile"}`
+  | `parsedCounts.${keyof ReproParsedCounts}`;
+
+/** A `DerivedSignals` axis, named by path. */
+export type DerivedAxis = `derived.${DerivedSignalKey}`;
+
+/**
+ * The typed path naming one load-bearing axis of a parse — e.g.
+ * `"sections.skills"`, `"parsedCounts.skillsCount"`,
+ * `"derived.emailChangedAcrossRoundtrip"`.
+ */
+export type AxisPath = ArtifactAxis | DerivedAxis;
+
+/** Line count of a routed section, or 0 when the router never cut one. The
+ *  probes all test `region.length > 0` for "was a region routed", so a section
+ *  present with zero lines reads the same as an absent one — deliberately. */
+export function sectionLineCount(
+  a: ReproArtifact,
+  name: SectionName | "profile",
+): number {
+  return a.sections.find((s) => s.name === name)?.lineCount ?? 0;
+}
+
+// ── The table ────────────────────────────────────────────────────────────────
+
+/**
+ * Every defect class the six probes can localize today. Derived 1:1 from their
+ * verdict strings — see the map in the file header. Do not add a class here
+ * that no probe can emit, and do not drop one a probe can.
+ */
+export const DEFECT_CLASSES = [
+  // probe-contact
+  "contact-email-parser-miss",
+  "contact-phone-parser-miss",
+  "contact-location-parser-miss",
+  // probe-skills
+  "skills-extraction-miss",
+  "skills-header-unrecognized",
+  "skills-no-section",
+  // probe-experience
+  "experience-parser-miss",
+  "experience-under-segmented",
+  // probe-education
+  "education-extraction-miss",
+  "education-header-unrecognized",
+  "education-no-section",
+  "education-under-chunked",
+  // probe-achievements
+  "achievements-parser-miss",
+  "achievements-under-segmented",
+  "achievements-no-section",
+  // probe-roundtrip
+  "roundtrip-contact-value-changed",
+  "roundtrip-experience-value-changed",
+  "roundtrip-education-value-changed",
+  "roundtrip-skills-value-changed",
+  "roundtrip-summary-value-changed",
+  "roundtrip-render-crash",
+] as const;
+
+export type DefectClass = (typeof DEFECT_CLASSES)[number];
+
+// ── Oracles ──────────────────────────────────────────────────────────────────
+
+/**
+ * The three optional INPUTS every derived signal is read from — see the
+ * `DERIVED_SIGNAL_KEYS` header for the bug class this models. Each has exactly
+ * one `*Unavailable` bit, and every `DefectSpec` declares the oracles its
+ * verdict depends on.
+ */
+export const ORACLES = ["text", "header", "roundtrip"] as const;
+
+export type Oracle = (typeof ORACLES)[number];
+
+/** The `DerivedSignals` bit that says an oracle could not run. Total over
+ *  `Oracle`, so a new oracle cannot be added without its bit. */
+export const ORACLE_UNAVAILABLE_KEY: Readonly<Record<Oracle, DerivedSignalKey>> = {
+  text: "textOracleUnavailable",
+  header: "headerOracleUnavailable",
+  roundtrip: "roundtripOracleUnavailable",
+};
+
+/** True when this parse could not run the named oracle. Module-internal: the
+ *  gate (`spec()`) and the withheld-reporting helpers below are the only callers,
+ *  which is the point — no consumer gets to re-implement the gate. */
+function oracleUnavailable(o: Oracle, d: DerivedSignals): boolean {
+  return d[ORACLE_UNAVAILABLE_KEY[o]];
+}
+
+export interface DefectSpec {
+  class: DefectClass;
+  /** The probe whose verdict this class names. */
+  probe: ProbeId;
+  /**
+   * ADVISORY — "this résumé has no <section>", not "the parser broke".
+   *
+   * The three `*-no-section` classes are in the table because #469's acceptance
+   * criterion demands one entry per probe verdict, and because a MISSING section
+   * is worth telling the maintainer about ("did a block get mis-routed?"). But
+   * they are NOT defects: 34 of the 45 fixtures parse zero achievements, 9 carry
+   * no skills section, 2 no education — because those résumés genuinely have
+   * none. The probe's own verdict text admits it ("the résumé may carry none").
+   *
+   * Left as ordinary defects, they fire on nearly every résumé, get trivially
+   * "covered" by the corpus, and INFLATE `COVERAGE n/m` — the single most
+   * important number the sweep prints. So the sweep excludes advisory classes
+   * from `DEFECTS FOUND` and from the coverage ratio, and prints them in a
+   * separate INFORMATIONAL block instead. The signal is kept; the headline
+   * number stops lying.
+   */
+  advisory?: true;
+  /**
+   * The oracles this class's verdict DEPENDS ON. If any of them could not run on
+   * a parse, the class is UNDECIDABLE there: `exhibits()` returns false, but that
+   * false means WITHHELD, not "observed clean" — `isWithheld()` / `withheldClasses()`
+   * report it, and the sweep prints it instead of an affirmative "no defects".
+   */
+  requires: readonly Oracle[];
+  /**
+   * Which axes are load-bearing for THIS class — i.e. exactly the axes
+   * `exhibits()` reads. Divergence on any OTHER axis (a different `pageCount`,
+   * an extra layout trigger) is informational, never disqualifying: a fixture
+   * that reproduces the defect is a valid reproducer even if it is a different
+   * résumé in every other respect.
+   *
+   * The `derived.*OracleUnavailable` axis of each required oracle is APPENDED
+   * automatically by `spec()` — `exhibits()` reads it, so it is load-bearing by
+   * construction and cannot drift out of this list.
+   */
+  loadBearingAxes: readonly AxisPath[];
+  /**
+   * True when this parse exhibits the defect — AND every oracle it requires
+   * actually ran. Structural classes read the artifact only; value-level classes
+   * read `derived` (see the file header for why `derived` is the escape hatch and
+   * why it is boolean-only).
+   *
+   * The `detect` predicates below mirror each probe's if/else verdict chain,
+   * INCLUDING its branch order — that is what keeps sibling classes mutually
+   * exclusive (e.g. an experience region with 0 entries is
+   * `experience-parser-miss`, never also `experience-under-segmented`, exactly as
+   * the probe reports it).
+   */
+  exhibits(a: ReproArtifact, derived: DerivedSignals): boolean;
+}
+
+/** A table row as written below: `detect` is the raw predicate; `spec()` wraps it
+ *  in the oracle gate and derives the oracle axes. */
+interface DefectSpecInput {
+  class: DefectClass;
+  probe: ProbeId;
+  advisory?: true;
+  requires: readonly Oracle[];
+  loadBearingAxes: readonly AxisPath[];
+  detect(a: ReproArtifact, derived: DerivedSignals): boolean;
+}
+
+/**
+ * The ONE place the oracle gate is applied. Every row in the table below goes
+ * through it, so there is no syntactic way to add a defect class that reads a
+ * blind oracle's `false` as an observation.
+ */
+function spec(input: DefectSpecInput): DefectSpec {
+  const oracleAxes = input.requires.map(
+    (o): AxisPath => `derived.${ORACLE_UNAVAILABLE_KEY[o]}`,
+  );
+  return {
+    class: input.class,
+    probe: input.probe,
+    ...(input.advisory ? { advisory: true as const } : {}),
+    requires: input.requires,
+    loadBearingAxes: [...new Set([...input.loadBearingAxes, ...oracleAxes])],
+    exhibits: (a, d) =>
+      input.requires.every((o) => !oracleUnavailable(o, d)) && input.detect(a, d),
+  };
+}
+
+/**
+ * The class → spec table. `Record<DefectClass, …>` is the gap guard: a class in
+ * `DEFECT_CLASSES` with no entry here is a COMPILE error, and an entry for a
+ * class not in the union is too. `defect-classes.test.ts` pins the same
+ * invariant at runtime (and that the key matches its spec's `class`).
+ */
+export const DEFECT_SPECS: Readonly<Record<DefectClass, DefectSpec>> = {
+  // ── probe-contact ──────────────────────────────────────────────────────────
+  // Verdict per field: empty field + a rawText candidate ⇒ PARSER-MISS. The
+  // `derived` bit already encodes "empty AND in rawText"; the artifact axis is
+  // carried alongside as the structural half of the evidence, and both are
+  // load-bearing so a near-miss report can say WHICH half diverged.
+  //
+  // `requires: ["text"]` — the bit is a re-scan of `cascade.rawText`. On a
+  // scanned PDF rawText is "", so it reads false for EVERY field: unknowable,
+  // not "the field is genuinely absent". Withheld, never guessed.
+  "contact-email-parser-miss": spec({
+    class: "contact-email-parser-miss",
+    probe: "probe-contact",
+    requires: ["text"],
+    loadBearingAxes: ["parsedCounts.hasEmail", "derived.emailInRawTextButNotParsed"],
+    detect: (a, d) => !a.parsedCounts.hasEmail && d.emailInRawTextButNotParsed,
+  }),
+  "contact-phone-parser-miss": spec({
+    class: "contact-phone-parser-miss",
+    probe: "probe-contact",
+    requires: ["text"],
+    loadBearingAxes: ["parsedCounts.hasPhone", "derived.phoneInRawTextButNotParsed"],
+    detect: (a, d) => !a.parsedCounts.hasPhone && d.phoneInRawTextButNotParsed,
+  }),
+  "contact-location-parser-miss": spec({
+    class: "contact-location-parser-miss",
+    probe: "probe-contact",
+    requires: ["text"],
+    loadBearingAxes: [
+      "parsedCounts.hasLocation",
+      "derived.locationInRawTextButNotParsed",
+    ],
+    detect: (a, d) => !a.parsedCounts.hasLocation && d.locationInRawTextButNotParsed,
+  }),
+
+  // ── probe-skills ───────────────────────────────────────────────────────────
+  // The probe's chain: skills > 0 → ok; else region routed → EXTRACTION-MISS;
+  // else a rejected skills-like header → HEADER-UNRECOGNIZED; else
+  // NO-SKILLS-SECTION. The three defect branches are mutually exclusive by the
+  // region/header split, which is reproduced exactly here. Note that
+  // HEADER-UNRECOGNIZED and NO-SKILLS-SECTION are STRUCTURALLY IDENTICAL in the
+  // artifact (0 skills, no routed region) — `skillsHeaderCandidateRejected` is
+  // the only thing that tells them apart, which is precisely why it exists, and
+  // why BOTH require the header oracle.
+  "skills-extraction-miss": spec({
+    class: "skills-extraction-miss",
+    probe: "probe-skills",
+    requires: ["text"],
+    loadBearingAxes: ["parsedCounts.skillsCount", "sections.skills"],
+    detect: (a) => a.parsedCounts.skillsCount === 0 && sectionLineCount(a, "skills") > 0,
+  }),
+  "skills-header-unrecognized": spec({
+    class: "skills-header-unrecognized",
+    probe: "probe-skills",
+    requires: ["text", "header"],
+    loadBearingAxes: [
+      "parsedCounts.skillsCount",
+      "sections.skills",
+      "derived.skillsHeaderCandidateRejected",
+    ],
+    detect: (a, d) =>
+      a.parsedCounts.skillsCount === 0 &&
+      sectionLineCount(a, "skills") === 0 &&
+      d.skillsHeaderCandidateRejected,
+  }),
+  // ADVISORY (see `DefectSpec.advisory`): "the résumé has no skills section".
+  // Requires the header oracle — on a scanned/sparse parse the router rejection
+  // is unobservable, so this class and `skills-header-unrecognized` are
+  // indistinguishable and NEITHER may fire.
+  "skills-no-section": spec({
+    class: "skills-no-section",
+    probe: "probe-skills",
+    advisory: true,
+    requires: ["text", "header"],
+    loadBearingAxes: [
+      "parsedCounts.skillsCount",
+      "sections.skills",
+      "derived.skillsHeaderCandidateRejected",
+    ],
+    detect: (a, d) =>
+      a.parsedCounts.skillsCount === 0 &&
+      sectionLineCount(a, "skills") === 0 &&
+      !d.skillsHeaderCandidateRejected,
+  }),
+
+  // ── probe-experience ───────────────────────────────────────────────────────
+  // The probe's chain: 0 entries AND the region holds date-range lines →
+  // PARSER-MISS; else entries < date-range lines → UNDER-SEGMENTED; else ok.
+  // A region that yields 0 entries and holds NO date-range lines is "ok" to the
+  // probe (nothing says a role was there), so the artifact's
+  // `experienceCount === 0 && lineCount > 0` alone would over-report — hence
+  // `experienceRegionHasDateRangeLines` rather than a section axis.
+  //
+  // Branch order matters: with 0 entries and N > 0 date-range lines BOTH
+  // predicates would read true, so `experience-under-segmented` additionally
+  // requires `experienceCount > 0`, reproducing the probe's `else if`.
+  "experience-parser-miss": spec({
+    class: "experience-parser-miss",
+    probe: "probe-experience",
+    requires: ["text"],
+    loadBearingAxes: [
+      "parsedCounts.experienceCount",
+      "derived.experienceRegionHasDateRangeLines",
+    ],
+    detect: (a, d) =>
+      a.parsedCounts.experienceCount === 0 && d.experienceRegionHasDateRangeLines,
+  }),
+  "experience-under-segmented": spec({
+    class: "experience-under-segmented",
+    probe: "probe-experience",
+    requires: ["text"],
+    loadBearingAxes: [
+      "parsedCounts.experienceCount",
+      "derived.experienceEntriesFewerThanDateRangeLines",
+    ],
+    detect: (a, d) =>
+      a.parsedCounts.experienceCount > 0 && d.experienceEntriesFewerThanDateRangeLines,
+  }),
+
+  // ── probe-education ────────────────────────────────────────────────────────
+  // The probe's chain: 0 entries AND region routed → EXTRACTION-MISS; else
+  // 0 entries AND a rejected education-like header → HEADER-UNRECOGNIZED; else
+  // 0 entries → NO-EDUCATION-SECTION; else more DEGREE_RE tokens in the region
+  // than entries → UNDER-CHUNKED; else ok. Same structural-blindness split as
+  // skills for the header case.
+  "education-extraction-miss": spec({
+    class: "education-extraction-miss",
+    probe: "probe-education",
+    requires: ["text"],
+    loadBearingAxes: ["parsedCounts.educationCount", "sections.education"],
+    detect: (a) =>
+      a.parsedCounts.educationCount === 0 && sectionLineCount(a, "education") > 0,
+  }),
+  "education-header-unrecognized": spec({
+    class: "education-header-unrecognized",
+    probe: "probe-education",
+    requires: ["text", "header"],
+    loadBearingAxes: [
+      "parsedCounts.educationCount",
+      "sections.education",
+      "derived.educationHeaderCandidateRejected",
+    ],
+    detect: (a, d) =>
+      a.parsedCounts.educationCount === 0 &&
+      sectionLineCount(a, "education") === 0 &&
+      d.educationHeaderCandidateRejected,
+  }),
+  // ADVISORY, and header-oracle-gated — same reasoning as `skills-no-section`.
+  "education-no-section": spec({
+    class: "education-no-section",
+    probe: "probe-education",
+    advisory: true,
+    requires: ["text", "header"],
+    loadBearingAxes: [
+      "parsedCounts.educationCount",
+      "sections.education",
+      "derived.educationHeaderCandidateRejected",
+    ],
+    detect: (a, d) =>
+      a.parsedCounts.educationCount === 0 &&
+      sectionLineCount(a, "education") === 0 &&
+      !d.educationHeaderCandidateRejected,
+  }),
+  "education-under-chunked": spec({
+    class: "education-under-chunked",
+    probe: "probe-education",
+    requires: ["text"],
+    loadBearingAxes: [
+      "parsedCounts.educationCount",
+      "derived.educationEntriesFewerThanDegreeTokens",
+    ],
+    // `educationCount > 0` reproduces the probe's `else if` position: the
+    // 0-entry cases are all claimed by the three branches above.
+    detect: (a, d) =>
+      a.parsedCounts.educationCount > 0 && d.educationEntriesFewerThanDegreeTokens,
+  }),
+
+  // ── probe-achievements ─────────────────────────────────────────────────────
+  // The probe's chain: 0 entries AND a non-empty region → PARSER-MISS; else
+  // entries < header-shaped lines → UNDER-SEGMENTED; else 0 entries AND no
+  // region → "no achievements region segmented"; else ok. `ReproParsedCounts`
+  // carries no achievements count, so emptiness is the derived bit; the region
+  // IS an artifact axis (`sections.achievements`).
+  //
+  // Header-shaped lines are a SUBSET of the region's lines, so
+  // `entries < headerLines` implies a non-empty region; combined with the
+  // probe's branch order that leaves UNDER-SEGMENTED reachable only when
+  // entries > 0 — hence the `!achievementsParsedEmpty` guard.
+  "achievements-parser-miss": spec({
+    class: "achievements-parser-miss",
+    probe: "probe-achievements",
+    requires: ["text"],
+    loadBearingAxes: ["sections.achievements", "derived.achievementsParsedEmpty"],
+    detect: (a, d) =>
+      d.achievementsParsedEmpty && sectionLineCount(a, "achievements") > 0,
+  }),
+  "achievements-under-segmented": spec({
+    class: "achievements-under-segmented",
+    probe: "probe-achievements",
+    requires: ["text"],
+    loadBearingAxes: [
+      "derived.achievementsParsedEmpty",
+      "derived.achievementsEntriesFewerThanHeaderLines",
+    ],
+    detect: (_a, d) =>
+      !d.achievementsParsedEmpty && d.achievementsEntriesFewerThanHeaderLines,
+  }),
+  // ADVISORY (see `DefectSpec.advisory`): 34 of 45 fixtures parse zero
+  // achievements. "This résumé has no Awards section" is not a parser defect.
+  // No HEADER oracle: achievements has no rejected-header class to be confused
+  // with — the section router is the only path. It does require the TEXT oracle:
+  // on a parse with no text there is trivially "no achievements region", which
+  // says nothing about the résumé.
+  "achievements-no-section": spec({
+    class: "achievements-no-section",
+    probe: "probe-achievements",
+    advisory: true,
+    requires: ["text"],
+    loadBearingAxes: ["sections.achievements", "derived.achievementsParsedEmpty"],
+    detect: (a, d) =>
+      d.achievementsParsedEmpty && sectionLineCount(a, "achievements") === 0,
+  }),
+
+  // ── probe-roundtrip ────────────────────────────────────────────────────────
+  // Value-level by definition: the parse → export → re-parse hop corrupts VALUES
+  // while leaving the structure identical, so `ReproArtifact` is blind to all
+  // six of these. Two fixtures with byte-identical artifacts are distinguished
+  // here, and only here, by the derived bits.
+  //
+  // All five value classes require BOTH oracles: with no `after` parse there is
+  // nothing to diff (every `*ChangedAcrossRoundtrip` bit is false because the
+  // comparison never happened), and with no extracted text the "before" side is
+  // empty, so "nothing changed" is vacuous rather than reassuring.
+  "roundtrip-contact-value-changed": spec({
+    class: "roundtrip-contact-value-changed",
+    probe: "probe-roundtrip",
+    requires: ["text", "roundtrip"],
+    // The five keys the harness's `contactFails` diffs.
+    loadBearingAxes: [
+      "derived.fullNameChangedAcrossRoundtrip",
+      "derived.emailChangedAcrossRoundtrip",
+      "derived.phoneChangedAcrossRoundtrip",
+      "derived.locationChangedAcrossRoundtrip",
+      "derived.linkedinUrlChangedAcrossRoundtrip",
+    ],
+    detect: (_a, d) =>
+      d.fullNameChangedAcrossRoundtrip ||
+      d.emailChangedAcrossRoundtrip ||
+      d.phoneChangedAcrossRoundtrip ||
+      d.locationChangedAcrossRoundtrip ||
+      d.linkedinUrlChangedAcrossRoundtrip,
+  }),
+  "roundtrip-experience-value-changed": spec({
+    class: "roundtrip-experience-value-changed",
+    probe: "probe-roundtrip",
+    requires: ["text", "roundtrip"],
+    loadBearingAxes: ["derived.experienceChangedAcrossRoundtrip"],
+    detect: (_a, d) => d.experienceChangedAcrossRoundtrip,
+  }),
+  "roundtrip-education-value-changed": spec({
+    class: "roundtrip-education-value-changed",
+    probe: "probe-roundtrip",
+    requires: ["text", "roundtrip"],
+    loadBearingAxes: ["derived.educationChangedAcrossRoundtrip"],
+    detect: (_a, d) => d.educationChangedAcrossRoundtrip,
+  }),
+  "roundtrip-skills-value-changed": spec({
+    class: "roundtrip-skills-value-changed",
+    probe: "probe-roundtrip",
+    requires: ["text", "roundtrip"],
+    loadBearingAxes: ["derived.skillsChangedAcrossRoundtrip"],
+    detect: (_a, d) => d.skillsChangedAcrossRoundtrip,
+  }),
+  "roundtrip-summary-value-changed": spec({
+    class: "roundtrip-summary-value-changed",
+    probe: "probe-roundtrip",
+    requires: ["text", "roundtrip"],
+    loadBearingAxes: ["derived.summaryChangedAcrossRoundtrip"],
+    detect: (_a, d) => d.summaryChangedAcrossRoundtrip,
+  }),
+  // The one class that requires NOTHING: `renderThrewOnRoundtrip` is an OBSERVED
+  // fact about the hop, not a comparison across it. It is exactly what the
+  // roundtrip oracle being unavailable MEANS, so gating it on that oracle would
+  // make the class unreachable.
+  "roundtrip-render-crash": spec({
+    class: "roundtrip-render-crash",
+    probe: "probe-roundtrip",
+    requires: [],
+    loadBearingAxes: ["derived.renderThrewOnRoundtrip"],
+    detect: (_a, d) => d.renderThrewOnRoundtrip,
+  }),
+};
+
+/**
+ * The spec for a class. Total over `DefectClass` by the `Record` above, so this
+ * never returns `undefined` — a class with no table entry is a compile error,
+ * never a silent gap.
+ */
+export function defectSpec(c: DefectClass): DefectSpec {
+  return DEFECT_SPECS[c];
+}
+
+/** True for a class that is INFORMATIONAL, not a parser defect — see
+ *  `DefectSpec.advisory`. Advisory classes never enter `DEFECTS FOUND` and never
+ *  enter the `COVERAGE n/m` ratio. */
+export function isAdvisory(c: DefectClass): boolean {
+  return DEFECT_SPECS[c].advisory === true;
+}
+
+/** Every class in the table owned by `probe`, in `DEFECT_CLASSES` order. The
+ *  other half of the verdict↔class pin: `defect-classes.test.ts` asserts this
+ *  equals each localizer's declared `*_DEFECT_CLASSES` tuple, so a class added
+ *  to the table with no localizer branch — or a branch for a class not in the
+ *  table — is a test failure, not a silent gap. */
+export function defectClassesForProbe(probe: ProbeId): DefectClass[] {
+  return DEFECT_CLASSES.filter((c) => DEFECT_SPECS[c].probe === probe);
+}
+
+/** Every class the given parse exhibits, in `DEFECT_CLASSES` order.
+ *
+ *  A class this OMITS is either "not exhibited" or "WITHHELD — its oracle could
+ *  not run" (`withheldClasses`). The two are NOT the same, and no consumer may
+ *  read the absence of a withheld class as a clean bill of health. */
+export function exhibitedDefects(
+  a: ReproArtifact,
+  derived: DerivedSignals,
+): DefectClass[] {
+  return DEFECT_CLASSES.filter((c) => DEFECT_SPECS[c].exhibits(a, derived));
+}
+
+/** The oracles this class requires that could NOT run on this parse. Non-empty ⇒
+ *  the class's verdict is UNDECIDABLE here — withheld, not "clean". */
+export function withheldOracles(c: DefectClass, derived: DerivedSignals): Oracle[] {
+  return DEFECT_SPECS[c].requires.filter((o) => oracleUnavailable(o, derived));
+}
+
+/** True when this parse cannot decide the class either way. */
+export function isWithheld(c: DefectClass, derived: DerivedSignals): boolean {
+  return withheldOracles(c, derived).length > 0;
+}
+
+/**
+ * Every class this parse could NOT evaluate, in `DEFECT_CLASSES` order.
+ *
+ * This is the list a harness MUST print instead of an affirmative "no defect
+ * class is exhibited by this parse". `exhibitedDefects()` returning `[]` means
+ * "clean" ONLY when this returns `[]` too.
+ */
+export function withheldClasses(derived: DerivedSignals): DefectClass[] {
+  return DEFECT_CLASSES.filter((c) => isWithheld(c, derived));
+}
+
+/** The oracles that could not run on this parse, in `ORACLES` order. */
+export function unavailableOracles(derived: DerivedSignals): Oracle[] {
+  return ORACLES.filter((o) => oracleUnavailable(o, derived));
+}

--- a/src/lib/heuristics/fixture-match.test.ts
+++ b/src/lib/heuristics/fixture-match.test.ts
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * `matchCorpus()` unit tests — hand-built artifacts only, NO PDF I/O.
+ *
+ * The load-bearing one is `"distinguishes two fixtures with deep-equal
+ * ReproArtifacts by a DerivedSignals boolean alone"` (issue #469's stated
+ * acceptance criterion): it proves the engine cannot be shortcut into
+ * "same artifact ⇒ same defect", which is the exact failure that would make a
+ * value-level (round-trip) defect look covered by a fixture that parses fine.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFECT_CLASSES,
+  EMPTY_DERIVED_SIGNALS,
+  type DefectClass,
+  type DerivedSignals,
+} from "./defect-classes.ts";
+import { CASCADE_VERSION } from "./types.ts";
+import { REPRO_ARTIFACT_VERSION, type ReproArtifact } from "./repro-artifact.ts";
+import {
+  NEAR_MISS_LIMIT,
+  divergedAxes,
+  matchCorpus,
+  type CorpusEntry,
+} from "./fixture-match.ts";
+
+// ── Builders ─────────────────────────────────────────────────────────────────
+
+function artifact(over: Partial<ReproArtifact> = {}): ReproArtifact {
+  return {
+    artifactVersion: REPRO_ARTIFACT_VERSION,
+    cascadeVersion: CASCADE_VERSION,
+    triggers: [],
+    sectionSource: "regex",
+    pageCount: 1,
+    rawCharCount: 2000,
+    extractedCharCount: 1800,
+    sections: [],
+    parsedCounts: {
+      hasFullName: true,
+      hasEmail: true,
+      hasPhone: true,
+      hasLocation: true,
+      hasSummary: true,
+      experienceCount: 3,
+      educationCount: 1,
+      skillsCount: 8,
+    },
+    linkAnnotationCount: 0,
+    disagreements: [],
+    ...over,
+  };
+}
+
+function derived(over: Partial<DerivedSignals> = {}): DerivedSignals {
+  return { ...EMPTY_DERIVED_SIGNALS, ...over };
+}
+
+function entry(
+  path: string,
+  a: ReproArtifact,
+  d: DerivedSignals = derived(),
+): CorpusEntry {
+  return { path, artifact: a, derived: d };
+}
+
+// A parse that exhibits NO defect class at all — the "healthy" baseline. Every
+// section is routed and every count is non-zero, so no `exhibits()` fires.
+const HEALTHY = artifact({
+  sections: [
+    { name: "skills", lineCount: 4 },
+    { name: "experience", lineCount: 20 },
+    { name: "education", lineCount: 5 },
+    { name: "achievements", lineCount: 3 },
+  ],
+});
+
+// ── The acceptance test ──────────────────────────────────────────────────────
+
+describe("matchCorpus — value-level defects (the DerivedSignals escape hatch)", () => {
+  it("distinguishes two fixtures with deep-equal ReproArtifacts by a DerivedSignals boolean alone", () => {
+    // Both fixtures parse to the SAME structure. A round-trip corruption is
+    // invisible to ReproArtifact by construction: hasEmail is `true` on both
+    // sides of a hop that mangled the address.
+    const shared = artifact({ sections: [{ name: "skills", lineCount: 4 }] });
+    const corrupting = entry(
+      "tests/fixtures/pdfs/word/a.pdf",
+      shared,
+      derived({ emailChangedAcrossRoundtrip: true }),
+    );
+    const clean = entry("tests/fixtures/pdfs/word/b.pdf", shared, derived());
+
+    // Pin the premise: the two artifacts really are indistinguishable.
+    expect(corrupting.artifact).toEqual(clean.artifact);
+
+    const [cov] = matchCorpus(
+      shared,
+      derived({ emailChangedAcrossRoundtrip: true }),
+      ["roundtrip-contact-value-changed"],
+      [corrupting, clean],
+    );
+
+    expect(cov.class).toBe("roundtrip-contact-value-changed");
+    expect(cov.coveredBy).toEqual(["tests/fixtures/pdfs/word/a.pdf"]);
+    expect(cov.nearMisses).toEqual([]);
+    expect(cov.nearMissCandidateCount).toBe(0);
+  });
+
+  it("separates the structurally-identical skills header pair by the derived bit", () => {
+    // skills-header-unrecognized and skills-no-section are BYTE-IDENTICAL in the
+    // artifact (0 skills, no routed region). Only the derived bit tells them apart.
+    const a = artifact({ parsedCounts: { ...HEALTHY.parsedCounts, skillsCount: 0 } });
+    const rejected = entry("f/rejected.pdf", a, derived({ skillsHeaderCandidateRejected: true }));
+    const genuinelyNone = entry("f/none.pdf", a, derived());
+
+    const corpus = [rejected, genuinelyNone];
+    const real = derived({ skillsHeaderCandidateRejected: true });
+
+    const [header, none] = matchCorpus(
+      a,
+      real,
+      ["skills-no-section", "skills-header-unrecognized"],
+      corpus,
+    );
+
+    // Output order follows DEFECT_CLASSES, not the caller's argument order.
+    expect(header.class).toBe("skills-header-unrecognized");
+    expect(header.coveredBy).toEqual(["f/rejected.pdf"]);
+    expect(none.class).toBe("skills-no-section");
+    expect(none.coveredBy).toEqual(["f/none.pdf"]);
+  });
+});
+
+// ── Coverage semantics ───────────────────────────────────────────────────────
+
+describe("matchCorpus — coverage", () => {
+  it("does NOT let a non-load-bearing axis diverge a fixture out of a cover", () => {
+    // The fixture exhibits skills-extraction-miss (0 skills parsed from a routed
+    // region) but differs from the résumé on every axis that is NOT load-bearing
+    // for that class: pages, char counts, triggers, splitter, links, other
+    // sections, every other parsed count. It is still a valid reproducer.
+    const real = artifact({
+      sections: [{ name: "skills", lineCount: 4 }],
+      parsedCounts: { ...HEALTHY.parsedCounts, skillsCount: 0 },
+    });
+    const wildlyDifferent = artifact({
+      triggers: ["two_column"],
+      sectionSource: "markdown",
+      pageCount: 3,
+      rawCharCount: 99_999,
+      extractedCharCount: 12,
+      linkAnnotationCount: 7,
+      disagreements: [{ kind: "missing_field", field: "email" }],
+      sections: [
+        { name: "skills", lineCount: 40 }, // load-bearing, but only as ">0"
+        { name: "experience", lineCount: 1 },
+      ],
+      parsedCounts: {
+        hasFullName: false,
+        hasEmail: false,
+        hasPhone: false,
+        hasLocation: false,
+        hasSummary: false,
+        experienceCount: 0,
+        educationCount: 0,
+        skillsCount: 0, // load-bearing
+      },
+    });
+
+    const [cov] = matchCorpus(
+      real,
+      derived(),
+      ["skills-extraction-miss"],
+      [entry("f/wild.pdf", wildlyDifferent)],
+    );
+
+    expect(cov.coveredBy).toEqual(["f/wild.pdf"]);
+    expect(cov.nearMisses).toEqual([]);
+  });
+
+  it("reports every covering fixture, in corpus order, de-duplicated", () => {
+    const miss = artifact({
+      sections: [{ name: "skills", lineCount: 4 }],
+      parsedCounts: { ...HEALTHY.parsedCounts, skillsCount: 0 },
+    });
+
+    const [cov] = matchCorpus(
+      miss,
+      derived(),
+      ["skills-extraction-miss"],
+      [
+        entry("f/z.pdf", miss),
+        entry("f/healthy.pdf", HEALTHY),
+        entry("f/a.pdf", miss),
+        entry("f/z.pdf", miss), // duplicate path
+      ],
+    );
+
+    expect(cov.coveredBy).toEqual(["f/z.pdf", "f/a.pdf"]);
+  });
+
+  it("returns one entry per DISTINCT class, in DEFECT_CLASSES order", () => {
+    const all = [...DEFECT_CLASSES];
+    const asked: DefectClass[] = [...all].reverse().concat(all);
+
+    const out = matchCorpus(HEALTHY, derived(), asked, []);
+
+    expect(out.map((c) => c.class)).toEqual(all);
+  });
+});
+
+// ── Near misses ──────────────────────────────────────────────────────────────
+
+describe("matchCorpus — near misses", () => {
+  // Résumé: skills header rejected by the strict router.
+  const real = artifact({ parsedCounts: { ...HEALTHY.parsedCounts, skillsCount: 0 } });
+  const realDerived = derived({ skillsHeaderCandidateRejected: true });
+  const CLS: DefectClass = "skills-header-unrecognized";
+  // loadBearingAxes: parsedCounts.skillsCount, sections.skills,
+  //                  derived.skillsHeaderCandidateRejected
+
+  it("populates near misses, ranked closest-first, when nothing covers", () => {
+    // 1 axis diverges: same 0-count + no region, but its header was recognized.
+    const oneAxis = entry("f/one.pdf", real, derived());
+    // 3 axes diverge: parses skills fine, from a routed region, header accepted.
+    const threeAxes = entry("f/three.pdf", HEALTHY, derived());
+
+    const [cov] = matchCorpus(real, realDerived, [CLS], [threeAxes, oneAxis]);
+
+    expect(cov.coveredBy).toEqual([]);
+    expect(cov.nearMisses).toEqual([
+      { fixture: "f/one.pdf", divergedAxes: ["derived.skillsHeaderCandidateRejected"] },
+      {
+        fixture: "f/three.pdf",
+        divergedAxes: [
+          "parsedCounts.skillsCount",
+          "sections.skills",
+          "derived.skillsHeaderCandidateRejected",
+        ],
+      },
+    ]);
+    expect(cov.nearMissCandidateCount).toBe(2);
+  });
+
+  it("caps the list but never truncates silently — nearMissCandidateCount stays whole", () => {
+    const corpus = ["e", "d", "c", "b", "a"].map((n) => entry(`f/${n}.pdf`, HEALTHY));
+
+    const [cov] = matchCorpus(real, realDerived, [CLS], corpus);
+
+    expect(cov.nearMisses).toHaveLength(NEAR_MISS_LIMIT);
+    expect(cov.nearMissCandidateCount).toBe(5);
+    // All five diverge equally (3 axes), so the tie-break is path-ascending —
+    // NOT corpus arrival order, which is the reverse.
+    expect(cov.nearMisses.map((m) => m.fixture)).toEqual([
+      "f/a.pdf",
+      "f/b.pdf",
+      "f/c.pdf",
+    ]);
+  });
+
+  it("emits an empty divergedAxes when a fixture matches every load-bearing axis yet does not exhibit the class", () => {
+    // Only reachable when the RÉSUMÉ does not exhibit the class either (the
+    // caller asked about a class it never found) — a real, reportable signal.
+    const [cov] = matchCorpus(HEALTHY, derived(), [CLS], [entry("f/twin.pdf", HEALTHY)]);
+
+    expect(cov.coveredBy).toEqual([]);
+    expect(cov.nearMisses).toEqual([{ fixture: "f/twin.pdf", divergedAxes: [] }]);
+  });
+
+  it("is empty when the corpus is empty", () => {
+    const [cov] = matchCorpus(real, realDerived, [CLS], []);
+
+    expect(cov).toEqual({
+      class: CLS,
+      coveredBy: [],
+      nearMisses: [],
+      nearMissCandidateCount: 0,
+    });
+  });
+});
+
+// ── Degenerate inputs ────────────────────────────────────────────────────────
+
+describe("matchCorpus — degenerate inputs", () => {
+  it("returns [] for an empty defect list, however large the corpus", () => {
+    expect(matchCorpus(HEALTHY, derived(), [], [entry("f/a.pdf", HEALTHY)])).toEqual([]);
+  });
+
+  it("returns [] for an empty defect list AND an empty corpus", () => {
+    expect(matchCorpus(HEALTHY, derived(), [], [])).toEqual([]);
+  });
+
+  it("does not mutate its inputs", () => {
+    const a = artifact({ triggers: ["two_column", "scanned"] });
+    const snapshot = structuredClone(a);
+    const corpus = [entry("f/a.pdf", a)];
+
+    matchCorpus(a, derived(), [...DEFECT_CLASSES], corpus);
+
+    expect(a).toEqual(snapshot);
+    expect(corpus.map((c) => c.path)).toEqual(["f/a.pdf"]);
+  });
+});
+
+// ── Axis comparison ──────────────────────────────────────────────────────────
+
+describe("divergedAxes", () => {
+  const d = derived();
+
+  it("compares array axes as order-insensitive multisets", () => {
+    const x = artifact({ triggers: ["two_column", "scanned"] });
+    const y = artifact({ triggers: ["scanned", "two_column"] });
+
+    expect(divergedAxes(x, d, y, d, ["triggers"])).toEqual([]);
+  });
+
+  it("still sees a genuine array-axis difference (cardinality is preserved)", () => {
+    const one = artifact({ triggers: ["scanned"] });
+    const twice = artifact({ triggers: ["scanned", "scanned"] });
+    const other = artifact({ triggers: ["two_column"] });
+
+    expect(divergedAxes(one, d, twice, d, ["triggers"])).toEqual(["triggers"]);
+    expect(divergedAxes(one, d, other, d, ["triggers"])).toEqual(["triggers"]);
+  });
+
+  it("compares disagreements order-insensitively, on kind/field/cause", () => {
+    const x = artifact({
+      disagreements: [
+        { kind: "missing_field", field: "email" },
+        { kind: "merged_roles", field: "experience", likelyCause: "two_column" },
+      ],
+    });
+    const reordered = artifact({ disagreements: [...x.disagreements].reverse() });
+    const causeDiffers = artifact({
+      disagreements: [
+        { kind: "missing_field", field: "email" },
+        { kind: "merged_roles", field: "experience", likelyCause: "scanned" },
+      ],
+    });
+
+    expect(divergedAxes(x, d, reordered, d, ["disagreements"])).toEqual([]);
+    expect(divergedAxes(x, d, causeDiffers, d, ["disagreements"])).toEqual([
+      "disagreements",
+    ]);
+  });
+
+  it("treats an unrouted section and a zero-line section as the same value", () => {
+    const absent = artifact({ sections: [] });
+    const empty = artifact({ sections: [{ name: "skills", lineCount: 0 }] });
+    const routed = artifact({ sections: [{ name: "skills", lineCount: 1 }] });
+
+    expect(divergedAxes(absent, d, empty, d, ["sections.skills"])).toEqual([]);
+    expect(divergedAxes(absent, d, routed, d, ["sections.skills"])).toEqual([
+      "sections.skills",
+    ]);
+  });
+
+  it("reads scalar, parsedCounts, and derived axes", () => {
+    const x = artifact({ pageCount: 1, sectionSource: "regex" });
+    const y = artifact({ pageCount: 2, sectionSource: "markdown" });
+
+    expect(
+      divergedAxes(x, derived({ renderThrewOnRoundtrip: true }), y, d, [
+        "pageCount",
+        "sectionSource",
+        "rawCharCount",
+        "parsedCounts.hasEmail",
+        "parsedCounts.experienceCount",
+        "derived.renderThrewOnRoundtrip",
+        "derived.emailChangedAcrossRoundtrip",
+      ]),
+    ).toEqual(["pageCount", "sectionSource", "derived.renderThrewOnRoundtrip"]);
+  });
+
+  it("returns the diverged axes in the order they were declared", () => {
+    const x = artifact({ pageCount: 1, linkAnnotationCount: 0 });
+    const y = artifact({ pageCount: 2, linkAnnotationCount: 5 });
+
+    expect(divergedAxes(x, d, y, d, ["linkAnnotationCount", "pageCount"])).toEqual([
+      "linkAnnotationCount",
+      "pageCount",
+    ]);
+  });
+});

--- a/src/lib/heuristics/fixture-match.ts
+++ b/src/lib/heuristics/fixture-match.ts
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The corpus-match engine (issue #469, step 3).
+ *
+ * Answers the one question the six read-only parser probes cannot:
+ *
+ *   > This real résumé exposes defect class C. **Does any fixture in
+ *   > `tests/fixtures/pdfs/` already reproduce C?**
+ *
+ * `COVERED` means STOP: go fix the parser against the existing fixture and never
+ * open the real résumé again. `NO FIXTURE COVERS THIS` is the only answer that
+ * justifies minting a new synthetic fixture.
+ *
+ * Pure, lib-layer, NO I/O — same discipline as `repro-artifact.ts`. It reads only
+ * `ReproArtifact` + `DerivedSignals`, both PII-free by construction (numbers,
+ * booleans, fixed enums; no free-form `string` slot), so nothing this file
+ * touches can carry a résumé value. See `defect-classes.ts`'s header.
+ *
+ * ── The four semantics that make this correct rather than merely plausible ──
+ *
+ * **1. Coverage is `exhibits()`, NOT artifact similarity.**
+ * A fixture covers class C iff `defectSpec(C).exhibits(fixtureArtifact,
+ * fixtureDerived)` is true. Full stop. It is NOT "the fixture's artifact looks
+ * like the résumé's artifact". Those come apart constantly, and conflating them
+ * is the failure mode that makes the whole tool worse than useless:
+ *
+ *   - Divergence on an axis OUTSIDE `spec.loadBearingAxes` (a different
+ *     `pageCount`, an extra layout trigger, a shorter `experience` section) is
+ *     INFORMATIONAL and must NEVER disqualify a cover. A one-page LaTeX fixture
+ *     is a perfectly good reproducer for a defect a three-page Word résumé
+ *     exposed, provided it exhibits the same class. Ranking a candidate by
+ *     whole-artifact distance would silently reject it.
+ *   - Conversely, near-identical artifacts do NOT imply coverage. See (2).
+ *
+ * Because `exhibits()` is a pure function of the load-bearing axes, this also
+ * means: if a fixture's load-bearing axis VALUES all equal the résumé's, and the
+ * résumé exhibits C, the fixture necessarily exhibits C too. That identity is
+ * why `nearMisses` (below) is a meaningful "why not" and not a rationalization.
+ *
+ * **2. Structurally-identical fixtures are separated by `derived` alone.**
+ * `skills-header-unrecognized` and `skills-no-section` are BYTE-IDENTICAL in
+ * `ReproArtifact` (0 skills parsed, no routed `skills` section — a rejected
+ * header leaves no structural trace). The same holds for the education pair, and
+ * for ALL SIX round-trip classes, whose entire domain is "the value changed while
+ * the structure did not". So the engine may never shortcut a comparison to "same
+ * artifact ⇒ same defect": it must run `exhibits()` over BOTH inputs, every time.
+ * `fixture-match.test.ts` pins exactly that with two fixtures whose
+ * `ReproArtifact`s are deep-equal and whose verdicts differ.
+ *
+ * **3. `nearMisses` is the "why not", and only exists when there is no cover.**
+ * Computed only for classes with `coveredBy.length === 0` — when a cover exists
+ * the near-miss is noise, and the caller's next action ("go use that fixture") is
+ * already decided. Candidates are every corpus fixture (none of which covers, by
+ * construction), ranked by how few of the CLASS's load-bearing axes diverge from
+ * the résumé. Non-load-bearing divergence is not counted and not reported: it
+ * cannot be the reason the fixture fails to reproduce, so printing it would bury
+ * the signal.
+ *
+ *   Ranking (total and deterministic — no `Math.random`, no `Date`, no locale):
+ *     a. fewer diverged load-bearing axes first;
+ *     b. ties broken by fixture path, ascending by UTF-16 code unit (`<`, not
+ *        `localeCompare`, whose order is locale-dependent);
+ *     c. remaining ties (duplicate paths) broken by corpus index, ascending.
+ *   Corpus ARRIVAL order therefore cannot change the output — only its content.
+ *
+ *   An empty `divergedAxes` on a near-miss is a real signal, not a bug: it means
+ *   the fixture matches the résumé on every load-bearing axis yet does not
+ *   exhibit the class. Given (1), that can only be (a) the caller passed a class
+ *   the RÉSUMÉ does not exhibit either, or (b) `exhibits()` reads an axis its
+ *   spec forgot to declare load-bearing — a table bug. Both are worth surfacing;
+ *   neither is worth silently hiding.
+ *
+ *   The list is capped at `NEAR_MISS_LIMIT`. The cap is VISIBLE, never a silent
+ *   truncation: `nearMissCandidateCount` always reports how many candidates were
+ *   ranked, so a printer can say "showing 3 of 41".
+ *
+ * **4. Array axes compare ORDER-INSENSITIVELY; absent ≡ zero for sections.**
+ * `triggers` and `disagreements` are SETS in meaning — the parser happens to emit
+ * them in a stable order today, but nothing in the type says so, and a reordering
+ * refactor must not spuriously light up a diverged axis. So both are canonicalized
+ * (each element to a stable string, then sorted) before comparison. Cardinality is
+ * preserved (a sorted multiset, not a deduped set), so a doubled trigger still
+ * reads as different. `sections.X` compares LINE COUNTS via `sectionLineCount`,
+ * which returns 0 for a section the router never cut — deliberately conflating
+ * "absent" with "present but empty", exactly as every probe's `region.length > 0`
+ * test does.
+ */
+
+import type { SectionName } from "./sections.config.ts";
+import type { ReproArtifact, ReproParsedCounts } from "./repro-artifact.ts";
+import type {
+  AxisPath,
+  DefectClass,
+  DerivedSignalKey,
+  DerivedSignals,
+} from "./defect-classes.ts";
+import {
+  DEFECT_CLASSES,
+  DERIVED_SIGNAL_KEYS,
+  defectSpec,
+  sectionLineCount,
+} from "./defect-classes.ts";
+
+/**
+ * How many near-misses to emit per uncovered class. Small on purpose: the report
+ * is read by a human deciding "do I mint a fixture?", and the 4th-closest
+ * near-miss has never changed that answer. The cap is never silent —
+ * `FixtureCoverage.nearMissCandidateCount` reports the full candidate count.
+ */
+export const NEAR_MISS_LIMIT = 3;
+
+/** One corpus fixture, as the caller must hand it in: its repo-relative path
+ *  plus the two PII-free halves of its parse. */
+export interface CorpusEntry {
+  /** e.g. `"tests/fixtures/pdfs/word/skills-glyph-header.pdf"`. Used verbatim in
+   *  the output and as the deterministic tie-break key. */
+  path: string;
+  artifact: ReproArtifact;
+  derived: DerivedSignals;
+}
+
+/** A fixture that does NOT reproduce the class, and the load-bearing axes on
+ *  which it diverges from the résumé — the "why not" signal. */
+export interface NearMiss {
+  fixture: string;
+  /** In the class's declared `loadBearingAxes` order. Empty ⇒ see semantics (3). */
+  divergedAxes: AxisPath[];
+}
+
+/** The corpus's verdict on one defect class. */
+export interface FixtureCoverage {
+  class: DefectClass;
+  /**
+   * Fixture paths whose (artifact, derived) `exhibits()` this class,
+   * de-duplicated. Non-empty ⇒ COVERED ⇒ do not mint a fixture.
+   *
+   * ORDER IS PRESENTATION ONLY. Membership is `exhibits()` and nothing else
+   * (semantics (1)) — every entry here is an equally valid reproducer. But a
+   * printer that shows one cover must pick one, and "alphabetically first" is an
+   * arbitrary pick out of 34. So the list is ordered by WHOLE-ARTIFACT
+   * divergence from the résumé, closest first: the fixture that most resembles
+   * the real document is the one a maintainer most wants to open. Ties keep
+   * corpus order. Reordering this list can never change a COVERED/NOT-COVERED
+   * verdict, and no consumer may treat position as evidence.
+   */
+  coveredBy: string[];
+  /** Only populated when `coveredBy` is empty. Ranked closest-first, capped at
+   *  `NEAR_MISS_LIMIT`. */
+  nearMisses: NearMiss[];
+  /** How many candidates were ranked to produce `nearMisses` — i.e. the corpus
+   *  size when uncovered, and 0 when covered. Makes the cap visible: a printer
+   *  showing `nearMisses.length` of `nearMissCandidateCount` never truncates
+   *  silently. */
+  nearMissCandidateCount: number;
+}
+
+/**
+ * For each requested defect class, which corpus fixtures already reproduce it —
+ * and, when none does, which come closest and why they miss.
+ *
+ * Pure. Output is one entry per DISTINCT requested class, in `DEFECT_CLASSES`
+ * order (never the caller's argument order), so two callers that found the same
+ * defects print the same report. A duplicate in `defects` yields one entry.
+ *
+ * `real` / `realDerived` are used ONLY as the divergence reference for
+ * `nearMisses`; coverage itself is decided entirely on the fixture's own parse
+ * (semantics (1)). Passing a class the résumé does not itself exhibit is
+ * therefore not an error — it is answered honestly, and shows up as a near-miss
+ * with an empty `divergedAxes`.
+ */
+export function matchCorpus(
+  real: ReproArtifact,
+  realDerived: DerivedSignals,
+  defects: readonly DefectClass[],
+  corpus: readonly CorpusEntry[],
+): FixtureCoverage[] {
+  const requested = new Set(defects);
+
+  // Memoized ONCE per call, before any sort: `wholeArtifactDivergence` walks
+  // every axis of both parses, and it is class-independent (it is the
+  // presentation tiebreak, never a coverage input). Computing it inside a sort
+  // comparator would re-walk every axis O(n log n) times per class.
+  const divergenceByIndex = corpus.map((f) =>
+    wholeArtifactDivergence(real, realDerived, f),
+  );
+
+  return DEFECT_CLASSES.filter((c) => requested.has(c)).map((cls) => {
+    const spec = defectSpec(cls);
+
+    // Membership: `exhibits()`, full stop. Order: closest-first by whole-artifact
+    // divergence (presentation only — see `FixtureCoverage.coveredBy`), corpus
+    // index breaking ties so arrival order is the only remaining input.
+    const coveredBy = dedupe(
+      corpus
+        .map((f, index) => ({ f, index }))
+        .filter(({ f }) => spec.exhibits(f.artifact, f.derived))
+        .sort(
+          (x, y) =>
+            divergenceByIndex[x.index] - divergenceByIndex[y.index] ||
+            x.index - y.index,
+        )
+        .map(({ f }) => f.path),
+    );
+
+    if (coveredBy.length > 0) {
+      return { class: cls, coveredBy, nearMisses: [], nearMissCandidateCount: 0 };
+    }
+
+    // No cover ⇒ every fixture is a candidate. Rank by load-bearing divergence.
+    const ranked = corpus
+      .map((f, index) => ({
+        index,
+        fixture: f.path,
+        divergedAxes: divergedAxes(
+          real,
+          realDerived,
+          f.artifact,
+          f.derived,
+          spec.loadBearingAxes,
+        ),
+      }))
+      .sort(
+        (x, y) =>
+          x.divergedAxes.length - y.divergedAxes.length ||
+          compareStrings(x.fixture, y.fixture) ||
+          x.index - y.index,
+      );
+
+    return {
+      class: cls,
+      coveredBy,
+      nearMisses: ranked
+        .slice(0, NEAR_MISS_LIMIT)
+        .map(({ fixture, divergedAxes: axes }) => ({ fixture, divergedAxes: axes })),
+      nearMissCandidateCount: ranked.length,
+    };
+  });
+}
+
+/**
+ * How many axes — of EVERY axis both parses carry, not just one class's
+ * load-bearing ones — differ between the résumé and a fixture.
+ *
+ * PRESENTATION ONLY. This is the "which cover most resembles the real document"
+ * tiebreak for `coveredBy`, and it must never touch coverage semantics
+ * (semantics (1): a cover is `exhibits()`, never distance). Deliberately a flat
+ * count, not a weighted distance: the density axes (`pageCount`,
+ * `rawCharCount`, `extractedCharCount`) almost always differ and so contribute a
+ * near-constant offset, leaving the STRUCTURAL and DERIVED axes — the ones that
+ * actually say "this fixture is shaped like your résumé" — to do the ranking.
+ *
+ * The section axes are the UNION of both parses' routed sections, so a section
+ * one has and the other lacks counts as a divergence (`sectionLineCount` reports
+ * 0 for the absent side).
+ */
+function wholeArtifactDivergence(
+  real: ReproArtifact,
+  realDerived: DerivedSignals,
+  f: CorpusEntry,
+): number {
+  const sections = new Set<SectionName | "profile">([
+    ...real.sections.map((s) => s.name),
+    ...f.artifact.sections.map((s) => s.name),
+  ]);
+
+  const axes: AxisPath[] = [
+    "triggers",
+    "sectionSource",
+    "pageCount",
+    "rawCharCount",
+    "extractedCharCount",
+    "linkAnnotationCount",
+    "disagreements",
+    ...[...sections].map((s): AxisPath => `sections.${s}`),
+    ...(Object.keys(real.parsedCounts) as (keyof ReproParsedCounts)[]).map(
+      (k): AxisPath => `parsedCounts.${k}`,
+    ),
+    ...DERIVED_SIGNAL_KEYS.map((k): AxisPath => `derived.${k}`),
+  ];
+
+  return divergedAxes(real, realDerived, f.artifact, f.derived, axes).length;
+}
+
+/**
+ * The subset of `axes` whose VALUE differs between the two parses, in the given
+ * axis order. Exported because the near-miss printer and any future
+ * fixture-selection tooling need exactly this, and re-deriving it is how the two
+ * drift apart.
+ */
+export function divergedAxes(
+  a: ReproArtifact,
+  aDerived: DerivedSignals,
+  b: ReproArtifact,
+  bDerived: DerivedSignals,
+  axes: readonly AxisPath[],
+): AxisPath[] {
+  return axes.filter(
+    (axis) => axisKey(axis, a, aDerived) !== axisKey(axis, b, bDerived),
+  );
+}
+
+/**
+ * The value at one `AxisPath`, canonicalized to a string so any two axis values
+ * are comparable with `!==` — including the array axes, which are compared as
+ * ORDER-INSENSITIVE multisets (semantics (4)).
+ *
+ * Total over `AxisPath`: the scalar axes are matched literally, the three
+ * template-literal families by their `head.tail` split. The final `throw` is
+ * unreachable through the type, and is here to fail loudly rather than silently
+ * report "equal" if a future axis family is added to the union without a branch.
+ */
+function axisKey(path: AxisPath, a: ReproArtifact, d: DerivedSignals): string {
+  switch (path) {
+    case "triggers":
+      // Sorted multiset: a reordering of the layout probes is not a divergence.
+      return canonicalList([...a.triggers]);
+    case "disagreements":
+      return canonicalList(
+        a.disagreements.map((x) => `${x.kind} ${x.field} ${x.likelyCause ?? ""}`),
+      );
+    case "sectionSource":
+      return a.sectionSource;
+    case "pageCount":
+      return String(a.pageCount);
+    case "rawCharCount":
+      return String(a.rawCharCount);
+    case "extractedCharCount":
+      return String(a.extractedCharCount);
+    case "linkAnnotationCount":
+      return String(a.linkAnnotationCount);
+    default:
+      break;
+  }
+
+  const dot = path.indexOf(".");
+  const head = path.slice(0, dot);
+  const tail = path.slice(dot + 1);
+
+  switch (head) {
+    case "sections":
+      // 0 for a section the router never cut — "absent" ≡ "present but empty".
+      return String(sectionLineCount(a, tail as SectionName | "profile"));
+    case "parsedCounts":
+      return String(a.parsedCounts[tail as keyof ReproParsedCounts]);
+    case "derived":
+      return String(d[tail as DerivedSignalKey]);
+    default:
+      throw new Error(`fixture-match: unhandled axis path "${path}"`);
+  }
+}
+
+/** A stable, unambiguous key for a list compared as an order-insensitive
+ *  multiset. `JSON.stringify` of the SORTED copy — sorting a copy so the caller's
+ *  array is never mutated, and JSON so no element can forge the separator. */
+function canonicalList(xs: string[]): string {
+  return JSON.stringify([...xs].sort(compareStrings));
+}
+
+/** Ascending by UTF-16 code unit. Explicit rather than `localeCompare`, whose
+ *  ordering depends on the host's locale — determinism is a hard requirement. */
+function compareStrings(x: string, y: string): number {
+  return x < y ? -1 : x > y ? 1 : 0;
+}
+
+/** First occurrence wins; input order preserved. */
+function dedupe(xs: string[]): string[] {
+  return [...new Set(xs)];
+}

--- a/src/lib/heuristics/localize/__test-utils__.ts
+++ b/src/lib/heuristics/localize/__test-utils__.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Minimal `CascadeResult` mock builder for the `localize/*.test.ts` suites.
+ * Every localizer here is a total function of `cascade.canonical.{fields,
+ * fieldConfidence,sections.byName}`, `cascade.rawText`, and
+ * `cascade.markdown` — this builder fills exactly those, casting the rest
+ * away, so a test can describe a parse in a few lines instead of a full
+ * `runCascade()` over a fixture PDF.
+ */
+
+import type { CascadeResult, HeuristicParsedResume, FieldConfidence } from "../types.ts";
+
+export function mkCascade(overrides: {
+  fields?: Partial<HeuristicParsedResume>;
+  fieldConfidence?: FieldConfidence;
+  sections?: Record<string, string[]>;
+  markdown?: string;
+  rawText?: string;
+}): CascadeResult {
+  return {
+    canonical: {
+      fields: {
+        skills: [],
+        experience: [],
+        education: [],
+        ...overrides.fields,
+      },
+      fieldConfidence: overrides.fieldConfidence ?? {},
+      sections: {
+        byName: new Map(Object.entries(overrides.sections ?? {})),
+      },
+    },
+    rawText: overrides.rawText ?? "",
+    markdown: overrides.markdown,
+    triggers: [],
+    linkAnnotations: [],
+  } as unknown as CascadeResult;
+}

--- a/src/lib/heuristics/localize/achievements.test.ts
+++ b/src/lib/heuristics/localize/achievements.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { localizeAchievements } from "./achievements.ts";
+import { mkCascade } from "./__test-utils__.ts";
+
+describe("localizeAchievements", () => {
+  it("emits no defect when entries are parsed", () => {
+    const cascade = mkCascade({
+      fields: {
+        heuristic_achievements: [
+          { type: "Award", title: "Best Paper", year: "2022" },
+        ],
+      },
+      sections: { achievements: ["Award · Best Paper, 2022"] },
+    });
+    const out = localizeAchievements(cascade);
+    expect(out.defects).toEqual([]);
+    expect(out.verdict).toBe("ok");
+  });
+
+  it("localizes achievements-parser-miss when the region is non-empty but nothing parsed", () => {
+    const cascade = mkCascade({
+      fields: { heuristic_achievements: [] },
+      sections: { achievements: ["Award · Best Paper, 2022"] },
+    });
+    const out = localizeAchievements(cascade);
+    expect(out.defects).toEqual(["achievements-parser-miss"]);
+    expect(out.derived.achievementsParsedEmpty).toBe(true);
+  });
+
+  it("localizes achievements-under-segmented when entries trail header-shaped lines", () => {
+    const cascade = mkCascade({
+      fields: {
+        heuristic_achievements: [
+          { type: "Award", title: "Best Paper", year: "2022" },
+        ],
+      },
+      sections: {
+        achievements: [
+          "Award · Best Paper, 2022",
+          "- detail bullet",
+          "Award · Second Prize, 2023",
+        ],
+      },
+    });
+    const out = localizeAchievements(cascade);
+    expect(out.defects).toEqual(["achievements-under-segmented"]);
+    expect(out.derived.achievementsEntriesFewerThanHeaderLines).toBe(true);
+  });
+
+  it("localizes achievements-no-section when no region segmented and nothing parsed", () => {
+    const cascade = mkCascade({
+      fields: { heuristic_achievements: [] },
+      sections: {},
+    });
+    const out = localizeAchievements(cascade);
+    expect(out.defects).toEqual(["achievements-no-section"]);
+  });
+});

--- a/src/lib/heuristics/localize/achievements.ts
+++ b/src/lib/heuristics/localize/achievements.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Achievements-section localization (issue #469 step 4) — extracted from
+ * `probe-achievements.test.ts` so a shared sweep (`/probe-resume`, a later
+ * step) can reuse the SAME detector instead of a copy-pasted seventh
+ * implementation.
+ *
+ * PURE: takes an already-parsed `CascadeResult`, never re-parses, never does
+ * I/O. This is a refactor of the probe's inline logic, not a behavior
+ * change — `probe-achievements.test.ts` must print byte-identical output
+ * after switching to call this.
+ */
+
+import type { CascadeResult } from "../types.ts";
+import type { DefectClass, DerivedSignals } from "../defect-classes.ts";
+
+/**
+ * Every `DefectClass` this localizer can emit — see `SKILLS_DEFECT_CLASSES` in
+ * `./skills.ts` for why the tuple exists and what pins it to the table.
+ */
+export const ACHIEVEMENTS_DEFECT_CLASSES = [
+  "achievements-parser-miss",
+  "achievements-under-segmented",
+  "achievements-no-section",
+] as const satisfies readonly DefectClass[];
+
+type AchievementsDefectClass =
+  (typeof ACHIEVEMENTS_DEFECT_CLASSES)[number];
+
+/** Bullet/numbered lead markers — a line carrying one is a BODY line, not a
+ *  candidate entry header (mirrors group-bullets' LEADING_MARKER_RE). */
+const BULLET_LINE_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·]|\d+[.)])\s/;
+
+export interface AchievementEntry {
+  type: string | null;
+  description: string;
+  /** Whether the header carried a LABEL — i.e. whether the export bolds just
+   *  the type (true) or the whole header line (false). */
+  typeIsLabel: boolean;
+  year: string | null;
+  url: string | null;
+  bullets: number;
+}
+
+export interface AchievementsLocalization {
+  /** OUTPUT: the parsed achievement entries. */
+  entries: AchievementEntry[];
+  /** INPUT: the achievements region the entry segmenter scanned. */
+  regionLines: string[];
+  /** Section-detection overview (all regions, line counts only). */
+  sectionOverview: string[];
+  achievementsPlacement: unknown;
+  /** VERIFY: non-bullet lines in the region — a lower-bound oracle for entries. */
+  headerLines: string[];
+  verdict: string;
+  defects: DefectClass[];
+  derived: Partial<DerivedSignals>;
+}
+
+/**
+ * Localize the achievements section: OUTPUT (parsed entries) vs INPUT (the
+ * region scanned) vs a header-shaped-line lower-bound oracle for entry
+ * segmentation.
+ */
+export function localizeAchievements(
+  cascade: CascadeResult,
+): AchievementsLocalization {
+  const p = cascade.canonical.fields;
+
+  const entries: AchievementEntry[] = (p.heuristic_achievements ?? []).map(
+    (a) => {
+      const type = a.type ?? null;
+      return {
+        type,
+        description: a.title,
+        typeIsLabel: type !== null,
+        year: a.year ?? null,
+        url: a.url ?? null,
+        bullets: a.description
+          ? a.description.split("\n").filter((l) => l.trim()).length
+          : 0,
+      };
+    },
+  );
+
+  const regionLines = [
+    ...(cascade.canonical.sections.byName.get("achievements") ?? []),
+  ];
+
+  const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
+    ([name, lines]) => `${name}(${lines.length})`,
+  );
+
+  const headerLines = regionLines.filter((l) => !BULLET_LINE_RE.test(l));
+
+  const achievementsParsedEmpty = entries.length === 0;
+  const achievementsEntriesFewerThanHeaderLines =
+    entries.length < headerLines.length;
+
+  // Verdict and class are CO-EMITTED, in one branch chain (see skills.ts).
+  // `achievements-no-section` is ADVISORY, not a defect — see `DefectSpec.advisory`.
+  let verdict: string;
+  let defect: AchievementsDefectClass | null;
+  if (achievementsParsedEmpty && regionLines.length > 0) {
+    verdict = `PARSER-MISS (0 entries; the achievements region has ${regionLines.length} lines)`;
+    defect = "achievements-parser-miss";
+  } else if (achievementsEntriesFewerThanHeaderLines) {
+    verdict = `UNDER-SEGMENTED (${entries.length} entries < ${headerLines.length} header-shaped lines — an achievement likely merged into a neighbor)`;
+    // Unreachable with 0 entries: header lines are a subset of region lines, so
+    // `0 < headerLines` implies a non-empty region, which PARSER-MISS claimed.
+    defect = "achievements-under-segmented";
+  } else if (achievementsParsedEmpty && regionLines.length === 0) {
+    verdict =
+      "no achievements region segmented (the résumé may carry none — check `Sections detected` for a mis-routed block)";
+    defect = "achievements-no-section";
+  } else {
+    verdict = "ok";
+    defect = null;
+  }
+
+  const derived: Partial<DerivedSignals> = {
+    achievementsParsedEmpty,
+    achievementsEntriesFewerThanHeaderLines,
+  };
+
+  const defects: DefectClass[] = defect ? [defect] : [];
+
+  return {
+    entries,
+    regionLines,
+    sectionOverview,
+    achievementsPlacement: p.achievements_placement ?? null,
+    headerLines,
+    verdict,
+    defects,
+    derived,
+  };
+}

--- a/src/lib/heuristics/localize/contact.test.ts
+++ b/src/lib/heuristics/localize/contact.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { localizeContact, rawTextCandidates } from "./contact.ts";
+import { mkCascade } from "./__test-utils__.ts";
+
+describe("localizeContact", () => {
+  it("emits no defects when every field is present", () => {
+    const cascade = mkCascade({
+      fields: {
+        full_name: "Jordan Rivera",
+        email: "jordan.rivera@example.com",
+        phone: "(312) 555-0123",
+        location: "Chicago, IL",
+      },
+      sections: { profile: ["Jordan Rivera", "jordan.rivera@example.com"] },
+    });
+    const out = localizeContact(cascade);
+    expect(out.defects).toEqual([]);
+    expect(out.derived).toEqual({
+      emailInRawTextButNotParsed: false,
+      phoneInRawTextButNotParsed: false,
+      locationInRawTextButNotParsed: false,
+    });
+    expect(out.verify.map((v) => v.verdict)).toEqual(["ok", "ok", "ok"]);
+  });
+
+  it("localizes a PARSER-MISS when a field is empty but recoverable from rawText", () => {
+    const cascade = mkCascade({
+      fields: { email: undefined },
+      rawText: "Contact jordan.rivera@example.com for details",
+      sections: { profile: [] },
+    });
+    const out = localizeContact(cascade);
+    expect(out.defects).toEqual(["contact-email-parser-miss"]);
+    expect(out.derived.emailInRawTextButNotParsed).toBe(true);
+    expect(
+      out.verify.find((v) => v.field === "email")?.verdict,
+    ).toBe("PARSER-MISS (in rawText, not in field)");
+  });
+
+  it("reports a genuinely absent field as absent-in-pdf, not a defect", () => {
+    const cascade = mkCascade({
+      fields: { phone: undefined },
+      rawText: "no phone number anywhere in this document",
+      sections: { profile: [] },
+    });
+    const out = localizeContact(cascade);
+    expect(out.defects).toEqual([]);
+    expect(out.derived.phoneInRawTextButNotParsed).toBe(false);
+    expect(
+      out.verify.find((v) => v.field === "phone")?.verdict,
+    ).toBe("absent-in-pdf");
+  });
+
+  it("rawTextCandidates finds the first email/phone/location in loose text", () => {
+    const cand = rawTextCandidates(
+      "Reach me at a@example.com or (312) 555-0100, based in Austin, TX",
+    );
+    expect(cand.email).toBe("a@example.com");
+    expect(cand.phone).toBeTruthy();
+    expect(cand.location).toBeTruthy();
+  });
+});

--- a/src/lib/heuristics/localize/contact.ts
+++ b/src/lib/heuristics/localize/contact.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Contact-section localization (issue #469 step 4) — extracted from
+ * `probe-contact.test.ts` so a shared sweep (`/probe-resume`, a later step)
+ * can reuse the SAME detector instead of a copy-pasted seventh implementation.
+ *
+ * PURE: takes an already-parsed `CascadeResult`, never re-parses, never does
+ * I/O. This is a refactor of the probe's inline logic, not a behavior change —
+ * `probe-contact.test.ts` must print byte-identical output after switching to
+ * call this.
+ */
+
+import type { CascadeResult } from "../types.ts";
+import { EMAIL_RE, US_LOCATION_RE, INTL_LOCATION_RE } from "../regex.ts";
+import { findFirstPhone } from "../phone.ts";
+import type { DefectClass, DerivedSignals } from "../defect-classes.ts";
+
+/** The contact scalar/URL fields the extractor produces. */
+export const CONTACT_FIELDS = [
+  "full_name",
+  "email",
+  "phone",
+  "location",
+  "linkedin_url",
+  "github_url",
+  "portfolio_url",
+  "website_url",
+] as const;
+
+export type ContactField = (typeof CONTACT_FIELDS)[number];
+
+/**
+ * Every `DefectClass` this localizer can emit — see `SKILLS_DEFECT_CLASSES` in
+ * `./skills.ts` for why the tuple exists and what pins it to the table.
+ */
+export const CONTACT_DEFECT_CLASSES = [
+  "contact-email-parser-miss",
+  "contact-phone-parser-miss",
+  "contact-location-parser-miss",
+] as const satisfies readonly DefectClass[];
+
+type ContactDefectClass = (typeof CONTACT_DEFECT_CLASSES)[number];
+
+/** The verified fields, and the class a PARSER-MISS on each one names. Total
+ *  over the three — a new verified field cannot be added without deciding its
+ *  class, which must exist in the table. */
+const CONTACT_MISS_CLASS: Readonly<
+  Record<"email" | "phone" | "location", ContactDefectClass>
+> = {
+  email: "contact-email-parser-miss",
+  phone: "contact-phone-parser-miss",
+  location: "contact-location-parser-miss",
+};
+
+/** Independent re-scan of rawText for the fields that most often drop when a
+ *  region filter mis-fires. Returns the first candidate for each, or
+ *  undefined. Deliberately loose — this is the "is it anywhere in the doc?"
+ *  oracle, not the precise extractor. */
+export function rawTextCandidates(rawText: string): {
+  email?: string;
+  phone?: string;
+  location?: string;
+} {
+  // EMAIL_RE is a module-global /gi regex, so `.exec()` ADVANCES its
+  // `lastIndex`. Reset on BOTH sides: before, so we start at 0 regardless of who
+  // ran last; after, so we hand the shared instance back rewound. `corpus.test.ts`
+  // now calls this 45× interleaved with `runCascade()` (which itself does
+  // `EMAIL_RE.test(...)` in `extract/name.ts`), so the two are on one event loop
+  // and a left-behind `lastIndex` is a cross-test action-at-a-distance bug.
+  EMAIL_RE.lastIndex = 0;
+  const email = EMAIL_RE.exec(rawText)?.[0];
+  EMAIL_RE.lastIndex = 0;
+  const phone = findFirstPhone(rawText, "US")?.formatted;
+  const us = US_LOCATION_RE.exec(rawText)?.[0];
+  const intl = INTL_LOCATION_RE.exec(rawText)?.[0];
+  return { email, phone, location: us ?? intl };
+}
+
+export interface ContactFieldVerify {
+  field: "email" | "phone" | "location";
+  field_value: string | null;
+  rawText_candidate: string | null;
+  verdict: string;
+}
+
+export interface ContactLocalization {
+  /** OUTPUT: the structured contact fields + their per-field confidence. */
+  extracted: Record<ContactField, { value: unknown; confidence: number }>;
+  /** INPUT: the profile region the contact extractor scanned. */
+  profileLines: string[];
+  /** VERIFY: independent rawText re-scan for the drop-prone fields. */
+  verify: ContactFieldVerify[];
+  /** Classes this parse exhibits (`contact-{email,phone,location}-parser-miss`). */
+  defects: DefectClass[];
+  /** The `derived.*InRawTextButNotParsed` signals this localizer can compute. */
+  derived: Partial<DerivedSignals>;
+}
+
+/**
+ * Localize the contact section: OUTPUT (extracted fields) vs INPUT (profile
+ * region) vs an independent rawText re-scan that tells a genuine absence from
+ * a parser drop.
+ */
+export function localizeContact(cascade: CascadeResult): ContactLocalization {
+  const p = cascade.canonical.fields as Record<string, unknown>;
+
+  const extracted = Object.fromEntries(
+    CONTACT_FIELDS.map((k) => [
+      k,
+      {
+        value: p[k] ?? null,
+        confidence:
+          cascade.canonical.fieldConfidence[
+            k as keyof typeof cascade.canonical.fieldConfidence
+          ] ?? 0,
+      },
+    ]),
+  ) as Record<ContactField, { value: unknown; confidence: number }>;
+
+  const profileLines = [
+    ...(cascade.canonical.sections.byName.get("profile") ?? []),
+  ];
+
+  const candidates = rawTextCandidates(cascade.rawText);
+
+  // Verdict and class are CO-EMITTED per field, in one branch chain: a verdict
+  // branch cannot exist without deciding a class (or an explicit `null` — "not a
+  // defect"). `verify` keeps exactly the shape the probe harness prints; the
+  // class rides alongside it and never reaches the console or the JSON report.
+  const verified = (["email", "phone", "location"] as const).map((k) => {
+    const got = (p[k] as string | undefined) ?? null;
+    const cand = candidates[k] ?? null;
+    let verdict: string;
+    let defect: ContactDefectClass | null;
+    if (got) {
+      verdict = "ok";
+      defect = null;
+    } else if (cand) {
+      verdict = "PARSER-MISS (in rawText, not in field)";
+      defect = CONTACT_MISS_CLASS[k];
+    } else {
+      verdict = "absent-in-pdf";
+      defect = null;
+    }
+    return {
+      verify: {
+        field: k,
+        field_value: got,
+        rawText_candidate: cand,
+        verdict,
+      } satisfies ContactFieldVerify,
+      defect,
+    };
+  });
+
+  const verify = verified.map((v) => v.verify);
+  const missed = (k: "email" | "phone" | "location"): boolean =>
+    verified.some((v) => v.verify.field === k && v.defect !== null);
+
+  const derived: Partial<DerivedSignals> = {
+    emailInRawTextButNotParsed: missed("email"),
+    phoneInRawTextButNotParsed: missed("phone"),
+    locationInRawTextButNotParsed: missed("location"),
+  };
+
+  const defects: DefectClass[] = verified
+    .map((v) => v.defect)
+    .filter((c): c is ContactDefectClass => c !== null);
+
+  return { extracted, profileLines, verify, defects, derived };
+}

--- a/src/lib/heuristics/localize/education.test.ts
+++ b/src/lib/heuristics/localize/education.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { localizeEducation, looseEducationReason, countDegrees } from "./education.ts";
+import { mkCascade } from "./__test-utils__.ts";
+
+describe("localizeEducation", () => {
+  it("emits no defect when entries are present and complete", () => {
+    const cascade = mkCascade({
+      fields: {
+        education: [
+          { institution: "State University", degree: "Bachelor of Science" },
+        ],
+      },
+      sections: { education: ["Bachelor of Science, State University"] },
+    });
+    const out = localizeEducation(cascade);
+    expect(out.defects).toEqual([]);
+    expect(out.verdict).toMatch(/^ok/);
+  });
+
+  it("localizes education-extraction-miss when the region routed but nothing parsed", () => {
+    const cascade = mkCascade({
+      fields: { education: [] },
+      sections: { education: ["Bachelor of Science, State University"] },
+    });
+    const out = localizeEducation(cascade);
+    expect(out.defects).toEqual(["education-extraction-miss"]);
+  });
+
+  it("localizes education-header-unrecognized for an anchor-bearing header the strict router rejects", () => {
+    const cascade = mkCascade({
+      fields: { education: [] },
+      sections: {},
+      markdown:
+        "# education overview\nBachelor of Science, State University\n# Skills\n",
+    });
+    const out = localizeEducation(cascade);
+    expect(out.defects).toEqual(["education-header-unrecognized"]);
+    expect(out.derived.educationHeaderCandidateRejected).toBe(true);
+  });
+
+  it("localizes education-no-section when nothing education-like exists", () => {
+    const cascade = mkCascade({
+      fields: { education: [] },
+      sections: {},
+      markdown: "# Experience\nSome role\n",
+    });
+    const out = localizeEducation(cascade);
+    expect(out.defects).toEqual(["education-no-section"]);
+  });
+
+  it("withholds education-no-section when there is no markdown to read (scanned/sparse)", () => {
+    const cascade = mkCascade({ fields: { education: [] }, sections: {} });
+    const out = localizeEducation(cascade);
+    expect(out.headerOracleUnavailable).toBe(true);
+    expect(out.defects).toEqual([]);
+    expect(out.verdict).toMatch(/^NO-EDUCATION-SECTION/);
+  });
+
+  it("localizes education-under-chunked when DEGREE_RE tokens exceed entries", () => {
+    const cascade = mkCascade({
+      fields: {
+        education: [{ institution: "State University", degree: "BS" }],
+      },
+      sections: {
+        education: [
+          "Bachelor of Science, State University",
+          "Master of Science, Other University",
+        ],
+      },
+    });
+    const out = localizeEducation(cascade);
+    expect(out.defects).toEqual(["education-under-chunked"]);
+    expect(out.derived.educationEntriesFewerThanDegreeTokens).toBe(true);
+  });
+
+  it("countDegrees counts DEGREE_RE tokens without mutating shared state", () => {
+    expect(
+      countDegrees("Bachelor of Science, State University\nMaster of Science, Other University"),
+    ).toBe(2);
+  });
+
+  it("looseEducationReason strips a leading decorative glyph", () => {
+    expect(looseEducationReason("★Education")).toMatch(/leading-glyph prefix/);
+    expect(looseEducationReason("Random Prose")).toBeNull();
+  });
+});

--- a/src/lib/heuristics/localize/education.ts
+++ b/src/lib/heuristics/localize/education.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Education-section localization (issue #469 step 4) — extracted from
+ * `probe-education.test.ts` so a shared sweep (`/probe-resume`, a later
+ * step) can reuse the SAME detector instead of a copy-pasted seventh
+ * implementation.
+ *
+ * PURE: takes an already-parsed `CascadeResult`, never re-parses, never does
+ * I/O. This is a refactor of the probe's inline logic, not a behavior
+ * change — `probe-education.test.ts` must print byte-identical output after
+ * switching to call this.
+ *
+ * The markdown header oracle lives in `./headers.ts` (shared with
+ * `./skills.ts`). Read ITS header for why `HeaderOracle.unavailable` — a
+ * scanned or sparse PDF with no markdown at all — is not the same fact as "no
+ * education-like header was rejected", and why `education-no-section` refuses to
+ * fire while it is true.
+ */
+
+import type { CascadeResult } from "../types.ts";
+import { SECTION_KEYWORDS, DEGREE_RE } from "../regex.ts";
+import { SECTION_ANCHORS } from "../sections.config.ts";
+import type { DefectClass, DerivedSignals } from "../defect-classes.ts";
+import type { MissedHeader } from "./headers.ts";
+import { findMissedHeaders, looseHeaderReason } from "./headers.ts";
+
+const EDUCATION_ALIASES: readonly string[] = SECTION_KEYWORDS.education ?? [];
+const EDUCATION_ANCHORS: ReadonlySet<string> =
+  SECTION_ANCHORS.education ?? new Set<string>();
+
+/**
+ * Every `DefectClass` this localizer can emit — see `SKILLS_DEFECT_CLASSES` in
+ * `./skills.ts` for why the tuple exists and what pins it to the table.
+ */
+export const EDUCATION_DEFECT_CLASSES = [
+  "education-extraction-miss",
+  "education-header-unrecognized",
+  "education-no-section",
+  "education-under-chunked",
+] as const satisfies readonly DefectClass[];
+
+type EducationDefectClass = (typeof EDUCATION_DEFECT_CLASSES)[number];
+
+/**
+ * Loose education-header oracle — the shared `looseHeaderReason` bound to the
+ * education alias/anchor sets.
+ */
+export function looseEducationReason(raw: string): string | null {
+  return looseHeaderReason(
+    raw,
+    EDUCATION_ALIASES,
+    EDUCATION_ANCHORS,
+    "education",
+  );
+}
+
+/** Count `DEGREE_RE` matches in `text` via a fresh global clone. `DEGREE_RE`
+ *  is non-global to keep `lastIndex` state out of the field heuristics, so
+ *  cloning here is the safe way to count without mutating the shared
+ *  instance. */
+export function countDegrees(text: string): number {
+  const flags = DEGREE_RE.flags.includes("g")
+    ? DEGREE_RE.flags
+    : `${DEGREE_RE.flags}g`;
+  return (text.match(new RegExp(DEGREE_RE.source, flags)) ?? []).length;
+}
+
+export interface EducationEntry {
+  institution: string | null;
+  degree: string | null;
+  field: string | null;
+  location: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  year: string | null;
+  coursework: number;
+}
+
+/** Alias kept for the probe harness's existing field name. */
+export type MissedEducationHeader = MissedHeader;
+
+export interface EducationLocalization {
+  /** OUTPUT: the parsed education entries. */
+  entries: EducationEntry[];
+  /** Per-entry field-presence sanity check (not a wrong-value oracle). */
+  perEntry: { i: number; missing: string[] }[];
+  /** INPUT (routed): the education region the chunker scanned, if any. */
+  educationRegion: string[];
+  regionPresent: boolean;
+  /** DEGREE_RE token count inside the routed region (lower-bound oracle). */
+  regionDegrees: number;
+  /** Section-detection overview (all regions, line counts only). */
+  sectionOverview: string[];
+  headerCandidates: { text: string; strict: string | null }[];
+  missedEducationHeaders: MissedEducationHeader[];
+  orphanBlock: string[];
+  /** TRUE when there was no markdown to run the header oracle over (scanned or
+   *  sparse PDF) — so `missedEducationHeaders` being empty proves NOTHING. */
+  headerOracleUnavailable: boolean;
+  verdict: string;
+  defects: DefectClass[];
+  derived: Partial<DerivedSignals>;
+}
+
+/**
+ * Localize the education section: OUTPUT (parsed entries) vs INPUT (routed
+ * region + header candidates the strict router rejected) vs a DEGREE_RE
+ * lower-bound oracle for entry chunking.
+ */
+export function localizeEducation(
+  cascade: CascadeResult,
+): EducationLocalization {
+  const p = cascade.canonical.fields;
+
+  const entries: EducationEntry[] = (p.education ?? []).map((e) => ({
+    institution: e.institution || null,
+    degree: e.degree || null,
+    field: e.field ?? null,
+    location: e.location ?? null,
+    start_date: e.start_date ?? null,
+    end_date: e.end_date ?? null,
+    year: e.year ?? null,
+    coursework: e.coursework?.length ?? 0,
+  }));
+
+  const educationRegion = [
+    ...(cascade.canonical.sections.byName.get("education") ?? []),
+  ];
+  const regionPresent = educationRegion.length > 0;
+
+  const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
+    ([name, lines]) => `${name}(${lines.length})`,
+  );
+
+  const oracle = findMissedHeaders(
+    cascade,
+    EDUCATION_ALIASES,
+    EDUCATION_ANCHORS,
+    "education",
+  );
+  const missedEducationHeaders = oracle.missedHeaders;
+  const educationHeaderCandidateRejected = missedEducationHeaders.length > 0;
+
+  const regionDegrees = countDegrees(educationRegion.join("\n"));
+  const educationEntriesFewerThanDegreeTokens = regionDegrees > entries.length;
+
+  const perEntry = entries.map((e, i) => {
+    const missing: string[] = [];
+    if (!e.institution) missing.push("institution");
+    if (!e.degree) missing.push("degree");
+    if (!e.start_date && !e.end_date) missing.push("date");
+    return { i, missing };
+  });
+
+  // ── Verdict and class are CO-EMITTED, in one branch chain (see skills.ts).
+  // `education-no-section` is withheld when the header oracle could not run.
+  let verdict: string;
+  let defect: EducationDefectClass | null;
+  if (entries.length === 0 && regionPresent) {
+    verdict = `EXTRACTION-MISS (education region routed with ${educationRegion.length} lines but 0 entries)`;
+    defect = "education-extraction-miss";
+  } else if (entries.length === 0 && educationHeaderCandidateRejected) {
+    verdict = `HEADER-UNRECOGNIZED (education-like header rejected by the strict router → ${missedEducationHeaders[0].reason})`;
+    defect = "education-header-unrecognized";
+  } else if (entries.length === 0) {
+    verdict =
+      "NO-EDUCATION-SECTION (no routed region and no education-like header candidate)";
+    defect = oracle.unavailable ? null : "education-no-section";
+  } else if (educationEntriesFewerThanDegreeTokens) {
+    verdict = `UNDER-CHUNKED (${entries.length} entries < ${regionDegrees} DEGREE_RE tokens in region — a degree line likely merged with a neighbour)`;
+    defect = "education-under-chunked";
+  } else {
+    verdict = `ok (${entries.length} education entries parsed)`;
+    defect = null;
+  }
+
+  const derived: Partial<DerivedSignals> = {
+    educationHeaderCandidateRejected,
+    educationEntriesFewerThanDegreeTokens,
+    headerOracleUnavailable: oracle.unavailable,
+  };
+
+  return {
+    entries,
+    perEntry,
+    educationRegion,
+    regionPresent,
+    regionDegrees,
+    sectionOverview,
+    headerCandidates: oracle.headerCandidates,
+    missedEducationHeaders,
+    orphanBlock: oracle.orphanBlock,
+    headerOracleUnavailable: oracle.unavailable,
+    verdict,
+    defects: defect ? [defect] : [],
+    derived,
+  };
+}

--- a/src/lib/heuristics/localize/experience.test.ts
+++ b/src/lib/heuristics/localize/experience.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { localizeExperience } from "./experience.ts";
+import { mkCascade } from "./__test-utils__.ts";
+
+describe("localizeExperience", () => {
+  it("emits no defect when entry count matches date-range lines", () => {
+    const cascade = mkCascade({
+      fields: {
+        experience: [
+          { title: "Engineer", company: "Acme", start_date: "2020", end_date: "2022" },
+        ],
+      },
+      sections: { experience: ["Engineer, Acme", "Jan 2020 – Jan 2022"] },
+    });
+    const out = localizeExperience(cascade);
+    expect(out.defects).toEqual([]);
+    expect(out.verdict).toBe("ok");
+  });
+
+  it("localizes experience-parser-miss when 0 entries but the region has date ranges", () => {
+    const cascade = mkCascade({
+      fields: { experience: [] },
+      sections: { experience: ["Engineer, Acme", "Jan 2020 – Jan 2022"] },
+    });
+    const out = localizeExperience(cascade);
+    expect(out.defects).toEqual(["experience-parser-miss"]);
+    expect(out.derived.experienceRegionHasDateRangeLines).toBe(true);
+  });
+
+  it("localizes experience-under-segmented when entries trail date-range lines", () => {
+    const cascade = mkCascade({
+      fields: {
+        experience: [
+          { title: "Engineer", company: "Acme", start_date: "2020", end_date: "2021" },
+        ],
+      },
+      sections: {
+        experience: [
+          "Engineer, Acme",
+          "Jan 2020 – Jan 2021",
+          "Manager, Beta",
+          "Feb 2021 – Feb 2022",
+        ],
+      },
+    });
+    const out = localizeExperience(cascade);
+    expect(out.defects).toEqual(["experience-under-segmented"]);
+    expect(out.derived.experienceEntriesFewerThanDateRangeLines).toBe(true);
+  });
+});

--- a/src/lib/heuristics/localize/experience.ts
+++ b/src/lib/heuristics/localize/experience.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Experience-section localization (issue #469 step 4) — extracted from
+ * `probe-experience.test.ts` so a shared sweep (`/probe-resume`, a later
+ * step) can reuse the SAME detector instead of a copy-pasted seventh
+ * implementation.
+ *
+ * PURE: takes an already-parsed `CascadeResult`, never re-parses, never does
+ * I/O. This is a refactor of the probe's inline logic, not a behavior
+ * change — `probe-experience.test.ts` must print byte-identical output after
+ * switching to call this.
+ */
+
+import type { CascadeResult } from "../types.ts";
+import { DATE_RANGE_RE } from "../regex.ts";
+import type { DefectClass, DerivedSignals } from "../defect-classes.ts";
+
+/**
+ * Every `DefectClass` this localizer can emit — see `SKILLS_DEFECT_CLASSES` in
+ * `./skills.ts` for why the tuple exists and what pins it to the table.
+ */
+export const EXPERIENCE_DEFECT_CLASSES = [
+  "experience-parser-miss",
+  "experience-under-segmented",
+] as const satisfies readonly DefectClass[];
+
+type ExperienceDefectClass = (typeof EXPERIENCE_DEFECT_CLASSES)[number];
+
+export interface ExperienceEntry {
+  title: string | null;
+  company: string | null;
+  location: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  bullets: number;
+}
+
+export interface ExperienceLocalization {
+  /** OUTPUT: the parsed role entries. */
+  entries: ExperienceEntry[];
+  /** INPUT: the experience region the entry segmenter scanned. */
+  regionLines: string[];
+  /** Section-detection overview (all regions, line counts only). */
+  sectionOverview: string[];
+  /** VERIFY: date-range lines inside the region (lower-bound oracle). */
+  dateRangeLines: string[];
+  verdict: string;
+  defects: DefectClass[];
+  derived: Partial<DerivedSignals>;
+}
+
+/**
+ * Localize the experience section: OUTPUT (parsed role entries) vs INPUT (the
+ * region scanned) vs an independent date-range re-scan that is a lower-bound
+ * oracle for how many roles should have segmented.
+ */
+export function localizeExperience(
+  cascade: CascadeResult,
+): ExperienceLocalization {
+  const p = cascade.canonical.fields;
+
+  const entries: ExperienceEntry[] = (p.experience ?? []).map((e) => ({
+    title: e.title || null,
+    company: e.company || null,
+    location: e.location ?? null,
+    start_date: e.start_date ?? null,
+    end_date: e.end_date ?? (e.is_current ? "Present" : null),
+    bullets: e.description
+      ? e.description.split("\n").filter((l) => l.trim()).length
+      : 0,
+  }));
+
+  const regionLines = [
+    ...(cascade.canonical.sections.byName.get("experience") ?? []),
+  ];
+
+  const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
+    ([name, lines]) => `${name}(${lines.length})`,
+  );
+
+  const dateRangeLines = regionLines.filter((l) => DATE_RANGE_RE.test(l));
+
+  const experienceRegionHasDateRangeLines = dateRangeLines.length > 0;
+  const experienceEntriesFewerThanDateRangeLines =
+    entries.length < dateRangeLines.length;
+
+  // Verdict and class are CO-EMITTED, in one branch chain (see skills.ts).
+  let verdict: string;
+  let defect: ExperienceDefectClass | null;
+  if (entries.length === 0 && experienceRegionHasDateRangeLines) {
+    verdict = `PARSER-MISS (0 entries; region has ${dateRangeLines.length} date-range lines)`;
+    defect = "experience-parser-miss";
+  } else if (experienceEntriesFewerThanDateRangeLines) {
+    verdict = `UNDER-SEGMENTED (${entries.length} entries < ${dateRangeLines.length} date-range lines — a role likely merged into a neighbor)`;
+    // Unreachable with 0 entries: that case is claimed by PARSER-MISS above
+    // (0 entries and `entries < dateRangeLines` implies date-range lines exist).
+    defect = "experience-under-segmented";
+  } else {
+    verdict = "ok";
+    defect = null;
+  }
+
+  const derived: Partial<DerivedSignals> = {
+    experienceRegionHasDateRangeLines,
+    experienceEntriesFewerThanDateRangeLines,
+  };
+
+  return {
+    entries,
+    regionLines,
+    sectionOverview,
+    dateRangeLines,
+    verdict,
+    defects: defect ? [defect] : [],
+    derived,
+  };
+}

--- a/src/lib/heuristics/localize/headers.ts
+++ b/src/lib/heuristics/localize/headers.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The shared markdown HEADER ORACLE — the one place `localize/skills.ts` and
+ * `localize/education.ts` read `cascade.markdown` to ask:
+ *
+ *   > The strict section router (`matchSectionHeader`) is EXACT-match after a
+ *   > trailing-punct strip. Did it REJECT a header that loosely reads as this
+ *   > section (a leading decorative glyph #414, an out-of-alias wording, a
+ *   > two-line wrap #374)?
+ *
+ * The two localizers had a ~60-line clone of this (headerCandidates →
+ * missedHeaders → orphanBlock) plus a `looseXReason` that differed only in its
+ * alias/anchor sets and one noun. One helper, two callers.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ `unavailable` — why the oracle can FAIL TO RUN, and why that is not      │
+ * │ the same as "no header was rejected". Read before touching this.         │
+ * │                                                                          │
+ * │ `cascade.markdown` is `undefined` in two real, common cases              │
+ * │ (`cascade.ts`): the layout probe called the PDF SCANNED (Tier 1 is        │
+ * │ short-circuited entirely — there is no markdown to emit), or             │
+ * │ `emitMarkdown()` returned undefined because the document was too sparse   │
+ * │ for the positional emitter. In both, this oracle has NOTHING to read.     │
+ * │                                                                          │
+ * │ The clone this replaced coalesced that to `""` — so "the oracle could     │
+ * │ not run" became indistinguishable from "the oracle ran and found no       │
+ * │ rejected header". That difference is load-bearing: `skills-header-        │
+ * │ unrecognized` and `skills-no-section` are BYTE-IDENTICAL in               │
+ * │ `ReproArtifact` (0 skills, no routed region), and the ONLY bit that       │
+ * │ separates them is `skillsHeaderCandidateRejected` — which is derived      │
+ * │ EXCLUSIVELY from this oracle. Coalescing therefore silently downgraded a  │
+ * │ real header-rejection on a scanned/sparse PDF to `skills-no-section`,     │
+ * │ which 9 corpus fixtures "cover" — so the sweep would answer COVERED       │
+ * │ ("stop, we already reproduce this") for a defect NO fixture reproduces.   │
+ * │                                                                          │
+ * │ So `unavailable` is reported, `derived.headerOracleUnavailable` carries   │
+ * │ it, and the `*-no-section` classes REFUSE to fire while it is true. An    │
+ * │ undecidable pair reports as undecided; it never guesses.                  │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * PURE: reads an already-parsed `CascadeResult`, never re-parses, never does I/O.
+ */
+
+import type { CascadeResult } from "../types.ts";
+import { matchSectionHeader } from "../regex.ts";
+
+/** A markdown line the emitter marked as a header (`#`/`##`/`###`). */
+const MD_HEADER_RE = /^#{1,3}\s+/;
+
+/** A section-like header the STRICT router did not map to this section, and why
+ *  a strict match would have failed. Text only — the caller decides whether that
+ *  text is safe to print (harness scratch: yes; PII-free `DerivedSignals`: the
+ *  text never enters it, only the boolean "was one rejected"). */
+export interface MissedHeader {
+  text: string;
+  reason: string;
+}
+
+export interface HeaderOracle {
+  /**
+   * TRUE when `cascade.markdown` is absent or empty — a scanned or sparse PDF.
+   * The oracle could not run: `missedHeaders` is empty because there was nothing
+   * to look at, NOT because nothing was rejected. Never read `missedHeaders`
+   * without reading this. See the file header.
+   */
+  unavailable: boolean;
+  /** Every markdown header, with what the strict router mapped it to (or null). */
+  headerCandidates: { text: string; strict: string | null }[];
+  /** Section-like headers the strict router rejected. */
+  missedHeaders: MissedHeader[];
+  /** The markdown block under the FIRST missed header, up to the next header —
+   *  i.e. the content that dropped with it. */
+  orphanBlock: string[];
+}
+
+/**
+ * The loose header oracle for one section. Mirrors the strict normalizer in
+ * `matchSectionHeaderDetailed` (trim + lowercase + trailing-punct strip) but
+ * ALSO strips a leading run of non-letter / non-number glyphs — the exact gap
+ * #414 identified. Returns the reason a strict match would have failed, or null
+ * if the line doesn't read as this section at all.
+ *
+ * `noun` appears verbatim in the returned reason, so the two callers' messages
+ * stay byte-identical to what they printed before the extraction.
+ */
+export function looseHeaderReason(
+  raw: string,
+  aliases: readonly string[],
+  anchors: ReadonlySet<string>,
+  noun: string,
+): string | null {
+  const trimmedLower = raw.trim().toLowerCase().replace(/[:·•]+$/, "").trim();
+  const glyphStripped = trimmedLower.replace(/^[^\p{L}\p{N}]+/u, "").trim();
+  if (glyphStripped.length === 0 || glyphStripped.length > 40) return null;
+  if (aliases.includes(glyphStripped)) {
+    return glyphStripped === trimmedLower
+      ? "alias match (would route — not a miss)"
+      : `leading-glyph prefix (${JSON.stringify(trimmedLower)} → ${JSON.stringify(glyphStripped)})`;
+  }
+  const tokens = glyphStripped.split(/\s+/).filter(Boolean);
+  if (tokens.some((t) => anchors.has(t)))
+    return `contains ${noun} anchor token but wording not in aliases (${JSON.stringify(glyphStripped)})`;
+  return null;
+}
+
+/**
+ * Run the header oracle over `cascade.markdown` for one section.
+ *
+ * `section` is BOTH the strict-router section name a candidate must NOT have
+ * matched, and the noun spliced into the reason string.
+ */
+export function findMissedHeaders(
+  cascade: CascadeResult,
+  aliases: readonly string[],
+  anchors: ReadonlySet<string>,
+  section: string,
+): HeaderOracle {
+  const md = cascade.markdown;
+  const unavailable = !md || md.trim().length === 0;
+  const mdLines = (md ?? "").split("\n");
+
+  const candidates = mdLines
+    .map((l, i) => ({
+      text: l.replace(MD_HEADER_RE, "").trim(),
+      i,
+      isHeader: MD_HEADER_RE.test(l),
+    }))
+    .filter((h) => h.isHeader && h.text.length > 0);
+
+  const missed = candidates
+    .map((h) => ({
+      ...h,
+      strict: matchSectionHeader(h.text),
+      reason: looseHeaderReason(h.text, aliases, anchors, section),
+    }))
+    .filter(
+      (h) =>
+        h.strict !== section &&
+        h.reason !== null &&
+        !h.reason.startsWith("alias match"),
+    );
+
+  const orphanBlock: string[] = [];
+  if (missed.length > 0) {
+    for (let i = missed[0].i + 1; i < mdLines.length; i++) {
+      if (MD_HEADER_RE.test(mdLines[i])) break;
+      if (mdLines[i].trim()) orphanBlock.push(mdLines[i].trim());
+    }
+  }
+
+  return {
+    unavailable,
+    headerCandidates: candidates.map((h) => ({
+      text: h.text,
+      strict: matchSectionHeader(h.text),
+    })),
+    missedHeaders: missed.map((h) => ({ text: h.text, reason: h.reason! })),
+    orphanBlock,
+  };
+}

--- a/src/lib/heuristics/localize/roundtrip.test.ts
+++ b/src/lib/heuristics/localize/roundtrip.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  localizeRoundtripHop,
+  contactFieldChanges,
+  harnessDiff,
+  invariantFailures,
+} from "./roundtrip.ts";
+import { mkCascade } from "./__test-utils__.ts";
+
+describe("localizeRoundtripHop", () => {
+  it("emits no defects when nothing changed across the hop", () => {
+    const before = mkCascade({ fields: { full_name: "Jordan Rivera" } });
+    const after = mkCascade({ fields: { full_name: "Jordan Rivera" } });
+    const out = localizeRoundtripHop(before, after);
+    expect(out.defects).toEqual([]);
+    expect(out.derived.renderThrewOnRoundtrip).toBe(false);
+  });
+
+  it("localizes roundtrip-contact-value-changed when a contact field drifts", () => {
+    const before = mkCascade({ fields: { email: "a@example.com" } });
+    const after = mkCascade({ fields: { email: "b@example.com" } });
+    const out = localizeRoundtripHop(before, after);
+    expect(out.defects).toEqual(["roundtrip-contact-value-changed"]);
+    expect(out.derived.emailChangedAcrossRoundtrip).toBe(true);
+    expect(out.derived.phoneChangedAcrossRoundtrip).toBe(false);
+  });
+
+  it("localizes roundtrip-experience-value-changed on a title drift", () => {
+    const before = mkCascade({
+      fields: { experience: [{ title: "Engineer", company: "Acme" }] },
+    });
+    const after = mkCascade({
+      fields: { experience: [{ title: "Senior Engineer", company: "Acme" }] },
+    });
+    const out = localizeRoundtripHop(before, after);
+    expect(out.defects).toEqual(["roundtrip-experience-value-changed"]);
+    expect(out.derived.experienceChangedAcrossRoundtrip).toBe(true);
+  });
+
+  it("localizes roundtrip-render-crash when the hop never produced an `after`", () => {
+    const before = mkCascade({ fields: { email: "a@example.com" } });
+    const out = localizeRoundtripHop(before, undefined, "boom");
+    expect(out.defects).toEqual(["roundtrip-render-crash"]);
+    expect(out.derived.renderThrewOnRoundtrip).toBe(true);
+  });
+
+  it("contactFieldChanges reports each field independently", () => {
+    const c1 = { full_name: "A", email: "a@x.com" } as never;
+    const c3 = { full_name: "A", email: "b@x.com" } as never;
+    const changes = contactFieldChanges(c1, c3);
+    expect(changes.fullName).toBe(false);
+    expect(changes.email).toBe(true);
+  });
+});
+
+describe("harnessDiff / invariantFailures", () => {
+  it("harnessDiff carries values; invariantFailures carries field names only", () => {
+    const before = mkCascade({
+      fields: { experience: [{ title: "Engineer", company: "Acme" }] },
+    });
+    const after = mkCascade({
+      fields: { experience: [{ title: "Senior Engineer", company: "Acme" }] },
+    });
+    const values = harnessDiff(before, after);
+    const mapping = invariantFailures(before, after);
+    expect(values.experience[0]).toContain("Engineer");
+    expect(mapping.experience).toEqual(["role[0].title"]);
+  });
+});

--- a/src/lib/heuristics/localize/roundtrip.ts
+++ b/src/lib/heuristics/localize/roundtrip.ts
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Round-trip localization (issue #469 step 4) — extracted from
+ * `corpus-roundtrip.test.ts` so a shared sweep (`/probe-resume`, a later
+ * step) can reuse the SAME detector instead of a copy-pasted seventh
+ * implementation. `/probe-roundtrip`'s harness IS the `RL_RT_PDF`-gated block
+ * at the bottom of `corpus-roundtrip.test.ts` — there is no
+ * `probe-roundtrip.test.ts` (issue #469's table is wrong on that row).
+ *
+ * PURE: every export here is a total function of two already-parsed
+ * `CascadeResult`s (or their diffs). Nothing re-parses, renders, or does I/O —
+ * the render→re-parse hop is the CALLER's job. `corpus-roundtrip.test.ts`
+ * does that hop for both the corpus gate and the RL_RT_PDF harness, and
+ * passes the resulting parses in here.
+ *
+ * This module is shared by TWO different consumers with different PII
+ * postures over the SAME underlying comparison:
+ *   - the corpus round-trip invariant gate (#293, top of
+ *     `corpus-roundtrip.test.ts`) — fixtures only (synthetic personas), field
+ *     MAPPING diffs (`entryListFails`) plus a values-included contact diff
+ *     (`contactFails` — safe here because fixture PDFs carry no real PII).
+ *   - the `RL_RT_PDF` dev harness (bottom of the same file) — an arbitrary,
+ *     possibly PII-bearing résumé, values-included diffs throughout
+ *     (`entryValueFails`, `skillsValueFails`, `harnessDiff`) so a maintainer
+ *     can see exactly what corrupted. That output is scratch-only by the
+ *     harness's own guardrail (gitignored `internal/roundtrip/`), never this
+ *     module's concern.
+ *
+ * `localizeRoundtripHop` is the only export that produces `DefectClass[]` /
+ * `DerivedSignals` — the PII-free half a future sweep consumes. It derives
+ * strictly from BOOLEAN field-level comparisons, never from the value-diff
+ * strings above (which may carry résumé text) — see `defect-classes.ts`'s
+ * header for why that separation is load-bearing.
+ */
+
+import type { CascadeResult, HeuristicParsedResume } from "../types.ts";
+import type { DefectClass, DerivedSignals } from "../defect-classes.ts";
+
+export type RoundtripCategory =
+  | "contact"
+  | "experience"
+  | "education"
+  | "skills"
+  | "summary"
+  // `render` = renderAtsResumePdf threw before any re-parse could run.
+  | "render";
+
+/**
+ * The probe-roundtrip verdict↔class pin.
+ *
+ * This harness has no single verdict string: a CATEGORY with a non-empty diff IS
+ * its verdict. So the pin is a TOTAL `Record<RoundtripCategory, DefectClass>` —
+ * adding a category to the union without a class here is a COMPILE error, and
+ * `localizeRoundtripHop` reads its classes from this map rather than restating
+ * them. `defect-classes.test.ts` pins its image against the table's
+ * `probe: "probe-roundtrip"` rows.
+ */
+export const ROUNDTRIP_CATEGORY_CLASS: Readonly<
+  Record<RoundtripCategory, DefectClass>
+> = {
+  contact: "roundtrip-contact-value-changed",
+  experience: "roundtrip-experience-value-changed",
+  education: "roundtrip-education-value-changed",
+  skills: "roundtrip-skills-value-changed",
+  summary: "roundtrip-summary-value-changed",
+  render: "roundtrip-render-crash",
+};
+
+const same = (a: unknown, b: unknown): boolean =>
+  JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+
+/** Contact scalar-field diffs (name/email/phone/location/linkedin), VALUES
+ *  included in the message. Safe over fixtures (synthetic personas); the
+ *  RL_RT_PDF harness's own guardrail routes its output to gitignored scratch
+ *  when the input is a real résumé. */
+function contactFails(
+  c1: HeuristicParsedResume,
+  c3: HeuristicParsedResume,
+): string[] {
+  const out: string[] = [];
+  for (const k of [
+    "full_name",
+    "email",
+    "phone",
+    "location",
+    "linkedin_url",
+  ] as const) {
+    if (!same(c1[k], c3[k]))
+      out.push(`${k}: ${JSON.stringify(c1[k])} → ${JSON.stringify(c3[k])}`);
+  }
+  return out;
+}
+
+/** Per-field boolean contact diff — the PII-free half `contactFails` cannot
+ *  give: `derived.*ChangedAcrossRoundtrip` reads booleans only, never a
+ *  `contactFails` string (which carries values). */
+export function contactFieldChanges(
+  c1: HeuristicParsedResume,
+  c3: HeuristicParsedResume,
+): {
+  fullName: boolean;
+  email: boolean;
+  phone: boolean;
+  location: boolean;
+  linkedin: boolean;
+} {
+  return {
+    fullName: !same(c1.full_name, c3.full_name),
+    email: !same(c1.email, c3.email),
+    phone: !same(c1.phone, c3.phone),
+    location: !same(c1.location, c3.location),
+    linkedin: !same(c1.linkedin_url, c3.linkedin_url),
+  };
+}
+
+/** Ordered-entry-list diff skeleton: a count mismatch short-circuits, else
+ *  each index/key inequality is rendered by `formatMismatch`. The mapping and
+ *  value callers below differ ONLY in that formatter. */
+function entryListDiff<T>(
+  a1: readonly T[],
+  a3: readonly T[],
+  keys: readonly (keyof T)[],
+  label: string,
+  formatMismatch: (
+    i: number,
+    k: keyof T,
+    v1: T[keyof T],
+    v3: T[keyof T] | undefined,
+  ) => string,
+): string[] {
+  if (a1.length !== a3.length)
+    return [`${label} count ${a1.length} → ${a3.length}`];
+  const out: string[] = [];
+  a1.forEach((r, i) => {
+    for (const k of keys)
+      if (!same(r[k], a3[i]?.[k])) out.push(formatMismatch(i, k, r[k], a3[i]?.[k]));
+  });
+  return out;
+}
+
+/** Ordered-entry-list diff (experience/education): a count mismatch, else
+ *  per-field inequality at each index. Prints field NAMES only, so it stays
+ *  PII-free (used by the corpus gate). */
+function entryListFails<T>(
+  a1: readonly T[],
+  a3: readonly T[],
+  keys: readonly (keyof T)[],
+  label: string,
+): string[] {
+  return entryListDiff(a1, a3, keys, label, (i, k) => `${label}[${i}].${String(k)}`);
+}
+
+/** Ordered-entry VALUE diff (experience/education): a count mismatch, else
+ *  the changed field VALUES `before → after` at each index. Harness-only —
+ *  never used by the PII-free corpus gate. */
+function entryValueFails<T>(
+  a1: readonly T[],
+  a3: readonly T[],
+  keys: readonly (keyof T)[],
+  label: string,
+): string[] {
+  return entryListDiff(
+    a1,
+    a3,
+    keys,
+    label,
+    (i, k, v1, v3) =>
+      `${label}[${i}].${String(k)}: ${JSON.stringify(v1)} → ${JSON.stringify(v3)}`,
+  );
+}
+
+/** Summary length drift ≥ 5% (the round-trip truncation signal, #292). */
+function summaryFails(s1: string, s3: string): string[] {
+  if (s1.length === 0) return [];
+  const deltaPct = (100 * Math.abs(s1.length - s3.length)) / s1.length;
+  return deltaPct >= 5
+    ? [`|Δ| ${deltaPct.toFixed(1)}% (${s1.length} → ${s3.length})`]
+    : [];
+}
+
+/** Skills value diff: the count delta plus the added/removed tokens.
+ *  Harness-only — never used by the PII-free corpus gate. */
+function skillsValueFails(
+  s1: readonly string[],
+  s3: readonly string[],
+): string[] {
+  const set1 = new Set(s1);
+  const set3 = new Set(s3);
+  const removed = s1.filter((s) => !set3.has(s));
+  const added = s3.filter((s) => !set1.has(s));
+  if (removed.length === 0 && added.length === 0) return [];
+  const out = [`count ${s1.length} → ${s3.length}`];
+  if (removed.length) out.push(`removed: ${JSON.stringify(removed)}`);
+  if (added.length) out.push(`added: ${JSON.stringify(added)}`);
+  return out;
+}
+
+/** Per-category before → after MAPPING diff for one hop — used by the corpus
+ *  gate's ratchet. Field names only for experience/education/skills/summary;
+ *  `contactFails` includes values (see its own doc — safe over fixtures). */
+export function invariantFailures(
+  p1: CascadeResult,
+  p3: CascadeResult,
+): Record<Exclude<RoundtripCategory, "render">, string[]> {
+  const c1 = p1.canonical.fields;
+  const c3 = p3.canonical.fields;
+  const sk1 = (c1.skills ?? []).length;
+  const sk3 = (c3.skills ?? []).length;
+  return {
+    contact: contactFails(c1, c3),
+    experience: entryListFails(
+      c1.experience ?? [],
+      c3.experience ?? [],
+      ["title", "company", "start_date", "end_date"] as const,
+      "role",
+    ),
+    education: entryListFails(
+      c1.education ?? [],
+      c3.education ?? [],
+      ["degree", "field", "institution"] as const,
+      "entry",
+    ),
+    skills: sk1 !== sk3 ? [`count ${sk1} → ${sk3}`] : [],
+    summary: summaryFails(c1.summary ?? "", c3.summary ?? ""),
+  };
+}
+
+/** Per-category before → after VALUE diff for one hop — used by the RL_RT_PDF
+ *  dev harness. */
+export function harnessDiff(
+  before: CascadeResult,
+  after: CascadeResult,
+): Record<Exclude<RoundtripCategory, "render">, string[]> {
+  const c1 = before.canonical.fields;
+  const c3 = after.canonical.fields;
+  return {
+    contact: contactFails(c1, c3),
+    experience: entryValueFails(
+      c1.experience ?? [],
+      c3.experience ?? [],
+      ["title", "company", "start_date", "end_date"] as const,
+      "role",
+    ),
+    education: entryValueFails(
+      c1.education ?? [],
+      c3.education ?? [],
+      ["degree", "field", "institution"] as const,
+      "entry",
+    ),
+    skills: skillsValueFails(c1.skills ?? [], c3.skills ?? []),
+    summary: summaryFails(c1.summary ?? "", c3.summary ?? ""),
+  };
+}
+
+/**
+ * The PII-free half: given one hop's before/after parse (`after` absent when
+ * `renderError` pre-empted the hop), the `DefectClass[]` it localizes and the
+ * `derived.*ChangedAcrossRoundtrip` / `renderThrewOnRoundtrip` booleans a
+ * sweep can merge into one `DerivedSignals`. Reads ONLY boolean field-level
+ * comparisons — never a `harnessDiff`/`invariantFailures` string, which may
+ * carry résumé values.
+ */
+export function localizeRoundtripHop(
+  before: CascadeResult,
+  after: CascadeResult | undefined,
+  renderError?: string,
+): { defects: DefectClass[]; derived: Partial<DerivedSignals> } {
+  if (!after || renderError) {
+    // The hop produced no `after`, so the nine `*ChangedAcrossRoundtrip` bits are
+    // NOT COMPUTABLE. Leaving them false would say "no value changed across the
+    // round-trip" about a round-trip that never happened — the unknowable-reads-
+    // false bug this whole layer exists to prevent. `roundtripOracleUnavailable`
+    // is the honest report: the five `roundtrip-*-value-changed` classes are
+    // WITHHELD (`defect-classes.ts`'s oracle gate), and only the observed fact —
+    // the crash — is claimed.
+    return {
+      defects: [ROUNDTRIP_CATEGORY_CLASS.render],
+      derived: { renderThrewOnRoundtrip: true, roundtripOracleUnavailable: true },
+    };
+  }
+
+  const c1 = before.canonical.fields;
+  const c3 = after.canonical.fields;
+  const contactChanges = contactFieldChanges(c1, c3);
+
+  const experienceChanged =
+    entryValueFails(
+      c1.experience ?? [],
+      c3.experience ?? [],
+      ["title", "company", "start_date", "end_date"] as const,
+      "role",
+    ).length > 0;
+  const educationChanged =
+    entryValueFails(
+      c1.education ?? [],
+      c3.education ?? [],
+      ["degree", "field", "institution"] as const,
+      "entry",
+    ).length > 0;
+  const skillsChanged =
+    skillsValueFails(c1.skills ?? [], c3.skills ?? []).length > 0;
+  const summaryChanged =
+    summaryFails(c1.summary ?? "", c3.summary ?? "").length > 0;
+
+  const derived: Partial<DerivedSignals> = {
+    fullNameChangedAcrossRoundtrip: contactChanges.fullName,
+    emailChangedAcrossRoundtrip: contactChanges.email,
+    phoneChangedAcrossRoundtrip: contactChanges.phone,
+    locationChangedAcrossRoundtrip: contactChanges.location,
+    linkedinUrlChangedAcrossRoundtrip: contactChanges.linkedin,
+    experienceChangedAcrossRoundtrip: experienceChanged,
+    educationChangedAcrossRoundtrip: educationChanged,
+    skillsChangedAcrossRoundtrip: skillsChanged,
+    summaryChangedAcrossRoundtrip: summaryChanged,
+    renderThrewOnRoundtrip: false,
+    roundtripOracleUnavailable: false,
+  };
+
+  // Category → verdict (a non-empty diff) → class, straight through the pin.
+  const changedByCategory: Record<Exclude<RoundtripCategory, "render">, boolean> =
+    {
+      contact:
+        contactChanges.fullName ||
+        contactChanges.email ||
+        contactChanges.phone ||
+        contactChanges.location ||
+        contactChanges.linkedin,
+      experience: experienceChanged,
+      education: educationChanged,
+      skills: skillsChanged,
+      summary: summaryChanged,
+    };
+
+  const defects: DefectClass[] = (
+    ["contact", "experience", "education", "skills", "summary"] as const
+  )
+    .filter((c) => changedByCategory[c])
+    .map((c) => ROUNDTRIP_CATEGORY_CLASS[c]);
+
+  return { defects, derived };
+}

--- a/src/lib/heuristics/localize/skills.test.ts
+++ b/src/lib/heuristics/localize/skills.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect } from "vitest";
+import { localizeSkills, looseSkillsReason } from "./skills.ts";
+import { mkCascade } from "./__test-utils__.ts";
+
+describe("localizeSkills", () => {
+  it("emits no defect when skills parsed", () => {
+    const cascade = mkCascade({
+      fields: { skills: ["Python", "TypeScript"] },
+      sections: { skills: ["Python, TypeScript"] },
+    });
+    const out = localizeSkills(cascade);
+    expect(out.defects).toEqual([]);
+    expect(out.verdict).toMatch(/^ok/);
+  });
+
+  it("localizes skills-extraction-miss when the region routed but nothing parsed", () => {
+    const cascade = mkCascade({
+      fields: { skills: [] },
+      sections: { skills: ["Python, TypeScript"] },
+    });
+    const out = localizeSkills(cascade);
+    expect(out.defects).toEqual(["skills-extraction-miss"]);
+    expect(out.verdict).toMatch(/^EXTRACTION-MISS/);
+  });
+
+  it("localizes skills-header-unrecognized when an out-of-alias header is rejected", () => {
+    const cascade = mkCascade({
+      fields: { skills: [] },
+      sections: {},
+      markdown: "# Skills Summary\nPython, TypeScript\n# Experience\n",
+    });
+    const out = localizeSkills(cascade);
+    expect(out.defects).toEqual(["skills-header-unrecognized"]);
+    expect(out.derived.skillsHeaderCandidateRejected).toBe(true);
+    expect(out.verdict).toMatch(/^HEADER-UNRECOGNIZED/);
+  });
+
+  it("localizes skills-no-section when nothing skills-like exists anywhere", () => {
+    const cascade = mkCascade({
+      fields: { skills: [] },
+      sections: {},
+      markdown: "# Experience\nSome role\n",
+    });
+    const out = localizeSkills(cascade);
+    expect(out.defects).toEqual(["skills-no-section"]);
+    expect(out.derived.skillsHeaderCandidateRejected).toBe(false);
+    expect(out.verdict).toMatch(/^NO-SKILLS-SECTION/);
+  });
+
+  it("withholds skills-no-section when there is no markdown to read (scanned/sparse)", () => {
+    // The header oracle reads `cascade.markdown` and nothing else. With no
+    // markdown it cannot tell a rejected header from a résumé with no skills
+    // section — so it reports NEITHER class rather than guessing the one 9
+    // fixtures "cover". The verdict text is unchanged (the harness contract);
+    // only the CLASS is withheld.
+    const cascade = mkCascade({ fields: { skills: [] }, sections: {} });
+    const out = localizeSkills(cascade);
+    expect(out.headerOracleUnavailable).toBe(true);
+    expect(out.derived.headerOracleUnavailable).toBe(true);
+    expect(out.defects).toEqual([]);
+    expect(out.verdict).toMatch(/^NO-SKILLS-SECTION/);
+  });
+
+  it("looseSkillsReason strips a leading decorative glyph", () => {
+    expect(looseSkillsReason("★Skills")).toMatch(/leading-glyph prefix/);
+    expect(looseSkillsReason("Random Prose")).toBeNull();
+  });
+});

--- a/src/lib/heuristics/localize/skills.ts
+++ b/src/lib/heuristics/localize/skills.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Skills-section localization (issue #469 step 4) — extracted from
+ * `probe-skills.test.ts` so a shared sweep (`/probe-resume`, a later step) can
+ * reuse the SAME detector instead of a copy-pasted seventh implementation.
+ *
+ * PURE: takes an already-parsed `CascadeResult`, never re-parses, never does
+ * I/O. This is a refactor of the probe's inline logic, not a behavior change —
+ * `probe-skills.test.ts` must print byte-identical output after switching to
+ * call this.
+ *
+ * The markdown header oracle lives in `./headers.ts` (shared with
+ * `./education.ts`). Read ITS header for why `HeaderOracle.unavailable` — a
+ * scanned or sparse PDF with no markdown at all — is not the same fact as "no
+ * skills-like header was rejected", and why `skills-no-section` refuses to fire
+ * while it is true.
+ */
+
+import type { CascadeResult } from "../types.ts";
+import { SECTION_KEYWORDS } from "../regex.ts";
+import { SECTION_ANCHORS } from "../sections.config.ts";
+import type { DefectClass, DerivedSignals } from "../defect-classes.ts";
+import type { MissedHeader } from "./headers.ts";
+import { findMissedHeaders, looseHeaderReason } from "./headers.ts";
+
+const SKILLS_ALIASES = SECTION_KEYWORDS.skills ?? [];
+const SKILLS_ANCHORS: ReadonlySet<string> = SECTION_ANCHORS.skills ?? new Set();
+
+/**
+ * Every `DefectClass` this localizer can emit. Declared as a tuple so the
+ * verdict chain below is TYPED to it: a verdict branch cannot exist without
+ * naming a class (or an explicit `null` — "not a defect"), and
+ * `defect-classes.test.ts` pins this tuple against the table's `probe:
+ * "probe-skills"` rows. A class in the table with no branch here — or a branch
+ * here for a class not in the table — is a test failure, not a silent gap.
+ */
+export const SKILLS_DEFECT_CLASSES = [
+  "skills-extraction-miss",
+  "skills-header-unrecognized",
+  "skills-no-section",
+] as const satisfies readonly DefectClass[];
+
+type SkillsDefectClass = (typeof SKILLS_DEFECT_CLASSES)[number];
+
+/**
+ * Loose skills-header oracle — the shared `looseHeaderReason` bound to the
+ * skills alias/anchor sets. Kept as a named export because it IS the #414
+ * oracle, and reads better at the call sites (and in its tests) than the
+ * four-argument generic.
+ */
+export function looseSkillsReason(raw: string): string | null {
+  return looseHeaderReason(raw, SKILLS_ALIASES, SKILLS_ANCHORS, "skills");
+}
+
+export type { MissedHeader };
+
+export interface SkillsLocalization {
+  /** OUTPUT: the parsed skills list. */
+  skills: string[];
+  /** INPUT (routed): the skills region the extractor scanned, if any. */
+  skillsRegion: string[];
+  skillsRegionPresent: boolean;
+  /** Section-detection overview (all regions, line counts only). */
+  sectionOverview: string[];
+  headerCandidates: { text: string; strict: string | null }[];
+  /** Skills-like headers the strict router did NOT map to skills. */
+  missedSkillsHeaders: MissedHeader[];
+  /** The markdown block under the first missed header, up to the next header. */
+  orphanBlock: string[];
+  /** TRUE when there was no markdown to run the header oracle over (scanned or
+   *  sparse PDF) — so `missedSkillsHeaders` being empty proves NOTHING. */
+  headerOracleUnavailable: boolean;
+  verdict: string;
+  defects: DefectClass[];
+  derived: Partial<DerivedSignals>;
+}
+
+/**
+ * Localize the skills section: OUTPUT (parsed skills) vs INPUT (routed region +
+ * header candidates the strict router rejected).
+ */
+export function localizeSkills(cascade: CascadeResult): SkillsLocalization {
+  const p = cascade.canonical.fields;
+
+  const skills = [...(p.skills ?? [])];
+
+  const skillsRegion = [
+    ...(cascade.canonical.sections.byName.get("skills") ?? []),
+  ];
+  const skillsRegionPresent = skillsRegion.length > 0;
+
+  const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
+    ([name, lines]) => `${name}(${lines.length})`,
+  );
+
+  const oracle = findMissedHeaders(
+    cascade,
+    SKILLS_ALIASES,
+    SKILLS_ANCHORS,
+    "skills",
+  );
+  const missedSkillsHeaders = oracle.missedHeaders;
+  const skillsHeaderCandidateRejected = missedSkillsHeaders.length > 0;
+
+  // ── Verdict and class are CO-EMITTED, in one branch chain. A new branch
+  // cannot print a verdict without deciding a class (or explicitly `null`).
+  // `skills-no-section` is withheld when the oracle could not run: the pair
+  // {header-unrecognized, no-section} is then undecidable, and guessing it is
+  // exactly the false-COVER the sweep exists to prevent (see headers.ts).
+  let verdict: string;
+  let defect: SkillsDefectClass | null;
+  if (skills.length > 0) {
+    verdict = `ok (${skills.length} skill entries parsed)`;
+    defect = null;
+  } else if (skillsRegionPresent) {
+    verdict = `EXTRACTION-MISS (skills region routed with ${skillsRegion.length} lines but 0 skills parsed)`;
+    defect = "skills-extraction-miss";
+  } else if (skillsHeaderCandidateRejected) {
+    verdict = `HEADER-UNRECOGNIZED (skills-like header rejected by the strict router → ${missedSkillsHeaders[0].reason})`;
+    defect = "skills-header-unrecognized";
+  } else {
+    verdict =
+      "NO-SKILLS-SECTION (no routed region and no skills-like header candidate)";
+    defect = oracle.unavailable ? null : "skills-no-section";
+  }
+
+  const derived: Partial<DerivedSignals> = {
+    skillsHeaderCandidateRejected,
+    headerOracleUnavailable: oracle.unavailable,
+  };
+
+  return {
+    skills,
+    skillsRegion,
+    skillsRegionPresent,
+    sectionOverview,
+    headerCandidates: oracle.headerCandidates,
+    missedSkillsHeaders,
+    orphanBlock: oracle.orphanBlock,
+    headerOracleUnavailable: oracle.unavailable,
+    verdict,
+    defects: defect ? [defect] : [],
+    derived,
+  };
+}

--- a/src/lib/heuristics/probe-achievements.test.ts
+++ b/src/lib/heuristics/probe-achievements.test.ts
@@ -56,12 +56,9 @@ import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { runCascade } from "./cascade.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
+import { localizeAchievements } from "./localize/achievements.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-
-/** Bullet/numbered lead markers — a line carrying one is a BODY line, not a
- *  candidate entry header (mirrors group-bullets' LEADING_MARKER_RE). */
-const BULLET_LINE_RE = /^[\s ]*(?:[-*•●–▪◦‣▶►·]|\d+[.)])\s/;
 
 describe.runIf(process.env.RL_ACHIEVEMENTS_PDF)(
   "achievements dev probe (RL_ACHIEVEMENTS_PDF)",
@@ -83,50 +80,8 @@ describe.runIf(process.env.RL_ACHIEVEMENTS_PDF)(
         sections: cascade.canonical.sections,
       });
 
-      // OUTPUT: the parsed achievement entries. `type` and `title` are the two
-      // stored halves the view/PDF/editor all read — no re-splitting here, the
-      // split happened once at parse (#456).
-      const entries = (p.heuristic_achievements ?? []).map((a) => {
-        const type = a.type ?? null;
-        return {
-          type,
-          description: a.title,
-          // Whether the header carried a LABEL — i.e. whether the export bolds
-          // just the type (true) or the whole header line (false).
-          typeIsLabel: type !== null,
-          year: a.year ?? null,
-          url: a.url ?? null,
-          bullets: a.description
-            ? a.description.split("\n").filter((l) => l.trim()).length
-            : 0,
-        };
-      });
-
-      // INPUT: the achievements region the entry segmenter scanned.
-      const regionLines = [
-        ...(cascade.canonical.sections.byName.get("achievements") ?? []),
-      ];
-
-      // Section-detection overview (all regions, line counts only). A missing
-      // `achievements` region means the failure is upstream of entry
-      // segmentation — the block was never routed here (heading unrecognized,
-      // or swallowed by a neighbor section).
-      const sectionOverview = [
-        ...cascade.canonical.sections.byName.entries(),
-      ].map(([name, lines]) => `${name}(${lines.length})`);
-
-      // VERIFY: non-bullet lines in the region are candidate entry headers —
-      // a lower-bound oracle for the entry count.
-      const headerLines = regionLines.filter((l) => !BULLET_LINE_RE.test(l));
-      let verdict: string;
-      if (entries.length === 0 && regionLines.length > 0)
-        verdict = `PARSER-MISS (0 entries; the achievements region has ${regionLines.length} lines)`;
-      else if (entries.length < headerLines.length)
-        verdict = `UNDER-SEGMENTED (${entries.length} entries < ${headerLines.length} header-shaped lines — an achievement likely merged into a neighbor)`;
-      else if (entries.length === 0 && regionLines.length === 0)
-        verdict =
-          "no achievements region segmented (the résumé may carry none — check `Sections detected` for a mis-routed block)";
-      else verdict = "ok";
+      const { entries, regionLines, sectionOverview, headerLines, verdict } =
+        localizeAchievements(cascade);
 
       const report = {
         path,

--- a/src/lib/heuristics/probe-contact.test.ts
+++ b/src/lib/heuristics/probe-contact.test.ts
@@ -41,39 +41,9 @@ import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
 import { runCascade } from "./cascade.ts";
-import { EMAIL_RE, US_LOCATION_RE, INTL_LOCATION_RE } from "./regex.ts";
-import { findFirstPhone } from "./phone.ts";
+import { CONTACT_FIELDS, localizeContact } from "./localize/contact.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-
-/** The contact scalar/URL fields the extractor produces. */
-const CONTACT_FIELDS = [
-  "full_name",
-  "email",
-  "phone",
-  "location",
-  "linkedin_url",
-  "github_url",
-  "portfolio_url",
-  "website_url",
-] as const;
-
-/** Independent re-scan of rawText for the fields that most often drop when a
- *  region filter mis-fires. Returns the first candidate for each, or undefined.
- *  Deliberately loose — this is the "is it anywhere in the doc?" oracle, not the
- *  precise extractor. */
-function rawTextCandidates(rawText: string): {
-  email?: string;
-  phone?: string;
-  location?: string;
-} {
-  EMAIL_RE.lastIndex = 0;
-  const email = EMAIL_RE.exec(rawText)?.[0];
-  const phone = findFirstPhone(rawText, "US")?.formatted;
-  const us = US_LOCATION_RE.exec(rawText)?.[0];
-  const intl = INTL_LOCATION_RE.exec(rawText)?.[0];
-  return { email, phone, location: us ?? intl };
-}
 
 describe.runIf(process.env.RL_CONTACT_PDF)(
   "contact dev probe (RL_CONTACT_PDF)",
@@ -84,37 +54,7 @@ describe.runIf(process.env.RL_CONTACT_PDF)(
         process.env.RL_CONTACT_OUT ?? join(HERE, "../../..", "internal/contact");
 
       const cascade = await runCascade(new Uint8Array(readFileSync(path)));
-      const p = cascade.canonical.fields;
-
-      // OUTPUT: the structured contact fields + their per-field confidence.
-      const extracted = Object.fromEntries(
-        CONTACT_FIELDS.map((k) => [
-          k,
-          {
-            value: (p as Record<string, unknown>)[k] ?? null,
-            confidence: cascade.canonical.fieldConfidence[k] ?? 0,
-          },
-        ]),
-      );
-
-      // INPUT: the profile region the contact extractor scanned. If the contact
-      // line never landed here, that alone explains a dropped location (location
-      // has NO full-doc fallback).
-      const profileLines = cascade.canonical.sections.byName.get("profile") ?? [];
-
-      // VERIFY: independent rawText re-scan for the drop-prone fields.
-      const candidates = rawTextCandidates(cascade.rawText);
-      const verify = (
-        ["email", "phone", "location"] as const
-      ).map((k) => {
-        const got = (p as Record<string, unknown>)[k] ?? null;
-        const cand = candidates[k] ?? null;
-        let verdict: string;
-        if (got) verdict = "ok";
-        else if (cand) verdict = "PARSER-MISS (in rawText, not in field)";
-        else verdict = "absent-in-pdf";
-        return { field: k, field_value: got, rawText_candidate: cand, verdict };
-      });
+      const { extracted, profileLines, verify } = localizeContact(cascade);
 
       const report = {
         path,

--- a/src/lib/heuristics/probe-education.test.ts
+++ b/src/lib/heuristics/probe-education.test.ts
@@ -57,49 +57,10 @@ import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
 import { runCascade } from "./cascade.ts";
-import { matchSectionHeader, SECTION_KEYWORDS, DEGREE_RE } from "./regex.ts";
-import { SECTION_ANCHORS } from "./sections.config.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
+import { localizeEducation } from "./localize/education.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-
-const EDUCATION_ALIASES: readonly string[] = SECTION_KEYWORDS.education ?? [];
-const EDUCATION_ANCHORS: ReadonlySet<string> =
-  SECTION_ANCHORS.education ?? new Set<string>();
-
-/**
- * Loose education-header oracle. Mirrors the strict normalizer in
- * `matchSectionHeaderDetailed` (trim + lowercase + trailing-punct strip) but
- * ALSO strips a leading run of non-letter / non-number glyphs — the exact gap
- * the routing miss classes (leading decorative glyph, out-of-alias wording)
- * exploit. Returns the reason a strict match would have failed, or null if
- * the line doesn't read as education at all.
- */
-function looseEducationReason(raw: string): string | null {
-  const trimmedLower = raw.trim().toLowerCase().replace(/[:·•]+$/, "").trim();
-  const glyphStripped = trimmedLower.replace(/^[^\p{L}\p{N}]+/u, "").trim();
-  if (glyphStripped.length === 0 || glyphStripped.length > 40) return null;
-  if (EDUCATION_ALIASES.includes(glyphStripped)) {
-    return glyphStripped === trimmedLower
-      ? "alias match (would route — not a miss)"
-      : `leading-glyph prefix (${JSON.stringify(trimmedLower)} → ${JSON.stringify(glyphStripped)})`;
-  }
-  const tokens = glyphStripped.split(/\s+/).filter(Boolean);
-  if (tokens.some((t) => EDUCATION_ANCHORS.has(t)))
-    return `contains education anchor token but wording not in aliases (${JSON.stringify(glyphStripped)})`;
-  return null;
-}
-
-/** Count `DEGREE_RE` matches in `text` via a fresh global clone. `DEGREE_RE`
- *  is non-global to keep `lastIndex` state out of the field heuristics, so
- *  cloning here is the safe way to count without mutating the shared
- *  instance. */
-function countDegrees(text: string): number {
-  const flags = DEGREE_RE.flags.includes("g")
-    ? DEGREE_RE.flags
-    : `${DEGREE_RE.flags}g`;
-  return (text.match(new RegExp(DEGREE_RE.source, flags)) ?? []).length;
-}
 
 describe.runIf(process.env.RL_EDUCATION_PDF)(
   "education dev probe (RL_EDUCATION_PDF)",
@@ -125,100 +86,17 @@ describe.runIf(process.env.RL_EDUCATION_PDF)(
         sections: cascade.canonical.sections,
       });
 
-      // OUTPUT: the parsed education entries.
-      const entries = (p.education ?? []).map((e) => ({
-        institution: e.institution || null,
-        degree: e.degree || null,
-        field: e.field ?? null,
-        location: e.location ?? null,
-        start_date: e.start_date ?? null,
-        end_date: e.end_date ?? null,
-        year: e.year ?? null,
-        coursework: e.coursework?.length ?? 0,
-      }));
-
-      // INPUT (routed): the education region the chunker scanned, if any.
-      const educationRegion = [
-        ...(cascade.canonical.sections.byName.get("education") ?? []),
-      ];
-      const regionPresent = educationRegion.length > 0;
-
-      // Section-detection overview (all regions, line counts only).
-      const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
-        ([name, lines]) => `${name}(${lines.length})`,
-      );
-
-      // Header candidates from the ordered markdown (`#`/`##`/`###` lines).
-      // The markdown header heuristic is looser than the router, so a rejected
-      // education header still shows up here — that is exactly what localizes
-      // a routing miss.
-      const md = cascade.markdown ?? "";
-      const mdLines = md.split("\n");
-      const headerCandidates = mdLines
-        .map((l, i) => ({
-          text: l.replace(/^#{1,3}\s+/, "").trim(),
-          i,
-          isHeader: /^#{1,3}\s+/.test(l),
-        }))
-        .filter((h) => h.isHeader && h.text.length > 0);
-
-      // An education-like header the strict router did NOT map to education.
-      const missedEducationHeaders = headerCandidates
-        .map((h) => ({
-          ...h,
-          strict: matchSectionHeader(h.text),
-          reason: looseEducationReason(h.text),
-        }))
-        .filter(
-          (h) =>
-            h.strict !== "education" &&
-            h.reason !== null &&
-            !h.reason.startsWith("alias match"),
-        );
-
-      // The markdown block under the first missed header (its dropped
-      // content), up to the next markdown header. Scrubbed to a line count in
-      // the console; full text only in the gitignored JSON.
-      const orphanBlock: string[] = [];
-      if (missedEducationHeaders.length > 0) {
-        const start = missedEducationHeaders[0].i + 1;
-        for (let i = start; i < mdLines.length; i++) {
-          if (/^#{1,3}\s+/.test(mdLines[i])) break;
-          if (mdLines[i].trim()) orphanBlock.push(mdLines[i].trim());
-        }
-      }
-
-      // Count `DEGREE_RE` tokens inside the routed region — a LOWER-BOUND
-      // oracle for entry count. `entries < regionDegrees` flags UNDER-CHUNKED
-      // (two degrees collapsed into one). `entries > regionDegrees` is NOT
-      // flagged — a degree-less program (#238) legitimately produces an entry
-      // with no `DEGREE_RE` match.
-      const regionDegrees = countDegrees(educationRegion.join("\n"));
-
-      // Per-entry field-presence sanity check. Not a wrong-value oracle (no
-      // ground truth for a real résumé) — just a presence gate that catches
-      // silent per-entry drops even when the count is right.
-      const perEntry = entries.map((e, i) => {
-        const missing: string[] = [];
-        if (!e.institution) missing.push("institution");
-        if (!e.degree) missing.push("degree");
-        if (!e.start_date && !e.end_date) missing.push("date");
-        return { i, missing };
-      });
-
-      let verdict: string;
-      if (entries.length === 0 && regionPresent) {
-        verdict = `EXTRACTION-MISS (education region routed with ${educationRegion.length} lines but 0 entries)`;
-      } else if (entries.length === 0 && missedEducationHeaders.length > 0) {
-        verdict = `HEADER-UNRECOGNIZED (education-like header rejected by the strict router → ${missedEducationHeaders[0].reason})`;
-      } else if (entries.length === 0) {
-        verdict =
-          "NO-EDUCATION-SECTION (no routed region and no education-like header candidate)";
-      } else if (regionDegrees > entries.length) {
-        verdict = `UNDER-CHUNKED (${entries.length} entries < ${regionDegrees} DEGREE_RE tokens in region — a degree line likely merged with a neighbour)`;
-      } else {
-        verdict = `ok (${entries.length} education entries parsed)`;
-      }
+      const {
+        entries,
+        perEntry,
+        educationRegion,
+        regionDegrees,
+        sectionOverview,
+        headerCandidates,
+        missedEducationHeaders,
+        orphanBlock,
+        verdict,
+      } = localizeEducation(cascade);
 
       const report = {
         path,
@@ -233,14 +111,8 @@ describe.runIf(process.env.RL_EDUCATION_PDF)(
         perEntry,
         educationRegion,
         regionDegrees,
-        headerCandidates: headerCandidates.map((h) => ({
-          text: h.text,
-          strict: matchSectionHeader(h.text),
-        })),
-        missedEducationHeaders: missedEducationHeaders.map((h) => ({
-          text: h.text,
-          reason: h.reason,
-        })),
+        headerCandidates,
+        missedEducationHeaders,
         orphanBlock,
         verdict,
         triggers: [...cascade.triggers],

--- a/src/lib/heuristics/probe-experience.test.ts
+++ b/src/lib/heuristics/probe-experience.test.ts
@@ -46,8 +46,8 @@ import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
 import { runCascade } from "./cascade.ts";
-import { DATE_RANGE_RE } from "./regex.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
+import { localizeExperience } from "./localize/experience.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -71,37 +71,8 @@ describe.runIf(process.env.RL_EXPERIENCE_PDF)(
         sections: cascade.canonical.sections,
       });
 
-      // OUTPUT: the parsed role entries.
-      const entries = (p.experience ?? []).map((e) => ({
-        title: e.title || null,
-        company: e.company || null,
-        location: e.location ?? null,
-        start_date: e.start_date ?? null,
-        end_date: e.end_date ?? (e.is_current ? "Present" : null),
-        bullets: e.description
-          ? e.description.split("\n").filter((l) => l.trim()).length
-          : 0,
-      }));
-
-      // INPUT: the experience region the entry segmenter scanned.
-      const regionLines = [
-        ...(cascade.canonical.sections.byName.get("experience") ?? []),
-      ];
-
-      // Section-detection overview (all regions, line counts only).
-      const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
-        ([name, lines]) => `${name}(${lines.length})`,
-      );
-
-      // VERIFY: date-range lines inside the region are a lower-bound oracle
-      // for the role count. DATE_RANGE_RE is non-global; test per line.
-      const dateRangeLines = regionLines.filter((l) => DATE_RANGE_RE.test(l));
-      let verdict: string;
-      if (entries.length === 0 && dateRangeLines.length > 0)
-        verdict = `PARSER-MISS (0 entries; region has ${dateRangeLines.length} date-range lines)`;
-      else if (entries.length < dateRangeLines.length)
-        verdict = `UNDER-SEGMENTED (${entries.length} entries < ${dateRangeLines.length} date-range lines — a role likely merged into a neighbor)`;
-      else verdict = "ok";
+      const { entries, regionLines, sectionOverview, dateRangeLines, verdict } =
+        localizeExperience(cascade);
 
       const report = {
         path,

--- a/src/lib/heuristics/probe-resume.test.ts
+++ b/src/lib/heuristics/probe-resume.test.ts
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Whole-résumé sweep probe (#469) — inert in CI, runs ONLY when
+ * `RL_RESUME_PDF=<path>` is set:
+ *
+ *   RL_RESUME_PDF=/abs/path/to/resume.pdf npx vitest run \
+ *     src/lib/heuristics/probe-resume.test.ts
+ *
+ * The execution vehicle for the `probe-resume` skill — the orchestrator of the
+ * six single-section probes (`probe-{contact,skills,experience,education,
+ * achievements,roundtrip}`). It runs ONE `runCascade()` and ONE render → re-parse
+ * hop, drives every localizer off that single parse, and then answers the one
+ * question no single-section probe can:
+ *
+ *   > This résumé exhibits defect class C. **Does a fixture already reproduce C?**
+ *
+ * `COVERED` means STOP: go fix the parser against the existing fixture and never
+ * open the real résumé again. `NO FIXTURE COVERS THIS` is the only answer that
+ * justifies minting a new synthetic fixture — and this harness MINTS NOTHING and
+ * COMMITS NOTHING. It prints the next step; a human takes it.
+ *
+ * ── PII guardrail (same rules as the six siblings) ──
+ * 1. The input PDF is local-only. NEVER commit it. It is not a fixture;
+ *    `tests/fixtures/pdfs/` is synthetic-personas-only by policy.
+ * 2. Unlike the siblings, this harness's CONSOLE OUTPUT PRINTS NO RÉSUMÉ VALUES
+ *    AT ALL — only defect CLASSES, axis names, fixture paths, counts, and
+ *    booleans. Every one of those is PII-free by construction (`ReproArtifact` +
+ *    `DerivedSignals` admit no free-form string). The only free-form string it
+ *    echoes is the PDF path YOU passed in, which may carry a name — so still do
+ *    not paste the console output verbatim into an issue/PR/Slack. Cite a defect
+ *    by CLASS.
+ * 3. The full JSON report goes to `RL_RESUME_OUT` (default `internal/resume/`,
+ *    gitignored). It, too, carries only the artifact + derived booleans + the
+ *    coverage map. An override that points inside the repo at a NON-gitignored
+ *    path is a hard failure, not a warning.
+ *
+ * | Var | Default | Meaning |
+ * |---|---|---|
+ * | `RL_RESUME_PDF` | *(unset)* | Absolute path to the résumé PDF. Unset → inert. |
+ * | `RL_RESUME_OUT` | `internal/resume/` | Directory for the full JSON report. |
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import { runCascade } from "./cascade.ts";
+import { runRoundtripHop } from "./roundtrip-hop.ts";
+import { buildReproArtifact } from "./repro-artifact.ts";
+import type { ReproArtifact } from "./repro-artifact.ts";
+import type { DefectClass, DerivedSignals, Oracle } from "./defect-classes.ts";
+import {
+  DEFECT_CLASSES,
+  ORACLE_UNAVAILABLE_KEY,
+  defectSpec,
+  isAdvisory,
+  unavailableOracles,
+} from "./defect-classes.ts";
+import { sweepParse, isParseUnreadable } from "./sweep.ts";
+import type { FixtureCoverage } from "./fixture-match.ts";
+import { matchCorpus } from "./fixture-match.ts";
+import { loadCorpus, REPO_ROOT } from "./__test-utils__/corpus-snapshots.ts";
+
+/**
+ * The report directory, validated.
+ *
+ * The default (`internal/`) is gitignored (`.gitignore:61`). An override is
+ * allowed — the maintainer may want the report on a scratch volume — but an
+ * override that lands INSIDE the repo and is NOT gitignored would stage a
+ * diagnostics file for commit, which is exactly the accident the PII policy
+ * exists to prevent. `git check-ignore` is the authority (it honours every
+ * ignore layer, including a global one); if git cannot be consulted at all we
+ * fail closed rather than guess.
+ */
+function resolveOutDir(): string {
+  const override = process.env.RL_RESUME_OUT;
+  if (!override) return join(REPO_ROOT, "internal/resume");
+
+  const dir = isAbsolute(override) ? override : resolve(process.cwd(), override);
+  const rel = relative(REPO_ROOT, dir);
+  const insideRepo = rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  if (!insideRepo) return dir; // outside the repo → nothing can be committed.
+
+  try {
+    execFileSync("git", ["check-ignore", "-q", "--", dir], { cwd: REPO_ROOT });
+    return dir; // exit 0 ⇒ ignored.
+  } catch {
+    throw new Error(
+      `RL_RESUME_OUT="${override}" resolves inside the repo at "${rel}" and is NOT ` +
+        `gitignored. The report is a diagnostics artifact derived from a real résumé — ` +
+        `it must never become committable. Point RL_RESUME_OUT at a gitignored path ` +
+        `(the default "internal/resume/") or somewhere outside the repo.`,
+    );
+  }
+}
+
+/** `COVERED …` / `NO FIXTURE COVERS THIS` + the why-not, for one class.
+ *
+ *  `coveredBy[0]` is the CLOSEST cover by whole-artifact divergence, not the
+ *  alphabetically-first one (`fixture-match.ts` ranks the list). Every entry is
+ *  an equally valid reproducer; the ranking only decides which one is worth
+ *  printing when there are 34 of them. */
+function renderCoverage(c: FixtureCoverage, resumePath: string): string {
+  const head = `  ${c.class.padEnd(34)}`;
+  if (c.coveredBy.length > 0) {
+    const extra =
+      c.coveredBy.length > 1
+        ? `  (closest of ${c.coveredBy.length}; full list in JSON)`
+        : "";
+    return `${head} → COVERED  ${c.coveredBy[0]}${extra}`;
+  }
+
+  // Uncovered. Print the nearest fixtures, the axes that diverged, and — always —
+  // how many candidates the cap hid, so the list is never a silent truncation.
+  const shown = c.nearMisses.length;
+  const lines = [
+    `${head} → NO FIXTURE COVERS THIS`,
+    `        nearest (showing ${shown} of ${c.nearMissCandidateCount}):`,
+    ...c.nearMisses.map(
+      (m) =>
+        `          - ${m.fixture}\n            diverged: ` +
+        (m.divergedAxes.length
+          ? m.divergedAxes.join(", ")
+          : "(none — matches on every load-bearing axis yet does not exhibit the " +
+            "class; suspect the defect table, not the fixture)"),
+    ),
+    `        → next step (nothing is minted or committed for you):`,
+    `          1. re-export a template with a SYNTHETIC persona reproducing \`${c.class}\``,
+    `             → tests/fixtures/pdfs/<category>/<name>.pdf  (see tests/fixtures/pdfs/README.md)`,
+    `          2. npm run bake-fixtures`,
+    `          3. add src/lib/heuristics/<name>.repro.test.ts pinning \`${c.class}\``,
+    `          4. re-run: RL_RESUME_PDF=${resumePath} npx vitest run src/lib/heuristics/probe-resume.test.ts`,
+  ];
+  return lines.join("\n");
+}
+
+/** `name(lineCount)` per routed section — PII-free (a section NAME is a fixed
+ *  enum, a line COUNT is a number). This is the pointer every `*-no-section`
+ *  advisory leans on: it is how a reader tells "the résumé has no skills block"
+ *  from "the skills block got swallowed by `profile`". */
+function renderSections(a: ReproArtifact): string {
+  return a.sections.length
+    ? a.sections.map((s) => `${s.name}(${s.lineCount})`).join(" ")
+    : "(none — the section router cut nothing)";
+}
+
+/** Why each oracle went blind, and what that costs. Static prose — no values. */
+const ORACLE_BANNER: Readonly<Record<Oracle, string[]>> = {
+  text: [
+    "⛔ TEXT ORACLE UNAVAILABLE — this parse produced NO readable text",
+    "   (the layout probe called the PDF `scanned`, or rawText came back empty).",
+    "   EVERY defect signal below the round-trip is read out of that text, so none",
+    "   of them could be computed. This is NOT a clean résumé — it is a résumé this",
+    "   parser could not read, which is resumelint's single most severe failure mode.",
+  ],
+  header: [
+    "⚠️  HEADER ORACLE UNAVAILABLE — this parse produced NO markdown",
+    "   (scanned PDF, or a document too sparse for the markdown emitter).",
+    "   The rejected-header signal is derived ONLY from markdown headers, so a",
+    "   header the strict router rejected cannot be told apart from \"the résumé",
+    "   simply has no such section\" on this document.",
+  ],
+  roundtrip: [
+    "⚠️  ROUNDTRIP ORACLE UNAVAILABLE — the export → re-parse hop produced no `after`",
+    "   parse (a layer of buildAtsResumeModel → renderAtsResumePdf → runCascade threw;",
+    "   `roundtrip-render-crash` reports the crash itself).",
+    "   The value diffs are a BEFORE→AFTER comparison, so with no `after` there was",
+    "   nothing to compare — \"no value changed\" would be a claim about a round-trip",
+    "   that never happened.",
+  ],
+};
+
+/** One banner per blind oracle, naming the classes it WITHHELD. Withholding is
+ *  the whole point: a class whose oracle is blind is undecided, and its silence
+ *  below must never be read as "clean". */
+function oracleBanner(o: Oracle): string {
+  const withheld = DEFECT_CLASSES.filter((c) =>
+    defectSpec(c).requires.includes(o),
+  );
+  return (
+    "\n" +
+    ORACLE_BANNER[o].map((l) => `  ${l}`).join("\n") +
+    `\n   WITHHELD (${withheld.length} classes — undecidable on this parse, NOT clean):\n` +
+    withheld.map((c) => `     - ${c}`).join("\n") +
+    `\n   signal: derived.${ORACLE_UNAVAILABLE_KEY[o]} = true\n`
+  );
+}
+
+/** The DEAD-PARSE read-out. There is deliberately NO `DEFECTS FOUND` line and NO
+ *  `COVERAGE` number here: both would be affirmative claims about a parse whose
+ *  oracles never ran, and a false "clean" is worse than no answer. */
+function renderUnreadable(
+  a: ReproArtifact,
+  claimed: DefectClass[],
+  withheld: DefectClass[],
+): string {
+  const stillClaimed = claimed.filter((c) => !withheld.includes(c));
+  return (
+    `\n  ⛔ PARSE UNREADABLE — DEFECT REPORT AND COVERAGE ARE WITHHELD\n` +
+    `     rawCharCount=${a.rawCharCount}  extractedCharCount=${a.extractedCharCount}` +
+    `  triggers=[${a.triggers.join(", ") || "none"}]\n` +
+    `     The parser read nothing out of this document, so NO defect class in the\n` +
+    `     table could be evaluated and NO corpus coverage can be claimed. Do not\n` +
+    `     read the absence of a DEFECTS FOUND block as "no defects": the correct\n` +
+    `     reading is "this résumé did not parse at all".\n` +
+    (withheld.length
+      ? `     ${withheld.length} classes withheld (see the banner above).\n`
+      : `     0 classes withheld — no oracle banner fired above (the parse read\n` +
+        `     nothing structured despite the text oracle being available; see\n` +
+        `     rawCharCount/extractedCharCount below).\n`) +
+    `     Observed regardless of the blind oracles: ` +
+    (stillClaimed.length ? stillClaimed.join(", ") : "(none)") +
+    `\n     → next step: this is a Tier-0 extraction failure, not a fixture-coverage\n` +
+    `       question. Triage the extraction (scanned/OCR, unmappable fonts), not the\n` +
+    `       section localizers.`
+  );
+}
+
+/** The normal read-out: the defect list + its corpus coverage. */
+function renderDefects(
+  coverage: FixtureCoverage[],
+  defects: DefectClass[],
+  covered: number,
+  path: string,
+): string {
+  if (defects.length) {
+    return (
+      `\n  DEFECTS FOUND (${defects.length})\n\n` +
+      coverage.map((c) => renderCoverage(c, path)).join("\n") +
+      `\n\n  COVERAGE  ${covered}/${defects.length} defects already pinned by the corpus`
+    );
+  }
+  return (
+    `\n  DEFECTS FOUND (0)\n` +
+    `    (none — no defect class in the table is exhibited by this parse)\n` +
+    `    Read this together with INFORMATIONAL and 'Sections detected' below: a\n` +
+    `    section that produced NOTHING is reported there, not here, and if the\n` +
+    `    résumé actually carries that section this parse is NOT clean.\n` +
+    `\n  COVERAGE  0/0 defects already pinned by the corpus`
+  );
+}
+
+describe.runIf(process.env.RL_RESUME_PDF)(
+  "whole-résumé sweep probe (RL_RESUME_PDF)",
+  () => {
+    // Deliberate monolithic diagnostic harness (mirrors the six siblings): one
+    // linear read-out of parse → defects → corpus coverage, visible in a single
+    // scroll. Not production logic.
+    // fallow-ignore-next-line complexity
+    it("sweeps every section and maps each defect onto the fixture corpus", async () => {
+      const path = process.env.RL_RESUME_PDF!;
+      const outDir = resolveOutDir();
+
+      // ── ONE parse, ONE hop. Every localizer is driven off these two. ────────
+      const cascade = await runCascade(new Uint8Array(readFileSync(path)));
+      const hop = await runRoundtripHop(cascade);
+
+      // `sweepParse()` is the SAME function `corpus.test.ts` bakes each fixture's
+      // `derived` with — that identity is what puts the résumé and the corpus on
+      // the same axes. It also applies the ORACLE GATE: a class whose oracle
+      // could not run lands in `withheld`, never in `defects`.
+      const sweep = sweepParse(cascade, hop);
+      const derived: DerivedSignals = sweep.derived;
+      const artifact = buildReproArtifact(cascade);
+
+      // ── DEFECTS vs INFORMATIONAL. The three `*-no-section` classes are
+      // ADVISORY (`DefectSpec.advisory`): "this résumé has no Awards section" is
+      // not a parser defect — 34 of the 45 fixtures parse zero achievements.
+      // Counting them as defects fires on nearly every résumé, corpus-matches
+      // trivially, and INFLATES `COVERAGE n/m`. They are still PRINTED — next to
+      // the section overview, which is the only thing that tells "the résumé has
+      // none" apart from "the block was mis-routed" — they just never enter the
+      // ratio. ──────────────────────────────────────────────────────────────────
+      const defects = sweep.defects.filter((c) => !isAdvisory(c));
+      const informational = sweep.defects.filter((c) => isAdvisory(c));
+      const withheld = sweep.withheld;
+      const blindOracles = unavailableOracles(derived);
+
+      // ── THE DEAD-PARSE GATE. `textOracleUnavailable` ⇒ the parse yielded no
+      // readable text at all; `extractedCharCount === 0` ⇒ it read text but
+      // produced NOTHING from it. Either way every oracle below was blind, and an
+      // affirmative "no defect class is exhibited by this parse" would be a false
+      // claim about a dead parse — resumelint's most severe failure mode reported
+      // as clean. The harness REFUSES: no DEFECTS FOUND block, no COVERAGE
+      // number, no corpus match. The only honest output is "we could not read
+      // this". ────────────────────────────────────────────────────────────────
+      const unreadable = isParseUnreadable(derived, artifact.extractedCharCount);
+
+      const corpus = loadCorpus();
+      // Coverage is a claim about defects. Over an unreadable parse there are no
+      // trustworthy defects to make claims about, so none is computed.
+      const coverage = unreadable
+        ? []
+        : matchCorpus(artifact, derived, defects, corpus);
+      const covered = coverage.filter((c) => c.coveredBy.length > 0).length;
+
+      // ── The JSON report: artifact + derived + coverage. PII-free by type; it
+      // still goes ONLY to the gitignored out dir. ────────────────────────────
+      const report = {
+        path,
+        corpusSize: corpus.length,
+        unreadable,
+        defects: unreadable ? [] : defects,
+        informational: unreadable ? [] : informational,
+        withheld,
+        unavailableOracles: blindOracles,
+        localizerClaims: sweep.defects,
+        sections: artifact.sections,
+        coverage,
+        reproArtifact: artifact,
+        derived,
+      };
+      mkdirSync(outDir, { recursive: true });
+      const outFile = join(
+        outDir,
+        `resume-${basename(path).replace(/\.[^.]+$/, "")}.json`,
+      );
+      writeFileSync(outFile, JSON.stringify(report, null, 2));
+
+      // ── The read-out. Classes, axes, fixture paths, counts, booleans, static
+      // prose. No résumé values, anywhere. ───────────────────────────────────
+      console.log(
+        `RL_RESUME_PDF résumé sweep for ${path}:\n` +
+          `\n  Corpus: ${corpus.length} baked fixtures\n` +
+          blindOracles.map(oracleBanner).join("") +
+          (unreadable
+            ? renderUnreadable(artifact, sweep.defects, withheld)
+            : renderDefects(coverage, defects, covered, path)) +
+          // The section overview: `name(lineCount)` per routed region, next to
+          // rawCharCount/extractedCharCount so an unaccounted-for region is
+          // visible — PII-free (counts only), and load-bearing for the
+          // advisories immediately below it: a `skills-no-section` on a résumé
+          // that HAS a skills block shows up either as a fat `profile`/`other`
+          // bucket that swallowed it, or as summed section line counts that
+          // don't account for the extracted characters (it vanished entirely).
+          `\n\n  Sections detected (rawCharCount=${artifact.rawCharCount} ` +
+          `extractedCharCount=${artifact.extractedCharCount}): ${renderSections(artifact)}` +
+          // The JSON report zeroes `informational` on the unreadable path (no
+          // oracle ran, so an advisory claim is as undecidable as a defect
+          // claim); the console must say the same thing, not print a non-empty
+          // list that contradicts it.
+          (unreadable
+            ? `\n\n  INFORMATIONAL — withheld (parse unreadable; see banner above)`
+            : `\n\n  INFORMATIONAL (${informational.length}) — not defects; excluded from COVERAGE\n` +
+              (informational.length
+                ? informational
+                    .map(
+                      (c) =>
+                        `    ${c.padEnd(34)} no such section was routed. If the résumé DOES carry one,\n` +
+                        `    ${" ".repeat(34)} the block was mis-routed — look for it in 'Sections detected'\n` +
+                        `    ${" ".repeat(34)} above (a fat profile/other bucket that swallowed it), or it\n` +
+                        `    ${" ".repeat(34)} landed nowhere at all — compare the section line counts to\n` +
+                        `    ${" ".repeat(34)} extractedCharCount above.`,
+                    )
+                    .join("\n")
+                : "    (none)")) +
+          `\n\n  Probes per defect: ` +
+          (defects.length && !unreadable
+            ? defects.map((c) => `${c}=${defectSpec(c).probe}`).join("  ")
+            : "(none)") +
+          `\n\n  Full JSON → ${outFile}  ⚠️ gitignored; do NOT commit.`,
+      );
+
+      // The sweep is a diagnostic: it never fails on what it FINDS. But it must
+      // fail if it could not do its job — a corpus that loaded to nothing would
+      // report every defect as "NO FIXTURE COVERS THIS", which reads as a
+      // legitimate result. (`loadCorpus` also throws on a stale snapshot; this
+      // is the belt to its braces.)
+      expect(corpus.length).toBeGreaterThan(0);
+    });
+  },
+);

--- a/src/lib/heuristics/probe-skills.test.ts
+++ b/src/lib/heuristics/probe-skills.test.ts
@@ -49,35 +49,10 @@ import { fileURLToPath } from "node:url";
 
 import { describe, it, expect } from "vitest";
 import { runCascade } from "./cascade.ts";
-import { matchSectionHeader, SECTION_KEYWORDS } from "./regex.ts";
-import { SECTION_ANCHORS } from "./sections.config.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
+import { localizeSkills } from "./localize/skills.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-
-const SKILLS_ALIASES = SECTION_KEYWORDS.skills ?? [];
-const SKILLS_ANCHORS: ReadonlySet<string> = SECTION_ANCHORS.skills ?? new Set();
-
-/**
- * Loose skills-header oracle. Mirrors the strict normalizer in
- * `matchSectionHeaderDetailed` but ALSO strips a leading run of non-letter /
- * non-number glyphs — the exact gap #414 identified. Returns the reason a
- * strict match would have failed, or null if the line doesn't read as skills.
- */
-function looseSkillsReason(raw: string): string | null {
-  const trimmedLower = raw.trim().toLowerCase().replace(/[:·•]+$/, "").trim();
-  const glyphStripped = trimmedLower.replace(/^[^\p{L}\p{N}]+/u, "").trim();
-  if (glyphStripped.length === 0 || glyphStripped.length > 40) return null;
-  if (SKILLS_ALIASES.includes(glyphStripped)) {
-    return glyphStripped === trimmedLower
-      ? "alias match (would route — not a miss)"
-      : `leading-glyph prefix (${JSON.stringify(trimmedLower)} → ${JSON.stringify(glyphStripped)})`;
-  }
-  const tokens = glyphStripped.split(/\s+/).filter(Boolean);
-  if (tokens.some((t) => SKILLS_ANCHORS.has(t)))
-    return `contains skills anchor token but wording not in aliases (${JSON.stringify(glyphStripped)})`;
-  return null;
-}
 
 describe.runIf(process.env.RL_SKILLS_PDF)(
   "skills dev probe (RL_SKILLS_PDF)",
@@ -102,61 +77,15 @@ describe.runIf(process.env.RL_SKILLS_PDF)(
         sections: cascade.canonical.sections,
       });
 
-      // OUTPUT: the parsed skills list.
-      const skills = [...(p.skills ?? [])];
-
-      // INPUT (routed): the skills region the extractor scanned, if any.
-      const skillsRegion = [...(cascade.canonical.sections.byName.get("skills") ?? [])];
-      const skillsRegionPresent = skillsRegion.length > 0;
-
-      // Section-detection overview (all regions, line counts only).
-      const sectionOverview = [...cascade.canonical.sections.byName.entries()].map(
-        ([name, lines]) => `${name}(${lines.length})`,
-      );
-
-      // Header candidates from the ordered markdown (`#`/`##`/`###` lines). The
-      // markdown header heuristic is looser than the router, so a rejected
-      // skills header still shows up here — that is exactly what localizes a
-      // routing miss.
-      const md = cascade.markdown ?? "";
-      const mdLines = md.split("\n");
-      const headerCandidates = mdLines
-        .map((l, i) => ({ text: l.replace(/^#{1,3}\s+/, "").trim(), i, isHeader: /^#{1,3}\s+/.test(l) }))
-        .filter((h) => h.isHeader && h.text.length > 0);
-
-      // A skills-like header the strict router did NOT map to skills.
-      const missedSkillsHeaders = headerCandidates
-        .map((h) => ({ ...h, strict: matchSectionHeader(h.text), reason: looseSkillsReason(h.text) }))
-        .filter(
-          (h) =>
-            h.strict !== "skills" &&
-            h.reason !== null &&
-            !h.reason.startsWith("alias match"),
-        );
-
-      // The markdown block under the first missed header (its dropped content),
-      // up to the next markdown header — the skills content that should have
-      // been routed. Scrubbed to a line count in the console; full text only in
-      // the gitignored JSON.
-      let orphanBlock: string[] = [];
-      if (missedSkillsHeaders.length > 0) {
-        const start = missedSkillsHeaders[0].i + 1;
-        for (let i = start; i < mdLines.length; i++) {
-          if (/^#{1,3}\s+/.test(mdLines[i])) break;
-          if (mdLines[i].trim()) orphanBlock.push(mdLines[i].trim());
-        }
-      }
-
-      let verdict: string;
-      if (skills.length > 0) {
-        verdict = `ok (${skills.length} skill entries parsed)`;
-      } else if (skillsRegionPresent) {
-        verdict = `EXTRACTION-MISS (skills region routed with ${skillsRegion.length} lines but 0 skills parsed)`;
-      } else if (missedSkillsHeaders.length > 0) {
-        verdict = `HEADER-UNRECOGNIZED (skills-like header rejected by the strict router → ${missedSkillsHeaders[0].reason})`;
-      } else {
-        verdict = "NO-SKILLS-SECTION (no routed region and no skills-like header candidate)";
-      }
+      const {
+        skills,
+        skillsRegion,
+        sectionOverview,
+        headerCandidates,
+        missedSkillsHeaders,
+        orphanBlock,
+        verdict,
+      } = localizeSkills(cascade);
 
       const report = {
         path,
@@ -169,14 +98,8 @@ describe.runIf(process.env.RL_SKILLS_PDF)(
         sectionOverview,
         skills,
         skillsRegion,
-        headerCandidates: headerCandidates.map((h) => ({
-          text: h.text,
-          strict: matchSectionHeader(h.text),
-        })),
-        missedSkillsHeaders: missedSkillsHeaders.map((h) => ({
-          text: h.text,
-          reason: h.reason,
-        })),
+        headerCandidates,
+        missedSkillsHeaders,
         orphanBlock,
         verdict,
         triggers: [...cascade.triggers],

--- a/src/lib/heuristics/roundtrip-hop.ts
+++ b/src/lib/heuristics/roundtrip-hop.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The ONE render → re-parse hop (issue #469 step 5).
+ *
+ * `localize/roundtrip.ts` is deliberately pure: `localizeRoundtripHop()` diffs a
+ * before/after pair but never renders and never re-parses — the CALLER performs
+ * the hop. Three callers now need that hop (the corpus round-trip gate, its
+ * `RL_RT_PDF` dev harness, and the corpus bake that writes each fixture's
+ * `derived` block), so the hop itself lives here once instead of being spelled
+ * out three times:
+ *
+ *   parse → buildAtsResumeModel → renderAtsResumePdf → runCascade
+ *
+ * A render crash is DATA, not a throw: `renderAtsResumePdf` failing yields
+ * `{ after: undefined, renderError }`, which is exactly the shape
+ * `localizeRoundtripHop()` expects for its `roundtrip-render-crash` class.
+ *
+ * PII-free: returns parses, never prints or persists a value.
+ */
+
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import { buildAtsResumeModel } from "../pdf/ats-resume-model.ts";
+import { renderAtsResumePdf } from "../pdf/render-ats-pdf.ts";
+import { runCascade } from "./cascade.ts";
+import type { CascadeResult } from "./types.ts";
+
+/** The score the reconstructed-PDF model is built against. */
+function scoreForCascade(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: { ...cascade.canonical.fields },
+    fieldConfidence: cascade.canonical.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.canonical.sections,
+  });
+}
+
+export interface RoundtripHop {
+  /** The re-parse of the reconstructed PDF, or `undefined` when the hop threw. */
+  after?: CascadeResult;
+  /** Set iff some layer of the hop threw. Names the LAYER that did. */
+  renderError?: string;
+}
+
+/**
+ * The four layers of the hop, in order. `renderError` names the one that threw,
+ * so a caller reading a crash report is never told "renderAtsResumePdf threw"
+ * about a failure that actually came from the re-parse.
+ */
+const HOP_LAYERS = [
+  "computeAnonymousAtsScore",
+  "buildAtsResumeModel",
+  "renderAtsResumePdf",
+  "runCascade (re-parse of the reconstructed PDF)",
+] as const;
+
+/**
+ * Render `before`'s reconstructed PDF and re-parse it. NEVER throws — a failure
+ * in ANY layer is DATA (`{ renderError }`), which is exactly the shape
+ * `localizeRoundtripHop()` turns into the `roundtrip-render-crash` class.
+ *
+ * EVERY layer is inside the `try`, deliberately: the score + model build used to
+ * sit outside it, so a throw there escaped the hop and erroed the whole
+ * `/probe-resume` sweep AND `npm run bake-fixtures` (which awaits this per
+ * fixture) — a crash in the export path taking down the tool whose job is to
+ * REPORT crashes in the export path.
+ */
+export async function runRoundtripHop(
+  before: CascadeResult,
+): Promise<RoundtripHop> {
+  let layer: (typeof HOP_LAYERS)[number] = HOP_LAYERS[0];
+  try {
+    const score = scoreForCascade(before);
+    layer = HOP_LAYERS[1];
+    const model = buildAtsResumeModel(before, score);
+    layer = HOP_LAYERS[2];
+    const bytes = await renderAtsResumePdf(model);
+    layer = HOP_LAYERS[3];
+    return { after: await runCascade(bytes) };
+  } catch (err) {
+    // `(err as Error).message` can embed a résumé character (e.g. pdf-lib's
+    // `WinAnsi cannot encode "X"`). Accepted: this never persists (the corpus
+    // goldens only store the boolean `renderThrewOnRoundtrip`, never this
+    // string) and #295's input sanitization makes the unencodable-glyph path
+    // near-unreachable — but the `RL_RT_PDF` harness does print it, so this is
+    // deliberate, not an oversight.
+    return { renderError: `${layer} threw: ${(err as Error).message}` };
+  }
+}

--- a/src/lib/heuristics/sweep.test.ts
+++ b/src/lib/heuristics/sweep.test.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * `sweepParse()` — the merge + oracle gate the `/probe-resume` harness and the
+ * corpus bake BOTH run. Its one load-bearing job: a class whose oracle could not
+ * run must land in `withheld`, never in `defects`, so no consumer can print an
+ * affirmative "no defects" over a parse that was never read.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { sweepParse, isTextOracleUnavailable, isParseUnreadable } from "./sweep.ts";
+import { mkCascade } from "./localize/__test-utils__.ts";
+import type { CascadeResult } from "./types.ts";
+
+/** A readable parse with a clean, fully-routed résumé. */
+const healthy = (): CascadeResult =>
+  mkCascade({
+    fields: {
+      full_name: "Jordan Rivera",
+      email: "jordan@example.com",
+      phone: "(312) 555-0123",
+      location: "Chicago, IL",
+      skills: ["Go"],
+      experience: [{ title: "Engineer", company: "Acme" }],
+      education: [{ institution: "State University", degree: "BS" }],
+      heuristic_achievements: [{ type: "Award", title: "Best Paper" }],
+    },
+    sections: {
+      profile: ["Jordan Rivera"],
+      skills: ["Go"],
+      experience: ["Engineer, Acme"],
+      education: ["BS, State University"],
+      achievements: ["Award · Best Paper"],
+    },
+    markdown: "# Skills\nGo\n",
+    rawText: "Jordan Rivera jordan@example.com (312) 555-0123 Chicago, IL",
+  });
+
+/** The scanned repro: the layout probe short-circuited Tier 1 — zero text. */
+const scanned = (): CascadeResult => {
+  const c = mkCascade({ fields: {}, sections: {}, rawText: "" });
+  return { ...c, triggers: ["scanned"] } as CascadeResult;
+};
+
+describe("isTextOracleUnavailable", () => {
+  it("is false on a parse that produced text", () => {
+    expect(isTextOracleUnavailable(healthy())).toBe(false);
+  });
+
+  it("is true on a scanned PDF and on an empty rawText", () => {
+    expect(isTextOracleUnavailable(scanned())).toBe(true);
+    expect(isTextOracleUnavailable(mkCascade({ rawText: "   " }))).toBe(true);
+  });
+});
+
+describe("sweepParse", () => {
+  it("reports a healthy parse as clean, with nothing withheld", () => {
+    const s = sweepParse(healthy(), { after: healthy() });
+    expect(s.defects).toEqual([]);
+    expect(s.withheld).toEqual([]);
+    expect(s.derived.textOracleUnavailable).toBe(false);
+    expect(s.derived.headerOracleUnavailable).toBe(false);
+    expect(s.derived.roundtripOracleUnavailable).toBe(false);
+    expect(s.sectionOverview).toContain("skills(1)");
+  });
+
+  it("WITHHOLDS every text-derived class on a scanned parse — it never reports clean", () => {
+    // THE regression this exists to prevent: 0 characters extracted, every
+    // derived bit false, and the sweep printing "no defect class is exhibited by
+    // this parse". `defects: []` here is meaningless UNLESS `withheld` is empty.
+    const s = sweepParse(scanned(), { after: scanned() });
+    expect(s.derived.textOracleUnavailable).toBe(true);
+    expect(s.defects).toEqual([]);
+    expect(s.withheld.length).toBeGreaterThan(0);
+    // Notably: the localizers DID claim `achievements-no-section` (0 entries, no
+    // region) — the gate is what stops that claim from being believed.
+    expect(s.achievements.defects).toEqual(["achievements-no-section"]);
+    expect(s.withheld).toContain("achievements-no-section");
+    expect(s.defects).not.toContain("achievements-no-section");
+  });
+
+  it("WITHHOLDS the roundtrip value classes when the hop produced no `after`", () => {
+    const s = sweepParse(healthy(), { renderError: "renderAtsResumePdf threw: boom" });
+    expect(s.derived.roundtripOracleUnavailable).toBe(true);
+    expect(s.derived.renderThrewOnRoundtrip).toBe(true);
+    // The crash itself is OBSERVED, so it is reported…
+    expect(s.defects).toEqual(["roundtrip-render-crash"]);
+    // …but "no value changed across the round-trip" is not a finding about a
+    // round-trip that never happened.
+    expect(s.withheld).toEqual([
+      "roundtrip-contact-value-changed",
+      "roundtrip-experience-value-changed",
+      "roundtrip-education-value-changed",
+      "roundtrip-skills-value-changed",
+      "roundtrip-summary-value-changed",
+    ]);
+  });
+
+  it("keeps a real defect, and the section overview that explains an advisory", () => {
+    // The dropped-skills repro: a real skills block under a header the router
+    // neither aliases nor anchors, so its 7 lines land in `profile` and the
+    // parse carries no `skills` section at all. The advisory is the only trace —
+    // and `sectionOverview` is what tells the reader the block did not vanish,
+    // it moved.
+    const cascade = mkCascade({
+      fields: {
+        full_name: "Jordan Rivera",
+        skills: [],
+        experience: [{ title: "Engineer", company: "Acme" }],
+      },
+      sections: {
+        profile: ["Jordan Rivera", "TECHNICAL PROFICIENCIES", "Go, Rust, SQL"],
+        experience: ["Engineer, Acme"],
+      },
+      markdown: "# TECHNICAL PROFICIENCIES\nGo, Rust, SQL\n",
+      rawText: "Jordan Rivera TECHNICAL PROFICIENCIES Go, Rust, SQL",
+    });
+    const s = sweepParse(cascade, { after: cascade });
+    expect(s.defects).toContain("skills-no-section");
+    expect(s.withheld).toEqual([]);
+    expect(s.sectionOverview).toEqual(["profile(3)", "experience(1)"]);
+  });
+});
+
+describe("isParseUnreadable", () => {
+  // The single definition of "⛔ PARSE UNREADABLE" the `/probe-resume` harness
+  // gates its defect report and corpus coverage on. It must agree with
+  // `sweepParse()`'s own oracle gate (`textOracleUnavailable`) AND catch the
+  // second failure mode `sweepParse()` cannot see on its own: a parse that read
+  // text but the extractor pulled nothing structured out of it.
+
+  it("is true on a scanned parse, regardless of extractedCharCount", () => {
+    const s = sweepParse(scanned(), { after: scanned() });
+    expect(isParseUnreadable(s.derived, 0)).toBe(true);
+    expect(isParseUnreadable(s.derived, 42)).toBe(true);
+  });
+
+  it("is true when extractedCharCount is 0 even though the text oracle read something", () => {
+    const s = sweepParse(healthy(), { after: healthy() });
+    expect(s.derived.textOracleUnavailable).toBe(false);
+    expect(isParseUnreadable(s.derived, 0)).toBe(true);
+  });
+
+  it("is false on a healthy parse with nonzero extraction", () => {
+    const s = sweepParse(healthy(), { after: healthy() });
+    expect(isParseUnreadable(s.derived, 42)).toBe(false);
+  });
+});

--- a/src/lib/heuristics/sweep.ts
+++ b/src/lib/heuristics/sweep.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The whole-parse sweep (issue #469) — the ONE place a `DerivedSignals` bag and
+ * a defect list are assembled from the six localizers.
+ *
+ * Two callers need exactly this and must never drift apart:
+ *   - `probe-resume.test.ts` (the `/probe-resume` harness) — over a REAL résumé.
+ *   - `corpus.test.ts`'s bake — over each of the 45 synthetic fixtures.
+ * If those two computed `derived` differently, the sweep would be comparing a
+ * résumé to fixtures on DIFFERENT axes, and every coverage answer it printed
+ * would be meaningless. So they both call `sweepParse()`.
+ *
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │ THE ORACLE GATE — the reason this module exists rather than a merge spread│
+ * │ across two call sites.                                                    │
+ * │                                                                           │
+ * │ A `DerivedSignals` bit computed from an ABSENT input reads `false`, and   │
+ * │ `false` there means UNKNOWABLE, not "observed absent" (see                │
+ * │ `defect-classes.ts`'s `DERIVED_SIGNAL_KEYS` header). Three inputs can be  │
+ * │ absent — the extracted TEXT, the markdown HEADERS, the round-trip `after` │
+ * │ parse — so three `*OracleUnavailable` bits record it, each `DefectSpec`   │
+ * │ declares which oracles it `requires`, and this module applies the gate    │
+ * │ ONCE: whatever the localizers emitted, a class whose oracle was blind      │
+ * │ lands in `withheld`, never in `defects`.                                  │
+ * │                                                                           │
+ * │ `defects: []` therefore means "clean" ONLY when `withheld: []` too. A     │
+ * │ consumer that prints an affirmative "no defects" without checking         │
+ * │ `withheld` (and `unreadable`) is reporting a dead parse as a healthy one. │
+ * └──────────────────────────────────────────────────────────────────────────┘
+ *
+ * PURE: takes an already-parsed `CascadeResult` and an already-run
+ * `RoundtripHop`. Never parses, renders, or does I/O — the caller performs both.
+ */
+
+import type { CascadeResult } from "./types.ts";
+import type { RoundtripHop } from "./roundtrip-hop.ts";
+import type { DefectClass, DerivedSignals } from "./defect-classes.ts";
+import {
+  DEFECT_CLASSES,
+  EMPTY_DERIVED_SIGNALS,
+  isWithheld,
+} from "./defect-classes.ts";
+import { localizeContact, type ContactLocalization } from "./localize/contact.ts";
+import { localizeSkills, type SkillsLocalization } from "./localize/skills.ts";
+import {
+  localizeExperience,
+  type ExperienceLocalization,
+} from "./localize/experience.ts";
+import {
+  localizeEducation,
+  type EducationLocalization,
+} from "./localize/education.ts";
+import {
+  localizeAchievements,
+  type AchievementsLocalization,
+} from "./localize/achievements.ts";
+import { localizeRoundtripHop } from "./localize/roundtrip.ts";
+
+/**
+ * TRUE when the parse produced NO readable text: the layout probe called the PDF
+ * `scanned` (the cascade short-circuits before Tier 1) or `rawText` came back
+ * empty. EVERY derived signal except the round-trip ones is read out of that
+ * text — or out of the sections cut from it — so on such a parse they are all
+ * `false` because there was nothing to read.
+ *
+ * This is resumelint's single most severe failure mode. It must never be
+ * reported as "no defect class is exhibited by this parse".
+ */
+export function isTextOracleUnavailable(cascade: CascadeResult): boolean {
+  return (
+    cascade.triggers.includes("scanned") || cascade.rawText.trim().length === 0
+  );
+}
+
+/**
+ * TRUE when the parse produced nothing readable at all — the definition of
+ * "⛔ PARSE UNREADABLE" that gates the `/probe-resume` harness's defect report
+ * and corpus coverage. Lives here, not in the harness, for the same reason
+ * `sweepParse()` does: the harness and `npm run bake-fixtures` must never
+ * compute "unreadable" on different terms, or a corpus coverage claim would be
+ * comparing a résumé and a fixture that don't agree on what "readable" means.
+ *
+ * `derived.textOracleUnavailable` catches a scanned PDF or empty `rawText`;
+ * `extractedCharCount === 0` catches a parse that produced text but the
+ * extractor pulled nothing structured out of it. Either way, every oracle
+ * below the round-trip was blind, so no defect claim over this parse can be
+ * trusted.
+ */
+export function isParseUnreadable(
+  derived: DerivedSignals,
+  extractedCharCount: number,
+): boolean {
+  return derived.textOracleUnavailable || extractedCharCount === 0;
+}
+
+/** The six localizations, plus the merged, gated verdict. */
+export interface ResumeSweep {
+  contact: ContactLocalization;
+  skills: SkillsLocalization;
+  experience: ExperienceLocalization;
+  education: EducationLocalization;
+  achievements: AchievementsLocalization;
+  roundtrip: { defects: DefectClass[]; derived: Partial<DerivedSignals> };
+  /** The full, merged bag — including the three `*OracleUnavailable` bits. */
+  derived: DerivedSignals;
+  /** Classes the localizers emitted AND whose required oracles all ran, in
+   *  `DEFECT_CLASSES` order. Deduplicated. */
+  defects: DefectClass[];
+  /** Classes whose verdict this parse could not decide — the oracle they need
+   *  did not run. NOT "clean": undecided. Print these, never swallow them. */
+  withheld: DefectClass[];
+  /** `name(lineCount)` per routed section — PII-free, and the ONE thing that
+   *  tells a reader whether a "no such section" advisory means "the résumé has
+   *  none" or "the block was mis-routed into another bucket". */
+  sectionOverview: string[];
+}
+
+/**
+ * Run every localizer off ONE parse and ONE hop, merge their `DerivedSignals`
+ * slices, and apply the oracle gate to what they claimed.
+ */
+export function sweepParse(
+  cascade: CascadeResult,
+  hop: RoundtripHop,
+): ResumeSweep {
+  const contact = localizeContact(cascade);
+  const skills = localizeSkills(cascade);
+  const experience = localizeExperience(cascade);
+  const education = localizeEducation(cascade);
+  const achievements = localizeAchievements(cascade);
+  const roundtrip = localizeRoundtripHop(cascade, hop.after, hop.renderError);
+
+  const derived: DerivedSignals = {
+    ...EMPTY_DERIVED_SIGNALS,
+    ...contact.derived,
+    ...skills.derived,
+    ...experience.derived,
+    ...education.derived,
+    ...achievements.derived,
+    ...roundtrip.derived,
+    // The cross-cutting oracle a localizer cannot own: it gates ALL of them.
+    textOracleUnavailable: isTextOracleUnavailable(cascade),
+  };
+
+  const claimed = new Set<DefectClass>([
+    ...contact.defects,
+    ...skills.defects,
+    ...experience.defects,
+    ...education.defects,
+    ...achievements.defects,
+    ...roundtrip.defects,
+  ]);
+
+  const defects = DEFECT_CLASSES.filter(
+    (c) => claimed.has(c) && !isWithheld(c, derived),
+  );
+  const withheld = DEFECT_CLASSES.filter((c) => isWithheld(c, derived));
+
+  return {
+    contact,
+    skills,
+    experience,
+    education,
+    achievements,
+    roundtrip,
+    derived,
+    defects,
+    withheld,
+    sectionOverview: skills.sectionOverview,
+  };
+}

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.89,
     "triggers": [],
@@ -66,5 +66,77 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1345,
+    "extractedCharCount": 1156,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 10
+      },
+      {
+        "name": "achievements",
+        "lineCount": 3
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 12
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.78,
     "triggers": [],
@@ -67,5 +67,73 @@
     },
     "bulletCount": 7,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1987,
+    "extractedCharCount": 1713,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 5
+      },
+      {
+        "name": "experience",
+        "lineCount": 14
+      },
+      {
+        "name": "projects",
+        "lineCount": 7
+      },
+      {
+        "name": "other",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 2,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -67,5 +67,73 @@
     },
     "bulletCount": 2,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 558,
+    "extractedCharCount": 447,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 3
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "certifications",
+        "lineCount": 3
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 1,
+      "educationCount": 1,
+      "skillsCount": 8
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.89,
     "triggers": [],
@@ -65,5 +65,73 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1647,
+    "extractedCharCount": 1376,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 14
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 3
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 14
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0,
     "triggers": [],
@@ -66,5 +66,65 @@
     },
     "bulletCount": 2,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 517,
+    "extractedCharCount": 257,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 3
+      },
+      {
+        "name": "education",
+        "lineCount": 9
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 1,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-honors-subheadings.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-honors-subheadings.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.82,
     "triggers": [],
@@ -68,5 +68,77 @@
     },
     "bulletCount": 0,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 2,
+    "rawCharCount": 2723,
+    "extractedCharCount": 2072,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 10
+      },
+      {
+        "name": "achievements",
+        "lineCount": 18
+      },
+      {
+        "name": "certifications",
+        "lineCount": 8
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 2,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 7,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 516,
+    "extractedCharCount": 410,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 11
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.88,
     "triggers": [],
@@ -68,5 +68,73 @@
     },
     "bulletCount": 13,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 2,
+    "rawCharCount": 2385,
+    "extractedCharCount": 1762,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "education",
+        "lineCount": 12
+      },
+      {
+        "name": "projects",
+        "lineCount": 7
+      },
+      {
+        "name": "experience",
+        "lineCount": 12
+      },
+      {
+        "name": "skills",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 2,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -67,5 +67,81 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1499,
+    "extractedCharCount": 1187,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 9
+      },
+      {
+        "name": "other",
+        "lineCount": 4
+      },
+      {
+        "name": "projects",
+        "lineCount": 3
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": false,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 9
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": true,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.88,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 11,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 2223,
+    "extractedCharCount": 1839,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 24
+      },
+      {
+        "name": "skills",
+        "lineCount": 6
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 16
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.91,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1428,
+    "extractedCharCount": 1149,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      },
+      {
+        "name": "skills",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 17
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": false,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 11
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": true,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column-long-role-header.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column-long-role-header.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -69,5 +69,79 @@
     },
     "bulletCount": 14,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 2915,
+    "extractedCharCount": 2410,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 6
+      },
+      {
+        "name": "experience",
+        "lineCount": 12
+      },
+      {
+        "name": "education",
+        "lineCount": 7
+      },
+      {
+        "name": "projects",
+        "lineCount": 8
+      },
+      {
+        "name": "skills",
+        "lineCount": 24
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 27
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -73,5 +73,79 @@
     },
     "bulletCount": 13,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1670,
+    "extractedCharCount": 1327,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 6
+      },
+      {
+        "name": "skills",
+        "lineCount": 5
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      },
+      {
+        "name": "achievements",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 15
+      },
+      {
+        "name": "projects",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 17
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -70,5 +70,77 @@
     },
     "bulletCount": 52,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 5,
+    "rawCharCount": 13992,
+    "extractedCharCount": 12859,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 5
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      },
+      {
+        "name": "skills",
+        "lineCount": 5
+      },
+      {
+        "name": "experience",
+        "lineCount": 89
+      },
+      {
+        "name": "achievements",
+        "lineCount": 21
+      },
+      {
+        "name": "certifications",
+        "lineCount": 22
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 17,
+      "educationCount": 1,
+      "skillsCount": 32
+    },
+    "linkAnnotationCount": 5,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -70,5 +70,77 @@
     },
     "bulletCount": 30,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 3,
+    "rawCharCount": 9391,
+    "extractedCharCount": 8607,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 5
+      },
+      {
+        "name": "summary",
+        "lineCount": 8
+      },
+      {
+        "name": "experience",
+        "lineCount": 47
+      },
+      {
+        "name": "achievements",
+        "lineCount": 16
+      },
+      {
+        "name": "certifications",
+        "lineCount": 9
+      },
+      {
+        "name": "education",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 8,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 5,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -73,5 +73,75 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 3205,
+    "extractedCharCount": 1847,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 1
+      },
+      {
+        "name": "education",
+        "lineCount": 36
+      },
+      {
+        "name": "skills",
+        "lineCount": 11
+      },
+      {
+        "name": "experience",
+        "lineCount": 27
+      },
+      {
+        "name": "achievements",
+        "lineCount": 14
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": false,
+      "hasSummary": false,
+      "experienceCount": 6,
+      "educationCount": 3,
+      "skillsCount": 22
+    },
+    "linkAnnotationCount": 9,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": true,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": true,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -73,5 +73,75 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 3207,
+    "extractedCharCount": 1849,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 1
+      },
+      {
+        "name": "education",
+        "lineCount": 36
+      },
+      {
+        "name": "skills",
+        "lineCount": 11
+      },
+      {
+        "name": "experience",
+        "lineCount": 26
+      },
+      {
+        "name": "achievements",
+        "lineCount": 13
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": false,
+      "hasSummary": false,
+      "experienceCount": 6,
+      "educationCount": 3,
+      "skillsCount": 22
+    },
+    "linkAnnotationCount": 9,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": true,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": true,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.87,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 5,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 744,
+    "extractedCharCount": 602,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 4
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 9
+      },
+      {
+        "name": "education",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.91,
     "triggers": [],
@@ -68,5 +68,73 @@
     },
     "bulletCount": 16,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 3428,
+    "extractedCharCount": 2625,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 6
+      },
+      {
+        "name": "experience",
+        "lineCount": 21
+      },
+      {
+        "name": "projects",
+        "lineCount": 6
+      },
+      {
+        "name": "skills",
+        "lineCount": 3
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": false,
+      "hasSummary": false,
+      "experienceCount": 4,
+      "educationCount": 2,
+      "skillsCount": 17
+    },
+    "linkAnnotationCount": 6,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": true,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -71,5 +71,79 @@
     },
     "bulletCount": 11,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1707,
+    "extractedCharCount": 1512,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "summary",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 26
+      },
+      {
+        "name": "other",
+        "lineCount": 0
+      },
+      {
+        "name": "skills",
+        "lineCount": 9
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 9
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.89,
     "triggers": [],
@@ -65,5 +65,73 @@
     },
     "bulletCount": 7,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 1319,
+    "extractedCharCount": 1138,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 14
+      },
+      {
+        "name": "education",
+        "lineCount": 1
+      },
+      {
+        "name": "skills",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 9
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -73,5 +73,87 @@
     },
     "bulletCount": 27,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "regex",
+    "pageCount": 2,
+    "rawCharCount": 3797,
+    "extractedCharCount": 3242,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "summary",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 53
+      },
+      {
+        "name": "other",
+        "lineCount": 10
+      },
+      {
+        "name": "skills",
+        "lineCount": 8
+      },
+      {
+        "name": "achievements",
+        "lineCount": 6
+      },
+      {
+        "name": "projects",
+        "lineCount": 10
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 5,
+      "educationCount": 1,
+      "skillsCount": 17
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": true,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 7,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 741,
+    "extractedCharCount": 654,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 9
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 9
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 4,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 499,
+    "extractedCharCount": 421,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 6
+      },
+      {
+        "name": "skills",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 8
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
+++ b/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 4,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 920,
+    "extractedCharCount": 764,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 13
+      },
+      {
+        "name": "experience",
+        "lineCount": 11
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 13
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/mid-dot-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/mid-dot-header.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 5,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 788,
+    "extractedCharCount": 610,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 1
+      },
+      {
+        "name": "experience",
+        "lineCount": 11
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.79,
     "triggers": [],
@@ -67,5 +67,69 @@
     },
     "bulletCount": 4,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 713,
+    "extractedCharCount": 606,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 8
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
+++ b/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.83,
     "triggers": [],
@@ -67,5 +67,73 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1884,
+    "extractedCharCount": 1318,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 14
+      },
+      {
+        "name": "education",
+        "lineCount": 5
+      },
+      {
+        "name": "other",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 20
+    },
+    "linkAnnotationCount": 2,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.85,
     "triggers": [],
@@ -65,5 +65,69 @@
     },
     "bulletCount": 2,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 462,
+    "extractedCharCount": 313,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 4
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 1,
+      "educationCount": 1,
+      "skillsCount": 8
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/shared-employer-banner-roles.expected.json
+++ b/tests/fixtures/pdfs/unknown/shared-employer-banner-roles.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.91,
     "triggers": [],
@@ -66,5 +66,65 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 635,
+    "extractedCharCount": 560,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 10
+      },
+      {
+        "name": "education",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/single-column-title-below-anchor.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-title-below-anchor.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 1128,
+    "extractedCharCount": 931,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 10
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 8
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.87,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 711,
+    "extractedCharCount": 596,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 12
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.89,
     "triggers": [],
@@ -64,5 +64,73 @@
     },
     "bulletCount": 5,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 1189,
+    "extractedCharCount": 1047,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 13
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 11
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.88,
     "triggers": [],
@@ -68,5 +68,73 @@
     },
     "bulletCount": 13,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 2,
+    "rawCharCount": 2279,
+    "extractedCharCount": 1654,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "education",
+        "lineCount": 13
+      },
+      {
+        "name": "projects",
+        "lineCount": 7
+      },
+      {
+        "name": "experience",
+        "lineCount": 11
+      },
+      {
+        "name": "skills",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 2,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/synthetic-dateless-experience.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-dateless-experience.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.83,
     "triggers": [],
@@ -67,5 +67,61 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 580,
+    "extractedCharCount": 555,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 12
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 0,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": false,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/synthetic-degreeless-two-programs.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-degreeless-two-programs.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.85,
     "triggers": [],
@@ -65,5 +65,73 @@
     },
     "bulletCount": 4,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 791,
+    "extractedCharCount": 574,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 8
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      },
+      {
+        "name": "education",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 2,
+      "skillsCount": 5
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0,
     "triggers": [],
@@ -66,5 +66,65 @@
     },
     "bulletCount": 0,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "markdown",
+    "pageCount": 1,
+    "rawCharCount": 880,
+    "extractedCharCount": 230,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 14
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 4,
+      "educationCount": 1,
+      "skillsCount": 0
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -73,5 +73,79 @@
     },
     "bulletCount": 16,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 3056,
+    "extractedCharCount": 2517,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 3
+      },
+      {
+        "name": "summary",
+        "lineCount": 4
+      },
+      {
+        "name": "experience",
+        "lineCount": 43
+      },
+      {
+        "name": "other",
+        "lineCount": 0
+      },
+      {
+        "name": "skills",
+        "lineCount": 6
+      },
+      {
+        "name": "achievements",
+        "lineCount": 7
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 4,
+      "educationCount": 0,
+      "skillsCount": 18
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": true,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.89,
     "triggers": [],
@@ -65,5 +65,73 @@
     },
     "bulletCount": 8,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1644,
+    "extractedCharCount": 1375,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 14
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 3
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 14
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -66,5 +66,69 @@
     },
     "bulletCount": 7,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 516,
+    "extractedCharCount": 410,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 11
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -67,5 +67,81 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1499,
+    "extractedCharCount": 1187,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 2
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      },
+      {
+        "name": "experience",
+        "lineCount": 9
+      },
+      {
+        "name": "other",
+        "lineCount": 4
+      },
+      {
+        "name": "projects",
+        "lineCount": 3
+      },
+      {
+        "name": "skills",
+        "lineCount": 1
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": false,
+      "hasSummary": true,
+      "experienceCount": 2,
+      "educationCount": 1,
+      "skillsCount": 9
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": true,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.64,
     "triggers": [
@@ -73,5 +73,79 @@
     },
     "bulletCount": 13,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [
+      "two_column"
+    ],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1669,
+    "extractedCharCount": 1328,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 6
+      },
+      {
+        "name": "skills",
+        "lineCount": 5
+      },
+      {
+        "name": "education",
+        "lineCount": 3
+      },
+      {
+        "name": "achievements",
+        "lineCount": 2
+      },
+      {
+        "name": "experience",
+        "lineCount": 15
+      },
+      {
+        "name": "projects",
+        "lineCount": 4
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 18
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": false,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -68,5 +68,69 @@
     },
     "bulletCount": 3,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 961,
+    "extractedCharCount": 798,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 7
+      },
+      {
+        "name": "experience",
+        "lineCount": 12
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 5
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.9,
     "triggers": [],
@@ -68,5 +68,69 @@
     },
     "bulletCount": 3,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 958,
+    "extractedCharCount": 797,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 7
+      },
+      {
+        "name": "experience",
+        "lineCount": 12
+      },
+      {
+        "name": "education",
+        "lineCount": 2
+      },
+      {
+        "name": "skills",
+        "lineCount": 2
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": true,
+      "hasLocation": true,
+      "hasSummary": false,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 6
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "cascade": {
     "confidence": 0.79,
     "triggers": [],
@@ -66,5 +66,73 @@
     },
     "bulletCount": 6,
     "algoVersion": "1.5"
+  },
+  "reproArtifact": {
+    "artifactVersion": "v1",
+    "cascadeVersion": "v1",
+    "triggers": [],
+    "sectionSource": "regex",
+    "pageCount": 1,
+    "rawCharCount": 1336,
+    "extractedCharCount": 856,
+    "sections": [
+      {
+        "name": "profile",
+        "lineCount": 5
+      },
+      {
+        "name": "summary",
+        "lineCount": 2
+      },
+      {
+        "name": "education",
+        "lineCount": 7
+      },
+      {
+        "name": "experience",
+        "lineCount": 11
+      },
+      {
+        "name": "skills",
+        "lineCount": 3
+      }
+    ],
+    "parsedCounts": {
+      "hasFullName": true,
+      "hasEmail": true,
+      "hasPhone": false,
+      "hasLocation": true,
+      "hasSummary": true,
+      "experienceCount": 3,
+      "educationCount": 1,
+      "skillsCount": 8
+    },
+    "linkAnnotationCount": 0,
+    "disagreements": []
+  },
+  "derived": {
+    "emailInRawTextButNotParsed": false,
+    "phoneInRawTextButNotParsed": false,
+    "locationInRawTextButNotParsed": false,
+    "skillsHeaderCandidateRejected": false,
+    "educationHeaderCandidateRejected": false,
+    "educationEntriesFewerThanDegreeTokens": false,
+    "experienceRegionHasDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
+    "achievementsParsedEmpty": true,
+    "achievementsEntriesFewerThanHeaderLines": false,
+    "fullNameChangedAcrossRoundtrip": false,
+    "emailChangedAcrossRoundtrip": false,
+    "phoneChangedAcrossRoundtrip": false,
+    "locationChangedAcrossRoundtrip": false,
+    "linkedinUrlChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": false,
+    "educationChangedAcrossRoundtrip": false,
+    "skillsChangedAcrossRoundtrip": false,
+    "summaryChangedAcrossRoundtrip": false,
+    "renderThrewOnRoundtrip": false,
+    "textOracleUnavailable": false,
+    "headerOracleUnavailable": false,
+    "roundtripOracleUnavailable": false
   }
 }


### PR DESCRIPTION
## Summary

Adds **`/probe-resume`** — a read-only, one-drop sweep over a real résumé — plus the **corpus-match engine** that answers the question the six single-section probes cannot: *this résumé exposes a defect; does a fixture in `tests/fixtures/pdfs/` already reproduce it?*

One `runCascade()` drives all six section localizers plus one export→re-parse hop, producing a PII-free `ReproArtifact` + a boolean-only `DerivedSignals` bag, matched against the 45 baked corpus fixtures. Each defect prints `COVERED <fixture>` — stop, fix the parser against the existing fixture, never open the real résumé again — or `NO FIXTURE COVERS THIS`, the only case that justifies minting a new one. The harness mints nothing, commits nothing, and is inert unless `RL_RESUME_PDF` is set, so CI never runs it.

Closes #469

## What shipped

- **`defect-classes.ts`** — 21 `DefectClass`es derived 1:1 from the six probes' existing verdict strings, plus an **oracle model**: each class declares which oracles it `requires` (`text` / `header` / `roundtrip`), and `spec()` gates its predicate on them. See *Adversarial review* below — this is the part that took three rounds to get right.
- **`fixture-match.ts`** — pure, no-I/O `matchCorpus()`. A cover is `exhibits()` on the fixture's own parse, never artifact similarity; divergence only *orders* the output. The near-miss cap is printed (`showing 3 of 41`), never a silent truncation.
- **`localize/`** — the six harnesses' localization logic extracted into pure importable functions, so the sweep reuses them instead of copy-pasting a seventh set of detectors. The six sibling probes keep **byte-identical output** (verified by diffing both trees).
- **`sweep.ts`** — the single place the localizers' derived signals merge and the oracle gate applies. Both the harness and the corpus bake call it, so they cannot drift.
- **`roundtrip-hop.ts`** — the one render→re-parse path, shared by the bake and the sweep. A crash anywhere in it is data, not a throw.
- **Corpus snapshots → `schemaVersion: 5`** with baked `reproArtifact` + `derived` blocks; all 45 regenerated.
- **`.claude/skills/probe-resume/SKILL.md`** + cross-links from the six siblings.

## PII

The repo is public and the input is a real résumé, so this is the load-bearing constraint:

- `ReproArtifact` gained **no string field** — `repro-artifact.test.ts`'s PII assertion is unmodified and passing. `DerivedSignals` carries the same boolean-only assertion (with a smuggled-string test proving the guard has teeth).
- The 45 committed `*.expected.json` were audited leaf-by-leaf: every string in the new blocks is a fixed enum (`v1`, `markdown`/`regex`, section names, `two_column`). No name, email, phone, company, school, or bullet text.
- The harness console prints only counts, defect **classes**, axis names, fixture paths, and booleans — never a candidate's value. The JSON report goes only to `internal/` (gitignored); an in-repo non-gitignored `RL_RESUME_OUT` is a hard error by design.
- **No fixture binary was added or changed.**

## Test plan

- [x] `npm run verify` green locally (typecheck → lint → coverage → build → fallow)
- [x] 2226+ tests pass; harness **inert** (skipped) with `RL_RESUME_PDF` unset
- [x] End-to-end: a fixture pointed at itself comes back `COVERED` **by itself**, including a value-level round-trip class (proves the `derived` half of the chain, not just the structural half)
- [x] Golden re-bake proven mechanically per-file: only `schemaVersion` 4→5 and the two added blocks changed; **zero** pre-existing keys moved
- [x] The six sibling probe harnesses print byte-identical output after the extraction
- [x] `verify` green in CI

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — defect-classes | Claude Opus 4.8 | ultra |
| Implementation — fixture-match engine | Claude Opus 4.8 | ultra |
| Implementation — localizer extraction | Claude Sonnet 5 | high |
| Implementation — schemaVersion 5 bake | Claude Opus 4.8 | high |
| Implementation — probe-resume harness | Claude Opus 4.8 | ultra |
| Implementation — SKILL.md + cross-links | Claude Sonnet 5 | medium |
| Adversarial review — round 1 | Claude Opus 4.8 | high |
| Review fixes — round 1 | Claude Opus 4.8 (1M context) | high |
| Adversarial review — round 2 | Claude Opus 4.8 (1M context) | high |
| Review fixes — round 2 | Claude Opus 4.8 | high |
| Adversarial review — round 3 (confirmation) | Claude Opus 4.8 | high |
| Review fixes — round 3 (nits) | Claude Sonnet 5 | medium |
| Orchestration + PR | Claude Opus 4.8 (1M context) | medium |
| Verification | `npm run verify` — green in CI | — |

## Adversarial review

Three rounds ran against the local diff **before** this PR opened (reviewer: an independent adversarial agent, prompted to break the change rather than approve it, and to *reproduce* suspected defects end-to-end rather than reason about them). Every blocking finding was fixed in this PR. Recording them here because two of them are the kind of bug that would have shipped as a green test.

**All three blocking findings shared one root cause.** A `DerivedSignals` bit computed from an optional cascade field reads `false` when the field is absent — but `false` there means *"unknowable"*, not *"observed absent"*. The predicate then silently doesn't fire, and the tool affirmatively reports no defect.

### Round 1 — 2 blocking

- **The headline `COVERAGE n/m` was routinely wrong.** The three `*-no-section` classes were reported as *defects*. "This résumé has no Awards section" is not a defect — 34 of 45 fixtures have none — yet it was listed under `DEFECTS FOUND`, corpus-matched, and counted in the ratio. Fixed: those classes are now `advisory`, printed in a separate `INFORMATIONAL` block and excluded from the ratio.
- **A false COVER** — the worst possible failure here. The only bit separating `skills-header-unrecognized` (which *no* fixture reproduces) from `skills-no-section` (covered by 9) is derived from `cascade.markdown`, which is `undefined` on scanned/sparse PDFs. So a scanned résumé with a rejected skills header silently degraded to **COVERED**, telling the maintainer "stop, the corpus already has this" when nothing did.

### Round 2 — 3 blocking (including two siblings of the same bug, and a flaw in round 1's own fix)

- **Round 1's fix traded a false COVER for a false CLEAN.** The `INFORMATIONAL` advisory told the reader to "check 'Sections detected'" — a line the harness never printed (the string was copied from a sibling probe that does). Reviewer minted a PDF with a real skills block under `TECHNICAL PROFICIENCIES`; the skills vanished from the parse and the tool printed `DEFECTS FOUND (0)`.
- **A scanned PDF reported clean.** `DEFECTS FOUND (0) — no defect class is exhibited by this parse`, for a parse that extracted **zero characters** — resumelint's single most severe failure mode, reported as healthy.
- **A throw in the round-trip model build escaped the hop**, aborting the whole sweep *and* `npm run bake-fixtures`, despite the file's own header promising a render crash is data.

**The fix generalized instead of patching.** Rather than repair the three instances, the class of bug is now closed structurally: three named **oracles** (`text`, `header`, `roundtrip`), each defect class declares which it `requires`, and `spec()` gates the predicate on them — so a class cannot be added without declaring what it depends on. Blind oracles withhold their classes with a loud banner naming exactly which; an unreadable parse **refuses to print a defect report at all**. All 23 derived keys were then audited one by one.

### Round 3 — confirmation, clean → ship

Walked all 23 keys × 21 classes (the gate is sound *and* not over-gated — no false non-covers), and tried five separately-minted PDFs to hole the dead-parse gate, including a prose-only PDF with 2,510 raw chars but zero extraction. No escape found. Five nits raised; **all five fixed** rather than deferred. Verdict: ship.

### Verified and cleared across the rounds

No PII in the 45 committed snapshots (every string leaf is a fixed enum) or in the console; no silent golden regression (per-key diff of all 45 against `HEAD` — zero pre-existing keys moved); the six sibling probes' output is genuinely byte-identical after the extraction (both trees rebuilt and diffed); `matchCorpus` membership is exactly `exhibits()` with no distance logic in the cover decision.

### Left for the human reviewer

`fallow` reports one complexity finding (`loadCorpus`, 12 cyclomatic) — it is the fail-loud snapshot-validation ladder, and fallow is report-only in CI. Dead code is 0.
