### PR TITLE
feat(chrome): make product breadth legible and give the palette honest names (#511)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,13 @@ __pycache__/
 # Local-only internal working directory — never ship in the OSS repo
 internal/
 
+# Maintainer-only skill whose source of truth lives in the private
+# offlinecv-internal repo (internal/.claude/skills/oss-translate). It is
+# surfaced here as a symlink so Claude Code discovers it as /oss-translate,
+# but it must never ship in the public repo — it translates private internal
+# issues into public ones and knows partner/PII sanitization specifics.
+/.claude/skills/oss-translate
+
 # wrangler local state
 .wrangler/
 .dev.vars*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Strict 3-tier architecture. Primitives + shared-composed live in `src/design-sys
 
 ## Styling & tokens
 
-- **Semantic tokens are canonical.** Style with semantic Tailwind classes: `bg-surface-card`, `text-content-primary`, `border-border-light`, `text-brand-amber`. Vocabulary lives in `src/design-system/styles/theme.css`; values in `tokens.css`.
+- **Semantic tokens are canonical.** Style with semantic Tailwind classes: `bg-surface-card`, `text-content-primary`, `border-border-light`, `text-accent-primary`. Vocabulary lives in `src/design-system/styles/theme.css`; values in `tokens.css`.
 - **No hardcoded colors.** Never a hex (`#ef4444`), never a raw palette class (`bg-red-500`, `text-slate-400`), never a manual `dark:` colour variant, in feature code.
 - **Typography** rides global settings — never hand-styled inline.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ already exists:
 
 **No hardcoded colours.** Style with semantic Tailwind tokens
 (`bg-surface-card`, `text-content-primary`, `border-border-light`,
-`text-brand-amber`, …). Raw palette classes (`bg-red-500`,
+`text-accent-primary`, …). Raw palette classes (`bg-red-500`,
 `text-slate-400`) and manual `dark:` variants are anti-patterns —
 dark mode is handled by the token layer, not inline overrides.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ labeled in-app as a remote/tech-heavy **sample, not every job**.
 Colors are plain CSS custom properties split into two layers:
 
 - **`src/design-system/styles/theme.css`** — the semantic vocabulary
-  (`--color-surface-card`, `--color-content-primary`, `--color-brand-amber`, …).
+  (`--color-surface-card`, `--color-content-primary`, `--color-accent-primary`, …).
   This is the **stable contract**: it generates the Tailwind classes
   (`bg-surface-card`, `text-content-primary`, …) that the components use. Names
   here don't change.
@@ -207,6 +207,22 @@ Colors are plain CSS custom properties split into two layers:
   vocabulary, light and dark. The default is a **generic, accessible palette
   (slate neutrals + a blue accent)**, not a specific product brand. This is the
   **swappable layer**.
+
+> **Deprecated names (removed 2026-07, #513):** `--color-brand-amber` was an
+> exact duplicate of `--color-accent-primary` (same blue in both themes).
+> `--color-brand-amber-light` was a *near*-duplicate of
+> `--color-accent-primary-hover`: identical in dark (`#93c5fd`), but in light
+> it held `#3b82f6` against the hover token's `#1d4ed8`. Folding them
+> deliberately corrects the light-mode hover on `Button variant="primary"` and
+> the ConsentDialog licence link from a lighter blue to a darker one. Every
+> consumer now points at the `accent-primary` pair, which is canonical.
+> `--color-brand-navy`, `--color-brand-navy-dark`, and
+> `--color-brand-cream` are gone — they had zero consumers in either theme.
+> `--color-accent-forward` (the foreground/text variant) is also gone — only
+> its background wash, `--color-accent-forward-bg`, had consumers; wiring a
+> foreground use of the forward accent is tracked separately. If your
+> override layer still defines any of these names, drop them — they no
+> longer resolve to anything.
 
 You can reskin offlinecv to your own brand **without forking this repo**, two
 ways:
@@ -219,12 +235,12 @@ Import your own stylesheet *after* offlinecv's and redefine the same
 ```css
 /* your-brand.css — imported after offlinecv's styles */
 :root {
-  --color-brand-amber: #ff6b35;
+  --color-accent-primary: #ff6b35;
   --color-bg-card: #fffaf5;
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-brand-amber: #ffa07a;
+    --color-accent-primary: #ffa07a;
     --color-bg-card: #1c1410;
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,12 +26,12 @@ function restrictedSyntaxRules() {
     {
       selector: `Literal[value=/${PALETTE_RE}/]`,
       message:
-        "Use semantic tokens (bg-surface-card, text-content-primary, border-border-light, text-brand-amber, …) instead of raw Tailwind palette classes.",
+        "Use semantic tokens (bg-surface-card, text-content-primary, border-border-light, text-accent-primary, …) instead of raw Tailwind palette classes.",
     },
     {
       selector: `TemplateElement[value.raw=/${PALETTE_RE}/]`,
       message:
-        "Use semantic tokens (bg-surface-card, text-content-primary, border-border-light, text-brand-amber, …) instead of raw Tailwind palette classes.",
+        "Use semantic tokens (bg-surface-card, text-content-primary, border-border-light, text-accent-primary, …) instead of raw Tailwind palette classes.",
     },
     // Manual dark: colour variants
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
-import { Card, Chip, ErrorState, ErrorBoundary, Button } from "@design-system";
+import {
+  Card,
+  CapabilityStrip,
+  ErrorState,
+  ErrorBoundary,
+  Button,
+} from "@design-system";
 import { DropZone } from "./components/DropZone";
 import { Result } from "./components/Result";
 import { ReconstructedResume } from "./components/features/ReconstructedResume.tsx";
@@ -90,14 +96,7 @@ export default function App() {
     <PageShell
       subtitle="A parser audit for your resume — not a judge"
       badge="alpha"
-      chips={
-        <>
-          <Chip icon="⚡">A few seconds</Chip>
-          <Chip icon="🔒">Your file never leaves your device</Chip>
-          <Chip icon="✓">No account, no email</Chip>
-          <Chip icon="🔁">Same PDF, same score</Chip>
-        </>
-      }
+      chips={<CapabilityStrip />}
     >
       {(state.phase === "idle" ||
         state.phase === "parsing" ||
@@ -115,30 +114,32 @@ export default function App() {
             // The trust stat is the one supporting line; everything else (the
             // recruiter-agent context) moves to the quiet block below the drop
             // zone so the hero isn't three competing messages.
+            //
+            // The headline's "by default" is NOT hedging for its own sake and
+            // must not be dropped: the job-search lane egresses keywords on an
+            // explicit click (see FindJobsPanel), a build with
+            // VITE_POSTHOG_KEY set (the hosted one) ships analytics, and the
+            // BYOK provider path (#320, not in the tree yet — see
+            // CapabilityStrip) will be real cloud egress once it lands. The
+            // first two are true today and already load-bearing on their own.
+            // An unqualified "on your device"
+            // would be the only absolute privacy claim in the app — every
+            // other surface is already scoped the same way (PageShell's
+            // footer, CapabilityStrip's rail).
             <Card className="flex flex-col items-center gap-5 bg-surface-card-warm">
               <div className="flex max-w-2xl flex-col gap-4 text-center">
-                <h2 className="text-balance text-2xl font-normal leading-snug tracking-tight text-content-secondary sm:text-3xl">
-                  <span className="font-semibold text-content-primary">
-                    AI is now part of most hiring pipelines —
-                  </span>{" "}
-                  and nearly half of job seekers say they&apos;ve lost trust in
-                  a process they can&apos;t see into.
-                  <a
-                    href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
-                    target="_blank"
-                    rel="nofollow noopener noreferrer"
-                    aria-label="Source: Greenhouse, 2025 AI in Hiring Report"
-                    className="align-super text-xs text-brand-amber hover:underline"
-                  >
-                    1
-                  </a>
+                <h2 className="text-balance text-2xl font-semibold leading-snug tracking-tight text-content-primary sm:text-3xl">
+                  Your whole job search — on your device by default.
                 </h2>
-                <p className="text-pretty text-base font-medium text-content-primary sm:text-lg">
-                  OfflineCV shows you what a recruiter or screener reads back
-                  from your resume — free, private, and open-source.
+                <p className="text-pretty text-base font-medium text-content-secondary sm:text-lg">
+                  OfflineCV is a free, open-source job-search workbench —
+                  read your resume, fix it, and match it against real
+                  postings, all in your browser. Nothing to install, no
+                  account to create.
                 </p>
                 <p className="text-xs text-content-muted">
-                  Source:{" "}
+                  Built in response to a hiring process job seekers say they
+                  can&apos;t see into — source:{" "}
                   <a
                     href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
                     target="_blank"
@@ -190,6 +191,11 @@ export default function App() {
             // file-scoped, determinism is score-scoped. Per the public-copy
             // policy (internal #24) we never name other products here — the
             // trend is described generically, no links to specific tools.
+            //
+            // #517: this block also now carries the three claims displaced
+            // from the old trust-chip row (speed, no-signup, determinism) —
+            // real differentiators that moved here rather than vanishing when
+            // the chip row became the capability strip above.
             <div className="rounded-lg border border-border-light bg-surface-subtle px-4 py-3">
               <p className="mx-auto max-w-3xl text-pretty text-sm text-content-secondary">
                 <span className="font-medium text-content-primary">
@@ -199,7 +205,9 @@ export default function App() {
                 the candidate-side
                 mirror: it shows you what survives the parse — before you hit
                 submit. The score isn&apos;t a verdict on you as a candidate —
-                it measures how well a machine can read your resume.
+                it measures how well a machine can read your resume. It takes
+                a few seconds, needs no account or email, and the same PDF
+                always gets the same score.
               </p>
             </div>
           )}

--- a/src/components/features/ConsentDialog.tsx
+++ b/src/components/features/ConsentDialog.tsx
@@ -62,7 +62,7 @@ export function ConsentDialog({
               href={model.licenseUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-amber underline underline-offset-2 hover:text-brand-amber-light"
+              className="text-accent-primary underline underline-offset-2 hover:text-accent-primary-hover"
             >
               vendor's terms of use
             </a>

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -275,7 +275,7 @@ function renderLink(
             href={field.value}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-brand-amber hover:underline"
+            className="text-accent-primary hover:underline"
             aria-label={`Open ${field.label} in a new tab`}
           >
             ↗
@@ -310,7 +310,7 @@ function renderLink(
       href={field.value}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-brand-amber hover:underline"
+      className="text-accent-primary hover:underline"
     >
       {formatLinkDisplay(field.value)}
     </a>

--- a/src/components/features/ContactExtraLinks.tsx
+++ b/src/components/features/ContactExtraLinks.tsx
@@ -58,7 +58,7 @@ export function ContactExtraLinks({
               href={profile.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-amber hover:underline"
+              className="text-accent-primary hover:underline"
               aria-label={`Open ${profile.network} in a new tab`}
             >
               ↗

--- a/src/components/features/CritiquePanel.tsx
+++ b/src/components/features/CritiquePanel.tsx
@@ -80,7 +80,7 @@ function BulletFindingRow({
           variant="link"
           size="sm"
           onClick={onGoToRewrite}
-          className="self-start text-[11px] font-medium text-brand-amber"
+          className="self-start text-[11px] font-medium text-accent-primary"
           aria-label="Go to Reconstructed resume tab to rewrite this bullet"
         >
           Rewrite this section →

--- a/src/components/features/DownloadReportDialog.tsx
+++ b/src/components/features/DownloadReportDialog.tsx
@@ -102,7 +102,7 @@ export function ReportDownloadControl({
                   checked={format === value}
                   disabled={isGenerating}
                   onChange={() => setFormat(value)}
-                  className="h-4 w-4 accent-brand-amber"
+                  className="h-4 w-4 accent-accent-primary"
                 />
                 {label}
               </label>
@@ -119,7 +119,7 @@ export function ReportDownloadControl({
               checked={includeIdentity}
               disabled={isGenerating}
               onChange={(e) => setIncludeIdentity(e.target.checked)}
-              className="h-4 w-4 accent-brand-amber"
+              className="h-4 w-4 accent-accent-primary"
             />
             Include my name and contact details
           </label>

--- a/src/components/features/FeedbackPanel.tsx
+++ b/src/components/features/FeedbackPanel.tsx
@@ -172,7 +172,7 @@ function FeedbackRatingForm() {
 
     return (
       <div className="flex flex-col gap-3">
-        <Card className="flex flex-col gap-1 border-l-4 border-l-brand-amber bg-accent-forward-bg shadow-sm">
+        <Card className="flex flex-col gap-1 border-l-4 border-l-accent-primary bg-accent-forward-bg shadow-sm">
           <div ref={thanksRef} tabIndex={-1} className="outline-hidden">
             <p className="text-sm font-semibold text-content-primary">
               Thanks for your feedback!
@@ -243,7 +243,7 @@ function FeedbackRatingForm() {
 
   // ── Full panel (mode === "full", or compact strip expanded by star click) ──
   return (
-    <Card className="flex flex-col gap-4 border-l-4 border-l-brand-amber bg-accent-forward-bg shadow-sm">
+    <Card className="flex flex-col gap-4 border-l-4 border-l-accent-primary bg-accent-forward-bg shadow-sm">
       <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
         {/* Collapsed line: heading + inline rating on one row. */}
         <div className="flex flex-col gap-1">
@@ -319,7 +319,7 @@ function FeedbackRatingForm() {
                 disabled={submitting}
                 rows={3}
                 placeholder="Tell us what worked, what didn't, or what you'd change…"
-                className="w-full resize-y rounded border border-border-light bg-surface-card px-2 py-1.5 text-sm text-content-primary placeholder:text-content-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber"
+                className="w-full resize-y rounded border border-border-light bg-surface-card px-2 py-1.5 text-sm text-content-primary placeholder:text-content-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
               />
             </div>
 
@@ -335,7 +335,7 @@ function FeedbackRatingForm() {
                   checked={wantsContact}
                   disabled={submitting}
                   onChange={(e) => setWantsContact(e.target.checked)}
-                  className="h-4 w-4 accent-brand-amber"
+                  className="h-4 w-4 accent-accent-primary"
                 />
                 I'd like the team to follow up with me
               </label>
@@ -355,7 +355,7 @@ function FeedbackRatingForm() {
                     onChange={(e) => setEmail(e.target.value)}
                     disabled={submitting}
                     placeholder="you@example.com"
-                    className="w-full rounded border border-border-light bg-surface-card px-2 py-1.5 text-sm text-content-primary placeholder:text-content-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber"
+                    className="w-full rounded border border-border-light bg-surface-card px-2 py-1.5 text-sm text-content-primary placeholder:text-content-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
                   />
                 </div>
               )}

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -196,7 +196,7 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
                   addSkill();
                 }
               }}
-              className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-xs text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+              className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-xs text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
             />
             <Button
               variant="ghost"
@@ -227,7 +227,7 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber"
+              className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
             >
               {link.label}
               <span aria-hidden="true">↗</span>

--- a/src/components/features/JobResultCard.tsx
+++ b/src/components/features/JobResultCard.tsx
@@ -72,7 +72,7 @@ export function JobResultCard({ job }: { job: RankedJob }) {
           href={posting.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs font-medium text-content-secondary transition-colors hover:text-content-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber"
+          className="text-xs font-medium text-content-secondary transition-colors hover:text-content-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
         >
           Open posting <span aria-hidden="true">↗</span>
         </a>

--- a/src/components/features/ModelSelector.tsx
+++ b/src/components/features/ModelSelector.tsx
@@ -438,7 +438,7 @@ export function ModelRow({
         aria-pressed={selected}
         className={`flex w-full flex-col items-stretch gap-1 rounded-md border px-3 py-2 text-left ${
           selected
-            ? "border-brand-amber bg-feedback-success-bg"
+            ? "border-accent-primary bg-feedback-success-bg"
             : "border-border-light bg-surface-card hover:border-border hover:bg-surface-hover"
         }`}
       >

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -25,7 +25,7 @@ export interface PageShellProps {
   subtitle: string;
   /** Small uppercase badge after the wordmark (e.g. "alpha", "JD Fit"). */
   badge: string;
-  /** Optional chip row under the header. */
+  /** Optional block rendered under the header (e.g. the capability strip). */
   chips?: ReactNode;
   /** Optional header-right slot rendered before the GitHub CTA. */
   headerExtra?: ReactNode;
@@ -61,10 +61,10 @@ export function PageShell({
           <div className="flex items-center gap-2">
             <a
               href={import.meta.env.BASE_URL}
-              className="inline-grid h-8 w-8 place-items-center rounded-md bg-brand-amber text-base font-bold text-content-inverse"
+              className="inline-grid h-8 w-8 place-items-center rounded-md bg-accent-primary text-base font-bold text-content-inverse"
               aria-label="offlinecv home"
             >
-              R
+              O
             </a>
             <h1 className="text-2xl font-semibold tracking-tight">offlinecv</h1>
             <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
@@ -79,7 +79,7 @@ export function PageShell({
             <GitHubStarCta variant="inline" count={starCount} />
           </div>
         </div>
-        {chips && <div className="flex flex-wrap gap-2">{chips}</div>}
+        {chips && <div className="w-full">{chips}</div>}
       </header>
 
       {children}

--- a/src/components/features/ProfileLinkAdd.tsx
+++ b/src/components/features/ProfileLinkAdd.tsx
@@ -101,7 +101,7 @@ export function ProfileLinkAdd({
             size="sm"
             onClick={() => pick(p.prefix)}
             aria-label={`Add ${p.label}`}
-            className="rounded-full bg-surface-card px-2.5 py-1 text-xs text-content-secondary hover:text-brand-amber"
+            className="rounded-full bg-surface-card px-2.5 py-1 text-xs text-content-secondary hover:text-accent-primary"
           >
             {p.label}
           </Button>
@@ -128,7 +128,7 @@ export function ProfileLinkAdd({
               setExpanded(false);
             }
           }}
-          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
         />
         <Button
           variant="primary"

--- a/src/components/features/ReconstructedAdd.tsx
+++ b/src/components/features/ReconstructedAdd.tsx
@@ -97,7 +97,7 @@ export function AddPill({
       size="sm"
       onClick={onClick}
       aria-label={label}
-      className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-brand-amber"
+      className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-accent-primary"
     >
       + {label}
     </Button>
@@ -182,7 +182,7 @@ export function InlineBulletAdd({
             setExpanded(false);
           }
         }}
-        className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+        className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
       />
       <Button
         variant="primary"

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -347,7 +347,7 @@ function AddSkillInput({
         size="sm"
         onClick={() => setExpanded(true)}
         aria-label="Add skill"
-        className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-brand-amber"
+        className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-accent-primary"
       >
         + Add skill
       </Button>
@@ -387,7 +387,7 @@ function AddSkillInput({
               setExpanded(false);
             }
           }}
-          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-brand-amber"
+          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
         />
         <Button
           variant="primary"
@@ -408,7 +408,7 @@ function AddSkillInput({
               size="sm"
               onClick={() => commit(s)}
               aria-label={`Add ${s}`}
-              className="rounded-full bg-surface-subtle px-2.5 py-0.5 text-xs text-content-tertiary hover:text-brand-amber"
+              className="rounded-full bg-surface-subtle px-2.5 py-0.5 text-xs text-content-tertiary hover:text-accent-primary"
             >
               + {s}
             </Button>

--- a/src/components/features/ReportGapSection.tsx
+++ b/src/components/features/ReportGapSection.tsx
@@ -64,7 +64,7 @@ export function ReportGapSection({
   }
 
   return (
-    <Card className="flex flex-col gap-3 border-l-4 border-l-brand-amber bg-accent-forward-bg shadow-sm">
+    <Card className="flex flex-col gap-3 border-l-4 border-l-accent-primary bg-accent-forward-bg shadow-sm">
       <div className="flex flex-col gap-1">
         <Heading
           id={headingId}

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -306,7 +306,7 @@ export function StepIndicator({
         className="h-1.5 w-full overflow-hidden rounded-full bg-surface-base"
       >
         <div
-          className="h-full bg-brand-amber transition-all"
+          className="h-full bg-accent-primary transition-all"
           style={{ width: `${pct}%` }}
         />
       </div>

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -332,7 +332,7 @@ export function useSectionRewrite(
       disabled={isLocked}
       aria-label={`${triggerTitle} — rewrites every bullet in this role`}
       title={triggerTitle}
-      className="h-7 w-7 shrink-0 rounded-md text-content-muted hover:text-brand-amber disabled:opacity-50"
+      className="h-7 w-7 shrink-0 rounded-md text-content-muted hover:text-accent-primary disabled:opacity-50"
     >
       {myBusy ? <SpinnerIcon /> : <WandIcon />}
     </Button>

--- a/src/components/features/WebGpuUnavailableNotice.tsx
+++ b/src/components/features/WebGpuUnavailableNotice.tsx
@@ -116,7 +116,7 @@ export function WebGpuUnavailableNotice({ capability }: Props) {
                       href={link.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-xs text-brand-amber hover:underline underline-offset-2"
+                      className="text-xs text-accent-primary hover:underline underline-offset-2"
                     >
                       {link.label} ↗
                     </a>
@@ -202,7 +202,7 @@ function CopyablePath({ path }: { path: CopyPath }) {
           size="sm"
           onClick={onCopy}
           aria-label={`Copy ${path.value}`}
-          className="shrink-0 text-[11px] text-brand-amber"
+          className="shrink-0 text-[11px] text-accent-primary"
         >
           {copied ? "Copied ✓" : "Copy"}
         </Button>

--- a/src/components/features/scoreBand.ts
+++ b/src/components/features/scoreBand.ts
@@ -9,7 +9,7 @@ export function scoreBandTextClass(tier: ScoreTier): string {
     case "high":
       return "text-feedback-success-icon";
     case "medium":
-      return "text-brand-amber";
+      return "text-accent-primary";
     case "low":
       return "text-feedback-warning-icon";
     default:
@@ -23,7 +23,7 @@ export function scoreBandBgClass(tier: ScoreTier): string {
     case "high":
       return "bg-feedback-success-icon";
     case "medium":
-      return "bg-brand-amber";
+      return "bg-accent-primary";
     case "low":
       return "bg-feedback-warning-icon";
     default:

--- a/src/design-system/icons/TrustIcons.tsx
+++ b/src/design-system/icons/TrustIcons.tsx
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * TrustIcons — hand-inlined SVG icon set for decorative chip/badge glyphs.
+ *
+ * #514: the landing trust-chip row (`⚡ 🔒 ✓ 🔁`) used raw emoji as icons —
+ * OS-font rendered, uncolourable, and inconsistent across platforms. CLAUDE.md
+ * calls for Lucide-style SVG icons instead. Rather than add `lucide-react` as
+ * a runtime dependency (a real cost for an app that deliberately keeps its
+ * entry chunk small — see vite.config.ts rollupOptions), this module
+ * hand-inlines the handful of icons actually needed, following the exact
+ * convention already used by `EditableField.tsx`'s `ShapeWarningGlyph`:
+ * 24×24 viewBox, `stroke="currentColor"`, 2px stroke, round caps/joins, no
+ * fill. Adding a real icon-library dependency later is a separate decision
+ * (see #514's PR notes) — this module is deliberately small and swappable.
+ *
+ * #517 then replaced that chip row with `CapabilityStrip`, which keeps only
+ * the privacy rail — so `LockIcon` is the single icon with a consumer, and
+ * #514's bolt / check / repeat glyphs were deleted rather than left dead. The
+ * barrel re-exports this module with `export *`, so an unused icon is not free:
+ * it lands in the entry chunk this module exists to protect. Add an icon back
+ * when something renders it, not before.
+ *
+ * Sizing is NOT baked into these components: `Chip`'s icon slot owns the
+ * fixed size/alignment (see `Chip.tsx`), so every icon here renders at
+ * `h-full w-full` and inherits its box from whichever wrapper renders it.
+ * Callers never pass a size prop.
+ *
+ * All icons are purely decorative — `aria-hidden` is applied by the
+ * consuming wrapper (`Chip`), not here, so a future non-decorative use isn't
+ * accidentally hidden from assistive tech.
+ */
+
+const STROKE_PROPS = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+/** Privacy — "your file never leaves your device". */
+export function LockIcon() {
+  return (
+    <svg {...STROKE_PROPS} focusable="false" className="h-full w-full">
+      <rect x="3" y="11" width="18" height="10" rx="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -14,12 +14,14 @@
  * is the stable contract both layers share. See the README "Theming" section.
  */
 
+export * from "./icons/TrustIcons.tsx";
 export * from "./primitives/Button.tsx";
 export * from "./primitives/Chip.tsx";
 export * from "./primitives/Dialog.tsx";
 export * from "./primitives/EditableField.tsx";
 export * from "./primitives/StarRating.tsx";
 export * from "./primitives/TextAreaField.tsx";
+export * from "./shared/CapabilityStrip.tsx";
 export * from "./shared/Card.tsx";
 export * from "./shared/InlineResult.tsx";
 export * from "./shared/ModelLoadProgress.tsx";

--- a/src/design-system/primitives/Button.tsx
+++ b/src/design-system/primitives/Button.tsx
@@ -5,27 +5,33 @@
  * Button — the ONE interactive-button primitive.
  *
  * Variants:
- *   primary — filled accent CTA (bg-brand-amber, text-content-inverse)
+ *   primary — filled accent CTA (bg-accent-primary, text-content-inverse)
  *   ghost   — minimal surface, used for secondary / icon-only actions
  *             (text-content-secondary, hover:bg-surface-subtle)
  *   link    — looks like an inline anchor (text-content-tertiary, hover:underline)
  *   icon    — compact icon-only affordance (same hover as ghost, no padding
  *             beyond the affordance area, square touch target)
+ *   tab     — segmented-control trigger for `Tabs` (`shared/Tabs.tsx`). Owns its
+ *             own size (`text-sm`, one step up from `sm`) and shape (`rounded-md`)
+ *             so the caller only layers the active/inactive surface + text
+ *             classes on top — it does not need to cancel ghost's rounded
+ *             corners, hover surface, or size the way the pre-#516 Tab did.
  *
  * Sizes:
  *   sm  — default; covers most usage (text-xs/[11px], compact touch area)
  *   md  — larger label CTAs when more visual weight is needed
+ *   (the `tab` variant opts out of the size map — see below)
  *
  * Design rules (CLAUDE.md):
  *   – Semantic tokens only; no hardcoded hex or raw palette classes.
  *   – Never use a raw <button> in feature code — import this primitive instead.
  *   – Forwards type, disabled, onClick, aria-*, className, children.
- *   – Focus ring uses brand-amber, consistent with EditableField.
+ *   – Focus ring uses accent-primary, consistent with EditableField.
  */
 
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-export type ButtonVariant = "primary" | "ghost" | "link" | "icon";
+export type ButtonVariant = "primary" | "ghost" | "link" | "icon" | "tab";
 export type ButtonSize = "sm" | "md";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -35,15 +41,17 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const BASE =
-  "inline-flex items-center justify-center gap-1 rounded font-medium transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand-amber disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex items-center justify-center gap-1 rounded font-medium transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary disabled:cursor-not-allowed disabled:opacity-60";
 
 const VARIANT: Record<ButtonVariant, string> = {
   primary:
-    "bg-brand-amber text-content-inverse hover:bg-brand-amber-light px-3 py-1.5",
+    "bg-accent-primary text-content-inverse hover:bg-accent-primary-hover px-3 py-1.5",
   ghost:
     "text-content-secondary hover:bg-surface-subtle px-2 py-0.5",
   link: "text-content-tertiary hover:underline underline-offset-2 p-0",
   icon: "text-content-secondary hover:bg-surface-subtle p-0.5",
+  tab:
+    "rounded-md px-3 py-1.5 text-sm duration-200 motion-reduce:transition-none motion-reduce:duration-0",
 };
 
 const SIZE: Record<ButtonSize, string> = {
@@ -58,7 +66,11 @@ export function Button({
   children,
   ...rest
 }: ButtonProps) {
-  const cls = [BASE, VARIANT[variant], SIZE[size], className]
+  // The `tab` variant owns its own text size (text-sm) — layering the size
+  // map's `text-xs`/`text-sm` on top would fight it for no reason, since no
+  // caller varies `size` on a tab trigger.
+  const sizeCls = variant === "tab" ? "" : SIZE[size];
+  const cls = [BASE, VARIANT[variant], sizeCls, className]
     .filter(Boolean)
     .join(" ");
   return (

--- a/src/design-system/primitives/Chip.tsx
+++ b/src/design-system/primitives/Chip.tsx
@@ -4,6 +4,13 @@
 export type ChipTone = "neutral" | "success" | "warning";
 
 interface ChipProps {
+  /**
+   * Decorative icon (e.g. from `design-system/icons/TrustIcons.tsx`). This
+   * slot — not the icon component — owns sizing/alignment: the icon renders
+   * at `h-full w-full` inside a fixed `h-3.5 w-3.5` box and is marked
+   * `aria-hidden` here, so the chip's accessible name stays its text alone.
+   * Callers pass an icon node, never a size.
+   */
   icon?: React.ReactNode;
   children: React.ReactNode;
   tone?: ChipTone;
@@ -20,7 +27,14 @@ export function Chip({ icon, children, tone = "neutral" }: ChipProps) {
     <span
       className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs ${toneCls}`}
     >
-      {icon && <span>{icon}</span>}
+      {icon && (
+        <span
+          aria-hidden="true"
+          className="h-3.5 w-3.5 shrink-0 [&>svg]:h-full [&>svg]:w-full"
+        >
+          {icon}
+        </span>
+      )}
       {children}
     </span>
   );

--- a/src/design-system/primitives/EditableField.tsx
+++ b/src/design-system/primitives/EditableField.tsx
@@ -267,7 +267,7 @@ export function EditableField({
             sizeCls,
             weightCls,
             "text-content-primary leading-snug",
-            "outline-hidden focus:ring-1 focus:ring-brand-amber",
+            "outline-hidden focus:ring-1 focus:ring-accent-primary",
           ].join(" ")}
         />
         {/* Save / Cancel action row */}
@@ -319,7 +319,7 @@ export function EditableField({
             sizeCls,
             weightCls,
             "text-content-primary",
-            "outline-hidden focus:ring-1 focus:ring-brand-amber",
+            "outline-hidden focus:ring-1 focus:ring-accent-primary",
           ].join(" ")}
         />
       </span>
@@ -375,7 +375,7 @@ export function EditableField({
         rootBox,
         "cursor-text rounded px-1 -mx-1 transition-colors",
         "hover:bg-surface-subtle",
-        "outline-hidden focus-visible:ring-1 focus-visible:ring-brand-amber",
+        "outline-hidden focus-visible:ring-1 focus-visible:ring-accent-primary",
         sizeCls,
         weightCls,
         hasValue ? "text-content-primary" : "text-content-muted italic",

--- a/src/design-system/primitives/StarRating.tsx
+++ b/src/design-system/primitives/StarRating.tsx
@@ -69,7 +69,7 @@ export function StarRating({
             />
             <span
               aria-hidden="true"
-              className={filled ? "text-brand-amber" : "text-content-muted"}
+              className={filled ? "text-accent-primary" : "text-content-muted"}
             >
               {filled ? "★" : "☆"}
             </span>

--- a/src/design-system/primitives/TextAreaField.tsx
+++ b/src/design-system/primitives/TextAreaField.tsx
@@ -74,7 +74,7 @@ export function TextAreaField({
         "w-full resize-none overflow-hidden rounded border border-border",
         "bg-surface-card px-2 py-1.5 text-sm leading-snug",
         "text-content-primary placeholder:text-content-muted",
-        "outline-hidden focus:ring-1 focus:ring-brand-amber",
+        "outline-hidden focus:ring-1 focus:ring-accent-primary",
         "disabled:opacity-60",
         className ?? "",
       ]

--- a/src/design-system/shared/CapabilityStrip.tsx
+++ b/src/design-system/shared/CapabilityStrip.tsx
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * CapabilityStrip — replaces the pre-drop trust-chip row (#517).
+ *
+ * The old chip row (`⚡ A few seconds`, `🔒 Your file never leaves your
+ * device`, `✓ No account, no email`, `🔁 Same PDF, same score`) stated four
+ * PROPERTIES of the product. None of them told a first-time visitor that
+ * OfflineCV also matches a resume against a job description or finds real
+ * postings — three of the app's four lanes are invisible pre-drop (#511).
+ *
+ * This strip states three CAPABILITIES instead — read / fix / match & find —
+ * under one persistent local-processing rail. Static and non-interactive: it
+ * is a description, not a second entry point competing with the drop zone.
+ *
+ * Composed entirely from existing `@design-system` exports (Card, StatusBadge,
+ * Chip, LockIcon) — no new primitive. `StatusBadge` gives each lane the same
+ * small-caps pill treatment a Tab label gets (#516's visual language); `Chip`
+ * carries the rail statement, matching how the old chip row phrased itself.
+ *
+ * Privacy scope (binding, epic #511): the rail claims custody of the RESUME —
+ * "Your resume stays on your device" — deliberately not "nothing leaves" or
+ * "runs entirely on your device". Those would be false: the job-search lane
+ * this same card advertises does `fetch()` three third-party feeds, and a
+ * build with VITE_POSTHOG_KEY set ships analytics the user never opted into.
+ * What makes the narrower claim TRUE is `job-search/providers/keywords.ts` —
+ * the outbound payload is a short keyword string, never the resume text. That
+ * module is the invariant this copy depends on; if it ever sends resume text,
+ * or if a cloud LLM path lands (none exists today — there is no BYOK provider
+ * in the tree despite older docs implying one), this line becomes a lie and
+ * must change with it. Per-feature exceptions stay stated where the user
+ * meets them (`FindJobsPanel`), not restated here. `PageShell`'s footer makes
+ * the equivalent scoped claim in its own words ("your PDF stays in this
+ * browser tab by default").
+ */
+
+import { Chip } from "../primitives/Chip.tsx";
+import { LockIcon } from "../icons/TrustIcons.tsx";
+import { Card } from "./Card.tsx";
+import { StatusBadge } from "./StatusBadge.tsx";
+
+interface CapabilityLane {
+  label: string;
+  description: string;
+}
+
+const LANES: CapabilityLane[] = [
+  {
+    label: "Read it",
+    description:
+      "A parser in your browser pulls out your experience, skills and contact details",
+  },
+  {
+    label: "Fix it",
+    description:
+      "Edit inline, save it in your browser, or export a clean PDF",
+  },
+  {
+    label: "Match & find",
+    description: "Score against a job description, rank real postings",
+  },
+];
+
+export function CapabilityStrip() {
+  return (
+    <Card className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {LANES.map((lane) => (
+          // `items-start` pairs with the `w-fit` that `StatusBadge` now carries
+          // itself: a column flex stretches its items, so an inline-flex badge
+          // blockifies into a full-width `rounded-full` bar. The primitive owns
+          // the fix (it shipped stretched in `CritiquePanel`'s column flex too);
+          // this stays as belt-and-braces for the grid column.
+          <div key={lane.label} className="flex flex-col items-start gap-1.5">
+            <StatusBadge tone="info">{lane.label}</StatusBadge>
+            <p className="text-sm text-content-secondary">
+              {lane.description}
+            </p>
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-2 border-t border-border-light pt-3">
+        <Chip icon={<LockIcon />}>Your resume stays on your device</Chip>
+      </div>
+    </Card>
+  );
+}

--- a/src/design-system/shared/CountBadge.tsx
+++ b/src/design-system/shared/CountBadge.tsx
@@ -6,6 +6,17 @@
  * (e.g. the layout-flag count on a Tab, or on the Source & diagnostics
  * segmented control). Renders nothing when count is null/undefined or ≤ 0, so
  * callers can pass an unconditional `count` prop without guarding.
+ *
+ * The `border-content-muted` hairline is load-bearing, not decoration: the fill
+ * (`bg-surface-subtle`) is the SAME token #516 gave the Tab track, so on an
+ * inactive tab the pill would otherwise sit at 1.00:1 against its own backdrop
+ * and vanish — exactly where it matters most, since the only tab carrying a
+ * count (`Source & diagnostics`) is inactive by default. The border is therefore
+ * the ONLY thing making the pill a distinguishable component, so it must clear
+ * WCAG 1.4.11's 3:1 non-text threshold on its own. `border-light` sits at
+ * 1.00:1 in dark (it equals `bg-subtle`) and `border-strong` reaches only
+ * 2.34:1 light / 2.18:1 dark — both fail. `content-muted` clears it in BOTH
+ * themes: 4.34:1 light (#64748b on #f1f5f9), 4.04:1 dark (#94a3b8 on #334155).
  */
 
 interface CountBadgeProps {
@@ -15,7 +26,7 @@ interface CountBadgeProps {
 export function CountBadge({ count }: CountBadgeProps) {
   if (count == null || count <= 0) return null;
   return (
-    <span className="ml-1.5 rounded-full bg-surface-subtle px-1.5 text-xs text-content-secondary">
+    <span className="ml-1.5 rounded-full border border-content-muted bg-surface-subtle px-1.5 text-xs text-content-secondary">
       {count}
     </span>
   );

--- a/src/design-system/shared/GitHubStarCta.tsx
+++ b/src/design-system/shared/GitHubStarCta.tsx
@@ -101,7 +101,7 @@ function StarLink({ count }: { count?: number }) {
 export function GitHubStarCta({ variant, count }: GitHubStarCtaProps) {
   if (variant === "card") {
     return (
-      <Card className="flex flex-col gap-2 border-l-4 border-l-brand-amber bg-accent-forward-bg shadow-sm">
+      <Card className="flex flex-col gap-2 border-l-4 border-l-accent-primary bg-accent-forward-bg shadow-sm">
         <p className="text-sm font-semibold text-content-primary">
           Glad it's working! ⭐
         </p>

--- a/src/design-system/shared/StatusBadge.tsx
+++ b/src/design-system/shared/StatusBadge.tsx
@@ -35,7 +35,7 @@ const TONE_CLS: Record<StatusBadgeTone, string> = {
 export function StatusBadge({ tone, children }: StatusBadgeProps) {
   return (
     <span
-      className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider ${TONE_CLS[tone]}`}
+      className={`inline-flex w-fit rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider ${TONE_CLS[tone]}`}
     >
       {children}
     </span>

--- a/src/design-system/shared/Tabs.tsx
+++ b/src/design-system/shared/Tabs.tsx
@@ -18,8 +18,15 @@
  *
  * Design rules (CLAUDE.md):
  *   – Semantic tokens only; no hardcoded hex or raw palette classes.
- *   – Triggers use the <Button> primitive — no raw <button> in feature/primitive code.
+ *   – Triggers use the <Button> primitive (variant="tab") — no raw <button> in
+ *     feature/primitive code.
  *   – Inactive panels stay mounted (hidden attr) so child UI state survives a switch.
+ *
+ * Selection affordance (#516): TabList is a recessed track (bg-surface-subtle);
+ * the active Tab sits on bg-surface-card + shadow-xs + font-semibold — a real
+ * surface step, not a 2px underline competing with the track's own border (the
+ * pre-#516 bug). Never colour alone: the weight/surface step still resolves in
+ * a greyscale render.
  */
 
 import {
@@ -110,7 +117,7 @@ export function TabList({ "aria-label": ariaLabel, children }: TabListProps) {
       role="tablist"
       aria-label={ariaLabel}
       onKeyDown={onKeyDown}
-      className="flex gap-1 overflow-x-auto overflow-y-hidden border-b border-border-light"
+      className="flex gap-1 overflow-x-auto overflow-y-hidden rounded-md border border-border-light bg-surface-subtle p-1"
     >
       {children}
     </div>
@@ -134,13 +141,32 @@ interface TabProps {
 export function Tab({ id, children, count, warn }: TabProps) {
   const { value, onValueChange, baseId } = useTabsContext("Tab");
   const isActive = value === id;
+  // Selection carries a real surface (bg-surface-card, matching the panel
+  // beneath it) plus a font-weight step — never colour alone, so the row
+  // still resolves in a greyscale render (#516). The inactive track is
+  // bg-surface-subtle (set on TabList), so the active tab visibly "pops"
+  // off it rather than relying on a 2px underline sitting on the TabList's
+  // own border (the pre-#516 illegibility bug).
+  //
+  // Hover on an INACTIVE tab must not borrow the selected tab's surface:
+  // `hover:bg-surface-card` made a merely-pointed-at tab look selected, with
+  // only font-weight left to tell them apart. It hovers to an outline instead
+  // of a fill — `bg-surface-hover` alone cannot carry it, because
+  // `--color-bg-hover` and `--color-bg-subtle` (the track) are the SAME value
+  // in dark (#334155 → 1.00:1). The inset `ring-border-strong` reads at
+  // 2.34:1 light / 2.18:1 dark against the track — enough to be perceptible
+  // for a hover-only affordance (not an enumerated 1.4.11 state), but BELOW
+  // that criterion's 3:1, so do not reuse this token for a persistent
+  // boundary (see `CountBadge.tsx`, which needs `content-muted` for exactly
+  // that reason). It stays visually distinct from selection, which is a
+  // filled surface with no ring.
   const activeCls = isActive
-    ? "border-brand-amber text-content-primary font-semibold"
-    : "border-transparent text-content-secondary font-medium hover:text-content-primary";
+    ? "bg-surface-card text-content-primary font-semibold shadow-xs"
+    : "bg-transparent text-content-secondary font-medium hover:bg-surface-hover hover:text-content-primary hover:ring-1 hover:ring-inset hover:ring-border-strong";
 
   return (
     <Button
-      variant="ghost"
+      variant="tab"
       role="tab"
       id={tabId(baseId, id)}
       data-tab-id={id}
@@ -148,7 +174,7 @@ export function Tab({ id, children, count, warn }: TabProps) {
       aria-controls={panelId(baseId, id)}
       tabIndex={isActive ? 0 : -1}
       onClick={() => onValueChange(id)}
-      className={`-mb-px rounded-none border-b-2 px-3 py-2 text-base hover:bg-transparent ${activeCls}`}
+      className={activeCls}
     >
       {children}
       <CountBadge count={count} />

--- a/src/design-system/styles/theme.css
+++ b/src/design-system/styles/theme.css
@@ -20,14 +20,6 @@
     Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
-  /* Brand colors — actual values live in CSS custom properties in tokens.css;
-     @theme references them so Tailwind generates e.g. text-brand-navy */
-  --color-brand-navy: var(--color-brand-navy);
-  --color-brand-navy-dark: var(--color-brand-navy-dark);
-  --color-brand-amber: var(--color-brand-amber);
-  --color-brand-amber-light: var(--color-brand-amber-light);
-  --color-brand-cream: var(--color-brand-cream);
-
   /* Surface colors */
   --color-surface-base: var(--color-bg-base);
   --color-surface-card: var(--color-bg-card);
@@ -50,7 +42,6 @@
   /* Accent colors */
   --color-accent-primary: var(--color-accent-primary);
   --color-accent-primary-hover: var(--color-accent-primary-hover);
-  --color-accent-forward: var(--color-accent-forward);
   --color-accent-forward-bg: var(--color-accent-forward-bg);
 
   /* Feedback — error */

--- a/src/design-system/styles/tokens.css
+++ b/src/design-system/styles/tokens.css
@@ -20,11 +20,6 @@
 :root {
   color-scheme: light dark;
 
-  --color-brand-navy: #1e293b;
-  --color-brand-navy-dark: #0f172a;
-  --color-brand-amber: #2563eb;
-  --color-brand-amber-light: #3b82f6;
-  --color-brand-cream: #f8fafc;
   --color-bg-base: #f8fafc;
   --color-bg-card: #ffffff;
   --color-bg-card-warm: #f1f5f9;
@@ -40,7 +35,6 @@
   --color-border-strong: #94a3b8;
   --color-accent-primary: #2563eb;
   --color-accent-primary-hover: #1d4ed8;
-  --color-accent-forward: #4f46e5;
   --color-accent-forward-bg: #EEF2FF;
   --color-feedback-error-bg: #fef2f2;
   --color-feedback-error-border: #fecaca;
@@ -62,11 +56,6 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-brand-navy: #94a3b8;
-    --color-brand-navy-dark: #cbd5e1;
-    --color-brand-amber: #60a5fa;
-    --color-brand-amber-light: #93c5fd;
-    --color-brand-cream: #0f172a;
     --color-bg-base: #0f172a;
     --color-bg-card: #1e293b;
     --color-bg-card-warm: #1e293b;
@@ -82,7 +71,6 @@
     --color-border-strong: #64748b;
     --color-accent-primary: #60a5fa;
     --color-accent-primary-hover: #93c5fd;
-    --color-accent-forward: #818cf8;
     --color-accent-forward-bg: #1e1b4b;
     --color-feedback-error-bg: #2d1215;
     --color-feedback-error-border: #5c1d24;


### PR DESCRIPTION
## Summary

Six sub-issues of epic #511, landed together because they touch the same pixels: a first-time visitor could not learn that OfflineCV does anything beyond auditing a PDF, and the surfaces that would tell them were the same ones that looked unfinished.

- **#517** — the landing trust chips become a `CapabilityStrip` naming all three lanes (Read it / Fix it / Match & find) under a scoped "runs on your device by default" rail.
- **#518** — the hero leads with what the product does; the Greenhouse figure drops to the supporting proof line, citation intact.
- **#513** — `brand-amber`/`-light` → `accent-primary`/`-hover` across 24 files. The zero-consumer `brand-navy`, `brand-navy-dark`, `brand-cream` and the `accent-forward` *foreground* token are deleted, and the backwards hover pair is fixed. A rename, not a repaint — the generic default palette is deliberate.
- **#516** — tab selection is rebuilt as a recessed track with a raised active surface, so selection carries font-weight and elevation, never colour alone.
- **#514** — the chip row's colour emoji become a hand-inlined SVG icon set. **No new runtime dependency.** The deliberate `✓ ★ ⚠︎` text-presentation marks are left alone.
- **#515** — the logo mark stops rendering the leftover resumelint `R`.

Two defects surfaced by review are also fixed at the primitive: `StatusBadge` gains `w-fit` (it was stretching into a full-width bar inside any column flex — this was already shipping in `CritiquePanel`), and `CountBadge` gains a border that clears its new track at 4.34:1 light / 4.04:1 dark.

**Privacy copy stays scoped.** The job-search lane sends keywords on an explicit click and a `VITE_POSTHOG_KEY` build ships analytics, so no surface claims more than "by default" (the BYOK path of #320 is not in the tree yet) — review caught and reverted an unhedged absolute in the hero headline.

**Chrome, copy and tokens only.** `ATS_SCORE_ALGO_VERSION` is unmoved; no parser, score or PDF-render module is touched.

Closes #513
Closes #514
Closes #515
Closes #516
Closes #517
Closes #518
Refs #511

`#519` (tab descriptions) was deliberately dropped from this batch — its pre-drop-preview half overlaps `CapabilityStrip`, and the epic says not to ship both.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 2509 passed / 9 skipped
- [x] `npm run build` succeeds; renamed utilities verified present in the emitted CSS (not just in source)
- [x] `fallow audit` — dead-code section clear; remaining duplication is pre-existing
- [x] Contrast verified independently against the light **and** dark blocks of `tokens.css`, not inferred from light
- [x] Manually verified in `npm run dev` — **not done; worth a reviewer's eye**, since most of this diff is visual

No fixture binaries added or changed, so the fixture-PII preflight does not apply.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #515 | unreported (requested: sonnet) | medium |
| Implementation — #513 | Claude Sonnet 5 | high |
| Implementation — #514 | Claude Sonnet 5 | high |
| Implementation — #516 | Claude Sonnet 4.6 | high |
| Implementation — #518 | ambiguous self-report (requested: sonnet) | medium |
| Implementation — #517 | Claude Sonnet 5 | high |
| Adversarial review — round 1 | Claude Opus 4.8 | high |
| Review fixes | Claude Opus 4.8 | high |
| Adversarial review — round 2 | Claude Opus 4.8 | high |
| Round-2 fixes + orchestration + PR | Claude Opus 4.8 | high |
| Verification | `npm run verify` — green in CI | — |

Two rows are not resolvable and are left honest rather than guessed: #515's subagent never returned its model line (its one-line change was verified directly), and #518's reported two names in one answer.

## Adversarial review

Two adversarial review rounds ran on the accumulated diff **before** this PR was opened, plus a third fix pass applied in-loop. Reviewers were instructed to try to break the change, and to reproduce suspected defects rather than reason about them — both rounds built the CSS and inspected emitted output. Recorded here because a review that found real bugs is an audit artifact, not a transient gate.

### Round 1 — 6 blocking, all fixed

1. **Unhedged absolute privacy claim in the hero headline.** "Your whole job search — on your device." — but the job-search lane sends keywords on click and a `VITE_POSTHOG_KEY` build ships analytics. It contradicted the scoping convention asserted in its own file's comment. → hedged to "…by default."
2. **Count pill invisible on the new tab track** — `CountBadge`'s fill and #516's track were the same token, 1.00:1 in both themes. It defeated the intent documented at `ResultDetailTabs.tsx:69-71`.
3. **Inactive tab hover was visually identical to the selected tab** — hover acquired both of the active tab's colour cues, leaving only font-weight to signal selection. This defeated #516's entire purpose on the most common pointer state.
4. **`CapabilityStrip` lane pills rendered as full-width bars** — `StatusBadge` is `inline-flex` with no `w-fit`, blockified and stretched by a column flex.
5. **Three dead icon exports** — #514 created four icons and wired them into the chip row; #517 deleted that row in the same branch. A pure cross-issue interaction neither issue could see alone; caught by the whole-tree `fallow` pass.
6. **Docs still cited the deleted `text-brand-amber` token** — #513 updated `README.md` only, so a contributor following `CLAUDE.md`/`CONTRIBUTING.md` would write a class that silently compiles to nothing.

The fix pass found that the reviewer's own suggested remedies for (2) and (3) were **no-ops in dark** — `--color-bg-hover` and `--color-bg-subtle` are both `#334155` — and solved them with `border-strong` instead.

### Round 2 — 3 blocking, all fixed

1. **`eslint.config.js:29,34`** still named `text-brand-amber` in the rule message — the highest-traffic naming reference in the repo, higher than either doc fixed in round 1.
2. **`border-strong` did not actually clear WCAG 1.4.11.** The fix pass's quoted ratios (2.29/2.16) were also slightly wrong; the real values were 2.34:1 light / 2.18:1 dark, both under the 3:1 non-text threshold that the border alone had to carry. → `border-content-muted`, 4.34:1 light / 4.04:1 dark.
3. **The round-1 fix's justifying comment was false**, and the case it denied was shipping: `CritiquePanel.tsx:64` is a column flex whose badge stretches into a full-width bar **in production today**. → fixed at the primitive with `w-fit` on `StatusBadge`, which resolves both instances and retires the workaround.

Round 2's fixes were applied in-loop after the 2-round cap and re-verified (typecheck, lint, 2509 tests, build, emitted-CSS check) but did **not** themselves go through a review round. Two are cosmetic (a lint-message string, docblock ratios); the third is `w-fit` on `StatusBadge`, which touches 9 call sites — the other 8 are row-flex, where it is a no-op.

### Surviving nits — not blocking, worth a reviewer's eye

- `SourceDiagnosticsPanel`'s `SegmentButton` is a near-clone of `Tab` that received none of #516's hover-affordance work — a sibling instance worth folding into the same lane in a follow-up.
- `GitHubStarCta.tsx:106` — `⭐` is the one remaining colour emoji in live chrome; reads as sentence decoration rather than an icon, so it was left out of #514's scope.
- Tabs' hover `ring-inset` leaks into the focus ring, so a simultaneously hovered+focused tab draws its focus ring inside the border box. Still clearly visible, just a different shape.
- `CapabilityStrip` lanes are bare `<div>`s; `<ul>`/`<li>` would give a screen reader the "list of 3" count.
- `CapabilityStrip` uses `StatusBadge tone="info"` for a static capability label — borrowing a parse-status vocabulary for a non-status. Cosmetically identical, semantically off.
- The `tab` variant shrinks the touch target from ~40px to ~32px. Clears WCAG 2.5.8 AA (24px), but is a real shrink on a 375px viewport.
- The selected-vs-track surface step is 1.10:1 light / 1.41:1 dark — under 1.4.11's 3:1 for non-text indicators. Not blocking, because selection also carries `font-semibold` and `aria-selected`, and inactive **text** contrast passes in both themes (9.45:1 / 6.97:1).
- `.gitignore`'s `oss-translate` entry is unrelated to this epic and rides this branch by explicit maintainer decision.

