### PR TITLE
fix(parser): disambiguate two more one-line experience header shapes (#436)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -150,30 +150,32 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   //   1. SWAP — a neutral two-segment middot header ("Composer · Northwind
   //      Ensemble", no company-suffix / title-keyword either side) re-parsed
   //      title↔company-swapped because the no-signal default read the first
-  //      segment as the company. FIXED: the `middot` title-first default in
-  //      `mapWithoutCompanyMatch` reads "Title · Company" per the export/#217
-  //      convention. Seven fixtures cleared their baseline via the ratchet.
+  //      segment as the company. FIXED (#495): the `middot` title-first default
+  //      in `mapWithoutCompanyMatch`. A related swap where BOTH segments look
+  //      like a company on one middot line — a soft title keyword vs a hard legal
+  //      tail ("Solutions Engineer · Acme Cloud, Inc.") — is now also fixed by
+  //      the `chooseCompanyIdx` hard-legal preference (certifications cleared).
+  //      A bare-location tail the exporter joins into the company cell
+  //      ("…, Remote") is peeled by `stripLocationSuffix` Pass F (achievements-
+  //      oneline, two-column, chromium-asymmetric, weasyprint-two-column cleared).
   //   2. TRUNCATION — a PARENTHETICAL / multi-word company on the one-line shape
   //      ("Danggeun Pay Inc. (KarrotPay)" → "(KarrotPay)") still re-parses
-  //      truncated. STILL OPEN — the remaining lines below are this root (plus
-  //      two-column re-segmentation), a distinct follow-up from the swap.
+  //      truncated. STILL OPEN — the four lines below are this root (plus
+  //      two-column re-segmentation). The fix needs a wrapped-header rejoin AND a
+  //      render-side date-column reserve, which perturb two-column round-trips
+  //      and so warrant their own follow-up, kept separate from the swap fix.
   //
   // Delete each line below as its root lands (the ratchet forces it — a fixed
   // fixture trips the stale-entry check).
-  "google-docs/google-docs-skia-proxy-achievements-oneline.pdf": ["experience"],
-  "google-docs/google-docs-skia-proxy-certifications.pdf": ["experience"],
   "google-docs/google-docs-skia-proxy-honors-subheadings.pdf": ["experience"],
   "google-docs/google-docs-skia-proxy-role-first-experience.pdf": ["experience"],
-  "google-docs/google-docs-skia-proxy-two-column.pdf": ["experience"],
   // awesome-cv-cv: #383 cleared its earlier abbreviated-date baseline (see the
   // #383 note above), but main's one-line header re-regresses `experience` for
-  // the #436 reason — 12 roles re-parse company-truncated/swapped off the
-  // one-line "Title · Company … Dates" shape. Same #436 root as the group here;
-  // the ratchet removes this line when #436 lands.
+  // the #436 TRUNCATION reason — 12 roles re-parse company-truncated/swapped off
+  // the one-line "Title · Company … Dates" shape. Removed when the truncation
+  // root lands.
   "latex/awesome-cv-cv.pdf": ["experience"],
   "latex/awesome-cv-resume.pdf": ["experience"],
-  "unknown/chromium-asymmetric-sidebar.pdf": ["experience"],
-  "unknown/weasyprint-cairo-two-column.pdf": ["experience"],
 };
 
 const CATEGORIES: Category[] = [

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -300,6 +300,26 @@ function stripLocationSuffix(s: string): {
     }
   }
 
+  // Pass F — comma-delimited trailing BARE-LOCATION keyword (#436). The one-line
+  // experience exporter joins "Company, Location" into a single middot cell, and
+  // when the model's `location` is a work-mode keyword ("Remote", "Hybrid",
+  // "On-site") or a bare well-known city with no state/country tail ("London",
+  // "Seattle") — the forms `BARE_LOCATION_RE` recognizes but Passes A–E (which
+  // all require a "City, ST" / "City, Country" shape) do not — the location bled
+  // into `company` on round-trip ("Globex Corporation, Remote"). Peel the tail
+  // when it whole-matches the closed `BARE_LOCATION_RE` vocabulary; a real
+  // company never ends in a bare ", Remote" / ", London" tail, so the closed set
+  // keeps this from stealing company text. Tried LAST so the richer city+state
+  // and city+country shapes above still win when they apply.
+  const commaF = s.lastIndexOf(",");
+  if (commaF > 0) {
+    const tail = s.slice(commaF + 1).trim();
+    if (BARE_LOCATION_RE.test(tail)) {
+      const before = stripDanglingSeparator(s.slice(0, commaF));
+      if (before) return { text: before, location: tail };
+    }
+  }
+
   return { text: s, location: undefined };
 }
 
@@ -540,6 +560,40 @@ function mapSegmentsToFields(
         (i) => splits[i].source === anchorIdx,
       );
       if (anchorMatch !== undefined) return anchorMatch;
+    }
+    // #436 (truncation root) — a single-line MIDDOT header "Title · Company"
+    // (no line above) where BOTH segments read like a company: the title carries
+    // a SOFT company word ("Solutions Engineer" → `Solutions`) and the real
+    // company carries a HARD legal-entity marker ("Acme Cloud, Inc." → `Inc.`).
+    // Without `hasAbove` the anchor tiebreak can't fire, so the topmost
+    // `companyMatchIdxs[0]` (the title) would be mis-labelled the company,
+    // swapping title↔company — the #495 middot title-first default never runs
+    // because `companyIdx !== -1` routes to `mapWithCompanyMatch`. Prefer the
+    // hard-legal segment: it is a strictly stronger company signal than a soft
+    // keyword. `COMPANY_LEGAL_TAIL_RE` is the same strict promotion vocab
+    // `mapTitleFirst` case 3a uses; a soft-only tie keeps the topmost default.
+    //
+    // GATED to the exact export shape — every company-match on ONE source line
+    // that split as `middot` — so a stacked two-line header (matches on
+    // different sources) and a non-middot single line are untouched. When the
+    // topmost match is itself the hard-legal one, `find` returns it and the
+    // result equals the default, so no extra guard is needed. Without this gate
+    // the preference
+    // fired on genuine two-column/stacked layouts and stole the company (#436
+    // review).
+    const allMatchesShareMiddotLine =
+      companyMatchIdxs.every(
+        (i) =>
+          splits[i].source === splits[companyMatchIdxs[0]].source &&
+          splits[i].middot,
+      );
+    if (allMatchesShareMiddotLine) {
+      const hardLegalIdx = companyMatchIdxs.find((i) =>
+        COMPANY_LEGAL_TAIL_RE.test(
+          splits[i].text.trim().split(/[\s,]+/).pop() ?? "",
+        ),
+      );
+      if (hardLegalIdx !== undefined) return hardLegalIdx;
     }
     return companyMatchIdxs[0];
   };

--- a/src/lib/heuristics/extract/experience.mid-dot.test.ts
+++ b/src/lib/heuristics/extract/experience.mid-dot.test.ts
@@ -177,4 +177,76 @@ describe("mid-dot (·) single-line experience headers (#217)", () => {
     expect(roles[0].company).toBe("Harborlight Chorale");
     expect(roles[0].title).toBe("Ensemble Member");
   });
+
+  it("a soft-keyword title does not steal the company from a hard legal tail (#436)", () => {
+    // "Solutions Engineer" carries a SOFT company word ("Solutions"), so BOTH
+    // middot segments read like a company; the #495 title-first default never
+    // runs because a company match routes to `mapWithCompanyMatch`. The hard
+    // legal tail ("Inc.") must win so title↔company don't swap on this single
+    // line (no line above to run the anchor tiebreak).
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Solutions Engineer · Acme Cloud, Inc.", fontSize: 11 },
+      { text: "01/2020 - Present", fontSize: 11 },
+      { text: "• Rolled out zero-downtime deploys across 12 services.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].title).toBe("Solutions Engineer");
+    expect(roles[0].company).toContain("Acme Cloud");
+  });
+
+  it("peels a bare-location tail ('Remote') off the company (#436, Pass F)", () => {
+    // The exporter joins "Company, Location" in one middot cell; a work-mode
+    // location keyword has no "City, ST" shape, so Pass F must peel it rather
+    // than let it bleed into `company` on round-trip.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Staff Engineer · Globex Corporation, Remote", fontSize: 11 },
+      { text: "06/2021 - Present", fontSize: 11 },
+      { text: "• Owned the billing platform end to end.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].title.toLowerCase()).toContain("engineer");
+    expect(roles[0].company).toBe("Globex Corporation");
+    expect(roles[0].company).not.toContain("Remote");
+  });
+
+  it("locks the accepted tie-break: a hard-legal TITLE tail commits to title-first (#436, #505 review)", () => {
+    // Documented convention tradeoff (PR #505 Secondary). The hard-legal
+    // promotion is one convention: it can't distinguish "soft-company title +
+    // hard-legal company" (the shape it fixes) from the signal-identical
+    // "soft-company company + hard-legal title". So a header whose *title* ends
+    // in a literal legal token ("Director, Holdings") commits to title-first —
+    // an undecidable edge that never occurs in the export domain (a title never
+    // ends in "Inc."/"Holdings") and is vanishingly rare in real résumés. This
+    // test pins the intended behavior so a future change to the tie-break is a
+    // visible diff, not a silent regression.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Acme Solutions · Director, Holdings", fontSize: 11 },
+      { text: "01/2020 - Present", fontSize: 11 },
+      { text: "• Led a team of 12.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].title).toBe("Acme Solutions");
+    expect(roles[0].company).toContain("Director, Holdings");
+  });
+
+  it("locks the Pass F boundary: a company ending in a listed city splits at the last comma (#436, #505 review)", () => {
+    // Pass F peels any last-comma tail that whole-matches the closed
+    // `BARE_LOCATION_RE` city vocab, so a real employer whose name ends in a
+    // listed city ("Lloyd's, London") splits company/location. The extracted
+    // location stays semantically correct and the split is gated to the last
+    // comma + a closed vocab, so this is a low-risk, documented boundary — pinned
+    // here so the intended behavior is a visible diff if the vocab changes.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Underwriter · Lloyd's, London", fontSize: 11 },
+      { text: "06/2021 - Present", fontSize: 11 },
+      { text: "• Priced specialty risk.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Lloyd's");
+    expect(roles[0].location).toBe("London");
+  });
 });

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
@@ -130,7 +130,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
@@ -127,7 +127,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
@@ -139,7 +139,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -137,7 +137,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -139,7 +139,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,


### PR DESCRIPTION
## Summary

Builds on **#495** (which fixed the neutral middot swap, `Composer · Northwind Ensemble`). Two sibling shapes on the same one-line `Title · Company, Location · Team` export header still re-parsed wrong; both are fixed here **without touching the renderer**:

- **Soft-vs-hard company swap** — when both middot segments read like a company because the title carries a soft company word (`Solutions Engineer`) and the company a hard legal tail (`Acme Cloud, Inc.`), `chooseCompanyIdx` now prefers the hard legal-entity tail. #495's title-first default can't fire here — a company match routes to `mapWithCompanyMatch`. Gated to a single-source **middot** line so stacked / two-column headers are untouched.
- **Location bleed** — the exporter joins `Company, Location` in one cell, so a bare-location tail with no `City, ST` shape (`…, Remote`, `…, London`) bled into `company`. `stripLocationSuffix` **Pass F** peels a trailing tail that whole-matches the closed `BARE_LOCATION_RE` vocab.

Clears **5** corpus baselines (`certifications`, `achievements-oneline`, `two-column`, `chromium-asymmetric`, `weasyprint-two-column`) with **zero round-trip regressions**, plus two value-asserting unit tests.

Refs #436

### Deferred: the TRUNCATION root

A parenthetical company (`Danggeun Pay Inc. (KarrotPay)` → `(KarrotPay)`) still re-parses truncated. Its fix needs a wrapped-header rejoin **plus** a render-side date-column reserve — both perturb two-column round-trips (measured: 4+ regressions), so it's split into its own follow-up. The `awesome-cv-cv/resume` + `role-first` + `honors-subheadings` baselines stay.

> Note: opened before the ResumeLint→OfflineCV rebrand + #495 landed; rebased onto current `main`, so the diff is now a focused 3-file change layered on #495.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `extract/` + `corpus-roundtrip` + `pdf/` suites — 543 pass / 2 skip, zero regressions
- [x] `npm run verify` — green in CI

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: `npm run verify` — green in CI
