### PR TITLE
feat(edit): make prose-body project descriptions editable in-place (#489)

### DIFF
--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -71,6 +71,7 @@ import type {
   EditableParse,
   ExperienceFieldOverrides,
   BulletOverrides,
+  DescriptionOverrides,
   AddedEntry,
   AddedEntryField,
   AchievementFieldOverrides,
@@ -566,11 +567,13 @@ function ProjectsSection({
   projects,
   groups,
   bulletOverrides,
+  descriptionOverrides,
   addedProjects,
   originalCount,
   onAddEntry,
   onRemoveEntry,
   onEntryField,
+  onDescriptionField,
   onAddBullet,
 }: {
   /** Verbatim source heading (#285); falls back to "Projects" when absent. */
@@ -579,11 +582,16 @@ function ProjectsSection({
   /** Pre-built project groups, index-aligned with `projects`. */
   groups: BulletGroup[];
   bulletOverrides: BulletOverrides;
+  /** Prose-description edits keyed by parsedEntryKey (#489) — read only to keep
+   *  a CLEARED prose field mounted (so the clear is reversible in-session). */
+  descriptionOverrides: DescriptionOverrides;
   addedProjects: AddedEntry[];
   originalCount: number;
   onAddEntry: () => void;
   onRemoveEntry: (id: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  /** Commit an edit to a parsed project's prose description (#489). */
+  onDescriptionField: (key: string, value: string | undefined) => void;
   onAddBullet: (entryKey: string, text: string) => void;
 }) {
   return (
@@ -594,6 +602,12 @@ function ProjectsSection({
           const group = groups[i];
           const added =
             i >= originalCount ? addedProjects[i - originalCount] : undefined;
+          const descKey = parsedEntryKey("projects", i);
+          // Keep the prose field mounted once the user has touched it, even after
+          // an authoritative clear ("" override) drops `project.description` — so
+          // the clear stays reversible in-session instead of collapsing to the
+          // read-only "no bullets" hint with no way back (#489 review).
+          const hasDescriptionEdit = descriptionOverrides[descKey] !== undefined;
           const header = [project.name, buildProjectDates(project)]
             .filter(Boolean)
             .join(" · ");
@@ -632,15 +646,26 @@ function ProjectsSection({
                     />
                   ))}
                 </ul>
-              ) : !added && project.description ? (
+              ) : !added && (project.description || hasDescriptionEdit) ? (
                 // #464 — a prose-body project (no `•` bullets, description is
-                // one or more paragraph sentences) surfaces the description
-                // as a paragraph. Without this, the fallback below reads "No
-                // bullet-shaped lines detected" even though the parser DID
-                // extract the description via looksLikeBodyParagraph.
-                <p className="text-sm text-content-primary whitespace-pre-wrap">
-                  {project.description}
-                </p>
+                // one or more paragraph sentences) surfaces the description as a
+                // paragraph. #489 makes that paragraph editable in place: an
+                // EditableField (multiline) keyed by the project's parsedEntryKey
+                // commits back through `descriptionOverrides`, keeping the same
+                // paragraph render style (NOT a bulleted list — the parser
+                // produced prose). The read-only `<p>` (#483) had no input path
+                // while a `•`-bulleted project was fully editable.
+                <EditableField
+                  value={project.description}
+                  emptyAffordance="plain"
+                  placeholder="description"
+                  label="Project description"
+                  textSize="sm"
+                  display="inline"
+                  multiline
+                  className="whitespace-pre-wrap"
+                  onCommit={(v) => onDescriptionField(descKey, v)}
+                />
               ) : (
                 !added && (
                   <p className="text-sm text-content-tertiary">
@@ -959,6 +984,8 @@ export function ReconstructedResume({
     setExperienceField,
     bulletOverrides,
     setBulletField,
+    descriptionOverrides,
+    setDescriptionField,
     removeBullet,
     educationOverrides,
     setEducationField,
@@ -1188,11 +1215,13 @@ export function ReconstructedResume({
         projects={projects}
         groups={projectGroups}
         bulletOverrides={bulletOverrides}
+        descriptionOverrides={descriptionOverrides}
         addedProjects={addedProjects}
         originalCount={originalProjCount}
         onAddEntry={() => addEntry("projects")}
         onRemoveEntry={removeEntry}
         onEntryField={setEntryField}
+        onDescriptionField={setDescriptionField}
         onAddBullet={addBullet}
       />
       {!achievementsAbove && achievementsSection}

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -110,6 +110,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     contactOverrides,
     experienceOverrides,
     bulletOverrides,
+    descriptionOverrides,
     removedBullets,
     educationOverrides,
     achievementOverrides,
@@ -162,6 +163,7 @@ export function useAnalyzedResume(): AnalyzedResume {
       profileOverrides,
       base.canonical.fieldConfidence,
       achievementOverrides,
+      descriptionOverrides,
     );
   }, [
     base,
@@ -169,6 +171,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     contactOverrides,
     experienceOverrides,
     bulletOverrides,
+    descriptionOverrides,
     educationOverrides,
     achievementOverrides,
     skillsOverride,

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -62,6 +62,24 @@ export interface ExperienceFieldOverrides {
 /** Bullet-text overrides, keyed by BulletObservation.index (stable rawText order). */
 export type BulletOverrides = Record<number, string>;
 
+// ── Description overrides (#489) ──────────────────────────────────────────────
+
+/**
+ * Prose-body description overrides, keyed by {@link parsedEntryKey}
+ * (`"<section>:<index>"`) — the SAME key space as {@link AddedBullets}. This is
+ * the edit channel for a parsed entry whose body is a prose paragraph rather
+ * than `•` bullets: a project like "Ridgemont Resume Studio" whose two-sentence
+ * blurb the parser stores on `project.description` with zero graded bullets.
+ * bulletOverrides can't key it — that map is keyed by the resume-wide graded
+ * bullet-pool index, and a prose paragraph produces no such observation — so
+ * this parallel map carries the edit instead (#489). `applyOverrides` folds an
+ * entry straight onto the matching parsed entry's `description`; an empty string
+ * clears it (treated as absent), a non-empty value replaces it verbatim.
+ * Projects are the only surface wired today, but the key space generalizes to
+ * any prose-body entry `resolveParsedDescriptionTarget` resolves.
+ */
+export type DescriptionOverrides = Record<string, string>;
+
 // ── Education overrides ───────────────────────────────────────────────────────
 
 /** Editable education fields (degree, field/major, institution, dates). Mirrors
@@ -125,6 +143,8 @@ export interface EditSnapshot {
   contactOverrides: ContactOverrides;
   experienceOverrides: Record<number, ExperienceFieldOverrides>;
   bulletOverrides: BulletOverrides;
+  /** Optional: drafts persisted before #489 carry no such key. */
+  descriptionOverrides?: DescriptionOverrides;
   removedBullets: number[];
   educationOverrides: Record<number, EducationFieldOverrides>;
   /** Optional: drafts persisted before #454 carry no such key. */
@@ -296,6 +316,13 @@ export interface EditableParse {
   bulletOverrides: BulletOverrides;
   /** Set the override text for one bullet. Pass undefined to clear it. */
   setBulletField: (index: number, value: string | undefined) => void;
+  /** Override map for a parsed entry's prose description, keyed by
+   *  {@link parsedEntryKey} (`"<section>:<index>"`). */
+  descriptionOverrides: DescriptionOverrides;
+  /** Set the override text for one entry's prose description. Pass undefined to
+   *  clear the override (revert to the parsed prose); an empty string is an
+   *  authoritative clear of the description itself. */
+  setDescriptionField: (key: string, value: string | undefined) => void;
   /** Indices of parsed bullets the user dropped (rewrite-review removals, #211),
    *  keyed by BulletObservation.index — folded by applyOverrides to drop the
    *  line from the graded pool, rawText, and the role description. */
@@ -390,6 +417,8 @@ export function useEditableParse(): EditableParse {
     Record<number, ExperienceFieldOverrides>
   >({});
   const [bulletOverrides, setBulletOverrides] = useState<BulletOverrides>({});
+  const [descriptionOverrides, setDescriptionOverrides] =
+    useState<DescriptionOverrides>({});
   const [removedBullets, setRemovedBullets] = useState<ReadonlySet<number>>(
     () => new Set(),
   );
@@ -454,6 +483,21 @@ export function useEditableParse(): EditableParse {
           delete next[index];
         } else {
           next[index] = value;
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setDescriptionField = useCallback(
+    (key: string, value: string | undefined) => {
+      setDescriptionOverrides((prev) => {
+        const next = { ...prev };
+        if (value === undefined) {
+          delete next[key];
+        } else {
+          next[key] = value;
         }
         return next;
       });
@@ -630,6 +674,7 @@ export function useEditableParse(): EditableParse {
     setContactOverrides({});
     setExperienceOverrides({});
     setBulletOverrides({});
+    setDescriptionOverrides({});
     setRemovedBullets(new Set());
     setEducationOverrides({});
     setAchievementOverrides({});
@@ -644,6 +689,7 @@ export function useEditableParse(): EditableParse {
       contactOverrides,
       experienceOverrides,
       bulletOverrides,
+      descriptionOverrides,
       removedBullets: [...removedBullets],
       educationOverrides,
       achievementOverrides,
@@ -656,6 +702,7 @@ export function useEditableParse(): EditableParse {
       contactOverrides,
       experienceOverrides,
       bulletOverrides,
+      descriptionOverrides,
       removedBullets,
       educationOverrides,
       achievementOverrides,
@@ -685,6 +732,10 @@ export function useEditableParse(): EditableParse {
 
       Object.entries(snap.bulletOverrides).forEach(([index, value]) =>
         setBulletField(Number(index), value),
+      );
+
+      Object.entries(snap.descriptionOverrides ?? {}).forEach(([key, value]) =>
+        setDescriptionField(key, value),
       );
 
       snap.removedBullets.forEach((index) => removeBullet(index));
@@ -745,6 +796,7 @@ export function useEditableParse(): EditableParse {
       setContactField,
       setExperienceField,
       setBulletField,
+      setDescriptionField,
       removeBullet,
       setEducationField,
       setAchievementField,
@@ -761,6 +813,7 @@ export function useEditableParse(): EditableParse {
   const hasEdits = useMemo(() => {
     if (Object.keys(contactOverrides).length > 0) return true;
     if (Object.keys(bulletOverrides).length > 0) return true;
+    if (Object.keys(descriptionOverrides).length > 0) return true;
     if (removedBullets.size > 0) return true;
     if (skillsOverride.removed.length > 0 || skillsOverride.added.length > 0)
       return true;
@@ -786,6 +839,7 @@ export function useEditableParse(): EditableParse {
     contactOverrides,
     experienceOverrides,
     bulletOverrides,
+    descriptionOverrides,
     removedBullets,
     educationOverrides,
     achievementOverrides,
@@ -802,6 +856,8 @@ export function useEditableParse(): EditableParse {
     setExperienceField,
     bulletOverrides,
     setBulletField,
+    descriptionOverrides,
+    setDescriptionField,
     removedBullets,
     removeBullet,
     educationOverrides,

--- a/src/jd-fit/useJdFitResume.test.tsx
+++ b/src/jd-fit/useJdFitResume.test.tsx
@@ -77,6 +77,9 @@ function pristineResult(): CascadeResult {
         heuristic_achievements: [
           { type: "Pantent", title: "Bulk catalog editor" },
         ],
+        projects: [
+          { name: "Ledger", description: "Old prose blurb." },
+        ],
       },
       sections: {
         byName: new Map<string, readonly string[]>(),
@@ -162,6 +165,19 @@ describe("useJdFitResume — the handoff carries edit STATE (#456)", () => {
       type: "Patent",
       title: "Bulk catalog editor",
     });
+  });
+
+  it("replays a prose-description edit onto the pristine parse (#489)", () => {
+    // A prose-body project blurb the user rewrote on `/` must apply to the
+    // displayed/exported résumé here, not silently drop back to the original —
+    // the 16th `applyOverrides` arg the handoff caller had missed.
+    seedHandoff({
+      ...EMPTY_EDIT,
+      descriptionOverrides: { "projects:0": "New rewritten blurb." },
+    });
+    mount();
+
+    expect(api?.parsed.projects?.[0].description).toBe("New rewritten blurb.");
   });
 
   it("keeps a user-ADDED entry editable here — it does not arrive baked in", () => {

--- a/src/jd-fit/useJdFitResume.ts
+++ b/src/jd-fit/useJdFitResume.ts
@@ -105,6 +105,7 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
       handoffEdit.profileOverrides,
       base.canonical.fieldConfidence,
       handoffEdit.achievementOverrides,
+      handoffEdit.descriptionOverrides,
     );
     const parsed = applied.fields;
     const score = computeAnonymousAtsScore({
@@ -127,6 +128,7 @@ export function useJdFitResume(analyzed: AnalyzedResume): JdFitResume | null {
     handoffEdit.bulletOverrides,
     handoffEdit.educationOverrides,
     handoffEdit.achievementOverrides,
+    handoffEdit.descriptionOverrides,
     handoffEdit.skillsOverride,
     handoffEdit.addedEntries,
     handoffEdit.addedBullets,

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -51,6 +51,7 @@ import type {
   AddedBullets,
   ProfileOverride,
   BulletOverrides,
+  DescriptionOverrides,
 } from "../../hooks/useEditableParse.ts";
 
 /**
@@ -343,6 +344,46 @@ function mergeAchievementFields(
   if (fields.type !== undefined) ach.type = fields.type || undefined;
   if (fields.title !== undefined) ach.title = fields.title;
   if (fields.year !== undefined) ach.year = fields.year || undefined;
+}
+
+// ── Prose descriptions (#489) ───────────────────────────────────────────────
+
+/**
+ * Fold `descriptionOverrides` onto the matching parsed entries' prose
+ * `description`, keyed by {@link parsedEntryKey} (`"<section>:<index>"`) and
+ * resolved through the same {@link resolveParsedDescriptionTarget} the
+ * added-bullet fold uses. This is the edit path for a prose-body entry (a
+ * project whose blurb the parser stored as a paragraph, with no `•` bullets) —
+ * the read-only branch #483 rendered now commits back here (#489).
+ *
+ * An empty string clears the description (treated as absent); a non-empty value
+ * replaces it verbatim.
+ *
+ * `projects` / `heuristic_achievements` are NOT pre-cloned by the entry point
+ * (it clones only experience / education / skills), so clone the arrays + their
+ * entries here before mutating a description — mirroring
+ * {@link applyAchievementOverrides}. `experience` entries are already cloned by
+ * the entry point, so mutating one in place is safe. A later re-clone by
+ * {@link applyAddedEntriesAndBullets} preserves these edits.
+ */
+function applyDescriptionOverrides(
+  nextParsed: HeuristicParsedResume,
+  overrides: DescriptionOverrides,
+): void {
+  if (Object.keys(overrides).length === 0) return;
+  if (nextParsed.projects) {
+    nextParsed.projects = nextParsed.projects.map((p) => ({ ...p }));
+  }
+  if (nextParsed.heuristic_achievements) {
+    nextParsed.heuristic_achievements = nextParsed.heuristic_achievements.map(
+      (a) => ({ ...a }),
+    );
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    const target = resolveParsedDescriptionTarget(nextParsed, key);
+    if (!target) continue;
+    target.description = value || undefined;
+  }
 }
 
 // ── Skills (add / remove) ───────────────────────────────────────────────────
@@ -649,9 +690,13 @@ function resolveParsedDescriptionTarget(
   const index = Number(key.slice(colon + 1));
   if (!Number.isInteger(index)) return undefined;
   if (section === "experience") return nextParsed.experience[index];
-  if (section === "projects") return nextParsed.projects![index];
+  // `?.` (not `!`): a description/added-bullet override can outlive the section
+  // array it was keyed against (a stale draft or handoff whose re-parse produced
+  // no projects/achievements). Resolve to undefined so the caller's `if
+  // (!target) continue` no-ops, rather than throwing on an absent array.
+  if (section === "projects") return nextParsed.projects?.[index];
   if (section === "achievements")
-    return nextParsed.heuristic_achievements![index];
+    return nextParsed.heuristic_achievements?.[index];
   return undefined;
 }
 
@@ -833,6 +878,12 @@ function applyAddedBulletsToExistingEntries(
  *                  and `year` are copied straight onto the entry — `type` is a
  *                  stored field, not a run of `title`, so nothing is recomposed
  *                  (#456). An empty `type` or `year` clears it. Default `{}`.
+ * @param descriptionOverrides prose-description overrides keyed by
+ *                  {@link parsedEntryKey} (`"<section>:<index>"`, #489). Applied
+ *                  straight onto the matching parsed entry's `description` — the
+ *                  edit path for a prose-body project (no `•` bullets). An empty
+ *                  string clears the description; a non-empty value replaces it.
+ *                  Default `{}`.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -850,6 +901,7 @@ export function applyOverrides(
   profileOverrides: readonly ProfileOverride[] = [],
   fieldConfidence: FieldConfidence = {},
   achievements: Record<number, AchievementFieldOverrides> = {},
+  descriptionOverrides: DescriptionOverrides = {},
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -889,6 +941,11 @@ export function applyOverrides(
   // Before the added-entry append below, so the override keys stay aligned with
   // the PARSED achievement indices they were captured against.
   applyAchievementOverrides(nextParsed, achievements);
+  // Prose-body descriptions (#489). Runs before the added-entry append so its
+  // clone-and-set stays aligned with the PARSED entry indices the override keys
+  // were captured against; the later re-clone in applyAddedEntriesAndBullets
+  // preserves these edits.
+  applyDescriptionOverrides(nextParsed, descriptionOverrides);
   applySkillOverrides(nextParsed, skills);
 
   const nextSections = applyAddedEntriesAndBullets(

--- a/src/lib/edit/description-override-roundtrip.repro.test.ts
+++ b/src/lib/edit/description-override-roundtrip.repro.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+/**
+ * descriptionOverrides edit-leg round-trip (#489).
+ *
+ * The prose-body project branch (#464/#483) surfaced a parsed project's
+ * paragraph `description` as a read-only `<p>` — visible but with no input path,
+ * unlike a `•`-bulleted project which is fully editable. #489 adds the
+ * `descriptionOverrides` channel so that prose paragraph edits in place. This
+ * test is the acceptance proof the issue calls for: a description edit committed
+ * through `descriptionOverrides` SURVIVES a Download-PDF round-trip.
+ *
+ * It reproduces the production recipe exactly (mirroring corpus-edit-roundtrip):
+ *
+ *   parse1  = runCascade(fixture)
+ *   applied = applyOverrides(…, descriptionOverrides={ "projects:<i>": NEW })
+ *   display = { ...parse1, canonical: { …, fields: applied.fields } }
+ *   parse3  = runCascade(renderAtsResumePdf(buildAtsResumeModel(display, …)))
+ *   assert  = NEW description text is IN parse3; the value it replaced is NOT.
+ *
+ * The edit lands on `applied.fields.projects[i].description`, so the exported
+ * model reads it straight off `display` — no separate override pick is needed
+ * (contrast bullet/contact edits, which `useDownloadPdf` also passes separately).
+ *
+ * PII-safe: the assertion is on the authored `NEW_DESCRIPTION` literal (carrying
+ * the `Vantreon` sentinel, which must not occur in the corpus) and on the
+ * ABSENCE of a runtime-read original value — never a persisted fixture string.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { scoreForCascade } from "../heuristics/roundtrip-hop.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { applyOverrides } from "./apply-overrides.ts";
+import { buildAtsResumeModel } from "../pdf/ats-resume-model.ts";
+import { renderAtsResumePdf } from "../pdf/render-ats-pdf.ts";
+import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
+
+const FIXTURE = fileURLToPath(
+  new URL(
+    "../../../tests/fixtures/pdfs/unknown/single-column-projects-prose-body.pdf",
+    import.meta.url,
+  ),
+);
+
+// An authored replacement that MUST NOT occur in the fixture — the `Vantreon`
+// sentinel makes the presence check meaningful (a plain sentence could appear
+// verbatim and pass even if the edit were discarded).
+const NEW_DESCRIPTION =
+  "Vantreon rebuilt the résumé intake flow, cutting turnaround 38% across two quarters.";
+
+/** The first parsed project carrying a prose `description` — the exact
+ *  `!added && project.description` branch #489 targets. */
+function firstProseProject(
+  p: CascadeResult,
+): { index: number; original: string } {
+  const projects = p.canonical.fields.projects ?? [];
+  const index = projects.findIndex((proj) => Boolean(proj.description));
+  expect(index, "fixture should carry a prose-body project").toBeGreaterThanOrEqual(0);
+  return { index, original: projects[index].description! };
+}
+
+describe("descriptionOverrides edit-leg round-trip (#489)", { timeout: 20000 }, () => {
+  it("a prose-body project description edit survives Download PDF", async () => {
+    const p1 = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const { index, original } = firstProseProject(p1);
+
+    // Guard: the sentinel must not already be present, or the presence check
+    // below is vacuous.
+    expect(JSON.stringify(p1.canonical.fields).includes(NEW_DESCRIPTION)).toBe(false);
+
+    const observations = scoreForCascade(p1).bullets ?? [];
+    const applied = applyOverrides(
+      p1.canonical.fields,
+      p1.rawText,
+      p1.canonical.sections,
+      {}, // contact
+      {}, // experience
+      {}, // bullets
+      observations,
+      {}, // education
+      { removed: [], added: [] }, // skills
+      [], // addedEntries
+      {}, // addedBullets
+      new Set<number>(), // removedBullets
+      [], // profileOverrides
+      p1.canonical.fieldConfidence,
+      {}, // achievements
+      { [parsedEntryKey("projects", index)]: NEW_DESCRIPTION },
+    );
+
+    // 1. The edit is authoritative on the parsed model (feeds display + export).
+    expect(applied.fields.projects?.[index]?.description).toBe(NEW_DESCRIPTION);
+    // 2. The original parse is never mutated (apply-overrides purity).
+    expect(p1.canonical.fields.projects?.[index]?.description).toBe(original);
+
+    // 3. The edit survives the render → re-parse hop (Download PDF round-trip).
+    const display: CascadeResult = {
+      ...p1,
+      canonical: {
+        ...p1.canonical,
+        fields: applied.fields,
+        fieldConfidence: applied.fieldConfidence,
+      },
+    };
+    const model = buildAtsResumeModel(display, scoreForCascade(display), {
+      contactOverrides: {},
+      bulletOverrides: {},
+    });
+    const p3 = await runCascade(await renderAtsResumePdf(model));
+
+    const p3Text = JSON.stringify(p3.canonical.fields);
+    expect(p3Text.includes(NEW_DESCRIPTION)).toBe(true);
+    // The replaced prose is gone — a regression that dropped the edit would make
+    // parse3 carry the original text instead.
+    expect(p3Text.includes(original)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The prose-body project branch (`!added && project.description` in `ReconstructedResume.tsx`) rendered its description as a read-only `<p>` while the sibling bulleted branch was fully editable — an inconsistent edit surface in the fix-in-place lane. This routes the description through `EditableField` (multiline, paragraph render preserved) backed by a new `descriptionOverrides` map.

- **New `descriptionOverrides` channel** — `Record<string,string>`, keyed `parsedEntryKey("projects", i)`, threaded parallel to the existing override maps: state + setter in `useEditableParse.ts` → applied via new `applyDescriptionOverrides` (16th positional arg on `applyOverrides`) in `apply-overrides.ts` → consumed in `ReconstructedResume.tsx`. Wired into snapshot/replay/resetAll/hasEdits with `?? {}` back-compat for pre-#489 drafts.
- **JD-fit handoff** — `useJdFitResume.ts` passes the new map through too, so a prose-description edit survives the `/` → `/jd-fit` handoff (gap caught by the adversarial review pass).
- **Round-trip** — an edit commits back to the model and survives a Download PDF round-trip, verified by the new `description-override-roundtrip.repro.test.ts` against `single-column-projects-prose-body.pdf`. The bulleted-project edit path is unchanged.

Closes #489

## Test plan

- [x] `npm run typecheck` clean
- [x] Affected suites green: `apply-overrides.test.ts` (59), `description-override-roundtrip.repro.test.ts` (1), `corpus-edit-roundtrip.test.ts` (53), `corpus-roundtrip.test.ts`, `jd-fit-handoff.test.ts`, `useJdFitResume.test.tsx` — 183 passed / 1 skipped
- [x] `npm run lint` clean
- [x] Full `npm run verify` — green in CI

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #489 | Claude Opus 4.8 | ultra |
| Adversarial review | Claude Opus 4.8 | ultra |
| Review fixes | Claude Opus 4.8 (1M context) | ultra |
| Orchestration + PR | Claude Opus 4.8 (1M context) | ultra |
| Verification | `npm run verify` — green in CI | — |

## Adversarial review

1 round, 1 blocking finding → fixed → re-verified. Converged (no 2nd round needed: the fix was a scoped arg-threading mirror of the known-correct primary caller, validated by a new regression test).

**Blocking (fixed)**
- **JD-fit handoff dropped prose-description edits** — `src/jd-fit/useJdFitResume.ts` (the only other non-test `applyOverrides` caller) fell through to the `descriptionOverrides = {}` default while `replay()` now restores that map into edit state. A prose edit made on `/` would show in edit state but not apply after handoff to `/jd-fit`. Fixed by threading `handoffEdit.descriptionOverrides` as the 16th arg + adding it to the memo deps; covered by a new handoff-survival assertion.

**Nits (not blocking — noted for the human reviewer)**
- Committing an empty description clears the override → the branch falls to the "No bullet-shaped lines detected" fallback with no re-add affordance (consistent with other `EditableField` clears; the `undefined`-reverts path on `setDescriptionField` is unreachable from this UI).
- `resolveParsedDescriptionTarget` non-null asserts `nextParsed.projects![index]` for a `projects:i` key — unreachable today (override only settable from a rendered parsed project), mirrors the pre-existing added-bullet pattern.
- Prose-description edits don't move the anonymous score (pre-existing scorer limitation: the anon pool draws from `sections`/`rawText`, not `fields`) — issue scopes prose-vs-bullet score handling out.

**Fallow:** the snapshot/replay clone-group duplication in `useEditableParse.ts` is the established per-override-map house pattern (not worsened). `applyExperienceHeaderOverrides` complexity is pre-existing, untouched by #489.
