### PR TITLE
fix(parser): round-trip the one-line middot experience header — title/company swap (#436)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -141,16 +141,25 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   // reliable scanned signal) restores the full round-trip; no line remains.
 
   // ── One-line experience header (#436) ──
-  // The Download-PDF exporter now emits a ONE-LINE experience header
+  // The Download-PDF exporter emits a ONE-LINE experience header
   // ("Title · Company, Location · Team", date flush-right) instead of the older
   // stacked two-line shape (#284/#298). The text-only parser has no font signal,
   // so it used the two-line STRUCTURE to tell title from company; on one line
-  // that signal is gone, and fixtures with neutral / parenthetical / two-column
-  // company names re-parse title↔company-swapped or company-truncated. This is a
-  // deliberate look-over-fidelity tradeoff (`ats-resume-model.ts`); teaching the
-  // parser to round-trip the one-line shape is tracked as #436. Delete each line
-  // below as #436 lands (the ratchet forces it — a fixed fixture trips the
-  // stale-entry check).
+  // that signal is gone. #436 has TWO roots:
+  //
+  //   1. SWAP — a neutral two-segment middot header ("Composer · Northwind
+  //      Ensemble", no company-suffix / title-keyword either side) re-parsed
+  //      title↔company-swapped because the no-signal default read the first
+  //      segment as the company. FIXED: the `middot` title-first default in
+  //      `mapWithoutCompanyMatch` reads "Title · Company" per the export/#217
+  //      convention. Seven fixtures cleared their baseline via the ratchet.
+  //   2. TRUNCATION — a PARENTHETICAL / multi-word company on the one-line shape
+  //      ("Danggeun Pay Inc. (KarrotPay)" → "(KarrotPay)") still re-parses
+  //      truncated. STILL OPEN — the remaining lines below are this root (plus
+  //      two-column re-segmentation), a distinct follow-up from the swap.
+  //
+  // Delete each line below as its root lands (the ratchet forces it — a fixed
+  // fixture trips the stale-entry check).
   "google-docs/google-docs-skia-proxy-achievements-oneline.pdf": ["experience"],
   "google-docs/google-docs-skia-proxy-certifications.pdf": ["experience"],
   "google-docs/google-docs-skia-proxy-honors-subheadings.pdf": ["experience"],
@@ -163,22 +172,8 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   // the ratchet removes this line when #436 lands.
   "latex/awesome-cv-cv.pdf": ["experience"],
   "latex/awesome-cv-resume.pdf": ["experience"],
-  "latex/deedy-resume-macfonts.pdf": ["experience"],
-  "latex/deedy-resume-openfonts.pdf": ["experience"],
   "unknown/chromium-asymmetric-sidebar.pdf": ["experience"],
-  "unknown/chromium-two-column-sidebar.pdf": ["experience"],
-  "unknown/single-column-year-only-roundtrip.pdf": ["experience"],
-  "unknown/synthetic-two-experience-sections.pdf": ["experience"],
-  "unknown/two-column-achievements-sidebar.pdf": ["experience"],
   "unknown/weasyprint-cairo-two-column.pdf": ["experience"],
-  // #467's fixture exhibits the #436 one-line-header title/company swap on the
-  // two involvement roles ("Founding Member" / "Student Composers Association"
-  // and "Music Educator" / "Campus Outreach Program"): neither segment has a
-  // company-suffix or a title keyword, so the exporter's one-line
-  // "Title · Company" shape re-parses with splits[0] taken as company by the
-  // no-signal fall-through. Same #436 root as the group above; un-baseline
-  // when #436 lands.
-  "unknown/qualified-experience-relevant-coursework.pdf": ["experience"],
 };
 
 const CATEGORIES: Category[] = [

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -27,6 +27,12 @@ type Split = {
   text: string;
   source: number;
   via: "delim" | "comma" | "whole";
+  /** True when the delim split was cleaved by a `" · "` MIDDOT and no other
+   *  delimiter was present on the line — the exporter's one-line
+   *  `Title · Company, Location · Team` shape and the #217 "Title · Company"
+   *  convention. Lets the no-signal default read the first segment as the TITLE
+   *  (not the company), which is what that convention means (#436). */
+  middot?: boolean;
 };
 
 const LEGAL_SUFFIX_RE =
@@ -455,8 +461,12 @@ function splitHeaderSegments(filtered: string[]): Split[] {
   filtered.forEach((h, idx) => {
     const atSplit = h.split(/\s+@\s+|\s+—\s+|\s+\|\s+|\s+·\s+/);
     if (atSplit.length > 1) {
+      // A PURE-middot line ("Title · Company · Team") — the exporter's one-line
+      // shape (#436). Excludes a line that also carries `@`/`—`/`|`, which follow
+      // other ordering conventions.
+      const middot = /\s+·\s+/.test(h) && !/\s+[@—|]\s+/.test(h);
       atSplit.forEach((s) =>
-        splits.push({ text: s.trim(), source: idx, via: "delim" }),
+        splits.push({ text: s.trim(), source: idx, via: "delim", middot }),
       );
       return;
     }
@@ -752,8 +762,28 @@ function mapWithoutCompanyMatch(
       team: splits.find((s) => s.source === anchorIdx)?.text,
     };
   }
-  // No title-keyword signal and no stacked-shape anchor — assume top line
-  // is company (single-line header default).
+  // No title-keyword signal and no stacked-shape anchor. Default: the top line is
+  // the company (the stacked "Company \n Title" convention the parser inherited).
+  //
+  // EXCEPTION (#436) — a single-line MIDDOT header follows the OPPOSITE ordering:
+  // "Title · Company" ("Composer · Northwind Ensemble"). That is the exporter's
+  // one-line shape AND the dominant single-line résumé convention (#217), so a
+  // neutral two-segment middot split (no company/title keyword either side) must
+  // read the FIRST segment as the title — otherwise the exported header re-parses
+  // title↔company swapped and no round-trip holds. Guarded to a pure-middot split
+  // whose two segments share one source, so pipe/em-dash/@/stacked shapes keep the
+  // company-first default.
+  if (
+    splits[0]?.middot &&
+    splits[1] !== undefined &&
+    splits[0].source === splits[1].source
+  ) {
+    return {
+      title: splits[0].text,
+      company: splits[1].text,
+      team: splits[2]?.text,
+    };
+  }
   return {
     company: splits[0]?.text,
     title: splits[1]?.text,

--- a/src/lib/heuristics/extract/experience.mid-dot.test.ts
+++ b/src/lib/heuristics/extract/experience.mid-dot.test.ts
@@ -145,4 +145,36 @@ describe("mid-dot (·) single-line experience headers (#217)", () => {
     expect(roles[0].title).not.toContain("·");
     expect(roles[0].company).toContain("Computer Science Society");
   });
+
+  it("neutral two-segment header keeps 'Title · Company' order (no swap, #436)", () => {
+    // Neither segment carries a company-suffix or a title-keyword, so the
+    // company/title tiebreaks can't decide. A single-line MIDDOT header follows
+    // the "Title · Company" convention (the exporter's one-line shape, #217), so
+    // the first segment must be the TITLE — otherwise the reconstructed header
+    // re-parses title↔company swapped (the #436 round-trip failure).
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Composer · Northwind Ensemble", fontSize: 11 },
+      { text: "2019 - 2021", fontSize: 11 },
+      { text: "• Premiered twelve original chamber works.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].title).toBe("Composer");
+    expect(roles[0].company).toBe("Northwind Ensemble");
+  });
+
+  it("a PIPE header keeps the company-first default (middot flip is middot-only)", () => {
+    // The #436 title-first flip is gated to the MIDDOT delimiter. A "Company |
+    // Location"-style pipe header must keep the company-first default so the flip
+    // can't invert a different single-line convention.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Harborlight Chorale | Ensemble Member", fontSize: 11 },
+      { text: "2020 - 2022", fontSize: 11 },
+      { text: "• Sang in the touring ensemble.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Harborlight Chorale");
+    expect(roles[0].title).toBe("Ensemble Member");
+  });
 });

--- a/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
@@ -74,7 +74,7 @@ describe("#358 — year-only experience role round-trips (no title/company swap,
   // relied on, so the year-only titled+located role now re-parses
   // title↔company-swapped. Un-skip when #436 teaches the parser to disambiguate
   // title/company on a single header line.
-  it.skip("keeps title/company (no swap) and re-attaches the bare-year start_date", () => {
+  it("keeps title/company (no swap) and re-attaches the bare-year start_date", () => {
     const exp = reparsed.canonical.fields.experience ?? [];
     const composer = exp.find(
       (e) => e.title === "Composer" || e.company === "Composer",

--- a/src/lib/pdf/render-roundtrip.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip.repro.test.ts
@@ -87,11 +87,14 @@ describe("#284 — Download-PDF reconstructed résumé round-trips through the p
 
   // SUSPENDED (#436): the one-line experience header ("Title · Company,
   // Location  Dates") removes the two-line structural signal the parser used to
-  // tell title from company. This dense 8-role fixture has a parenthetical
-  // company ("Danggeun Pay Inc. (KarrotPay)") that now re-parses truncated, so
-  // per-role title/company no longer round-trips. The role COUNT (AC#1) and the
-  // education round-trip (#291) below are unaffected and still enforced. Un-skip
-  // when #436 lands the one-line title/company disambiguation.
+  // tell title from company. #436 has TWO roots: the title↔company SWAP on
+  // neutral middot segments (fixed — the `middot` title-first default in
+  // `mapWithoutCompanyMatch`), and company TRUNCATION on a PARENTHETICAL company
+  // ("Danggeun Pay Inc. (KarrotPay)" → "(KarrotPay)"), which this dense 8-role
+  // fixture exercises and which is NOT the swap. The truncation root is still
+  // open; the role COUNT (AC#1) and the education round-trip (#291) below are
+  // unaffected and still enforced. Un-skip when the parenthetical-company
+  // truncation lands.
   it.skip("re-parses each role's title / company back into the right fields (AC#3)", () => {
     const origExp = original.canonical.fields.experience ?? [];
     const reExp = reparsed.canonical.fields.experience ?? [];

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -135,7 +135,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -135,7 +135,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -147,7 +147,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/qualified-experience-relevant-coursework.expected.json
+++ b/tests/fixtures/pdfs/unknown/qualified-experience-relevant-coursework.expected.json
@@ -118,7 +118,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
@@ -122,7 +122,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
@@ -118,7 +118,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -139,7 +139,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,


### PR DESCRIPTION
## Summary

The Download-PDF exporter emits a one-line `Title · Company, Location · Team` header, dropping the two-line structural signal the parser used to tell title from company. A role whose two **middot** segments are both **neutral** (no company-suffix, no title-keyword) re-parsed title↔company **swapped**, because `mapWithoutCompanyMatch`'s no-signal default reads the first segment as the *company* (the stacked "Company \n Title" convention).

Captured live (parse1 → parse3): `Composer @ Northwind Ensemble` → `Northwind Ensemble @ Composer`.

A single-line **middot** header follows the opposite convention — `Title · Company` (the export shape and the dominant single-line résumé form, #217). Fix:
- Track the delimiter on each `Split` (pure-middot vs `@`/`—`/`|`).
- In the no-signal default, read a **single-source middot two-segment** split as **title-first**. Gated to the middot so pipe/em-dash/`@`/stacked shapes keep the company-first default (there's a pipe control test).

## Scope — the SWAP root only

#436 has two roots. This PR lands the **swap**; the **truncation** root (a parenthetical / multi-word company, `Danggeun Pay Inc. (KarrotPay)` → `(KarrotPay)`) is distinct and still open.

- **7 fixtures round-trip** and drop their `corpus-roundtrip` baselines (the ratchet forced it): deedy ×2, chromium-two-column-sidebar, qualified-experience-relevant-coursework, single-column-year-only, synthetic-two-experience-sections, two-column-achievements-sidebar.
- **Un-skipped** the #358 year-only repro (`render-roundtrip-year-only.repro`).
- **Still suspended** (truncation root, documented): the #284 AC#3 repro and the remaining 9 baselines (awesome-cv ×2, weasyprint-two-column, chromium-asymmetric, the 5 google-docs).

`Refs #436` (not `Closes` — truncation root remains).

## Test plan

- [x] New unit tests (`experience.mid-dot.test.ts`): neutral middot header keeps `Title · Company` order (no swap); a pipe header keeps company-first (flip is middot-only).
- [x] `corpus-roundtrip.test.ts` green — 7 baselines removed, ratchet satisfied; 9 remain (truncation root).
- [x] `corpus.test.ts` green — the 7 fixed fixtures' `experienceChangedAcrossRoundtrip` flips `true → false` (round-trip now holds); no forward-parse or `extractedCharCount` change.
- [x] `npm run typecheck` / `lint` clean; `npm run test` green (2473 passed).

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: full deterministic gate green locally; corpus snapshots are the derived round-trip boolean (deterministic — verify against CI).