### PR TITLE
fix(experience): read company + location off the next line for a "Title, Team" comma header (#466)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -173,6 +173,14 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   "unknown/synthetic-two-experience-sections.pdf": ["experience"],
   "unknown/two-column-achievements-sidebar.pdf": ["experience"],
   "unknown/weasyprint-cairo-two-column.pdf": ["experience"],
+  // label-rail grids: the employer is glued into the header with no delimiter
+  // ("Staff Engineer, Platform Northwind Systems"), so the parser cannot read a
+  // company. On main it MIRRORED the title into `company` (bad data that happened
+  // to round-trip mirror==mirror); #466 replaced that with an honest empty
+  // company. The now-empty company re-parses non-empty off the one-line export
+  // header — the same #436 root as the group above. Delete when #436 lands.
+  "unknown/label-rail-grid-fragmented.pdf": ["experience"],
+  "unknown/label-rail-inline-headers.pdf": ["experience"],
 };
 
 function walkPdfs(dir: string): string[] {

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -152,6 +152,20 @@ function locationFromAnchorCell(cell: string): string | undefined {
   return isBareLocationString(c) ? c : undefined;
 }
 
+/** Front-anchored `City, ST` at the START of a cell, guarded by a valid USPS code
+ *  (`US_STATE_CODE_RE`) — the same closed-vocabulary discipline `stripLocationSuffix`
+ *  applies at the END. This catches an employer-line cell that leads with the
+ *  location and carries a trailing dept/sub-org after it ("Chicago, IL  Consumer
+ *  Banking" → "Chicago, IL"), where neither `isBareLocationString` (not a
+ *  whole-string location) nor `stripLocationSuffix` (location is not the trailing
+ *  suffix) can claim it (#466). Multi-word city allowed via the comma boundary. */
+function leadingLocation(cell: string): string | undefined {
+  const m = cell
+    .trim()
+    .match(/^([A-Z][A-Za-z.\-]+(?:\s+[A-Z][A-Za-z.\-]+)*),\s*([A-Z]{2})(?:\s|$)/);
+  return m && US_STATE_CODE_RE.test(m[2]) ? `${m[1]}, ${m[2]}` : undefined;
+}
+
 function stripLocationSuffix(s: string): {
   text: string;
   location: string | undefined;
@@ -516,31 +530,66 @@ function mapWithCompanyMatch(
 
 /**
  * Phase 2b-i — the first split reads like a title and the second does not:
- * "Title, Team" over "Company | Location Dates" (#372).
+ * "Title, Team" over a separate employer line (#372, #466).
  *
  * splits[0]/splits[1] are a role-comma split of ONE header line (same source,
  * `via: "comma"`), so the post-comma splits[1] is a team/sub-org suffix, not the
- * company. When the anchor (date) line below was delimiter-split into "Company |
- * Location Dates", its leading segment is the real company — take it and demote
- * the post-comma segment to team. Guarded on `via: "comma"` so a same-line
- * `|`/`@`/`·`/`—` delimiter split (also same-source) can't misfire this
- * comma-shape branch. Additive: fires only for the comma-split + delimited-anchor
- * shape; every other case keeps the "Title, Company" default.
+ * company. The employer therefore lives on a DIFFERENT header line, and which one
+ * is the anchor (date) line depends on the layout:
+ *
+ *   - #372 — the title line has NO date; the employer line below is the anchor and
+ *     was delimiter-split into "Company | Location Dates". Its leading segment is
+ *     the company (`anchorCompany`). Guarded on `anchorIdx !== titleSource` so this
+ *     only fires when the anchor really is a separate line.
+ *   - #466 — the DATE sits on the "Title, Team" line, so that line is the anchor.
+ *     `anchorSplits[0]` would then be the TITLE, not a company — reading it as the
+ *     company mirrored the title into `company` and never consulted the real
+ *     employer on the line below. Instead take the company off the first segment
+ *     whose `source` differs from the title line's; never mirror the title.
+ *   - No separate employer line at all — a genuine single-line "Title, Company"
+ *     ("Office manager, Nod Publishing") — the post-comma segment IS the company.
+ *
+ * Guarded on `via: "comma"` so a same-line `|`/`@`/`·`/`—` delimiter split (also
+ * same-source) can't misfire this comma-shape branch.
  */
 function mapTitleFirst(splits: Split[], anchorIdx: number | undefined): Fields {
   const title = splits[0]?.text;
+  const titleSource = splits[0]?.source;
   const isRoleCommaSplit =
     splits[1] !== undefined &&
     splits[0]?.via === "comma" &&
     splits[0]?.source === splits[1].source;
+  // The anchor supplies the company only when it is a DIFFERENT line than the
+  // title's comma line (#372). When the date is on the title line itself (#466),
+  // `anchorIdx === titleSource`, so its segments are the title — not a company.
   const anchorSplits =
     anchorIdx !== undefined ? splits.filter((s) => s.source === anchorIdx) : [];
   const anchorCompany =
-    anchorSplits.length >= 2 && !looksLikeLocationTail(anchorSplits[0].text)
+    anchorIdx !== titleSource &&
+    anchorSplits.length >= 2 &&
+    !looksLikeLocationTail(anchorSplits[0].text)
       ? anchorSplits[0].text
       : undefined;
-  if (isRoleCommaSplit && anchorCompany) {
-    return { company: anchorCompany, title, team: splits[1]?.text };
+  if (isRoleCommaSplit) {
+    // #372 — company on the separate anchor (employer) line below.
+    if (anchorCompany) return { company: anchorCompany, title, team: splits[1].text };
+    // #466 — employer on a different line than the title's comma line. Take that
+    // line's leading segment as company; never mirror the title into `company`.
+    const employer = splits.find((s) => s.source !== titleSource);
+    if (employer) return { company: employer.text, title, team: splits[1].text };
+    // No separate employer line. The date's position disambiguates the post-comma:
+    if (anchorIdx === titleSource) {
+      // Date is ON the "Title, X" line — the #382 shared-employer shape: X is a
+      // team/sub-org, and the employer is a banner above (or genuinely absent).
+      // Leave `company` EMPTY (a miss, not a title mirror) with the team set, so
+      // `isBannerContinuation` can inherit the banner employer; if none rescues it,
+      // it honestly reads as absent rather than as the title (#466).
+      return { title, team: splits[1].text };
+    }
+    // A separate date line below with no employer segments → a genuine single-line
+    // "Title, Company" ("Office manager, Nod Publishing"): the post-comma is the
+    // company (#372 no-regression).
+    return { company: splits[1].text, title };
   }
   return { company: splits[1]?.text, title, team: splits[2]?.text };
 }
@@ -723,25 +772,76 @@ function recoverLocation(
   //      yields a bare location once the date range is peeled, use it (and clear
   //      the segment from `team` if it landed there).
   if (!location && anchorIdx !== undefined) {
-    for (const s of splits) {
-      // Skip the company and the title cells: a location cell that landed in
-      // `title` is the empty-title "Company · City, ST" export shape, which
-      // step 5 rescues correctly (title → "", location set) — claiming it here
-      // would set `location` and block that rescue, orphaning the location in
-      // `title`. Only an unused/team location cell is claimed here.
-      if (s.source !== anchorIdx || s.text === company || s.text === title) {
-        continue;
-      }
-      const loc = locationFromAnchorCell(s.text);
-      if (loc) {
-        location = loc;
-        if (team === s.text) team = undefined;
-        break;
-      }
-    }
+    const r = anchorCellLocation(splits, anchorIdx, company, title, team);
+    location = r.location;
+    team = r.team;
+  }
+
+  // (3d) #466 — recover a `City, ST` that LEADS an employer-line cell ("Chicago, IL
+  //      Consumer Banking"). See {@link employerLineLocation}.
+  if (!location) {
+    const r = employerLineLocation(splits, company, title, team);
+    location = r.location;
+    team = r.team;
   }
 
   return { company, title, team, location };
+}
+
+/**
+ * Step 3c (#373) — recover a per-entry location from an ANCHOR-row cell that folds
+ * "<City, ST> <dates>" with no separator ("Globex Financial | New York, NY August
+ * 2024 - Present" — the second `|` cell). The date parse already took the range into
+ * `block.dates`, but the location residue never reached a field. Scans the anchor
+ * line's non-company / non-title segments for a whole-string bare location; when one
+ * led the `team` cell, clears the team. Skipping the title cell keeps the empty-title
+ * "Company · City, ST" export shape for step 5 to rescue (setting it here would orphan
+ * the location in `title`).
+ */
+function anchorCellLocation(
+  splits: Split[],
+  anchorIdx: number,
+  company: string | undefined,
+  title: string | undefined,
+  team: string | undefined,
+): { location?: string; team?: string } {
+  for (const s of splits) {
+    if (s.source !== anchorIdx || s.text === company || s.text === title) continue;
+    const loc = locationFromAnchorCell(s.text);
+    if (loc) return { location: loc, team: team === s.text ? undefined : team };
+  }
+  return { team };
+}
+
+/**
+ * Step 3d (#466) — recover a `City, ST` that LEADS an employer-line cell ("Chicago,
+ * IL  Consumer Banking" — a pipe cell carrying the location plus a trailing
+ * dept/sub-org). Unlike step 3c this is NOT restricted to the anchor line: for the
+ * "Title, Team <dates>" / "Company | City, ST Dept" shape the employer and its
+ * location sit on a NON-anchor line, and the location is neither a whole-string bare
+ * location (3c) nor a trailing suffix (`stripLocationSuffix`), so a front-anchored
+ * match claims it. The closed-vocabulary USPS guard inside `leadingLocation` keeps a
+ * "Word, XX" title/company from false-matching; company/title cells are skipped so
+ * only an unclaimed (or team-carried) cell is read. When the location led the `team`
+ * cell, the residual text after it (a trailing dept) is returned as the new team.
+ */
+function employerLineLocation(
+  splits: Split[],
+  company: string | undefined,
+  title: string | undefined,
+  team: string | undefined,
+): { location?: string; team?: string } {
+  for (const s of splits) {
+    if (s.text === company || s.text === title) continue;
+    const loc = leadingLocation(s.text);
+    if (!loc) continue;
+    if (team === s.text) {
+      const rest = s.text.slice(loc.length).replace(/^[\s,·|–—-]+/, "").trim();
+      return { location: loc, team: rest || undefined };
+    }
+    return { location: loc, team };
+  }
+  return { team };
 }
 
 /**
@@ -873,5 +973,13 @@ export function disambiguateCompanyTitle(
   const mapped = mapSegmentsToFields(splits, strip.filtered, strip.anchorIdx);
   const located = recoverLocation(mapped, splits, strip.anchorIdx);
   const cleaned = cleanFieldArtifacts(located);
-  return applyTrailingCompanyGuard(cleaned, strip.leadsFreshEntry);
+  const guarded = applyTrailingCompanyGuard(cleaned, strip.leadsFreshEntry);
+  // Backstop (#466): a `company` byte-identical to its own `title` is never a real
+  // employer — it is a mirror left by a mapping that could not find one. Prefer a
+  // miss over bad data: drop it so the gap reads as a gap (and no downstream reader
+  // scores or renders the title as the company).
+  if (guarded.company !== undefined && guarded.company === guarded.title) {
+    return { ...guarded, company: undefined };
+  }
+  return guarded;
 }

--- a/src/lib/heuristics/extract/experience.title-team-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.title-team-comma.test.ts
@@ -72,3 +72,75 @@ describe("'Title, Team' over 'Company | Location Dates' (#372)", () => {
     expect(role.company).toBe("Nod Publishing");
   });
 });
+
+/**
+ * Regression for #466 — the INVERSE anchor placement of #372: the DATE sits on the
+ * "Title, Team" line itself, with the employer on the NEXT line:
+ *
+ *   Product Designer, Growth      Jan 2020 - Dec 2021
+ *   Acme | Chicago, IL  Design
+ *
+ * Because the date-bearing anchor is the title line, `mapTitleFirst` read that
+ * line's own comma segments as the company and mirrored the title into `company`
+ * (a suffix-less employer like "Acme" never triggers `looksLikeCompany`, so it
+ * fell to this branch); `location`, sitting on the employer line, was dropped by
+ * both the company-correct path AND the mirror path. The fix reads the company off
+ * the separate employer line, recovers a leading `City, ST` from that line, and
+ * backstops `company === title` to an honest miss.
+ */
+describe("'Title, Team <dates>' over a next-line employer (#466)", () => {
+  it("reads the company + location off the next line for a suffix-less employer (no mirror)", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Product Designer, Growth  Jan 2020 - Dec 2021", fontSize: 11 },
+      { text: "Acme | Chicago, IL  Design", fontSize: 11 },
+      { text: "• Shipped the onboarding redesign.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title).toBe("Product Designer");
+    expect(role.company).toBe("Acme");
+    expect(role.team).toBe("Growth");
+    expect(role.location).toBe("Chicago, IL");
+    // The title is never mirrored into the company.
+    expect(role.company).not.toBe(role.title);
+  });
+
+  it("recovers the employer-line location even when the company already resolved (suffixed)", () => {
+    // "Northwind Systems" carries a company suffix, so `company` was already
+    // correct — but `location` on the employer line (before a trailing dept) was
+    // still dropped. This pins the location half of the fix independently.
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Software Engineer II, Payments Platform  Aug 2024 - Present", fontSize: 11 },
+      { text: "Northwind Systems | Chicago, IL  Consumer Banking", fontSize: 11 },
+      { text: "• Led the platform reliability program.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title).toBe("Software Engineer II");
+    expect(role.company).toBe("Northwind Systems");
+    expect(role.team).toBe("Payments Platform");
+    expect(role.location).toBe("Chicago, IL");
+    expect(role.company).not.toBe(role.title);
+  });
+
+  it("prefers an absent company over a mirrored title when no employer line exists", () => {
+    // A standalone "Title, Team <dates>" with no employer line and no shared-
+    // employer banner: the company genuinely cannot be read, so it must be a miss
+    // (empty), never the title mirrored back.
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Data Analyst, Growth Squad  Feb 2021 - Dec 2022", fontSize: 11 },
+      { text: "• Built the retention dashboard.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+
+    expect(role.title).toBe("Data Analyst");
+    expect(role.company).not.toBe(role.title);
+    expect(role.company).toBe("");
+  });
+});

--- a/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
@@ -73,7 +73,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 1319,
-    "extractedCharCount": 1138,
+    "extractedCharCount": 1119,
     "sections": [
       {
         "name": "profile",

--- a/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
@@ -1,15 +1,14 @@
 {
   "schemaVersion": 5,
   "cascade": {
-    "confidence": 0.9,
+    "confidence": 0.83,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "none",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
-      "current_company",
       "current_title",
       "education",
       "email",
@@ -74,7 +73,7 @@
     "sectionSource": "regex",
     "pageCount": 1,
     "rawCharCount": 741,
-    "extractedCharCount": 654,
+    "extractedCharCount": 625,
     "sections": [
       {
         "name": "profile",
@@ -122,7 +121,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
@@ -1,15 +1,14 @@
 {
   "schemaVersion": 5,
   "cascade": {
-    "confidence": 0.9,
+    "confidence": 0.83,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "none",
+    "suggestedEscalation": "llm",
     "fieldsPopulated": [
-      "current_company",
       "current_title",
       "education",
       "email",
@@ -74,7 +73,7 @@
     "sectionSource": "regex",
     "pageCount": 1,
     "rawCharCount": 499,
-    "extractedCharCount": 421,
+    "extractedCharCount": 392,
     "sections": [
       {
         "name": "profile",
@@ -122,7 +121,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": false,
+    "experienceChangedAcrossRoundtrip": true,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
@@ -74,7 +74,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 711,
-    "extractedCharCount": 596,
+    "extractedCharCount": 572,
     "sections": [
       {
         "name": "profile",


### PR DESCRIPTION
## Summary

A single-column role header of shape `Title, Team  <dates>` with the employer on the **next** line parsed wrong: the comma-suffix split short-circuited the next-line-employer lookup, **mirroring the title into `company`** (suffix-less employers) and **dropping the employer-line `City, ST`** on every variant. Confirmed by direct reproduction against `disambiguateCompanyTitle` — the issue's synthetic table was partly inaccurate (a suffixed employer like `Northwind Systems` dodges the mirror via `looksLikeCompany`; the mirror needs a suffix-less employer), so the fix targets the reproduced mechanism.

- **`mapTitleFirst`** — distinguishes the #372 layout (anchor = employer line below the title) from #466 (date on the `Title, Team` line, so it is the anchor). In the #466 case it reads the company off the separate employer line and never mirrors the title; reconciled with the #382 shared-employer banner (empty company + team set stays banner-eligible).
- **`leadingLocation` + step 3d (`employerLineLocation`)** — recovers a front-anchored `City, ST` from an employer-line cell carrying a trailing dept (`Chicago, IL  Consumer Banking`), which is neither a whole-string bare location nor a trailing suffix, so no prior pass claimed it. Path-independent, so it also fixes the location drop on the suffixed (company-correct) path.
- **`company === title` backstop** — a company byte-identical to its title is dropped to an honest miss rather than left as mirrored bad data (per the issue).
- Extracted steps 3c/3d into helpers (`anchorCellLocation` / `employerLineLocation`) to keep `recoverLocation` under the fallow complexity gate.

Two `label-rail` corpus fixtures **already carried the mirror** on `main` (`company` = title); the backstop converts that to an honest empty company, so their score honestly drops and their now-empty company doesn't round-trip the one-line export header — baselined under the existing **#436** group.

Closes #466

## Corpus snapshots re-baked (4)

`extractedCharCount` is `countExtractedChars(parsed, sections)` — **derived from the parsed fields**, so the corrected mapping shifts it. Four snapshots re-baked to the values the current code produces (verified identical on CI and locally):

- `label-rail-grid-fragmented`, `label-rail-inline-headers` — company drops from a mirror to empty (confidence / `current_company` / `experienceChangedAcrossRoundtrip` + the derived count).
- `chromium-qualified-experience-headers`, `single-column-year-only-roundtrip` — **only** the derived `extractedCharCount` shifts; no experience field/score change (no regression).

## Test plan

- [x] `npm run typecheck` / `npm run lint` clean
- [x] New value-asserting unit tests (`experience.title-team-comma.test.ts`, #466 block): suffix-less + suffixed employers, and the no-employer-line honest miss — green through the full `extractExperience` path.
- [x] `experience.shared-banner` (#382) / `pipe-location` (#373) regressions green.
- [x] `corpus.test.ts` + `corpus-roundtrip.test.ts` green (2 label-rail experience baselines added to the #436 group).
- [x] `npm run test` green (full suite).

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: full deterministic gate green locally; corpus snapshots verified against CI extraction.