### PR TITLE
fix(parser): route "<QUALIFIER> EXPERIENCE" headers via the exact-alias tier (#467)

### DIFF
--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -2,7 +2,12 @@
 // Copyright 2026 The resumelint Authors
 
 import { describe, it, expect } from "vitest";
-import { matchSectionHeader, matchSectionAnchorToken, DATE_RANGE_RE } from "./regex.ts";
+import {
+  matchSectionHeader,
+  matchSectionHeaderDetailed,
+  matchSectionAnchorToken,
+  DATE_RANGE_RE,
+} from "./regex.ts";
 import { parseDateRange, stripDateRange } from "./line-primitives.ts";
 
 describe("matchSectionHeader — split-letter headers (#56)", () => {
@@ -55,6 +60,45 @@ describe("matchSectionHeader — head-noun anchor fallback (#108 / #111)", () =>
     // Exact aliases still resolve via the keyword path, not the fallback.
     expect(matchSectionHeader("Experience")).toBe("experience");
     expect(matchSectionHeader("Work Experience")).toBe("experience");
+  });
+
+  describe("closed-vocabulary qualifier fold promotes to the EXACT tier (#467)", () => {
+    // A closed set of qualifier words ("Relevant / Additional / Performance /
+    // Involvement / …" + Experience) folds to the bare "experience" anchor so it
+    // matches the EXACT-alias tier (viaAnchorFallback:false), NOT the softer L2
+    // anchor-fallback tier the splitter suppresses on a repeat open (#258 Layer B).
+    // Without this a SECOND qualified experience header is swallowed as a content
+    // line and the roles beneath it lose their entry boundary.
+    it.each([
+      "Relevant Experience",
+      "Additional Experience",
+      "Performance Experience",
+      "Involvement Experience",
+      "Leadership Experience",
+    ])("routes %s via the exact tier (not anchor-fallback)", (header) => {
+      expect(matchSectionHeaderDetailed(header)).toEqual({
+        section: "experience",
+        viaAnchorFallback: false,
+      });
+    });
+
+    it("leaves an OPEN-ended qualifier on the soft anchor-fallback tier", () => {
+      // "Customer Service Experience" is a genuine heading but its qualifier is not
+      // in the closed set, so it stays a soft L2 match — unchanged by #467.
+      expect(matchSectionHeaderDetailed("Customer Service Experience")).toEqual({
+        section: "experience",
+        viaAnchorFallback: true,
+      });
+    });
+
+    it("does not fold prose or a non-experience anchor", () => {
+      // The fold only fires on "<closed-qualifier…> experience"; a lowercase prose
+      // fragment or a different trailing anchor is untouched.
+      expect(matchSectionHeader("i have relevant experience")).toBeNull();
+      expect(matchSectionHeaderDetailed("Relevant Coursework")?.viaAnchorFallback).toBe(
+        false, // exact education alias, not the experience fold
+      );
+    });
   });
 
   it("rejects prose: long-form sentence with an incidental head noun", () => {

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -323,6 +323,43 @@ const LEADING_GLYPH_RE = /^[^\p{L}\p{N}]+(?=\p{L})/u;
  * already-trimmed/lowercased/colon-stripped text from the caller. Returns the
  * matched section, or null when no guardrail-passing anchor is found.
  */
+/**
+ * Closed set of header QUALIFIER words that modify the EXPERIENCE anchor without
+ * changing which section it names — "Relevant / Additional / Performance /
+ * Involvement / Other … Experience" are all the experience section (#467). Closed
+ * vocabulary (not any Title-case word) so a prose line ending in "experience"
+ * cannot be folded into a heading; the anchor-fallback tier's casing/word-count
+ * guards still gate anything outside this list.
+ */
+const EXPERIENCE_QUALIFIERS = new Set<string>([
+  "relevant",
+  "additional",
+  "performance",
+  "involvement",
+  "other",
+  "related",
+  "leadership",
+  "extracurricular",
+  "selected",
+  "further",
+]);
+
+/**
+ * Fold `"<qualifier…> experience"` to the bare `"experience"` anchor when every
+ * word before the trailing anchor is a known {@link EXPERIENCE_QUALIFIERS} word;
+ * otherwise return the input unchanged. Lets a qualified experience header route
+ * via the EXACT-alias tier rather than the splitter-suppressed L2 tier (#467).
+ */
+function stripExperienceQualifier(normalized: string): string {
+  const tokens = normalized.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length < 2 || tokens[tokens.length - 1] !== "experience") {
+    return normalized;
+  }
+  return tokens.slice(0, -1).every((t) => EXPERIENCE_QUALIFIERS.has(t))
+    ? "experience"
+    : normalized;
+}
+
 function matchAnchorFallback(
   raw: string,
   normalized: string,
@@ -480,10 +517,21 @@ export function matchSectionHeaderDetailed(
     normalized = normalized.replace(LEADING_GLYPH_RE, "");
   }
   if (normalized.length === 0 || normalized.length > 40) return null;
+  // #467 — fold a qualifier-prefixed EXPERIENCE header ("Relevant Experience",
+  // "Involvement Experience", "Additional Experience") to the bare "experience"
+  // anchor so it matches the EXACT-alias tier below (viaAnchorFallback:false).
+  // The anchor-fallback tier would also route it, but as a SOFT (L2) match the
+  // splitter suppresses a REPEAT open of an already-open section (#258 Layer B) —
+  // swallowing a second qualified experience header as a content line and
+  // stranding the roles beneath it. A closed qualifier vocabulary keeps this from
+  // minting a section out of prose; enumerating every "<qualifier> experience"
+  // permutation as its own alias is exactly the gap this replaces.
+  const dequalified = stripExperienceQualifier(normalized);
   for (const [name, keywords] of Object.entries(SECTION_KEYWORDS) as Array<
     [SectionName, readonly string[]]
   >) {
-    if (keywords.includes(normalized)) return { section: name, viaAnchorFallback: false };
+    if (keywords.includes(normalized) || keywords.includes(dequalified))
+      return { section: name, viaAnchorFallback: false };
   }
   // Split-letter headers: pdfjs reads a tracked/decorated `EXPERIENCE` as
   // `E XPERIENCE`. Rejoin single split letters and retry, gated to the

--- a/src/lib/heuristics/sections.test.ts
+++ b/src/lib/heuristics/sections.test.ts
@@ -1361,3 +1361,35 @@ describe("groupIntoLines — ≥2 adjacent flush-right-date rows are NOT a colum
     ]);
   });
 });
+
+describe("qualified experience headers each open a boundary (#467)", () => {
+  it("a SECOND <qualifier> EXPERIENCE header is a boundary, not a content line", () => {
+    // Both headers fold to the exact "experience" alias (#467), so neither is a
+    // soft L2 match — the splitter no longer suppresses the second one as a repeat
+    // open (#258 Layer B). Before the fold, "INVOLVEMENT EXPERIENCE" was swallowed
+    // as a content line inside the first experience region, stranding the roles
+    // beneath it without an entry boundary.
+    const sections = build([
+      { text: "RELEVANT EXPERIENCE", fontSize: 13 },
+      { text: "Lakeside Opera  Springfield, IL", fontSize: 11 },
+      { text: "Production Intern  June 2023 - Present", fontSize: 11 },
+      { text: "• Supported departmental assignments", fontSize: 11 },
+      { text: "INVOLVEMENT EXPERIENCE", fontSize: 13 },
+      { text: "Student Composers Association  August 2022 - Present", fontSize: 11 },
+      { text: "• Created work ranging from symphonic to electronic music", fontSize: 11 },
+    ]);
+
+    // Two distinct experience sections, one per header.
+    expect(names(sections).filter((n) => n === "experience")).toHaveLength(2);
+    // The header text never survives as a content line inside a region.
+    for (const s of sections) {
+      expect(s.lines.some((l) => l.text.includes("INVOLVEMENT EXPERIENCE"))).toBe(
+        false,
+      );
+    }
+    // The role under the second header rides in the second experience section.
+    expect(
+      sectionContaining(sections, "Student Composers Association")?.name,
+    ).toBe("experience");
+  });
+});

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
@@ -86,7 +86,7 @@
       },
       {
         "name": "experience",
-        "lineCount": 24
+        "lineCount": 23
       },
       {
         "name": "skills",


### PR DESCRIPTION
## Summary

A qualified experience header — `Relevant / Additional / Performance / Involvement Experience` — matched only via the soft head-noun **anchor-fallback** tier (`viaAnchorFallback: true`). The splitter suppresses a **repeat** anchor-fallback open of an already-open section (#258 Layer B), so a **second** qualified experience header was swallowed as a content line inside the first experience region — stranding the roles beneath it without an entry boundary (`INVOLVEMENT EXPERIENCE` in the #467 repro).

Fix: fold a **closed vocabulary** of qualifier words + `experience` to the bare `experience` anchor in `matchSectionHeaderDetailed`, so these route via the **exact** tier (`viaAnchorFallback: false`) and each opens its own boundary. The closed set (not any Title-case word) keeps prose from minting a section, and the anchor-fallback guards still gate everything outside it. Open-ended qualifiers (`Customer Service Experience`) stay on the soft tier, unchanged — this is a `normalizer`, not an enumeration of every permutation (the gap the issue calls out).

Reproduced end-to-end before/after via the real section splitter; confirmed `INVOLVEMENT EXPERIENCE` flips from a swallowed content line to its own experience section boundary.

Refs #467

## Scope note (why not `Closes`)

#467 bundles three fixes. This PR lands the **routing** half. The other two — splitting `RELEVANT COURSEWORK` into its own region, and the education entry-boundary guard against a phantom degree — **only reproduce from real-résumé line assembly** (verified: `"Certificate, Music Business"` is inert to the education chunker; `extractEducation` yields one clean entry on every synthetic form). Per the house rule of verifying a parser fix against a reproducing case before shipping, those are deferred to **#462**, which was filed from a résumé that reproduces the phantom and shares the exact same guard.

## Corpus

One snapshot re-baked: `google-docs-skia-proxy-programs-skills-software` — a `Leadership Experience` header previously absorbed as content is now consumed as a boundary (section `lineCount` 24 → 23). No experience/score regression; `extractedCharCount` unchanged.

## Test plan

- [x] `npm run typecheck` / `npm run lint` clean
- [x] New unit tests: closed-qualifier fold routes via the exact tier (`regex.test.ts`); open-ended qualifier stays on the soft tier; prose still rejected.
- [x] New splitter test (`sections.test.ts`): a second `<QUALIFIER> EXPERIENCE` opens its own section — header never survives as a content line.
- [x] `corpus.test.ts` + `corpus-roundtrip.test.ts` green.
- [x] `npm run test` green (2252 passed).

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: full deterministic gate green locally; corpus snapshot verified against CI extraction.