### PR TITLE
fix(parser): split experience title off a tight-right pipe header (#554)

### DIFF
--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -510,7 +510,13 @@ function stripLeadingSectionHeaders(
 function splitHeaderSegments(filtered: string[]): Split[] {
   const splits: Split[] = [];
   filtered.forEach((h, idx) => {
-    const atSplit = h.split(/\s+@\s+|\s+—\s+|\s+\|\s+|\s+·\s+/);
+    // The pipe accepts whitespace on AT LEAST ONE side (`\s+\|\s*` or
+    // `\s*\|\s+`), not both — a tight-right header "Company, Location |Title"
+    // (space before the pipe, none after) must still cleave the title off
+    // (#554). A zero-width `A|B` with no surrounding whitespace stays unsplit
+    // so a URL / table residue is never split. `@`/`—`/`·` keep the stricter
+    // both-sides rule (an email `a@b` must not split).
+    const atSplit = h.split(/\s+@\s+|\s+—\s+|\s+\|\s*|\s*\|\s+|\s+·\s+/);
     if (atSplit.length > 1) {
       // A PURE-middot line ("Title · Company · Team") — the exporter's one-line
       // shape (#436). Excludes a line that also carries `@`/`—`/`|`, which follow

--- a/src/lib/heuristics/extract/experience.tight-pipe-title.test.ts
+++ b/src/lib/heuristics/extract/experience.tight-pipe-title.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression for #554 — a "Company, Location |Title" header whose pipe is tight
+ * against the title (space BEFORE the pipe, none after) dropped the title:
+ *
+ *   Globex AI Labs LLC ,CA, USA |Intern    Jul 2025 - Present
+ *
+ * The delimiter split in `splitHeaderSegments` required whitespace on BOTH
+ * sides of the pipe (`\s+\|\s+`), so `USA |Intern` never cleaved — the whole
+ * run collapsed into `company` and `title` came back empty. The split now
+ * accepts whitespace on at least one side, while a zero-width `A|B` (no
+ * surrounding whitespace) still stays unsplit.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return extractExperience(experience).value;
+}
+
+describe("tight-right pipe 'Company, Location |Title' (#554)", () => {
+  it("cleaves the title off a pipe with no trailing space", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      // The issue's header verbatim, internal comma run and all.
+      {
+        text: "Globex AI Labs LLC ,CA, USA |Intern Jul 2025 - Present",
+        fontSize: 11,
+      },
+      { text: "• Built a secure transcription pipeline.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    const role = roles[0];
+    // #554 is the title/company split: the tail after the tight pipe must land
+    // in `title`, and `company` must no longer carry the "|Intern" run.
+    expect(role.title).toBe("Intern");
+    expect(role.company).toContain("Globex AI Labs LLC");
+    expect(role.company).not.toContain("|");
+    expect(role.company).not.toContain("Intern");
+    // The widened split must not eat the trailing location off the comma run.
+    expect(role.location).toBe("USA");
+  });
+
+  it("does NOT split a zero-width 'A|B' with no surrounding whitespace", () => {
+    const roles = roleFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Acme|Beta Systems Jan 2020 - Dec 2021", fontSize: 11 },
+      { text: "• Shipped the platform.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toContain("Acme|Beta Systems");
+    expect(roles[0].title ?? "").toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

An experience header of the shape `Company, Location |Title` — where the pipe hugs the title (space before the pipe, none after) — dropped the title: the delimiter split in `splitHeaderSegments` required whitespace on **both** sides of the pipe (`\s+\|\s+`), so `USA |Intern` never cleaved and the whole run collapsed into `company` with an empty `title`. The split now fires when whitespace is present on **at least one** side, while a zero-width `A|B` with no surrounding whitespace stays unsplit (URL / table residue never breaks). `@`/`—`/`·` keep the stricter both-sides rule.

Closes #554

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run src/lib/heuristics/` green (1067 passed) — incl. new `experience.tight-pipe-title.test.ts` and unchanged `experience.pipe-location`/`mid-dot`/`location`/`role-comma`/`title-team-comma`
- [x] Verified against the reporting résumé: the affected role now parses `title = "Intern"`

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Review revisions via: Claude Opus 5 (1M context)
Verification: `npm run verify` — CI (local pre-push hook is broken under Windows cmd; typecheck + full heuristics suite run manually, green)
