### PR TITLE
chore(rename): drop dead resumelint wrapper entries from .gitignore (#498)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,6 @@ __pycache__/
 # above (which only exist on the maintainer's machine), so they're broken for
 # anyone else — kept on disk for local use, not shipped. Contributors use the
 # npm scripts; build/deploy guidance lives in README.md.
-/scripts/run_resumelint.sh
-/scripts/deploy_resumelint.sh
 /scripts/run_offlinecv.sh
 /scripts/deploy_offlinecv.sh
 


### PR DESCRIPTION
## Summary

Last in-repo leftover from the ResumeLint → OfflineCV rename (#498).

`.gitignore` carried both the old `run_resumelint.sh` / `deploy_resumelint.sh`
maintainer wrappers and their `*_offlinecv.sh` replacements (added in #499).
Neither resumelint-named file exists on disk any more, so the two rules match
nothing. Dropping them.

No behaviour change — ignore-only, zero tracked files affected.

## Verification

- `ls scripts/run_resumelint.sh scripts/deploy_resumelint.sh` → both absent
- `git status` clean after the edit; no previously-ignored file becomes tracked

## Provenance

Authored with Claude Code (Opus 4.8).
