### PR TITLE
chore(rename): rebrand ResumeLint → OfflineCV

### DIFF
--- a/.github/workflows/moderate-comments.yml
+++ b/.github/workflows/moderate-comments.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
 # Auto-hide obvious spam on issue / PR comments.
 # Hide-only: matched comments are minimized as "spam" (collapsed, reversible).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ the exception: they stay here because breaking them is silent, and for two of th
 
 ## Project overview
 
-resumelint started as a browser-side PDF parser stress test for resumes and is growing into a **private, no-login job-search workbench**: drop a PDF in, see what a generic text extractor reads back, get an anonymous heuristic score, fix the resume in place (inline edit + on-device LLM rewrite), download a clean ATS-safe PDF, match it against a job description, and discover relevant job postings. The non-negotiable product constraint: **everything runs client-side — no PDF bytes, resume text, or job-search queries leave the browser** (the only cloud path is the opt-in BYOK provider, keyed and initiated by the user).
+offlinecv started as a browser-side PDF parser stress test for resumes and is growing into a **private, no-login job-search workbench**: drop a PDF in, see what a generic text extractor reads back, get an anonymous heuristic score, fix the resume in place (inline edit + on-device LLM rewrite), download a clean ATS-safe PDF, match it against a job description, and discover relevant job postings. The non-negotiable product constraint: **everything runs client-side — no PDF bytes, resume text, or job-search queries leave the browser** (the only cloud path is the opt-in BYOK provider, keyed and initiated by the user).
 
 ### Product lanes and entry points
 
@@ -63,7 +63,7 @@ npm run lint       # eslint .
 npm run verify     # full local CI mirror: typecheck → lint → coverage → build → fallow
 ```
 
-`npm run verify` is the canonical pre-push gate — the exact CI sequence. A git `pre-push` hook runs it automatically (installed by `npm install`); bypass with `RESUMELINT_SKIP_HOOKS=1`.
+`npm run verify` is the canonical pre-push gate — the exact CI sequence. A git `pre-push` hook runs it automatically (installed by `npm install`); bypass with `OFFLINECV_SKIP_HOOKS=1`.
 
 **While iterating, prefer the narrow gate** — `npx vitest run <path>` on the files you touched, plus `npm run typecheck`. Save the full `verify` for when you think you're done. It runs coverage + build + fallow and is slow enough to cost you iterations.
 
@@ -109,7 +109,7 @@ constraint it guards** — not what the code does line by line.
 
 ```ts
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 ```
 
 | Writing a… | Read first | Why it's the model |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-# Contributing to resumelint
+# Contributing to offlinecv
 
-Thanks for picking up a piece of this. resumelint is a browser-side PDF
+Thanks for picking up a piece of this. offlinecv is a browser-side PDF
 parser audit and job-search workbench. Code lives under `src/`, license is
 [Apache-2.0](./LICENSE) (patent grant included; see `NOTICE`). See
-[`README.md`](./README.md) for what resumelint is and what it surfaces;
+[`README.md`](./README.md) for what offlinecv is and what it surfaces;
 see [`CLAUDE.md`](./CLAUDE.md) for the pipeline shape and tier layout; and see
 [`docs/CONTRIBUTING-PROCESS.md`](./docs/CONTRIBUTING-PROCESS.md) for the shipping
 process this file summarizes — the **test-fixture PII policy** (mandatory before
@@ -48,8 +48,8 @@ available, do the equivalent by hand:
    `scripts/hooks/check_conventions.py` for the exact prefixes the
    project enforces.
 3. To skip the Claude Code commit-block hook for the session, export
-   `RESUMELINT_SKIP_HOOKS=1` in the shell **before** launching `claude`.
-   Inline prefixing (`RESUMELINT_SKIP_HOOKS=1 git commit ...`) does
+   `OFFLINECV_SKIP_HOOKS=1` in the shell **before** launching `claude`.
+   Inline prefixing (`OFFLINECV_SKIP_HOOKS=1 git commit ...`) does
    **not** work — the env assignment is part of the command string the
    hook never executes. The constraint is documented at the top of
    `scripts/hooks/block_commit.sh`.
@@ -96,7 +96,7 @@ header — see the canonical form in [`CLAUDE.md`](./CLAUDE.md) under
 
 ```ts
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 ```
 
 TypeScript strict mode is on. Default to writing no comments — add one
@@ -106,7 +106,7 @@ explain **what** the code does; the names already do that.
 
 ## UI primitives & tokens
 
-resumelint enforces a strict component hierarchy. Before writing any
+offlinecv enforces a strict component hierarchy. Before writing any
 interactive element or styled surface, check whether a shared primitive
 already exists:
 
@@ -134,7 +134,7 @@ These architecture rules are enforced at two layers:
    (`scripts/hooks/style_guard.sh`) fires immediately after a file edit
    inside Claude Code, giving you instant feedback before commit.
    Warnings are non-blocking; bypass for one session with
-   `export RESUMELINT_SKIP_HOOKS=1`.
+   `export OFFLINECV_SKIP_HOOKS=1`.
 
 ## Filing issues
 
@@ -146,8 +146,8 @@ are the most common and the hardest to repro without a sample.
 
 ## Project board
 
-Issues are tracked on the **ResumeLint v1** board
-([`resumelint-org/projects/1`](https://github.com/orgs/resumelint-org/projects/1)),
+Issues are tracked on the **OfflineCV v1** board
+([`offlinecv/projects/1`](https://github.com/orgs/offlinecv/projects/1)),
 grouped by **Phase** — the milestone each issue belongs to (`M1 Parser
 Hardening`, `M2 UI Parity`, `M3 JD Matching`, `M4 AI Rewrite`, `v1.1
 Post-Launch`). v1.0 ships when M1–M4 land; v1.1 holds post-launch work.
@@ -157,7 +157,7 @@ After filing an issue, place it on the roadmap. With Claude Code, run
 board, and sets its Phase. By hand:
 
 ```bash
-gh issue edit <number> --repo resumelint-org/resumelint --milestone "<milestone title>"
+gh issue edit <number> --repo offlinecv/OfflineCV --milestone "<milestone title>"
 ```
 
 Adding an issue to the board (the Phase column) needs the `project`

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-resumelint
-Copyright 2026 The resumelint Authors
+offlinecv
+Copyright 2026 The offlinecv Authors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may
 not use this file except in compliance with the License. You may obtain

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# resumelint
+# offlinecv
 
 **Try it:** [resumelint.org](https://resumelint.org) — stable, promoted daily once
 CI is green · [dev.resumelint.org](https://dev.resumelint.org) — bleeding edge,
@@ -10,7 +10,7 @@ reports what its own parser sees, so you can spot the failure modes that
 quietly drop a candidate's text on the floor before any downstream system
 ever looks at it.
 
-The core failure modes resumelint surfaces are common but rarely visible:
+The core failure modes offlinecv surfaces are common but rarely visible:
 two-column layouts that text extractors read across, image-only PDFs that
 return zero selectable text, and "fonts-unmappable" PDFs (Framer, Affinity,
 and some InDesign exports) where the source carries real text but the font
@@ -47,7 +47,7 @@ locally instead of on the PR.
   its findings are printed but never fail the push. Typecheck, lint, test,
   and build failures **do** block the push.
 - Bypass the hook for a single push with
-  `RESUMELINT_SKIP_HOOKS=1 git push`.
+  `OFFLINECV_SKIP_HOOKS=1 git push`.
 - The hook install is a no-op on tarball installs and CI `npm ci` (no
   `.git/` work tree), so it never breaks a non-developer install.
 
@@ -95,7 +95,7 @@ filing an issue; pair the finding with a synthetic, PII-free fixture under
 
 ## Telemetry
 
-resumelint ships with no analytics by default. `package.json` declares
+offlinecv ships with no analytics by default. `package.json` declares
 `posthog-js` as a dependency, but the import is dynamic and only resolved
 when `VITE_POSTHOG_KEY` is set at build time. In an OSS build (no env vars),
 the PostHog branch is dead-code-eliminated by Vite/Rollup and the dep does
@@ -138,7 +138,7 @@ scoped to your browser:
 
 #### IndexedDB (local-first storage)
 
-For structured/binary data the app uses an IndexedDB database named `resumelint`
+For structured/binary data the app uses an IndexedDB database named `offlinecv`
 (via the ~1KB [`idb`](https://github.com/jakearchibald/idb) wrapper;
 `src/lib/storage/`), separate from the `rl_*` UI flags above. It has two object
 stores — `resumes` (raw PDF bytes as a `Blob` plus a cached parse so a reopened
@@ -162,7 +162,7 @@ state and the eviction note inline, with the export backup reachable from there.
 ### GitHub star count
 
 The footer shows the live repo star count via an unauthenticated call to
-`https://api.github.com/repos/resumelint-org/resumelint` (`src/hooks/useGitHubStars.ts`).
+`https://api.github.com/repos/offlinecv/OfflineCV` (`src/hooks/useGitHubStars.ts`).
 It runs from your browser on app load whenever the ~1h cache
 (`rl_gh_stars_cache`) is stale, and is **fail-silent** — on network error or
 rate-limit (GitHub allows 60 req/hr/IP unauthenticated) the count is hidden
@@ -208,16 +208,16 @@ Colors are plain CSS custom properties split into two layers:
   (slate neutrals + a blue accent)**, not a specific product brand. This is the
   **swappable layer**.
 
-You can reskin resumelint to your own brand **without forking this repo**, two
+You can reskin offlinecv to your own brand **without forking this repo**, two
 ways:
 
 ### 1. Cascade override (no build config)
 
-Import your own stylesheet *after* resumelint's and redefine the same
+Import your own stylesheet *after* offlinecv's and redefine the same
 `--color-*` properties. The last definition wins in the cascade:
 
 ```css
-/* your-brand.css — imported after resumelint's styles */
+/* your-brand.css — imported after offlinecv's styles */
 :root {
   --color-brand-amber: #ff6b35;
   --color-bg-card: #fffaf5;
@@ -327,8 +327,8 @@ The hosted preview at the top of this README is published from `dist/`
 to GitHub Pages by `.github/workflows/deploy-pages.yml` — read that
 workflow for a working end-to-end example. The canonical production URL
 is the custom domain **<https://resumelint.org>**; the project-Pages URL
-<https://resumelint-org.github.io/resumelint/> remains as a fallback (built
-with `VITE_BASE_PATH=/resumelint/`).
+<https://offlinecv.github.io/OfflineCV/> remains as a fallback (built
+with `VITE_BASE_PATH=/OfflineCV/`).
 
 The build emits two root pages — `/` (the parser audit) and `/jd-fit`
 (JD-match + JD-driven rewrite) — as a multi-entry Vite build, so both ship

--- a/docs/CONTRIBUTING-PROCESS.md
+++ b/docs/CONTRIBUTING-PROCESS.md
@@ -113,9 +113,9 @@ Rules:
 
 The hosted preview is published to GitHub Pages via `.github/workflows/deploy-pages.yml` (the canonical, in-repo deploy example).
 
-The maintainer also keeps an **untracked, local-only** `scripts/deploy_resumelint.sh` that uploads `dist/` to a GCS bucket (config from a gitignored `.env.deploy`; sources the `~/tools/scripts/` symlinked helpers). It's gitignored alongside `run_resumelint.sh` because it depends on machine-local tooling — don't recommend it to contributors or recreate it as a tracked file.
+The maintainer also keeps an **untracked, local-only** `scripts/deploy_offlinecv.sh` that uploads `dist/` to a GCS bucket (config from a gitignored `.env.deploy`; sources the `~/tools/scripts/` symlinked helpers). It's gitignored alongside `run_offlinecv.sh` because it depends on machine-local tooling — don't recommend it to contributors or recreate it as a tracked file.
 
-Likewise, a maintainer convenience wrapper (`scripts/run_resumelint.sh`, an interactive menu) exists locally but is **not tracked** — it `source`s shared bash helpers symlinked from `~/tools/scripts/` (`common.sh`, `deploy_web_utils.sh`, `load_env.sh`) that only exist on the maintainer's machine. Don't reintroduce either to the repo; build/deploy guidance for contributors lives in the README's Deploy section.
+Likewise, a maintainer convenience wrapper (`scripts/run_offlinecv.sh`, an interactive menu) exists locally but is **not tracked** — it `source`s shared bash helpers symlinked from `~/tools/scripts/` (`common.sh`, `deploy_web_utils.sh`, `load_env.sh`) that only exist on the maintainer's machine. Don't reintroduce either to the repo; build/deploy guidance for contributors lives in the README's Deploy section.
 
 ## License
 

--- a/docs/canonical-resume-model.md
+++ b/docs/canonical-resume-model.md
@@ -1,10 +1,10 @@
 # Canonical résumé model — target representation + staged migration plan (#439)
 
-Design for [#439](https://github.com/resumelint-org/resumelint/issues/439), the follow-up to the architecture decision in [#438](https://github.com/resumelint-org/resumelint/issues/438) ("one canonical representation, staged").
+Design for [#439](https://github.com/offlinecv/OfflineCV/issues/439), the follow-up to the architecture decision in [#438](https://github.com/offlinecv/OfflineCV/issues/438) ("one canonical representation, staged").
 
 **Status:** design only — no production code changed by this issue (acceptance criterion). Implementation lands as the sequenced, per-stage follow-up issues at the end of this doc. Each stage is separately reviewable and keeps the round-trip invariant green; **nothing here is a big-bang PR.**
 
-**Baseline the design is written against:** `main` as of the mapping in this doc. All `file:line` citations are against that baseline. `ATS_SCORE_ALGO_VERSION` is `"1.4"` (`src/lib/score/score.ts:73`); [#435](https://github.com/resumelint-org/resumelint/issues/435) bumps it to `1.5` in flight — the cache-version hook in §6 keys off whatever value is current at each stage's cutover, not a pinned literal.
+**Baseline the design is written against:** `main` as of the mapping in this doc. All `file:line` citations are against that baseline. `ATS_SCORE_ALGO_VERSION` is `"1.4"` (`src/lib/score/score.ts:73`); [#435](https://github.com/offlinecv/OfflineCV/issues/435) bumps it to `1.5` in flight — the cache-version hook in §6 keys off whatever value is current at each stage's cutover, not a pinned literal.
 
 ---
 
@@ -24,7 +24,7 @@ The decision (#438) is to collapse these toward **one canonical internal model**
 
 Two structural costs the canonical model must dissolve, not just relocate:
 
-- **Cost 1 — N peer shapes, N hand-sync adapters.** `apply-overrides.ts` is the sharpest tell: `ApplyOverridesResult` (`edit/apply-overrides.ts:52`) must return `parsed` **and** `rawText` **and** `sections` **and** `fieldConfidence` **together**, because one un-mirrored user edit re-grades or re-parses wrong (comments cite [#133](https://github.com/resumelint-org/resumelint/issues/133), [#421](https://github.com/resumelint-org/resumelint/issues/421) Blocking #1/#3). The `LlmParsedResume` hand-sync note (`parse-resume.ts:52-54`: *"Keep field names in sync with that interface"*) is the same cost in a second place.
+- **Cost 1 — N peer shapes, N hand-sync adapters.** `apply-overrides.ts` is the sharpest tell: `ApplyOverridesResult` (`edit/apply-overrides.ts:52`) must return `parsed` **and** `rawText` **and** `sections` **and** `fieldConfidence` **together**, because one un-mirrored user edit re-grades or re-parses wrong (comments cite [#133](https://github.com/offlinecv/OfflineCV/issues/133), [#421](https://github.com/offlinecv/OfflineCV/issues/421) Blocking #1/#3). The `LlmParsedResume` hand-sync note (`parse-resume.ts:52-54`: *"Keep field names in sync with that interface"*) is the same cost in a second place.
 - **Cost 2 — the render model encodes re-parse invariants.** `AtsEntry` is doing triple duty (display, PDF layout, **and** export hint via `AtsEntryFields`). Its layout fields exist to satisfy the parse→export→parse identity: `headerLineDate` (#425/#302 entry-boundary date cue), `subLineDate` (#425, avoids the #298 title↔company re-parse swap), `atomicSegments` (#301 skills-middot atomicity), `headerBold` (#425) — each documented in terms of how the exported PDF must re-parse (`ats-resume-model.ts:118-158`). So the renderer knows parser internals, and a fidelity fix touches model + renderer + the parser exemption it leans on + regenerated corpus goldens — four surfaces **by construction**. That is why #425/#434/#435 each landed at 40–54 files.
 
 ---
@@ -33,13 +33,13 @@ Two structural costs the canonical model must dissolve, not just relocate:
 
 ### 1 · `HeuristicParsedResume` + `CascadeResult`
 - `HeuristicParsedResume = Partial<ParsedResume> & { skills; experience; education; phoneIsValid? }` — `heuristics/types.ts:121`. `phoneIsValid?` (`:126-129`) precomputes libphonenumber `isValid()` so the scorer skips importing `libphonenumber-js` (entry-chunk budget).
-- `CascadeResult` — `heuristics/types.ts:174`: `parsed`, `rawText` (`:185`), `markdown?` (`:188`), **`sections: SectionedResume`** (`:194`, cites [#132](https://github.com/resumelint-org/resumelint/issues/132) — replaces the retired `skillsSectionText` side-channel), `linkAnnotations`, `diagnostics.sectionSource`, `timings`.
+- `CascadeResult` — `heuristics/types.ts:174`: `parsed`, `rawText` (`:185`), `markdown?` (`:188`), **`sections: SectionedResume`** (`:194`, cites [#132](https://github.com/offlinecv/OfflineCV/issues/132) — replaces the retired `skillsSectionText` side-channel), `linkAnnotations`, `diagnostics.sectionSource`, `timings`.
 
 ### 2 · `SectionedResume`
 - `heuristics/sections.ts:85` (cites #127 §2.1, #132). `byName: ReadonlyMap<SectionName|"profile", readonly string[]>` (`:89`), `accomplishmentSections` (`:90`, *not yet consumed by pool sourcing*), `sectionHeadings?` (`:94`, #285), `source: "markdown"|"regex"` (`:101`). Built by `toSectionedResume` (`sections.ts:122`) over `PdfSection` (`:62`).
 
 ### 3 · `LlmParsedResume`
-- `webllm/parse-resume.ts:56`. Fields mirror the heuristic parser **by hand** (`:52-54`) so the disagreement detector can diff field-by-field ([#242](https://github.com/resumelint-org/resumelint/issues/242)). No converter exists between #1 and #3 — the "adapter" is the intentional structural mirror; `diffParses(heuristic, llm)` at `heuristics/disagreement.ts:186` consumes both.
+- `webllm/parse-resume.ts:56`. Fields mirror the heuristic parser **by hand** (`:52-54`) so the disagreement detector can diff field-by-field ([#242](https://github.com/offlinecv/OfflineCV/issues/242)). No converter exists between #1 and #3 — the "adapter" is the intentional structural mirror; `diffParses(heuristic, llm)` at `heuristics/disagreement.ts:186` consumes both.
 
 ### 4 · `AtsResumeModel`
 - `pdf/ats-resume-model.ts:181` (`sections: AtsSection[]` `:188`). `AtsSection` `:173`; `AtsEntry` `:114` with the four round-trip-encoding layout fields above; `AtsEntryFields` `:87` (machine-readable mirror; *"Display/render code never reads this"* `:160`). Built by `buildAtsResumeModel(result, score, edit?)` — `ats-resume-model.ts:425`; date-slot routing to `headerLineDate`/`subLineDate` at `:597-613` cites #425/#302. Round-trip-tradeoff note at `:469`.
@@ -155,7 +155,7 @@ Per-stage implementation issues were minted from **this** list once it was fixed
 
 The `resumes` IndexedDB store caches a **pre-canonical `CascadeResult`**: `SavedResumeSnapshot { result: CascadeResult; score; sourceKind }` (`resume-library.ts:37`), written in `saveResumeToLibrary` (`:90-99`), read via `readSnapshot` (`:66`); it round-trips through IndexedDB structured clone, which preserves the `sections` `Map` (`:6-13`, #321).
 
-Any stage that changes the **persisted** shape (Stage E, and Stage B if the façade is persisted) MUST invalidate or migrate that cache — not only the in-memory model + corpus goldens. **Cheapest hook:** version the cached record by `ATS_SCORE_ALGO_VERSION` (`score.ts:73`, currently `"1.4"`, →`1.5` via #435) **plus a new parser-shape version constant**, so a representation change auto-invalidates on read and re-parses from the stored PDF `Blob` (#321 keeps the blob). A stale-shape read must **re-parse**, never silently deserialize an old shape into the canonical model. Refs [#321](https://github.com/resumelint-org/resumelint/issues/321), [#401](https://github.com/resumelint-org/resumelint/issues/401).
+Any stage that changes the **persisted** shape (Stage E, and Stage B if the façade is persisted) MUST invalidate or migrate that cache — not only the in-memory model + corpus goldens. **Cheapest hook:** version the cached record by `ATS_SCORE_ALGO_VERSION` (`score.ts:73`, currently `"1.4"`, →`1.5` via #435) **plus a new parser-shape version constant**, so a representation change auto-invalidates on read and re-parses from the stored PDF `Blob` (#321 keeps the blob). A stale-shape read must **re-parse**, never silently deserialize an old shape into the canonical model. Refs [#321](https://github.com/offlinecv/OfflineCV/issues/321), [#401](https://github.com/offlinecv/OfflineCV/issues/401).
 
 ---
 
@@ -198,4 +198,4 @@ Minted **after** this plan is accepted, one per stage, each with its round-trip-
 3. **Stage C** — move the round-trip invariant onto the canonical model; renderer draws from the projection. *(carries the §7 header-vs-entry acceptance test.)*
 4. **Stage D+E** (shipped combined, #445 — supersedes the separate #446) — collapse `LlmParsedResume` + `ApplyOverridesResult` into projections and delete the hand-sync note, **and** cut over: remove the `CascadeResult` façade + ship #321 cache versioning/invalidation (§6). Combined so the façade removal is provable in one round-trip gate rather than two.
 
-Refs [#438](https://github.com/resumelint-org/resumelint/issues/438), [#321](https://github.com/resumelint-org/resumelint/issues/321), [#401](https://github.com/resumelint-org/resumelint/issues/401), [#425](https://github.com/resumelint-org/resumelint/issues/425), [#434](https://github.com/resumelint-org/resumelint/issues/434), [#435](https://github.com/resumelint-org/resumelint/issues/435).
+Refs [#438](https://github.com/offlinecv/OfflineCV/issues/438), [#321](https://github.com/offlinecv/OfflineCV/issues/321), [#401](https://github.com/offlinecv/OfflineCV/issues/401), [#425](https://github.com/offlinecv/OfflineCV/issues/425), [#434](https://github.com/offlinecv/OfflineCV/issues/434), [#435](https://github.com/offlinecv/OfflineCV/issues/435).

--- a/docs/segmentation-spike.md
+++ b/docs/segmentation-spike.md
@@ -1,10 +1,10 @@
 # Segmentation-as-source-of-truth — design spike (#127)
 
-Spike for [#127](https://github.com/resumelint-org/resumelint/issues/127), under the section-recognizer epic [#109](https://github.com/resumelint-org/resumelint/issues/109).
+Spike for [#127](https://github.com/offlinecv/OfflineCV/issues/127), under the section-recognizer epic [#109](https://github.com/offlinecv/OfflineCV/issues/109).
 
 **Status:** design only — no production code changed by this issue (acceptance criterion). Implementation lands as the sequenced follow-up issues at the end of this doc.
 
-**Note on the moving target:** issue [#126](https://github.com/resumelint-org/resumelint/issues/126) is concurrently splitting `src/lib/heuristics/extract-fields.ts` into `src/lib/heuristics/extract/*.ts`. All `extract-fields.ts:NNN` citations below are against the current main baseline (what is in this worktree). Follow-ups should target the **post-split** module paths once #126 merges; the per-symbol names (`extractSkills`, `looksLikeContactLink`, `disambiguateCompanyTitle`, …) are stable across the split and are the durable anchors.
+**Note on the moving target:** issue [#126](https://github.com/offlinecv/OfflineCV/issues/126) is concurrently splitting `src/lib/heuristics/extract-fields.ts` into `src/lib/heuristics/extract/*.ts`. All `extract-fields.ts:NNN` citations below are against the current main baseline (what is in this worktree). Follow-ups should target the **post-split** module paths once #126 merges; the per-symbol names (`extractSkills`, `looksLikeContactLink`, `disambiguateCompanyTitle`, …) are stable across the split and are the durable anchors.
 
 ---
 
@@ -259,13 +259,13 @@ Gate each on the corpus suite. Sequence after #126 lands (or rebase onto it) so 
 
 ## 6. Follow-up issues filed
 
-Filed on `resumelint-org/resumelint`, each referencing #127 and #109, in dependency order:
+Filed on `offlinecv/OfflineCV`, each referencing #127 and #109, in dependency order:
 
 | Seq | Issue | Title | Bucket | Risk |
 |---|---|---|---|---|
-| A (PR 1) | [#132](https://github.com/resumelint-org/resumelint/issues/132) | Emit typed `SectionedResume` from cascade + retire `skillsSectionText` (proof PR) | (S) | ~zero (behavior-preserving; goldens unchanged) |
-| B (PR 2) | [#133](https://github.com/resumelint-org/resumelint/issues/133) | Pool anon scorer bullets from accomplishment sections (retire rawText walk + `buildSkillsExclusion`) | (S) | medium (deliberate score change; algo bump) |
-| C (PR 3) | [#134](https://github.com/resumelint-org/resumelint/issues/134) | Replace `stripPromotedUrls` scrub with a section-ownership/provenance model | (B) | medium |
-| D (PR 4) | [#135](https://github.com/resumelint-org/resumelint/issues/135) | Replace `extractContact` y-band header proxy with a real contact/links section boundary | (B) | medium |
+| A (PR 1) | [#132](https://github.com/offlinecv/OfflineCV/issues/132) | Emit typed `SectionedResume` from cascade + retire `skillsSectionText` (proof PR) | (S) | ~zero (behavior-preserving; goldens unchanged) |
+| B (PR 2) | [#133](https://github.com/offlinecv/OfflineCV/issues/133) | Pool anon scorer bullets from accomplishment sections (retire rawText walk + `buildSkillsExclusion`) | (S) | medium (deliberate score change; algo bump) |
+| C (PR 3) | [#134](https://github.com/offlinecv/OfflineCV/issues/134) | Replace `stripPromotedUrls` scrub with a section-ownership/provenance model | (B) | medium |
+| D (PR 4) | [#135](https://github.com/offlinecv/OfflineCV/issues/135) | Replace `extractContact` y-band header proxy with a real contact/links section boundary | (B) | medium |
 
 A is the gating dependency for B/C/D and is the provably-inert first step. Sequence the whole set after #126 (the `extract/*.ts` split) lands, or rebase onto it.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 // eslint.config.js — flat config (ESLint 9+, ESM)
-// Architecture/token guard for resumelint. Minimal ruleset: no style
+// Architecture/token guard for offlinecv. Minimal ruleset: no style
 // bikeshedding, just the structural rules that style_guard.sh checked.
 // These same checks run (blocking) in CI via `npm run lint`.
 

--- a/eval-rewrite.html
+++ b/eval-rewrite.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>resumelint — rewrite eval (dev only)</title>
+    <title>OfflineCV — rewrite eval (dev only)</title>
     <meta
       name="description"
       content="Dev-only eval harness for rewrite quality (issue #65). Not part of the production bundle."

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ResumeLint — see what a resume parser reads from your PDF</title>
+    <title>OfflineCV — see what a resume parser reads from your PDF</title>
     <meta
       name="description"
       content="Drop a resume PDF and see what a generic parser pulls out of it. Free, private, open-source — your PDF never leaves your browser."

--- a/jd-fit/index.html
+++ b/jd-fit/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>resumelint — JD Fit</title>
+    <title>OfflineCV — JD Fit</title>
     <meta
       name="description"
       content="Paste a job description; see which of its skills and key phrases your resume covers, and rewrite toward the role."

--- a/jd-spike.html
+++ b/jd-spike.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>resumelint — JD spike (dev only)</title>
+    <title>OfflineCV — JD spike (dev only)</title>
     <meta
       name="description"
       content="Dev-only spike harness for JD requirement extraction + evidence judging (issue #198 / #156). Not part of the production bundle."
@@ -114,7 +114,7 @@
     <pre id="log"></pre>
     <p class="note">
       Download the Markdown report and paste findings into
-      <a href="https://github.com/resumelint-org/resumelint/issues/156" target="_blank"
+      <a href="https://github.com/offlinecv/OfflineCV/issues/156" target="_blank"
         >issue #156</a
       >. This page is not committed to <code>dist/</code> — see
       <code>src/lib/webllm/spike/README.md</code> for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@resumelint/web",
+  "name": "@offlinecv/web",
   "version": "0.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@resumelint/web",
+      "name": "@offlinecv/web",
       "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@resumelint/web",
+  "name": "@offlinecv/web",
   "private": true,
   "version": "0.1.0-alpha.1",
   "license": "Apache-2.0",

--- a/parse-eval.html
+++ b/parse-eval.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>resumelint — Parse-resume eval (dev only)</title>
+    <title>OfflineCV — Parse-resume eval (dev only)</title>
     <meta
       name="description"
       content="Dev-only eval harness for the LLM structured-parse provider (issue #241). Not part of the production bundle."
@@ -117,7 +117,7 @@
     <p class="note">
       The parse-only report goes in PR #241; the combined-comparison report
       goes in
-      <a href="https://github.com/resumelint-org/resumelint/issues/262" target="_blank"
+      <a href="https://github.com/offlinecv/OfflineCV/issues/262" target="_blank"
         >PR #262</a
       >
       under the quality-measurement gate. This page is not committed to

--- a/scripts/check-fixture-pii.mjs
+++ b/scripts/check-fixture-pii.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture-PII gate (#478). Fails the build when a PDF under

--- a/scripts/check-fixture-pii.test.mjs
+++ b/scripts/check-fixture-pii.test.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the fixture-PII gate (#478).

--- a/scripts/create-gh-issue.sh
+++ b/scripts/create-gh-issue.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# create-gh-issue.sh — Create a resumelint GitHub issue via `gh issue create`,
+# create-gh-issue.sh — Create a offlinecv GitHub issue via `gh issue create`,
 # passing the body as a FILE so backticks, tables, and fenced code blocks survive
 # shell escaping intact.
 #

--- a/scripts/fidelity.ts
+++ b/scripts/fidelity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Parser-fidelity diagnostic (`npm run fidelity <pdf|dir>`).

--- a/scripts/fixture-audit.ts
+++ b/scripts/fixture-audit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The fixture-ledger staleness auditor (`npm run fixture-audit`, issue #39).

--- a/scripts/fixture-derive.ts
+++ b/scripts/fixture-derive.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The fixture-derivation tool (`npm run fixture-derive`, issue #39).
@@ -463,7 +463,7 @@ function reproTestScaffold(
 ): string {
   const stem = basename(fixtureRel, ".pdf");
   return `// SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Repro regression for #${issue} — ${cls} (${probe}).

--- a/scripts/fixtures/gen-bulleted-labelled-skills.mjs
+++ b/scripts/fixtures/gen-bulleted-labelled-skills.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #465 — a well-formatted SINGLE-COLUMN résumé whose

--- a/scripts/fixtures/gen-compound-header-block-bleed.mjs
+++ b/scripts/fixtures/gen-compound-header-block-bleed.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #462 — a single-column résumé whose tail carries

--- a/scripts/fixtures/gen-label-rail-grid.mjs
+++ b/scripts/fixtures/gen-label-rail-grid.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #355 — the SEPARATED label-rail résumé that the

--- a/scripts/fixtures/gen-label-rail.mjs
+++ b/scripts/fixtures/gen-label-rail.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #355 — single-column label-rail résumé whose

--- a/scripts/fixtures/gen-qualified-experience-coursework.mjs
+++ b/scripts/fixtures/gen-qualified-experience-coursework.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #467 — a single-column student résumé whose

--- a/scripts/fixtures/gen-shared-banner.mjs
+++ b/scripts/fixtures/gen-shared-banner.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #382 — a single-column résumé where one employer

--- a/scripts/fixtures/gen-single-column-intl-role-headers.mjs
+++ b/scripts/fixtures/gen-single-column-intl-role-headers.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #461 — a single-column résumé whose role headers

--- a/scripts/fixtures/gen-single-column-projects-prose-body.mjs
+++ b/scripts/fixtures/gen-single-column-projects-prose-body.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #464 — a single-column Projects section whose

--- a/scripts/fixtures/gen-title-team-next-line-employer.mjs
+++ b/scripts/fixtures/gen-title-team-next-line-employer.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Fixture generator for issue #466 — a single-column résumé whose role headers

--- a/scripts/hooks/_hooklib.py
+++ b/scripts/hooks/_hooklib.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
-"""Shared helpers for resumelint Claude Code hooks written in Python.
+# Copyright 2026 The offlinecv Authors
+"""Shared helpers for offlinecv Claude Code hooks written in Python.
 
 Each hook reads a JSON payload from stdin describing the tool call.
 Convention checks fail with ``fail()`` (exit 2) so the parent tool call
 is blocked; advisory hooks (warnings, reminders) exit 0.
 
-Bypass for one tool call: ``RESUMELINT_SKIP_HOOKS=1``.
+Bypass for one tool call: ``OFFLINECV_SKIP_HOOKS=1``.
 """
 
 from __future__ import annotations
@@ -17,7 +17,7 @@ import os
 import sys
 from typing import Any
 
-SKIP_ENV = "RESUMELINT_SKIP_HOOKS"
+SKIP_ENV = "OFFLINECV_SKIP_HOOKS"
 
 
 def maybe_skip() -> None:

--- a/scripts/hooks/_lib.sh
+++ b/scripts/hooks/_lib.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
-# Shared helper for resumelint Claude Code hooks. Sourced by every *.sh
+# Shared helper for offlinecv Claude Code hooks. Sourced by every *.sh
 # hook in this directory. No shebang — this file is sourced, not executed.
 #
 # Each hook receives a JSON payload on stdin describing the tool call
@@ -28,13 +28,13 @@
 hook_input_field() {
   local payload="$1"
   local path="$2"
-  printf '%s' "$payload" | RESUMELINT_HOOK_FIELD="$path" python3 -c '
+  printf '%s' "$payload" | OFFLINECV_HOOK_FIELD="$path" python3 -c '
 import json, os, sys
 try:
     d = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-for part in os.environ["RESUMELINT_HOOK_FIELD"].split("."):
+for part in os.environ["OFFLINECV_HOOK_FIELD"].split("."):
     if not isinstance(d, dict):
         sys.exit(0)
     d = d.get(part)

--- a/scripts/hooks/block_commit.sh
+++ b/scripts/hooks/block_commit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
 # PreToolUse(Bash) hook: refuse `git commit` on the protected `main`
 # branch, so changes land on a feature branch and merge through a
@@ -20,12 +20,12 @@
 #   - inherited $PWD if no `cd` prefix.
 # Not bulletproof (subshells, pushd) but covers day-to-day shapes.
 #
-# Override (rare): export RESUMELINT_SKIP_HOOKS=1 in the shell that
+# Override (rare): export OFFLINECV_SKIP_HOOKS=1 in the shell that
 # launched `claude` BEFORE starting the session.
 
 set -euo pipefail
 
-[[ "${RESUMELINT_SKIP_HOOKS:-0}" == "1" ]] && exit 0
+[[ "${OFFLINECV_SKIP_HOOKS:-0}" == "1" ]] && exit 0
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_lib.sh
@@ -64,7 +64,7 @@ fi
 if [[ "$command" =~ (^|[[:space:];|&]|\|\|)git[[:space:]]+commit([[:space:]]|$|\;) ]]; then
   current_branch="$(git -C "$effective_cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
   if [[ "$current_branch" == "main" ]]; then
-    echo "resumelint: refusing \`git commit\` on main." >&2
+    echo "offlinecv: refusing \`git commit\` on main." >&2
     echo "main is protected — commit on a feature branch and open a PR (see the /open-pr skill)." >&2
     echo "  git switch -c feat/<slug>   # then commit, then /open-pr" >&2
     exit 2

--- a/scripts/hooks/check_conventions.py
+++ b/scripts/hooks/check_conventions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
-"""PostToolUse(Edit|Write) convention check for resumelint.
+# Copyright 2026 The offlinecv Authors
+"""PostToolUse(Edit|Write) convention check for offlinecv.
 
 Fires after a .ts / .tsx file under ``src/`` is edited. Fails (exit 2
 with a clear message) when the change introduces a known anti-pattern.
@@ -24,7 +24,7 @@ Checks:
 5. No raw ``console.log`` in ``src/lib/``. Easy to slip in during
    debugging, would ship in the OSS bundle.
 
-Override for one tool call: ``RESUMELINT_SKIP_HOOKS=1``.
+Override for one tool call: ``OFFLINECV_SKIP_HOOKS=1``.
 """
 
 from __future__ import annotations
@@ -39,11 +39,11 @@ from _hooklib import fail, load_payload, maybe_skip, tool_file_path  # noqa: E40
 
 REPO_ROOT = HOOK_DIR.parent.parent
 SRC = REPO_ROOT / "src"
-PREFIX = "resumelint convention check"
+PREFIX = "offlinecv convention check"
 
 SPDX_HEADER = (
     "// SPDX-License-Identifier: Apache-2.0\n"
-    "// Copyright 2026 The resumelint Authors\n"
+    "// Copyright 2026 The offlinecv Authors\n"
 )
 USER_FACING_TOP = {"App.tsx", "components"}
 TIER_MODULES = ("pdf-extract", "openresume", "regex-fallback")

--- a/scripts/hooks/format_typescript.sh
+++ b/scripts/hooks/format_typescript.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
 # PostToolUse(Edit|Write) hook: drop a per-session sentinel when a .ts
 # or .tsx file under src/ is touched, so lint_and_test.sh knows to run
@@ -11,11 +11,11 @@
 # config. When that lands, add the per-file format call here (single
 # file, ~300ms budget).
 #
-# Override: RESUMELINT_SKIP_HOOKS=1.
+# Override: OFFLINECV_SKIP_HOOKS=1.
 
 set -euo pipefail
 
-[[ "${RESUMELINT_SKIP_HOOKS:-0}" == "1" ]] && exit 0
+[[ "${OFFLINECV_SKIP_HOOKS:-0}" == "1" ]] && exit 0
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_lib.sh
@@ -40,7 +40,7 @@ esac
 
 # Per-session sentinel for the Stop hook.
 if [[ -n "$session_id" ]]; then
-  : >"/tmp/resumelint_ts_edited.$session_id"
+  : >"/tmp/offlinecv_ts_edited.$session_id"
 fi
 
 exit 0

--- a/scripts/hooks/lint_and_test.sh
+++ b/scripts/hooks/lint_and_test.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
 # Stop hook: when format_typescript.sh's per-session sentinel exists,
 # run `npm run verify` (the full local CI mirror — typecheck, lint,
 # coverage, build, and report-only fallow). Exits non-zero on failure so
 # the transcript surfaces red checks even when Claude said "done."
 #
-# Override: RESUMELINT_SKIP_HOOKS=1.
+# Override: OFFLINECV_SKIP_HOOKS=1.
 
 set -euo pipefail
 
-[[ "${RESUMELINT_SKIP_HOOKS:-0}" == "1" ]] && exit 0
+[[ "${OFFLINECV_SKIP_HOOKS:-0}" == "1" ]] && exit 0
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_lib.sh
@@ -20,7 +20,7 @@ source "${HOOK_DIR}/_lib.sh"
 input="$(cat)"
 session_id="$(hook_input_field "$input" session_id)"
 
-sentinel="/tmp/resumelint_ts_edited.${session_id:-none}"
+sentinel="/tmp/offlinecv_ts_edited.${session_id:-none}"
 if [[ ! -f "$sentinel" ]]; then
   exit 0
 fi
@@ -33,7 +33,7 @@ cd "$REPO_ROOT"
 [[ -f package.json && -d node_modules ]] || exit 0
 
 if ! out="$(npm run --silent verify 2>&1)"; then
-  echo "resumelint stop hook: verify failed (typecheck/lint/test/build)" >&2
+  echo "offlinecv stop hook: verify failed (typecheck/lint/test/build)" >&2
   printf '%s\n' "$out" | tail -40 >&2
   exit 2
 fi

--- a/scripts/hooks/style_guard.sh
+++ b/scripts/hooks/style_guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
 # PostToolUse(Edit|Write) hook: warn when a component or App.tsx edit
 # introduces UI-primitive / token anti-patterns memorialized in CLAUDE.md:
@@ -13,11 +13,11 @@
 # Scope: src/components/**, src/design-system/**, and src/App.tsx (all .ts/.tsx).
 #
 # NON-blocking — emits warnings but always exits 0 so the edit proceeds.
-# Override: RESUMELINT_SKIP_HOOKS=1.
+# Override: OFFLINECV_SKIP_HOOKS=1.
 
 set -euo pipefail
 
-[[ "${RESUMELINT_SKIP_HOOKS:-0}" == "1" ]] && exit 0
+[[ "${OFFLINECV_SKIP_HOOKS:-0}" == "1" ]] && exit 0
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_lib.sh
@@ -85,7 +85,7 @@ fi
 if [[ $WARNINGS -gt 0 ]]; then
   echo ""
   echo "   $WARNINGS warning(s) above are non-blocking. To suppress for this session:"
-  echo "   export RESUMELINT_SKIP_HOOKS=1 (before launching claude)."
+  echo "   export OFFLINECV_SKIP_HOOKS=1 (before launching claude)."
 fi
 
 exit 0

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 //
 // Installs a git `pre-push` hook that runs `npm run verify` (the local
 // CI mirror) before every push. Wired into package.json's `prepare`
@@ -12,17 +12,17 @@
 //   - Graceful no-op when `.git/` is absent (tarball install, or a CI
 //     `npm ci` checkout that ran `prepare` outside a work tree). `prepare`
 //     must never fail the install, so every path exits 0.
-//   - Honors the `RESUMELINT_SKIP_HOOKS=1` escape hatch at hook runtime.
+//   - Honors the `OFFLINECV_SKIP_HOOKS=1` escape hatch at hook runtime.
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-const MARKER_BEGIN = "# >>> resumelint managed pre-push (npm run verify) >>>";
-const MARKER_END = "# <<< resumelint managed pre-push <<<";
+const MARKER_BEGIN = "# >>> offlinecv managed pre-push (npm run verify) >>>";
+const MARKER_END = "# <<< offlinecv managed pre-push <<<";
 
 const MANAGED_BLOCK = `${MARKER_BEGIN}
-# Mirror CI locally before push. Bypass with RESUMELINT_SKIP_HOOKS=1.
-if [ "\${RESUMELINT_SKIP_HOOKS:-0}" = "1" ]; then
+# Mirror CI locally before push. Bypass with OFFLINECV_SKIP_HOOKS=1.
+if [ "\${OFFLINECV_SKIP_HOOKS:-0}" = "1" ]; then
   exit 0
 fi
 npm run verify

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { Card, Chip, ErrorState, ErrorBoundary, Button } from "@design-system";
 import { DropZone } from "./components/DropZone";
@@ -64,7 +64,7 @@ export default function App() {
   // Cross-link to /jd-fit (#226). On click we stash the edited parse in
   // sessionStorage (one-shot handoff) so JD-fit rehydrates it without
   // re-parsing, then navigate to the base-aware /jd-fit URL — works under both
-  // the custom-domain "/" base and the "/resumelint/" Pages-fallback base.
+  // the custom-domain "/" base and the "/OfflineCV/" Pages-fallback base.
   const goToJdFit = () => {
     if (state.phase === "done") {
       // The PRISTINE parse + score and the edit state as SEPARATE payloads —
@@ -111,7 +111,7 @@ export default function App() {
           {(state.phase === "idle" || state.phase === "error") && (
             // One consolidated hero message (internal #265): a single,
             // non-hyperbolic headline — no "they don't read your PDF" claim and
-            // no "parser" jargon — that says what resumelint does in one angle.
+            // no "parser" jargon — that says what OfflineCV does in one angle.
             // The trust stat is the one supporting line; everything else (the
             // recruiter-agent context) moves to the quiet block below the drop
             // zone so the hero isn't three competing messages.
@@ -134,7 +134,7 @@ export default function App() {
                   </a>
                 </h2>
                 <p className="text-pretty text-base font-medium text-content-primary sm:text-lg">
-                  resumelint shows you what a recruiter or screener reads back
+                  OfflineCV shows you what a recruiter or screener reads back
                   from your resume — free, private, and open-source.
                 </p>
                 <p className="text-xs text-content-muted">
@@ -195,7 +195,7 @@ export default function App() {
                 <span className="font-medium text-content-primary">
                   Recruiters are starting to run AI agents over resumes.
                 </span>{" "}
-                Several products score candidates for recruiters. resumelint is
+                Several products score candidates for recruiters. OfflineCV is
                 the candidate-side
                 mirror: it shows you what survives the parse — before you hit
                 submit. The score isn&apos;t a verdict on you as a candidate —

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { useCallback, useId, useRef, useState } from "react";
 import {

--- a/src/components/PdfPreview.tsx
+++ b/src/components/PdfPreview.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { useEffect, useRef, useState } from "react";
 import { getDocument } from "pdfjs-dist";

--- a/src/components/Result.test.tsx
+++ b/src/components/Result.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { useCallback, useMemo, useState } from "react";
 import type { CascadeResult } from "../lib/heuristics/types.ts";

--- a/src/components/features/AchievementTypePicker.test.tsx
+++ b/src/components/features/AchievementTypePicker.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/AchievementTypePicker.tsx
+++ b/src/components/features/AchievementTypePicker.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * AchievementTypePicker — pick an achievement's `type` label (#456).

--- a/src/components/features/AtsScoreReadout.test.tsx
+++ b/src/components/features/AtsScoreReadout.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/AtsScoreReadout.tsx
+++ b/src/components/features/AtsScoreReadout.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * AtsScoreReadout — renders the full score section: ring, verdict header,

--- a/src/components/features/ConsentDialog.test.ts
+++ b/src/components/features/ConsentDialog.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";

--- a/src/components/features/ConsentDialog.tsx
+++ b/src/components/features/ConsentDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ConsentDialog — modal shown before any Restricted-Community model begins

--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ContactCard — a centered visual contact card (#146) with optional inline

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ContactDetails — the contact line and links line of the centered ContactCard.

--- a/src/components/features/ContactExtraLinks.tsx
+++ b/src/components/features/ContactExtraLinks.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ContactExtraLinks — the variable-length "extra links" affordance on the

--- a/src/components/features/CritiquePanel.test.tsx
+++ b/src/components/features/CritiquePanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/CritiquePanel.tsx
+++ b/src/components/features/CritiquePanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * CritiquePanel — body-only "Resume quality" results (issue #244).

--- a/src/components/features/DisagreementPanel.test.tsx
+++ b/src/components/features/DisagreementPanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/DisagreementPanel.tsx
+++ b/src/components/features/DisagreementPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * DisagreementPanel — body-only "What an ATS misses" results (issue #242).

--- a/src/components/features/DownloadGateDialog.tsx
+++ b/src/components/features/DownloadGateDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * DownloadGateDialog — the pre-download checklist popover (#312).

--- a/src/components/features/DownloadReportDialog.tsx
+++ b/src/components/features/DownloadReportDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReportDownloadControl — the "Download report" affordance (#343).

--- a/src/components/features/EvidencePanel.tsx
+++ b/src/components/features/EvidencePanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Evidence panel bodies — "how a generic extractor read this file".

--- a/src/components/features/FeedbackPanel.test.tsx
+++ b/src/components/features/FeedbackPanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/FeedbackPanel.tsx
+++ b/src/components/features/FeedbackPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * FeedbackPanel — inline, PostHog-backed feedback panel (#51, #193).
@@ -178,7 +178,7 @@ function FeedbackRatingForm() {
               Thanks for your feedback!
             </p>
             <p className="text-sm text-content-tertiary">
-              It helps us improve ResumeLint.
+              It helps us improve OfflineCV.
             </p>
           </div>
         </Card>
@@ -227,7 +227,7 @@ function FeedbackRatingForm() {
       // side is empty) — turns two stacked footnote rows into one, killing the
       // empty band below the score. Right-aligned, so the lift can't misalign.
       <div className="flex items-center justify-end gap-2 -mt-8">
-        <span className="text-xs text-content-muted">Rate ResumeLint</span>
+        <span className="text-xs text-content-muted">Rate OfflineCV</span>
         <StarRating
           value={rating}
           onChange={(v) => {
@@ -235,7 +235,7 @@ function FeedbackRatingForm() {
             setRatingError(false);
             setCompactExpanded(true);
           }}
-          ariaLabel="Rate ResumeLint from 1 to 5 stars"
+          ariaLabel="Rate OfflineCV from 1 to 5 stars"
         />
       </div>
     );
@@ -252,7 +252,7 @@ function FeedbackRatingForm() {
               id={headingId}
               className="text-sm font-semibold text-content-primary"
             >
-              How's ResumeLint working for you?
+              How's OfflineCV working for you?
             </h2>
             <StarRating
               value={rating}
@@ -261,7 +261,7 @@ function FeedbackRatingForm() {
                 setRatingError(false);
               }}
               disabled={submitting}
-              ariaLabel="Rate ResumeLint from 1 to 5 stars"
+              ariaLabel="Rate OfflineCV from 1 to 5 stars"
               ariaDescribedBy={ratingError ? errorId : undefined}
             />
           </div>

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * FindJobsPanel — first slice of the job-search lane (#318). Builds a search

--- a/src/components/features/JdInput.test.ts
+++ b/src/components/features/JdInput.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JdInput — unit tests.

--- a/src/components/features/JdInput.tsx
+++ b/src/components/features/JdInput.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JdInput — Job description entry panel.

--- a/src/components/features/JdMatch.test.ts
+++ b/src/components/features/JdMatch.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";

--- a/src/components/features/JdMatch.tsx
+++ b/src/components/features/JdMatch.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JdMatch — diagnostic JD-coverage panel.

--- a/src/components/features/JobResultCard.test.tsx
+++ b/src/components/features/JobResultCard.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/JobResultCard.tsx
+++ b/src/components/features/JobResultCard.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JobResultCard — one ranked posting in the Find Jobs results list (#319).

--- a/src/components/features/JobSearchResults.test.tsx
+++ b/src/components/features/JobSearchResults.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/JobSearchResults.tsx
+++ b/src/components/features/JobSearchResults.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JobSearchResults — the Results region of the Find Jobs panel (#319).

--- a/src/components/features/LayoutFlagsList.tsx
+++ b/src/components/features/LayoutFlagsList.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * LayoutFlagsList — renders the layout-trigger warning list.

--- a/src/components/features/LlmEscapeHatchBanner.test.tsx
+++ b/src/components/features/LlmEscapeHatchBanner.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/LlmEscapeHatchBanner.tsx
+++ b/src/components/features/LlmEscapeHatchBanner.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * LlmEscapeHatchBanner — the degenerate-case recovery CTA (issue #243).

--- a/src/components/features/ModelSelector.test.ts
+++ b/src/components/features/ModelSelector.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Smoke tests for `ModelSelector`'s presentational surface.

--- a/src/components/features/ModelSelector.tsx
+++ b/src/components/features/ModelSelector.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ModelSelector — picker UI for the curated WebLLM model registry.

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * PageShell — the chrome both root surfaces share (issue #226).
@@ -62,11 +62,11 @@ export function PageShell({
             <a
               href={import.meta.env.BASE_URL}
               className="inline-grid h-8 w-8 place-items-center rounded-md bg-brand-amber text-base font-bold text-content-inverse"
-              aria-label="resumelint home"
+              aria-label="offlinecv home"
             >
               R
             </a>
-            <h1 className="text-2xl font-semibold tracking-tight">resumelint</h1>
+            <h1 className="text-2xl font-semibold tracking-tight">offlinecv</h1>
             <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
               {badge}
             </span>
@@ -88,7 +88,7 @@ export function PageShell({
         <p>Your PDF stays in this browser tab by default and is never used to train AI. AI analysis is optional.</p>
         <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
           <a
-            href="https://github.com/resumelint-org/resumelint/blob/main/LICENSE"
+            href="https://github.com/offlinecv/OfflineCV/blob/main/LICENSE"
             target="_blank"
             rel="noreferrer noopener"
             className="hover:underline"
@@ -104,7 +104,7 @@ export function PageShell({
             Further reading: HBS Hidden Workers
           </a>
           <a
-            href="https://github.com/resumelint-org/resumelint/blob/main/README.md#telemetry"
+            href="https://github.com/offlinecv/OfflineCV/blob/main/README.md#telemetry"
             target="_blank"
             rel="noreferrer noopener"
             className="hover:underline"

--- a/src/components/features/ParsedHeader.tsx
+++ b/src/components/features/ParsedHeader.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { Button, StatusBadge } from "@design-system";
 

--- a/src/components/features/ProfileLinkAdd.test.tsx
+++ b/src/components/features/ProfileLinkAdd.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/ProfileLinkAdd.tsx
+++ b/src/components/features/ProfileLinkAdd.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ProfileLinkAdd — the GUIDED profile-link add affordance for the contact card.

--- a/src/components/features/ReconstructedAdd.test.ts
+++ b/src/components/features/ReconstructedAdd.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FocusEvent } from "react";

--- a/src/components/features/ReconstructedAdd.tsx
+++ b/src/components/features/ReconstructedAdd.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReconstructedAdd — shared "+ Add" affordances for the reconstructed-resume

--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReconstructedEducationSkills — the editable Education and Skills sections of

--- a/src/components/features/ReconstructedResume.test.ts
+++ b/src/components/features/ReconstructedResume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the pure chain-of-sections input builders (#67) that

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReconstructedResume — the primary post-parse surface. A faithful, read-only

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReconstructedRole — one parsed experience role rendered in resume shape.

--- a/src/components/features/ReplaceResumeDropOverlay.tsx
+++ b/src/components/features/ReplaceResumeDropOverlay.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReplaceResumeDropOverlay — the visual half of drag-to-replace on the results

--- a/src/components/features/ReportGapSection.test.tsx
+++ b/src/components/features/ReportGapSection.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/ReportGapSection.tsx
+++ b/src/components/features/ReportGapSection.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ReportGapSection — "Report a parsing gap" affordance (#245).
@@ -93,12 +93,12 @@ export function ReportGapSection({
           <p className="text-sm text-content-tertiary">
             Attach it to a new issue at{" "}
             <a
-              href="https://github.com/resumelint-org/resumelint/issues/new"
+              href="https://github.com/offlinecv/OfflineCV/issues/new"
               target="_blank"
               rel="noreferrer noopener"
               className="underline decoration-dotted hover:decoration-solid"
             >
-              github.com/resumelint-org/resumelint
+              github.com/offlinecv/OfflineCV
             </a>{" "}
             describing what the parser got wrong.
           </p>

--- a/src/components/features/ResultDetailTabs.test.tsx
+++ b/src/components/features/ResultDetailTabs.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { useState } from "react";
 import { Card, Tabs, TabList, Tab, TabPanel } from "@design-system";

--- a/src/components/features/ResumeLibrary.tsx
+++ b/src/components/features/ResumeLibrary.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ResumeLibrary — the saved-resumes picker on the landing view (#322). Lists

--- a/src/components/features/ResumeLibraryEntry.tsx
+++ b/src/components/features/ResumeLibraryEntry.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ResumeLibraryEntry — one saved-resume row in the library (#322): editable

--- a/src/components/features/ResumeQualityPanel.test.tsx
+++ b/src/components/features/ResumeQualityPanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/ResumeQualityPanel.tsx
+++ b/src/components/features/ResumeQualityPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ResumeQualityPanel — consolidated "Resume Quality" tab shell (issue #273).

--- a/src/components/features/ResumeRewrite.test.ts
+++ b/src/components/features/ResumeRewrite.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Smoke tests for ResumeRewrite's presentational helpers.

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Whole-résumé "Rewrite full résumé" feature (issue #67 — Phase 4 of #66).

--- a/src/components/features/ResumeRewriteProposed.test.tsx
+++ b/src/components/features/ResumeRewriteProposed.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Final "all sections rewritten" panel for the whole-résumé rewrite flow

--- a/src/components/features/RewriteReviewList.test.tsx
+++ b/src/components/features/RewriteReviewList.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * RewriteReviewList — per-bullet accept/reject/edit surface for a rewrite

--- a/src/components/features/SaveResumeBar.tsx
+++ b/src/components/features/SaveResumeBar.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * SaveResumeBar — the "save this resume to your library" affordance shown under

--- a/src/components/features/ScoreRing.tsx
+++ b/src/components/features/ScoreRing.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { getScoreTier } from "../../lib/score/score.ts";
 import { scoreBandTextClass } from "./scoreBand.ts";

--- a/src/components/features/SectionRewrite.test.ts
+++ b/src/components/features/SectionRewrite.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Smoke tests for SectionRewrite's presentational branches.

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Per-role "Rewrite section" CTA. Runs Qwen2.5-1.5B in the browser via WebLLM

--- a/src/components/features/SourceDiagnosticsPanel.test.tsx
+++ b/src/components/features/SourceDiagnosticsPanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/components/features/SourceDiagnosticsPanel.tsx
+++ b/src/components/features/SourceDiagnosticsPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * SourceDiagnosticsPanel — the "Source & diagnostics" primary tab body (#263).

--- a/src/components/features/VerdictHeader.tsx
+++ b/src/components/features/VerdictHeader.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { getScoreLabel, getScoreTier } from "../../lib/score/score.ts";
 import { scoreBandTextClass } from "./scoreBand.ts";

--- a/src/components/features/WebGpuUnavailableNotice.tsx
+++ b/src/components/features/WebGpuUnavailableNotice.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * WebGpuUnavailableNotice — the shared explainer that replaces the silent

--- a/src/components/features/scoreBand.ts
+++ b/src/components/features/scoreBand.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { ScoreTier } from "../../lib/score/types.ts";
 

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Design-system barrel — the `@design-system` seam.

--- a/src/design-system/primitives/Button.tsx
+++ b/src/design-system/primitives/Button.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Button — the ONE interactive-button primitive.

--- a/src/design-system/primitives/Chip.tsx
+++ b/src/design-system/primitives/Chip.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 export type ChipTone = "neutral" | "success" | "warning";
 

--- a/src/design-system/primitives/Dialog.test.ts
+++ b/src/design-system/primitives/Dialog.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Smoke tests for the `Dialog` primitive.

--- a/src/design-system/primitives/Dialog.tsx
+++ b/src/design-system/primitives/Dialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Dialog — the ONE modal-dialog primitive.

--- a/src/design-system/primitives/EditableField.test.tsx
+++ b/src/design-system/primitives/EditableField.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tests for the `EditableField` primitive's empty-state placeholder treatment

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * EditableField — the ONE shared inline-edit primitive.

--- a/src/design-system/primitives/StarRating.tsx
+++ b/src/design-system/primitives/StarRating.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * StarRating — the ONE 1–N star rating primitive.
@@ -27,7 +27,7 @@ interface StarRatingProps {
   /** Number of stars. Defaults to 5. */
   max?: number;
   disabled?: boolean;
-  /** Accessible name for the group (e.g. "Rate ResumeLint from 1 to 5 stars"). */
+  /** Accessible name for the group (e.g. "Rate OfflineCV from 1 to 5 stars"). */
   ariaLabel?: string;
   /** Id of an external element (e.g. a validation error) describing the group. */
   ariaDescribedBy?: string;

--- a/src/design-system/primitives/TextAreaField.tsx
+++ b/src/design-system/primitives/TextAreaField.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * TextAreaField — the ONE always-visible multiline text input primitive.

--- a/src/design-system/shared/Card.tsx
+++ b/src/design-system/shared/Card.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Card — the canonical surface chrome (radius, border, card background,

--- a/src/design-system/shared/CountBadge.tsx
+++ b/src/design-system/shared/CountBadge.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * CountBadge — the ONE pill that renders a small numeric count after a label

--- a/src/design-system/shared/ErrorBoundary.test.ts
+++ b/src/design-system/shared/ErrorBoundary.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ErrorBoundary — unit tests.

--- a/src/design-system/shared/ErrorBoundary.tsx
+++ b/src/design-system/shared/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ErrorBoundary — class component wrapping the result surface.

--- a/src/design-system/shared/ErrorState.tsx
+++ b/src/design-system/shared/ErrorState.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ErrorState — inline error / warning banner.

--- a/src/design-system/shared/GitHubStarCta.tsx
+++ b/src/design-system/shared/GitHubStarCta.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * GitHubStarCta — quiet, policy-compliant GitHub star CTA.
@@ -26,7 +26,7 @@
 
 import { Card } from "./Card.tsx";
 
-const REPO_URL = "https://github.com/resumelint-org/resumelint";
+const REPO_URL = "https://github.com/offlinecv/OfflineCV";
 
 /**
  * Minimum star count before we surface the number as social proof. Below this,
@@ -80,8 +80,8 @@ function StarLink({ count }: { count?: number }) {
       className="inline-flex items-center gap-1.5 text-xs text-content-secondary transition-colors hover:text-content-primary"
       aria-label={
         showCount
-          ? `Star resumelint on GitHub — ${formatCount(count)} stars`
-          : "Star resumelint on GitHub"
+          ? `Star offlinecv on GitHub — ${formatCount(count)} stars`
+          : "Star offlinecv on GitHub"
       }
     >
       <GitHubIcon />
@@ -106,7 +106,7 @@ export function GitHubStarCta({ variant, count }: GitHubStarCtaProps) {
           Glad it's working! ⭐
         </p>
         <p className="text-sm text-content-secondary">
-          Star us on GitHub so others can find ResumeLint.
+          Star us on GitHub so others can find OfflineCV.
         </p>
         <StarLink count={count} />
       </Card>

--- a/src/design-system/shared/InlineDiff.tsx
+++ b/src/design-system/shared/InlineDiff.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * InlineDiff — renders a pre-computed diff as inline redline text.

--- a/src/design-system/shared/InlineResult.tsx
+++ b/src/design-system/shared/InlineResult.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * InlineResult — feedback-toned result-strip chrome (rounded border +

--- a/src/design-system/shared/ModelLoadProgress.test.ts
+++ b/src/design-system/shared/ModelLoadProgress.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";

--- a/src/design-system/shared/ModelLoadProgress.tsx
+++ b/src/design-system/shared/ModelLoadProgress.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ModelLoadProgress — the shared WebLLM model-download progress panel.

--- a/src/design-system/shared/StatusBadge.tsx
+++ b/src/design-system/shared/StatusBadge.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * StatusBadge — shared pill for parse-status labels.

--- a/src/design-system/shared/Tabs.tsx
+++ b/src/design-system/shared/Tabs.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tabs — the ONE accessible, controlled tabbed-navigation primitive.

--- a/src/design-system/shared/UpdateBanner.tsx
+++ b/src/design-system/shared/UpdateBanner.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * UpdateBanner — non-blocking notice that a newer build is deployed.
@@ -27,7 +27,7 @@ export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
       className="flex items-center justify-between gap-3 rounded-md border border-feedback-info-border bg-feedback-info-bg px-4 py-2.5 text-sm text-feedback-info-text"
     >
       <span>
-        A new version of resumelint is available. Reload to get the latest.
+        A new version of offlinecv is available. Reload to get the latest.
       </span>
       <div className="flex shrink-0 items-center gap-1">
         <Button variant="primary" size="sm" onClick={onReload}>

--- a/src/design-system/styles/theme.css
+++ b/src/design-system/styles/theme.css
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright 2026 The resumelint Authors */
+/* Copyright 2026 The offlinecv Authors */
 
 /*
  * Semantic token vocabulary — the STABLE CONTRACT.

--- a/src/design-system/styles/tokens.css
+++ b/src/design-system/styles/tokens.css
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright 2026 The resumelint Authors */
+/* Copyright 2026 The offlinecv Authors */
 
 /*
  * Default token VALUES — the SWAPPABLE layer.
@@ -12,7 +12,7 @@
  * semantic vocabulary in styles/theme.css. They are the override seam: a
  * downstream productionizer supplies their own brand without forking, either
  * by (1) redefining these same properties in a stylesheet imported after
- * resumelint's (cascade wins), or (2) pointing the Vite `@design-tokens`
+ * offlinecv's (cascade wins), or (2) pointing the Vite `@design-tokens`
  * alias at their own complete copy of this file. See the README "Theming"
  * section. The semantic Tailwind classes are generated from these names and
  * do not change — only the values here are meant to be replaced.

--- a/src/hooks/__test-utils__/memory-storage.ts
+++ b/src/hooks/__test-utils__/memory-storage.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * In-memory `Storage` shim for hook tests that persist to `localStorage`.

--- a/src/hooks/useAnalyzedResume.test.tsx
+++ b/src/hooks/useAnalyzedResume.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useAnalyzedResume — the full parse → edit → re-grade orchestration that both

--- a/src/hooks/useDownloadPdf.test.tsx
+++ b/src/hooks/useDownloadPdf.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useDownloadPdf — drives the "Download PDF" action on the reconstructed-resume

--- a/src/hooks/useDownloadReport.ts
+++ b/src/hooks/useDownloadReport.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useDownloadReport — drives the "Download report" action on the reconstructed-

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useEditableParse — in-memory overrides for the reconstructed resume fields.

--- a/src/hooks/useGitHubStars.ts
+++ b/src/hooks/useGitHubStars.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
- * useGitHubStars — fetches the resumelint-org/resumelint star count from the
+ * useGitHubStars — fetches the offlinecv/OfflineCV star count from the
  * GitHub REST API, caches the result in localStorage (~1 h TTL), and returns
  * it fail-silently: any network error, rate-limit, or localStorage unavailability
  * resolves to `{ count: undefined }` without throwing or rendering an error UI.
@@ -16,7 +16,7 @@ import { useEffect, useState } from "react";
 const LS_KEY = "rl_gh_stars_cache";
 const TTL_MS = 60 * 60 * 1000; // 1 hour
 const API_URL =
-  "https://api.github.com/repos/resumelint-org/resumelint";
+  "https://api.github.com/repos/offlinecv/OfflineCV";
 
 interface StarCache {
   count: number;

--- a/src/hooks/useLlmEscapeHatch.ts
+++ b/src/hooks/useLlmEscapeHatch.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useLlmEscapeHatch — drives the degenerate-case LLM recovery pass (issue #243).

--- a/src/hooks/useModelSelection.integration.test.tsx
+++ b/src/hooks/useModelSelection.integration.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useModelSelection.test.ts
+++ b/src/hooks/useModelSelection.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tests for the pure I/O surface of `useModelSelection`. The React hook
@@ -43,7 +43,7 @@ describe("readPersistedModelId", () => {
     // Simulate a registry entry that existed in a previous version and was
     // removed since (e.g. a model deprecated by MLC).
     globalThis.localStorage.setItem(
-      "resumelint:webllm:modelId",
+      "offlinecv:webllm:modelId",
       "deprecated-old-model-id",
     );
     expect(readPersistedModelId()).toBe(DEFAULT_MODEL_ID);

--- a/src/hooks/useModelSelection.ts
+++ b/src/hooks/useModelSelection.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * `useModelSelection` — drives the user's persisted WebLLM model choice and
@@ -22,8 +22,8 @@
  * with Qwen2.5 (Apache-2.0) regardless.
  *
  * Storage layout:
- *   - `resumelint:webllm:modelId` → exact `model_id` from MODEL_REGISTRY
- *   - `resumelint:webllm:consent:<LicenseType>` → "accepted" (presence
+ *   - `offlinecv:webllm:modelId` → exact `model_id` from MODEL_REGISTRY
+ *   - `offlinecv:webllm:consent:<LicenseType>` → "accepted" (presence
  *     only; absence means "no consent recorded")
  *
  * The pure I/O functions (`readPersistedModelId`, `writePersistedModelId`,
@@ -45,8 +45,8 @@ const LICENSE_TYPES: readonly LicenseType[] = Array.from(
   new Set(MODEL_REGISTRY.map((m) => m.licenseType)),
 );
 
-const MODEL_ID_KEY = "resumelint:webllm:modelId";
-const CONSENT_KEY_PREFIX = "resumelint:webllm:consent:";
+const MODEL_ID_KEY = "offlinecv:webllm:modelId";
+const CONSENT_KEY_PREFIX = "offlinecv:webllm:consent:";
 const CONSENT_VALUE = "accepted";
 
 function safeGet(key: string): string | null {

--- a/src/hooks/usePersistentFlag.ts
+++ b/src/hooks/usePersistentFlag.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * usePersistentFlag / usePersistentCounter — thin localStorage-backed hooks.

--- a/src/hooks/useReplaceResumeOnDrop.test.tsx
+++ b/src/hooks/useReplaceResumeOnDrop.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useReplaceResumeOnDrop.ts
+++ b/src/hooks/useReplaceResumeOnDrop.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useReplaceResumeOnDrop — window-level drag-to-replace for the results view.

--- a/src/hooks/useReportGap.test.tsx
+++ b/src/hooks/useReportGap.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useReportGap.ts
+++ b/src/hooks/useReportGap.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useReportGap — drives the "Report a parsing gap" download (issue #245).
@@ -42,7 +42,7 @@ function artifactFilename(): string {
   const stamp =
     `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
     `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-  return `resumelint-repro-${stamp}.json`;
+  return `offlinecv-repro-${stamp}.json`;
 }
 
 export function useReportGap(

--- a/src/hooks/useResumeAnalysis.migration.test.ts
+++ b/src/hooks/useResumeAnalysis.migration.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Persistence back-compat for the #427 contact-link consolidation.

--- a/src/hooks/useResumeAnalysis.ts
+++ b/src/hooks/useResumeAnalysis.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useResumeAnalysis — owns the ParseState machine, file-handling logic,

--- a/src/hooks/useResumeAnalysisLlm.ts
+++ b/src/hooks/useResumeAnalysisLlm.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useResumeAnalysisLlm — the single controller driving both opt-in WebLLM

--- a/src/hooks/useResumeLibrary.ts
+++ b/src/hooks/useResumeLibrary.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useResumeLibrary — UI-facing state over the resume-library domain layer
@@ -114,7 +114,7 @@ export function useResumeLibrary(): ResumeLibrary {
     );
     const a = document.createElement("a");
     a.href = url;
-    a.download = "resumelint-backup.json";
+    a.download = "offlinecv-backup.json";
     a.click();
     URL.revokeObjectURL(url);
   }, []);

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * `useResumeRewrite` — controller for the whole-résumé "rewrite resume" flow

--- a/src/hooks/useRewriteReview.test.tsx
+++ b/src/hooks/useRewriteReview.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/hooks/useRewriteReview.ts
+++ b/src/hooks/useRewriteReview.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useRewriteReview — in-memory per-bullet accept/reject/edit decision model for

--- a/src/hooks/useSectionRewriteLock.test.ts
+++ b/src/hooks/useSectionRewriteLock.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { beforeEach, describe, expect, it } from "vitest";
 

--- a/src/hooks/useSectionRewriteLock.ts
+++ b/src/hooks/useSectionRewriteLock.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Cross-instance "at most one section rewrite running at a time" lock.

--- a/src/hooks/useUpdateChecker.ts
+++ b/src/hooks/useUpdateChecker.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { APP_VERSION, fetchDeployedVersion } from "../lib/version.ts";

--- a/src/hooks/webllm-controllers.test.tsx
+++ b/src/hooks/webllm-controllers.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/jd-fit/JdFitApp.tsx
+++ b/src/jd-fit/JdFitApp.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JdFitApp — the `/jd-fit` root surface (issue #226).

--- a/src/jd-fit/main.tsx
+++ b/src/jd-fit/main.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/src/jd-fit/useJdFitResume.test.tsx
+++ b/src/jd-fit/useJdFitResume.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // @vitest-environment jsdom
 

--- a/src/jd-fit/useJdFitResume.ts
+++ b/src/jd-fit/useJdFitResume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * useJdFitResume — resolve the résumé source for `/jd-fit` (issue #226).

--- a/src/lib/achievements/presets.test.ts
+++ b/src/lib/achievements/presets.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/achievements/presets.ts
+++ b/src/lib/achievements/presets.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Achievement type presets — the catalog behind the type picker (#456).

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { buildFeedbackProps } from "./analytics.ts";

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { CASCADE_VERSION } from "./heuristics/types";
 import type { LayoutTrigger, ParseEvent } from "./heuristics/types";

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * anchors — the typed scroll-target contract (#153).

--- a/src/lib/contact.test.ts
+++ b/src/lib/contact.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Contact field display helper for the anonymous ATS check UI.

--- a/src/lib/contact/contact-profiles.test.ts
+++ b/src/lib/contact/contact-profiles.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * `deriveContactProfiles` is the ONE consolidated contact-link list the scorer +

--- a/src/lib/contact/contact-profiles.ts
+++ b/src/lib/contact/contact-profiles.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * contact-profiles.ts — the ONE consolidated contact-link model (#427).

--- a/src/lib/contact/profile-registry.test.ts
+++ b/src/lib/contact/profile-registry.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/contact/profile-registry.ts
+++ b/src/lib/contact/profile-registry.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Contributor-extensible host registry for classifying contact/identity links

--- a/src/lib/contact/url-utils.test.ts
+++ b/src/lib/contact/url-utils.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { normalizeUrl, urlSlug } from "./url-utils.ts";

--- a/src/lib/contact/url-utils.ts
+++ b/src/lib/contact/url-utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Leaf URL helpers shared by the contact extractor (`heuristics/extract/

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { timeAgo } from "./date-utils.ts";

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Compact relative-time formatting. Pure, zero-dependency.

--- a/src/lib/diff/text-diff.test.ts
+++ b/src/lib/diff/text-diff.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { computeTextDiff, computeWordDiff } from "./text-diff.ts";
 

--- a/src/lib/diff/text-diff.ts
+++ b/src/lib/diff/text-diff.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Minimal in-browser text diff using `fast-diff` (MIT). Produces a flat list

--- a/src/lib/download/blob-download.ts
+++ b/src/lib/download/blob-download.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * blob-download — the one place the app turns bytes into a same-document

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { applyOverrides, applyProfileOverrides } from "./apply-overrides.ts";

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * apply-overrides.ts — make in-memory edit overrides authoritative.

--- a/src/lib/edit/description-override-roundtrip.repro.test.ts
+++ b/src/lib/edit/description-override-roundtrip.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * descriptionOverrides edit-leg round-trip (#489).

--- a/src/lib/edit/field-validators.test.ts
+++ b/src/lib/edit/field-validators.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/edit/field-validators.ts
+++ b/src/lib/edit/field-validators.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shape validators for the inline-edit fields on the reconstructed résumé (#357).
  *
- * These are **shape** checks, not judgments. ResumeLint is a "parser audit, not
+ * These are **shape** checks, not judgments. OfflineCV is a "parser audit, not
  * a judge": the user is authoritative over their own résumé, so future dates,
  * unusual company names, redacted placeholders, and other odd-but-real values
  * must NOT be flagged. A validator returns a message ONLY when the value is the

--- a/src/lib/edit/skill-canonical.test.ts
+++ b/src/lib/edit/skill-canonical.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { canonicalizeSkill, suggestSkills } from "./skill-canonical.ts";

--- a/src/lib/edit/skill-canonical.ts
+++ b/src/lib/edit/skill-canonical.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * skill-canonical — a small, self-contained skills-name normalizer + suggester

--- a/src/lib/file-accept.ts
+++ b/src/lib/file-accept.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared resume-file accept predicate.

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Feature flags — two-layer gate.

--- a/src/lib/format-bytes.ts
+++ b/src/lib/format-bytes.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Human-readable file size string.

--- a/src/lib/heuristics/__test-utils__/corpus-snapshots.ts
+++ b/src/lib/heuristics/__test-utils__/corpus-snapshots.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The corpus loader (issue #469, step 6) — the sweep's I/O half.

--- a/src/lib/heuristics/__test-utils__/mkItem.ts
+++ b/src/lib/heuristics/__test-utils__/mkItem.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Factories for synthetic `PdfTextItem` / `PdfPageInfo` inputs used by the

--- a/src/lib/heuristics/__test-utils__/origin-links.ts
+++ b/src/lib/heuristics/__test-utils__/origin-links.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The `.origin.json` breadcrumb convention (issue #39).

--- a/src/lib/heuristics/canonical.ts
+++ b/src/lib/heuristics/canonical.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * canonical — the single internal résumé representation the migration collapses

--- a/src/lib/heuristics/cascade-markdown.test.ts
+++ b/src/lib/heuristics/cascade-markdown.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Integration tests for `runCascadeFromMarkdown`.

--- a/src/lib/heuristics/cascade.ts
+++ b/src/lib/heuristics/cascade.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Cascade orchestrator.

--- a/src/lib/heuristics/confidence.test.ts
+++ b/src/lib/heuristics/confidence.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { computeConfidence, CANONICAL_CONFIDENCE_THRESHOLD } from "./confidence.ts";
 import type { HeuristicResult, LayoutProbes } from "./types.ts";

--- a/src/lib/heuristics/confidence.ts
+++ b/src/lib/heuristics/confidence.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Confidence scorer + escalation router.

--- a/src/lib/heuristics/corpus-edit-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-edit-roundtrip.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Corpus EDIT-leg round-trip gate (#459).

--- a/src/lib/heuristics/corpus-gate.test-utils.ts
+++ b/src/lib/heuristics/corpus-gate.test-utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared corpus-gate harness (#459).

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Corpus round-trip invariant gate (#293).

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Snapshot-driven corpus regression test (#1).

--- a/src/lib/heuristics/defect-classes.test.ts
+++ b/src/lib/heuristics/defect-classes.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tests for the defect-class table (issue #469).

--- a/src/lib/heuristics/defect-classes.ts
+++ b/src/lib/heuristics/defect-classes.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Defect-class taxonomy + the load-bearing-axis table (issue #469).
@@ -17,7 +17,7 @@
  * │ This file exists to answer "does any fixture already reproduce the defect │
  * │ this REAL résumé exposes?" — so it sits, by construction, one function    │
  * │ call away from a real name, a real email, a real phone, real bullet text. │
- * │ resumelint is a PUBLIC repo. Anything this layer can carry is one         │
+ * │ offlinecv is a PUBLIC repo. Anything this layer can carry is one         │
  * │ copy-paste from a public issue, and the `*.expected.json` corpus          │
  * │ snapshots (which will bake a `DerivedSignals` per fixture, #469 step 5)   │
  * │ are COMMITTED. A single free-form `string` slot here would turn both into │
@@ -216,7 +216,7 @@ export const DERIVED_SIGNAL_KEYS = [
   // `scanned`, so the cascade short-circuits before Tier 1; or `rawText` is
   // empty). EVERY key above except the round-trip ones is derived from the
   // extracted text or from the sections cut out of it, so on such a parse they
-  // are all false because there was nothing to read. This is resumelint's single
+  // are all false because there was nothing to read. This is offlinecv's single
   // most severe failure mode (zero characters extracted) and it must never be
   // reported as "no defect class is exhibited by this parse".
   "textOracleUnavailable",

--- a/src/lib/heuristics/disagreement.test.ts
+++ b/src/lib/heuristics/disagreement.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for diffParses (issue #242).

--- a/src/lib/heuristics/disagreement.ts
+++ b/src/lib/heuristics/disagreement.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Disagreement detector — heuristic vs LLM parse (issue #242, headline feature).

--- a/src/lib/heuristics/empty-result.test.ts
+++ b/src/lib/heuristics/empty-result.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { buildBlankResult } from "./empty-result.ts";

--- a/src/lib/heuristics/empty-result.ts
+++ b/src/lib/heuristics/empty-result.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * empty-result.ts — the from-scratch résumé factory (#313).

--- a/src/lib/heuristics/entry-blocks.test.ts
+++ b/src/lib/heuristics/entry-blocks.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the shared `parseEntryBlocks` primitive.

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared "dated entry block" primitive for entry-style resume sections.

--- a/src/lib/heuristics/extract-fields.test.ts
+++ b/src/lib/heuristics/extract-fields.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {
@@ -1217,13 +1217,13 @@ describe("extractExperience", () => {
 describe("extractProjects", () => {
   it("lifts a URL out of the header and keeps the clean name", () => {
     const section = mkSection("projects", [
-      { text: "Resume Linter https://github.com/acme/resumelint" },
+      { text: "Resume Linter https://github.com/acme/offlinecv" },
       { text: "• Parses PDFs in the browser" },
     ]);
     const { value, confidence } = extractProjects(section);
     expect(value).toHaveLength(1);
     expect(value[0].name).toBe("Resume Linter");
-    expect(value[0].url).toBe("https://github.com/acme/resumelint");
+    expect(value[0].url).toBe("https://github.com/acme/offlinecv");
     expect(value[0].description).toContain("Parses PDFs");
     expect(confidence).toBeGreaterThan(0);
   });

--- a/src/lib/heuristics/extract-fields.ts
+++ b/src/lib/heuristics/extract-fields.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Barrel re-export — keeps `openresume.ts` and test imports stable while the

--- a/src/lib/heuristics/extract/achievements.test.ts
+++ b/src/lib/heuristics/extract/achievements.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { liftHeaderLabel } from "./projects.ts";

--- a/src/lib/heuristics/extract/achievements.ts
+++ b/src/lib/heuristics/extract/achievements.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { HeuristicAchievement } from "../../score/types.ts";
 import type { PdfLine, PdfSection } from "../sections.ts";

--- a/src/lib/heuristics/extract/contact.test.ts
+++ b/src/lib/heuristics/extract/contact.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { extractContact } from "./contact.ts";

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { PdfLine, PdfSection } from "../sections.ts";
 import type { PdfLinkAnnotation } from "../types.ts";

--- a/src/lib/heuristics/extract/dateless-entries.test.ts
+++ b/src/lib/heuristics/extract/dateless-entries.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression tests for page-2 entry loss (#219).

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression for the coursework continuation loop over-consuming the next

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { ResumeEducation } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import {
   US_LOCATION_RE,

--- a/src/lib/heuristics/extract/experience.anchor-tiebreak.test.ts
+++ b/src/lib/heuristics/extract/experience.anchor-tiebreak.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression tests for the anchor-position company/title tiebreak in

--- a/src/lib/heuristics/extract/experience.date-location.test.ts
+++ b/src/lib/heuristics/extract/experience.date-location.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression tests for a `Date · Location` experience sub-line (#347).

--- a/src/lib/heuristics/extract/experience.location.test.ts
+++ b/src/lib/heuristics/extract/experience.location.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression tests for role location extraction (#218, #229).

--- a/src/lib/heuristics/extract/experience.mid-dot.test.ts
+++ b/src/lib/heuristics/extract/experience.mid-dot.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression tests for `·`-delimited single-line experience headers (#217).

--- a/src/lib/heuristics/extract/experience.multiword-city.test.ts
+++ b/src/lib/heuristics/extract/experience.multiword-city.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression tests for multi-word city extraction on a space-folded header

--- a/src/lib/heuristics/extract/experience.pipe-location.test.ts
+++ b/src/lib/heuristics/extract/experience.pipe-location.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression for #373 — a per-entry location dropped when a

--- a/src/lib/heuristics/extract/experience.role-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.role-comma.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression for the `"Title, Location"` role-comma split (PR #159 review):

--- a/src/lib/heuristics/extract/experience.shared-banner.test.ts
+++ b/src/lib/heuristics/extract/experience.shared-banner.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression for #382 — a single employer named ONCE as a banner above a

--- a/src/lib/heuristics/extract/experience.title-team-comma.test.ts
+++ b/src/lib/heuristics/extract/experience.title-team-comma.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression for #372 — a "Title, Team" role header over a

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { ResumeExperience } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";

--- a/src/lib/heuristics/extract/name.test.ts
+++ b/src/lib/heuristics/extract/name.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { extractHeadline } from "./name.ts";

--- a/src/lib/heuristics/extract/name.ts
+++ b/src/lib/heuristics/extract/name.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { PdfLine, PdfSection } from "../sections.ts";
 import { matchSectionHeader } from "../regex.ts";

--- a/src/lib/heuristics/extract/projects.ts
+++ b/src/lib/heuristics/extract/projects.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { ResumeProject } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";

--- a/src/lib/heuristics/extract/shared.ts
+++ b/src/lib/heuristics/extract/shared.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import {
   COMPANY_SUFFIX_RE,

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { extractSkills, tokenizeSkillLine } from "./skills.ts";

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { PdfSection } from "../sections.ts";
 import type { PdfTextItem } from "../types.ts";

--- a/src/lib/heuristics/extract/summary.test.ts
+++ b/src/lib/heuristics/extract/summary.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { extractSummary } from "./summary.ts";

--- a/src/lib/heuristics/extract/summary.ts
+++ b/src/lib/heuristics/extract/summary.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import type { PdfLine, PdfSection } from "../sections.ts";
 

--- a/src/lib/heuristics/fixture-match.test.ts
+++ b/src/lib/heuristics/fixture-match.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * `matchCorpus()` unit tests — hand-built artifacts only, NO PDF I/O.

--- a/src/lib/heuristics/fixture-match.ts
+++ b/src/lib/heuristics/fixture-match.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The corpus-match engine (issue #469, step 3).

--- a/src/lib/heuristics/index.ts
+++ b/src/lib/heuristics/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Client-side heuristic resume parser cascade.

--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Leaf-level line primitives shared by the entry-block parser and the field

--- a/src/lib/heuristics/localize/__test-utils__.ts
+++ b/src/lib/heuristics/localize/__test-utils__.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Minimal `CascadeResult` mock builder for the `localize/*.test.ts` suites.

--- a/src/lib/heuristics/localize/achievements.test.ts
+++ b/src/lib/heuristics/localize/achievements.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { localizeAchievements } from "./achievements.ts";

--- a/src/lib/heuristics/localize/achievements.ts
+++ b/src/lib/heuristics/localize/achievements.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Achievements-section localization (issue #469 step 4) — extracted from

--- a/src/lib/heuristics/localize/contact.test.ts
+++ b/src/lib/heuristics/localize/contact.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { localizeContact, rawTextCandidates } from "./contact.ts";

--- a/src/lib/heuristics/localize/contact.ts
+++ b/src/lib/heuristics/localize/contact.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Contact-section localization (issue #469 step 4) — extracted from

--- a/src/lib/heuristics/localize/education.test.ts
+++ b/src/lib/heuristics/localize/education.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { localizeEducation, looseEducationReason, countDegrees } from "./education.ts";

--- a/src/lib/heuristics/localize/education.ts
+++ b/src/lib/heuristics/localize/education.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Education-section localization (issue #469 step 4) — extracted from

--- a/src/lib/heuristics/localize/experience.test.ts
+++ b/src/lib/heuristics/localize/experience.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { localizeExperience } from "./experience.ts";

--- a/src/lib/heuristics/localize/experience.ts
+++ b/src/lib/heuristics/localize/experience.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Experience-section localization (issue #469 step 4) — extracted from

--- a/src/lib/heuristics/localize/headers.ts
+++ b/src/lib/heuristics/localize/headers.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The shared markdown HEADER ORACLE — the one place `localize/skills.ts` and

--- a/src/lib/heuristics/localize/roundtrip.test.ts
+++ b/src/lib/heuristics/localize/roundtrip.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/heuristics/localize/roundtrip.ts
+++ b/src/lib/heuristics/localize/roundtrip.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip localization (issue #469 step 4) — extracted from

--- a/src/lib/heuristics/localize/skills.test.ts
+++ b/src/lib/heuristics/localize/skills.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { localizeSkills, looseSkillsReason } from "./skills.ts";

--- a/src/lib/heuristics/localize/skills.ts
+++ b/src/lib/heuristics/localize/skills.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Skills-section localization (issue #469 step 4) — extracted from

--- a/src/lib/heuristics/markdown-emit.test.ts
+++ b/src/lib/heuristics/markdown-emit.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the PDF → markdown emitter. Covers the exported utility

--- a/src/lib/heuristics/markdown-emit.ts
+++ b/src/lib/heuristics/markdown-emit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * PDF → markdown emitter.

--- a/src/lib/heuristics/markdown-lines.test.ts
+++ b/src/lib/heuristics/markdown-lines.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the markdown/DOCX section path (`sectionizeMarkdown`).

--- a/src/lib/heuristics/markdown-lines.ts
+++ b/src/lib/heuristics/markdown-lines.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Markdown → pseudo-`PdfLine[]` adapter.

--- a/src/lib/heuristics/multi-experience-roundtrip.test.ts
+++ b/src/lib/heuristics/multi-experience-roundtrip.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * #311 — preserve MULTIPLE experience-category sections end-to-end.

--- a/src/lib/heuristics/openresume-markdown.test.ts
+++ b/src/lib/heuristics/openresume-markdown.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for `parseHeuristicFromMarkdown`.

--- a/src/lib/heuristics/openresume.test.ts
+++ b/src/lib/heuristics/openresume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { parseHeuristic } from "./openresume.ts";
 import { mkItems, mkDefaultPages } from "./__test-utils__/mkItem.ts";

--- a/src/lib/heuristics/openresume.ts
+++ b/src/lib/heuristics/openresume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tier 1 — heuristic resume parser (OpenResume-style).

--- a/src/lib/heuristics/page-furniture-experience.repro.test.ts
+++ b/src/lib/heuristics/page-furniture-experience.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Repro regression for #283 — a page running-header/footer line

--- a/src/lib/heuristics/pdf-extract.test.ts
+++ b/src/lib/heuristics/pdf-extract.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { assembleTextFromLines, dropDecorativeGlyphs } from "./pdf-extract.ts";

--- a/src/lib/heuristics/pdf-extract.ts
+++ b/src/lib/heuristics/pdf-extract.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tier 0 — PDF extraction with positional data.

--- a/src/lib/heuristics/pdf-layout.test.ts
+++ b/src/lib/heuristics/pdf-layout.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { analyzeLayout, detectColumnBoundaries } from "./pdf-layout.ts";
 import type { PdfPageInfo, PdfTextItem } from "./types.ts";

--- a/src/lib/heuristics/pdf-layout.ts
+++ b/src/lib/heuristics/pdf-layout.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tier 0 — layout probes.

--- a/src/lib/heuristics/phone.test.ts
+++ b/src/lib/heuristics/phone.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { normalizePhone, findFirstPhone, regionFromLocation } from "./phone.ts";

--- a/src/lib/heuristics/phone.ts
+++ b/src/lib/heuristics/phone.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Phone number recognition, validation, and formatting helpers.

--- a/src/lib/heuristics/probe-achievements.test.ts
+++ b/src/lib/heuristics/probe-achievements.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Achievements-section dev probe — inert in CI, runs ONLY when

--- a/src/lib/heuristics/probe-contact.test.ts
+++ b/src/lib/heuristics/probe-contact.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Contact-section dev probe — inert in CI, runs ONLY when `RL_CONTACT_PDF=<path>`

--- a/src/lib/heuristics/probe-education.test.ts
+++ b/src/lib/heuristics/probe-education.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Education-section dev probe — inert in CI, runs ONLY when

--- a/src/lib/heuristics/probe-experience.test.ts
+++ b/src/lib/heuristics/probe-experience.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Experience-section dev probe — inert in CI, runs ONLY when

--- a/src/lib/heuristics/probe-resume.test.ts
+++ b/src/lib/heuristics/probe-resume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Whole-résumé sweep probe (#469) — inert in CI, runs ONLY when
@@ -155,7 +155,7 @@ const ORACLE_BANNER: Readonly<Record<Oracle, string[]>> = {
     "   (the layout probe called the PDF `scanned`, or rawText came back empty).",
     "   EVERY defect signal below the round-trip is read out of that text, so none",
     "   of them could be computed. This is NOT a clean résumé — it is a résumé this",
-    "   parser could not read, which is resumelint's single most severe failure mode.",
+    "   parser could not read, which is offlinecv's single most severe failure mode.",
   ],
   header: [
     "⚠️  HEADER ORACLE UNAVAILABLE — this parse produced NO markdown",
@@ -284,7 +284,7 @@ describe.runIf(process.env.RL_RESUME_PDF)(
       // readable text at all; `extractedCharCount === 0` ⇒ it read text but
       // produced NOTHING from it. Either way every oracle below was blind, and an
       // affirmative "no defect class is exhibited by this parse" would be a false
-      // claim about a dead parse — resumelint's most severe failure mode reported
+      // claim about a dead parse — offlinecv's most severe failure mode reported
       // as clean. The harness REFUSES: no DEFECTS FOUND block, no COVERAGE
       // number, no corpus match. The only honest output is "we could not read
       // this". ────────────────────────────────────────────────────────────────

--- a/src/lib/heuristics/probe-skills.test.ts
+++ b/src/lib/heuristics/probe-skills.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Skills-section dev probe — inert in CI, runs ONLY when

--- a/src/lib/heuristics/projections.test.ts
+++ b/src/lib/heuristics/projections.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Faithfulness gate for the Stage B canonical projections (#443).

--- a/src/lib/heuristics/projections.ts
+++ b/src/lib/heuristics/projections.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * projections — pure `(CanonicalResume) => T` views that replace the direct

--- a/src/lib/heuristics/regex-fallback.test.ts
+++ b/src/lib/heuristics/regex-fallback.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { runRegexFallback } from "./regex-fallback.ts";

--- a/src/lib/heuristics/regex-fallback.ts
+++ b/src/lib/heuristics/regex-fallback.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tier 1.5 — lightweight regex fallback.

--- a/src/lib/heuristics/regex.test.ts
+++ b/src/lib/heuristics/regex.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared regex library for heuristic resume extraction.

--- a/src/lib/heuristics/repro-artifact.test.ts
+++ b/src/lib/heuristics/repro-artifact.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tests for buildReproArtifact (issue #245).

--- a/src/lib/heuristics/repro-artifact.ts
+++ b/src/lib/heuristics/repro-artifact.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Repro artifact builder — a structure-only, PII-redacted-BY-CONSTRUCTION
@@ -8,7 +8,7 @@
  * ┌─────────────────────────────────────────────────────────────────────────┐
  * │ WHY THIS FILE NEVER CARRIES RÉSUMÉ TEXT — read before editing.            │
  * │                                                                           │
- * │ resumelint is a PUBLIC repo. A user reporting a parser gap is, by         │
+ * │ offlinecv is a PUBLIC repo. A user reporting a parser gap is, by         │
  * │ definition, sitting on top of their OWN résumé — real name, real email,   │
  * │ real phone, real bullet text. If any of that literal text rode along in   │
  * │ the downloadable repro artifact, the user would unknowingly publish their │

--- a/src/lib/heuristics/roundtrip-hop.ts
+++ b/src/lib/heuristics/roundtrip-hop.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The ONE render → re-parse hop (issue #469 step 5).

--- a/src/lib/heuristics/section-routing.repro.test.ts
+++ b/src/lib/heuristics/section-routing.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Repro regressions for section-routing parser bugs, reproduced from the parser

--- a/src/lib/heuristics/sections-column.test.ts
+++ b/src/lib/heuristics/sections-column.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Column-aware line grouping (#60).

--- a/src/lib/heuristics/sections.config.ts
+++ b/src/lib/heuristics/sections.config.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Typed loader for section keyword configuration.

--- a/src/lib/heuristics/sections.test.ts
+++ b/src/lib/heuristics/sections.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Direct unit coverage for `splitIntoSections`' visual-primary boundary path

--- a/src/lib/heuristics/sections.ts
+++ b/src/lib/heuristics/sections.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Group positional PDF items into logical "lines" and "sections".

--- a/src/lib/heuristics/split-letter-header.test.ts
+++ b/src/lib/heuristics/split-letter-header.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Regression for #56: a letter-spaced "E XPERIENCE" header must still open an

--- a/src/lib/heuristics/sweep.test.ts
+++ b/src/lib/heuristics/sweep.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * `sweepParse()` — the merge + oracle gate the `/probe-resume` harness and the

--- a/src/lib/heuristics/sweep.ts
+++ b/src/lib/heuristics/sweep.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * The whole-parse sweep (issue #469) — the ONE place a `DerivedSignals` bag and
@@ -65,7 +65,7 @@ import { localizeRoundtripHop } from "./localize/roundtrip.ts";
  * text — or out of the sections cut from it — so on such a parse they are all
  * `false` because there was nothing to read.
  *
- * This is resumelint's single most severe failure mode. It must never be
+ * This is offlinecv's single most severe failure mode. It must never be
  * reported as "no defect class is exhibited by this parse".
  */
 export function isTextOracleUnavailable(cascade: CascadeResult): boolean {

--- a/src/lib/heuristics/thresholds.ts
+++ b/src/lib/heuristics/thresholds.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Tunable thresholds for the heuristic resume cascade.

--- a/src/lib/heuristics/trigger-copy.ts
+++ b/src/lib/heuristics/trigger-copy.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * trigger-copy — the single source of the plain-language layout-trigger

--- a/src/lib/heuristics/two-column-experience-values.repro.test.ts
+++ b/src/lib/heuristics/two-column-experience-values.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Value-locking regression for #369 and #370 — a two-column Google-Docs résumé

--- a/src/lib/heuristics/types.ts
+++ b/src/lib/heuristics/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Types for the heuristic resume parser cascade.

--- a/src/lib/ingest/docx.test.ts
+++ b/src/lib/ingest/docx.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the DOCX ingest adapter (parseDocx).

--- a/src/lib/ingest/docx.ts
+++ b/src/lib/ingest/docx.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Thin DOCX → { rawText, markdown } adapter.

--- a/src/lib/jd-fit-handoff.test.ts
+++ b/src/lib/jd-fit-handoff.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, beforeEach } from "vitest";
 import {

--- a/src/lib/jd-fit-handoff.ts
+++ b/src/lib/jd-fit-handoff.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * One-shot resume handoff from `/` (parser audit) to `/jd-fit` (issue #226).

--- a/src/lib/jd-match/coverage.test.ts
+++ b/src/lib/jd-match/coverage.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";

--- a/src/lib/jd-match/coverage.ts
+++ b/src/lib/jd-match/coverage.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Resume ↔ JD coverage check.

--- a/src/lib/jd-match/extract-jd-terms.test.ts
+++ b/src/lib/jd-match/extract-jd-terms.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { extractJdTerms, stripBoilerplate } from "./extract-jd-terms.ts";

--- a/src/lib/jd-match/extract-jd-terms.ts
+++ b/src/lib/jd-match/extract-jd-terms.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Deterministic JD term extraction.

--- a/src/lib/jd-match/fetch-jd.test.ts
+++ b/src/lib/jd-match/fetch-jd.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 // ATS public JSON API clients — fetch a job description as plaintext.
 // These APIs are free, unauthenticated, and legally safe.

--- a/src/lib/jd-match/index.ts
+++ b/src/lib/jd-match/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 export { extractJdTerms, stripBoilerplate } from "./extract-jd-terms.ts";
 export type {

--- a/src/lib/jd-match/llm/extract-requirements.test.ts
+++ b/src/lib/jd-match/llm/extract-requirements.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for extractRequirements (#200), driven by a canned model stub —

--- a/src/lib/jd-match/llm/extract-requirements.ts
+++ b/src/lib/jd-match/llm/extract-requirements.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * extract-requirements.ts — LLM call #1 of the semantic JD-match path (#200).

--- a/src/lib/jd-match/llm/judge-evidence.test.ts
+++ b/src/lib/jd-match/llm/judge-evidence.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for judgeEvidence (#201), driven by a canned model stub — no

--- a/src/lib/jd-match/llm/judge-evidence.ts
+++ b/src/lib/jd-match/llm/judge-evidence.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * judge-evidence.ts — LLM call #2 of the semantic JD-match path (#201).

--- a/src/lib/jd-match/llm/prompts.test.ts
+++ b/src/lib/jd-match/llm/prompts.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Pins the extract-requirements (#200) and judge-evidence (#201) prompt

--- a/src/lib/jd-match/llm/prompts.ts
+++ b/src/lib/jd-match/llm/prompts.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Prompt builders for the semantic JD-match LLM calls: requirement extraction

--- a/src/lib/jd-match/llm/run-llm-match.test.ts
+++ b/src/lib/jd-match/llm/run-llm-match.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for runLlmMatch (#202) — the semantic orchestrator's two

--- a/src/lib/jd-match/llm/run-llm-match.ts
+++ b/src/lib/jd-match/llm/run-llm-match.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * run-llm-match.ts — semantic JD-match orchestrator + path selection (#202).

--- a/src/lib/jd-match/regex-utils.ts
+++ b/src/lib/jd-match/regex-utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared regex shapes for the JD-match passes.

--- a/src/lib/jd-match/rewrite-context.test.ts
+++ b/src/lib/jd-match/rewrite-context.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { buildJdRewriteContext } from "./rewrite-context.ts";

--- a/src/lib/jd-match/rewrite-context.ts
+++ b/src/lib/jd-match/rewrite-context.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JD-driven rewrite steering (issue #226).

--- a/src/lib/jd-match/skills.test.ts
+++ b/src/lib/jd-match/skills.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { SKILLS, getSkillIndex, skillCount } from "./skills.ts";

--- a/src/lib/jd-match/skills.ts
+++ b/src/lib/jd-match/skills.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Curated skill dictionary for JD-match v1.

--- a/src/lib/jd-match/types.ts
+++ b/src/lib/jd-match/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Path-agnostic JD-match result type (issue #199, anchor #156 — "JD Matching v2").

--- a/src/lib/job-search/deep-links.test.ts
+++ b/src/lib/job-search/deep-links.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { buildDeepLinks } from "./deep-links.ts";

--- a/src/lib/job-search/deep-links.ts
+++ b/src/lib/job-search/deep-links.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * buildDeepLinks — maps a `JobQuery` to prefilled search URLs on major job

--- a/src/lib/job-search/providers/arbeitnow.test.ts
+++ b/src/lib/job-search/providers/arbeitnow.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { arbeitnowProvider } from "./arbeitnow.ts";

--- a/src/lib/job-search/providers/arbeitnow.ts
+++ b/src/lib/job-search/providers/arbeitnow.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Arbeitnow adapter — https://www.arbeitnow.com/api/job-board-api?search=<kw>

--- a/src/lib/job-search/providers/index.test.ts
+++ b/src/lib/job-search/providers/index.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Registry contract for the keyless provider set (#319).

--- a/src/lib/job-search/providers/index.ts
+++ b/src/lib/job-search/providers/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Provider registry for the in-app job search.

--- a/src/lib/job-search/providers/jobicy.test.ts
+++ b/src/lib/job-search/providers/jobicy.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { jobicyProvider } from "./jobicy.ts";

--- a/src/lib/job-search/providers/jobicy.ts
+++ b/src/lib/job-search/providers/jobicy.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Jobicy adapter — https://jobicy.com/api/v2/remote-jobs?tag=<kw>

--- a/src/lib/job-search/providers/keywords.ts
+++ b/src/lib/job-search/providers/keywords.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Derive the outbound search keyword(s) from a `JobQuery`.

--- a/src/lib/job-search/providers/remotive.test.ts
+++ b/src/lib/job-search/providers/remotive.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { remotiveProvider } from "./remotive.ts";

--- a/src/lib/job-search/providers/remotive.ts
+++ b/src/lib/job-search/providers/remotive.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Remotive adapter — https://remotive.com/api/remote-jobs?search=<kw>

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { buildJobQuery, MAX_SKILLS } from "./query-builder.ts";

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * buildJobQuery — derives a job-search query from a parsed resume (#318,

--- a/src/lib/job-search/rank.test.ts
+++ b/src/lib/job-search/rank.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { rankPostings } from "./rank.ts";

--- a/src/lib/job-search/rank.ts
+++ b/src/lib/job-search/rank.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Rank fetched postings against the parsed résumé, reusing the jd-match

--- a/src/lib/job-search/search.test.ts
+++ b/src/lib/job-search/search.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { JobProvider, JobPosting } from "./types.ts";

--- a/src/lib/job-search/search.ts
+++ b/src/lib/job-search/search.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Job-search orchestrator — fan out enabled providers, filter, dedup, rank.

--- a/src/lib/job-search/types.ts
+++ b/src/lib/job-search/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Provider adapter contract for the in-app job search (#319, slice 2 of the

--- a/src/lib/pdf/ats-export-projection.ts
+++ b/src/lib/pdf/ats-export-projection.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ats-export-projection — the export-semantic view of an {@link AtsResumeModel},

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { buildAtsResumeModel } from "./ats-resume-model.ts";

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ats-resume-model — a pure, UI-free adapter that flattens a parsed résumé

--- a/src/lib/pdf/auto-bold-metrics.test.ts
+++ b/src/lib/pdf/auto-bold-metrics.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for `autoBoldMetrics` (#425) — the pure helper that wraps

--- a/src/lib/pdf/auto-bold-metrics.ts
+++ b/src/lib/pdf/auto-bold-metrics.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * auto-bold-metrics — a pure helper that wraps quantifiable metrics inside a

--- a/src/lib/pdf/country-registry.test.ts
+++ b/src/lib/pdf/country-registry.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import {

--- a/src/lib/pdf/country-registry.ts
+++ b/src/lib/pdf/country-registry.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * ISO-3166 country registry for structuring the trailing token of a free-form

--- a/src/lib/pdf/export-layout-contract.test.ts
+++ b/src/lib/pdf/export-layout-contract.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Export layout-contract gate (#334).

--- a/src/lib/pdf/load-pdf-lib.ts
+++ b/src/lib/pdf/load-pdf-lib.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * load-pdf-lib — dynamic-import-and-cache for `pdf-lib` (+ `@pdf-lib/fontkit`).

--- a/src/lib/pdf/render-ats-pdf.flush-right-links.test.ts
+++ b/src/lib/pdf/render-ats-pdf.flush-right-links.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * #425 — flush-right entry dates + clickable link annotations in the exported

--- a/src/lib/pdf/render-ats-pdf.fonts.test.ts
+++ b/src/lib/pdf/render-ats-pdf.fonts.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * render-ats-pdf.fonts.test.ts — Poppins font-embed behavior (#314).

--- a/src/lib/pdf/render-ats-pdf.test-utils.ts
+++ b/src/lib/pdf/render-ats-pdf.test-utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared test helper for render-ats-pdf's test files (render-ats-pdf.test.ts,

--- a/src/lib/pdf/render-ats-pdf.test.ts
+++ b/src/lib/pdf/render-ats-pdf.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { renderAtsResumePdf, toWinAnsi, parseBoldRuns } from "./render-ats-pdf.ts";

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * render-ats-pdf — the single-column, text-only ATS PDF draw engine (#171).
@@ -230,7 +230,7 @@ type PdfFont = Awaited<ReturnType<Doc["embedFont"]>>;
 // The Poppins TTF bytes are bundled as Vite assets (imported via `?url` above
 // — the same mechanism `src/main.tsx` uses for the pdfjs worker) and fetched
 // from the app's own bundled-asset origin at download time. That `fetch()`
-// never leaves the browser's own origin, so it does NOT violate resumelint's
+// never leaves the browser's own origin, so it does NOT violate offlinecv's
 // zero-egress guarantee — this is loading a local asset, not calling a font
 // CDN (e.g. `fonts.gstatic.com`), which is explicitly forbidden here.
 // Cached module-scoped so repeat downloads reuse the same fetched bytes.

--- a/src/lib/pdf/render-audit-report.test.ts
+++ b/src/lib/pdf/render-audit-report.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { renderAuditReportPdf } from "./render-audit-report.ts";

--- a/src/lib/pdf/render-audit-report.ts
+++ b/src/lib/pdf/render-audit-report.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * render-audit-report — the human-readable half of the shareable audit report
@@ -36,7 +36,7 @@ import { formatJsonResumeLocation } from "./to-json-resume.ts";
 import { APP_VERSION } from "../version.ts";
 
 /** Where the artifact points readers back to (branded footer). */
-const APP_URL = "github.com/resumelint-org/resumelint";
+const APP_URL = "github.com/offlinecv/OfflineCV";
 
 // ── Page geometry (points) ────────────────────────────────────────────────────
 

--- a/src/lib/pdf/render-roundtrip-achievement-add.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-achievement-add.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip guard for #455 — a user-ADDED achievement (type / description /

--- a/src/lib/pdf/render-roundtrip-achievement-edit.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-achievement-edit.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip guard for #454 — an inline-edited achievement survives the export.

--- a/src/lib/pdf/render-roundtrip-empty-company-location.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-empty-company-location.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip guard for the #466 empty-company + location shape (PR #483

--- a/src/lib/pdf/render-roundtrip-header-vs-entry.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-header-vs-entry.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * §7 header-vs-entry acceptance test (#444, Stage C;

--- a/src/lib/pdf/render-roundtrip-literal-asterisks.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-literal-asterisks.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip regression for #284/#425 — literal `**` in a bullet must survive

--- a/src/lib/pdf/render-roundtrip-team.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-team.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip guard for the #425 team-on-the-org-line change.

--- a/src/lib/pdf/render-roundtrip-www-link.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-www-link.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip guard for the #425 full `www.`-strip on contact links.

--- a/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip regression for #358 — a single-column experience role whose ONLY

--- a/src/lib/pdf/render-roundtrip.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip.repro.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip regression for #284 — the "Download PDF" reconstructed résumé must

--- a/src/lib/pdf/skills-wrap-roundtrip.test.ts
+++ b/src/lib/pdf/skills-wrap-roundtrip.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Round-trip regression for #301 — a multi-word skill token must not split

--- a/src/lib/pdf/text-wrap.test.ts
+++ b/src/lib/pdf/text-wrap.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { wrapWordsToLines, type TextMeasurer } from "./text-wrap.ts";

--- a/src/lib/pdf/text-wrap.ts
+++ b/src/lib/pdf/text-wrap.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * text-wrap — the shared greedy word-wrap used by both PDF renderers

--- a/src/lib/pdf/to-json-resume.export-projection.test.ts
+++ b/src/lib/pdf/to-json-resume.export-projection.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Byte-identical extraction gate for the export-projection split (#442, Stage A).

--- a/src/lib/pdf/to-json-resume.test.ts
+++ b/src/lib/pdf/to-json-resume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the pure `toJsonResume` adapter (#334): basics (incl. profiles

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * to-json-resume — a PURE adapter from the exporter's `AtsResumeModel` to a

--- a/src/lib/report/serialize.test.ts
+++ b/src/lib/report/serialize.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import {

--- a/src/lib/report/serialize.ts
+++ b/src/lib/report/serialize.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * report/serialize — the machine-readable half of the shareable audit report

--- a/src/lib/resume-library.test.ts
+++ b/src/lib/resume-library.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Resume-library domain tests (#322): save → list → load → rename → delete

--- a/src/lib/resume-library.ts
+++ b/src/lib/resume-library.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Resume library (#322) — the domain layer between the parse pipeline and the

--- a/src/lib/rewrite-review/align-bullets.test.ts
+++ b/src/lib/rewrite-review/align-bullets.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/rewrite-review/align-bullets.ts
+++ b/src/lib/rewrite-review/align-bullets.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * align-bullets.ts — greedily align a rewrite's proposed bullets to the

--- a/src/lib/rewrite-review/apply-accepted.test.ts
+++ b/src/lib/rewrite-review/apply-accepted.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import { alignBullets } from "./align-bullets.ts";

--- a/src/lib/rewrite-review/apply-accepted.ts
+++ b/src/lib/rewrite-review/apply-accepted.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * apply-accepted.ts — fold per-bullet accept/reject/edit decisions over an

--- a/src/lib/score/entry-dates.test.ts
+++ b/src/lib/score/entry-dates.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/score/entry-dates.ts
+++ b/src/lib/score/entry-dates.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Display-string formatters for the dates on reconstructed résumé entries.

--- a/src/lib/score/group-bullets.test.ts
+++ b/src/lib/score/group-bullets.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { promises as fsp } from "node:fs";
 import { dirname, join } from "node:path";

--- a/src/lib/score/group-bullets.ts
+++ b/src/lib/score/group-bullets.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * group-bullets.ts — maps BulletObservation entries to parsed experience roles.

--- a/src/lib/score/recommendation.test.ts
+++ b/src/lib/score/recommendation.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { getScoreRecommendation } from "./recommendation";
 import type { AnonymousAtsScore } from "./score";

--- a/src/lib/score/recommendation.ts
+++ b/src/lib/score/recommendation.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Verdict recommendation — turns a computed {@link AnonymousAtsScore} into one

--- a/src/lib/score/sanitize.test.ts
+++ b/src/lib/score/sanitize.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { sanitizeForDb, sanitizeJsonForDb, normalizeForAts } from "./sanitize";
 

--- a/src/lib/score/sanitize.ts
+++ b/src/lib/score/sanitize.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Text sanitization utilities.

--- a/src/lib/score/score.test.ts
+++ b/src/lib/score/score.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import {
   computeAtsScore,

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Deterministic ATS scoring — pure TypeScript, zero dependencies.

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared resume data shapes. The heuristic kernel produces a partial

--- a/src/lib/storage/backup.ts
+++ b/src/lib/storage/backup.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Export / import (#321) — the user's own backup path and the mitigation for

--- a/src/lib/storage/crud.ts
+++ b/src/lib/storage/crud.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Generic typed CRUD over one object store (#321). Both `resumes` and `jobs`

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * IndexedDB handle for the local-first storage foundation (#321).
@@ -18,23 +18,27 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 import type { ResumeRecord, JobRecord } from "./types.ts";
 
+// Kept as "resumelint" through the OfflineCV rename: this is the IndexedDB
+// database name, not a brand string. Renaming it would orphan every existing
+// user's locally stored resumes/jobs (no migration path). It is invisible to
+// users, so it stays for data continuity.
 export const DB_NAME = "resumelint";
 /** Bump when adding/altering a store or index; add a matching `oldVersion < N`
  *  branch in `upgrade()`. */
 export const DB_VERSION = 1;
 
-interface ResumeLintDB extends DBSchema {
+interface OfflineCvDB extends DBSchema {
   resumes: { key: string; value: ResumeRecord };
   jobs: { key: string; value: JobRecord };
 }
 
-let dbPromise: Promise<IDBPDatabase<ResumeLintDB>> | null = null;
+let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
 
 /** Open (once) and return the shared DB handle. Cached so concurrent callers
  *  share one connection. */
-export function getDB(): Promise<IDBPDatabase<ResumeLintDB>> {
+export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
   if (dbPromise === null) {
-    dbPromise = openDB<ResumeLintDB>(DB_NAME, DB_VERSION, {
+    dbPromise = openDB<OfflineCvDB>(DB_NAME, DB_VERSION, {
       upgrade(db, oldVersion) {
         // v0 → v1: both stores keyed on `id`. Keep future migrations as
         // additional `if (oldVersion < N)` blocks below — never edit an

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Local-first storage foundation (#321) — public surface.

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Job store — domain wrappers over the generic CRUD (#321). The record shape is

--- a/src/lib/storage/persist.ts
+++ b/src/lib/storage/persist.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Storage durability (#321). By default IndexedDB is "best-effort" — the browser

--- a/src/lib/storage/resumes.ts
+++ b/src/lib/storage/resumes.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Resume store — domain wrappers over the generic CRUD (#321). Handles id

--- a/src/lib/storage/storage.test.ts
+++ b/src/lib/storage/storage.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Storage foundation tests (#321). Runs against `fake-indexeddb` (imported via

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Local-first storage — record shapes for the IndexedDB foundation (#321).

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Build identity + deployed-version probe.

--- a/src/lib/webllm/analyze-resume.test.ts
+++ b/src/lib/webllm/analyze-resume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for analyzeResumeWithLlm — the combined parse+critique inference

--- a/src/lib/webllm/analyze-resume.ts
+++ b/src/lib/webllm/analyze-resume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Combined LLM analysis pass — parse + quality critique in one inference

--- a/src/lib/webllm/capability.test.ts
+++ b/src/lib/webllm/capability.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/src/lib/webllm/capability.ts
+++ b/src/lib/webllm/capability.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { trackWebllmCapabilityDetected } from "../analytics.ts";
 import type { WebGpuCapability } from "./types.ts";

--- a/src/lib/webllm/critique-resume.test.ts
+++ b/src/lib/webllm/critique-resume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for critiqueResumeWithLlm (issue #244).

--- a/src/lib/webllm/critique-resume.ts
+++ b/src/lib/webllm/critique-resume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * critique-resume.ts — on-device LLM quality judge (issue #244).

--- a/src/lib/webllm/eval/README.md
+++ b/src/lib/webllm/eval/README.md
@@ -37,7 +37,7 @@ Real models run only in a browser. The entry point is the dev-only
 
 ```sh
 npm run eval:rewrite
-# opens http://localhost:5173/resumelint/eval-rewrite.html
+# opens http://localhost:5173/offlinecv/eval-rewrite.html
 ```
 
 **One model per tab.** The page asks you to pick a model from the

--- a/src/lib/webllm/eval/fixtures.test.ts
+++ b/src/lib/webllm/eval/fixtures.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/eval/fixtures.ts
+++ b/src/lib/webllm/eval/fixtures.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import weak from "../../../../tests/fixtures/rewrite/weak.json" with { type: "json" };
 import strong from "../../../../tests/fixtures/rewrite/strong.json" with { type: "json" };

--- a/src/lib/webllm/eval/prompt-variants.ts
+++ b/src/lib/webllm/eval/prompt-variants.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { SECTION_REWRITE_SYSTEM_PROMPT } from "../rewrite-section.ts";
 import type { PromptVariant } from "./types.ts";

--- a/src/lib/webllm/eval/report.test.ts
+++ b/src/lib/webllm/eval/report.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/eval/report.ts
+++ b/src/lib/webllm/eval/report.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { getModelById } from "../models.ts";
 import { getVariantById } from "./prompt-variants.ts";

--- a/src/lib/webllm/eval/rubric.test.ts
+++ b/src/lib/webllm/eval/rubric.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/eval/rubric.ts
+++ b/src/lib/webllm/eval/rubric.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { checkNumbersPreserved } from "../preserve-numbers.ts";
 import type {

--- a/src/lib/webllm/eval/run-eval-browser.ts
+++ b/src/lib/webllm/eval/run-eval-browser.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Browser entry for the rewrite-quality eval harness.
  *
  * Reached via `npm run eval:rewrite` → opens
- * `/resumelint/eval-rewrite.html` in the dev server. Loads the model
+ * `/offlinecv/eval-rewrite.html` in the dev server. Loads the model
  * the user picked, runs every prompt variant against every fixture,
  * scores with the deterministic rubric, and renders a downloadable
  * JSON + Markdown report.

--- a/src/lib/webllm/eval/runner.test.ts
+++ b/src/lib/webllm/eval/runner.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/eval/runner.ts
+++ b/src/lib/webllm/eval/runner.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { emptyRubricForError, scoreRubric } from "./rubric.ts";
 import type {

--- a/src/lib/webllm/eval/types.ts
+++ b/src/lib/webllm/eval/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Shared types for the rewrite-quality eval harness (issue #65).

--- a/src/lib/webllm/eval/verbs.ts
+++ b/src/lib/webllm/eval/verbs.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { ACTION_VERBS as SCORER_ACTION_VERBS } from "../../score/score.ts";
 

--- a/src/lib/webllm/json-repair.test.ts
+++ b/src/lib/webllm/json-repair.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the shared JSON repair ladder. Pure functions — no engine, no

--- a/src/lib/webllm/json-repair.ts
+++ b/src/lib/webllm/json-repair.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * JSON repair ladder for small on-device LLM outputs.

--- a/src/lib/webllm/merge-override.test.ts
+++ b/src/lib/webllm/merge-override.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * mergeLlmParse (#243) — folds an LLM-recovered parse into the cascade result.

--- a/src/lib/webllm/merge-override.ts
+++ b/src/lib/webllm/merge-override.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * merge-override.ts — fold an LLM-recovered parse into the original cascade

--- a/src/lib/webllm/models.test.ts
+++ b/src/lib/webllm/models.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/models.ts
+++ b/src/lib/webllm/models.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Curated WebLLM model registry — what the user can pick from.
@@ -10,7 +10,7 @@
  *
  * Three constraints shape this list:
  *
- *   1. License — resumelint is Apache-2.0. The default MUST be Apache-2.0
+ *   1. License — offlinecv is Apache-2.0. The default MUST be Apache-2.0
  *      (Qwen2.5-1.5B) so every install works without surfacing a
  *      Restricted-Community consent modal up front. Gemma + Llama ship as
  *      opt-in extras gated by the consent modal (see #64 Step 5).

--- a/src/lib/webllm/parse-eval/README.md
+++ b/src/lib/webllm/parse-eval/README.md
@@ -1,9 +1,9 @@
 # Parse-resume eval harness
 
 Dev-only eval harness for the LLM structured-parse provider
-([issue #241](https://github.com/resumelint-org/resumelint/issues/241)) and
+([issue #241](https://github.com/offlinecv/OfflineCV/issues/241)) and
 the combined parse+critique pass
-([issue #262](https://github.com/resumelint-org/resumelint/issues/262)).
+([issue #262](https://github.com/offlinecv/OfflineCV/issues/262)).
 
 ## What it measures
 

--- a/src/lib/webllm/parse-eval/combined-report.ts
+++ b/src/lib/webllm/parse-eval/combined-report.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Report renderers for the separate-vs-combined comparison eval (issue #262).

--- a/src/lib/webllm/parse-eval/combined-score.test.ts
+++ b/src/lib/webllm/parse-eval/combined-score.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the combined-pass eval comparison scorer (issue #262). Pure

--- a/src/lib/webllm/parse-eval/combined-score.ts
+++ b/src/lib/webllm/parse-eval/combined-score.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Combined-pass eval scoring + comparison aggregation (issue #262, load-bearing

--- a/src/lib/webllm/parse-eval/fixtures.ts
+++ b/src/lib/webllm/parse-eval/fixtures.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Inline eval fixtures for the parse-resume provider (issue #241).

--- a/src/lib/webllm/parse-eval/parse-eval-browser.ts
+++ b/src/lib/webllm/parse-eval/parse-eval-browser.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Browser entry for the parse-resume eval harness (issues #241 + #262).

--- a/src/lib/webllm/parse-eval/report.ts
+++ b/src/lib/webllm/parse-eval/report.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Report renderers for the parse-resume eval harness (issue #241).

--- a/src/lib/webllm/parse-eval/score.test.ts
+++ b/src/lib/webllm/parse-eval/score.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for the parse-eval scorer (issue #241).

--- a/src/lib/webllm/parse-eval/score.ts
+++ b/src/lib/webllm/parse-eval/score.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Pure, model-free scorer for the parse-resume eval harness (issue #241).

--- a/src/lib/webllm/parse-resume.test.ts
+++ b/src/lib/webllm/parse-resume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Unit tests for parseResumeWithLlm (issue #241).

--- a/src/lib/webllm/parse-resume.ts
+++ b/src/lib/webllm/parse-resume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * LLM-backed structured resume parser (issue #241).

--- a/src/lib/webllm/phrase-tracking.test.ts
+++ b/src/lib/webllm/phrase-tracking.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import {

--- a/src/lib/webllm/phrase-tracking.ts
+++ b/src/lib/webllm/phrase-tracking.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Strong-phrase tracking helpers (issue #67's "track used action verbs **and

--- a/src/lib/webllm/platform.test.ts
+++ b/src/lib/webllm/platform.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import {

--- a/src/lib/webllm/platform.ts
+++ b/src/lib/webllm/platform.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Browser + OS detection and per-platform "how to enable WebGPU" guidance.

--- a/src/lib/webllm/post-process.test.ts
+++ b/src/lib/webllm/post-process.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/post-process.ts
+++ b/src/lib/webllm/post-process.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Per-line cleanup shared by the per-bullet and section rewrite paths.

--- a/src/lib/webllm/preserve-numbers.test.ts
+++ b/src/lib/webllm/preserve-numbers.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 

--- a/src/lib/webllm/preserve-numbers.ts
+++ b/src/lib/webllm/preserve-numbers.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Number-preservation guardrail.

--- a/src/lib/webllm/rewrite-resume.test.ts
+++ b/src/lib/webllm/rewrite-resume.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/lib/webllm/rewrite-resume.ts
+++ b/src/lib/webllm/rewrite-resume.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Chain-of-sections whole-resume rewrite orchestrator (issue #67).

--- a/src/lib/webllm/rewrite-section.test.ts
+++ b/src/lib/webllm/rewrite-section.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/lib/webllm/rewrite-section.ts
+++ b/src/lib/webllm/rewrite-section.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import {
   trackWebllmFirstSectionRewrite,

--- a/src/lib/webllm/rewrite-summary.test.ts
+++ b/src/lib/webllm/rewrite-summary.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/src/lib/webllm/rewrite-summary.ts
+++ b/src/lib/webllm/rewrite-summary.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { cleanRewriteLine } from "./post-process.ts";
 import { checkNumbersPreserved } from "./preserve-numbers.ts";

--- a/src/lib/webllm/spike/README.md
+++ b/src/lib/webllm/spike/README.md
@@ -1,6 +1,6 @@
 # JD Spike Harness
 
-Dev-only spike for issue [#198](https://github.com/resumelint-org/resumelint/issues/198).
+Dev-only spike for issue [#198](https://github.com/offlinecv/OfflineCV/issues/198).
 Validates Qwen2.5-1.5B (the default WebLLM model) for two tasks before any production
 design commitment:
 
@@ -16,12 +16,12 @@ design commitment:
 ## How to run
 
 1. Start the dev server: `npm run dev`
-2. Open: `http://localhost:5173/resumelint/jd-spike.html`
+2. Open: `http://localhost:5173/offlinecv/jd-spike.html`
 3. Select **Qwen 2.5 (1.5B)** (default) in the model picker.
 4. Set **Repeats** (default 3 — higher values give better failure-rate estimates).
 5. Click **Run spike** — the model downloads on first run (~1.6 GB); subsequent runs use the cached IndexedDB copy.
 6. When done, click **Download Markdown report**.
-7. Paste the Markdown into issue [#156](https://github.com/resumelint-org/resumelint/issues/156) as the spike findings.
+7. Paste the Markdown into issue [#156](https://github.com/offlinecv/OfflineCV/issues/156) as the spike findings.
 
 ## Not bundled / no prod code
 

--- a/src/lib/webllm/spike/fixtures.ts
+++ b/src/lib/webllm/spike/fixtures.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Inline spike fixtures for the JD-extraction + evidence-judging experiment

--- a/src/lib/webllm/spike/jd-spike-browser.ts
+++ b/src/lib/webllm/spike/jd-spike-browser.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Browser entry for the JD-extraction + evidence-judging spike (issue #198).
  *
  * Reached via `npm run eval:jd-spike` or by opening
- * `http://localhost:5173/resumelint/jd-spike.html` while the dev server
+ * `http://localhost:5173/offlinecv/jd-spike.html` while the dev server
  * is running. Loads the selected model via WebLLM, runs the spike
  * measurement over the 3 inline fixtures (see fixtures.ts), and offers
  * downloadable JSON + Markdown reports.

--- a/src/lib/webllm/spike/measure.ts
+++ b/src/lib/webllm/spike/measure.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Run logic for the JD spike (issue #198).

--- a/src/lib/webllm/spike/prompts.ts
+++ b/src/lib/webllm/spike/prompts.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Prototype prompts for the JD spike's two-call contract (issue #198).

--- a/src/lib/webllm/spike/types.ts
+++ b/src/lib/webllm/spike/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Spike-local types for the JD requirement-extraction + evidence-judging

--- a/src/lib/webllm/steering.test.ts
+++ b/src/lib/webllm/steering.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import { buildSteeringSuffix } from "./steering.ts";

--- a/src/lib/webllm/steering.ts
+++ b/src/lib/webllm/steering.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Rewrite steering (issue #210) — the user's freeform intent + a page-length

--- a/src/lib/webllm/types.ts
+++ b/src/lib/webllm/types.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * WebGPU detection outcome. `"available"` is the only branch that lights up

--- a/src/lib/webllm/verb-tracking.test.ts
+++ b/src/lib/webllm/verb-tracking.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { describe, expect, it } from "vitest";
 import {

--- a/src/lib/webllm/verb-tracking.ts
+++ b/src/lib/webllm/verb-tracking.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Lexical helpers for cross-section action-verb tracking (issue #67).

--- a/src/lib/webllm/web-llm.test.ts
+++ b/src/lib/webllm/web-llm.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/lib/webllm/web-llm.ts
+++ b/src/lib/webllm/web-llm.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { trackWebllmDownloadStarted, trackWebllmLoaded } from "../analytics.ts";
 import type { ProgressUpdate, WebLlmEngine } from "./types.ts";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /**
  * Project-wide vitest setup (wired as `test.setupFiles` in `vite.config.ts`).

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /// <reference types="vite/client" />
 

--- a/tests/fixtures/rewrite/reports/README.md
+++ b/tests/fixtures/rewrite/reports/README.md
@@ -25,7 +25,7 @@ PR descriptions.
 ## Workflow
 
 ```sh
-npm run eval:rewrite        # opens /resumelint/eval-rewrite.html with WebGPU
+npm run eval:rewrite        # opens /offlinecv/eval-rewrite.html with WebGPU
 # in the browser: click "Run eval", wait, download both report files
 mv ~/Downloads/eval-rewrite-*.json tests/fixtures/rewrite/reports/
 mv ~/Downloads/eval-rewrite-*.md   tests/fixtures/rewrite/reports/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 The resumelint Authors
+// Copyright 2026 The offlinecv Authors
 
 /// <reference types="vitest" />
 import { execSync } from "node:child_process";
@@ -51,7 +51,7 @@ const APP_VERSION = resolveAppVersion();
 
 // Base path. The custom domain (resumelint.org) and the GCS bucket root both
 // serve at "/"; the bare github.io project-Pages fallback
-// (resumelint-org.github.io/resumelint/) needs "/resumelint/". Env-driven so
+// (offlinecv.github.io/OfflineCV/) needs "/OfflineCV/". Env-driven so
 // each deploy target builds with its own prefix without a code edit — set
 // VITE_BASE_PATH to override. Default "/" is the custom-domain production
 // target and local dev.
@@ -62,7 +62,7 @@ const BASE_PATH = process.env.VITE_BASE_PATH ?? "/";
 // short-lived Cache-Control, so the client cache-busts the fetch anyway.
 function emitVersionJson(version: string): Plugin {
   return {
-    name: "resumelint:emit-version-json",
+    name: "offlinecv:emit-version-json",
     apply: "build",
     generateBundle() {
       this.emitFile({
@@ -99,7 +99,7 @@ function jdFitTrailingSlash(): Plugin {
     next();
   };
   return {
-    name: "resumelint:jd-fit-trailing-slash",
+    name: "offlinecv:jd-fit-trailing-slash",
     configureServer(server) {
       server.middlewares.use(redirect);
     },
@@ -113,7 +113,7 @@ export default defineConfig({
   base: BASE_PATH,
   // Multi-page app, not SPA. The default 'spa' appType silently falls back to
   // serving the root index.html (the parser) for ANY unmatched path — so
-  // `/resumelint`, or `/jd-fit` without its trailing slash, would render the
+  // `/offlinecv`, or `/jd-fit` without its trailing slash, would render the
   // parser instead of 404ing. 'mpa' disables that catch-all: `/` → parser,
   // `/jd-fit/` → JD fit, and anything else 404s honestly. The two products are
   // real, separate HTML entries — there is no client-side router to fall back


### PR DESCRIPTION
## Summary

Renames the project brand and all in-repo name strings from **ResumeLint → OfflineCV** to match the new GitHub home `github.com/offlinecv/OfflineCV`. Covers the brand tokens, org/repo slug (`resumelint-org/resumelint` → `offlinecv/OfflineCV`), npm package (`@resumelint/web` → `@offlinecv/web`), ~458 SPDX headers, env vars (`RESUMELINT_SKIP_HOOKS`/`RESUMELINT_HOOK_FIELD` → `OFFLINECV_*`), vite plugin names, git-hook installer, docs, and UI copy/titles.

**Deliberately kept:**
- IndexedDB `DB_NAME = "resumelint"` — renaming orphans existing users' saved resumes; it's invisible to users. Only the TS type `ResumeLintDB` → `OfflineCvDB`.
- DNS domain `resumelint.org` / `dev.resumelint.org` (`public/CNAME`) — deferred to a later DNS PR.
- `.claude/skills`, memory store, working-directory path — out of scope.

Naming trap handled: `resumelint.org` (domain, kept) vs `resumelint-org` (org, renamed) both start with `resumelint` — ordered passes + a `(?!\.org)` lookahead prevented corrupting the domain. Guard grep confirmed zero over-replace.

Refs #498

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (2493 pass, 9 skipped)
- [x] `npm run build` green — both entries build; `dist/CNAME` still `dev.resumelint.org`, title reads "OfflineCV"
- [x] `npm run verify` — green (ran via pre-push hook)

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: `npm run verify` — green in pre-push + CI