### PR TITLE
feat(edit): confirm what an applied rewrite changed, make it undoable, and name controls by content (#511)

### DIFF
--- a/src/components/features/ApplyConfirmation.test.tsx
+++ b/src/components/features/ApplyConfirmation.test.tsx
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Direct tests for the apply-confirmation strip (issues 508 and 510). Until
+ * now it was only exercised through its two callers, which is how a batch of
+ * defects reached review: the strip announced a count its callers had already
+ * inflated, and rendered a dangling em dash for an empty section list. Those
+ * are properties of THIS component's contract — what it announces, for how
+ * long, and what a screen reader hears — so they are pinned here rather than
+ * re-derived at each callsite.
+ *
+ * jsdom via the pragma, raw `createRoot` + `act`, matching the sibling
+ * `ResumeRewriteProposed.test.tsx`. Timers are faked because the whole point
+ * of the strip is that it holds for a bounded window and then collapses.
+ */
+
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import {
+  ApplyConfirmation,
+  UndoBatchButton,
+  UNDO_HOLD_MS,
+} from "./ApplyConfirmation.tsx";
+
+/** The strip's own default hold, asserted rather than imported — it is
+ *  deliberately not exported, and a silent change to it is a behaviour change. */
+const DEFAULT_HOLD_MS = 3000;
+/** The collapse animation the strip waits out before calling `onCollapse`. */
+const EXIT_MS = 150;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function render(node: React.ReactNode): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(node);
+  });
+  return container;
+}
+
+/** Advance past the enter frame so `visible` has flipped. */
+function settle() {
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+function strip(el: HTMLDivElement): HTMLElement {
+  const node = el.querySelector('[role="status"]');
+  expect(node).not.toBeNull();
+  return node as HTMLElement;
+}
+
+/** What a screen reader reads: the live region minus anything aria-hidden. */
+function announced(el: HTMLDivElement): string {
+  const clone = strip(el).cloneNode(true) as HTMLElement;
+  clone.querySelectorAll("[aria-hidden]").forEach((n) => n.remove());
+  return clone.textContent ?? "";
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+  vi.useRealTimers();
+});
+
+describe("ApplyConfirmation — what it announces", () => {
+  it("names the count and the sections touched", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 2,
+        sections: ["Senior Engineer — Acme", "Staff Engineer — Globex"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).textContent).toContain(
+      "Applied 2 changes — Senior Engineer — Acme, Staff Engineer — Globex",
+    );
+  });
+
+  it("says 'change' not 'changes' for a single write", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).textContent).toContain("Applied 1 change —");
+    expect(strip(el).textContent).not.toContain("1 changes");
+  });
+
+  it("renders no dangling em dash when no section is named", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: [],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).textContent).toContain("Applied 1 change");
+    expect(strip(el).textContent).not.toMatch(/—\s*$/);
+  });
+
+  it("treats a blank label as naming nothing, not as a section", () => {
+    // The guard keys off content, not array length: [""] has length 1 but
+    // names nothing, and would otherwise render "Applied 1 change — ".
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["", "   "],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).textContent).not.toMatch(/—\s*$/);
+  });
+
+  it("drops blank labels but keeps the real ones", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 2,
+        sections: ["", "Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).textContent).toContain(
+      "Applied 2 changes — Senior Engineer — Acme",
+    );
+  });
+
+  it("acknowledges the reverse trip with the same strip", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 2,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+        verb: "Reverted",
+      }),
+    );
+    settle();
+    expect(strip(el).textContent).toContain(
+      "Reverted 2 changes — Senior Engineer — Acme",
+    );
+    expect(strip(el).textContent).not.toContain("Applied");
+  });
+});
+
+describe("ApplyConfirmation — accessibility", () => {
+  it("is a polite live region", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("announces the verb exactly once — the badge repeats it visually only", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 2,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    // The badge carries the word too, but aria-hidden, so the reader does not
+    // hear "AppliedApplied 2 changes".
+    expect(announced(el).match(/Applied/g)).toHaveLength(1);
+    // Meaning is still not carried by colour alone: the word is in the line.
+    expect(announced(el)).toContain("Applied 2 changes");
+  });
+
+  it("keeps the animation opt-out on the strip", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(strip(el).className).toContain("motion-reduce:transition-none");
+    expect(strip(el).className).toContain("motion-reduce:duration-0");
+  });
+});
+
+describe("ApplyConfirmation — timing", () => {
+  it("holds ~3s, then collapses and hands control back", () => {
+    const onCollapse = vi.fn();
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse,
+      }),
+    );
+    settle();
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_HOLD_MS - 100);
+    });
+    expect(onCollapse).not.toHaveBeenCalled();
+    expect(strip(el).className).not.toContain("grid-rows-[0fr]");
+
+    // Hold elapses: the strip starts collapsing but has not yet handed back.
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(strip(el).className).toContain("grid-rows-[0fr]");
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_MS);
+    });
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds longer when the caller asks for the undo window", () => {
+    const onCollapse = vi.fn();
+    render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse,
+        holdMs: UNDO_HOLD_MS,
+        action: createElement(UndoBatchButton, { onUndo: vi.fn() }),
+      }),
+    );
+    settle();
+
+    // An undo the user cannot reach is not a recovery path: at the default
+    // hold the strip is still up and still undoable.
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_HOLD_MS + EXIT_MS);
+    });
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    // The exit timer is only scheduled once the hold's state update commits,
+    // so it has to be advanced in its own act — same as the default-hold case.
+    act(() => {
+      vi.advanceTimersByTime(UNDO_HOLD_MS - DEFAULT_HOLD_MS);
+    });
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_MS);
+    });
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onCollapse after unmount", () => {
+    const onCollapse = vi.fn();
+    render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse,
+      }),
+    );
+    settle();
+    act(() => {
+      root?.unmount();
+    });
+    root = null;
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_HOLD_MS + EXIT_MS);
+    });
+    expect(onCollapse).not.toHaveBeenCalled();
+  });
+});
+
+describe("ApplyConfirmation — the action slot", () => {
+  it("renders the undo control the caller passes", () => {
+    const onUndo = vi.fn();
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+        action: createElement(UndoBatchButton, { onUndo }),
+      }),
+    );
+    settle();
+
+    const undo = [...el.querySelectorAll("button")].find(
+      (b) => b.textContent === "Undo",
+    ) as HTMLButtonElement;
+    expect(undo).toBeDefined();
+    // Named for the résumé, not just "Undo" — the strip is one of several
+    // live regions on the page.
+    expect(undo.getAttribute("aria-label")).toBe(
+      "Undo the changes just applied to the résumé",
+    );
+
+    act(() => {
+      undo.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no control when the batch is not reversible", () => {
+    const el = render(
+      createElement(ApplyConfirmation, {
+        count: 1,
+        sections: ["Senior Engineer — Acme"],
+        onCollapse: vi.fn(),
+      }),
+    );
+    settle();
+    expect(el.querySelectorAll("button")).toHaveLength(0);
+  });
+});

--- a/src/components/features/ApplyConfirmation.tsx
+++ b/src/components/features/ApplyConfirmation.tsx
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ApplyConfirmation — the in-place "Applied ✓" state shown once a rewrite
+ * Apply commits its writes (issue #508). Before this, `onApply` wrote the
+ * accepted changes and unconditionally dismissed the whole review panel in
+ * the same tick — the only signal anything happened was the panel
+ * disappearing. Shared by both apply surfaces so they show identical
+ * copy/timing/motion:
+ *   - `SectionRewrite.tsx` (per-role review) renders it for its "applied"
+ *     status.
+ *   - `ResumeRewrite.tsx` renders it for the whole-résumé review's
+ *     "applied" status (writes land in the sibling `ResumeRewriteProposed.tsx`).
+ *
+ * No new toast/snackbar primitive — see CLAUDE.md's reuse rule and #508's
+ * Notes on why not. This renders inside the caller's already-mounted
+ * `InlineResult`, using `StatusBadge` from the `@design-system` barrel; the
+ * word "Applied" always appears in the text, so meaning is never carried by
+ * colour alone.
+ *
+ * Owns its own timing: fades in over ENTER_MS, holds for HOLD_MS, then
+ * collapses (grid-rows + opacity) over EXIT_MS and calls `onCollapse` so the
+ * caller can drop its status back to idle. Gated on `prefers-reduced-motion`
+ * via `motion-reduce:` (the same duration-zeroing idiom the Button primitive
+ * uses) — the hold/collapse still happen on schedule, only the animation is
+ * skipped.
+ *
+ * `action` is the slot #510's Undo control mounts in, and `holdMs` is why the
+ * strip can outlive its default 3s: an Undo the user cannot reach is not a
+ * recovery path, so a confirmation that HOSTS an undo holds for
+ * {@link UNDO_HOLD_MS} instead. A confirmation with no `action` still holds for
+ * {@link HOLD_MS} — #508's timing is unchanged for the no-undo case.
+ *
+ * `verb` lets the same strip acknowledge the reverse trip ("Reverted N changes
+ * — …") without a second component or a toast primitive.
+ */
+
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Button, StatusBadge } from "@design-system";
+
+// Hold ~3s before collapsing (#508's acceptance criteria). The enter (200ms,
+// `duration-200` below) and exit (EXIT_MS, `duration-150` below) both sit
+// inside the 150-300ms band, exit shorter than enter — keep those Tailwind
+// classes and this constant in sync if either changes.
+const HOLD_MS = 3000;
+const EXIT_MS = 150;
+
+/** Hold for a confirmation that hosts an Undo (issue 510). Long enough to
+ *  read the line, decide, and click — 3s is not. Still bounded, so the strip
+ *  never becomes permanent page furniture. */
+export const UNDO_HOLD_MS = 12000;
+
+export function ApplyConfirmation({
+  count,
+  sections,
+  onCollapse,
+  action,
+  holdMs = HOLD_MS,
+  verb = "Applied",
+}: {
+  count: number;
+  sections: readonly string[];
+  onCollapse: () => void;
+  action?: ReactNode;
+  /** Milliseconds to hold before collapsing. Defaults to {@link HOLD_MS}. */
+  holdMs?: number;
+  /** Past-tense verb for the badge and the line. */
+  verb?: string;
+}) {
+  const [visible, setVisible] = useState(false);
+  const [collapsing, setCollapsing] = useState(false);
+
+  // A section whose label is blank names nothing, so it must not open the
+  // "— …" clause. `roleLabel` never returns "" today, which is exactly why the
+  // guard has to key off content rather than length — a caller that grows a
+  // blank label would otherwise re-open the dangling-em-dash hole.
+  const named = sections.filter((section) => section.trim().length > 0);
+
+  useEffect(() => {
+    // Flip to visible on the next frame — otherwise the initial opacity-0
+    // paint and this update coalesce into one and the enter never plays.
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  useEffect(() => {
+    const holdTimer = setTimeout(() => setCollapsing(true), holdMs);
+    return () => clearTimeout(holdTimer);
+  }, [holdMs]);
+
+  useEffect(() => {
+    if (!collapsing) return;
+    const exitTimer = setTimeout(onCollapse, EXIT_MS);
+    return () => clearTimeout(exitTimer);
+  }, [collapsing, onCollapse]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`grid transition-[grid-template-rows,opacity] motion-reduce:transition-none motion-reduce:duration-0 ${
+        collapsing
+          ? "grid-rows-[0fr] opacity-0 duration-150"
+          : `grid-rows-[1fr] duration-200 ${visible ? "opacity-100" : "opacity-0"}`
+      }`}
+    >
+      <div className="flex min-h-0 flex-wrap items-center gap-2 overflow-hidden">
+        {/* aria-hidden: the badge repeats the verb that already opens the
+            line, so a screen reader would announce it twice with no space
+            ("AppliedApplied 2 changes"). Meaning is still not carried by
+            colour alone — the word itself is in the visible line. */}
+        <StatusBadge tone="ok" aria-hidden>
+          {verb}
+        </StatusBadge>
+        <span className="text-[11px] text-content-secondary">
+          {verb} {count} change{count === 1 ? "" : "s"}
+          {/* No trailing "— " when nothing was named; an empty list left a
+              dangling em dash. */}
+          {named.length > 0 && ` — ${named.join(", ")}`}
+        </span>
+        {action}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The Undo control both apply surfaces mount in the confirmation's `action`
+ * slot (issue 510). One component so the per-role and whole-résumé paths offer
+ * the same word, the same affordance, and the same label — an undo the user
+ * has to re-learn per surface is not a recovery path.
+ */
+export function UndoBatchButton({ onUndo }: { onUndo: () => void }) {
+  return (
+    <Button
+      variant="link"
+      size="sm"
+      onClick={onUndo}
+      className="text-[11px] font-medium text-content-secondary"
+      aria-label="Undo the changes just applied to the résumé"
+    >
+      Undo
+    </Button>
+  );
+}

--- a/src/components/features/ModelSelector.tsx
+++ b/src/components/features/ModelSelector.tsx
@@ -338,7 +338,7 @@ export function ModelSelector() {
                 onClick={onDownloadAhead}
                 className="text-xs"
               >
-                Download now · ~{(selectedModel.downloadSizeMb / 1024).toFixed(1)}{" "}
+                Download model · ~{(selectedModel.downloadSizeMb / 1024).toFixed(1)}{" "}
                 GB
               </Button>
             )}

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -40,6 +40,7 @@ import type {
 import {
   groupBulletsByExperience,
   needsAttention,
+  roleLabel,
   suppressTitleOwnedBullets,
   toBulletExperience,
 } from "../../lib/score/group-bullets.ts";
@@ -77,6 +78,10 @@ import type {
   AchievementFieldOverrides,
 } from "../../hooks/useEditableParse.ts";
 import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
+import {
+  batchUndoTargets,
+  type BulletUndoTargets,
+} from "../../lib/rewrite-review/undo-batch.ts";
 import {
   AddPill,
   RemoveButton,
@@ -398,6 +403,7 @@ function ExperienceSection({
   onRemoveEntry,
   onEntryField,
   onAddBullet,
+  captureBulletUndo,
   onPruneEmpty,
 }: {
   /** Verbatim source heading (#285); falls back to "Experience" when absent. */
@@ -432,6 +438,9 @@ function ExperienceSection({
   onRemoveEntry: (id: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
   onAddBullet: (entryKey: string, text: string) => void;
+  /** Snapshot the slots a rewrite batch will write, for a one-action undo of
+   *  the whole batch (issue 510). */
+  captureBulletUndo: (targets: BulletUndoTargets) => () => void;
   /** Drop a blank added entry when focus leaves the section (#379). */
   onPruneEmpty: () => void;
 }) {
@@ -462,10 +471,22 @@ function ExperienceSection({
         onReplace: (obsIndex, text) => onBulletChange(obsIndex, text),
         onRemove: (obsIndex) => onRemoveBullet(obsIndex),
         onAdd: (text) => onAddBullet(entryKey, text),
+        // Adds land in THIS role's bucket, so the entry key the snapshot
+        // records is the same one `onAdd` writes to (issue 510).
+        captureUndo: (writes) =>
+          captureBulletUndo(batchUndoTargets(writes, entryKey)),
       });
     }
     return map;
-  }, [groups, originalCount, addedExperience, onBulletChange, onRemoveBullet, onAddBullet]);
+  }, [
+    groups,
+    originalCount,
+    addedExperience,
+    onBulletChange,
+    onRemoveBullet,
+    onAddBullet,
+    captureBulletUndo,
+  ]);
   // The whole-résumé rewrite CTA (#67) lives at the top of Experience next to
   // the picker. Trigger + panel render only when WebGPU is available AND
   // there's at least one rewriteable section — same silent-absence rule as
@@ -541,6 +562,14 @@ function ExperienceSection({
                   onAddBullet(
                     added ? added.id : parsedEntryKey("experience", idx),
                     text,
+                  )
+                }
+                captureUndo={(writes) =>
+                  captureBulletUndo(
+                    batchUndoTargets(
+                      writes,
+                      added ? added.id : parsedEntryKey("experience", idx),
+                    ),
                   )
                 }
                 onRemove={added ? () => onRemoveEntry(added.id) : undefined}
@@ -950,14 +979,11 @@ export function buildResumeSections(
   return out;
 }
 
-export function roleLabel(exp: BulletGroup["experience"]): string {
-  if (exp === null) return "Other bullets";
-  const { title, company } = exp;
-  if (title && company) return `${title} — ${company}`;
-  if (title) return title;
-  if (company) return company;
-  return "Untitled role";
-}
+// `roleLabel` now lives in group-bullets.ts (#508 — the per-role
+// SectionRewrite apply-confirmation copy needed the same label without a
+// circular import back into this file). Re-exported so the existing public
+// surface (and ReconstructedResume.test.ts's import) is unchanged.
+export { roleLabel };
 
 // ── Container ─────────────────────────────────────────────────────────────────
 
@@ -1014,6 +1040,7 @@ export function ReconstructedResume({
     pruneEmptyAddedEntries,
     setEntryField,
     addBullet,
+    captureBulletUndo,
     addSkill,
     removeSkill,
     profileOverrides,
@@ -1175,7 +1202,7 @@ export function ReconstructedResume({
               disabled={isGenerating}
               aria-label="Download the reconstructed resume as an ATS-friendly PDF"
             >
-              {isGenerating ? "Generating…" : "Download PDF"}
+              {isGenerating ? "Generating…" : "Download resume"}
             </Button>
           </div>
         </div>
@@ -1231,6 +1258,7 @@ export function ReconstructedResume({
         onRemoveEntry={removeEntry}
         onEntryField={setEntryField}
         onAddBullet={addBullet}
+        captureBulletUndo={captureBulletUndo}
       />
       <ProjectsSection
         heading={display.sectionHeadings?.get("projects")}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
-import { needsAttention } from "../../lib/score/group-bullets.ts";
+import { needsAttention, roleLabel } from "../../lib/score/group-bullets.ts";
 import type { BulletObservation } from "../../lib/score/score.ts";
 import { EditableField } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
@@ -492,6 +492,9 @@ interface RoleEntryProps {
    *  alongside onBulletChange + onAddBullet — to wire the section-rewrite
    *  per-bullet Apply (accept/reject/edit writes back here). */
   onRemoveBullet?: (index: number) => void;
+  /** Snapshot the slots a rewrite batch will write, so the whole batch can be
+   *  reversed in one action (issue 510). Omitted → no Undo is offered. */
+  captureUndo?: SectionRewriteApply["captureUndo"];
   /** Remove this role (only set for user-ADDED roles). Renders an X control in
    *  the header row when provided. */
   onRemove?: () => void;
@@ -510,6 +513,7 @@ export function RoleEntry({
   onBulletChange,
   onAddBullet,
   onRemoveBullet,
+  captureUndo,
   onRemove,
 }: RoleEntryProps) {
   // Bullet display text honors #82 overrides — section rewrite must see the
@@ -530,14 +534,16 @@ export function RoleEntry({
       onReplace: (index, text) => onBulletChange(index, text),
       onRemove: (index) => onRemoveBullet(index),
       onAdd: (text) => onAddBullet(text),
+      captureUndo,
     };
     // obsIndices identity churns each render; key on its stable string form.
-  }, [obsIndicesKey, onBulletChange, onAddBullet, onRemoveBullet]);
+  }, [obsIndicesKey, onBulletChange, onAddBullet, onRemoveBullet, captureUndo]);
   // The "Rewrite section" trigger sits on the header row (right of the title);
   // its result panel renders full-width below the bullet list.
   const { trigger: rewriteTrigger, panel: rewritePanel } = useSectionRewrite(
     sectionBullets,
     rewriteApply,
+    roleLabel(group.experience),
   );
   return (
     <div className="flex flex-col gap-1.5">

--- a/src/components/features/ResultDetailTabs.test.tsx
+++ b/src/components/features/ResultDetailTabs.test.tsx
@@ -113,7 +113,7 @@ describe("ResultDetailTabs", () => {
     expect(el.textContent).toContain("Reconstructed resume");
     expect(el.textContent).toContain("Find jobs");
     expect(el.textContent).toContain("Source & diagnostics");
-    expect(el.textContent).not.toContain("Resume Quality");
+    expect(el.textContent).not.toContain("Resume quality");
   });
 
   it("mounts the single Resume Quality tab (2nd position) when analysis is available", () => {
@@ -129,7 +129,7 @@ describe("ResultDetailTabs", () => {
     expect(labels).toHaveLength(4);
     expect(labels[0]).toContain("Reconstructed resume");
     expect(labels[1]).toContain("Find jobs");
-    expect(labels[2]).toContain("Resume Quality");
+    expect(labels[2]).toContain("Resume quality");
     expect(labels[3]).toContain("Source & diagnostics");
   });
 
@@ -178,7 +178,7 @@ describe("ResultDetailTabs", () => {
       "Senior engineer with a track record of shipping.",
     );
     const qualityTab = Array.from(el.querySelectorAll('[role="tab"]')).find((t) =>
-      (t.textContent ?? "").includes("Resume Quality"),
+      (t.textContent ?? "").includes("Resume quality"),
     );
     expect(qualityTab).toBeDefined();
     // Warn marker is announced, not colour-only.

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -70,14 +70,36 @@ export function ResultDetailTabs({
             is promoted to this parent tab so the warning count stays visible
             without opening it. */}
         <TabList aria-label="Parsed result views">
-          <Tab id="reconstructed">Reconstructed resume</Tab>
-          <Tab id="find-jobs">Find jobs</Tab>
+          <Tab
+            id="reconstructed"
+            description="what a parser pulled out — edit it here"
+          >
+            Reconstructed resume
+          </Tab>
+          <Tab
+            id="find-jobs"
+            description="search job boards, ranked by fit to this résumé"
+          >
+            Find jobs
+          </Tab>
           {showQualityTab && (
-            <Tab id="quality" warn={!analysis.isAvailable}>
-              Resume Quality
+            <Tab
+              id="quality"
+              warn={!analysis.isAvailable}
+              description={
+                analysis.isAvailable
+                  ? "on-device critique and rewrites"
+                  : "on-device critique — needs browser support"
+              }
+            >
+              Resume quality
             </Tab>
           )}
-          <Tab id="diagnostics" count={triggerCount}>
+          <Tab
+            id="diagnostics"
+            count={triggerCount}
+            description="raw text, layout flags, what went wrong"
+          >
             Source &amp; diagnostics
           </Tab>
         </TabList>

--- a/src/components/features/ResumeRewrite.test.ts
+++ b/src/components/features/ResumeRewrite.test.ts
@@ -205,14 +205,24 @@ describe("StepIndicator", () => {
 describe("ResumeRewritePanel", () => {
   it("renders nothing for the idle status", () => {
     const html = renderToStaticMarkup(
-      createElement(ResumeRewritePanel, { status: idle, onDismiss: () => {} }),
+      createElement(ResumeRewritePanel, {
+        status: idle,
+        onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
+      }),
     );
     expect(html).toBe("");
   });
 
   it("renders the model-load progress bar in the loading status", () => {
     const html = renderToStaticMarkup(
-      createElement(ResumeRewritePanel, { status: loading, onDismiss: () => {} }),
+      createElement(ResumeRewritePanel, {
+        status: loading,
+        onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
+      }),
     );
     expect(html).toContain("Loading the rewrite model");
     expect(html).toContain('role="progressbar"');
@@ -220,7 +230,12 @@ describe("ResumeRewritePanel", () => {
 
   it("renders the error message in the error status", () => {
     const html = renderToStaticMarkup(
-      createElement(ResumeRewritePanel, { status: errored, onDismiss: () => {} }),
+      createElement(ResumeRewritePanel, {
+        status: errored,
+        onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
+      }),
     );
     expect(html).toContain("Engine failed to load");
     expect(html).toContain('role="alert"');
@@ -231,6 +246,8 @@ describe("ResumeRewritePanel", () => {
       createElement(ResumeRewritePanel, {
         status: running,
         onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
       }),
     );
     expect(html).toContain("Rewriting 2 of 3");
@@ -254,6 +271,8 @@ describe("ResumeRewritePanel", () => {
       createElement(ResumeRewritePanel, {
         status: finishing,
         onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
       }),
     );
     expect(html).toContain("Finishing…");
@@ -272,7 +291,12 @@ describe("ResumeRewritePanel", () => {
       snapshot: [],
     };
     const html = renderToStaticMarkup(
-      createElement(ResumeRewritePanel, { status, onDismiss: () => {} }),
+      createElement(ResumeRewritePanel, {
+        status,
+        onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
+      }),
     );
     // Section labels (h4 headings) are unaffected by the diff swap.
     expect(html).toContain("Summary");
@@ -294,7 +318,12 @@ describe("ResumeRewritePanel", () => {
       snapshot: [],
     };
     const html = renderToStaticMarkup(
-      createElement(ResumeRewritePanel, { status, onDismiss: () => {} }),
+      createElement(ResumeRewritePanel, {
+        status,
+        onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
+      }),
     );
     expect(html).toContain("AI altered a metric");
     expect(html).toContain("$5K");

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -31,7 +31,7 @@
  */
 
 import { useState } from "react";
-import { Button, Dialog, ModelLoadProgress, TextAreaField } from "@design-system";
+import { Button, Dialog, InlineResult, ModelLoadProgress, TextAreaField } from "@design-system";
 import {
   labelForResumeRewrite,
   useResumeRewrite,
@@ -40,6 +40,11 @@ import {
 } from "../../hooks/useResumeRewrite.ts";
 import type { SectionInput, SectionOutcome } from "../../lib/webllm/rewrite-resume.ts";
 import type { PageTarget } from "../../lib/webllm/steering.ts";
+import {
+  ApplyConfirmation,
+  UndoBatchButton,
+  UNDO_HOLD_MS,
+} from "./ApplyConfirmation.tsx";
 import {
   ProposedPanel,
   type ResumeRewriteApply,
@@ -89,6 +94,8 @@ export function useResumeRewriteUi(
       <ResumeRewritePanel
         status={controller.status}
         onDismiss={controller.dismiss}
+        onApplied={controller.confirmApplied}
+        onUndo={controller.undoApplied}
         applyBySection={applyBySection}
       />
     );
@@ -228,10 +235,19 @@ function RewriteSteeringBox({
 export function ResumeRewritePanel({
   status,
   onDismiss,
+  onApplied,
+  onUndo,
   applyBySection,
 }: {
   status: ResumeRewriteStatus;
   onDismiss: () => void;
+  onApplied: (
+    count: number,
+    sections: readonly string[],
+    undo?: () => void,
+  ) => void;
+  /** Reverse the applied batch (issue 510). */
+  onUndo: () => void;
   applyBySection?: ResumeRewriteApply;
 }) {
   if (status.kind === "idle") return null;
@@ -269,10 +285,38 @@ export function ResumeRewritePanel({
       </div>
     );
   }
+  if (status.kind === "applied") {
+    return (
+      <InlineResult tone="success">
+        <ApplyConfirmation
+          count={status.count}
+          sections={status.sections}
+          onCollapse={onDismiss}
+          // Only a confirmation that actually hosts an Undo gets the longer
+          // hold — with no undo this stays on #508's 3s.
+          holdMs={status.undo ? UNDO_HOLD_MS : undefined}
+          action={status.undo && <UndoBatchButton onUndo={onUndo} />}
+        />
+      </InlineResult>
+    );
+  }
+  if (status.kind === "undone") {
+    return (
+      <InlineResult tone="success">
+        <ApplyConfirmation
+          verb="Reverted"
+          count={status.count}
+          sections={status.sections}
+          onCollapse={onDismiss}
+        />
+      </InlineResult>
+    );
+  }
   return (
     <ProposedPanel
       result={status.result}
       onDismiss={onDismiss}
+      onApplied={onApplied}
       applyBySection={applyBySection}
     />
   );

--- a/src/components/features/ResumeRewriteProposed.test.tsx
+++ b/src/components/features/ResumeRewriteProposed.test.tsx
@@ -99,6 +99,7 @@ describe("ProposedPanel — whole-résumé per-bullet review + apply", () => {
       createElement(ProposedPanel, {
         result: RESULT,
         onDismiss: vi.fn(),
+        onApplied: vi.fn(),
         applyBySection: map,
       }),
     );
@@ -116,13 +117,14 @@ describe("ProposedPanel — whole-résumé per-bullet review + apply", () => {
     expect(apply.disabled).toBe(true);
   });
 
-  it("Accept all + global Apply writes back through mapped obsIndices, then dismisses", () => {
+  it("Accept all + global Apply writes back through mapped obsIndices, then reports what was applied", () => {
     const { map, handlers } = makeApply();
-    const onDismiss = vi.fn();
+    const onApplied = vi.fn();
     const el = render(
       createElement(ProposedPanel, {
         result: RESULT,
-        onDismiss,
+        onDismiss: vi.fn(),
+        onApplied,
         applyBySection: map,
       }),
     );
@@ -144,12 +146,102 @@ describe("ProposedPanel — whole-résumé per-bullet review + apply", () => {
     expect(handlers.onReplace).toHaveBeenCalledWith(10, "Led a team of 5 engineers");
     expect(handlers.onRemove).toHaveBeenCalledWith(11);
     expect(handlers.onAdd).toHaveBeenCalledWith("Mentored two interns");
-    expect(onDismiss).toHaveBeenCalledTimes(1);
+    // Apply no longer dismisses synchronously — it reports the count and the
+    // touched section labels so the caller can confirm in place (#508).
+    // Third arg is the batch undo (issue 510) — undefined here because these
+    // handlers carry no `captureUndo`, so no Undo is offered.
+    expect(onApplied).toHaveBeenCalledWith(
+      3,
+      ["Senior Engineer — Acme"],
+      undefined,
+    );
+  });
+
+  it("hands back one undo thunk that reverses the whole batch (issue 510)", () => {
+    const { handlers } = makeApply();
+    const reverse = vi.fn();
+    const captureUndo =
+      vi.fn<NonNullable<SectionRewriteApply["captureUndo"]>>(() => reverse);
+    const withUndo: SectionRewriteApply = { ...handlers, captureUndo };
+    const onApplied = vi.fn();
+    const el = render(
+      createElement(ProposedPanel, {
+        result: RESULT,
+        onDismiss: vi.fn(),
+        onApplied,
+        applyBySection: new Map([["experience:0", withUndo]]),
+      }),
+    );
+
+    click(
+      [...el.querySelectorAll("button")].find(
+        (b) => b.textContent === "Accept all",
+      ) as HTMLButtonElement,
+    );
+    click(
+      el.querySelector(
+        'button[aria-label="Apply accepted changes to the resume"]',
+      ) as HTMLButtonElement,
+    );
+
+    // The snapshot saw every write the loop was about to issue, and was taken
+    // BEFORE any of them landed — otherwise it captures post-apply values.
+    expect(captureUndo).toHaveBeenCalledTimes(1);
+    expect(captureUndo.mock.calls[0]![0]).toEqual([
+      { kind: "replace", obsIndex: 10, text: "Led a team of 5 engineers" },
+      { kind: "add", text: "Mentored two interns" },
+      { kind: "remove", obsIndex: 11 },
+    ]);
+    expect(captureUndo.mock.invocationCallOrder[0]!).toBeLessThan(
+      vi.mocked(withUndo.onReplace).mock.invocationCallOrder[0]!,
+    );
+
+    const undo = onApplied.mock.calls[0]![2] as () => void;
+    expect(undo).toBeTypeOf("function");
+    expect(reverse).not.toHaveBeenCalled();
+    undo();
+    expect(reverse).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers no undo when any written section can't be snapshotted", () => {
+    // A written section with no `captureUndo` makes the batch unreversible.
+    // A partial revert would leave the résumé in a state the user never
+    // authored, so the control is withheld for the whole batch.
+    const bare: SectionRewriteApply = {
+      obsIndices: [10, 11],
+      onReplace: vi.fn(),
+      onRemove: vi.fn(),
+      onAdd: vi.fn(),
+    };
+    const onApplied = vi.fn();
+    const el = render(
+      createElement(ProposedPanel, {
+        result: RESULT,
+        onDismiss: vi.fn(),
+        onApplied,
+        applyBySection: new Map([["experience:0", bare]]),
+      }),
+    );
+    click(
+      [...el.querySelectorAll("button")].find(
+        (b) => b.textContent === "Accept all",
+      ) as HTMLButtonElement,
+    );
+    click(
+      el.querySelector(
+        'button[aria-label="Apply accepted changes to the resume"]',
+      ) as HTMLButtonElement,
+    );
+    expect(onApplied.mock.calls[0]![2]).toBeUndefined();
   });
 
   it("falls back to read-only (no review controls) when no apply wiring is given", () => {
     const el = render(
-      createElement(ProposedPanel, { result: RESULT, onDismiss: vi.fn() }),
+      createElement(ProposedPanel, {
+        result: RESULT,
+        onDismiss: vi.fn(),
+        onApplied: vi.fn(),
+      }),
     );
     // No per-bullet Accept controls without an apply map; the diff still renders.
     const acceptButtons = [...el.querySelectorAll("button")].filter((b) =>

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -59,10 +59,26 @@ interface ReviewSection {
 export function ProposedPanel({
   result,
   onDismiss,
+  onApplied,
   applyBySection,
 }: {
   result: ResumeRewriteResult;
+  /** Discard CTA only — Apply no longer calls this (#508; it calls
+   *  `onApplied` instead so the confirmation shows in place). */
   onDismiss: () => void;
+  /** Apply just committed its writes: the count of writes that actually
+   *  landed — NOT `acceptedCount`, which includes accepted-but-verbatim pairs
+   *  that resolve to no write — and the section labels that got one (#508).
+   *  Never called with a count of 0; a zero-write batch dismisses instead. The caller shows the
+   *  confirmation and holds the panel instead of dismissing synchronously.
+   *  `undo` reverses the whole batch (issue 510) — undefined when any written
+   *  section couldn't be snapshotted, so the control is never offered for a
+   *  partial revert. */
+  onApplied: (
+    count: number,
+    sections: readonly string[],
+    undo?: () => void,
+  ) => void;
   /** Per-section write-back handlers (#211 apply for the whole-résumé path).
    *  Absent → every section renders read-only (graceful fallback). */
   applyBySection?: ResumeRewriteApply;
@@ -102,6 +118,22 @@ export function ProposedPanel({
   );
 
   const onApply = useCallback(() => {
+    // Track which sections actually got a write — an accepted-but-unedited
+    // pair resolves to zero writes (resolveSectionWrites drops no-ops), so
+    // "touched" is the writes list, not the section's accepted-pair count.
+    const touchedSections: string[] = [];
+    // Undo is all-or-nothing across the batch (issue 510): a per-section
+    // snapshot is taken before that section's writes land, and the control is
+    // offered only if EVERY written section handed one back. Reversing four
+    // sections out of five would silently leave the résumé in a state the user
+    // never authored — worse than offering no undo at all.
+    const undos: (() => void)[] = [];
+    let reversible = true;
+    // The confirmation must report WRITES, not accepted pairs: accepting a
+    // bullet whose rewrite equals the original is a legitimate accept the
+    // Apply button counts, but it commits nothing. Announcing the accepted
+    // count would claim changes that never landed.
+    let writtenCount = 0;
     for (const sec of reviewSections) {
       const writes = resolveSectionWrites(
         sec.pairs,
@@ -109,14 +141,36 @@ export function ProposedPanel({
         review.decisions,
         review.edits,
       );
+      if (writes.length === 0) continue;
+      writtenCount += writes.length;
+      touchedSections.push(sec.label);
+      const undo = sec.apply.captureUndo?.(writes);
+      if (undo) undos.push(undo);
+      else reversible = false;
       for (const w of writes) {
         if (w.kind === "add") sec.apply.onAdd(w.text);
         else if (w.kind === "replace") sec.apply.onReplace(w.obsIndex, w.text);
         else sec.apply.onRemove(w.obsIndex);
       }
     }
-    onDismiss();
-  }, [reviewSections, review.decisions, review.edits, onDismiss]);
+    // An all-verbatim batch commits nothing — no confirmation at all, or the
+    // strip would announce "Applied N changes — " with an empty section list
+    // and (on the per-role path) a live Undo over an empty snapshot. Fall back
+    // to the pre-#508 behaviour: just drop the proposal.
+    if (writtenCount === 0) {
+      onDismiss();
+      return;
+    }
+    onApplied(
+      writtenCount,
+      touchedSections,
+      reversible && undos.length > 0
+        ? () => {
+            for (const undo of undos) undo();
+          }
+        : undefined,
+    );
+  }, [reviewSections, review.decisions, review.edits, onApplied, onDismiss]);
 
   const accepted = review.acceptedCount;
 

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -23,6 +23,10 @@
  * "Show changes" disclosure underneath. Accept / Reject are icon-only toggles
  * (✓ / ✗) so a long list of rows reads as content, not a wall of buttons —
  * each keeps its descriptive `aria-label` + a hover `title`.
+ *
+ * The apply-confirmation state (#508) lives in the sibling
+ * `ApplyConfirmation.tsx` rather than here — this file was already past the
+ * ~200 LOC soft cap from CLAUDE.md.
  */
 
 import { Button, EditableField, InlineDiff } from "@design-system";

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -54,8 +54,16 @@ import {
   alignBullets,
   type AlignedPair,
 } from "../../lib/rewrite-review/align-bullets.ts";
-import { resolveBulletActions } from "../../lib/rewrite-review/apply-accepted.ts";
+import {
+  resolveSectionWrites,
+  type ResolvedWrite,
+} from "../../lib/rewrite-review/apply-accepted.ts";
 import { useRewriteReview } from "../../hooks/useRewriteReview.ts";
+import {
+  ApplyConfirmation,
+  UndoBatchButton,
+  UNDO_HOLD_MS,
+} from "./ApplyConfirmation.tsx";
 import { RewriteReviewList } from "./RewriteReviewList.tsx";
 
 /**
@@ -74,6 +82,14 @@ export interface SectionRewriteApply {
   onRemove: (obsIndex: number) => void;
   /** Append a new bullet to this role (→ addBullet on the role's entry key). */
   onAdd: (text: string) => void;
+  /**
+   * Snapshot the pre-apply state of the slots `writes` will touch and return
+   * the thunk that restores them (issue 510). Called BEFORE the write loop.
+   * Absent → this surface offers no Undo at all: a partial undo that restores
+   * some sections and not others is worse than none, so both apply paths only
+   * surface the control when EVERY section they write has this wired.
+   */
+  captureUndo?: (writes: readonly ResolvedWrite[]) => () => void;
 }
 
 /** Stable empty alignment so the review hook doesn't reset on every idle render. */
@@ -147,6 +163,23 @@ export type Status =
        *  bullet underneath a previous rewrite. */
       snapshot: readonly string[];
     }
+  | {
+      /** Apply just committed its writes (#508) — shown in place of the
+       *  review surface for a few seconds instead of dismissing silently. */
+      kind: "applied";
+      count: number;
+      sections: readonly string[];
+      /** Reverses the whole batch (issue 510). Absent when the edit model
+       *  didn't hand back a capture — then no Undo is offered. */
+      undo?: () => void;
+    }
+  | {
+      /** Undo just ran (issue 510) — acknowledged in the same strip rather
+       *  than reverting silently. One-shot: there is no re-apply. */
+      kind: "undone";
+      count: number;
+      sections: readonly string[];
+    }
   | { kind: "error"; message: string };
 
 function bulletsEqual(a: readonly string[], b: readonly string[]): boolean {
@@ -167,6 +200,10 @@ function bulletsEqual(a: readonly string[], b: readonly string[]): boolean {
 export function useSectionRewrite(
   bullets: readonly string[],
   apply?: SectionRewriteApply,
+  /** Display label for the "Applied N changes — <label>" confirmation
+   *  (#508) — the role's `roleLabel(group.experience)`. Falls back to a
+   *  generic name when the caller has none to give. */
+  sectionLabel = "This section",
 ): SectionRewriteParts {
   const [capability, setCapability] = useState<WebGpuCapability | null>(null);
   const [status, setStatus] = useState<Status>({ kind: "idle" });
@@ -286,26 +323,60 @@ export function useSectionRewrite(
     setCopied(false);
   }, []);
 
+  // `ApplyConfirmation` re-arms its EXIT_MS collapse timer whenever `onCollapse`
+  // changes identity, so both confirmation states hand it this stable callback
+  // rather than a fresh inline arrow per render — symmetric with the
+  // whole-résumé surface, which already passes a stable `onDismiss`.
+  const backToIdle = useCallback(() => {
+    setStatus({ kind: "idle" });
+  }, []);
+
   // Apply accepted decisions back into the reconstructed résumé via the edit
   // model, then dismiss the proposal. Each action's `originalIndex` is a
   // position in the trimmed snapshot, mapped to its BulletObservation.index
   // through `keptObsIndices`.
   const onApply = useCallback(() => {
     if (!apply) return;
-    const actions = resolveBulletActions(pairs, review.decisions, review.edits);
-    for (const action of actions) {
-      if (action.kind === "add") {
-        apply.onAdd(action.text);
-        continue;
-      }
-      const obsIndex = keptObsIndices[action.originalIndex];
-      if (obsIndex === undefined || obsIndex < 0) continue;
-      if (action.kind === "replace") apply.onReplace(obsIndex, action.text);
-      else apply.onRemove(obsIndex);
+    const writes = resolveSectionWrites(
+      pairs,
+      keptObsIndices,
+      review.decisions,
+      review.edits,
+    );
+    // An all-verbatim batch resolves to zero writes (resolveSectionWrites
+    // drops no-op accepts). Confirming it would announce changes that never
+    // landed AND offer an Undo over an empty snapshot — a control that
+    // reverses nothing. Bail to idle instead, mirroring the whole-résumé
+    // path's zero-write dismiss.
+    if (writes.length === 0) {
+      setStatus({ kind: "idle" });
+      setCopied(false);
+      return;
     }
-    setStatus({ kind: "idle" });
+    // Snapshot BEFORE the loop — once a write lands the prior value is gone
+    // (issue 510).
+    const undo = apply.captureUndo?.(writes);
+    for (const write of writes) {
+      if (write.kind === "add") apply.onAdd(write.text);
+      else if (write.kind === "replace") apply.onReplace(write.obsIndex, write.text);
+      else apply.onRemove(write.obsIndex);
+    }
+    setStatus({
+      kind: "applied",
+      // Writes committed, not pairs accepted — see the zero-write bail above.
+      count: writes.length,
+      sections: [sectionLabel],
+      undo,
+    });
     setCopied(false);
-  }, [apply, pairs, review.decisions, review.edits, keptObsIndices]);
+  }, [
+    apply,
+    pairs,
+    review.decisions,
+    review.edits,
+    keptObsIndices,
+    sectionLabel,
+  ]);
 
   const onCopyAll = useCallback(async () => {
     if (status.kind !== "proposed") return;
@@ -385,6 +456,44 @@ export function useSectionRewrite(
               onReject={onReject}
             />
           ))}
+
+        {status.kind === "applied" && (
+          <InlineResult tone="success">
+            <ApplyConfirmation
+              count={status.count}
+              sections={status.sections}
+              onCollapse={backToIdle}
+              // Only a confirmation that actually hosts an Undo gets the longer
+              // hold — with no undo this stays on #508's 3s.
+              holdMs={status.undo ? UNDO_HOLD_MS : undefined}
+              action={
+                status.undo && (
+                  <UndoBatchButton
+                    onUndo={() => {
+                      status.undo?.();
+                      setStatus({
+                        kind: "undone",
+                        count: status.count,
+                        sections: status.sections,
+                      });
+                    }}
+                  />
+                )
+              }
+            />
+          </InlineResult>
+        )}
+
+        {status.kind === "undone" && (
+          <InlineResult tone="success">
+            <ApplyConfirmation
+              verb="Reverted"
+              count={status.count}
+              sections={status.sections}
+              onCollapse={backToIdle}
+            />
+          </InlineResult>
+        )}
 
         {status.kind === "error" && (
           <p role="alert" className="text-[11px] text-feedback-error-text">

--- a/src/design-system/shared/StatusBadge.tsx
+++ b/src/design-system/shared/StatusBadge.tsx
@@ -23,6 +23,11 @@ type StatusBadgeTone = "ok" | "limited" | "warning" | "info";
 interface StatusBadgeProps {
   tone: StatusBadgeTone;
   children: ReactNode;
+  /** Hide the badge from the accessibility tree — for a callsite where the
+   *  badge's word is already spoken by adjacent text, so exposing it would
+   *  announce the same word twice. Only ever safe when that duplicate exists;
+   *  the badge is otherwise the only carrier of its status. */
+  "aria-hidden"?: boolean;
 }
 
 const TONE_CLS: Record<StatusBadgeTone, string> = {
@@ -32,9 +37,14 @@ const TONE_CLS: Record<StatusBadgeTone, string> = {
   info: "bg-feedback-info-bg text-feedback-info-text",
 };
 
-export function StatusBadge({ tone, children }: StatusBadgeProps) {
+export function StatusBadge({
+  tone,
+  children,
+  "aria-hidden": ariaHidden,
+}: StatusBadgeProps) {
   return (
     <span
+      aria-hidden={ariaHidden}
       className={`inline-flex w-fit rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider ${TONE_CLS[tone]}`}
     >
       {children}

--- a/src/design-system/shared/Tabs.test.tsx
+++ b/src/design-system/shared/Tabs.test.tsx
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Tests for `Tab`'s optional `description` prop (issue 519) — the shared-
+ * primitive regression risk is a description-less `Tab` picking up the new
+ * two-line wrapper, and the two-line one changing the roving-tabindex keyboard
+ * contract `TabList.onKeyDown` implements.
+ *
+ * Two render paths on purpose: the markup assertions stay on
+ * `renderToStaticMarkup` (cheap, no DOM), while the keyboard block needs a real
+ * document to move focus — hence the jsdom pragma and the raw createRoot + act
+ * harness the sibling render tests use.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Tabs, TabList, Tab } from "./Tabs.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function renderTab(tab: ReactElement): string {
+  return renderToStaticMarkup(
+    <Tabs value="a" onValueChange={() => {}} id="t">
+      <TabList aria-label="Test tabs">{tab}</TabList>
+    </Tabs>,
+  );
+}
+
+describe("Tab description", () => {
+  it("omitting description reproduces today's single-line rendering exactly", () => {
+    const html = renderTab(<Tab id="a">Reconstructed resume</Tab>);
+    // No two-line wrapper, no subtitle markup, no flex-col grouping — just the
+    // label directly inside the button, same as before this prop existed.
+    expect(html).not.toContain("flex-col");
+    expect(html).not.toContain("sm:block");
+    expect(html).toContain("Reconstructed resume");
+  });
+
+  it("a description renders as a subtitle under the label, not a stray floating span", () => {
+    const html = renderTab(
+      <Tab id="a" description="what a parser pulled out — edit it here">
+        Reconstructed resume
+      </Tab>,
+    );
+    expect(html).toContain("Reconstructed resume");
+    expect(html).toContain("what a parser pulled out — edit it here");
+    // Subtitle is nested inside the same <button> as the label, so it
+    // contributes to the tab's accessible name (see Tabs.tsx doc comment) —
+    // not a sibling element outside the tab.
+    const buttonOpen = html.indexOf("<button");
+    const buttonClose = html.indexOf("</button>");
+    const subtitleIndex = html.indexOf("what a parser pulled out");
+    expect(subtitleIndex).toBeGreaterThan(buttonOpen);
+    expect(subtitleIndex).toBeLessThan(buttonClose);
+  });
+
+  it("suppresses the subtitle below the sm breakpoint so 375px degrades to single-line", () => {
+    const html = renderTab(
+      <Tab id="a" description="search job boards">
+        Find jobs
+      </Tab>,
+    );
+    expect(html).toContain("hidden");
+    expect(html).toContain("sm:block");
+  });
+
+  it("a description-less Tab still carries count and warn inline, unchanged", () => {
+    const html = renderTab(
+      <Tab id="a" count={3} warn>
+        Source &amp; diagnostics
+      </Tab>,
+    );
+    expect(html).toContain("setup needed");
+    expect(html).not.toContain("flex-col");
+  });
+});
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+/** Three tabs with the middle one selected by default, so a roving-tabindex
+ *  assertion can distinguish "the active tab" from "the first tab". `value`
+ *  moves the selection to an edge tab for the wrap-around cases. */
+function renderTabList(
+  onValueChange: (value: string) => void,
+  description: string | undefined,
+  value = "b",
+): HTMLButtonElement[] {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      <Tabs value={value} onValueChange={onValueChange} id="t">
+        <TabList aria-label="Test tabs">
+          <Tab id="a" description={description}>
+            Alpha
+          </Tab>
+          <Tab id="b" description={description}>
+            Beta
+          </Tab>
+          <Tab id="c" description={description}>
+            Gamma
+          </Tab>
+        </TabList>
+      </Tabs>,
+    );
+  });
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+  );
+}
+
+function press(el: Element, key: string) {
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+// The keyboard contract must not depend on `description` (issue 519's "keyboard
+// behaviour unchanged" criterion): the two-line branch nests the label in an
+// extra wrapper span, and `onKeyDown` resolves tabs through `data-tab-id` on
+// the button — so a regression there would only show up on one of the two.
+for (const withDesc of [false, true]) {
+  const description = withDesc ? "a one-line subtitle" : undefined;
+  describe(`TabList keyboard navigation (${withDesc ? "with" : "without"} description)`, () => {
+    it("gives only the selected tab a reachable tabindex", () => {
+      const tabs = renderTabList(() => {}, description);
+      expect(tabs.map((t) => t.tabIndex)).toEqual([-1, 0, -1]);
+    });
+
+    it("ArrowRight selects and focuses the next tab", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description);
+      press(tabs[1]!, "ArrowRight");
+      expect(onValueChange).toHaveBeenCalledWith("c");
+      expect(document.activeElement).toBe(tabs[2]);
+    });
+
+    it("ArrowLeft selects and focuses the previous tab", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description);
+      press(tabs[1]!, "ArrowLeft");
+      expect(onValueChange).toHaveBeenCalledWith("a");
+      expect(document.activeElement).toBe(tabs[0]);
+    });
+
+    it("Home selects and focuses the first tab", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description);
+      press(tabs[1]!, "Home");
+      expect(onValueChange).toHaveBeenCalledWith("a");
+      expect(document.activeElement).toBe(tabs[0]);
+    });
+
+    it("End selects and focuses the last tab", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description);
+      press(tabs[1]!, "End");
+      expect(onValueChange).toHaveBeenCalledWith("c");
+      expect(document.activeElement).toBe(tabs[2]);
+    });
+
+    // The modulo in `onKeyDown` is the whole wrap-around contract, and an
+    // off-by-one there (`% tabs.length` dropped, or the `+ tabs.length` that
+    // keeps ArrowLeft from going negative) only misbehaves at the two edges —
+    // which the middle-selected cases above can never reach.
+    it("ArrowRight wraps from the last tab to the first", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description, "c");
+      press(tabs[2]!, "ArrowRight");
+      expect(onValueChange).toHaveBeenCalledWith("a");
+      expect(document.activeElement).toBe(tabs[0]);
+    });
+
+    it("ArrowLeft wraps from the first tab to the last", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description, "a");
+      press(tabs[0]!, "ArrowLeft");
+      expect(onValueChange).toHaveBeenCalledWith("c");
+      expect(document.activeElement).toBe(tabs[2]);
+    });
+
+    it("leaves an unhandled key alone", () => {
+      const onValueChange = vi.fn();
+      const tabs = renderTabList(onValueChange, description);
+      press(tabs[1]!, "ArrowDown");
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+}

--- a/src/design-system/shared/Tabs.tsx
+++ b/src/design-system/shared/Tabs.tsx
@@ -136,9 +136,28 @@ interface TabProps {
    * isn't conveyed by colour alone.
    */
   warn?: boolean;
+  /**
+   * Optional one-line subtitle rendered under the label (issue #519), so a
+   * tab's purpose is legible without clicking it. Omitting this prop
+   * reproduces today's single-line rendering exactly — Tabs is a shared
+   * primitive and a future consumer must not be forced into two-line tabs.
+   *
+   * Accessibility: the subtitle is plain visible text nested inside the tab
+   * `<button>`, so it becomes part of the tab's accessible NAME via the
+   * standard accessible-name-from-content algorithm — the same mechanism
+   * `warn`'s `sr-only` addendum already uses to extend the name. No separate
+   * `aria-describedby` wiring, so there's nothing to keep in sync if the
+   * label or subtitle changes.
+   *
+   * Responsive: hidden below the `sm` breakpoint so a narrow viewport (375px)
+   * degrades to today's single-line tab row instead of widening it — the
+   * existing `overflow-x-auto` track only has to absorb one line at that
+   * width, same as before this prop existed.
+   */
+  description?: string;
 }
 
-export function Tab({ id, children, count, warn }: TabProps) {
+export function Tab({ id, children, count, warn, description }: TabProps) {
   const { value, onValueChange, baseId } = useTabsContext("Tab");
   const isActive = value === id;
   // Selection carries a real surface (bg-surface-card, matching the panel
@@ -176,18 +195,44 @@ export function Tab({ id, children, count, warn }: TabProps) {
       onClick={() => onValueChange(id)}
       className={activeCls}
     >
-      {children}
-      <CountBadge count={count} />
-      {warn && (
+      {description == null ? (
         <>
-          {/* U+26A0 + U+FE0E (VS-15) forces TEXT presentation so the glyph
-              renders monochrome (tinted by the warning token), not as a colour
-              emoji — the codebase's no-emoji-as-icon rule. */}
-          <span aria-hidden="true" className="ml-1.5 text-feedback-warning-text">
-            {"⚠︎"}
-          </span>
-          <span className="sr-only"> (setup needed)</span>
+          {children}
+          <CountBadge count={count} />
+          {warn && (
+            <>
+              {/* U+26A0 + U+FE0E (VS-15) forces TEXT presentation so the
+                  glyph renders monochrome (tinted by the warning token), not
+                  as a colour emoji — the codebase's no-emoji-as-icon rule. */}
+              <span aria-hidden="true" className="ml-1.5 text-feedback-warning-text">
+                {"⚠︎"}
+              </span>
+              <span className="sr-only"> (setup needed)</span>
+            </>
+          )}
         </>
+      ) : (
+        // Two-line layout only when a description is supplied. The label row
+        // reuses the exact same inline sequence (label, CountBadge, warn dot)
+        // as the single-line case above, just wrapped so the subtitle can sit
+        // underneath without displacing either.
+        <span className="flex flex-col items-start gap-0.5 text-left">
+          <span className="flex items-center gap-1">
+            {children}
+            <CountBadge count={count} />
+            {warn && (
+              <>
+                <span aria-hidden="true" className="text-feedback-warning-text">
+                  {"⚠︎"}
+                </span>
+                <span className="sr-only"> (setup needed)</span>
+              </>
+            )}
+          </span>
+          <span className="hidden text-xs font-normal text-content-secondary sm:block">
+            {description}
+          </span>
+        </span>
       )}
     </Button>
   );

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -22,6 +22,11 @@
  */
 
 import { useState, useCallback, useMemo, useRef } from "react";
+import {
+  captureBulletUndoSnapshot,
+  restoreBulletUndoSnapshot,
+  type BulletUndoTargets,
+} from "../lib/rewrite-review/undo-batch.ts";
 import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
 import { classifyProfile } from "../lib/contact/profile-registry.ts";
 import type { LegacyLinkKey, ProfileLink } from "../lib/score/types.ts";
@@ -387,6 +392,13 @@ export interface EditableParse {
   /** Append a bullet line to an entry. No-op on blank text. An added entry's
    *  bullets are dropped wholesale when the entry is removed. */
   addBullet: (entryKey: string, text: string) => void;
+  /**
+   * Snapshot the pre-apply state of exactly the bullet slots a rewrite batch is
+   * about to write, and return the thunk that restores them (issue 510). Call
+   * BEFORE the write loop; the returned thunk is single-level, one-shot and
+   * idempotent. Stable identity — safe as a memo dep of the rewrite wiring.
+   */
+  captureBulletUndo: (targets: BulletUndoTargets) => () => void;
   /** The ONE consolidated contact-link edit channel (#427): corrections to the
    *  four detected legacy slots (entries carrying a `legacyKey`) AND user-added
    *  extra links (untagged), in insertion order. */
@@ -653,6 +665,63 @@ export function useEditableParse(): EditableParse {
     }));
   }, []);
 
+  // ── Rewrite-batch undo primitives (issue 510) ─────────────────────────────
+  // The inverses of removeBullet / addBullet. Deliberately NOT on the public
+  // `EditableParse` surface: the only supported way to reach them is
+  // `captureBulletUndo`, which pairs each inverse with a pre-apply snapshot.
+  // A bare "un-remove" or "overwrite this entry's bullets" control would be a
+  // second, un-snapshotted mutation path into the same state.
+
+  const restoreBullet = useCallback((index: number) => {
+    setRemovedBullets((prev) => {
+      if (!prev.has(index)) return prev;
+      const next = new Set(prev);
+      next.delete(index);
+      return next;
+    });
+  }, []);
+
+  const replaceAddedBullets = useCallback(
+    (entryKey: string, bullets: readonly string[]) => {
+      setAddedBullets((prev) => {
+        const next = { ...prev };
+        // An empty list must DELETE the bucket, not leave `{key: []}` behind —
+        // `hasEdits` keys off `Object.keys(addedBullets).length`, so a stray
+        // empty bucket would leave the résumé permanently "dirty" after undo.
+        if (bullets.length === 0) delete next[entryKey];
+        else next[entryKey] = [...bullets];
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Live edit state readable synchronously at capture time. Refs, not the
+  // render closure, so `captureBulletUndo` keeps a STABLE identity — it is
+  // memo-dep of the rewrite-apply wiring, and a churning identity there resets
+  // the in-flight proposal's accept/reject decisions.
+  const bulletOverridesRef = useRef(bulletOverrides);
+  bulletOverridesRef.current = bulletOverrides;
+  const removedBulletsRef = useRef(removedBullets);
+  removedBulletsRef.current = removedBullets;
+
+  const captureBulletUndo = useCallback(
+    (targets: BulletUndoTargets) => {
+      const snap = captureBulletUndoSnapshot(targets, {
+        bulletOverrides: bulletOverridesRef.current,
+        removedBullets: removedBulletsRef.current,
+        addedBullets: addedBulletsRef.current,
+      });
+      return () =>
+        restoreBulletUndoSnapshot(snap, {
+          setBulletField,
+          restoreBullet,
+          setAddedBullets: replaceAddedBullets,
+        });
+    },
+    [setBulletField, restoreBullet, replaceAddedBullets],
+  );
+
   const setLegacyLink = useCallback(
     (key: LegacyLinkKey, url: string | undefined) => {
       setProfileOverrides((prev) => {
@@ -912,6 +981,7 @@ export function useEditableParse(): EditableParse {
     setEntryField,
     addedBullets,
     addBullet,
+    captureBulletUndo,
     profileOverrides,
     setLegacyLink,
     addProfile,

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -28,7 +28,7 @@
  * absence, matching `RewriteButton` / `SectionRewrite`).
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { detectWebGpu } from "../lib/webllm/capability.ts";
 import {
   acquireInference,
@@ -73,6 +73,23 @@ export type ResumeRewriteStatus =
       /** Snapshot of the section list the model actually saw — see useEffect below. */
       snapshot: readonly SectionInput[];
     }
+  | {
+      /** Apply just committed its writes (#508) — held in place for a few
+       *  seconds instead of dismissing the panel silently. */
+      kind: "applied";
+      count: number;
+      sections: readonly string[];
+      /** Reverses the whole applied batch (issue 510). Absent when the batch
+       *  couldn't be snapshotted in full — then no Undo is offered. */
+      undo?: () => void;
+    }
+  | {
+      /** Undo just ran (issue 510) — acknowledged in the same strip rather
+       *  than reverting silently. One-shot: there is no re-apply. */
+      kind: "undone";
+      count: number;
+      sections: readonly string[];
+    }
   | { kind: "error"; message: string };
 
 export interface ResumeRewriteController {
@@ -95,8 +112,19 @@ export interface ResumeRewriteController {
   isLockedByOther: boolean;
   /** Start the whole-résumé run. No-op if the lock is already held. */
   start: () => Promise<void>;
-  /** Drop a proposed/error state back to idle. */
+  /** Drop a proposed/error/applied state back to idle. */
   dismiss: () => void;
+  /** Move from "proposed" to "applied" (#508) — Apply just committed its
+   *  writes; hold the confirmation instead of dismissing synchronously.
+   *  `undo` reverses the whole batch (issue 510). */
+  confirmApplied: (
+    count: number,
+    sections: readonly string[],
+    undo?: () => void,
+  ) => void;
+  /** Run the applied batch's undo and move to "undone" (issue 510). One-shot:
+   *  a no-op unless the current status is "applied" WITH an undo. */
+  undoApplied: () => void;
   /** Freeform "what I want from this rewrite" text (#210). Persisted. */
   userInstructions: string;
   /** Update the freeform instructions (persists to localStorage). */
@@ -277,6 +305,29 @@ export function useResumeRewrite(
     setStatus({ kind: "idle" });
   }, []);
 
+  const confirmApplied = useCallback(
+    (count: number, sections: readonly string[], undo?: () => void) => {
+      setStatus({ kind: "applied", count, sections, undo });
+    },
+    [],
+  );
+
+  // Read the live status through a ref rather than a `setStatus` updater: the
+  // undo thunk is a side effect, and an updater is re-invoked under StrictMode.
+  // (The restore is idempotent, but a state updater is the wrong place for it.)
+  const statusRef = useRef(status);
+  statusRef.current = status;
+  const undoApplied = useCallback(() => {
+    const current = statusRef.current;
+    if (current.kind !== "applied" || !current.undo) return;
+    current.undo();
+    setStatus({
+      kind: "undone",
+      count: current.count,
+      sections: current.sections,
+    });
+  }, []);
+
   const isAvailable =
     capability === "available" && rewriteableSections.length > 0;
 
@@ -291,6 +342,8 @@ export function useResumeRewrite(
     isLockedByOther,
     start,
     dismiss,
+    confirmApplied,
+    undoApplied,
     userInstructions,
     setUserInstructions: setUserInstructionsRaw,
     pageTarget,

--- a/src/lib/rewrite-review/undo-batch.test.ts
+++ b/src/lib/rewrite-review/undo-batch.test.ts
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Tests for the single-level rewrite-batch undo (issue 510).
+ *
+ * The thing that must not rot: an undone batch leaves the edit state — and
+ * therefore the export — byte-identical to a batch that was never applied. So
+ * the store below is not a loose stub; it reimplements `useEditableParse`'s
+ * bullet write semantics exactly (blank adds dropped, `removeBullet`
+ * idempotent, `undefined` deletes an override, an emptied added-bullet bucket
+ * deleted rather than left as `[]`). A divergence there would make these tests
+ * pass against a fiction.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  batchUndoTargets,
+  captureBulletUndoSnapshot,
+  restoreBulletUndoSnapshot,
+  type BulletEditReadModel,
+  type BulletUndoWriter,
+} from "./undo-batch.ts";
+import type { ResolvedWrite } from "./apply-accepted.ts";
+import { applyOverrides } from "../edit/apply-overrides.ts";
+import type { BulletObservation } from "../score/score.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+
+/** In-memory mirror of the bullet slice of `useEditableParse`. */
+class EditStore implements BulletEditReadModel, BulletUndoWriter {
+  bulletOverrides: Record<number, string> = {};
+  removedBullets: Set<number> = new Set();
+  addedBullets: Record<string, string[]> = {};
+
+  // ── forward writes (what an Apply issues) ──
+  setBulletField = (index: number, value: string | undefined) => {
+    if (value === undefined) delete this.bulletOverrides[index];
+    else this.bulletOverrides[index] = value;
+  };
+  removeBullet = (index: number) => {
+    this.removedBullets.add(index);
+  };
+  addBullet = (entryKey: string, text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    this.addedBullets[entryKey] = [...(this.addedBullets[entryKey] ?? []), trimmed];
+  };
+
+  // ── inverse writes ──
+  restoreBullet = (index: number) => {
+    this.removedBullets.delete(index);
+  };
+  setAddedBullets = (entryKey: string, bullets: readonly string[]) => {
+    if (bullets.length === 0) delete this.addedBullets[entryKey];
+    else this.addedBullets[entryKey] = [...bullets];
+  };
+
+  /** A structurally comparable copy — `Set` doesn't deep-equal usefully. */
+  freeze() {
+    return {
+      bulletOverrides: { ...this.bulletOverrides },
+      removedBullets: [...this.removedBullets].sort((a, b) => a - b),
+      addedBullets: JSON.parse(JSON.stringify(this.addedBullets)) as Record<
+        string,
+        string[]
+      >,
+    };
+  }
+
+  /** Dispatch one section's writes the way both apply surfaces do. */
+  apply(entryKey: string, writes: readonly ResolvedWrite[]) {
+    for (const w of writes) {
+      if (w.kind === "add") this.addBullet(entryKey, w.text);
+      else if (w.kind === "replace") this.setBulletField(w.obsIndex, w.text);
+      else this.removeBullet(w.obsIndex);
+    }
+  }
+}
+
+/** Capture → apply → return the undo thunk, the exact order both callers use. */
+function applyWithUndo(
+  store: EditStore,
+  entryKey: string,
+  writes: readonly ResolvedWrite[],
+): () => void {
+  const snap = captureBulletUndoSnapshot(batchUndoTargets(writes, entryKey), store);
+  store.apply(entryKey, writes);
+  return () => restoreBulletUndoSnapshot(snap, store);
+}
+
+describe("batchUndoTargets", () => {
+  it("splits writes into replaced / removed slots", () => {
+    const targets = batchUndoTargets(
+      [
+        { kind: "replace", obsIndex: 3, text: "a" },
+        { kind: "remove", obsIndex: 7 },
+        { kind: "replace", obsIndex: 4, text: "b" },
+      ],
+      "experience:0",
+    );
+    expect(targets.replaced).toEqual([3, 4]);
+    expect(targets.removed).toEqual([7]);
+  });
+
+  it("records the added-bullet entry key only when the batch adds", () => {
+    expect(
+      batchUndoTargets([{ kind: "remove", obsIndex: 1 }], "experience:0")
+        .addedEntryKey,
+    ).toBeUndefined();
+    expect(
+      batchUndoTargets([{ kind: "add", text: "new" }], "experience:0")
+        .addedEntryKey,
+    ).toBe("experience:0");
+  });
+});
+
+describe("undo of an applied batch", () => {
+  it("restores every touched slot to its exact pre-apply value", () => {
+    const store = new EditStore();
+    // Pre-existing edit state the batch must not disturb or lose.
+    store.setBulletField(1, "hand-edited bullet one");
+    store.setBulletField(9, "an untouched bullet");
+    store.removeBullet(5); // already removed BEFORE the batch
+    store.addBullet("experience:0", "hand-added");
+    store.addBullet("experience:0", "hand-added"); // duplicate text on purpose
+    const before = store.freeze();
+
+    const undo = applyWithUndo(store, "experience:0", [
+      { kind: "replace", obsIndex: 1, text: "rewritten one" }, // over an override
+      { kind: "replace", obsIndex: 2, text: "rewritten two" }, // no prior override
+      { kind: "remove", obsIndex: 4 }, // newly removed
+      { kind: "remove", obsIndex: 5 }, // already removed — a no-op
+      { kind: "add", text: "hand-added" }, // same text as an existing add
+    ]);
+
+    // The batch really landed.
+    expect(store.bulletOverrides[1]).toBe("rewritten one");
+    expect(store.bulletOverrides[2]).toBe("rewritten two");
+    expect(store.removedBullets.has(4)).toBe(true);
+    expect(store.addedBullets["experience:0"]).toHaveLength(3);
+
+    undo();
+
+    expect(store.freeze()).toEqual(before);
+    // The specific traps: a bullet with no prior override is DELETED, not
+    // blanked; a pre-batch removal survives the undo.
+    expect(2 in store.bulletOverrides).toBe(false);
+    expect(store.removedBullets.has(5)).toBe(true);
+    expect(store.removedBullets.has(4)).toBe(false);
+  });
+
+  it("clears the added-bullet bucket rather than leaving an empty array", () => {
+    const store = new EditStore();
+    const undo = applyWithUndo(store, "experience:2", [
+      { kind: "add", text: "only added bullet" },
+    ]);
+    expect(store.addedBullets["experience:2"]).toEqual(["only added bullet"]);
+    undo();
+    // `hasEdits` keys off Object.keys(addedBullets).length — a leftover `[]`
+    // would leave the résumé permanently dirty after an undo.
+    expect(Object.keys(store.addedBullets)).toEqual([]);
+  });
+
+  it("is idempotent — replaying the restore changes nothing", () => {
+    const store = new EditStore();
+    store.setBulletField(1, "original");
+    const before = store.freeze();
+    const undo = applyWithUndo(store, "experience:0", [
+      { kind: "replace", obsIndex: 1, text: "rewritten" },
+      { kind: "remove", obsIndex: 3 },
+      { kind: "add", text: "added" },
+    ]);
+    undo();
+    undo();
+    expect(store.freeze()).toEqual(before);
+  });
+
+  it("reverses a MULTI-SECTION batch as one action", () => {
+    const store = new EditStore();
+    store.setBulletField(0, "role A bullet, hand-edited");
+    store.addBullet("experience:1", "role B pre-existing add");
+    const before = store.freeze();
+
+    // Two sections, captured before their own writes, undone together — the
+    // shape `ResumeRewriteProposed` builds for the whole-résumé apply.
+    const undos = [
+      applyWithUndo(store, "experience:0", [
+        { kind: "replace", obsIndex: 0, text: "A rewritten" },
+        { kind: "add", text: "A new bullet" },
+      ]),
+      applyWithUndo(store, "experience:1", [
+        { kind: "remove", obsIndex: 10 },
+        { kind: "replace", obsIndex: 11, text: "B rewritten" },
+      ]),
+    ];
+    expect(store.freeze()).not.toEqual(before);
+
+    for (const undo of undos) undo();
+    expect(store.freeze()).toEqual(before);
+  });
+});
+
+// ── Export invariant ────────────────────────────────────────────────────────
+
+function obs(index: number, text: string): BulletObservation {
+  return {
+    text,
+    index,
+    hasMetric: false,
+    startsWithActionVerb: false,
+    wellFormedLength: false,
+    wordCount: text.split(/\s+/).filter(Boolean).length,
+  };
+}
+
+function baseParsed(): HeuristicParsedResume {
+  return {
+    full_name: "Dana Ruiz",
+    email: "dana@example.com",
+    phone: "(312) 555-0123",
+    skills: ["typescript"],
+    experience: [
+      {
+        title: "Engineer",
+        company: "Acme",
+        start_date: "2020",
+        end_date: "2022",
+        description: "Built a thing\nShipped another thing",
+      },
+    ],
+    education: [],
+  };
+}
+
+function makeSections(experience: readonly string[]): SectionedResume {
+  const byName = new Map<string, readonly string[]>([["experience", experience]]);
+  return {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
+
+describe("an undone batch exports identically to one never applied", () => {
+  it("folds to the same parse through applyOverrides", () => {
+    const rawText = "• Built a thing\n• Shipped another thing";
+    const observations = [obs(0, "Built a thing"), obs(1, "Shipped another thing")];
+    const sections = makeSections(["• Built a thing", "• Shipped another thing"]);
+    const fold = (store: EditStore) =>
+      applyOverrides(
+        baseParsed(),
+        rawText,
+        sections,
+        {},
+        {},
+        store.bulletOverrides,
+        observations,
+        {},
+        undefined,
+        [],
+        store.addedBullets,
+        store.removedBullets,
+      );
+
+    const store = new EditStore();
+    store.setBulletField(0, "Built a thing, carefully");
+    const neverApplied = fold(store);
+
+    const undo = applyWithUndo(store, "experience:0", [
+      { kind: "replace", obsIndex: 0, text: "Drove a 30% lift in throughput" },
+      { kind: "remove", obsIndex: 1 },
+      { kind: "add", text: "Owned the migration end to end" },
+    ]);
+    // Sanity: the applied batch really does change the exported parse, so the
+    // equality below is not vacuously true.
+    expect(fold(store)).not.toEqual(neverApplied);
+
+    undo();
+    expect(fold(store)).toEqual(neverApplied);
+  });
+});

--- a/src/lib/rewrite-review/undo-batch.ts
+++ b/src/lib/rewrite-review/undo-batch.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * undo-batch.ts — single-level, exact undo for an applied rewrite batch
+ * (issue 510).
+ *
+ * Applying a rewrite proposal is the one bulk mutation in the app with no way
+ * back: `ResumeRewriteProposed`'s `onApply` (whole-résumé) and
+ * `SectionRewrite`'s `onApply` (per-role) walk every accepted pair and fire
+ * `replace` / `remove` / `add` writes across many sections in one pass, then
+ * drop the proposal. This module is the inverse.
+ *
+ * SNAPSHOT, not reverse-diff. The requirement is "restore every field the
+ * batch touched to its EXACT pre-apply value", single-level, one-shot — which
+ * is exactly what a snapshot gives with no reconstruction step to get wrong. A
+ * reverse diff would have to re-derive the prior value of each slot from the
+ * write itself, and for two of the three channels it simply cannot:
+ *
+ *   - `remove` writes into a SET. `removeBullet(i)` on an already-removed
+ *     bullet is a no-op, so the inverse of "remove i" is "restore i" only when
+ *     i was not already removed. That fact lives in the pre-state, nowhere in
+ *     the write.
+ *   - `add` APPENDS to a per-entry array and silently drops blank text, so the
+ *     number of writes issued is not the number of bullets appended, and
+ *     duplicate texts make removal-by-value ambiguous.
+ *
+ * The snapshot is SCOPED to the slots the batch will touch, not the whole
+ * résumé model — capturing three small maps rather than cloning the parse, and
+ * leaving every untouched field alone.
+ *
+ * Because the restore is wholesale over those slots, an undo issued after the
+ * user has hand-edited one of the SAME slots also reverts that hand edit. That
+ * is the literal reading of "restore to its exact pre-apply value", and the
+ * window is bounded — the Undo affordance is only mounted alongside the apply
+ * confirmation and is one-shot.
+ *
+ * Pure: no I/O, no React, no mutation of the inputs. The caller (see
+ * `useEditableParse.captureBulletUndo`) binds the live edit state and the
+ * setters; the two apply surfaces only ever see the returned thunk.
+ */
+
+import type { ResolvedWrite } from "./apply-accepted.ts";
+
+/** The bullet slots one section's batch is about to write. */
+export interface BulletUndoTargets {
+  /** BulletObservation indices a `replace` will overwrite. */
+  replaced: readonly number[];
+  /** BulletObservation indices a `remove` will drop. */
+  removed: readonly number[];
+  /** The added-bullet entry key an `add` appends to — set iff the batch has
+   *  at least one `add` write. */
+  addedEntryKey?: string;
+}
+
+/**
+ * Which slots `writes` will touch. `entryKey` is the caller's own added-bullet
+ * bucket (the role's `AddedEntry.id` or its `parsedEntryKey`); it is recorded
+ * only when the batch actually adds, so a replace-only batch snapshots no
+ * array.
+ */
+export function batchUndoTargets(
+  writes: readonly ResolvedWrite[],
+  entryKey: string,
+): BulletUndoTargets {
+  const replaced: number[] = [];
+  const removed: number[] = [];
+  let adds = false;
+  for (const write of writes) {
+    if (write.kind === "replace") replaced.push(write.obsIndex);
+    else if (write.kind === "remove") removed.push(write.obsIndex);
+    else adds = true;
+  }
+  return adds ? { replaced, removed, addedEntryKey: entryKey } : { replaced, removed };
+}
+
+/** The live edit state the snapshot reads. Structural on purpose — this module
+ *  must not import the hook that owns it. */
+export interface BulletEditReadModel {
+  bulletOverrides: Readonly<Record<number, string>>;
+  removedBullets: ReadonlySet<number>;
+  addedBullets: Readonly<Record<string, readonly string[]>>;
+}
+
+/** Pre-apply state of exactly the targeted slots. */
+export interface BulletUndoSnapshot {
+  /** `[obsIndex, prior override]` — `undefined` means "no override", which
+   *  restores by DELETING the key, not by writing an empty string. */
+  overrides: readonly (readonly [number, string | undefined])[];
+  /** Indices the batch will newly remove — i.e. those NOT already removed.
+   *  An already-removed index is left out so undo can't un-remove a bullet
+   *  the user had dropped before the batch ran. */
+  restore: readonly number[];
+  /** `[entryKey, prior bullet list]` for the one bucket the batch appends to. */
+  added?: readonly [string, readonly string[]];
+}
+
+/** Read the pre-apply value of every targeted slot. Call BEFORE the write loop. */
+export function captureBulletUndoSnapshot(
+  targets: BulletUndoTargets,
+  model: BulletEditReadModel,
+): BulletUndoSnapshot {
+  const overrides = targets.replaced.map(
+    (index) => [index, model.bulletOverrides[index]] as const,
+  );
+  const restore = targets.removed.filter((index) => !model.removedBullets.has(index));
+  const key = targets.addedEntryKey;
+  return key === undefined
+    ? { overrides, restore }
+    : { overrides, restore, added: [key, [...(model.addedBullets[key] ?? [])]] };
+}
+
+/** The inverse writes. Mirrors `useEditableParse`'s own edit primitives. */
+export interface BulletUndoWriter {
+  /** `undefined` deletes the override (back to the parsed text). */
+  setBulletField: (index: number, value: string | undefined) => void;
+  /** Un-remove a bullet the batch dropped. */
+  restoreBullet: (index: number) => void;
+  /** Replace an entry's added-bullet list wholesale; `[]` clears the bucket. */
+  setAddedBullets: (entryKey: string, bullets: readonly string[]) => void;
+}
+
+/** Write every captured slot back. Idempotent — replaying it is a no-op, so a
+ *  double-invoked handler (React StrictMode) cannot double-revert. */
+export function restoreBulletUndoSnapshot(
+  snapshot: BulletUndoSnapshot,
+  writer: BulletUndoWriter,
+): void {
+  for (const [index, value] of snapshot.overrides) writer.setBulletField(index, value);
+  for (const index of snapshot.restore) writer.restoreBullet(index);
+  if (snapshot.added) writer.setAddedBullets(snapshot.added[0], snapshot.added[1]);
+}

--- a/src/lib/score/group-bullets.ts
+++ b/src/lib/score/group-bullets.ts
@@ -111,6 +111,22 @@ export interface BulletGroup {
   bullets: BulletObservation[];
 }
 
+/**
+ * Short "Title — Company" display label for a role, falling back to whichever
+ * of the two is present, or "Untitled role" / "Other bullets" when neither is.
+ * Shared by `ReconstructedResume` (role headings, whole-résumé rewrite section
+ * labels) and the per-role `SectionRewrite` apply-confirmation copy (#508) —
+ * one label format across every surface that names a role.
+ */
+export function roleLabel(exp: BulletGroup["experience"]): string {
+  if (exp === null) return "Other bullets";
+  const { title, company } = exp;
+  if (title && company) return `${title} — ${company}`;
+  if (title) return title;
+  if (company) return company;
+  return "Untitled role";
+}
+
 // ── Core logic ────────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Four sub-issues of the epic, implemented on one branch and landed as one commit.

Each of the four sub-issues is fully resolved here, so they close. The epic itself gets `Refs` rather than `Closes` — it still has three open children (#391, #379, #381).

## What changed

- **#508 — applying a rewrite gives no confirmation.** Apply no longer dismisses the review
  panel in the same tick with no signal. A new `ApplyConfirmation` renders in place inside the
  caller's already-mounted `InlineResult` (no new toast primitive — see CLAUDE.md's reuse
  rule): a `StatusBadge` plus the line *"Applied N changes — <sections touched>"*, held ~3s,
  then collapsed. `role="status" aria-live="polite"`; the word "Applied" is in the text, so
  meaning is never carried by colour alone; motion is gated on `prefers-reduced-motion`.
  Shared by both apply surfaces so the per-role and whole-résumé paths show identical copy,
  timing, and motion.
- **#509 — download controls named by file format.** "Download PDF" → "Download resume" and
  "Download now" → "Download model", so each control names the *content* it emits rather than
  the container. "Download report" was already content-named and is unchanged.
- **#510 — no undo for an applied rewrite batch.** The confirmation now hosts a one-shot
  **Undo**, backed by `src/lib/rewrite-review/undo-batch.ts`. It is a **snapshot**, not a
  reverse diff: `remove` writes into a set (so the inverse of "remove i" depends on pre-state
  that lives nowhere in the write) and `add` appends while silently dropping blank text (so
  write count ≠ bullets appended, and duplicate texts make removal-by-value ambiguous). The
  snapshot is scoped to the slots the batch will touch — three small maps, not a clone of the
  parse. A confirmation that hosts an Undo holds for 12s instead of 3, because an Undo the
  user cannot reach is not a recovery path; the no-undo timing from #508 is unchanged.
  Documented tradeoff: undoing after a hand-edit to one of the *same* slots also reverts that
  hand edit — the literal reading of "restore the exact pre-apply value", bounded because the
  affordance is one-shot and only mounted alongside the confirmation.
- **#519 — tab labels read as inspector panes.** The shared `Tab` primitive takes an optional
  `description`, and the three result tabs now carry one-line subtitles. Copy was checked
  against the governing privacy sentences in `FindJobsPanel` — the find-jobs subtitle claims
  ranking, not upload — and the resume-quality subtitle is conditioned on
  `analysis.isAvailable` so it does not promise on-device critique where WebGPU is missing.
  Keyboard behaviour is unchanged and now pinned by tests.

## Known, deliberate behaviour

A batch where every accepted pair is verbatim writes nothing, so it shows **no** confirmation
and simply dismisses — pre-#508 behaviour. Confirming a mutation that did not happen would be
a false claim; the honest answer, if this ever needs one, is a "No changes to apply" variant
of the same strip, not a re-inflated count.

## Verification

`npm run typecheck`, `npx eslint src`, and the full `npx vitest run` are green over the
accumulated tree: **184 files passed | 6 skipped; 2561 tests passed | 9 skipped**. The
authoritative full `verify` runs in CI on this PR.

`npx fallow audit --base origin/main` is clean of anything this batch introduced. The one
CRITICAL it raised mid-run — `Tabs.tsx` `onKeyDown` at CRAP 110 with 0% coverage, against
#519's explicit "keyboard behaviour unchanged" criterion — is fixed: `Tabs.test.tsx` now pins
roving tabindex and ArrowRight/ArrowLeft/Home/End, parameterised over the description and
no-description branches. The remaining complexity findings and the flagged duplication are
pre-existing and untouched by this diff.

No fixtures were added or changed by any of the four issues, so the fixture-PII surface is
untouched.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #508 | unreported (requested: sonnet) | high |
| Implementation — #509 | unreported (requested: sonnet) | medium |
| Implementation — #510 | unreported (requested: opus) | ultra |
| Implementation — #519 | unreported (requested: sonnet) | high |
| Adversarial review — round 1 | Claude Opus 4.8 | high |
| Review fixes | Claude Opus 4.8 | high |
| Adversarial review — round 2 | Claude Opus 4.8 | high |
| Orchestration + PR | Claude Opus 4.8 | high |
| Review revisions | Claude Opus 4.8 | high |

The four implementing subagents went idle without emitting their structured return, so their
model strings are genuinely unknown — the requested alias is recorded instead of a guess. Their
work was verified from the tree by the orchestrator and by both review rounds.

Refs #511
Closes #508
Closes #509
Closes #510
Closes #519

## Adversarial review

Two bounded rounds against the accumulated diff, pre-PR, each reproducing suspected defects
end-to-end rather than reasoning about the code.

**Round 1 — 3 blocking, all reproduced with scratch jsdom tests:**

1. *The confirmation counted accepted pairs, not writes that landed.* `resolveBulletActions`
   drops a matched-accept whose text equals the original, but `acceptMany` accepts every pair
   including verbatim ones — so a rewrite that returns any bullet unchanged (routine model
   behaviour) announced more changes than it committed. Reproduced: one `onReplace`, count of
   2. Both apply surfaces. **Fixed** by accumulating `writes.length` into a `writtenCount`;
   `acceptedCount` now only labels the Apply button.
2. *An all-verbatim batch still confirmed, with an empty section list.* Apply gates on
   `accepted === 0`, not on writes, so every section was skipped and the strip rendered
   literally `"Applied 2 changes — "` — a dangling em dash claiming a mutation that never
   happened, with no Undo. **Fixed** by never entering the confirmation state for a zero-write
   batch (both surfaces), plus a belt-and-braces guard that omits the clause when there are no
   sections.
3. *The per-role surface offered an Undo over an empty snapshot.* `captureUndo?.(writes)` ran
   unconditionally, so clicking Undo would flip the strip to "Reverted 2 changes — …" while
   restoring nothing — a false statement about the résumé on the one surface whose purpose is a
   trustworthy recovery path. **Fixed** with an early return before the capture.

Also repaired from the fallow leads: `Tabs.tsx` `onKeyDown` was CRAP 110 at 0% coverage while
"keyboard behaviour unchanged" is an explicit acceptance criterion — now pinned by 12 tests
parameterised over the description / no-description branches. `HOLD_MS` unexported. The
confirmation's `StatusBadge` is `aria-hidden` so a screen reader hears "Applied" once rather
than `"AppliedApplied"`.

**Round 2 — `clean: true`.** Each fix re-verified by repro on both surfaces, including attacks
that tried to re-inflate the count (already-removed bullet, blank `add`, no-op `replace` — all
unreachable) and a hand-audit of the edited `useCallback` dep lists for stale closures, since
this repo does not enforce `exhaustive-deps`. Confirmed a nonzero count can no longer coexist
with an empty section list by construction.

**Surviving nits, none blocking:** the blank-string-label guard hole is latent only (`roleLabel`
never returns `""`); the zero-write dismiss is silent by design (see *Known, deliberate
behaviour* above); and `role="status"` mounts with its content already present, which some
screen readers do not announce — a property of the original design, not of these fixes.

## Review round (Samhit21)

Approved with one inline nit, now fixed in the branch's single commit:

- **Collapse-timer dependency.** `SectionRewrite`'s two confirmation states passed
  `ApplyConfirmation` an inline `onCollapse` arrow, so its `EXIT_MS` timer re-armed on any
  re-render inside the ~150ms collapse window. Both now pass one stable `backToIdle`
  `useCallback` — symmetric with the whole-résumé surface's stable `onDismiss`.

Also cleared while revising: the second surviving nit above — the **arrow-key wrap-around** case
is now tested at both edges (ArrowRight from the last tab, ArrowLeft from the first),
parameterised over the description / no-description branches like the rest of `Tabs.test.tsx`.
The modulo in `onKeyDown` exists only for those two positions, and every prior keyboard test
started from the middle tab, so an off-by-one there was unreachable by the suite.

The flagged `ResumeRewriteProposed`/`RewriteReviewList` duplication and
`ReconstructedResume`'s unmemoized `captureUndo` arrow were both traced and left alone:
pre-existing, and no correctness impact.


