### PR TITLE
feat(job-search): company-targeted ATS-board search v2 — boards, multi-title, seniority, skills rank, location, fan-out (#528)

### DIFF
--- a/src/components/features/ChipListEditor.tsx
+++ b/src/components/features/ChipListEditor.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ChipListEditor — a labelled list of removable chips plus an "add" input, the
+ * shared editing surface for both the Titles and Skills rows of `FindJobsPanel`
+ * (#539). Extracted so the two lists share one implementation rather than the
+ * panel hand-rolling a second copy of the chip + add-input pattern for titles.
+ *
+ * Owns only its own draft-input state; the chip list itself is fully
+ * controlled by the parent (`items` / `onAdd` / `onRemove`). Adds are
+ * trimmed, empty-rejected, and deduped case-insensitively against the current
+ * items here so every caller gets the same add semantics. Display-only beyond
+ * that draft — no domain logic, all styling through semantic tokens and the
+ * `@design-system` `Button` + `Chip` primitives (no raw `<button>`, and the
+ * removable chips are the `Chip` primitive's `onRemove` variant, not a copy).
+ */
+
+import { useState } from "react";
+import { Button, Chip } from "@design-system";
+
+interface ChipListEditorProps {
+  /** Row label shown above the chips (e.g. "Titles", "Skills"). */
+  label: string;
+  /** The controlled chip values, in display order. */
+  items: string[];
+  /** Called with a trimmed, non-duplicate value when the user adds one. */
+  onAdd: (value: string) => void;
+  /** Called with the exact item string to remove. */
+  onRemove: (value: string) => void;
+  /** Placeholder for the add input. */
+  placeholder: string;
+  /** Accessible label for the add input. */
+  addAriaLabel: string;
+}
+
+export function ChipListEditor({
+  label,
+  items,
+  onAdd,
+  onRemove,
+  placeholder,
+  addAriaLabel,
+}: ChipListEditorProps) {
+  const [draft, setDraft] = useState("");
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    const alreadyPresent = items.some(
+      (item) => item.toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (!alreadyPresent) onAdd(trimmed);
+    setDraft("");
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs text-content-tertiary">{label}</span>
+      {items.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {items.map((item) => (
+            <Chip
+              key={item}
+              onRemove={() => onRemove(item)}
+              removeLabel={`Remove ${item}`}
+            >
+              {item}
+            </Chip>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={draft}
+          aria-label={addAriaLabel}
+          placeholder={placeholder}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-xs text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={commit}
+          disabled={draft.trim().length === 0}
+        >
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/CompanyTargets.test.tsx
+++ b/src/components/features/CompanyTargets.test.tsx
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * CompanyTargets + useCompanyTargets (#533). Drives the real hook through a
+ * host component with raw createRoot + act (the repo's component-test pattern),
+ * so the lazy registry/taxonomy imports and the selection edits are exercised
+ * end to end rather than against a stubbed state object.
+ *
+ * The assertions that matter are the ones the fan-out depends on: what
+ * `selected` contains after a toggle, and that a sector switch re-seeds it —
+ * because that array is passed straight to `searchJobs`.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CompanyTargets } from "./CompanyTargets.tsx";
+import {
+  useCompanyTargets,
+  companyKey,
+  toggleKey,
+  COMPANY_LIMIT,
+  type CompanyTargets as CompanyTargetsState,
+} from "../../hooks/useCompanyTargets.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+import type { CompanyEntry } from "../../lib/job-search/company-registry.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+/** A payments-heavy resume, so the heuristic classifier lands on fintech. */
+const fintechResume: HeuristicParsedResume = {
+  skills: ["payments", "ledger", "fraud detection"],
+  experience: [
+    { title: "Senior Backend Engineer", company: "PayCo" },
+  ],
+  education: [],
+};
+
+/**
+ * Straddles two sectors on purpose, so the classifier reports a `runnerUp` and
+ * the "not right? switch" affordance actually exists. `fintechResume` scores
+ * only fintech, which would make the switch tests vacuously pass.
+ */
+const twoSectorResume: HeuristicParsedResume = {
+  skills: ["payments", "ledger", "penetration testing", "siem"],
+  experience: [{ title: "Backend Engineer", company: "X" }],
+  education: [],
+};
+
+/** Captures the live hook state so assertions can read it between acts. */
+let latest: CompanyTargetsState | null = null;
+
+function Host({ parsed }: { parsed: HeuristicParsedResume }) {
+  const targets = useCompanyTargets(parsed);
+  latest = targets;
+  return createElement(CompanyTargets, { targets });
+}
+
+async function mount(parsed: HeuristicParsedResume): Promise<void> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(Host, { parsed }));
+  });
+  // The hook seeds itself from two dynamic imports, so the first render lands
+  // before `ready`. A fixed number of ticks is not enough: the FIRST mount in
+  // the file pays a cold module load while later ones hit the module cache, so
+  // flush until the hook reports ready rather than guessing a tick count.
+  for (let i = 0; i < 50 && !latest?.ready; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+function buttons(): HTMLButtonElement[] {
+  return [...(container?.querySelectorAll("button") ?? [])] as HTMLButtonElement[];
+}
+
+function companyButtons(): HTMLButtonElement[] {
+  return buttons().filter((b) => b.hasAttribute("aria-pressed"));
+}
+
+describe("useCompanyTargets", () => {
+  it("suggests sector-matched companies and selects them all by default", async () => {
+    await mount(fintechResume);
+
+    expect(latest?.ready).toBe(true);
+    expect(latest?.sector).toBe("fintech");
+    expect(latest?.suggested.length).toBeGreaterThan(0);
+    expect(latest?.suggested.length).toBeLessThanOrEqual(COMPANY_LIMIT);
+    // Default-on: a user who just wants to search shouldn't have to opt in.
+    expect(latest?.selected).toEqual(latest?.suggested);
+  });
+
+  it("removing a company drops it from the set handed to the search", async () => {
+    await mount(fintechResume);
+    const dropped = latest!.suggested[0];
+
+    await act(async () => {
+      latest!.toggle(dropped);
+    });
+
+    expect(latest?.selected.map(companyKey)).not.toContain(companyKey(dropped));
+    expect(latest?.selected).toHaveLength(latest!.suggested.length - 1);
+    // Still suggested — off is a reversible state, not a deletion.
+    expect(latest?.suggested).toContain(dropped);
+  });
+
+  it("re-adding a company restores it in registry order, not at the end", async () => {
+    await mount(fintechResume);
+    const first = latest!.suggested[0];
+
+    await act(async () => latest!.toggle(first));
+    await act(async () => latest!.toggle(first));
+
+    expect(latest?.selected).toEqual(latest?.suggested);
+  });
+
+  it("deselecting everything yields an empty set (keyless-only search)", async () => {
+    await mount(fintechResume);
+    const all = [...latest!.suggested];
+
+    await act(async () => {
+      for (const entry of all) latest!.toggle(entry);
+    });
+
+    expect(latest?.selected).toEqual([]);
+  });
+
+  it("offers no switch when the classifier found only one sector", async () => {
+    await mount(fintechResume);
+    expect(latest?.runnerUp).toBeNull();
+    expect(container?.textContent).not.toContain("Not right?");
+  });
+
+  it("switching to the runner-up re-suggests and re-selects for that sector", async () => {
+    await mount(twoSectorResume);
+    const before = latest!.suggested.map(companyKey);
+    const runnerUp = latest!.runnerUp;
+    expect(runnerUp).toBe("security");
+
+    await act(async () => latest!.switchToRunnerUp());
+
+    expect(latest?.sector).toBe(runnerUp);
+    expect(latest?.suggested.map(companyKey)).not.toEqual(before);
+    // Freshly seeded: every newly suggested company starts selected.
+    expect(latest?.selected).toEqual(latest?.suggested);
+  });
+
+  it("makes the sector switch reversible by swapping the pair", async () => {
+    await mount(twoSectorResume);
+    const original = latest!.sector;
+    expect(latest?.runnerUp).toBe("security");
+
+    await act(async () => latest!.switchToRunnerUp());
+    expect(latest?.sector).toBe("security");
+    expect(latest?.runnerUp).toBe(original);
+
+    await act(async () => latest!.switchToRunnerUp());
+    expect(latest?.sector).toBe(original);
+    expect(latest?.runnerUp).toBe("security");
+  });
+
+  it("renders the switch affordance when a runner-up exists", async () => {
+    await mount(twoSectorResume);
+    expect(container?.textContent).toContain("Not right?");
+  });
+});
+
+describe("CompanyTargets rendering", () => {
+  it("renders one toggle per suggested company, all pressed initially", async () => {
+    await mount(fintechResume);
+    const chips = companyButtons();
+    expect(chips).toHaveLength(latest!.suggested.length);
+    expect(chips.every((b) => b.getAttribute("aria-pressed") === "true")).toBe(true);
+  });
+
+  it("clicking a company toggles aria-pressed, not just its colour", async () => {
+    await mount(fintechResume);
+    const chip = companyButtons()[0];
+
+    await act(async () => {
+      chip.click();
+    });
+
+    expect(companyButtons()[0].getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("says the search falls back to feeds only when nothing is selected", async () => {
+    await mount(fintechResume);
+    await act(async () => {
+      for (const entry of [...latest!.suggested]) latest!.toggle(entry);
+    });
+    expect(container?.textContent).toContain("job feeds only");
+  });
+
+  it("states that only the company name is sent, never the resume", async () => {
+    await mount(fintechResume);
+    expect(container?.textContent).toContain("never your resume");
+  });
+
+  it("degrades to a plain explanation when no sector companies exist", async () => {
+    // An unclassifiable resume falls to the "other" sector, which by design has
+    // no registry entries.
+    await mount({ skills: [], experience: [], education: [] });
+    expect(latest?.suggested).toEqual([]);
+    expect(companyButtons()).toHaveLength(0);
+    expect(container?.textContent).toContain("job feeds only");
+  });
+
+  // #542
+  it("notes that self-hosted-careers employers aren't reachable here", async () => {
+    await mount(fintechResume);
+    expect(container?.textContent).toContain("their own careers site");
+  });
+});
+
+describe("selection helpers", () => {
+  it("companyKey distinguishes the same slug on two vendors", () => {
+    const base = { name: "Circle", slug: "circle", sectors: ["fintech"] } satisfies
+      Omit<CompanyEntry, "ats">;
+    expect(companyKey({ ...base, ats: "greenhouse" })).not.toBe(
+      companyKey({ ...base, ats: "ashby" }),
+    );
+  });
+
+  it("toggleKey adds a missing key and removes a present one", () => {
+    const empty = new Set<string>();
+    const added = toggleKey(empty, "a");
+    expect([...added]).toEqual(["a"]);
+    expect([...toggleKey(added, "a")]).toEqual([]);
+    // Pure: the input set is never mutated.
+    expect([...empty]).toEqual([]);
+  });
+});

--- a/src/components/features/CompanyTargets.tsx
+++ b/src/components/features/CompanyTargets.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * CompanyTargets — the suggested-companies block of the Find Jobs panel (#533).
+ *
+ * Display-only: every piece of state (the sector guess, which companies are
+ * selected) is owned by `useCompanyTargets`, and the fan-out is owned by
+ * `FindJobsPanel`. Split into its own sibling rather than appended to the panel
+ * because `FindJobsPanel` is already past the ~200 LOC guide in CLAUDE.md.
+ *
+ * Each company is a toggle `Button` with `aria-pressed`, not a chip with a
+ * remove "×". Two reasons: the `Chip` primitive is non-interactive by design,
+ * and a company that is off is still a suggestion the user can turn back on —
+ * "×" would imply it's gone. `aria-pressed` carries the state to a screen
+ * reader, and a "✓" text mark carries it visually, so selection is never
+ * signalled by colour alone.
+ */
+
+import { Button } from "@design-system";
+import type { CompanyEntry } from "../../lib/job-search/company-registry.ts";
+import type { CompanyTargets as CompanyTargetsState } from "../../hooks/useCompanyTargets.ts";
+
+/** Sector slugs are kebab-case taxonomy values ("crypto-web3"); this is the
+ *  only place they are shown to a human, so they get spaced out here rather
+ *  than carrying a display-name column through the taxonomy. */
+function sectorLabel(sector: string): string {
+  return sector.replace(/-/g, " / ");
+}
+
+export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
+  const { ready, sector, runnerUp, suggested, selected } = targets;
+
+  // Before the registry chunk resolves there is nothing truthful to say, and
+  // a spinner for a lazy import that usually takes a frame would flicker.
+  if (!ready) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-xs text-content-tertiary">
+          {suggested.length > 0 && sector
+            ? `Companies we matched to your background (${sectorLabel(sector)})`
+            : "Companies"}
+        </span>
+        {runnerUp && (
+          <Button
+            variant="link"
+            size="sm"
+            onClick={targets.switchToRunnerUp}
+          >
+            Not right? Try {sectorLabel(runnerUp)}
+          </Button>
+        )}
+      </div>
+
+      {suggested.length === 0 ? (
+        <p className="max-w-prose text-xs text-content-tertiary">
+          We couldn&apos;t match your resume to a sector we have companies for,
+          so this search uses the job feeds only.
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-1.5">
+            {suggested.map((entry: CompanyEntry) => {
+              const isOn = targets.isSelected(entry);
+              return (
+                <Button
+                  key={`${entry.ats}:${entry.slug}`}
+                  variant="ghost"
+                  size="sm"
+                  aria-pressed={isOn}
+                  onClick={() => targets.toggle(entry)}
+                  className={
+                    isOn
+                      ? "rounded-full border border-accent-primary px-2.5 py-1"
+                      : "rounded-full border border-border-light px-2.5 py-1 text-content-tertiary"
+                  }
+                >
+                  <span aria-hidden="true">{isOn ? "✓︎" : "+"}</span>
+                  {entry.name}
+                </Button>
+              );
+            })}
+          </div>
+          <p className="max-w-prose text-xs text-content-tertiary">
+            {selected.length === 0
+              ? "No companies selected — this search uses the job feeds only."
+              : `We'll read ${selected.length} ${
+                  selected.length === 1 ? "company's" : "companies'"
+                } public job board directly. Only the company name is sent — never your resume.`}
+          </p>
+        </>
+      )}
+
+      {/* #542: large employers with self-hosted careers sites (Apple, Google,
+       *  Meta, …) aren't on Greenhouse/Lever/Ashby, so they can never appear
+       *  in this list — a structural boundary of the three-vendor design, not
+       *  a curation gap. "Search external boards" above (LinkedIn / Indeed /
+       *  Google Jobs) is the intended path to those. */}
+      <p className="max-w-prose text-xs text-content-tertiary">
+        Large employers with their own careers site (e.g. Apple, Google,
+        Meta) aren&apos;t reachable here — find them via the external boards
+        above.
+      </p>
+    </div>
+  );
+}

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -27,78 +27,43 @@ import {
   JobSearchResults,
   type SearchPhase,
 } from "./JobSearchResults.tsx";
+import { ChipListEditor } from "./ChipListEditor.tsx";
+import { CompanyTargets } from "./CompanyTargets.tsx";
+import { useCompanyTargets } from "../../hooks/useCompanyTargets.ts";
+import { AddPill } from "./ReconstructedAdd.tsx";
 
 interface FindJobsPanelProps {
-  /** The live cascade's parsed résumé. `buildJobQuery` reads only title/skills;
+  /** The live cascade's parsed résumé. `buildJobQuery` reads only titles/skills;
    *  the fit-ranking (via `searchJobs`) needs the fuller shape (summary,
    *  education) for accurate coverage, so we take the whole `HeuristicParsedResume`
    *  rather than the narrow query-only Pick. */
   parsed: HeuristicParsedResume;
 }
 
-function RemoveIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="10"
-      height="10"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-    >
-      <path d="M3 3l10 10M13 3L3 13" />
-    </svg>
-  );
-}
-
-function RemovableSkillChip({
-  skill,
-  onRemove,
-}: {
-  skill: string;
-  onRemove: () => void;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-surface-subtle py-1 pl-2.5 pr-1 text-xs text-content-secondary">
-      {skill}
-      <Button
-        variant="icon"
-        aria-label={`Remove ${skill}`}
-        onClick={onRemove}
-        className="shrink-0 text-content-muted hover:text-content-secondary"
-      >
-        <RemoveIcon />
-      </Button>
-    </span>
-  );
-}
-
 export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   // Seed local query state from the parse once (lazy initializer — runs only
   // on mount); the user edits it from here.
   const [query, setQuery] = useState<JobQuery>(() => buildJobQuery(parsed));
-  const [skillDraft, setSkillDraft] = useState("");
+  // Progressive disclosure for Seniority (#540): a résumé whose titles carry
+  // no recognized seniority keyword renders no inert placeholder field — the
+  // row appears only once a seniority was derived, or the user opts in via
+  // the "+ Seniority" pill.
+  const [seniorityExpanded, setSeniorityExpanded] = useState(false);
 
   const links = useMemo(() => buildDeepLinks(query), [query]);
-  const isDegenerate = !query.title.trim() && query.skills.length === 0;
+  const isDegenerate = query.titles.length === 0 && query.skills.length === 0;
 
-  const addSkill = () => {
-    const trimmed = skillDraft.trim();
-    if (!trimmed) return;
-    const alreadyPresent = query.skills.some(
-      (s) => s.toLowerCase() === trimmed.toLowerCase(),
-    );
-    if (!alreadyPresent) {
-      setQuery((q) => ({ ...q, skills: [...q.skills, trimmed] }));
-    }
-    setSkillDraft("");
-  };
+  // ChipListEditor already trims + case-insensitively dedups before calling
+  // onAdd, so these handlers just append / filter the controlled list.
+  const addTitle = (title: string) =>
+    setQuery((q) => ({ ...q, titles: [...q.titles, title] }));
+  const removeTitle = (title: string) =>
+    setQuery((q) => ({ ...q, titles: q.titles.filter((t) => t !== title) }));
 
-  const removeSkill = (skill: string) => {
+  const addSkill = (skill: string) =>
+    setQuery((q) => ({ ...q, skills: [...q.skills, skill] }));
+  const removeSkill = (skill: string) =>
     setQuery((q) => ({ ...q, skills: q.skills.filter((s) => s !== skill) }));
-  };
 
   // In-app search state. The fetch fires ONLY from runSearch (the Search
   // click) — never on drop, tab open, or query edit. searchJobs dynamic-imports
@@ -106,6 +71,12 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   const [phase, setPhase] = useState<SearchPhase>({ kind: "idle" });
   const abortRef = useRef<AbortController | null>(null);
   const isLoading = phase.kind === "loading";
+
+  // Sector-suggested companies whose ATS boards join the fan-out. Selecting
+  // none is a supported state: the search falls back to the keyless feeds
+  // alone, exactly as it behaved before #533.
+  const companyTargets = useCompanyTargets(parsed);
+  const selectedCompanies = companyTargets.selected;
 
   // Abort any in-flight search on unmount so a late response can't try to
   // update state on an unmounted component.
@@ -120,7 +91,12 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
     void (async () => {
       try {
         const { searchJobs } = await import("../../lib/job-search/search.ts");
-        const result = await searchJobs(query, parsed, ctrl.signal);
+        const result = await searchJobs(
+          query,
+          parsed,
+          ctrl.signal,
+          selectedCompanies,
+        );
         if (ctrl.signal.aborted) return;
         setPhase({ kind: "loaded", result });
       } catch {
@@ -149,65 +125,53 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
       </header>
 
       <div className="flex flex-col gap-3">
+        <ChipListEditor
+          label="Titles"
+          items={query.titles}
+          onAdd={addTitle}
+          onRemove={removeTitle}
+          placeholder="Add a title…"
+          addAriaLabel="Add title"
+        />
+        {/* Location (#545): always shown, unlike Seniority's AddPill-gated
+         *  disclosure — location is a primary axis of every job-board search
+         *  form (not an auxiliary facet the way seniority is), and a résumé
+         *  with no parsed location still needs a visible place to type one to
+         *  get any location-aware ranking or deep-link behavior at all. */}
         <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-          <span className="text-xs text-content-tertiary">Title</span>
+          <span className="text-xs text-content-tertiary">Location</span>
           <EditableField
-            value={query.title}
-            placeholder="job title"
-            label="Job title"
-            textWeight="semibold"
-            onCommit={(v) => setQuery((q) => ({ ...q, title: v }))}
-          />
-        </div>
-        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-          <span className="text-xs text-content-tertiary">Seniority</span>
-          <EditableField
-            value={query.seniority}
-            placeholder="seniority"
-            label="Seniority"
+            value={query.location}
+            placeholder="location"
+            label="Location"
             onCommit={(v) =>
-              setQuery((q) => ({ ...q, seniority: v || undefined }))
+              setQuery((q) => ({ ...q, location: v || undefined }))
             }
           />
         </div>
-        <div className="flex flex-col gap-1.5">
-          <span className="text-xs text-content-tertiary">Skills</span>
-          {query.skills.length > 0 && (
-            <div className="flex flex-wrap gap-1.5">
-              {query.skills.map((skill) => (
-                <RemovableSkillChip
-                  key={skill}
-                  skill={skill}
-                  onRemove={() => removeSkill(skill)}
-                />
-              ))}
-            </div>
-          )}
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={skillDraft}
-              aria-label="Add skill"
-              placeholder="Add a skill…"
-              onChange={(e) => setSkillDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  addSkill();
-                }
-              }}
-              className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-xs text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+        {query.seniority || seniorityExpanded ? (
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+            <span className="text-xs text-content-tertiary">Seniority</span>
+            <EditableField
+              value={query.seniority}
+              placeholder="seniority"
+              label="Seniority"
+              onCommit={(v) =>
+                setQuery((q) => ({ ...q, seniority: v || undefined }))
+              }
             />
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={addSkill}
-              disabled={skillDraft.trim().length === 0}
-            >
-              Add
-            </Button>
           </div>
-        </div>
+        ) : (
+          <AddPill label="Seniority" onClick={() => setSeniorityExpanded(true)} />
+        )}
+        <ChipListEditor
+          label="Skills"
+          items={query.skills}
+          onAdd={addSkill}
+          onRemove={removeSkill}
+          placeholder="Add a skill…"
+          addAriaLabel="Add skill"
+        />
         {isDegenerate && (
           <p className="text-xs text-content-tertiary">
             We couldn&apos;t derive a search from this resume — add a title or
@@ -239,6 +203,8 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
           above.
         </p>
       </div>
+
+      <CompanyTargets targets={companyTargets} />
 
       <div className="flex flex-col gap-2">
         <div>

--- a/src/design-system/primitives/Chip.tsx
+++ b/src/design-system/primitives/Chip.tsx
@@ -1,7 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
+import { Button } from "./Button.tsx";
+
 export type ChipTone = "neutral" | "success" | "warning";
+
+/** The chip's own remove (×) glyph — kept inline so the primitive stays
+ *  self-contained (no feature-layer icon import). Matches the SkillChip X. */
+function ChipRemoveIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="10"
+      height="10"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <path d="M3 3l10 10M13 3L3 13" />
+    </svg>
+  );
+}
 
 interface ChipProps {
   /**
@@ -14,18 +35,35 @@ interface ChipProps {
   icon?: React.ReactNode;
   children: React.ReactNode;
   tone?: ChipTone;
+  /**
+   * When set, the chip renders a trailing remove (×) control that calls this
+   * on click — the removable-chip variant, so a labelled list (Titles, Skills)
+   * reuses the one chip implementation instead of hand-rolling its own. Pass
+   * `removeLabel` for the control's accessible name.
+   */
+  onRemove?: () => void;
+  /** Accessible name for the remove control; required when `onRemove` is set. */
+  removeLabel?: string;
 }
 
-export function Chip({ icon, children, tone = "neutral" }: ChipProps) {
+export function Chip({
+  icon,
+  children,
+  tone = "neutral",
+  onRemove,
+  removeLabel,
+}: ChipProps) {
   const toneCls =
     tone === "success"
       ? "bg-feedback-success-bg text-feedback-success-text"
       : tone === "warning"
         ? "bg-feedback-warning-bg text-feedback-warning-text"
         : "bg-surface-subtle text-content-secondary";
+  // Tighten the trailing padding when a remove control sits in that slot.
+  const padCls = onRemove ? "py-1 pl-2.5 pr-1" : "px-2.5 py-1";
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs ${toneCls}`}
+      className={`inline-flex items-center gap-1 rounded-full text-xs ${padCls} ${toneCls}`}
     >
       {icon && (
         <span
@@ -36,6 +74,16 @@ export function Chip({ icon, children, tone = "neutral" }: ChipProps) {
         </span>
       )}
       {children}
+      {onRemove && (
+        <Button
+          variant="icon"
+          aria-label={removeLabel ?? "Remove"}
+          onClick={onRemove}
+          className="shrink-0 text-content-muted hover:text-content-secondary"
+        >
+          <ChipRemoveIcon />
+        </Button>
+      )}
     </span>
   );
 }

--- a/src/hooks/useCompanyTargets.ts
+++ b/src/hooks/useCompanyTargets.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Which companies the next job search targets (#533).
+ *
+ * Owns the sector guess and the user's add/remove edits over the registry's
+ * suggestions, so `FindJobsPanel` stays a layout shell and `CompanyTargets`
+ * stays a renderer. Selection state lives here rather than in either because
+ * both need it: the panel passes `selected` to `searchJobs`, the component
+ * toggles it.
+ *
+ * TWO DELIBERATE CHOICES:
+ *
+ * 1. HEURISTIC CLASSIFIER, NOT `classifySector`. `sector.ts` also exports the
+ *    semantic `classifySector`, which loads a WebLLM model when WebGPU is
+ *    present. Calling it here would kick off a multi-hundred-MB model download
+ *    as a side effect of the panel merely rendering — a cost the user never
+ *    asked for, on a surface whose whole value is being instant. The heuristic
+ *    is synchronous, free, and supplies the same `runnerUp` the "not right?"
+ *    affordance needs. Upgrading to the semantic guess belongs behind an
+ *    explicit user action, not a mount.
+ *
+ * 2. SEEDED ONCE, ON MOUNT. `parsed` is a fresh object on many parent renders,
+ *    so keying the effect on it would re-classify (and stomp the user's chip
+ *    edits) on unrelated re-renders. This mirrors how the panel already seeds
+ *    its `JobQuery` — "local scratch state seeded once from the parse".
+ *    NOTE: `exhaustive-deps` is NOT enabled in this repo, so nothing would
+ *    have flagged the alternative; the empty dep array is a decision, not an
+ *    oversight.
+ *
+ * The registry and the sector taxonomy are dynamic-imported (the cascade-tier
+ * pattern) so neither reaches the entry chunk — the panel renders before they
+ * resolve, which is what `ready` is for.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { CompanyEntry } from "../lib/job-search/company-registry.ts";
+import type { Sector } from "../lib/job-search/sector.ts";
+
+/**
+ * How many companies a sector suggests (#542). Together with
+ * `DEFAULT_PER_COMPANY_CAP` (8 by default, `role-keywords.ts`) this bounds the
+ * company-board half of a search at 14 * 8 = 112 postings before ranking —
+ * a real sample without a firehose, and comfortably under the ~120 ceiling
+ * this pairing has always targeted. It is also the width of the board
+ * fan-out, which the concurrency limiter then meters.
+ *
+ * 14 was picked because it is the largest per-sector count the curated
+ * registry actually has (`fintech` and `devtools`, 14 entries each as of
+ * #542) — raising the cap further would not surface any more companies for
+ * ANY sector today, only widen a ceiling nothing fills. Several sectors still
+ * bottom out well below 14 (`gaming`, `hardware-iot`, `logistics-mobility`,
+ * `government-defense` at 6; `ecommerce`, `media-adtech` at 7) — that is a
+ * registry-content gap, not a cap problem, and is explicit follow-up (#542
+ * part (a): growing the registry with existence-audited companies).
+ */
+export const COMPANY_LIMIT = 14;
+
+/** Stable identity for a registry entry. `slug` alone collides across vendors. */
+export function companyKey(entry: CompanyEntry): string {
+  return `${entry.ats}:${entry.slug}`;
+}
+
+/** Add/remove one key from a selection set, returning a new set. */
+export function toggleKey(
+  keys: ReadonlySet<string>,
+  key: string,
+): ReadonlySet<string> {
+  const next = new Set(keys);
+  if (!next.delete(key)) next.add(key);
+  return next;
+}
+
+export interface CompanyTargets {
+  /** False until the lazy registry/taxonomy chunks resolve (or fail). */
+  ready: boolean;
+  /** The classified sector, or null before `ready`. */
+  sector: Sector | null;
+  /** Second-best sector, when the classifier found one — powers the switch. */
+  runnerUp: Sector | null;
+  /** Every company the sector suggests, in registry order. */
+  suggested: CompanyEntry[];
+  /** The subset that will actually be searched, in `suggested` order. */
+  selected: CompanyEntry[];
+  isSelected(entry: CompanyEntry): boolean;
+  toggle(entry: CompanyEntry): void;
+  /** Re-suggest against `runnerUp`; no-op when there isn't one. */
+  switchToRunnerUp(): void;
+}
+
+export function useCompanyTargets(parsed: HeuristicParsedResume): CompanyTargets {
+  const [ready, setReady] = useState(false);
+  const [sector, setSector] = useState<Sector | null>(null);
+  const [runnerUp, setRunnerUp] = useState<Sector | null>(null);
+  const [suggested, setSuggested] = useState<CompanyEntry[]>([]);
+  const [keys, setKeys] = useState<ReadonlySet<string>>(() => new Set());
+
+  // The lazily-imported registry lookup, kept so `switchToRunnerUp` can
+  // re-query without a second dynamic import round-trip.
+  const lookupRef = useRef<
+    ((sector: Sector, limit: number) => CompanyEntry[]) | null
+  >(null);
+  const parsedRef = useRef(parsed);
+  parsedRef.current = parsed;
+
+  // Mount-only on purpose — see the docblock.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [{ classifySectorHeuristic }, { companiesForSector }] =
+          await Promise.all([
+            import("../lib/job-search/sector.ts"),
+            import("../lib/job-search/company-registry.ts"),
+          ]);
+        if (cancelled) return;
+        const guess = classifySectorHeuristic(parsedRef.current);
+        const pool = companiesForSector(guess.sector, COMPANY_LIMIT);
+        lookupRef.current = companiesForSector;
+        setSector(guess.sector);
+        setRunnerUp(guess.runnerUp ?? null);
+        setSuggested(pool);
+        setKeys(new Set(pool.map(companyKey)));
+      } catch {
+        // Chunk failed to load (offline first-load). Company targeting is
+        // additive: leaving `suggested` empty degrades to the keyless-only
+        // search rather than breaking the panel.
+      } finally {
+        if (!cancelled) setReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggle = useCallback((entry: CompanyEntry) => {
+    setKeys((current) => toggleKey(current, companyKey(entry)));
+  }, []);
+
+  const switchToRunnerUp = useCallback(() => {
+    const lookup = lookupRef.current;
+    if (!lookup || !runnerUp) return;
+    const pool = lookup(runnerUp, COMPANY_LIMIT);
+    setSuggested(pool);
+    setKeys(new Set(pool.map(companyKey)));
+    // Swap the pair rather than clearing the runner-up, so the affordance is
+    // reversible — one more click returns to the original guess.
+    setSector(runnerUp);
+    setRunnerUp(sector);
+  }, [sector, runnerUp]);
+
+  const selected = suggested.filter((entry) => keys.has(companyKey(entry)));
+
+  return {
+    ready,
+    sector,
+    runnerUp,
+    suggested,
+    selected,
+    isSelected: (entry) => keys.has(companyKey(entry)),
+    toggle,
+    switchToRunnerUp,
+  };
+}

--- a/src/lib/job-search/board-cache.test.ts
+++ b/src/lib/job-search/board-cache.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Board-cache tests (#533). Run against `fake-indexeddb/auto` like
+ * `src/lib/storage/storage.test.ts`, so the real `idb` + schema-upgrade path is
+ * exercised — which is also what proves the `DB_VERSION` 1 → 2 bump actually
+ * creates the `boards` store.
+ *
+ * The load-bearing property here is the negative one: no failure mode of the
+ * cache may reject, because callers deliberately don't wrap it in a try/catch.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { DB_NAME, closeDB, getDB } from "../storage/db.ts";
+import { putRecord } from "../storage/crud.ts";
+import type { BoardCacheRecord } from "../storage/types.ts";
+import {
+  readCachedBoard,
+  writeCachedBoard,
+  boardCacheKey,
+  BOARD_CACHE_TTL_MS,
+  MAX_CACHED_POSTINGS,
+} from "./board-cache.ts";
+import type { JobPosting } from "./types.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function posting(id: string): JobPosting {
+  return {
+    id,
+    title: "Backend Engineer",
+    company: "Stripe",
+    location: "Remote",
+    url: `https://example.com/${id}`,
+    description: "",
+    source: "Stripe",
+  };
+}
+
+describe("boardCacheKey", () => {
+  it("namespaces by vendor, since one slug can exist on two ATSes", () => {
+    expect(boardCacheKey("greenhouse", "circle")).not.toBe(
+      boardCacheKey("ashby", "circle"),
+    );
+  });
+});
+
+describe("board cache round-trip", () => {
+  it("returns null on a miss", async () => {
+    expect(await readCachedBoard("greenhouse", "nobody")).toBeNull();
+  });
+
+  it("reads back what it wrote", async () => {
+    await writeCachedBoard("greenhouse", "stripe", [posting("a"), posting("b")]);
+    const cached = await readCachedBoard("greenhouse", "stripe");
+    expect(cached?.map((p) => p.id)).toEqual(["a", "b"]);
+  });
+
+  it("strips descriptions so only the light index persists (even for Lever)", async () => {
+    // Lever's adapter returns a real descriptionPlain inline; the cache must
+    // never store it, or a cached Lever board balloons IndexedDB with the one
+    // field the "light index only" invariant exists to keep out.
+    await writeCachedBoard("lever", "palantir", [
+      { ...posting("a"), description: "a long hydrated job description" },
+      { ...posting("b"), description: "another full description" },
+    ]);
+    const cached = await readCachedBoard("lever", "palantir");
+    expect(cached?.map((p) => p.description)).toEqual(["", ""]);
+    // The rest of the light index survives the strip.
+    expect(cached?.map((p) => p.id)).toEqual(["a", "b"]);
+  });
+
+  it("caps the number of cached postings at MAX_CACHED_POSTINGS", async () => {
+    const big = Array.from({ length: MAX_CACHED_POSTINGS + 50 }, (_, i) =>
+      posting(`p${i}`),
+    );
+    await writeCachedBoard("greenhouse", "huge", big);
+    const cached = await readCachedBoard("greenhouse", "huge");
+    expect(cached).toHaveLength(MAX_CACHED_POSTINGS);
+    // The cap keeps the FIRST rows, not a random slice.
+    expect(cached?.[0].id).toBe("p0");
+  });
+
+  it("keeps vendors with the same slug separate", async () => {
+    await writeCachedBoard("greenhouse", "circle", [posting("gh")]);
+    await writeCachedBoard("ashby", "circle", [posting("ashby")]);
+    expect((await readCachedBoard("greenhouse", "circle"))?.[0].id).toBe("gh");
+    expect((await readCachedBoard("ashby", "circle"))?.[0].id).toBe("ashby");
+  });
+
+  it("treats a row past the TTL as a miss", async () => {
+    await writeCachedBoard("greenhouse", "stripe", [posting("a")]);
+    expect(await readCachedBoard("greenhouse", "stripe")).not.toBeNull();
+
+    // Jump past the window rather than back-dating the row, so the assertion
+    // runs against the same `updatedAt` putRecord actually stamped.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + BOARD_CACHE_TTL_MS + 1000);
+    expect(await readCachedBoard("greenhouse", "stripe")).toBeNull();
+  });
+
+  it("treats a corrupt row (postings not an array) as a miss, not a throw", async () => {
+    await putRecord<BoardCacheRecord>("boards", {
+      id: boardCacheKey("greenhouse", "stripe"),
+      postings: "not an array" as unknown as unknown[],
+    });
+    expect(await readCachedBoard("greenhouse", "stripe")).toBeNull();
+  });
+
+  it("treats a row with a non-numeric updatedAt as a miss, not fresh forever", async () => {
+    // A corrupted/missing timestamp makes `Date.now() - updatedAt` NaN, and
+    // `NaN > TTL` is `false` — without the type guard the row would read as
+    // fresh for all time. putRecord always stamps updatedAt, so write the bad
+    // value through the raw store to reach the guard directly.
+    const db = await getDB();
+    await db.put("boards", {
+      id: boardCacheKey("greenhouse", "stripe"),
+      postings: [posting("a")],
+      createdAt: Date.now(),
+      updatedAt: undefined as unknown as number,
+    });
+    expect(await readCachedBoard("greenhouse", "stripe")).toBeNull();
+  });
+
+  it("never rejects when IndexedDB itself is unavailable", async () => {
+    const original = globalThis.indexedDB;
+    // Simulate private-browsing / storage-disabled: opening throws.
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        open() {
+          throw new Error("storage disabled");
+        },
+      },
+    });
+    await closeDB();
+    try {
+      await expect(readCachedBoard("greenhouse", "stripe")).resolves.toBeNull();
+      await expect(
+        writeCachedBoard("greenhouse", "stripe", [posting("a")]),
+      ).resolves.toBeUndefined();
+    } finally {
+      Object.defineProperty(globalThis, "indexedDB", {
+        configurable: true,
+        value: original,
+      });
+      await closeDB();
+    }
+  });
+});

--- a/src/lib/job-search/board-cache.ts
+++ b/src/lib/job-search/board-cache.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * IndexedDB cache for company ATS boards (#533, slice 5 of epic #528).
+ *
+ * A company board has no server-side search, so every search pulls that
+ * company's WHOLE light index. Re-opening the panel or tweaking a skill chip
+ * would otherwise re-hit a dozen boards for bytes that barely change day to
+ * day. This caches one board's light index under `${ats}:${slug}` with a
+ * TTL, so a second search inside the window costs zero network.
+ *
+ * What is cached is the LIGHT INDEX ONLY — titles/locations/departments, with
+ * `description: ""`. `writeCachedBoard` ENFORCES that: it strips every
+ * description before persisting and caps the row count at `MAX_CACHED_POSTINGS`,
+ * so the invariant holds regardless of what the adapter handed in. That matters
+ * because it is NOT adapter-uniform: Greenhouse's light index already carries
+ * `description: ""`, but Lever's response carries the real `descriptionPlain`,
+ * so without the strip a cached Lever board would persist every full
+ * description — the one field that dominates the cache's size. Descriptions are
+ * re-hydrated per surviving posting downstream (see `company-boards.ts`):
+ * Greenhouse and Lever both have a keyless per-job endpoint. Ashby has none, so
+ * Ashby is never cached at all — its small, monolithic board is re-fetched
+ * fresh each time, descriptions intact; that skip lives in `makeBoardProvider`.
+ *
+ * THE CACHE MAY NEVER SINK A SEARCH. Every failure mode here — IndexedDB
+ * unavailable (private browsing, disabled storage), a blocked upgrade, an
+ * expired row, a corrupt row written by an older build — resolves to "treat as
+ * a miss" or "silently skip the write". Neither function rejects, so a caller
+ * never needs a try/catch around them.
+ */
+
+import { getRecord, putRecord } from "../storage/crud.ts";
+import type { BoardCacheRecord } from "../storage/types.ts";
+import type { JobPosting } from "./types.ts";
+
+/**
+ * How long a cached board stays fresh. 12h sits inside the issue's 6–24h
+ * band: job boards move on a scale of days, and a full day of staleness would
+ * outlive a single job-hunting session, which is the unit a user would notice.
+ */
+export const BOARD_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * Hard cap on postings persisted per board. A light-index row (title, location,
+ * departments, ids, timestamp — no description) is a few hundred bytes, so 300
+ * rows stays comfortably under ~100 KB per board even for the largest
+ * Greenhouse index, while still covering every board in the registry with room
+ * to spare. The cap is a backstop against a pathologically huge board ballooning
+ * IndexedDB, not a functional limit: the cache is an optimization, so anything
+ * past the cap is simply re-fetched rather than served stale.
+ */
+export const MAX_CACHED_POSTINGS = 300;
+
+/** Cache key. `ats` is in the key because the same slug can exist on two
+ *  vendors and mean two different companies. */
+export function boardCacheKey(ats: string, slug: string): string {
+  return `${ats}:${slug}`;
+}
+
+/**
+ * The cached light index for a board, or `null` on miss / expiry / any error.
+ * `null` always means "go fetch" — it never distinguishes the reasons, because
+ * no caller acts differently on them.
+ */
+export async function readCachedBoard(
+  ats: string,
+  slug: string,
+): Promise<JobPosting[] | null> {
+  try {
+    const record = await getRecord<BoardCacheRecord>(
+      "boards",
+      boardCacheKey(ats, slug),
+    );
+    if (!record || !Array.isArray(record.postings)) return null;
+    // `updatedAt` is stamped by putRecord on every write, so freshness tracks
+    // the last fetch rather than when the row was first created. Guard the type
+    // first: a corrupted/missing timestamp makes `Date.now() - x` NaN, and
+    // `NaN > TTL` is `false` — which would treat an unbounded-age row as fresh.
+    if (
+      typeof record.updatedAt !== "number" ||
+      Date.now() - record.updatedAt > BOARD_CACHE_TTL_MS
+    )
+      return null;
+    return record.postings as JobPosting[];
+  } catch {
+    return null;
+  }
+}
+
+/** Store a board's light index. Resolves even when the write fails — a cache
+ *  that can't persist degrades to no cache, never to a failed search. */
+export async function writeCachedBoard(
+  ats: string,
+  slug: string,
+  postings: readonly JobPosting[],
+): Promise<void> {
+  try {
+    // Enforce "light index only" at the write boundary, so no caller — and no
+    // vendor whose adapter returns a full `descriptionPlain` (Lever) — can
+    // sneak a heavy description into the cache. Cap first, then strip: even a
+    // 1000-row board persists at most `MAX_CACHED_POSTINGS` description-less
+    // rows. A survivor's description is re-hydrated on read downstream.
+    const light: JobPosting[] = postings
+      .slice(0, MAX_CACHED_POSTINGS)
+      .map((p) => (p.description === "" ? p : { ...p, description: "" }));
+    await putRecord<BoardCacheRecord>("boards", {
+      id: boardCacheKey(ats, slug),
+      postings: light,
+    });
+  } catch {
+    // Intentionally swallowed — see the module docblock.
+  }
+}

--- a/src/lib/job-search/company-boards.test.ts
+++ b/src/lib/job-search/company-boards.test.ts
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The bounded-pipeline tests (#533) — the ones that actually defend the epic's
+ * central claim: "a 1000-role board does not flood the browser".
+ *
+ * The assertion that carries that weight is the hydrate CALL COUNT. Filtering
+ * and capping the results is easy to get right by accident; hydrating after
+ * filtering is the part a refactor can silently invert, and the only way to
+ * catch it is to count the description fetches against the board size rather
+ * than inspecting the output.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { JobPosting } from "./types.ts";
+import type { JobQuery } from "./query-builder.ts";
+import type { CompanyEntry } from "./company-registry.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import { DB_NAME, closeDB } from "../storage/db.ts";
+
+const hoisted = vi.hoisted(() => ({
+  /** Light-index rows the fake board returns. */
+  board: [] as JobPosting[],
+  boardCalls: 0,
+  hydrateCalls: [] as string[],
+  /** Lever per-job hydrate ids, tracked separately from Greenhouse's. */
+  leverHydrateCalls: [] as string[],
+  /** When set, the fake board rejects with it — the CORS/404 case. */
+  boardError: null as Error | null,
+  /** Job ids whose description fetch should reject. */
+  hydrateFailIds: new Set<string>(),
+}));
+
+// Stub the adapter layer, not `fetch`: this suite is about the ORDER of the
+// pipeline stages, and the adapters have their own suites.
+vi.mock("./providers/index.ts", () => ({
+  makeCompanyProvider: (entry: CompanyEntry) => ({
+    id: `${entry.ats}:${entry.slug}`,
+    label: entry.name,
+    search: async () => {
+      hoisted.boardCalls += 1;
+      if (hoisted.boardError) throw hoisted.boardError;
+      return hoisted.board;
+    },
+  }),
+}));
+
+vi.mock("./providers/greenhouse.ts", () => ({
+  hydrateGreenhouse: async (_slug: string, jobId: string) => {
+    hoisted.hydrateCalls.push(jobId);
+    if (hoisted.hydrateFailIds.has(jobId)) throw new Error("404");
+    return `description for ${jobId}`;
+  },
+}));
+
+vi.mock("./providers/lever.ts", () => ({
+  hydrateLever: async (_slug: string, jobId: string) => {
+    hoisted.leverHydrateCalls.push(jobId);
+    return `lever description for ${jobId}`;
+  },
+}));
+
+import {
+  makeBoardProvider,
+  makeBoardProviders,
+  greenhouseJobId,
+  leverJobId,
+  hydrateDescriptions,
+} from "./company-boards.ts";
+import { DEFAULT_PER_COMPANY_CAP } from "./role-keywords.ts";
+import { readCachedBoard } from "./board-cache.ts";
+
+const STRIPE: CompanyEntry = {
+  name: "Stripe",
+  ats: "greenhouse",
+  slug: "stripe",
+  sectors: ["fintech"],
+};
+const query: JobQuery = { titles: ["Backend Engineer"], skills: [] };
+const signal = new AbortController().signal;
+
+/** A backend-titled resume, so `roleFilterForResume` yields a real (non-"all")
+ *  filter rather than the permissive floor. */
+const backendResume: HeuristicParsedResume = {
+  skills: [],
+  experience: [{ title: "Senior Backend Engineer", company: "X" }],
+  education: [],
+};
+
+function ghPosting(n: number, title: string): JobPosting {
+  return {
+    id: `greenhouse:stripe:${n}`,
+    title,
+    company: "Stripe",
+    location: "Remote",
+    url: `https://boards.greenhouse.io/stripe/jobs/${n}`,
+    description: "",
+    source: "Stripe",
+  };
+}
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+  hoisted.board = [];
+  hoisted.boardCalls = 0;
+  hoisted.hydrateCalls = [];
+  hoisted.leverHydrateCalls = [];
+  hoisted.boardError = null;
+  hoisted.hydrateFailIds = new Set();
+});
+
+describe("greenhouseJobId", () => {
+  it("strips the known prefix", () => {
+    expect(greenhouseJobId("stripe", "greenhouse:stripe:12345")).toBe("12345");
+  });
+
+  it("returns '' for a posting from another provider", () => {
+    expect(greenhouseJobId("stripe", "lever:stripe:abc")).toBe("");
+  });
+
+  it("is not fooled by a slug containing a colon-like segment", () => {
+    // A trailing-colon search would return "b:9" here; prefix-stripping is exact.
+    expect(greenhouseJobId("a:b", "greenhouse:a:b:9")).toBe("9");
+  });
+});
+
+describe("leverJobId", () => {
+  it("strips the known prefix", () => {
+    expect(leverJobId("palantir", "lever:palantir:abc-123")).toBe("abc-123");
+  });
+
+  it("returns '' for a posting from another provider", () => {
+    expect(leverJobId("palantir", "greenhouse:palantir:9")).toBe("");
+  });
+
+  it("is not fooled by a slug containing a colon-like segment", () => {
+    expect(leverJobId("a:b", "lever:a:b:9")).toBe("9");
+  });
+});
+
+describe("makeBoardProvider — filter and cap run BEFORE hydration", () => {
+  it("hydrates once per survivor, not once per board row", async () => {
+    // 500-row board: 3 backend roles, 497 unrelated.
+    hoisted.board = [
+      ghPosting(1, "Senior Backend Engineer"),
+      ghPosting(2, "Staff Backend Engineer"),
+      ghPosting(3, "Backend Engineer, Payments"),
+      ...Array.from({ length: 497 }, (_, i) => ghPosting(100 + i, "Account Executive")),
+    ];
+
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+    const results = await provider.search(query, signal);
+
+    expect(results).toHaveLength(3);
+    // The whole point: 3 description fetches for a 500-row board.
+    expect(hoisted.hydrateCalls).toEqual(["1", "2", "3"]);
+    expect(results.map((p) => p.description)).toEqual([
+      "description for 1",
+      "description for 2",
+      "description for 3",
+    ]);
+  });
+
+  it("caps per company, and hydrates only the capped set", async () => {
+    // 40 rows that ALL match the role filter — only the cap can bound this.
+    hoisted.board = Array.from({ length: 40 }, (_, i) =>
+      ghPosting(i, "Backend Engineer"),
+    );
+
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+    const results = await provider.search(query, signal);
+
+    expect(results).toHaveLength(DEFAULT_PER_COMPANY_CAP);
+    expect(hoisted.hydrateCalls).toHaveLength(DEFAULT_PER_COMPANY_CAP);
+  });
+
+  it("honours an explicit per-company cap", async () => {
+    hoisted.board = Array.from({ length: 40 }, (_, i) =>
+      ghPosting(i, "Backend Engineer"),
+    );
+    const provider = makeBoardProvider(
+      STRIPE,
+      { families: ["backend"], keywords: ["backend"], source: "heuristic" },
+      2,
+    );
+    expect(await provider.search(query, signal)).toHaveLength(2);
+    expect(hoisted.hydrateCalls).toHaveLength(2);
+  });
+
+  it("keeps a posting whose hydrate fails, minus its description", async () => {
+    hoisted.board = [ghPosting(1, "Backend Engineer"), ghPosting(2, "Backend Engineer")];
+    hoisted.hydrateFailIds = new Set(["1"]);
+
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+    const results = await provider.search(query, signal);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].description).toBe("");
+    expect(results[1].description).toBe("description for 2");
+  });
+
+  it("propagates a board failure so the orchestrator can degrade it", async () => {
+    hoisted.boardError = new Error("CORS blocked");
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+    await expect(provider.search(query, signal)).rejects.toThrow("CORS blocked");
+  });
+
+  it("does not hydrate a FRESH Lever board — it already carries descriptionPlain", async () => {
+    // On a cache MISS the board fetch returns descriptions inline, so a Lever
+    // survivor whose text is already present costs zero per-job requests.
+    const lever: CompanyEntry = {
+      name: "Palantir",
+      ats: "lever",
+      slug: "palantir",
+      sectors: ["government-defense"],
+    };
+    hoisted.board = [
+      {
+        ...ghPosting(1, "Backend Engineer"),
+        id: "lever:palantir:1",
+        company: "Palantir",
+        description: "already plaintext",
+      },
+    ];
+    const [provider] = makeBoardProviders([lever], backendResume);
+    const results = await provider.search(query, signal);
+    expect(hoisted.leverHydrateCalls).toEqual([]);
+    expect(hoisted.hydrateCalls).toEqual([]);
+    expect(results[0].description).toBe("already plaintext");
+  });
+
+  it("passes the whole (capped) board through for an unclassifiable resume", async () => {
+    // The never-fail-closed floor: an empty resume must not yield zero jobs.
+    hoisted.board = [ghPosting(1, "Chef"), ghPosting(2, "Welder")];
+    const [provider] = makeBoardProviders([STRIPE], {
+      skills: [],
+      experience: [],
+      education: [],
+    });
+    expect(await provider.search(query, signal)).toHaveLength(2);
+  });
+});
+
+describe("makeBoardProvider — IndexedDB cache", () => {
+  it("does not re-fetch a board that is cached within the TTL", async () => {
+    hoisted.board = [ghPosting(1, "Backend Engineer")];
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+
+    await provider.search(query, signal);
+    expect(hoisted.boardCalls).toBe(1);
+
+    await provider.search(query, signal);
+    expect(hoisted.boardCalls).toBe(1);
+  });
+
+  it("caches the LIGHT index, so a cache hit still hydrates", async () => {
+    hoisted.board = [ghPosting(1, "Backend Engineer")];
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+
+    await provider.search(query, signal);
+    hoisted.hydrateCalls = [];
+
+    const results = await provider.search(query, signal);
+    expect(hoisted.hydrateCalls).toEqual(["1"]);
+    expect(results[0].description).toBe("description for 1");
+  });
+
+  it("re-hydrates Lever survivors from the stripped cache — once per survivor, not board size", async () => {
+    const PALANTIR: CompanyEntry = {
+      name: "Palantir",
+      ats: "lever",
+      slug: "palantir",
+      sectors: ["government-defense"],
+    };
+    // 2 backend roles that survive the filter + 50 unrelated that don't.
+    const lv = (n: number, title: string, desc: string): JobPosting => ({
+      ...ghPosting(n, title),
+      id: `lever:palantir:${n}`,
+      company: "Palantir",
+      description: desc,
+    });
+    hoisted.board = [
+      lv(1, "Senior Backend Engineer", "fresh plaintext 1"),
+      lv(2, "Backend Engineer", "fresh plaintext 2"),
+      ...Array.from({ length: 50 }, (_, i) => lv(100 + i, "Account Executive", "x")),
+    ];
+    const [provider] = makeBoardProviders([PALANTIR], backendResume);
+
+    // Cache miss: descriptions arrive inline, so nothing is hydrated per-job.
+    const first = await provider.search(query, signal);
+    expect(hoisted.boardCalls).toBe(1);
+    expect(hoisted.leverHydrateCalls).toEqual([]);
+    expect(first.map((p) => p.description)).toEqual(["fresh plaintext 1", "fresh plaintext 2"]);
+
+    // Cache hit: the cache stored the LIGHT index (descriptions stripped), so
+    // each survivor is hydrated per-job — count == survivors (2), never the
+    // 52-row board size.
+    hoisted.leverHydrateCalls = [];
+    const second = await provider.search(query, signal);
+    expect(hoisted.boardCalls).toBe(1); // no re-fetch
+    expect(hoisted.leverHydrateCalls).toEqual(["1", "2"]);
+    expect(second.map((p) => p.description)).toEqual([
+      "lever description for 1",
+      "lever description for 2",
+    ]);
+  });
+
+  it("never caches Ashby — it re-fetches fresh, descriptions intact, no hydrate", async () => {
+    const RAMP: CompanyEntry = {
+      name: "Ramp",
+      ats: "ashby",
+      slug: "ramp",
+      sectors: ["fintech"],
+    };
+    hoisted.board = [
+      {
+        ...ghPosting(1, "Backend Engineer"),
+        id: "ashby:ramp:1",
+        company: "Ramp",
+        description: "ashby plaintext",
+      },
+    ];
+    const [provider] = makeBoardProviders([RAMP], backendResume);
+
+    const first = await provider.search(query, signal);
+    expect(first[0].description).toBe("ashby plaintext");
+    expect(hoisted.boardCalls).toBe(1);
+
+    // No cache was written, so the second search re-fetches the whole board.
+    const second = await provider.search(query, signal);
+    expect(hoisted.boardCalls).toBe(2);
+    expect(second[0].description).toBe("ashby plaintext");
+    expect(hoisted.hydrateCalls).toEqual([]);
+    expect(hoisted.leverHydrateCalls).toEqual([]);
+    // Nothing landed in the cache under the Ashby key.
+    expect(await readCachedBoard("ashby", "ramp")).toBeNull();
+  });
+
+  it("fetches when the cache read throws — a cache error never sinks a search", async () => {
+    hoisted.board = [ghPosting(1, "Backend Engineer")];
+    const original = globalThis.indexedDB;
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        open() {
+          throw new Error("storage disabled");
+        },
+      },
+    });
+    await closeDB();
+    try {
+      const [provider] = makeBoardProviders([STRIPE], backendResume);
+      expect(await provider.search(query, signal)).toHaveLength(1);
+      expect(hoisted.boardCalls).toBe(1);
+    } finally {
+      Object.defineProperty(globalThis, "indexedDB", {
+        configurable: true,
+        value: original,
+      });
+      await closeDB();
+    }
+  });
+});
+
+describe("hydrateDescriptions", () => {
+  it("returns non-Greenhouse postings untouched without any fetch", async () => {
+    const postings = [
+      { ...ghPosting(1, "X"), id: "ashby:vanta:1", description: "plain" },
+    ];
+    const result = await hydrateDescriptions(
+      { name: "Vanta", ats: "ashby", slug: "vanta", sectors: ["security"] },
+      postings,
+      signal,
+    );
+    expect(result).toEqual(postings);
+    expect(hoisted.hydrateCalls).toEqual([]);
+  });
+
+  it("skips a posting whose id doesn't carry a recoverable job id", async () => {
+    const postings = [{ ...ghPosting(1, "X"), id: "greenhouse:stripe:" }];
+    const result = await hydrateDescriptions(STRIPE, postings, signal);
+    expect(hoisted.hydrateCalls).toEqual([]);
+    expect(result[0].description).toBe("");
+  });
+});

--- a/src/lib/job-search/company-boards.ts
+++ b/src/lib/job-search/company-boards.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The bounded company-board pipeline (#533, slice 5 — the integration — of the
+ * job-search-v2 epic #528).
+ *
+ * The five build slices (#529–#532, #534) each shipped a piece with no wiring.
+ * This is where they connect, and the ONE thing it exists to guarantee is that
+ * a big board stays cheap:
+ *
+ *   cached light index (or fetch it)   board-cache.ts / the slice-1/2 adapters
+ *     → filterPostingsByRole           role-keywords.ts (#534)
+ *     → capPerCompany                  role-keywords.ts (#534)
+ *     → hydrate ONLY the survivors     hydrateGreenhouse / hydrateLever
+ *
+ * ORDER IS THE WHOLE POINT. A 1000-role Greenhouse board costs exactly one
+ * light-index request plus at most `perCompanyCap` description fetches, because
+ * hydration runs strictly AFTER the filter and the cap. Hydrating first — or
+ * capping after hydrating — would issue 1000 requests for descriptions that are
+ * then thrown away.
+ *
+ * DESCRIPTIONS PER VENDOR (they do NOT behave alike):
+ *   - Greenhouse: light index has `description: ""`; every survivor is hydrated
+ *     per-job via `hydrateGreenhouse`.
+ *   - Lever: a FRESH board fetch already carries `descriptionPlain` inline, so
+ *     its survivors need no hydrate — but the cache stores light rows only
+ *     (descriptions stripped), so on a CACHE HIT a Lever survivor is re-hydrated
+ *     per-job via `hydrateLever`. `hydrateDescriptions` keys off the empty
+ *     description, so it fetches exactly the survivors that lost their text.
+ *   - Ashby: no keyless per-job endpoint exists, so a stripped light cache could
+ *     never rehydrate it. Ashby is therefore NOT cached at all; its small,
+ *     monolithic board is fetched fresh each search (descriptions intact) and
+ *     never hydrated.
+ *
+ * Each board is wrapped as an ordinary `JobProvider`, so the orchestrator's
+ * existing `allSettled` semantics carry over unchanged and for free: a board
+ * that 404s, times out, or is blocked by CORS lands in `degradedProviders` and
+ * the rest of the search still returns. That is also why the pipeline lives
+ * behind the provider interface rather than in a parallel fan-out.
+ *
+ * PRIVACY: the request carries the public company slug (and a job id when
+ * hydrating) and nothing else. `roleFilterForResume` and `filterPostingsByRole`
+ * run purely on-device over already-fetched postings, so this slice adds no
+ * egress. `providers/keywords.ts` — the single audited resume-derived egress
+ * helper — is used only by the keyless feeds and is deliberately not imported
+ * here.
+ */
+
+import type { CompanyEntry } from "./company-registry.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobProvider, JobPosting } from "./types.ts";
+import {
+  roleFilterForResume,
+  filterPostingsByRole,
+  capPerCompany,
+  DEFAULT_PER_COMPANY_CAP,
+  type RoleFilter,
+} from "./role-keywords.ts";
+import { makeCompanyProvider } from "./providers/index.ts";
+import { hydrateGreenhouse } from "./providers/greenhouse.ts";
+import { hydrateLever } from "./providers/lever.ts";
+import { readCachedBoard, writeCachedBoard } from "./board-cache.ts";
+import { mapWithConcurrency } from "./concurrency.ts";
+
+/**
+ * Description fetches in flight per board. Lower than the board-level fan-out
+ * cap because these are same-host requests — Greenhouse would queue them behind
+ * its own connection limit anyway, and this is the only place we issue a burst
+ * of requests to one origin.
+ */
+const HYDRATE_CONCURRENCY = 4;
+
+/** `id` on a Greenhouse posting is `greenhouse:{slug}:{jobId}` (see
+ *  `providers/greenhouse.ts`). Recover the job id by stripping the known
+ *  prefix — a substring search for the last ":" would break on a slug that
+ *  itself contains one. Returns "" when the shape doesn't match, which the
+ *  caller reads as "not hydratable". */
+export function greenhouseJobId(slug: string, postingId: string): string {
+  const prefix = `greenhouse:${slug}:`;
+  return postingId.startsWith(prefix) ? postingId.slice(prefix.length) : "";
+}
+
+/** `id` on a Lever posting is `lever:{slug}:{jobId}` (see `providers/lever.ts`).
+ *  Recover the job id by stripping the known prefix, exactly as
+ *  `greenhouseJobId` does — a last-":" search would break on a slug that itself
+ *  contains one. Returns "" when the shape doesn't match, read by the caller as
+ *  "not hydratable". */
+export function leverJobId(slug: string, postingId: string): string {
+  const prefix = `lever:${slug}:`;
+  return postingId.startsWith(prefix) ? postingId.slice(prefix.length) : "";
+}
+
+/**
+ * Fill in `description` for the postings that survived filtering + capping.
+ *
+ * Only survivors whose description is EMPTY are hydrated — that is exactly the
+ * set that lost its text: a Greenhouse light-index row (always `""`) or a
+ * cache-hit row whose description `writeCachedBoard` stripped. A survivor that
+ * still carries text (a fresh Lever board fetch) is left untouched, so a Lever
+ * cache MISS costs zero per-job requests. Ashby is a hard no-op: it has no
+ * per-job endpoint and is never cached, so its board-fetch descriptions are
+ * always already present.
+ *
+ * A hydrate failure costs that ONE posting its description, never its place in
+ * THIS function's output — an undescribed posting still has a title, company,
+ * and link, so hydration never drops it. The guarantee is provider-local,
+ * though: downstream, `searchJobs` re-filters every posting through
+ * `matchesQuery` (title + description), so a text-less survivor whose title
+ * carries no query token can still be dropped there. That is a deliberate
+ * second gate, not a hydrate bug — it just means the "never dropped" promise
+ * holds for hydration, not end-to-end. An undescribed posting also ranks lower,
+ * the honest consequence of having no text to match against.
+ */
+export async function hydrateDescriptions(
+  entry: CompanyEntry,
+  postings: readonly JobPosting[],
+  signal: AbortSignal,
+): Promise<JobPosting[]> {
+  if (entry.ats === "ashby") return [...postings];
+
+  const settled = await mapWithConcurrency(
+    postings,
+    HYDRATE_CONCURRENCY,
+    async (posting) => {
+      // Already-hydrated survivor (a fresh Lever fetch) — no request.
+      if (posting.description !== "") return posting.description;
+      if (entry.ats === "greenhouse") {
+        const jobId = greenhouseJobId(entry.slug, posting.id);
+        return jobId ? hydrateGreenhouse(entry.slug, jobId, signal) : posting.description;
+      }
+      // entry.ats === "lever"
+      const jobId = leverJobId(entry.slug, posting.id);
+      return jobId ? hydrateLever(entry.slug, jobId, signal) : posting.description;
+    },
+  );
+
+  return postings.map((posting, i) => {
+    const outcome = settled[i];
+    return outcome.status === "fulfilled"
+      ? { ...posting, description: outcome.value }
+      : posting;
+  });
+}
+
+/**
+ * Wrap one registry entry as a bounded `JobProvider`. `search()` runs the full
+ * pipeline and returns only the filtered, capped, hydrated postings — so the
+ * orchestrator downstream never sees the raw board.
+ */
+export function makeBoardProvider(
+  entry: CompanyEntry,
+  filter: RoleFilter,
+  perCompanyCap: number = DEFAULT_PER_COMPANY_CAP,
+): JobProvider {
+  const base = makeCompanyProvider(entry);
+  // Ashby has no keyless per-job endpoint, so a light (description-stripped)
+  // cache could never rehydrate it. Rather than persist a record that would
+  // violate the "light index only" invariant, Ashby is never cached: its board
+  // is small and monolithic, so a fresh fetch each search is cheap and keeps
+  // descriptions intact.
+  const cacheable = entry.ats !== "ashby";
+  return {
+    id: base.id,
+    label: base.label,
+    async search(query, signal): Promise<JobPosting[]> {
+      const cached = cacheable ? await readCachedBoard(entry.ats, entry.slug) : null;
+      let index: JobPosting[];
+      if (cached) {
+        index = cached;
+      } else {
+        // A rejection here propagates: this board becomes one degraded
+        // provider, which is exactly the intended failure mode.
+        index = await base.search(query, signal);
+        // Awaited deliberately: the write must commit before `search` returns so
+        // a rapid follow-up search hits the cache instead of re-fetching the
+        // board (company-boards.test.ts pins this). It's one IndexedDB put and
+        // never rejects — cheap enough to keep on the path for that guarantee.
+        if (cacheable) await writeCachedBoard(entry.ats, entry.slug, index);
+      }
+
+      // `capPerCompany` truncates in the board's NATIVE order, before hydrate
+      // and before `rankPostings` — a deliberate request-bounding tradeoff: a
+      // strong-fit role past the cap in board order is dropped before ranking
+      // can see it. Fit-aware selection here would need a pre-hydrate signal
+      // (title/skill-in-title); today the cap is board-order, and rank only
+      // reorders the survivors. See the epic-#528 follow-up on skills ranking.
+      const survivors = capPerCompany(
+        filterPostingsByRole(index, filter),
+        perCompanyCap,
+      );
+      return hydrateDescriptions(entry, survivors, signal);
+    },
+  };
+}
+
+/**
+ * Bounded providers for every selected company. The role filter is derived from
+ * the resume ONCE here and shared by every board — it does not vary per company,
+ * and recomputing it per board would re-scan the resume for each one.
+ */
+export function makeBoardProviders(
+  entries: readonly CompanyEntry[],
+  parsed: HeuristicParsedResume,
+  perCompanyCap: number = DEFAULT_PER_COMPANY_CAP,
+): JobProvider[] {
+  const filter = roleFilterForResume(parsed);
+  return entries.map((entry) => makeBoardProvider(entry, filter, perCompanyCap));
+}

--- a/src/lib/job-search/company-registry.test.ts
+++ b/src/lib/job-search/company-registry.test.ts
@@ -40,17 +40,36 @@ describe("COMPANY_REGISTRY", () => {
     }
   });
 
-  it("seeds ~150-250 companies", () => {
-    expect(COMPANY_REGISTRY.length).toBeGreaterThanOrEqual(150);
+  /**
+   * The original #532 list was 162 hand-curated, unverified entries and
+   * asserted 150–250. The #533 existence audit fetched every one of them and
+   * removed the 48 whose board could not be found on any supported vendor, so
+   * the floor drops to ~100. Deliberately NOT re-pinned to exactly 114: entries
+   * will be pruned and added as boards churn, and a hard equality here would
+   * turn every routine refresh into a test edit.
+   */
+  it("seeds ~100-250 companies", () => {
+    expect(COMPANY_REGISTRY.length).toBeGreaterThanOrEqual(100);
     expect(COMPANY_REGISTRY.length).toBeLessThanOrEqual(250);
   });
 
-  it("populates every non-'other' sector with at least one company", () => {
-    for (const sector of SECTORS) {
-      if (sector === "other") continue;
-      const count = COMPANY_REGISTRY.filter((e) => e.sectors.includes(sector)).length;
-      expect(count).toBeGreaterThanOrEqual(1);
-    }
+  /**
+   * The audit pruned unevenly across sectors, so this guards the property that
+   * actually matters after a prune: `companiesForSector` must never hand the
+   * #533 fan-out an empty set for a sector the classifier can return. A bare
+   * ">= 1" would pass with a single company — too thin to be a useful search.
+   */
+  it("leaves every non-'other' sector with enough companies to search", () => {
+    const MIN_PER_SECTOR = 5;
+    // Collect the shortfalls rather than asserting in the loop, so a failure
+    // names the starved sector instead of just "expected 3 to be >= 5".
+    const starved = SECTORS.filter(
+      (sector) =>
+        sector !== "other" &&
+        COMPANY_REGISTRY.filter((e) => e.sectors.includes(sector)).length <
+          MIN_PER_SECTOR,
+    );
+    expect(starved).toEqual([]);
   });
 });
 
@@ -77,5 +96,20 @@ describe("companiesForSector", () => {
     const results = companiesForSector("government-defense", 1000);
     expect(results.length).toBeLessThan(1000);
     expect(results.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * #542 raised `COMPANY_LIMIT` (`useCompanyTargets.ts`) from 8 to 14 — the
+   * largest per-sector count the registry has today (fintech, devtools). This
+   * guards the premise: if a future prune shrinks every sector back under 8,
+   * the cap raise silently stops mattering and nobody would notice.
+   */
+  it("has at least one sector with 14 or more entries, justifying the #542 cap", () => {
+    const withFourteenOrMore = SECTORS.filter(
+      (sector) =>
+        sector !== "other" &&
+        COMPANY_REGISTRY.filter((e) => e.sectors.includes(sector)).length >= 14,
+    );
+    expect(withFourteenOrMore.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/job-search/company-registry.ts
+++ b/src/lib/job-search/company-registry.ts
@@ -15,17 +15,42 @@
  * Sourcing: hand-curated from each ATS vendor's public board directory and
  * general familiarity with well-known companies' public careers pages, one
  * company per entry, tagged with 1-2 sectors from `./sector.ts`. Curated
- * 2026-07-21.
+ * 2026-07-21; EXISTENCE-AUDITED 2026-07-22 (#533).
  *
- * IMPORTANT — slugs are NOT CORS-verified. Unlike the slice-1/2 adapters
- * (whose docblocks note "unverified from a browser origin" pending a live
- * check), these slugs have not even been curl-checked for existence; they
- * are a best-effort curated list. #533 (the live wiring slice) is expected
- * to browser-verify each board it actually queries and silently drop any
- * slug that 404s or fails CORS — a dead entry here costs nothing worse than
- * an empty search result. Treat this list as "plausible, needs-verification"
- * data, not a source of truth for "company X uses ATS Y". A periodic
- * re-verify/refresh pass is future work, not this slice.
+ * EXISTENCE-audited, NOT CORS-verified — two different claims, do not
+ * conflate them:
+ *
+ *  - What the audit proves: every entry below was fetched from its vendor
+ *    endpoint and returned HTTP 200 with at least one real posting. The
+ *    original curated list was 162 entries and only 68 of them resolved;
+ *    46 were wrong about the VENDOR rather than the company (Notion is on
+ *    Ashby, not Lever; Vercel on Greenhouse, not Ashby) and were corrected,
+ *    and 48 whose board could not be found on any of the three vendors were
+ *    REMOVED rather than left as known-404s. Two lookalike boards were also
+ *    dropped after inspection: `ashby:rec` is a recreation-booking startup,
+ *    not Rec Room, and `ashby:circle` carries no USDC/stablecoin signal, so
+ *    it is not Circle Internet Financial.
+ *  - What the audit does NOT prove: browser CORS. The audit ran over `curl`,
+ *    which ignores CORS entirely, so a 200 here says the board EXISTS — not
+ *    that a page on offlinecv.org may read it. Browser-origin CORS
+ *    verification per vendor remains an open task (a human/dev step).
+ *
+ * Boards churn: a company can move ATS or close its board at any time, so a
+ * stale entry is expected drift, not a bug. The wiring in `company-boards.ts`
+ * treats a dead board as one degraded provider, never a failed search, so the
+ * cost of drift stays bounded. A periodic re-verify pass is future work.
+ *
+ * STRUCTURAL LIMITATION — large self-hosted-careers employers (#542): Apple,
+ * Google, Meta, and most other FAANG-scale companies run their own careers
+ * site rather than a Greenhouse/Lever/Ashby board, so they cannot be added
+ * here as-is — there is no API endpoint of the shape this registry (and
+ * `company-boards.ts`) assumes. This is a structural boundary of the
+ * three-vendor design, not a bug or a curation gap. Those employers are
+ * reachable through `FindJobsPanel`'s "Search external boards" deep links
+ * (LinkedIn / Indeed / Google Jobs), which crawl self-hosted sites too. A 4th
+ * source (a scraper for company-owned careers pages) would close this gap
+ * properly but is a separate, larger lane — see #542's "explicitly out of
+ * scope".
  */
 
 import type { Sector } from "./sector.ts";
@@ -51,195 +76,147 @@ export interface CompanyEntry {
 export const COMPANY_REGISTRY: readonly CompanyEntry[] = [
   // -- fintech ------------------------------------------------------------
   { name: "Stripe", ats: "greenhouse", slug: "stripe", sectors: ["fintech"] },
-  { name: "Plaid", ats: "greenhouse", slug: "plaid", sectors: ["fintech"] },
+  { name: "Plaid", ats: "ashby", slug: "plaid", sectors: ["fintech"] },
   { name: "Robinhood", ats: "greenhouse", slug: "robinhood", sectors: ["fintech"] },
   { name: "Affirm", ats: "greenhouse", slug: "affirm", sectors: ["fintech"] },
   { name: "Chime", ats: "greenhouse", slug: "chime", sectors: ["fintech"] },
   { name: "Brex", ats: "greenhouse", slug: "brex", sectors: ["fintech"] },
   { name: "Ramp", ats: "ashby", slug: "ramp", sectors: ["fintech"] },
-  { name: "Mercury", ats: "ashby", slug: "mercury", sectors: ["fintech"] },
+  { name: "Mercury", ats: "greenhouse", slug: "mercury", sectors: ["fintech"] },
   { name: "Coinbase", ats: "greenhouse", slug: "coinbase", sectors: ["fintech", "crypto-web3"] },
   { name: "Marqeta", ats: "greenhouse", slug: "marqeta", sectors: ["fintech"] },
-  { name: "Wealthfront", ats: "greenhouse", slug: "wealthfront", sectors: ["fintech"] },
-  { name: "Klarna", ats: "lever", slug: "klarna", sectors: ["fintech"] },
+  { name: "Wealthfront", ats: "lever", slug: "wealthfront", sectors: ["fintech"] },
   { name: "Gusto", ats: "greenhouse", slug: "gusto", sectors: ["fintech", "enterprise-saas"] },
   { name: "Carta", ats: "greenhouse", slug: "carta", sectors: ["fintech"] },
 
   // -- devtools -------------------------------------------------------------
   { name: "GitLab", ats: "greenhouse", slug: "gitlab", sectors: ["devtools"] },
-  { name: "GitHub", ats: "greenhouse", slug: "github", sectors: ["devtools"] },
-  { name: "HashiCorp", ats: "greenhouse", slug: "hashicorp", sectors: ["devtools"] },
-  { name: "Docker", ats: "greenhouse", slug: "docker", sectors: ["devtools"] },
-  { name: "Postman", ats: "lever", slug: "postman", sectors: ["devtools"] },
-  { name: "Vercel", ats: "ashby", slug: "vercel", sectors: ["devtools"] },
-  { name: "Netlify", ats: "lever", slug: "netlify", sectors: ["devtools"] },
+  { name: "Docker", ats: "ashby", slug: "docker", sectors: ["devtools"] },
+  { name: "Postman", ats: "greenhouse", slug: "postman", sectors: ["devtools"] },
+  { name: "Vercel", ats: "greenhouse", slug: "vercel", sectors: ["devtools"] },
+  { name: "Netlify", ats: "greenhouse", slug: "netlify", sectors: ["devtools"] },
   { name: "CircleCI", ats: "greenhouse", slug: "circleci", sectors: ["devtools"] },
   { name: "JFrog", ats: "greenhouse", slug: "jfrog", sectors: ["devtools"] },
-  { name: "Sentry", ats: "greenhouse", slug: "sentry", sectors: ["devtools"] },
+  { name: "Sentry", ats: "ashby", slug: "sentry", sectors: ["devtools"] },
   { name: "LaunchDarkly", ats: "greenhouse", slug: "launchdarkly", sectors: ["devtools"] },
   { name: "Replit", ats: "ashby", slug: "replit", sectors: ["devtools"] },
   { name: "Warp", ats: "ashby", slug: "warp", sectors: ["devtools"] },
 
   // -- data-ml --------------------------------------------------------------
   { name: "Databricks", ats: "greenhouse", slug: "databricks", sectors: ["data-ml"] },
-  { name: "Snowflake", ats: "greenhouse", slug: "snowflake", sectors: ["data-ml"] },
-  { name: "Scale AI", ats: "ashby", slug: "scaleai", sectors: ["data-ml"] },
-  { name: "Weights & Biases", ats: "greenhouse", slug: "wandb", sectors: ["data-ml"] },
-  { name: "Hugging Face", ats: "lever", slug: "huggingface", sectors: ["data-ml"] },
-  { name: "DataRobot", ats: "greenhouse", slug: "datarobot", sectors: ["data-ml"] },
+  { name: "Snowflake", ats: "ashby", slug: "snowflake", sectors: ["data-ml"] },
+  { name: "Scale AI", ats: "greenhouse", slug: "scaleai", sectors: ["data-ml"] },
   { name: "Fivetran", ats: "greenhouse", slug: "fivetran", sectors: ["data-ml"] },
-  { name: "dbt Labs", ats: "greenhouse", slug: "dbtlabs", sectors: ["data-ml"] },
   { name: "Anthropic", ats: "greenhouse", slug: "anthropic", sectors: ["data-ml"] },
   { name: "Cohere", ats: "ashby", slug: "cohere", sectors: ["data-ml"] },
   { name: "Pinecone", ats: "ashby", slug: "pinecone", sectors: ["data-ml"] },
   { name: "Modal", ats: "ashby", slug: "modal", sectors: ["data-ml"] },
 
   // -- healthtech -------------------------------------------------------------
-  { name: "Oscar Health", ats: "greenhouse", slug: "oscarhealth", sectors: ["healthtech"] },
-  { name: "Ro", ats: "greenhouse", slug: "ro", sectors: ["healthtech"] },
-  { name: "Cedar", ats: "greenhouse", slug: "cedar", sectors: ["healthtech"] },
-  { name: "Tempus", ats: "greenhouse", slug: "tempus", sectors: ["healthtech"] },
+  { name: "Oscar Health", ats: "greenhouse", slug: "oscar", sectors: ["healthtech"] },
+  { name: "Ro", ats: "lever", slug: "ro", sectors: ["healthtech"] },
+  { name: "Cedar", ats: "ashby", slug: "cedar", sectors: ["healthtech"] },
   { name: "Zocdoc", ats: "greenhouse", slug: "zocdoc", sectors: ["healthtech"] },
-  { name: "Included Health", ats: "greenhouse", slug: "includedhealth", sectors: ["healthtech"] },
+  { name: "Included Health", ats: "lever", slug: "includedhealth", sectors: ["healthtech"] },
   { name: "Komodo Health", ats: "greenhouse", slug: "komodohealth", sectors: ["healthtech"] },
   { name: "Clover Health", ats: "greenhouse", slug: "cloverhealth", sectors: ["healthtech"] },
-  { name: "Benchling", ats: "greenhouse", slug: "benchling", sectors: ["healthtech", "data-ml"] },
-  { name: "Devoted Health", ats: "greenhouse", slug: "devotedhealth", sectors: ["healthtech"] },
-  { name: "Nuna", ats: "lever", slug: "nuna", sectors: ["healthtech"] },
+  { name: "Benchling", ats: "ashby", slug: "benchling", sectors: ["healthtech", "data-ml"] },
+  { name: "Nuna", ats: "ashby", slug: "nuna", sectors: ["healthtech"] },
   { name: "Maven Clinic", ats: "greenhouse", slug: "mavenclinic", sectors: ["healthtech"] },
 
   // -- ecommerce --------------------------------------------------------------
-  { name: "Shopify", ats: "lever", slug: "shopify", sectors: ["ecommerce"] },
-  { name: "Wayfair", ats: "greenhouse", slug: "wayfair", sectors: ["ecommerce"] },
   { name: "Instacart", ats: "greenhouse", slug: "instacart", sectors: ["ecommerce"] },
   { name: "Faire", ats: "greenhouse", slug: "faire", sectors: ["ecommerce"] },
-  { name: "Whatnot", ats: "ashby", slug: "whatnot", sectors: ["ecommerce", "consumer-social"] },
-  { name: "Allbirds", ats: "greenhouse", slug: "allbirds", sectors: ["ecommerce"] },
-  { name: "Warby Parker", ats: "greenhouse", slug: "warbyparker", sectors: ["ecommerce"] },
-  { name: "Glossier", ats: "lever", slug: "glossier", sectors: ["ecommerce"] },
+  { name: "Glossier", ats: "greenhouse", slug: "glossier", sectors: ["ecommerce"] },
   { name: "Stitch Fix", ats: "greenhouse", slug: "stitchfix", sectors: ["ecommerce"] },
-  { name: "Chewy", ats: "greenhouse", slug: "chewy", sectors: ["ecommerce"] },
-  { name: "Poshmark", ats: "greenhouse", slug: "poshmark", sectors: ["ecommerce"] },
+  { name: "Poshmark", ats: "ashby", slug: "poshmark", sectors: ["ecommerce"] },
 
   // -- gaming ---------------------------------------------------------------
   { name: "Discord", ats: "greenhouse", slug: "discord", sectors: ["gaming", "consumer-social"] },
   { name: "Roblox", ats: "greenhouse", slug: "roblox", sectors: ["gaming"] },
   { name: "Riot Games", ats: "greenhouse", slug: "riotgames", sectors: ["gaming"] },
-  { name: "Unity", ats: "greenhouse", slug: "unity", sectors: ["gaming"] },
-  { name: "Niantic", ats: "greenhouse", slug: "niantic", sectors: ["gaming"] },
   { name: "Twitch", ats: "greenhouse", slug: "twitch", sectors: ["gaming", "media-adtech"] },
   { name: "Epic Games", ats: "greenhouse", slug: "epicgames", sectors: ["gaming"] },
   { name: "Scopely", ats: "greenhouse", slug: "scopely", sectors: ["gaming"] },
-  { name: "Zynga", ats: "greenhouse", slug: "zynga", sectors: ["gaming"] },
-  { name: "Rec Room", ats: "ashby", slug: "recroom", sectors: ["gaming"] },
 
   // -- security ---------------------------------------------------------------
-  { name: "CrowdStrike", ats: "greenhouse", slug: "crowdstrike", sectors: ["security"] },
   { name: "Okta", ats: "greenhouse", slug: "okta", sectors: ["security"] },
-  { name: "SentinelOne", ats: "greenhouse", slug: "sentinelone", sectors: ["security"] },
-  { name: "1Password", ats: "lever", slug: "1password", sectors: ["security"] },
-  { name: "Snyk", ats: "greenhouse", slug: "snyk", sectors: ["security", "devtools"] },
-  { name: "Wiz", ats: "ashby", slug: "wiz", sectors: ["security"] },
+  { name: "1Password", ats: "ashby", slug: "1password", sectors: ["security"] },
+  { name: "Wiz", ats: "greenhouse", slug: "wizinc", sectors: ["security"] },
   { name: "Vanta", ats: "ashby", slug: "vanta", sectors: ["security"] },
-  { name: "Tailscale", ats: "ashby", slug: "tailscale", sectors: ["security", "devtools"] },
+  { name: "Tailscale", ats: "greenhouse", slug: "tailscale", sectors: ["security", "devtools"] },
   { name: "Netskope", ats: "greenhouse", slug: "netskope", sectors: ["security"] },
-  { name: "Rapid7", ats: "greenhouse", slug: "rapid7", sectors: ["security"] },
   { name: "Datadog", ats: "greenhouse", slug: "datadog", sectors: ["security", "devtools"] },
 
   // -- enterprise-saas --------------------------------------------------------
   { name: "Asana", ats: "greenhouse", slug: "asana", sectors: ["enterprise-saas"] },
-  { name: "Notion", ats: "lever", slug: "notion", sectors: ["enterprise-saas"] },
+  { name: "Notion", ats: "ashby", slug: "notion", sectors: ["enterprise-saas"] },
   { name: "Airtable", ats: "greenhouse", slug: "airtable", sectors: ["enterprise-saas"] },
-  { name: "Zapier", ats: "lever", slug: "zapier", sectors: ["enterprise-saas"] },
-  { name: "DocuSign", ats: "greenhouse", slug: "docusign", sectors: ["enterprise-saas"] },
-  { name: "Calendly", ats: "lever", slug: "calendly", sectors: ["enterprise-saas"] },
-  { name: "Rippling", ats: "ashby", slug: "rippling", sectors: ["enterprise-saas"] },
+  { name: "Zapier", ats: "ashby", slug: "zapier", sectors: ["enterprise-saas"] },
+  { name: "Calendly", ats: "greenhouse", slug: "calendly", sectors: ["enterprise-saas"] },
   { name: "Checkr", ats: "greenhouse", slug: "checkr", sectors: ["enterprise-saas"] },
   { name: "Samsara", ats: "greenhouse", slug: "samsara", sectors: ["enterprise-saas", "hardware-iot"] },
   { name: "Figma", ats: "greenhouse", slug: "figma", sectors: ["enterprise-saas", "consumer-social"] },
-  { name: "Monday.com", ats: "lever", slug: "monday", sectors: ["enterprise-saas"] },
-  { name: "Miro", ats: "greenhouse", slug: "miro", sectors: ["enterprise-saas"] },
-  { name: "Coda", ats: "ashby", slug: "coda", sectors: ["enterprise-saas"] },
+  { name: "Miro", ats: "ashby", slug: "miro", sectors: ["enterprise-saas"] },
 
   // -- consumer-social ----------------------------------------------------
   { name: "Reddit", ats: "greenhouse", slug: "reddit", sectors: ["consumer-social"] },
   { name: "Pinterest", ats: "greenhouse", slug: "pinterest", sectors: ["consumer-social"] },
-  { name: "Medium", ats: "lever", slug: "medium", sectors: ["consumer-social"] },
-  { name: "Patreon", ats: "lever", slug: "patreon", sectors: ["consumer-social"] },
-  { name: "Quora", ats: "lever", slug: "quora", sectors: ["consumer-social"] },
+  { name: "Medium", ats: "greenhouse", slug: "medium", sectors: ["consumer-social"] },
+  { name: "Patreon", ats: "ashby", slug: "patreon", sectors: ["consumer-social"] },
+  { name: "Quora", ats: "ashby", slug: "quora", sectors: ["consumer-social"] },
   { name: "Duolingo", ats: "greenhouse", slug: "duolingo", sectors: ["consumer-social", "edtech"] },
   { name: "Nextdoor", ats: "greenhouse", slug: "nextdoor", sectors: ["consumer-social"] },
-  { name: "Bumble", ats: "greenhouse", slug: "bumble", sectors: ["consumer-social"] },
-  { name: "Strava", ats: "greenhouse", slug: "strava", sectors: ["consumer-social"] },
-  { name: "Letterboxd", ats: "ashby", slug: "letterboxd", sectors: ["consumer-social"] },
+  { name: "Bumble", ats: "lever", slug: "bumbleinc", sectors: ["consumer-social"] },
+  { name: "Strava", ats: "ashby", slug: "strava", sectors: ["consumer-social"] },
   { name: "Cameo", ats: "greenhouse", slug: "cameo", sectors: ["consumer-social"] },
 
   // -- hardware-iot -----------------------------------------------------------
-  { name: "Anduril", ats: "ashby", slug: "anduril", sectors: ["hardware-iot", "government-defense"] },
-  { name: "Ouster", ats: "greenhouse", slug: "ouster", sectors: ["hardware-iot"] },
-  { name: "Skydio", ats: "greenhouse", slug: "skydio", sectors: ["hardware-iot"] },
-  { name: "Zipline", ats: "greenhouse", slug: "zipline", sectors: ["hardware-iot"] },
+  { name: "Skydio", ats: "ashby", slug: "skydio", sectors: ["hardware-iot"] },
   { name: "Verkada", ats: "greenhouse", slug: "verkada", sectors: ["hardware-iot", "security"] },
-  { name: "Wyze", ats: "greenhouse", slug: "wyze", sectors: ["hardware-iot"] },
-  { name: "Particle", ats: "greenhouse", slug: "particle", sectors: ["hardware-iot"] },
   { name: "Bird", ats: "greenhouse", slug: "bird", sectors: ["hardware-iot", "logistics-mobility"] },
-  { name: "Astranis", ats: "ashby", slug: "astranis", sectors: ["hardware-iot"] },
+  { name: "Astranis", ats: "greenhouse", slug: "astranis", sectors: ["hardware-iot"] },
 
   // -- crypto-web3 --------------------------------------------------------------
-  { name: "Kraken", ats: "greenhouse", slug: "kraken", sectors: ["crypto-web3"] },
-  { name: "Circle", ats: "greenhouse", slug: "circle", sectors: ["crypto-web3", "fintech"] },
-  { name: "Uniswap Labs", ats: "ashby", slug: "uniswaplabs", sectors: ["crypto-web3"] },
+  { name: "Uniswap Labs", ats: "ashby", slug: "uniswap", sectors: ["crypto-web3"] },
   { name: "Consensys", ats: "greenhouse", slug: "consensys", sectors: ["crypto-web3"] },
   { name: "Alchemy", ats: "ashby", slug: "alchemy", sectors: ["crypto-web3", "devtools"] },
   { name: "OpenSea", ats: "ashby", slug: "opensea", sectors: ["crypto-web3"] },
-  { name: "Chainalysis", ats: "greenhouse", slug: "chainalysis", sectors: ["crypto-web3", "security"] },
-  { name: "Anchorage Digital", ats: "greenhouse", slug: "anchoragedigital", sectors: ["crypto-web3"] },
+  { name: "Anchorage Digital", ats: "lever", slug: "anchorage", sectors: ["crypto-web3"] },
   { name: "Ripple", ats: "greenhouse", slug: "ripple", sectors: ["crypto-web3", "fintech"] },
   { name: "Gemini", ats: "greenhouse", slug: "gemini", sectors: ["crypto-web3"] },
 
   // -- edtech -----------------------------------------------------------------
   { name: "Coursera", ats: "greenhouse", slug: "coursera", sectors: ["edtech"] },
   { name: "Udemy", ats: "greenhouse", slug: "udemy", sectors: ["edtech"] },
-  { name: "Khan Academy", ats: "lever", slug: "khanacademy", sectors: ["edtech"] },
-  { name: "Course Hero", ats: "greenhouse", slug: "coursehero", sectors: ["edtech"] },
+  { name: "Khan Academy", ats: "greenhouse", slug: "khanacademy", sectors: ["edtech"] },
   { name: "Outschool", ats: "greenhouse", slug: "outschool", sectors: ["edtech"] },
-  { name: "Guild Education", ats: "greenhouse", slug: "guildeducation", sectors: ["edtech"] },
-  { name: "Handshake", ats: "greenhouse", slug: "handshake", sectors: ["edtech"] },
-  { name: "Quizlet", ats: "greenhouse", slug: "quizlet", sectors: ["edtech"] },
-  { name: "Photomath", ats: "ashby", slug: "photomath", sectors: ["edtech"] },
-  { name: "ClassDojo", ats: "greenhouse", slug: "classdojo", sectors: ["edtech"] },
+  { name: "Guild Education", ats: "greenhouse", slug: "guild", sectors: ["edtech"] },
+  { name: "Handshake", ats: "ashby", slug: "handshake", sectors: ["edtech"] },
+  { name: "ClassDojo", ats: "ashby", slug: "classdojo", sectors: ["edtech"] },
 
   // -- logistics-mobility -------------------------------------------------
   { name: "Flexport", ats: "greenhouse", slug: "flexport", sectors: ["logistics-mobility"] },
-  { name: "Convoy", ats: "greenhouse", slug: "convoy", sectors: ["logistics-mobility"] },
-  { name: "Getaround", ats: "greenhouse", slug: "getaround", sectors: ["logistics-mobility"] },
-  { name: "Turo", ats: "greenhouse", slug: "turo", sectors: ["logistics-mobility"] },
-  { name: "Gopuff", ats: "greenhouse", slug: "gopuff", sectors: ["logistics-mobility", "ecommerce"] },
-  { name: "Deliverr", ats: "greenhouse", slug: "deliverr", sectors: ["logistics-mobility"] },
+  { name: "Gopuff", ats: "lever", slug: "gopuff", sectors: ["logistics-mobility", "ecommerce"] },
   { name: "Route", ats: "greenhouse", slug: "route", sectors: ["logistics-mobility", "ecommerce"] },
-  { name: "Loadsmart", ats: "ashby", slug: "loadsmart", sectors: ["logistics-mobility"] },
+  { name: "Loadsmart", ats: "lever", slug: "loadsmart", sectors: ["logistics-mobility"] },
   { name: "Fleetio", ats: "greenhouse", slug: "fleetio", sectors: ["logistics-mobility"] },
 
   // -- media-adtech -------------------------------------------------------------
   { name: "Spotify", ats: "lever", slug: "spotify", sectors: ["media-adtech", "consumer-social"] },
   { name: "The Trade Desk", ats: "greenhouse", slug: "thetradedesk", sectors: ["media-adtech"] },
-  { name: "Criteo", ats: "greenhouse", slug: "criteo", sectors: ["media-adtech"] },
   { name: "Roku", ats: "greenhouse", slug: "roku", sectors: ["media-adtech"] },
-  { name: "Vimeo", ats: "greenhouse", slug: "vimeo", sectors: ["media-adtech"] },
   { name: "Buzzfeed", ats: "greenhouse", slug: "buzzfeed", sectors: ["media-adtech"] },
-  { name: "Outbrain", ats: "greenhouse", slug: "outbrain", sectors: ["media-adtech"] },
   { name: "Taboola", ats: "greenhouse", slug: "taboola", sectors: ["media-adtech"] },
-  { name: "Chartbeat", ats: "lever", slug: "chartbeat", sectors: ["media-adtech"] },
-  { name: "Nielsen", ats: "greenhouse", slug: "nielsen", sectors: ["media-adtech"] },
+  { name: "Chartbeat", ats: "greenhouse", slug: "chartbeatinc", sectors: ["media-adtech"] },
 
   // -- government-defense -------------------------------------------------
-  { name: "Palantir", ats: "greenhouse", slug: "palantir", sectors: ["government-defense", "data-ml"] },
-  { name: "Shield AI", ats: "ashby", slug: "shieldai", sectors: ["government-defense"] },
-  { name: "Rebellion Defense", ats: "ashby", slug: "rebelliondefense", sectors: ["government-defense"] },
-  { name: "Saildrone", ats: "greenhouse", slug: "saildrone", sectors: ["government-defense", "hardware-iot"] },
+  { name: "Palantir", ats: "lever", slug: "palantir", sectors: ["government-defense", "data-ml"] },
+  { name: "Shield AI", ats: "lever", slug: "shieldai", sectors: ["government-defense"] },
+  { name: "Saildrone", ats: "greenhouse", slug: "saildroneinc", sectors: ["government-defense", "hardware-iot"] },
   { name: "HawkEye 360", ats: "greenhouse", slug: "hawkeye360", sectors: ["government-defense"] },
-  { name: "Second Front Systems", ats: "ashby", slug: "secondfrontsystems", sectors: ["government-defense"] },
-  { name: "Vannevar Labs", ats: "ashby", slug: "vannevarlabs", sectors: ["government-defense"] },
+  { name: "Second Front Systems", ats: "ashby", slug: "second-front-systems", sectors: ["government-defense"] },
+  { name: "Vannevar Labs", ats: "greenhouse", slug: "vannevarlabs", sectors: ["government-defense"] },
 ];
 
 /**

--- a/src/lib/job-search/concurrency.test.ts
+++ b/src/lib/job-search/concurrency.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `mapWithConcurrency` is the fan-out limiter the company-board search depends
+ * on, so these pin the three properties `search.ts` actually relies on: results
+ * land in INPUT order (the degraded-provider mapping indexes into it), a
+ * rejection is a slot not a throw, and the in-flight count never exceeds the
+ * limit.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mapWithConcurrency } from "./concurrency.ts";
+
+/** Resolve after a macrotask, so interleaving is real rather than microtask-
+ *  ordered by luck. */
+function tick(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("mapWithConcurrency", () => {
+  it("returns results in input order regardless of completion order", async () => {
+    // Deliberately inverted durations: the last item finishes first.
+    const items = [30, 20, 10, 0];
+    const settled = await mapWithConcurrency(items, 4, async (ms) => {
+      await tick(ms);
+      return ms;
+    });
+    expect(settled.map((s) => (s.status === "fulfilled" ? s.value : null))).toEqual([
+      30, 20, 10, 0,
+    ]);
+  });
+
+  it("never exceeds `limit` in flight", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(Array.from({ length: 20 }, (_, i) => i), 3, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await tick(1);
+      inFlight -= 1;
+      return null;
+    });
+    expect(peak).toBe(3);
+  });
+
+  it("records a rejection as a slot and still runs the rest", async () => {
+    const settled = await mapWithConcurrency([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error("boom");
+      return n;
+    });
+    expect(settled[0]).toEqual({ status: "fulfilled", value: 1 });
+    expect(settled[1].status).toBe("rejected");
+    expect(settled[2]).toEqual({ status: "fulfilled", value: 3 });
+  });
+
+  it("clamps a limit below 1 to serial instead of deadlocking", async () => {
+    let peak = 0;
+    let inFlight = 0;
+    const settled = await mapWithConcurrency([1, 2, 3], 0, async (n) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await tick(1);
+      inFlight -= 1;
+      return n;
+    });
+    expect(peak).toBe(1);
+    expect(settled).toHaveLength(3);
+  });
+
+  it("resolves to an empty array for no items", async () => {
+    expect(await mapWithConcurrency([], 4, async () => 1)).toEqual([]);
+  });
+});

--- a/src/lib/job-search/concurrency.ts
+++ b/src/lib/job-search/concurrency.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Bounded-concurrency `Promise.allSettled` (#533, slice 5 of the job-search-v2
+ * epic #528).
+ *
+ * The keyless fan-out was three feeds, so `Promise.allSettled(all)` was fine.
+ * Company-board search fans out to one provider PER SELECTED COMPANY, and
+ * firing every board at once means a dozen simultaneous cross-origin fetches
+ * competing for the browser's per-host connection pool — the slowest board
+ * gates the whole search and the tab stalls. This runs at most `limit`
+ * in flight and starts the next as soon as one settles.
+ *
+ * Contract deliberately mirrors `Promise.allSettled`: results come back in
+ * INPUT INDEX ORDER regardless of completion order (the orchestrator maps a
+ * rejected slot back to `providers[i].label` for `degradedProviders`), and the
+ * returned promise never rejects — a task's failure is a `rejected` slot.
+ */
+
+/**
+ * Run `fn` over `items` with at most `limit` concurrent calls. Never rejects;
+ * each slot is a `PromiseSettledResult` in the item's original index position.
+ * A `limit` below 1 is clamped to 1 (serial) rather than deadlocking on zero
+ * workers.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  const workers = Math.max(1, Math.min(Math.floor(limit), items.length));
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    // Read-then-increment in one synchronous step, so two workers resuming in
+    // the same microtask turn can never claim the same index.
+    for (let i = cursor++; i < items.length; i = cursor++) {
+      try {
+        results[i] = { status: "fulfilled", value: await fn(items[i], i) };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workers }, worker));
+  return results;
+}

--- a/src/lib/job-search/deep-links.test.ts
+++ b/src/lib/job-search/deep-links.test.ts
@@ -2,16 +2,16 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
-import { buildDeepLinks } from "./deep-links.ts";
+import { buildDeepLinks, MAX_DEEP_LINK_SKILLS } from "./deep-links.ts";
 import type { JobQuery } from "./query-builder.ts";
 
 function query(overrides: Partial<JobQuery> = {}): JobQuery {
-  return { title: "", skills: [], ...overrides };
+  return { titles: [], skills: [], ...overrides };
 }
 
 describe("buildDeepLinks", () => {
   it("returns one link each for LinkedIn, Indeed, and Google Jobs", () => {
-    const links = buildDeepLinks(query({ title: "Software Engineer" }));
+    const links = buildDeepLinks(query({ titles: ["Software Engineer"] }));
     expect(links.map((l) => l.label)).toEqual(["LinkedIn", "Indeed", "Google Jobs"]);
     for (const link of links) {
       expect(() => new URL(link.url)).not.toThrow();
@@ -20,7 +20,7 @@ describe("buildDeepLinks", () => {
 
   it("prefills keywords from seniority + title + skills, space-joined", () => {
     const links = buildDeepLinks(
-      query({ title: "Backend Engineer", seniority: "Senior", skills: ["python", "go"] }),
+      query({ titles: ["Backend Engineer"], seniority: "Senior", skills: ["python", "go"] }),
     );
     const linkedin = new URL(links[0].url);
     expect(linkedin.searchParams.get("keywords")).toBe(
@@ -30,17 +30,40 @@ describe("buildDeepLinks", () => {
     expect(indeed.searchParams.get("q")).toBe("Senior Backend Engineer python go");
   });
 
-  it("skips seniority when the title already contains it (no 'Senior Senior …')", () => {
+  it("includes EVERY title in the keyword phrase, most-recent-first (#539)", () => {
     const links = buildDeepLinks(
-      query({ title: "Senior Backend Engineer", seniority: "Senior", skills: ["go"] }),
+      query({
+        titles: ["VP Engineering", "Engineering Manager", "Staff Engineer"],
+        skills: ["go"],
+      }),
+    );
+    const linkedin = new URL(links[0].url);
+    expect(linkedin.searchParams.get("keywords")).toBe(
+      "VP Engineering Engineering Manager Staff Engineer go",
+    );
+  });
+
+  it("skips seniority when ANY title already contains it (no 'Senior Senior …')", () => {
+    const links = buildDeepLinks(
+      query({ titles: ["Senior Backend Engineer"], seniority: "Senior", skills: ["go"] }),
     );
     const linkedin = new URL(links[0].url);
     expect(linkedin.searchParams.get("keywords")).toBe("Senior Backend Engineer go");
   });
 
+  it("prepends seniority when no title carries it (user-typed seniority)", () => {
+    const links = buildDeepLinks(
+      query({ titles: ["Backend Engineer", "Platform Engineer"], seniority: "Staff" }),
+    );
+    const linkedin = new URL(links[0].url);
+    expect(linkedin.searchParams.get("keywords")).toBe(
+      "Staff Backend Engineer Platform Engineer",
+    );
+  });
+
   it("URL-encodes special characters in title/skills", () => {
     const links = buildDeepLinks(
-      query({ title: "C++ Engineer & Architect", skills: ["c#", "R&D"] }),
+      query({ titles: ["C++ Engineer & Architect"], skills: ["c#", "R&D"] }),
     );
     const linkedin = new URL(links[0].url);
     // Round-trips through URLSearchParams decoding back to the original string.
@@ -51,9 +74,57 @@ describe("buildDeepLinks", () => {
   });
 
   it("Google Jobs appends the word 'jobs' to the keyword string", () => {
-    const links = buildDeepLinks(query({ title: "Data Scientist" }));
+    const links = buildDeepLinks(query({ titles: ["Data Scientist"] }));
     const google = new URL(links[2].url);
     expect(google.searchParams.get("q")).toBe("Data Scientist jobs");
+  });
+
+  it("caps skills folded into the keyword phrase at MAX_DEEP_LINK_SKILLS, keeping a sane URL length (#541)", () => {
+    // MAX_SKILLS (query-builder.ts) can put up to 12 ranked skills into
+    // query.skills; the deep-link keyword phrase should only carry the
+    // top MAX_DEEP_LINK_SKILLS of those, not all of them.
+    const twelveSkills = [
+      "python", "java", "go", "rust", "ruby", "php",
+      "swift", "kotlin", "scala", "sql", "html", "css",
+    ];
+    const links = buildDeepLinks(query({ titles: ["Engineer"], skills: twelveSkills }));
+    const linkedin = new URL(links[0].url);
+    const keywords = linkedin.searchParams.get("keywords") ?? "";
+    for (const skill of twelveSkills.slice(0, MAX_DEEP_LINK_SKILLS)) {
+      expect(keywords).toContain(skill);
+    }
+    for (const skill of twelveSkills.slice(MAX_DEEP_LINK_SKILLS)) {
+      expect(keywords).not.toContain(skill);
+    }
+    // Sanity bound: the full URL stays well under common board/browser limits.
+    expect(links[0].url.length).toBeLessThan(500);
+  });
+
+  it("adds location to LinkedIn's location param and Indeed's l param (#545)", () => {
+    const links = buildDeepLinks(
+      query({ titles: ["Engineer"], location: "Austin, TX" }),
+    );
+    const linkedin = new URL(links[0].url);
+    const indeed = new URL(links[1].url);
+    expect(linkedin.searchParams.get("location")).toBe("Austin, TX");
+    expect(indeed.searchParams.get("l")).toBe("Austin, TX");
+  });
+
+  it("Google Jobs has no location param — left unchanged when location is set (#545)", () => {
+    const links = buildDeepLinks(
+      query({ titles: ["Engineer"], location: "Austin, TX" }),
+    );
+    const google = new URL(links[2].url);
+    expect(google.searchParams.get("q")).toBe("Engineer jobs");
+    expect(google.searchParams.has("location")).toBe(false);
+  });
+
+  it("omits location params entirely when query.location is absent (#545)", () => {
+    const links = buildDeepLinks(query({ titles: ["Engineer"] }));
+    const linkedin = new URL(links[0].url);
+    const indeed = new URL(links[1].url);
+    expect(linkedin.searchParams.has("location")).toBe(false);
+    expect(indeed.searchParams.has("l")).toBe(false);
   });
 
   it("still produces valid URLs for a fully degenerate query (no title, no skills)", () => {

--- a/src/lib/job-search/deep-links.ts
+++ b/src/lib/job-search/deep-links.ts
@@ -7,14 +7,35 @@
  * resulting URLs are rendered as inert `<a target="_blank" rel="noopener
  * noreferrer">` — nothing here fetches anything.
  *
- * Keyword composition: seniority + title + skills, space-joined — with the
- * seniority skipped when the title already contains it (the usual case, since
+ * Keyword composition: seniority + every title + skills, space-joined — with
+ * the seniority skipped when a title already contains it (the usual case, since
  * seniority is derived from a title word; see query-builder.ts), so "Senior
- * Backend Engineer" never becomes "Senior Senior Backend Engineer". A fully
- * degenerate query (no title, no skills) still
- * produces valid URLs — LinkedIn/Indeed get an empty query string, Google
- * Jobs falls back to the bare word "jobs" — so the deep-link row never
- * breaks even before the user has typed anything.
+ * Backend Engineer" never becomes "Senior Senior Backend Engineer". All titles
+ * (not just the most-recent) go into the keyword phrase — #539: the major
+ * boards' keyword field is OR-weighted, so listing every held title broadens
+ * the results to cover each facet of the candidate rather than the single most-
+ * recent one. A fully degenerate query (no titles, no skills) still produces
+ * valid URLs — LinkedIn/Indeed get an empty query string, Google Jobs falls
+ * back to the bare word "jobs" — so the deep-link row never breaks even before
+ * the user has typed anything.
+ *
+ * Skill count in the keyword phrase (#541): `query.skills` can hold up to
+ * `MAX_SKILLS` (12, query-builder.ts) — plenty for the in-app chip list, but
+ * pasting all 12 plus every title into a URL query param risks tipping
+ * pathological cases past board/browser URL-length limits. `deriveSkills`
+ * already rank-sorts canonical/taxonomy skills first, so slicing again here
+ * to `MAX_DEEP_LINK_SKILLS` keeps only the most relevant subset in the
+ * outbound link without re-deriving anything — the in-app query (chips,
+ * titles, seniority) is untouched.
+ *
+ * Location (#545): only LinkedIn and Indeed get a dedicated location param
+ * (`location` / `l`) — both boards honor it as a distinct location filter on
+ * their search UI. Google Jobs has no structured location param (it's a
+ * free-text query), so it's left alone rather than folding location into the
+ * keyword text and changing that builder's existing shape. The location
+ * string is trimmed and capped at `MAX_DEEP_LINK_LOCATION_LENGTH` so a
+ * pathological free-typed value can't blow out the egress URL length the way
+ * an uncapped skill list could (see `MAX_DEEP_LINK_SKILLS` above).
  */
 
 import type { JobQuery } from "./query-builder.ts";
@@ -24,31 +45,55 @@ export interface JobBoardLink {
   url: string;
 }
 
+/**
+ * Cap on skills folded into the deep-link keyword phrase — narrower than
+ * `MAX_SKILLS` on purpose (see docblock above). `query.skills` is already
+ * ranked most-relevant-first, so slicing to the top N here drops the least-
+ * relevant tail, not an arbitrary one.
+ */
+export const MAX_DEEP_LINK_SKILLS = 6;
+
+/** Cap on the location string folded into a deep link's location param —
+ *  bounds egress URL length against a pathological free-typed value. */
+const MAX_DEEP_LINK_LOCATION_LENGTH = 100;
+
+function buildLocationParam(query: JobQuery): string | undefined {
+  const location = query.location?.trim();
+  if (!location) return undefined;
+  return location.slice(0, MAX_DEEP_LINK_LOCATION_LENGTH);
+}
+
 function buildKeywords(query: JobQuery): string {
-  // Seniority is usually DERIVED from a word in the title (query-builder.ts),
-  // so prepending it blindly doubles it ("Senior Senior Backend Engineer").
-  // Only add it when the title doesn't already carry it (e.g. a user-typed
-  // seniority, or an abbreviated title like "Sr. Engineer" with the expanded
-  // "Senior" label).
+  // Seniority is usually DERIVED from a word in the primary title
+  // (query-builder.ts), so prepending it blindly doubles it ("Senior Senior
+  // Backend Engineer"). Only add it when NO title already carries it (e.g. a
+  // user-typed seniority, or an abbreviated title like "Sr. Engineer" with the
+  // expanded "Senior" label).
+  const seniorityLower = query.seniority?.toLowerCase();
   const seniority =
-    query.seniority &&
-    !query.title.toLowerCase().includes(query.seniority.toLowerCase())
+    seniorityLower &&
+    !query.titles.some((t) => t.toLowerCase().includes(seniorityLower))
       ? query.seniority
       : undefined;
-  const parts = [seniority, query.title, ...query.skills].filter(
-    (part): part is string => Boolean(part && part.trim()),
-  );
+  const parts = [
+    seniority,
+    ...query.titles,
+    ...query.skills.slice(0, MAX_DEEP_LINK_SKILLS),
+  ].filter((part): part is string => Boolean(part && part.trim()));
   return parts.join(" ");
 }
 
 export function buildDeepLinks(query: JobQuery): JobBoardLink[] {
   const keywords = buildKeywords(query);
+  const location = buildLocationParam(query);
 
   const linkedinParams = new URLSearchParams();
   if (keywords) linkedinParams.set("keywords", keywords);
+  if (location) linkedinParams.set("location", location);
 
   const indeedParams = new URLSearchParams();
   if (keywords) indeedParams.set("q", keywords);
+  if (location) indeedParams.set("l", location);
 
   const googleParams = new URLSearchParams();
   googleParams.set("q", keywords ? `${keywords} jobs` : "jobs");

--- a/src/lib/job-search/providers/arbeitnow.test.ts
+++ b/src/lib/job-search/providers/arbeitnow.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { arbeitnowProvider } from "./arbeitnow.ts";
 import type { JobQuery } from "../query-builder.ts";
 
-const query: JobQuery = { title: "Frontend Engineer", skills: ["React"] };
+const query: JobQuery = { titles: ["Frontend Engineer"], skills: ["React"] };
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({

--- a/src/lib/job-search/providers/ashby.test.ts
+++ b/src/lib/job-search/providers/ashby.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { makeAshbyProvider } from "./ashby.ts";
 import type { JobQuery } from "../query-builder.ts";
 
-const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+const query: JobQuery = { titles: ["Backend Engineer"], skills: ["Go", "Python"] };
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({

--- a/src/lib/job-search/providers/greenhouse.test.ts
+++ b/src/lib/job-search/providers/greenhouse.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { makeGreenhouseProvider, hydrateGreenhouse } from "./greenhouse.ts";
 import type { JobQuery } from "../query-builder.ts";
 
-const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+const query: JobQuery = { titles: ["Backend Engineer"], skills: ["Go", "Python"] };
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({

--- a/src/lib/job-search/providers/index.test.ts
+++ b/src/lib/job-search/providers/index.test.ts
@@ -12,7 +12,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { KEYLESS_PROVIDERS, getProviders } from "./index.ts";
+import { KEYLESS_PROVIDERS, getProviders, makeCompanyProvider } from "./index.ts";
+import type { CompanyEntry } from "../company-registry.ts";
+import type { JobProvider } from "../types.ts";
 
 describe("keyless provider registry", () => {
   it("ships the three CORS-verified feeds in display order", () => {
@@ -33,7 +35,55 @@ describe("keyless provider registry", () => {
     }
   });
 
-  it("getProviders resolves the keyless set today (the #320 seam)", () => {
+  it("getProviders with no companies resolves exactly the keyless set", () => {
     expect(getProviders()).toEqual(KEYLESS_PROVIDERS);
+  });
+});
+
+describe("makeCompanyProvider (#533)", () => {
+  function entry(ats: CompanyEntry["ats"]): CompanyEntry {
+    return { name: "Acme Corp", ats, slug: "acme", sectors: ["fintech"] };
+  }
+
+  it.each([
+    ["greenhouse", "greenhouse:acme"],
+    ["lever", "lever:acme"],
+    ["ashby", "ashby:acme"],
+  ] as const)("dispatches %s to the matching adapter factory", (ats, id) => {
+    expect(makeCompanyProvider(entry(ats)).id).toBe(id);
+  });
+
+  it("threads the display name through as the label, not the ATS vendor", () => {
+    for (const ats of ["greenhouse", "lever", "ashby"] as const) {
+      // The card must read "Acme Corp", never "Greenhouse · acme".
+      expect(makeCompanyProvider(entry(ats)).label).toBe("Acme Corp");
+    }
+  });
+});
+
+describe("getProviders composition (#533)", () => {
+  const company: JobProvider = {
+    id: "greenhouse:acme",
+    label: "Acme Corp",
+    search: async () => [],
+  };
+
+  it("appends company providers after the always-on keyless feeds", () => {
+    const resolved = getProviders([company]);
+    expect(resolved.map((p) => p.id)).toEqual([
+      "remotive",
+      "arbeitnow",
+      "jobicy",
+      "greenhouse:acme",
+    ]);
+  });
+
+  it("never drops a keyless feed, whatever the company selection", () => {
+    for (const selection of [[], [company], [company, company]]) {
+      const ids = getProviders(selection).map((p) => p.id);
+      for (const keyless of KEYLESS_PROVIDERS) {
+        expect(ids).toContain(keyless.id);
+      }
+    }
   });
 });

--- a/src/lib/job-search/providers/index.ts
+++ b/src/lib/job-search/providers/index.ts
@@ -16,12 +16,23 @@
  * #320 (BYOK) will append its keyed adapter to the returned list ONLY when a
  * key is present — `getProviders()` is the single seam that decides who
  * participates in the fan-out.
+ *
+ * #533 makes that seam PARAMETERIZED: company ATS-board providers, derived
+ * from the candidate's sector via the registry, are passed in and appended to
+ * the always-on keyless set. `makeCompanyProvider` is the raw registry-entry →
+ * adapter dispatch; the bounded pipeline that wraps it (cache → light fetch →
+ * role filter → per-company cap → lazy hydrate) lives in `../company-boards.ts`,
+ * so this module stays a plain registry.
  */
 
 import type { JobProvider } from "../types.ts";
+import type { CompanyEntry } from "../company-registry.ts";
 import { remotiveProvider } from "./remotive.ts";
 import { arbeitnowProvider } from "./arbeitnow.ts";
 import { jobicyProvider } from "./jobicy.ts";
+import { makeGreenhouseProvider } from "./greenhouse.ts";
+import { makeLeverProvider } from "./lever.ts";
+import { makeAshbyProvider } from "./ashby.ts";
 
 /** The always-on keyless providers, in display order. */
 export const KEYLESS_PROVIDERS: readonly JobProvider[] = [
@@ -31,10 +42,35 @@ export const KEYLESS_PROVIDERS: readonly JobProvider[] = [
 ];
 
 /**
- * Resolve the providers that participate in the next fan-out. Today this is
- * just the keyless set; #320 folds in a keyed provider here when a stored key
- * is present.
+ * Build the raw board provider for one registry entry. `entry.name` is threaded
+ * through as the provider label so a result card reads "Stripe", not
+ * "Greenhouse · stripe" — the company is the thing the candidate recognizes,
+ * and the ATS vendor is an implementation detail.
+ *
+ * The returned provider fetches the WHOLE light index, unfiltered and uncapped.
+ * Callers wanting the bounded pipeline want `makeBoardProvider` in
+ * `../company-boards.ts` instead.
  */
-export function getProviders(): readonly JobProvider[] {
-  return KEYLESS_PROVIDERS;
+export function makeCompanyProvider(entry: CompanyEntry): JobProvider {
+  switch (entry.ats) {
+    case "greenhouse":
+      return makeGreenhouseProvider(entry.slug, entry.name);
+    case "lever":
+      return makeLeverProvider(entry.slug, entry.name);
+    case "ashby":
+      return makeAshbyProvider(entry.slug, entry.name);
+  }
+}
+
+/**
+ * Resolve the providers that participate in the next fan-out: the always-on
+ * keyless feeds, plus any company-board providers the caller selected. No
+ * companies selected (the default) yields exactly the pre-#533 keyless set, so
+ * the parser-audit lane's behaviour is unchanged for a user who never touches
+ * the company selector. #320 folds a keyed provider in here too.
+ */
+export function getProviders(
+  companyProviders: readonly JobProvider[] = [],
+): readonly JobProvider[] {
+  return [...KEYLESS_PROVIDERS, ...companyProviders];
 }

--- a/src/lib/job-search/providers/jobicy.test.ts
+++ b/src/lib/job-search/providers/jobicy.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { jobicyProvider } from "./jobicy.ts";
 import type { JobQuery } from "../query-builder.ts";
 
-const query: JobQuery = { title: "Senior Software Engineer", skills: ["Kubernetes", "Go"] };
+const query: JobQuery = { titles: ["Senior Software Engineer"], skills: ["Kubernetes", "Go"] };
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
@@ -55,7 +55,7 @@ describe("jobicyProvider", () => {
   it("falls back to the title when there are no skills", async () => {
     const fetchMock = mockFetch({ jobs: [] });
     await jobicyProvider.search(
-      { title: "Data Analyst", skills: [] },
+      { titles: ["Data Analyst"], skills: [] },
       new AbortController().signal,
     );
     expect(fetchMock.mock.calls[0][0]).toContain("tag=Data%20Analyst");

--- a/src/lib/job-search/providers/keywords.ts
+++ b/src/lib/job-search/providers/keywords.ts
@@ -14,19 +14,26 @@ import type { JobQuery } from "../query-builder.ts";
 
 /**
  * Full-text search phrase for feeds with a `search=` param (Remotive,
- * Arbeitnow). Prefers the title; falls back to the top few skills when the
- * résumé had no derivable title.
+ * Arbeitnow). Prefers the PRIMARY (most-recent) title; falls back to the top
+ * few skills when the résumé had no derivable title.
+ *
+ * Deliberately sends only the primary title, not the full multi-title set
+ * (#539): a `search=` param is a single-intent full-text query, so stacking
+ * distinct titles ("Executive Staff Engineer") would over-constrain the feed,
+ * and it would widen the audited egress for no gain. The multi-title broadening
+ * happens client-side in `search.ts`'s `matchesQuery`, which ORs across every
+ * title's tokens against the (unfiltered) feed response.
  */
 export function searchPhrase(query: JobQuery): string {
-  const title = query.title.trim();
-  const parts = title ? [title] : query.skills.slice(0, 3);
+  const primary = query.titles[0]?.trim();
+  const parts = primary ? [primary] : query.skills.slice(0, 3);
   return parts.join(" ").trim();
 }
 
 /**
  * A single keyword for tag-style feeds (Jobicy's `tag=`). Prefers the first
- * skill (feed tags are skill/tech-shaped), falls back to the title.
+ * skill (feed tags are skill/tech-shaped), falls back to the primary title.
  */
 export function primaryKeyword(query: JobQuery): string {
-  return (query.skills[0] ?? query.title).trim();
+  return (query.skills[0] ?? query.titles[0] ?? "").trim();
 }

--- a/src/lib/job-search/providers/lever.test.ts
+++ b/src/lib/job-search/providers/lever.test.ts
@@ -2,10 +2,10 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { makeLeverProvider } from "./lever.ts";
+import { makeLeverProvider, hydrateLever } from "./lever.ts";
 import type { JobQuery } from "../query-builder.ts";
 
-const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+const query: JobQuery = { titles: ["Backend Engineer"], skills: ["Go", "Python"] };
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
@@ -120,5 +120,41 @@ describe("makeLeverProvider", () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url as string).toContain("?mode=json&limit=");
     expect((init as RequestInit).signal).toBe(signal);
+  });
+});
+
+describe("hydrateLever", () => {
+  it("maps a 200 to descriptionPlain", async () => {
+    mockFetch({ id: "1", descriptionPlain: "Full plaintext body" });
+    expect(await hydrateLever("acme", "1", new AbortController().signal)).toBe(
+      "Full plaintext body",
+    );
+  });
+
+  it("falls back to HTML-stripping description when descriptionPlain is absent", async () => {
+    mockFetch({ id: "1", description: "<p>Build &amp; ship <strong>APIs</strong></p>" });
+    expect(await hydrateLever("acme", "1")).toBe("Build & ship APIs");
+  });
+
+  it("returns '' on a non-ok response without throwing", async () => {
+    mockFetch({}, false, 404);
+    await expect(hydrateLever("acme", "1")).resolves.toBe("");
+  });
+
+  it("returns '' when the fetch itself throws (network / abort)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    await expect(hydrateLever("acme", "1")).resolves.toBe("");
+  });
+
+  it("hits the keyless per-job endpoint with ?mode=json", async () => {
+    const fetchMock = mockFetch({ descriptionPlain: "x" });
+    await hydrateLever("acme", "job-1");
+    const [url] = fetchMock.mock.calls[0];
+    expect(url as string).toBe("https://api.lever.co/v0/postings/acme/job-1?mode=json");
   });
 });

--- a/src/lib/job-search/providers/lever.ts
+++ b/src/lib/job-search/providers/lever.ts
@@ -8,12 +8,15 @@
  * `JobProvider` scoped to that company's public board. Lever has no
  * server-side free-text search either, but it does support server-side
  * paging: `?limit=` caps the fetch instead of pulling an unbounded board.
- * Unlike Greenhouse, Lever already returns a plaintext description
- * (`descriptionPlain`) in the same response, so there is no separate hydrate
- * step — prefer `descriptionPlain`, falling back to HTML-stripping
- * `description` only when plaintext is absent.
+ * Lever's light response already returns a plaintext description
+ * (`descriptionPlain`) inline — prefer it, falling back to HTML-stripping
+ * `description` only when plaintext is absent. That inline description is used
+ * as-is on a fresh fetch; it is stripped when the board is cached (the cache is
+ * light-index only), so a cache hit re-hydrates each survivor via the keyless
+ * per-job endpoint below (`hydrateLever`), mirroring Greenhouse.
  *
- *   GET https://api.lever.co/v0/postings/{slug}?mode=json&limit=100
+ *   Light index:  GET https://api.lever.co/v0/postings/{slug}?mode=json&limit=100
+ *   Hydrate one:  GET https://api.lever.co/v0/postings/{slug}/{id}?mode=json
  *
  * Response is a **top-level array** (not wrapped in an object), unlike
  * Greenhouse's `{ jobs: [] }` and Ashby's `{ jobs: [] }`.
@@ -65,7 +68,12 @@ function mapJob(slug: string, label: string, job: LeverJob): JobPosting {
     location: (job.categories?.location ?? "").trim(),
     url: job.hostedUrl ?? "",
     description: job.descriptionPlain ?? htmlToPlaintext(job.description ?? ""),
-    postedAt: typeof job.createdAt === "number" ? new Date(job.createdAt).toISOString() : undefined,
+    // `Number.isFinite` (not just `typeof number`) guards `toISOString`, which
+    // throws `RangeError` on ±Infinity / |v| > 8.64e15 — cheap insurance so one
+    // malformed board row can't abort the whole `.map` in `search()`.
+    postedAt: Number.isFinite(job.createdAt)
+      ? new Date(job.createdAt as number).toISOString()
+      : undefined,
     source: label,
     departments,
   };
@@ -93,4 +101,30 @@ export function makeLeverProvider(slug: string, companyName = slug): JobProvider
       return jobs.map((j) => mapJob(slug, LABEL, j)).filter((p) => p.title && p.url);
     },
   };
+}
+
+/**
+ * Lazy per-job hydrate: fetches one Lever posting and returns its plaintext
+ * description. Called only for survivors whose cached light-index row had its
+ * description stripped — never for the whole board.
+ *
+ * Unlike `hydrateGreenhouse`, this NEVER throws: a hydrate failure (non-ok
+ * response, network error, aborted fetch) resolves to `""`. A missing
+ * description must cost that one posting its text, never sink the surrounding
+ * `mapWithConcurrency` slot — an undescribed posting still ranks and links.
+ */
+export async function hydrateLever(
+  slug: string,
+  jobId: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  try {
+    const url = `${BASE}/${encodeURIComponent(slug)}/${encodeURIComponent(jobId)}?mode=json`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) return "";
+    const data = (await res.json()) as LeverJob;
+    return data.descriptionPlain ?? htmlToPlaintext(data.description ?? "");
+  } catch {
+    return "";
+  }
 }

--- a/src/lib/job-search/providers/remotive.test.ts
+++ b/src/lib/job-search/providers/remotive.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { remotiveProvider } from "./remotive.ts";
 import type { JobQuery } from "../query-builder.ts";
 
-const query: JobQuery = { title: "Backend Engineer", skills: ["Go", "Python"] };
+const query: JobQuery = { titles: ["Backend Engineer"], skills: ["Go", "Python"] };
 
 function mockFetch(body: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
-import { buildJobQuery, MAX_SKILLS } from "./query-builder.ts";
+import { buildJobQuery, MAX_SKILLS, MAX_TITLES } from "./query-builder.ts";
 import type { ParsedResume, ResumeExperience } from "../score/types.ts";
 
 function baseParsed(overrides: Partial<ParsedResume> = {}): ParsedResume {
@@ -28,10 +28,32 @@ function experience(overrides: Partial<ResumeExperience> = {}): ResumeExperience
 describe("buildJobQuery", () => {
   it("returns an empty query for a fully empty resume", () => {
     const query = buildJobQuery(baseParsed());
-    expect(query).toEqual({ title: "", skills: [], seniority: undefined });
+    expect(query).toEqual({
+      titles: [],
+      skills: [],
+      seniority: undefined,
+      location: undefined,
+    });
   });
 
-  it("derives title from the most recent (first) experience entry", () => {
+  it("seeds location from the parsed résumé's top-level location (#545)", () => {
+    const query = buildJobQuery(baseParsed({ location: "Austin, TX" }));
+    expect(query.location).toBe("Austin, TX");
+  });
+
+  it("leaves location undefined when the parse has none (#545)", () => {
+    const query = buildJobQuery(baseParsed());
+    expect(query.location).toBeUndefined();
+  });
+
+  it("trims location and treats whitespace-only as absent (#545)", () => {
+    expect(buildJobQuery(baseParsed({ location: "  Denver, CO  " })).location).toBe(
+      "Denver, CO",
+    );
+    expect(buildJobQuery(baseParsed({ location: "   " })).location).toBeUndefined();
+  });
+
+  it("derives the distinct titles across experience, most-recent-first", () => {
     const parsed = baseParsed({
       experience: [
         experience({ title: "Staff Software Engineer" }),
@@ -39,19 +61,71 @@ describe("buildJobQuery", () => {
       ],
     });
     const query = buildJobQuery(parsed);
-    expect(query.title).toBe("Staff Software Engineer");
+    expect(query.titles).toEqual([
+      "Staff Software Engineer",
+      "Software Engineer II",
+    ]);
+    // titles[0] is the primary (most-recent) title.
+    expect(query.titles[0]).toBe("Staff Software Engineer");
   });
 
-  it("falls back to current_title when there is no experience", () => {
+  it("dedups titles case-insensitively, keeping first-seen order + casing", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "Engineering Manager" }),
+        experience({ title: "Staff Engineer" }),
+        experience({ title: "engineering MANAGER" }), // dup of the first, case-only
+        experience({ title: "  Staff Engineer  " }), // dup after trim
+      ],
+    });
+    const query = buildJobQuery(parsed);
+    expect(query.titles).toEqual(["Engineering Manager", "Staff Engineer"]);
+  });
+
+  it("caps titles at MAX_TITLES, keeping the most-recent ones", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "T1" }),
+        experience({ title: "T2" }),
+        experience({ title: "T3" }),
+        experience({ title: "T4" }),
+        experience({ title: "T5" }),
+        experience({ title: "T6" }),
+      ],
+    });
+    const query = buildJobQuery(parsed);
+    expect(query.titles).toHaveLength(MAX_TITLES);
+    expect(query.titles).toEqual(["T1", "T2", "T3", "T4"]);
+  });
+
+  it("skips blank experience titles when deriving titles", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "   " }),
+        experience({ title: "Product Manager" }),
+      ],
+    });
+    expect(buildJobQuery(parsed).titles).toEqual(["Product Manager"]);
+  });
+
+  it("falls back to current_title (as a single title) when there is no experience title", () => {
     const parsed = baseParsed({ current_title: "Product Manager" });
     const query = buildJobQuery(parsed);
-    expect(query.title).toBe("Product Manager");
+    expect(query.titles).toEqual(["Product Manager"]);
+  });
+
+  it("does not use current_title when experience already yields a title", () => {
+    const parsed = baseParsed({
+      current_title: "Product Manager",
+      experience: [experience({ title: "Staff Engineer" })],
+    });
+    expect(buildJobQuery(parsed).titles).toEqual(["Staff Engineer"]);
   });
 
   it("falls back to skills-only query when there is no experience and no current_title", () => {
     const parsed = baseParsed({ skills: ["Python", "SQL"] });
     const query = buildJobQuery(parsed);
-    expect(query.title).toBe("");
+    expect(query.titles).toEqual([]);
     expect(query.skills).toEqual(["python", "sql"]);
     expect(query.seniority).toBeUndefined();
   });
@@ -74,11 +148,120 @@ describe("buildJobQuery", () => {
     ).toBe("Junior");
   });
 
-  it("leaves seniority undefined when the title carries no seniority keyword", () => {
+  it("prefers a PRIMARY title match over a later title's keyword (#539)", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "Engineering Manager" }), // primary: matches Manager
+        experience({ title: "Staff Engineer" }), // later: Staff, must NOT win
+      ],
+    });
+    expect(buildJobQuery(parsed).seniority).toBe("Manager");
+  });
+
+  it("falls back to a later title's keyword when the primary has none (#540)", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "Board Member" }), // primary: no keyword
+        experience({ title: "Staff Engineer" }), // fallback match
+      ],
+    });
+    expect(buildJobQuery(parsed).seniority).toBe("Staff");
+  });
+
+  it("falls back across multiple titles to find an exec title after a primary board seat (#540)", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "Board Member" }), // primary: no keyword
+        experience({ title: "Advisor" }), // still no keyword
+        experience({ title: "Chief Executive Officer" }), // fallback match
+      ],
+    });
+    expect(buildJobQuery(parsed).seniority).toBe("Executive");
+  });
+
+  it("leaves seniority undefined when no title carries a seniority keyword", () => {
     const parsed = baseParsed({
       experience: [experience({ title: "Software Engineer" })],
     });
     expect(buildJobQuery(parsed).seniority).toBeUndefined();
+  });
+
+  it("leaves seniority undefined when none of several titles carries a keyword", () => {
+    const parsed = baseParsed({
+      experience: [
+        experience({ title: "Board Member" }),
+        experience({ title: "Advisor" }),
+      ],
+    });
+    expect(buildJobQuery(parsed).seniority).toBeUndefined();
+  });
+
+  it("derives Executive for founder/C-suite titles", () => {
+    expect(
+      buildJobQuery(baseParsed({ experience: [experience({ title: "Co-Founder" })] }))
+        .seniority,
+    ).toBe("Executive");
+    expect(
+      buildJobQuery(baseParsed({ experience: [experience({ title: "Founder & CEO" })] }))
+        .seniority,
+    ).toBe("Executive");
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Chief Technology Officer" })] }),
+      ).seniority,
+    ).toBe("Executive");
+    expect(
+      buildJobQuery(baseParsed({ experience: [experience({ title: "CTO" })] })).seniority,
+    ).toBe("Executive");
+  });
+
+  it("derives Executive for 'Chief of Staff', not IC Staff", () => {
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Chief of Staff" })] }),
+      ).seniority,
+    ).toBe("Executive");
+  });
+
+  it("derives VP for VP/SVP/EVP titles, specific-before-general", () => {
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "VP of Engineering" })] }),
+      ).seniority,
+    ).toBe("VP");
+    expect(
+      buildJobQuery(
+        baseParsed({
+          experience: [experience({ title: "Senior Vice President, Product" })],
+        }),
+      ).seniority,
+    ).toBe("VP");
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "EVP, Sales" })] }),
+      ).seniority,
+    ).toBe("VP");
+  });
+
+  it("derives Director for Director/Head of titles", () => {
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Director of Engineering" })] }),
+      ).seniority,
+    ).toBe("Director");
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Head of Product" })] }),
+      ).seniority,
+    ).toBe("Director");
+  });
+
+  it("derives Manager for Manager titles", () => {
+    expect(
+      buildJobQuery(
+        baseParsed({ experience: [experience({ title: "Engineering Manager" })] }),
+      ).seniority,
+    ).toBe("Manager");
   });
 
   it("canonicalizes and dedupes skills via the shared SKILLS index", () => {
@@ -96,15 +279,80 @@ describe("buildJobQuery", () => {
 
   it("caps skills at MAX_SKILLS", () => {
     const parsed = baseParsed({
-      skills: ["python", "java", "go", "rust", "ruby", "php", "swift"],
+      skills: [
+        "python", "java", "go", "rust", "ruby", "php", "swift",
+        "kotlin", "scala", "c", "cpp", "csharp", "haskell",
+      ],
     });
     const query = buildJobQuery(parsed);
     expect(query.skills).toHaveLength(MAX_SKILLS);
+  });
+
+  it("does not truncate a normal ~12-skill résumé section", () => {
+    const parsed = baseParsed({
+      skills: [
+        "python", "java", "go", "rust", "ruby", "php", "swift",
+        "kotlin", "scala", "sql", "html", "css",
+      ],
+    });
+    const query = buildJobQuery(parsed);
+    expect(query.skills).toHaveLength(12);
   });
 
   it("ignores blank/whitespace-only skill entries", () => {
     const parsed = baseParsed({ skills: ["  ", "", "python"] });
     const query = buildJobQuery(parsed);
     expect(query.skills).toEqual(["python"]);
+  });
+
+  it("ranks canonical (taxonomy-recognized) skills ahead of unrecognized ones, past the old cap of 5 (#541)", () => {
+    // First 5 entries are incidental/unrecognized strings; a coherent AI/ML
+    // cluster sits at positions 6-10. Under the OLD unranked cap of 5, the
+    // whole cluster would have been truncated away entirely.
+    const parsed = baseParsed({
+      skills: [
+        "team leadership",
+        "stakeholder management",
+        "public speaking",
+        "cross-functional collaboration",
+        "mentoring",
+        "python",
+        "machine learning",
+        "pytorch",
+        "tensorflow",
+        "nlp",
+      ],
+    });
+    const query = buildJobQuery(parsed);
+    // The AI/ML cluster (canonical skills) surfaces ahead of the incidental,
+    // unrecognized entries that were typed first.
+    const aiClusterIndex = query.skills.indexOf("python");
+    const incidentalIndex = query.skills.indexOf("Team Leadership");
+    expect(aiClusterIndex).toBeGreaterThanOrEqual(0);
+    expect(incidentalIndex).toBeGreaterThanOrEqual(0);
+    expect(aiClusterIndex).toBeLessThan(incidentalIndex);
+    // All 5 canonical AI/ML skills survive the cap.
+    expect(query.skills).toEqual(
+      expect.arrayContaining([
+        "python",
+        "machine learning",
+        "pytorch",
+        "tensorflow",
+        "nlp",
+      ]),
+    );
+  });
+
+  it("preserves résumé order within the canonical and unrecognized tiers (stable sort)", () => {
+    const parsed = baseParsed({
+      skills: ["go", "rust", "underwater basket weaving", "competitive juggling"],
+    });
+    const query = buildJobQuery(parsed);
+    // Canonical tier keeps its own relative order (go before rust)...
+    expect(query.skills.indexOf("go")).toBeLessThan(query.skills.indexOf("rust"));
+    // ...and the unrecognized tier keeps its own relative order too.
+    expect(query.skills.indexOf("Underwater Basket Weaving")).toBeLessThan(
+      query.skills.indexOf("Competitive Juggling"),
+    );
   });
 });

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -5,37 +5,76 @@
  * buildJobQuery — derives a job-search query from a parsed resume (#318,
  * slice 1 of the job-search epic). Pure function, no I/O.
  *
- * Title: prefers the most recent experience entry's title (experience[0] —
- * the cascade parses roles most-recent-first, mirroring the résumé's own
- * reverse-chronological order); falls back to the top-level `current_title`
- * when there's no experience at all. A résumé with no experience and no
- * current title naturally falls back to a skills-only query (empty title,
+ * Titles: the DISTINCT titles across parsed experience, most-recent-first
+ * (the cascade parses roles most-recent-first, mirroring the résumé's own
+ * reverse-chronological order), deduped case-insensitively and capped at
+ * MAX_TITLES. Someone who has held several distinct titles (common in
+ * leadership — an exec whose prior roles were engineering-leadership or IC
+ * titles) keeps every facet of their identity in the search rather than
+ * collapsing to the single most-recent title (#539). Falls back to the
+ * top-level `current_title` when there's no experience title at all; a résumé
+ * with neither naturally falls back to a skills-only query (empty `titles`,
  * populated skills) — the degenerate-query UI state handles the rest.
  *
- * Seniority: derived from keywords in the title itself (senior/staff/lead/
- * principal/junior/intern), not from `ParsedResume.seniority_level` — the
- * issue asks for a title-keyword derivation so the seniority shown always
- * traces back to a word the user can see in their own title.
+ * Seniority: derived from keywords in the résumé's titles, not from
+ * `ParsedResume.seniority_level` — the issue asks for a title-keyword
+ * derivation so the seniority shown always traces back to a word the user can
+ * see in their own title. The PRIMARY (first / most-recent) title is checked
+ * first; when it carries no seniority keyword at all, we fall back to
+ * scanning the remaining titles in the same most-recent-first order and take
+ * the first one that matches (#540) — this is what lets an exec whose most
+ * recent line is a board seat still show "Executive" off an earlier CEO
+ * title, without letting a later IC title outrank a primary title that DID
+ * carry a keyword (the #539 scope boundary: a real primary match always
+ * wins, no fallback scan once we have one).
  *
  * Skills: reuses the shared SKILLS canonical index (`getSkillIndex` from
  * jd-match) to canonicalize + dedupe `parsed.skills` — two raw entries that
  * alias the same canonical skill (e.g. "JS" and "Javascript") collapse into
  * one. Skills that don't match a known canonical alias pass through verbatim
  * (title-cased raw string) rather than being dropped, so an unusual but real
- * skill still surfaces. Capped at MAX_SKILLS for URL-length sanity.
+ * skill still surfaces.
+ *
+ * Ranking (#541): a résumé's skills section is typically NOT already ordered
+ * by relevance — an incidental early entry (a soft skill, a one-off tool) can
+ * sit ahead of an entire coherent cluster (e.g. AI/ML) simply because of
+ * where it was typed. Before capping, skills are stable-sorted so entries
+ * that match the shared SKILLS taxonomy (`canonicalId` is set) rank ahead of
+ * ones that don't — a known, named skill is a stronger relevance signal than
+ * an arbitrary string, and it's the same index the JD-match lane already
+ * trusts for evidence matching. Ties keep their original résumé order
+ * (`Array.prototype.sort` is stable), so within "canonical" and within
+ * "unrecognized" the input order is preserved — this is deliberately simple:
+ * title/seniority-aware weighting was considered (see the issue) but adds a
+ * second dependency + tie-breaking policy for a v1 fix; revisit if canonical-
+ * only ranking proves too coarse in practice. Capped at MAX_SKILLS after
+ * ranking, so the cap drops the least-relevant tail instead of an arbitrary
+ * one.
  */
 
 import type { ParsedResume } from "../score/types.ts";
 import { getSkillIndex } from "../jd-match/skills.ts";
 
 export interface JobQuery {
-  /** Most recent role title, or "" when none could be derived. */
-  title: string;
+  /** Distinct role titles, most-recent-first, deduped case-insensitively and
+   *  capped at MAX_TITLES. Empty when none could be derived (skills-only /
+   *  degenerate query). `titles[0]` is the primary (most-recent) title. */
+  titles: string[];
   /** Top-ranked skills, canonicalized + deduped, capped at MAX_SKILLS. */
   skills: string[];
-  /** Seniority keyword found in the title (Staff/Principal/Lead/Senior/
-   *  Junior/Intern), or undefined when the title carries no such keyword. */
+  /** Seniority keyword found across the résumé's titles (Executive/VP/
+   *  Director/Manager/Staff/Principal/Lead/Senior/Junior/Intern) — the
+   *  PRIMARY title wins when it has a keyword, otherwise the first match
+   *  scanning the rest of `titles` in order (#540) — or undefined when none
+   *  of them carries a recognized keyword. */
   seniority?: string;
+  /** Candidate location, seeded from the parsed résumé's top-level
+   *  `location` (contact address, e.g. "Austin, TX") when present (#545).
+   *  Single free-text value, user-editable — unlike titles/skills this is
+   *  not a list: a candidate has one search location at a time, not several
+   *  to union together. Undefined when the parse has no location and the
+   *  user hasn't typed one. */
+  location?: string;
 }
 
 /**
@@ -49,15 +88,59 @@ export interface JobQuery {
  */
 export type ResumeQueryInput = Pick<
   ParsedResume,
-  "skills" | "experience" | "current_title"
+  "skills" | "experience" | "current_title" | "location"
 >;
 
-/** Cap on skills surfaced in the query — keeps deep-link URLs a sane length. */
-export const MAX_SKILLS = 5;
+/**
+ * Cap on skills surfaced in the query (and rendered as removable chips in
+ * `FindJobsPanel`). 5 (the original value) majority-truncated a normal ~12-
+ * skill résumé section — most of a candidate's skills, sometimes a whole
+ * coherent cluster, silently vanished from the query (#541). 12 covers a
+ * normal-length skills section without materially truncating it, while still
+ * bounding the pathological case (a résumé with 60 keyword-stuffed skills).
+ * Deep-link URL length is bounded separately — see
+ * `MAX_DEEP_LINK_SKILLS` in deep-links.ts, which slices this already-ranked
+ * list further for the egress keyword phrase rather than sharing one cap
+ * across both the in-app query and the outbound URLs.
+ */
+export const MAX_SKILLS = 12;
 
+/**
+ * Cap on distinct titles surfaced in the query. Bounds the deep-link keyword
+ * string, the in-app query-term filter, and the audited egress phrase so a
+ * résumé with a long, varied history can't balloon any of them. Four keeps the
+ * common leadership case (current exec title + one or two prior IC/leadership
+ * titles) intact while dropping the long tail of early-career titles.
+ */
+export const MAX_TITLES = 4;
+
+// Order matters throughout this table: every row is checked top-to-bottom and
+// the FIRST match wins, so a more specific keyword must sit above the more
+// general one it would otherwise be swallowed by. Two ordering constraints in
+// particular:
+//   - "Senior Staff Engineer" must read as Staff, not Senior → the IC ladder
+//     keeps its original specific-before-general order (Staff/Principal/Lead
+//     before Senior).
+//   - "Senior Vice President" must read as VP (specifically SVP), not
+//     Executive-via-"Chief" and not the bare "Senior" IC keyword → SVP/EVP sit
+//     above the generic VP row, and the whole leadership tier sits above the
+//     IC tier so a compound title like "Senior Director" reads as Director,
+//     not Senior (#540).
 const SENIORITY_PATTERNS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
-  // Order matters: check the more specific/senior keywords before "senior"
-  // itself so "Senior Staff Engineer" reads as Staff, not Senior.
+  // Leadership/exec tier (#540) — most specific/senior first.
+  { label: "Executive", pattern: /\bco-?founder\b|\bfounder\b/i },
+  { label: "Executive", pattern: /\bchief\s+.+?\s+officer\b/i },
+  { label: "Executive", pattern: /\bceo\b|\bcto\b|\bcfo\b|\bcoo\b|\bcio\b|\bcmo\b|\bciso\b|\bcxo\b/i },
+  { label: "VP", pattern: /\bsvp\b|\bsenior\s+vice\s+president\b/i },
+  { label: "VP", pattern: /\bevp\b|\bexecutive\s+vice\s+president\b/i },
+  { label: "VP", pattern: /\bvp\b|\bvice\s+president\b/i },
+  { label: "Director", pattern: /\bdirector\b|\bhead\s+of\b/i },
+  { label: "Manager", pattern: /\bmanager\b/i },
+  // "Chief of Staff" is an exec/leadership role, not the IC "Staff" rung — it
+  // lacks the trailing "officer" the generic Chief row requires, so it must be
+  // caught explicitly ABOVE the IC ladder or it falls through to `\bstaff\b`.
+  { label: "Executive", pattern: /\bchief\s+of\s+staff\b/i },
+  // IC ladder (original #539 table) — specific before general.
   { label: "Staff", pattern: /\bstaff\b/i },
   { label: "Principal", pattern: /\bprincipal\b/i },
   { label: "Lead", pattern: /\blead\b/i },
@@ -66,15 +149,44 @@ const SENIORITY_PATTERNS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
   { label: "Intern", pattern: /\bintern(?:ship)?\b/i },
 ];
 
-function deriveTitle(parsed: ResumeQueryInput): string {
-  const mostRecent = parsed.experience?.[0]?.title?.trim();
-  if (mostRecent) return mostRecent;
-  return parsed.current_title?.trim() ?? "";
+function deriveTitles(parsed: ResumeQueryInput): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const exp of parsed.experience ?? []) {
+    const title = exp.title?.trim();
+    if (!title) continue;
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue; // dedup case-insensitively, keep first-seen casing
+    seen.add(key);
+    out.push(title);
+    if (out.length >= MAX_TITLES) break; // most-recent-first, so we keep the recent ones
+  }
+  if (out.length > 0) return out;
+  // No experience title at all → fall back to the top-level current_title, or
+  // an empty set (skills-only / degenerate query).
+  const current = parsed.current_title?.trim();
+  return current ? [current] : [];
 }
 
 function deriveSeniority(title: string): string | undefined {
   for (const { label, pattern } of SENIORITY_PATTERNS) {
     if (pattern.test(title)) return label;
+  }
+  return undefined;
+}
+
+/**
+ * Scans `titles` in order (most-recent-first) and returns the label from the
+ * first one that carries a seniority keyword. Called with the PRIMARY title
+ * first, so a real match there always wins immediately; the scan only
+ * continues into the rest of the array when the primary carries no keyword at
+ * all (#540) — e.g. a most-recent title that is a board seat or a sabbatical
+ * line, with a CEO/VP/etc. title earlier in the history.
+ */
+function deriveSeniorityAcrossTitles(titles: string[]): string | undefined {
+  for (const title of titles) {
+    const match = deriveSeniority(title);
+    if (match) return match;
   }
   return undefined;
 }
@@ -87,10 +199,19 @@ function titleCase(raw: string): string {
     .join(" ");
 }
 
+interface RankedSkill {
+  label: string;
+  /** true when the entry matched the shared SKILLS taxonomy — ranks first. */
+  isCanonical: boolean;
+  /** original résumé-order index — the stable tie-breaker within a rank. */
+  index: number;
+}
+
 function deriveSkills(parsed: ResumeQueryInput): string[] {
   const index = getSkillIndex();
   const seen = new Set<string>();
-  const out: string[] = [];
+  const ranked: RankedSkill[] = [];
+  let order = 0;
   for (const raw of parsed.skills ?? []) {
     const trimmed = raw.trim();
     if (!trimmed) continue;
@@ -98,17 +219,32 @@ function deriveSkills(parsed: ResumeQueryInput): string[] {
     const dedupeKey = canonicalId ?? trimmed.toLowerCase();
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
-    out.push(
-      canonicalId ? (index.idToLabel.get(canonicalId) ?? trimmed) : titleCase(trimmed),
-    );
-    if (out.length >= MAX_SKILLS) break;
+    ranked.push({
+      label: canonicalId ? (index.idToLabel.get(canonicalId) ?? trimmed) : titleCase(trimmed),
+      isCanonical: Boolean(canonicalId),
+      index: order++,
+    });
   }
-  return out;
+  // Canonical (taxonomy-recognized) skills rank ahead of unrecognized ones;
+  // `sort` is stable, so ties keep their résumé order via the explicit
+  // `index` tie-breaker (belt-and-suspenders against non-stable engines).
+  ranked.sort((a, b) => {
+    if (a.isCanonical !== b.isCanonical) return a.isCanonical ? -1 : 1;
+    return a.index - b.index;
+  });
+  return ranked.slice(0, MAX_SKILLS).map((entry) => entry.label);
+}
+
+function deriveLocation(parsed: ResumeQueryInput): string | undefined {
+  const location = parsed.location?.trim();
+  return location || undefined;
 }
 
 export function buildJobQuery(parsed: ResumeQueryInput): JobQuery {
-  const title = deriveTitle(parsed);
-  const seniority = title ? deriveSeniority(title) : undefined;
+  const titles = deriveTitles(parsed);
+  // Primary title first, then fall back across the rest of the titles (#540).
+  const seniority = deriveSeniorityAcrossTitles(titles);
   const skills = deriveSkills(parsed);
-  return { title, skills, seniority };
+  const location = deriveLocation(parsed);
+  return { titles, skills, seniority, location };
 }

--- a/src/lib/job-search/rank.test.ts
+++ b/src/lib/job-search/rank.test.ts
@@ -16,12 +16,16 @@ const parsed: HeuristicParsedResume = {
   education: [],
 };
 
-function posting(id: string, description: string): JobPosting {
+function posting(
+  id: string,
+  description: string,
+  location = "Remote",
+): JobPosting {
   return {
     id,
     title: `Job ${id}`,
     company: "Co",
-    location: "Remote",
+    location,
     url: `https://x/${id}`,
     description,
     source: "Test",
@@ -49,5 +53,73 @@ describe("rankPostings", () => {
     const fresh = computeCoverage(parsed, extractJdTerms(p.description).all);
     expect(job.jdMatch.coverage.score).toBe(fresh.score);
     expect(job.jdMatch.path).toBe("keyword");
+  });
+
+  it("sorts by score alone when no location query is given (no regression, #545)", () => {
+    const strong = posting("strong", "We need React and TypeScript experts.", "Austin, TX");
+    const weak = posting("weak", "We need Rust and Kubernetes and Terraform experts.", "Austin, TX");
+    const ranked = rankPostings(parsed, [weak, strong]);
+    expect(ranked.map((j) => j.posting.id)).toEqual(["strong", "weak"]);
+  });
+
+  it("boosts a location-matching posting above a slightly-stronger non-local one (#545)", () => {
+    // "local" has a lower raw coverage score than "faraway" (more uncovered
+    // terms diluting its coverage %), but matches the query location — the
+    // boost (10 points) should move it ahead in sort order without touching
+    // either posting's displayed `score`.
+    const local = posting(
+      "local",
+      "We need React experts, plus Rust, Kubernetes, Terraform, Golang, and GraphQL skills.",
+      "Austin, TX",
+    );
+    const faraway = posting(
+      "faraway",
+      "We are hiring a React engineer. Familiarity with Rust, Kubernetes, Terraform, GraphQL helpful.",
+      "Berlin, Germany",
+    );
+    const ranked = rankPostings(parsed, [local, faraway], { location: "Austin, TX" });
+    const localScore = ranked.find((j) => j.posting.id === "local")!.score;
+    const farawayScore = ranked.find((j) => j.posting.id === "faraway")!.score;
+    // Sanity check the fixture: faraway scores at least as high as local on
+    // raw coverage, and the gap is within the location boost, for this to be
+    // a meaningful boost test (not just "local was already winning").
+    expect(farawayScore).toBeGreaterThanOrEqual(localScore);
+    expect(ranked[0].posting.id).toBe("local");
+    // score parity is untouched by the boost — still equals coverage.score.
+    const local2 = ranked.find((j) => j.posting.id === "local")!;
+    expect(local2.score).toBe(local2.jdMatch.coverage.score);
+  });
+
+  it("does not drop a strong non-local match — soft boost, not a hard filter (#545)", () => {
+    const strongFaraway = posting(
+      "strong-faraway",
+      "We need React and TypeScript experts.",
+      "Berlin, Germany",
+    );
+    const weakLocal = posting("weak-local", "Rust and Kubernetes.", "Austin, TX");
+    const ranked = rankPostings(parsed, [weakLocal, strongFaraway], {
+      location: "Austin, TX",
+    });
+    // The strong non-local match still appears — it isn't filtered out.
+    expect(ranked.map((j) => j.posting.id)).toContain("strong-faraway");
+  });
+
+  it("treats a Remote posting as matching any query location (#545)", () => {
+    // Same description on both (tied raw coverage score) so the ONLY thing
+    // that can break the tie is the location boost. The query location
+    // ("Seattle, WA") doesn't textually match either posting's location, but
+    // "Remote" must still count as a match — a remote posting fits any
+    // candidate location — while "Austin, TX" (a real, non-matching, non-
+    // remote city) must not.
+    const remote = posting("remote", "We need React and TypeScript experts.", "Remote");
+    const nonLocal = posting(
+      "non-local",
+      "We need React and TypeScript experts.",
+      "Austin, TX",
+    );
+    const ranked = rankPostings(parsed, [nonLocal, remote], {
+      location: "Seattle, WA",
+    });
+    expect(ranked[0].posting.id).toBe("remote");
   });
 });

--- a/src/lib/job-search/rank.ts
+++ b/src/lib/job-search/rank.ts
@@ -13,6 +13,19 @@
  * + covered/missing) and the detail view is fed that same `job.jdMatch`, so the
  * two can never diverge (there is only one coverage computation).
  *
+ * Location (#545): a SOFT rank boost, never a hard filter — a posting whose
+ * location doesn't match the query is still ranked and shown, just lower, so a
+ * strong non-local fit is never dropped. The boost is applied ONLY to sort
+ * order, never to `RankedJob.score` itself — `score` stays byte-identical to
+ * `jdMatch.coverage.score` so the ranking-parity guarantee above (score ===
+ * what the card shows === what the detail view computes) holds whether or not
+ * a location boost fired. When `query.location` is empty/undefined the sort is
+ * byte-identical to pre-#545 behavior (plain coverage-score descending) — no
+ * regression for the no-location case. "Remote" (or "Worldwide"/"Anywhere"/
+ * "WFH") postings always count as a location match: a remote posting fits any
+ * candidate location, so it shouldn't be penalized for lacking a specific
+ * city.
+ *
  * Dynamic-imported by `search.ts` so jd-match's skill dictionary stays out of
  * the entry chunk.
  */
@@ -22,6 +35,7 @@ import type { JdMatchResult } from "../jd-match/types.ts";
 import { extractJdTerms } from "../jd-match/extract-jd-terms.ts";
 import { computeCoverage } from "../jd-match/coverage.ts";
 import type { JobPosting } from "./types.ts";
+import type { JobQuery } from "./query-builder.ts";
 
 /** The keyword arm of `JdMatchResult` — the only shape produced here. */
 export type KeywordJdMatch = Extract<JdMatchResult, { path: "keyword" }>;
@@ -37,13 +51,51 @@ export interface RankedJob {
 }
 
 /**
+ * Points added to a posting's SORT key (never its displayed `score`) when its
+ * location matches `query.location` — see the location docblock above. Chosen
+ * to outrank a small coverage-score gap between an otherwise-similar local and
+ * non-local posting, without letting location swamp a large fit-quality
+ * difference (a posting must still be a reasonably close fit to rise above a
+ * much stronger non-local match).
+ */
+const LOCATION_BOOST = 10;
+
+const REMOTE_PATTERN = /\b(remote|worldwide|anywhere|wfh)\b/i;
+
+/** True for a posting location that reads as remote/location-agnostic — see
+ *  the location docblock above for why these always count as a match. */
+function isRemotePosting(location: string): boolean {
+  return REMOTE_PATTERN.test(location);
+}
+
+/**
+ * True when `postingLocation` should count as a match for `queryLocation`.
+ * Compares the leading city/region token (text before the first comma) so
+ * "Austin, TX" matches a feed's "Austin, TX, USA" without requiring an exact
+ * string match, and falls back to a loose substring check either direction
+ * for postings that don't follow the "City, ST" shape.
+ */
+function locationBoostMatches(queryLocation: string, postingLocation: string): boolean {
+  if (isRemotePosting(postingLocation)) return true;
+  const posting = postingLocation.trim().toLowerCase();
+  const query = queryLocation.trim().toLowerCase();
+  if (!posting || !query) return false;
+  const postingCity = posting.split(",")[0].trim();
+  const queryCity = query.split(",")[0].trim();
+  return postingCity === queryCity || posting.includes(query) || query.includes(posting);
+}
+
+/**
  * Score every posting against `parsed` and return them sorted by fit
- * descending. Ties keep input order (stable sort), which preserves the
- * provider/dedup order from the fan-out.
+ * descending, with an optional location boost breaking ties toward postings
+ * matching `query.location` (see the location docblock above). Ties keep
+ * input order (stable sort), which preserves the provider/dedup order from
+ * the fan-out.
  */
 export function rankPostings(
   parsed: HeuristicParsedResume,
   postings: readonly JobPosting[],
+  query?: Pick<JobQuery, "location">,
 ): RankedJob[] {
   const ranked = postings.map((posting): RankedJob => {
     const extracted = extractJdTerms(posting.description);
@@ -56,5 +108,24 @@ export function rankPostings(
     };
     return { posting, jdMatch, score: coverage.score };
   });
-  return ranked.sort((a, b) => b.score - a.score);
+
+  const queryLocation = query?.location?.trim();
+  if (!queryLocation) {
+    // No location signal → identical to pre-#545 behavior.
+    return ranked.sort((a, b) => b.score - a.score);
+  }
+  // Decorate-sort-undecorate: compute the boosted key ONCE per posting (the
+  // boost does a regex test + two splits), not O(n log n) times inside the
+  // comparator. Sort is stable, so equal keys keep fan-out/dedup order.
+  return ranked
+    .map((job) => ({
+      job,
+      key:
+        job.score +
+        (locationBoostMatches(queryLocation, job.posting.location)
+          ? LOCATION_BOOST
+          : 0),
+    }))
+    .sort((a, b) => b.key - a.key)
+    .map(({ job }) => job);
 }

--- a/src/lib/job-search/role-keywords.ts
+++ b/src/lib/job-search/role-keywords.ts
@@ -235,8 +235,13 @@ const MAX_FAMILIES = 2;
  */
 const RUNNER_UP_SHARE = 2;
 
-/** A sensible default per-company cap for callers (#533) that don't specify. */
-export const DEFAULT_PER_COMPANY_CAP = 15;
+/**
+ * A sensible default per-company cap for callers (#533) that don't specify.
+ * Lowered from 15 to 8 alongside the #542 `COMPANY_LIMIT` raise (8 → 14) so
+ * the pre-rank posting ceiling stays sane: 14 * 8 = 112, versus the previous
+ * 8 * 15 = 120 — the pairing changed shape but not its order of magnitude.
+ */
+export const DEFAULT_PER_COMPANY_CAP = 8;
 
 /** Declaration-order index of a family, for the deterministic tie-break. */
 const FAMILY_ORDER: ReadonlyMap<RoleFamily, number> = new Map(

--- a/src/lib/job-search/search.test.ts
+++ b/src/lib/job-search/search.test.ts
@@ -8,20 +8,42 @@ import type { JobQuery } from "./query-builder.ts";
 
 // Mutable holder so each test can install its own provider set. rank.ts is NOT
 // mocked — it runs the real jd-match coverage, exercising ranking parity.
-const holder = vi.hoisted(() => ({ providers: [] as JobProvider[] }));
+const holder = vi.hoisted(() => ({
+  providers: [] as JobProvider[],
+  /** Registry entries `searchJobs` asked the company-board tier to build. */
+  boardEntriesSeen: [] as { name: string }[],
+  boardTierCalls: 0,
+}));
 
 vi.mock("./providers/index.ts", () => ({
-  getProviders: () => holder.providers,
+  // Mirrors the real signature: keyless set + whatever the caller passed.
+  getProviders: (companyProviders: readonly JobProvider[] = []) => [
+    ...holder.providers,
+    ...companyProviders,
+  ],
+}));
+
+vi.mock("./company-boards.ts", () => ({
+  makeBoardProviders: (entries: { name: string }[]) => {
+    holder.boardTierCalls += 1;
+    holder.boardEntriesSeen = entries;
+    return entries.map((entry) => ({
+      id: `board:${entry.name}`,
+      label: entry.name,
+      search: async () => [],
+    }));
+  },
 }));
 
 import { searchJobs } from "./search.ts";
+import type { CompanyEntry } from "./company-registry.ts";
 
 const parsed: HeuristicParsedResume = {
   skills: ["React", "TypeScript"],
   experience: [],
   education: [],
 };
-const query: JobQuery = { title: "Frontend Engineer", skills: ["React"] };
+const query: JobQuery = { titles: ["Frontend Engineer"], skills: ["React"] };
 
 function posting(overrides: Partial<JobPosting>): JobPosting {
   return {
@@ -42,6 +64,8 @@ function provider(id: string, impl: JobProvider["search"]): JobProvider {
 
 beforeEach(() => {
   holder.providers = [];
+  holder.boardEntriesSeen = [];
+  holder.boardTierCalls = 0;
 });
 
 describe("searchJobs", () => {
@@ -113,6 +137,40 @@ describe("searchJobs", () => {
     expect(ids).toEqual(["alpha:skill", "alpha:title"]);
   });
 
+  it("keeps postings matching ANY title token, not just the primary title (#539)", async () => {
+    // A leadership résumé: primary title is an exec title, a prior title is an
+    // IC/engineering-leadership one. Postings for the SECOND title must survive.
+    const multiTitleQuery: JobQuery = {
+      titles: ["Chief Technology Officer", "Backend Engineer"],
+      skills: [],
+    };
+    holder.providers = [
+      provider("alpha", async () => [
+        // Matches only the non-primary title's token ("backend").
+        posting({
+          id: "alpha:secondary",
+          title: "Backend Engineer",
+          description: "Own our services.",
+        }),
+        // Matches the primary title's token ("technology").
+        posting({
+          id: "alpha:primary",
+          title: "VP Technology",
+          description: "Lead the org.",
+        }),
+        // Matches neither title → dropped.
+        posting({
+          id: "alpha:off",
+          title: "Forklift Operator",
+          description: "Night shift warehouse work.",
+        }),
+      ]),
+    ];
+    const res = await searchJobs(multiTitleQuery, parsed, new AbortController().signal);
+    const ids = res.jobs.map((j) => j.posting.id).sort();
+    expect(ids).toEqual(["alpha:primary", "alpha:secondary"]);
+  });
+
   it("drops postings whose url is not http(s) — javascript: urls never render", async () => {
     holder.providers = [
       provider("alpha", async () => [
@@ -156,5 +214,105 @@ describe("searchJobs", () => {
     for (const job of res.jobs) {
       expect(job.score).toBe(job.jdMatch.coverage.score);
     }
+  });
+});
+
+/**
+ * The #533 wiring. The important case is the NEGATIVE one: a user who never
+ * touches the company selector must get byte-for-byte the pre-#533 search,
+ * including not paying for the company-board chunk at all.
+ */
+describe("searchJobs — company boards (#533)", () => {
+  const stripe: CompanyEntry = {
+    name: "Stripe",
+    ats: "greenhouse",
+    slug: "stripe",
+    sectors: ["fintech"],
+  };
+  const vanta: CompanyEntry = {
+    name: "Vanta",
+    ats: "ashby",
+    slug: "vanta",
+    sectors: ["security"],
+  };
+
+  it("does not load the company-board tier when no companies are selected", async () => {
+    holder.providers = [provider("alpha", async () => [posting({ id: "alpha:1" })])];
+
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+
+    expect(holder.boardTierCalls).toBe(0);
+    expect(res.providerCount).toBe(1);
+  });
+
+  it("defaults to keyless-only when the companies argument is omitted entirely", async () => {
+    holder.providers = [provider("alpha", async () => [])];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.providerCount).toBe(holder.providers.length);
+  });
+
+  it("adds one provider per selected company, alongside the keyless feeds", async () => {
+    holder.providers = [provider("alpha", async () => [posting({ id: "alpha:1" })])];
+
+    const res = await searchJobs(
+      query,
+      parsed,
+      new AbortController().signal,
+      [stripe, vanta],
+    );
+
+    expect(holder.boardTierCalls).toBe(1);
+    expect(holder.boardEntriesSeen).toEqual([stripe, vanta]);
+    expect(res.providerCount).toBe(3);
+    // The keyless result still comes through unchanged.
+    expect(res.jobs.map((j) => j.posting.id)).toEqual(["alpha:1"]);
+  });
+
+  it("degrades a single failing board without sinking the rest of the fan-out", async () => {
+    holder.providers = [
+      provider("alpha", async () => [posting({ id: "alpha:1" })]),
+      provider("beta", async () => {
+        throw new Error("CORS blocked");
+      }),
+      provider("gamma", async () => [
+        posting({ id: "gamma:1", title: "Backend Engineer", company: "G" }),
+      ]),
+    ];
+
+    const res = await searchJobs(query, parsed, new AbortController().signal, [stripe]);
+
+    expect(res.degradedProviders).toEqual(["Beta"]);
+    expect(res.degradedProviders.length).toBeLessThan(res.providerCount);
+    expect(res.jobs.map((j) => j.posting.id).sort()).toEqual(["alpha:1", "gamma:1"]);
+  });
+
+  it("keeps results in provider order when the fan-out exceeds the concurrency cap", async () => {
+    // 12 providers > the limiter's 6, so this also exercises the second wave.
+    holder.providers = Array.from({ length: 12 }, (_, i) =>
+      provider(`p${i}`, async () => [
+        posting({ id: `p${i}:1`, company: `Co${i}` }),
+      ]),
+    );
+
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+
+    expect(res.providerCount).toBe(12);
+    expect(res.jobs).toHaveLength(12);
+    expect(res.degradedProviders).toEqual([]);
+  });
+
+  it("maps a rejected slot back to the right label under concurrency", async () => {
+    // The failure sits past the first concurrency wave, so an index/order bug
+    // in the limiter would name the wrong provider here.
+    holder.providers = Array.from({ length: 10 }, (_, i) =>
+      provider(`p${i}`, async () => {
+        if (i === 8) throw new Error("down");
+        return [posting({ id: `p${i}:1`, company: `Co${i}` })];
+      }),
+    );
+
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+
+    expect(res.degradedProviders).toEqual(["P8"]);
   });
 });

--- a/src/lib/job-search/search.ts
+++ b/src/lib/job-search/search.ts
@@ -31,12 +31,39 @@
  *
  * AbortSignal is threaded into every provider's `search()` so an in-flight
  * search can be cancelled or superseded by a newer one.
+ *
+ * Company boards (#533): when the caller passes selected companies, each one
+ * joins the fan-out as an ordinary `JobProvider` wrapping the bounded pipeline
+ * in `company-boards.ts`. Everything below this line therefore treats a company
+ * board exactly like a keyless feed — same dedup, same url trust boundary, same
+ * per-provider degradation — which is the point of routing them through the
+ * provider interface. Two consequences worth stating outright:
+ *
+ *  - `matchesQuery` applies to company postings too. They already passed the
+ *    #534 role-title filter, but the user's editable query is the final say on
+ *    every source uniformly; special-casing company boards would make the query
+ *    box silently mean different things for different cards.
+ *  - The fan-out now runs through a concurrency limiter rather than a bare
+ *    `Promise.allSettled`, because its width grows with the number of selected
+ *    companies. `mapWithConcurrency` preserves allSettled's index-ordered,
+ *    never-rejecting contract, so the degraded-provider mapping is unchanged.
  */
 
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { JobQuery } from "./query-builder.ts";
 import type { JobPosting } from "./types.ts";
 import type { RankedJob } from "./rank.ts";
+import type { CompanyEntry } from "./company-registry.ts";
+import { mapWithConcurrency } from "./concurrency.ts";
+
+/**
+ * Providers fetched at once. Bounds the burst when company boards join the
+ * keyless feeds: the fan-out grows with the number of selected companies, and
+ * a dozen simultaneous cross-origin fetches would let the slowest board gate
+ * the search. Six keeps the common case (3 keyless + ~8 companies) moving
+ * without saturating the connection pool.
+ */
+const PROVIDER_CONCURRENCY = 6;
 
 export interface JobSearchResult {
   /** Postings ranked by fit descending (deduped across providers). */
@@ -75,16 +102,21 @@ function escapeRegExp(value: string): string {
 
 /**
  * Significant query terms as whole-word-ish case-insensitive patterns:
- * the query title's tokens (minus stopwords/short tokens) plus every skill
- * verbatim. Lookarounds instead of `\b` so symbol-bearing skills ("C++",
- * "Node.js") still match on word-ish edges.
+ * the tokens of EVERY query title (minus stopwords/short tokens) plus every
+ * skill verbatim. `matchesQuery` ORs across these, so a posting survives when
+ * it matches ANY title's tokens — the multi-title broadening from #539: an
+ * exec whose prior roles were engineering-leadership titles keeps postings for
+ * both facets, not just the most-recent title. Lookarounds instead of `\b` so
+ * symbol-bearing skills ("C++", "Node.js") still match on word-ish edges.
  */
 function buildQueryTermPatterns(query: JobQuery): RegExp[] {
   const terms = new Set<string>();
-  for (const token of query.title.toLowerCase().split(/[^a-z0-9+#.]+/)) {
-    const term = token.replace(/^\.+|\.+$/g, "");
-    if (term.length < 3 || STOPWORDS.has(term)) continue;
-    terms.add(term);
+  for (const title of query.titles) {
+    for (const token of title.toLowerCase().split(/[^a-z0-9+#.]+/)) {
+      const term = token.replace(/^\.+|\.+$/g, "");
+      if (term.length < 3 || STOPWORDS.has(term)) continue;
+      terms.add(term);
+    }
   }
   for (const skill of query.skills) {
     const term = skill.trim().toLowerCase();
@@ -113,15 +145,26 @@ export async function searchJobs(
   query: JobQuery,
   parsed: HeuristicParsedResume,
   signal: AbortSignal,
+  companies: readonly CompanyEntry[] = [],
 ): Promise<JobSearchResult> {
   const [{ getProviders }, { rankPostings }] = await Promise.all([
     import("./providers/index.ts"),
     import("./rank.ts"),
   ]);
 
-  const providers = getProviders();
-  const settled = await Promise.allSettled(
-    providers.map((p) => p.search(query, signal)),
+  // Only pull in the company-board tier (and, through it, the role-keyword
+  // taxonomy and the board cache) when the user actually selected companies —
+  // an empty selection is byte-for-byte the pre-#533 keyless search.
+  const companyProviders =
+    companies.length > 0
+      ? (await import("./company-boards.ts")).makeBoardProviders(companies, parsed)
+      : [];
+
+  const providers = getProviders(companyProviders);
+  const settled = await mapWithConcurrency(
+    providers,
+    PROVIDER_CONCURRENCY,
+    (p) => p.search(query, signal),
   );
 
   const degradedProviders: string[] = [];
@@ -145,7 +188,7 @@ export async function searchJobs(
   });
 
   return {
-    jobs: rankPostings(parsed, merged),
+    jobs: rankPostings(parsed, merged, query),
     degradedProviders,
     providerCount: providers.length,
   };

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -16,7 +16,7 @@
  */
 
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
-import type { ResumeRecord, JobRecord } from "./types.ts";
+import type { ResumeRecord, JobRecord, BoardCacheRecord } from "./types.ts";
 
 // Renamed from "resumelint" during the OfflineCV rename (#498). Safe to change
 // outright: the store had no external users at cutover, so there was no data to
@@ -25,12 +25,13 @@ import type { ResumeRecord, JobRecord } from "./types.ts";
 // `DB_VERSION` migration.
 export const DB_NAME = "offlinecv";
 /** Bump when adding/altering a store or index; add a matching `oldVersion < N`
- *  branch in `upgrade()`. */
-export const DB_VERSION = 1;
+ *  branch in `upgrade()`. Internal — only `getDB()` below reads it. */
+const DB_VERSION = 2;
 
 interface OfflineCvDB extends DBSchema {
   resumes: { key: string; value: ResumeRecord };
   jobs: { key: string; value: JobRecord };
+  boards: { key: string; value: BoardCacheRecord };
 }
 
 let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
@@ -47,6 +48,12 @@ export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
         if (oldVersion < 1) {
           db.createObjectStore("resumes", { keyPath: "id" });
           db.createObjectStore("jobs", { keyPath: "id" });
+        }
+        // v1 → v2 (#533): the company-ATS-board cache. Purely additive — an
+        // existing user's resumes/jobs are untouched, and the new store simply
+        // starts empty (a cache miss, which the caller already handles).
+        if (oldVersion < 2) {
+          db.createObjectStore("boards", { keyPath: "id" });
         }
       },
     });

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -10,7 +10,7 @@
  * `../lib/storage` (the barrel), not the internal files.
  */
 
-export { DB_NAME, DB_VERSION, closeDB } from "./db.ts";
+export { DB_NAME, closeDB } from "./db.ts";
 export {
   saveResume,
   getResume,

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -41,8 +41,18 @@ export interface JobRecord extends StoredRecord {
   [field: string]: unknown;
 }
 
+/** A cached company ATS board: the light-index postings one board returned,
+ *  keyed `${ats}:${slug}` (#533). A pure CACHE — deliberately absent from the
+ *  backup document, because re-fetching a board is cheap and a stale export
+ *  would resurrect boards the registry has since dropped. `postings` is opaque
+ *  here for the same reason `ResumeRecord.parse` is: this module never imports
+ *  the job-search graph. */
+export interface BoardCacheRecord extends StoredRecord {
+  postings: unknown[];
+}
+
 /** Object-store names. Adding a store is a schema-version bump (see db.ts). */
-export type StoreName = "resumes" | "jobs";
+export type StoreName = "resumes" | "jobs" | "boards";
 
 /** A resume as it appears in an export file: blob replaced by base64 + MIME so
  *  the whole backup is a single JSON document. */


### PR DESCRIPTION
## Summary

Epic #528 **job-search v2**, delivered as one PR on this branch across two rounds. Round 1 wired the company-targeted ATS-board search into the live panel (#533); round 2 hardened the query, ranking, and coverage surfaces (#539/#540/#541/#545 + the mechanical part of #542).

**Privacy:** no new egress across either round. A board request carries only the public company slug; `providers/keywords.ts` stays the sole resume-derived egress helper (round 2 keeps its egress to `titles[0]`/`skills[0]` even though the in-app query now holds the full title/skill sets).

Closes #533
Closes #539
Closes #540
Closes #541
Closes #545
Refs #542
Refs #546
Refs #528

> **Epic #528 left open on purpose.** #542 landed only its mechanical part (cap raise + docs); the registry-growth work — adding existence-audited, browser-CORS-verified companies for the under-covered sectors — is tracked in **#546**. Close #528 after #546 and the outstanding live-CORS board check.

## Round 1 — wire company ATS boards (#533)

On a parsed resume the panel classifies the candidate's sector, suggests registry companies, fetches each company's public **Greenhouse / Lever / Ashby** board (light index), role-title-filters and per-company-caps the postings, hydrates descriptions **only for the survivors**, ranks by resume fit, and caches boards in IndexedDB — alongside the existing keyless feeds.

- **`company-boards.ts`** — bounded pipeline: cache/fetch light index → `filterPostingsByRole` → `capPerCompany` → hydrate survivors. One degraded/CORS-blocked board lands in `degradedProviders` and never sinks the fan-out.
- **`board-cache.ts`** — IndexedDB board cache, light-index only (descriptions stripped, capped), 12h TTL; every failure degrades to a miss.
- **`concurrency.ts`** — order-preserving, never-rejecting limiter for the fan-out + hydration.
- **`providers/lever.ts`** — `hydrateLever` per-job endpoint (Greenhouse already had one). **Ashby is never cached** — no keyless per-job endpoint to rehydrate a light cache.
- **`company-registry.ts`** — existence-audited every slug: 162 curated → 68 surviving. Proves board *existence* via `curl`, not browser CORS.
- **`CompanyTargets.tsx` + `useCompanyTargets.ts`** — sector-suggested company chips, extracted as a sibling of `FindJobsPanel`.

## Round 2 — query / ranking / coverage hardening

- **#539 Multi-value title** — `JobQuery.title` (string) → `titles[]` (`MAX_TITLES=4`, distinct experience titles, most-recent-first, case-insensitive dedup). New shared `ChipListEditor` renders titles + skills as removable chips (reuses `ReconstructedAdd`'s `RemoveButton`). `search.ts` ORs tokens across all titles; deep-links join every title; egress stays `titles[0]`. No-titles → skills-only fallback.
- **#540 Exec/leadership seniority** — `SENIORITY_PATTERNS` extended with an Executive/VP/Director/Manager tier (specific-before-general; Chief-of-Staff → Executive). `deriveSeniorityAcrossTitles` scans primary-first then falls back. Empty seniority field hidden behind an AddPill, not an inert placeholder.
- **#541 Skills cap + rank** — `MAX_SKILLS` 5 → 12; `deriveSkills` stable-sorts canonical (taxonomy-recognized) skills ahead of unrecognized before capping. `MAX_DEEP_LINK_SKILLS=6` bounds the outbound URL keyword phrase.
- **#545 Location** — `JobQuery.location` seeded from the parsed résumé; `rank.ts` `LOCATION_BOOST=10` as a **sort-only** boost (`RankedJob.score` untouched; no-location path byte-identical) with Remote handling; location wired into LinkedIn/Indeed deep links.
- **#542 (mechanical scope)** — `COMPANY_LIMIT` 8 → 14, `DEFAULT_PER_COMPANY_CAP` 15 → 8 (pre-rank ceiling ~112). FAANG/self-hosted-careers limitation documented in the registry docblock + a `CompanyTargets` UI note. Registry growth deferred to **#546**.

## Test plan

- [x] `npm run typecheck` clean (both rounds)
- [x] Affected `vitest` green — job-search + storage + components (211 tests, round 2)
- [x] `npm run lint` clean
- [x] `npm run verify` — green (pre-push hook + CI PR gate)
- [x] **Human step:** browser-origin CORS verification of the wired boards from the dev server (round 1); registry growth + CORS verify tracked in #546

## Provenance

Two rounds, several models; every model string self-reported by the agent that ran, never inferred from the requested alias.

| Stage | Model | Effort |
|---|---|---|
| Implementation — #533 | unreported (requested: opus) | ultra |
| Implementation — #539 | Claude Opus 4.8 | ultra |
| Implementation — #540, #541, #545 | Claude Sonnet 5 | high |
| Implementation — #542 (mechanical) | Claude Sonnet 5 | medium |
| Adversarial review — round 1 (#533) | Claude Sonnet 5 | ultra |
| Adversarial review — round 2 (#539–#545) | Claude Sonnet 5 | high |
| Review fixes — round 1 | Claude Opus 4.8 (1M context) | ultra |
| Review fixes — round 2 | Claude Opus 4.8 | high |
| Review revisions — round 3 | Claude Opus 4.8 (1M context) | medium |
| Orchestration + PR | Claude Opus 4.8 (1M context) | high |
| Verification | `npm run verify` — green | — |

## Adversarial review

### Round 1 (#533)

One `ecc:react-reviewer` pass + one fix round, converged clean. **1 blocking (fixed):** the board cache wrote `base.search()` before the filter/cap pipeline, so Lever/Ashby's inline `descriptionPlain` meant ~35% of the registry cached full, unfiltered boards with descriptions (the exact growth the docblock claimed to prevent). Reproduced end-to-end. Fix: strip + size-cap at the cache write boundary; add `hydrateLever`; exclude Ashby from caching; rewrite docblocks. Surviving nits: `DB_VERSION` export (fixed in a follow-up), deliberate per-vendor adapter duplication, pre-existing `lever.ts mapJob` complexity.

### Round 2 (#539–#545)

One `ecc:react-reviewer` pass + one opus fix round, converged with 0 blocking.

**Blocking (fixed):**
- Reuse Gate — `ChipListEditor.tsx` hand-rolled a remove-button that already exists as `RemoveButton` in `ReconstructedAdd.tsx`. Fixed: imports and reuses it; local `RemoveIcon`/inline `<Button>` deleted.
- Seniority — "Chief of Staff" fell through the Executive `chief … officer` pattern to the IC `staff` row and mislabeled as "Staff". Fixed: explicit `Executive` row `/\bchief\s+of\s+staff\b/i` above the IC Staff row, with a test.

**Nit fixed:** `MAX_DEEP_LINK_LOCATION_LENGTH` made module-private (was an unnecessary export).

**Nits left for reviewer judgment (report-only):**
- `FindJobsPanel.tsx` is 228 LOC (>200 soft guideline, not on the known-debt list) — the query block could be extracted like `CompanyTargets` was.
- `isDegenerate` ignores a location-only query (Search button stays disabled if only Location is typed).
- User-added title/skill chips aren't capped at `MAX_TITLES`/`MAX_SKILLS` (only initial derivation is) — likely intentional.
- No test feeds a >100-char location to exercise the deep-link truncation slice.

**#542 scope note:** mechanical only (cap + docs). Registry growth deferred to #546 — needs live browser-CORS existence verification a headless agent can't do. Sectors furthest from the new cap of 14: gaming/hardware-iot/logistics-mobility/government-defense (6), ecommerce/media-adtech (7).

