### PR TITLE
chore(rename): domain cutover to offlinecv.org — CNAME, docs, workflows, skill refs

### DIFF
--- a/.claude/hooks/fallow-stop.sh
+++ b/.claude/hooks/fallow-stop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 The resumelint Authors
+# Copyright 2026 The offlinecv Authors
 #
 # Stop hook: run `fallow audit` over the TS/JS files changed vs the base
 # branch and drop a JSON report under .fallow/. Informational only — this

--- a/.claude/skills/batch-issues/SKILL.md
+++ b/.claude/skills/batch-issues/SKILL.md
@@ -18,9 +18,9 @@ off a ready invocation.
 > an explicit list: `/implement-batch 341,346,349`. `/implement-batch` already
 > accepts a raw list — this skill earns its keep only by making the group real.
 
-## Repo facts (resumelint)
+## Repo facts (offlinecv)
 
-- **Repo:** `resumelint-org/resumelint`, GitHub-only (no Linear). All grouping is
+- **Repo:** `offlinecv/OfflineCV`, GitHub-only (no Linear). All grouping is
   native GitHub: sub-issues via `gh api .../sub_issues`, dependency order via
   `.../dependencies/blocked_by`, board via `gh project`.
 - **This skill only creates/links issues** — no branch, no commit, no PR. The
@@ -62,7 +62,7 @@ CHILDREN=($(printf '%s' "$RAW_LIST" | tr ',' ' ' | tr -s ' ' | sed 's/#//g'))
 
 Resolve the repo once:
 ```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # resumelint-org/resumelint
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # offlinecv/OfflineCV
 OWNER="${REPO%%/*}"
 ```
 
@@ -225,7 +225,7 @@ blocked by A, C by B — each edge uses the **blocking** issue's internal id, ty
 
 Four failure modes bit real runs — the loop below defends against all four:
 
-1. **`${ARR[i]}` index math breaks under zsh (THE load-bearing one).** resumelint's
+1. **`${ARR[i]}` index math breaks under zsh (THE load-bearing one).** offlinecv's
    shell is **zsh, whose arrays are 1-indexed**; a `for ((i=1; i<${#ORDER[@]}; i++))`
    loop written for **bash's 0-indexing** silently wires the *wrong* pairs — the first
    edge gets an empty blocker and the last edge (which needs `i==len`) never runs.
@@ -329,7 +329,7 @@ Implement it:  /implement-batch <PARENT>   ⚠ executor lands in #387 — not ru
   incoherent batch produces an unreviewable PR.
 - **Typed `-F` for every id.** Sub-issue and dependency links use the child's
   internal REST `id` with `-F` (integer), never the number, never `-f`.
-- **Never index a bash array — resumelint's shell is zsh (1-indexed).** A
+- **Never index a bash array — offlinecv's shell is zsh (1-indexed).** A
   `for ((i=1;…)); ${ORDER[i-1]}` loop written for bash's 0-indexing wires the wrong
   dependency pairs under zsh (empty first blocker, last edge skipped). Iterate values
   with a `PREV` cursor instead; it behaves identically in both shells.

--- a/.claude/skills/create-gh-issue/SKILL.md
+++ b/.claude/skills/create-gh-issue/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: create-gh-issue
-description: File a thorough, self-contained GitHub issue against resumelint-org/resumelint — full analysis, implementation plan, acceptance criteria — using the scripts/create-gh-issue.sh writer so backticks/tables/code blocks survive intact. Use when the user says "create an issue", "file an issue", "/create-gh-issue", or wants a well-scoped issue written from the current conversation.
+description: File a thorough, self-contained GitHub issue against offlinecv/OfflineCV — full analysis, implementation plan, acceptance criteria — using the scripts/create-gh-issue.sh writer so backticks/tables/code blocks survive intact. Use when the user says "create an issue", "file an issue", "/create-gh-issue", or wants a well-scoped issue written from the current conversation.
 ---
 
-# Create GitHub Issue (resumelint)
+# Create GitHub Issue (offlinecv)
 
-File a comprehensive, **self-contained** issue against `resumelint-org/resumelint`.
+File a comprehensive, **self-contained** issue against `offlinecv/OfflineCV`.
 The issue must carry enough detail that someone with **no prior context** (a
 contributor after `/clear`, or another intern) can implement it start to finish.
 
 This skill is the intern-facing, in-repo version of the maintainer's private
 issue tooling. It depends on nothing outside this checkout: only `gh`
 (authenticated) and `scripts/create-gh-issue.sh`. No `~/tools`, no Linear,
-no machine-local `.env`. GitHub-only — resumelint has no Linear backend.
+no machine-local `.env`. GitHub-only — offlinecv has no Linear backend.
 
 ## Input
 
@@ -29,7 +29,7 @@ anywhere (branch names, commits, cross-links) until the script reports the real
 First, confirm the backend is reachable (one line, non-blocking):
 
 ```bash
-gh repo view --json nameWithOwner -q .nameWithOwner   # → resumelint-org/resumelint
+gh repo view --json nameWithOwner -q .nameWithOwner   # → offlinecv/OfflineCV
 ```
 
 If `gh` isn't installed or authenticated, stop and tell the user to run
@@ -67,7 +67,7 @@ If `gh` isn't installed or authenticated, stop and tell the user to run
    invariant that must still hold (`corpus.test.ts`, `corpus-roundtrip.test.ts`).
 
 5b. **Reuse analysis — required when the issue adds a UI/workflow surface.**
-   resumelint enforces a Reuse Gate (`CLAUDE.md` → "Component architecture & reuse").
+   offlinecv enforces a Reuse Gate (`CLAUDE.md` → "Component architecture & reuse").
    Before finalizing a body that proposes a **new component, panel, dialog, or
    page**, search for an existing surface that already owns that capability:
    - Check the design-system (`src/design-system/`) for an existing primitive or
@@ -155,7 +155,7 @@ the full plan back for line-by-line approval.
 **Error handling:**
 - Exit 2 = arg/env error (missing required arg, `gh` not on PATH, or no GitHub
   remote detected). For the last, run from the repo root or pass `--repo
-  resumelint-org/resumelint`.
+  offlinecv/OfflineCV`.
 - Exit 1 = `gh issue create` failed. Most common cause: a `--labels` value that
   doesn't exist. Check `gh label list`; drop or correct the label and retry. If a
   genuinely new label is needed, ask the user before `gh label create`.
@@ -164,7 +164,7 @@ the full plan back for line-by-line approval.
 
 Every issue needs at least one **type** label; add the domain labels that fit
 (most issues carry 2–3). These are the labels that exist in
-`resumelint-org/resumelint` today — check `gh label list` if unsure:
+`offlinecv/OfflineCV` today — check `gh label list` if unsure:
 
 ### Type (pick at least one)
 | Label | When |
@@ -189,8 +189,8 @@ existing one or ask the user before creating a new label — don't invent taxono
 
 ## Milestones (the roadmap)
 
-resumelint plans on four milestones (read live with
-`gh api repos/resumelint-org/resumelint/milestones --jq '.[] | "\(.number)\t\(.title)"'`).
+offlinecv plans on four milestones (read live with
+`gh api repos/offlinecv/OfflineCV/milestones --jq '.[] | "\(.number)\t\(.title)"'`).
 Pass `--milestone` by title or number when the issue's home is clear:
 
 | # | Title | Role |

--- a/.claude/skills/implement-batch/SKILL.md
+++ b/.claude/skills/implement-batch/SKILL.md
@@ -14,7 +14,7 @@ and opening **one PR** via `/open-pr`.
 This is the GitHub-only, self-contained sibling of the global `/implement-epic`.
 It has **no Linear code** and **no dependency on `/implement-issue`** — the
 per-issue implementation contract is embedded here, in the subagent spawn
-prompt, so this skill works for anyone who clones `resumelint-org/resumelint`
+prompt, so this skill works for anyone who clones `offlinecv/OfflineCV`
 (interns included), not just a maintainer whose `~/tools/skills/` has the global
 skills.
 
@@ -24,9 +24,9 @@ skills.
 > explore/edit context stays down there; only a tight structured summary returns.
 > The orchestrator stays lean across the whole sequence.
 
-## Repo facts (resumelint)
+## Repo facts (offlinecv)
 
-- **Repo:** `resumelint-org/resumelint`. `main` is protected — every change
+- **Repo:** `offlinecv/OfflineCV`. `main` is protected — every change
   merges through a PR that needs **1 approving review** + a green **`verify`**
   check. Direct commits/pushes to `main` are blocked (server-side protection +
   the local `block_commit` hook). So this skill **never commits on `main`** — it
@@ -57,7 +57,7 @@ Parse `$ARGUMENTS` for **either**:
 
 Resolve `<owner>/<repo>` once:
 ```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # resumelint-org/resumelint
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # offlinecv/OfflineCV
 ```
 
 **Flags** (strip before parsing the identifier):

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-pr
-description: Open a pull request against resumelint from your current work — branch if needed, commit, push, and create the PR with a filled body that links the issue. Use when the user says "open a PR", "send a PR", "/open-pr", or has finished a change and wants it reviewed.
+description: Open a pull request against offlinecv from your current work — branch if needed, commit, push, and create the PR with a filled body that links the issue. Use when the user says "open a PR", "send a PR", "/open-pr", or has finished a change and wants it reviewed.
 ---
 
 # Open PR
@@ -35,7 +35,7 @@ branch, never on `main`.
 ### Step 0: Detect repo + base
 
 ```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"          # resumelint-org/resumelint
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"          # offlinecv/OfflineCV
 BASE="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"  # main
 # If --base <ref> was provided, override BASE here: BASE="<ref>"
 ```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: pr-review
-description: Review a resumelint pull request the way a maintainer does — pull the diff, run the generic /code-review correctness pass, then layer resumelint's own gates (fixture PII, design-system reuse, style tokens, fallow dead-code, command-level bugs in skill/script files), structure the findings Blocking / Secondary / Nits, and post a PR review whose verdict matches what was found. Use when the user says "review PR #N", "/pr-review", "review this PR", or hands you a PR to critique before merge.
+description: Review an offlinecv pull request the way a maintainer does — pull the diff, run the generic /code-review correctness pass, then layer offlinecv's own gates (fixture PII, design-system reuse, style tokens, fallow dead-code, command-level bugs in skill/script files), structure the findings Blocking / Secondary / Nits, and post a PR review whose verdict matches what was found. Use when the user says "review PR #N", "/pr-review", "review this PR", or hands you a PR to critique before merge.
 argument-hint: <#|#N> [--repo owner/repo] [--post|--local] [--effort low|medium|high]
 ---
 
 # Review PR
 
-Take a resumelint PR from "someone opened it" to "a maintainer-grade review is on
+Take an offlinecv PR from "someone opened it" to "a maintainer-grade review is on
 the thread": check out the diff → run the built-in `/code-review` for the generic
-correctness pass → **layer the resumelint-specific gates** → structure findings
+correctness pass → **layer the offlinecv-specific gates** → structure findings
 **Blocking / Secondary / Nits** → draft the review → confirm → post a `gh` PR
 review whose **verdict matches the findings**.
 
@@ -18,7 +18,7 @@ the PR, `revise-pr` addresses the review — this skill *is* the review in betwe
 ## Why this skill exists
 
 `/code-review` is a strong **generic** diff pass (correctness, reuse, simplify,
-efficiency) but it doesn't know resumelint's house rules: the public-repo fixture
+efficiency) but it doesn't know offlinecv's house rules: the public-repo fixture
 PII policy, the 3-tier design-system + reuse gate, the semantic-token style rules,
 the `fallow` dead-code gate, or that a **skill/script file is code too** — the kind
 of `gh`/bash command-level bug that sank PR #390 (a `--json` flag that doesn't
@@ -29,7 +29,7 @@ are blocking) and the posting path (**inline anchors where the finding lives**, 
 for the rest, one `422`-safe fallback).
 
 **Don't reimplement bug-finding** — delegate the generic pass to `/code-review` and
-spend the skill's effort on the resumelint-specific gates and the workflow.
+spend the skill's effort on the offlinecv-specific gates and the workflow.
 
 ## Input
 
@@ -49,7 +49,7 @@ guess. `--effort` is passed straight through to `/code-review` (default `high`).
 ### Step 0 — Detect repo + PR
 
 ```bash
-REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"   # resumelint-org/resumelint
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"   # offlinecv/OfflineCV
 gh pr view "$PR_NUM" --repo "$REPO" \
   --json number,title,state,headRefName,baseRefName,author,files \
   -q '{n:.number,t:.title,s:.state,h:.headRefName,b:.baseRefName,a:.author.login}'
@@ -85,7 +85,7 @@ simplify + efficiency. This is the bug-finding engine — don't duplicate it:
 `/code-review` is **diff-scoped and repo-agnostic**. Everything below is what it
 *won't* catch.
 
-### Step 3 — Layer the resumelint gates
+### Step 3 — Layer the offlinecv gates
 
 Run each gate against the **changed files** (`git diff --name-only "origin/$BASE...HEAD"`).
 A gate that doesn't apply to this diff is skipped — say so, don't invent findings.
@@ -329,7 +329,7 @@ were lost to a mid-review push, not to laziness.
 ## Rules
 
 - **Wrap, don't duplicate.** `/code-review` owns the generic correctness pass; this
-  skill owns the resumelint gates + workflow + posting. Don't re-litigate what
+  skill owns the offlinecv gates + workflow + posting. Don't re-litigate what
   `/code-review` already found — fold it in.
 - **Verify before flagging.** Read the file at each cited line; drop findings that
   don't reproduce. A wrong finding costs more trust than a missed nit.

--- a/.claude/skills/probe-achievements/SKILL.md
+++ b/.claude/skills/probe-achievements/SKILL.md
@@ -109,7 +109,7 @@ which one:
 ## Filing what you find (gated auto-file)
 
 Once you've localized the layer, you can turn the finding into a
-`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+`offlinecv/OfflineCV` issue **without leaving the probe** — via the in-repo
 [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
 show, confirm, then write. Never blast-file.
 
@@ -121,7 +121,7 @@ can't file it yet — build the synthetic repro first.
 ### 1. Dedup first (required)
 
 ```bash
-gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+gh issue list --repo offlinecv/OfflineCV --state open --limit 50 \
   --search "achievements <symptom keyword>"   # e.g. "achievements award merged"
 ```
 

--- a/.claude/skills/probe-contact/SKILL.md
+++ b/.claude/skills/probe-contact/SKILL.md
@@ -99,7 +99,7 @@ PDF and the bug is ours; `absent-in-pdf` means stop — nothing to fix.
 ## Filing what you find (gated auto-file)
 
 Once you've localized the layer, you can turn the finding into a
-`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+`offlinecv/OfflineCV` issue **without leaving the probe** — via the in-repo
 [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
 show, confirm, then write. Never blast-file.
 
@@ -116,7 +116,7 @@ Before drafting, search open issues for the same **layer + symptom** so you don'
 pile onto the existing open contact/parser bugs:
 
 ```bash
-gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+gh issue list --repo offlinecv/OfflineCV --state open --limit 50 \
   --search "contact <symptom keyword>"   # e.g. "contact letter-spaced name"
 ```
 

--- a/.claude/skills/probe-education/SKILL.md
+++ b/.claude/skills/probe-education/SKILL.md
@@ -143,7 +143,7 @@ one:
 ## Filing what you find (gated auto-file)
 
 Once you've localized the layer, you can turn the finding into a
-`resumelint-org/resumelint` issue **without leaving the probe** — via the
+`offlinecv/OfflineCV` issue **without leaving the probe** — via the
 in-repo [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is
 **gated**: draft, show, confirm, then write. Never blast-file.
 
@@ -163,7 +163,7 @@ collapses, #366-class institution/location gluing, #371-class annotation-date
 mis-selection):
 
 ```bash
-gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+gh issue list --repo offlinecv/OfflineCV --state open --limit 50 \
   --search "education <symptom keyword>"   # e.g. "education chunker collapse"
 ```
 

--- a/.claude/skills/probe-experience/SKILL.md
+++ b/.claude/skills/probe-experience/SKILL.md
@@ -105,7 +105,7 @@ assembly.
 ## Filing what you find (gated auto-file)
 
 Once you've localized the layer, you can turn the finding into a
-`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+`offlinecv/OfflineCV` issue **without leaving the probe** — via the in-repo
 [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
 show, confirm, then write. Never blast-file.
 
@@ -122,7 +122,7 @@ Before drafting, search open issues for the same **layer + symptom** so you don'
 pile onto the existing open experience/parser bugs:
 
 ```bash
-gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+gh issue list --repo offlinecv/OfflineCV --state open --limit 50 \
   --search "experience <symptom keyword>"   # e.g. "experience role merged two-column"
 ```
 

--- a/.claude/skills/probe-resume/SKILL.md
+++ b/.claude/skills/probe-resume/SKILL.md
@@ -155,7 +155,7 @@ Printed to the console (full JSON mirrored to the gitignored out dir):
   extracted **0 characters**), the harness **refuses to print `DEFECTS FOUND` or
   `COVERAGE` at all**, and runs no corpus match. There is no honest defect report
   over a document the parser never read, and an affirmative "no defect class is
-  exhibited by this parse" there would report resumelint's **single most severe
+  exhibited by this parse" there would report offlinecv's **single most severe
   failure mode as clean**. What you get instead is the char counts, the layout
   triggers, the withheld list, and a pointer at the real problem: this is a
   **Tier-0 extraction failure** (scanned/OCR, unmappable fonts), not a

--- a/.claude/skills/probe-roundtrip/SKILL.md
+++ b/.claude/skills/probe-roundtrip/SKILL.md
@@ -82,7 +82,7 @@ Use an **absolute path** for `RL_RT_PDF`.
   value swap, a skills `added`/`removed` split) → that is a renderer or parser
   bug. Localize it, then file it via **Filing what you find** below. The
   round-trip bugs this probe hunts are tracked at
-  resumelint-org/resumelint#295–#299.
+  offlinecv/OfflineCV#295–#299.
 - **`renderError`** → `renderAtsResumePdf` crashed (e.g. a non-WinAnsi glyph the
   pdf-lib StandardFonts can't encode). Highest-severity find — the Download-PDF
   path throws for real users.
@@ -90,7 +90,7 @@ Use an **absolute path** for `RL_RT_PDF`.
 ## Filing what you find (gated auto-file)
 
 Once you've localized the corruption to a hop + layer, you can turn the finding
-into a `resumelint-org/resumelint` issue **without leaving the probe** — via the
+into an `offlinecv/OfflineCV` issue **without leaving the probe** — via the
 in-repo [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is
 **gated**: draft, show, confirm, then write. Never blast-file.
 
@@ -107,7 +107,7 @@ Before drafting, search open issues for the same **symptom** so you don't pile
 onto the tracked round-trip bugs (#295–#299) or the open parser backlog:
 
 ```bash
-gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+gh issue list --repo offlinecv/OfflineCV --state open --limit 50 \
   --search "round-trip <symptom keyword>"   # e.g. "round-trip education count"
 ```
 

--- a/.claude/skills/probe-skills/SKILL.md
+++ b/.claude/skills/probe-skills/SKILL.md
@@ -108,7 +108,7 @@ split points at which one:
 ## Filing what you find (gated auto-file)
 
 Once you've localized the layer, you can turn the finding into a
-`resumelint-org/resumelint` issue **without leaving the probe** — via the in-repo
+`offlinecv/OfflineCV` issue **without leaving the probe** — via the in-repo
 [`create-gh-issue`](../create-gh-issue/SKILL.md) skill. Filing is **gated**: draft,
 show, confirm, then write. Never blast-file.
 
@@ -126,7 +126,7 @@ pile onto the existing open skills/parser bugs (e.g. #374 two-line wrap, #414
 leading glyph):
 
 ```bash
-gh issue list --repo resumelint-org/resumelint --state open --limit 50 \
+gh issue list --repo offlinecv/OfflineCV --state open --limit 50 \
   --search "skills <symptom keyword>"   # e.g. "skills header glyph"
 ```
 

--- a/.claude/skills/revise-pr/SKILL.md
+++ b/.claude/skills/revise-pr/SKILL.md
@@ -39,7 +39,7 @@ every thread gets a visible reply (the PR-author signal norm: don't push silent)
 ### Step 0: Detect repo + PR
 
 ```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # resumelint-org/resumelint
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # offlinecv/OfflineCV
 OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
 # PR_NUM from the argument, or inferred from the current branch (see Input).
 gh pr view "$PR_NUM" --repo "$REPO" \

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Place a GitHub issue onto the resumelint roadmap — assign it to the right milestone, add it to the "ResumeLint v1" project board, and set its Phase. Use when the user says "triage this issue", "/triage-issue", "add this to the roadmap/board", or files/finds an issue with no milestone.
+description: Place a GitHub issue onto the offlinecv roadmap — assign it to the right milestone, add it to the "ResumeLint v1" project board, and set its Phase. Use when the user says "triage this issue", "/triage-issue", "add this to the roadmap/board", or files/finds an issue with no milestone.
 ---
 
 # Triage Issue
@@ -29,8 +29,8 @@ gh issue list --state open --json number,title,milestone \
 ### Step 0: Detect repo + read the live roadmap
 
 ```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # resumelint-org/resumelint
-OWNER="${REPO%%/*}"                                             # resumelint-org
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"   # offlinecv/OfflineCV
+OWNER="${REPO%%/*}"                                             # offlinecv
 
 # Open milestones (the canonical roadmap buckets)
 gh api "repos/$REPO/milestones?state=open" \

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,10 +1,10 @@
 name: Promote main → release (prod gate)
 
 # Advances the `release` branch (Cloudflare Pages production source, served at
-# resumelint.org) to the latest `main` SHA — but only when the full local CI
+# offlinecv.org) to the latest `main` SHA — but only when the full local CI
 # gate (`npm run verify`) passes on that commit. Runs once a day, and on manual
 # dispatch. If verify fails, `release` stays on the last good commit, so prod
-# holds a known-good build while `main` (dev.resumelint.org, via GitHub Pages)
+# holds a known-good build while `main` (dev.offlinecv.org, via GitHub Pages)
 # keeps taking every push.
 #
 # No secrets: pushes to `release` with the built-in GITHUB_TOKEN. Cloudflare

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ __pycache__/
 # npm scripts; build/deploy guidance lives in README.md.
 /scripts/run_resumelint.sh
 /scripts/deploy_resumelint.sh
+/scripts/run_offlinecv.sh
+/scripts/deploy_offlinecv.sh
 
 # Local-only internal working directory — never ship in the OSS repo
 internal/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # offlinecv
 
-**Try it:** [resumelint.org](https://resumelint.org) — stable, promoted daily once
-CI is green · [dev.resumelint.org](https://dev.resumelint.org) — bleeding edge,
+**Try it:** [offlinecv.org](https://offlinecv.org) — stable, promoted daily once
+CI is green · [dev.offlinecv.org](https://dev.offlinecv.org) — bleeding edge,
 updated on every push
 
 A PDF parser stress test for resumes. Drop a PDF in; see what a generic
@@ -102,7 +102,7 @@ the PostHog branch is dead-code-eliminated by Vite/Rollup and the dep does
 not appear in the output bundle.
 
 A build with `VITE_POSTHOG_KEY` set — such as the hosted preview at
-resumelint.org — emits events such as `file_accepted`, `parse_completed`, and
+offlinecv.org — emits events such as `file_accepted`, `parse_completed`, and
 `parse_failed`. The payloads are listed in `src/lib/analytics.ts` and contain
 only file size, page count, parse duration, score breakdown, layout triggers,
 and error name — never PDF bytes, never extracted text, never names or URLs.
@@ -326,7 +326,7 @@ aws s3 sync dist s3://your-bucket     # S3
 The hosted preview at the top of this README is published from `dist/`
 to GitHub Pages by `.github/workflows/deploy-pages.yml` — read that
 workflow for a working end-to-end example. The canonical production URL
-is the custom domain **<https://resumelint.org>**; the project-Pages URL
+is the custom domain **<https://offlinecv.org>**; the project-Pages URL
 <https://offlinecv.github.io/OfflineCV/> remains as a fallback (built
 with `VITE_BASE_PATH=/OfflineCV/`).
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-dev.resumelint.org
+dev.offlinecv.org

--- a/src/lib/webllm/eval/runner.ts
+++ b/src/lib/webllm/eval/runner.ts
@@ -59,7 +59,7 @@ export interface RunEvalInput {
    */
   judgeEnabled?: boolean;
   /**
-   * Resumelint commit SHA the eval ran against, surfaced in the report.
+   * OfflineCV commit SHA the eval ran against, surfaced in the report.
    * The browser entry passes `__APP_VERSION__`; tests pass `null`.
    */
   appVersion?: string | null;

--- a/src/lib/webllm/eval/types.ts
+++ b/src/lib/webllm/eval/types.ts
@@ -156,7 +156,7 @@ export interface RunRecord {
 export interface EvalReport {
   /** ISO-8601 timestamp the run started. */
   startedAt: string;
-  /** Resumelint commit SHA the eval ran against, if resolvable. */
+  /** OfflineCV commit SHA the eval ran against, if resolvable. */
   appVersion: string | null;
   /** Models compared in this run. */
   modelIds: readonly string[];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,7 @@ function resolveAppVersion(): string {
 
 const APP_VERSION = resolveAppVersion();
 
-// Base path. The custom domain (resumelint.org) and the GCS bucket root both
+// Base path. The custom domain (offlinecv.org) and the GCS bucket root both
 // serve at "/"; the bare github.io project-Pages fallback
 // (offlinecv.github.io/OfflineCV/) needs "/OfflineCV/". Env-driven so
 // each deploy target builds with its own prefix without a code edit — set


### PR DESCRIPTION
Refs #498 — the domain-cutover + remaining-references slice of the ResumeLint → OfflineCV rename (code rebrand itself landed in #499).

## What changed

- **`public/CNAME`** → `dev.offlinecv.org` (GitHub Pages dev build). DNS CNAME `dev.offlinecv.org → offlinecv.github.io` is already in place; the Pages custom domain was switched via API alongside this PR and the HTTPS cert is provisioning.
- **README.md** — `resumelint.org` / `dev.resumelint.org` → `offlinecv.org` / `dev.offlinecv.org` (Try-it links, telemetry section, deploy section).
- **vite.config.ts / .github/workflows/promote-release.yml** — comment-level domain references updated.
- **`.claude/skills/*` (14 files) + `.claude/hooks/fallow-stop.sh`** — repo slug `resumelint-org/resumelint` → `offlinecv/OfflineCV` in gh command examples and prose; copyright header updated.
- **`.gitignore`** — added `offlinecv`-named local-script paths (old lines kept; local files still exist).
- **src/lib/webllm/eval/{runner,types}.ts** — doc comments "Resumelint" → "OfflineCV".

## Deliberately unchanged

- `DB_NAME = "resumelint"` (`src/lib/storage/db.ts`) — renaming the IndexedDB would strand existing users' stored state; comment in file explains.
- `"ResumeLint v1"` project-board title in triage-issue/batch-issues skills — the board itself is not renamed yet; the skill must match the live title.

## Done outside this diff (API, already applied)

- GitHub Pages custom domain → `dev.offlinecv.org` (cert state: authorized/provisioning)
- Repo description + homepage → offlinecv.org; topics added (resume, pdf, parser, ats, client-side, webllm, job-search)

## Remaining follow-ups (not in this PR — Cloudflare/PostHog side)

- Apex `offlinecv.org` has **no DNS record yet** (www + dev resolve; apex empty) — needs A/CNAME in Cloudflare
- Attach `offlinecv.org` as custom domain on the Cloudflare Pages project (prod serves from `release` branch)
- Decide + set `resumelint.org` 301 → `offlinecv.org`
- PostHog project rename (id 483474) + verify `VITE_POSTHOG_KEY` env on the Cloudflare Pages build
- Rename the "ResumeLint v1" project board (then update the two skill references)

## Verification

- `npm run typecheck` ✓ · `npm run lint` ✓ · `npx vitest run src/lib/webllm/eval` 34/34 ✓ · `fallow audit --base origin/main` clean (22 changed files)
- Full `verify` runs in CI on this PR

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation + orchestration — #498 remainder | Claude Fable 5 | high |
| Adversarial review | Claude Sonnet 5 | high |

## Adversarial review

One round, zero findings (`clean: true`). Reviewer verified slug/product casing, gh command examples, grammar after the mechanical replace, and swept the tree for missed `resumelint` references outside the deliberately-kept set. Verdict: APPROVE.
