### PR TITLE
feat(job-search): company-targeted ATS-board search foundation (#528)

### DIFF
--- a/src/lib/job-search/company-registry.test.ts
+++ b/src/lib/job-search/company-registry.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import { COMPANY_REGISTRY, companiesForSector } from "./company-registry.ts";
+import { SECTORS, isSector } from "./sector.ts";
+import type { Ats } from "./company-registry.ts";
+
+const VALID_ATS: readonly Ats[] = ["greenhouse", "lever", "ashby"];
+
+describe("COMPANY_REGISTRY", () => {
+  it("tags every entry with a supported ats vendor", () => {
+    for (const entry of COMPANY_REGISTRY) {
+      expect(VALID_ATS).toContain(entry.ats);
+    }
+  });
+
+  it("tags every entry's sectors with values from the slice-3 taxonomy", () => {
+    for (const entry of COMPANY_REGISTRY) {
+      expect(entry.sectors.length).toBeGreaterThan(0);
+      for (const sector of entry.sectors) {
+        expect(isSector(sector)).toBe(true);
+      }
+    }
+  });
+
+  it("has a non-empty name and slug on every entry", () => {
+    for (const entry of COMPANY_REGISTRY) {
+      expect(entry.name.trim().length).toBeGreaterThan(0);
+      expect(entry.slug.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate (ats, slug) pairs", () => {
+    const seen = new Set<string>();
+    for (const entry of COMPANY_REGISTRY) {
+      const key = `${entry.ats}:${entry.slug}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it("seeds ~150-250 companies", () => {
+    expect(COMPANY_REGISTRY.length).toBeGreaterThanOrEqual(150);
+    expect(COMPANY_REGISTRY.length).toBeLessThanOrEqual(250);
+  });
+
+  it("populates every non-'other' sector with at least one company", () => {
+    for (const sector of SECTORS) {
+      if (sector === "other") continue;
+      const count = COMPANY_REGISTRY.filter((e) => e.sectors.includes(sector)).length;
+      expect(count).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe("companiesForSector", () => {
+  it("returns at most `limit` entries, all tagged with the requested sector", () => {
+    const results = companiesForSector("fintech", 5);
+    expect(results.length).toBeLessThanOrEqual(5);
+    for (const entry of results) {
+      expect(entry.sectors).toContain("fintech");
+    }
+  });
+
+  it("returns entries in deterministic order across repeated calls", () => {
+    const first = companiesForSector("devtools", 10);
+    const second = companiesForSector("devtools", 10);
+    expect(second.map((e) => e.slug)).toEqual(first.map((e) => e.slug));
+  });
+
+  it("returns an empty array for a sector with a limit of 0", () => {
+    expect(companiesForSector("fintech", 0)).toEqual([]);
+  });
+
+  it("returns fewer than `limit` when the sector has fewer matches", () => {
+    const results = companiesForSector("government-defense", 1000);
+    expect(results.length).toBeLessThan(1000);
+    expect(results.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/job-search/company-registry.ts
+++ b/src/lib/job-search/company-registry.ts
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * company-registry.ts — curated `company → ATS → slug` data (#532, slice 4
+ * of the job-search-v2 epic #528).
+ *
+ * Sector tags reuse `Sector` from `./sector.ts` verbatim — this module does
+ * NOT fork a second taxonomy. Slice 5 (#533) dynamic-imports this module
+ * (same cascade-tier lazy-load discipline as `src/lib/heuristics/`) so the
+ * payload never enters the entry chunk, and turns a `companiesForSector()`
+ * result into live providers via the slice-1/2 adapter factories
+ * (`makeGreenhouseProvider` / `makeLeverProvider` / `makeAshbyProvider`).
+ *
+ * Sourcing: hand-curated from each ATS vendor's public board directory and
+ * general familiarity with well-known companies' public careers pages, one
+ * company per entry, tagged with 1-2 sectors from `./sector.ts`. Curated
+ * 2026-07-21.
+ *
+ * IMPORTANT — slugs are NOT CORS-verified. Unlike the slice-1/2 adapters
+ * (whose docblocks note "unverified from a browser origin" pending a live
+ * check), these slugs have not even been curl-checked for existence; they
+ * are a best-effort curated list. #533 (the live wiring slice) is expected
+ * to browser-verify each board it actually queries and silently drop any
+ * slug that 404s or fails CORS — a dead entry here costs nothing worse than
+ * an empty search result. Treat this list as "plausible, needs-verification"
+ * data, not a source of truth for "company X uses ATS Y". A periodic
+ * re-verify/refresh pass is future work, not this slice.
+ */
+
+import type { Sector } from "./sector.ts";
+
+/** ATS vendor identifier — maps 1:1 to the slice-1/2 adapter factories. */
+export type Ats = "greenhouse" | "lever" | "ashby";
+
+export interface CompanyEntry {
+  /** Display name, e.g. "Stripe" — used for the provider label/source. */
+  name: string;
+  /** Which adapter factory builds this entry's provider. */
+  ats: Ats;
+  /** The ATS board slug, e.g. "stripe". */
+  slug: string;
+  /** One or more sectors this company belongs to (from `./sector.ts`). */
+  sectors: Sector[];
+}
+
+/**
+ * The curated registry. Order is deliberate and stable — `companiesForSector`
+ * relies on declaration order for its deterministic result order.
+ */
+export const COMPANY_REGISTRY: readonly CompanyEntry[] = [
+  // -- fintech ------------------------------------------------------------
+  { name: "Stripe", ats: "greenhouse", slug: "stripe", sectors: ["fintech"] },
+  { name: "Plaid", ats: "greenhouse", slug: "plaid", sectors: ["fintech"] },
+  { name: "Robinhood", ats: "greenhouse", slug: "robinhood", sectors: ["fintech"] },
+  { name: "Affirm", ats: "greenhouse", slug: "affirm", sectors: ["fintech"] },
+  { name: "Chime", ats: "greenhouse", slug: "chime", sectors: ["fintech"] },
+  { name: "Brex", ats: "greenhouse", slug: "brex", sectors: ["fintech"] },
+  { name: "Ramp", ats: "ashby", slug: "ramp", sectors: ["fintech"] },
+  { name: "Mercury", ats: "ashby", slug: "mercury", sectors: ["fintech"] },
+  { name: "Coinbase", ats: "greenhouse", slug: "coinbase", sectors: ["fintech", "crypto-web3"] },
+  { name: "Marqeta", ats: "greenhouse", slug: "marqeta", sectors: ["fintech"] },
+  { name: "Wealthfront", ats: "greenhouse", slug: "wealthfront", sectors: ["fintech"] },
+  { name: "Klarna", ats: "lever", slug: "klarna", sectors: ["fintech"] },
+  { name: "Gusto", ats: "greenhouse", slug: "gusto", sectors: ["fintech", "enterprise-saas"] },
+  { name: "Carta", ats: "greenhouse", slug: "carta", sectors: ["fintech"] },
+
+  // -- devtools -------------------------------------------------------------
+  { name: "GitLab", ats: "greenhouse", slug: "gitlab", sectors: ["devtools"] },
+  { name: "GitHub", ats: "greenhouse", slug: "github", sectors: ["devtools"] },
+  { name: "HashiCorp", ats: "greenhouse", slug: "hashicorp", sectors: ["devtools"] },
+  { name: "Docker", ats: "greenhouse", slug: "docker", sectors: ["devtools"] },
+  { name: "Postman", ats: "lever", slug: "postman", sectors: ["devtools"] },
+  { name: "Vercel", ats: "ashby", slug: "vercel", sectors: ["devtools"] },
+  { name: "Netlify", ats: "lever", slug: "netlify", sectors: ["devtools"] },
+  { name: "CircleCI", ats: "greenhouse", slug: "circleci", sectors: ["devtools"] },
+  { name: "JFrog", ats: "greenhouse", slug: "jfrog", sectors: ["devtools"] },
+  { name: "Sentry", ats: "greenhouse", slug: "sentry", sectors: ["devtools"] },
+  { name: "LaunchDarkly", ats: "greenhouse", slug: "launchdarkly", sectors: ["devtools"] },
+  { name: "Replit", ats: "ashby", slug: "replit", sectors: ["devtools"] },
+  { name: "Warp", ats: "ashby", slug: "warp", sectors: ["devtools"] },
+
+  // -- data-ml --------------------------------------------------------------
+  { name: "Databricks", ats: "greenhouse", slug: "databricks", sectors: ["data-ml"] },
+  { name: "Snowflake", ats: "greenhouse", slug: "snowflake", sectors: ["data-ml"] },
+  { name: "Scale AI", ats: "ashby", slug: "scaleai", sectors: ["data-ml"] },
+  { name: "Weights & Biases", ats: "greenhouse", slug: "wandb", sectors: ["data-ml"] },
+  { name: "Hugging Face", ats: "lever", slug: "huggingface", sectors: ["data-ml"] },
+  { name: "DataRobot", ats: "greenhouse", slug: "datarobot", sectors: ["data-ml"] },
+  { name: "Fivetran", ats: "greenhouse", slug: "fivetran", sectors: ["data-ml"] },
+  { name: "dbt Labs", ats: "greenhouse", slug: "dbtlabs", sectors: ["data-ml"] },
+  { name: "Anthropic", ats: "greenhouse", slug: "anthropic", sectors: ["data-ml"] },
+  { name: "Cohere", ats: "ashby", slug: "cohere", sectors: ["data-ml"] },
+  { name: "Pinecone", ats: "ashby", slug: "pinecone", sectors: ["data-ml"] },
+  { name: "Modal", ats: "ashby", slug: "modal", sectors: ["data-ml"] },
+
+  // -- healthtech -------------------------------------------------------------
+  { name: "Oscar Health", ats: "greenhouse", slug: "oscarhealth", sectors: ["healthtech"] },
+  { name: "Ro", ats: "greenhouse", slug: "ro", sectors: ["healthtech"] },
+  { name: "Cedar", ats: "greenhouse", slug: "cedar", sectors: ["healthtech"] },
+  { name: "Tempus", ats: "greenhouse", slug: "tempus", sectors: ["healthtech"] },
+  { name: "Zocdoc", ats: "greenhouse", slug: "zocdoc", sectors: ["healthtech"] },
+  { name: "Included Health", ats: "greenhouse", slug: "includedhealth", sectors: ["healthtech"] },
+  { name: "Komodo Health", ats: "greenhouse", slug: "komodohealth", sectors: ["healthtech"] },
+  { name: "Clover Health", ats: "greenhouse", slug: "cloverhealth", sectors: ["healthtech"] },
+  { name: "Benchling", ats: "greenhouse", slug: "benchling", sectors: ["healthtech", "data-ml"] },
+  { name: "Devoted Health", ats: "greenhouse", slug: "devotedhealth", sectors: ["healthtech"] },
+  { name: "Nuna", ats: "lever", slug: "nuna", sectors: ["healthtech"] },
+  { name: "Maven Clinic", ats: "greenhouse", slug: "mavenclinic", sectors: ["healthtech"] },
+
+  // -- ecommerce --------------------------------------------------------------
+  { name: "Shopify", ats: "lever", slug: "shopify", sectors: ["ecommerce"] },
+  { name: "Wayfair", ats: "greenhouse", slug: "wayfair", sectors: ["ecommerce"] },
+  { name: "Instacart", ats: "greenhouse", slug: "instacart", sectors: ["ecommerce"] },
+  { name: "Faire", ats: "greenhouse", slug: "faire", sectors: ["ecommerce"] },
+  { name: "Whatnot", ats: "ashby", slug: "whatnot", sectors: ["ecommerce", "consumer-social"] },
+  { name: "Allbirds", ats: "greenhouse", slug: "allbirds", sectors: ["ecommerce"] },
+  { name: "Warby Parker", ats: "greenhouse", slug: "warbyparker", sectors: ["ecommerce"] },
+  { name: "Glossier", ats: "lever", slug: "glossier", sectors: ["ecommerce"] },
+  { name: "Stitch Fix", ats: "greenhouse", slug: "stitchfix", sectors: ["ecommerce"] },
+  { name: "Chewy", ats: "greenhouse", slug: "chewy", sectors: ["ecommerce"] },
+  { name: "Poshmark", ats: "greenhouse", slug: "poshmark", sectors: ["ecommerce"] },
+
+  // -- gaming ---------------------------------------------------------------
+  { name: "Discord", ats: "greenhouse", slug: "discord", sectors: ["gaming", "consumer-social"] },
+  { name: "Roblox", ats: "greenhouse", slug: "roblox", sectors: ["gaming"] },
+  { name: "Riot Games", ats: "greenhouse", slug: "riotgames", sectors: ["gaming"] },
+  { name: "Unity", ats: "greenhouse", slug: "unity", sectors: ["gaming"] },
+  { name: "Niantic", ats: "greenhouse", slug: "niantic", sectors: ["gaming"] },
+  { name: "Twitch", ats: "greenhouse", slug: "twitch", sectors: ["gaming", "media-adtech"] },
+  { name: "Epic Games", ats: "greenhouse", slug: "epicgames", sectors: ["gaming"] },
+  { name: "Scopely", ats: "greenhouse", slug: "scopely", sectors: ["gaming"] },
+  { name: "Zynga", ats: "greenhouse", slug: "zynga", sectors: ["gaming"] },
+  { name: "Rec Room", ats: "ashby", slug: "recroom", sectors: ["gaming"] },
+
+  // -- security ---------------------------------------------------------------
+  { name: "CrowdStrike", ats: "greenhouse", slug: "crowdstrike", sectors: ["security"] },
+  { name: "Okta", ats: "greenhouse", slug: "okta", sectors: ["security"] },
+  { name: "SentinelOne", ats: "greenhouse", slug: "sentinelone", sectors: ["security"] },
+  { name: "1Password", ats: "lever", slug: "1password", sectors: ["security"] },
+  { name: "Snyk", ats: "greenhouse", slug: "snyk", sectors: ["security", "devtools"] },
+  { name: "Wiz", ats: "ashby", slug: "wiz", sectors: ["security"] },
+  { name: "Vanta", ats: "ashby", slug: "vanta", sectors: ["security"] },
+  { name: "Tailscale", ats: "ashby", slug: "tailscale", sectors: ["security", "devtools"] },
+  { name: "Netskope", ats: "greenhouse", slug: "netskope", sectors: ["security"] },
+  { name: "Rapid7", ats: "greenhouse", slug: "rapid7", sectors: ["security"] },
+  { name: "Datadog", ats: "greenhouse", slug: "datadog", sectors: ["security", "devtools"] },
+
+  // -- enterprise-saas --------------------------------------------------------
+  { name: "Asana", ats: "greenhouse", slug: "asana", sectors: ["enterprise-saas"] },
+  { name: "Notion", ats: "lever", slug: "notion", sectors: ["enterprise-saas"] },
+  { name: "Airtable", ats: "greenhouse", slug: "airtable", sectors: ["enterprise-saas"] },
+  { name: "Zapier", ats: "lever", slug: "zapier", sectors: ["enterprise-saas"] },
+  { name: "DocuSign", ats: "greenhouse", slug: "docusign", sectors: ["enterprise-saas"] },
+  { name: "Calendly", ats: "lever", slug: "calendly", sectors: ["enterprise-saas"] },
+  { name: "Rippling", ats: "ashby", slug: "rippling", sectors: ["enterprise-saas"] },
+  { name: "Checkr", ats: "greenhouse", slug: "checkr", sectors: ["enterprise-saas"] },
+  { name: "Samsara", ats: "greenhouse", slug: "samsara", sectors: ["enterprise-saas", "hardware-iot"] },
+  { name: "Figma", ats: "greenhouse", slug: "figma", sectors: ["enterprise-saas", "consumer-social"] },
+  { name: "Monday.com", ats: "lever", slug: "monday", sectors: ["enterprise-saas"] },
+  { name: "Miro", ats: "greenhouse", slug: "miro", sectors: ["enterprise-saas"] },
+  { name: "Coda", ats: "ashby", slug: "coda", sectors: ["enterprise-saas"] },
+
+  // -- consumer-social ----------------------------------------------------
+  { name: "Reddit", ats: "greenhouse", slug: "reddit", sectors: ["consumer-social"] },
+  { name: "Pinterest", ats: "greenhouse", slug: "pinterest", sectors: ["consumer-social"] },
+  { name: "Medium", ats: "lever", slug: "medium", sectors: ["consumer-social"] },
+  { name: "Patreon", ats: "lever", slug: "patreon", sectors: ["consumer-social"] },
+  { name: "Quora", ats: "lever", slug: "quora", sectors: ["consumer-social"] },
+  { name: "Duolingo", ats: "greenhouse", slug: "duolingo", sectors: ["consumer-social", "edtech"] },
+  { name: "Nextdoor", ats: "greenhouse", slug: "nextdoor", sectors: ["consumer-social"] },
+  { name: "Bumble", ats: "greenhouse", slug: "bumble", sectors: ["consumer-social"] },
+  { name: "Strava", ats: "greenhouse", slug: "strava", sectors: ["consumer-social"] },
+  { name: "Letterboxd", ats: "ashby", slug: "letterboxd", sectors: ["consumer-social"] },
+  { name: "Cameo", ats: "greenhouse", slug: "cameo", sectors: ["consumer-social"] },
+
+  // -- hardware-iot -----------------------------------------------------------
+  { name: "Anduril", ats: "ashby", slug: "anduril", sectors: ["hardware-iot", "government-defense"] },
+  { name: "Ouster", ats: "greenhouse", slug: "ouster", sectors: ["hardware-iot"] },
+  { name: "Skydio", ats: "greenhouse", slug: "skydio", sectors: ["hardware-iot"] },
+  { name: "Zipline", ats: "greenhouse", slug: "zipline", sectors: ["hardware-iot"] },
+  { name: "Verkada", ats: "greenhouse", slug: "verkada", sectors: ["hardware-iot", "security"] },
+  { name: "Wyze", ats: "greenhouse", slug: "wyze", sectors: ["hardware-iot"] },
+  { name: "Particle", ats: "greenhouse", slug: "particle", sectors: ["hardware-iot"] },
+  { name: "Bird", ats: "greenhouse", slug: "bird", sectors: ["hardware-iot", "logistics-mobility"] },
+  { name: "Astranis", ats: "ashby", slug: "astranis", sectors: ["hardware-iot"] },
+
+  // -- crypto-web3 --------------------------------------------------------------
+  { name: "Kraken", ats: "greenhouse", slug: "kraken", sectors: ["crypto-web3"] },
+  { name: "Circle", ats: "greenhouse", slug: "circle", sectors: ["crypto-web3", "fintech"] },
+  { name: "Uniswap Labs", ats: "ashby", slug: "uniswaplabs", sectors: ["crypto-web3"] },
+  { name: "Consensys", ats: "greenhouse", slug: "consensys", sectors: ["crypto-web3"] },
+  { name: "Alchemy", ats: "ashby", slug: "alchemy", sectors: ["crypto-web3", "devtools"] },
+  { name: "OpenSea", ats: "ashby", slug: "opensea", sectors: ["crypto-web3"] },
+  { name: "Chainalysis", ats: "greenhouse", slug: "chainalysis", sectors: ["crypto-web3", "security"] },
+  { name: "Anchorage Digital", ats: "greenhouse", slug: "anchoragedigital", sectors: ["crypto-web3"] },
+  { name: "Ripple", ats: "greenhouse", slug: "ripple", sectors: ["crypto-web3", "fintech"] },
+  { name: "Gemini", ats: "greenhouse", slug: "gemini", sectors: ["crypto-web3"] },
+
+  // -- edtech -----------------------------------------------------------------
+  { name: "Coursera", ats: "greenhouse", slug: "coursera", sectors: ["edtech"] },
+  { name: "Udemy", ats: "greenhouse", slug: "udemy", sectors: ["edtech"] },
+  { name: "Khan Academy", ats: "lever", slug: "khanacademy", sectors: ["edtech"] },
+  { name: "Course Hero", ats: "greenhouse", slug: "coursehero", sectors: ["edtech"] },
+  { name: "Outschool", ats: "greenhouse", slug: "outschool", sectors: ["edtech"] },
+  { name: "Guild Education", ats: "greenhouse", slug: "guildeducation", sectors: ["edtech"] },
+  { name: "Handshake", ats: "greenhouse", slug: "handshake", sectors: ["edtech"] },
+  { name: "Quizlet", ats: "greenhouse", slug: "quizlet", sectors: ["edtech"] },
+  { name: "Photomath", ats: "ashby", slug: "photomath", sectors: ["edtech"] },
+  { name: "ClassDojo", ats: "greenhouse", slug: "classdojo", sectors: ["edtech"] },
+
+  // -- logistics-mobility -------------------------------------------------
+  { name: "Flexport", ats: "greenhouse", slug: "flexport", sectors: ["logistics-mobility"] },
+  { name: "Convoy", ats: "greenhouse", slug: "convoy", sectors: ["logistics-mobility"] },
+  { name: "Getaround", ats: "greenhouse", slug: "getaround", sectors: ["logistics-mobility"] },
+  { name: "Turo", ats: "greenhouse", slug: "turo", sectors: ["logistics-mobility"] },
+  { name: "Gopuff", ats: "greenhouse", slug: "gopuff", sectors: ["logistics-mobility", "ecommerce"] },
+  { name: "Deliverr", ats: "greenhouse", slug: "deliverr", sectors: ["logistics-mobility"] },
+  { name: "Route", ats: "greenhouse", slug: "route", sectors: ["logistics-mobility", "ecommerce"] },
+  { name: "Loadsmart", ats: "ashby", slug: "loadsmart", sectors: ["logistics-mobility"] },
+  { name: "Fleetio", ats: "greenhouse", slug: "fleetio", sectors: ["logistics-mobility"] },
+
+  // -- media-adtech -------------------------------------------------------------
+  { name: "Spotify", ats: "lever", slug: "spotify", sectors: ["media-adtech", "consumer-social"] },
+  { name: "The Trade Desk", ats: "greenhouse", slug: "thetradedesk", sectors: ["media-adtech"] },
+  { name: "Criteo", ats: "greenhouse", slug: "criteo", sectors: ["media-adtech"] },
+  { name: "Roku", ats: "greenhouse", slug: "roku", sectors: ["media-adtech"] },
+  { name: "Vimeo", ats: "greenhouse", slug: "vimeo", sectors: ["media-adtech"] },
+  { name: "Buzzfeed", ats: "greenhouse", slug: "buzzfeed", sectors: ["media-adtech"] },
+  { name: "Outbrain", ats: "greenhouse", slug: "outbrain", sectors: ["media-adtech"] },
+  { name: "Taboola", ats: "greenhouse", slug: "taboola", sectors: ["media-adtech"] },
+  { name: "Chartbeat", ats: "lever", slug: "chartbeat", sectors: ["media-adtech"] },
+  { name: "Nielsen", ats: "greenhouse", slug: "nielsen", sectors: ["media-adtech"] },
+
+  // -- government-defense -------------------------------------------------
+  { name: "Palantir", ats: "greenhouse", slug: "palantir", sectors: ["government-defense", "data-ml"] },
+  { name: "Shield AI", ats: "ashby", slug: "shieldai", sectors: ["government-defense"] },
+  { name: "Rebellion Defense", ats: "ashby", slug: "rebelliondefense", sectors: ["government-defense"] },
+  { name: "Saildrone", ats: "greenhouse", slug: "saildrone", sectors: ["government-defense", "hardware-iot"] },
+  { name: "HawkEye 360", ats: "greenhouse", slug: "hawkeye360", sectors: ["government-defense"] },
+  { name: "Second Front Systems", ats: "ashby", slug: "secondfrontsystems", sectors: ["government-defense"] },
+  { name: "Vannevar Labs", ats: "ashby", slug: "vannevarlabs", sectors: ["government-defense"] },
+];
+
+/**
+ * Up to `limit` registry entries tagged with `sector`, in stable declaration
+ * order (deterministic across calls — the fan-out cap in #533 relies on it).
+ */
+export function companiesForSector(sector: Sector, limit: number): CompanyEntry[] {
+  const result: CompanyEntry[] = [];
+  for (const entry of COMPANY_REGISTRY) {
+    if (result.length >= limit) break;
+    if (entry.sectors.includes(sector)) result.push(entry);
+  }
+  return result;
+}

--- a/src/lib/job-search/providers/ashby.test.ts
+++ b/src/lib/job-search/providers/ashby.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { makeAshbyProvider } from "./ashby.ts";
+import type { JobQuery } from "../query-builder.ts";
+
+const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok,
+    status,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("makeAshbyProvider", () => {
+  it("maps the { jobs: [] } shape to JobPosting, preferring descriptionPlain", async () => {
+    mockFetch({
+      jobs: [
+        {
+          id: "uuid",
+          title: "Staff Engineer",
+          jobUrl: "https://jobs.ashbyhq.com/acme/uuid",
+          location: "San Francisco",
+          department: "Engineering",
+          descriptionPlain: "Plaintext description.",
+          descriptionHtml: "<p>…</p>",
+          publishedAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const provider = makeAshbyProvider("acme", "Acme Inc");
+    const [job] = await provider.search(query, new AbortController().signal);
+    expect(job.id).toBe("ashby:acme:uuid");
+    expect(job.title).toBe("Staff Engineer");
+    expect(job.company).toBe("Acme Inc");
+    expect(job.location).toBe("San Francisco");
+    expect(job.url).toBe("https://jobs.ashbyhq.com/acme/uuid");
+    expect(job.description).toBe("Plaintext description.");
+    expect(job.postedAt).toBe("2026-07-01T00:00:00.000Z");
+    expect(job.departments).toEqual(["Engineering"]);
+    expect(job.source).toBe("Acme Inc");
+  });
+
+  it("falls back to HTML-stripped descriptionHtml when descriptionPlain is absent", async () => {
+    mockFetch({
+      jobs: [
+        {
+          id: "1",
+          title: "Engineer",
+          jobUrl: "https://jobs.ashbyhq.com/acme/1",
+          descriptionHtml: "<p>Build &amp; ship <strong>APIs</strong></p>",
+        },
+      ],
+    });
+    const [job] = await makeAshbyProvider("acme").search(query, new AbortController().signal);
+    expect(job.description).toBe("Build & ship APIs");
+  });
+
+  it("defaults the display name/label to the slug when no companyName is given", async () => {
+    mockFetch({ jobs: [] });
+    const provider = makeAshbyProvider("acme");
+    expect(provider.id).toBe("ashby:acme");
+    expect(provider.label).toBe("acme");
+  });
+
+  it("drops entries missing a title or url", async () => {
+    mockFetch({
+      jobs: [
+        { id: "1", title: "", jobUrl: "https://x" },
+        { id: "2", title: "Real Job", jobUrl: "" },
+        { id: "3", title: "Keeper", jobUrl: "https://y" },
+      ],
+    });
+    const jobs = await makeAshbyProvider("acme").search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual(["ashby:acme:3"]);
+  });
+
+  // The id doubles as the React key and the cross-provider dedup id, so two
+  // id-less postings must not both key `ashby:acme:`.
+  it("falls back to the url so id-less postings do not collide", async () => {
+    mockFetch({
+      jobs: [
+        { title: "One", jobUrl: "https://x" },
+        { title: "Two", jobUrl: "https://y" },
+      ],
+    });
+    const jobs = await makeAshbyProvider("acme").search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual(["ashby:acme:https://x", "ashby:acme:https://y"]);
+  });
+
+  it("rejects on a non-ok response so the orchestrator can degrade it", async () => {
+    mockFetch({}, false, 503);
+    await expect(
+      makeAshbyProvider("acme", "Acme Inc").search(query, new AbortController().signal),
+    ).rejects.toThrow(/Acme Inc responded 503/);
+  });
+
+  it("tolerates a missing jobs array", async () => {
+    mockFetch({});
+    await expect(
+      makeAshbyProvider("acme").search(query, new AbortController().signal),
+    ).resolves.toEqual([]);
+  });
+
+  it("threads the abort signal and includes includeCompensation=false in the request URL", async () => {
+    const fetchMock = mockFetch({ jobs: [] });
+    const signal = new AbortController().signal;
+    await makeAshbyProvider("acme").search(query, signal);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url as string).toContain("includeCompensation=false");
+    expect((init as RequestInit).signal).toBe(signal);
+  });
+});

--- a/src/lib/job-search/providers/ashby.ts
+++ b/src/lib/job-search/providers/ashby.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Ashby ATS-board adapter (job-search v2, epic #528, slice 2 of 5).
+ *
+ * Parameterized by company slug — `makeAshbyProvider("acme")` returns a
+ * `JobProvider` scoped to that company's public board. Ashby has no
+ * server-side free-text search and no paging — the whole board comes back
+ * in one response. Ashby boards trend smaller, and `?includeCompensation=false`
+ * trims the payload; if a board is still large, the #534 title-filter and
+ * per-company cap downstream bound what's kept. Like Lever, Ashby already
+ * returns a plaintext description (`descriptionPlain`) in the same response,
+ * so there is no separate hydrate step — prefer `descriptionPlain`, falling
+ * back to HTML-stripping `descriptionHtml` only when plaintext is absent.
+ *
+ *   GET https://api.ashbyhq.com/posting-api/job-board/{slug}?includeCompensation=false
+ *
+ * Response is `{ jobs: [] }`, matching Greenhouse's wrapper shape (Lever's
+ * is a top-level array, unlike either of these).
+ *
+ * Keyless. CORS status: unverified from a browser origin as of this slice —
+ * an explicit open task, not a curl check (curl ignores CORS). Verify
+ * against real slugs from the dev server before this adapter is wired into
+ * `getProviders()` (#533).
+ *
+ * The request carries only the public company slug and the static
+ * `includeCompensation=false` flag — never resume-derived data; `query` is
+ * unused here, client-side title-filtering happens downstream in #534.
+ */
+
+import type { JobProvider, JobPosting } from "../types.ts";
+import { htmlToPlaintext } from "../../jd-match/fetch-jd.ts";
+
+const BASE = "https://api.ashbyhq.com/posting-api/job-board";
+
+interface AshbyJob {
+  id?: string;
+  title?: string;
+  jobUrl?: string;
+  location?: string;
+  department?: string;
+  team?: string;
+  descriptionPlain?: string;
+  descriptionHtml?: string;
+  publishedAt?: string;
+}
+
+interface AshbyResponse {
+  jobs?: AshbyJob[];
+}
+
+function mapJob(slug: string, label: string, job: AshbyJob): JobPosting {
+  const departments = [job.department, job.team].filter((d): d is string => Boolean(d));
+  return {
+    // `ashby:{slug}:{id}` is unique across companies — doubles as the React
+    // key and cross-provider dedup id, matching the `provider:id` convention
+    // in types.ts. Falls back to the url (guaranteed non-empty by the post-map
+    // filter) so two id-less postings never collide on `ashby:{slug}:`,
+    // matching remotive.ts/jobicy.ts.
+    id: `ashby:${slug}:${job.id ?? job.jobUrl ?? ""}`,
+    title: (job.title ?? "").trim(),
+    company: label,
+    location: (job.location ?? "").trim(),
+    url: job.jobUrl ?? "",
+    description: job.descriptionPlain ?? htmlToPlaintext(job.descriptionHtml ?? ""),
+    postedAt: job.publishedAt,
+    source: label,
+    departments,
+  };
+}
+
+/** Factory, not a singleton — one `JobProvider` per company board. */
+export function makeAshbyProvider(slug: string, companyName = slug): JobProvider {
+  const ID = `ashby:${slug}`;
+  const LABEL = companyName;
+  return {
+    id: ID,
+    label: LABEL,
+    // Whole board is always fetched (no server-side search, no paging) —
+    // narrowing by keyword happens client-side downstream (#534).
+    async search(_query, signal: AbortSignal): Promise<JobPosting[]> {
+      const url = `${BASE}/${encodeURIComponent(slug)}?includeCompensation=false`;
+      const res = await fetch(url, { signal });
+      if (!res.ok) throw new Error(`${LABEL} responded ${res.status}`);
+      const data = (await res.json()) as AshbyResponse;
+      return (data.jobs ?? []).map((j) => mapJob(slug, LABEL, j)).filter((p) => p.title && p.url);
+    },
+  };
+}

--- a/src/lib/job-search/providers/greenhouse.test.ts
+++ b/src/lib/job-search/providers/greenhouse.test.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { makeGreenhouseProvider, hydrateGreenhouse } from "./greenhouse.ts";
+import type { JobQuery } from "../query-builder.ts";
+
+const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok,
+    status,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("makeGreenhouseProvider", () => {
+  it("maps the light index shape to JobPosting with an empty description", async () => {
+    mockFetch({
+      jobs: [
+        {
+          id: 4012345,
+          title: "Senior Backend Engineer",
+          absolute_url: "https://boards.greenhouse.io/acme/jobs/4012345",
+          location: { name: "Remote - US" },
+          updated_at: "2026-07-01T12:00:00-04:00",
+          departments: [{ name: "Engineering" }],
+        },
+      ],
+    });
+
+    const provider = makeGreenhouseProvider("acme", "Acme Inc");
+    const [job] = await provider.search(query, new AbortController().signal);
+    expect(job.id).toBe("greenhouse:acme:4012345");
+    expect(job.title).toBe("Senior Backend Engineer");
+    expect(job.company).toBe("Acme Inc");
+    expect(job.location).toBe("Remote - US");
+    expect(job.url).toBe("https://boards.greenhouse.io/acme/jobs/4012345");
+    expect(job.postedAt).toBe("2026-07-01T12:00:00-04:00");
+    expect(job.departments).toEqual(["Engineering"]);
+    expect(job.description).toBe("");
+    expect(job.source).toBe("Acme Inc");
+  });
+
+  it("defaults the display name/label to the slug when no companyName is given", async () => {
+    mockFetch({ jobs: [] });
+    const provider = makeGreenhouseProvider("acme");
+    expect(provider.id).toBe("greenhouse:acme");
+    expect(provider.label).toBe("acme");
+  });
+
+  it("produces unique ids across two different company slugs", async () => {
+    mockFetch({
+      jobs: [
+        {
+          id: 1,
+          title: "Engineer",
+          absolute_url: "https://boards.greenhouse.io/acme/jobs/1",
+        },
+      ],
+    });
+    const acme = await makeGreenhouseProvider("acme").search(
+      query,
+      new AbortController().signal,
+    );
+
+    mockFetch({
+      jobs: [
+        {
+          id: 1,
+          title: "Engineer",
+          absolute_url: "https://boards.greenhouse.io/globex/jobs/1",
+        },
+      ],
+    });
+    const globex = await makeGreenhouseProvider("globex").search(
+      query,
+      new AbortController().signal,
+    );
+
+    expect(acme[0].id).toBe("greenhouse:acme:1");
+    expect(globex[0].id).toBe("greenhouse:globex:1");
+    expect(acme[0].id).not.toBe(globex[0].id);
+  });
+
+  it("drops entries missing a title or url", async () => {
+    mockFetch({
+      jobs: [
+        { id: 1, title: "", absolute_url: "https://x" },
+        { id: 2, title: "Real Job", absolute_url: "" },
+        { id: 3, title: "Keeper", absolute_url: "https://y" },
+      ],
+    });
+    const jobs = await makeGreenhouseProvider("acme").search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual(["greenhouse:acme:3"]);
+  });
+
+  // The id doubles as the React key and the cross-provider dedup id, so two
+  // id-less postings must not both key `greenhouse:acme:`.
+  it("falls back to the url so id-less postings do not collide", async () => {
+    mockFetch({
+      jobs: [
+        { title: "One", absolute_url: "https://x" },
+        { title: "Two", absolute_url: "https://y" },
+      ],
+    });
+    const jobs = await makeGreenhouseProvider("acme").search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual([
+      "greenhouse:acme:https://x",
+      "greenhouse:acme:https://y",
+    ]);
+  });
+
+  it("rejects on a non-ok response so the orchestrator can degrade it", async () => {
+    mockFetch({}, false, 503);
+    await expect(
+      makeGreenhouseProvider("acme", "Acme Inc").search(query, new AbortController().signal),
+    ).rejects.toThrow(/Acme Inc responded 503/);
+  });
+
+  it("tolerates a missing jobs array", async () => {
+    mockFetch({});
+    await expect(
+      makeGreenhouseProvider("acme").search(query, new AbortController().signal),
+    ).resolves.toEqual([]);
+  });
+
+  it("threads the abort signal into fetch", async () => {
+    const fetchMock = mockFetch({ jobs: [] });
+    const signal = new AbortController().signal;
+    await makeGreenhouseProvider("acme").search(query, signal);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).signal).toBe(signal);
+  });
+});
+
+describe("hydrateGreenhouse", () => {
+  it("fetches /jobs/{id} and strips + unescapes content to plaintext", async () => {
+    const fetchMock = mockFetch({
+      id: 4012345,
+      title: "Senior Backend Engineer",
+      content: "<p>Build &amp; ship <strong>APIs</strong></p>",
+    });
+
+    const text = await hydrateGreenhouse("acme", "4012345", new AbortController().signal);
+    expect(text).not.toContain("<");
+    expect(text).not.toContain("&amp;");
+    expect(text).toContain("Build & ship APIs");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://boards-api.greenhouse.io/v1/boards/acme/jobs/4012345");
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("rejects on a non-ok response", async () => {
+    mockFetch({}, false, 404);
+    await expect(
+      hydrateGreenhouse("acme", "999", new AbortController().signal),
+    ).rejects.toThrow(/Greenhouse job 999 responded 404/);
+  });
+
+  it("tolerates a missing content field", async () => {
+    mockFetch({ id: 1, title: "Engineer" });
+    await expect(hydrateGreenhouse("acme", "1", new AbortController().signal)).resolves.toBe("");
+  });
+});

--- a/src/lib/job-search/providers/greenhouse.ts
+++ b/src/lib/job-search/providers/greenhouse.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Greenhouse ATS-board adapter (job-search v2, epic #528, slice 1 of 5).
+ *
+ * Parameterized by company slug — `makeGreenhouseProvider("stripe")` returns a
+ * `JobProvider` scoped to that company's public board. Unlike the keyless
+ * feeds (Remotive, Jobicy), Greenhouse's public board API has no server-side
+ * free-text search: a company's whole board comes back in one response. To
+ * keep that payload bounded regardless of board size, `search()` fetches the
+ * **light index** (no `?content=true`) — titles, locations, departments, ids,
+ * timestamps, but no `content` blob, so every posting's `description` is `""`.
+ * Descriptions are hydrated lazily, per-job, via `hydrateGreenhouse` — called
+ * only for postings that survive the #534 title filter and per-company cap.
+ *
+ *   Light index:  GET https://boards-api.greenhouse.io/v1/boards/{slug}/jobs
+ *   Hydrate one:  GET https://boards-api.greenhouse.io/v1/boards/{slug}/jobs/{id}
+ *
+ * Keyless. CORS status: unverified from a browser origin as of this slice —
+ * an explicit open task, not a curl check (curl ignores CORS). Verify against
+ * real slugs from the dev server before this adapter is wired into
+ * `getProviders()` (#533).
+ *
+ * The request carries only the public company slug/job id — never
+ * resume-derived data (no `keywords.ts` involvement); `query` is unused here,
+ * client-side title-filtering happens downstream in #534.
+ */
+
+import type { JobProvider, JobPosting } from "../types.ts";
+import { htmlToPlaintext } from "../../jd-match/fetch-jd.ts";
+
+const BASE = "https://boards-api.greenhouse.io/v1/boards";
+
+interface GreenhouseJob {
+  id?: number | string;
+  title?: string;
+  absolute_url?: string;
+  location?: { name?: string };
+  updated_at?: string;
+  departments?: { name?: string }[];
+  content?: string;
+}
+
+interface GreenhouseIndex {
+  jobs?: GreenhouseJob[];
+}
+
+function mapJob(slug: string, label: string, job: GreenhouseJob): JobPosting {
+  return {
+    // `greenhouse:{slug}:{jobId}` is unique across companies — doubles as the
+    // React key and cross-provider dedup id, matching the `provider:id`
+    // convention in types.ts. Falls back to the url (guaranteed non-empty by
+    // the post-map filter) so two id-less postings never collide on
+    // `greenhouse:{slug}:`, matching remotive.ts/jobicy.ts.
+    id: `greenhouse:${slug}:${job.id ?? job.absolute_url ?? ""}`,
+    title: (job.title ?? "").trim(),
+    company: label,
+    location: (job.location?.name ?? "").trim(),
+    url: job.absolute_url ?? "",
+    // Light index has no content — hydrated lazily via hydrateGreenhouse.
+    description: "",
+    postedAt: job.updated_at,
+    source: label,
+    departments: (job.departments ?? [])
+      .map((d) => d.name)
+      .filter((n): n is string => Boolean(n)),
+  };
+}
+
+/** Factory, not a singleton — one `JobProvider` per company board. */
+export function makeGreenhouseProvider(slug: string, companyName = slug): JobProvider {
+  const ID = `greenhouse:${slug}`;
+  const LABEL = companyName;
+  return {
+    id: ID,
+    label: LABEL,
+    // Whole board is always fetched (no server-side search) — narrowing by
+    // keyword happens client-side downstream (#534).
+    async search(_query, signal: AbortSignal): Promise<JobPosting[]> {
+      const url = `${BASE}/${encodeURIComponent(slug)}/jobs`;
+      const res = await fetch(url, { signal });
+      if (!res.ok) throw new Error(`${LABEL} responded ${res.status}`);
+      const data = (await res.json()) as GreenhouseIndex;
+      return (data.jobs ?? []).map((j) => mapJob(slug, LABEL, j)).filter((p) => p.title && p.url);
+    },
+  };
+}
+
+/**
+ * Lazy per-job hydrate: fetches one Greenhouse posting and returns its
+ * `content` as plaintext. Called only for postings that survive the #534
+ * title filter and per-company cap — never for the whole board.
+ */
+export async function hydrateGreenhouse(
+  slug: string,
+  jobId: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const url = `${BASE}/${encodeURIComponent(slug)}/jobs/${encodeURIComponent(jobId)}`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`Greenhouse job ${jobId} responded ${res.status}`);
+  const data = (await res.json()) as GreenhouseJob;
+  // htmlToPlaintext decodes HTML entities (named + numeric) and strips tags
+  // in one pass, so the HTML-entity-escaped `content` field needs no separate
+  // unescape step.
+  return htmlToPlaintext(data.content ?? "");
+}

--- a/src/lib/job-search/providers/lever.test.ts
+++ b/src/lib/job-search/providers/lever.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { makeLeverProvider } from "./lever.ts";
+import type { JobQuery } from "../query-builder.ts";
+
+const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok,
+    status,
+    json: async () => body,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("makeLeverProvider", () => {
+  it("maps the top-level array shape to JobPosting, preferring descriptionPlain", async () => {
+    mockFetch([
+      {
+        id: "abc-123-uuid",
+        text: "Senior Frontend Engineer",
+        hostedUrl: "https://jobs.lever.co/acme/abc-123-uuid",
+        categories: { location: "Remote", team: "Engineering", commitment: "Full-time" },
+        descriptionPlain: "Plaintext description already provided.",
+        description: "<p>HTML description…</p>",
+        createdAt: 1719763200000,
+      },
+    ]);
+
+    const provider = makeLeverProvider("acme", "Acme Inc");
+    const [job] = await provider.search(query, new AbortController().signal);
+    expect(job.id).toBe("lever:acme:abc-123-uuid");
+    expect(job.title).toBe("Senior Frontend Engineer");
+    expect(job.company).toBe("Acme Inc");
+    expect(job.location).toBe("Remote");
+    expect(job.url).toBe("https://jobs.lever.co/acme/abc-123-uuid");
+    expect(job.description).toBe("Plaintext description already provided.");
+    expect(job.postedAt).toBe(new Date(1719763200000).toISOString());
+    expect(job.departments).toEqual(["Engineering"]);
+    expect(job.source).toBe("Acme Inc");
+  });
+
+  it("falls back to HTML-stripped description when descriptionPlain is absent", async () => {
+    mockFetch([
+      {
+        id: "1",
+        text: "Engineer",
+        hostedUrl: "https://jobs.lever.co/acme/1",
+        description: "<p>Build &amp; ship <strong>APIs</strong></p>",
+      },
+    ]);
+    const [job] = await makeLeverProvider("acme").search(query, new AbortController().signal);
+    expect(job.description).toBe("Build & ship APIs");
+  });
+
+  it("defaults the display name/label to the slug when no companyName is given", async () => {
+    mockFetch([]);
+    const provider = makeLeverProvider("acme");
+    expect(provider.id).toBe("lever:acme");
+    expect(provider.label).toBe("acme");
+  });
+
+  it("drops entries missing a title or url", async () => {
+    mockFetch([
+      { id: "1", text: "", hostedUrl: "https://x" },
+      { id: "2", text: "Real Job", hostedUrl: "" },
+      { id: "3", text: "Keeper", hostedUrl: "https://y" },
+    ]);
+    const jobs = await makeLeverProvider("acme").search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual(["lever:acme:3"]);
+  });
+
+  // The id doubles as the React key and the cross-provider dedup id, so two
+  // id-less postings must not both key `lever:acme:`.
+  it("falls back to the url so id-less postings do not collide", async () => {
+    mockFetch([
+      { text: "One", hostedUrl: "https://x" },
+      { text: "Two", hostedUrl: "https://y" },
+    ]);
+    const jobs = await makeLeverProvider("acme").search(query, new AbortController().signal);
+    expect(jobs.map((j) => j.id)).toEqual(["lever:acme:https://x", "lever:acme:https://y"]);
+  });
+
+  it("rejects on a non-ok response so the orchestrator can degrade it", async () => {
+    mockFetch({}, false, 503);
+    await expect(
+      makeLeverProvider("acme", "Acme Inc").search(query, new AbortController().signal),
+    ).rejects.toThrow(/Acme Inc responded 503/);
+  });
+
+  it("tolerates a null response", async () => {
+    mockFetch(null);
+    await expect(
+      makeLeverProvider("acme").search(query, new AbortController().signal),
+    ).resolves.toEqual([]);
+  });
+
+  // A 200 carrying an object error envelope is the expected shape for a wrong
+  // registry slug, and `?? []` does not guard it — `({}).map` is not a
+  // function. Only `Array.isArray` does.
+  it("tolerates a 200 whose body is an object, not an array", async () => {
+    mockFetch({ error: "not found" });
+    await expect(
+      makeLeverProvider("acme").search(query, new AbortController().signal),
+    ).resolves.toEqual([]);
+  });
+
+  it("threads the abort signal and includes ?limit= in the request URL", async () => {
+    const fetchMock = mockFetch([]);
+    const signal = new AbortController().signal;
+    await makeLeverProvider("acme").search(query, signal);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url as string).toContain("?mode=json&limit=");
+    expect((init as RequestInit).signal).toBe(signal);
+  });
+});

--- a/src/lib/job-search/providers/lever.ts
+++ b/src/lib/job-search/providers/lever.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Lever ATS-board adapter (job-search v2, epic #528, slice 2 of 5).
+ *
+ * Parameterized by company slug — `makeLeverProvider("acme")` returns a
+ * `JobProvider` scoped to that company's public board. Lever has no
+ * server-side free-text search either, but it does support server-side
+ * paging: `?limit=` caps the fetch instead of pulling an unbounded board.
+ * Unlike Greenhouse, Lever already returns a plaintext description
+ * (`descriptionPlain`) in the same response, so there is no separate hydrate
+ * step — prefer `descriptionPlain`, falling back to HTML-stripping
+ * `description` only when plaintext is absent.
+ *
+ *   GET https://api.lever.co/v0/postings/{slug}?mode=json&limit=100
+ *
+ * Response is a **top-level array** (not wrapped in an object), unlike
+ * Greenhouse's `{ jobs: [] }` and Ashby's `{ jobs: [] }`.
+ *
+ * Keyless. CORS status: unverified from a browser origin as of this slice —
+ * an explicit open task, not a curl check (curl ignores CORS). Verify
+ * against real slugs from the dev server before this adapter is wired into
+ * `getProviders()` (#533).
+ *
+ * The request carries only the public company slug and the static `limit`
+ * cap — never resume-derived data; `query` is unused here, client-side
+ * title-filtering happens downstream in #534.
+ */
+
+import type { JobProvider, JobPosting } from "../types.ts";
+import { htmlToPlaintext } from "../../jd-match/fetch-jd.ts";
+
+const BASE = "https://api.lever.co/v0/postings";
+const LIMIT = 100;
+
+interface LeverJob {
+  id?: string;
+  text?: string;
+  hostedUrl?: string;
+  categories?: {
+    location?: string;
+    team?: string;
+    department?: string;
+    commitment?: string;
+  };
+  descriptionPlain?: string;
+  description?: string;
+  createdAt?: number;
+}
+
+function mapJob(slug: string, label: string, job: LeverJob): JobPosting {
+  const departments = [job.categories?.team, job.categories?.department].filter(
+    (d): d is string => Boolean(d),
+  );
+  return {
+    // `lever:{slug}:{id}` is unique across companies — doubles as the React
+    // key and cross-provider dedup id, matching the `provider:id` convention
+    // in types.ts. Falls back to the url (guaranteed non-empty by the post-map
+    // filter) so two id-less postings never collide on `lever:{slug}:`,
+    // matching remotive.ts/jobicy.ts.
+    id: `lever:${slug}:${job.id ?? job.hostedUrl ?? ""}`,
+    title: (job.text ?? "").trim(),
+    company: label,
+    location: (job.categories?.location ?? "").trim(),
+    url: job.hostedUrl ?? "",
+    description: job.descriptionPlain ?? htmlToPlaintext(job.description ?? ""),
+    postedAt: typeof job.createdAt === "number" ? new Date(job.createdAt).toISOString() : undefined,
+    source: label,
+    departments,
+  };
+}
+
+/** Factory, not a singleton — one `JobProvider` per company board. */
+export function makeLeverProvider(slug: string, companyName = slug): JobProvider {
+  const ID = `lever:${slug}`;
+  const LABEL = companyName;
+  return {
+    id: ID,
+    label: LABEL,
+    // Whole board is fetched (no server-side search), capped via `?limit=` —
+    // narrowing by keyword happens client-side downstream (#534).
+    async search(_query, signal: AbortSignal): Promise<JobPosting[]> {
+      const url = `${BASE}/${encodeURIComponent(slug)}?mode=json&limit=${LIMIT}`;
+      const res = await fetch(url, { signal });
+      if (!res.ok) throw new Error(`${LABEL} responded ${res.status}`);
+      const data = (await res.json()) as unknown;
+      // Lever is the only one of the three boards whose success shape is a
+      // bare top-level array, so a 200 carrying an object error envelope (the
+      // expected shape for a wrong registry slug) would land straight on
+      // `.map`. `Array.isArray` guards that; `?? []` would not.
+      const jobs: LeverJob[] = Array.isArray(data) ? (data as LeverJob[]) : [];
+      return jobs.map((j) => mapJob(slug, LABEL, j)).filter((p) => p.title && p.url);
+    },
+  };
+}

--- a/src/lib/job-search/role-keywords.test.ts
+++ b/src/lib/job-search/role-keywords.test.ts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  ROLE_KEYWORDS,
+  ROLE_FAMILIES,
+  roleFilterForResume,
+  filterPostingsByRole,
+  capPerCompany,
+  DEFAULT_PER_COMPANY_CAP,
+  type RoleFilter,
+} from "./role-keywords.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobPosting } from "./types.ts";
+
+// Minimal typed stub over the parsed model, like contact.test.ts / sector.test.ts
+// — only the fields role-keywords reads (experience titles + headline/current_title).
+function makeParsed(
+  overrides: Partial<HeuristicParsedResume> = {},
+): HeuristicParsedResume {
+  return {
+    skills: [],
+    experience: [],
+    education: [],
+    ...overrides,
+  };
+}
+
+// Minimal JobPosting stub — only fields the filter/cap read matter.
+function makePosting(overrides: Partial<JobPosting> = {}): JobPosting {
+  return {
+    id: overrides.id ?? "test:1",
+    title: overrides.title ?? "",
+    company: overrides.company ?? "Acme",
+    location: overrides.location ?? "",
+    url: overrides.url ?? "https://example.com",
+    description: overrides.description ?? "",
+    source: overrides.source ?? "Test",
+    ...overrides,
+  };
+}
+
+describe("ROLE_KEYWORDS taxonomy", () => {
+  it("has an entry for every family with non-empty, lowercased keywords", () => {
+    expect(ROLE_FAMILIES.length).toBeGreaterThanOrEqual(12);
+    expect(ROLE_FAMILIES.length).toBeLessThanOrEqual(20);
+    for (const family of ROLE_FAMILIES) {
+      const keywords = ROLE_KEYWORDS[family];
+      expect(keywords.length).toBeGreaterThan(0);
+      for (const kw of keywords) {
+        expect(kw.length).toBeGreaterThan(0);
+        expect(kw).toBe(kw.toLowerCase());
+      }
+    }
+  });
+});
+
+describe("roleFilterForResume — titles, not skills", () => {
+  it("maps a frontend-titled resume to the frontend family with front-end/react keywords", () => {
+    const filter = roleFilterForResume(
+      makeParsed({
+        experience: [
+          { title: "Senior Frontend Engineer", company: "Acme" },
+          { title: "Front End Developer", company: "Globex" },
+        ],
+      }),
+    );
+    expect(filter.families).toContain("frontend");
+    expect(filter.families[0]).toBe("frontend");
+    expect(filter.keywords).toContain("front end");
+    expect(filter.keywords).toContain("react developer");
+    expect(filter.source).toBe("heuristic");
+  });
+
+  it("maps a data-titled resume to the data family", () => {
+    const filter = roleFilterForResume(
+      makeParsed({
+        experience: [{ title: "Senior Data Engineer", company: "Acme" }],
+      }),
+    );
+    expect(filter.families).toContain("data");
+  });
+
+  it("reads the standalone headline / current_title target-role signal", () => {
+    const filter = roleFilterForResume(
+      makeParsed({
+        experience: [],
+        headline: "Product Manager",
+        current_title: "Group Product Manager",
+      }),
+    );
+    expect(filter.families).toContain("pm");
+    expect(filter.keywords).toContain("product manager");
+  });
+
+  it("classifies from TITLES ONLY — skills matching a family do NOT classify it", () => {
+    // Skills scream frontend; the only TITLE is a sales role. The filter must
+    // reflect the title (sales), never the skills (frontend).
+    const filter = roleFilterForResume(
+      makeParsed({
+        skills: ["React", "TypeScript", "CSS", "Frontend", "Web"],
+        experience: [{ title: "Account Executive", company: "Acme" }],
+      }),
+    );
+    expect(filter.families).toContain("sales");
+    expect(filter.families).not.toContain("frontend");
+    expect(filter.keywords).not.toContain("front end");
+  });
+
+  it("empty resume yields a permissive 'all' filter (never zero)", () => {
+    const filter = roleFilterForResume(makeParsed());
+    expect(filter.families).toEqual([]);
+    expect(filter.keywords).toEqual([]);
+    expect(filter.source).toBe("heuristic");
+  });
+
+  it("degenerate resume with unrecognized titles yields the permissive 'all' filter", () => {
+    const filter = roleFilterForResume(
+      makeParsed({
+        skills: ["Communication"],
+        experience: [{ title: "Chief Vibes Officer", company: "Somewhere" }],
+      }),
+    );
+    expect(filter.families).toEqual([]);
+    expect(filter.keywords).toEqual([]);
+  });
+
+  it("keeps at most 2 dominant families, dominant first", () => {
+    const filter = roleFilterForResume(
+      makeParsed({
+        experience: [
+          { title: "Frontend Engineer", company: "A" },
+          { title: "Frontend Engineer", company: "B" },
+          { title: "Backend Engineer", company: "C" },
+          { title: "Data Engineer", company: "D" },
+        ],
+      }),
+    );
+    expect(filter.families.length).toBeLessThanOrEqual(2);
+    expect(filter.families[0]).toBe("frontend"); // score 2 beats the 1s
+  });
+
+  // A lopsided split is the career-switcher case: `score > 0` alone would keep
+  // "design", whose broad keywords ("designer", "user experience") then match
+  // every Designer posting on every board.
+  it("drops a runner-up family that trails the winner by more than half", () => {
+    const filter = roleFilterForResume(
+      makeParsed({
+        experience: [
+          { title: "Backend Engineer", company: "A" },
+          { title: "Senior Backend Engineer", company: "B" },
+          { title: "Staff Backend Engineer", company: "C" },
+          { title: "UX Designer", company: "D" },
+        ],
+      }),
+    );
+    expect(filter.families).toEqual(["backend"]);
+    expect(filter.keywords).not.toContain("designer");
+  });
+
+  it("never throws on a malformed/empty parsed model", () => {
+    expect(() => roleFilterForResume(makeParsed())).not.toThrow();
+  });
+});
+
+describe("filterPostingsByRole", () => {
+  const frontendFilter = roleFilterForResume(
+    makeParsed({ experience: [{ title: "Frontend Engineer", company: "X" }] }),
+  );
+
+  it("keeps a matching title and drops a non-matching one", () => {
+    const postings = [
+      makePosting({ id: "1", title: "Senior Frontend Engineer" }),
+      makePosting({ id: "2", title: "Account Executive" }),
+    ];
+    const kept = filterPostingsByRole(postings, frontendFilter);
+    expect(kept.map((p) => p.id)).toEqual(["1"]);
+  });
+
+  it("matches case-insensitively", () => {
+    const postings = [makePosting({ id: "1", title: "SENIOR FRONTEND ENGINEER" })];
+    expect(filterPostingsByRole(postings, frontendFilter)).toHaveLength(1);
+  });
+
+  it("matches both hyphen and space title variants", () => {
+    const postings = [
+      makePosting({ id: "hyphen", title: "Front-End Developer" }),
+      makePosting({ id: "space", title: "Front End Developer" }),
+    ];
+    const kept = filterPostingsByRole(postings, frontendFilter);
+    expect(kept.map((p) => p.id).sort()).toEqual(["hyphen", "space"]);
+  });
+
+  it("optionally matches on departments[] when the title alone does not", () => {
+    const filter = roleFilterForResume(
+      makeParsed({ experience: [{ title: "Data Engineer", company: "X" }] }),
+    );
+    const postings = [
+      makePosting({ id: "dept", title: "Engineer II", departments: ["Data Platform"] }),
+    ];
+    expect(filterPostingsByRole(postings, filter)).toHaveLength(1);
+  });
+
+  it("preserves input order", () => {
+    const postings = [
+      makePosting({ id: "a", title: "Frontend Engineer" }),
+      makePosting({ id: "b", title: "Account Executive" }),
+      makePosting({ id: "c", title: "Web Developer" }),
+    ];
+    expect(filterPostingsByRole(postings, frontendFilter).map((p) => p.id)).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  it("returns the input UNCHANGED for an 'all' filter (no accidental narrowing)", () => {
+    const allFilter: RoleFilter = { families: [], keywords: [], source: "heuristic" };
+    const postings = [
+      makePosting({ id: "1", title: "Account Executive" }),
+      makePosting({ id: "2", title: "Barista" }),
+    ];
+    const kept = filterPostingsByRole(postings, allFilter);
+    expect(kept).toBe(postings);
+    expect(kept).toHaveLength(2);
+  });
+});
+
+describe("capPerCompany", () => {
+  it("returns at most N per company, preserving order", () => {
+    const postings = [
+      makePosting({ id: "a1", company: "Acme" }),
+      makePosting({ id: "a2", company: "Acme" }),
+      makePosting({ id: "a3", company: "Acme" }),
+      makePosting({ id: "g1", company: "Globex" }),
+      makePosting({ id: "a4", company: "Acme" }),
+    ];
+    const capped = capPerCompany(postings, 2);
+    expect(capped.map((p) => p.id)).toEqual(["a1", "a2", "g1"]);
+  });
+
+  it("counts companies case-insensitively / trimmed", () => {
+    const postings = [
+      makePosting({ id: "1", company: "Acme" }),
+      makePosting({ id: "2", company: " acme " }),
+      makePosting({ id: "3", company: "ACME" }),
+    ];
+    expect(capPerCompany(postings, 2)).toHaveLength(2);
+  });
+
+  it("keeps everything when under the cap", () => {
+    const postings = [
+      makePosting({ id: "1", company: "A" }),
+      makePosting({ id: "2", company: "B" }),
+    ];
+    expect(capPerCompany(postings, DEFAULT_PER_COMPANY_CAP)).toHaveLength(2);
+  });
+
+  it("keeps none for a non-positive limit", () => {
+    const postings = [makePosting({ id: "1", company: "A" })];
+    expect(capPerCompany(postings, 0)).toEqual([]);
+  });
+});

--- a/src/lib/job-search/role-keywords.ts
+++ b/src/lib/job-search/role-keywords.ts
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * role-keywords.ts — a curated role/function → title-synonym taxonomy plus the
+ * board title-filter and per-company size caps (#534, slice of the
+ * job-search-v2 epic #528).
+ *
+ * Company ATS boards have no server-side free-text search — a search pulls the
+ * WHOLE board (100s–1000s of roles). This module is the layer that narrows a
+ * board's light-index postings to the ones relevant to the candidate and caps
+ * the count, before descriptions are hydrated and `rankPostings` ranks them. It
+ * only *narrows and caps*; ranking is out of scope.
+ *
+ * THREE LOAD-BEARING INVARIANTS:
+ *
+ * 1. TITLES, NOT SKILLS. `roleFilterForResume` classifies the candidate from
+ *    their ROLE TITLES — `experience[].title` plus any standalone `headline` /
+ *    `current_title` target-role signal — and NEVER from `skills`. Skills almost
+ *    never appear in a job title (`Senior Frontend Engineer` names no library),
+ *    so filtering board titles by resume skills (`React`, `Postgres`) mismatches
+ *    the surfaces. A resume whose *skills* match a family but whose *titles* do
+ *    not must NOT be classified into that family — this function does not read
+ *    `parsed.skills*` at all, which is the mechanical guarantee of that.
+ *
+ * 2. NEVER FAIL CLOSED. An empty / degenerate / unrecognized resume yields a
+ *    PERMISSIVE "all" filter (`families: []`, `keywords: []`) that keeps every
+ *    posting. The feature degrades to "whole board, capped" — never to zero
+ *    results. `filterPostingsByRole` returns its input unchanged for an "all"
+ *    filter.
+ *
+ * 3. ZERO-EGRESS / DIFFERENT PRIVACY CLASS. This keyword set is a purely local
+ *    title filter and is a DIFFERENT privacy class from `keywords.ts` (the
+ *    audited egress string sent to the keyless job feeds). It never leaves the
+ *    browser: it is not sent to any ATS board and MUST NOT be imported into,
+ *    routed through, or built from `keywords.ts`. No network, no raw-PDF text —
+ *    pure over the parsed resume model, mirroring `src/lib/score/score.ts`.
+ *
+ * `RoleFamily` (which roles WITHIN a board) is deliberately distinct from
+ * #531's `Sector` (which COMPANIES to search); do not conflate them.
+ *
+ * ROLE_KEYWORDS sourcing: hand-curated from common software job-title phrasings
+ * (each family's real title synonyms, including hyphen/space variants such as
+ * `front-end` / `front end` / `frontend`), chosen for precision on titles — a
+ * keyword is specific enough not to cross-match another family (bare "engineer"
+ * would be useless). Staleness is tolerable: a missing synonym only filters
+ * slightly narrower, never wrong. Curated on 2026-07-21.
+ */
+
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobPosting } from "./types.ts";
+
+/**
+ * Fixed role-family taxonomy — the SINGLE SOURCE OF TRUTH for "which roles
+ * within a board". Declaration order is also the deterministic tie-break order
+ * when two families score equally in `roleFilterForResume`. Distinct from
+ * #531's `Sector`; there is intentionally no `"other"` member — an
+ * unclassifiable resume produces the permissive "all" filter instead.
+ */
+export const ROLE_FAMILIES = [
+  "frontend",
+  "backend",
+  "fullstack",
+  "mobile",
+  "data",
+  "ml",
+  "sre-devops",
+  "security",
+  "qa",
+  "design",
+  "pm",
+  "sales",
+  "marketing",
+  "support",
+] as const;
+
+export type RoleFamily = (typeof ROLE_FAMILIES)[number];
+
+/**
+ * Curated function → title-synonym map. Each family maps to lowercased
+ * substrings that appear in real job titles for that family. Every substring is
+ * matched case-insensitively against a posting's lowercased title (+ optional
+ * departments). Keep entries specific enough not to cross-match a sibling
+ * family. Curated on 2026-07-21 (see file docblock for sourcing).
+ */
+export const ROLE_KEYWORDS: Readonly<Record<RoleFamily, readonly string[]>> = {
+  frontend: [
+    "frontend",
+    "front end",
+    "front-end",
+    "ui engineer",
+    "ui developer",
+    "web developer",
+    "web engineer",
+    "react developer",
+    "javascript engineer",
+  ],
+  backend: [
+    "backend",
+    "back end",
+    "back-end",
+    "server-side",
+    "server side",
+    "api engineer",
+    "distributed systems",
+    "golang engineer",
+  ],
+  fullstack: ["fullstack", "full stack", "full-stack"],
+  mobile: [
+    "mobile engineer",
+    "mobile developer",
+    "ios engineer",
+    "ios developer",
+    "android engineer",
+    "android developer",
+    "react native",
+    "flutter developer",
+  ],
+  data: [
+    "data engineer",
+    "data analyst",
+    "analytics engineer",
+    "business intelligence",
+    "bi developer",
+    "data platform",
+    "data warehouse",
+  ],
+  ml: [
+    "machine learning",
+    "ml engineer",
+    "ml scientist",
+    "data scientist",
+    "deep learning",
+    "nlp engineer",
+    "computer vision",
+    "applied scientist",
+    "research scientist",
+    "ai engineer",
+  ],
+  "sre-devops": [
+    "devops",
+    "sre",
+    "site reliability",
+    "platform engineer",
+    "infrastructure engineer",
+    "cloud engineer",
+    "reliability engineer",
+    "systems engineer",
+  ],
+  security: [
+    "security engineer",
+    "security analyst",
+    "security architect",
+    "appsec",
+    "application security",
+    "infosec",
+    "penetration tester",
+    "cybersecurity",
+  ],
+  qa: [
+    "qa engineer",
+    "quality assurance",
+    "test engineer",
+    "sdet",
+    "automation engineer",
+    "quality engineer",
+  ],
+  design: [
+    "designer",
+    "ux researcher",
+    "user experience",
+    "design lead",
+    "interaction design",
+    "visual design",
+  ],
+  pm: [
+    "product manager",
+    "product management",
+    "program manager",
+    "project manager",
+    "technical product manager",
+    "group product manager",
+  ],
+  sales: [
+    "account executive",
+    "sales engineer",
+    "sales representative",
+    "business development",
+    "account manager",
+    "sales development",
+    "solutions engineer",
+  ],
+  marketing: [
+    "marketing manager",
+    "growth marketing",
+    "content marketing",
+    "seo specialist",
+    "demand generation",
+    "brand manager",
+    "product marketing",
+    "social media manager",
+  ],
+  support: [
+    "customer support",
+    "customer success",
+    "technical support",
+    "support engineer",
+  ],
+};
+
+/**
+ * The candidate's inferred role filter. `families: []` (⟺ `keywords: []`) is
+ * the permissive "all" filter — the never-fail-closed floor that keeps every
+ * posting. `source` is `"heuristic"` today and reserves room for a future
+ * semantic (WebLLM) upgrade, like #531's classifier.
+ */
+export interface RoleFilter {
+  /** Inferred role families, dominant first (usually 1–2). Empty ⇒ "all". */
+  families: RoleFamily[];
+  /** Flattened, deduped, lowercased substrings to match titles against. */
+  keywords: string[];
+  source: "heuristic";
+}
+
+/** How many dominant families `roleFilterForResume` keeps. */
+const MAX_FAMILIES = 2;
+
+/**
+ * Relative floor the runner-up family must clear to be kept alongside the
+ * winner: at least half the winner's score. Without it, `score > 0` alone
+ * admits any stray title — a career-switcher with eight backend titles and one
+ * early-career "UX Designer" would get `["backend", "design"]`, and design's
+ * very broad keywords ("designer", "user experience") then keep every Designer
+ * posting on every board: precisely the roles the candidate left.
+ */
+const RUNNER_UP_SHARE = 2;
+
+/** A sensible default per-company cap for callers (#533) that don't specify. */
+export const DEFAULT_PER_COMPANY_CAP = 15;
+
+/** Declaration-order index of a family, for the deterministic tie-break. */
+const FAMILY_ORDER: ReadonlyMap<RoleFamily, number> = new Map(
+  ROLE_FAMILIES.map((family, index) => [family, index]),
+);
+
+/**
+ * Collect the lowercased, non-empty TITLE strings the filter reads: every
+ * `experience[].title`, plus the standalone `headline` and `current_title`
+ * target-role signals when the parsed model carries them. Deliberately does NOT
+ * touch `skills` — that is the titles-not-skills invariant, enforced by
+ * omission.
+ */
+function collectTitles(parsed: HeuristicParsedResume): string[] {
+  const titles: string[] = [];
+  for (const exp of parsed.experience ?? []) {
+    if (exp.title) titles.push(exp.title.toLowerCase());
+  }
+  if (parsed.headline) titles.push(parsed.headline.toLowerCase());
+  if (parsed.current_title) titles.push(parsed.current_title.toLowerCase());
+  return titles;
+}
+
+/** Dedupe while preserving first-seen order (deterministic keyword list). */
+function dedupe(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+/**
+ * Derive the role filter from the parsed resume's TITLES (never its skills).
+ * Scores every family by how many title strings match one of its keywords,
+ * keeps the dominant family plus a runner-up that clears `RUNNER_UP_SHARE`
+ * (deterministic tie-break by taxonomy order),
+ * and flattens their keywords. A resume that matches no family yields the
+ * permissive "all" filter — never zero results.
+ */
+export function roleFilterForResume(parsed: HeuristicParsedResume): RoleFilter {
+  const titles = collectTitles(parsed);
+
+  const scored = ROLE_FAMILIES.map((family) => {
+    const keywords = ROLE_KEYWORDS[family];
+    const score = titles.reduce(
+      (count, title) =>
+        count + (keywords.some((kw) => title.includes(kw)) ? 1 : 0),
+      0,
+    );
+    return { family, score };
+  }).filter((entry) => entry.score > 0);
+
+  if (scored.length === 0) {
+    // Never fail closed: unrecognized/empty resume → permissive "all".
+    return { families: [], keywords: [], source: "heuristic" };
+  }
+
+  scored.sort(
+    (a, b) =>
+      b.score - a.score ||
+      (FAMILY_ORDER.get(a.family) ?? 0) - (FAMILY_ORDER.get(b.family) ?? 0),
+  );
+
+  const [winner, ...rest] = scored;
+  const families = [winner, ...rest.filter((e) => e.score * RUNNER_UP_SHARE >= winner.score)]
+    .slice(0, MAX_FAMILIES)
+    .map((entry) => entry.family);
+  const keywords = dedupe(families.flatMap((family) => [...ROLE_KEYWORDS[family]]));
+
+  return { families, keywords, source: "heuristic" };
+}
+
+/** Lowercased haystack a posting is matched against: title + any departments. */
+function postingHaystack(posting: JobPosting): string {
+  const departments = posting.departments ?? [];
+  return `${posting.title} ${departments.join(" ")}`.toLowerCase();
+}
+
+/**
+ * Keep a posting when any filter keyword is a case-insensitive substring of its
+ * title (or one of its departments). Input order is preserved. An "all" filter
+ * (empty keyword set) returns the input array UNCHANGED — the never-fail-closed
+ * floor — so the caller shows the whole (capped) board rather than nothing.
+ */
+export function filterPostingsByRole(
+  postings: JobPosting[],
+  filter: RoleFilter,
+): JobPosting[] {
+  if (filter.keywords.length === 0) return postings;
+  return postings.filter((posting) => {
+    const haystack = postingHaystack(posting);
+    return filter.keywords.some((kw) => haystack.includes(kw));
+  });
+}
+
+/**
+ * Bound the kept set to at most `limit` postings per company so hydration and
+ * ranking stay cheap. Preserves input order and keeps the first `limit`
+ * postings of each company (companies compared case-insensitively, trimmed).
+ * `limit <= 0` keeps none.
+ */
+export function capPerCompany(
+  postings: JobPosting[],
+  limit: number,
+): JobPosting[] {
+  if (limit <= 0) return [];
+  const counts = new Map<string, number>();
+  const kept: JobPosting[] = [];
+  for (const posting of postings) {
+    const key = posting.company.trim().toLowerCase();
+    const seen = counts.get(key) ?? 0;
+    if (seen >= limit) continue;
+    counts.set(key, seen + 1);
+    kept.push(posting);
+  }
+  return kept;
+}

--- a/src/lib/job-search/sector.test.ts
+++ b/src/lib/job-search/sector.test.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  classifySectorHeuristic,
+  SECTORS,
+  isSector,
+} from "./sector.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+
+// Minimal typed stub over the parsed model, like contact.test.ts — only the
+// fields sector.ts reads (skills + experience titles/companies).
+function makeParsed(
+  overrides: Partial<HeuristicParsedResume> = {},
+): HeuristicParsedResume {
+  return {
+    skills: [],
+    experience: [],
+    education: [],
+    ...overrides,
+  };
+}
+
+describe("classifySectorHeuristic", () => {
+  it("maps a clearly-fintech skill/title set to fintech", () => {
+    const parsed = makeParsed({
+      skills: ["Payments", "KYC", "Fraud Detection"],
+      experience: [
+        { title: "Senior Payments Engineer", company: "Stripe" },
+      ],
+    });
+    const guess = classifySectorHeuristic(parsed);
+    expect(guess.sector).toBe("fintech");
+    expect(guess.source).toBe("heuristic");
+    expect(guess.confidence).toBeGreaterThan(0);
+  });
+
+  it("maps a clearly-devtools skill/title set to devtools", () => {
+    const parsed = makeParsed({
+      skills: ["Kubernetes", "CI/CD", "SDK design"],
+      experience: [{ title: "Developer Experience Engineer", company: "Acme CLI" }],
+    });
+    const guess = classifySectorHeuristic(parsed);
+    expect(guess.sector).toBe("devtools");
+  });
+
+  it("maps a clearly-data-ml skill/title set to data-ml", () => {
+    const parsed = makeParsed({
+      skills: ["PyTorch", "Machine Learning", "MLOps"],
+      experience: [{ title: "ML Engineer", company: "Data Co" }],
+    });
+    const guess = classifySectorHeuristic(parsed);
+    expect(guess.sector).toBe("data-ml");
+  });
+
+  it("returns other with low confidence for an empty resume, never throws", () => {
+    const parsed = makeParsed();
+    expect(() => classifySectorHeuristic(parsed)).not.toThrow();
+    const guess = classifySectorHeuristic(parsed);
+    expect(guess.sector).toBe("other");
+    expect(guess.confidence).toBe(0);
+    expect(guess.runnerUp).toBeUndefined();
+  });
+
+  it("returns other with low confidence for a degenerate resume with unrelated words", () => {
+    const parsed = makeParsed({
+      skills: ["Communication", "Teamwork"],
+      experience: [{ title: "Generalist", company: "Somewhere Inc" }],
+    });
+    const guess = classifySectorHeuristic(parsed);
+    expect(guess.sector).toBe("other");
+    expect(guess.confidence).toBe(0);
+  });
+
+  it("populates runnerUp when two sectors both score above the floor", () => {
+    const parsed = makeParsed({
+      skills: ["Payments", "Kubernetes", "CI/CD"],
+      experience: [{ title: "Payments Platform / DevEx Engineer", company: "Acme" }],
+    });
+    const guess = classifySectorHeuristic(parsed);
+    expect(guess.runnerUp).toBeDefined();
+    expect(guess.runnerUp).not.toBe(guess.sector);
+  });
+
+  // Share-of-top-two alone gives a lone keyword hit confidence 1.0, because
+  // every sector is scored so the runner-up is 0. The evidence factor has to
+  // pull it below a well-evidenced multi-hit guess.
+  it("rates a single-hit guess below a well-evidenced one", () => {
+    const oneHit = classifySectorHeuristic(
+      makeParsed({
+        skills: ["React", "Route optimization"],
+        experience: [{ title: "Frontend Engineer", company: "Acme" }],
+      }),
+    );
+    const wellEvidenced = classifySectorHeuristic(
+      makeParsed({
+        skills: ["Data warehouse", "ETL", "Spark"],
+        experience: [{ title: "Data Engineer", company: "Acme" }],
+      }),
+    );
+    expect(oneHit.sector).toBe("logistics-mobility");
+    expect(wellEvidenced.sector).toBe("data-ml");
+    expect(oneHit.confidence).toBeLessThan(wellEvidenced.confidence);
+    expect(oneHit.confidence).toBeLessThan(1);
+  });
+
+  // Single tokens that live inside another family's phrase ("data warehouse",
+  // "Kafka streaming", "NFT marketplace") must not score their own family.
+  it("does not score a family off a token borrowed from another family's phrase", () => {
+    const guess = classifySectorHeuristic(
+      makeParsed({
+        skills: ["Data warehouse", "Kafka streaming", "ETL", "Spark"],
+        experience: [{ title: "Data Engineer", company: "Acme" }],
+      }),
+    );
+    expect(guess.sector).toBe("data-ml");
+    expect(guess.runnerUp).toBeUndefined();
+  });
+});
+
+describe("isSector", () => {
+  it("accepts every taxonomy value", () => {
+    for (const sector of SECTORS) {
+      expect(isSector(sector)).toBe(true);
+    }
+  });
+
+  it("rejects off-taxonomy strings and non-strings", () => {
+    expect(isSector("not-a-sector")).toBe(false);
+    expect(isSector(undefined)).toBe(false);
+    expect(isSector(42)).toBe(false);
+  });
+});
+
+describe("classifySector", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns the heuristic result unchanged when WebGPU is unavailable", async () => {
+    vi.doMock("../webllm/capability.ts", () => ({
+      detectWebGpu: vi.fn().mockResolvedValue("no-webgpu"),
+    }));
+    const { classifySector: classify } = await import("./sector.ts");
+
+    const parsed = makeParsed({
+      skills: ["Payments", "KYC"],
+      experience: [{ title: "Payments Engineer", company: "Stripe" }],
+    });
+    const guess = await classify(parsed);
+    expect(guess.source).toBe("heuristic");
+    expect(guess.sector).toBe("fintech");
+  });
+
+  it("falls back to heuristic when the semantic response is off-taxonomy", async () => {
+    vi.doMock("../webllm/capability.ts", () => ({
+      detectWebGpu: vi.fn().mockResolvedValue("available"),
+    }));
+    vi.doMock("../webllm/web-llm.ts", () => ({
+      loadEngine: vi.fn().mockResolvedValue({
+        chat: {
+          completions: {
+            create: vi.fn().mockResolvedValue({
+              choices: [{ message: { content: '{"sector": "not-a-real-sector"}' } }],
+            }),
+          },
+        },
+      }),
+      acquireInference: vi.fn(),
+      releaseInference: vi.fn(),
+    }));
+    vi.doMock("../webllm/models.ts", () => ({
+      DEFAULT_MODEL_ID: "test-model",
+    }));
+
+    const { classifySector: classify } = await import("./sector.ts");
+    const parsed = makeParsed({
+      skills: ["Payments", "KYC"],
+      experience: [{ title: "Payments Engineer", company: "Stripe" }],
+    });
+    const guess = await classify(parsed);
+    expect(guess.source).toBe("heuristic");
+    expect(guess.sector).toBe("fintech");
+  });
+
+  it("returns the semantic result when the engine gives a valid taxonomy value", async () => {
+    vi.doMock("../webllm/capability.ts", () => ({
+      detectWebGpu: vi.fn().mockResolvedValue("available"),
+    }));
+    vi.doMock("../webllm/web-llm.ts", () => ({
+      loadEngine: vi.fn().mockResolvedValue({
+        chat: {
+          completions: {
+            create: vi.fn().mockResolvedValue({
+              choices: [{ message: { content: '{"sector": "devtools"}' } }],
+            }),
+          },
+        },
+      }),
+      acquireInference: vi.fn(),
+      releaseInference: vi.fn(),
+    }));
+    vi.doMock("../webllm/models.ts", () => ({
+      DEFAULT_MODEL_ID: "test-model",
+    }));
+
+    const { classifySector: classify } = await import("./sector.ts");
+    const parsed = makeParsed({
+      skills: ["Payments"],
+      experience: [{ title: "Payments Engineer", company: "Stripe" }],
+    });
+    const guess = await classify(parsed);
+    expect(guess.source).toBe("semantic");
+    expect(guess.sector).toBe("devtools");
+  });
+
+  it("falls back to heuristic when the engine call throws", async () => {
+    vi.doMock("../webllm/capability.ts", () => ({
+      detectWebGpu: vi.fn().mockResolvedValue("available"),
+    }));
+    vi.doMock("../webllm/web-llm.ts", () => ({
+      loadEngine: vi.fn().mockRejectedValue(new Error("engine load failed")),
+      acquireInference: vi.fn(),
+      releaseInference: vi.fn(),
+    }));
+    vi.doMock("../webllm/models.ts", () => ({
+      DEFAULT_MODEL_ID: "test-model",
+    }));
+
+    const { classifySector: classify } = await import("./sector.ts");
+    const parsed = makeParsed({
+      skills: ["Payments"],
+      experience: [{ title: "Payments Engineer", company: "Stripe" }],
+    });
+    const guess = await classify(parsed);
+    expect(guess.source).toBe("heuristic");
+    expect(guess.sector).toBe("fintech");
+  });
+});

--- a/src/lib/job-search/sector.ts
+++ b/src/lib/job-search/sector.ts
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * sector.ts — classify a parsed resume into a company sector (#531, slice 3
+ * of the job-search-v2 epic #528).
+ *
+ * `Sector` is the SINGLE SOURCE OF TRUTH for "which companies" (fintech,
+ * devtools, healthtech, …) — distinct from #534's `RoleFamily`, which
+ * partitions roles WITHIN a board. Slice 4's company registry tags each
+ * company with a `Sector` drawn from this same list; slice 5 uses the guess
+ * to pick which registry companies to search.
+ *
+ * Fallback invariant: the heuristic path (`classifySectorHeuristic`) is pure,
+ * synchronous, and always answers — `"other"` is the floor, so classification
+ * never fails closed. The semantic path (`classifySector`) is a strict
+ * upgrade: it is only attempted when WebGPU capability detection says a
+ * model can run, and ANY failure — no WebGPU, model not ready, a throw, an
+ * off-taxonomy response — resolves to the heuristic guess unchanged. Mirrors
+ * the semantic-with-keyword-fallback shape `src/lib/jd-match/llm/run-llm-match.ts`
+ * uses for JD matching. WebLLM weights are dynamic-imported (the cascade-tier
+ * pattern) so they never enter the entry chunk.
+ *
+ * Classification is pure over the parsed resume model (`skills` +
+ * `experience[].title`/`company`) — no raw-PDF text, no network access.
+ */
+
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+
+/**
+ * Fixed sector taxonomy — ~12–16 entries chosen to partition the company
+ * registry (slice 4), not to be exhaustive. `"other"` is the always-valid
+ * fallback. Reused verbatim by the registry's sector tags — do not fork a
+ * second copy of this list.
+ */
+export const SECTORS = [
+  "fintech",
+  "devtools",
+  "data-ml",
+  "healthtech",
+  "ecommerce",
+  "gaming",
+  "security",
+  "enterprise-saas",
+  "consumer-social",
+  "hardware-iot",
+  "crypto-web3",
+  "edtech",
+  "logistics-mobility",
+  "media-adtech",
+  "government-defense",
+  "other",
+] as const;
+
+export type Sector = (typeof SECTORS)[number];
+
+const SECTOR_SET: ReadonlySet<string> = new Set(SECTORS);
+
+/** Type guard: is `value` one of the fixed `Sector` literals? */
+export function isSector(value: unknown): value is Sector {
+  return typeof value === "string" && SECTOR_SET.has(value);
+}
+
+export interface SectorGuess {
+  sector: Sector;
+  /** 0..1. Low/zero when the guess fell to the `"other"` floor. */
+  confidence: number;
+  source: "heuristic" | "semantic";
+  /** Second-best sector, when one cleared the floor alongside the winner —
+   *  feeds a "not fintech? try devtools" UI affordance in slice 5. */
+  runnerUp?: Sector;
+}
+
+/**
+ * Weighted keyword table: sector → patterns matched against a lowercased
+ * haystack of skills + experience titles (+ lightly, company names). A hit
+ * count below `HEURISTIC_FLOOR` falls to `"other"`.
+ *
+ * Patterns are phrases, not bare nouns, wherever the bare noun belongs to
+ * another family's vocabulary: "data warehouse" is data-ml, not logistics;
+ * "Kafka streaming" is data-ml, not media; "NFT marketplace" is crypto, not
+ * ecommerce. A single-token pattern that cross-matches like that fires on one
+ * unrelated skill and, with `HEURISTIC_FLOOR = 1`, decides the sector outright.
+ */
+const SECTOR_KEYWORDS: Readonly<Record<Exclude<Sector, "other">, RegExp[]>> = {
+  fintech: [
+    /\bpayments?\b/, /\bledger\b/, /\bkyc\b/, /\btrading\b/, /\bbanking\b/,
+    /\bfintech\b/, /\bpayment processing\b/, /\bwire transfer\b/,
+    /\bunderwriting\b/, /\bfraud detection\b/, /\bplaid\b/, /\bstripe\b/,
+  ],
+  devtools: [
+    /\bci\/cd\b/, /\bsdk\b/, /\bdeveloper experience\b/, /\bcompiler\b/,
+    /\bkubernetes\b/, /\bdevex\b/, /\bcli\b/, /\bbuild system\b/,
+    /\blinter\b/, /\bide\b/, /\bdeveloper tools?\b/, /\bapi platform\b/,
+  ],
+  "data-ml": [
+    /\bmachine learning\b/, /\bpytorch\b/, /\betl\b/, /\bspark\b/,
+    /\bllm\b/, /\bdata pipeline\b/, /\btensorflow\b/, /\bmlops\b/,
+    /\bfeature store\b/, /\bdata warehouse\b/, /\bdata science\b/,
+    /\bnlp\b/,
+  ],
+  healthtech: [
+    /\bhealthcare\b/, /\bclinical\b/, /\bhipaa\b/, /\behr\b/, /\bemr\b/,
+    /\bpatient\b/, /\btelehealth\b/, /\bpharma(?:ceutical)?\b/,
+    /\bmedical device\b/, /\bfhir\b/,
+  ],
+  ecommerce: [
+    /\becommerce\b/, /\be-commerce\b/, /\bcheckout\b/, /\bshopping cart\b/,
+    /\bmerchandising\b/, /\bshopify\b/, /\bfulfillment\b/,
+    /\b(?:online|retail|seller|consumer) marketplace\b/,
+    /\bmarketplace (?:platform|operations)\b/,
+    /\binventory management\b/,
+  ],
+  gaming: [
+    /\bgame (?:engine|design|development)\b/, /\bunity3d\b/, /\bunreal engine\b/,
+    /\bgameplay\b/, /\bmultiplayer\b/, /\besports\b/, /\bgame studio\b/,
+  ],
+  security: [
+    /\bcybersecurity\b/, /\bpenetration testing\b/, /\bthreat detection\b/,
+    /\bsoc 2\b/, /\bvulnerability\b/, /\bincident response\b/,
+    /\bzero trust\b/, /\biam\b/, /\bsiem\b/,
+  ],
+  "enterprise-saas": [
+    /\benterprise saas\b/, /\bb2b saas\b/, /\bcrm\b/, /\berp\b/,
+    /\bworkflow automation\b/, /\bsalesforce\b/, /\bhrms\b/, /\bsso\b/,
+  ],
+  "consumer-social": [
+    /\bsocial media\b/, /\bsocial network\b/, /\buser engagement\b/,
+    /\bconsumer app\b/, /\bcontent feed\b/, /\bcreator economy\b/,
+    /\bdating app\b/,
+  ],
+  "hardware-iot": [
+    /\biot\b/, /\bfirmware\b/, /\bembedded systems?\b/, /\brobotics\b/,
+    /\bpcb\b/, /\bsensors?\b/, /\bwearables?\b/, /\bhardware engineering\b/,
+  ],
+  "crypto-web3": [
+    /\bblockchain\b/, /\bweb3\b/, /\bcrypto(?:currency)?\b/,
+    /\bsmart contracts?\b/, /\bsolidity\b/, /\bdefi\b/, /\bnft\b/,
+  ],
+  edtech: [
+    /\bedtech\b/, /\be-?learning\b/, /\bcurriculum\b/, /\blms\b/,
+    /\bonline courses?\b/, /\bstudent engagement\b/,
+  ],
+  "logistics-mobility": [
+    /\blogistics\b/, /\bsupply chain\b/, /\bfleet management\b/,
+    /\bride-?sharing\b/, /\blast mile\b/, /\bfreight\b/,
+    /\bwarehouse (?:management|operations|automation)\b/,
+    /\broute optimization\b/,
+  ],
+  "media-adtech": [
+    /\badtech\b/, /\bad tech\b/, /\bprogrammatic advertising\b/,
+    /\bpublishing platform\b/, /\bmedia platform\b/,
+    /\b(?:video|live|music) streaming\b/, /\bstreaming (?:platform|service)s?\b/,
+    /\bad network\b/, /\bcontent monetization\b/,
+  ],
+  "government-defense": [
+    /\bgovernment contract\b/, /\bdefense\b/, /\bfedramp\b/, /\bdod\b/,
+    /\bpublic sector\b/, /\bclearance required\b/, /\bcivic tech\b/,
+    /\bmilitary\b/,
+  ],
+};
+
+/** Minimum weighted hit count a sector needs to beat the `"other"` floor. */
+const HEURISTIC_FLOOR = 1;
+
+/** Hit count at which the winner's evidence factor saturates at 1.0. Below it,
+ *  confidence is scaled down proportionally — see `classifySectorHeuristic`. */
+const CONFIDENT_HITS = 3;
+
+/** Declaration-order index of a sector, for the deterministic tie-break.
+ *  Mirrors `role-keywords.ts`'s `FAMILY_ORDER`. */
+const SECTOR_ORDER: ReadonlyMap<Exclude<Sector, "other">, number> = new Map(
+  (Object.keys(SECTOR_KEYWORDS) as Array<Exclude<Sector, "other">>).map(
+    (sector, index) => [sector, index],
+  ),
+);
+
+/** Build the lowercased haystack the heuristic scans: skills, experience
+ *  titles, and (lightly — same weight as titles) company names. */
+function buildHaystack(parsed: HeuristicParsedResume): string {
+  const parts: string[] = [];
+  if (parsed.skills && parsed.skills.length > 0) {
+    parts.push(parsed.skills.join(" "));
+  }
+  for (const exp of parsed.experience ?? []) {
+    if (exp.title) parts.push(exp.title);
+    if (exp.company) parts.push(exp.company);
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+/** Weighted hit count for one sector's keyword table over `haystack`. */
+function scoreSector(haystack: string, patterns: readonly RegExp[]): number {
+  let score = 0;
+  for (const pattern of patterns) {
+    if (pattern.test(haystack)) score += 1;
+  }
+  return score;
+}
+
+/**
+ * Heuristic classifier — always available, pure, synchronous. Scores every
+ * non-"other" sector by weighted keyword hit count over skills + titles (+
+ * lightly, company names), picks the top scorer, and falls to `"other"` when
+ * nothing clears `HEURISTIC_FLOOR`. `runnerUp` is set when a second sector
+ * also clears the floor.
+ */
+export function classifySectorHeuristic(
+  parsed: HeuristicParsedResume,
+): SectorGuess {
+  const haystack = buildHaystack(parsed);
+
+  const scored: Array<{ sector: Exclude<Sector, "other">; score: number }> =
+    (Object.keys(SECTOR_KEYWORDS) as Array<Exclude<Sector, "other">>).map(
+      (sector) => ({ sector, score: scoreSector(haystack, SECTOR_KEYWORDS[sector]) }),
+    );
+
+  // Deterministic tie-break: score desc, then taxonomy order (declaration
+  // order in SECTOR_KEYWORDS, which mirrors SECTORS) as an explicit secondary
+  // key — the ordering does not lean on Array.sort stability.
+  scored.sort(
+    (a, b) =>
+      b.score - a.score ||
+      (SECTOR_ORDER.get(a.sector) ?? 0) - (SECTOR_ORDER.get(b.sector) ?? 0),
+  );
+
+  const top = scored[0];
+  if (!top || top.score < HEURISTIC_FLOOR) {
+    return { sector: "other", confidence: 0, source: "heuristic" };
+  }
+
+  const runnerUpCandidate = scored[1];
+  const runnerUp =
+    runnerUpCandidate && runnerUpCandidate.score >= HEURISTIC_FLOOR
+      ? runnerUpCandidate.sector
+      : undefined;
+
+  // Confidence has two independent factors, and it needs both:
+  //   share    — top score's slice of the top-two total, so a near-tie reads
+  //              as low confidence.
+  //   evidence — how much absolute evidence the winner rests on, saturating
+  //              at CONFIDENT_HITS.
+  // Share alone inverts: every sector is scored, so a resume matching exactly
+  // one keyword has second === 0 and share === 1.0 — maximum confidence off a
+  // single hit — while a genuine 3-vs-2 match reads 0.6. Multiplying by the
+  // evidence factor makes confidence monotone in absolute evidence, so one
+  // stray hit lands at 1/CONFIDENT_HITS, below any well-evidenced guess.
+  const second = runnerUpCandidate?.score ?? 0;
+  const share = top.score / (top.score + second);
+  const evidence = Math.min(1, top.score / CONFIDENT_HITS);
+  const confidence = share * evidence;
+
+  return {
+    sector: top.sector,
+    confidence,
+    source: "heuristic",
+    ...(runnerUp ? { runnerUp } : {}),
+  };
+}
+
+const SECTOR_LIST_FOR_PROMPT = SECTORS.join(", ");
+
+const SEMANTIC_SYSTEM_PROMPT =
+  "You classify a resume's most likely target company sector for a job " +
+  "search. Respond with ONLY a JSON object of the shape " +
+  '{"sector": "<one value>"} where <one value> is EXACTLY one of: ' +
+  `${SECTOR_LIST_FOR_PROMPT}. If none clearly fit, use "other". No prose, ` +
+  "no markdown fences, no explanation.";
+
+function buildSemanticUserPrompt(parsed: HeuristicParsedResume): string {
+  const skills = (parsed.skills ?? []).join(", ");
+  const titles = (parsed.experience ?? [])
+    .map((exp) => [exp.title, exp.company].filter(Boolean).join(" @ "))
+    .filter(Boolean)
+    .join("; ");
+  return `Skills: ${skills || "(none)"}\nRoles: ${titles || "(none)"}`;
+}
+
+/** Headroom for a single short JSON object response. */
+const SEMANTIC_MAX_TOKENS = 64;
+
+/**
+ * Semantic upgrade over `classifySectorHeuristic`. Gates on WebGPU
+ * capability (`src/lib/webllm/capability.ts`); on `"no-webgpu"` /
+ * `"unsupported-os"` it returns the heuristic guess immediately without
+ * touching WebLLM. When a model is available, dynamic-imports the engine
+ * loader, asks it to pick one taxonomy value, and validates the response
+ * against `SECTORS` — anything off-enum, unparseable, or a thrown/timed-out
+ * engine call falls back to the heuristic guess unchanged. Never rejects.
+ */
+export async function classifySector(
+  parsed: HeuristicParsedResume,
+): Promise<SectorGuess> {
+  const heuristic = classifySectorHeuristic(parsed);
+
+  try {
+    const { detectWebGpu } = await import("../webllm/capability.ts");
+    const capability = await detectWebGpu();
+    if (capability !== "available") return heuristic;
+
+    const [
+      { loadEngine, acquireInference, releaseInference },
+      { DEFAULT_MODEL_ID },
+      { tryParseJsonObject },
+    ] = await Promise.all([
+      import("../webllm/web-llm.ts"),
+      import("../webllm/models.ts"),
+      import("../webllm/json-repair.ts"),
+    ]);
+
+    acquireInference(DEFAULT_MODEL_ID);
+    try {
+      const engine = await loadEngine(DEFAULT_MODEL_ID, () => {});
+      const response = await engine.chat.completions.create({
+        messages: [
+          { role: "system", content: SEMANTIC_SYSTEM_PROMPT },
+          { role: "user", content: buildSemanticUserPrompt(parsed) },
+        ],
+        temperature: 0,
+        max_tokens: SEMANTIC_MAX_TOKENS,
+      });
+      const content = response.choices[0]?.message?.content ?? "";
+      const outcome = tryParseJsonObject(content);
+      if (!outcome.ok || typeof outcome.value !== "object" || outcome.value === null) {
+        return heuristic;
+      }
+      const candidate = (outcome.value as Record<string, unknown>)["sector"];
+      if (!isSector(candidate)) return heuristic;
+
+      return {
+        sector: candidate,
+        confidence: 1,
+        source: "semantic",
+        ...(heuristic.sector !== candidate ? { runnerUp: heuristic.sector } : {}),
+      };
+    } finally {
+      releaseInference(DEFAULT_MODEL_ID);
+    }
+  } catch (err) {
+    console.warn(
+      "[sector] semantic classification failed; falling back to heuristic:",
+      err,
+    );
+    return heuristic;
+  }
+}

--- a/src/lib/job-search/types.ts
+++ b/src/lib/job-search/types.ts
@@ -36,6 +36,10 @@ export interface JobPosting {
   /** Provider display name, shown on the card to reinforce the honest-sample
    *  framing ("Remotive"). */
   source: string;
+  /** Department/team names, when the provider's feed carries them (e.g. a
+   *  Greenhouse board's `departments[].name`). Optional — most keyless feeds
+   *  don't have this axis. Consumed by the #534 title/board-size filter. */
+  departments?: string[];
 }
 
 /** One keyless job feed, adapted to the normalized shape. */


### PR DESCRIPTION
## Summary

Build the client-side foundation for **company-targeted ATS-board search** (epic #528, the follow-on to the closed job-search epic #317): keyless per-company board adapters (Greenhouse/Lever/Ashby), a sector classifier, a curated sector→company→slug registry, and a role-title filter/cap layer.

Everything here is built and unit-tested but **deliberately not wired into the live `getProviders()` seam** — that integration is **#533**, held until this keyword/cap layer exists so a whole-board fetch is filtered and bounded before it ever reaches the UI (the deliberate build-everything-then-connect order from #528).

**Privacy:** all egress stays the public company slug only; no resume-derived data leaves the browser. `keywords.ts` remains the sole resume-derived egress helper, unused by these adapters and the role filter.

Refs #528

## What's in this PR (5 slices)

| Slice | Module | What |
|---|---|---|
| #529 | `providers/greenhouse.ts` (+test) | `makeGreenhouseProvider(slug, companyName?)` — light-index fetch (no `?content=true`), lazy `hydrateGreenhouse` per surviving job |
| #529 | `types.ts` | add optional `JobPosting.departments?` — the shared field the role filter reads |
| #530 | `providers/lever.ts`, `providers/ashby.ts` (+tests) | same `JobProvider` contract; Lever top-level array `?mode=json&limit=100`, Ashby `{jobs:[]}` `?includeCompensation=false`; both prefer `descriptionPlain` |
| #531 | `sector.ts` (+test) | heuristic sector classifier over parsed titles/skills, WebGPU-gated WebLLM semantic upgrade; 16-family taxonomy |
| #532 | `company-registry.ts` (+test) | curated sector-tagged company→ATS→slug map (162 entries), `companiesForSector(sector, limit)`; slugs **not yet CORS-verified** (flagged in docblock) |
| #534 | `role-keywords.ts` (+test) | curated role→title-synonym taxonomy, `roleFilterForResume`, `filterPostingsByRole`, `capPerCompany`; titles-not-skills, never-fail-closed, zero-egress |

## Review round 2 (@Samhit21) — four fixes, all in code

Each only bites once a wrong or thin input reaches the layer, which is exactly the path #532's unverified slugs make ordinary:

- **id-less postings collided.** All three adapters used a bare `job.id ?? ""`, dropping the url fallback `remotive.ts`/`jobicy.ts` added for this reason. Two id-less postings both keyed `greenhouse:acme:` → duplicate React keys and a silent dedup collapse. Now `job.id ?? job.absolute_url` / `hostedUrl` / `jobUrl`, with a test per adapter.
- **Lever's `(data ?? [])` didn't guard a non-array.** Lever is the one adapter whose success shape is a bare top-level array, so a 200 with an object error envelope landed on `.map`. Now `Array.isArray`; the test that claimed to cover this mocked `null` (which `??` already handles) and is split into a `null` case and a real `{}` case.
- **Sector confidence was inverted.** Share-of-top-two alone gave a lone keyword hit `confidence 1.0` (every sector is scored, so second is 0), while a genuine 3-vs-2 match read 0.6. Confidence is now `share × min(1, top/3)` — monotone in absolute evidence. The generic single tokens that cross-matched other families' phrases (`routing`, `warehouse`, `streaming`, `marketplace`) become phrase patterns, so "data warehouse" no longer scores logistics and "Kafka streaming" no longer scores media.
- **Role filter kept an arbitrarily-far-behind runner-up.** `score > 0` was the only gate, so one early-career "UX Designer" rode alongside eight backend titles and design's broad keywords ("designer", "user experience") kept every Designer posting on every board. The runner-up now needs at least half the winner's score; an 8-vs-1 test covers the lopsided split the existing 2-1-1 case never exercised.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run src/lib/job-search` — 113/113 green (7 new)
- [x] `npm run test` — 2592 passed | 9 skipped
- [x] `npm run lint` clean
- [x] `npm run verify` — full CI mirror runs green on this PR
- [x] **CORS verification (human/dev, before #533 ships):** confirm each vendor endpoint returns a permissive `access-control-allow-origin` from a real browser origin against ≥2 real slugs; drop any board that fails. A headless run cannot prove browser CORS — this stays an explicit unchecked task carried into #533.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #529 | Claude Sonnet 5 | high |
| Implementation — #530 | Claude Sonnet 5 | high |
| Implementation — #531 | Claude Sonnet 5 | high |
| Implementation — #532 | Claude Sonnet 5 | medium |
| Implementation — #534 | Claude Opus 4.8 (1M context) | ultra |
| Adversarial review | Claude Sonnet 5 | high |
| Review fixes — adversarial round 1 | (none — clean, zero blocking) | — |
| Review revisions — human round 2 | Claude Opus 4.8 (1M context) | medium |
| Orchestration + PR | Claude Opus 4.8 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |

## Adversarial review

Round 1 — **clean** (`clean: true`), zero blocking findings. Converged in one round; no fix subagent needed. Reviewer: Claude Sonnet 5 (high).

Four nits, all investigated, all no-action:

- **Adapter `mapJob`/post-filter duplication** across greenhouse/lever/ashby (fallow `dup:93eac9e2` ×3) — established house pattern (existing `remotive`/`arbeitnow`/`jobicy` adapters already use one-mapJob-per-vendor), per-vendor divergence is deliberate, not a shared-helper candidate.
- **`sector.test.ts` clone groups** — standard per-case mock/fixture boilerplate; not a divergence bug.
- **Static `htmlToPlaintext` import** in the adapters — heads-up for #533 lazy-load wiring only; correct as-is for a pure lib module.
- **Lever/Ashby "slice 2 of 5" docblock label** — cosmetic, and actually correct.

