### PR TITLE
feat(export): markdown cv.md round-trip — export + import (#552)

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -28,7 +28,7 @@ const FONTS_UNMAPPABLE_BLURB =
 const TWO_COLUMN_BLURB =
   "This resume uses a two-column layout. Text extractors often read the columns out of order — merging or interleaving them. The reconstructed text below is what a generic parser actually pulled out; if it looks scrambled, that's the ATS risk. A single-column layout parses most reliably.";
 
-type SourceKind = "pdf" | "docx";
+type SourceKind = "pdf" | "docx" | "markdown";
 
 interface ResultProps {
   result: CascadeResult;

--- a/src/components/features/EvidencePanel.tsx
+++ b/src/components/features/EvidencePanel.tsx
@@ -14,7 +14,7 @@
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import { PdfPreview } from "../PdfPreview.tsx";
 
-type SourceKind = "pdf" | "docx";
+type SourceKind = "pdf" | "docx" | "markdown";
 
 interface SourcePdfPanelProps {
   bytes?: ArrayBuffer;
@@ -31,7 +31,7 @@ export function SourcePdfPanel({ bytes, sourceKind }: SourcePdfPanelProps) {
   }
   return (
     <p className="text-sm text-content-muted">
-      No source preview available for DOCX — see the Extracted text view.
+      No source preview available for this file type — see the Extracted text view.
     </p>
   );
 }

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -101,6 +101,7 @@ import { SkillsSection } from "./ReconstructedSkills.tsx";
 import { Button, EditableField } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
+import { useDownloadMarkdown } from "../../hooks/useDownloadMarkdown.ts";
 import { ReportDownloadControl } from "./DownloadReportDialog.tsx";
 
 // ── Attention strip ────────────────────────────────────────────────────────────
@@ -1105,6 +1106,11 @@ export function ReconstructedResume({
   // so no PDF bytes ever leave the browser (#171).
   const { download, isGenerating } = useDownloadPdf(result, score, edit);
 
+  // Download the same reconstructed résumé as a career-ops-shaped `cv.md`
+  // (#552) — a plain-text sibling artifact, not a competing "primary" export.
+  const { download: downloadMarkdown, isGenerating: isGeneratingMarkdown } =
+    useDownloadMarkdown(result, score, edit);
+
   // Pre-download checklist popover (#312) — a soft guardrail, not a hard
   // block. Download click re-derives the gate from the CURRENT (override-
   // applied) fields every time, so an edit made via "Fix now" clears the item
@@ -1200,6 +1206,18 @@ export function ReconstructedResume({
           </h2>
           <div className="flex flex-wrap items-center gap-2">
             <ReportDownloadControl result={result} score={score} edit={edit} />
+            {/* No pre-download checklist gate here (unlike the PDF button):
+                cv.md is a plain-text interchange file, not an ATS-submitted
+                artifact, so the "missing name/contact/experience" nudge that
+                protects the PDF doesn't apply. */}
+            <Button
+              variant="ghost"
+              onClick={() => void downloadMarkdown()}
+              disabled={isGeneratingMarkdown}
+              aria-label="Download the reconstructed resume as a markdown file"
+            >
+              {isGeneratingMarkdown ? "Generating…" : "Download as Markdown"}
+            </Button>
             <Button
               variant="primary"
               onClick={handleDownloadClick}

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -13,7 +13,7 @@ import type { AnonymousAtsScore } from "../../lib/score/score.ts";
 import type { EditableParse } from "../../hooks/useEditableParse.ts";
 import type { AnalysisController } from "../../hooks/useResumeAnalysisLlm.ts";
 
-type SourceKind = "pdf" | "docx";
+type SourceKind = "pdf" | "docx" | "markdown";
 
 interface ResultDetailTabsProps {
   activeResult: CascadeResult;

--- a/src/components/features/SaveResumeBar.tsx
+++ b/src/components/features/SaveResumeBar.tsx
@@ -19,7 +19,7 @@ interface SaveResumeBarProps {
   library: ResumeLibrary;
   fileName: string;
   bytes?: ArrayBuffer;
-  sourceKind: "pdf" | "docx";
+  sourceKind: "pdf" | "docx" | "markdown";
   result: CascadeResult;
   score: AnonymousAtsScore;
 }

--- a/src/components/features/SourceDiagnosticsPanel.test.tsx
+++ b/src/components/features/SourceDiagnosticsPanel.test.tsx
@@ -79,7 +79,7 @@ describe("SourceDiagnosticsPanel", () => {
     expect(segment("PDF").getAttribute("aria-pressed")).toBe("true");
     expect(segment("Extracted text").getAttribute("aria-pressed")).toBe("false");
     // The docx no-preview fallback (PDF panel) is the visible body.
-    expect(container.textContent).toContain("No source preview available for DOCX");
+    expect(container.textContent).toContain("No source preview available for this file type");
   });
 
   it("shows the trigger count badge on the Layout flags segment", () => {
@@ -104,7 +104,7 @@ describe("SourceDiagnosticsPanel", () => {
   it("keeps all three panels mounted (hidden, not unmounted) across switches", () => {
     render();
     // PDF body present at first.
-    const pdfText = "No source preview available for DOCX";
+    const pdfText = "No source preview available for this file type";
     expect(container.textContent).toContain(pdfText);
     act(() => {
       segment("Layout flags").click();

--- a/src/components/features/SourceDiagnosticsPanel.tsx
+++ b/src/components/features/SourceDiagnosticsPanel.tsx
@@ -27,7 +27,7 @@ import { Button, CountBadge } from "@design-system";
 import { LayoutFlagsList } from "./LayoutFlagsList.tsx";
 import { SourcePdfPanel, ExtractedTextPanel } from "./EvidencePanel.tsx";
 
-type SourceKind = "pdf" | "docx";
+type SourceKind = "pdf" | "docx" | "markdown";
 type Segment = "pdf" | "extracted" | "flags";
 
 interface SourceDiagnosticsPanelProps {

--- a/src/hooks/useDownloadMarkdown.ts
+++ b/src/hooks/useDownloadMarkdown.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useDownloadMarkdown — drives the "Download as Markdown" action on the
+ * reconstructed-resume surface (#552), a sibling of `useDownloadPdf.ts`.
+ *
+ * Flow: build the flat ATS model from the surface's own props → lazily load
+ * the pure `toCareerOpsMarkdown` adapter → encode to UTF-8 bytes → trigger a
+ * same-document download. Everything is client-side; no network request is
+ * made, satisfying the zero-egress AC. `to-markdown.ts` is dynamic-imported so
+ * it stays out of the entry chunk, matching every other heavy/optional lane.
+ */
+
+import { useCallback, useState } from "react";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../lib/score/score.ts";
+import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
+import { slugifyName, triggerBlobDownload } from "../lib/download/blob-download.ts";
+import type { EditableParse } from "./useEditableParse.ts";
+import { trackDownloadCompleted, type DownloadSource } from "../lib/analytics.ts";
+
+export interface UseDownloadMarkdown {
+  download: () => Promise<void>;
+  isGenerating: boolean;
+  error: string | null;
+}
+
+/** Turn a candidate name into a safe, lower-kebab markdown filename. */
+function filenameFromName(name: string | undefined): string {
+  const slug = slugifyName(name);
+  return slug ? `${slug}-cv.md` : "cv.md";
+}
+
+export function useDownloadMarkdown(
+  result: CascadeResult,
+  score: AnonymousAtsScore,
+  edit?: Pick<EditableParse, "contactOverrides" | "bulletOverrides">,
+): UseDownloadMarkdown {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const download = useCallback(async () => {
+    setIsGenerating(true);
+    setError(null);
+    try {
+      const model = buildAtsResumeModel(result, score, edit);
+      const { toCareerOpsMarkdown } = await import("../lib/pdf/to-markdown.ts");
+      const bytes = new TextEncoder().encode(toCareerOpsMarkdown(model));
+      triggerBlobDownload(
+        bytes,
+        "text/markdown;charset=utf-8",
+        filenameFromName(model.contact.name),
+      );
+
+      // Same source-derivation as `useDownloadPdf.ts` (#313): `tiers` is empty
+      // ONLY for `buildBlankResult()`'s output.
+      const source: DownloadSource =
+        result.tiers.length === 0 ? "blank" : "upload";
+      trackDownloadCompleted({ source, format: "markdown" });
+      // Deliberately does NOT clear the blank draft (unlike `useDownloadPdf.ts`):
+      // markdown is a plain-text interchange artifact, not the final ATS export,
+      // so a user may download it mid-authoring and keep editing — wiping the
+      // durable from-scratch draft here would be a data-loss surprise.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not generate the markdown file.");
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [result, score, edit]);
+
+  return { download, isGenerating, error };
+}

--- a/src/hooks/useDownloadPdf.test.tsx
+++ b/src/hooks/useDownloadPdf.test.tsx
@@ -23,9 +23,10 @@ import type { CascadeResult } from "../lib/heuristics/types.ts";
 import { computeAnonymousAtsScore } from "../lib/score/score.ts";
 import { BLANK_DRAFT_STORAGE_KEY } from "./useResumeAnalysis.ts";
 
-const tracked: Array<{ source: string }> = [];
+const tracked: Array<{ source: string; format?: string }> = [];
 vi.mock("../lib/analytics.ts", () => ({
-  trackDownloadCompleted: (args: { source: string }) => tracked.push(args),
+  trackDownloadCompleted: (args: { source: string; format?: string }) =>
+    tracked.push(args),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -112,7 +113,7 @@ describe("useDownloadPdf — download-source tagging (#313)", () => {
       await api.download();
     });
 
-    expect(tracked).toEqual([{ source: "upload" }]);
+    expect(tracked).toEqual([{ source: "upload", format: "pdf" }]);
   });
 
   it("tags a blank/authored result's download as source: 'blank'", async () => {
@@ -121,7 +122,7 @@ describe("useDownloadPdf — download-source tagging (#313)", () => {
       await api.download();
     });
 
-    expect(tracked).toEqual([{ source: "blank" }]);
+    expect(tracked).toEqual([{ source: "blank", format: "pdf" }]);
   });
 
   it("clears the persisted blank draft on a successful blank-authored download", async () => {

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -62,7 +62,7 @@ export function useDownloadPdf(
       // extra prop through `ReconstructedResume` (out of scope here).
       const source: DownloadSource =
         result.tiers.length === 0 ? "blank" : "upload";
-      trackDownloadCompleted({ source });
+      trackDownloadCompleted({ source, format: "pdf" });
       // A successful blank-authored export is one of the explicit
       // draft-clearing triggers (#313) — the user has what they came for.
       if (source === "blank") clearBlankDraft();

--- a/src/hooks/useResumeAnalysis.ts
+++ b/src/hooks/useResumeAnalysis.ts
@@ -37,7 +37,7 @@ import { LEGACY_LINK_KEYS } from "../lib/contact/contact-profiles.ts";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-type SourceKind = "pdf" | "docx";
+type SourceKind = "pdf" | "docx" | "markdown";
 
 /**
  * The persisted from-scratch draft (#313) is exactly `useEditableParse`'s own
@@ -242,14 +242,30 @@ export function useResumeAnalysis(): ResumeAnalysis {
       file.type ===
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
       file.name.toLowerCase().endsWith(".docx");
+    // The import side of the `cv.md` round-trip (#552) — a dropped .md/.markdown
+    // file. Mirrors the DOCX branch below: no bytes stored, cascade runs
+    // straight off markdown (it already parses markdown natively).
+    const isMarkdownFile =
+      file.type === "text/markdown" || /\.(md|markdown)$/i.test(file.name);
 
     try {
-      const bytes = await file.arrayBuffer();
       let result: CascadeResult;
       let pdfBytes: ArrayBuffer | undefined;
 
-      if (isDocxFile) {
+      if (isMarkdownFile) {
+        // Markdown path — the file already IS markdown; no extraction step.
+        const text = await file.text();
+        const { parseMarkdownFile } = await import("../lib/ingest/markdown.ts");
+        const { rawText, markdown } = parseMarkdownFile(text);
+        result = await runCascadeFromMarkdown(rawText, markdown, {
+          userType: "anon",
+          onEvent: trackCascadeEvent,
+        });
+        // No source bytes to store — PdfPreview won't be shown (docx-shaped).
+        pdfBytes = undefined;
+      } else if (isDocxFile) {
         // DOCX path — extract markdown via mammoth+turndown, then cascade on it.
+        const bytes = await file.arrayBuffer();
         const { rawText, markdown } = await parseDocx(bytes);
         result = await runCascadeFromMarkdown(rawText, markdown, {
           userType: "anon",
@@ -260,6 +276,7 @@ export function useResumeAnalysis(): ResumeAnalysis {
       } else {
         // PDF path — pdfjs mutates the buffer it parses; hand it a copy so we
         // can re-render the source PDF in the side-by-side preview afterward.
+        const bytes = await file.arrayBuffer();
         result = await runCascade(bytes.slice(0), {
           userType: "anon",
           onEvent: trackCascadeEvent,
@@ -293,7 +310,7 @@ export function useResumeAnalysis(): ResumeAnalysis {
         fileName: file.name,
         fileSize: file.size,
         bytes: pdfBytes,
-        sourceKind: isDocxFile ? "docx" : "pdf",
+        sourceKind: isMarkdownFile ? "markdown" : isDocxFile ? "docx" : "pdf",
         result,
         score,
       });

--- a/src/hooks/useResumeLibrary.ts
+++ b/src/hooks/useResumeLibrary.ts
@@ -33,7 +33,7 @@ export interface SaveResumeParams {
   id?: string;
   filename: string;
   bytes?: ArrayBuffer;
-  sourceKind: "pdf" | "docx";
+  sourceKind: "pdf" | "docx" | "markdown";
   result: CascadeResult;
   score: AnonymousAtsScore;
 }

--- a/src/jd-fit/useJdFitResume.ts
+++ b/src/jd-fit/useJdFitResume.ts
@@ -43,7 +43,7 @@ export interface JdFitResume {
   parsed: HeuristicParsedResume;
   /** PDF bytes for the source pane — only the local path has them. */
   bytes?: ArrayBuffer;
-  sourceKind: "pdf" | "docx";
+  sourceKind: "pdf" | "docx" | "markdown";
   /** Live inline-edit state threaded into `<Result>`. */
   edit: EditableParse;
   /** Clear the résumé (handoff: back to DropZone; local: reset parse). */

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -521,10 +521,16 @@ export type DownloadSource = "blank" | "upload";
  * A reconstructed résumé was downloaded as a PDF. There was no prior
  * download-tracking event to extend (`useDownloadPdf.ts` didn't track at
  * all) — this is a new event, distinguishing blank-authored from uploaded
- * downloads via `source` per #313's requirement.
+ * downloads via `source` per #313's requirement. `format` (#552) distinguishes
+ * the ATS PDF from the plain-text `cv.md` markdown export sharing this event;
+ * it defaults to `"pdf"` so every existing call site (and every already-fired
+ * event) stays unchanged.
  */
-export function trackDownloadCompleted(args: { source: DownloadSource }): void {
-  track("download_completed", { source: args.source });
+export function trackDownloadCompleted(args: {
+  source: DownloadSource;
+  format?: "pdf" | "markdown";
+}): void {
+  track("download_completed", { source: args.source, format: args.format ?? "pdf" });
 }
 
 /** Which format the shareable audit report (#343) was exported in. */

--- a/src/lib/file-accept.ts
+++ b/src/lib/file-accept.ts
@@ -15,11 +15,11 @@ const DOCX_MIME =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
 /** Value for a file input's `accept` attribute. */
-export const RESUME_ACCEPT_ATTR = `application/pdf,.pdf,${DOCX_MIME},.docx`;
+export const RESUME_ACCEPT_ATTR = `application/pdf,.pdf,${DOCX_MIME},.docx,text/markdown,.md,.markdown`;
 
 /** User-facing hint shown when a rejected file is dropped. */
 export const RESUME_REJECT_HINT =
-  "That doesn't look like a PDF or DOCX. Please drop a .pdf or .docx file.";
+  "That doesn't look like a PDF, DOCX, or markdown file. Please drop a .pdf, .docx, or .md file.";
 
 function isPdf(f: File): boolean {
   return f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf");
@@ -29,8 +29,16 @@ function isDocx(f: File): boolean {
   return f.type === DOCX_MIME || f.name.toLowerCase().endsWith(".docx");
 }
 
+/** `.md`/`.markdown` (#552) — the import side of the `cv.md` round-trip. */
+function isMarkdown(f: File): boolean {
+  return (
+    f.type === "text/markdown" ||
+    /\.(md|markdown)$/i.test(f.name)
+  );
+}
+
 export function isAcceptedResumeFile(f: File): boolean {
-  return isPdf(f) || isDocx(f);
+  return isPdf(f) || isDocx(f) || isMarkdown(f);
 }
 
 /**

--- a/src/lib/ingest/markdown.test.ts
+++ b/src/lib/ingest/markdown.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit tests for the markdown ingest adapter (#552): `parseMarkdownFile`
+ * passes `markdown` through verbatim, and `mdToPlainText` strips heading,
+ * emphasis, list-bullet, and link syntax down to prose.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mdToPlainText, parseMarkdownFile } from "./markdown.ts";
+
+describe("parseMarkdownFile", () => {
+  it("carries the source text through as markdown verbatim", () => {
+    const text = "# Jane Doe\n\n- Shipped X\n";
+    expect(parseMarkdownFile(text).markdown).toBe(text);
+  });
+
+  it("derives rawText from the same source via mdToPlainText", () => {
+    const text = "# Jane Doe\n\n- Shipped X";
+    expect(parseMarkdownFile(text).rawText).toBe(mdToPlainText(text));
+  });
+});
+
+describe("mdToPlainText", () => {
+  it("strips a leading heading marker", () => {
+    expect(mdToPlainText("## Experience")).toBe("Experience");
+  });
+
+  it("strips leading list-bullet markers (-, *, +)", () => {
+    expect(mdToPlainText("- Shipped X")).toBe("Shipped X");
+    expect(mdToPlainText("* Shipped Y")).toBe("Shipped Y");
+    expect(mdToPlainText("+ Shipped Z")).toBe("Shipped Z");
+  });
+
+  it("strips bold and italic emphasis", () => {
+    expect(mdToPlainText("**Acme Corp**")).toBe("Acme Corp");
+    expect(mdToPlainText("*Senior Engineer*")).toBe("Senior Engineer");
+    expect(mdToPlainText("_Senior Engineer_")).toBe("Senior Engineer");
+  });
+
+  it("expands [text](url) links to 'text url', keeping both searchable", () => {
+    expect(mdToPlainText("[LinkedIn](https://linkedin.com/in/jane)")).toBe(
+      "LinkedIn https://linkedin.com/in/jane",
+    );
+  });
+
+  it("handles a multi-line document", () => {
+    const input = "# Jane Doe\n\n## Experience\n\n**Acme Corp**\n- Shipped X\n- Led Y";
+    const expected = "Jane Doe\n\nExperience\n\nAcme Corp\nShipped X\nLed Y";
+    expect(mdToPlainText(input)).toBe(expected);
+  });
+
+  it("preserves intraword underscores (snake_case, slugs) — not emphasis", () => {
+    expect(mdToPlainText("Built scikit_learn pipelines")).toBe(
+      "Built scikit_learn pipelines",
+    );
+    expect(mdToPlainText("owned answer_bank_ingestion path")).toBe(
+      "owned answer_bank_ingestion path",
+    );
+  });
+});

--- a/src/lib/ingest/markdown.ts
+++ b/src/lib/ingest/markdown.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Thin markdown → { rawText, markdown } adapter — the import side of the
+ * `cv.md` round-trip (#552), sibling to `ingest/docx.ts`.
+ *
+ * Unlike DOCX, a dropped `.md` file already IS markdown, so there is no
+ * extraction step: `markdown` is the file's text verbatim, and `rawText` is a
+ * light plaintext strip of it (headings/emphasis/bullets/link syntax) so the
+ * scorer's raw-text scans — which expect prose, not markdown syntax — see the
+ * same content DOCX's `extractRawText` would have produced. Pure, string-only,
+ * no I/O: the caller reads the File via `file.text()` before calling this.
+ */
+
+export interface MarkdownParseResult {
+  rawText: string;
+  markdown: string;
+}
+
+/**
+ * Strip common inline markdown syntax down to plaintext: leading heading `#`
+ * markers, `*`/`_` emphasis, leading list-bullet markers (`-`/`*`/`+`), and
+ * `[text](url)` links (→ `text url`, keeping both the label and the target
+ * searchable). Not a full markdown parser — just enough that the scorer's
+ * raw-text heuristics (which never expect markdown syntax) see prose.
+ *
+ * Underscore emphasis is stripped only at word boundaries, so intraword
+ * underscores (`snake_case_name`, an SDK symbol, a slug) survive verbatim —
+ * matching CommonMark, which disallows single-underscore emphasis mid-word.
+ * Asterisk emphasis has no intraword ambiguity and is stripped directly.
+ */
+export function mdToPlainText(text: string): string {
+  return text
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(/^\s{0,3}#{1,6}\s+/, "") // heading markers
+        .replace(/^\s*[-*+]\s+/, "") // list bullet markers
+        .replace(/\[([^\]]*)\]\(([^)]+)\)/g, "$1 $2") // [text](url) → text url
+        .replace(/\*\*(.+?)\*\*/g, "$1") // bold (asterisk)
+        .replace(/\*(.+?)\*/g, "$1") // italic (asterisk)
+        .replace(/(^|\W)__(\S(?:.*?\S)?)__(?=\W|$)/g, "$1$2") // bold (underscore, word-boundary)
+        .replace(/(^|\W)_(\S(?:.*?\S)?)_(?=\W|$)/g, "$1$2"), // italic (underscore, word-boundary)
+    )
+    .join("\n");
+}
+
+/**
+ * Parse a dropped `.md`/`.markdown` file's text into `{ rawText, markdown }`,
+ * the same shape `parseDocx` returns — `markdown` feeds `runCascadeFromMarkdown`
+ * unchanged (it already parses markdown), `rawText` feeds the scorer's plain-
+ * text scans.
+ */
+export function parseMarkdownFile(text: string): MarkdownParseResult {
+  return { rawText: mdToPlainText(text), markdown: text };
+}

--- a/src/lib/pdf/to-markdown-roundtrip.test.ts
+++ b/src/lib/pdf/to-markdown-roundtrip.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Round-trip test for the markdown export ↔ import pair (#552): a model
+ * exported via `toCareerOpsMarkdown` and dropped back in must re-parse to the
+ * same load-bearing fields. Mirrors the exact app path a user takes —
+ * `toCareerOpsMarkdown` → `parseMarkdownFile` → `runCascadeFromMarkdown` —
+ * so the two halves are pinned as a pair, not just unit-tested in isolation.
+ *
+ * This is the markdown analogue of the PDF `corpus-roundtrip` invariant, scoped
+ * to the fields the freeform career-ops shape can carry (name, email,
+ * experience org/title, education, skills) — NOT byte-exact fidelity, which the
+ * freeform target never promised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toCareerOpsMarkdown } from "./to-markdown.ts";
+import { parseMarkdownFile } from "../ingest/markdown.ts";
+import { runCascadeFromMarkdown } from "../heuristics/cascade.ts";
+import type { AtsResumeModel } from "./ats-resume-model.ts";
+
+const MODEL: AtsResumeModel = {
+  contact: {
+    name: "Jane Q. Candidate",
+    email: "jane.candidate@example.com",
+    phone: "(415) 555-0123",
+    location: "San Francisco, CA",
+    links: [],
+    profiles: [
+      {
+        url: "https://linkedin.com/in/janecandidate",
+        network: "LinkedIn",
+        kind: "social",
+        legacyKey: "linkedin_url",
+      },
+    ],
+  },
+  summary: "A pragmatic engineer who ships.",
+  summaryHeading: "Summary",
+  sections: [
+    {
+      heading: "Experience",
+      kind: "experience",
+      entries: [
+        {
+          headerLine: "Senior Software Engineer",
+          bullets: [
+            "Led migration of the payments service, cutting P95 latency by 40%.",
+            "Mentored four engineers and owned the weekly design-review cadence.",
+          ],
+          fields: {
+            organization: "Acme Corp",
+            position: "Senior Software Engineer",
+            startDate: "2022",
+            isCurrent: true,
+          },
+        },
+        {
+          headerLine: "Software Engineer",
+          bullets: ["Shipped v2 of the analytics pipeline handling 1B events/day."],
+          fields: {
+            organization: "Globex Inc",
+            position: "Software Engineer",
+            startDate: "2019",
+            endDate: "2021",
+          },
+        },
+      ],
+    },
+    {
+      heading: "Education",
+      kind: "education",
+      entries: [
+        {
+          headerLine: "B.S., Computer Science",
+          bullets: [],
+          fields: {
+            organization: "State University",
+            studyType: "B.S.",
+            area: "Computer Science",
+            endDate: "2019",
+          },
+        },
+      ],
+    },
+    {
+      heading: "Skills",
+      kind: "skills",
+      entries: [
+        {
+          headerLine: "Languages",
+          bullets: [],
+          fields: {
+            skillCategory: "Languages",
+            skills: ["TypeScript", "Kotlin", "Go", "Postgres"],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe("toCareerOpsMarkdown ↔ parseMarkdownFile round-trip", () => {
+  it("re-parses to the same load-bearing fields via the real import path", async () => {
+    const md = toCareerOpsMarkdown(MODEL);
+    const { rawText, markdown } = parseMarkdownFile(md);
+    const result = await runCascadeFromMarkdown(rawText, markdown);
+
+    expect(result.canonical.fields.full_name).toBe("Jane Q. Candidate");
+    expect(result.canonical.fields.email).toBe("jane.candidate@example.com");
+
+    // Both experience entries survive with their organizations recovered.
+    expect(result.canonical.fields.experience.length).toBeGreaterThanOrEqual(2);
+    const orgs = result.canonical.fields.experience
+      .map((e) => e.company ?? "")
+      .join(" | ");
+    expect(orgs).toMatch(/Acme/);
+    expect(orgs).toMatch(/Globex/);
+
+    // Education and skills carry across.
+    expect(result.canonical.fields.education.length).toBeGreaterThanOrEqual(1);
+    expect(result.canonical.fields.skills.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/lib/pdf/to-markdown.test.ts
+++ b/src/lib/pdf/to-markdown.test.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit tests for the pure `toCareerOpsMarkdown` adapter (#552): contact line,
+ * summary, experience (incl. `isCurrent`), projects, education, categorised
+ * and flat skills, achievements, empty-section omission, and the
+ * never-fabricate-a-date contract.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toCareerOpsMarkdown } from "./to-markdown.ts";
+import type { AtsResumeModel } from "./ats-resume-model.ts";
+
+// A structurally complete model covering every mapped section kind.
+const FULL_MODEL: AtsResumeModel = {
+  contact: {
+    name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    location: "Chicago, IL",
+    links: ["linkedin.com/in/jane"],
+    profiles: [
+      {
+        url: "https://linkedin.com/in/jane",
+        network: "LinkedIn",
+        kind: "social",
+        legacyKey: "linkedin_url",
+      },
+      {
+        url: "https://github.com/JaneC",
+        network: "GitHub",
+        kind: "code",
+        legacyKey: "github_url",
+      },
+      {
+        url: "https://jane.dev",
+        network: "jane.dev",
+        kind: "other",
+        legacyKey: "website_url",
+      },
+    ],
+  },
+  summary: "A pragmatic engineer who ships.",
+  summaryHeading: "Summary",
+  sections: [
+    {
+      heading: "Experience",
+      kind: "experience",
+      entries: [
+        {
+          headerLine: "Senior Engineer",
+          bullets: ["Shipped X", "Led Y"],
+          fields: {
+            organization: "Acme Corp",
+            position: "Senior Engineer",
+            startDate: "2020",
+            endDate: "2022",
+          },
+        },
+        {
+          headerLine: "Engineer",
+          bullets: [],
+          fields: {
+            organization: "Startup Inc",
+            position: "Engineer",
+            startDate: "2022",
+            isCurrent: true,
+            endDate: "2099", // must be dropped because isCurrent
+          },
+        },
+      ],
+    },
+    {
+      heading: "Education",
+      kind: "education",
+      entries: [
+        {
+          headerLine: "B.S., Computer Science",
+          bullets: [],
+          fields: {
+            organization: "State University",
+            studyType: "B.S.",
+            area: "Computer Science",
+            endDate: "2019",
+          },
+        },
+      ],
+    },
+    {
+      heading: "Skills",
+      kind: "skills",
+      entries: [
+        {
+          headerLine: "Languages: TypeScript · Python",
+          bullets: [],
+          fields: { skillCategory: "Languages", skills: ["TypeScript", "Python"] },
+        },
+      ],
+    },
+    {
+      heading: "Achievements",
+      kind: "achievements",
+      entries: [
+        {
+          headerLine: "Employee of the year",
+          bullets: [],
+          fields: { title: "Employee of the year" },
+        },
+      ],
+    },
+  ],
+};
+
+describe("toCareerOpsMarkdown — header + contact", () => {
+  const md = toCareerOpsMarkdown(FULL_MODEL);
+
+  it("opens with the name heading", () => {
+    expect(md).toMatch(/^# Jane Candidate\n/);
+  });
+
+  it("emits a middot-joined contact line in order: location · email · linkedin · portfolio/website · github", () => {
+    expect(md).toContain(
+      "Chicago, IL · jane@example.com · https://linkedin.com/in/jane · https://jane.dev · https://github.com/JaneC",
+    );
+  });
+});
+
+describe("toCareerOpsMarkdown — summary", () => {
+  it("emits the summary paragraph under ## Summary", () => {
+    const md = toCareerOpsMarkdown(FULL_MODEL);
+    expect(md).toContain("## Summary\n\nA pragmatic engineer who ships.");
+  });
+});
+
+describe("toCareerOpsMarkdown — experience", () => {
+  const md = toCareerOpsMarkdown(FULL_MODEL);
+
+  it("emits company, title, date range, and bullets", () => {
+    expect(md).toContain(
+      "**Acme Corp**\n**Senior Engineer**\n2020-2022\n- Shipped X\n- Led Y",
+    );
+  });
+
+  it("emits Present (not the placeholder endDate) for an isCurrent role", () => {
+    expect(md).toContain("**Startup Inc**\n**Engineer**\n2022-Present");
+    expect(md).not.toContain("2099");
+  });
+});
+
+describe("toCareerOpsMarkdown — education", () => {
+  it("emits studyType, area, organization, and year", () => {
+    const md = toCareerOpsMarkdown(FULL_MODEL);
+    expect(md).toContain("**B.S., Computer Science — State University** (2019)");
+  });
+});
+
+describe("toCareerOpsMarkdown — skills", () => {
+  it("emits a categorised entry as a labeled line", () => {
+    const md = toCareerOpsMarkdown(FULL_MODEL);
+    expect(md).toContain("**Languages:** TypeScript, Python");
+  });
+
+  it("emits a flat (uncategorised) entry as a bare comma-joined line", () => {
+    const flatModel: AtsResumeModel = {
+      ...FULL_MODEL,
+      sections: [
+        {
+          heading: "Skills",
+          kind: "skills",
+          entries: [
+            {
+              headerLine: "TypeScript · React",
+              bullets: [],
+              fields: { skills: ["TypeScript", "React"] },
+            },
+          ],
+        },
+      ],
+    };
+    const md = toCareerOpsMarkdown(flatModel);
+    expect(md).toContain("## Skills\n\nTypeScript, React");
+    expect(md).not.toContain("**TypeScript");
+  });
+});
+
+describe("toCareerOpsMarkdown — achievements", () => {
+  it("maps fields.title to a bullet under ## Achievements", () => {
+    const md = toCareerOpsMarkdown(FULL_MODEL);
+    expect(md).toContain("## Achievements\n\n- Employee of the year");
+  });
+});
+
+describe("toCareerOpsMarkdown — empty sections omitted", () => {
+  it("omits ## Projects entirely when there are none", () => {
+    const md = toCareerOpsMarkdown(FULL_MODEL);
+    expect(md).not.toContain("## Projects");
+  });
+
+  it("omits ## Summary when the model has no summary", () => {
+    const md = toCareerOpsMarkdown({ ...FULL_MODEL, summary: undefined });
+    expect(md).not.toContain("## Summary");
+  });
+
+  it("omits every section on a bare contact-only model", () => {
+    const bare: AtsResumeModel = {
+      contact: { name: "Bare Candidate", links: [] },
+      sections: [],
+    };
+    const md = toCareerOpsMarkdown(bare);
+    expect(md).toBe("# Bare Candidate\n");
+  });
+});
+
+describe("toCareerOpsMarkdown — escapes inline metacharacters in prose fields", () => {
+  it("backslash-escapes *, _, backtick so a value can't break the emphasis", () => {
+    const model: AtsResumeModel = {
+      contact: { name: "Jane", links: [] },
+      sections: [
+        {
+          heading: "Experience",
+          kind: "experience",
+          entries: [
+            {
+              headerLine: "Senior **Staff** Eng",
+              bullets: ["Owned the `answer_bank` ingestion path"],
+              fields: {
+                organization: "Acme_Corp",
+                position: "Senior **Staff** Eng",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const md = toCareerOpsMarkdown(model);
+    expect(md).toContain("**Acme\\_Corp**");
+    expect(md).toContain("**Senior \\*\\*Staff\\*\\* Eng**");
+    expect(md).toContain("- Owned the \\`answer\\_bank\\` ingestion path");
+  });
+
+  it("leaves the contact line (URLs) unescaped so links round-trip byte-for-byte", () => {
+    const model: AtsResumeModel = {
+      contact: {
+        name: "Jane",
+        links: [],
+        profiles: [
+          {
+            url: "https://linkedin.com/in/jane_candidate",
+            network: "LinkedIn",
+            kind: "social",
+            legacyKey: "linkedin_url",
+          },
+        ],
+      },
+      sections: [],
+    };
+    const md = toCareerOpsMarkdown(model);
+    expect(md).toContain("https://linkedin.com/in/jane_candidate");
+    expect(md).not.toContain("jane\\_candidate");
+  });
+});
+
+describe("toCareerOpsMarkdown — never fabricates a date", () => {
+  it("keeps an unparseable free-form date raw, not guessed", () => {
+    const model: AtsResumeModel = {
+      contact: { name: "Jane", links: [] },
+      sections: [
+        {
+          heading: "Experience",
+          kind: "experience",
+          entries: [
+            {
+              headerLine: "Contractor",
+              bullets: [],
+              fields: { organization: "Freelance", startDate: "Summer 2021" },
+            },
+          ],
+        },
+      ],
+    };
+    const md = toCareerOpsMarkdown(model);
+    expect(md).toContain("Summer 2021");
+  });
+
+  it("omits the date line entirely when the entry carries no date", () => {
+    const model: AtsResumeModel = {
+      contact: { name: "Jane", links: [] },
+      sections: [
+        {
+          heading: "Experience",
+          kind: "experience",
+          entries: [
+            {
+              headerLine: "Contractor",
+              bullets: [],
+              fields: { organization: "Freelance" },
+            },
+          ],
+        },
+      ],
+    };
+    const md = toCareerOpsMarkdown(model);
+    expect(md).toContain("**Freelance**\n");
+    expect(md).not.toMatch(/\d{4}/);
+  });
+});

--- a/src/lib/pdf/to-markdown.ts
+++ b/src/lib/pdf/to-markdown.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * to-markdown — a PURE adapter from the exporter's `AtsResumeModel` to a
+ * freeform `cv.md` string, following the section conventions of
+ * [santifer/career-ops](https://github.com/santifer/career-ops)'s
+ * `examples/cv-example.md` (#552). career-ops reads a project-root `cv.md` to
+ * evaluate job fit and generate keyword-injected ATS PDFs; this is what makes
+ * offlinecv's cleaned/edited résumé feed straight into it. career-ops is a
+ * downstream CONSUMER, not a dependency — this module knows nothing about it
+ * beyond the section shape it targets.
+ *
+ * Design contract (mirrors `to-json-resume.ts`):
+ *   - NO `pdf-lib` import, NO I/O — a plain `(model) => string` function,
+ *     unit-testable in isolation.
+ *   - Reads the STRUCTURED source via {@link AtsExportProjection}
+ *     (`projectAtsExport`, #442) — the export-semantic view of the model
+ *     (`entry.kind`, `entry.fields`, `contact.profiles`) — never the render
+ *     model's layout fields (`headerLine`/`subLine`) and never `result.rawText`.
+ *   - **Never fabricates a date.** A four-digit-year-shaped raw date is
+ *     trimmed to its year; anything else (free-form, "Present", empty) passes
+ *     through unchanged or is omitted — never guessed.
+ *   - **Empty sections are omitted** — no bare `## Heading` with nothing under
+ *     it.
+ *
+ * `AtsEntryFields` (the export-semantic source, see `ats-resume-model.ts`)
+ * carries no per-entry LOCATION for experience/project entries — only the
+ * render layout's `subLine` glues location into a display string, and this
+ * module is contractually forbidden from reading that. So unlike the
+ * `**Company — Location**` shape in career-ops's own example file, the
+ * emitted experience/project header is `**Company**` alone; inventing a
+ * location by re-parsing `subLine` would violate the no-layout-fields
+ * contract this module shares with `to-json-resume.ts`.
+ */
+
+import type {
+  AtsResumeModel,
+  AtsContact,
+  AtsEntryFields,
+} from "./ats-resume-model.ts";
+import { projectAtsExport } from "./ats-export-projection.ts";
+import type { AtsExportEntry } from "./ats-export-projection.ts";
+import type { LegacyLinkKey, ProfileLink } from "../score/types.ts";
+
+// ── inline escaping ─────────────────────────────────────────────────────────
+
+/**
+ * Backslash-escape inline markdown emphasis/code metacharacters (`*`, `_`,
+ * backtick) in a raw résumé value, so a value that literally contains one
+ * (e.g. a position "Senior **Staff** Eng", a bullet with a `code_span`) can't
+ * break the emitted `**bold**`/bullet emphasis. Applied ONLY to prose/label
+ * fields — never to the contact line, whose URLs legitimately carry `_`/`~`
+ * and must round-trip byte-for-byte.
+ */
+function escapeInline(value: string): string {
+  return value.replace(/([*_`])/g, "\\$1");
+}
+
+// ── date helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort trim a raw date string to its year. An ISO-shaped
+ * `YYYY`/`YYYY-MM`/`YYYY-MM-DD` collapses to `YYYY`; anything else (free-form,
+ * "Summer 2022", …) is returned unchanged — never fabricated.
+ * `undefined`/empty in ⇒ `undefined` out.
+ */
+function toYearOrRaw(raw: string | undefined): string | undefined {
+  const s = raw?.trim();
+  if (!s) return undefined;
+  const iso = s.match(/^(\d{4})(-\d{2}(-\d{2})?)?$/);
+  return iso ? iso[1] : s;
+}
+
+/**
+ * `YYYY-YYYY` (or `YYYY-Present` when `isCurrent`) date-line for an entry
+ * header, per the career-ops convention. `undefined` when the entry carries
+ * no date at all.
+ */
+function formatDateLine(fields: AtsEntryFields): string | undefined {
+  const start = toYearOrRaw(fields.startDate);
+  const end = fields.isCurrent ? "Present" : toYearOrRaw(fields.endDate);
+  if (start && end) return `${start}-${end}`;
+  return start ?? end;
+}
+
+// ── contact line ────────────────────────────────────────────────────────────
+
+/** First profile matching one of `keys`, by its legacy slot (#427) — the same
+ *  identity `to-json-resume.ts`'s `basicsFromContact` reads off `profiles`. */
+function profileUrlFor(
+  profiles: readonly ProfileLink[],
+  keys: readonly LegacyLinkKey[],
+): string | undefined {
+  for (const key of keys) {
+    const hit = profiles.find((p) => p.legacyKey === key);
+    if (hit) return hit.url;
+  }
+  return undefined;
+}
+
+/**
+ * `<Location> · <Email> · <linkedin> · <portfolio/website> · <github>` — any
+ * absent field is dropped, never an empty `·` slot. `undefined` when nothing
+ * is present (the caller omits the line entirely).
+ */
+function formatContactLine(contact: AtsContact): string | undefined {
+  const profiles = contact.profiles ?? [];
+  const parts = [
+    contact.location,
+    contact.email,
+    profileUrlFor(profiles, ["linkedin_url"]),
+    profileUrlFor(profiles, ["portfolio_url", "website_url"]),
+    profileUrlFor(profiles, ["github_url"]),
+  ].filter((p): p is string => Boolean(p && p.trim()));
+  return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
+// ── section renderers ───────────────────────────────────────────────────────
+
+function renderExperience(entry: AtsExportEntry): string | undefined {
+  const f = entry.fields;
+  if (!f) return undefined;
+  if (!f.organization && !f.position) return undefined;
+  const lines: string[] = [];
+  if (f.organization) lines.push(`**${escapeInline(f.organization)}**`);
+  if (f.position) lines.push(`**${escapeInline(f.position)}**`);
+  const dateLine = formatDateLine(f);
+  if (dateLine) lines.push(dateLine);
+  for (const bullet of entry.bullets) lines.push(`- ${escapeInline(bullet)}`);
+  return lines.join("\n");
+}
+
+function renderProject(entry: AtsExportEntry): string | undefined {
+  const f = entry.fields;
+  if (!f || !f.organization) return undefined;
+  const lines: string[] = [`**${escapeInline(f.organization)}**`];
+  for (const bullet of entry.bullets) lines.push(`- ${escapeInline(bullet)}`);
+  return lines.join("\n");
+}
+
+/** `**<studyType>, <area> — <organization>** (<YYYY>)` — any missing piece is
+ *  dropped from its slot rather than leaving a stray separator. */
+function renderEducation(entry: AtsExportEntry): string | undefined {
+  const f = entry.fields;
+  if (!f) return undefined;
+  if (!f.organization && !f.studyType && !f.area) return undefined;
+  const degree = [f.studyType, f.area].filter((p): p is string => Boolean(p)).join(", ");
+  const header = [degree, f.organization].filter((p): p is string => Boolean(p)).join(" — ");
+  const year = toYearOrRaw(f.endDate) ?? toYearOrRaw(f.startDate);
+  return `**${escapeInline(header)}**${year ? ` (${year})` : ""}`;
+}
+
+/** Categorised entry (#473) → `**<category>:** a, b, c`; a flat entry → one
+ *  comma-joined line with no label. */
+function renderSkillsEntry(entry: AtsExportEntry): string | undefined {
+  const f = entry.fields;
+  const skills = f?.skills ?? [];
+  if (skills.length === 0) return undefined;
+  const joined = skills.map(escapeInline).join(", ");
+  return f?.skillCategory ? `**${escapeInline(f.skillCategory)}:** ${joined}` : joined;
+}
+
+function renderAchievement(entry: AtsExportEntry): string | undefined {
+  return entry.fields?.title ? `- ${escapeInline(entry.fields.title)}` : undefined;
+}
+
+/** Render a `## Heading` section from `blocks`, or `undefined` (section
+ *  omitted entirely) when every block came back empty. */
+function renderSection(heading: string, blocks: readonly (string | undefined)[]): string | undefined {
+  const rendered = blocks.filter((b): b is string => Boolean(b));
+  if (rendered.length === 0) return undefined;
+  return `## ${heading}\n\n${rendered.join("\n\n")}`;
+}
+
+// ── Adapter ─────────────────────────────────────────────────────────────────
+
+/**
+ * Map an {@link AtsResumeModel} to a career-ops-shaped `cv.md` string. Pure —
+ * no I/O, no pdf-lib. Drives entirely off {@link projectAtsExport} for the
+ * section entries; `summary` is read straight off the model (it has no
+ * per-section entry of its own). Section order: Summary, Experience,
+ * Projects, Education, Skills, Achievements — an empty section is omitted.
+ */
+export function toCareerOpsMarkdown(model: AtsResumeModel): string {
+  const projection = projectAtsExport(model);
+  const doc: string[] = [];
+
+  const name = model.contact.name?.trim();
+  if (name) doc.push(`# ${name}`);
+
+  const contactLine = formatContactLine(projection.contact);
+  if (contactLine) doc.push(contactLine);
+
+  const summaryRaw = model.summary?.trim();
+  const summary = summaryRaw ? escapeInline(summaryRaw) : undefined;
+  const summarySection = renderSection("Summary", [summary]);
+  if (summarySection) doc.push(summarySection);
+
+  const experience: (string | undefined)[] = [];
+  const projects: (string | undefined)[] = [];
+  const education: (string | undefined)[] = [];
+  const skills: (string | undefined)[] = [];
+  const achievements: (string | undefined)[] = [];
+
+  for (const entry of projection.entries) {
+    switch (entry.kind) {
+      case "experience":
+        experience.push(renderExperience(entry));
+        break;
+      case "projects":
+        projects.push(renderProject(entry));
+        break;
+      case "education":
+        education.push(renderEducation(entry));
+        break;
+      case "skills":
+        skills.push(renderSkillsEntry(entry));
+        break;
+      case "achievements":
+        achievements.push(renderAchievement(entry));
+        break;
+      default:
+        break;
+    }
+  }
+
+  const experienceSection = renderSection("Experience", experience);
+  if (experienceSection) doc.push(experienceSection);
+  const projectsSection = renderSection("Projects", projects);
+  if (projectsSection) doc.push(projectsSection);
+  const educationSection = renderSection("Education", education);
+  if (educationSection) doc.push(educationSection);
+  const skillsSection = renderSection("Skills", skills);
+  if (skillsSection) doc.push(skillsSection);
+  const achievementsSection = renderSection("Achievements", achievements);
+  if (achievementsSection) doc.push(achievementsSection);
+
+  return doc.join("\n\n") + "\n";
+}

--- a/src/lib/resume-library.ts
+++ b/src/lib/resume-library.ts
@@ -31,11 +31,12 @@ import {
   type AnonymousAtsScore,
 } from "./score/score.ts";
 
-type SourceKind = "pdf" | "docx";
+type SourceKind = "pdf" | "docx" | "markdown";
 
 const MIME: Record<SourceKind, string> = {
   pdf: "application/pdf",
   docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  markdown: "text/markdown",
 };
 
 /**


### PR DESCRIPTION
## What & why

Closes #552. Adds a **markdown `cv.md` round-trip** to the parser-audit lane — both halves:

- **Export** — a "Download as Markdown" action beside Download PDF that emits a [santifer/career-ops](https://github.com/santifer/career-ops)-conventional `cv.md` (header + contact line, `## Summary`, `## Experience` with `**Company**` / `**Title**` / date line / bullets, `## Projects`, `## Education`, `## Skills`, `## Achievements`). This lets offlinecv's cleaned/edited résumé feed straight into career-ops (or any markdown-consuming tool) instead of being retyped.
- **Import** — dropping a `.md`/`.markdown` file parses it back into the résumé model through the existing markdown cascade, the round-trip opposite of the export.

## Design

- **`src/lib/pdf/to-markdown.ts`** — pure `toCareerOpsMarkdown(model): string`, mirroring `to-json-resume.ts`. Reads via `projectAtsExport` (the export-semantic view) — never the render layout fields (`headerLine`/`subLine`), never `rawText`. Never fabricates a date (`isCurrent` → `Present`; raw strings pass through). Omits empty sections. Backslash-escapes inline emphasis/code metacharacters in prose fields; the contact line (URLs) is left intact so links round-trip byte-for-byte. Lazy-loaded (own chunk).
- **`src/hooks/useDownloadMarkdown.ts`** — mirrors `useDownloadPdf`. Unlike the PDF path it deliberately does **not** clear the blank draft — markdown is an interchange artifact a user may download mid-authoring.
- **`src/lib/ingest/markdown.ts`** — `parseMarkdownFile(text) → { rawText, markdown }`, docx-shaped so it feeds `runCascadeFromMarkdown` unchanged. `mdToPlainText` strips markdown syntax for the scorer's raw-text scan while preserving intraword underscores (`snake_case`, slugs) per CommonMark.
- **`SourceKind`** widened `"pdf" | "docx" | "markdown"` across its consumers; a markdown source is docx-shaped downstream (no bytes, no source preview).
- **Analytics** — `trackDownloadCompleted` gained `format?: "pdf" | "markdown"` (default `"pdf"`, existing events unchanged).

### Deviation from career-ops's example

The experience/project header emits `**Company**` alone, not `**Company — Location**`: `AtsEntryFields` (the export-semantic source) carries no per-entry location — only the render layout's `subLine` glues it into a display string, and reading that would break the no-layout-fields contract this module shares with `to-json-resume.ts`. Documented in the module docblock.

## Invariants

- **Zero egress** — the export is a client-side file download; the résumé text never leaves the browser. No new `fetch(`.
- **Round-trip** — `to-markdown-roundtrip.test.ts` pins export → `parseMarkdownFile` → `runCascadeFromMarkdown` recovering name, email, experience (both orgs), education, and skills through the real app path.
- **Reuse** — extends the existing Download surface (no new panel); reuses the `@design-system` `Button` and `triggerBlobDownload`.

## Validation

`npm run verify` green (typecheck → lint → coverage → build; fallow report-only). Full `vitest` suite passes; the only fallow findings on the diff are pre-existing debt (`ReconstructedResume`, `analytics`) plus the deliberate `useDownloadMarkdown`↔`useDownloadPdf` clone (issue said "mirror `useDownloadPdf`", same house pattern as the per-vendor job-search adapters).

## Adversarial review

An independent reviewer pass found **no Blocking defects** — zero-egress holds, `to-markdown.ts` is pure, `SourceKind` widening is exhaustive, hook dep arrays are correct. Six Secondary/Nit findings surfaced; all were addressed in this branch:

1. Markdown download no longer wipes the blank from-scratch draft (was copied from the PDF path).
2. No-source-preview copy is now file-type-generic (was hardcoded "for DOCX", mislabeling a markdown source).
3. A nameless model no longer emits a stray empty `# ` heading.
4. Prose field values are inline-escaped so a value containing `**`/`_`/backtick can't break the emitted emphasis.
5. `mdToPlainText` preserves intraword underscores (`snake_case`) instead of stripping them as emphasis.
6. Added the export↔import round-trip test (the gap for a feature named "round-trip").

## Provenance

Implemented with Claude Code (Opus 4.8). Execution ran on a Sonnet sub-agent; the adversarial review + nit fixes ran on Opus.
