### PR TITLE
chore(deploy): minimal Cloudflare Workers static-assets config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ __pycache__/
 
 # Local-only internal working directory — never ship in the OSS repo
 internal/
+
+# wrangler local state
+.wrangler/
+.dev.vars*
+!.dev.vars.example

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,14 @@
+// Cloudflare Workers static-assets config — required in-repo for Workers git
+// builds (build: `npm run build`, deploy: `npx wrangler deploy`). Assets-only:
+// no worker script, no build-time Cloudflare dependency — the OSS build stays
+// host-agnostic (vite build → dist/), matching the repo's client-side-only
+// constraint. SPA not-found handling mirrors the old Pages behavior.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "offlinecv",
+  "compatibility_date": "2026-07-20",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
Refs #498. Replaces #501 (Cloudflare Workers autoconfig).

## Why not #501 as-is

- Its `wrangler.jsonc` had no `assets.directory`, so `npx wrangler deploy` had nothing to deploy — the "Workers Builds: offlinecv" preview check on that PR failed.
- It injected `@cloudflare/vite-plugin` into `vite.config.ts` + a `wrangler` devDependency (~7,800-line package-lock churn). The site is a pure static Vite build; an assets-only Worker needs no build-time Cloudflare dependency, and the public OSS build should stay host-agnostic.
- It rewrote `npm run preview` to `wrangler dev`, breaking the existing local workflow.
- Its transitive deps want Node ≥22; the repo pins Node 20 (`.nvmrc`).

## What this PR does instead

- `wrangler.jsonc` — name, compatibility date, `assets.directory: ./dist`, SPA not-found handling (mirrors old Pages behavior). That's the entire contract Workers git builds need: `npm run build` → `npx wrangler deploy` uploads `dist/`.
- `.gitignore` — wrangler local state (`.wrangler/`, `.dev.vars*`).

No changes to package.json, the lockfile, or the Vite build.

## Verification

- Config is deploy-metadata only; app code untouched. CI `verify` + the Workers Builds preview check on this PR are the gates.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation + orchestration | Claude Fable 5 | medium |
