### PR TITLE
fixture-derivation tooling — derive/audit CLIs + .origin.json enforcement

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -37,7 +37,16 @@
     "ignore": [
       "src/lib/webllm/spike/**",
       "src/lib/webllm/eval/**",
-      "src/lib/webllm/parse-eval/**"
+      "src/lib/webllm/parse-eval/**",
+
+      // `scripts/**` is dev/CI tooling (fidelity, fixture-derive, fixture-audit)
+      // deliberately outside the production rollup (`input` in vite.config.ts) —
+      // it never ships to dist/. Like the WebLLM harnesses above, these CLIs
+      // score high CRAP purely from carrying no test coverage (they need Node 22
+      // + real PDFs + pdfjs, so they're maintainer-run, not unit-tested), not
+      // from genuine complexity debt. Hold the shipped bundle to the CRAP bar,
+      // not the tooling.
+      "scripts/**"
     ]
   },
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:watch": "vitest",
     "bake-fixtures": "UPDATE_FIXTURES=1 vitest run src/lib/heuristics/corpus.test.ts",
     "fidelity": "vite-node scripts/fidelity.ts --",
+    "fixture-derive": "vite-node scripts/fixture-derive.ts --",
+    "fixture-audit": "vite-node scripts/fixture-audit.ts --",
     "eval:rewrite": "vite --open=/eval-rewrite.html",
     "eval:jd-spike": "vite --open=/jd-spike.html",
     "eval:parse": "vite --open=/parse-eval.html",

--- a/scripts/fixture-audit.ts
+++ b/scripts/fixture-audit.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The fixture-ledger staleness auditor (`npm run fixture-audit`, issue #39).
+ *
+ * A maintainer-only REPORT. Never wired into CI, never exits non-zero on
+ * staleness — a moved signature or a healed bug is NEWS for a human, not a build
+ * break. (It exits non-zero only on a usage/IO error it cannot proceed past.)
+ *
+ * For every row in `internal/fixtures/registry.jsonl` it checks three things:
+ *
+ *   (a) SOURCE — does `sources.local.json` still resolve the row's handle to a
+ *       file on disk, and does that file still hash to the recorded `sha256`?
+ *       A missing path is expected on a machine that never held the résumé; a
+ *       hash MISMATCH means the source was edited/replaced under a stale row.
+ *
+ *   (b) REPRO — re-parse the fixture and re-sweep it; does its signature still
+ *       `exhibits()` the recorded class? If NOT, the parser most likely improved
+ *       and the fixture no longer reproduces the bug → "signature moved → flip
+ *       status to fixed".
+ *
+ *   (c) BREADCRUMB — any fixture PDF whose `.origin.json` `reproduces:[N]` has no
+ *       matching `src/lib/heuristics/*.repro.test.ts` referencing `#N`. (The
+ *       corpus test enforces this too; here it is surfaced as a report line so a
+ *       maintainer scanning the whole corpus sees it without running vitest.)
+ *
+ * PII-safe: reads the committed row (opaque handle + hashes + PII-free artifacts)
+ * and the fixture PDFs; the only real path it touches is the one it reads from
+ * the gitignored `sources.local.json`, and it prints only whether it resolves and
+ * hashes — never the path itself, never a résumé value.
+ *
+ * Runs under vite-node. Usage: `npm run fixture-audit`.
+ */
+
+import { promises as fsp, existsSync, readFileSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join, relative } from "node:path";
+
+import { runCascade } from "../src/lib/heuristics/cascade.ts";
+import { runRoundtripHop } from "../src/lib/heuristics/roundtrip-hop.ts";
+import { sweepParse } from "../src/lib/heuristics/sweep.ts";
+import { buildReproArtifact } from "../src/lib/heuristics/repro-artifact.ts";
+import { defectSpec, type DefectClass } from "../src/lib/heuristics/defect-classes.ts";
+import { REPO_ROOT } from "../src/lib/heuristics/__test-utils__/corpus-snapshots.ts";
+import {
+  readOriginJson,
+  reproTestsReferencingIssue,
+} from "../src/lib/heuristics/__test-utils__/origin-links.ts";
+
+const REGISTRY_PATH = join(REPO_ROOT, "internal/fixtures/registry.jsonl");
+const SOURCES_PATH = join(REPO_ROOT, "internal/fixtures/sources.local.json");
+const FIXTURE_ROOT = join(REPO_ROOT, "tests/fixtures/pdfs");
+
+interface RegistryRow {
+  id: string;
+  source: { handle: string; sha256: string; generator: string; provenance: string };
+  fixture: string;
+  derivation: string;
+  defects: {
+    issue: number;
+    class: DefectClass;
+    probe: string;
+    regressionTest: string;
+    status: string;
+  }[];
+  verifiedRepro: string;
+}
+
+interface SourcesFile {
+  sources?: Record<string, { stem: string; path: string | null }>;
+}
+
+function readRegistry(): RegistryRow[] {
+  if (!existsSync(REGISTRY_PATH)) return [];
+  return readFileSync(REGISTRY_PATH, "utf8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as RegistryRow);
+}
+
+function readSources(): SourcesFile {
+  if (!existsSync(SOURCES_PATH)) return {};
+  return JSON.parse(readFileSync(SOURCES_PATH, "utf8")) as SourcesFile;
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+async function exhibitsStill(fixtureRel: string, cls: DefectClass): Promise<boolean> {
+  const fixturePath = join(REPO_ROOT, fixtureRel);
+  const cascade = await runCascade(new Uint8Array(await fsp.readFile(fixturePath)));
+  const sweep = sweepParse(cascade, await runRoundtripHop(cascade));
+  return defectSpec(cls).exhibits(buildReproArtifact(cascade), sweep.derived);
+}
+
+function walkPdfs(dir: string): string[] {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkPdfs(p));
+    else if (e.isFile() && e.name.toLowerCase().endsWith(".pdf")) out.push(p);
+  }
+  return out.sort();
+}
+
+// pdfjs (via `runCascade`) needs `Promise.withResolvers` (Node 22); the repo's
+// `.nvmrc` pins Node 20, where it is absent. Fail fast with the fix instead of
+// an opaque pdfjs crash deep in the audit.
+if (typeof (Promise as { withResolvers?: unknown }).withResolvers !== "function") {
+  console.error(
+    `fixture-audit needs Node 22+ (pdfjs uses Promise.withResolvers); ` +
+      `running Node ${process.version}. Run under Node 22, e.g. \`nvm use 22\`.`,
+  );
+  process.exit(1);
+}
+
+const rows = readRegistry();
+const sources = readSources().sources ?? {};
+
+console.log(`\n══════ fixture-ledger audit ══════`);
+console.log(`registry: ${rows.length} row(s)\n`);
+
+for (const row of rows) {
+  console.log(`── ${row.id} · ${row.fixture}`);
+
+  // (a) SOURCE resolution + hash.
+  const src = sources[row.source.handle];
+  if (!src || !src.path) {
+    console.log(`   source(${row.source.handle}): unresolved on this machine — OK (source is local-only)`);
+  } else if (!existsSync(src.path)) {
+    console.log(`   source(${row.source.handle}): recorded path no longer exists — stale sources entry`);
+  } else {
+    const actual = sha256File(src.path);
+    console.log(
+      actual === row.source.sha256
+        ? `   source(${row.source.handle}): resolves, sha256 matches ✔`
+        : `   source(${row.source.handle}): ⚠ sha256 MISMATCH — the source file changed under this row`,
+    );
+  }
+
+  // (b) REPRO still exhibits?
+  if (!existsSync(join(REPO_ROOT, row.fixture))) {
+    console.log(`   fixture: ⚠ MISSING at ${row.fixture}`);
+  } else {
+    for (const d of row.defects) {
+      let still: boolean;
+      try {
+        still = await exhibitsStill(row.fixture, d.class);
+      } catch (err) {
+        console.log(`   defect ${d.class}: ⚠ re-parse threw (${(err as Error).message})`);
+        continue;
+      }
+      if (still) {
+        console.log(`   defect ${d.class} (#${d.issue}): still reproduces ✔ [status=${d.status}]`);
+      } else {
+        console.log(
+          `   defect ${d.class} (#${d.issue}): ✱ signature moved — fixture NO LONGER exhibits this class. ` +
+            `The parser likely improved → flip status "${d.status}" → "fixed".`,
+        );
+      }
+      // Cross-check the recorded repro test still references the issue.
+      if (reproTestsReferencingIssue(d.issue).length === 0) {
+        console.log(`      ⚠ no *.repro.test.ts references #${d.issue} (recorded: ${d.regressionTest})`);
+      }
+    }
+  }
+}
+
+// (c) Orphaned breadcrumbs across the WHOLE corpus (not just ledgered rows).
+console.log(`\n── .origin.json breadcrumb cross-check`);
+let orphan = 0;
+for (const pdf of walkPdfs(FIXTURE_ROOT)) {
+  const origin = readOriginJson(pdf);
+  if (!origin || origin.reproduces.length === 0) continue;
+  for (const issue of origin.reproduces) {
+    if (reproTestsReferencingIssue(issue).length === 0) {
+      orphan++;
+      console.log(
+        `   ⚠ ${relative(REPO_ROOT, pdf)} (ledger ${origin.ledgerId}) claims #${issue} ` +
+          `but no *.repro.test.ts references it`,
+      );
+    }
+  }
+}
+if (orphan === 0) console.log(`   all .origin.json reproduces[] are pinned by a repro test ✔`);
+
+console.log(`\n══════ audit complete ══════`);

--- a/scripts/fixture-derive.ts
+++ b/scripts/fixture-derive.ts
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The fixture-derivation tool (`npm run fixture-derive`, issue #39).
+ *
+ * Closes the loop the six read-only probes + the #469 corpus-match engine opened:
+ * a REAL résumé exposes a parse defect → does a synthetic fixture already
+ * reproduce it? → if not, mint one → PROVE the equivalence and record it in the
+ * ledger. Two modes over ONE parse+sweep engine:
+ *
+ *   --match  (no --fixture): "does a fixture already cover this?" Parse the real
+ *            résumé, sweep it, and for each requested class run `matchCorpus` over
+ *            the baked corpus. COVERED ⇒ STOP and exit NON-ZERO naming the
+ *            fixture — refusing to mint a duplicate is the whole point.
+ *
+ *   verify+write (--fixture ...): re-parse BOTH the real résumé and the candidate
+ *            fixture live, and assert `defectSpec(class).exhibits(fixtureArtifact,
+ *            fixtureDerived)`. A fixture that parses CORRECTLY while the real one
+ *            fails is worse than no fixture, so a false verdict is a loud FAIL
+ *            that writes NOTHING. On PASS: append a PII-free row to
+ *            `internal/fixtures/registry.jsonl`, record the handle→path map in the
+ *            gitignored `sources.local.json`, and print a repro-test scaffold.
+ *
+ * PII DISCIPLINE (the point of the whole issue): the committed row carries only
+ * an opaque `handle`, a `sha256`, and two `ReproArtifact`s (PII-free BY TYPE —
+ * numbers/booleans/enums, no free-form string). NEVER a path, filename, or name.
+ * The real path lives ONLY in the gitignored `sources.local.json`. Nothing here
+ * prints or persists a résumé field VALUE.
+ *
+ * Runs under vite-node (`runCascade` needs no pdfjs `?url` setup here). The
+ * round-trip hop's Poppins font fetch fails under vite-node and falls back to
+ * Helvetica with a stderr warning — expected and harmless; the render succeeds.
+ *
+ * Usage:
+ *   npm run fixture-derive -- --real "<abs path>" [--probe <id> | --class <C>]
+ *   npm run fixture-derive -- --real "<abs>" --fixture <repo-rel.pdf> \
+ *     --issue <N> --class <C> --probe <P> [--handle src-NN] \
+ *     [--generator word|latex|google-docs|unknown] [--provenance "..."] \
+ *     [--derivation "..."]
+ */
+
+import { promises as fsp, existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { basename, isAbsolute, join } from "node:path";
+
+import { runCascade } from "../src/lib/heuristics/cascade.ts";
+import type { CascadeResult } from "../src/lib/heuristics/types.ts";
+import { runRoundtripHop } from "../src/lib/heuristics/roundtrip-hop.ts";
+import {
+  sweepParse,
+  isParseUnreadable,
+  type ResumeSweep,
+} from "../src/lib/heuristics/sweep.ts";
+import {
+  buildReproArtifact,
+  type ReproArtifact,
+} from "../src/lib/heuristics/repro-artifact.ts";
+import {
+  DEFECT_CLASSES,
+  PROBE_IDS,
+  defectSpec,
+  defectClassesForProbe,
+  isAdvisory,
+  type DefectClass,
+  type ProbeId,
+  type AxisPath,
+} from "../src/lib/heuristics/defect-classes.ts";
+import { matchCorpus, divergedAxes } from "../src/lib/heuristics/fixture-match.ts";
+import {
+  loadCorpus,
+  REPO_ROOT,
+} from "../src/lib/heuristics/__test-utils__/corpus-snapshots.ts";
+
+const GENERATORS = ["word", "latex", "google-docs", "unknown"] as const;
+type Generator = (typeof GENERATORS)[number];
+
+const REGISTRY_PATH = join(REPO_ROOT, "internal/fixtures/registry.jsonl");
+const SOURCES_PATH = join(REPO_ROOT, "internal/fixtures/sources.local.json");
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+/** `--key value` pairs; bare `--flag` becomes `"true"`. */
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = "true";
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function die(msg: string, code = 2): never {
+  console.error(msg);
+  process.exit(code);
+}
+
+/** pdfjs (pulled in by `runCascade`) needs `Promise.withResolvers`, which lands
+ *  in Node 22. The repo's `.nvmrc` pins Node 20, where it is absent — so without
+ *  this guard a maintainer on the pinned version gets an opaque
+ *  `Promise.withResolvers is not a function` from deep inside pdfjs. Fail fast
+ *  with the fix instead. */
+function requireNode22(): void {
+  if (typeof (Promise as { withResolvers?: unknown }).withResolvers !== "function") {
+    die(
+      `fixture-derive needs Node 22+ (pdfjs uses Promise.withResolvers); ` +
+        `running Node ${process.version}. Run under Node 22, e.g. \`nvm use 22\`.`,
+      1,
+    );
+  }
+}
+
+function asDefectClass(v: string): DefectClass {
+  if (!(DEFECT_CLASSES as readonly string[]).includes(v)) {
+    die(`unknown --class "${v}". One of:\n  ${DEFECT_CLASSES.join("\n  ")}`);
+  }
+  return v as DefectClass;
+}
+
+function asProbe(v: string): ProbeId {
+  if (!(PROBE_IDS as readonly string[]).includes(v)) {
+    die(`unknown --probe "${v}". One of: ${PROBE_IDS.join(", ")}`);
+  }
+  return v as ProbeId;
+}
+
+// ── shared engine ────────────────────────────────────────────────────────────
+
+interface Analysis {
+  cascade: CascadeResult;
+  sweep: ResumeSweep;
+  artifact: ReproArtifact;
+}
+
+/** Parse → round-trip hop → sweep → repro artifact. The one place a PDF becomes
+ *  a (sweep, artifact) pair, so both modes read a résumé and a fixture the SAME
+ *  way `corpus.test.ts`'s bake does. */
+async function analyze(pdfPath: string): Promise<Analysis> {
+  const bytes = await fsp.readFile(pdfPath);
+  const cascade = await runCascade(new Uint8Array(bytes));
+  const hop = await runRoundtripHop(cascade);
+  const sweep = sweepParse(cascade, hop);
+  const artifact = buildReproArtifact(cascade);
+  return { cascade, sweep, artifact };
+}
+
+function bailIfUnreadable(a: Analysis, label: string): void {
+  if (isParseUnreadable(a.sweep.derived, a.artifact.extractedCharCount)) {
+    die(
+      `⛔ ${label} parse is UNREADABLE (scanned or zero extracted characters). ` +
+        `No defect claim over this parse can be trusted; fix extraction first.`,
+      2,
+    );
+  }
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+// ── --match mode ─────────────────────────────────────────────────────────────
+
+/**
+ * Which classes to ask the corpus about:
+ *   --class C  → exactly C.
+ *   --probe P  → P's classes the résumé EXHIBITS and that are non-advisory.
+ *   neither    → ALL exhibited non-advisory classes (the sweep's `defects`,
+ *                which already excludes withheld).
+ */
+function requestedClasses(
+  sweep: ResumeSweep,
+  cls: DefectClass | undefined,
+  probe: ProbeId | undefined,
+): DefectClass[] {
+  if (cls) return [cls];
+  const exhibited = new Set(sweep.defects.filter((c) => !isAdvisory(c)));
+  if (probe) {
+    return defectClassesForProbe(probe).filter((c) => exhibited.has(c));
+  }
+  return [...exhibited];
+}
+
+async function runMatch(args: Record<string, string>): Promise<never> {
+  const real = args.real;
+  if (!real) die("--match mode requires --real <abs path to real résumé pdf>");
+  if (!isAbsolute(real)) die(`--real must be an ABSOLUTE path (got "${real}")`);
+  if (!existsSync(real)) die(`--real not found: ${real}`);
+
+  const cls = args.class ? asDefectClass(args.class) : undefined;
+  const probe = args.probe ? asProbe(args.probe) : undefined;
+
+  const analysis = await analyze(real);
+  bailIfUnreadable(analysis, "real résumé");
+
+  const requested = requestedClasses(analysis.sweep, cls, probe);
+  console.log(
+    `\nreal résumé exhibits (non-advisory): ` +
+      `${analysis.sweep.defects.filter((c) => !isAdvisory(c)).join(", ") || "(none)"}`,
+  );
+  if (analysis.sweep.withheld.length > 0) {
+    console.log(`withheld (oracle unavailable): ${analysis.sweep.withheld.join(", ")}`);
+  }
+
+  // An explicit --class the real résumé does NOT itself exhibit: the corpus can
+  // still be asked "does a fixture cover it?", but a resulting "safe to mint"
+  // would be misleading — you'd mint a fixture for a defect this résumé never
+  // exposed, undercutting the derived-from-a-real-defect premise. Warn loudly.
+  if (cls && !new Set(analysis.sweep.defects.filter((c) => !isAdvisory(c))).has(cls)) {
+    console.warn(
+      `\n⚠️  --class ${cls} is NOT exhibited by this real résumé ` +
+        `(it exhibits: ${analysis.sweep.defects.filter((c) => !isAdvisory(c)).join(", ") || "none"}).\n` +
+        `    Any "safe to mint" below is an OVERRIDE, not evidence this résumé exposes ${cls}.`,
+    );
+  }
+
+  if (requested.length === 0) {
+    console.log(
+      `\nNo non-advisory defect class to match against the corpus. Nothing to do.`,
+    );
+    process.exit(0);
+  }
+
+  const corpus = loadCorpus();
+  const coverage = matchCorpus(
+    analysis.artifact,
+    analysis.sweep.derived,
+    requested,
+    corpus,
+  );
+
+  console.log(`\n══════ corpus coverage (${corpus.length} fixtures) ══════`);
+  const coveredClasses: DefectClass[] = [];
+  for (const c of coverage) {
+    if (c.coveredBy.length > 0) {
+      coveredClasses.push(c.class);
+      console.log(`\n  ✔ COVERED — ${c.class}`);
+      console.log(`      by: ${c.coveredBy.join("\n          ")}`);
+    } else {
+      console.log(`\n  ✘ NO FIXTURE COVERS THIS — ${c.class}`);
+      console.log(
+        `      (${c.nearMisses.length} of ${c.nearMissCandidateCount} near-misses)`,
+      );
+      for (const nm of c.nearMisses) {
+        const axes = nm.divergedAxes.length ? nm.divergedAxes.join(", ") : "(none)";
+        console.log(`        · ${nm.fixture}\n            diverged: ${axes}`);
+      }
+    }
+  }
+
+  if (coveredClasses.length > 0) {
+    console.error(
+      `\n⛔ ${coveredClasses.length} requested class(es) already COVERED — ` +
+        `do NOT mint a duplicate. Go fix the parser against the fixture(s) above.\n` +
+        `   ${coveredClasses.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\n✔ No requested class is covered — an uncovered class is the only thing ` +
+      `that justifies minting a new synthetic fixture.`,
+  );
+  process.exit(0);
+}
+
+// ── verify + write mode ──────────────────────────────────────────────────────
+
+interface RegistryRow {
+  id: string;
+  source: {
+    handle: string;
+    sha256: string;
+    generator: Generator;
+    provenance: string;
+  };
+  fixture: string;
+  derivation: string;
+  defects: {
+    issue: number;
+    class: DefectClass;
+    probe: ProbeId;
+    regressionTest: string;
+    status: "open" | "fixed";
+  }[];
+  signature: {
+    real: ReproArtifact;
+    fixture: ReproArtifact;
+    matchedAxes: AxisPath[];
+  };
+  verifiedRepro: string;
+}
+
+function nextLedgerId(): string {
+  let max = 0;
+  if (existsSync(REGISTRY_PATH)) {
+    for (const line of readFileSync(REGISTRY_PATH, "utf8").split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      const m = /"id"\s*:\s*"rl-(\d+)"/.exec(t);
+      if (m) max = Math.max(max, parseInt(m[1], 10));
+    }
+  }
+  return `rl-${String(max + 1).padStart(4, "0")}`;
+}
+
+async function mergeSources(
+  handle: string,
+  stem: string,
+  realPath: string,
+): Promise<void> {
+  interface SourcesFile {
+    _comment?: unknown;
+    sources: Record<string, { stem: string; path: string | null }>;
+  }
+  let file: SourcesFile = { sources: {} };
+  if (existsSync(SOURCES_PATH)) {
+    file = JSON.parse(readFileSync(SOURCES_PATH, "utf8")) as SourcesFile;
+    if (!file.sources) file.sources = {};
+  }
+  // Preserve an existing stem if present (it may be the pre-ledger filename);
+  // otherwise record the current file's stem. Always fill in the real path.
+  const existing = file.sources[handle];
+  file.sources[handle] = { stem: existing?.stem ?? stem, path: realPath };
+  await fsp.writeFile(SOURCES_PATH, JSON.stringify(file, null, 2) + "\n");
+}
+
+async function runWrite(args: Record<string, string>): Promise<never> {
+  const real = args.real;
+  const fixtureRel = args.fixture;
+  if (!real) die("write mode requires --real <abs path>");
+  if (!isAbsolute(real)) die(`--real must be an ABSOLUTE path (got "${real}")`);
+  if (!existsSync(real)) die(`--real not found: ${real}`);
+  if (!args.issue) die("write mode requires --issue <N>");
+  if (!args.class) die("write mode requires --class <DefectClass>");
+  if (!args.probe) die("write mode requires --probe <ProbeId>");
+
+  const issue = parseInt(args.issue, 10);
+  if (!Number.isInteger(issue)) die(`--issue must be an integer (got "${args.issue}")`);
+  const cls = asDefectClass(args.class);
+  const probe = asProbe(args.probe);
+  const handle = args.handle ?? "src-01";
+  const generator = ((): Generator => {
+    const g = args.generator ?? "unknown";
+    if (!(GENERATORS as readonly string[]).includes(g)) {
+      die(`--generator must be one of: ${GENERATORS.join(", ")}`);
+    }
+    return g as Generator;
+  })();
+  const provenance = args.provenance ?? "";
+  const regressionTest =
+    args["regression-test"] ??
+    `src/lib/heuristics/${basename(fixtureRel ?? "fixture", ".pdf")}.repro.test.ts`;
+
+  const fixturePath = isAbsolute(fixtureRel)
+    ? fixtureRel
+    : join(REPO_ROOT, fixtureRel);
+  if (!existsSync(fixturePath)) die(`--fixture not found: ${fixturePath}`);
+
+  // Parse BOTH live — never trust a stale snapshot for the verification.
+  const realA = await analyze(real);
+  const fixA = await analyze(fixturePath);
+  bailIfUnreadable(realA, "real résumé");
+  bailIfUnreadable(fixA, "fixture");
+
+  const spec = defectSpec(cls);
+
+  // ── THE VERIFICATION. A fixture that does NOT exhibit the class is worse than
+  // no fixture; refuse to write anything.
+  const fixtureExhibits = spec.exhibits(fixA.artifact, fixA.sweep.derived);
+  if (!fixtureExhibits) {
+    console.error(
+      `\n⛔ FAIL — the fixture does NOT exhibit "${cls}".\n` +
+        `   ${fixtureRel}\n` +
+        `   A fixture that parses correctly while the real résumé fails cannot ` +
+        `pin the defect. Writing NOTHING (no registry row, no sources entry).\n` +
+        `   Load-bearing axes for this class: ${spec.loadBearingAxes.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  const realExhibits = spec.exhibits(realA.artifact, realA.sweep.derived);
+  if (!realExhibits) {
+    console.warn(
+      `\n⚠ WARNING — the REAL résumé does not itself exhibit "${cls}" ` +
+        `(the fixture does). Recording anyway, but double-check the class is right.`,
+    );
+  }
+
+  // matchedAxes: the class's load-bearing axes that DIVERGE between real and
+  // fixture, intersected with the load-bearing set. For a covered/dedup row the
+  // pair agrees on every load-bearing axis (that agreement IS why the fixture
+  // covers the class the real exhibits), so this intersection is empty — which
+  // says nothing useful. So we record the load-bearing axes THEMSELVES: the axes
+  // on which the fixture reproduces the defect. The divergence set is logged
+  // (empty, for a dedup row) for transparency.
+  const diverged = divergedAxes(
+    realA.artifact,
+    realA.sweep.derived,
+    fixA.artifact,
+    fixA.sweep.derived,
+    spec.loadBearingAxes,
+  );
+  const matchedAxes: AxisPath[] = [...spec.loadBearingAxes];
+
+  const realBytes = new Uint8Array(await fsp.readFile(real));
+  const stem = basename(real, ".pdf");
+  const id = nextLedgerId();
+
+  const derivation =
+    args.derivation ??
+    (realExhibits
+      ? `existing corpus fixture already covers ${cls} (dedup row); real résumé ` +
+        `${handle} exhibits the same class and the fixture reproduces it — no new ` +
+        `fixture minted`
+      : `fixture reproduces ${cls}`);
+
+  const row: RegistryRow = {
+    id,
+    source: { handle, sha256: sha256(realBytes), generator, provenance },
+    fixture: fixtureRel,
+    derivation,
+    defects: [{ issue, class: cls, probe, regressionTest, status: "open" }],
+    signature: {
+      real: realA.artifact,
+      fixture: fixA.artifact,
+      matchedAxes,
+    },
+    verifiedRepro: new Date().toISOString().slice(0, 10),
+  };
+
+  await fsp.mkdir(join(REPO_ROOT, "internal/fixtures"), { recursive: true });
+  await fsp.appendFile(REGISTRY_PATH, JSON.stringify(row) + "\n");
+  await mergeSources(handle, stem, real);
+
+  console.log(`\n✔ VERIFIED — ${fixtureRel} exhibits "${cls}".`);
+  console.log(`  ledger row ${id} appended to internal/fixtures/registry.jsonl`);
+  console.log(`  sources.local.json: ${handle} → path recorded (gitignored)`);
+  console.log(
+    `  matchedAxes (load-bearing): ${matchedAxes.join(", ")}\n` +
+      `  divergence on load-bearing axes (real vs fixture): ` +
+      `${diverged.length ? diverged.join(", ") : "(none — agrees on all load-bearing axes)"}`,
+  );
+  console.log(`  regressionTest recorded: ${regressionTest}`);
+
+  console.log(`\n── repro-test scaffold (only if you MINTED a new fixture) ──`);
+  console.log(reproTestScaffold(fixtureRel, issue, cls, probe));
+  process.exit(0);
+}
+
+function reproTestScaffold(
+  fixtureRel: string,
+  issue: number,
+  cls: DefectClass,
+  probe: ProbeId,
+): string {
+  const stem = basename(fixtureRel, ".pdf");
+  return `// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * Repro regression for #${issue} — ${cls} (${probe}).
+ * Persona is synthetic per the fixtures PII policy. Ledger: internal/fixtures/registry.jsonl.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { runCascade } from "./cascade.ts";
+
+const FIXTURE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+  "${fixtureRel}",
+);
+
+describe("#${issue} — ${cls}", () => {
+  it("pins the corrected field values (fill in the exact assertions)", async () => {
+    const c = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    expect(c.canonical.fields).toBeTruthy();
+  });
+});
+// Also write ${stem}.origin.json next to the fixture:
+//   { "derivedFrom": "real-resume", "ledgerId": "<rl-id>",
+//     "reproduces": [${issue}], "defectClass": "${cls}", "probe": "${probe}" }`;
+}
+
+// ── entry ────────────────────────────────────────────────────────────────────
+
+requireNode22();
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || args.h) {
+  console.log(
+    `fixture-derive — issue #39\n\n` +
+      `  --match:  --real <abs> [--probe <id> | --class <C>]\n` +
+      `  write:    --real <abs> --fixture <repo-rel.pdf> --issue <N> --class <C> ` +
+      `--probe <P>\n            [--handle src-NN] [--generator ${GENERATORS.join("|")}] ` +
+      `[--provenance "..."] [--derivation "..."] [--regression-test <path>]`,
+  );
+  process.exit(0);
+}
+
+if (args.fixture) {
+  await runWrite(args);
+} else {
+  await runMatch(args);
+}

--- a/src/lib/heuristics/__test-utils__/origin-links.ts
+++ b/src/lib/heuristics/__test-utils__/origin-links.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * The `.origin.json` breadcrumb convention (issue #39).
+ *
+ * A fixture that was DERIVED from a real résumé (a real document exposed a parse
+ * defect; we minted a synthetic-persona reproduction of it) carries a sibling
+ * `<name>.origin.json` next to its `<name>.expected.json`. The breadcrumb links
+ * the fixture to the ledger row that verified the equivalence, and — the part
+ * this module enforces — to the ISSUE(s) it reproduces.
+ *
+ * The invariant a derived fixture must keep: every issue it claims to reproduce
+ * still has a live `*.repro.test.ts` pinning that bug. When the parser improves
+ * and the fixture stops reproducing, or someone deletes the repro test, the
+ * fixture is silently no longer pinning anything — and a snapshot golden
+ * (`*.expected.json`) is lossy by design, so it will not catch a value-level
+ * regression coming back. `corpus.test.ts` reads this module to turn that drift
+ * into a test failure; `scripts/fixture-audit.ts` reads it to report it.
+ *
+ * PII-FREE BY CONSTRUCTION, same as everything else in the fixture pipeline: the
+ * breadcrumb carries an opaque ledger handle (`ledgerId`), issue numbers, a
+ * `DefectClass`, and a `ProbeId` — never a path, a hash, or a name. The real
+ * source path lives ONLY in the gitignored `internal/fixtures/sources.local.json`.
+ *
+ * Test/tooling-only (imports `node:fs`), so it sits in `__test-utils__` beside
+ * `corpus-snapshots.ts`, its only other filesystem sibling.
+ */
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** `src/lib/heuristics/__test-utils__` → `src/lib/heuristics`. */
+const HEURISTICS_DIR = join(HERE, "..");
+
+/**
+ * The sibling breadcrumb written next to a derived fixture's `.expected.json`.
+ * Opaque handle only — see the file header for the PII contract.
+ */
+export interface OriginJson {
+  /** Always `"real-resume"` — the fixture was minted FROM a real document. */
+  derivedFrom: "real-resume";
+  /** The `internal/fixtures/registry.jsonl` row id, e.g. `"rl-0001"`. */
+  ledgerId: string;
+  /** GitHub issue numbers this fixture reproduces. Non-empty ⇒ each must have a
+   *  live `*.repro.test.ts`. */
+  reproduces: number[];
+  /** The `DefectClass` the fixture reproduces (kept as a string here so this
+   *  test-util has no dependency on the taxonomy module). */
+  defectClass: string;
+  /** The `ProbeId` whose verdict names the class. */
+  probe: string;
+}
+
+/** The `.origin.json` path for a fixture PDF. */
+function originJsonPathFor(pdfPath: string): string {
+  return pdfPath.replace(/\.pdf$/i, ".origin.json");
+}
+
+/**
+ * Read a fixture's `.origin.json`, or `null` when it carries none (the common
+ * case — most fixtures are synthetic-by-construction, not derived-from-a-real-
+ * résumé, and correctly have no breadcrumb).
+ */
+export function readOriginJson(pdfPath: string): OriginJson | null {
+  const p = originJsonPathFor(pdfPath);
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf8")) as OriginJson;
+}
+
+/** Every `*.repro.test.ts` under `src/lib/heuristics/`, as absolute paths. */
+function reproTestFiles(): string[] {
+  return readdirSync(HEURISTICS_DIR)
+    .filter((n) => n.endsWith(".repro.test.ts"))
+    .map((n) => join(HEURISTICS_DIR, n))
+    .sort();
+}
+
+/**
+ * The `*.repro.test.ts` files whose body references `#<issue>` — today's
+ * convention for "this test pins issue N" (repro tests encode the issue number
+ * in their header prose). The `(?!\d)` guard stops `#39` matching `#390`.
+ */
+export function reproTestsReferencingIssue(issue: number): string[] {
+  const needle = new RegExp(`#${issue}(?!\\d)`);
+  return reproTestFiles().filter((f) => needle.test(readFileSync(f, "utf8")));
+}

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -32,6 +32,11 @@ import type { DerivedSignals } from "./defect-classes.ts";
 import { sweepParse } from "./sweep.ts";
 import { runRoundtripHop } from "./roundtrip-hop.ts";
 import { CORPUS_SNAPSHOT_SCHEMA_VERSION } from "./__test-utils__/corpus-snapshots.ts";
+import {
+  readOriginJson,
+  reproTestsReferencingIssue,
+  type OriginJson,
+} from "./__test-utils__/origin-links.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "../../..");
@@ -257,6 +262,50 @@ describe("corpus snapshots", () => {
         // re-parse (the same budget `corpus-roundtrip.test.ts` runs on).
         25_000,
       );
+    });
+  }
+});
+
+/**
+ * `.origin.json` breadcrumb enforcement (issue #39).
+ *
+ * A fixture DERIVED from a real résumé carries a sibling `<name>.origin.json`
+ * naming the issue(s) it reproduces (see `__test-utils__/origin-links.ts`). The
+ * `*.expected.json` golden is lossy by design and cannot catch a value-level
+ * regression sneaking back, so the derived fixture's guard is its `*.repro.test.ts`.
+ * This asserts that guard EXISTS: every issue a breadcrumb claims to reproduce
+ * still has a live `src/lib/heuristics/*.repro.test.ts` referencing `#<issue>`.
+ * A derived fixture that stops pinning its bug becomes a test failure here rather
+ * than a silent hole.
+ */
+describe(".origin.json breadcrumbs pin a live repro test", () => {
+  const withOrigin = pdfs
+    .map((pdf) => ({ pdf, origin: readOriginJson(pdf) }))
+    .filter(
+      (x): x is { pdf: string; origin: OriginJson } =>
+        x.origin !== null && x.origin.reproduces.length > 0,
+    );
+
+  if (withOrigin.length === 0) {
+    // No derived fixtures carry a breadcrumb yet — the convention ships as
+    // infrastructure ahead of the first `.origin.json`. Vacuously green.
+    it.skip("no fixture carries a .origin.json with reproduces[] yet", () => {});
+    return;
+  }
+
+  for (const { pdf, origin } of withOrigin) {
+    const rel = relative(REPO_ROOT, pdf);
+    it(`${rel}: each reproduced issue has a *.repro.test.ts`, () => {
+      for (const issue of origin.reproduces) {
+        const tests = reproTestsReferencingIssue(issue);
+        expect(
+          tests.length,
+          `${rel} (ledger ${origin.ledgerId}) declares it reproduces #${issue}, ` +
+            `but no src/lib/heuristics/*.repro.test.ts references #${issue}. ` +
+            `A derived fixture that stops pinning its bug must fail here — either ` +
+            `restore the repro test or update the .origin.json.`,
+        ).toBeGreaterThan(0);
+      }
     });
   }
 });


### PR DESCRIPTION
## What

Adds the **fixture-derivation tooling** that sits on top of the #469 corpus-match engine:

- **`npm run fixture-derive`** — two modes over one parse+sweep engine:
  - `--match` (dedup check): parse a real résumé, sweep its defects, ask the baked corpus "does a fixture already reproduce this?" — **exits non-zero on COVERED** so a maintainer never mints a duplicate.
  - verify + write: re-parse the real résumé *and* a candidate fixture, assert `defectSpec(class).exhibits(...)` on the fixture, and only then record the equivalence. A fixture that parses *correctly* while the real one fails is a loud FAIL that writes nothing.
- **`npm run fixture-audit`** — report-only staleness auditor (source hash still matches, fixture still reproduces, `.origin.json` breadcrumbs still pinned by a repro test).
- **`.origin.json` breadcrumb convention** + a `corpus.test.ts` assertion: every fixture with `reproduces:[N]` must have a live `*.repro.test.ts` referencing `#N`, so a fixture cannot silently stop pinning its bug.

The **ledger data** (which maps a real résumé to its fixture) is intentionally *not* in this repo — it lives in the private internal repo. Nothing here carries a résumé path, filename, or value; the shipped code is PII-free by construction.

## Notes

- Both CLIs preflight-guard for **Node 22** (pdfjs uses `Promise.withResolvers`, absent on the `.nvmrc`-pinned Node 20) — a clear message instead of an opaque crash. The CI-executed `corpus.test.ts` addition uses no Node-22 API and passes on Node 20.
- `scripts/**` follows the existing eslint-ignore precedent (`fidelity.ts`).

## Verification

- `npm run typecheck` — pass.
- `npx vitest run src/lib/heuristics/corpus.test.ts` — 51 passed, 1 skipped (the `.origin.json` block, vacuous until a breadcrumb exists).
- `--match` COVERED → exit 1; uncovered → exit 0; explicit non-exhibited `--class` → loud override warning.
- Refuse-to-write path: a clean fixture → FAIL, exit 1, writes nothing.

## Provenance

- Planning, review orchestration, and post-review fixes: Claude Opus 4.8 (1M context).
- Implementation sub-agent: Claude Opus.
- Independent adversarial review sub-agent: Claude Opus (verdict: safe to finalize, no blockers).
