### PR TITLE
fix(parser): correct three education one-line-entry defects (#555, #556, #557)

### DIFF
--- a/src/lib/heuristics/extract/education.connectiveless-degree.test.ts
+++ b/src/lib/heuristics/extract/education.connectiveless-degree.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression for #557 — a connective-less degree name ("<prefix> of <Type>
+ * <Field>" with no " in ") mis-partitioned into degree/field:
+ *
+ *   Master of Science Information Technology        → field lost entirely
+ *   Bachelor of Technology Electronics & Comm. Eng. → split mid-phrase
+ *
+ * `DEGREE_RE`'s greedy `of <subject>` branch swallowed the field into the
+ * credential. `DEGREE_TYPE_RE` now cuts the credential at the end of the
+ * degree-TYPE word so the field survives, while a type-only credential
+ * ("Master of Business Administration") is left whole and the US " in "
+ * connective form is untouched.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEducation } from "../extract/education.ts";
+import { type PdfLine, type PdfSection } from "../sections.ts";
+
+const mkLine = (text: string): PdfLine => ({
+  page: 0,
+  y: 0,
+  x: 0,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkEduSection = (texts: string[]): PdfSection => ({
+  name: "education",
+  lines: texts.map(mkLine),
+});
+
+const parse1 = (line: string) => extractEducation(mkEduSection([line])).value[0];
+
+describe("extractEducation — connective-less 'of <Type> <Field>' degree (#557)", () => {
+  it("splits 'Master of Science Information Technology'", () => {
+    const e = parse1("Master of Science Information Technology, Northwind University");
+    expect(e.degree).toBe("Master of Science");
+    expect(e.field).toBe("Information Technology");
+  });
+
+  it("splits 'Bachelor of Technology Electronics & Communication Eng.' without losing the ampersand", () => {
+    const e = parse1(
+      "Bachelor of Technology Electronics & Communication Eng., Northwind Institute of Tech",
+    );
+    expect(e.degree).toBe("Bachelor of Technology");
+    expect(e.field).toBe("Electronics & Communication Eng.");
+  });
+
+  it("leaves a type-only credential whole (no field to cut)", () => {
+    const e = parse1("Master of Business Administration, Northwind University");
+    expect(e.degree).toBe("Master of Business Administration");
+    expect(e.field ?? "").toBe("");
+  });
+
+  it("does not regress the ' in ' connective form", () => {
+    const e = parse1("Bachelor of Science in Biology, Northwind University");
+    expect(e.degree).toBe("Bachelor of Science");
+    expect(e.field).toBe("Biology");
+  });
+});

--- a/src/lib/heuristics/extract/education.coursework-tail-date.test.ts
+++ b/src/lib/heuristics/extract/education.coursework-tail-date.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression for #555 — an education entry's attendance date is dropped when
+ * the date range sits at the TAIL of a coursework line rather than on the
+ * degree/institution line:
+ *
+ *   Master of Science Information Technology, Northwind University
+ *   Coursework: Advanced Databases, Data Analytics, Data Mining. Aug 2023 – May 2025
+ *
+ * `filterAnnotationLinesForDates` drops the whole coursework line before date
+ * parsing (it matches the "coursework" annotation keyword and carries no degree
+ * token), taking the trailing `Aug 2023 – May 2025` with it — the entry came
+ * back with no dates. The fix peels that trailing date off inside the coursework
+ * collector (so it is not surfaced as a phantom course) and re-attributes it via
+ * `courseworkDates` — but ONLY when the target entry parsed no date of its own.
+ *
+ * That guard is the whole point, and the third test pins it: recovering the tail
+ * date through the whole-chunk `filterAnnotationLinesForDates` path instead would
+ * reopen the #371 over-capture class, because `parseDateRange` prefers a range
+ * over a bare year and the chunk path has no way to express "only when the entry
+ * is dateless".
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEducation } from "../extract/education.ts";
+import { type PdfLine, type PdfSection } from "../sections.ts";
+
+const mkLine = (text: string): PdfLine => ({
+  page: 0,
+  y: 0,
+  x: 0,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkEduSection = (texts: string[]): PdfSection => ({
+  name: "education",
+  lines: texts.map(mkLine),
+});
+
+describe("extractEducation — attendance date at the coursework-line tail (#555)", () => {
+  it("recovers the range from the coursework tail and keeps it out of the course list", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Master of Science Information Technology, Northwind University",
+        "Coursework: Advanced Databases, Data Analytics, Data Mining. Aug 2023 – May 2025",
+      ]),
+    );
+    expect(value.length).toBe(1);
+    const edu = value[0];
+    expect(edu.start_date).toBeTruthy();
+    expect(edu.end_date).toBeTruthy();
+    expect(edu.year).toBe("2025");
+    // The date must not leak into the coursework items.
+    const courses = edu.coursework ?? [];
+    expect(courses).toContain("Data Mining");
+    expect(courses.join(" ")).not.toMatch(/2023|2025|Aug|May/);
+  });
+
+  it("still drops a dateless annotation line and does not over-capture a sibling's year (#371)", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "B.S. Computer Science, Some University, 2017",
+        "GPA: 3.7 · Dean's List 2013 - 2015",
+      ]),
+    );
+    expect(value.length).toBe(1);
+    // The real graduation year wins; the Dean's-List range must not override it.
+    expect(value[0].year).toBe("2017");
+  });
+
+  it("does not let a MONTH-YEAR annotation range override a sibling's graduation year (#371)", () => {
+    // The year-only sibling above ("Dean's List 2013 - 2015") is dropped by
+    // `parseDateRange`'s bare-year start; a month-year-precision annotation range
+    // is the shape that would survive a tail-date carve-out on the whole-chunk
+    // path and silently beat the real single-year graduation date. Pinned here so
+    // the #555 recovery can never be re-plumbed through that path.
+    const { value } = extractEducation(
+      mkEduSection([
+        "B.S. Computer Science, Some University, 2017",
+        "Awards: Best Thesis, Sep 2019 - Jun 2020",
+      ]),
+    );
+    expect(value.length).toBe(1);
+    expect(value[0].year).toBe("2017");
+    expect(value[0].start_date).toBeUndefined();
+  });
+});

--- a/src/lib/heuristics/extract/education.gpa-institution.test.ts
+++ b/src/lib/heuristics/extract/education.gpa-institution.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression for #556 — a GPA/CGPA note appended to the institution string with
+ * no comma boundary was left glued to the school name:
+ *
+ *   Master of Science Information Technology, Northwind University GPA 3.8
+ *
+ * `stripInstitutionDate` only peels trailing dates, and `cleanField`'s GPA cut
+ * runs on the degree *field* and only after a `,`/`;`. Nothing removed a
+ * space-separated `GPA <n.nn>` tail from the institution. A dedicated
+ * `stripInstitutionGrade` now peels it.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEducation } from "../extract/education.ts";
+import { type PdfLine, type PdfSection } from "../sections.ts";
+
+const mkLine = (text: string): PdfLine => ({
+  page: 0,
+  y: 0,
+  x: 0,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkEduSection = (texts: string[]): PdfSection => ({
+  name: "education",
+  lines: texts.map(mkLine),
+});
+
+const instOf = (line: string) =>
+  extractEducation(mkEduSection([line])).value[0]?.institution;
+
+describe("extractEducation — GPA glued to institution (#556)", () => {
+  it("strips a space-separated GPA tail", () => {
+    expect(
+      instOf("Master of Science Information Technology, Northwind University GPA 3.8"),
+    ).toBe("Northwind University");
+  });
+
+  it("strips a colon / slash-scale CGPA tail", () => {
+    expect(instOf("B.Tech Computer Science, Northwind Institute of Tech CGPA 8.7/10")).toBe(
+      "Northwind Institute of Tech",
+    );
+  });
+
+  it("strips a comma-delimited GPA tail", () => {
+    expect(instOf("B.S. Biology, Northwind College, GPA: 3.8")).toBe("Northwind College");
+  });
+
+  it("does not cut a school name that merely ends in a digit", () => {
+    expect(instOf("B.A. History, Route 66 University")).toBe("Route 66 University");
+  });
+});

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -7,6 +7,7 @@ import {
   DEGREE_RE,
   INSTITUTION_HINTS,
   MONTH_YEAR_RE,
+  STRICT_MONTH_YEAR_RE,
   NUMERIC_MONTH_YEAR_RE,
   US_STATE_CODE_RE,
   COUNTRY_GAZETTEER,
@@ -143,23 +144,61 @@ function educationDateFields(
 const EDUCATION_ANNOTATION_RE =
   /\b(dean'?s? list|awards?|honou?rs?|thesis|teaching assistant|research assistant|study abroad|coursework|scholarships?|fellowships?|cum laude|capstone|(?:senior|final|independent|group|team)\s+project)\b/i;
 
+/** A month-year attendance/graduation date range sitting at the very END of a
+ *  line — "… Data Mining. Aug 2023 – May 2025" — captured in the `date` group.
+ *  The leading `[.,;\s]+` swallows the separator (a period, comma, or space)
+ *  between the prose and the date so the whole tail can be stripped in one
+ *  replace. The range START must be a month-year (`STRICT_MONTH_YEAR_RE` /
+ *  numeric), never a bare year — a coursework item that merely ends in a 4-digit
+ *  token ("… since 2020") must not be mistaken for an attendance date; only the
+ *  range END may be a bare year ("Aug 2023 – 2025") or an open marker
+ *  ("Aug 2023 – Present"). Uses the STRICT month regex, not the loose
+ *  `MONTH_YEAR_RE`, because this value is both EXTRACTED and DELETED — the loose
+ *  `[a-z]*` tail would false-match a word like "Marketing" and eat it (#380). */
+const ATTENDANCE_RANGE_END = `(?:${STRICT_MONTH_YEAR_RE.source}|${NUMERIC_MONTH_YEAR_RE.source}|\\b\\d{4}\\b|present|current|ongoing|now)`;
+const TRAILING_ATTENDANCE_DATE_RE = new RegExp(
+  `[.,;\\s]+(?<date>(?:${STRICT_MONTH_YEAR_RE.source}|${NUMERIC_MONTH_YEAR_RE.source})(?:\\s*[–—-]\\s*${ATTENDANCE_RANGE_END})?)\\s*$`,
+  "i",
+);
+
+/** Peel a trailing attendance-date range off a coursework line and return just
+ *  the date, or `undefined` when the line carries none. Lets a real attendance
+ *  date that rides at the tail of a coursework line reach the entry (#555)
+ *  instead of being surfaced as a phantom last course — the coursework line is
+ *  `consumed`, so it never reaches the chunk's own date parse. The recovered
+ *  date is attributed by {@link extractEducation}'s `courseworkDates` pass,
+ *  which applies it ONLY when the entry parsed no date of its own. */
+function trailingAttendanceDate(line: string): string | undefined {
+  return TRAILING_ATTENDANCE_DATE_RE.exec(line)?.groups?.date?.trim();
+}
+
 /** Strip lines that read as honors / awards / activity annotations from a
  *  chunk before {@link parseEducationDates} runs on the joined text (#371).
  *  Without this, a line like "GPA: 3.7 · Dean's List 2015–2017" contributes
  *  its range to the entry and `parseDateRange`'s range-first preference makes
  *  the annotation range (2015–2017) win over the real graduation year (2017)
- *  on a sibling line. Line-level filter — an annotation phrase inline with a
- *  real date on the SAME line is rare in practice; keeping the whole line
- *  when it doesn't lead with an annotation is safer than mid-line surgery.
+ *  on a sibling line.
  *
  *  DEGREE-carve-out: a line that ALSO matches {@link DEGREE_RE} carries the
  *  real attendance / graduation date and stays regardless of which annotation
  *  keywords it contains. Commonwealth shapes like "Honours Bachelor of Science,
  *  2015 - 2019" or "Thesis-based M.Sc. Data Science, 2018 - 2020" mention
  *  `honours` / `thesis` on the SAME line as the degree + real dates; filtering
- *  the whole line would drop both. */
+ *  the whole line would drop both.
+ *
+ *  No tail-date carve-out here, deliberately: peeling a trailing range off an
+ *  annotation line and feeding it to {@link parseEducationDates} would reopen
+ *  the #371 over-capture class for month-year-precision ranges — an "Awards:
+ *  Best Thesis, Sep 2019 - Jun 2020" line would beat a real single-year
+ *  graduation date on the sibling degree line, because `parseDateRange` prefers
+ *  a range over a bare year. A coursework line's real attendance date is
+ *  recovered instead by {@link extractEducation}'s `courseworkDates` pass
+ *  (#555), which carries the "only when the entry has no date of its own" guard
+ *  this whole-chunk path cannot express. */
 function filterAnnotationLinesForDates(lines: readonly string[]): string[] {
-  return lines.filter((l) => DEGREE_RE.test(l) || !EDUCATION_ANNOTATION_RE.test(l));
+  return lines.filter(
+    (l) => DEGREE_RE.test(l) || !EDUCATION_ANNOTATION_RE.test(l),
+  );
 }
 
 /** Source-side coursework label to peel off the bullet residue before the
@@ -421,6 +460,15 @@ function cleanField(raw: string): string | undefined {
   return f.length > 0 ? f : undefined;
 }
 
+/** The degree-TYPE word that follows "of" in a spelled-out credential
+ *  ("Bachelor **of Technology**", "Master **of Science**"). Anchored to the
+ *  start of the post-"of" run, longest-first so "Business Administration" and
+ *  "Fine Arts" win over their prefixes. Used by {@link parseDegreeAndField} to
+ *  find where the credential ends and the subject field begins in a
+ *  connective-less "of <Type> <Field>" header (#557). */
+const DEGREE_TYPE_RE =
+  /^(?:Business Administration|Fine Arts|Computer Applications|Science|Arts|Technology|Engineering|Philosophy|Education|Commerce|Laws|Law|Medicine|Architecture|Design|Nursing|Pharmacy|Business|Management)\b/i;
+
 /** Parse a degree-bearing line into a bare credential + its subject field.
  *
  * `DEGREE_RE` either matches just the credential ("B.S.") or — via its optional
@@ -432,7 +480,16 @@ function cleanField(raw: string): string | undefined {
  * whatever text follows the credential, with dates/notes stripped by
  * `cleanField`. Connective-less shapes ("M.S. Computer Science", "B.S. Business
  * Administration — May 2027") are handled too: the field is the post-credential
- * remainder. */
+ * remainder.
+ *
+ * CONNECTIVE-LESS "of" shapes (#557): a spelled-out "<Bachelor|Master|…> of
+ * <Type> <Field>" with no " in " ("Master of Science Information Technology",
+ * "Bachelor of Technology Electronics & Communication Eng.") is common in
+ * Indian résumés. `DEGREE_RE`'s greedy `of [A-Za-z ]{2,40}` swallows the field
+ * INTO the credential, so the split below would leave `field` empty (or, when an
+ * "&" halts the greedy run, split it mid-phrase). {@link DEGREE_TYPE_RE} cuts
+ * the credential at the end of the degree-TYPE word so the remainder is the
+ * field. */
 function parseDegreeAndField(line: string): {
   degree: string;
   field?: string;
@@ -452,6 +509,21 @@ function parseDegreeAndField(line: string): {
   } else {
     degree = matched.trim();
     fieldStart = dm.index + matched.length;
+    // Connective-less "<prefix> of <Type> <Field>" (#557): if the match ran
+    // "of <Type>" straight into a field, cut the credential at the end of the
+    // degree-TYPE word so <Field> is not buried in the degree. Only fires when
+    // real field text follows the type word — "Master of Business
+    // Administration" (type IS the whole credential) is left whole.
+    const ofm = /\bof\s+/i.exec(matched);
+    if (ofm) {
+      const afterOf = matched.slice(ofm.index + ofm[0].length);
+      const typeM = DEGREE_TYPE_RE.exec(afterOf);
+      if (typeM && afterOf.slice(typeM[0].length).trim().length > 0) {
+        const degreeEnd = ofm.index + ofm[0].length + typeM[0].length;
+        degree = matched.slice(0, degreeEnd).trim();
+        fieldStart = dm.index + degreeEnd;
+      }
+    }
   }
   const fieldRaw = line
     .slice(fieldStart)
@@ -655,6 +727,23 @@ function stripInstitutionDate(s: string): string {
   return stripped || s;
 }
 
+/** A trailing GPA / CGPA note glued onto the institution string with no comma
+ *  boundary — "State University GPA 3.8" (#556). Covers "GPA 3.8", "GPA: 3.8",
+ *  "CGPA 8.7", a "/N" scale ("GPA 3.8/4.0", "CGPA 8.7/10") and a percentage
+ *  ("GPA 85%"), with an optional leading separator, `$`-anchored. Requires the
+ *  `gpa`/`cgpa` keyword, so a school name that merely ends in a digit is never
+ *  cut. */
+const INSTITUTION_GRADE_RE =
+  /[\s,;·|-]*\bc?gpa\b[:\s]*\d(?:\.\d+)?(?:\s*\/\s*\d+(?:\.\d+)?)?%?\s*$/i;
+
+/** Peel a trailing GPA/CGPA note off an institution string, leaving the bare
+ *  school name. Never consumes the whole string (a GPA-only value keeps the
+ *  original). Mirrors {@link stripInstitutionDate}'s trailing-strip contract. */
+function stripInstitutionGrade(s: string): string {
+  const stripped = s.replace(INSTITUTION_GRADE_RE, "").trim();
+  return stripped || s;
+}
+
 /** Map one education chunk (the degree + institution + date lines of a single
  *  qualification) to a `ResumeEducation` and its confidence. */
 function educationFromChunk(chunk: string[]): {
@@ -793,6 +882,12 @@ function educationFromChunk(chunk: string[]): {
   // otherwise the date blocks the $-anchored location strip below.
   institution = stripInstitutionDate(institution);
 
+  // Peel a trailing GPA/CGPA note glued on with no comma boundary
+  // ("… State University GPA 3.8", #556) — otherwise it rides into the school
+  // name (the comma-delimited GPA cut in `cleanField` only touches the degree
+  // field, not the institution).
+  institution = stripInstitutionGrade(institution);
+
   // Peel a trailing "City, ST" / "City, Country" off the institution so it isn't
   // glued on ("University of Example, …   Seattle, WA" → institution without the
   // location, location surfaced separately).
@@ -866,6 +961,10 @@ export function extractEducation(
   // to the nearest preceding degree below.
   const ls = education.lines;
   const coursework: { text: string; idx: number }[] = [];
+  // A real attendance-date range peeled off the END of a coursework line (#555),
+  // tagged with the source-line `idx` so it can be attributed to the same entry
+  // the courses on that line belong to.
+  const courseworkDates: { date: string; idx: number }[] = [];
   const consumed = new Set<number>();
   for (let i = 0; i < ls.length; i++) {
     // Coursework is usually a bullet list, but some résumés write it as a plain
@@ -897,6 +996,13 @@ export function extractEducation(
     // the course list itself and the reconstructed résumé doesn't render a
     // redundant "Coursework: Relevant Coursework: …" double-label (#367).
     item = item.replace(COURSEWORK_LABEL_RE, "").trim();
+    // Peel a trailing attendance-date range that rode at the END of the
+    // coursework line ("… Data Mining. Aug 2023 – May 2025", #555) so the date
+    // is not surfaced as a phantom last course, and remember it to attribute to
+    // this entry below (the coursework line is `consumed`, so it never reaches
+    // the chunk's own date parse).
+    const tailDate = trailingAttendanceDate(item);
+    item = item.replace(TRAILING_ATTENDANCE_DATE_RE, "").trim();
     // Split a comma-separated course list into individual entries so each
     // course is addressable in the reconstructed view (#367). A single-course
     // bullet with no comma remains one entry. The Title-case guard runs on
@@ -910,6 +1016,7 @@ export function extractEducation(
       : [item];
     if (items.length > 0 && /^[A-Z0-9]/.test(items[0])) {
       for (const c of items) coursework.push({ text: c, idx: i });
+      if (tailDate) courseworkDates.push({ date: tailDate, idx: i });
       for (const k of span) consumed.add(k);
     }
     i = j - 1;
@@ -1095,6 +1202,21 @@ export function extractEducation(
       else break;
     }
     (value[target].coursework ??= []).push(course.text);
+  }
+
+  // Attribute a date recovered from a coursework-line tail (#555) to the nearest
+  // preceding entry, but only when that entry parsed NO date of its own — a real
+  // date on the degree/institution line always wins over a coursework-tail date.
+  for (const cd of courseworkDates) {
+    let target = 0;
+    for (let e = 0; e < built.length; e++) {
+      if (built[e].startIdx <= cd.idx) target = e;
+      else break;
+    }
+    const entry = value[target];
+    if (!entry.start_date && !entry.end_date && !entry.year) {
+      Object.assign(entry, educationDateFields(parseEducationDates(cd.date)));
+    }
   }
 
   // Deduplicate coursework on each entry (#223). When a standalone "Relevant

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
@@ -75,7 +75,7 @@
     "sectionSource": "regex",
     "pageCount": 1,
     "rawCharCount": 1987,
-    "extractedCharCount": 1713,
+    "extractedCharCount": 1700,
     "sections": [
       {
         "name": "profile",

--- a/tests/fixtures/pdfs/unknown/compound-certifications-activities-tail.expected.json
+++ b/tests/fixtures/pdfs/unknown/compound-certifications-activities-tail.expected.json
@@ -74,7 +74,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 617,
-    "extractedCharCount": 455,
+    "extractedCharCount": 440,
     "sections": [
       {
         "name": "profile",


### PR DESCRIPTION
## Summary

Three independent education-parser defects, all surfaced by **single-line education entries** where degree, institution, GPA, coursework, and dates share one or two physical lines. Each is fixed in `src/lib/heuristics/extract/education.ts` with a targeted, value-asserting unit test; one corpus golden is re-baked per fix.

- **#555 — attendance date at a coursework-line tail.** A range appended to the END of a coursework line (`Coursework: … Data Mining. Aug 2023 – May 2025`) was dropped: the coursework line is `consumed` before the chunk's date parse, and the range also leaked into the last course. Now peeled, attributed to the entry (only when it parsed no date of its own, so a real degree-line date wins), and kept out of the course list. Extraction uses `STRICT_MONTH_YEAR_RE`, so the peel never eats a word.
- **#556 — GPA glued to the institution.** A `GPA`/`CGPA` note with no comma boundary (`State University GPA 3.8`, `College · GPA 8.0 / 10`) rode into the institution name. New `stripInstitutionGrade` (keyword-gated, so a school name ending in a digit is never cut) applied in the institution-building path.
- **#557 — connective-less degree/field.** A `<prefix> of <Type> <Field>` degree with no ` in ` (`Master of Science Information Technology`, `Bachelor of Technology Electronics & Communication Eng.`) had its field swallowed into the credential by `DEGREE_RE`'s greedy `of` branch. `DEGREE_TYPE_RE` now cuts the credential at the degree-TYPE word so the field survives; a type-only credential (`Master of Business Administration`) stays whole; the US ` in ` form is untouched.

All three were found probing a real résumé; the real PDF is local-only and was never committed, and every repro string in the tests is a synthetic persona.

Closes #555
Closes #556
Closes #557

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run src/lib/heuristics/` green (1075 passed) — three new tests (`education.coursework-tail-date`, `education.gpa-institution`, `education.connectiveless-degree`) plus the existing #371 date-over-capture guard
- [x] Two corpus goldens re-baked (`google-docs-skia-proxy-additional-skills`, `compound-certifications-activities-tail`), each a strict improvement (a GPA / a leaked date removed from a parsed field)
- [x] Verified on the reporting résumé: Masters parses `Aug 2023 – May 2025`, institution has no GPA tail

## Provenance

Code implementation via: Claude Opus 4.8 (high)
Review revisions via: Claude Opus 5 (high)
Verification: `npm run verify` — CI (local pre-push hook is broken under Windows cmd; typecheck + full heuristics suite run manually, green)

