### PR TITLE
feat(skills): model, robustly extract, and edit categorised skills (#415)

### DIFF
--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -2,24 +2,20 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * ReconstructedEducationSkills — the editable Education and Skills sections of
- * the reconstructed resume (#176). Split out of ReconstructedResume.tsx to keep
- * that container under ~200 LOC.
+ * ReconstructedEducationSkills — the editable Education section of the
+ * reconstructed resume (#176). Split out of ReconstructedResume.tsx to keep that
+ * container under ~200 LOC; the Skills section moved to its sibling
+ * `ReconstructedSkills.tsx` when category editing (#476) grew it past that limit.
  *
- * Both sections were read-only; since the surface exports to PDF, a parser miss
- * was uncorrectable. They now expose inline edit affordances wired to the lifted
- * override model (useEditableParse):
- *   - Education: degree / institution / dates editable via the shared
- *     EditableField. A cleared field shows an "+ <noun>" add-affordance.
- *   - Skills: each skill is a removable chip; a "+ Add skill" pill expands
- *     inline into an input (canonical-name normalization + suggestions),
- *     collapsing back on Escape or empty blur.
+ * Education was read-only; since the surface exports to PDF, a parser miss was
+ * uncorrectable. It now exposes inline edit affordances wired to the lifted
+ * override model (useEditableParse): degree / institution / dates editable via
+ * the shared EditableField, a cleared field shows an "+ <noun>" add-affordance.
  *
  * The override maps live in App and feed applyOverrides → re-grade → PDF, so an
  * edit here moves the ATS score AND the downloaded PDF, not just the display.
  */
 
-import { useMemo, useState } from "react";
 import type { ResumeEducation } from "../../lib/score/types.ts";
 import type {
   EducationFieldOverrides,
@@ -27,8 +23,7 @@ import type {
   AddedEntryField,
 } from "../../hooks/useEditableParse.ts";
 import { buildEducationDates } from "../../lib/score/entry-dates.ts";
-import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
-import { Button, EditableField } from "@design-system";
+import { EditableField } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
 import { AddPill, RemoveButton, sectionExitBlur } from "./ReconstructedAdd.tsx";
 
@@ -276,181 +271,6 @@ export function EducationSection({
         </ul>
       )}
       <AddPill label="Add education" onClick={onAddEntry} />
-    </section>
-  );
-}
-
-// ── Skills ─────────────────────────────────────────────────────────────────────
-
-function SkillChip({
-  skill,
-  onRemove,
-}: {
-  skill: string;
-  onRemove: () => void;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-secondary">
-      {skill}
-      <Button
-        variant="icon"
-        aria-label={`Remove ${skill}`}
-        onClick={onRemove}
-        className="shrink-0 text-content-muted hover:text-content-secondary"
-      >
-        <svg
-          aria-hidden="true"
-          width="10"
-          height="10"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-        >
-          <path d="M3 3l10 10M13 3L3 13" />
-        </svg>
-      </Button>
-    </span>
-  );
-}
-
-function AddSkillInput({
-  skills,
-  onAdd,
-}: {
-  skills: string[];
-  onAdd: (skill: string) => void;
-}) {
-  const [draft, setDraft] = useState("");
-  const suggestions = useMemo(
-    () => suggestSkills(draft, skills),
-    [draft, skills],
-  );
-
-  const [expanded, setExpanded] = useState(false);
-
-  const commit = (value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) return;
-    onAdd(trimmed);
-    setDraft("");
-  };
-
-  // Collapsed: a chip-shaped "+ Add skill" pill that sits inline with the
-  // skill chips. Progressive disclosure — the input only exists while adding,
-  // so it doesn't sit heavy under the lightweight chip cluster (#180-followup).
-  if (!expanded) {
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setExpanded(true)}
-        aria-label="Add skill"
-        className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-accent-primary"
-      >
-        + Add skill
-      </Button>
-    );
-  }
-
-  return (
-    <div
-      className="flex flex-col gap-1.5"
-      onBlur={(e) => {
-        // Collapse back to the pill when focus leaves the editor entirely and
-        // nothing is typed. relatedTarget within the container (suggestion or
-        // Add button click) keeps it open.
-        if (
-          !e.currentTarget.contains(e.relatedTarget as Node | null) &&
-          draft.trim().length === 0
-        ) {
-          setExpanded(false);
-        }
-      }}
-    >
-      <div className="flex items-center gap-2">
-        <input
-          type="text"
-          value={draft}
-          autoFocus
-          aria-label="Add skill"
-          placeholder="Add a skill…"
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              commit(draft);
-            } else if (e.key === "Escape") {
-              e.preventDefault();
-              setDraft("");
-              setExpanded(false);
-            }
-          }}
-          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
-        />
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={() => commit(draft)}
-          disabled={draft.trim().length === 0}
-          aria-label="Add skill"
-        >
-          Add
-        </Button>
-      </div>
-      {suggestions.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {suggestions.map((s) => (
-            <Button
-              key={s}
-              variant="ghost"
-              size="sm"
-              onClick={() => commit(s)}
-              aria-label={`Add ${s}`}
-              className="rounded-full bg-surface-subtle px-2.5 py-0.5 text-xs text-content-tertiary hover:text-accent-primary"
-            >
-              + {s}
-            </Button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-export function SkillsSection({
-  heading,
-  skills,
-  onAddSkill,
-  onRemoveSkill,
-}: {
-  /** Verbatim source heading (#285); falls back to "Skills" when absent. */
-  heading?: string;
-  /** The edited skills list (parsed minus removed, plus added) — what renders.
-   *  App already folds skillsOverride into this via applyOverrides, so the
-   *  section renders the resolved list directly. */
-  skills: string[];
-  onAddSkill: (skill: string) => void;
-  onRemoveSkill: (skill: string) => void;
-}) {
-  return (
-    <section className="flex flex-col gap-2">
-      <SectionHeading>{heading ?? "Skills"}</SectionHeading>
-      {skills.length === 0 ? (
-        <NotDetected what="skills" />
-      ) : (
-        <div className="flex flex-wrap gap-1.5">
-          {skills.map((skill, i) => (
-            <SkillChip
-              key={`${skill}-${i}`}
-              skill={skill}
-              onRemove={() => onRemoveSkill(skill)}
-            />
-          ))}
-        </div>
-      )}
-      <AddSkillInput skills={skills} onAdd={onAddSkill} />
     </section>
   );
 }

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -96,10 +96,8 @@ import {
   DEFAULT_ACHIEVEMENT_YEAR_SEPARATOR,
 } from "../../lib/score/entry-dates.ts";
 import { validateDate } from "../../lib/edit/field-validators.ts";
-import {
-  EducationSection,
-  SkillsSection,
-} from "./ReconstructedEducationSkills.tsx";
+import { EducationSection } from "./ReconstructedEducationSkills.tsx";
+import { SkillsSection } from "./ReconstructedSkills.tsx";
 import { Button, EditableField } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
@@ -1043,6 +1041,12 @@ export function ReconstructedResume({
     captureBulletUndo,
     addSkill,
     removeSkill,
+    renameSkillCategory,
+    deleteSkillCategory,
+    addSkillCategory,
+    addSkillToCategory,
+    moveSkillToCategory,
+    removeCategorySkill,
     profileOverrides,
     setLegacyLink,
     addProfile,
@@ -1293,8 +1297,30 @@ export function ReconstructedResume({
       <SkillsSection
         heading={display.sectionHeadings?.get("skills")}
         skills={parsed.skills}
+        skillCategories={parsed.skillCategories}
         onAddSkill={addSkill}
         onRemoveSkill={removeSkill}
+        // Categorised edits (#476) — bound to the CURRENT edited grouping, which
+        // the override snapshot keeps in lockstep with the flat list. Each
+        // dispatches the same grouping-snapshot transform.
+        onRenameCategory={(i, label) =>
+          renameSkillCategory(parsed.skillCategories ?? [], i, label)
+        }
+        onDeleteCategory={(i) =>
+          deleteSkillCategory(parsed.skillCategories ?? [], i)
+        }
+        onAddCategory={(label) =>
+          addSkillCategory(parsed.skillCategories ?? [], label)
+        }
+        onAddSkillToCategory={(i, skill) =>
+          addSkillToCategory(parsed.skillCategories ?? [], i, skill)
+        }
+        onMoveSkill={(skill, destIndex) =>
+          moveSkillToCategory(parsed.skillCategories ?? [], skill, destIndex)
+        }
+        onRemoveCategorySkill={(skill) =>
+          removeCategorySkill(parsed.skillCategories ?? [], skill)
+        }
       />
     </section>
   );

--- a/src/components/features/ReconstructedSkillControls.tsx
+++ b/src/components/features/ReconstructedSkillControls.tsx
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ReconstructedSkillControls — the leaf UI controls of the editable Skills
+ * section (#476), split out of `ReconstructedSkills.tsx` to keep that file near
+ * the ~200 LOC guideline. These are display-only building blocks: a removable
+ * skill chip (optionally draggable, with a keyboard "Move to" menu), the add-
+ * skill / add-category inputs, and the confirm-then-delete control for a whole
+ * category. All mutation flows up through callbacks — the grouping snapshot lives
+ * in the override model (`skills-categories.ts`).
+ */
+
+import { useMemo, useState } from "react";
+import { suggestSkills } from "../../lib/edit/skill-canonical.ts";
+import { Button, Dialog } from "@design-system";
+import { AddPill } from "./ReconstructedAdd.tsx";
+
+/** The other categories a chip can move to — label + its index in the grouping. */
+export interface MoveTarget {
+  label: string;
+  index: number;
+}
+
+/** Keyboard-reachable "Move to" menu — the accessible primary path for a move.
+ *  Expands to a list of the OTHER categories as buttons; picking one dispatches
+ *  the same override the drag-and-drop drop does. */
+function MoveMenu({
+  targets,
+  onMove,
+}: {
+  targets: MoveTarget[];
+  onMove: (destIndex: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (targets.length === 0) return null;
+  if (!open) {
+    return (
+      <Button
+        variant="icon"
+        size="sm"
+        aria-label="Move to another category"
+        onClick={() => setOpen(true)}
+        className="text-content-muted hover:text-accent-primary"
+      >
+        <svg
+          aria-hidden="true"
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M6 3l5 5-5 5" />
+        </svg>
+      </Button>
+    );
+  }
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1"
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null))
+          setOpen(false);
+      }}
+    >
+      <span className="text-[11px] text-content-muted">Move to</span>
+      {targets.map((t) => (
+        <Button
+          key={t.index}
+          variant="ghost"
+          size="sm"
+          autoFocus={t === targets[0]}
+          aria-label={`Move to ${t.label}`}
+          onClick={() => {
+            onMove(t.index);
+            setOpen(false);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setOpen(false);
+          }}
+          className="rounded-full bg-surface-subtle px-2 py-0.5 text-[11px] text-content-tertiary hover:text-accent-primary"
+        >
+          {t.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export function SkillChip({
+  skill,
+  onRemove,
+  moveTargets,
+  onMove,
+  onDragStart,
+}: {
+  skill: string;
+  onRemove: () => void;
+  /** Other categories this chip can move to (categorised only). */
+  moveTargets?: MoveTarget[];
+  onMove?: (destIndex: number) => void;
+  /** Set on a categorised chip so it can be dragged onto another category row. */
+  onDragStart?: () => void;
+}) {
+  return (
+    <span
+      draggable={onDragStart ? true : undefined}
+      onDragStart={
+        onDragStart
+          ? (e) => {
+              // Firefox refuses to initiate a drag unless `dragstart` writes
+              // transfer data. The payload is unused — the drop handler reads
+              // the dragged skill from React state — but it must be present or
+              // the drag never starts (the keyboard "Move to" menu is the
+              // input-agnostic fallback either way).
+              e.dataTransfer.setData("text/plain", skill);
+              onDragStart();
+            }
+          : undefined
+      }
+      className="inline-flex items-center gap-1 rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-secondary"
+    >
+      {skill}
+      {moveTargets && onMove && <MoveMenu targets={moveTargets} onMove={onMove} />}
+      <Button
+        variant="icon"
+        aria-label={`Remove ${skill}`}
+        onClick={onRemove}
+        className="shrink-0 text-content-muted hover:text-content-secondary"
+      >
+        <svg
+          aria-hidden="true"
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        >
+          <path d="M3 3l10 10M13 3L3 13" />
+        </svg>
+      </Button>
+    </span>
+  );
+}
+
+/** A flat, ungrouped row of removable skill chips — the whole Skills section when
+ *  the résumé was not categorised, and the trailing "no category" row for any
+ *  skill that falls outside every category. When `moveTargets`/`onMoveSkill` are
+ *  supplied (the categorised "no category" row), each chip also gets a "Move to"
+ *  menu + drag handle so an ungrouped skill can be regrouped into a category;
+ *  the uncategorised résumé omits them (there is nowhere to move to). */
+export function SkillChipRow({
+  skills,
+  onRemoveSkill,
+  moveTargets,
+  onMoveSkill,
+  onDragStartSkill,
+}: {
+  skills: string[];
+  onRemoveSkill: (skill: string) => void;
+  moveTargets?: MoveTarget[];
+  onMoveSkill?: (skill: string, destIndex: number) => void;
+  onDragStartSkill?: (skill: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {skills.map((skill, i) => (
+        <SkillChip
+          key={`${skill}-${i}`}
+          skill={skill}
+          onRemove={() => onRemoveSkill(skill)}
+          moveTargets={moveTargets}
+          onMove={onMoveSkill ? (destIndex) => onMoveSkill(skill, destIndex) : undefined}
+          onDragStart={onDragStartSkill ? () => onDragStartSkill(skill) : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function AddSkillInput({
+  skills,
+  onAdd,
+  label = "Add skill",
+}: {
+  skills: string[];
+  onAdd: (skill: string) => void;
+  label?: string;
+}) {
+  const [draft, setDraft] = useState("");
+  const suggestions = useMemo(() => suggestSkills(draft, skills), [draft, skills]);
+  const [expanded, setExpanded] = useState(false);
+
+  const commit = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setDraft("");
+  };
+
+  if (!expanded) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setExpanded(true)}
+        aria-label={label}
+        className="self-start rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-tertiary hover:text-accent-primary"
+      >
+        + {label}
+      </Button>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-1.5"
+      onBlur={(e) => {
+        if (
+          !e.currentTarget.contains(e.relatedTarget as Node | null) &&
+          draft.trim().length === 0
+        ) {
+          setExpanded(false);
+        }
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={draft}
+          autoFocus
+          aria-label={label}
+          placeholder="Add a skill…"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit(draft);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setDraft("");
+              setExpanded(false);
+            }
+          }}
+          className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => commit(draft)}
+          disabled={draft.trim().length === 0}
+          aria-label={label}
+        >
+          Add
+        </Button>
+      </div>
+      {suggestions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {suggestions.map((s) => (
+            <Button
+              key={s}
+              variant="ghost"
+              size="sm"
+              onClick={() => commit(s)}
+              aria-label={`Add ${s}`}
+              className="rounded-full bg-surface-subtle px-2.5 py-0.5 text-xs text-content-tertiary hover:text-accent-primary"
+            >
+              + {s}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsed "+ Add category" pill that expands to a label input. */
+export function AddCategoryInput({ onAdd }: { onAdd: (label: string) => void }) {
+  const [draft, setDraft] = useState<string | null>(null);
+  if (draft === null) {
+    return <AddPill label="Add category" onClick={() => setDraft("")} />;
+  }
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed) onAdd(trimmed);
+    setDraft(null);
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="text"
+        value={draft}
+        autoFocus
+        aria-label="New category label"
+        placeholder="Category name…"
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft(null);
+          }
+        }}
+        onBlur={commit}
+        className="min-w-0 flex-1 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+      />
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={commit}
+        disabled={draft.trim().length === 0}
+        aria-label="Add category"
+      >
+        Add
+      </Button>
+    </div>
+  );
+}
+
+/** Confirm-then-delete control for a whole category (destructive — takes its
+ *  members with it), using the shared Dialog primitive (no hand-rolled modal). */
+export function DeleteCategoryButton({
+  label,
+  onDelete,
+}: {
+  label: string;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="icon"
+        size="sm"
+        aria-label={`Delete ${label} category`}
+        onClick={() => setOpen(true)}
+        className="text-content-muted hover:text-feedback-error-text"
+      >
+        <svg
+          aria-hidden="true"
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        >
+          <path d="M3 4h10M6 4V2.5h4V4M5 4l.5 9h5l.5-9" />
+        </svg>
+      </Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title={`Delete "${label}"?`}
+        className="fixed left-1/2 top-1/2 w-[min(24rem,90vw)] -translate-x-1/2 -translate-y-1/2"
+      >
+        <p className="text-sm text-content-secondary">
+          This removes the category and all the skills in it. To keep the skills,
+          move them to another category first.
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => {
+              onDelete();
+              setOpen(false);
+            }}
+          >
+            Delete category
+          </Button>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/features/ReconstructedSkills.test.ts
+++ b/src/components/features/ReconstructedSkills.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  SkillsSection,
+  partitionSkillCategories,
+} from "./ReconstructedSkills.tsx";
+import type { SkillCategory } from "../../lib/heuristics/types.ts";
+
+const noop = () => {};
+
+// ── partitionSkillCategories (#473 render helper, empty-but-present for #476) ──
+
+describe("partitionSkillCategories", () => {
+  const cats: SkillCategory[] = [
+    { label: "Frontend", skills: ["React", "TypeScript"] },
+    { label: "Backend", skills: ["Java", "Go"] },
+  ];
+
+  it("keeps categories intact when the flat list matches the flattened members", () => {
+    const { rows, ungrouped } = partitionSkillCategories(
+      ["React", "TypeScript", "Java", "Go"],
+      cats,
+    );
+    expect(rows).toEqual(cats);
+    expect(ungrouped).toEqual([]);
+  });
+
+  it("keeps an emptied category PRESENT (empty-but-present, issue 476)", () => {
+    const { rows, ungrouped } = partitionSkillCategories(["Java", "Go"], cats);
+    expect(rows).toEqual([
+      { label: "Frontend", skills: [] },
+      { label: "Backend", skills: ["Java", "Go"] },
+    ]);
+    expect(ungrouped).toEqual([]);
+  });
+
+  it("routes an uncovered skill into the ungrouped tail", () => {
+    const { rows, ungrouped } = partitionSkillCategories(
+      ["React", "TypeScript", "Java", "Go", "Rust"],
+      cats,
+    );
+    expect(rows).toEqual(cats);
+    expect(ungrouped).toEqual(["Rust"]);
+  });
+});
+
+// ── SkillsSection rendering ────────────────────────────────────────────────────
+
+describe("SkillsSection rendering", () => {
+  const render = (skills: string[], skillCategories?: SkillCategory[]): string =>
+    renderToStaticMarkup(
+      createElement(SkillsSection, {
+        skills,
+        skillCategories,
+        onAddSkill: noop,
+        onRemoveSkill: noop,
+        onRenameCategory: noop,
+        onDeleteCategory: noop,
+        onAddCategory: noop,
+        onAddSkillToCategory: noop,
+        onMoveSkill: noop,
+        onRemoveCategorySkill: noop,
+      }),
+    );
+
+  const cats: SkillCategory[] = [
+    { label: "Frontend", skills: ["React", "TypeScript"] },
+    { label: "Backend", skills: ["Java", "Go"] },
+  ];
+
+  it("renders one labelled, editable row per category with edit affordances", () => {
+    const html = render(["React", "TypeScript", "Java", "Go"], cats);
+    // Rename affordance (EditableField carries the aria-label).
+    expect(html).toContain("Rename Frontend category");
+    expect(html).toContain("Rename Backend category");
+    // Delete-category and move affordances exist.
+    expect(html).toContain("Delete Frontend category");
+    expect(html).toContain("Move to another category");
+    // Add-category affordance is offered on a categorised résumé.
+    expect(html).toContain("Add category");
+    expect(html).toContain("React");
+    expect(html).toContain("Go");
+  });
+
+  it("shows an emptied category as present with a hint, not dropped", () => {
+    const html = render(["Java", "Go"], cats);
+    expect(html).toContain("Rename Frontend category");
+    expect(html).toContain("empty");
+  });
+
+  it("renders a flat list with no category chrome when uncategorised", () => {
+    const html = render(["React", "TypeScript"]);
+    expect(html).not.toContain("Rename");
+    expect(html).not.toContain("Add category");
+    expect(html).toContain("React");
+    expect(html).toContain("TypeScript");
+  });
+
+  it("gives an ungrouped chip a Move menu so it can be regrouped (issue 476 nit)", () => {
+    // Rust falls outside both categories → lands in the ungrouped tail. Every
+    // chip (4 categorised + 1 ungrouped) now carries a "Move to" affordance, so
+    // an ungrouped skill is not stranded remove-only.
+    const html = render(["React", "TypeScript", "Java", "Go", "Rust"], cats);
+    expect(html).toContain("Rust");
+    const moveMenus = html.split("Move to another category").length - 1;
+    expect(moveMenus).toBe(5);
+  });
+
+  it("uncategorised flat chips stay remove-only (no move menu, nowhere to move)", () => {
+    const html = render(["React", "TypeScript"]);
+    expect(html).not.toContain("Move to another category");
+  });
+});

--- a/src/components/features/ReconstructedSkills.tsx
+++ b/src/components/features/ReconstructedSkills.tsx
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ReconstructedSkills — the editable Skills section of the reconstructed resume.
+ * Split out of ReconstructedEducationSkills.tsx (#176) when category editing
+ * (#476) grew it past the ~200 LOC guideline; the leaf controls live in the
+ * sibling `ReconstructedSkillControls.tsx`.
+ *
+ * #473 rendered the parser's category grouping read-only; #476 makes it editable
+ * without a parallel surface — the same chip cluster now supports renaming a
+ * category label, deleting a whole category (behind a confirm Dialog), adding a
+ * new category, and moving a skill between categories. The move has TWO
+ * invocations over ONE mutation path: a keyboard-reachable "Move to" menu on each
+ * chip (the required, accessible primary) and native HTML5 drag-and-drop as a
+ * pointer enhancement — both call `onMoveSkill`, which dispatches the same
+ * grouping-snapshot transform (`skills-categories.ts`). A live region announces
+ * each move so a non-visual user learns it happened.
+ *
+ * Native `draggable` is used (no DnD library): the accessibility requirement is
+ * already met by the keyboard menu, so DnD is a pure pointer nicety where a
+ * dependency in this bundle-conscious codebase isn't justified.
+ *
+ * Display-only otherwise: it renders the edited grouping (`skillCategories`,
+ * which for a categorised résumé the override snapshot keeps in lockstep with the
+ * flat `skills` list) and routes every edit up to the lifted override model.
+ */
+
+import { useState } from "react";
+import type { SkillCategory } from "../../lib/heuristics/types.ts";
+import { EditableField } from "@design-system";
+import {
+  AddCategoryInput,
+  AddSkillInput,
+  DeleteCategoryButton,
+  SkillChip,
+  SkillChipRow,
+  type MoveTarget,
+} from "./ReconstructedSkillControls.tsx";
+
+// ── Shared section chrome (mirrors ReconstructedEducationSkills' local helpers) ─
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+      {children}
+    </h2>
+  );
+}
+
+function NotDetected({ what }: { what: string }) {
+  return <p className="text-sm text-content-tertiary">No {what} detected.</p>;
+}
+
+// ── Category row ───────────────────────────────────────────────────────────────
+
+/** One editable category row: an EditableField label (rename), a delete-category
+ *  control, its member chips (each with a Move menu + drag handle), and an
+ *  add-skill input. Rendered even when empty (empty-but-present, #476) so the
+ *  user can still rename it, re-populate it, or delete it. Also a drop target for
+ *  a chip dragged from another row. */
+function SkillCategoryRow({
+  category,
+  index,
+  moveTargets,
+  skills,
+  onRename,
+  onDelete,
+  onAddSkill,
+  onRemoveSkill,
+  onMoveSkill,
+  onDragStartSkill,
+  onDropSkill,
+}: {
+  category: SkillCategory;
+  index: number;
+  /** The other categories, for this row's chips' move menus. */
+  moveTargets: MoveTarget[];
+  /** The full flat skill list, for the add-input's suggestions. */
+  skills: string[];
+  onRename: (label: string) => void;
+  onDelete: () => void;
+  onAddSkill: (skill: string) => void;
+  onRemoveSkill: (skill: string) => void;
+  onMoveSkill: (skill: string, destIndex: number) => void;
+  onDragStartSkill: (skill: string) => void;
+  onDropSkill: (destIndex: number) => void;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-1.5 rounded-md p-1"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={() => onDropSkill(index)}
+    >
+      <div className="flex items-center gap-1.5">
+        <EditableField
+          value={category.label}
+          placeholder="category"
+          label={`Rename ${category.label} category`}
+          textSize="xs"
+          textWeight="semibold"
+          onCommit={onRename}
+        />
+        <span className="text-xs text-content-muted">:</span>
+        <DeleteCategoryButton label={category.label} onDelete={onDelete} />
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {category.skills.map((skill, i) => (
+          <SkillChip
+            key={`${skill}-${i}`}
+            skill={skill}
+            onRemove={() => onRemoveSkill(skill)}
+            moveTargets={moveTargets}
+            onMove={(destIndex) => onMoveSkill(skill, destIndex)}
+            onDragStart={() => onDragStartSkill(skill)}
+          />
+        ))}
+        {category.skills.length === 0 && (
+          <span className="text-xs text-content-tertiary">
+            (empty — add a skill or delete this category)
+          </span>
+        )}
+      </div>
+      <AddSkillInput skills={skills} onAdd={onAddSkill} label="Add to category" />
+    </div>
+  );
+}
+
+// ── Partition ──────────────────────────────────────────────────────────────────
+
+/**
+ * Partition the resolved flat skills into category rows + a trailing ungrouped
+ * row (#473). Members are intersected with the resolved list, and — unlike the
+ * pre-#476 helper — an EMPTIED category is KEPT (empty-but-present): the editor
+ * needs the row so the user can rename, re-populate, or delete it (#476). Any
+ * skill not covered by a category collects into `ungrouped` (the snapshot
+ * invariant keeps this empty in practice). Pure, so verifiable without rendering.
+ */
+export function partitionSkillCategories(
+  skills: string[],
+  categories: SkillCategory[],
+): { rows: SkillCategory[]; ungrouped: string[] } {
+  const present = new Set(skills);
+  const rows = categories.map((c) => ({
+    label: c.label,
+    skills: c.skills.filter((s) => present.has(s)),
+  }));
+  const grouped = new Set(rows.flatMap((r) => r.skills));
+  const ungrouped = skills.filter((s) => !grouped.has(s));
+  return { rows, ungrouped };
+}
+
+// ── Section ──────────────────────────────────────────────────────────────────
+
+export function SkillsSection({
+  heading,
+  skills,
+  skillCategories,
+  onAddSkill,
+  onRemoveSkill,
+  onRenameCategory,
+  onDeleteCategory,
+  onAddCategory,
+  onAddSkillToCategory,
+  onMoveSkill,
+  onRemoveCategorySkill,
+}: {
+  /** Verbatim source heading (#285); falls back to "Skills" when absent. */
+  heading?: string;
+  /** The edited flat skills list — what renders (App folds the override in). */
+  skills: string[];
+  /** The edited category grouping (#473/#476). Present → the section renders one
+   *  editable labelled row per category; absent → the flat chip cluster. */
+  skillCategories?: SkillCategory[];
+  /** Uncategorised flat add/remove (unchanged from #176). */
+  onAddSkill: (skill: string) => void;
+  onRemoveSkill: (skill: string) => void;
+  /** Categorised edits (#476) — pre-bound to the current grouping by the caller. */
+  onRenameCategory: (index: number, label: string) => void;
+  onDeleteCategory: (index: number) => void;
+  onAddCategory: (label: string) => void;
+  onAddSkillToCategory: (index: number, skill: string) => void;
+  onMoveSkill: (skill: string, destIndex: number) => void;
+  onRemoveCategorySkill: (skill: string) => void;
+}) {
+  const categorised = skillCategories && skillCategories.length > 0;
+  const { rows, ungrouped } = categorised
+    ? partitionSkillCategories(skills, skillCategories)
+    : { rows: [], ungrouped: skills };
+
+  // The skill currently being dragged (native HTML5 DnD) — read by a row's drop
+  // handler. The keyboard Move menu bypasses this entirely.
+  const [dragging, setDragging] = useState<string | null>(null);
+  // Announced to assistive tech on every move (either input modality).
+  const [announcement, setAnnouncement] = useState("");
+
+  const announceMove = (skill: string, destIndex: number) => {
+    setAnnouncement(
+      `Moved ${skill} to ${skillCategories?.[destIndex]?.label ?? "category"}`,
+    );
+  };
+  const moveViaMenu = (skill: string, destIndex: number) => {
+    onMoveSkill(skill, destIndex);
+    announceMove(skill, destIndex);
+  };
+  const dropOnCategory = (destIndex: number) => {
+    if (dragging === null) return;
+    onMoveSkill(dragging, destIndex);
+    announceMove(dragging, destIndex);
+    setDragging(null);
+  };
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeading>{heading ?? "Skills"}</SectionHeading>
+      {skills.length === 0 && !categorised ? (
+        <NotDetected what="skills" />
+      ) : categorised ? (
+        <div className="flex flex-col gap-1.5">
+          {rows.map((row, i) => {
+            const moveTargets = rows
+              .map((r, j) => ({ label: r.label, index: j }))
+              .filter((t) => t.index !== i);
+            return (
+              <SkillCategoryRow
+                key={`${row.label}-${i}`}
+                category={row}
+                index={i}
+                moveTargets={moveTargets}
+                skills={skills}
+                onRename={(label) => onRenameCategory(i, label)}
+                onDelete={() => onDeleteCategory(i)}
+                onAddSkill={(skill) => onAddSkillToCategory(i, skill)}
+                onRemoveSkill={onRemoveCategorySkill}
+                onMoveSkill={moveViaMenu}
+                onDragStartSkill={setDragging}
+                onDropSkill={dropOnCategory}
+              />
+            );
+          })}
+          {ungrouped.length > 0 && (
+            <SkillChipRow
+              skills={ungrouped}
+              onRemoveSkill={onRemoveCategorySkill}
+              moveTargets={rows.map((r, j) => ({ label: r.label, index: j }))}
+              onMoveSkill={moveViaMenu}
+              onDragStartSkill={setDragging}
+            />
+          )}
+          <AddCategoryInput onAdd={onAddCategory} />
+        </div>
+      ) : (
+        <SkillChipRow skills={skills} onRemoveSkill={onRemoveSkill} />
+      )}
+      {!categorised && <AddSkillInput skills={skills} onAdd={onAddSkill} />}
+      <div className="sr-only" aria-live="polite" role="status">
+        {announcement}
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -21,6 +21,8 @@ import {
   type EditableParse,
   type AddedEntry,
 } from "./useEditableParse.ts";
+import type { SkillCategory } from "../lib/heuristics/types.ts";
+import { computeEditedSkills } from "../lib/edit/skills-categories.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -127,5 +129,92 @@ describe("useEditableParse — pruneEmptyAddedEntries (#379)", () => {
 
     act(() => api.pruneEmptyAddedEntries("projects"));
     expect(api.addedEntries).toBe(before);
+  });
+});
+
+describe("useEditableParse — Skills category edits (#476)", () => {
+  const cats: SkillCategory[] = [
+    { label: "Frontend", skills: ["React", "TypeScript"] },
+    { label: "Backend", skills: ["Java"] },
+  ];
+
+  it("takes a grouping snapshot on the first category edit and marks hasEdits", () => {
+    expect(api.skillsOverride.categories).toBeUndefined();
+    expect(api.hasEdits).toBe(false);
+
+    act(() => api.renameSkillCategory(cats, 0, "UI"));
+    expect(api.skillsOverride.categories?.[0].label).toBe("UI");
+    // Rename is label-only — members untouched.
+    expect(api.skillsOverride.categories?.[0].skills).toEqual(["React", "TypeScript"]);
+    expect(api.hasEdits).toBe(true);
+  });
+
+  it("moves a skill through the same path the DnD drop uses", () => {
+    act(() => api.moveSkillToCategory(cats, "React", 1));
+    const snap = api.skillsOverride.categories!;
+    expect(snap[0].skills).toEqual(["TypeScript"]);
+    expect(snap[1].skills).toContain("React");
+  });
+
+  it("resetAll clears the category snapshot back to pristine", () => {
+    act(() => api.addSkillCategory(cats, "Data"));
+    expect(api.skillsOverride.categories).toBeDefined();
+    act(() => api.resetAll());
+    expect(api.skillsOverride.categories).toBeUndefined();
+    expect(api.hasEdits).toBe(false);
+  });
+
+  it("round-trips the snapshot through snapshot → replay", () => {
+    act(() => api.renameSkillCategory(cats, 0, "UI"));
+    // Second op composes on the flushed snapshot (mirrors the component reading
+    // the applied `parsed.skillCategories` between edits).
+    act(() => api.deleteSkillCategory(api.skillsOverride.categories!, 1));
+    const saved = api.snapshot;
+    act(() => api.resetAll());
+    expect(api.skillsOverride.categories).toBeUndefined();
+    act(() => api.replay(saved));
+    expect(api.skillsOverride.categories?.map((c) => c.label)).toEqual(["UI"]);
+  });
+
+  it("delete-all-categories then flat addSkill does NOT resurrect deleted skills (#415)", () => {
+    // The pristine parse `applyOverrides` always re-folds against.
+    const parsed = { skills: cats.flatMap((c) => c.skills), skillCategories: cats };
+
+    // Delete every category. Each op composes on the current applied snapshot,
+    // mirroring the component reading `parsed.skillCategories` between edits.
+    act(() => api.deleteSkillCategory(cats, 0));
+    act(() => api.deleteSkillCategory(api.skillsOverride.categories!, 0));
+    // Degraded: an empty-but-present snapshot (`[]`), NOT absent — this is what
+    // keeps computeEditedSkills out of the pristine flat branch.
+    expect(api.skillsOverride.categories).toEqual([]);
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([]);
+
+    // The flat AddSkillInput is now live; the user adds one skill.
+    act(() => api.addSkill("Rust"));
+    // addSkill must PRESERVE the `[]` snapshot (align with removeSkill), else the
+    // override falls back to the pristine flat branch and every deleted skill
+    // reappears — the #415 bug.
+    expect(api.skillsOverride.categories).toEqual([]);
+    expect(api.skillsOverride.added).toEqual(["Rust"]);
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "Rust",
+    ]);
+
+    // …then removes it → back to empty (not resurrected).
+    act(() => api.removeSkill("Rust"));
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([]);
+  });
+
+  it("delete-all then add twice keeps both adds, no pristine skills (#415)", () => {
+    const parsed = { skills: cats.flatMap((c) => c.skills), skillCategories: cats };
+    act(() => api.deleteSkillCategory(cats, 0));
+    act(() => api.deleteSkillCategory(api.skillsOverride.categories!, 0));
+    act(() => api.addSkill("Rust"));
+    act(() => api.addSkill("Go"));
+    expect(api.skillsOverride.categories).toEqual([]);
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "Rust",
+      "Go",
+    ]);
   });
 });

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -28,6 +28,16 @@ import {
   type BulletUndoTargets,
 } from "../lib/rewrite-review/undo-batch.ts";
 import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
+import {
+  addCategory as addSkillCategoryTx,
+  addSkillToCategory as addSkillToCategoryTx,
+  deleteCategory as deleteSkillCategoryTx,
+  isEmptySkillsOverride,
+  moveSkillBetweenCategories,
+  removeSkillFromCategories,
+  renameCategory as renameSkillCategoryTx,
+} from "../lib/edit/skills-categories.ts";
+import type { SkillCategory } from "../lib/heuristics/types.ts";
 import { classifyProfile } from "../lib/contact/profile-registry.ts";
 import type { LegacyLinkKey, ProfileLink } from "../lib/score/types.ts";
 
@@ -305,14 +315,27 @@ export interface ProfileOverride {
 // ── Skills override ───────────────────────────────────────────────────────────
 
 /**
- * Add/remove edits against `parsed.skills`. `removed` holds the lower-cased keys
- * of parsed skills the user dropped; `added` holds user-typed (canonicalized)
- * skills in insertion order. applyOverrides folds these into the final skills
- * list: parsed skills minus `removed`, then `added` appended (de-duplicated).
+ * Edits against `parsed.skills` AND its `skillCategories` grouping (#476).
+ *
+ * The flat pair is unchanged from before #476 and drives UNCATEGORISED résumés:
+ *   - `removed` — lower-cased keys of skills the user dropped (delete-single-skill);
+ *   - `added` — user-typed (canonicalized) skills appended to the flat list.
+ *
+ * `categories` is a SNAPSHOT of the edited grouping — present once the user makes
+ * any category edit on a categorised résumé, and it IS what the editor renders.
+ * Every grouping op (rename / delete category / add category / move / delete a
+ * single categorised skill) is a pure array→array transform in
+ * `skills-categories.ts` producing the next snapshot, so a rename is not a
+ * delete-plus-add and a move is not a remove-plus-add. When present it is
+ * authoritative: `applyOverrides` flattens it to the flat `skills`, so the #473
+ * invariant holds by construction and the flat `removed`/`added` are unused.
+ * Absent means the categorised grouping is untouched (or the résumé is
+ * uncategorised). Reset clears it back to `undefined` in one step.
  */
 export interface SkillsOverride {
   removed: string[];
   added: string[];
+  categories?: SkillCategory[];
 }
 
 const EMPTY_SKILLS_OVERRIDE: SkillsOverride = { removed: [], added: [] };
@@ -425,10 +448,45 @@ export interface EditableParse {
   /** Add a (canonicalized) skill. No-op for blank input or an exact dupe of an
    *  already-present skill. Re-adding a previously-removed skill un-removes it. */
   addSkill: (skill: string) => void;
-  /** Remove a skill by its display text — drops it whether it came from the
-   *  parse (records its key in `removed`) or from a prior add (drops it from
-   *  `added`). */
+  /** Remove a skill by its display text — the UNCATEGORISED delete-single-skill
+   *  path (drops it whether it came from the parse or a prior flat add). For a
+   *  categorised résumé the editor uses {@link removeCategorySkill} instead so
+   *  the grouping snapshot stays authoritative. */
   removeSkill: (skill: string) => void;
+  /** The current edited Skills grouping — the {@link SkillsOverride.categories}
+   *  snapshot when a category edit has been made, else `undefined`. */
+  skillCategoriesOverride: SkillCategory[] | undefined;
+  /** Rename the category at `index` in `cats` (the current rendered grouping) —
+   *  label-only, members untouched (#476). */
+  renameSkillCategory: (
+    cats: readonly SkillCategory[],
+    index: number,
+    label: string,
+  ) => void;
+  /** Delete the whole category at `index` (label AND members), atomically —
+   *  behind the caller's confirmation dialog. */
+  deleteSkillCategory: (cats: readonly SkillCategory[], index: number) => void;
+  /** Append a new empty category with `label`; populate via
+   *  {@link addSkillToCategory}. */
+  addSkillCategory: (cats: readonly SkillCategory[], label: string) => void;
+  /** Add a (canonicalized) skill into the category at `index`. No-op for blank
+   *  input or a dupe of any already-present skill. */
+  addSkillToCategory: (
+    cats: readonly SkillCategory[],
+    index: number,
+    skill: string,
+  ) => void;
+  /** Move a skill (by display text) into the category at `destIndex` — one
+   *  atomic op. The DnD drop and the keyboard "Move to" control both call this. */
+  moveSkillToCategory: (
+    cats: readonly SkillCategory[],
+    skill: string,
+    destIndex: number,
+  ) => void;
+  /** Remove a single skill from the categorised grouping — the categorised
+   *  delete-single-skill path (the source category stays present even if now
+   *  empty). */
+  removeCategorySkill: (cats: readonly SkillCategory[], skill: string) => void;
   /** The complete override state as a JSON-safe value (#456) — the one shape
    *  every consumer that must carry edits across a boundary uses (draft
    *  persistence, the `/` → `/jd-fit` handoff). */
@@ -599,7 +657,11 @@ export function useEditableParse(): EditableParse {
       // Don't duplicate an already-added skill (case-insensitive).
       const alreadyAdded = prev.added.some((a) => a.toLowerCase() === key);
       const added = alreadyAdded ? prev.added : [...prev.added, canonical];
-      return { removed, added };
+      // Preserve `categories` (align with removeSkill): an all-deleted snapshot
+      // leaves `categories: []`, degrading the section to the flat AddSkillInput.
+      // Dropping the `[]` here would let computeEditedSkills fall back to the
+      // pristine flat branch and resurrect every deleted skill (#415).
+      return { ...prev, removed, added };
     });
   }, []);
 
@@ -614,9 +676,61 @@ export function useEditableParse(): EditableParse {
       const removed = prev.removed.includes(key)
         ? prev.removed
         : [...prev.removed, key];
-      return { removed, added };
+      return { ...prev, removed, added };
     });
   }, []);
+
+  // ── Categorised Skills edits (#476) ───────────────────────────────────────
+  // Each takes the CURRENT rendered grouping, runs a pure array→array transform
+  // (skills-categories.ts), and stores the result as the authoritative snapshot.
+  // Because the snapshot IS what the editor renders, `cats` is always the live
+  // grouping and the transforms compose without any pristine-vs-edited mapping.
+
+  const setSkillCategories = useCallback((next: SkillCategory[]) => {
+    setSkillsOverride((prev) => ({ ...prev, categories: next }));
+  }, []);
+
+  const renameSkillCategory = useCallback(
+    (cats: readonly SkillCategory[], index: number, label: string) => {
+      setSkillCategories(renameSkillCategoryTx(cats, index, label));
+    },
+    [setSkillCategories],
+  );
+
+  const deleteSkillCategory = useCallback(
+    (cats: readonly SkillCategory[], index: number) => {
+      setSkillCategories(deleteSkillCategoryTx(cats, index));
+    },
+    [setSkillCategories],
+  );
+
+  const addSkillCategory = useCallback(
+    (cats: readonly SkillCategory[], label: string) => {
+      setSkillCategories(addSkillCategoryTx(cats, label));
+    },
+    [setSkillCategories],
+  );
+
+  const addSkillToCategory = useCallback(
+    (cats: readonly SkillCategory[], index: number, skill: string) => {
+      setSkillCategories(addSkillToCategoryTx(cats, index, skill));
+    },
+    [setSkillCategories],
+  );
+
+  const moveSkillToCategory = useCallback(
+    (cats: readonly SkillCategory[], skill: string, destIndex: number) => {
+      setSkillCategories(moveSkillBetweenCategories(cats, skill, destIndex));
+    },
+    [setSkillCategories],
+  );
+
+  const removeCategorySkill = useCallback(
+    (cats: readonly SkillCategory[], skill: string) => {
+      setSkillCategories(removeSkillFromCategories(cats, skill));
+    },
+    [setSkillCategories],
+  );
 
   const addEntry = useCallback((section: AddableSection) => {
     const id = `added:${idCounter.current++}`;
@@ -873,8 +987,13 @@ export function useEditableParse(): EditableParse {
         },
       );
 
-      snap.skillsOverride.added.forEach((skill) => addSkill(skill));
-      snap.skillsOverride.removed.forEach((skill) => removeSkill(skill));
+      // Skills. The edited grouping is a whole snapshot (#476), so replay just
+      // restores it — no per-op id remapping (the snapshot carries no ids). The
+      // flat add/remove replay as before, for uncategorised résumés.
+      const so = snap.skillsOverride;
+      if (so.categories) setSkillCategories(so.categories);
+      so.added.forEach((skill) => addSkill(skill));
+      so.removed.forEach((skill) => removeSkill(skill));
 
       const idMap = new Map<string, string>();
       for (const entry of snap.addedEntries) {
@@ -912,6 +1031,7 @@ export function useEditableParse(): EditableParse {
       setAchievementField,
       addSkill,
       removeSkill,
+      setSkillCategories,
       addEntry,
       setEntryField,
       addBullet,
@@ -925,8 +1045,7 @@ export function useEditableParse(): EditableParse {
     if (Object.keys(bulletOverrides).length > 0) return true;
     if (Object.keys(descriptionOverrides).length > 0) return true;
     if (removedBullets.size > 0) return true;
-    if (skillsOverride.removed.length > 0 || skillsOverride.added.length > 0)
-      return true;
+    if (!isEmptySkillsOverride(skillsOverride)) return true;
     if (addedEntries.length > 0) return true;
     if (Object.keys(addedBullets).length > 0) return true;
     if (profileOverrides.length > 0) return true;
@@ -990,6 +1109,13 @@ export function useEditableParse(): EditableParse {
     skillsOverride,
     addSkill,
     removeSkill,
+    skillCategoriesOverride: skillsOverride.categories,
+    renameSkillCategory,
+    deleteSkillCategory,
+    addSkillCategory,
+    addSkillToCategory,
+    moveSkillToCategory,
+    removeCategorySkill,
     snapshot,
     replay,
     hasEdits,

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -39,6 +39,10 @@ import type { HeuristicAchievement } from "../score/types.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 import type { SectionName } from "../heuristics/regex.ts";
 import { normalizeBulletText } from "../score/group-bullets.ts";
+import {
+  computeEditedSkills,
+  isEmptySkillsOverride,
+} from "./skills-categories.ts";
 import { classifyProfile, profilesFromUrls } from "../contact/profile-registry.ts";
 import type { LegacyLinkKey, ProfileLink } from "../score/types.ts";
 import type {
@@ -389,27 +393,30 @@ function applyDescriptionOverrides(
 // ── Skills (add / remove) ───────────────────────────────────────────────────
 
 /**
- * Rebuild `nextParsed.skills` in place from add/remove edits: final list =
- * parsed skills minus `removed` (by lower-cased key), then `added` appended,
- * de-duplicated case-insensitively against the survivors.
+ * Rebuild `nextParsed.skills` — and, for a categorised résumé, its
+ * `skillCategories` grouping — in place from the {@link SkillsOverride} edits,
+ * delegating to {@link computeEditedSkills} (the single mutation path, #476).
+ *
+ * The #473 stopgap this replaces DROPPED `skillCategories` on any flat edit,
+ * treating the edited résumé as uncategorised. The reducer instead reduces the
+ * parsed categories through the rename / delete-category / add-category / move /
+ * delete-skill edits and DERIVES the flat list by flattening, so the
+ * `skills === skillCategories.flatMap((c) => c.skills)` invariant holds after
+ * every op. `skillCategories` is deleted only when the reducer returns none
+ * (every category was deleted) or the résumé was never categorised.
  */
 function applySkillOverrides(
   nextParsed: HeuristicParsedResume,
   skills: SkillsOverride,
 ): void {
-  if (skills.removed.length === 0 && skills.added.length === 0) return;
-  const removedSet = new Set(skills.removed.map((s) => s.toLowerCase()));
-  const kept = nextParsed.skills.filter(
-    (s) => !removedSet.has(s.toLowerCase()),
+  if (isEmptySkillsOverride(skills)) return;
+  const result = computeEditedSkills(
+    { skills: nextParsed.skills, skillCategories: nextParsed.skillCategories },
+    skills,
   );
-  const present = new Set(kept.map((s) => s.toLowerCase()));
-  for (const add of skills.added) {
-    const key = add.toLowerCase();
-    if (present.has(key)) continue;
-    present.add(key);
-    kept.push(add);
-  }
-  nextParsed.skills = kept;
+  nextParsed.skills = result.skills;
+  if (result.skillCategories) nextParsed.skillCategories = result.skillCategories;
+  else delete nextParsed.skillCategories;
 }
 
 // ── Shared "find first matching line, then mutate" primitives ──────────────

--- a/src/lib/edit/skills-categories.test.ts
+++ b/src/lib/edit/skills-categories.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Exhaustive per-operation tests for the #476 Skills-category mutation path.
+ * Every op asserts the #473 invariant — flat `skills` deep-equals
+ * `skillCategories.flatMap((c) => c.skills)` — holds AFTER it, plus its own
+ * op-specific contract (rename byte-identity, move set-equality, empty-but-
+ * present agreement, uncategorised unchanged).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  addCategory,
+  addSkillToCategory,
+  computeEditedSkills,
+  deleteCategory,
+  isEmptySkillsOverride,
+  moveSkillBetweenCategories,
+  removeSkillFromCategories,
+  renameCategory,
+} from "./skills-categories.ts";
+import type { SkillCategory } from "../heuristics/types.ts";
+import type { SkillsOverride } from "../../hooks/useEditableParse.ts";
+
+const cats = (): SkillCategory[] => [
+  { label: "Databases & Caching", skills: ["PostgreSQL", "MySQL", "Redis"] },
+  { label: "Backend", skills: ["Java", "Python"] },
+];
+
+const EMPTY: SkillsOverride = { removed: [], added: [] };
+
+/** The invariant every op must preserve. */
+function invariantHolds(result: {
+  skills: string[];
+  skillCategories?: SkillCategory[];
+}): boolean {
+  if (!result.skillCategories) return true; // uncategorised — invariant N/A.
+  const flat = result.skillCategories.flatMap((c) => c.skills);
+  return JSON.stringify(flat) === JSON.stringify(result.skills);
+}
+
+/** Reduce a parsed categorised résumé through a category snapshot. */
+function reduce(snapshot: SkillCategory[]) {
+  const parsed = { skills: cats().flatMap((c) => c.skills), skillCategories: cats() };
+  return computeEditedSkills(parsed, { ...EMPTY, categories: snapshot });
+}
+
+describe("isEmptySkillsOverride", () => {
+  it("is empty only with no flat edits and no category snapshot", () => {
+    expect(isEmptySkillsOverride(EMPTY)).toBe(true);
+    expect(isEmptySkillsOverride({ ...EMPTY, added: ["Rust"] })).toBe(false);
+    expect(isEmptySkillsOverride({ ...EMPTY, categories: [] })).toBe(false);
+  });
+});
+
+describe("rename a category", () => {
+  it("changes the label only — flat list byte-identical, members untouched", () => {
+    const before = reduce(cats());
+    const renamed = renameCategory(cats(), 0, "Data Stores");
+    const after = reduce(renamed);
+    expect(after.skillCategories![0].label).toBe("Data Stores");
+    expect(after.skillCategories![0].skills).toEqual([
+      "PostgreSQL",
+      "MySQL",
+      "Redis",
+    ]);
+    // Byte-identical flat list (the cheap catch for a rename that rebuilds members).
+    expect(after.skills).toEqual(before.skills);
+    expect(invariantHolds(after)).toBe(true);
+  });
+
+  it("ignores a blank label (never a bare ':')", () => {
+    const renamed = renameCategory(cats(), 0, "   ");
+    expect(renamed[0].label).toBe("Databases & Caching");
+  });
+});
+
+describe("delete an entire category", () => {
+  it("removes the label AND its members in one op", () => {
+    const after = reduce(deleteCategory(cats(), 0));
+    expect(after.skillCategories!.map((c) => c.label)).toEqual(["Backend"]);
+    expect(after.skills).toEqual(["Java", "Python"]);
+    expect(invariantHolds(after)).toBe(true);
+  });
+
+  it("degrades to uncategorised when the last category is deleted", () => {
+    let snap = deleteCategory(cats(), 0);
+    snap = deleteCategory(snap, 0);
+    const after = reduce(snap);
+    expect(after.skillCategories).toBeUndefined();
+    expect(after.skills).toEqual([]);
+  });
+});
+
+describe("add a new category", () => {
+  it("appears empty, then populates; shows in the flat list once populated", () => {
+    let snap = addCategory(cats(), "Machine Learning");
+    const emptyAdd = reduce(snap);
+    expect(emptyAdd.skillCategories!.at(-1)).toEqual({
+      label: "Machine Learning",
+      skills: [],
+    });
+    // Empty category contributes nothing to the flat list (invariant holds).
+    expect(emptyAdd.skills).not.toContain("Machine Learning");
+    expect(invariantHolds(emptyAdd)).toBe(true);
+
+    snap = addSkillToCategory(snap, 2, "PyTorch");
+    const after = reduce(snap);
+    expect(after.skillCategories!.at(-1)!.skills).toEqual(["PyTorch"]);
+    expect(after.skills).toContain("PyTorch");
+    expect(invariantHolds(after)).toBe(true);
+  });
+
+  it("does not add a duplicate of an existing skill", () => {
+    const snap = addSkillToCategory(cats(), 1, "Redis"); // already in category 0
+    expect(snap.flatMap((c) => c.skills).filter((s) => s === "Redis")).toHaveLength(1);
+  });
+});
+
+describe("move a skill between categories", () => {
+  it("is atomic: same SET, invariant holds, only the grouping changes", () => {
+    const before = reduce(cats());
+    const snap = moveSkillBetweenCategories(cats(), "Redis", 1); // → Backend
+    const after = reduce(snap);
+    expect(after.skillCategories![0].skills).toEqual(["PostgreSQL", "MySQL"]);
+    expect(after.skillCategories![1].skills).toContain("Redis");
+    // Flat SET unchanged (order may differ).
+    expect(new Set(after.skills)).toEqual(new Set(before.skills));
+    expect(invariantHolds(after)).toBe(true);
+  });
+
+  it("is a no-op when the skill is already in the destination", () => {
+    const snap = moveSkillBetweenCategories(cats(), "Redis", 0);
+    expect(snap).toEqual(cats());
+  });
+
+  it("moving the last member out empties the source (empty-but-present)", () => {
+    let snap = moveSkillBetweenCategories(cats(), "Java", 0);
+    snap = moveSkillBetweenCategories(snap, "Python", 0);
+    const after = reduce(snap);
+    expect(after.skillCategories![1]).toEqual({ label: "Backend", skills: [] });
+    expect(invariantHolds(after)).toBe(true);
+  });
+});
+
+describe("delete a single skill (categorised)", () => {
+  it("drops the skill from its category, category stays present", () => {
+    const after = reduce(removeSkillFromCategories(cats(), "MySQL"));
+    expect(after.skillCategories![0].skills).toEqual(["PostgreSQL", "Redis"]);
+    expect(after.skills).not.toContain("MySQL");
+    expect(invariantHolds(after)).toBe(true);
+  });
+
+  it("delete-last-chip and move-last-member-out agree (both empty-but-present)", () => {
+    // Empty "Backend" via chip deletes:
+    let byDelete = removeSkillFromCategories(cats(), "Java");
+    byDelete = removeSkillFromCategories(byDelete, "Python");
+    // Empty "Backend" via moving both members into "Databases & Caching":
+    let byMove = moveSkillBetweenCategories(cats(), "Java", 0);
+    byMove = moveSkillBetweenCategories(byMove, "Python", 0);
+    // Both leave Backend present and empty.
+    expect(byDelete[1]).toEqual({ label: "Backend", skills: [] });
+    expect(byMove[1]).toEqual({ label: "Backend", skills: [] });
+  });
+});
+
+describe("all-deleted snapshot composes flat edits on an EMPTY base (#415)", () => {
+  // Pristine categorised résumé (the flat list is the flattening of the groups).
+  const pristine = {
+    skills: cats().flatMap((c) => c.skills), // Postgres, MySQL, Redis, Java, Python
+    skillCategories: cats(),
+  };
+  /** Reduce the pristine parse through a degraded (`[]`) snapshot + flat edits —
+   *  exactly what `applyOverrides` runs after the flat AddSkillInput becomes live. */
+  const degraded = (over: Partial<SkillsOverride>) =>
+    computeEditedSkills(pristine, { ...EMPTY, categories: [], ...over });
+
+  it("delete-all then add: the added skill is the ONLY skill — no resurrection", () => {
+    const after = degraded({ added: ["Rust"] });
+    expect(after.skills).toEqual(["Rust"]);
+    expect(after.skillCategories).toBeUndefined();
+  });
+
+  it("delete-all then add then remove: back to empty", () => {
+    // removeSkill drops "rust" from `added` and records it in `removed`.
+    const after = degraded({ removed: ["rust"], added: [] });
+    expect(after.skills).toEqual([]);
+    expect(after.skillCategories).toBeUndefined();
+  });
+
+  it("delete-all then add twice: both adds present, still no pristine skills", () => {
+    const after = degraded({ added: ["Rust", "Go"] });
+    expect(after.skills).toEqual(["Rust", "Go"]);
+    expect(after.skillCategories).toBeUndefined();
+  });
+
+  it("delete-all with no flat edit yet stays empty (regression guard)", () => {
+    const after = degraded({});
+    expect(after.skills).toEqual([]);
+    expect(after.skillCategories).toBeUndefined();
+  });
+
+  it("a pristine skill name is never re-derived — even if re-added by name", () => {
+    // Re-adding a name that happened to exist in the pristine parse adds ONLY
+    // that one, not the rest of the pristine list.
+    const after = degraded({ added: ["Redis"] });
+    expect(after.skills).toEqual(["Redis"]);
+    expect(after.skills).not.toContain("PostgreSQL");
+  });
+});
+
+describe("uncategorised résumé (unchanged from pre-#476)", () => {
+  const flat = { skills: ["React", "Vue", "Svelte"] };
+
+  it("flat remove + add behave exactly as before; no categories introduced", () => {
+    const result = computeEditedSkills(flat, {
+      removed: ["vue"],
+      added: ["Angular"],
+    });
+    expect(result.skills).toEqual(["React", "Svelte", "Angular"]);
+    expect(result.skillCategories).toBeUndefined();
+  });
+
+  it("an empty override is a true passthrough", () => {
+    const result = computeEditedSkills(flat, EMPTY);
+    expect(result.skills).toEqual(["React", "Vue", "Svelte"]);
+    expect(result.skillCategories).toBeUndefined();
+  });
+});
+
+describe("categorised-untouched résumé", () => {
+  it("passes the parsed grouping through unchanged with no snapshot", () => {
+    const parsed = {
+      skills: cats().flatMap((c) => c.skills),
+      skillCategories: cats(),
+    };
+    const result = computeEditedSkills(parsed, EMPTY);
+    expect(result.skillCategories).toEqual(cats());
+    expect(invariantHolds(result)).toBe(true);
+  });
+});
+
+describe("non-empty snapshot + flat edits (unreachable-by-design guard)", () => {
+  // The editor never emits `removed`/`added` while a category survives (every
+  // categorised edit is snapshotted). Honouring them here would derive a flat
+  // list that no longer equals flatMap(categories); the dev guard makes that
+  // structurally-impossible state loud instead of silently dropping the edit.
+  const parsed = { skills: cats().flatMap((c) => c.skills) };
+
+  it("throws in dev when a non-empty snapshot carries a flat `added`", () => {
+    expect(() =>
+      computeEditedSkills(parsed, { removed: [], added: ["Rust"], categories: cats() }),
+    ).toThrow(/unreachable by design/);
+  });
+
+  it("throws in dev when a non-empty snapshot carries a flat `removed`", () => {
+    expect(() =>
+      computeEditedSkills(parsed, { removed: ["react"], added: [], categories: cats() }),
+    ).toThrow(/unreachable by design/);
+  });
+
+  it("does NOT throw when the snapshot is empty (degraded-to-flat path)", () => {
+    const result = computeEditedSkills(parsed, {
+      removed: [],
+      added: ["Rust"],
+      categories: [],
+    });
+    expect(result.skills).toEqual(["Rust"]);
+    expect(result.skillCategories).toBeUndefined();
+  });
+});

--- a/src/lib/edit/skills-categories.ts
+++ b/src/lib/edit/skills-categories.ts
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * skills-categories — the SINGLE mutation path for editing a categorised Skills
+ * section (#476).
+ *
+ * #473 rendered the parser's `skillCategories` grouping read-only; #476 makes it
+ * editable (rename a category, delete a category with its members, add a new
+ * category, move a skill between categories, delete a single skill). Rather than
+ * key each edit against the frozen parse (which forces the editor to translate
+ * between the parsed grouping and the edited one), the edited grouping is carried
+ * whole as {@link SkillsOverride.categories} — a SNAPSHOT that is exactly what the
+ * editor renders. Each edit is a pure array→array transform below
+ * (`renameCategory`, `deleteCategory`, `addCategory`, `addSkillToCategory`,
+ * `moveSkillBetweenCategories`, `removeSkillFromCategories`); the drag-and-drop
+ * drop and the keyboard "Move to" control BOTH call
+ * {@link moveSkillBetweenCategories} on the current snapshot, so there is one
+ * mutation code path with two ways to invoke it.
+ *
+ * The load-bearing invariant (from #473, and the whole point of doing this in one
+ * place): the flat `skills` array ALWAYS deep-equals
+ * `skillCategories.flatMap((c) => c.skills)` — because {@link computeEditedSkills}
+ * DERIVES the flat list from the snapshot by flattening, never maintaining the two
+ * independently.
+ *
+ * Empty-category policy (the #476 stated decision): emptying a category (deleting
+ * its last chip, or moving its last member out) leaves an EMPTY-BUT-PRESENT
+ * category — it survives in the snapshot so the editor can still rename it,
+ * re-populate it, or explicitly delete it. It is never silently auto-deleted. Both
+ * the delete-last-chip path ({@link removeSkillFromCategories}) and the
+ * move-last-member-out path ({@link moveSkillBetweenCategories}) leave the source
+ * category present with an empty member list, so the two agree by construction.
+ * The exporter (`ats-resume-model.ts`) drops empty categories so the Download PDF
+ * / JSON Resume never render a dangling `Label:` with nothing after it.
+ *
+ * Uncategorised résumés (`skillCategories` absent, and no snapshot taken) keep the
+ * flat `removed` / `added` path unchanged — byte-identical to before #476.
+ *
+ * Pure and dependency-free (aside from `canonicalizeSkill`): unit-tested directly.
+ */
+
+import type { SkillCategory } from "../heuristics/types.ts";
+import type { SkillsOverride } from "../../hooks/useEditableParse.ts";
+import { canonicalizeSkill } from "./skill-canonical.ts";
+
+/** True when no field of the override carries an edit — lets the caller keep the
+ *  pristine parse (and its category identity) as a true no-op. */
+export function isEmptySkillsOverride(o: SkillsOverride): boolean {
+  return (
+    o.removed.length === 0 && o.added.length === 0 && o.categories === undefined
+  );
+}
+
+/** True when any category in `cats` already holds `skill` (case-insensitive). */
+function presentAnywhere(cats: readonly SkillCategory[], skill: string): boolean {
+  const lc = skill.toLowerCase();
+  return cats.some((c) => c.skills.some((s) => s.toLowerCase() === lc));
+}
+
+// ── Pure snapshot transforms (each returns a NEW array) ───────────────────────
+
+/** Rename the category at `index` — label-only, members untouched (so the flat
+ *  list is byte-identical after a rename). A blank label is ignored (a category
+ *  must not render as a bare `:`). */
+export function renameCategory(
+  cats: readonly SkillCategory[],
+  index: number,
+  label: string,
+): SkillCategory[] {
+  const trimmed = label.trim();
+  if (!trimmed) return cats.map((c) => ({ ...c, skills: [...c.skills] }));
+  return cats.map((c, i) =>
+    i === index ? { label: trimmed, skills: [...c.skills] } : { ...c, skills: [...c.skills] },
+  );
+}
+
+/** Delete the whole category at `index` (label AND its members), atomically. */
+export function deleteCategory(
+  cats: readonly SkillCategory[],
+  index: number,
+): SkillCategory[] {
+  return cats
+    .filter((_, i) => i !== index)
+    .map((c) => ({ ...c, skills: [...c.skills] }));
+}
+
+/** Append a new, empty category with `label` (populate it via
+ *  {@link addSkillToCategory}). A blank label falls back to "New category". */
+export function addCategory(
+  cats: readonly SkillCategory[],
+  label: string,
+): SkillCategory[] {
+  return [
+    ...cats.map((c) => ({ ...c, skills: [...c.skills] })),
+    { label: label.trim() || "New category", skills: [] },
+  ];
+}
+
+/** Add a (canonicalized) skill into the category at `index`. No-op for blank
+ *  input or a duplicate of any already-present skill (the set stays unique). */
+export function addSkillToCategory(
+  cats: readonly SkillCategory[],
+  index: number,
+  skill: string,
+): SkillCategory[] {
+  const canonical = canonicalizeSkill(skill);
+  const next = cats.map((c) => ({ ...c, skills: [...c.skills] }));
+  if (!canonical || presentAnywhere(next, canonical)) return next;
+  if (index < 0 || index >= next.length) return next;
+  next[index].skills.push(canonical);
+  return next;
+}
+
+/**
+ * Move `skill` (matched case-insensitively) into the category at `destIndex` —
+ * one atomic op. It leaves whatever category currently holds it (which may empty
+ * that category — empty-but-present) and joins the destination; a no-op when it
+ * is already in the destination or when either endpoint can't be resolved. The
+ * flat SET is unchanged; only the grouping (and possibly the flat order) moves.
+ */
+export function moveSkillBetweenCategories(
+  cats: readonly SkillCategory[],
+  skill: string,
+  destIndex: number,
+): SkillCategory[] {
+  const lc = skill.toLowerCase();
+  const next = cats.map((c) => ({ ...c, skills: [...c.skills] }));
+  if (destIndex < 0 || destIndex >= next.length) return next;
+  let display: string | undefined;
+  for (let i = 0; i < next.length; i++) {
+    const at = next[i].skills.findIndex((s) => s.toLowerCase() === lc);
+    if (at < 0) continue;
+    if (i === destIndex) return next; // already in the destination → no reorder.
+    display = next[i].skills[at];
+    next[i].skills.splice(at, 1);
+    break;
+  }
+  if (display === undefined) return next;
+  const dest = next[destIndex];
+  if (!dest.skills.some((s) => s.toLowerCase() === lc)) dest.skills.push(display);
+  return next;
+}
+
+/** Remove `skill` (case-insensitive) from whichever category holds it — the
+ *  categorised delete-single-skill path. The category stays present even if it is
+ *  now empty (empty-but-present), matching the move-last-member-out result. */
+export function removeSkillFromCategories(
+  cats: readonly SkillCategory[],
+  skill: string,
+): SkillCategory[] {
+  const lc = skill.toLowerCase();
+  return cats.map((c) => ({
+    ...c,
+    skills: c.skills.filter((s) => s.toLowerCase() !== lc),
+  }));
+}
+
+// ── Reducer (override → edited skills) ────────────────────────────────────────
+
+/** The two flat fields of the parsed résumé this reducer reads. */
+export interface SkillsInput {
+  skills: string[];
+  skillCategories?: SkillCategory[];
+}
+
+/** The reduced result: the flat list, plus the structured view when the résumé
+ *  is (still) categorised. `skillCategories` is ABSENT — never `[]` — when every
+ *  category was deleted, degrading the résumé to uncategorised (#473 convention:
+ *  absent means "no categories", not "an empty set of categories"). */
+export interface SkillsResult {
+  skills: string[];
+  skillCategories?: SkillCategory[];
+}
+
+/** Apply the flat `removed` / `added` edits to `base`: drop every `removed` key
+ *  (case-insensitive), then append each `added` skill that isn't already present
+ *  (case-insensitive). Shared by the uncategorised path (base = the pristine
+ *  parsed skills) AND the all-deleted degraded snapshot (base = the emptied
+ *  grouping's flattening — NEVER the pristine list, so deleted skills stay gone).
+ *  Returns a fresh array; `base` is not mutated. */
+function applyFlatEdits(
+  base: readonly string[],
+  override: SkillsOverride,
+): string[] {
+  const removedSet = new Set(override.removed.map((s) => s.toLowerCase()));
+  const kept = base.filter((s) => !removedSet.has(s.toLowerCase()));
+  const present = new Set(kept.map((s) => s.toLowerCase()));
+  for (const add of override.added) {
+    const key = add.toLowerCase();
+    if (present.has(key)) continue;
+    present.add(key);
+    kept.push(add);
+  }
+  return kept;
+}
+
+/**
+ * Apply a {@link SkillsOverride} to a parsed résumé's skills.
+ *
+ * When a category SNAPSHOT is present, it IS the edited grouping: the flat list
+ * is its flattening, so the #473 invariant holds by construction.
+ *
+ * An all-deleted snapshot (`categories: []`) degrades the section to
+ * uncategorised — `SkillsSection` then renders the flat `AddSkillInput` wired to
+ * the flat `addSkill`/`removeSkill` setters. Those flat edits are composed ON TOP
+ * of the emptied snapshot (an EMPTY base), NOT re-derived from the pristine parse:
+ * re-deriving from `parsed.skills` would resurrect every skill the user just
+ * deleted (#415). `categories: []` (present, empty — distinct from absent) is what
+ * keeps this branch selected over the pristine flat branch below; the flat setters
+ * therefore MUST preserve the `[]` snapshot through subsequent adds/removes so the
+ * override never falls back into the pristine branch.
+ *
+ * With no snapshot (`categories` ABSENT), the résumé is either uncategorised or
+ * categorised-untouched: apply the flat `removed` / `added` to the pristine parse
+ * (the pre-#476 behaviour), and pass a categorised-untouched résumé's
+ * `skillCategories` through unchanged (its flat edits are empty by construction —
+ * the editor takes a snapshot for any category résumé's skill edit). A non-empty
+ * flat edit on a categorised résumé (which the editor never produces — the flat
+ * input is unreachable while any category survives) drops the grouping rather than
+ * let it drift.
+ */
+export function computeEditedSkills(
+  parsed: SkillsInput,
+  override: SkillsOverride,
+): SkillsResult {
+  if (override.categories) {
+    const cats = override.categories;
+    // Degraded-to-uncategorised: flat edits accumulate on the emptied snapshot.
+    if (cats.length === 0) return { skills: applyFlatEdits([], override) };
+    // A non-empty snapshot is authoritative: the flat list is DERIVED from it, so
+    // honouring `removed`/`added` here would break the load-bearing invariant
+    // `skills === flatMap(categories)`. The editor never emits flat edits while a
+    // category survives (every categorised edit is snapshotted; the flat
+    // AddSkillInput renders only once the section has degraded to uncategorised),
+    // so those fields are structurally empty on this branch. Assert it in dev
+    // rather than silently drop a flat edit a future caller might wrongly attach.
+    if (
+      import.meta.env?.DEV &&
+      (override.removed.length > 0 || override.added.length > 0)
+    ) {
+      throw new Error(
+        "computeEditedSkills: flat removed/added with a non-empty category " +
+          "snapshot — unreachable by design (would violate skills === flatMap(categories))",
+      );
+    }
+    return { skills: cats.flatMap((c) => c.skills), skillCategories: cats };
+  }
+
+  const kept = applyFlatEdits(parsed.skills, override);
+  const untouched = override.removed.length === 0 && override.added.length === 0;
+  if (parsed.skillCategories && untouched) {
+    return { skills: kept, skillCategories: parsed.skillCategories };
+  }
+  return { skills: kept };
+}

--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -230,6 +230,51 @@ describe("corpus round-trip invariants (#293)", { timeout: 20000 }, () => {
 });
 
 /**
+ * Skills category round-trip (#473). The whole-corpus ratchet above pins the
+ * FLAT invariants only; the structured category view is new, so this asserts
+ * directly that a categorised résumé's `skillCategories` survives the
+ * parse → export → re-parse hop intact — the exported PDF renders one
+ * `Label: a · b · c` row per category, and re-parsing recovers the same
+ * labels and members (not just the same flat skills).
+ *
+ * PII-free: the fixture is a synthetic persona; labels/counts are asserted, no
+ * value snapshot is dumped.
+ */
+describe("skills categories round-trip (#473)", () => {
+  const CATEGORISED_FIXTURE = join(
+    FIXTURE_ROOT,
+    "unknown",
+    "bulleted-labelled-single-column-skills.pdf",
+  );
+
+  it("re-parses the categorised fixture to the same categories", async () => {
+    const before = await runCascade(
+      new Uint8Array(readFileSync(CATEGORISED_FIXTURE)),
+    );
+    const cats = before.canonical.fields.skillCategories;
+
+    // The categories the parser captured, and their coherence invariant.
+    expect(cats?.map((c) => c.label)).toEqual([
+      "Frontend",
+      "Frontend Testing",
+      "Backend",
+      "Cloud & Infra",
+      "Databases & Caching",
+      "Product & Collaboration",
+      "Data & Analytics",
+    ]);
+    expect(before.canonical.fields.skills).toEqual(
+      cats!.flatMap((c) => c.skills),
+    );
+
+    // parse → export → re-parse recovers the SAME category structure.
+    const { after, renderError } = await runRoundtripHop(before);
+    expect(renderError).toBeUndefined();
+    expect(after?.canonical.fields.skillCategories).toEqual(cats);
+  });
+});
+
+/**
  * Dev triage harness — inert in CI, runs ONLY when `RL_RT_PDF=<path>` is set:
  *
  *   RL_RT_PDF=/path/to/real-resume.pdf [RL_RT_ROUNDS=2] npx vitest run \

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -111,6 +111,11 @@ function fieldsPopulated(parsed: HeuristicParsedResume): string[] {
     // keep the Phase-1 migration snapshot-safe (no re-bake). Phase 2 flips the
     // legacy keys to `profiles` and re-bakes the corpus deliberately.
     if (k === "profiles") continue;
+    // `skillCategories` (#473) is an additive STRUCTURED view over `skills` — it
+    // carries no new field-presence signal (its presence implies `skills`), so
+    // it is excluded here to keep the snapshot migration-safe: a categorised
+    // fixture's `fieldsPopulated` does not move, no re-bake needed.
+    if (k === "skillCategories") continue;
     keys.push(k);
   }
   return keys.sort();

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -709,26 +709,64 @@ describe("extractSkills — bulleted labelled single-column rows (#465)", () => 
     );
   });
 
-  it("KNOWN LIMIT: a clarifier wrapping across THREE lines is still shredded", () => {
-    // Pins current behavior, not an aspiration. Condition C joins only when the
-    // NEXT line closes the clarifier; "Cloud: AWS (EC2," ⏎ "S3," ⏎ "RDS)" leaves
-    // it open after the second line, so no join fires and the clarifier shreds.
-    // Same as main — deferred, not regressed by #465.
+  it("keeps a clarifier whole when it wraps across THREE lines (#475)", () => {
+    // The complement of the two-line case above: closure now arrives on the
+    // THIRD line. Condition C's bounded n-line look-ahead sees that
+    // "Cloud & Infra: AWS (EC2," ⏎ "S3," ⏎ "RDS), Docker, Kubernetes" closes the
+    // clarifier within the window, so the wrapped lines rejoin and
+    // splitRespectingParens re-splits on the outside commas. Previously this was
+    // a KNOWN LIMIT (shredded into "AWS (EC2" / "S3" / "RDS)").
+    const section = skillsLines([
+      [{ x: 74, str: "Cloud & Infra: AWS (EC2,", w: 118 }],
+      [{ x: 74, str: "S3,", w: 20 }],
+      [{ x: 74, str: "RDS), Docker, Kubernetes", w: 118 }],
+    ]);
+    const value = extractSkills(section).value;
+
+    expect(value).toEqual(["AWS (EC2, S3, RDS)", "Docker", "Kubernetes"]);
+    expect(value).not.toContain("AWS (EC2");
+    expect(value).not.toContain("S3");
+    expect(value).not.toContain("RDS)");
+  });
+
+  it("degrades to shredded-but-bounded when a clarifier wraps past the window", () => {
+    // The look-ahead is CLARIFIER_WRAP_LOOKAHEAD lines deep, on purpose: a paren
+    // whose close never arrives inside the window is treated as a stray "(" and
+    // the join is refused — never swallowing the section into one cell. Here the
+    // clarifier's items are spread one-per-line so closure sits well beyond the
+    // window; the fallback shreds it, but every item survives as its own token
+    // (nothing is lost, nothing is merged into a garbage super-token).
     const section = skillsLines([
       [{ x: 74, str: "Cloud: AWS (EC2,", w: 80 }],
       [{ x: 74, str: "S3,", w: 20 }],
-      [{ x: 74, str: "RDS)", w: 25 }],
+      [{ x: 74, str: "RDS,", w: 25 }],
+      [{ x: 74, str: "Lambda,", w: 40 }],
+      [{ x: 74, str: "DynamoDB,", w: 55 }],
+      [{ x: 74, str: "ECS,", w: 30 }],
+      [{ x: 74, str: "EKS,", w: 30 }],
+      [{ x: 74, str: "CloudFront)", w: 60 }],
     ]);
+    const value = extractSkills(section).value;
 
-    expect(extractSkills(section).value).toEqual(["AWS (EC2", "S3", "RDS)"]);
+    // Bounded: the stray-looking "(" is not swallowed; the trailing items are
+    // recovered individually rather than collapsed into one cell.
+    expect(value).toContain("AWS (EC2");
+    expect(value).toContain("DynamoDB");
+    expect(value).toContain("CloudFront)");
+    expect(value).not.toContain(
+      "AWS (EC2, S3, RDS, Lambda, DynamoDB, ECS, EKS, CloudFront)",
+    );
   });
 
-  it("KNOWN BEHAVIOR: a line that closes one clarifier and opens another recovers the second", () => {
+  it("recovers BOTH clarifiers when one closes and another opens across the wrap (#475)", () => {
     // "Cloud: AWS (EC2," ⏎ "S3), Azure (VMs," ⏎ "Blobs)". The middle line closes
-    // the first clarifier and opens a second, so the first join is declined (the
-    // join would not resolve the imbalance) and the first clarifier shreds — but
-    // the SECOND is rejoined whole. Better than main, which shreds both
-    // ("Azure (VMs" / "Blobs)"). Pinned so the recovery cannot silently vanish.
+    // the first clarifier and opens a second. Under #465's single-line look-ahead
+    // the first join was declined (the one-line join `…(EC2, S3), Azure (VMs,`
+    // does not balance) and the first clarifier shredded to "AWS (EC2" / "S3)".
+    // With #475's bounded n-line look-ahead the scan sees the whole run balance
+    // by the third line, so it rejoins; splitRespectingParens then re-splits on
+    // the outside comma and BOTH clarifiers come back whole — strictly better
+    // than the old shred-the-first behaviour.
     const section = skillsLines([
       [{ x: 74, str: "Cloud: AWS (EC2,", w: 80 }],
       [{ x: 74, str: "S3), Azure (VMs,", w: 80 }],
@@ -736,8 +774,7 @@ describe("extractSkills — bulleted labelled single-column rows (#465)", () => 
     ]);
 
     expect(extractSkills(section).value).toEqual([
-      "AWS (EC2",
-      "S3)",
+      "AWS (EC2, S3)",
       "Azure (VMs, Blobs)",
     ]);
   });
@@ -763,5 +800,80 @@ describe("extractSkills — bulleted labelled single-column rows (#465)", () => 
       "Data analysis",
       "Communication",
     ]);
+  });
+});
+
+describe("extractSkills — category capture (#473)", () => {
+  it("captures each label as a category and keeps `skills` the flat union", () => {
+    const section = skillsLines([
+      [...BULLET_RUNS, { x: 74, str: "Frontend: React, TypeScript", w: 140 }],
+      [...BULLET_RUNS, { x: 74, str: "Backend: Java, Python", w: 120 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual(["React", "TypeScript", "Java", "Python"]);
+    expect(categories).toEqual([
+      { label: "Frontend", skills: ["React", "TypeScript"] },
+      { label: "Backend", skills: ["Java", "Python"] },
+    ]);
+  });
+
+  it("INVARIANT 1: `skills` deep-equals `categories.flatMap((c) => c.skills)`", () => {
+    // A wrapped Frontend list whose continuation flushed as its own bare cell
+    // ("… HTML5," ⏎ "CSS3, JavaScript") must fold back into Frontend, not become
+    // an uncategorised tail that suppresses the whole structured view.
+    const section = skillsLines([
+      [
+        ...BULLET_RUNS,
+        { x: 74, str: "Frontend: React, TypeScript, HTML5,", w: 180 },
+      ],
+      [{ x: 74, str: "CSS3, JavaScript", w: 78 }],
+      [...BULLET_RUNS, { x: 74, str: "Backend: Java, Go", w: 110 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(categories).toBeDefined();
+    expect(value).toEqual(categories!.flatMap((c) => c.skills));
+    // The wrap continuation belongs to Frontend, not to a bare bucket.
+    expect(categories![0]).toEqual({
+      label: "Frontend",
+      skills: ["React", "TypeScript", "HTML5", "CSS3", "JavaScript"],
+    });
+  });
+
+  it("INVARIANT 2: an uncategorised comma list yields `categories === undefined`", () => {
+    const section = skillsLines([
+      [{ x: 74, str: "React, TypeScript, Java, Python", w: 180 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual(["React", "TypeScript", "Java", "Python"]);
+    expect(categories).toBeUndefined(); // not [], not a synthetic empty bucket
+  });
+
+  it("suppresses categories when a bare head precedes the first label", () => {
+    // A partly-categorised section cannot satisfy invariant (1) without inventing
+    // a bucket for the leading bare skills, so the structured view is dropped and
+    // the flat list is preserved intact.
+    const section = skillsLines([
+      [{ x: 74, str: "React, TypeScript", w: 110 }],
+      [...BULLET_RUNS, { x: 74, str: "Backend: Java, Go", w: 110 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual(["React", "TypeScript", "Java", "Go"]);
+    expect(categories).toBeUndefined();
+  });
+
+  it("does not treat a hobbies/interests sub-label as a category", () => {
+    // A non-skill sub-label contributes no tokens and must not become a category.
+    const section = skillsLines([
+      [...BULLET_RUNS, { x: 74, str: "Backend: Java, Go", w: 110 }],
+      [...BULLET_RUNS, { x: 74, str: "Interests: Tennis, Gardening", w: 150 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual(["Java", "Go"]);
+    expect(categories).toEqual([{ label: "Backend", skills: ["Java", "Go"] }]);
   });
 });

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 import type { PdfSection } from "../sections.ts";
-import type { PdfTextItem } from "../types.ts";
+import type { PdfTextItem, SkillCategory } from "../types.ts";
 import { mergeItemText } from "../sections.ts";
 import { isBulletGlyph, stripBullet } from "../line-primitives.ts";
 
@@ -352,6 +352,24 @@ function hasUnclosedParen(text: string): boolean {
 }
 
 /**
+ * How many subsequent physical lines Condition C will scan for the paren that
+ * closes a clarifier which soft-wrapped mid-list.
+ *
+ * A clarifier only wraps when its own comma-list is wider than the résumé
+ * column, and a column that narrow fits, at most, a handful of items per line —
+ * so a realistic wrap is two or three lines (`AWS (EC2,` / `S3,` / `RDS)`),
+ * never a dozen. A window of 4 covers every real case with margin while keeping
+ * the scan a bounded O(N) peek. The bound is the whole point of the check: an
+ * open `(` whose close never arrives within the window is a STRAY paren (an OCR
+ * artifact like `Vim (advanced`, not a wrap). Refusing the join there degrades
+ * to today's shredded-but-bounded output and hands the trailing items to
+ * `splitRespectingParens`' unbalanced-paren fallback — it must NEVER swallow the
+ * rest of the section into one cell, which is exactly what an unbounded scan
+ * (or the pre-#465 code) did.
+ */
+const CLARIFIER_WRAP_LOOKAHEAD = 4;
+
+/**
  * True when the pending accumulated text and `nextText` together indicate a
  * soft-wrap: the line break happened mid-skill-name or mid-list, not between
  * two independent items.
@@ -367,7 +385,11 @@ function hasUnclosedParen(text: string): boolean {
  * Both guards also reject standalone profile/contact links and new-sub-list
  * patterns unconditionally.
  */
-function isSoftWrapContinuation(pending: string, nextText: string): boolean {
+function isSoftWrapContinuation(
+  pending: string,
+  nextText: string,
+  upcoming: string[],
+): boolean {
   // Always skip standalone profile/contact links — they are their own items.
   if (looksLikeContactLink(nextText)) return false;
   // Always skip if the next line starts a new sub-list (label or bullet).
@@ -397,12 +419,13 @@ function isSoftWrapContinuation(pending: string, nextText: string): boolean {
   }
 
   // Condition C: the pending line broke MID-LIST INSIDE a parenthesised
-  // clarifier, and the next line closes that clarifier ("… AWS (EC2," ⏎
-  // "S3, RDS)"). Such a break is unambiguously mid-token, and it is the one case
-  // Condition B structurally cannot reach: pending ends on a comma, so B reads
-  // it as a completed entry and declines to join — leaving
-  // splitRespectingParens' unbalanced-paren fallback to shred the clarifier into
-  // "AWS (EC2" / "S3" / "RDS)" (#465).
+  // clarifier, and the clarifier closes within a bounded look-ahead ("… AWS
+  // (EC2," ⏎ "S3, RDS)", or the 3+-line form "… AWS (EC2," ⏎ "S3," ⏎ "RDS)").
+  // Such a break is unambiguously mid-token, and it is the one case Condition B
+  // structurally cannot reach: pending ends on a comma, so B reads it as a
+  // completed entry and declines to join — leaving splitRespectingParens'
+  // unbalanced-paren fallback to shred the clarifier into "AWS (EC2" / "S3" /
+  // "RDS)" (#465).
   //
   // Three conjuncts, each load-bearing:
   //
@@ -416,22 +439,34 @@ function isSoftWrapContinuation(pending: string, nextText: string): boolean {
   //     Condition B rather than a superset of it: B handles every wrapped list
   //     that does NOT end on a comma, C handles only the comma-terminated ones B
   //     refuses. Every real clarifier wrap breaks after a comma.
-  //  3. `!hasUnclosedParen(joined)` — the join RESOLVES the imbalance. An open
-  //     paren the next line does NOT close is a stray paren (the OCR artifact
-  //     "C++ (advanced, Node"), not a wrap. Joining on the open paren alone
-  //     never re-satisfies its own predicate, so every subsequent line would keep
-  //     joining and the whole rest of the section would collapse into one garbage
-  //     token — starving the unbalanced-paren fallback in `splitRespectingParens`
-  //     that exists precisely to recover the items after a stray "(".
+  //  3. Some prefix of `[nextText, ...upcoming]`, appended to `pending`, RESOLVES
+  //     the imbalance — the clarifier closes within `CLARIFIER_WRAP_LOOKAHEAD`
+  //     lines. This is #465's `!hasUnclosedParen(pending + nextText)` widened
+  //     from a single-line check to a bounded n-line scan, so closure can arrive
+  //     two or three lines out (a clarifier that wraps 3+ times) instead of
+  //     exactly one. The BOUND is what keeps the safety property #465's single
+  //     line bought: an open paren that NO prefix within the window closes is a
+  //     stray paren (the OCR artifact "C++ (advanced, Node"), not a wrap, so the
+  //     join is refused and `splitRespectingParens`' fallback recovers the items
+  //     after it — the section is never swallowed into one garbage token. The
+  //     scan only tests whether closure is reachable; the actual joining still
+  //     happens one hop at a time back in `collectSkillCells`, each hop
+  //     re-checking all three conjuncts, so a continuation line that does not end
+  //     on a comma flushes and bounds the accumulation further.
   //
   // Invariant: join only when the break is mid-list INSIDE an open clarifier and
-  // the join CLOSES that clarifier.
-  if (
-    hasUnclosedParen(pending) &&
-    /,\s*$/.test(pending) &&
-    !hasUnclosedParen(`${pending} ${nextText}`)
-  )
-    return true;
+  // that clarifier demonstrably CLOSES within the look-ahead window.
+  if (hasUnclosedParen(pending) && /,\s*$/.test(pending)) {
+    let joined = `${pending} ${nextText}`;
+    if (!hasUnclosedParen(joined)) return true;
+    for (const following of upcoming.slice(0, CLARIFIER_WRAP_LOOKAHEAD)) {
+      joined += ` ${following}`;
+      if (!hasUnclosedParen(joined)) return true;
+    }
+    // No closing prefix within the window: fall through. Conjunct 2 guarantees
+    // pending ends on a comma, so Conditions A and B below are both structurally
+    // false too — the join is refused, leaving the clarifier shredded-but-bounded.
+  }
 
   // Condition A: pending ends with an explicit continuation glyph — the glyph
   // must be its OWN whitespace-separated token ("Hiring &", "Data -"), not the
@@ -495,8 +530,16 @@ function collectSkillCells(lines: PdfSection["lines"]): string[] {
     }
   };
 
-  for (const line of lines) {
-    const cells = splitColumnCells(line);
+  // Split every line's columns once up front. Condition C's n-line look-ahead
+  // (see `isSoftWrapContinuation`) needs to peek at the single-column line texts
+  // that FOLLOW the current one to decide whether an open clarifier ever closes;
+  // computing the splits here keeps that peek O(1) per hop and keeps the
+  // predicate pure — it receives the upcoming texts as data rather than reaching
+  // back into the loop.
+  const lineCells = lines.map(splitColumnCells);
+
+  for (let i = 0; i < lineCells.length; i++) {
+    const cells = lineCells[i];
     if (cells.length > 1) {
       // Multi-column row: flush any pending single-col accumulation, then add
       // each column cell individually (they are separate logical groups).
@@ -506,7 +549,10 @@ function collectSkillCells(lines: PdfSection["lines"]): string[] {
       // Single-column line — may be a soft-wrap continuation of the previous.
       const text = (cells[0] ?? "").trim();
       if (!text) continue;
-      if (pending && isSoftWrapContinuation(pending, text)) {
+      if (
+        pending &&
+        isSoftWrapContinuation(pending, text, upcomingContinuationTexts(lineCells, i + 1))
+      ) {
         // Looks like a continuation — join with a space.
         pending += " " + text;
       } else {
@@ -519,16 +565,107 @@ function collectSkillCells(lines: PdfSection["lines"]): string[] {
   return result;
 }
 
+/**
+ * The subsequent single-column line texts that COULD extend a soft-wrap, in
+ * document order, for Condition C's bounded clarifier-close look-ahead.
+ *
+ * Gathers up to `CLARIFIER_WRAP_LOOKAHEAD` following texts, stopping at the
+ * first line that breaks a continuation so the scan can never count a paren that
+ * lives past a boundary as "closing" the clarifier:
+ *   - a MULTI-COLUMN row (`cells.length !== 1`) flushes pending in the loop;
+ *   - a NEW-ENTRY line (bullet/label) or a CONTACT link is where
+ *     `isSoftWrapContinuation` itself would refuse to join.
+ * A blank single-column line is skipped without counting — it neither breaks nor
+ * extends the wrap (the loop `continue`s past it too), so it must not consume the
+ * window budget or terminate the scan.
+ */
+function upcomingContinuationTexts(lineCells: string[][], from: number): string[] {
+  const out: string[] = [];
+  for (
+    let j = from;
+    j < lineCells.length && out.length < CLARIFIER_WRAP_LOOKAHEAD;
+    j++
+  ) {
+    const cells = lineCells[j];
+    if (cells.length !== 1) break; // multi-column row: continuation boundary
+    const t = (cells[0] ?? "").trim();
+    if (t === "") continue; // blank: skipped by the loop too, not a boundary
+    if (SKILLS_NEW_ENTRY_RE.test(t) || looksLikeContactLink(t)) break;
+    out.push(t);
+  }
+  return out;
+}
+
+/**
+ * The category label a skills cell opens with, minus its trailing colon — or
+ * `undefined` when the cell carries no leading `Label:` (#473). Mirrors the
+ * label recognition `tokenizeCell` already performs (`stripBullet` then
+ * `SUBLABEL_PREFIX_RE`), so a cell captured as a category is exactly one whose
+ * label `tokenizeCell` would otherwise strip and drop.
+ *
+ * A non-skill sub-label (Interests/Hobbies) is not a category: `tokenizeCell`
+ * drops such a cell whole, so it never contributes tokens and never reaches the
+ * caller's category branch — but the guard here keeps the two decisions aligned.
+ */
+function matchCellLabel(cell: string): string | undefined {
+  const m = stripBullet(cell).match(SUBLABEL_PREFIX_RE);
+  if (!m || NON_SKILL_SUBLABEL_RE.test(m[1])) return undefined;
+  return m[1].trim();
+}
+
 export function extractSkills(
   skills: PdfSection | undefined,
-): { value: string[]; confidence: number } {
+): { value: string[]; categories?: SkillCategory[]; confidence: number } {
   if (!skills || skills.lines.length === 0) return { value: [], confidence: 0 };
 
-  const tokens = new Set<string>();
+  // One walk builds BOTH views off the same cell stream, sharing a single dedup
+  // set so the flat list is byte-identical to the pre-#473 global-Set behavior
+  // (per-cell dedup via `tokenizeSkillLine`, then a global dedup here) and the
+  // categories' members are exactly the flat list re-partitioned by label —
+  // guaranteeing `skills === skillCategories.flatMap((c) => c.skills)`.
+  const seen = new Set<string>();
+  const value: string[] = [];
+  const categories: SkillCategory[] = [];
+  // A skill that surfaced BEFORE any category label is a bare, uncategorised
+  // head of the section. It cannot belong to a category, so its presence means
+  // the section is only PARTLY categorised — we then drop the structured view
+  // entirely rather than invent a bucket, keeping invariant (1) exact.
+  let hasUncategorisedHead = false;
+
   for (const cell of collectSkillCells(skills.lines)) {
-    tokenizeCell(cell, tokens);
+    const cellTokens: string[] = [];
+    for (const tok of tokenizeSkillLine(cell)) {
+      if (seen.has(tok)) continue;
+      seen.add(tok);
+      value.push(tok);
+      cellTokens.push(tok);
+    }
+    // A cell that produced nothing (dropped link/hobbies label, or all-duplicate)
+    // is neither a category nor a bare contribution — skip it on both axes.
+    if (cellTokens.length === 0) continue;
+
+    const label = matchCellLabel(cell);
+    if (label !== undefined) {
+      categories.push({ label, skills: cellTokens });
+    } else if (categories.length > 0) {
+      // A bare cell that follows a category is a soft-wrap continuation of it —
+      // the wrap flushed as its own cell (e.g. the pending line ended on a comma,
+      // which declines the comma-list rejoin) — so its tokens extend the last
+      // category. `collectSkillCells` preserves document order, so a
+      // continuation always trails its own category and precedes the next label.
+      categories[categories.length - 1].skills.push(...cellTokens);
+    } else {
+      hasUncategorisedHead = true;
+    }
   }
-  const value = [...tokens];
+
   const confidence = value.length >= 5 ? 0.85 : value.length >= 2 ? 0.6 : 0.2;
-  return { value, confidence };
+  return {
+    value,
+    // Emit the structured view ONLY when the section is fully categorised: at
+    // least one label AND no bare head. Otherwise the field is absent (never
+    // `[]`), which reads as "uncategorised" per invariant (2).
+    ...(categories.length > 0 && !hasUncategorisedHead ? { categories } : {}),
+    confidence,
+  };
 }

--- a/src/lib/heuristics/openresume.ts
+++ b/src/lib/heuristics/openresume.ts
@@ -432,6 +432,11 @@ function buildHeuristicResult(
     ...(contact.profiles.length > 0 ? { profiles: contact.profiles } : {}),
     ...(summary.value ? { summary: summary.value } : {}),
     skills: skills.value,
+    // Structured category view (#473) — additive over the flat `skills`, present
+    // only when the Skills section was actually categorised. The inline-label
+    // recovery below never sets it (it fires only when `skills.value` is empty,
+    // which leaves `skills.categories` absent), so flat-only stays flat-only.
+    ...(skills.categories ? { skillCategories: skills.categories } : {}),
     skills_explicit: [],
     skills_inferred: [],
     experience: experience.value,

--- a/src/lib/heuristics/types.ts
+++ b/src/lib/heuristics/types.ts
@@ -118,10 +118,34 @@ export interface LayoutProbes {
 
 // ── Tier 1 heuristic output ─────────────────────────────────────────────────
 
+/**
+ * One labelled group inside the Skills section — the category label as written
+ * and its member skills. This is the STRUCTURED view over the flat `skills`
+ * union: a labelled row `Frontend: React, TypeScript` is one category
+ * (`Frontend`) holding two skills, rather than the label being dropped (#473).
+ */
+export interface SkillCategory {
+  /** The category label as written, minus the trailing colon: "Cloud & Infra". */
+  label: string;
+  /** Members, in document order. Each also appears in the flat `skills` array. */
+  skills: string[];
+}
+
 /** Subset of ParsedResume that the heuristic path can reliably produce. */
 export type HeuristicParsedResume = Partial<ParsedResume> & {
   /** Always present (empty array if none found). */
   skills: string[];
+  /**
+   * Structured view of a CATEGORISED Skills section (#473) — additive over the
+   * flat `skills`. Two invariants hold whenever this is present:
+   *   1. `skills` deep-equals `skillCategories.flatMap((c) => c.skills)` — the
+   *      flat list is the union of the categories' members, in document order.
+   *   2. Present ONLY when the section was actually categorised. A plain comma
+   *      list has no categories: the field is ABSENT (undefined), never `[]`,
+   *      never a synthetic `{ label: "", skills: [...] }` bucket. Absent means
+   *      "the résumé did not say", not "there are no categories".
+   */
+  skillCategories?: SkillCategory[];
   experience: ResumeExperience[];
   education: ResumeEducation[];
   /** libphonenumber isValid() result for the extracted phone — plumbed from

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -445,4 +445,34 @@ describe("buildAtsResumeModel", () => {
     const exp = model.sections.find((s) => s.heading === "Experience")!;
     expect(exp.entries[0].headerBold).toBeUndefined();
   });
+
+  it("exports one entry per category under its (edited) label (#473/#476)", () => {
+    const result = makeResult({
+      skills: ["PostgreSQL", "Redis", "Java"],
+      skillCategories: [
+        { label: "Data Stores", skills: ["PostgreSQL", "Redis"] },
+        { label: "Backend", skills: ["Java"] },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const skills = model.sections.find((s) => s.heading === "Skills")!;
+    expect(skills.entries.map((e) => e.fields?.skillCategory)).toEqual([
+      "Data Stores",
+      "Backend",
+    ]);
+    expect(skills.entries[0].headerLine).toBe("Data Stores: PostgreSQL · Redis");
+  });
+
+  it("drops an empty category so the PDF renders no dangling 'Label:' (#476)", () => {
+    const result = makeResult({
+      skills: ["Java"],
+      skillCategories: [
+        { label: "Data Stores", skills: [] }, // emptied in the editor
+        { label: "Backend", skills: ["Java"] },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const skills = model.sections.find((s) => s.heading === "Skills")!;
+    expect(skills.entries.map((e) => e.fields?.skillCategory)).toEqual(["Backend"]);
+  });
 });

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -108,9 +108,14 @@ export interface AtsEntryFields {
   url?: string;
   /** JSON Resume `education.courses` — relevant-coursework items (#164). */
   courses?: string[];
-  /** JSON Resume `skills` — the flat skill list, carried only on the single
-   *  skills entry (whose `headerLine` is the same list joined by " · "). */
+  /** JSON Resume `skills` — the flat skill list, carried on the skills entry
+   *  (whose `headerLine` is the same list joined by " · "). On a CATEGORISED
+   *  skills entry (#473) this holds that ONE category's members. */
   skills?: string[];
+  /** The category label of a categorised skills entry (#473) — its `headerLine`
+   *  is `"<label>: a · b · c"` and the JSON export maps it to
+   *  `{ name: label, keywords: members }`. Absent on a flat skills entry. */
+  skillCategory?: string;
   /** JSON Resume `awards.title` — carried on achievement entries (#421). */
   title?: string;
 }
@@ -768,22 +773,41 @@ export function buildAtsResumeModel(
     };
   });
 
-  // ── Skills (one entry, no header line — bullets carry the joined list) ──
+  // ── Skills ──────────────────────────────────────────────────────────────
+  // Categorised (#473): one entry PER category, each `"<label>: a · b · c"`, so
+  // the exported PDF reproduces the input's grouping and re-parses back to the
+  // same categories. Uncategorised: the single flat " · "-joined entry, exactly
+  // as before (byte-identical). Both read as regular-weight body text (#425) and
+  // keep segments atomic so a multi-word skill never wraps mid-name (#301).
+  // Drop empty categories (an editor "empty-but-present" state, #476) so the PDF
+  // never renders a dangling "Label:" with nothing after it; the flat list is
+  // already the flatten of the non-empty ones, so this stays invariant-safe.
+  const skillCategories = parsed.skillCategories?.filter(
+    (c) => c.skills.length > 0,
+  );
   const skillsEntries: AtsEntry[] =
-    skills.length > 0
-      ? [
-          {
-            headerLine: skills.join(" · "),
-            bullets: [],
-            atomicSegments: true,
-            // Skills read as regular-weight body text, not a bold header (#425).
-            headerBold: false,
-            // The flat skill list, carried structurally so the JSON export (#334)
-            // maps `skills[] ← { name }` without re-splitting the joined header.
-            fields: { skills: [...skills] },
-          },
-        ]
-      : [];
+    skillCategories && skillCategories.length > 0
+      ? skillCategories.map((c) => ({
+          headerLine: `${c.label}: ${c.skills.join(" · ")}`,
+          bullets: [],
+          atomicSegments: true,
+          headerBold: false,
+          fields: { skills: [...c.skills], skillCategory: c.label },
+        }))
+      : skills.length > 0
+        ? [
+            {
+              headerLine: skills.join(" · "),
+              bullets: [],
+              atomicSegments: true,
+              // Skills read as regular-weight body text, not a bold header (#425).
+              headerBold: false,
+              // The flat skill list, carried structurally so the JSON export
+              // (#334) maps `skills[] ← { name }` without re-splitting the header.
+              fields: { skills: [...skills] },
+            },
+          ]
+        : [];
 
   const achievementsAbove =
     parsed.achievements_placement === "above_experience";

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -90,7 +90,13 @@ export interface JsonResumeEducation {
 }
 
 export interface JsonResumeSkill {
+  /** JSON Resume `skills[].name`. Flat export: the skill itself. Categorised
+   *  export (#473): the CATEGORY label, with the members under `keywords`. */
   name: string;
+  /** JSON Resume `skills[].keywords` — the category's member skills. Present
+   *  only on a categorised entry; absent keeps the flat one-object-per-skill
+   *  shape byte-identical to the pre-#473 export. */
+  keywords?: string[];
 }
 
 export interface JsonResumeProject {
@@ -384,7 +390,18 @@ function appendEntry(entry: AtsExportEntry, buckets: ResumeBuckets): void {
       if (fields) buckets.education.push(toEducation(fields));
       break;
     case "skills":
-      for (const name of fields?.skills ?? []) buckets.skills.push({ name });
+      // Categorised entry (#473): one skill object per category, `name` =
+      // category label + `keywords` = its members — the shape the JSON Resume
+      // spec actually defines (`{ name, level, keywords[] }`). A flat entry
+      // (no `skillCategory`) stays one `{ name }` per skill, byte-identical.
+      if (fields?.skillCategory) {
+        buckets.skills.push({
+          name: fields.skillCategory,
+          keywords: [...(fields.skills ?? [])],
+        });
+      } else {
+        for (const name of fields?.skills ?? []) buckets.skills.push({ name });
+      }
       break;
     case "achievements":
       if (fields) buckets.awards.push(toAward(fields));


### PR DESCRIPTION
## Summary

Carries the Skills section's category structure end to end — parsed, rendered, exported, and editable — instead of flattening it to a bare token list. `HeuristicParsedResume.skills` stays the flat union for every existing consumer; the structure rides alongside on an additive, absent-means-uncategorised `skillCategories` field. Three epic children in one branch:

- **#473** — add optional `skillCategories?: SkillCategory[]` (`{label, skills}`); capture the category labels the extractor already detected and dropped. Invariants: flat `skills` deep-equals `skillCategories.flatMap(c => c.skills)` when present; absent (`undefined`) means uncategorised — never `[]`, never a synthetic empty bucket. Threaded through types, `extract/skills.ts`, `openresume.ts`, the reconstructed résumé, JSON Resume (`{name, keywords}` per category), and the Download PDF. Flat extraction byte-identical — corpus `skillsCount` snapshots unmoved.
- **#475** — generalise the clarifier soft-wrap join from a single-line close lookahead to a bounded n-line scan (`CLARIFIER_WRAP_LOOKAHEAD = 4`), so a parenthesised clarifier wrapping across 3+ lines rejoins instead of shredding. Unbounded-swallow bound preserved: a stray never-closed `(` degrades to shredded-but-bounded, never swallows the section. Deletes the `KNOWN LIMIT` test, replaces with the positive assertion.
- **#476** — make categories editable: rename, delete (confirm dialog), add, add-skill, and move-between-categories, each via one mutation path invoked by both native drag-and-drop and a keyboard-reachable "Move to" menu (`aria-live` announced). `SkillsOverride` gains a `categories` snapshot; emptying a category leaves it empty-but-present in the editor and filtered from export (no dangling `Label:`); add/move not offered on an uncategorised résumé.

Refs #415
Closes #473
Closes #475
Closes #476

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — affected suites green (1472 pass over merged tree; skills/edit/component/corpus/pdf)
- [x] `npm run lint` clean
- [x] Corpus `skillsCount` snapshots unmoved (additive extraction)
- [x] `npm run verify` — green in CI
- [ ] Manually verify category edit ops in `npm run dev` (rename / delete / add / move via DnD + keyboard)

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #473 | Claude Opus 4.8 (1M context) | ultra |
| Implementation — #475 | Claude Opus 4.8 (1M context) | ultra |
| Implementation — #476 | Claude Opus 4.8 (1M context) | ultra |
| Adversarial review (round 1) | Claude Opus 4.8 | ultra |
| Review fixes | Claude Opus 4.8 | ultra |
| Adversarial review (round 2) | Claude Opus 4.8 | ultra |
| Orchestration + PR | Claude Opus 4.8 (1M context) | high |
| Verification | \`npm run verify\` — green in CI | — |

## Adversarial review

Two rounds, adversarial (ecc:react-reviewer, opus), pre-PR on the local diff.

**Round 1 — 1 blocking finding (reproduced end-to-end):**
- **[HIGH] Flat `addSkill` dropped the `categories` snapshot, resurrecting deleted skills.** After deleting every category (`override.categories = []`) the section degrades to uncategorised and renders the flat add-skill input; the flat `addSkill` setter returned `{removed, added}`, dropping `categories: []`, so `applyOverrides` re-derived from the pristine parse and every previously-deleted skill reappeared on screen, in the score, and in the exported PDF. Root: `addSkill` (dropped `categories`) and `removeSkill` (preserved it) disagreed, while `computeEditedSkills` treats `categories: []` as authoritative-empty.
  - **Fix (option B):** extracted `applyFlatEdits(base, override)`; the degraded `categories.length === 0` branch composes flat edits on an **empty base** (never touches pristine skills); `addSkill` now preserves the snapshot (`{...prev, removed, added}`), aligning with `removeSkill`. Pinned by new tests in `skills-categories.test.ts` + end-to-end hook repros in `useEditableParse.test.tsx`. Reviewer noted the same bug had a second surface in `replay` (draft/JD-fit handoff) that the fix also closes.

**Round 2 — clean, no blocking findings.** Confirmed the round-1 repro dead, the originally-uncategorised path stays byte-identical (`categories` key absent, not `[]`), base selection correct in both branches, still-categorised path genuinely unreachable-to-coexist with flat edits, and no stale-closure from the `addSkill` change (`useCallback([])` + functional updater).

**Surviving nits (non-blocking, for the human reviewer):**
- `skills-categories.ts` — a one-line comment noting `[]` is present-and-empty (truthy → selects the degraded branch) vs absent would clarify the load-bearing absent-vs-`[]` distinction.
- `ReconstructedSkillControls.tsx:111` — native DnD sets no `dataTransfer` in `onDragStart`; Chrome drags anyway but Firefox will not start a pointer drag without `setData`. Keyboard "Move to" is the accessible primary and works; cosmetic.
- `ReconstructedSkillControls.tsx` is 365 LOC (over the ~200 guideline; advisory, not CI-blocking) — a bag of independent leaf controls, split candidate if it grows.

**Fallow (report-only in `verify`):** `isSoftWrapContinuation` grew to 115 LOC / cc 15 from #475's n-line lookahead (Nit). A 99-line clone group between `ReconstructedResume.tsx` and the new `ReconstructedSkills.tsx` was reviewed and ruled benign (unrelated JSX, no reuse-gate violation).
