### PR TITLE
feat(app): reframe hero around resume custody, not device runtime

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,27 +115,41 @@ export default function App() {
             // recruiter-agent context) moves to the quiet block below the drop
             // zone so the hero isn't three competing messages.
             //
-            // The headline's "by default" is NOT hedging for its own sake and
-            // must not be dropped: the job-search lane egresses keywords on an
-            // explicit click (see FindJobsPanel), a build with
+            // The headline claims custody, NOT runtime — the distinction is
+            // load-bearing and must survive edits. "in your browser" scopes the
+            // claim to a place; it is NOT an absolute "runs on your device"
+            // claim, which would be false: the job-search lane egresses
+            // keywords on an explicit click (see FindJobsPanel), a build with
             // VITE_POSTHOG_KEY set (the hosted one) ships analytics, and the
             // BYOK provider path (#320, not in the tree yet — see
-            // CapabilityStrip) will be real cloud egress once it lands. The
-            // first two are true today and already load-bearing on their own.
-            // An unqualified "on your device"
-            // would be the only absolute privacy claim in the app — every
-            // other surface is already scoped the same way (PageShell's
-            // footer, CapabilityStrip's rail).
+            // CapabilityStrip) will be real cloud egress once it lands.
+            //
+            // "Browser" is also the noun the sibling surfaces use, and the
+            // three are read together on the idle screen: CapabilityStrip's
+            // rail ("Your resume stays in your browser") renders as PageShell's
+            // `chips` a few inches below, and PageShell's footer states its own
+            // narrower, hedged claim about a different object ("your PDF stays
+            // in this browser tab by default"). Same noun, three different
+            // sentences — if you change the noun in one, change it in all.
+            //
+            // What is absolute is the subhead's promise — the *resume* never
+            // leaves the browser — guaranteed by keywords.ts (only a derived
+            // keyword string egresses, never the resume/PDF/queries). That is
+            // absolute only while keywords.ts is the sole resume-derived
+            // egress: if #320's BYOK path lands, it sends resume text to a
+            // cloud provider and this subhead becomes false, so it must be
+            // rescoped in the same PR that ships it. Keep the headline about
+            // place and the subhead about the resume; do not merge them into a
+            // blanket "everything stays on your device."
             <Card className="flex flex-col items-center gap-5 bg-surface-card-warm">
               <div className="flex max-w-2xl flex-col gap-4 text-center">
                 <h2 className="text-balance text-2xl font-semibold leading-snug tracking-tight text-content-primary sm:text-3xl">
-                  Your whole job search — on your device by default.
+                  Your whole job search — in your browser.
                 </h2>
                 <p className="text-pretty text-base font-medium text-content-secondary sm:text-lg">
-                  OfflineCV is a free, open-source job-search workbench —
-                  read your resume, fix it, and match it against real
-                  postings, all in your browser. Nothing to install, no
-                  account to create.
+                  OfflineCV is a free, open-source job-search workbench. Drop a
+                  PDF, score it, fix it, match a JD, and find jobs — all without
+                  your resume leaving your browser.
                 </p>
                 <p className="text-xs text-content-muted">
                   Built in response to a hiring process job seekers say they

--- a/src/design-system/shared/CapabilityStrip.tsx
+++ b/src/design-system/shared/CapabilityStrip.tsx
@@ -20,7 +20,7 @@
  * carries the rail statement, matching how the old chip row phrased itself.
  *
  * Privacy scope (binding, epic #511): the rail claims custody of the RESUME —
- * "Your resume stays on your device" — deliberately not "nothing leaves" or
+ * "Your resume stays in your browser" — deliberately not "nothing leaves" or
  * "runs entirely on your device". Those would be false: the job-search lane
  * this same card advertises does `fetch()` three third-party feeds, and a
  * build with VITE_POSTHOG_KEY set ships analytics the user never opted into.
@@ -30,9 +30,16 @@
  * or if a cloud LLM path lands (none exists today — there is no BYOK provider
  * in the tree despite older docs implying one), this line becomes a lie and
  * must change with it. Per-feature exceptions stay stated where the user
- * meets them (`FindJobsPanel`), not restated here. `PageShell`'s footer makes
- * the equivalent scoped claim in its own words ("your PDF stays in this
- * browser tab by default").
+ * meets them (`FindJobsPanel`), not restated here.
+ *
+ * The noun is "browser", not "device", and that is deliberate (#537): this
+ * rail renders a few inches below `App`'s hero, which says "in your browser"
+ * in the headline and "leaving your browser" in the subhead, so a visitor
+ * reads all three at once. "Device" also understates the guarantee — another
+ * app on the same device cannot read the resume either. If you change the
+ * noun here, change it in `App.tsx`'s hero in the same commit. `PageShell`'s
+ * footer states a narrower, hedged claim about a different object ("your PDF
+ * stays in this browser tab by default") — same noun, not the same sentence.
  */
 
 import { Chip } from "../primitives/Chip.tsx";
@@ -81,7 +88,7 @@ export function CapabilityStrip() {
         ))}
       </div>
       <div className="flex flex-wrap items-center gap-2 border-t border-border-light pt-3">
-        <Chip icon={<LockIcon />}>Your resume stays on your device</Chip>
+        <Chip icon={<LockIcon />}>Your resume stays in your browser</Chip>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary

Rewrites the landing hero so the privacy claim is about **custody, not runtime**. The old line — *"Your whole job search — on your device by default"* — overclaimed (the app makes network calls: job feeds + PostHog analytics) and hedged with *"by default."*

- **Headline:** *Your whole job search — in your browser.* (a place claim, not a runtime claim)
- **Subhead:** keeps *free, open-source*; states the absolute, accurate promise — the **resume** never leaves the browser (guaranteed by `keywords.ts`, which egresses only a derived keyword string, never the resume/PDF/queries).
- **Propagates the noun to `CapabilityStrip`** (review feedback): the rail said *"Your resume stays on your **device**"* and renders as `PageShell`'s `chips` a few inches under the hero, so the idle screen read back two nouns for one promise. It now says *"in your **browser**"* — also the stronger claim, since another app on the same device can't see the resume either. `PageShell`'s footer already used *"browser tab."*
- Rewrites the load-bearing comment that used to defend *"by default"* so a future edit doesn't collapse headline + subhead into a false blanket *"everything stays on your device"* — and records the **trip-wire** that would falsify the subhead: it is absolute only while `keywords.ts` is the sole resume-derived egress, so #320's BYOK path (sends resume text to a cloud provider) must rescope the subhead in the PR that ships it.

Copy-only + comment; no logic change.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (2526 passed)
- [x] `npm run verify` green (pre-push gate)
- [x] Manually verified in `npm run dev`

## Provenance

Copy iteration + implementation: Claude Opus 4.8 (1M context), high effort — guided by the `ui-ux-pro-max` landing-pattern search (minimal single-column / benefit-led hero).
Review revisions: Claude Opus 4.8 (1M context), medium effort.
