### PR TITLE
fix(skills): split inline ● (U+25CF) and sibling bullet glyphs as separators

### DIFF
--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -22,6 +22,33 @@ describe("tokenizeSkillLine", () => {
     expect(result).not.toContain("CSS");
   });
 
+  it("splits on inline round/square bullet glyphs incl. ● U+25CF (not just • U+2022)", () => {
+    // Word / Google-Docs commonly separate inline skills with a `●` BLACK CIRCLE
+    // (U+25CF), a different codepoint from the `•` BULLET (U+2022) the splitter
+    // already handled — so `Python ● SQL ● Docker` used to come back as ONE
+    // merged token carrying two literal `●` glyphs (which then rewrote to `?` on
+    // the Download-PDF round-trip via the WinAnsi sanitizer).
+    const result = tokenizeSkillLine("Python ● SQL ● Docker ● Kubernetes");
+    expect(result).toEqual(["Python", "SQL", "Docker", "Kubernetes"]);
+    // The sibling bullet glyphs from the canonical set split too.
+    expect(tokenizeSkillLine("Go ‣ Rust ▪ Scala ◦ Elixir")).toEqual([
+      "Go",
+      "Rust",
+      "Scala",
+      "Elixir",
+    ]);
+  });
+
+  it("does NOT split a hyphenated skill name on its dash", () => {
+    // The dash glyphs are excluded from the bullet-separator set precisely so a
+    // real hyphenated skill survives whole.
+    expect(tokenizeSkillLine("CI-CD, front-end, back-end")).toEqual([
+      "CI-CD",
+      "front-end",
+      "back-end",
+    ]);
+  });
+
   it("strips an inline Label: prefix before tokenizing", () => {
     // The full line as it would appear in the PDF — label is NOT pre-stripped.
     // SKILL_SPLIT_RE splits on comma/semicolon, so the actual tokens are:

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -20,11 +20,11 @@ import { isBulletGlyph, stripBullet } from "../line-primitives.ts";
  * balanced parentheses (e.g. `Cloud Infrastructure (GCP, Hybrid Cloud)`) must
  * not split the token. Only commas OUTSIDE parens are delimiters.
  */
-// Bullet-glyph separators mirror the canonical leading-bullet set
-// (`regex.ts` LEADING_BULLET_RE, `sections.ts` VISUAL_BULLET_RE): `·` (U+00B7),
-// `•` (U+2022), `‣` (U+2023), `▪` (U+25AA), `●` (U+25CF), `◦` (U+25E6),
-// `⁃` (U+2043) — every round/square bullet Word / Google-Docs emit inline
-// between skills. The dash glyphs (`-`/`–`/`—`) and `*` in that set are
+// Bullet-glyph separators cover `·` (U+00B7) plus the round/square bullets from
+// the canonical leading-bullet set (`regex.ts` LEADING_BULLET_RE, `sections.ts`
+// VISUAL_BULLET_RE): `•` (U+2022), `‣` (U+2023), `▪` (U+25AA), `●` (U+25CF),
+// `◦` (U+25E6), `⁃` (U+2043) — every round/square bullet Word / Google-Docs
+// emit inline between skills. The dash glyphs (`-`/`–`/`—`) and `*` in that set are
 // DELIBERATELY excluded: they occur inside real skill names (`CI-CD`,
 // `front-end`, `C*`), so splitting on them would fragment a legitimate token.
 const SKILL_SPLIT_RE = /[;·•‣▪●◦⁃|]+|\s{2,}|(?<!\w)\/+(?!\w)/;

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -20,7 +20,14 @@ import { isBulletGlyph, stripBullet } from "../line-primitives.ts";
  * balanced parentheses (e.g. `Cloud Infrastructure (GCP, Hybrid Cloud)`) must
  * not split the token. Only commas OUTSIDE parens are delimiters.
  */
-const SKILL_SPLIT_RE = /[;·•|]+|\s{2,}|(?<!\w)\/+(?!\w)/;
+// Bullet-glyph separators mirror the canonical leading-bullet set
+// (`regex.ts` LEADING_BULLET_RE, `sections.ts` VISUAL_BULLET_RE): `·` (U+00B7),
+// `•` (U+2022), `‣` (U+2023), `▪` (U+25AA), `●` (U+25CF), `◦` (U+25E6),
+// `⁃` (U+2043) — every round/square bullet Word / Google-Docs emit inline
+// between skills. The dash glyphs (`-`/`–`/`—`) and `*` in that set are
+// DELIBERATELY excluded: they occur inside real skill names (`CI-CD`,
+// `front-end`, `C*`), so splitting on them would fragment a legitimate token.
+const SKILL_SPLIT_RE = /[;·•‣▪●◦⁃|]+|\s{2,}|(?<!\w)\/+(?!\w)/;
 
 /**
  * Single paren depth-walk over `text` — the one source of truth for what

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 6,
+    "skillsCount": 8,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,
@@ -76,7 +76,7 @@
     "sectionSource": "regex",
     "pageCount": 2,
     "rawCharCount": 2385,
-    "extractedCharCount": 1762,
+    "extractedCharCount": 1817,
     "sections": [
       {
         "name": "profile",
@@ -107,7 +107,7 @@
       "hasSummary": false,
       "experienceCount": 3,
       "educationCount": 2,
-      "skillsCount": 6
+      "skillsCount": 8
     },
     "linkAnnotationCount": 0,
     "disagreements": []

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 6,
+    "skillsCount": 8,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,
@@ -76,7 +76,7 @@
     "sectionSource": "regex",
     "pageCount": 2,
     "rawCharCount": 2279,
-    "extractedCharCount": 1654,
+    "extractedCharCount": 1709,
     "sections": [
       {
         "name": "profile",
@@ -107,7 +107,7 @@
       "hasSummary": false,
       "experienceCount": 3,
       "educationCount": 2,
-      "skillsCount": 6
+      "skillsCount": 8
     },
     "linkAnnotationCount": 0,
     "disagreements": []


### PR DESCRIPTION
## Summary

Inline skill lists separated by a `●` **BLACK CIRCLE (U+25CF)** — and the other round/square bullets Word / Google-Docs emit — were not split. `SKILL_SPLIT_RE` recognized only `·` (U+00B7) and `•` (U+2022), so `Python ● SQL ● Docker` came back as ONE merged token carrying literal `●` glyphs. That collapsed distinct skills (an over-long merged token can also trip the word-limit filter and drop entirely) **and** broke the Download-PDF round-trip, where the `●` rewrites to `?` via the WinAnsi sanitizer.

Surfaced by a sweep of real résumés; reproduced by existing corpus fixtures that already carry `●` in their skills line (invisible to `pdftotext`, which renders `●` as whitespace).

## Fix

Extend the bullet-glyph class to the round/square bullets already in the canonical leading-bullet set (`regex.ts` `LEADING_BULLET_RE`, `sections.ts` `VISUAL_BULLET_RE`): `·•‣▪●◦⁃`. The dash glyphs (`-`/`–`/`—`) and `*` in that set are **deliberately excluded** — they occur inside real skill names (`CI-CD`, `front-end`).

## What moved

- Two corpus fixtures that already contain `●` re-bake to `skillsCount: 6 → 8` — both correct (merged skills now separate; recovered tokens the word-limit filter had dropped now survive, so `extractedCharCount` rises too). No other snapshot moves.
- `tokenizeSkillLine` unit tests for the bullet glyphs + a hyphenated-skill non-split regression guard.

No new fixture: pdf-lib's StandardFont cannot even encode `●`, and the corpus already reproduces the defect.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `extract/skills`, `corpus`, `corpus-roundtrip`, `corpus-edit-roundtrip` green
- [x] Only the two intended snapshots moved
- [x] `npm run check:fixtures` green

Closes #522

## Provenance

Code implementation via: Claude Opus 4.8 (high effort)
Verification: `npm run verify` — to be confirmed green in CI