### PR TITLE
chore(rename): rename storage identifiers to OfflineCV (#498)

### DIFF
--- a/.claude/skills/batch-issues/SKILL.md
+++ b/.claude/skills/batch-issues/SKILL.md
@@ -299,7 +299,7 @@ gh api -X DELETE "repos/$REPO/issues/<BLOCKED>/dependencies/blocked_by/$DEP_ID"
 Don't re-implement project logic — **delegate to the repo's `/triage-issue`**, which
 owns board placement **and the parent's milestone/Phase**:
 
-> Run `/triage-issue <PARENT>` to put the epic on the "ResumeLint v1" board and
+> Run `/triage-issue <PARENT>` to put the epic on the "OfflineCV v1" board and
 > set its Phase/milestone.
 
 Invoke it (or tell the user to) so the batch shows up on the roadmap as one row.

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Place a GitHub issue onto the offlinecv roadmap — assign it to the right milestone, add it to the "ResumeLint v1" project board, and set its Phase. Use when the user says "triage this issue", "/triage-issue", "add this to the roadmap/board", or files/finds an issue with no milestone.
+description: Place a GitHub issue onto the offlinecv roadmap — assign it to the right milestone, add it to the "OfflineCV v1" project board, and set its Phase. Use when the user says "triage this issue", "/triage-issue", "add this to the roadmap/board", or files/finds an issue with no milestone.
 ---
 
 # Triage Issue
@@ -75,9 +75,9 @@ gh issue edit <N> --milestone "<exact milestone title>"
 
 ```bash
 PROJ_NUM="$(gh project list --owner "$OWNER" --format json \
-  --jq '.projects[] | select(.title=="ResumeLint v1") | .number')"
+  --jq '.projects[] | select(.title=="OfflineCV v1") | .number')"
 PROJ_ID="$(gh project list --owner "$OWNER" --format json \
-  --jq '.projects[] | select(.title=="ResumeLint v1") | .id')"
+  --jq '.projects[] | select(.title=="OfflineCV v1") | .id')"
 ```
 
 If `PROJ_NUM` is empty, the board doesn't exist yet — see **First-time setup**
@@ -152,7 +152,7 @@ gh api "repos/$REPO/milestones" -f title="<title>" -f description="<role in the 
 Create the board + the Phase field, with one option per milestone:
 
 ```bash
-gh project create --owner "$OWNER" --title "ResumeLint v1"
+gh project create --owner "$OWNER" --title "OfflineCV v1"
 # Phase options should mirror the CURRENT milestone titles so triage can set a
 # matching Phase (Step 4). Read them live first, don't paste a stale list:
 #   gh api "repos/$REPO/milestones?state=open" --jq '[.[].title]|join(",")'

--- a/README.md
+++ b/README.md
@@ -131,16 +131,16 @@ scoped to your browser:
 
 | Key | Purpose |
 |---|---|
-| `rl_feedback_seen` | counts how many times the feedback ask has rendered; after 2 the panel switches from the full card to a quiet compact star strip |
-| `rl_feedback_submitted` | set after a successful feedback submit so the panel never re-asks in that browser |
-| `rl_star_cta_seen` | one-time flag so the post-feedback GitHub-star prompt shows only once per browser |
-| `rl_gh_stars_cache` | caches the fetched star count (~1h TTL) to avoid re-hitting the GitHub API on every parse |
+| `ocv_feedback_seen` | counts how many times the feedback ask has rendered; after 2 the panel switches from the full card to a quiet compact star strip |
+| `ocv_feedback_submitted` | set after a successful feedback submit so the panel never re-asks in that browser |
+| `ocv_star_cta_seen` | one-time flag so the post-feedback GitHub-star prompt shows only once per browser |
+| `ocv_gh_stars_cache` | caches the fetched star count (~1h TTL) to avoid re-hitting the GitHub API on every parse |
 
 #### IndexedDB (local-first storage)
 
 For structured/binary data the app uses an IndexedDB database named `offlinecv`
 (via the ~1KB [`idb`](https://github.com/jakearchibald/idb) wrapper;
-`src/lib/storage/`), separate from the `rl_*` UI flags above. It has two object
+`src/lib/storage/`), separate from the `ocv_*` UI flags above. It has two object
 stores — `resumes` (raw PDF bytes as a `Blob` plus a cached parse so a reopened
 resume doesn't re-run the cascade) and `jobs` (tracked-job records) — versioned
 together under one `onupgradeneeded` migration path. This is **still first-party
@@ -164,7 +164,7 @@ state and the eviction note inline, with the export backup reachable from there.
 The footer shows the live repo star count via an unauthenticated call to
 `https://api.github.com/repos/offlinecv/OfflineCV` (`src/hooks/useGitHubStars.ts`).
 It runs from your browser on app load whenever the ~1h cache
-(`rl_gh_stars_cache`) is stale, and is **fail-silent** — on network error or
+(`ocv_gh_stars_cache`) is stale, and is **fail-silent** — on network error or
 rate-limit (GitHub allows 60 req/hr/IP unauthenticated) the count is hidden
 and the rest of the UI is unaffected. Because the request originates in your
 browser, **your IP address is seen by GitHub** (a US third party) as a result

--- a/src/components/features/FeedbackPanel.test.tsx
+++ b/src/components/features/FeedbackPanel.test.tsx
@@ -53,8 +53,8 @@ async function mountPanel(opts: {
   return container;
 }
 
-// FeedbackPanel persists render-state to localStorage (rl_feedback_seen /
-// rl_feedback_submitted / rl_star_cta_seen / rl_gh_stars_cache, #193/#194).
+// FeedbackPanel persists render-state to localStorage (ocv_feedback_seen /
+// ocv_feedback_submitted / ocv_star_cta_seen / ocv_gh_stars_cache, #193/#194).
 // Without a clean store, the submit test flips later mounts into "done"
 // (renders null) and the seen counter accumulates into "compact" mode — both
 // hide the form. The global setup (src/test-setup.ts, #398) installs a fresh

--- a/src/components/features/FeedbackPanel.tsx
+++ b/src/components/features/FeedbackPanel.tsx
@@ -28,8 +28,8 @@
  * | "compact"| not submitted AND seen count >= 2  | quiet inline star strip        |
  *
  * localStorage keys:
- *   rl_feedback_seen      — integer, incremented once per real mount
- *   rl_feedback_submitted — "1" once handleSubmit succeeds
+ *   ocv_feedback_seen      — integer, incremented once per real mount
+ *   ocv_feedback_submitted — "1" once handleSubmit succeeds
  *
  * Design rules (CLAUDE.md): `Card` + `Button` + `StarRating` from
  * `@design-system`; semantic tokens only; explicit labels on every field.
@@ -70,10 +70,10 @@ const CATEGORIES = ["Parsing", "Scoring", "UI", "Other"] as const;
 type Category = (typeof CATEGORIES)[number];
 
 // localStorage key constants (internal — only used within this module).
-const LS_KEY_SEEN = "rl_feedback_seen";
-const LS_KEY_SUBMITTED = "rl_feedback_submitted";
+const LS_KEY_SEEN = "ocv_feedback_seen";
+const LS_KEY_SUBMITTED = "ocv_feedback_submitted";
 // One-time star CTA seen flag (set when shown after a 4–5★ submission).
-const LS_KEY_STAR_CTA_SEEN = "rl_star_cta_seen";
+const LS_KEY_STAR_CTA_SEEN = "ocv_star_cta_seen";
 
 /**
  * FeedbackPanel — the one owning star-rating feedback surface (#51, #193).
@@ -167,7 +167,7 @@ function FeedbackRatingForm() {
   // ── Done state ────────────────────────────────────────────────────────────
   if (submitted) {
     // Sentiment gate: only show star CTA after a 4–5 star rating, and only
-    // once per browser (rl_star_cta_seen flag). Mark seen on first render.
+    // once per browser (ocv_star_cta_seen flag). Mark seen on first render.
     const showStarCta = rating >= 4 && starCtaSeen !== "1";
 
     return (

--- a/src/hooks/useGitHubStars.ts
+++ b/src/hooks/useGitHubStars.ts
@@ -7,13 +7,13 @@
  * it fail-silently: any network error, rate-limit, or localStorage unavailability
  * resolves to `{ count: undefined }` without throwing or rendering an error UI.
  *
- * Cache key : "rl_gh_stars_cache"
+ * Cache key : "ocv_gh_stars_cache"
  * Cache format: JSON `{ count: number; fetchedAt: number }` (fetchedAt = ms epoch)
  */
 
 import { useEffect, useState } from "react";
 
-const LS_KEY = "rl_gh_stars_cache";
+const LS_KEY = "ocv_gh_stars_cache";
 const TTL_MS = 60 * 60 * 1000; // 1 hour
 const API_URL =
   "https://api.github.com/repos/offlinecv/OfflineCV";

--- a/src/hooks/useResumeAnalysis.migration.test.ts
+++ b/src/hooks/useResumeAnalysis.migration.test.ts
@@ -4,7 +4,7 @@
 /**
  * Persistence back-compat for the #427 contact-link consolidation.
  *
- * Before #427 a saved blank-authoring draft (`rl_blank_draft`) carried contact
+ * Before #427 a saved blank-authoring draft (`ocv_blank_draft`) carried contact
  * LINK edits on `contactOverrides` under the four legacy `*_url` keys and had no
  * `profileOverrides` list. `migrateBlankDraft` upconverts such a draft on read
  * into the consolidated shape without losing edits, and leaves a current-shape

--- a/src/hooks/useResumeAnalysis.ts
+++ b/src/hooks/useResumeAnalysis.ts
@@ -121,10 +121,10 @@ export interface LoadedDoneState {
 // ── Draft persistence (#313) ─────────────────────────────────────────────────
 
 /** localStorage key for the in-progress from-scratch draft, following the
- *  `rl_*` functional-key convention (README's Telemetry section). Exported so
+ *  `ocv_*` functional-key convention (README's Telemetry section). Exported so
  *  `useDownloadPdf` can clear it on a successful blank-authored export
  *  without sharing any React state with this hook. */
-export const BLANK_DRAFT_STORAGE_KEY = "rl_blank_draft";
+export const BLANK_DRAFT_STORAGE_KEY = "ocv_blank_draft";
 
 function isBlankDraftSnapshot(value: unknown): value is BlankDraftSnapshot {
   if (typeof value !== "object" || value === null) return false;

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -54,8 +54,8 @@ import { usePersistentFlag } from "./usePersistentFlag.ts";
 import { useSectionRewriteLock } from "./useSectionRewriteLock.ts";
 
 /** localStorage keys for the last-used steering (issue #210). */
-const INSTRUCTIONS_KEY = "rl_rewrite_instructions";
-const PAGE_TARGET_KEY = "rl_rewrite_page_target";
+const INSTRUCTIONS_KEY = "ocv_rewrite_instructions";
+const PAGE_TARGET_KEY = "ocv_rewrite_page_target";
 
 function parsePageTarget(stored: string): PageTarget | null {
   return stored === "1" || stored === "2" || stored === "3"

--- a/src/lib/jd-fit-handoff.ts
+++ b/src/lib/jd-fit-handoff.ts
@@ -24,7 +24,7 @@
  * later, unrelated session. Consumed once: `/jd-fit` reads then clears the key
  * on mount, so a manual reload falls back to its own DropZone.
  *
- * Key follows the repo's `rl_*` storage convention.
+ * Key follows the repo's `ocv_*` storage convention.
  */
 
 import type { CascadeResult } from "./heuristics/types.ts";
@@ -32,7 +32,7 @@ import type { AnonymousAtsScore } from "./score/score.ts";
 import type { EditSnapshot } from "../hooks/useEditableParse.ts";
 
 /** sessionStorage key for the parser-audit → JD-fit handoff payload (#226). */
-export const JDFIT_HANDOFF_KEY = "rl_jdfit_handoff";
+export const JDFIT_HANDOFF_KEY = "ocv_jdfit_handoff";
 
 /**
  * Sentinel wrapper for a `Map` in the JSON payload (#450). `JSON.stringify`

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -11,18 +11,19 @@
  * for the range `(oldVersion, DB_VERSION]`, so guarding each step with
  * `oldVersion < N` makes the migrations cumulative and idempotent.
  *
- * localStorage stays the home for the `rl_*` UI flags (see README) — this module
+ * localStorage stays the home for the `ocv_*` UI flags (see README) — this module
  * is for structured/binary data only.
  */
 
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 import type { ResumeRecord, JobRecord } from "./types.ts";
 
-// Kept as "resumelint" through the OfflineCV rename: this is the IndexedDB
-// database name, not a brand string. Renaming it would orphan every existing
-// user's locally stored resumes/jobs (no migration path). It is invisible to
-// users, so it stays for data continuity.
-export const DB_NAME = "resumelint";
+// Renamed from "resumelint" during the OfflineCV rename (#498). Safe to change
+// outright: the store had no external users at cutover, so there was no data to
+// strand. Treat it as frozen from here — a later rename WOULD orphan real users'
+// resumes/jobs, because a different database name is a different database, not a
+// `DB_VERSION` migration.
+export const DB_NAME = "offlinecv";
 /** Bump when adding/altering a store or index; add a matching `oldVersion < N`
  *  branch in `upgrade()`. */
 export const DB_VERSION = 1;

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -5,7 +5,7 @@
  * Project-wide vitest setup (wired as `test.setupFiles` in `vite.config.ts`).
  *
  * Installs a fresh in-memory `localStorage` shim before EVERY test, globally.
- * The `rl_*` functional keys touch a `localStorage` that neither the Node env
+ * The `ocv_*` functional keys touch a `localStorage` that neither the Node env
  * (default) provisions nor Node 22+'s built-in global exposes as a working
  * `Storage` (#398). Doing this once at the workload level — instead of an
  * `import + beforeEach` per file — closes the "new test forgot to install the


### PR DESCRIPTION
## Summary

Two name-derived identifiers survived the #499 rename sweep because neither contains the literal string `resumelint` — so the audit `grep` never saw them. Both are safe to change **now** and would not be later.

### 1. IndexedDB database name — `resumelint` → `offlinecv`

`src/lib/storage/db.ts` still opened a database literally named `resumelint`. Notably `README.md:141` already documented it as `offlinecv`, so this closes a **doc/code drift** rather than introducing a change.

The previous comment argued it should stay for data continuity. That reasoning was sound in general but not applicable here: usage to date has been testing only, with no external users, so there is no stored data to strand. The comment is rewritten to mark the name **frozen from here** — a database name is not a `DB_VERSION` migration, so a rename after real users exist silently orphans their resumes/jobs.

### 2. localStorage prefix — `rl_*` → `ocv_*`

All eight keys: `feedback_seen`, `feedback_submitted`, `star_cta_seen`, `gh_stars_cache`, `blank_draft`, `rewrite_instructions`, `rewrite_page_target`, `jdfit_handoff` — plus the README key table and the five docblocks that name the convention.

Replaced **by exact key name**, not a bare `rl_` sweep, so `url_`/`curl_` substrings can't be caught. Verified zero `rl_` remain and no unintended token changed.

### 3. Project board title in skills

`triage-issue` and `batch-issues` select the Projects v2 board by exact title. The board is **`OfflineCV v1`** (org project 1, `PVT_kwDOEkplDM4Bd8Qo`, 31 items) — it transferred with the org and was already renamed. The skills still looked for `ResumeLint v1`, which matched nothing, so board placement was silently a no-op.

## Verification

- `npm run verify` → **exit 0** (typecheck, lint, coverage, build, fallow)
- Skill lookup re-run against the live API: resolves `PROJ_NUM=1`, `PROJ_ID=PVT_kwDOEkplDM4Bd8Qo`
- `grep -rn "rl_"` across all touched files → none

## Note

This does not migrate old keys or the old database. That is deliberate — with no external users there is nothing to migrate, and a migration shim would be dead code from the day it merged. Local dev browsers will drop their feedback flags and any in-progress blank draft on next load.

Closes the last in-repo items of #498.

## Provenance

Authored with Claude Code (Opus 4.8).
