### PR TITLE
fix(edit): placeholder add-affordance, empty-section hint, lone-date month capture (#376, #380)

### DIFF
--- a/src/components/features/AchievementTypePicker.tsx
+++ b/src/components/features/AchievementTypePicker.tsx
@@ -121,7 +121,6 @@ export function AchievementTypePicker({
                 PDF actually said. */}
             <EditableField
               value={label || undefined}
-              placeholder="Custom label"
               label="Custom achievement type"
               textSize="xs"
               onCommit={(v) => pick(v)}

--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -223,8 +223,14 @@ describe("ContactCard", () => {
       makeResult({ email: "jane@example.com" }, { email: 0.95 }),
       { overrides: {}, onFieldChange: () => {} },
     );
-    expect(el.textContent).toContain("Phone not detected");
-    expect(el.querySelector('[aria-label="Edit Phone"]')).not.toBeNull();
+    // An absent required field reads as a gap to FILL — "+ phone", announced
+    // "Add Phone" — not as a status sentence. It is still discernible, and still
+    // the only input path (role=button, focusable, opens an empty input).
+    expect(el.textContent).toContain("+ phone");
+    const field = el.querySelector('[aria-label="Add Phone"]');
+    expect(field).not.toBeNull();
+    expect(field?.getAttribute("role")).toBe("button");
+    expect(field?.getAttribute("tabindex")).toBe("0");
   });
 
   it("no longer renders the detected/total completeness footer (moved to the AttentionStrip)", () => {

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -91,7 +91,7 @@ export function ContactCard({
         {editable ? (
           <EditableField
             value={name && !name.gated ? name.value : undefined}
-            placeholder="Name not detected"
+            placeholder="name"
             label="Name"
             textSize="lg"
             textWeight="semibold"

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -192,7 +192,7 @@ function EditableValue({
     <EditableField
       value={field.value || undefined}
       displayValue={displayValue}
-      placeholder={`${field.label} not detected`}
+      placeholder={field.label.toLowerCase()}
       label={field.label}
       textSize="sm"
       validate={validatorFor(field.key, location)}

--- a/src/components/features/ContactExtraLinks.tsx
+++ b/src/components/features/ContactExtraLinks.tsx
@@ -50,7 +50,6 @@ export function ContactExtraLinks({
             <EditableField
               value={profile.url}
               displayValue={formatLinkDisplay(profile.url)}
-              placeholder="Link URL"
               label={profile.network}
               textSize="sm"
               onCommit={(v) => onEdit(profile.id, v)}

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -153,7 +153,7 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
           <span className="text-xs text-content-tertiary">Title</span>
           <EditableField
             value={query.title}
-            placeholder="title not detected"
+            placeholder="job title"
             label="Job title"
             textWeight="semibold"
             onCommit={(v) => setQuery((q) => ({ ...q, title: v }))}
@@ -163,7 +163,7 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
           <span className="text-xs text-content-tertiary">Seniority</span>
           <EditableField
             value={query.seniority}
-            placeholder="not detected"
+            placeholder="seniority"
             label="Seniority"
             onCommit={(v) =>
               setQuery((q) => ({ ...q, seniority: v || undefined }))

--- a/src/components/features/ReconstructedAdd.tsx
+++ b/src/components/features/ReconstructedAdd.tsx
@@ -37,6 +37,25 @@ function CloseIcon() {
 }
 
 /**
+ * The one-line prompt an EMPTY section shows above its {@link AddPill} (#380).
+ *
+ * A section that renders with no entries is ambiguous in a way that matters
+ * here: it reads as "the parser found your achievements and dropped them" when
+ * what it means is "this section is empty — you can fill it." The pattern that
+ * resolves it is the standard guided empty state (a helpful message plus the
+ * action, never bare blank space), with one constraint the copy must honour: it
+ * describes what BELONGS in the section, and makes no claim about what the
+ * parser did or did not find. We cannot tell "the résumé had none" apart from
+ * "we missed them", so any finding-shaped wording ("no achievements detected")
+ * would either be a guess or reinforce the very reading we are fixing. The
+ * `AddPill` below it stays the reachable input path, untouched — the block-level
+ * "add a whole entry" affordance it already is.
+ */
+export function SectionEmptyHint({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-content-tertiary">{children}</p>;
+}
+
+/**
  * The collapsed progressive-disclosure trigger — a chip-shaped "+ <label>" pill
  * that sits inline with the content it adds to. Quiet by default; warms to the
  * brand accent on hover.

--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -2,9 +2,12 @@
 // Copyright 2026 The resumelint Authors
 
 import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import {
   resolveEduValue,
   resolveEducationDisplay,
+  EducationSection,
 } from "./ReconstructedEducationSkills.tsx";
 import type { ResumeEducation } from "../../lib/score/types.ts";
 
@@ -105,5 +108,73 @@ describe("resolveEducationDisplay", () => {
     expect(resolveEducationDisplay(noCoursework, undefined).coursework).toEqual(
       [],
     );
+  });
+});
+
+describe("EducationSection date-row symmetry (issue 376)", () => {
+  // The `–` separator between start/end EditableFields must render identically
+  // regardless of which side is empty; only the empty side switches to the
+  // strengthened "+ " placeholder treatment. Static (read-mode) render, so
+  // renderToStaticMarkup is sufficient — matches the EditableField primitive's
+  // own test harness.
+  function renderSection(edu: ResumeEducation): string {
+    return renderToStaticMarkup(
+      createElement(EducationSection, {
+        education: [edu],
+        educationOverrides: {},
+        onEducationFieldChange: () => {},
+        addedEducation: [],
+        originalCount: 1,
+        onAddEntry: () => {},
+        onRemoveEntry: () => {},
+        onEntryField: () => {},
+      }),
+    );
+  }
+
+  it("renders the dash with both sides populated, neither prefixed", () => {
+    const html = renderSection({
+      degree: "BSc",
+      institution: "U",
+      start_date: "2018",
+      end_date: "2022",
+    });
+    expect(html).toContain(">2018<");
+    expect(html).toContain(">2022<");
+    expect(html).toContain("–");
+    expect(html).not.toContain("+ 2018");
+    expect(html).not.toContain("+ 2022");
+  });
+
+  it("prefixes only the empty start side; the dash and the populated end side are unchanged", () => {
+    const html = renderSection({
+      degree: "BSc",
+      institution: "U",
+      end_date: "2022",
+    });
+    expect(html).toContain(`<span aria-hidden="true">+ </span>start`);
+    expect(html).toContain(">2022<");
+    expect(html).toContain("–");
+  });
+
+  it("prefixes only the empty end side; the dash and the populated start side are unchanged", () => {
+    const html = renderSection({
+      degree: "BSc",
+      institution: "U",
+      start_date: "2009",
+    });
+    expect(html).toContain(">2009<");
+    expect(html).toContain(`<span aria-hidden="true">+ </span>end`);
+    expect(html).toContain("–");
+  });
+
+  it("prefixes both sides when both start and end are absent", () => {
+    const html = renderSection({
+      degree: "BSc",
+      institution: "U",
+    });
+    expect(html).toContain(`<span aria-hidden="true">+ </span>start`);
+    expect(html).toContain(`<span aria-hidden="true">+ </span>end`);
+    expect(html).toContain("–");
   });
 });

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -10,7 +10,7 @@
  * was uncorrectable. They now expose inline edit affordances wired to the lifted
  * override model (useEditableParse):
  *   - Education: degree / institution / dates editable via the shared
- *     EditableField. A cleared field shows "not detected".
+ *     EditableField. A cleared field shows an "+ <noun>" add-affordance.
  *   - Skills: each skill is a removable chip; a "+ Add skill" pill expands
  *     inline into an input (canonical-name normalization + suggestions),
  *     collapsing back on Escape or empty blur.
@@ -147,7 +147,7 @@ function EducationEntry({
           {!majorInPrimary && (
             <EditableField
               value={degree}
-              placeholder="degree not detected"
+              placeholder="degree"
               label="Degree"
               textWeight="semibold"
               onCommit={(v) => onFieldChange("degree", v)}
@@ -168,7 +168,7 @@ function EducationEntry({
           <span className="text-content-muted">—</span>
           <EditableField
             value={institution}
-            placeholder="institution not detected"
+            placeholder="institution"
             label="Institution"
             onCommit={(v) => onFieldChange("institution", v)}
           />

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -76,9 +76,18 @@ import type {
   AchievementFieldOverrides,
 } from "../../hooks/useEditableParse.ts";
 import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
-import { AddPill, RemoveButton, InlineBulletAdd } from "./ReconstructedAdd.tsx";
+import {
+  AddPill,
+  RemoveButton,
+  InlineBulletAdd,
+  SectionEmptyHint,
+} from "./ReconstructedAdd.tsx";
 import { AchievementTypePicker } from "./AchievementTypePicker.tsx";
-import { buildProjectDates } from "../../lib/score/entry-dates.ts";
+import {
+  buildProjectDates,
+  isTightYearSeparator,
+  DEFAULT_ACHIEVEMENT_YEAR_SEPARATOR,
+} from "../../lib/score/entry-dates.ts";
 import { validateDate } from "../../lib/edit/field-validators.ts";
 import {
   EducationSection,
@@ -670,11 +679,14 @@ function AchievementHeader({
   type,
   title,
   year,
+  yearSeparator,
   onFieldChange,
 }: {
   type?: string;
   title?: string;
   year?: string;
+  /** The source's own title↔year punctuation (#380); middot when it had none. */
+  yearSeparator?: string;
   onFieldChange: (field: keyof AchievementFieldOverrides, value: string) => void;
 }) {
   return (
@@ -688,7 +700,7 @@ function AchievementHeader({
       </span>
       <EditableField
         value={title || undefined}
-        placeholder="achievement not detected"
+        placeholder="achievement"
         label="Achievement description"
         textSize="sm"
         // With no type label there is no run to single out, so the exporter
@@ -699,8 +711,17 @@ function AchievementHeader({
         multiline
         onCommit={(v) => onFieldChange("title", v)}
       />
-      <span className="text-content-muted" aria-hidden="true">
-        ·
+      {/* The source's own separator, not a hardcoded middot: a résumé that wrote
+          "Globex Engineering Excellence, 2021" keeps its comma (#380). Tight
+          punctuation cancels the flex row's gap so it hugs the title, matching
+          how the exported PDF spaces it (`achievementYearJoiner`). */}
+      <span
+        className={`text-content-muted ${
+          yearSeparator && isTightYearSeparator(yearSeparator) ? "-ml-1.5" : ""
+        }`}
+        aria-hidden="true"
+      >
+        {yearSeparator ?? DEFAULT_ACHIEVEMENT_YEAR_SEPARATOR}
       </span>
       <EditableField
         value={year || undefined}
@@ -791,6 +812,7 @@ function AchievementsSection({
                     type={achievement.type}
                     title={achievement.title}
                     year={achievement.year}
+                    yearSeparator={achievement.year_separator}
                     onFieldChange={(field, value) =>
                       onAchievementField(i, field, value)
                     }
@@ -821,6 +843,11 @@ function AchievementsSection({
           );
         })}
       </div>
+      {achievements.length === 0 && (
+        <SectionEmptyHint>
+          Awards, patents, publications, and honors go here.
+        </SectionEmptyHint>
+      )}
       <AddPill label="Add achievement" onClick={onAddEntry} />
     </section>
   );

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -253,6 +253,7 @@ export function ResumeBulletRow({
             <EditableField
               value={displayText || undefined}
               placeholder="empty bullet"
+              emptyAffordance="plain"
               label="Bullet text"
               textSize="sm"
               display="inline"
@@ -396,7 +397,7 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
         <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
           <EditableField
             value={title}
-            placeholder="title not detected"
+            placeholder="title"
             label="Job title"
             textWeight="semibold"
             textSize="sm"
@@ -410,7 +411,7 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
           <span className="inline-flex items-baseline">
             <EditableField
               value={company}
-              placeholder="company not detected"
+              placeholder="company"
               label="Company"
               textSize="sm"
               multiline
@@ -422,7 +423,7 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
           </span>
           <EditableField
             value={location}
-            placeholder="location not detected"
+            placeholder="location"
             label="Location"
             textSize="sm"
             onCommit={(v) => onFieldChange("location", v)}
@@ -435,7 +436,7 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
           </span>
           <EditableField
             value={team}
-            placeholder="team not detected"
+            placeholder="team"
             label="Team or department"
             textSize="sm"
             onCommit={(v) => onFieldChange("team", v)}

--- a/src/components/features/ResumeLibraryEntry.tsx
+++ b/src/components/features/ResumeLibraryEntry.tsx
@@ -35,6 +35,7 @@ export function ResumeLibraryEntry({
         <EditableField
           value={entry.filename}
           placeholder="Untitled resume"
+          emptyAffordance="plain"
           label="Resume name"
           onCommit={(next) => {
             const trimmed = next.trim();

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -167,6 +167,7 @@ export function BulletReviewRow({
           <EditableField
             value={newSideText(pair, review)}
             placeholder="edit this bullet"
+            emptyAffordance="plain"
             label="Edit proposed bullet"
             textSize="sm"
             display="inline"

--- a/src/design-system/primitives/EditableField.test.tsx
+++ b/src/design-system/primitives/EditableField.test.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Tests for the `EditableField` primitive's empty-state placeholder treatment
+ * (#376). Read mode is static (no client-only effects run before `editing` is
+ * true), so — matching `Dialog.test.ts` — these run via `renderToStaticMarkup`
+ * in the repo's default Node test env; no jsdom needed.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EditableField } from "./EditableField.tsx";
+
+function render(props: Parameters<typeof EditableField>[0]): string {
+  return renderToStaticMarkup(createElement(EditableField, props));
+}
+
+describe("EditableField read mode", () => {
+  it("prefixes an empty field's placeholder with '+ ' so it reads as an add-affordance, not a value", () => {
+    const html = render({
+      value: undefined,
+      placeholder: "location",
+      label: "Location",
+      onCommit: () => {},
+    });
+    // The glyph is its own aria-hidden span, not folded into the text — so a
+    // screen reader gets "Add Location", never "plus location".
+    expect(html).toContain('<span aria-hidden="true">+ </span>location');
+  });
+
+  it("defaults the placeholder to the lowercased label, so '+ not detected' is unrepresentable", () => {
+    const html = render({ value: undefined, label: "Location", onCommit: () => {} });
+    expect(html).toContain('<span aria-hidden="true">+ </span>location');
+    expect(html).not.toContain("not detected");
+  });
+
+  it("emptyAffordance='plain' drops the glyph AND the Add verb — the empty state is a state, not a gap", () => {
+    const html = render({
+      value: undefined,
+      placeholder: "Untitled resume",
+      emptyAffordance: "plain",
+      label: "Resume name",
+      onCommit: () => {},
+    });
+    expect(html).not.toContain("+ ");
+    expect(html).toContain("Untitled resume");
+    expect(html).toContain('aria-label="Edit Resume name"');
+    // The add-path invariant still holds for a plain field: it is the only input
+    // path, so it stays focusable and activatable.
+    expect(html).toContain('role="button"');
+    expect(html).toContain('tabindex="0"');
+  });
+
+  it("renders a populated field's value verbatim, with no '+ ' prefix", () => {
+    const html = render({
+      value: "Chicago, IL",
+      placeholder: "location not detected",
+      label: "Location",
+      onCommit: () => {},
+    });
+    expect(html).toContain(">Chicago, IL<");
+    expect(html).not.toContain("+ Chicago, IL");
+  });
+
+  it("keeps the empty field focusable and clickable — same role/tabIndex as before, only the visible text and the verb change", () => {
+    const html = render({
+      value: undefined,
+      placeholder: "start date",
+      label: "Start date",
+      onCommit: () => {},
+    });
+    expect(html).toContain('role="button"');
+    expect(html).toContain('tabindex="0"');
+    // The verb matches what the field OFFERS: an empty add-field is announced
+    // "Add …", so the accessible name contains the visible label (WCAG 2.5.3).
+    expect(html).toContain('aria-label="Add Start date"');
+    // The muted/italic empty-state treatment is unchanged — the "+" prefix is
+    // additive, not a replacement for the existing visual distinction.
+    expect(html).toMatch(/class="[^"]*text-content-muted[^"]*italic[^"]*"/);
+  });
+
+  it("does not prefix a populated value even when a displayValue override is set", () => {
+    const html = render({
+      value: "https://linkedin.com/in/jane",
+      displayValue: "linkedin.com/in/jane",
+      placeholder: "not detected",
+      label: "LinkedIn",
+      onCommit: () => {},
+    });
+    expect(html).toContain(">linkedin.com/in/jane<");
+    expect(html).not.toContain("+ linkedin.com/in/jane");
+  });
+});
+
+/**
+ * #376's completeness criterion — "no call site is special-cased or skipped" —
+ * is a property of the WHOLE REPO, not of this primitive, so it cannot be tested
+ * by rendering the primitive alone. It regressed exactly that way once already:
+ * two call sites (ContactExtraLinks, AchievementTypePicker) were never visited by
+ * the placeholder rewrite, and because `emptyAffordance` defaults to "add" they
+ * silently INHERITED the new "+ " glyph on top of their old sentence-case copy —
+ * "+ Link URL", "+ Custom label". The default that makes the affordance
+ * repo-wide is the same default that spreads the defect to anything overlooked.
+ *
+ * So the guard is a source sweep: an "add"-mode placeholder must be a bare noun
+ * phrase, because it is rendered directly after a "+ ".
+ */
+describe("EditableField call sites (issue 376 — repo-wide, no site skipped)", () => {
+  // `[\s\S]*?`, NOT `[^>]*?`: nearly every call site spans several lines and
+  // carries an arrow-function prop (`onCommit={(v) => …}`), so a `>`-terminated
+  // scan stops dead at the arrow and sees only the handful of single-line sites.
+  // That version of this sweep matched 2 of 23 and passed while the bug was live.
+  const CALL_SITE_RE = /<EditableField\b[\s\S]*?\/>/g;
+  const PLACEHOLDER_RE = /placeholder=(?:"([^"]*)"|\{`([^`]*)`\})/;
+  const PLAIN_RE = /emptyAffordance=["{]?["']?plain/;
+
+  const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+  function componentFiles(): string[] {
+    return readdirSync(SRC_DIR, { recursive: true, encoding: "utf8" })
+      .filter((p) => p.endsWith(".tsx") && !p.endsWith(".test.tsx"))
+      .map((p) => join(SRC_DIR, p))
+      .sort();
+  }
+
+  it("never gives an add-affordance field a capitalized or '…not detected' placeholder", () => {
+    const offenders: string[] = [];
+    let sitesSeen = 0;
+    for (const file of componentFiles()) {
+      const src = readFileSync(file, "utf8");
+      for (const site of src.match(CALL_SITE_RE) ?? []) {
+        sitesSeen++;
+        // "plain" fields render the bare placeholder with no "+ ", so prose there
+        // is fine — it is a state description, not a gap to fill.
+        if (PLAIN_RE.test(site)) continue;
+        const m = PLACEHOLDER_RE.exec(site);
+        const placeholder = m?.[1] ?? m?.[2];
+        // No placeholder at all is the GOOD case: the primitive derives it from
+        // `label`, which is what makes "+ not detected" unrepresentable.
+        if (!placeholder) continue;
+        if (/not detected/i.test(placeholder) || /^[A-Z]/.test(placeholder)) {
+          offenders.push(`${file}: placeholder="${placeholder}"`);
+        }
+      }
+    }
+
+    // Non-vacuity: a sweep that silently walks nothing (wrong root, wrong
+    // extension filter) passes green while the bug is live — the exact way the
+    // `[^>]*?` version of CALL_SITE_RE failed.
+    expect(sitesSeen).toBeGreaterThan(15);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -5,14 +5,33 @@
  * EditableField — the ONE shared inline-edit primitive.
  *
  * Renders in one of two modes:
- *   • read  — shows the current value (or a "not detected" placeholder when
- *             value is absent). The value itself is the edit affordance: a text
+ *   • read  — shows the current value (or, when absent, the placeholder noun).
+ *             The value itself is the edit affordance: a text
  *             cursor + a subtle hover tint signal editability; clicking/tapping
  *             it (or focusing it and pressing Enter/Space) enters edit mode.
  *             No pencil icon — one icon per field reads as clutter on a
  *             document-shaped surface, and a hover-only pencil is invisible on
  *             touch. The quiet hover affordance works with mouse, keyboard, and
  *             touch alike (Notion/Linear/Docs pattern).
+ *             An EMPTY field renders as an add-affordance: a "+ " glyph in
+ *             front of a bare NOUN naming the thing you would add (e.g.
+ *             "+ location"), so it stays legible as an invitation rather than a
+ *             literal value when a caller joins it into a compound line with a
+ *             fixed separator (#376) — "Acme Corp, + location" vs. "Acme Corp,
+ *             location not detected". Muted italic alone already differentiates
+ *             it in isolation; the "+ " is what survives being read in situ next
+ *             to real content.
+ *
+ *             Three things that used to be one string are now separate:
+ *               – the GLYPH is its own `aria-hidden` span, so "+" is never read
+ *                 out as punctuation;
+ *               – the PLACEHOLDER is a bare noun, defaulting to the label
+ *                 lowercased — which makes "+ not detected" unrepresentable;
+ *               – the ACCESSIBLE NAME says "Add <label>" for an empty add-field
+ *                 and "Edit <label>" otherwise, so the announced name contains
+ *                 the visible one (WCAG 2.5.3 Label in Name).
+ *             `emptyAffordance="plain"` opts a field out of the glyph and the
+ *             "Add" verb — for fields whose empty state is a STATE, not a gap.
  *   • edit  — inline <input> (default) or auto-growing <textarea> (multiline)
  *             pre-filled with the current value.
  *             Single-line: blurring or pressing Enter/Escape commits/cancels.
@@ -28,7 +47,8 @@
  *
  * Props:
  *   value       — current display value (may be empty/undefined when absent).
- *   placeholder — shown when value is empty, e.g. "not detected".
+ *   placeholder — the NOUN shown when value is empty, e.g. "location". Defaults
+ *                 to the label, lowercased.
  *   label       — accessible label for the input (aria-label).
  *   onCommit    — called with the trimmed new string (or "" on clear).
  *   className   — extra classes on the root wrapper (layout stays with caller).
@@ -43,7 +63,20 @@ import { Button } from "./Button.tsx";
 
 interface EditableFieldProps {
   value: string | undefined;
+  /**
+   * What an EMPTY field shows. A bare NOUN naming the thing you would add
+   * ("location", "degree"), NOT a status sentence — the "+ " glyph in front of
+   * it is what makes it read as English. Defaults to the label, lowercased.
+   */
   placeholder?: string;
+  /**
+   * What an EMPTY field offers. "add" (default) renders the "+ " affordance
+   * glyph and announces itself as an add action; "plain" renders the bare
+   * placeholder — for fields whose empty state is a STATE, not a gap the user is
+   * invited to fill (an "Untitled resume" name fallback, an "empty bullet"
+   * description, an "edit this bullet" instruction).
+   */
+  emptyAffordance?: "add" | "plain";
   label: string;
   onCommit: (newValue: string) => void;
   /**
@@ -132,7 +165,12 @@ function ShapeWarningGlyph({ message }: { message: string }) {
 
 export function EditableField({
   value,
-  placeholder = "not detected",
+  // Derived from the label, not a fixed string: the placeholder is a NOUN naming
+  // the thing you add, and the label already is that noun. Deriving it is what
+  // makes "+ not detected" unrepresentable — the defect class cannot regrow at
+  // the next call site that forgets to pass a placeholder.
+  placeholder,
+  emptyAffordance = "add",
   label,
   onCommit,
   displayValue,
@@ -178,6 +216,9 @@ export function EditableField({
   }, [value]);
 
   const hasValue = Boolean(value);
+  const emptyText = placeholder ?? label.toLowerCase();
+  // The "+ " glyph is offered only where the empty state is a gap to fill.
+  const offersAdd = !hasValue && emptyAffordance === "add";
 
   const weightCls =
     textWeight === "semibold" ? "font-semibold" : "font-normal";
@@ -303,6 +344,8 @@ export function EditableField({
     ? "inline"
     : "inline-flex min-w-0 items-center";
 
+  const addOrEdit = offersAdd ? "Add" : "Edit";
+
   return (
     <span
       role="button"
@@ -310,7 +353,17 @@ export function EditableField({
       // Fold the shape warning into the accessible name: an explicit aria-label
       // on this button suppresses the inner glyph's <title>, so screen readers
       // would otherwise get zero warning signal (WCAG 1.4.1 — colour-only).
-      aria-label={warning ? `Edit ${label} — ${warning}` : `Edit ${label}`}
+      //
+      // The VERB has to match what the field visibly offers. An explicit
+      // aria-label overrides the element's text content, so an empty field
+      // reading "+ location" was announced "Edit Location" — a name that does
+      // not contain the visible label (WCAG 2.5.3 Label in Name), and one a
+      // voice-control user cannot speak. "Add" for an empty add-field, "Edit"
+      // otherwise; the "+" itself is aria-hidden, so it is never read as
+      // punctuation.
+      aria-label={
+        warning ? `${addOrEdit} ${label} — ${warning}` : `${addOrEdit} ${label}`
+      }
       onClick={startEdit}
       onKeyDown={(e: ReactKeyboardEvent) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -331,7 +384,16 @@ export function EditableField({
         .filter(Boolean)
         .join(" ")}
     >
-      {hasValue ? (displayValue ?? value) : placeholder}
+      {hasValue ? (
+        (displayValue ?? value)
+      ) : offersAdd ? (
+        <>
+          <span aria-hidden="true">+ </span>
+          {emptyText}
+        </>
+      ) : (
+        emptyText
+      )}
       {warning && <ShapeWarningGlyph message={warning} />}
     </span>
   );

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -31,12 +31,11 @@ import {
   DATE_RANGE_RE,
   PRESENT_RE,
   INSTITUTION_HINTS,
-  MONTH_YEAR_RE,
-  NUMERIC_MONTH_YEAR_RE,
-  YEAR_RE,
   PROGRAM_NOTE_RE,
 } from "./regex.ts";
 import {
+  dateRegionStart,
+  dateSeparator,
   parseDateRange,
   stripDateRange,
   isBulletLine,
@@ -225,6 +224,15 @@ export interface EntryBlock {
   anchorHeaderIndex?: number;
   /** Parsed start/end/is_current off the anchor line (empty object if none). */
   dates: ReturnType<typeof parseDateRange>;
+  /**
+   * The punctuation the anchor line used to set its date off from the text
+   * before it (`","` in "Best Paper Award, 2021"), or undefined when whitespace
+   * alone did. Stripping the date deletes this, so it is captured HERE, at the
+   * one place that still sees the raw anchor line — a consumer that re-composes
+   * the header from its parts (the achievements editor, #380) would otherwise
+   * have to invent a separator and would silently rewrite the résumé's own.
+   */
+  dateSeparator?: string;
   /**
    * Bullet body collected for this entry, joined with "\n", or undefined when
    * there were no bullets or `collectBody` was false.
@@ -635,21 +643,9 @@ function startsNewAnchor(text: string): boolean {
   return stripDateRange(text).replace(PRESENT_RE, "").trim().length > 0;
 }
 
-/** Index of the earliest date-region token (month-year, numeric month/year, or
- *  a bare year) in `text`, or -1 if none. Marks where the right-hand date column
- *  begins so a wrapped header's left (org) and right (date) continuations fold
- *  back onto the correct side. The three source regexes are global; reset
- *  `lastIndex` before each scan so repeated calls are idempotent. */
-function dateRegionStart(text: string): number {
-  let idx = -1;
-  for (const re of [MONTH_YEAR_RE, NUMERIC_MONTH_YEAR_RE, YEAR_RE]) {
-    re.lastIndex = 0;
-    const m = re.exec(text);
-    re.lastIndex = 0;
-    if (m && (idx === -1 || m.index < idx)) idx = m.index;
-  }
-  return idx;
-}
+// `dateRegionStart` moved to `line-primitives.ts` (#380) — the achievements
+// extractor needs the same "where does the date column begin" scan to recover
+// the separator that preceded the date, and two copies would drift.
 
 /** A continuation fragment belongs to the right-hand date column when it sits
  *  past the bullet-marker margin (geometry) OR reads as a bare date tail — just
@@ -1021,6 +1017,7 @@ function buildBulletEntry(
   return {
     headerLines: title ? [title] : [],
     dates,
+    dateSeparator: dateSeparator(combined),
     body,
     bulletCount: cfg.collectBody ? bodyLines.length : 0,
   };
@@ -1297,5 +1294,12 @@ function buildEntryBlock(
   }
   const body = cfg.collectBody ? bodyUnits.join("\n").trim() || undefined : undefined;
 
-  return { headerLines, anchorHeaderIndex, dates, body, bulletCount: bodyUnits.length };
+  return {
+    headerLines,
+    anchorHeaderIndex,
+    dates,
+    dateSeparator: dateSeparator(anchorLine.text),
+    body,
+    bulletCount: bodyUnits.length,
+  };
 }

--- a/src/lib/heuristics/extract/achievements.test.ts
+++ b/src/lib/heuristics/extract/achievements.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect } from "vitest";
 import { liftHeaderLabel } from "./projects.ts";
+import { extractAchievements } from "./achievements.ts";
+import { achievementYearJoiner } from "../../score/entry-dates.ts";
+import type { PdfLine, PdfSection } from "../sections.ts";
 
 // liftHeaderLabel is defined in projects.ts and shared by achievementFromBlock
 // (achievements.ts imports it from there). These tests cover the URL-lift
@@ -100,4 +103,156 @@ describe("liftHeaderLabel — substring/duplicate URL aliasing (#249)", () => {
     // Label must not contain a raw URL or a dangling separator run.
     expect(label).toBe("Repo");
   });
+});
+
+// ── year_separator: the source's own title↔year punctuation (#380) ───────────
+//
+// The header is stored decomposed (type / title / year), so every consumer that
+// shows it re-composes it and has to emit SOME separator between the parts. The
+// separator the SOURCE used is therefore parse-time information — and stripping
+// the date deletes it, which is how "Globex Engineering Excellence, 2021" came
+// back as "Globex Engineering Excellence · 2021".
+
+const mkLine = (text: string): PdfLine => ({
+  page: 0,
+  y: 0,
+  x: 0,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkAchievements = (rows: string[]): PdfSection => ({
+  name: "achievements",
+  lines: rows.map(mkLine),
+});
+
+describe("extractAchievements — year_separator (#380)", () => {
+  it("keeps the comma a flat award list set its year off with", () => {
+    const { value } = extractAchievements(
+      mkAchievements(["Globex Engineering Excellence, 2021"]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].title).toBe("Globex Engineering Excellence");
+    expect(value[0].year).toBe("2021");
+    expect(value[0].year_separator).toBe(",");
+  });
+
+  it("records NO separator when whitespace alone set the year off", () => {
+    // Absent is not "no separator" — the consumer falls back to the middot. What
+    // matters is that we don't invent a comma the résumé never wrote.
+    const { value } = extractAchievements(
+      mkAchievements(["Best Paper Award 2021"]),
+    );
+    expect(value[0].year).toBe("2021");
+    expect(value[0].year_separator).toBeUndefined();
+  });
+
+  it("keeps the separator on the bulleted entry-block path too", () => {
+    // A section carrying bullets routes through parseEntryBlocks, which strips
+    // the date (and its punctuation) off the header before the achievement is
+    // built — so the separator has to ride along on the block.
+    const { value } = extractAchievements(
+      mkAchievements([
+        "Globex Engineering Excellence, 2021",
+        "• Cited by 100+ downstream projects",
+      ]),
+    );
+    expect(value[0].title).toBe("Globex Engineering Excellence");
+    expect(value[0].year_separator).toBe(",");
+  });
+});
+
+// ── A word that merely STARTS with a month prefix is not a month ─────────────
+//
+// The lone-date fallback and `stripDateRange` both key on a month regex. Keyed
+// on the LOOSE one (`Mar` + `[a-z]*`), "Marketing", "Marathon", "Mayor" and
+// friends parse as months — so the word is deleted from the title AND recorded
+// as the date. STRICT_MONTH_YEAR_RE is what keeps ordinary headers intact.
+
+describe("extractAchievements — false-month words in the title", () => {
+  it.each([
+    ["Head of Marketing 2020", "Head of Marketing", "2020"],
+    ["Boston Marathon 2021", "Boston Marathon", "2021"],
+    ["Deputy Mayor 2021", "Deputy Mayor", "2021"],
+    ["Junior Fellow 2019", "Junior Fellow", "2019"],
+    ["Decathlon Champion 2018", "Decathlon Champion", "2018"],
+    ["Sepsis Research Grant 2020", "Sepsis Research Grant", "2020"],
+  ])("keeps the whole title of %s", (row, title, year) => {
+    const { value } = extractAchievements(mkAchievements([row]));
+    expect(value[0].title).toBe(title);
+    expect(value[0].year).toBe(year);
+  });
+
+  it("still opens a NEW entry for a header that is only a false month + year (B1b)", () => {
+    // `startsNewAnchor` keys on "does anything survive stripDateRange?". When the
+    // false month was eaten too, "Marketing 2021 - 2022" stripped to "" and the
+    // second entry was silently merged into the first.
+    const { value } = extractAchievements(
+      mkAchievements([
+        "Best Paper Award 2019 - 2020",
+        "• Cited by 100+ downstream projects",
+        "Marketing 2021 - 2022",
+        "• Grew pipeline 3x",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value.map((a) => a.title)).toEqual(["Best Paper Award", "Marketing"]);
+  });
+
+  it("still captures a REAL lone month-year whole", () => {
+    const { value } = extractAchievements(mkAchievements(["tinylm Jan. 2026"]));
+    expect(value[0].title).toBe("tinylm");
+    expect(value[0].year).toBe("2026");
+  });
+
+  it.each(["March 2021", "Sept 2021", "Sep. 2021", "May 2021"])(
+    "still strips the real month-year %s off the title",
+    (date) => {
+      const { value } = extractAchievements(
+        mkAchievements([`Best Paper Award ${date}`]),
+      );
+      expect(value[0].title).toBe("Best Paper Award");
+    },
+  );
+});
+
+// ── parse → export → re-parse is byte-stable for EVERY separator glyph ───────
+//
+// `dateSeparator` reports the source's own title↔year punctuation and the
+// exporter re-emits it via `achievementYearJoiner`. If `stripDateRange` does not
+// also REMOVE that glyph from the title, the title keeps it and the exporter
+// adds a second copy — and the doubling compounds on every Download-PDF cycle
+// ("Tech Lead: 2020" → "Tech Lead:: 2020" → "Tech Lead::: 2020"). One cycle
+// would not catch it; two do.
+
+/** The exporter's own recomposition of a decomposed achievement header. */
+const recompose = (a: { title: string; year?: string; year_separator?: string }) =>
+  a.year ? `${a.title}${achievementYearJoiner(a.year_separator)}${a.year}` : a.title;
+
+describe("achievement header — round-trips through every date separator", () => {
+  // Every glyph DATE_SEPARATOR_RE can report.
+  it.each([",", ";", ":", "|", "·", "–", "—", "-"])(
+    "is idempotent across two cycles with %s",
+    (sep) => {
+      const source = `Tech Lead${sep} 2020`;
+
+      const first = extractAchievements(mkAchievements([source])).value[0];
+      expect(first.title).toBe("Tech Lead");
+      expect(first.year).toBe("2020");
+      expect(first.year_separator).toBe(sep);
+
+      // Cycle 1: export, re-parse.
+      const exported1 = recompose(first);
+      const second = extractAchievements(mkAchievements([exported1])).value[0];
+      expect(second).toEqual(first);
+
+      // Cycle 2: the fixed point must hold, not merely the first hop.
+      const exported2 = recompose(second);
+      expect(exported2).toBe(exported1);
+      const third = extractAchievements(mkAchievements([exported2])).value[0];
+      expect(third).toEqual(first);
+    },
+  );
 });

--- a/src/lib/heuristics/extract/achievements.ts
+++ b/src/lib/heuristics/extract/achievements.ts
@@ -8,6 +8,7 @@ import type { EntryBlock } from "../entry-blocks.ts";
 import { YEAR_RE } from "../regex.ts";
 import { splitAchievementType } from "../../score/entry-dates.ts";
 import {
+  dateSeparator,
   isBulletLine,
   isPageFurniture,
   parseDateRange,
@@ -149,6 +150,12 @@ function achievementFromBlock(block: EntryBlock): {
   const cleanedHeader = block.dates.start_date
     ? block.headerLines
     : [stripDateRange(headerText), ...block.headerLines.slice(1)];
+  // Same fork as the dates: the entry-block path already stripped the date (and
+  // with it the punctuation that set it off), so it carries the separator on the
+  // block; the flat-list path still has the raw header, so read it off that.
+  const separator = block.dates.start_date
+    ? block.dateSeparator
+    : dateSeparator(headerText);
   const { label, url } = liftHeaderLabel(cleanedHeader);
 
   // Lift the leading "Patent · …" type label off the header into its own field
@@ -177,6 +184,7 @@ function achievementFromBlock(block: EntryBlock): {
       ...(type ? { type } : {}),
       title,
       ...(year ? { year } : {}),
+      ...(year && separator ? { year_separator: separator } : {}),
       ...(url ? { url } : {}),
       ...(description ? { description } : {}),
     },

--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -13,7 +13,13 @@
  */
 
 import type { PdfLine } from "./sections.ts";
-import { DATE_RANGE_RE, YEAR_RE } from "./regex.ts";
+import {
+  DATE_RANGE_RE,
+  MONTH_YEAR_RE,
+  NUMERIC_MONTH_YEAR_RE,
+  STRICT_MONTH_YEAR_RE,
+  YEAR_RE,
+} from "./regex.ts";
 
 /** Glyphs a template may use as a list bullet. One source of truth for the
  *  line-level tests below and the item-level `isBulletGlyph` — they must agree
@@ -159,11 +165,100 @@ export function parseDateRange(text: string): {
       ? { start_date: start }
       : { start_date: start, end_date: end };
   }
-  // Fall back to loose detection: first year.
+  // Fall back to loose detection: the EARLIEST lone date token in the line.
+  //
+  // A lone (un-paired) date — a project or award dated "Jan. 2026" with no end
+  // date — never matches `DATE_RANGE_RE`, which needs two anchors. It used to
+  // decay here to the bare year, which had two consequences, not one: the date
+  // lost its month, AND the month word survived in the entry title, because
+  // `stripDateRange` only removes what a date regex matched ("tinylm | Link
+  // Jan." · "2026", #380). So the month-anchored form is tried alongside the
+  // bare year and the earlier of the two wins — preserving the long-standing
+  // "first date token in the line" semantics for every line that has only a
+  // bare year, while a `Mon. YYYY` is now captured whole. `stripDateRange`
+  // removes exactly the same token, so the two stay in lockstep by
+  // construction; anything else would re-leak the month into the title.
+  //
+  // STRICT_MONTH_YEAR_RE, not the loose MONTH_YEAR_RE: this is a date VALUE, and
+  // the loose form's `[a-z]*` tail reads "Marketing 2020" as a month-year, so
+  // "Head of Marketing 2020" would record start_date "Marketing 2020" and lose
+  // the word from the title.
+  const lone = STRICT_MONTH_YEAR_RE.exec(text);
+  STRICT_MONTH_YEAR_RE.lastIndex = 0;
   const year = YEAR_RE.exec(text);
   YEAR_RE.lastIndex = 0;
+  if (lone && (!year || lone.index <= year.index)) {
+    return { start_date: normalizeDate(lone[0]) };
+  }
   if (year) return { start_date: year[0] };
   return {};
+}
+
+/** Index of the earliest date-region token (month-year, numeric month/year, or
+ *  a bare year) in `text`, or -1 if none. Marks where the right-hand date column
+ *  begins so a wrapped header's left (org) and right (date) continuations fold
+ *  back onto the correct side, and where {@link dateSeparator} looks for the
+ *  punctuation that set the date off. The three source regexes are global; reset
+ *  `lastIndex` before each scan so repeated calls are idempotent. */
+export function dateRegionStart(text: string): number {
+  let idx = -1;
+  for (const re of [MONTH_YEAR_RE, NUMERIC_MONTH_YEAR_RE, YEAR_RE]) {
+    re.lastIndex = 0;
+    const m = re.exec(text);
+    re.lastIndex = 0;
+    if (m && (idx === -1 || m.index < idx)) idx = m.index;
+  }
+  return idx;
+}
+
+// Punctuation a résumé uses to set a trailing date off from the text before it.
+// Two sets that have to be reasoned about TOGETHER:
+//   - DATE_SEPARATOR_CHARS — what `dateSeparator` REPORTS, so a consumer (the
+//     achievements header, the PDF exporter) can re-emit the source's own glyph.
+//   - TRIMMED_SEPARATOR_CHARS — what `stripDateRange` REMOVES from the title
+//     once the date is gone.
+// A glyph the first set reports and the second leaves behind is kept TWICE —
+// once on the title, once re-emitted by the consumer — and the doubling GROWS on
+// every parse→export→re-parse cycle ("Tech Lead: 2020" → "Tech Lead:: 2020" →
+// "Tech Lead::: 2020"). `;` and `:` were exactly that: reported, never trimmed.
+// They are added to the trim here — no résumé title legitimately ends in a
+// semicolon or a colon, so removing them is safe.
+//
+// The middot is the ONE deliberate asymmetry: it is reported (a source that
+// wrote "Award · 2021" must get its middot back) but NOT trimmed, because a
+// TRAILING " ·" is the org-signature marker the experience anchor-position
+// tiebreak keys on (#298) and stripping it there mis-anchors the role. It does
+// not double on the achievements path — `liftHeaderLabel` clears the dangling
+// glyph before the title is stored — which the two-cycle round-trip test over
+// every separator pins. Do not "fix" the asymmetry by adding `·` to the trim.
+// `-` sits last in each class so it is a literal, never a range.
+const DATE_SEPARATOR_CHARS = ",;:|·–—-";
+const TRIMMED_SEPARATOR_CHARS = ",;:|–—-";
+const DATE_SEPARATOR_RE = new RegExp(`([${DATE_SEPARATOR_CHARS}])\\s*$`);
+const SEPARATOR_TRIM_RE = new RegExp(
+  `^[\\s${TRIMMED_SEPARATOR_CHARS}]+|[\\s${TRIMMED_SEPARATOR_CHARS}]+$`,
+  "g",
+);
+
+/**
+ * The punctuation the source used between an entry's header text and its
+ * trailing date — "Globex Engineering Excellence, 2021" → `","` — or undefined
+ * when the date was set off by whitespace alone (or by nothing at all).
+ *
+ * `stripDateRange` deletes the date AND the separator that held it, so the
+ * separator is source information that would otherwise be lost at parse. The
+ * achievements header renders type/title/year as three separately editable
+ * fields and therefore must re-emit SOME separator between them; without this it
+ * hardcoded a middot and silently rewrote the résumé's comma (#380). Callers
+ * fall back to the middot when this returns undefined — with no source
+ * punctuation to honour there is nothing to preserve, and the fields still need
+ * to be told apart.
+ */
+export function dateSeparator(text: string): string | undefined {
+  const idx = dateRegionStart(text);
+  if (idx <= 0) return undefined;
+  const m = DATE_SEPARATOR_RE.exec(text.slice(0, idx));
+  return m ? m[1] : undefined;
 }
 
 // A range whose START token is a bare SEASON ("Fall 2013 – Spring 2014",
@@ -230,11 +325,21 @@ export function stripDateRange(text: string): string {
   let cleaned = text.replace(DATE_RANGE_RE, "").trim();
   DATE_RANGE_RE.lastIndex = 0;
   cleaned = cleaned.replace(/\b(Present|Current|Now|Ongoing)\b/gi, "").trim();
+  // Lone month-year tokens BEFORE bare years: a `Mon. YYYY` that no range
+  // matched is one token, and removing its year first would strand the month in
+  // the title ("… Link Jan.", #380). This is the exact token `parseDateRange`'s
+  // lone-date fallback captures — the SAME strict regex, deliberately — so the
+  // date the parser records and the text the title loses are the same run, and a
+  // word that merely starts with a month prefix ("Marketing") is not eaten.
+  cleaned = cleaned.replace(STRICT_MONTH_YEAR_RE, "").trim();
+  STRICT_MONTH_YEAR_RE.lastIndex = 0;
   cleaned = cleaned.replace(YEAR_RE, "").trim();
   YEAR_RE.lastIndex = 0;
   // After year removal, bracket/paren pairs that held only the year are now
   // empty (e.g. "[2019]" → "[]", "(2019)" → "()"). Strip them.
   cleaned = cleaned.replace(/\[\s*\]|\(\s*\)/g, "").trim();
-  cleaned = cleaned.replace(/^[-–—,|\s]+|[-–—,|\s]+$/g, "");
+  // Trim the separator that held the date (and any leading counterpart).
+  cleaned = cleaned.replace(SEPARATOR_TRIM_RE, "");
+  SEPARATOR_TRIM_RE.lastIndex = 0;
   return cleaned;
 }

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -2,8 +2,17 @@
 // Copyright 2026 The resumelint Authors
 
 import { describe, it, expect } from "vitest";
-import { matchSectionHeader, matchSectionAnchorToken, DATE_RANGE_RE } from "./regex.ts";
-import { parseDateRange, stripDateRange } from "./line-primitives.ts";
+import {
+  matchSectionHeader,
+  matchSectionAnchorToken,
+  DATE_RANGE_RE,
+  STRICT_MONTH_YEAR_RE,
+} from "./regex.ts";
+import {
+  dateSeparator,
+  parseDateRange,
+  stripDateRange,
+} from "./line-primitives.ts";
 
 describe("matchSectionHeader — split-letter headers (#56)", () => {
   it("matches a clean header unchanged", () => {
@@ -468,5 +477,183 @@ describe("matchSectionHeader — compound X & Y headers (#462)", () => {
     expect(matchSectionHeader("• Committee member and volunteer")).toBeNull();
     expect(matchSectionHeader("• Dean's List and Honors")).toBeNull();
     expect(matchSectionHeader("• Mentored juniors and interests")).toBeNull();
+  });
+});
+
+describe("parseDateRange — lone (un-paired) dates (#380)", () => {
+  // A project/award dated with a single "Mon. YYYY" and no end date never
+  // matches the PAIRED DATE_RANGE_RE, so it falls to the loose fallback. That
+  // fallback used to keep only the bare year, which left the month word stuck in
+  // the entry title ("tinylm | Link Jan." · "2026"). Start and strip must move
+  // together: whatever the date captures, the title must lose.
+  it("captures a lone 'Mon. YYYY' whole — month AND year", () => {
+    expect(parseDateRange("tinylm | Link Jan. 2026")).toEqual({
+      start_date: "Jan. 2026",
+    });
+  });
+
+  it("strips the month with the year, leaving a clean title", () => {
+    expect(stripDateRange("tinylm | Link Jan. 2026")).toBe("tinylm | Link");
+  });
+
+  it("captures a lone month spelled in full, and without a period", () => {
+    expect(parseDateRange("Portfolio site January 2026").start_date).toBe(
+      "January 2026",
+    );
+    expect(parseDateRange("Portfolio site May 2023").start_date).toBe("May 2023");
+    expect(stripDateRange("Portfolio site May 2023")).toBe("Portfolio site");
+  });
+
+  it("still parses a lone BARE year exactly as before (no month to absorb)", () => {
+    expect(parseDateRange("Best Paper Award 2021")).toEqual({
+      start_date: "2021",
+    });
+    expect(stripDateRange("Best Paper Award 2021")).toBe("Best Paper Award");
+  });
+
+  it("keeps the EARLIEST date token when a bare year precedes a month-year", () => {
+    // The fallback has always taken the FIRST date token in the line; absorbing
+    // the month must not reorder that. Here the bare year comes first, so it
+    // still wins.
+    expect(parseDateRange("2019 cohort, revisited Jan. 2026").start_date).toBe(
+      "2019",
+    );
+  });
+
+  it("leaves PAIRED ranges untouched (the fallback never runs)", () => {
+    expect(parseDateRange("Jan. 2020 – Mar. 2021")).toEqual({
+      start_date: "Jan. 2020",
+      end_date: "Mar. 2021",
+    });
+    expect(parseDateRange("2019 - 2021")).toEqual({
+      start_date: "2019",
+      end_date: "2021",
+    });
+    expect(parseDateRange("Jan 2020 - Present")).toEqual({
+      start_date: "Jan 2020",
+      is_current: true,
+    });
+    expect(parseDateRange("Sep. 2023 Mar. 2024")).toEqual({
+      start_date: "Sep. 2023",
+      end_date: "Mar. 2024",
+    });
+    expect(stripDateRange("Acme Corp Jan. 2020 – Mar. 2021")).toBe("Acme Corp");
+  });
+
+  it("records no date for an unfilled 'Month Year' template placeholder", () => {
+    // The word placeholders live only in the PAIRED anchors, so the lone
+    // fallback must not resurrect them as a real date.
+    expect(parseDateRange("Production Intern Month Year")).toEqual({});
+  });
+
+  it("reports no date when the line carries none", () => {
+    expect(parseDateRange("Outstanding Performer Award")).toEqual({});
+  });
+});
+
+describe("dateSeparator — the punctuation a date was set off by (#380)", () => {
+  it("returns the comma a flat award list used", () => {
+    expect(dateSeparator("Globex Engineering Excellence, 2021")).toBe(",");
+  });
+
+  it("returns undefined when whitespace alone set the date off", () => {
+    expect(dateSeparator("Best Paper Award 2021")).toBeUndefined();
+  });
+
+  it("returns undefined when the date LEADS the line (nothing to set off)", () => {
+    expect(dateSeparator("2021 2nd Place, AWS GameDay")).toBeUndefined();
+  });
+
+  it("returns undefined when the line carries no date", () => {
+    expect(dateSeparator("Dean's List")).toBeUndefined();
+  });
+
+  it("reads the separator in front of a month-year date too", () => {
+    expect(dateSeparator("tinylm – Jan. 2026")).toBe("–");
+  });
+});
+
+describe("month regexes — loose for POSITION, strict for VALUE", () => {
+  it("STRICT_MONTH_YEAR_RE does not match a word that merely starts with a month", () => {
+    for (const word of ["Marketing", "Marathon", "Mayor", "Junior", "Decathlon", "Sepsis"]) {
+      STRICT_MONTH_YEAR_RE.lastIndex = 0;
+      expect(STRICT_MONTH_YEAR_RE.test(`${word} 2020`)).toBe(false);
+      STRICT_MONTH_YEAR_RE.lastIndex = 0;
+    }
+  });
+
+  it("STRICT_MONTH_YEAR_RE matches every real month spelling it must", () => {
+    for (const m of [
+      "Jan", "January", "Feb", "February", "Mar", "March", "Apr", "April",
+      "May", "Jun", "June", "Jul", "July", "Aug", "August", "Sep", "Sept",
+      "September", "Oct", "October", "Nov", "November", "Dec", "December",
+    ]) {
+      STRICT_MONTH_YEAR_RE.lastIndex = 0;
+      expect(STRICT_MONTH_YEAR_RE.test(`${m} 2020`), m).toBe(true);
+      STRICT_MONTH_YEAR_RE.lastIndex = 0;
+      expect(STRICT_MONTH_YEAR_RE.test(`${m}. '20`), `${m}. '20`).toBe(true);
+      STRICT_MONTH_YEAR_RE.lastIndex = 0;
+    }
+  });
+
+  it("parseDateRange does not read a false month as the date", () => {
+    // Loose MONTH_YEAR_RE reads "Marketing 2020" as a month-year, so the lone-date
+    // fallback recorded start_date "Marketing 2020" and stripDateRange ate the word.
+    expect(parseDateRange("Head of Marketing 2020")).toEqual({ start_date: "2020" });
+    expect(parseDateRange("Boston Marathon 2021")).toEqual({ start_date: "2021" });
+    expect(parseDateRange("Deputy Mayor 2021")).toEqual({ start_date: "2021" });
+  });
+
+  it("parseDateRange still captures a real lone month-year whole", () => {
+    expect(parseDateRange("tinylm | Link Jan. 2026")).toEqual({
+      start_date: "Jan. 2026",
+    });
+  });
+
+  it("stripDateRange leaves a false month in the title", () => {
+    expect(stripDateRange("Head of Marketing 2020")).toBe("Head of Marketing");
+    expect(stripDateRange("Sepsis 2020")).toBe("Sepsis");
+  });
+
+  it("leaves a remainder for a header that is ONLY a false month + year", () => {
+    // `startsNewAnchor` (entry-blocks.ts) decides "is this line a NEW entry?" by
+    // asking whether anything SURVIVES stripDateRange. Over-stripping reduced
+    // "Marketing 2021 - 2022" to "" — so the header stopped being an anchor and
+    // was silently merged into the previous entry. The remainder is the contract.
+    expect(stripDateRange("Marketing 2021 - 2022")).toBe("Marketing");
+    expect(stripDateRange("Marathon 2019 - 2020")).toBe("Marathon");
+    // A genuine bare date tail still strips to nothing — that is what lets a
+    // wrapped "… Jan 2022 -" / "Present" reassemble instead of opening a role.
+    expect(stripDateRange("Jan 2020 - Present")).toBe("");
+  });
+});
+
+describe("stripDateRange — trailing separator trim", () => {
+  // Every glyph `dateSeparator` reports EXCEPT `·`. A glyph that is reported but
+  // not trimmed is kept twice — once on the title, once re-emitted by the
+  // consumer that was told about it — and the doubling grows on every
+  // parse→export→re-parse cycle ("Tech Lead: 2020" → "Tech Lead:: 2020" → …).
+  // `;` and `:` were exactly that case (#380).
+  it.each([",", ";", ":", "|", "–", "—", "-"])(
+    "removes %s along with the date it held",
+    (sep) => {
+      expect(stripDateRange(`Tech Lead${sep} 2020`)).toBe("Tech Lead");
+    },
+  );
+
+  // `·` is the deliberate exception, and it must STAY one. The middot is the
+  // org-signature marker the anchor-position tiebreak keys on: a location-less
+  // reconstructed role emits "Company · Dates", and the gate has to SEE that
+  // marker to know the anchor line is the company rather than the title — it
+  // strips the marker itself, after firing. Trimming the middot here destroys the
+  // evidence before the gate can read it, and the role's title and company swap
+  // (extract/experience.anchor-tiebreak.test.ts, #298).
+  //
+  // It cannot double the way `;`/`:` did, because `splitAchievementType` consumes
+  // the " · " boundary before a middot can ever end up trailing a title.
+  it("preserves · — it is the org-signature marker, not date punctuation", () => {
+    expect(stripDateRange("Northern Trust · Jan 2019 - Mar 2021")).toBe(
+      "Northern Trust ·",
+    );
   });
 });

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -139,6 +139,37 @@ export const MONTH_YEAR_RE = new RegExp(
   "gi",
 );
 
+// Month names spelled out in full, longest-first. NO `[a-z]*` tail — see
+// STRICT_MONTH_YEAR_RE.
+const STRICT_MONTH =
+  "January|Jan|February|Feb|March|Mar|April|Apr|May|June|Jun|July|Jul|" +
+  "August|Aug|September|Sept|Sep|October|Oct|November|Nov|December|Dec";
+
+/**
+ * The same "Mmm YYYY" shape as {@link MONTH_YEAR_RE}, but with the month
+ * ENUMERATED rather than prefix-matched. A strict variant exists alongside the
+ * loose one because the two are used for different jobs, and only one of them
+ * can afford to be wrong.
+ *
+ * `MONTH_YEAR_RE`'s `[a-z]*` tail also matches ordinary words that merely BEGIN
+ * with a month prefix — Marketing, Marathon, Mayor, Junior, Decathlon, Sepsis.
+ * That is harmless for a POSITION probe like `dateRegionStart`, which only needs
+ * to know roughly where the right-hand date column starts. It is NOT harmless
+ * the moment the same regex is used to extract a date VALUE or to DELETE text:
+ * a false month then eats a word out of the entry title and lands in the date
+ * ("Head of Marketing 2020" → title "Head of", start_date "Marketing 2020").
+ *
+ * So the two value-level call sites — `parseDateRange`'s lone-date fallback and
+ * `stripDateRange`'s month strip — use THIS regex, and they must keep using the
+ * SAME one as each other: the token the date captures has to be exactly the
+ * token the title loses, or the month re-leaks into the title (#380). Do not
+ * "simplify" the two regexes back into one.
+ */
+export const STRICT_MONTH_YEAR_RE = new RegExp(
+  `\\b(?:${STRICT_MONTH})\\.?\\s+(?:\\d{4}|'\\d{2})\\b`,
+  "gi",
+);
+
 /** "01/2020", "1/2020", "01-2020". */
 export const NUMERIC_MONTH_YEAR_RE = /\b(0?[1-9]|1[0-2])[\/\-]\d{4}\b/g;
 
@@ -172,7 +203,16 @@ const YEAR_FORMS = `\\d{4}|'\\d{2}|20XX|XXXX|####|Year`;
 // placeholder (see YEAR_FORMS note). Scoped to the anchors only — the shared
 // `MONTH` const and `MONTH_YEAR_RE` are left untouched so education/date-region
 // detection keep requiring a real month name.
-const MONTH_OR_PLACEHOLDER = `(?:${MONTH}|Month)`;
+//
+// STRICT_MONTH, not the loose MONTH: a date ANCHOR is a value, so the same
+// `[a-z]*` false-month problem bites here. With the loose month, "Marketing
+// 2021" is a legal anchor — so "Marketing 2021 - 2022" full-matched
+// DATE_RANGE_RE, `stripDateRange` deleted the ENTIRE header, and
+// `startsNewAnchor` (which asks whether anything survives the strip) stopped
+// seeing it as a new entry and merged it into the one above. The bare-year
+// alternative below still anchors the real "2021 - 2022" range, so the date is
+// parsed and only the false month stays where it belongs — in the title.
+const MONTH_OR_PLACEHOLDER = `(?:${STRICT_MONTH}|Month)`;
 
 // Shared fragment for one date anchor (Mmm YYYY | 'YY, mm/yyyy, YYYY, Season YYYY).
 // Reused by DATE_RANGE_RE's start and end groups. Apostrophe-year keeps

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -211,6 +211,36 @@ describe("buildAtsResumeModel", () => {
     );
   });
 
+  it("exports an achievement's year behind the source's own separator (#380)", () => {
+    // Ground truth on the fixture is "Globex Engineering Excellence, 2021". The
+    // exporter re-composes the header from the stored parts, so without the
+    // parsed `year_separator` it re-punctuated the résumé's comma into a middot
+    // — and the on-screen header and the PDF have to agree, so both read it.
+    const result = makeResult({
+      heuristic_achievements: [
+        {
+          title: "Globex Engineering Excellence",
+          year: "2021",
+          year_separator: ",",
+        },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const ach = model.sections.find((s) => s.kind === "achievements");
+    expect(ach!.entries[0].headerLine).toBe(
+      "Globex Engineering Excellence, 2021",
+    );
+  });
+
+  it("falls back to the middot when the source set the year off with a space", () => {
+    const result = makeResult({
+      heuristic_achievements: [{ title: "Best Paper Award", year: "2021" }],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const ach = model.sections.find((s) => s.kind === "achievements");
+    expect(ach!.entries[0].headerLine).toBe("Best Paper Award · 2021");
+  });
+
   it("bolds only the leading type label of a 'Type · description' achievement", () => {
     const result = makeResult({
       heuristic_achievements: [

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -31,7 +31,10 @@ import {
   groupBulletsByExperience,
   toBulletExperience,
 } from "../score/group-bullets.ts";
-import { buildProjectDates } from "../score/entry-dates.ts";
+import {
+  achievementYearJoiner,
+  buildProjectDates,
+} from "../score/entry-dates.ts";
 import { isLoneDateRange } from "../heuristics/line-primitives.ts";
 import { projectDisplay } from "../heuristics/projections.ts";
 import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
@@ -388,17 +391,22 @@ function buildAchievementHeader(
   type: string | undefined,
   title: string,
   year: string | undefined,
+  yearSeparator?: string,
 ): { headerLine: string; emphasized: boolean } {
   const label = type?.trim();
+  // The year is set off by the source's own punctuation when it had any (#380),
+  // so the exported PDF re-parses to the same `year_separator` it came from —
+  // and reads as the résumé's own line, not one we re-punctuated.
+  const yearSep = achievementYearJoiner(yearSeparator);
   if (label && title) {
     const emphasizedTitle = `${EMPHASIS_OPEN}${label}${EMPHASIS_CLOSE} · ${title}`;
     return {
-      headerLine: joinHeader([emphasizedTitle, year], " · "),
+      headerLine: joinHeader([emphasizedTitle, year], yearSep),
       emphasized: true,
     };
   }
   return {
-    headerLine: joinHeader([label || title, year], " · "),
+    headerLine: joinHeader([label || title, year], yearSep),
     emphasized: false,
   };
 }
@@ -624,6 +632,7 @@ export function buildAtsResumeModel(
       ach.type,
       ach.title,
       ach.year,
+      ach.year_separator,
     );
     const awardTitle = [ach.type?.trim(), ach.title].filter(Boolean).join(" · ");
     return {

--- a/src/lib/score/entry-dates.test.ts
+++ b/src/lib/score/entry-dates.test.ts
@@ -7,6 +7,8 @@ import {
   buildEducationDates,
   splitAchievementType,
   ACHIEVEMENT_TYPE_MAX_LEN,
+  achievementYearJoiner,
+  isTightYearSeparator,
 } from "./entry-dates.ts";
 
 describe("buildProjectDates", () => {
@@ -128,5 +130,23 @@ describe("splitAchievementType — parse-time only (#456)", () => {
       type: "KubeCon",
       rest: "Amsterdam",
     });
+  });
+});
+
+describe("achievementYearJoiner — the source's own title↔year separator (#380)", () => {
+  it("falls back to the middot when the source used none", () => {
+    expect(achievementYearJoiner(undefined)).toBe(" · ");
+  });
+
+  it("binds a comma tight to the title, with one space after", () => {
+    // "Globex Engineering Excellence, 2021" — not " , 2021".
+    expect(achievementYearJoiner(",")).toBe(", ");
+    expect(isTightYearSeparator(",")).toBe(true);
+  });
+
+  it("gives a dash or a pipe air on both sides", () => {
+    expect(achievementYearJoiner("–")).toBe(" – ");
+    expect(achievementYearJoiner("|")).toBe(" | ");
+    expect(isTightYearSeparator("–")).toBe(false);
   });
 });

--- a/src/lib/score/entry-dates.ts
+++ b/src/lib/score/entry-dates.ts
@@ -36,6 +36,29 @@ export function buildEducationDates(edu: ResumeEducation): string {
   return edu.year ?? "";
 }
 
+/** The separator an achievement header falls back to between its title and its
+ *  year when the source used none of its own (whitespace only). */
+export const DEFAULT_ACHIEVEMENT_YEAR_SEPARATOR = "·";
+
+/** True when a separator glyph binds TIGHT to the word before it — a comma, a
+ *  semicolon, a colon take no space in front ("Award, 2021"), where a dash or a
+ *  pipe takes one on both sides ("Award – 2021"). The one place that rule is
+ *  written down: the edit surface renders the separator as its own flex child
+ *  and the exporter joins it into a string, and the two must not disagree about
+ *  the spacing of the same résumé (#380). */
+export function isTightYearSeparator(separator: string): boolean {
+  return /^[,;:]$/.test(separator);
+}
+
+/** The exact string that joins an achievement's header text to its trailing year
+ *  — the source's own separator ({@link isTightYearSeparator} decides its
+ *  spacing), or the middot fallback. Used by the PDF exporter; the edit surface
+ *  renders the same glyph with the same spacing. */
+export function achievementYearJoiner(separator?: string): string {
+  if (!separator) return ` ${DEFAULT_ACHIEVEMENT_YEAR_SEPARATOR} `;
+  return isTightYearSeparator(separator) ? `${separator} ` : ` ${separator} `;
+}
+
 /** Longest a leading achievement segment can be and still read as a "type"
  *  label ("Patent", "Publication", "Exit", "Best Paper Award") rather than a
  *  full sentence — guards against emphasizing an entire prose title that merely

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -267,6 +267,17 @@ export interface HeuristicAchievement {
   /** Lead year when the header carried a date (achievements show a single year,
    *  not a range — we keep the first year of any range the header carried). */
   year?: string;
+  /** The punctuation the source put between {@link title} and {@link year}
+   *  ("Globex Engineering Excellence, 2021" → `","`), when it used any.
+   *
+   *  The header is stored decomposed (type / title / year) and RE-COMPOSED by
+   *  every consumer that shows it — the edit surface and the PDF exporter — so
+   *  each of them has to emit some separator. Without the source's own, they
+   *  hardcoded a middot and rewrote the résumé's comma into "Globex Engineering
+   *  Excellence · 2021" (#380). Absent (whitespace-separated in the source) is
+   *  NOT the same as "no separator": consumers fall back to the middot, which is
+   *  the only thing that keeps the year legible as a distinct field. */
+  year_separator?: string;
   /** A URL on the header line (e.g. a publication / patent link), when found. */
   url?: string;
   /** Bullet body joined with "\n", mirroring `ResumeProject.description`, so the

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -78,7 +78,7 @@
     "sectionSource": "markdown",
     "pageCount": 5,
     "rawCharCount": 13992,
-    "extractedCharCount": 12859,
+    "extractedCharCount": 12854,
     "sections": [
       {
         "name": "profile",


### PR DESCRIPTION
Two edit-interaction issues from the Friends & Family QC sweep, batched onto one branch. Part of epic #391 (3 of its 5 children remain open, so this `Refs` rather than closes it).

## #376 — empty placeholders read as values

An empty field's placeholder was indistinguishable from real data once a separator joined it into a compound line: `Acme Corp, location not detected`, `start – 2013`. Muted italic isn't enough when the joiner doesn't change.

`EditableField` now renders an empty field as a `+` affordance glyph — its own `aria-hidden` span, not concatenated into the text — followed by a bare noun naming the thing to add, and announces itself as **"Add \<label\>"** instead of "Edit \<label\>". That last part closes a pre-existing WCAG 2.5.3 (Label in Name) failure: the explicit `aria-label` on a `role="button"` overrides its text content, so the field was announced "Edit Location" while visibly reading "location not detected". The accessible name now contains the visible text, and the `+` is never announced.

The placeholder remains **the only input path** — `role`, `tabIndex`, `onClick` and the Enter/Space handler are untouched. That invariant is why the issue's "hide the field when empty" option was rejected: hiding it strands the user with no way to add a missing start date.

Two things worth calling out:

- **The default placeholder is derived from `label`.** That's what makes the old `+ not detected` copy *unrepresentable* rather than merely fixed — a call site that forgets a placeholder now gets a correct one instead of the broken default.
- **Fields whose empty state is a *state*, not a gap** (`Untitled resume`, `edit this bullet`, `empty bullet`) opt out with `emptyAffordance="plain"`. A blanket prefix in the primitive was the wrong seam — it produced `+ Untitled resume`.

## #380 — three display/parse nits

**Empty Achievements section.** Kept rendering (by design — the `+ Add achievement` pill is the only input path on a résumé with none), but it could read as *"the parser dropped my achievements"*. It now carries a `SectionEmptyHint` naming what belongs there. The copy deliberately makes **no claim about what the parser found**: we cannot distinguish "the résumé had none" from "we missed them", so finding-shaped wording ("no achievements detected") would either be a guess or reinforce the exact misreading we're fixing.

**Lone dates lost their month (parser).** `parseDateRange` decayed a lone `Mon. YYYY` to a bare year, and because the strip only removes what a date regex matched, the month stayed welded to the title — `tinylm | Link Jan.` · `2026`. It now captures the token whole. The strip runs month-year *before* bare-year (order is load-bearing — strip the year first and the month is stranded), and both halves use the **same** regex, so the token the date captures is exactly the token the title loses.

That regex is new, and it's the interesting part. `MONTH`'s `[a-z]*` tail also matches **Marketing, Marathon, Mayor, Junior, Decathlon**. That was harmless while `MONTH_YEAR_RE` was only a *position* hint — the moment this change promoted it to a date **value** and a text **deletion**, it started eating words out of titles:

```
"Head of Marketing 2020"  →  start_date: "Marketing 2020",  title: "Head of"
"Boston Marathon 2021"    →  start_date: "Marathon 2021",   title: "Boston"
```

`STRICT_MONTH_YEAR_RE` enumerates the month names instead. `dateRegionStart` keeps the loose form — it only ever needs a position, never a value.

**Achievements separator.** `AchievementHeader` hardcoded a middot between title and year, rewriting the source's own comma (`Globex Engineering Excellence, 2021` → `… · 2021`). The separator is destroyed by the date strip, so it's now read off the raw line at parse and carried on `HeuristicAchievement` as an **additive optional `year_separator`**. Both consumers — the on-screen header and the PDF exporter — re-emit it through one shared joiner, so screen and PDF cannot disagree and the comma survives the parse→export→re-parse round trip.

`·` is *reported* as a separator but deliberately **never trimmed** from the title: a trailing middot is the org-signature marker the anchor-position tiebreak (#298) keys on, and stripping it swaps a role's title and company. It can't double, because `liftHeaderLabel` clears the dangling glyph first. The two character sets are asymmetric on purpose, and the code says so — that asymmetry got "simplified" away once during review and broke role attribution.

### Contract change (approved)

`HeuristicAchievement.year_separator?: string` is new on the parser's public output. Strictly additive and optional; no existing consumer breaks. It's the only way to satisfy #380's "renders using the source's original separator" criterion, since the header is stored decomposed (type / title / year) and every consumer must therefore emit *some* separator.

### Corpus snapshot

`awesome-cv-cv.expected.json` moves by 5 characters (`extractedCharCount` 12859 → 12854): one leaked month token, `"Freelance Penetration Tester Sep."` → `"Freelance Penetration Tester"`. Re-baked via `npm run bake-fixtures`, not hand-edited. It is the only field in that fixture that changed — diffed against `main`'s parser to confirm the cause rather than assume it.

## Verification

`npm run verify` green: typecheck, lint, **2310 tests** (174 files, corpus + round-trip suites included), build.

## Reviewer notes

- `ReconstructedResume.tsx` grew to ~1211 LOC against the known-debt rule in `CLAUDE.md`. `AchievementHeader` is the natural extraction; `SectionEmptyHint` already went out to `ReconstructedAdd.tsx`.
- The type↔title middot at `ReconstructedResume.tsx:677` is **not** changed, though #380 named it alongside the title↔year one. It's defensible: `splitAchievementType` synthesizes that boundary rather than reading it from the source, so there is no original separator to preserve. Flagging it rather than leaving it silent.
- Follow-up, not fixed here: a lone **numeric** date (`01/2026`) still parses to a bare year and leaves `01/` in the title — `NUMERIC_MONTH_YEAR_RE` isn't in the lone-date fallback. Pre-existing, same class as #380's month bug. Will file separately.

## Provenance

Every model string below is self-reported by the agent that produced the work. Where an agent did not report, the row says so rather than guessing from the alias that was requested.

| Stage | Model | Effort |
|---|---|---|
| Implementation — #376 | Claude Sonnet 5 | high |
| Implementation — #380 | Claude Opus 4.8 (1M context) | ultra |
| Adversarial review — round 1 | Claude Opus 4.8 | — |
| Review fixes — round 1 | `unreported (requested: opus)` | — |
| Adversarial review — round 2 | Claude Opus 4.8 | — |
| Orchestration, parser repair, PR | Claude Opus 4.8 (1M context) | — |

## Adversarial review

Two rounds, pre-PR, on the local diff. Both rounds returned `clean: false` — the findings below were fixed before this PR existed, and they are recorded rather than quietly dropped.

**The headline: the tree was fully green when round 1 found a data-corruption bug.** typecheck clean, lint clean, 2273 tests passing, fallow showing no new findings — and `"Head of Marketing 2020"` parsed to `start_date: "Marketing 2020"` with the title truncated to `"Head of"`. A green suite proves nothing broke that we thought to test. It was found by reproducing against the pre-change parser, not by reading the diff.

### Round 1 — 3 blocking

| # | Finding | Resolution |
|---|---|---|
| B1 | `MONTH`'s `[a-z]*` tail matches **Marketing, Marathon, Mayor, Junior, Decathlon**. This change promoted `MONTH_YEAR_RE` from a position hint to a date *value* and a global text *deletion*, so a false month ate a word out of the title and landed in `start_date`. Reaches every entry type. | `STRICT_MONTH_YEAR_RE` (enumerated months, no prefix tail), used in both the lone-date fallback and the strip, as the same regex. `dateRegionStart` keeps the loose form. |
| B1b | Same root cause: a header that is *entirely* a false month + year (`"Marketing 2021"`) stripped to `""`, stopped registering as a new anchor, and silently **merged into the previous entry**. Invisible to the corpus snapshots, which are keys/counts-only. | Fixed by B1. Verified: `"Marketing 2021"` opens a new entry again. |
| B2 | `;` and `:` were *reported* by `dateSeparator` but never *trimmed* from the title, so the consumer re-emitted them: `"Tech Lead: 2020"` → `"Tech Lead:: 2020"` → `"Tech Lead::: 2020"`. **Unbounded** — one glyph per Download-PDF cycle. `,` `|` `–` `—` `·` round-trip cleanly, which is exactly why the new tests missed it. | Trim set gains `;:`. The first attempt unified the report and trim sets, which silently added `·` to the trim and **broke role attribution** — the trailing middot is the org-signature marker the anchor tiebreak keys on. The sets are asymmetric on purpose now, and the code says why. |
| B3 | The `+` prefix was concatenated into the span's text, conflating the affordance glyph, the placeholder noun, and the accessible name — producing `+ location not detected`, `+ Untitled resume`, `+ edit this bullet`. | `emptyAffordance` prop, `+` as its own `aria-hidden` span, noun-phrase placeholders, default derived from `label`, `aria-label` verb switches to `Add`. |

### Round 2 — 1 blocking

**Two call sites were never visited** (`ContactExtraLinks.tsx`, `AchievementTypePicker.tsx`). Because `emptyAffordance` defaults to `"add"`, they *inherited* the new `+` glyph on top of their old sentence-case copy — `+ Link URL`, `+ Custom label`. The default that makes the affordance repo-wide is the same default that propagates the defect to anything overlooked. Before the change these read as inert labels; the change made them incoherent.

Fixed by deleting their stale placeholders so the label-derived default applies. #376's completeness criterion ("no call site is special-cased or skipped") is a property of the **repo**, not of the primitive, so it is now guarded by a source sweep over all 23 call sites — falsified by reintroducing the defect and confirming the guard fails.

### Verified by execution, not by reading

Round 2 ran, against the real code: 12 false-month titles; every separator glyph × 3 entry shapes × 3 round-trip cycles (24 scenarios, byte-stable from cycle 1); the anchor-tiebreak shape; and all 23 `EditableField` empty-state renders. It also found the *mechanism* that makes the `·` asymmetry correct rather than lucky — `liftHeaderLabel` (`extract/projects.ts:106`) clears the dangling middot — and confirmed the `awesome-cv-cv` snapshot delta is one leaked month token and nothing else, by diffing the full parse against `main`.

**Not covered:** the four fixture PDFs were never driven through a live browser. UI verification is `renderToStaticMarkup` against the real components, so #376's fixture-render criteria are unit-level only.

### Surviving nits (not iterated)

- `dateSeparator` locates the date with the *loose* position scan while the value comes from the *strict* parse, so a false-month word between the separator and the year misattributes it: `"Award, Marketing 2020"` exports as `"Award, Marketing, 2020"`. Converges at cycle 1 — a one-time fidelity wart, **not** the B2 doubling class.
- Education date placeholders read `+ start` / `+ end`; #376's own illustration used `+ start date`, which `ReconstructedRole` already uses.
- `AchievementHeader` has 0% coverage on its render. The load-bearing leg of `year_separator` is the **exporter** (that's what the round-trip re-parses) and it has direct tests; what's untested is a `-ml-1.5` spacing class, where a wrong result is cosmetic and instantly visible.
