### PR TITLE
fix(parser): recover an education date from a coursework-line tail (#555)

### DIFF
--- a/src/lib/heuristics/extract/education.coursework-tail-date.test.ts
+++ b/src/lib/heuristics/extract/education.coursework-tail-date.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression for #555 — an education entry's attendance date is dropped when
+ * the date range sits at the TAIL of a coursework line rather than on the
+ * degree/institution line:
+ *
+ *   Master of Science Information Technology, Northwind University
+ *   Coursework: Advanced Databases, Data Analytics, Data Mining. Aug 2023 – May 2025
+ *
+ * `filterAnnotationLinesForDates` used to drop the whole coursework line before
+ * date parsing (it matches the "coursework" annotation keyword and carries no
+ * degree token), taking the trailing `Aug 2023 – May 2025` with it — the entry
+ * came back with no dates. The fix keeps just the trailing date for parsing and
+ * peels it off the coursework list so it is not surfaced as a phantom course.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEducation } from "../extract/education.ts";
+import { type PdfLine, type PdfSection } from "../sections.ts";
+
+const mkLine = (text: string): PdfLine => ({
+  page: 0,
+  y: 0,
+  x: 0,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkEduSection = (texts: string[]): PdfSection => ({
+  name: "education",
+  lines: texts.map(mkLine),
+});
+
+describe("extractEducation — attendance date at the coursework-line tail (#555)", () => {
+  it("recovers the range from the coursework tail and keeps it out of the course list", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Master of Science Information Technology, Northwind University",
+        "Coursework: Advanced Databases, Data Analytics, Data Mining. Aug 2023 – May 2025",
+      ]),
+    );
+    expect(value.length).toBe(1);
+    const edu = value[0];
+    expect(edu.start_date).toBeTruthy();
+    expect(edu.end_date).toBeTruthy();
+    expect(edu.year).toBe("2025");
+    // The date must not leak into the coursework items.
+    const courses = edu.coursework ?? [];
+    expect(courses).toContain("Data Mining");
+    expect(courses.join(" ")).not.toMatch(/2023|2025|Aug|May/);
+  });
+
+  it("still drops a dateless annotation line and does not over-capture a sibling's year (#371)", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "B.S. Computer Science, Some University, 2017",
+        "GPA: 3.7 · Dean's List 2013 - 2015",
+      ]),
+    );
+    expect(value.length).toBe(1);
+    // The real graduation year wins; the Dean's-List range must not override it.
+    expect(value[0].year).toBe("2017");
+  });
+});

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -7,6 +7,7 @@ import {
   DEGREE_RE,
   INSTITUTION_HINTS,
   MONTH_YEAR_RE,
+  STRICT_MONTH_YEAR_RE,
   NUMERIC_MONTH_YEAR_RE,
   US_STATE_CODE_RE,
   COUNTRY_GAZETTEER,
@@ -143,23 +144,57 @@ function educationDateFields(
 const EDUCATION_ANNOTATION_RE =
   /\b(dean'?s? list|awards?|honou?rs?|thesis|teaching assistant|research assistant|study abroad|coursework|scholarships?|fellowships?|cum laude|capstone|(?:senior|final|independent|group|team)\s+project)\b/i;
 
+/** A month-year attendance/graduation date range sitting at the very END of a
+ *  line — "… Data Mining. Aug 2023 – May 2025" — captured in the `date` group.
+ *  The leading `[.,;\s]+` swallows the separator (a period, comma, or space)
+ *  between the prose and the date so the whole tail can be stripped in one
+ *  replace. The range START must be a month-year (`STRICT_MONTH_YEAR_RE` /
+ *  numeric), never a bare year — a coursework item that merely ends in a 4-digit
+ *  token ("… since 2020") must not be mistaken for an attendance date; only the
+ *  range END may be a bare year ("Aug 2023 – 2025") or an open marker
+ *  ("Aug 2023 – Present"). Uses the STRICT month regex, not the loose
+ *  `MONTH_YEAR_RE`, because this value is both EXTRACTED and DELETED — the loose
+ *  `[a-z]*` tail would false-match a word like "Marketing" and eat it (#380). */
+const END = `(?:${STRICT_MONTH_YEAR_RE.source}|${NUMERIC_MONTH_YEAR_RE.source}|\\b\\d{4}\\b|present|current|ongoing|now)`;
+const TRAILING_ATTENDANCE_DATE_RE = new RegExp(
+  `[.,;\\s]+(?<date>(?:${STRICT_MONTH_YEAR_RE.source}|${NUMERIC_MONTH_YEAR_RE.source})(?:\\s*[–—-]\\s*${END})?)\\s*$`,
+  "i",
+);
+
+/** Peel a trailing attendance-date range off an annotation line and return just
+ *  the date, or `undefined` when the line carries none. Lets a real attendance
+ *  date that rides at the tail of a coursework line survive
+ *  {@link filterAnnotationLinesForDates}'s line drop (#555). */
+function trailingAttendanceDate(line: string): string | undefined {
+  return TRAILING_ATTENDANCE_DATE_RE.exec(line)?.groups?.date?.trim();
+}
+
 /** Strip lines that read as honors / awards / activity annotations from a
  *  chunk before {@link parseEducationDates} runs on the joined text (#371).
  *  Without this, a line like "GPA: 3.7 · Dean's List 2015–2017" contributes
  *  its range to the entry and `parseDateRange`'s range-first preference makes
  *  the annotation range (2015–2017) win over the real graduation year (2017)
- *  on a sibling line. Line-level filter — an annotation phrase inline with a
- *  real date on the SAME line is rare in practice; keeping the whole line
- *  when it doesn't lead with an annotation is safer than mid-line surgery.
+ *  on a sibling line.
  *
  *  DEGREE-carve-out: a line that ALSO matches {@link DEGREE_RE} carries the
  *  real attendance / graduation date and stays regardless of which annotation
  *  keywords it contains. Commonwealth shapes like "Honours Bachelor of Science,
  *  2015 - 2019" or "Thesis-based M.Sc. Data Science, 2018 - 2020" mention
  *  `honours` / `thesis` on the SAME line as the degree + real dates; filtering
- *  the whole line would drop both. */
+ *  the whole line would drop both.
+ *
+ *  TAIL-DATE carve-out (#555): a non-degree annotation line whose real
+ *  attendance date rides at its END — "Coursework: Databases, Data Mining.
+ *  Aug 2023 – May 2025" — keeps just that trailing date (the annotation prose
+ *  is still dropped) so the date reaches `parseEducationDates` instead of being
+ *  discarded with the line. An annotation line with no trailing date is dropped
+ *  as before, so the #371 over-capture guard is unchanged for that shape. */
 function filterAnnotationLinesForDates(lines: readonly string[]): string[] {
-  return lines.filter((l) => DEGREE_RE.test(l) || !EDUCATION_ANNOTATION_RE.test(l));
+  return lines.flatMap((l) => {
+    if (DEGREE_RE.test(l) || !EDUCATION_ANNOTATION_RE.test(l)) return [l];
+    const tail = trailingAttendanceDate(l);
+    return tail ? [tail] : [];
+  });
 }
 
 /** Source-side coursework label to peel off the bullet residue before the
@@ -866,6 +901,10 @@ export function extractEducation(
   // to the nearest preceding degree below.
   const ls = education.lines;
   const coursework: { text: string; idx: number }[] = [];
+  // A real attendance-date range peeled off the END of a coursework line (#555),
+  // tagged with the source-line `idx` so it can be attributed to the same entry
+  // the courses on that line belong to.
+  const courseworkDates: { date: string; idx: number }[] = [];
   const consumed = new Set<number>();
   for (let i = 0; i < ls.length; i++) {
     // Coursework is usually a bullet list, but some résumés write it as a plain
@@ -897,6 +936,13 @@ export function extractEducation(
     // the course list itself and the reconstructed résumé doesn't render a
     // redundant "Coursework: Relevant Coursework: …" double-label (#367).
     item = item.replace(COURSEWORK_LABEL_RE, "").trim();
+    // Peel a trailing attendance-date range that rode at the END of the
+    // coursework line ("… Data Mining. Aug 2023 – May 2025", #555) so the date
+    // is not surfaced as a phantom last course, and remember it to attribute to
+    // this entry below (the coursework line is `consumed`, so it never reaches
+    // the chunk's own date parse).
+    const tailDate = trailingAttendanceDate(item);
+    item = item.replace(TRAILING_ATTENDANCE_DATE_RE, "").trim();
     // Split a comma-separated course list into individual entries so each
     // course is addressable in the reconstructed view (#367). A single-course
     // bullet with no comma remains one entry. The Title-case guard runs on
@@ -910,6 +956,7 @@ export function extractEducation(
       : [item];
     if (items.length > 0 && /^[A-Z0-9]/.test(items[0])) {
       for (const c of items) coursework.push({ text: c, idx: i });
+      if (tailDate) courseworkDates.push({ date: tailDate, idx: i });
       for (const k of span) consumed.add(k);
     }
     i = j - 1;
@@ -1095,6 +1142,21 @@ export function extractEducation(
       else break;
     }
     (value[target].coursework ??= []).push(course.text);
+  }
+
+  // Attribute a date recovered from a coursework-line tail (#555) to the nearest
+  // preceding entry, but only when that entry parsed NO date of its own — a real
+  // date on the degree/institution line always wins over a coursework-tail date.
+  for (const cd of courseworkDates) {
+    let target = 0;
+    for (let e = 0; e < built.length; e++) {
+      if (built[e].startIdx <= cd.idx) target = e;
+      else break;
+    }
+    const entry = value[target];
+    if (!entry.start_date && !entry.end_date && !entry.year) {
+      Object.assign(entry, educationDateFields(parseEducationDates(cd.date)));
+    }
   }
 
   // Deduplicate coursework on each entry (#223). When a standalone "Relevant


### PR DESCRIPTION
## Summary

An education entry's attendance dates were dropped when the date range sat at the **tail of a coursework line** — `Coursework: … Data Mining. Aug 2023 – May 2025` — rather than on the degree/institution line. The coursework line is `consumed` before chunking, so the chunk's own date parse never saw it, and the trailing range also leaked into the last course item. The fix peels the trailing month-year range off the coursework line, attributes it to the entry it belongs to (only when that entry parsed **no** date of its own, so a real degree-line date always wins), and keeps it out of the course list. `filterAnnotationLinesForDates` gains the same tail-date carve-out for an annotation line that reaches the chunk directly. Extraction uses `STRICT_MONTH_YEAR_RE`, so the peel can never eat a word.

Closes #555

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run src/lib/heuristics/` green (1067 passed) — incl. new `education.coursework-tail-date.test.ts` and the #371 over-capture guard
- [x] Verified on the reporting résumé: the Masters entry now parses `Aug 2023 – May 2025` (year 2025), and the date no longer appears as a course

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Verification: `npm run verify` — CI (local pre-push hook is broken under Windows cmd; typecheck + full heuristics suite run manually, green)