### PR TITLE
fix(parser): round-trip the truncated one-line experience header (#436)

### DIFF
--- a/src/lib/heuristics/corpus-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-roundtrip.test.ts
@@ -159,22 +159,22 @@ const KNOWN_FAILURES: Record<string, Category[]> = {
   //      ("…, Remote") is peeled by `stripLocationSuffix` Pass F (achievements-
   //      oneline, two-column, chromium-asymmetric, weasyprint-two-column cleared).
   //   2. TRUNCATION — a PARENTHETICAL / multi-word company on the one-line shape
-  //      ("Danggeun Pay Inc. (KarrotPay)" → "(KarrotPay)") still re-parses
-  //      truncated. STILL OPEN — the four lines below are this root (plus
-  //      two-column re-segmentation). The fix needs a wrapped-header rejoin AND a
-  //      render-side date-column reserve, which perturb two-column round-trips
-  //      and so warrant their own follow-up, kept separate from the swap fix.
+  //      ("Danggeun Pay Inc. (KarrotPay)" → "(KarrotPay)") re-parsed truncated
+  //      when the too-wide header WRAPPED its org tail onto the row below and the
+  //      wrapped words were stranded (or glued to the flush-right date). FIXED:
+  //      the renderer now reserves the flush-right date column only when the
+  //      header actually reaches it (`drawText` in render-ats-pdf.ts), so the org
+  //      wraps clear of the date; and the parser folds that wrapped tail back
+  //      into the header before disambiguation (`tryFoldCompleteDateHeader` in
+  //      entry-blocks.ts), gated to single-column sections so a two-column source
+  //      is untouched. awesome-cv-cv / awesome-cv-resume cleared.
   //
   // Delete each line below as its root lands (the ratchet forces it — a fixed
   // fixture trips the stale-entry check).
+  //
+  // honors-subheadings: NOT the one-line header roots above — a bullet-as-title
+  // parse defect on a subheading-style role, tracked separately.
   "google-docs/google-docs-skia-proxy-honors-subheadings.pdf": ["experience"],
-  // awesome-cv-cv: #383 cleared its earlier abbreviated-date baseline (see the
-  // #383 note above), but main's one-line header re-regresses `experience` for
-  // the #436 TRUNCATION reason — 12 roles re-parse company-truncated/swapped off
-  // the one-line "Title · Company … Dates" shape. Removed when the truncation
-  // root lands.
-  "latex/awesome-cv-cv.pdf": ["experience"],
-  "latex/awesome-cv-resume.pdf": ["experience"],
 };
 
 const CATEGORIES: Category[] = [

--- a/src/lib/heuristics/entry-blocks.test.ts
+++ b/src/lib/heuristics/entry-blocks.test.ts
@@ -602,6 +602,52 @@ describe("parseEntryBlocks — wrapped multi-line role header (#166)", () => {
     expect(blocks[0].headerLines).toContain("Senior Engineer");
   });
 
+  it("folds a COMPLETE-range one-line header whose org tail wrapped indented (#436)", () => {
+    // The reconstructed "Download PDF" shape: the header carries the whole date
+    // range on its first physical row, but its "· Company, Location" tail overran
+    // the flush-right date column and word-wrapped onto the row below, INDENTED
+    // past the bullet margin (the exporter's hanging indent). Left un-folded the
+    // company re-parses truncated ("Danggeun Pay Inc. (KarrotPay)" → the tail is
+    // stranded). `tryFoldCompleteDateHeader` re-inserts the tail before the date
+    // region, reconstructing the one-line header so the full company survives.
+    const section = xSection("experience", [
+      { text: "Founding Engineer, Team Lead · Mar 2021 - Jun 2023", x: 70 },
+      { text: "Danggeun Pay Inc. (KarrotPay), Seoul, S.Korea", x: 82 }, // indented tail
+      { text: "● Built the payments platform.", x: 70 },
+    ]);
+    const blocks = parseEntryBlocks(section, {
+      anchor: "date_range",
+      collectBody: true,
+      headerLookback: 2,
+    });
+    expect(blocks).toHaveLength(1);
+    const [b] = blocks;
+    // Full company preserved — no truncation to the parenthetical tail.
+    expect(b.headerLines.join(" ")).toContain("Danggeun Pay Inc. (KarrotPay)");
+    expect(b.dates.start_date).toBe("Mar 2021");
+    expect(b.dates.end_date).toBe("Jun 2023");
+    expect(b.bulletCount).toBe(1);
+  });
+
+  it("does not fold a complete-range header whose next line sits AT the margin (#342/#466)", () => {
+    // Same complete-range header, but the company is on its OWN row at the SAME
+    // left margin — a stacked second header line, not a wrapped tail. The indent
+    // gate must leave it a distinct line so the anchor/title mapping still works.
+    const section = xSection("experience", [
+      { text: "Founding Engineer, Team Lead · Mar 2021 - Jun 2023", x: 70 },
+      { text: "Danggeun Pay Inc. (KarrotPay)", x: 70 }, // same margin — not a wrap
+      { text: "● Built the payments platform.", x: 70 },
+    ]);
+    const blocks = parseEntryBlocks(section, {
+      anchor: "date_range",
+      collectBody: true,
+      headerLookback: 2,
+    });
+    expect(blocks).toHaveLength(1);
+    // The company line stays a separate header line (not folded into the date row).
+    expect(blocks[0].headerLines).toContain("Danggeun Pay Inc. (KarrotPay)");
+  });
+
   it("reassembles a wrapped open-ended range (date sep on the header, 'Present' wrapped)", () => {
     // "… Jan 2022 -" with "Present" wrapped onto its own line. `Present` reads as
     // a complete range on its own, so the gather must treat it as a wrapped tail

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -570,6 +570,26 @@ function isWrappedContinuation(line: PdfLine, markerX: number): boolean {
 /** x tolerance (pt) for treating two lines as sitting at the same left margin. */
 const MARGIN_TOL = 2;
 
+/** Left-x spread (pt) above which a section is treated as MULTI-COLUMN. A
+ *  single-column résumé clusters every line within a dozen points of one left
+ *  margin (header, indented wrap tail, hanging-indent bullet); a two-column
+ *  layout parks a whole column 200–370 pt to the right, so this sits safely
+ *  between. Gates the #436 complete-date header fold. */
+const MULTI_COLUMN_SPREAD = 150;
+
+/** True when every line sits within {@link MULTI_COLUMN_SPREAD} of the section's
+ *  leftmost x — one column, no far-right sidebar. No-op-safe for a no-geometry
+ *  section (all x = 0 → spread 0 → single column). */
+function isSingleColumnSection(lines: PdfLine[]): boolean {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const l of lines) {
+    if (l.x < min) min = l.x;
+    if (l.x > max) max = l.x;
+  }
+  return max - min <= MULTI_COLUMN_SPREAD;
+}
+
 /**
  * The entry-header left margin of a `date_range` section — the x at which the
  * dated anchor lines (and the company / title lines that band with them) sit.
@@ -697,10 +717,21 @@ function isDateColumnFragment(line: PdfLine, markerX: number): boolean {
 function mergeWrappedHeaderRows(lines: PdfLine[], maxConts: number): PdfLine[] {
   if (lines.length === 0) return lines;
   const markerX = bulletMarkerX(lines);
+  // The complete-date fold (#436) targets the single-column reconstructed export,
+  // where a too-wide one-line header wraps its org tail onto an INDENTED row. It
+  // must NOT run on a TWO-COLUMN source, whose far-right sidebar cells also sit
+  // "indented past the marker" and would be vacuumed into a header. A
+  // single-column section clusters every line near one left margin; a two-column
+  // layout parks a whole column far to the right, so a wide x-spread is the tell.
+  const singleColumn = isSingleColumnSection(lines);
   const out: PdfLine[] = [];
   let i = 0;
   while (i < lines.length) {
-    const folded = tryFoldHeaderAt(lines, i, markerX, maxConts);
+    const folded =
+      tryFoldHeaderAt(lines, i, markerX, maxConts) ??
+      (singleColumn
+        ? tryFoldCompleteDateHeader(lines, i, markerX, maxConts)
+        : null);
     if (folded) {
       out.push(folded.line);
       i = folded.next;
@@ -710,6 +741,81 @@ function mergeWrappedHeaderRows(lines: PdfLine[], maxConts: number): PdfLine[] {
     }
   }
   return out;
+}
+
+/**
+ * Fold a wrapped role header whose date range is already COMPLETE on its first
+ * physical row but whose company / team text overran the flush-right date column
+ * and wrapped onto the INDENTED row below (#436).
+ *
+ * The reconstructed one-line exporter draws "Title · Company, Location · Team"
+ * with the date flush-right AND a hanging indent on the header, so a header wider
+ * than the page word-wraps its org tail onto a marker-less row indented past the
+ * bullet margin while the date stays put:
+ *
+ *     "Founding … Team Lead ·            Mar. 2021 – Jun. 2023"   ← complete range
+ *         "Danggeun Pay Inc. (KarrotPay), Seoul, S.Korea"        ← indented tail
+ *
+ * {@link tryFoldHeaderAt} folds the INCOMPLETE-range wrap (the date itself
+ * wrapped); this is its complete-range twin (the date stayed, the org wrapped).
+ * Word-wrap preserves every token — including the " · " middot joiners — so
+ * re-inserting the tail BEFORE the date region reconstructs the exact one-line
+ * header, which then disambiguates title/company as if never wrapped.
+ *
+ * The tail must be INDENTED past the bullet-marker margin
+ * ({@link isWrappedContinuation}) — the hanging-indent signature the exporter
+ * stamps on a wrapped header. That is what separates a genuine wrap from a
+ * STACKED second header line (a company on its OWN row at the SAME left margin —
+ * the #342/#466 shapes), which sits AT the margin and must stay a distinct line
+ * for the anchor logic to map. Further guarded: the header row must carry a
+ * complete range AND real text before a locatable date region; each folded row
+ * must be non-empty and neither a bullet (`isBulletLine`) nor its own dated
+ * anchor (`startsNewAnchor`). Bounded by `maxConts`.
+ */
+function tryFoldCompleteDateHeader(
+  lines: PdfLine[],
+  i: number,
+  markerX: number,
+  maxConts: number,
+): { line: PdfLine; next: number } | null {
+  const line = lines[i];
+  if (isBulletLine(line) || !hasCompleteDateRange(line.text)) return null;
+  const dateIdx = dateRegionStart(line.text);
+  if (dateIdx < 0) return null;
+  const textPart = line.text.slice(0, dateIdx).trim();
+  // A date-first row ("04/2021 – Present  Mountain View, CA") is a bare date/loc
+  // cell, not a wrapped role header — it must not absorb the line below it.
+  if (textPart.length === 0) return null;
+
+  const conts: PdfLine[] = [];
+  let j = i + 1;
+  while (
+    j < lines.length &&
+    conts.length < maxConts &&
+    !isBulletLine(lines[j]) &&
+    !startsNewAnchor(lines[j].text) &&
+    isWrappedContinuation(lines[j], markerX) &&
+    lines[j].text.trim().length > 0
+  ) {
+    conts.push(lines[j]);
+    j++;
+  }
+  if (conts.length === 0) return null;
+
+  const datePart = line.text.slice(dateIdx).trim();
+  const folded = [textPart, ...conts.map((c) => c.text.trim()), datePart]
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return {
+    line: {
+      ...line,
+      text: folded,
+      items: [...line.items, ...conts.flatMap((c) => c.items)],
+    },
+    next: j,
+  };
 }
 
 /**

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -44,6 +44,15 @@ import type {
   EditableParse,
 } from "../../hooks/useEditableParse.ts";
 
+/**
+ * Hanging indent (pt) for a wrapped experience-header tail (#436). Matches the
+ * renderer's bullet text indent so the tail sits just PAST the bullet-marker
+ * margin — the threshold `isWrappedContinuation` (entry-blocks.ts) uses to fold
+ * a marker-less continuation into the line it wraps from. Any value clear of that
+ * margin works; 12 pt keeps the indented tail visually aligned with the bullets.
+ */
+const HEADER_WRAP_INDENT = 12;
+
 // ── Model shape ───────────────────────────────────────────────────────────────
 
 export interface AtsContact {
@@ -160,6 +169,17 @@ export interface AtsEntry {
    * word-wrap normally, so this defaults to `false`/unset everywhere else.
    */
   atomicSegments?: boolean;
+  /**
+   * Hanging indent (pt) applied to the header's WRAPPED continuation lines
+   * (#436). Set on the one-line experience header ("Title · Company, Location ·
+   * Team", date flush-right): when it is too wide to fit, its org tail wraps onto
+   * the row below, and indenting that tail past the bullet-marker margin lets the
+   * parser's `mergeWrappedContinuations` fold it back into the header before
+   * disambiguation — so a wrapped "…Company, Location" re-parses whole instead of
+   * stranding its leading words. A header that fits one line is unaffected (only
+   * wrapped lines are indented). Unset elsewhere.
+   */
+  headerHangingIndent?: number;
   /** Structured source fields for the JSON-Resume export (#334). See
    *  {@link AtsEntryFields}. Display/render code never reads this. */
   fields?: AtsEntryFields;
@@ -591,6 +611,9 @@ export function buildAtsResumeModel(
         headerLine: headerText,
         headerLineDate: dateRange,
         ...(emptyCompanySubLine ? { subLine: emptyCompanySubLine } : {}),
+        // Indent a wrapped org tail so `mergeWrappedContinuations` re-folds it
+        // (#436) — see AtsEntry.headerHangingIndent.
+        headerHangingIndent: HEADER_WRAP_INDENT,
         bullets,
         fields,
       };
@@ -598,6 +621,7 @@ export function buildAtsResumeModel(
     return {
       headerLine: [headerText, dateRange].filter(Boolean).join("  ") || "Experience",
       ...(emptyCompanySubLine ? { subLine: emptyCompanySubLine } : {}),
+      headerHangingIndent: HEADER_WRAP_INDENT,
       bullets,
       fields,
     };

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -83,6 +83,14 @@ const GAP_AFTER_HEADER = 2;
 const BULLET_MARKER = "• ";
 const BULLET_INDENT = 12; // hanging-indent width for wrapped bullet lines
 
+// Minimum blank gutter (pt) kept between the wrapped header text and the
+// flush-right date tail (#436). Without a reserve the header text wraps to the
+// full content width and its last word runs UNDER the date on re-extraction
+// ("…Inc." + "Mar. 2021" → "Inc.Mar. 2021"), corrupting the company on
+// round-trip. Reserving the date's measured width + this gutter forces the
+// header to wrap BEFORE the date column.
+const DATE_COLUMN_GAP = 8;
+
 // The middot list/org-line join separator emitted by ats-resume-model.ts
 // (skills, "Company · Location", "Institution · Location", ...). Wrap logic
 // treats each middot-delimited segment as atomic — see `wrap()` (#301).
@@ -525,6 +533,37 @@ class Layout {
   }
 
   /**
+   * Wrap `value` at `maxWidth`, but reserve `rightReserve` pt for a flush-right
+   * tail (the header's date column, #436) — and ONLY when the first line would
+   * actually reach it. Wrapping at the full width first and re-wrapping just the
+   * colliding case keeps every header that already fits one line (or wraps clear
+   * of the date) byte-identical; a blanket reserve instead forces borderline
+   * headers to wrap and re-parse worse, regressing fixtures whose reconstructed
+   * header sat just shy of the date column. When the first line DOES overrun the
+   * date, its trailing word extracts glued to the date ("…Inc." + "Mar. 2021" →
+   * "Inc.Mar. 2021"), corrupting the company; re-wrapping at the reserved width
+   * (atomic, so "Company, Location" moves whole rather than splitting mid-name)
+   * restores the round-trip. A zero reserve is a plain {@link wrap}.
+   */
+  private wrapReservingRight(
+    value: string,
+    font: PdfFont,
+    size: number,
+    maxWidth: number,
+    atomic: boolean,
+    rightReserve: number,
+  ): string[] {
+    const lines = this.wrap(value, font, size, maxWidth, atomic);
+    if (
+      rightReserve > 0 &&
+      font.widthOfTextAtSize(lines[0], size) > maxWidth - rightReserve
+    ) {
+      return this.wrap(value, font, size, maxWidth - rightReserve, atomic);
+    }
+    return lines;
+  }
+
+  /**
    * Draw a wrapped block of text. `x` is the left edge; `hangingIndent`
    * indents continuation lines (for bullet hanging indent). `atomicSegments`
    * opts into segment-atomic middot wrapping (see `wrap()` above) — leave it
@@ -571,14 +610,28 @@ class Layout {
     // — see the constructor doc) since Poppins encodes the glyphs directly.
     const cased = opts.uppercase ? text.toUpperCase() : text;
     const value = this.sanitize ? toWinAnsi(cased) : cased;
+    const atomic = opts.atomicSegments ?? false;
     const maxWidth = CONTENT_WIDTH - (x - MARGIN);
+    const rSize = opts.rightSize ?? size;
+    const rValue = opts.rightText
+      ? this.sanitize
+        ? toWinAnsi(opts.rightText)
+        : opts.rightText
+      : "";
+    const rightReserve = rValue
+      ? this.fonts.regular.widthOfTextAtSize(rValue, rSize) + DATE_COLUMN_GAP
+      : 0;
 
-    const lines = this.wrap(
+    // Reserve the flush-right date column when the header collides with it
+    // (#436) — see wrapReservingRight for why this is collision-gated, not a
+    // blanket reserve.
+    const lines = this.wrapReservingRight(
       value,
       font,
       size,
       maxWidth,
-      opts.atomicSegments ?? false,
+      atomic,
+      rightReserve,
     );
     const lineHeight = size * LINE_GAP;
     const singleLine = lines.length === 1;
@@ -597,9 +650,7 @@ class Layout {
         // Flush-right date tail on the first line's baseline (#425), right-
         // aligned to the content margin and drawn regular-weight/muted.
         if (opts.rightText) {
-          const rSize = opts.rightSize ?? size;
           const rFont = this.fonts.regular;
-          const rValue = this.sanitize ? toWinAnsi(opts.rightText) : opts.rightText;
           const rX = PAGE_WIDTH - MARGIN - rFont.widthOfTextAtSize(rValue, rSize);
           this.page.drawText(rValue, {
             x: rX,
@@ -898,6 +949,7 @@ function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
         bold: entry.headerBold ?? true,
         size: SIZE_HEADER,
         atomicSegments: entry.atomicSegments,
+        hangingIndent: entry.headerHangingIndent,
         // Flush-right date on the header line (#425) — set for a title-less role /
         // degree-less program, where the org/date anchor lives on the header.
         rightText: entry.headerLineDate,

--- a/src/lib/pdf/render-roundtrip.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip.repro.test.ts
@@ -85,17 +85,17 @@ describe("#284 — Download-PDF reconstructed résumé round-trips through the p
     expect(reExp.length).toBe(origExp.length);
   });
 
-  // SUSPENDED (#436): the one-line experience header ("Title · Company,
-  // Location  Dates") removes the two-line structural signal the parser used to
-  // tell title from company. #436 has TWO roots: the title↔company SWAP on
-  // neutral middot segments (fixed — the `middot` title-first default in
-  // `mapWithoutCompanyMatch`), and company TRUNCATION on a PARENTHETICAL company
-  // ("Danggeun Pay Inc. (KarrotPay)" → "(KarrotPay)"), which this dense 8-role
-  // fixture exercises and which is NOT the swap. The truncation root is still
-  // open; the role COUNT (AC#1) and the education round-trip (#291) below are
-  // unaffected and still enforced. Un-skip when the parenthetical-company
-  // truncation lands.
-  it.skip("re-parses each role's title / company back into the right fields (AC#3)", () => {
+  // #436 — the one-line experience header ("Title · Company, Location  Dates")
+  // removes the two-line structural signal the parser used to tell title from
+  // company. Both roots are now fixed: the title↔company SWAP on neutral middot
+  // segments (the `middot` title-first default in `mapWithoutCompanyMatch`), and
+  // company TRUNCATION on a PARENTHETICAL / multi-word company
+  // ("Danggeun Pay Inc. (KarrotPay)", "R.O.K Cyber Command, MND") — this dense
+  // 8-role fixture exercises the truncation, which wrapped the org tail onto the
+  // row below. The renderer now reserves the flush-right date column only when
+  // the header reaches it, and `tryFoldCompleteDateHeader` folds the wrapped tail
+  // back before disambiguation, so every role's title/company round-trips.
+  it("re-parses each role's title / company back into the right fields (AC#3)", () => {
     const origExp = original.canonical.fields.experience ?? [];
     const reExp = reparsed.canonical.fields.experience ?? [];
     origExp.forEach((orig, i) => {

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -134,7 +134,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -134,7 +134,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,


### PR DESCRIPTION
## Summary

Fixes the remaining (TRUNCATION) root of #436. A too-wide one-line export header (`Title · Company, Location · Team`, date flush-right) wrapped its org tail onto the row below, stranding or gluing the wrapped words to the date, so the company re-parsed truncated (`Danggeun Pay Inc. (KarrotPay)` → `(KarrotPay)`, `R.O.K Cyber Command, MND` → `MND`). Three coordinated parts:

- **render — collision-gated date-column reserve** (`render-ats-pdf.ts`): wrap at full width first, re-wrap reserving the flush-right date column only when the first line actually reaches it, so borderline headers that already fit are untouched (a blanket reserve regressed them).
- **render — hanging indent** on experience headers (`ats-resume-model.ts`): stamps a wrapped org tail as indented past the bullet-marker margin.
- **parse — fold the indented tail back** into the header before disambiguation (`tryFoldCompleteDateHeader` in `entry-blocks.ts`), gated on `isWrappedContinuation` (indented, *not* same-margin — so stacked #342/#466 second-line shapes are left alone) and a single-column section x-spread guard (so two-column sources are untouched).

Clears `awesome-cv-cv` / `awesome-cv-resume` from the corpus `KNOWN_FAILURES`, un-skips the AC#3 truncation assertion, and re-bakes those two corpus snapshots (only `experienceChangedAcrossRoundtrip` flips `true`→`false`). `honors-subheadings` stays baselined — a separate bullet-as-title root, not truncation.

Closes #436

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — full `src/lib/pdf` + `src/lib/heuristics` suites: 1330 pass / 0 fail
- [x] `npm run build` succeeds
- [x] `npm run check:fixtures` — 54 PDFs, all synthetic (no fixture binaries changed)
- [x] Corpus round-trip + edit-round-trip gates green; no new regressions

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: `npm run verify` — green in CI