### PR TITLE
fix(edit): drop blank "+ Add" entries left empty on section exit (#379)

### DIFF
--- a/src/components/features/ReconstructedAdd.test.ts
+++ b/src/components/features/ReconstructedAdd.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FocusEvent } from "react";
+import { sectionExitBlur } from "./ReconstructedAdd.tsx";
+
+/** Minimal stand-in for the parts of a React FocusEvent the handler reads:
+ *  `currentTarget.contains(relatedTarget)` decides whether focus stayed inside
+ *  the section subtree. */
+function blurEvent(focusStaysInside: boolean): FocusEvent<HTMLElement> {
+  return {
+    currentTarget: { contains: () => focusStaysInside },
+    relatedTarget: focusStaysInside ? {} : null,
+  } as unknown as FocusEvent<HTMLElement>;
+}
+
+describe("sectionExitBlur (issue 379)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("fires onExit (deferred a tick) when focus leaves the section", () => {
+    const onExit = vi.fn();
+    sectionExitBlur(onExit)(blurEvent(false));
+
+    // Deferred: not called synchronously, so an in-flight field commit lands first.
+    expect(onExit).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire when focus moves to another element inside the section", () => {
+    const onExit = vi.fn();
+    sectionExitBlur(onExit)(blurEvent(true));
+
+    vi.runAllTimers();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/features/ReconstructedAdd.tsx
+++ b/src/components/features/ReconstructedAdd.tsx
@@ -16,7 +16,31 @@
  */
 
 import { useState } from "react";
+import type { FocusEvent } from "react";
 import { Button } from "@design-system";
+
+/**
+ * Build an `onBlur` handler for a section container that fires `onExit` when
+ * focus leaves the section's DOM subtree (the standard
+ * `currentTarget.contains(relatedTarget)` idiom, shared with
+ * {@link InlineBulletAdd}). Used to prune a blank "ghost" entry the user opened
+ * with "+ Add …" and abandoned without typing (#379): the "+ Add" pill lives
+ * inside the section and holds focus after the click, so a focus-exit fires
+ * reliably even though the click-to-edit fields never autofocus.
+ *
+ * The prune is deferred one tick because a field commit fires on the SAME blur
+ * event that leaves the section; running `onExit` synchronously would test the
+ * entry's emptiness against pre-commit state and wrongly drop an entry the user
+ * just typed into. The macrotask lets React flush the commit first.
+ */
+export function sectionExitBlur(
+  onExit: () => void,
+): (e: FocusEvent<HTMLElement>) => void {
+  return (e) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setTimeout(onExit, 0);
+  };
+}
 
 /** A small X glyph, matching the SkillChip remove control. */
 function CloseIcon() {

--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -128,6 +128,7 @@ describe("EducationSection date-row symmetry (issue 376)", () => {
         onAddEntry: () => {},
         onRemoveEntry: () => {},
         onEntryField: () => {},
+        onPruneEmpty: () => {},
       }),
     );
   }

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -30,7 +30,7 @@ import { buildEducationDates } from "../../lib/score/entry-dates.ts";
 import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
 import { Button, EditableField } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
-import { AddPill, RemoveButton } from "./ReconstructedAdd.tsx";
+import { AddPill, RemoveButton, sectionExitBlur } from "./ReconstructedAdd.tsx";
 
 /** Map an EducationEntry field name to the flat AddedEntry field it edits.
  *  `field` (major) is intentionally omitted — added entries carry no major slot,
@@ -216,6 +216,7 @@ export function EducationSection({
   onAddEntry,
   onRemoveEntry,
   onEntryField,
+  onPruneEmpty,
 }: {
   /** Verbatim source heading (#285); falls back to "Education" when absent. */
   heading?: string;
@@ -233,9 +234,14 @@ export function EducationSection({
   onAddEntry: () => void;
   onRemoveEntry: (id: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
+  /** Drop a blank added entry when focus leaves the section (#379). */
+  onPruneEmpty: () => void;
 }) {
   return (
-    <section className="flex flex-col gap-2">
+    <section
+      className="flex flex-col gap-2"
+      onBlur={sectionExitBlur(onPruneEmpty)}
+    >
       <SectionHeading>{heading ?? "Education"}</SectionHeading>
       {education.length === 0 ? (
         <NotDetected what="education" />

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -82,6 +82,7 @@ import {
   RemoveButton,
   InlineBulletAdd,
   SectionEmptyHint,
+  sectionExitBlur,
 } from "./ReconstructedAdd.tsx";
 import { AchievementTypePicker } from "./AchievementTypePicker.tsx";
 import {
@@ -397,6 +398,7 @@ function ExperienceSection({
   onRemoveEntry,
   onEntryField,
   onAddBullet,
+  onPruneEmpty,
 }: {
   /** Verbatim source heading (#285); falls back to "Experience" when absent. */
   heading?: string;
@@ -430,6 +432,8 @@ function ExperienceSection({
   onRemoveEntry: (id: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
   onAddBullet: (entryKey: string, text: string) => void;
+  /** Drop a blank added entry when focus leaves the section (#379). */
+  onPruneEmpty: () => void;
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
@@ -471,7 +475,10 @@ function ExperienceSection({
     panel: resumeRewritePanel,
   } = useResumeRewriteUi(resumeSections, rewriteApplyBySection, jdContext);
   return (
-    <section className="flex flex-col gap-3">
+    <section
+      className="flex flex-col gap-3"
+      onBlur={sectionExitBlur(onPruneEmpty)}
+    >
       {/* Heading row: the flag legend sits beside the Experience title (next to
           where the inline glyphs actually appear), not at the top of the
           section where it reads as detached. */}
@@ -575,6 +582,7 @@ function ProjectsSection({
   onEntryField,
   onDescriptionField,
   onAddBullet,
+  onPruneEmpty,
 }: {
   /** Verbatim source heading (#285); falls back to "Projects" when absent. */
   heading?: string;
@@ -593,9 +601,14 @@ function ProjectsSection({
   /** Commit an edit to a parsed project's prose description (#489). */
   onDescriptionField: (key: string, value: string | undefined) => void;
   onAddBullet: (entryKey: string, text: string) => void;
+  /** Drop a blank added entry when focus leaves the section (#379). */
+  onPruneEmpty: () => void;
 }) {
   return (
-    <section className="flex flex-col gap-3">
+    <section
+      className="flex flex-col gap-3"
+      onBlur={sectionExitBlur(onPruneEmpty)}
+    >
       <SectionHeading>{heading ?? "Projects"}</SectionHeading>
       <div className="flex flex-col gap-4">
         {projects.map((project, i) => {
@@ -784,6 +797,7 @@ function AchievementsSection({
   onEntryField,
   onAchievementField,
   onAddBullet,
+  onPruneEmpty,
 }: {
   /** Verbatim source heading (#285); falls back to "Achievements" when absent. */
   heading?: string;
@@ -802,9 +816,14 @@ function AchievementsSection({
     value: string,
   ) => void;
   onAddBullet: (entryKey: string, text: string) => void;
+  /** Drop a blank added entry when focus leaves the section (#379). */
+  onPruneEmpty: () => void;
 }) {
   return (
-    <section className="flex flex-col gap-3">
+    <section
+      className="flex flex-col gap-3"
+      onBlur={sectionExitBlur(onPruneEmpty)}
+    >
       <SectionHeading>{heading ?? "Achievements"}</SectionHeading>
       <div className="flex flex-col gap-4">
         {achievements.map((achievement, i) => {
@@ -992,6 +1011,7 @@ export function ReconstructedResume({
     setAchievementField,
     addEntry,
     removeEntry,
+    pruneEmptyAddedEntries,
     setEntryField,
     addBullet,
     addSkill,
@@ -1129,6 +1149,7 @@ export function ReconstructedResume({
       addedAchievements={addedAchievements}
       originalCount={originalAchCount}
       onAddEntry={() => addEntry("achievements")}
+      onPruneEmpty={() => pruneEmptyAddedEntries("achievements")}
       onRemoveEntry={removeEntry}
       onEntryField={setEntryField}
       onAchievementField={setAchievementField}
@@ -1206,6 +1227,7 @@ export function ReconstructedResume({
         addedExperience={addedExperience}
         originalCount={originalExpCount}
         onAddEntry={() => addEntry("experience")}
+        onPruneEmpty={() => pruneEmptyAddedEntries("experience")}
         onRemoveEntry={removeEntry}
         onEntryField={setEntryField}
         onAddBullet={addBullet}
@@ -1219,6 +1241,7 @@ export function ReconstructedResume({
         addedProjects={addedProjects}
         originalCount={originalProjCount}
         onAddEntry={() => addEntry("projects")}
+        onPruneEmpty={() => pruneEmptyAddedEntries("projects")}
         onRemoveEntry={removeEntry}
         onEntryField={setEntryField}
         onDescriptionField={setDescriptionField}
@@ -1235,6 +1258,7 @@ export function ReconstructedResume({
         addedEducation={addedEducation}
         originalCount={originalEduCount}
         onAddEntry={() => addEntry("education")}
+        onPruneEmpty={() => pruneEmptyAddedEntries("education")}
         onRemoveEntry={removeEntry}
         onEntryField={setEntryField}
       />

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The resumelint Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Tests for the empty-added-entry pruning that backs #379 — a "+ Add …" entry
+ * the user opens and abandons without typing must not persist.
+ *
+ * `isAddedEntryEmpty` is pure and tested directly. `pruneEmptyAddedEntries` is
+ * exercised through a probe component (the project has no
+ * @testing-library/react — same pattern as `useAnalyzedResume.test.tsx`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  useEditableParse,
+  isAddedEntryEmpty,
+  type EditableParse,
+  type AddedEntry,
+} from "./useEditableParse.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+describe("isAddedEntryEmpty", () => {
+  const base: AddedEntry = { id: "added:0", section: "education", title: "" };
+
+  it("is true for a freshly-added, untouched entry with no bullets", () => {
+    expect(isAddedEntryEmpty(base, {})).toBe(true);
+  });
+
+  it("treats whitespace-only header fields as empty", () => {
+    expect(isAddedEntryEmpty({ ...base, title: "   ", subtitle: "\t" }, {})).toBe(
+      true,
+    );
+  });
+
+  it("is false when any header field carries content", () => {
+    expect(isAddedEntryEmpty({ ...base, title: "BSc CS" }, {})).toBe(false);
+    expect(isAddedEntryEmpty({ ...base, subtitle: "State U" }, {})).toBe(false);
+    expect(isAddedEntryEmpty({ ...base, start_date: "2019" }, {})).toBe(false);
+  });
+
+  it("is false when the entry has appended bullets, even with a blank header", () => {
+    expect(isAddedEntryEmpty(base, { "added:0": ["Did a thing"] })).toBe(false);
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+let api: EditableParse;
+
+function Probe() {
+  api = useEditableParse();
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Probe />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useEditableParse — pruneEmptyAddedEntries (#379)", () => {
+  it("drops a blank added entry in the target section", () => {
+    let id = "";
+    act(() => {
+      id = api.addEntry("education");
+    });
+    expect(api.addedEntries).toHaveLength(1);
+
+    act(() => api.pruneEmptyAddedEntries("education"));
+    expect(api.addedEntries).toHaveLength(0);
+    expect(id).toMatch(/^added:/);
+  });
+
+  it("keeps an entry that has any populated field", () => {
+    let id = "";
+    act(() => {
+      id = api.addEntry("education");
+      api.setEntryField(id, "title", "BSc CS");
+    });
+
+    act(() => api.pruneEmptyAddedEntries("education"));
+    expect(api.addedEntries).toHaveLength(1);
+    expect(api.addedEntries[0].title).toBe("BSc CS");
+  });
+
+  it("keeps a blank entry that has appended bullets", () => {
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+      api.addBullet(id, "Shipped a feature");
+    });
+
+    act(() => api.pruneEmptyAddedEntries("experience"));
+    expect(api.addedEntries).toHaveLength(1);
+  });
+
+  it("prunes only the named section, leaving a fresh entry in another section", () => {
+    act(() => {
+      api.addEntry("education");
+      api.addEntry("experience");
+    });
+    expect(api.addedEntries).toHaveLength(2);
+
+    // Leaving Education must not nuke the just-added (still-blank) Experience one.
+    act(() => api.pruneEmptyAddedEntries("education"));
+    expect(api.addedEntries.map((e) => e.section)).toEqual(["experience"]);
+  });
+
+  it("is a no-op (stable identity) when nothing is empty", () => {
+    act(() => {
+      const id = api.addEntry("projects");
+      api.setEntryField(id, "title", "Portfolio site");
+    });
+    const before = api.addedEntries;
+
+    act(() => api.pruneEmptyAddedEntries("projects"));
+    expect(api.addedEntries).toBe(before);
+  });
+});

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -232,6 +232,24 @@ const ADDED_ENTRY_FIELDS = [
 export type AddedEntryField = (typeof ADDED_ENTRY_FIELDS)[number];
 
 /**
+ * True when a user-added entry carries no content at all: every header field is
+ * blank/whitespace AND it has no appended bullets. This is the "ghost entry"
+ * left behind when the user clicks "+ Add …" and navigates away without typing
+ * anything (#379) — such an entry must not persist in the list, the score, or
+ * the exported PDF. Iterates {@link ADDED_ENTRY_FIELDS} so a newly-added header
+ * field is covered automatically, in lockstep with the replay/snapshot tuple.
+ */
+export function isAddedEntryEmpty(
+  entry: AddedEntry,
+  addedBullets: AddedBullets,
+): boolean {
+  const headerEmpty = ADDED_ENTRY_FIELDS.every(
+    (f) => (entry[f] ?? "").trim().length === 0,
+  );
+  return headerEmpty && (addedBullets[entry.id] ?? []).length === 0;
+}
+
+/**
  * Bullet lines a user appended to an entry, keyed by entry key. A PARSED entry's
  * key is `"<section>:<index>"` (see {@link parsedEntryKey}); an ADDED entry's key
  * is its `id`. The two namespaces never collide (added ids are `"added:<n>"`).
@@ -356,6 +374,11 @@ export interface EditableParse {
   addEntry: (section: AddableSection) => string;
   /** Remove a previously-added entry by id (also drops its added bullets). */
   removeEntry: (id: string) => void;
+  /** Drop every EMPTY user-added entry in a section — one the user opened with
+   *  "+ Add …" and left with no populated field and no bullets (#379). Called
+   *  when focus leaves the section, so a blank ghost entry never persists in the
+   *  list, the score, or the exported PDF. No-op when nothing is empty. */
+  pruneEmptyAddedEntries: (section: AddableSection) => void;
   /** Edit one header field on an added entry. */
   setEntryField: (id: string, field: AddedEntryField, value: string) => void;
   /** Bullet lines appended to entries, keyed by entry key (parsedEntryKey or
@@ -433,6 +456,11 @@ export function useEditableParse(): EditableParse {
   );
   const [addedEntries, setAddedEntries] = useState<AddedEntry[]>([]);
   const [addedBullets, setAddedBullets] = useState<AddedBullets>({});
+  // Latest bullets, readable synchronously inside `pruneEmptyAddedEntries` —
+  // which is called deferred (a tick after a blur), by which point an in-flight
+  // add-bullet may have landed. A render-time closure would read a stale map.
+  const addedBulletsRef = useRef(addedBullets);
+  addedBulletsRef.current = addedBullets;
   const [profileOverrides, setProfileOverrides] = useState<ProfileOverride[]>(
     [],
   );
@@ -591,6 +619,19 @@ export function useEditableParse(): EditableParse {
       const next = { ...prev };
       delete next[id];
       return next;
+    });
+  }, []);
+
+  const pruneEmptyAddedEntries = useCallback((section: AddableSection) => {
+    const bullets = addedBulletsRef.current;
+    setAddedEntries((prev) => {
+      const kept = prev.filter(
+        (e) => e.section !== section || !isAddedEntryEmpty(e, bullets),
+      );
+      // An empty entry has no bullets by definition, so `addedBullets` needs no
+      // cleanup here (unlike `removeEntry`). Preserve identity when nothing
+      // changed so an idle blur doesn't churn a re-render.
+      return kept.length === prev.length ? prev : kept;
     });
   }, []);
 
@@ -867,6 +908,7 @@ export function useEditableParse(): EditableParse {
     addedEntries,
     addEntry,
     removeEntry,
+    pruneEmptyAddedEntries,
     setEntryField,
     addedBullets,
     addBullet,


### PR DESCRIPTION
## Summary

Clicking **+ Add education / experience / project / achievement** appends an empty entry so the click-to-edit fields have something to bind to. If the user then clicked away without typing, that blank entry **persisted** — in the list, the ATS score, and the exported PDF (#379).

The edit fields never autofocus, so a per-entry blur can't catch the primary repro (add → click away without ever focusing the entry). But the **+ Add** pill lives *inside* the section and holds focus after the click, so a **section-level focus-exit** fires reliably. On focus leaving a section, prune every added entry in it that's completely empty (no populated header field, no bullets). The prune is **deferred one tick** so an in-flight field commit — which fires on the same blur — lands first, and a just-typed entry is kept.

Pruning happens in the edit hook (removing the entry from `addedEntries`), not in `applyOverrides`, so the rendered list and the score/PDF stay index-aligned.

### Changes
- **`useEditableParse`** — `isAddedEntryEmpty` (pure, iterates `ADDED_ENTRY_FIELDS` so new header fields are covered automatically) + `pruneEmptyAddedEntries(section)`, **section-scoped** so a freshly-added entry in *another* section is never swept.
- **`ReconstructedAdd`** — shared `sectionExitBlur()` `onBlur` helper (the `currentTarget.contains(relatedTarget)` idiom already used by `InlineBulletAdd`, plus the deferred fire).
- Wired onto all four editable-entry `<section>`s.

Skills / bullets / profile adds already no-op on blank input, so only whole-entry adds could ghost — those are the four sections covered here.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (2486 passed) — new tests: `isAddedEntryEmpty` (pure), `pruneEmptyAddedEntries` behavior via a probe-hook (drop blank / keep populated / keep bulleted / section-scoping / no-op identity), and `sectionExitBlur` (deferred fire + focus-containment)
- [x] `npm run build` passes

## Provenance
Authored with Claude Opus 4.8 (1M context).