### PR TITLE
docs(claude): correct egress claim, add job-search + design-system lane rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,12 @@ the exception: they stay here because breaking them is silent, and for two of th
 
 ## Project overview
 
-offlinecv started as a browser-side PDF parser stress test for resumes and is growing into a **private, no-login job-search workbench**: drop a PDF in, see what a generic text extractor reads back, get an anonymous heuristic score, fix the resume in place (inline edit + on-device LLM rewrite), download a clean ATS-safe PDF, match it against a job description, and discover relevant job postings. The non-negotiable product constraint: **everything runs client-side — no PDF bytes, resume text, or job-search queries leave the browser** (the only cloud path is the opt-in BYOK provider, keyed and initiated by the user).
+offlinecv started as a browser-side PDF parser stress test for resumes and is growing into a **private, no-login job-search workbench**: drop a PDF in, see what a generic text extractor reads back, get an anonymous heuristic score, fix the resume in place (inline edit + on-device LLM rewrite), download a clean ATS-safe PDF, match it against a job description, and discover relevant job postings. The non-negotiable product constraint: **the PDF bytes and the resume text never leave the browser.** Scope the claim to *data custody*, not runtime — "runs on your device" is falsifiable and two egress paths ship today:
+
+- **Job search** hits third-party feeds. What egresses is a short **keyword string** built from the user-editable query title + skills, never the resume text — `src/lib/job-search/providers/keywords.ts` is the sole resume-derived egress helper and the invariant the copy depends on. Company adapters egress only the **public company slug**.
+- **Analytics** is env-gated PostHog (`src/lib/analytics.ts`, `VITE_POSTHOG_KEY`) — dead-code-eliminated when unset, but a hosted build ships it, so it is not the user's choice.
+
+There is **no BYOK LLM provider in the tree** — `#320` is future; App.tsx / CapabilityStrip docblocks that mention BYOK are describing an unbuilt path. Don't cite BYOK as a current cloud path, and don't write a privacy line without grepping the actual `fetch(`/analytics/provider egress first.
 
 ### Product lanes and entry points
 
@@ -64,6 +69,8 @@ npm run verify     # full local CI mirror: typecheck → lint → coverage → b
 ```
 
 `npm run verify` is the canonical pre-push gate — the exact CI sequence. A git `pre-push` hook runs it automatically (installed by `npm install`); bypass with `OFFLINECV_SKIP_HOOKS=1`.
+
+**fallow is report-only inside `verify`.** The step ends `|| echo '…report-only, ignored'`, so a `fallow audit` exit 1 (complexity / CRAP / duplication) does **not** fail `verify` — branch protection requires only the `verify` job. A fallow complexity/CRAP finding on a PR is a **Nit / Secondary**, never Blocking on its own.
 
 **While iterating, prefer the narrow gate** — `npx vitest run <path>` on the files you touched, plus `npm run typecheck`. Save the full `verify` for when you think you're done. It runs coverage + build + fallow and is slow enough to cost you iterations.
 
@@ -144,6 +151,7 @@ Strict 3-tier architecture. Primitives + shared-composed live in `src/design-sys
 
 - **Domain logic stays in `src/lib/`** (`heuristics/`, `score/`, `pdf/`, …), strictly separated from UI. Components import typed async functions or hooks from `lib/`.
 - **Cross-cutting interaction state** (modals, drop zones, locks) belongs in `src/hooks/`, not inline `useState`/`useEffect` boilerplate in feature components. Single-use render-only logic can stay inline.
+- **`exhaustive-deps` is NOT enforced.** `eslint.config.js` registers no `react-hooks` plugin — a clean `npx eslint src` is zero evidence about a hook dep list; a stale closure lints green. Hand-audit any `useCallback`/`useEffect`/`useMemo` dep array you touch, both directions (missing dep → stale closure; extra dep → needless re-fire).
 
 ## What NOT to do
 

--- a/src/design-system/CLAUDE.md
+++ b/src/design-system/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md — design system
+
+Primitives + shared-composed behind the `@design-system` barrel (`index.ts`). Feature code
+imports via `import { … } from "@design-system"`, never deep paths. Read the root
+`CLAUDE.md` "Component architecture" + "Styling & tokens" sections first; this file adds
+three things that are easy to get wrong.
+
+## No Toast / Snackbar — confirm in place
+
+The barrel ships **no `Toast` and no `Snackbar`.** The reflex fix for "action completes
+with no feedback" is a success toast — but that means adding a *shared* component for a
+single callsite, which the reuse rule forbids. House pattern: **confirm in the surface
+already mounted**, swap its content rather than dismissing it. Two existing tones carry
+"done" with zero new components:
+
+- `InlineResult` — `tone="success"`
+- `StatusBadge` — `tone="ok"`
+
+Announce the swap with `aria-live="polite"` (precedent: `JobSearchResults.tsx`,
+`shared/UpdateBanner.tsx`). Never let colour alone carry meaning — the word ("Applied")
+must be present.
+
+## The default palette is deliberate — rename, never repaint
+
+`styles/tokens.css` is intentionally a generic slate-neutrals-plus-blue palette, **not** a
+product brand — its docblock is the swap seam for an outside cloner. Do not repaint the
+shared default to make the app "less bland"; that destroys the seam. Audit tokens by
+**consumption, not by reading the file**: `rg -o 'token-name' src/ --glob '!**/styles/*' |
+sort | uniq -c`. Name/value drift and dead tokens are invisible to reading and obvious to
+counting (a token whose name asserts a colour family is the highest-risk kind). Prefer a
+rename/merge to a repaint; prefer consuming an existing accent to defining a new one.
+
+## Emoji rule is about presentation, not codepoint
+
+Root `CLAUDE.md` forbids emoji as icons. A codepoint-range grep over-reports ~4x — most
+hits are deliberate **text-presentation marks**, not violations. Allowed: monochrome marks
+that inherit `currentColor` and carry an `aria-hidden` + `sr-only`/label pair (e.g. `✓ ✗`
+decorative toggles, `★ ☆` in `StarRating`, `⚠︎` written `U+26A0 U+FE0E` in `Tabs.tsx`).
+Banned: colour pictographs from the OS emoji font. Before flagging a hit, check for an
+adjacent `U+FE0E` and an `aria-hidden`/`sr-only` pair.

--- a/src/lib/job-search/CLAUDE.md
+++ b/src/lib/job-search/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md — job-search lane
+
+Query builder → provider search → rank by resume fit → deep links. Rides inside the
+main page (`FindJobsPanel`), not a separate HTML entry. Consumes the parsed resume,
+never the raw PDF. Read the root `CLAUDE.md` first; this file adds only the
+lane-specific rules that are silent to break.
+
+## Privacy invariant (hard)
+
+- **`providers/keywords.ts` is the sole resume-derived egress helper** in the whole
+  app. It builds a short keyword string from the user-editable query title + skills —
+  never the resume text. Used only by the keyless aggregator feeds.
+- **Company adapters egress only the public company slug** (plus static caps like
+  `?limit=`) — never resume-derived data, not even via `keywords.ts`. The role filter
+  (`filterPostingsByRole`) is local.
+- Before adding any `fetch()` here, confirm what leaves. A new adapter that sends more
+  than its slug breaks epic #528's privacy posture and the root-`CLAUDE.md` custody claim.
+
+## Per-vendor adapters duplicate on purpose
+
+Each provider in `providers/` is its own factory with its own inline `mapJob`/post-filter
+(`greenhouse.ts`, `lever.ts`, `ashby.ts`, `remotive.ts`, `arbeitnow.ts`, `jobicy.ts`).
+fallow flags the mapping bodies as a clone group (`dup:… ×N`). **This is the house
+pattern, not a shared-helper miss** — vendor response shapes diverge (Lever top-level
+array + unix-ms `createdAt`; Ashby `{jobs:[]}` + ISO `publishedAt`; Greenhouse needs a
+separate lazy `hydrate` call), so a "shared" mapper would be a switch-on-vendor that is
+worse than the duplication. When fallow or a reviewer re-raises this on the next adapter:
+**Nit / no-action.**
+
+Shared contract every adapter maps into: `JobPosting` in `types.ts` — includes optional
+`departments?: string[]` (the #534 role-title filter reads it). New adapters emit
+`departments` from the vendor's team/department field.
+
+## `await writeCachedBoard` is load-bearing
+
+In `company-boards.ts`, `if (cacheable) await writeCachedBoard(…)` (~line 179) looks like
+a fire-and-forget candidate (one IndexedDB put that never rejects). It is **not**.
+`company-boards.test.ts` (the "no re-fetch" case, ~line 304) asserts a second `search()`
+issues **1** board fetch, not 2 — the write must commit before `search()` resolves or a
+rapid follow-up misses the cache. The await enforces the happens-before. Do not "fire-and-
+forget the non-critical write."


### PR DESCRIPTION
## Summary

Corrects a false privacy claim in the project overview and promotes durable, recurring gotchas from working memory into `CLAUDE.md` and two new lane-scoped `CLAUDE.md` files.

The overview line claimed *no job-search queries leave the browser* and named BYOK as *the only cloud path*. Both are false on the current tree: aggregator feeds egress a keyword string (`providers/keywords.ts`), PostHog is env-gated (`analytics.ts`) but ships in hosted builds, and **no BYOK LLM provider exists** (`#320` is unbuilt — App.tsx/CapabilityStrip docblocks describe a future path). Rescoped to *data custody*: PDF bytes + resume text never leave; `keywords.ts` is the sole resume-derived egress.

No closing keyword — no issue tracks this.

## Changes

- **Root `CLAUDE.md`**
  - rewrite the project-overview egress paragraph (custody, not runtime; BYOK not in tree)
  - `exhaustive-deps` is not ESLint-enforced — hand-audit hook dep arrays
  - fallow is report-only in `verify` — a CRAP finding is a Nit, not Blocking
- **New `src/lib/job-search/CLAUDE.md`** — privacy invariant (keywords.ts / slug-only), deliberate per-vendor adapter dup (fallow Nit), `await writeCachedBoard` is load-bearing
- **New `src/design-system/CLAUDE.md`** — no Toast (confirm in place), palette is deliberate (rename not repaint), emoji rule is presentation not codepoint

## Test plan

- [x] Docs-only — no code paths touched; `verify` green in CI
- [x] Every claim verified against the current tree before writing (keywords.ts, providers dir, `JobPosting.departments?`, `await writeCachedBoard` at company-boards.ts:179, analytics VITE_POSTHOG_KEY gate, DS barrel has no Toast, tokens.css docblock, no BYOK provider in src)

## Provenance

Documentation authored via: Claude Opus 4.8 (1M context), medium effort
Every factual claim verified by grep/read against the working tree.
Verification: `npm run verify` — green in CI