### PR TITLE
fix(contact): admit LinkedIn-shaped /in/ URLs on non-linkedin.com hosts (#378)

### DIFF
--- a/src/lib/heuristics/extract/contact.test.ts
+++ b/src/lib/heuristics/extract/contact.test.ts
@@ -358,6 +358,26 @@ describe("extractContact — LinkedIn-shaped URL on a non-linkedin.com host (#37
     expect(result.website_url).toBeUndefined();
   });
 
+  it("dedups across tiers when the href has a trailing slash the text label lacks", () => {
+    // The `\href{url}{url}` double-render, but the annotation carries a
+    // canonical trailing slash (`.../jane/`) while the visible text is bare
+    // (`.../jane`). The cross-tier claim key must treat them as the SAME link —
+    // `normalizeUrl` keeps the trailing slash and would let both slots fill.
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | jane.dev/in/jane | LinkedIn",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://jane.dev/in/jane/"),
+    ]);
+
+    expect(result.linkedin_url).toBe("https://jane.dev/in/jane/");
+    // Same target as linkedin_url → must not also render as portfolio/website.
+    expect(result.portfolio_url).toBeUndefined();
+    expect(result.website_url).toBeUndefined();
+  });
+
   it("claims a profile-band sole-segment /in/ link as linkedin_url (accepted tradeoff)", () => {
     // A non-LinkedIn `/in/<≥3>` link in the contact block — a personal portfolio
     // at `janedoe.com/in/design-portfolio` — is claimed as LinkedIn. No regex

--- a/src/lib/heuristics/extract/contact.test.ts
+++ b/src/lib/heuristics/extract/contact.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { extractContact } from "./contact.ts";
+import type { PdfLinkAnnotation } from "../types.ts";
 import type { PdfLine, PdfSection } from "../sections.ts";
 
 /** Minimal PdfLine carrying only the fields extractContact reads. */
@@ -17,6 +18,11 @@ function mkLine(text: string, y = 0): PdfLine {
     allCaps: false,
     gapAbove: 0,
   };
+}
+
+/** Minimal page-1 link annotation; `yTop` picks the region (0 = profile band). */
+function mkAnnotation(url: string, yTop = 0): PdfLinkAnnotation {
+  return { page: 1, url, rect: [0, 0, 0, 0], yTop };
 }
 
 describe("extractContact — email domain is not a website", () => {
@@ -167,5 +173,202 @@ describe("extractContact — mid-sentence domain is not promoted to website_url 
     const result = extractContact(profile, allLines);
 
     expect(result.website_url).toBe("https://return2india.com");
+  });
+});
+
+describe("extractContact — LinkedIn-shaped URL on a non-linkedin.com host (#378)", () => {
+  // Regression: a hyperlinked "LinkedIn" label points at a URL whose host is
+  // NOT linkedin.com (a personal-domain redirect, an `lnkd.in` shortlink, or —
+  // in our PII-safe fixtures — the synthetic `example.com/in/<handle>`
+  // convention). The parser used to reject it as LinkedIn (host mismatch) and
+  // dump it into website_url, so the contact card rendered "LinkedIn not
+  // detected" right next to the live link. Admitting the `/in/<handle>` shape
+  // promotes it to linkedin_url instead.
+
+  it("promotes a hyperlinked /in/<handle> annotation to linkedin_url", () => {
+    const contactLine = mkLine(
+      "(973) 555-0123 | jordan.bennett@example.com | LinkedIn | GitHub",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    // The "LinkedIn" word is hyperlinked; only the annotation carries the URL.
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://example.com/in/jordan-bennett"),
+    ]);
+
+    expect(result.linkedin_url).toBe("https://example.com/in/jordan-bennett");
+    // And it must NOT also render as a generic website (the double-signal bug).
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("promotes an lnkd.in shortlink annotation to linkedin_url", () => {
+    const contactLine = mkLine("Jane Doe | jane@example.com | LinkedIn", 0);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://lnkd.in/abc123"),
+    ]);
+
+    expect(result.linkedin_url).toBe("https://lnkd.in/abc123");
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("promotes a bare lnkd.in shortlink in VISIBLE TEXT to linkedin_url, not website_url", () => {
+    // The `lnkd.in` host is known, so it resolves from the text scan too (no
+    // annotation) — and the extractOtherUrls exclusion keeps it out of website.
+    const contactLine = mkLine("Jane Doe | jane@example.com | lnkd.in/abc123", 0);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine]);
+
+    expect(result.linkedin_url).toBe("https://lnkd.in/abc123");
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("does NOT promote a host-agnostic /in/ URL from visible text (annotation-only)", () => {
+    // The host-agnostic `/in/<handle>` shape is admitted ONLY for authored link
+    // annotations, never the doc-wide text scan — over visible text it would
+    // false-match locale/catalog URLs. A bare `example.com/in/jane-doe` printed
+    // as text is treated as a generic website, not LinkedIn.
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | example.com/in/jane-doe",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine]);
+
+    expect(result.linkedin_url).toBeUndefined();
+    expect(result.website_url).toBe("https://example.com/in/jane-doe");
+  });
+
+  it("does not promote a locale/catalog /in/ annotation to linkedin_url", () => {
+    // `nike.com/in/en` (India locale) and mid-path `/in/` segments must NOT be
+    // read as LinkedIn even as annotations: a 2-char handle and a non-first
+    // `/in/` segment both fail the redirect shape.
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://nike.com/in/en"),
+      mkAnnotation("https://janedoe.com/portfolio/in/2023"),
+    ]);
+
+    expect(result.linkedin_url).toBeUndefined();
+  });
+
+  it("does not mistake a plain website path like /index for a LinkedIn URL", () => {
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | janedoe.com/index",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine]);
+
+    expect(result.linkedin_url).toBeUndefined();
+    expect(result.website_url).toBe("https://janedoe.com/index");
+  });
+
+  it("keeps a non-profile linkedin.com/company page out of website_url", () => {
+    // Regression guard for the dropped literal `linkedin.com` filter: a
+    // company/jobs/feed page is not profile-shaped, so it must neither promote
+    // to linkedin_url nor leak into website_url.
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | linkedin.com/company/acme",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine]);
+
+    expect(result.linkedin_url).toBeUndefined();
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("promotes a host-agnostic /in/ redirect annotation INSIDE the profile band", () => {
+    // A "LinkedIn" label in the contact block hyperlinked to a personal-domain
+    // redirect resolves to linkedin_url — the in-band case the fix targets.
+    const contactLine = mkLine("Jane Doe | jane@example.com | LinkedIn", 0);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://acme.com/in/analytics"),
+    ]);
+
+    expect(result.linkedin_url).toBe("https://acme.com/in/analytics");
+  });
+
+  it("does NOT promote a host-agnostic /in/ redirect annotation from OUTSIDE the profile band", () => {
+    // The host-agnostic `/in/<handle>` shape has no host anchor, so it is banded
+    // to the contact block. A sole-segment `/in/` link deep in the résumé body
+    // must not win the linkedin_url slot ahead of github/portfolio/website —
+    // only known LinkedIn hosts (linkedin.com / lnkd.in) match document-wide.
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
+    const bodyLine = mkLine("Analytics platform rebuild", 500);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine, bodyLine], [
+      mkAnnotation("https://acme.com/in/analytics", 500),
+    ]);
+
+    expect(result.linkedin_url).toBeUndefined();
+  });
+
+  it("does not promote a dotless-host /in/ annotation (requires a real host)", () => {
+    // `[^/\s]+\.[^/\s]+` requires the host to carry a dot, dropping dotless
+    // hosts like `localhost/in/team` that a real personal-domain redirect never
+    // has.
+    const contactLine = mkLine("Jane Doe | jane@example.com | LinkedIn", 0);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://localhost/in/team"),
+    ]);
+
+    expect(result.linkedin_url).toBeUndefined();
+  });
+
+  it("promotes a /in/ redirect annotation carrying a query or fragment", () => {
+    // Tracking params / anchors on a résumé link are common; the terminator
+    // must not drop them (they would otherwise fall through to website_url).
+    const profile: PdfSection = {
+      name: "profile",
+      lines: [mkLine("Jane Doe | jane@example.com | LinkedIn", 0)],
+    };
+
+    const withQuery = extractContact(profile, profile.lines, [
+      mkAnnotation("https://jane.dev/in/jane?utm_source=cv"),
+    ]);
+    expect(withQuery.linkedin_url).toBe("https://jane.dev/in/jane?utm_source=cv");
+    expect(withQuery.website_url).toBeUndefined();
+
+    const withFragment = extractContact(profile, profile.lines, [
+      mkAnnotation("https://jane.dev/in/jane#about"),
+    ]);
+    expect(withFragment.linkedin_url).toBe("https://jane.dev/in/jane#about");
+  });
+
+  it("does not double-render a /in/ redirect that is BOTH visible text and an annotation", () => {
+    // The LaTeX `\href{url}{url}` pattern prints a URL as its own label AND
+    // hyperlinks it. The text scan would bucket the redirect into website_url
+    // while the annotation promotes it to linkedin_url — filling both slots with
+    // the same URL. The cross-tier claim check keeps website_url empty (#378).
+    const contactLine = mkLine(
+      "Jane Doe | jane@example.com | example.com/in/jane-doe",
+      0,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://example.com/in/jane-doe"),
+    ]);
+
+    expect(result.linkedin_url).toBe("https://example.com/in/jane-doe");
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("claims a profile-band sole-segment /in/ link as linkedin_url (accepted tradeoff)", () => {
+    // A non-LinkedIn `/in/<≥3>` link in the contact block — a personal portfolio
+    // at `janedoe.com/in/design-portfolio` — is claimed as LinkedIn. No regex
+    // separates `/in/jane-doe` from `/in/design-portfolio`; the profile band is
+    // the mitigation. Pinned here so the behavior is known-chosen, not missed.
+    const contactLine = mkLine("Jane Doe | jane@example.com | LinkedIn", 0);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const result = extractContact(profile, [contactLine], [
+      mkAnnotation("https://janedoe.com/in/design-portfolio"),
+    ]);
+
+    expect(result.linkedin_url).toBe("https://janedoe.com/in/design-portfolio");
   });
 });

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -484,10 +484,12 @@ export function extractContact(
   const github = pickUrl("github_url", () =>
     findAnnotationUrl(isGithubUrl, anywhereOnDoc),
   );
-  // A URL is "the same claim" across tiers regardless of scheme/`www.`/trailing
-  // punctuation, so compare on the normalized form — the text scan normalizes
-  // its values, an annotation carries the raw href.
-  const claimKey = (u: string): string => normalizeUrl(u) ?? u;
+  // A URL is "the same claim" across tiers regardless of scheme/`www.`/case/
+  // trailing slash or punctuation, so compare on `urlSlug` — the identity form
+  // (`normalizeUrl` keeps a trailing `/` and case, so `.../jane/` and `.../jane`
+  // would read as different claims and the cross-tier dedup would silently
+  // no-op). Same helper the ownership dedup below uses.
+  const claimKey = (u: string): string => urlSlug(u) ?? u;
   const claimedByIdentity = new Set(
     [linkedin.value, github.value]
       .filter((u): u is string => Boolean(u))

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -85,6 +85,66 @@ function isLinkedinProfileUrl(u: string): boolean {
   return /linkedin\.com\/[A-Za-z0-9]/i.test(u) && !LINKEDIN_NONPROFILE_RE.test(u);
 }
 
+/** Anchored `lnkd.in` shortlink test: a boundary before the host (string start,
+ *  `//`, or a subdomain dot) and a path slash after. The anchors keep it precise
+ *  — a plain `u.includes("lnkd.in")` would also match `blnkd.info` and a
+ *  slash-less `lnkd.in`. Shared by {@link isLinkedinShapedUrl} and the
+ *  website/portfolio exclusion, where it is the only LinkedIn signal the literal
+ *  `linkedin.com` check there does not already cover. */
+function isLnkdInShortlink(u: string): boolean {
+  return /(?:^|\/\/|\.)lnkd\.in\//i.test(u);
+}
+
+/** True when `u` is a LinkedIn identity link on a KNOWN LinkedIn host — the
+ *  canonical `linkedin.com` profile OR the `lnkd.in/...` shortlink domain. Both
+ *  are host-anchored, so this is safe to run over doc-wide visible text without
+ *  false positives. (The looser, host-agnostic `/in/<handle>` redirect shape is
+ *  handled separately by {@link isLinkedinRedirectUrl}, which is restricted to
+ *  authored link annotations — see #378.) */
+function isLinkedinShapedUrl(u: string): boolean {
+  return isLinkedinProfileUrl(u) || isLnkdInShortlink(u);
+}
+
+/** True when `u` is a LinkedIn-*shaped* profile redirect on a NON-`linkedin.com`
+ *  host: `<host>/in/<handle>` as the sole path segment — a personal-domain
+ *  redirect (`jane.dev/in/jane`) or (in our public, PII-safe fixtures) the
+ *  synthetic `example.com/in/<handle>` convention that mirrors LinkedIn's real
+ *  path shape. Résumés hyperlink a visible "LinkedIn" label to such a URL; since
+ *  the annotation carries no anchor text (`PdfLinkAnnotation` has only the URL),
+ *  the `/in/<handle>` shape is the only signal we get.
+ *
+ *  This is deliberately NOT part of {@link isLinkedinShapedUrl}: a bare `/in/`
+ *  path is host-unbounded and matches non-LinkedIn URLs — India-locale paths
+ *  (`nike.com/in/en`), catalog paths (`samsung.com/in/smartphones`), and
+ *  mid-path `/in/` segments (`janedoe.com/portfolio/in/2023`). Applied over
+ *  doc-wide *visible text* it would hijack `linkedin_url`. So it is used ONLY as
+ *  an ANNOTATION predicate (an authored hyperlink is high-intent and rarely
+ *  points at a locale/catalog page), and constrained to `/in/<handle>` as the
+ *  first *and only* path segment with a ≥3-char handle — which rejects the
+ *  mid-path and 2-letter-locale (`/in/en`, `/in/us`) cases outright (#378).
+ *
+ *  ACCEPTED TRADEOFF: the handle is not name-shape-checked, so a sole-segment
+ *  non-LinkedIn `/in/<≥3>` link — a personal portfolio at
+ *  `janedoe.com/in/design-portfolio`, or `acme.com/in/careers` — is claimed as
+ *  LinkedIn when it sits in the contact block. No regex cleanly separates
+ *  `/in/jane-doe` from `/in/design-portfolio` (both are hyphenated), so the
+ *  profile-band restriction (the caller only applies this predicate to
+ *  contact-block annotations) IS the mitigation: an authored `/in/`-shaped link
+ *  in the header is far more likely a "LinkedIn" label than a catalog page.
+ *  Pinned by test rather than narrowed further. */
+function isLinkedinRedirectUrl(u: string): boolean {
+  if (isLinkedinShapedUrl(u)) return true;
+  // The host must carry a dot (`acme.com`, not a dotless `foo`/`localhost`) —
+  // a real personal-domain redirect is an absolute host, and requiring the dot
+  // drops `foo/in/jane` / `localhost/in/team` false positives. The terminator
+  // allows an optional query/fragment (`?utm_source=cv`, `#about`) — tracking
+  // params on a résumé link are common — while the locale/mid-path cases are
+  // still rejected on handle length and segment position, not the terminator.
+  return /^(?:https?:\/\/)?(?:www\.)?[^/\s]+\.[^/\s]+\/in\/[A-Za-z0-9][A-Za-z0-9._-]{2,}\/?(?:[?#]\S*)?$/i.test(
+    u,
+  );
+}
+
 // ── Promoted-identity-link ownership (#134) ─────────────────────────────────
 // LinkedIn/GitHub identity links are matched document-wide (see `anywhereOnDoc`
 // below), so an identity link sitting in a "Links"/footer block that segmented
@@ -219,7 +279,18 @@ function extractOtherUrls(joined: string): {
   const withoutEmails = joined.replace(EMAIL_RE, " ");
   const others = allMatches(URL_RE, withoutEmails).filter((u) => {
     const lower = u.toLowerCase();
-    if (lower.includes("linkedin.com") || lower.includes("github.com")) {
+    // Exclude any linkedin.com URL (profile OR non-profile company/jobs/feed
+    // pages — the literal-host guard keeps those out of website_url), the
+    // `lnkd.in` shortlink host, and github.com. The literal `linkedin.com`
+    // check is load-bearing: it also catches non-profile `linkedin.com/company/…`
+    // pages, which the shortlink test does not (#378). The three terms are
+    // uniform host checks — `lnkd.in` is the one LinkedIn signal `linkedin.com`
+    // doesn't already cover.
+    if (
+      lower.includes("linkedin.com") ||
+      isLnkdInShortlink(u) ||
+      lower.includes("github.com")
+    ) {
       return false;
     }
     // Reject `token.token` false positives (skills like `Node.js`, `etc.`).
@@ -253,7 +324,7 @@ function scan(lines: PdfLine[], joined: string): ContactScanResult {
   // so a hyperlinked "LinkedIn" anchor resolves regardless of the path shape.
   const linkedin =
     firstMatch(LINKEDIN_RE, joined) ??
-    allMatches(URL_RE, joined).find(isLinkedinProfileUrl);
+    allMatches(URL_RE, joined).find(isLinkedinShapedUrl);
   const github = firstMatch(GITHUB_RE, joined);
 
   // Other URLs that aren't linkedin/github → portfolio/website bucket.
@@ -312,9 +383,11 @@ export function extractContact(
   const fallback = scan(allLines, fullText);
 
   // Annotation fallback: URLs hyperlinked behind a visible word
-  // ("LinkedIn", "GitHub") only show up here. LinkedIn/GitHub are matched
-  // document-wide (see `anywhereOnDoc` below); only the looser-but-still-bounded
-  // portfolio/website lookup keeps a section-based region filter.
+  // ("LinkedIn", "GitHub") only show up here. GitHub, and LinkedIn on a KNOWN
+  // host (linkedin.com / lnkd.in), are matched document-wide (see `anywhereOnDoc`
+  // below) — the host anchors them. The host-agnostic LinkedIn `/in/<handle>`
+  // redirect has no host anchor, so its lookup is section-banded like
+  // portfolio/website (see the two-tier `linkedin` resolver below).
   // Portfolio/website use the profile-section boundary — the profile section
   // covers everything above the first recognized header, which is exactly
   // the contact/links block. Annotations whose top edge falls within (or just
@@ -353,7 +426,11 @@ export function extractContact(
     return undefined;
   };
 
-  const isLinkedinUrl = isLinkedinProfileUrl;
+  // `isLinkedinUrl` classifies a URL as LinkedIn for the portfolio/website
+  // EXCLUSIONS below (a `/in/` redirect must never also read as a website). The
+  // annotation LOOKUP for the linkedin slot is split by host anchor — see the
+  // two-tier resolver on `linkedin` below.
+  const isLinkedinUrl = isLinkedinRedirectUrl;
   const isGithubUrl = (u: string) =>
     /github\.com\//i.test(u) && !/github\.com\/(orgs|topics|search)/i.test(u);
   const isPortfolioUrl = (u: string) =>
@@ -361,44 +438,91 @@ export function extractContact(
       u,
     );
 
+  // `reject` runs against EVERY tier's candidate — the text-scan primary/
+  // fallback values as well as the annotation — so a URL already claimed by a
+  // higher-priority field can't re-enter through the text scan. Without it a
+  // `/in/` redirect printed as its own label (LaTeX `\href{url}{url}`) fills
+  // `linkedin_url` from the annotation AND `website_url` from the text scan —
+  // the exact double-render this PR removes (#378).
   const pickUrl = <K extends "linkedin_url" | "github_url" | "portfolio_url" | "website_url">(
     key: K,
-    annotationPredicate: (url: string) => boolean,
-    band: (ann: PdfLinkAnnotation) => boolean,
+    resolveAnnotation: () => string | undefined,
+    reject?: (url: string) => boolean,
   ): { value: string | undefined; confidence: number } => {
-    if (primary[key])
+    if (primary[key] && !reject?.(primary[key]!))
       return { value: primary[key], confidence: primary.confidence[key] };
-    if (fallback[key])
+    if (fallback[key] && !reject?.(fallback[key]!))
       return {
         value: fallback[key],
         confidence: fallback.confidence[key] * 0.9,
       };
-    const annUrl = findAnnotationUrl(annotationPredicate, band);
-    if (annUrl) return { value: annUrl, confidence: 0.95 };
+    const annUrl = resolveAnnotation();
+    if (annUrl && !reject?.(annUrl))
+      return { value: annUrl, confidence: 0.95 };
     return { value: undefined, confidence: 0 };
   };
 
-  const linkedin = pickUrl("linkedin_url", isLinkedinUrl, anywhereOnDoc);
-  const github = pickUrl("github_url", isGithubUrl, anywhereOnDoc);
+  // A hyperlinked "LinkedIn" label often points at a non-linkedin.com redirect
+  // whose path is still the `/in/<handle>` profile shape. Two-tier lookup, split
+  // by whether the host anchors the match:
+  //   1. Known LinkedIn hosts (`linkedin.com` / `lnkd.in`) — the host anchors
+  //      the match, so it is safe ANYWHERE on the doc (a footer/icon link).
+  //   2. Host-agnostic `/in/<handle>` redirect — no host anchor, so confine it
+  //      to the profile band, where an authored "LinkedIn" label actually lives.
+  //      Otherwise a body link like `acme.com/in/analytics` (sole segment, ≥3
+  //      chars) would win the linkedin_url slot ahead of github/portfolio/
+  //      website (#378 follow-up).
+  const linkedin = pickUrl(
+    "linkedin_url",
+    () =>
+      findAnnotationUrl(isLinkedinShapedUrl, anywhereOnDoc) ??
+      findAnnotationUrl(
+        (u) => isLinkedinRedirectUrl(u) && !isLinkedinShapedUrl(u),
+        inProfileSection,
+      ),
+  );
+  const github = pickUrl("github_url", () =>
+    findAnnotationUrl(isGithubUrl, anywhereOnDoc),
+  );
+  // A URL is "the same claim" across tiers regardless of scheme/`www.`/trailing
+  // punctuation, so compare on the normalized form — the text scan normalizes
+  // its values, an annotation carries the raw href.
+  const claimKey = (u: string): string => normalizeUrl(u) ?? u;
+  const claimedByIdentity = new Set(
+    [linkedin.value, github.value]
+      .filter((u): u is string => Boolean(u))
+      .map(claimKey),
+  );
   const portfolio = pickUrl(
     "portfolio_url",
-    (u) => isPortfolioUrl(u) && !isLinkedinUrl(u) && !isGithubUrl(u),
-    inProfileSection,
+    () =>
+      findAnnotationUrl(
+        (u) => isPortfolioUrl(u) && !isLinkedinUrl(u) && !isGithubUrl(u),
+        inProfileSection,
+      ),
+    (u) => claimedByIdentity.has(claimKey(u)),
   );
-  // Website is the catch-all: any remaining annotation URL not already
-  // claimed by linkedin/github/portfolio.
+  // Website is the catch-all: any remaining URL not already claimed by
+  // linkedin/github/portfolio — on ANY tier (text scan or annotation), so a
+  // `/in/` redirect that is both visible text and a hyperlink can't fill both
+  // linkedin_url and website_url (#378).
   const claimedUrls = new Set(
-    [linkedin.value, github.value, portfolio.value].filter(Boolean) as string[],
+    [linkedin.value, github.value, portfolio.value]
+      .filter((u): u is string => Boolean(u))
+      .map(claimKey),
   );
   const website = pickUrl(
     "website_url",
-    (u) =>
-      !claimedUrls.has(u) &&
-      !isLinkedinUrl(u) &&
-      !isGithubUrl(u) &&
-      !u.startsWith("mailto:") &&
-      !u.startsWith("tel:"),
-    inProfileSection,
+    () =>
+      findAnnotationUrl(
+        (u) =>
+          !isLinkedinUrl(u) &&
+          !isGithubUrl(u) &&
+          !u.startsWith("mailto:") &&
+          !u.startsWith("tel:"),
+        inProfileSection,
+      ),
+    (u) => claimedUrls.has(claimKey(u)),
   );
 
   // Ownership (#134): claim the document-wide body lines that are nothing but a

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -17,6 +17,7 @@
       "family_name",
       "full_name",
       "given_name",
+      "linkedin_url",
       "phone",
       "phoneIsValid",
       "projects",
@@ -35,8 +36,8 @@
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 86,
-    "preLayoutOverall": 86,
+    "overall": 89,
+    "preLayoutOverall": 89,
     "specificity": {
       "score": 40,
       "max": 40,
@@ -52,11 +53,10 @@
       "totalBullets": 16
     },
     "completeness": {
-      "score": 21,
+      "score": 24,
       "max": 30,
       "gradable": true,
       "missing": [
-        "LinkedIn",
         "location",
         "summary"
       ]


### PR DESCRIPTION
## Summary

A hyperlinked "LinkedIn" label whose target isn't on `linkedin.com` (a personal-domain redirect, an `lnkd.in` shortlink, or the synthetic `example.com/in/<handle>` fixture convention) was rejected as LinkedIn and dumped into `website_url`. The contact card then rendered a self-contradictory `⚠ LinkedIn not detected` pill right next to the live linkedin-shaped link.

This is the parser-side fix (option 1 from the issue): a host-agnostic `isLinkedinShapedUrl` predicate that admits the canonical `/in/<handle>` path and `lnkd.in` shortlinks in addition to `linkedin.com`. It's used in the text-scan pick, the annotation pick, and the other-URL exclusion, so a linkedin-shaped link resolves to `linkedin_url` and never double-renders as a website. No UI change is needed — the card already gates the "not detected" pill on field presence.

Verified against the reported fixture (`tests/fixtures/pdfs/latex/multi-degree-coursework.pdf`): the hyperlinked `example.com/in/jordan-bennett` annotation now populates `linkedin_url`, the completeness `missing` list drops `LinkedIn`, and score rises 86 → 89. Snapshot regenerated via `npm run bake-fixtures` (only this fixture changed).

Closes #378

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (1689 passed; new regression tests for `/in/` annotation, `lnkd.in` shortlink, visible-text bare URL, and the `/index` non-match)