### PR TITLE
feat(job-search): rank on honest fit — level, comp, exclusions, specificity (#566)

### DIFF
--- a/.claude/skills/probe-jobs/SKILL.md
+++ b/.claude/skills/probe-jobs/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: probe-jobs
+description: Whole-lane job-search probe — reproduces the deployed Find-Jobs panel's DEFAULT search against a real, PII-bearing résumé (parse → buildJobQuery → sector companies → live searchJobs), then DECOMPOSES every ranking decision into its additive sort-key terms (base coverage × specificity, location boost, seniority penalty, comp-floor penalty) so you can see WHERE the ranker put a fine fit below a thin one — instead of theorizing. Classifies each defect PII-free, names the unit-test file that should carry a synthetic JobPosting reproducer, and (skill layer) drafts + scrub-gates + auto-files a GitHub issue. The job-search sibling of the six parser `probe-*` skills (see `probe-resume`). Use when the user says "probe jobs", "/probe-jobs", "why are the job results bad", "debug the job ranking", hands you a résumé and the Find-Jobs results feel wrong, or asks which job-search bug a real résumé reproduces. NETWORKED + non-deterministic, unlike the parser probes: running it egresses the keyword string + company slugs prod already egresses.
+---
+
+# Probe: Jobs (whole-lane search + rank decomposition)
+
+The job-search counterpart of `probe-resume`. Where the parser probes sweep the
+**parser** off a single parse, this sweeps the **ranker** off a single live
+search: it runs the exact default path the deployed `FindJobsPanel` runs, then
+decomposes every posting's sort key into the terms `rank.ts` actually adds up —
+so "these results are bad for the fine jobs" becomes a mechanical, located
+finding, not a guess.
+
+Execution vehicle: `src/lib/job-search/probe-jobs.test.ts` (a dev harness gated
+on `RL_JOBS_PDF`). There is **no standalone script and you should not write
+one** — the pdfjs worker uses Vite's `?url` import, which resolves only under
+the Vite/vitest transform, so plain `tsx`/node breaks (same constraint as the
+parser probes). The vitest run **is** the execution vehicle.
+
+## ⚠️ PII + egress guardrail — read first
+
+Stricter than the six parser probes, because this lane is **networked** and the
+matched postings are the candidate's **real job search**. Non-negotiable:
+
+1. **The input PDF is local-only. NEVER commit it.** It is not a fixture;
+   `tests/fixtures/pdfs/` is synthetic-personas-only by policy.
+2. **This probe EGRESSES.** Running it fires the real search: the audited
+   `providers/keywords.ts` keyword string + the public company slugs leave the
+   machine, exactly as the deployed app does. It is **not** offline like the
+   parser probes. Don't run it where that egress is unwanted. Node has no CORS,
+   so the capture can reach feeds a browser's CORS set can't, and live postings
+   drift run-to-run — the snapshot it writes is what **this** run saw.
+3. **Three PII tiers:**
+   - *Résumé PII* (name, employers, title, skill cluster) and *the real search
+     surface* (matched company names, live posting titles/text) live **only** in
+     the gitignored JSON report (`internal/job-search/`, default).
+   - *The console prints neither.* Every posting is a stable index (`job#3`);
+     every axis is a number, boolean, defect **class**, or fixed enum. Cite a
+     defect by class + index, never by title/company. Cross-reference an index
+     to a real posting in the gitignored report **locally**; never paste it on.
+   - The report carries a `piiValues` list (name tokens, employers, matched
+     company names, posting titles) — the auto-file scrub-gate's denylist.
+4. **`RL_JOBS_OUT` inside the repo at a NON-gitignored path is a hard error**,
+   by design (validated with `git check-ignore`). Don't "fix" it by un-ignoring
+   the path — point it at the gitignored default or outside the repo.
+
+## Run it
+
+```bash
+RL_JOBS_PDF=/abs/path/to/real-resume.pdf \
+  npx vitest run src/lib/job-search/probe-jobs.test.ts
+```
+
+Use an **absolute path**. Requires network (it fetches the real feeds + boards).
+
+### Env vars
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RL_JOBS_PDF` | *(unset)* | Absolute path to the résumé PDF. Unset → the harness is **inert** (skipped); CI never runs it. |
+| `RL_JOBS_OUT` | `internal/job-search/` | Directory for the full JSON report. Default is gitignored. An override inside the repo that is NOT gitignored is a hard error. |
+
+## What it does
+
+One `runCascade()` → `parsed`, then reproduces the panel's **default** wiring
+verbatim (no user edits): `roleFilterForResume` seeds families + exclude chips,
+`buildJobQuery` builds the query, `classifySectorHeuristic` + `companiesForSector`
+seed the company pool (all suggested = selected on mount). One live
+`searchJobs()` captures the postings. Then it decomposes every shown job with
+`explainSortKey` — **the single source of truth in `rank.ts`** (the production
+`sortKey` returns `.key` from it, so the decomposition can't drift from the real
+ordering).
+
+## What you get
+
+Console (PII-free; full JSON mirrored to the gitignored out dir):
+
+- **`QUERY SHAPE`** — counts only (titles/skills/seniority-set/location-set/
+  families/compFloor). No values.
+- **`CAPTURE`** — raw vs shown posting counts, provider count, degraded count,
+  `roleSuppressed`/`excludeSuppressed`.
+- **`RANK DECOMPOSITION`** — per job (by index): `score`, `terms`,
+  `specificityConfidence`, `base`, `+loc`, `−sen`, `−comp`, final `key`, posting
+  `rung`, `hasComp`, `belowFloor`, `locationMatch`. This is the table that shows
+  a fine fit sunk below a thin one and **which term did it**.
+- **`DEFECTS FOUND`** — each class with severity, PII-free evidence, and the
+  **unit-test file that owns its synthetic reproducer**. Classes include:
+  `thin-specificity-inversion` (#561 correction too weak on real data),
+  `seniority-axis-inert-no-query-level` / `seniority-titles-unparsed` (#562 level
+  axis dead), `comp-extraction-sparse` / `comp-below-floor-misattributed` (#564),
+  `location-boost-inert-*` (#545), `role-filter-suppressed` /
+  `exclude-filter-suppressed` (never-fail-closed fired), `providers-degraded`,
+  `empty-result-set`.
+- **The gitignored JSON path** — real titles/companies + `piiValues`. Do not
+  commit or paste it.
+
+## Filing what you find (auto-file, scrub-gated)
+
+For each PII-free defect the skill layer (you, not the harness) files a GitHub
+issue against `offlinecv/OfflineCV`:
+
+1. **Draft** a body describing the defect by **class + structural axes** — a
+   synthetic `JobPosting` shape (title pattern, comp-string shape, `departments`,
+   seniority token) + query shape (families, rung, floor) → the wrong-rank
+   outcome. Strip every real value.
+2. **Scrub-gate (hard).** Grep the drafted body against the report's `piiValues`
+   list. If **any** appears, **refuse to file** — rewrite until clean. This is a
+   by-construction gate, not a filter: auto-file proceeds only on a clean scrub.
+3. **Mint the reproducer.** Add a synthetic `JobPosting` scenario to the named
+   owner test (`rank.test.ts`, `compensation.test.ts`, `seniority.test.ts`,
+   `role-keywords.test.ts`, `query-builder.test.ts`, `refine.test.ts`) as a
+   `*.repro.test.ts` — and **prove it guards** by reverting the fix: the new
+   assertion must flip (the fix+fixture-in-one-commit anti-pattern proves
+   nothing). There is **no posting corpus** — the reproducer is the "fixture".
+4. **File** via the gated `create-gh-issue` flow (public repo: lowercase
+   `[epic]`-style prefixes, `feature`/`improvement` labels — no `epic` label).
+
+## Boundaries
+
+- **Dev/triage tool, not a CI gate.** Inert unless `RL_JOBS_PDF` is set; never
+  reddens the suite; asserts only that it could run (providerCount > 0), never on
+  what it finds.
+- **Reproduces the DEFAULT search**, not your exact browser session: no company
+  chip edits, no query edits, and Node-no-CORS may diverge from the browser's
+  feed set. A rank finding still localizes to the pure ranker regardless.
+- **Mints/commits/files nothing by itself.** The harness classifies; the skill
+  layer drafts, scrub-gates, and files. A finding that needs deeper parser-side
+  localization (e.g. a title that never parsed) drops to `probe-resume`.

--- a/src/components/features/CompFloorInput.tsx
+++ b/src/components/features/CompFloorInput.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * CompFloorInput — the optional minimum-annual-pay control for the Find Jobs
+ * query (#564). Extracted out of `FindJobsPanel` (already at the ~200 LOC
+ * gate) rather than grown inline — CLAUDE.md's component-size rule.
+ *
+ * A SOFT signal only, matching the #545/#561/#562 precedent already used for
+ * location/specificity/seniority: `rankPostings` reads `query.compFloor` for
+ * a sort-key penalty and `JobResultCard` reads `job.belowFloor` for a "below
+ * your floor" badge, but a below-floor posting is never dropped from the
+ * results. Purely local query state — never appended to any outbound
+ * keyword/deep-link string; `providers/keywords.ts` stays the sole
+ * resume-derived egress helper.
+ */
+
+import { EditableField } from "@design-system";
+
+interface CompFloorInputProps {
+  /** Undefined = no floor set (the default, byte-identical to pre-#564). */
+  value: number | undefined;
+  onCommit: (value: number | undefined) => void;
+}
+
+export function CompFloorInput({ value, onCommit }: CompFloorInputProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+      <span className="text-xs text-content-tertiary">Minimum pay ($/yr)</span>
+      <EditableField
+        value={value !== undefined ? String(value) : undefined}
+        placeholder="minimum pay"
+        label="Minimum annual pay"
+        onCommit={(raw) => {
+          const digits = raw.trim().replace(/[^\d.]/g, "");
+          if (!digits) {
+            onCommit(undefined);
+            return;
+          }
+          const parsed = Number(digits);
+          onCommit(Number.isFinite(parsed) && parsed > 0 ? parsed : undefined);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -18,18 +18,24 @@
  * (useEditableParse) — editing the search query is not editing the résumé.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button, EditableField } from "@design-system";
 import { buildJobQuery, type JobQuery } from "../../lib/job-search/query-builder.ts";
 import { buildDeepLinks } from "../../lib/job-search/deep-links.ts";
-import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import {
-  JobSearchResults,
-  type SearchPhase,
-} from "./JobSearchResults.tsx";
+  roleFilterForResume,
+  seedExcludeTermsForFamilies,
+  type RoleFamily,
+} from "../../lib/job-search/role-keywords.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+import { JobSearchResults } from "./JobSearchResults.tsx";
 import { ChipListEditor } from "./ChipListEditor.tsx";
+import { CompFloorInput } from "./CompFloorInput.tsx";
+import { RoleFamilyChips } from "./RoleFamilyChips.tsx";
+import { LevelSelect } from "./LevelSelect.tsx";
 import { CompanyTargets } from "./CompanyTargets.tsx";
 import { useCompanyTargets } from "../../hooks/useCompanyTargets.ts";
+import { useJobSearch } from "../../hooks/useJobSearch.ts";
 import { AddPill } from "./ReconstructedAdd.tsx";
 
 interface FindJobsPanelProps {
@@ -42,8 +48,18 @@ interface FindJobsPanelProps {
 
 export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   // Seed local query state from the parse once (lazy initializer — runs only
-  // on mount); the user edits it from here.
-  const [query, setQuery] = useState<JobQuery>(() => buildJobQuery(parsed));
+  // on mount); the user edits it from here. Exclude-term chips (#563) AND
+  // role-family chips (#568) are seeded from the SAME role-family
+  // classification the company-board pipeline derives — visibly, as ordinary
+  // removable chips below, never applied invisibly.
+  const [query, setQuery] = useState<JobQuery>(() => {
+    const roleFilter = roleFilterForResume(parsed);
+    return buildJobQuery(
+      parsed,
+      seedExcludeTermsForFamilies(roleFilter.families),
+      roleFilter.families,
+    );
+  });
   // Progressive disclosure for Seniority (#540): a résumé whose titles carry
   // no recognized seniority keyword renders no inert placeholder field — the
   // row appears only once a seniority was derived, or the user opts in via
@@ -65,12 +81,25 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   const removeSkill = (skill: string) =>
     setQuery((q) => ({ ...q, skills: q.skills.filter((s) => s !== skill) }));
 
-  // In-app search state. The fetch fires ONLY from runSearch (the Search
-  // click) — never on drop, tab open, or query edit. searchJobs dynamic-imports
-  // the provider/rank tiers, so nothing job-fetch-related is in the entry chunk.
-  const [phase, setPhase] = useState<SearchPhase>({ kind: "idle" });
-  const abortRef = useRef<AbortController | null>(null);
-  const isLoading = phase.kind === "loading";
+  const addExcludeTerm = (term: string) =>
+    setQuery((q) => ({ ...q, excludeTerms: [...(q.excludeTerms ?? []), term] }));
+  const removeExcludeTerm = (term: string) =>
+    setQuery((q) => ({
+      ...q,
+      excludeTerms: (q.excludeTerms ?? []).filter((t) => t !== term),
+    }));
+
+  // Role families (#568): REMOVAL only — see RoleFamilyChips' doc for why
+  // there's no free-text add. Narrowing to an empty list is safe: readers
+  // resolve `families: []` to the permissive "all" filter, never zero results.
+  const removeRoleFamily = (family: RoleFamily) =>
+    setQuery((q) => ({
+      ...q,
+      families: (q.families ?? []).filter((f) => f !== family),
+    }));
+
+  const setLevel = (level: string | undefined) =>
+    setQuery((q) => ({ ...q, seniority: level }));
 
   // Sector-suggested companies whose ATS boards join the fan-out. Selecting
   // none is a supported state: the search falls back to the keyless feeds
@@ -78,33 +107,8 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   const companyTargets = useCompanyTargets(parsed);
   const selectedCompanies = companyTargets.selected;
 
-  // Abort any in-flight search on unmount so a late response can't try to
-  // update state on an unmounted component.
-  useEffect(() => () => abortRef.current?.abort(), []);
-
-  const runSearch = () => {
-    // Supersede any in-flight search so its results can't land after this one.
-    abortRef.current?.abort();
-    const ctrl = new AbortController();
-    abortRef.current = ctrl;
-    setPhase({ kind: "loading" });
-    void (async () => {
-      try {
-        const { searchJobs } = await import("../../lib/job-search/search.ts");
-        const result = await searchJobs(
-          query,
-          parsed,
-          ctrl.signal,
-          selectedCompanies,
-        );
-        if (ctrl.signal.aborted) return;
-        setPhase({ kind: "loaded", result });
-      } catch {
-        if (ctrl.signal.aborted) return;
-        setPhase({ kind: "failed" });
-      }
-    })();
-  };
+  // Fetch lifecycle + #568's live re-rank — see the hook's own docblock.
+  const { phase, runSearch, isLoading } = useJobSearch(query, parsed, selectedCompanies);
 
   return (
     <div className="flex flex-col gap-4">
@@ -133,11 +137,19 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
           placeholder="Add a title…"
           addAriaLabel="Add title"
         />
-        {/* Location (#545): always shown, unlike Seniority's AddPill-gated
-         *  disclosure — location is a primary axis of every job-board search
-         *  form (not an auxiliary facet the way seniority is), and a résumé
-         *  with no parsed location still needs a visible place to type one to
-         *  get any location-aware ranking or deep-link behavior at all. */}
+        {/* Role families (#568): seeded from the same classification the
+         *  company-board pipeline uses, removable so a fullstack résumé that
+         *  also matched `data` can drop it. */}
+        <RoleFamilyChips
+          families={(query.families ?? []) as RoleFamily[]}
+          onRemove={removeRoleFamily}
+        />
+        {/* Location (#545): always shown, unlike the target level's
+         *  AddPill-gated disclosure — location is a primary axis of every
+         *  job-board search form (not an auxiliary facet the way level is),
+         *  and a résumé with no parsed location still needs a visible place
+         *  to type one to get any location-aware ranking or deep-link
+         *  behavior at all. */}
         <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
           <span className="text-xs text-content-tertiary">Location</span>
           <EditableField
@@ -149,20 +161,15 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
             }
           />
         </div>
+        {/* Target level (#562/#568): progressive disclosure, same pattern as
+         *  pre-#568 free-text Seniority — a résumé whose titles carry no
+         *  recognized level renders no inert control until the user opts in
+         *  via "+ Seniority". Changing the level re-runs the #562 rung-
+         *  distance penalty (live, via the refinement effect above). */}
         {query.seniority || seniorityExpanded ? (
-          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-            <span className="text-xs text-content-tertiary">Seniority</span>
-            <EditableField
-              value={query.seniority}
-              placeholder="seniority"
-              label="Seniority"
-              onCommit={(v) =>
-                setQuery((q) => ({ ...q, seniority: v || undefined }))
-              }
-            />
-          </div>
+          <LevelSelect value={query.seniority} onChange={setLevel} />
         ) : (
-          <AddPill label="Seniority" onClick={() => setSeniorityExpanded(true)} />
+          <AddPill label="Target level" onClick={() => setSeniorityExpanded(true)} />
         )}
         <ChipListEditor
           label="Skills"
@@ -171,6 +178,22 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
           onRemove={removeSkill}
           placeholder="Add a skill…"
           addAriaLabel="Add skill"
+        />
+        {/* Exclude (#563): title-only — a posting is dropped when its TITLE
+         *  contains one of these, never when only its description does.
+         *  Removable chips may already be seeded from the role-family
+         *  classification (e.g. GTM/field roles for an engineering search). */}
+        <ChipListEditor
+          label="Exclude (title only)"
+          items={query.excludeTerms ?? []}
+          onAdd={addExcludeTerm}
+          onRemove={removeExcludeTerm}
+          placeholder="Add a title to exclude…"
+          addAriaLabel="Add exclude term"
+        />
+        <CompFloorInput
+          value={query.compFloor}
+          onCommit={(v) => setQuery((q) => ({ ...q, compFloor: v }))}
         />
         {isDegenerate && (
           <p className="text-xs text-content-tertiary">

--- a/src/components/features/JobResultCard.test.tsx
+++ b/src/components/features/JobResultCard.test.tsx
@@ -6,8 +6,8 @@
 /**
  * Render coverage for JobResultCard (#319). Drives the card with a real
  * `RankedJob` built through `rankPostings` (no hand-mocked coverage) so the
- * fit-% headline, matched/missing chips, external link, and the "View match
- * detail" toggle → inline `<JdMatch>` all exercise. Raw createRoot + act,
+ * star-rating headline, matched/missing chips, external link, and the "View
+ * match detail" toggle → inline `<JdMatch>` all exercise. Raw createRoot + act,
  * matching the other feature render tests (no @testing-library in this repo).
  */
 
@@ -16,7 +16,7 @@ import { createElement } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { JobResultCard } from "./JobResultCard.tsx";
-import { rankPostings } from "../../lib/job-search/rank.ts";
+import { rankPostings, type RankedJob } from "../../lib/job-search/rank.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import type { JobPosting } from "../../lib/job-search/types.ts";
 
@@ -47,6 +47,10 @@ let root: Root;
 
 function render() {
   const [job] = rankPostings(parsed, [posting]);
+  return renderJob(job);
+}
+
+function renderJob(job: RankedJob) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -62,19 +66,85 @@ afterEach(() => {
 });
 
 describe("JobResultCard", () => {
-  it("renders title, source line, fit %, and a safe external link", () => {
+  it("renders title, meta line, a star rating headline, and a safe external link (issue 561)", () => {
     const el = render();
     expect(el.textContent).toContain("Senior Frontend Engineer");
     expect(el.textContent).toContain("Globex");
     expect(el.textContent).toContain("Remotive");
     expect(el.textContent).toContain("Remote");
-    expect(el.textContent).toContain("/100");
-    expect(el.textContent).toContain("fit");
+    // Star rating replaces the fit percentage. No "/100" percentage anywhere.
+    expect(el.textContent).not.toContain("/100");
+    const overall = el.querySelector('[role="img"][aria-label^="Overall match"]');
+    expect(overall).toBeTruthy();
+    expect(overall!.getAttribute("aria-label")).toMatch(/out of 5 stars$/);
 
     const link = el.querySelector("a") as HTMLAnchorElement;
     expect(link.getAttribute("href")).toBe("https://example.com/jobs/1");
     expect(link.getAttribute("target")).toBe("_blank");
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("shows exactly ONE star widget — no fit/pay sub-stars (issue 569)", () => {
+    const compPosting = {
+      ...posting,
+      id: "remotive:9",
+      description: `${posting.description} Salary: $180,000 - $240,000.`,
+    };
+    const [job] = rankPostings(parsed, [compPosting]);
+    const el = renderJob(job);
+    // Comp IS extracted here, so the old card would have rendered a "pay"
+    // sub-star alongside the "fit" one. Both are gone; the axes are words now.
+    expect(el.querySelectorAll('[role="img"]')).toHaveLength(1);
+    expect(el.querySelector('[role="img"][aria-label^="Fit:"]')).toBeNull();
+    expect(el.querySelector('[role="img"][aria-label^="Pay:"]')).toBeNull();
+  });
+
+  it("prints the rating numeral beside the stars (issue 569)", () => {
+    const [job] = rankPostings(parsed, [posting]);
+    const el = renderJob(job);
+    const shown = (Math.round(job.rating.overall * 10) / 10).toFixed(1);
+    expect((el.querySelector('[role="img"]') as HTMLElement).textContent).toContain(shown);
+  });
+
+  it("shows the coverage denominator as VISIBLE text, not a tooltip (issue 569)", () => {
+    const el = render();
+    const [job] = rankPostings(parsed, [posting]);
+    const covered = job.jdMatch.coverage.covered.length;
+    const total = covered + job.jdMatch.coverage.missing.length;
+    expect(total).toBeGreaterThan(0);
+    // Was a `title` on the fit sub-star — unreachable by touch and keyboard.
+    expect(el.textContent).toContain(`${covered} of ${total} terms`);
+    const tooltipped = [...el.querySelectorAll("span")].find((s) =>
+      s.getAttribute("title")?.includes("terms"),
+    );
+    expect(tooltipped).toBeUndefined();
+  });
+
+  it("renders a reason phrase per rating axis (issue 569)", () => {
+    const el = render();
+    // Fitness is always present, so a fit phrase always renders.
+    expect(el.textContent).toMatch(/(Top fit here|Strong fit|Partial fit|Weak fit)/);
+  });
+
+  it("drops a source that only repeats the company name (issue 569)", () => {
+    // Company-board adapters set `source` to the company's own display name.
+    const boardPosting = { ...posting, id: "greenhouse:1", source: "Globex" };
+    const [job] = rankPostings(parsed, [boardPosting]);
+    const el = renderJob(job);
+    expect(el.textContent).toContain("Globex");
+    expect(el.textContent).not.toContain("Globex · Globex");
+  });
+
+  it("collapses a multi-location posting to first + count (issue 569)", () => {
+    const multi = {
+      ...posting,
+      id: "greenhouse:2",
+      location: "San Francisco, CA | New York City, NY | Seattle, WA",
+    };
+    const [job] = rankPostings(parsed, [multi]);
+    const el = renderJob(job);
+    expect(el.textContent).toContain("San Francisco, CA +2");
+    expect(el.textContent).not.toContain("Seattle, WA");
   });
 
   it("toggles the inline JdMatch detail via View match detail", () => {
@@ -92,5 +162,42 @@ describe("JobResultCard", () => {
     expect(el.textContent).toContain("Hide match detail");
     // Reused JdMatch detail is now inline.
     expect(el.textContent).toContain("JD match");
+  });
+
+  it("shows an extracted compensation range with the raw text as a tooltip (issue 564)", () => {
+    const compPosting = {
+      ...posting,
+      id: "remotive:2",
+      description: `${posting.description} Salary: $180,000 - $240,000.`,
+    };
+    const [job] = rankPostings(parsed, [compPosting]);
+    const el = renderJob(job);
+    expect(el.textContent).toContain("$180,000–$240,000/yr");
+    const range = [...el.querySelectorAll("span")].find((s) =>
+      s.textContent?.includes("$180,000–$240,000/yr"),
+    ) as HTMLSpanElement;
+    expect(range.getAttribute("title")).toContain("$180,000 - $240,000");
+    // No floor set — no badge.
+    expect(el.textContent).not.toContain("Below your floor");
+  });
+
+  it("renders nothing compensation-related for a posting with no extractable range (issue 564)", () => {
+    const el = render();
+    expect(el.textContent).not.toContain("/yr");
+    expect(el.textContent).not.toContain("/hr");
+    expect(el.textContent).not.toContain("Below your floor");
+  });
+
+  it("badges a below-floor posting without hiding it (issue 564)", () => {
+    const compPosting = {
+      ...posting,
+      id: "remotive:3",
+      description: `${posting.description} Salary: $80,000 - $90,000.`,
+    };
+    const [job] = rankPostings(parsed, [compPosting], { compFloor: 200000 });
+    expect(job.belowFloor).toBe(true);
+    const el = renderJob(job);
+    expect(el.textContent).toContain("$80,000–$90,000/yr");
+    expect(el.textContent).toContain("Below your floor");
   });
 });

--- a/src/components/features/JobResultCard.tsx
+++ b/src/components/features/JobResultCard.tsx
@@ -9,50 +9,128 @@
  * two explicit affordances — "View match detail" toggles the reused `<JdMatch>`
  * detail inline, "Open posting" is a plain external anchor.
  *
- * Ranking parity: the card's fit % (`job.score`) and the expanded `<JdMatch>`
- * are fed from the SAME `job.jdMatch` object computed once in `rank.ts`, so the
- * headline number can never disagree with the detail view.
+ * Rating parity (#561): the card headline is a 0–5 STAR rating (`job.rating`),
+ * not a fit percentage — raw coverage compressed into single digits on real
+ * résumés and stopped discriminating (see `rating.ts`). The headline stars and
+ * the reason line are read straight off the SAME `job.rating` computed once in
+ * `rank.ts`, and the expanded `<JdMatch>` is fed the same `job.jdMatch`, so
+ * headline and detail can never disagree.
+ *
+ * ONE star rating per card (#569). The card used to stack fit and pay sub-stars
+ * under the overall — three identical glyph rows, three meanings, nothing
+ * marking the headline, and at `sm` the fractional fill is a two-pixel sliver so
+ * a 4.2 and a 4.6 looked the same. Now: the overall stars carry a NUMERAL
+ * (`showValue`), and the sub-axes are words from `describeRating` on a single
+ * reason line. Words fit all four axes — location and seniority were computed
+ * and never displayed at all — and drop the two that were near-duplicates of the
+ * overall. The coverage denominator rides that line as VISIBLE text ("12 of 18
+ * terms"); it used to be a `title` tooltip, which no touch or keyboard user can
+ * reach.
+ *
+ * Density (#569): company, source, location and compensation are all FACTS about
+ * the posting, so they share one meta line instead of owning a row each — the
+ * card is 4 rows, not 6, and a screenful holds more of the list. Two facts are
+ * squeezed on the way in: `source` is dropped when it merely repeats `company`
+ * (the company-board adapters set `source` to the company's own display name, so
+ * every Greenhouse/Lever/Ashby hit read "Anthropic · Anthropic"), and a posting
+ * listing many locations collapses to "San Francisco, CA +2".
+ *
+ * Compensation (#564): `posting.compensation` — extracted once in `rank.ts` —
+ * renders as a plain-text range when present (the actual figure). Absent
+ * entirely for a posting with no extractable range (silence is neutral, no
+ * placeholder). The matched source text (`raw`) rides as a `title` tooltip so a
+ * misparse is diagnosable. `job.belowFloor` (a SOFT signal — see `rank.ts`) adds
+ * a "Below your floor" badge; the posting itself is never hidden or reordered
+ * out of the list.
  */
 
 import { useState } from "react";
-import { Button, Chip } from "@design-system";
+import { Button, Chip, RatingStars, StatusBadge } from "@design-system";
 import { JdMatch } from "./JdMatch.tsx";
 import type { RankedJob } from "../../lib/job-search/rank.ts";
+import { formatCompensationRange } from "../../lib/job-search/compensation.ts";
+import { describeRating } from "../../lib/job-search/rating.ts";
 
-/** Top matched/missing terms shown on the card face before expansion. */
+/** Top matched terms shown on the card face before expansion. Matched only —
+ *  the missing terms doubled the chip row to say what the user has not got yet,
+ *  which is detail-view material; `<JdMatch>` still lists them in full. */
 const CHIP_CAP = 4;
+
+/** Separators a feed uses between several locations in one string (Greenhouse
+ *  and Lever both do this). NOT the comma — that separates city from state. */
+const LOCATION_SEPARATORS = /\s*[|;]\s*/;
+
+/** Round a 0–5 star value to one decimal for an aria-label. */
+function star1(v: number): number {
+  return Math.round(v * 10) / 10;
+}
+
+/** "San Francisco, CA | New York, NY | Seattle, WA" → "San Francisco, CA +2". */
+function summarizeLocation(location: string): string {
+  const parts = location.split(LOCATION_SEPARATORS).filter((p) => p.trim());
+  if (parts.length <= 1) return location.trim();
+  return `${parts[0].trim()} +${parts.length - 1}`;
+}
+
+/** The provider label, or null when it only repeats the company name. */
+function distinctSource(company: string, source: string): string | null {
+  const c = company.trim().toLowerCase();
+  const s = source.trim().toLowerCase();
+  return s && s !== c ? source : null;
+}
 
 export function JobResultCard({ job }: { job: RankedJob }) {
   const [open, setOpen] = useState(false);
-  const { posting, jdMatch, score } = job;
+  const { posting, jdMatch, rating, belowFloor, compFloorSet } = job;
   const matched = jdMatch.coverage.covered.slice(0, CHIP_CAP);
-  const missing = jdMatch.coverage.missing.slice(0, CHIP_CAP);
+  const coveredCount = jdMatch.coverage.covered.length;
+  const termCount = coveredCount + jdMatch.coverage.missing.length;
+
+  const facts = [
+    posting.company,
+    posting.company ? distinctSource(posting.company, posting.source) : posting.source,
+    posting.location ? summarizeLocation(posting.location) : "",
+  ].filter(Boolean);
+
+  const reasons = describeRating(rating, { hasCompFloor: compFloorSet });
+  if (termCount > 0) reasons.push(`${coveredCount} of ${termCount} terms`);
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border-light p-3">
+    <div className="flex flex-col gap-1.5 rounded-lg border border-border-light p-3">
       <div className="flex items-baseline justify-between gap-3">
         <h3 className="text-sm font-semibold text-content-primary">
           {posting.title}
         </h3>
-        <span className="shrink-0 whitespace-nowrap text-xs text-content-tertiary">
-          <span className="font-mono text-content-secondary">{score}/100</span> fit
-        </span>
+        <RatingStars
+          value={rating.overall}
+          size="md"
+          showValue
+          ariaLabel={`Overall match: ${star1(rating.overall)} out of 5 stars`}
+        />
       </div>
 
-      <p className="text-xs text-content-tertiary">
-        {[posting.company, posting.source].filter(Boolean).join(" · ")}
-        {posting.location ? ` · ${posting.location}` : ""}
-      </p>
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-content-tertiary">
+        <span>{facts.join(" · ")}</span>
+        {posting.compensation && (
+          <>
+            <span aria-hidden="true">·</span>
+            <span
+              className="font-medium text-content-secondary"
+              title={`Parsed from: "${posting.compensation.raw}"`}
+            >
+              {formatCompensationRange(posting.compensation)}
+            </span>
+            {belowFloor && <StatusBadge tone="warning">Below your floor</StatusBadge>}
+          </>
+        )}
+      </div>
 
-      {(matched.length > 0 || missing.length > 0) && (
+      <p className="text-xs text-content-tertiary">{reasons.join(" · ")}</p>
+
+      {matched.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {matched.map((term) => (
             <Chip key={`m:${term.source}:${term.id}`} tone="success">
-              {term.display}
-            </Chip>
-          ))}
-          {missing.map((term) => (
-            <Chip key={`x:${term.source}:${term.id}`} tone="neutral">
               {term.display}
             </Chip>
           ))}

--- a/src/components/features/JobSearchResults.test.tsx
+++ b/src/components/features/JobSearchResults.test.tsx
@@ -45,16 +45,38 @@ function posting(id: string): JobPosting {
   };
 }
 
+/** Shares none of the parsed résumé's skills, so `rankPostings` scores it 0. */
+function weakPosting(id: string): JobPosting {
+  return {
+    id,
+    title: `Rust Engineer ${id}`,
+    company: `Co ${id}`,
+    location: "Remote",
+    url: `https://example.com/${id}`,
+    description: "We need Rust and Kubernetes and Terraform experts.",
+    source: "Remotive",
+  };
+}
+
 function loaded(
   count: number,
   degradedProviders: string[] = [],
   providerCount = 3,
+  excludeSuppressed = false,
+  roleSuppressed = false,
 ): JobSearchResult {
   const jobs = rankPostings(
     parsed,
     Array.from({ length: count }, (_, i) => posting(String(i))),
   );
-  return { jobs, degradedProviders, providerCount };
+  return {
+    jobs,
+    degradedProviders,
+    providerCount,
+    excludeSuppressed,
+    roleSuppressed,
+    rawPostings: [],
+  };
 }
 
 let container: HTMLDivElement;
@@ -126,5 +148,62 @@ describe("JobSearchResults", () => {
     });
     expect(el.textContent).toContain("Couldn't reach any of the job feeds");
     expect(el.textContent).toContain("Retry search");
+  });
+
+  it("collapses below-threshold postings into a labelled, expandable weak-matches section (issue 567)", () => {
+    const jobs = rankPostings(parsed, [posting("s1"), weakPosting("w1")]);
+    const result: JobSearchResult = {
+      jobs,
+      degradedProviders: [],
+      providerCount: 1,
+      excludeSuppressed: false,
+      roleSuppressed: false,
+      rawPostings: [],
+    };
+    const el = render({ kind: "loaded", result });
+
+    // Strong posting renders immediately; the weak one is named in the
+    // collapsed toggle but its card is not yet in the DOM.
+    expect(el.querySelectorAll("h3").length).toBe(1);
+    expect(el.textContent).toContain("React Engineer s1");
+    expect(el.textContent).not.toContain("Rust Engineer w1");
+    expect(el.textContent).toContain("weak matches (1)");
+    // Header names the cut, derived from the single threshold constant.
+    expect(el.textContent).toContain("below 2.5★ match");
+
+    const toggle = [...el.querySelectorAll("button")].find((b) =>
+      b.getAttribute("aria-expanded") === "false" &&
+      b.textContent?.includes("weak matches"),
+    ) as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+
+    act(() => toggle.click());
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(el.querySelectorAll("h3").length).toBe(2);
+    expect(el.textContent).toContain("Rust Engineer w1");
+  });
+
+  it("an all-weak result set still shows results — auto-expands rather than rendering empty (issue 567)", () => {
+    const jobs = rankPostings(parsed, [weakPosting("w1"), weakPosting("w2")]);
+    const result: JobSearchResult = {
+      jobs,
+      degradedProviders: [],
+      providerCount: 1,
+      excludeSuppressed: false,
+      roleSuppressed: false,
+      rawPostings: [],
+    };
+    const el = render({ kind: "loaded", result });
+
+    // No strong matches, but the weak section is auto-expanded, not hidden.
+    expect(el.querySelectorAll("h3").length).toBe(2);
+    expect(el.textContent).toContain("Rust Engineer w1");
+    expect(el.textContent).toContain("Rust Engineer w2");
+    const toggle = [...el.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("weak matches"),
+    ) as HTMLButtonElement;
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(toggle.textContent).toContain("Hide weak matches (2)");
   });
 });

--- a/src/components/features/JobSearchResults.tsx
+++ b/src/components/features/JobSearchResults.tsx
@@ -15,6 +15,8 @@
 
 import { Button, ErrorState, StatusBadge } from "@design-system";
 import { JobResultCard } from "./JobResultCard.tsx";
+import { WeakMatchesSection } from "./WeakMatchesSection.tsx";
+import { isWeakMatch } from "./weakMatchThreshold.ts";
 import type { JobSearchResult } from "../../lib/job-search/search.ts";
 
 /** Cap on rendered cards — the sample is a taster, not a firehose (spec §4). */
@@ -85,7 +87,7 @@ function Loaded({
   result: JobSearchResult;
   onRetry: () => void;
 }) {
-  const { jobs, degradedProviders, providerCount } = result;
+  const { jobs, degradedProviders, providerCount, excludeSuppressed, roleSuppressed } = result;
 
   // Every provider rejected → hard error (with retry). Guarded on a non-zero
   // provider count so an empty registry (possible once #320 makes the set
@@ -105,6 +107,13 @@ function Loaded({
   }
 
   const shown = jobs.slice(0, RENDER_CAP);
+  // Split BENEATH the cap, not the ranking — #561's star rating is the only fit
+  // number, this just partitions the already-ranked, already-capped list on it.
+  // Never-empty-by-construction (issue 567): if every shown posting is weak,
+  // the strong list renders nothing, so the weak section is auto-expanded
+  // instead of leaving the page looking result-free behind a click.
+  const strong = shown.filter((job) => !isWeakMatch(job.rating));
+  const weak = shown.filter((job) => isWeakMatch(job.rating));
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-1.5">
@@ -121,13 +130,31 @@ function Loaded({
             from the other feeds.
           </p>
         )}
+        {excludeSuppressed && (
+          <p className="text-xs text-content-tertiary">
+            Your exclude terms would have removed every match, so we skipped
+            them for this search — remove or narrow a term above to apply
+            exclusion again.
+          </p>
+        )}
+        {roleSuppressed && (
+          <p className="text-xs text-content-tertiary">
+            Role filter skipped — it would have hidden every result, so we kept
+            them all for this search. Adjust the Role chips above to apply role
+            filtering again.
+          </p>
+        )}
       </div>
 
-      <div className="flex flex-col gap-2">
-        {shown.map((job) => (
-          <JobResultCard key={job.posting.id} job={job} />
-        ))}
-      </div>
+      {strong.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {strong.map((job) => (
+            <JobResultCard key={job.posting.id} job={job} />
+          ))}
+        </div>
+      )}
+
+      <WeakMatchesSection jobs={weak} defaultOpen={strong.length === 0} />
 
       {jobs.length > RENDER_CAP && (
         <p className="text-xs text-content-muted">

--- a/src/components/features/LevelSelect.test.tsx
+++ b/src/components/features/LevelSelect.test.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for LevelSelect (#568). Raw createRoot + act, matching the
+ * other feature render tests in this lane (no @testing-library here).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { LevelSelect } from "./LevelSelect.tsx";
+import { SENIORITY_LADDER } from "../../lib/job-search/seniority.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(value: string | undefined, onChange: (v: string | undefined) => void) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(LevelSelect, { value, onChange }));
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("LevelSelect", () => {
+  it("renders one radio option per SENIORITY_LADDER label", () => {
+    const el = render(undefined, () => {});
+    const radios = el.querySelectorAll('[role="radio"]');
+    expect(radios.length).toBe(Object.keys(SENIORITY_LADDER).length);
+    expect(el.textContent).toContain("Senior");
+    expect(el.textContent).toContain("Executive");
+  });
+
+  it("marks the current value's option as checked and no Clear button when unset", () => {
+    const el = render(undefined, () => {});
+    expect(el.querySelectorAll('button[aria-label="Clear"], a[aria-label="Clear"]').length).toBe(0);
+    const checked = [...el.querySelectorAll('[role="radio"]')].filter(
+      (n) => n.getAttribute("aria-checked") === "true",
+    );
+    expect(checked.length).toBe(0);
+  });
+
+  it("selecting a level calls onChange with that level", () => {
+    let selected: string | undefined;
+    const el = render(undefined, (v) => {
+      selected = v;
+    });
+    const senior = [...el.querySelectorAll('[role="radio"]')].find(
+      (n) => n.textContent === "Senior",
+    ) as HTMLButtonElement;
+    act(() => senior.click());
+    expect(selected).toBe("Senior");
+  });
+
+  it("selecting the already-active level clears it (toggle-to-clear)", () => {
+    let selected: string | undefined = "Senior";
+    const el = render("Senior", (v) => {
+      selected = v;
+    });
+    const senior = [...el.querySelectorAll('[role="radio"]')].find(
+      (n) => n.textContent === "Senior",
+    ) as HTMLButtonElement;
+    expect(senior.getAttribute("aria-checked")).toBe("true");
+    act(() => senior.click());
+    expect(selected).toBeUndefined();
+  });
+
+  it("shows a Clear control when a level is set, which clears the value", () => {
+    let selected: string | undefined = "Staff";
+    const el = render("Staff", (v) => {
+      selected = v;
+    });
+    const clear = [...el.querySelectorAll("button")].find(
+      (b) => b.textContent === "Clear",
+    ) as HTMLButtonElement;
+    expect(clear).toBeTruthy();
+    act(() => clear.click());
+    expect(selected).toBeUndefined();
+  });
+});

--- a/src/components/features/LevelSelect.tsx
+++ b/src/components/features/LevelSelect.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * LevelSelect — the target-level control for the #568 refinement surface.
+ * A segmented single-select over `SENIORITY_LADDER` (#562's single ordered
+ * ladder, `seniority.ts`) plus a Clear affordance for "no target level".
+ * Extracted out of `FindJobsPanel` (already at the ~200 LOC gate) rather than
+ * grown inline.
+ *
+ * No `Select`/`Dropdown` primitive exists in `@design-system` (checked the
+ * barrel + `primitives/`) — this is built from the `Button` primitive
+ * (variant="tab", the same segmented-trigger surface `Tabs` uses for its
+ * selected-tab affordance) rather than a raw `<select>`/`<button>`, per
+ * CLAUDE.md. It is deliberately NOT `Tabs` itself: `Tabs` is a controlled
+ * panel-switcher (`role="tablist"`/`"tabpanel"`, arrow-key roving focus over
+ * DOM panels); this is a plain single-value picker with no panels, so it uses
+ * `role="radiogroup"` + `role="radio"`/`aria-checked` instead of tab
+ * semantics — reusing `Tabs`' machinery here would misdescribe the control to
+ * assistive tech.
+ *
+ * Selecting the already-active level clears it (toggle-to-clear), and a
+ * dedicated "Clear" button appears next to the label whenever a level is set,
+ * so clearing is discoverable two ways, not just via the toggle.
+ */
+
+import { Button } from "@design-system";
+import { SENIORITY_LADDER } from "../../lib/job-search/seniority.ts";
+
+/** Declaration order in `SENIORITY_LADDER` is already the logical Intern →
+ *  Executive ladder walk (IC and management rungs interleaved) — see that
+ *  module's docblock. Sorting by rung VALUE would tie Manager/Principal (both
+ *  6), so this reuses the table's own order instead. */
+const LEVELS = Object.keys(SENIORITY_LADDER);
+
+interface LevelSelectProps {
+  /** Undefined = no target level set (the default). */
+  value: string | undefined;
+  onChange: (value: string | undefined) => void;
+}
+
+export function LevelSelect({ value, onChange }: LevelSelectProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span id="level-select-label" className="text-xs text-content-tertiary">
+          Target level
+        </span>
+        {value !== undefined && (
+          <Button variant="link" size="sm" onClick={() => onChange(undefined)}>
+            Clear
+          </Button>
+        )}
+      </div>
+      <div
+        role="radiogroup"
+        aria-labelledby="level-select-label"
+        className="flex flex-wrap gap-1 rounded-md border border-border-light bg-surface-subtle p-1"
+      >
+        {LEVELS.map((level) => {
+          const selected = value === level;
+          return (
+            <Button
+              key={level}
+              type="button"
+              variant="tab"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => onChange(selected ? undefined : level)}
+              className={
+                selected
+                  ? "bg-surface-card text-content-primary font-semibold shadow-xs"
+                  : "bg-transparent text-content-secondary font-medium hover:bg-surface-hover hover:text-content-primary"
+              }
+            >
+              {level}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/RoleFamilyChips.test.tsx
+++ b/src/components/features/RoleFamilyChips.test.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for RoleFamilyChips (#568). Raw createRoot + act, matching
+ * the other feature render tests in this lane (no @testing-library here).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RoleFamilyChips } from "./RoleFamilyChips.tsx";
+import type { RoleFamily } from "../../lib/job-search/role-keywords.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(families: RoleFamily[], onRemove: (f: RoleFamily) => void) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(RoleFamilyChips, { families, onRemove }));
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("RoleFamilyChips", () => {
+  it("renders one removable chip per family", () => {
+    const el = render(["frontend", "data"], () => {});
+    expect(el.textContent).toContain("frontend");
+    expect(el.textContent).toContain("data");
+    expect(el.querySelectorAll('button[aria-label="Remove frontend"]').length).toBe(1);
+    expect(el.querySelectorAll('button[aria-label="Remove data"]').length).toBe(1);
+  });
+
+  it("calls onRemove with the clicked family", () => {
+    const removed: RoleFamily[] = [];
+    const el = render(["frontend", "data"], (f) => removed.push(f));
+    const button = el.querySelector(
+      'button[aria-label="Remove data"]',
+    ) as HTMLButtonElement;
+    act(() => button.click());
+    expect(removed).toEqual(["data"]);
+  });
+
+  it("never fails closed: an empty family list shows a notice, not an empty/broken row", () => {
+    const el = render([], () => {});
+    expect(el.textContent).toContain("No role narrowing");
+    expect(el.querySelectorAll("button").length).toBe(0);
+  });
+});

--- a/src/components/features/RoleFamilyChips.tsx
+++ b/src/components/features/RoleFamilyChips.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * RoleFamilyChips — removable chips for the résumé-derived role families
+ * (#568), narrowing which of the classified `ROLE_FAMILIES`
+ * (`role-keywords.ts`) the search keeps — so a fullstack résumé that also
+ * matched `data` can drop `data` and keep only `fullstack`. Extracted out of
+ * `FindJobsPanel` (already at the ~200 LOC gate) rather than grown inline.
+ *
+ * Reuses the `Chip` primitive's removable variant directly (not
+ * `ChipListEditor`) because families are a FIXED, enum-only vocabulary —
+ * there is no free-text add the way there is for titles/skills, so there's no
+ * add-input to share.
+ *
+ * NEVER FAIL CLOSED (#568's own acceptance criterion): removing every chip
+ * does not filter the search at all — `roleFilterForFamilies([])` is the same
+ * permissive "all" filter `roleFilterForResume` already returns for an
+ * unclassified résumé — so the row degrades to "no role narrowing" rather
+ * than an empty panel, and says so.
+ */
+
+import { Chip } from "@design-system";
+import type { RoleFamily } from "../../lib/job-search/role-keywords.ts";
+
+interface RoleFamilyChipsProps {
+  families: readonly RoleFamily[];
+  onRemove: (family: RoleFamily) => void;
+}
+
+export function RoleFamilyChips({ families, onRemove }: RoleFamilyChipsProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs text-content-tertiary">Role</span>
+      {families.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {families.map((family) => (
+            <Chip
+              key={family}
+              onRemove={() => onRemove(family)}
+              removeLabel={`Remove ${family}`}
+            >
+              {family}
+            </Chip>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-content-tertiary">
+          No role narrowing — searching every role.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/WeakMatchesSection.tsx
+++ b/src/components/features/WeakMatchesSection.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * WeakMatchesSection — the collapsed tail of below-threshold postings
+ * beneath the strong results in `JobSearchResults.tsx` (issue 567).
+ *
+ * Split out to keep `JobSearchResults.tsx` under the ~200 LOC gate (mirrors
+ * `JobResultCard.tsx`'s split off `FindJobsPanel.tsx`). Reuses the same
+ * expand/collapse idiom `JobResultCard` already uses for "View match
+ * detail" — a `<Button>` toggling local `open` state — rather than adding a
+ * new disclosure primitive to the design system for one callsite.
+ *
+ * Never hard-drops a posting: every job passed in still renders, just
+ * behind the toggle. `defaultOpen` lets the caller auto-expand when there
+ * are zero strong matches, so an all-weak result set is never
+ * empty-by-construction (see `JobSearchResults.tsx`).
+ */
+
+import { useState } from "react";
+import { Button } from "@design-system";
+import { JobResultCard } from "./JobResultCard.tsx";
+import type { RankedJob } from "../../lib/job-search/rank.ts";
+import { WEAK_MATCH_LABEL } from "./weakMatchThreshold.ts";
+
+export function WeakMatchesSection({
+  jobs,
+  defaultOpen = false,
+}: {
+  jobs: RankedJob[];
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  if (jobs.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border-light pt-3">
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-expanded={open}
+        className="self-start"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? "Hide" : "Show"} weak matches ({jobs.length}) — {WEAK_MATCH_LABEL}
+      </Button>
+      {open && (
+        <div className="flex flex-col gap-2">
+          {jobs.map((job) => (
+            <JobResultCard key={job.posting.id} job={job} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/weakMatchThreshold.ts
+++ b/src/components/features/weakMatchThreshold.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Weak-match display threshold (issue 567) — the ONE place the "is this posting
+ * weak" cutoff lives. Reads #561's `RankedJob.rating.overall` (the 0–5 star
+ * rating shown on the card — see `rank.ts`/`rating.ts`); this module never
+ * computes a second fit number, it only names a cut point on the existing one.
+ *
+ * Keyed on the STAR rating, not raw coverage: the star is what the user sees on
+ * the card, so the fold must agree with it — a posting shown at 3★ must never be
+ * hidden in "weak matches" because some invisible raw-coverage number was low.
+ *
+ * A posting whose overall rating falls below this constant is collapsed into the
+ * "weak matches" disclosure (`WeakMatchesSection.tsx`) beneath the strong
+ * results instead of interleaved with them — never hard-dropped, always
+ * reachable by expanding (the #545/epic never-hard-drop precedent).
+ *
+ * Deliberately a fixed named constant, not a derived/adaptive one — the issue
+ * calls for a simple, legible cut, and `WEAK_MATCH_LABEL` derives its text from
+ * this value so the section header can never drift out of sync with the cutoff.
+ */
+const WEAK_MATCH_STAR_THRESHOLD = 2.5;
+
+/** "below 2.5★ match" — always in sync with `WEAK_MATCH_STAR_THRESHOLD`. */
+export const WEAK_MATCH_LABEL = `below ${WEAK_MATCH_STAR_THRESHOLD}★ match`;
+
+/** True when a ranked posting's overall star rating is below the weak cutoff —
+ *  the single predicate `JobSearchResults` splits the capped list on. */
+export function isWeakMatch(rating: { overall: number }): boolean {
+  return rating.overall < WEAK_MATCH_STAR_THRESHOLD;
+}

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -33,3 +33,4 @@ export * from "./shared/ErrorBoundary.tsx";
 export * from "./shared/UpdateBanner.tsx";
 export * from "./shared/GitHubStarCta.tsx";
 export * from "./shared/InlineDiff.tsx";
+export * from "./shared/RatingStars.tsx";

--- a/src/design-system/shared/RatingStars.test.tsx
+++ b/src/design-system/shared/RatingStars.test.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RatingStars } from "./RatingStars.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(props: Parameters<typeof RatingStars>[0]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(createElement(RatingStars, props)));
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+/** The fill overlay is the second star row (the clipped, accent-coloured one). */
+function fillWidth(el: HTMLElement): string {
+  const overlay = el.querySelector('[aria-hidden="true"].absolute') as HTMLElement;
+  return overlay.style.width;
+}
+
+describe("RatingStars", () => {
+  it("exposes one role=img with a numeric aria-label; glyphs are hidden", () => {
+    const el = render({ value: 4.2 });
+    const img = el.querySelector('[role="img"]') as HTMLElement;
+    expect(img.getAttribute("aria-label")).toBe("4.2 out of 5 stars");
+    // Every star glyph span is aria-hidden — AT reads the label, not ten stars.
+    for (const g of el.querySelectorAll("span[aria-hidden]")) {
+      expect(g.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+
+  it("fills the overlay to (value / max) · 100%", () => {
+    expect(fillWidth(render({ value: 4.2 }))).toBe("84%"); // 4.2 / 5
+    expect(fillWidth(render({ value: 2.5 }))).toBe("50%");
+    expect(fillWidth(render({ value: 0 }))).toBe("0%");
+    expect(fillWidth(render({ value: 5 }))).toBe("100%");
+  });
+
+  it("honours a custom max in both the label and the fill", () => {
+    const el = render({ value: 3, max: 10 });
+    expect((el.querySelector('[role="img"]') as HTMLElement).getAttribute("aria-label")).toBe(
+      "3 out of 10 stars",
+    );
+    expect(fillWidth(el)).toBe("30%");
+  });
+
+  it("clamps an out-of-range value into [0, max]", () => {
+    expect(fillWidth(render({ value: 9 }))).toBe("100%");
+    expect(fillWidth(render({ value: -3 }))).toBe("0%");
+  });
+
+  it("prints no numeral by default and a one-decimal, aria-hidden one with showValue", () => {
+    expect(render({ value: 4.2 }).textContent).not.toContain("4.2");
+
+    const el = render({ value: 4.2, showValue: true });
+    const numeral = [...el.querySelectorAll("span")].find(
+      (s) => s.textContent === "4.2",
+    ) as HTMLElement;
+    expect(numeral).toBeTruthy();
+    // The aria-label already says "4.2 out of 5 stars" — AT must not hear it twice.
+    expect(numeral.getAttribute("aria-hidden")).toBe("true");
+    // A whole value still shows a decimal, so the column width does not jitter.
+    expect(render({ value: 4, showValue: true }).textContent).toContain("4.0");
+  });
+
+  it("keeps the fill measured against the stars alone when a numeral is shown", () => {
+    // Regression guard: a numeral inside the overlay's positioning box would
+    // widen it and under-fill every rating.
+    expect(fillWidth(render({ value: 4.2, showValue: true }))).toBe("84%");
+  });
+
+  it("rounds the label to one decimal but a custom label wins verbatim", () => {
+    expect(
+      (render({ value: 3.14159 }).querySelector('[role="img"]') as HTMLElement).getAttribute(
+        "aria-label",
+      ),
+    ).toBe("3.1 out of 5 stars");
+    expect(
+      (
+        render({ value: 4, ariaLabel: "Overall match: 4 out of 5 stars" }).querySelector(
+          '[role="img"]',
+        ) as HTMLElement
+      ).getAttribute("aria-label"),
+    ).toBe("Overall match: 4 out of 5 stars");
+  });
+});

--- a/src/design-system/shared/RatingStars.tsx
+++ b/src/design-system/shared/RatingStars.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * RatingStars — a READ-ONLY, fractional 0–max star display.
+ *
+ * Distinct concern from the `StarRating` primitive: that one is an INTERACTIVE
+ * radio group for a user to GIVE a rating (discrete, keyboard-operable, fires
+ * `onChange`). This one DISPLAYS a computed rating that can land between stars
+ * (e.g. a 4.2★ job fit), so it is non-interactive and supports fractional fill.
+ * Reuse this everywhere a rating is shown; never hand-roll a parallel star row.
+ *
+ * Fractional fill is a two-layer overlay: a muted row of outline stars, and an
+ * identical row of filled stars clipped to `(value / max) · 100%` width. This
+ * gives true sub-star precision (a 4.2 shows four full stars plus a fifth filled
+ * ~20%) without per-star half/quarter glyph juggling.
+ *
+ * `showValue` prints the rounded number beside the glyphs. Stars are a
+ * low-precision encoding — at a small size the fractional overlay is a couple of
+ * pixels wide, so a 4.2 and a 4.6 are indistinguishable by eye. Turn it on
+ * wherever the exact value matters (#569); the numeral is `aria-hidden` because
+ * the `aria-label` already carries it, so AT must not hear it twice.
+ *
+ * Accessibility: the whole widget is one `role="img"` with an `aria-label`
+ * carrying the numeric value ("4.2 out of 5") — assistive tech reads the number,
+ * not ten individual star glyphs. The glyphs themselves are `aria-hidden`.
+ *
+ * Design rules (CLAUDE.md): semantic tokens only (accent for fill, muted for the
+ * track); no hardcoded colour.
+ */
+
+const SIZE_CLS = {
+  sm: "text-xs",
+  md: "text-base",
+} as const;
+
+interface RatingStarsProps {
+  /** The rating to display, 0..max (may be fractional). */
+  value: number;
+  /** Number of stars. Defaults to 5. */
+  max?: number;
+  /** Glyph size. Defaults to "md". */
+  size?: keyof typeof SIZE_CLS;
+  /** Accessible label. Defaults to "{value} out of {max} stars". Pass a richer
+   *  one (e.g. "Overall match: 4.2 out of 5 stars") at a callsite where context
+   *  matters. */
+  ariaLabel?: string;
+  /** Print the rounded value beside the stars. Defaults to false. */
+  showValue?: boolean;
+}
+
+export function RatingStars({
+  value,
+  max = 5,
+  size = "md",
+  ariaLabel,
+  showValue = false,
+}: RatingStarsProps) {
+  const clamped = value < 0 ? 0 : value > max ? max : value;
+  // Round to 2 dp so the inline width is a clean "84%", not "84.00000000000001%".
+  const pct = Math.round((clamped / max) * 10000) / 100;
+  const rounded = Math.round(clamped * 10) / 10;
+  const label = ariaLabel ?? `${rounded} out of ${max} stars`;
+  const stars = "★".repeat(max);
+
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      className={`inline-flex items-center gap-1 leading-none ${SIZE_CLS[size]}`}
+    >
+      {/* The glyph box is its own element so the fill overlay's `inset-0` is
+          measured against the STARS alone — an adjacent numeral inside it would
+          widen the box and under-fill every rating. */}
+      <span aria-hidden="true" className="relative inline-block whitespace-nowrap">
+        {/* Track: outline/muted stars fill the width and set the box size. */}
+        <span aria-hidden="true" className="text-content-muted">
+          {stars}
+        </span>
+        {/* Fill: filled stars clipped to the rating fraction, overlaid exactly. */}
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 overflow-hidden text-accent-primary"
+          style={{ width: `${pct}%` }}
+        >
+          {stars}
+        </span>
+      </span>
+      {showValue && (
+        <span aria-hidden="true" className="tabular-nums text-content-secondary">
+          {rounded.toFixed(1)}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/hooks/useJobSearch.ts
+++ b/src/hooks/useJobSearch.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Owns the Find Jobs fetch lifecycle AND the #568 live re-rank, so
+ * `FindJobsPanel` stays a layout shell. Cross-cutting interaction state per
+ * CLAUDE.md's "hooks own modals/drop zones/locks" rule — this is the same
+ * shape (a fetch + a derived recompute), just for the search panel.
+ *
+ * TWO responsibilities, one hook, because they share state a split would
+ * have to duplicate (the abort controller, the raw-postings snapshot):
+ *
+ * 1. `runSearch` — the ONLY thing that fetches. Never fires on mount, drop,
+ *    tab open, or a query edit — only an explicit caller invocation (the
+ *    panel's Search button). `searchJobs` dynamic-imports the provider/rank
+ *    tiers, so nothing job-fetch-related sits in the entry chunk.
+ * 2. The live re-rank effect (#568) — re-runs `refineSearchResult` (the SAME
+ *    role/exclude filter + rank pipeline `searchJobs` used) over the last
+ *    fetch's raw postings whenever a refinement control changes, with NO new
+ *    fetch — that's what lets `FindJobsPanel` re-rank live without breaking
+ *    responsibility 1's invariant. Scoped to exactly the controls #568
+ *    wires (role families, target level, exclude terms, comp floor,
+ *    location); a titles/skills edit still requires a fresh Search, since
+ *    `matchesQuery` already ran against the OLD titles/skills when the
+ *    snapshot was taken.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { JobQuery } from "../lib/job-search/query-builder.ts";
+import type { JobPosting } from "../lib/job-search/types.ts";
+import type { CompanyEntry } from "../lib/job-search/company-registry.ts";
+import { refineSearchResult } from "../lib/job-search/refine.ts";
+import type { SearchPhase } from "../components/features/JobSearchResults.tsx";
+
+interface RawFetchSnapshot {
+  raw: JobPosting[];
+  degradedProviders: string[];
+  providerCount: number;
+}
+
+export function useJobSearch(
+  query: JobQuery,
+  parsed: HeuristicParsedResume,
+  selectedCompanies: readonly CompanyEntry[],
+) {
+  const [phase, setPhase] = useState<SearchPhase>({ kind: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+  // Snapshot of the last fetch's raw (deduped, matchesQuery-filtered but not
+  // yet role/exclude-filtered or ranked) postings — kept OUTSIDE `phase` so
+  // the re-rank effect below doesn't feed back into its own trigger.
+  // `undefined` until the first successful search; the effect is a no-op
+  // until then.
+  const rawFetchRef = useRef<RawFetchSnapshot | undefined>(undefined);
+
+  // Abort any in-flight search on unmount so a late response can't try to
+  // update state on an unmounted component.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const runSearch = () => {
+    // Supersede any in-flight search so its results can't land after this one.
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setPhase({ kind: "loading" });
+    void (async () => {
+      try {
+        const { searchJobs } = await import("../lib/job-search/search.ts");
+        const result = await searchJobs(query, parsed, ctrl.signal, selectedCompanies);
+        if (ctrl.signal.aborted) return;
+        rawFetchRef.current = {
+          raw: result.rawPostings,
+          degradedProviders: result.degradedProviders,
+          providerCount: result.providerCount,
+        };
+        setPhase({ kind: "loaded", result });
+      } catch {
+        if (ctrl.signal.aborted) return;
+        setPhase({ kind: "failed" });
+      }
+    })();
+  };
+
+  useEffect(() => {
+    const snapshot = rawFetchRef.current;
+    if (!snapshot) return;
+    let cancelled = false;
+    void (async () => {
+      const result = await refineSearchResult(
+        snapshot.raw,
+        parsed,
+        query,
+        snapshot.degradedProviders,
+        snapshot.providerCount,
+      );
+      if (!cancelled) setPhase({ kind: "loaded", result });
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // `exhaustive-deps` is NOT lint-enforced here (no react-hooks plugin) —
+    // this array is deliberately scoped to the five refinement knobs #568
+    // wires, not titles/skills (see the file docblock) and not `parsed`
+    // (stable per panel mount — the résumé isn't edited from here).
+  }, [query.families, query.excludeTerms, query.seniority, query.compFloor, query.location]);
+
+  return { phase, runSearch, isLoading: phase.kind === "loading" };
+}

--- a/src/lib/job-search/company-boards.test.ts
+++ b/src/lib/job-search/company-boards.test.ts
@@ -178,6 +178,32 @@ describe("makeBoardProvider — filter and cap run BEFORE hydration", () => {
     expect(hoisted.hydrateCalls).toHaveLength(DEFAULT_PER_COMPANY_CAP);
   });
 
+  it("(issue 563) excludes title-matched postings BEFORE the per-company cap, so they never consume a cap slot", async () => {
+    // DEFAULT_PER_COMPANY_CAP (8) rows that pass the "backend" role filter
+    // (title contains "backend") but should be excluded on title, followed by
+    // 3 real "Backend Engineer" rows. If exclusion ran AFTER the cap (or not
+    // at all), the 8 excluded rows would fill the cap and the 3 real roles
+    // would never be hydrated.
+    hoisted.board = [
+      ...Array.from({ length: DEFAULT_PER_COMPANY_CAP }, (_, i) =>
+        ghPosting(i, "Backend Solutions Architect"),
+      ),
+      ghPosting(100, "Senior Backend Engineer"),
+      ghPosting(101, "Staff Backend Engineer"),
+      ghPosting(102, "Backend Engineer, Payments"),
+    ];
+
+    const [provider] = makeBoardProviders([STRIPE], backendResume);
+    const results = await provider.search(
+      { ...query, excludeTerms: ["solutions architect"] },
+      signal,
+    );
+
+    expect(results.map((p) => p.id).sort()).toEqual(
+      ["greenhouse:stripe:100", "greenhouse:stripe:101", "greenhouse:stripe:102"].sort(),
+    );
+  });
+
   it("honours an explicit per-company cap", async () => {
     hoisted.board = Array.from({ length: 40 }, (_, i) =>
       ghPosting(i, "Backend Engineer"),

--- a/src/lib/job-search/company-boards.ts
+++ b/src/lib/job-search/company-boards.ts
@@ -11,8 +11,15 @@
  *
  *   cached light index (or fetch it)   board-cache.ts / the slice-1/2 adapters
  *     → filterPostingsByRole           role-keywords.ts (#534)
+ *     → filterPostingsByExcludeTerms   role-keywords.ts (#563)
+ *     → orderPostingsByTitleScore      role-keywords.ts (#565)
  *     → capPerCompany                  role-keywords.ts (#534)
  *     → hydrate ONLY the survivors     hydrateGreenhouse / hydrateLever
+ *
+ * Exclusion runs BEFORE the order/cap stages on purpose (#563): an excluded
+ * posting (title matches a user or seeded exclude term) must never consume a
+ * company's `capPerCompany` slot, and never fails closed — see
+ * `filterPostingsByExcludeTerms`'s own doc for the per-call skip behavior.
  *
  * ORDER IS THE WHOLE POINT. A 1000-role Greenhouse board costs exactly one
  * light-index request plus at most `perCompanyCap` description fetches, because
@@ -40,9 +47,10 @@
  * behind the provider interface rather than in a parallel fan-out.
  *
  * PRIVACY: the request carries the public company slug (and a job id when
- * hydrating) and nothing else. `roleFilterForResume` and `filterPostingsByRole`
- * run purely on-device over already-fetched postings, so this slice adds no
- * egress. `providers/keywords.ts` — the single audited resume-derived egress
+ * hydrating) and nothing else. `roleFilterForResume`, `filterPostingsByRole`,
+ * and `orderPostingsByTitleScore` all run purely on-device over
+ * already-fetched postings, so this slice adds no egress.
+ * `providers/keywords.ts` — the single audited resume-derived egress
  * helper — is used only by the keyless feeds and is deliberately not imported
  * here.
  */
@@ -52,9 +60,13 @@ import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { JobProvider, JobPosting } from "./types.ts";
 import {
   roleFilterForResume,
+  roleFilterForFamilies,
   filterPostingsByRole,
+  filterPostingsByExcludeTerms,
+  orderPostingsByTitleScore,
   capPerCompany,
   DEFAULT_PER_COMPANY_CAP,
+  type RoleFamily,
   type RoleFilter,
 } from "./role-keywords.ts";
 import { makeCompanyProvider } from "./providers/index.ts";
@@ -179,14 +191,30 @@ export function makeBoardProvider(
         if (cacheable) await writeCachedBoard(entry.ats, entry.slug, index);
       }
 
-      // `capPerCompany` truncates in the board's NATIVE order, before hydrate
-      // and before `rankPostings` — a deliberate request-bounding tradeoff: a
-      // strong-fit role past the cap in board order is dropped before ranking
-      // can see it. Fit-aware selection here would need a pre-hydrate signal
-      // (title/skill-in-title); today the cap is board-order, and rank only
-      // reorders the survivors. See the epic-#528 follow-up on skills ranking.
+      // `capPerCompany` truncates in the ORDER IT'S GIVEN, before hydrate and
+      // before `rankPostings` — a deliberate request-bounding tradeoff, so
+      // WHICH postings reach it matters. `filterPostingsByExcludeTerms` (#563)
+      // drops title-matched exclusions BEFORE `orderPostingsByTitleScore`
+      // (#565) reorders the survivors by a cheap, title-only, no-I/O score
+      // against `query.titles`/`query.seniority` and BEFORE the cap slices —
+      // so an excluded posting never consumes a company's cap slot, and the
+      // survivors are the best title-side matches per company rather than an
+      // arbitrary board-order prefix. A degenerate query (no derivable titles)
+      // scores everything 0 and keeps ties in board order; an empty
+      // `excludeTerms` is a no-op — both byte-identical to pre-#563/#565
+      // behavior, the never-fail-closed floor.
+      const roleFiltered = filterPostingsByRole(index, filter);
+      // `suppressed` is intentionally discarded here: one board's own survivor
+      // set emptying out is a normal, local outcome (that board just doesn't
+      // have any non-excluded roles), not a whole-panel failure. The
+      // panel-level never-fail-closed notice is computed once in `search.ts`,
+      // over the full merged result set across every provider.
+      const { postings: excludeFiltered } = filterPostingsByExcludeTerms(
+        roleFiltered,
+        query.excludeTerms,
+      );
       const survivors = capPerCompany(
-        filterPostingsByRole(index, filter),
+        orderPostingsByTitleScore(excludeFiltered, query),
         perCompanyCap,
       );
       return hydrateDescriptions(entry, survivors, signal);
@@ -195,15 +223,24 @@ export function makeBoardProvider(
 }
 
 /**
- * Bounded providers for every selected company. The role filter is derived from
- * the resume ONCE here and shared by every board — it does not vary per company,
- * and recomputing it per board would re-scan the resume for each one.
+ * Bounded providers for every selected company. The role filter is derived
+ * from the resume ONCE here and shared by every board — it does not vary per
+ * company, and recomputing it per board would re-scan the resume for each one.
+ *
+ * @param families Explicit family override (#568) — pass `query.families`
+ *   from `FindJobsPanel`'s refinement chips. `undefined` (every pre-#568
+ *   caller, including this module's own tests) keeps the resume-derived
+ *   filter, byte-identical to prior behavior. An empty array (every chip
+ *   removed) resolves through `roleFilterForFamilies([])` to the permissive
+ *   "all" filter — never-fail-closed, not zero results.
  */
 export function makeBoardProviders(
   entries: readonly CompanyEntry[],
   parsed: HeuristicParsedResume,
   perCompanyCap: number = DEFAULT_PER_COMPANY_CAP,
+  families?: readonly RoleFamily[],
 ): JobProvider[] {
-  const filter = roleFilterForResume(parsed);
+  const filter =
+    families !== undefined ? roleFilterForFamilies(families) : roleFilterForResume(parsed);
   return entries.map((entry) => makeBoardProvider(entry, filter, perCompanyCap));
 }

--- a/src/lib/job-search/compensation.test.ts
+++ b/src/lib/job-search/compensation.test.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  extractCompensation,
+  isBelowFloor,
+  formatCompensationRange,
+} from "./compensation.ts";
+
+describe("extractCompensation", () => {
+  it("parses a comma-separated dollar range (issue 564)", () => {
+    const comp = extractCompensation(
+      "We offer a base salary of $180,000 - $240,000 depending on experience.",
+    );
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(180000);
+    expect(comp!.max).toBe(240000);
+    expect(comp!.currency).toBe("USD");
+    expect(comp!.period).toBe("year");
+    expect(comp!.raw).toContain("180,000");
+    expect(comp!.raw).toContain("240,000");
+  });
+
+  it("parses a K-suffixed en-dash range", () => {
+    const comp = extractCompensation("Compensation: $180K–$240K annually.");
+    expect(comp).toEqual({
+      min: 180000,
+      max: 240000,
+      currency: "USD",
+      period: "year",
+      raw: "$180K–$240K annually",
+    });
+  });
+
+  it("parses a currency-code-prefixed 'to' range with plain digits", () => {
+    const comp = extractCompensation("Salary range: USD 180000 to 240000 per year.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(180000);
+    expect(comp!.max).toBe(240000);
+    expect(comp!.currency).toBe("USD");
+    expect(comp!.period).toBe("year");
+  });
+
+  it("parses an hourly single value", () => {
+    const comp = extractCompensation("This contract role pays $95/hour.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(95);
+    expect(comp!.max).toBe(95);
+    expect(comp!.currency).toBe("USD");
+    expect(comp!.period).toBe("hour");
+    expect(comp!.raw).toBe("$95/hour");
+  });
+
+  it("parses a plain single-value dollar figure, defaulting to yearly", () => {
+    const comp = extractCompensation("Base pay: $120,000.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(120000);
+    expect(comp!.max).toBe(120000);
+    expect(comp!.period).toBe("year");
+  });
+
+  it("does NOT infer hourly from magnitude alone — a bare '$N' with no period is not extractable (issue 566)", () => {
+    // Old behavior guessed hourly for any figure under $1,000. That guess drove
+    // the below-floor badge + sort penalty off nothing, so it is gone: a lone
+    // "$45" with no period token and no salary context is now silence-neutral.
+    expect(extractCompensation("Rate: $45.")).toBeUndefined();
+    // A salary-context word rescues it, but the period stays yearly (never a
+    // magnitude-inferred hour).
+    const withContext = extractCompensation("Base pay: $45.");
+    expect(withContext).toBeDefined();
+    expect(withContext!.period).toBe("year");
+  });
+
+  it("parses GBP and EUR symbols", () => {
+    const gbp = extractCompensation("£65,000 - £85,000 per annum.");
+    expect(gbp!.currency).toBe("GBP");
+    expect(gbp!.min).toBe(65000);
+    expect(gbp!.max).toBe(85000);
+
+    const eur = extractCompensation("€70K–€90K per year.");
+    expect(eur!.currency).toBe("EUR");
+    expect(eur!.min).toBe(70000);
+    expect(eur!.max).toBe(90000);
+  });
+
+  it("parses a monthly range", () => {
+    const comp = extractCompensation("$6,000-$8,000/month");
+    expect(comp!.period).toBe("month");
+    expect(comp!.min).toBe(6000);
+    expect(comp!.max).toBe(8000);
+  });
+
+  it("does not swallow a trailing word that starts with K", () => {
+    // Salary context ("base pay") makes the single figure extractable; the
+    // K-lookahead guard is what this asserts — "180" must NOT read as 180,000
+    // just because "Kubernetes" starts with K.
+    const comp = extractCompensation("Base pay covers $180 Kubernetes tooling.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(180);
+  });
+
+  it("SILENCE IS NEUTRAL: returns undefined for a bare numeric range with no currency", () => {
+    // "5-10 years" / "50-100 employees" are extremely common false-positive
+    // shapes in posting text — no currency marker means no match at all.
+    expect(extractCompensation("5-10 years of experience with 50-100 person teams.")).toBeUndefined();
+  });
+
+  it("SILENCE IS NEUTRAL: returns undefined for text with no numbers", () => {
+    expect(extractCompensation("Join our growing team and make an impact.")).toBeUndefined();
+  });
+
+  it("SILENCE IS NEUTRAL: returns undefined for empty text", () => {
+    expect(extractCompensation("")).toBeUndefined();
+  });
+
+  it("prefers a genuine range over its own first number", () => {
+    const comp = extractCompensation("Pay: $100,000 - $150,000 (DOE)");
+    expect(comp!.min).toBe(100000);
+    expect(comp!.max).toBe(150000);
+  });
+
+  // Non-salary dollar figures must NOT parse as pay (issue 566) — each drives
+  // the below-floor badge + sort penalty no human vets, so a wrong number here
+  // is a silent mis-signal.
+  it("rejects a millions/billions funding figure rather than reading its bare number", () => {
+    // Must NOT drop the "M" and read "$5" (previously "$5/hour").
+    expect(extractCompensation("We recently raised $5M in Series B funding.")).toBeUndefined();
+    expect(extractCompensation("Backed by $50 million in venture capital.")).toBeUndefined();
+    expect(extractCompensation("A $2.5bn total addressable market.")).toBeUndefined();
+    expect(
+      extractCompensation("…raised over $50,000,000 in venture funding."),
+    ).toBeUndefined();
+  });
+
+  it("rejects a budget figure with no salary context", () => {
+    expect(
+      extractCompensation("You'll manage a budget of $250,000 for marketing."),
+    ).toBeUndefined();
+  });
+
+  it("rejects an equity figure with no salary context", () => {
+    expect(extractCompensation("Equity worth up to $100,000 over 4 years.")).toBeUndefined();
+  });
+
+  it("rejects a monthly savings figure (a lone monthly single is not pay)", () => {
+    expect(
+      extractCompensation("Our product helps customers save $200/month on tooling."),
+    ).toBeUndefined();
+  });
+
+  // Directional (nearest-figure) salary attribution (issue 566). A non-salary
+  // figure must NOT capture a salary word that sits closer to a LATER figure —
+  // the later, truly-salaried figure is the one extracted.
+  it("attributes the salary word to the nearer LATER figure, not a leading equity figure", () => {
+    const comp = extractCompensation("equity worth $100,000, salary $180,000");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(180000);
+    expect(comp!.max).toBe(180000);
+    expect(comp!.currency).toBe("USD");
+    expect(comp!.period).toBe("year");
+    // The whole point: a $160K floor must NOT read this job as below floor.
+    expect(isBelowFloor(comp, 160000)).toBe(false);
+  });
+
+  it("attributes the salary word past a leading budget figure to the real salary", () => {
+    const comp = extractCompensation("You'll manage a budget of $250,000. Salary is $150,000.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(150000);
+    expect(comp!.max).toBe(150000);
+  });
+
+  it("prefers a salary-attached figure over an earlier period-only contractor rate", () => {
+    const comp = extractCompensation(
+      "$45/hour contractor rate mentioned but real salary $180,000",
+    );
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(180000);
+    expect(comp!.period).toBe("year");
+    // ~$93.6K annualized from $45/hr would have tripped a $150K floor; the real
+    // $180K salary must not.
+    expect(isBelowFloor(comp, 150000)).toBe(false);
+  });
+
+  it("extracts a bare 'annual $N' — annual is now salary-context vocabulary (issue 566)", () => {
+    const comp = extractCompensation("annual $115,000");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(115000);
+    expect(comp!.max).toBe(115000);
+    expect(comp!.period).toBe("year");
+  });
+
+  it("still skips a leading funding figure when a real salary follows", () => {
+    const comp = extractCompensation("We raised $5M in Series B. Base salary $180,000.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(180000);
+    expect(isBelowFloor(comp, 160000)).toBe(false);
+  });
+
+  it("still returns the first genuine range even when two ranges are present", () => {
+    const comp = extractCompensation("Base $100,000 - $150,000 or senior $200,000 - $250,000.");
+    expect(comp!.min).toBe(100000);
+    expect(comp!.max).toBe(150000);
+  });
+
+  it("extracts a figure with a salary word on BOTH sides", () => {
+    const comp = extractCompensation("Annual base salary $150,000 pay, negotiable.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(150000);
+    expect(comp!.period).toBe("year");
+  });
+
+  it("returns undefined when a salary word is isolated from every figure by sentence boundaries", () => {
+    // "Salary" lives in its own sentence — both figures sit across a period, so
+    // the word binds to neither, and neither figure carries a period. Ambiguous/
+    // unreachable attribution is dropped rather than guessed (safe direction).
+    expect(
+      extractCompensation("$120,000 total. Salary policy applies. Bonus $180,000."),
+    ).toBeUndefined();
+  });
+
+  it("binds the salary word to the nearest figure across a currency switch (multi-currency)", () => {
+    const comp = extractCompensation("Prior role paid £100,000; here the salary is $120,000.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(120000);
+    expect(comp!.currency).toBe("USD");
+  });
+});
+
+describe("isBelowFloor", () => {
+  const range = extractCompensation("$100,000 - $150,000 per year")!;
+  const single = extractCompensation("$45/hour")!;
+
+  it("is false when there is no compensation (silence is neutral, even with a floor set)", () => {
+    expect(isBelowFloor(undefined, 200000)).toBe(false);
+  });
+
+  it("is false when there is no floor", () => {
+    expect(isBelowFloor(range, undefined)).toBe(false);
+  });
+
+  it("is true when the top of the range is under the floor", () => {
+    expect(isBelowFloor(range, 200000)).toBe(true);
+  });
+
+  it("is false when the range's top reaches the floor", () => {
+    expect(isBelowFloor(range, 150000)).toBe(false);
+    expect(isBelowFloor(range, 120000)).toBe(false); // straddles — not "below"
+  });
+
+  it("annualizes an hourly figure before comparing", () => {
+    // $45/hr * 2080 = $93,600/yr — below a $150K floor, above a $50K floor.
+    expect(isBelowFloor(single, 150000)).toBe(true);
+    expect(isBelowFloor(single, 50000)).toBe(false);
+  });
+
+  it("is neutral for a non-USD currency", () => {
+    const eur = extractCompensation("€50,000 per year")!;
+    expect(isBelowFloor(eur, 200000)).toBe(false);
+  });
+});
+
+describe("formatCompensationRange", () => {
+  it("formats a range with an en dash and period suffix", () => {
+    const comp = extractCompensation("$180,000 - $240,000")!;
+    expect(formatCompensationRange(comp)).toBe("$180,000–$240,000/yr");
+  });
+
+  it("formats a single value", () => {
+    const comp = extractCompensation("$95/hour")!;
+    expect(formatCompensationRange(comp)).toBe("$95/hr");
+  });
+
+  it("formats a non-USD currency with its symbol", () => {
+    const comp = extractCompensation("£65,000 - £85,000 per annum")!;
+    expect(formatCompensationRange(comp)).toBe("£65,000–£85,000/yr");
+  });
+});

--- a/src/lib/job-search/compensation.ts
+++ b/src/lib/job-search/compensation.ts
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Compensation extraction — pull a pay range out of a posting's description
+ * (#564, job-search-v3 epic #566).
+ *
+ * US pay-transparency laws (CO, CA, NY, WA, IL, and more) require postings to
+ * state a range, and the ATS boards this lane already reads (Greenhouse,
+ * Lever, Ashby) reproduce it verbatim in the description text the lane
+ * already fetched — nothing new is fetched, nothing new leaves the browser.
+ * `extractCompensation` regexes that text entirely on-device.
+ *
+ * Two invariants the rest of the lane depends on:
+ *
+ *   - SILENCE IS NEUTRAL. A posting with no extractable range returns
+ *     `undefined` here, and every downstream consumer (rank.ts's sort key,
+ *     JobResultCard) must treat that identically to "no compensation field at
+ *     all" — never as "pays badly." Non-extraction is the common case
+ *     (non-US postings, older listings, boards that omit pay) and must never
+ *     read as a signal.
+ *   - `raw` IS ALWAYS THE MATCHED SUBSTRING. A misparse must be visible, not
+ *     a silent wrong number — the card surfaces `raw` in a tooltip so a bad
+ *     match is diagnosable rather than trusted blindly.
+ *
+ * Shapes covered (from the issue): "$180,000 - $240,000", "$180K–$240K",
+ * "USD 180000 to 240000", "$95/hour", and single-value forms ("$120,000").
+ * A CURRENCY MARKER (symbol or ISO code) IS REQUIRED for a match — a bare
+ * number range ("5-10 years", "50-100 employees") is extremely common in
+ * posting text and would false-positive constantly without this gate. The
+ * tradeoff: a posting that states pay with neither a symbol nor a code (rare
+ * in practice) is silently missed, which is the correct failure mode per the
+ * silence-is-neutral invariant above — better to under-match than to
+ * misreport a random number as a salary.
+ *
+ * NON-SALARY DOLLAR FIGURES ARE THE HARD PART (job-search-v3 epic #566). A
+ * description routinely carries currency figures that are NOT the pay: "raised
+ * $5M in Series B", "$250,000 marketing budget", "equity worth $100,000",
+ * "customers save $200/month". The extractor MUST NOT read those as a salary,
+ * because the parse drives two signals no human vets — the "below your floor"
+ * badge and the `COMP_FLOOR_PENALTY` sort demotion. Three guards keep it
+ * honest, all scanning EVERY currency match (not just the first) so a leading
+ * funding figure is skipped rather than locked in:
+ *
+ *   1. MAGNITUDE-SUFFIX GUARD. A figure immediately followed by a millions/
+ *      billions suffix ("$5M", "$5 million", "$50bn") is funding/valuation, not
+ *      a salary shape — the match is rejected outright rather than silently
+ *      read as "$5". Never drop the magnitude and keep the number.
+ *   2. NO MAGNITUDE→HOURLY INFERENCE. A bare small "$N" is NOT assumed hourly.
+ *      `hour` is inferred ONLY from an explicit period token (/hr, per hour,
+ *      hourly, …). Without one a small figure is not silently turned into a wage.
+ *   3. SALARY-CONTEXT GATE for lone single values, applied DIRECTIONALLY. A
+ *      single figure with neither a salary-context word ATTACHED to it
+ *      (salary/comp/pay/base/OTE/annual/…) nor a trustworthy standalone period
+ *      (explicit annual or hourly — a lone MONTHLY single is usually SaaS
+ *      pricing/savings, not pay) is treated as NOT extractable. Attachment is
+ *      nearest-figure, not window-membership: each salary word binds to the
+ *      single closest figure, so a non-salary figure ("equity worth $100,000")
+ *      no longer captures a salary word that sits closer to a LATER figure
+ *      ("…, salary $180,000") — the later, truly-salaried figure wins (#566).
+ *      Attribution also never crosses a sentence boundary, so "budget of
+ *      $250,000. Salary is $150,000" binds "Salary" forward to $150,000.
+ *      Aligned with, not a regression of, #564's single-value acceptance: a
+ *      genuine single salary still parses when a salary word sits next to it
+ *      ("Base pay: $120,000") or it carries an explicit annual/hourly period.
+ *      Ranges are exempt — a currency-anchored range that survives the suffix
+ *      guard is a deliberate pay statement and wins before singles are scored.
+ */
+
+export type CompensationPeriod = "year" | "hour" | "month";
+
+export interface Compensation {
+  min?: number;
+  max?: number;
+  /** ISO-ish currency code, e.g. "USD", "GBP", "EUR". */
+  currency: string;
+  period: CompensationPeriod;
+  /** The exact matched source substring — surfaced on the card so a misparse
+   *  is visible rather than a silent wrong number. */
+  raw: string;
+}
+
+const CURRENCY_SYMBOL_TO_CODE: Record<string, string> = {
+  $: "USD",
+  "£": "GBP",
+  "€": "EUR",
+};
+
+const CUR_SYM = String.raw`\$|£|€`;
+const CUR_CODE = String.raw`USD|EUR|GBP|CAD|AUD|NZD|CHF`;
+
+/**
+ * A number, either comma-grouped ("180,000", "1,234,567", with an optional
+ * decimal tail) or a bare digit run ("180000", "95", "95.5"). The
+ * comma-grouped alternative is tried FIRST and must consume the whole
+ * grouped number (one-or-more ",ddd" groups) — without that ordering,
+ * "180000" would short-match as just "180" (the comma-grouped branch's
+ * `\d{1,3}` head) and silently drop the rest of the digits. The bare-digit
+ * branch is the fallback for ungrouped numbers.
+ */
+const NUM = String.raw`\d+(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?`;
+
+/** Range separators: ASCII hyphen, en dash, em dash, "~", or the word "to"
+ *  (word-bounded so it never matches inside "photo" etc.). */
+const SEP = String.raw`-|–|—|~|\bto\b`;
+
+/** Period tokens that require an explicit "/" or "per " prefix to count —
+ *  "hour" alone is too generic to trust unprefixed. */
+const PERIOD_WORD = String.raw`hour|hr|year|yr|annum|month|mo`;
+
+/** Period ADVERBS are unambiguous on their own, no "/" or "per" needed. */
+const PERIOD_ADVERB = String.raw`annually|hourly|monthly|yearly`;
+
+/** A number immediately followed by an optional "K"/"k" suffix (thousands
+ *  shorthand), guarded so it doesn't swallow the first letter of an
+ *  adjacent word ("180Kubernetes" must not read as "180K"). */
+function numWithK(numGroup: string, kGroup: string): string {
+  return String.raw`(?<${numGroup}>${NUM})\s*(?:(?<${kGroup}>[kK])(?![a-zA-Z]))?`;
+}
+
+/** A mandatory currency marker — either a symbol or a word-bounded ISO code.
+ *  Mandatory (no trailing `?`) so every match is anchored to an actual
+ *  currency mention, never a bare number. */
+function currencyGroup(symName: string, codeName: string): string {
+  return String.raw`(?:(?<${symName}>${CUR_SYM})|\b(?<${codeName}>${CUR_CODE})\b)`;
+}
+
+const PERIOD_TAIL = String.raw`(?:\s*(?:\/|per\s+)\s*(?<per1>${PERIOD_WORD})\b)?(?:\s*\b(?<per2>${PERIOD_ADVERB})\b)?`;
+
+/** Range shape: currency + num [+K] + separator + [currency] + num [+K] +
+ *  optional period. Tried before `SINGLE_RE` so a genuine range always wins
+ *  over accidentally matching just its first number. */
+const RANGE_RE = new RegExp(
+  currencyGroup("sym1", "code1") +
+    String.raw`\s*` +
+    numWithK("num1", "k1") +
+    String.raw`\s*(?:${SEP})\s*` +
+    String.raw`(?:${currencyGroup("sym2", "code2")}\s*)?` +
+    numWithK("num2", "k2") +
+    PERIOD_TAIL,
+  "gi",
+);
+
+/** Single-value shape: currency + num [+K] + optional period. No range
+ *  separator required. */
+const SINGLE_RE = new RegExp(
+  currencyGroup("sym1", "code1") + String.raw`\s*` + numWithK("num1", "k1") + PERIOD_TAIL,
+  "gi",
+);
+
+/**
+ * A millions/billions magnitude suffix immediately after a matched figure.
+ * "$5M" / "$5 million" / "$50bn" is funding, valuation, or market size — never
+ * a salary shape — so a match trailed by one is rejected rather than read as
+ * the bare number with its magnitude silently dropped (#566). Anchored at the
+ * start of the post-match remainder; word-bounded so "$90K bonus" (a "b" word)
+ * is not mistaken for a "$90 billion" suffix.
+ */
+const MAGNITUDE_SUFFIX_RE = /^\s*(?:million|billion|mm|bn|m|b)\b/i;
+
+/**
+ * A salary/pay context word. Proximity to a lone single figure is what
+ * distinguishes "Base pay: $120,000" (a salary) from "$250,000 marketing
+ * budget" or "equity worth $100,000" (not). Word-bounded so it keys on the
+ * actual token, not a substring of an unrelated word. "annual"/"annually" are
+ * included as period-flavoured context so a bare "annual $115,000" — a real
+ * salary shape whose only marker is the period word — is extractable (#566).
+ * The tradeoff: "annual budget $250,000" can now match, but a lone high budget
+ * figure rarely trips the floor, and a false-negative on real pay is the worse
+ * failure mode than an occasional benign over-match.
+ */
+const SALARY_CONTEXT_RE =
+  /\b(?:salary|salaries|compensation|comp|pay|base|ote|wage|wages|earn|earnings|remuneration|stipend|annual|annually)\b/i;
+
+/** Global twin of `SALARY_CONTEXT_RE` for enumerating every salary-word
+ *  occurrence (with position) — needed for the directional nearest-figure
+ *  attribution below, which a single boolean `.test()` cannot express. */
+const SALARY_CONTEXT_GLOBAL_RE = new RegExp(SALARY_CONTEXT_RE.source, "gi");
+
+/** Maximum character gap between a salary word and the figure it may attach to.
+ *  Beyond this the word is unrelated. Mirrors the previous 60-char left window,
+ *  now applied in EITHER direction since a qualifier can trail the figure
+ *  ("$150,000 base salary") as well as precede it. */
+const SALARY_WINDOW = 60;
+
+/** Sentence-boundary characters a salary word may NOT bind across. Without this,
+ *  a trailing punctuation gap ("$250,000. Salary…" — only ". " wide) would read
+ *  as nearer than the salary word's own introductory clause (" Salary is …"),
+ *  so the label would bind backwards to the previous sentence's figure. A colon
+ *  is deliberately NOT a boundary — "Base pay: $120,000" must still bind. */
+const SENTENCE_BOUNDARY_RE = /[.;!?\n]/;
+
+function parseNum(raw: string, kFlag: string | undefined): number {
+  const value = parseFloat(raw.replace(/,/g, ""));
+  return kFlag ? value * 1000 : value;
+}
+
+function resolveCurrency(sym: string | undefined, code: string | undefined): string | undefined {
+  if (code) return code.toUpperCase();
+  if (sym) return CURRENCY_SYMBOL_TO_CODE[sym];
+  return undefined;
+}
+
+/**
+ * Resolve a period token/adverb to the normalized field. When the text carries
+ * NO explicit period marker the period defaults to yearly — the overwhelmingly
+ * common unstated case for salaried listings. A missing marker is NEVER read as
+ * hourly from magnitude alone (#566): a bare small "$N" must not become an
+ * hourly wage on a guess; `hour` requires an explicit /hr, per hour, or hourly
+ * token.
+ */
+function resolvePeriod(per1: string | undefined, per2: string | undefined): CompensationPeriod {
+  const token = (per1 ?? per2 ?? "").toLowerCase();
+  if (token === "hour" || token === "hr" || token === "hourly") return "hour";
+  if (token === "month" || token === "mo" || token === "monthly") return "month";
+  if (["year", "yr", "annum", "annually", "yearly"].includes(token)) return "year";
+  return "year";
+}
+
+/** A structurally valid `Compensation` plus whether its period is a
+ *  trustworthy standalone salary marker (explicit annual/hourly; a lone monthly
+ *  single is not). The flag lets the single-figure selector rank a
+ *  period-carrying figure below a salary-word-attached one without re-deriving
+ *  it. */
+type RawCandidate = Compensation & { hasTrustedPeriod: boolean };
+
+/**
+ * Build a `Compensation` from one regex match, applying only the magnitude
+ * guard (#566) and structural checks. Does NOT apply the salary-context gate —
+ * that is directional and the caller's job (ranges skip it entirely; singles
+ * apply the nearest-figure rule in `bestSingle`). Returns `undefined` when the
+ * match is not a structurally valid currency figure.
+ */
+function candidateFrom(text: string, match: RegExpMatchArray): RawCandidate | undefined {
+  const groups = match.groups;
+  if (!groups || match.index === undefined) return undefined;
+
+  // Guard 1 — magnitude suffix: "$5M"/"$5 billion" is funding, not salary.
+  if (MAGNITUDE_SUFFIX_RE.test(text.slice(match.index + match[0].length))) return undefined;
+
+  const currency = resolveCurrency(groups.sym1, groups.code1);
+  if (!currency) return undefined;
+
+  const num1 = parseNum(groups.num1, groups.k1);
+  if (!Number.isFinite(num1)) return undefined;
+
+  const num2Raw = groups.num2;
+  const num2 = typeof num2Raw === "string" ? parseNum(num2Raw, groups.k2) : undefined;
+
+  const period = resolvePeriod(groups.per1, groups.per2);
+  const hasExplicitPeriod = Boolean(groups.per1 || groups.per2);
+  // A lone MONTHLY single with no salary context is usually SaaS pricing/
+  // savings, not pay — so a month period is NOT a trustworthy standalone marker.
+  const hasTrustedPeriod = hasExplicitPeriod && period !== "month";
+
+  const min = num2 !== undefined ? Math.min(num1, num2) : num1;
+  const max = num2 !== undefined ? Math.max(num1, num2) : num1;
+  return { min, max, currency, period, raw: match[0].trim(), hasTrustedPeriod };
+}
+
+/** Drop the ranking metadata, yielding the public `Compensation`. */
+function stripMeta(c: RawCandidate): Compensation {
+  return { min: c.min, max: c.max, currency: c.currency, period: c.period, raw: c.raw };
+}
+
+interface SingleFigure {
+  match: RegExpMatchArray;
+  index: number;
+  length: number;
+}
+
+/**
+ * Every currency-anchored single figure in `text`, in position order. Includes
+ * magnitude-suffixed figures ("$5M") on purpose: they still count as a figure
+ * that can sit BETWEEN a salary word and another figure, so a salary word never
+ * leapfrogs a funding figure to bind to a farther salary. The magnitude figure
+ * itself is still rejected at extraction time by `candidateFrom`.
+ */
+function collectSingleFigures(text: string): SingleFigure[] {
+  const figs: SingleFigure[] = [];
+  for (const match of text.matchAll(SINGLE_RE)) {
+    const groups = match.groups;
+    if (!groups || match.index === undefined) continue;
+    if (!resolveCurrency(groups.sym1, groups.code1)) continue;
+    if (!Number.isFinite(parseNum(groups.num1, groups.k1))) continue;
+    figs.push({ match, index: match.index, length: match[0].length });
+  }
+  return figs;
+}
+
+/**
+ * Character gap between a salary-word span [ws,we) and a figure span [fs,fe),
+ * or `Infinity` if a sentence boundary sits between them (the word cannot bind
+ * across it). 0 if they overlap.
+ */
+function salaryGap(text: string, ws: number, we: number, fs: number, fe: number): number {
+  if (fe <= ws) {
+    // figure entirely before the word — reject if a boundary intervenes.
+    return SENTENCE_BOUNDARY_RE.test(text.slice(fe, ws)) ? Infinity : ws - fe;
+  }
+  if (fs >= we) {
+    // figure entirely after the word.
+    return SENTENCE_BOUNDARY_RE.test(text.slice(we, fs)) ? Infinity : fs - we;
+  }
+  return 0;
+}
+
+/**
+ * Figure start-indices that a salary word ATTACHES to, by the directional
+ * nearest-figure rule (#566). Each salary word binds to the single closest
+ * figure within `SALARY_WINDOW` that it can reach WITHOUT crossing a sentence
+ * boundary. A word equidistant between two reachable figures is a TIE and
+ * attaches to NEITHER — ambiguous attribution is dropped rather than guessed,
+ * protecting the never-a-false-below-floor invariant. Together these stop a
+ * non-salary figure ("equity worth $100,000") from validating itself off a
+ * salary word that actually introduces a later figure ("…, salary $180,000").
+ */
+function salaryAttachedIndices(text: string, figs: SingleFigure[]): Set<number> {
+  const attached = new Set<number>();
+  for (const w of text.matchAll(SALARY_CONTEXT_GLOBAL_RE)) {
+    if (w.index === undefined) continue;
+    const ws = w.index;
+    const we = w.index + w[0].length;
+    let bestGap = Infinity;
+    let bestIndex = -1;
+    let tie = false;
+    for (const f of figs) {
+      const g = salaryGap(text, ws, we, f.index, f.index + f.length);
+      if (g < bestGap) {
+        bestGap = g;
+        bestIndex = f.index;
+        tie = false;
+      } else if (g === bestGap && g !== Infinity) {
+        tie = true;
+      }
+    }
+    if (bestIndex >= 0 && bestGap <= SALARY_WINDOW && !tie) attached.add(bestIndex);
+  }
+  return attached;
+}
+
+/** First accepted range across ALL matches of `RANGE_RE` — a currency-anchored
+ *  range that survives the magnitude guard is a deliberate pay statement, so a
+ *  leading non-salary figure is skipped and the first real range wins. */
+function firstRange(text: string): Compensation | undefined {
+  for (const match of text.matchAll(RANGE_RE)) {
+    const c = candidateFrom(text, match);
+    if (c) return stripMeta(c);
+  }
+  return undefined;
+}
+
+/**
+ * Pick the best single-figure salary via directional attribution (#566).
+ * Priority, highest first:
+ *   1. A figure a salary word ATTACHES to (nearest-figure rule) — this beats a
+ *      period-only figure regardless of position, so "$45/hour … real salary
+ *      $180,000" resolves to the $180,000 salary, not the contractor rate.
+ *   2. A figure carrying a trustworthy standalone period (explicit annual/
+ *      hourly), when no salary-attached figure exists ("$95/hour").
+ * Within a priority the EARLIEST figure by position wins — deterministic, and
+ * for co-attached figures ("base salary $120,000 … OTE $200,000") the earliest
+ * is the base/primary figure, the conservative floor-comparison choice. A
+ * figure with neither signal is never returned. Ranges win before this runs.
+ */
+function bestSingle(text: string): Compensation | undefined {
+  const figs = collectSingleFigures(text);
+  if (figs.length === 0) return undefined;
+  const attached = salaryAttachedIndices(text, figs);
+
+  let attachedComp: Compensation | undefined;
+  let periodComp: Compensation | undefined;
+  for (const f of figs) {
+    const c = candidateFrom(text, f.match);
+    if (!c) continue; // magnitude-suffixed / structurally invalid → not a salary
+    if (attached.has(f.index)) {
+      attachedComp ??= stripMeta(c);
+    } else if (c.hasTrustedPeriod) {
+      periodComp ??= stripMeta(c);
+    }
+  }
+  return attachedComp ?? periodComp;
+}
+
+/**
+ * Extract a compensation range from free text (a posting's `description`).
+ * Returns `undefined` when no trustworthy currency-anchored salary is found —
+ * the neutral, common case (#566: a non-salary dollar figure returns undefined
+ * rather than a guessed wage). Ranges are tried before single values so a
+ * genuine range always wins over matching just its first number; among singles,
+ * salary attachment is DIRECTIONAL (nearest-figure) so a non-salary figure never
+ * captures a salary word that belongs to a later figure. Never throws.
+ */
+export function extractCompensation(text: string): Compensation | undefined {
+  if (!text) return undefined;
+  return firstRange(text) ?? bestSingle(text);
+}
+
+/** Full-time-equivalent hours/year (40hr × 52wk) — the standard approximation
+ *  used to compare an hourly or monthly range against an annual floor. */
+const HOURS_PER_YEAR = 2080;
+const MONTHS_PER_YEAR = 12;
+
+/** Annualize one `Compensation` figure so it can be compared against a
+ *  user-entered annual floor, regardless of the posting's stated period. */
+function annualize(amount: number, period: CompensationPeriod): number {
+  if (period === "hour") return amount * HOURS_PER_YEAR;
+  if (period === "month") return amount * MONTHS_PER_YEAR;
+  return amount;
+}
+
+/**
+ * True when `comp`'s best-case (top of range) figure still falls below
+ * `floor` — the SOFT signal `rank.ts` reads for its sort-key penalty and
+ * `JobResultCard` reads for the "below your floor" badge (#564). NEVER a
+ * hard filter — callers must keep the posting either way.
+ *
+ * Neutral (false) whenever there is nothing safe to compare:
+ *   - no `comp` (nothing extracted — silence is neutral, the core invariant)
+ *   - no `floor` set
+ *   - `comp.currency !== "USD"` — the floor is a plain number with no
+ *     currency of its own (assumed USD, matching the deep-link/keyword
+ *     lane's US-centric defaults); comparing a non-USD figure against it
+ *     would silently misreport an FX mismatch as "underpaying."
+ */
+export function isBelowFloor(comp: Compensation | undefined, floor: number | undefined): boolean {
+  if (!comp || floor === undefined) return false;
+  if (comp.currency !== "USD") return false;
+  const best = comp.max ?? comp.min;
+  if (best === undefined) return false;
+  return annualize(best, comp.period) < floor;
+}
+
+/**
+ * Below this annualized figure, an extracted "compensation" is not a plausible
+ * full-time salary — it is almost always a misparse (a "$300" fee/stipend, a
+ * bare number the period defaulted to yearly, a dropped "million"). The rating's
+ * comp axis (#561) uses this to REJECT such a value rather than let a garbage
+ * $300/yr tank a genuinely strong fit. Deliberately loose (a real salary clears
+ * it by an order of magnitude); it only screens out the obviously-not-a-salary.
+ */
+const PLAUSIBLE_ANNUAL_COMP_MIN = 10000;
+
+/**
+ * The annualized top-of-range for a comp (`max ?? min`), period-normalized so an
+ * hourly/monthly posting compares fairly against a yearly one — or `undefined`
+ * when there is no figure OR it is below `PLAUSIBLE_ANNUAL_COMP_MIN` (a misparse
+ * the rating should ignore, not trust). The single place the rating reads a
+ * posting's pay, so a comp too small to be real never enters a `JobRating`.
+ */
+export function annualizedTop(comp: Compensation): number | undefined {
+  const top = comp.max ?? comp.min;
+  if (top === undefined) return undefined;
+  const annual = annualize(top, comp.period);
+  return annual >= PLAUSIBLE_ANNUAL_COMP_MIN ? annual : undefined;
+}
+
+/** Format a `Compensation` for the card face, e.g. "$180K–$240K/yr" or
+ *  "$95/hr". Non-USD currencies show the ISO code as a prefix since there's
+ *  no universal symbol convention to lean on. */
+export function formatCompensationRange(comp: Compensation): string {
+  const symbol =
+    comp.currency === "USD"
+      ? "$"
+      : comp.currency === "GBP"
+        ? "£"
+        : comp.currency === "EUR"
+          ? "€"
+          : `${comp.currency} `;
+  const fmt = (n: number) => `${symbol}${Math.round(n).toLocaleString("en-US")}`;
+  const periodSuffix = comp.period === "hour" ? "/hr" : comp.period === "month" ? "/mo" : "/yr";
+  const body =
+    comp.min !== undefined && comp.max !== undefined && comp.min !== comp.max
+      ? `${fmt(comp.min)}–${fmt(comp.max)}`
+      : fmt(comp.max ?? comp.min ?? 0);
+  return `${body}${periodSuffix}`;
+}

--- a/src/lib/job-search/probe-jobs.test.ts
+++ b/src/lib/job-search/probe-jobs.test.ts
@@ -1,0 +1,657 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Whole-lane job-search probe — inert in CI, runs ONLY when
+ * `RL_JOBS_PDF=<path>` is set:
+ *
+ *   RL_JOBS_PDF=/abs/path/to/resume.pdf npx vitest run \
+ *     src/lib/job-search/probe-jobs.test.ts
+ *
+ * The execution vehicle for the `probe-jobs` skill. It is the job-search
+ * sibling of `probe-resume`: where that one sweeps the PARSER off a single
+ * parse, this one sweeps the RANKER off a single live search. It reproduces the
+ * exact default path the deployed panel runs (`FindJobsPanel` →
+ * `useCompanyTargets` → `buildJobQuery` → `searchJobs`), then DECOMPOSES every
+ * ranking decision into the STAR rating axes (`rating.ts`: fitness / comp /
+ * location / seniority → overall) plus the raw signals behind them (coverage,
+ * specificity-weighted base, comp attribution, seniority rung), to answer the
+ * question theory can't:
+ *
+ *   > These results feel wrong for the fine-grained jobs. WHERE, mechanically,
+ *   > did the ranker put the good fit below the thin one?
+ *
+ * Since the #561 star redesign, the probe's job is twofold: CONFIRM the rating
+ * spreads the compressed real-data set across the 0–5 range (the fine jobs
+ * separate from the noise) and catch residual issues (a non-discriminating
+ * rating, sparse comp, unparsed seniority, degraded feeds).
+ *
+ * Unlike the six parser probes this lane is NETWORKED and NON-DETERMINISTIC:
+ *   - Running it EGRESSES the same keyword string prod does (the audited
+ *     `providers/keywords.ts` surface) + the public company slugs. It is not
+ *     offline. Do not run it where that egress is unwanted.
+ *   - Node has no CORS, so the capture may reach feeds a browser's CORS set
+ *     cannot, and live postings drift run-to-run. The snapshot it writes is the
+ *     record of what THIS run saw; a rank finding is reproduced against that
+ *     snapshot, not against tomorrow's live feed.
+ *
+ * ── PII guardrail (three tiers — stricter than the parser probes) ──
+ * 1. RÉSUMÉ PII (name, employers, title, skill cluster) and 2. the REAL SEARCH
+ *    SURFACE (matched company names, live posting titles/text — the candidate's
+ *    actual job search) live ONLY in the gitignored JSON report. The CONSOLE
+ *    prints NO résumé value and NO posting title/company: every posting is a
+ *    stable index (`job#3`), and every axis is a number, a boolean, a defect
+ *    CLASS, or a fixed enum. Cross-reference `job#3` → real title in the
+ *    gitignored report locally; never paste it onward.
+ * 3. The report also carries a `piiValues` list (name tokens, employers, email,
+ *    phone, matched company names, posting titles) so the skill's auto-file
+ *    scrub-gate can hard-refuse any drafted issue body containing one.
+ *
+ * | Var | Default | Meaning |
+ * |---|---|---|
+ * | `RL_JOBS_PDF` | *(unset)* | Absolute path to the résumé PDF. Unset → inert. |
+ * | `RL_JOBS_OUT` | `internal/job-search/` | Directory for the full JSON report. |
+ *
+ * MINTS NOTHING, COMMITS NOTHING, FILES NOTHING. It classifies defects PII-free
+ * and names the owning unit-test file; the skill layer drafts + scrub-gates +
+ * files. A human path exists too (see the skill's "Filing what you find").
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import { runCascade } from "../heuristics/cascade.ts";
+import { REPO_ROOT } from "../heuristics/__test-utils__/corpus-snapshots.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import { buildJobQuery, type JobQuery } from "./query-builder.ts";
+import { seniorityRung } from "./seniority.ts";
+import type { JobSearchResult } from "./search.ts";
+import type { CompanyEntry } from "./company-registry.ts";
+import {
+  roleFilterForResume,
+  seedExcludeTermsForFamilies,
+} from "./role-keywords.ts";
+import { classifySectorHeuristic } from "./sector.ts";
+import { companiesForSector } from "./company-registry.ts";
+import { COMPANY_LIMIT } from "../../hooks/useCompanyTargets.ts";
+import { ratingInputFor, type RankedJob } from "./rank.ts";
+import type { RatingInput, JobRating } from "./rating.ts";
+
+/**
+ * The report directory, validated the same way `probe-resume` validates its
+ * own: the default (`internal/`) is gitignored; an override that lands inside
+ * the repo and is NOT gitignored is a hard failure, because the report is a
+ * diagnostics artifact derived from a real résumé + the candidate's live search
+ * and must never become committable. `git check-ignore` is the authority.
+ */
+function resolveOutDir(): string {
+  const override = process.env.RL_JOBS_OUT;
+  if (!override) return join(REPO_ROOT, "internal/job-search");
+
+  const dir = isAbsolute(override) ? override : resolve(process.cwd(), override);
+  const rel = relative(REPO_ROOT, dir);
+  const insideRepo = rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  if (!insideRepo) return dir;
+
+  try {
+    execFileSync("git", ["check-ignore", "-q", "--", dir], { cwd: REPO_ROOT });
+    return dir;
+  } catch {
+    throw new Error(
+      `RL_JOBS_OUT="${override}" resolves inside the repo at "${rel}" and is NOT ` +
+        `gitignored. The report carries a real résumé's derived query and the ` +
+        `candidate's live matched postings — it must never become committable. ` +
+        `Point RL_JOBS_OUT at a gitignored path (the default "internal/job-search/") ` +
+        `or somewhere outside the repo.`,
+    );
+  }
+}
+
+// ── Classification thresholds. Named so a reader can calibrate — not magic. ──
+/** Above this share of shown postings carrying no extracted comp, the comp
+ *  floor knob is effectively inert on this résumé's real feed sample. */
+const COMP_SPARSE_SHARE = 0.8;
+/** Above this share of shown postings whose TITLE yields no seniority rung, the
+ *  seniority axis is silently absent for most of the set (level axis near-dead). */
+const SENIORITY_UNPARSED_SHARE = 0.8;
+/** The overall star rating must spread at least this far (max − min) across the
+ *  shown set, else it fails #561's whole point — it is not separating the fine
+ *  jobs from the noise, just relabeling a flat percentage as flat stars. */
+const DISCRIMINATION_MIN_SPREAD = 2;
+/** A "strong fit" is a posting in the top this-share by FITNESS. */
+const STRONG_FIT_SHARE = 0.1;
+/** A strong fit is BURIED (the #570/#562 pathology) if its overall rank falls
+ *  outside the top this-share of the set — fitness dominates the rating, so a
+ *  top-fitness posting should never be pushed deep by the minor axes. */
+const BURIED_RANK_SHARE = 0.25;
+
+/** Non-salary dollar contexts that, if present in an extracted comp's source
+ *  substring, make a below-floor penalty suspect (#564 misattribution class).
+ *  Matched only against `compensation.raw` (a posting-text substring), never
+ *  printed to the console. */
+const NON_SALARY_CONTEXT = /\b(funding|raised|valuation|budget|revenue|arr|seed|series\s+[a-e]|million|billion|[0-9]\s*[mb]n?\b)/i;
+
+interface Defect {
+  /** PII-free class slug. */
+  class: string;
+  severity: "blocking" | "signal" | "info";
+  /** PII-free numeric/boolean evidence. */
+  evidence: Record<string, number | boolean | string>;
+  /** Which unit-test file owns a synthetic reproducer for this class. */
+  ownerTest: string;
+}
+
+/** One posting's PII-free decomposition row (console-safe). */
+interface DecompRow {
+  idx: number;
+  /** The raw signals that fed the rating (base, comp, distances). */
+  input: RatingInput;
+  /** The 0–5 star rating (overall + sub-axes). */
+  rating: JobRating;
+  /** Raw coverage 0..100 — the compressed number the rating works around. */
+  score: number;
+  termCount: number;
+  hasComp: boolean;
+  belowFloor: boolean;
+  locationMatch: boolean;
+  /** True when a below-floor penalty fired AND the extracted comp's source
+   *  substring reads like non-salary dollars — a #564 misattribution suspect. */
+  compRawSuspect: boolean;
+}
+
+describe.runIf(process.env.RL_JOBS_PDF)(
+  "whole-lane job-search probe (RL_JOBS_PDF)",
+  () => {
+    // Deliberate monolithic diagnostic harness (mirrors probe-resume): one
+    // linear read-out of capture → decomposition → defect classification, in a
+    // single scroll. Not production logic; it never asserts on what it FINDS.
+    // fallow-ignore-next-line complexity
+    it("captures a live search, decomposes the star rating, classifies defects PII-free", async () => {
+      const path = process.env.RL_JOBS_PDF!;
+      const outDir = resolveOutDir();
+
+      // ── Parse. `canonical.fields` IS the HeuristicParsedResume the panel holds. ─
+      const cascade = await runCascade(new Uint8Array(readFileSync(path)));
+      const parsed = cascade.canonical.fields;
+
+      // ── Reproduce the panel's DEFAULT search wiring exactly (no user edits):
+      //    role filter seeds families + exclude chips; sector heuristic seeds
+      //    the company pool (all suggested = selected on mount). ────────────────
+      const roleFilter = roleFilterForResume(parsed);
+      const query = buildJobQuery(
+        parsed,
+        seedExcludeTermsForFamilies(roleFilter.families),
+        roleFilter.families,
+      );
+      const guess = classifySectorHeuristic(parsed);
+      const companies = companiesForSector(guess.sector, COMPANY_LIMIT);
+
+      // ── Capture: one live search. Egresses keywords + slugs (documented). ────
+      const result = await searchLive(query, parsed, companies);
+
+      // ── Decompose every shown job into the SAME rating inputs rank.ts used. ───
+      const queryLocation = query.location?.trim() || undefined;
+      const querySeniorityRung = seniorityRung(query.seniority);
+      const rows: DecompRow[] = result.jobs.map((job, idx) => {
+        const input = ratingInputFor(job, queryLocation, querySeniorityRung, query.compFloor);
+        const raw = job.posting.compensation?.raw ?? "";
+        return {
+          idx,
+          input,
+          rating: job.rating,
+          score: job.score,
+          termCount: job.jdMatch.terms.length,
+          hasComp: Boolean(job.posting.compensation),
+          belowFloor: job.belowFloor,
+          locationMatch: input.locationMatch,
+          compRawSuspect: job.belowFloor && NON_SALARY_CONTEXT.test(raw),
+        };
+      });
+
+      // ── Classify defects (PII-free). ─────────────────────────────────────────
+      const defects = classify(rows, result, query, queryLocation);
+
+      // ── The gitignored report: everything, incl. the real search surface. ────
+      const piiValues = collectPiiValues(parsed, query, result);
+      const report = {
+        path,
+        capturedAt: "(stamped by the skill after the run — Date.now is unavailable in-harness)",
+        ratingAlgoNote: "star rating per the weights + curves in rating.ts",
+        query, // titles/skills/location/seniority — résumé-derived, PII
+        sector: guess.sector,
+        companyCount: companies.length,
+        degradedProviders: result.degradedProviders,
+        providerCount: result.providerCount,
+        excludeSuppressed: result.excludeSuppressed,
+        roleSuppressed: result.roleSuppressed,
+        rawPostingCount: result.rawPostings.length,
+        shownCount: result.jobs.length,
+        defects,
+        // The index → real posting map. This is the tier-2 surface; gitignored only.
+        postings: result.jobs.map((job, idx) => ({
+          idx,
+          title: job.posting.title,
+          company: job.posting.company,
+          location: job.posting.location,
+          source: job.posting.source,
+          url: job.posting.url,
+          score: job.score,
+          termCount: job.jdMatch.terms.length,
+          rating: job.rating,
+          compRaw: job.posting.compensation?.raw ?? null,
+          belowFloor: job.belowFloor,
+        })),
+        rows,
+        piiValues,
+      };
+      mkdirSync(outDir, { recursive: true });
+      const outFile = join(
+        outDir,
+        `jobs-${basename(path).replace(/\.[^.]+$/, "")}.json`,
+      );
+      writeFileSync(outFile, JSON.stringify(report, null, 2));
+
+      // ── The console read-out. Indices, numbers, booleans, classes only. ──────
+      console.log(renderReadout(rows, defects, result, query, outFile));
+
+      // Diagnostic: never fails on findings, but must fail if it could not run.
+      expect(result.providerCount).toBeGreaterThan(0);
+    }, 120_000); // live network capture — well over the 5s default.
+  },
+);
+
+/**
+ * Run the real orchestrator against live feeds. Split out so the one networked
+ * call is named and the egress is obvious. Uses a never-aborted signal — the
+ * probe wants the full sample, not a superseded partial. `searchJobs` is
+ * dynamic-imported (the cascade-tier pattern) exactly as `FindJobsPanel` reaches
+ * it, so nothing pulls the provider chunk into this module's static graph.
+ */
+async function searchLive(
+  query: JobQuery,
+  parsed: HeuristicParsedResume,
+  companies: readonly CompanyEntry[],
+): Promise<JobSearchResult> {
+  const { searchJobs } = await import("./search.ts");
+  return searchJobs(query, parsed, new AbortController().signal, companies);
+}
+
+/**
+ * The defect classifier. Every branch reports PII-free evidence (counts,
+ * shares, booleans) and names the unit-test file that should carry a synthetic
+ * reproducer for the class.
+ */
+function classify(
+  rows: DecompRow[],
+  result: JobSearchResult,
+  query: { location?: string; seniority?: string; compFloor?: number; families?: string[] },
+  queryLocation: string | undefined,
+): Defect[] {
+  const defects: Defect[] = [];
+  const n = rows.length;
+
+  if (n === 0) {
+    defects.push({
+      class: "empty-result-set",
+      severity: "blocking",
+      evidence: {
+        rawPostingCount: result.rawPostings.length,
+        degraded: result.degradedProviders.length,
+        providerCount: result.providerCount,
+        roleSuppressed: result.roleSuppressed,
+        excludeSuppressed: result.excludeSuppressed,
+      },
+      ownerTest: "search.test.ts",
+    });
+    return defects;
+  }
+
+  defects.push(...classifyRating(rows, n));
+  defects.push(...classifyLevelAndComp(rows, query, n));
+  defects.push(...classifyLocation(rows, queryLocation, n));
+  defects.push(...classifyResultHealth(result, query, n));
+  return defects;
+}
+
+/**
+ * Rating-model health: does the star rating discriminate (#561), and does a
+ * minor axis bury a strong fit (#570/#562)?
+ */
+function classifyRating(rows: DecompRow[], n: number): Defect[] {
+  const defects: Defect[] = [];
+
+  // ── Rating discrimination (#561's success criterion). ────────────────────────
+  // The whole point of the star redesign is to spread a compressed set across
+  // 0–5 so the fine jobs separate. Measure the overall-star spread; if the
+  // rating is as flat as the percentage it replaced, the redesign failed here.
+  const overalls = rows.map((r) => r.rating.overall);
+  const overallMax = Math.max(...overalls);
+  const overallMin = Math.min(...overalls);
+  const overallMean = overalls.reduce((a, b) => a + b, 0) / n;
+  const spread = overallMax - overallMin;
+  defects.push({
+    class: "rating-distribution",
+    severity: spread < DISCRIMINATION_MIN_SPREAD ? "blocking" : "info",
+    evidence: {
+      overallMax: round2(overallMax),
+      overallMin: round2(overallMin),
+      overallMean: round2(overallMean),
+      spread: round2(spread),
+      topBand4plus: rows.filter((r) => r.rating.overall >= 4).length,
+      threshold: DISCRIMINATION_MIN_SPREAD,
+      note:
+        spread < DISCRIMINATION_MIN_SPREAD
+          ? "overall stars do not separate the set — the rating is not discriminating (#561 unmet)"
+          : "overall stars spread across the range — the rating separates the fine jobs (#561 met)",
+    },
+    ownerTest: "rating.test.ts",
+  });
+
+  // ── Raw coverage compression (the upstream cause the rating works around). ───
+  // INFO, not blocking: the star rating exists precisely to handle this, so a
+  // compressed raw coverage is expected. Surfaced so a reader sees the gap the
+  // rating is bridging and can confirm the fitness stretch actually bridged it.
+  const scores = rows.map((r) => r.score);
+  const rawMax = Math.max(...scores);
+  const rawMean = scores.reduce((a, b) => a + b, 0) / n;
+  if (rawMax < 60 && rawMean < 20) {
+    defects.push({
+      class: "raw-coverage-compressed",
+      severity: "info",
+      evidence: {
+        rawMax,
+        rawMean: round2(rawMean),
+        shareOver30: round2(scores.filter((s) => s >= 30).length / n),
+        shown: n,
+        note: "raw JD-term coverage is compressed; the star rating stretches it — see rating-distribution",
+      },
+      ownerTest: "rating.test.ts",
+    });
+  }
+
+  // ── Strong-fit-buried guard (the #570/#562 regression the model prevents). ───
+  // The old model let a flat location/seniority penalty sink a strong fit from
+  // rank ~1 to rank ~9. Fitness dominates the star rating (weight 0.45, and comp
+  // — the only other driver — is a legitimate co-driver, NOT a bug when it
+  // reorders), so a top-fitness posting should still surface near the top. Take
+  // the strongest fits and check none is buried outside the top band by overall
+  // rank (rows are in overall-rank order, so idx === rank). Comp reordering
+  // within the top band is fine; a strong fit shoved deep is not.
+  const byFitness = [...rows].sort((a, b) => b.rating.fitness - a.rating.fitness);
+  const strongCount = Math.max(1, Math.round(n * STRONG_FIT_SHARE));
+  const buriedRank = Math.round(n * BURIED_RANK_SHARE);
+  const buried = byFitness.slice(0, strongCount).filter((r) => r.idx >= buriedRank);
+  if (buried.length > 0) {
+    defects.push({
+      class: "strong-fit-buried",
+      severity: "blocking",
+      evidence: {
+        buriedCount: buried.length,
+        strongFitCount: strongCount,
+        deepestBuriedRank: Math.max(...buried.map((r) => r.idx)),
+        buriedRankThreshold: buriedRank,
+        shown: n,
+        note: "a top-fitness posting ranks outside the top band — a minor axis is burying it (#570/#562 regression)",
+      },
+      ownerTest: "rating.test.ts",
+    });
+  }
+
+  return defects;
+}
+
+/**
+ * Input-health diagnostics for the level and compensation axes — these are
+ * about what feeds the model, not about the model itself.
+ */
+function classifyLevelAndComp(
+  rows: DecompRow[],
+  query: { seniority?: string; compFloor?: number },
+  n: number,
+): Defect[] {
+  const defects: Defect[] = [];
+
+  // #562 — the level axis is inert or near-dead on this résumé's real set.
+  if (query.seniority === undefined) {
+    defects.push({
+      class: "seniority-axis-inert-no-query-level",
+      severity: "signal",
+      evidence: { querySeniority: "undefined", shown: n },
+      ownerTest: "query-builder.test.ts",
+    });
+  } else {
+    const unparsed = rows.filter((r) => r.input.seniorityDistance === null).length;
+    if (unparsed / n >= SENIORITY_UNPARSED_SHARE) {
+      defects.push({
+        class: "seniority-titles-unparsed",
+        severity: "signal",
+        evidence: {
+          unparsedShare: round2(unparsed / n),
+          unparsed,
+          shown: n,
+          threshold: SENIORITY_UNPARSED_SHARE,
+        },
+        ownerTest: "seniority.test.ts",
+      });
+    }
+  }
+
+  // #564 — comp knob effectively inert (nothing extracted on the real feeds).
+  const noComp = rows.filter((r) => !r.hasComp).length;
+  if (noComp / n >= COMP_SPARSE_SHARE) {
+    defects.push({
+      class: "comp-extraction-sparse",
+      severity: query.compFloor !== undefined ? "blocking" : "info",
+      evidence: {
+        noCompShare: round2(noComp / n),
+        noComp,
+        shown: n,
+        floorSet: query.compFloor !== undefined,
+      },
+      ownerTest: "compensation.test.ts",
+    });
+  }
+
+  // #564 — a below-floor penalty fired on a posting whose extracted comp source
+  // reads like non-salary dollars (funding/budget/valuation). Suspect misparse.
+  const belowFloor = rows.filter((r) => r.belowFloor);
+  if (belowFloor.length > 0) {
+    const suspect = belowFloor.filter((r) => r.compRawSuspect).length;
+    defects.push({
+      class: suspect > 0 ? "comp-below-floor-misattributed" : "comp-below-floor-fired",
+      severity: suspect > 0 ? "blocking" : "info",
+      evidence: {
+        belowFloorCount: belowFloor.length,
+        suspectNonSalaryRaw: suspect,
+        shown: n,
+        note: "suspect rows: comp.raw matched a non-salary dollar context; inspect the gitignored report",
+      },
+      ownerTest: "compensation.test.ts",
+    });
+  }
+
+  return defects;
+}
+
+/**
+ * #545 — location axis inert: the query has a location but ~nothing matches, or
+ * there is no location at all, so the axis never breaks a tie.
+ */
+function classifyLocation(
+  rows: DecompRow[],
+  queryLocation: string | undefined,
+  n: number,
+): Defect[] {
+  const defects: Defect[] = [];
+
+  if (queryLocation === undefined) {
+    defects.push({
+      class: "location-axis-inert-no-query-location",
+      severity: "info",
+      evidence: { shown: n },
+      ownerTest: "rating.test.ts",
+    });
+  } else {
+    const matched = rows.filter((r) => r.locationMatch).length;
+    if (matched === 0) {
+      defects.push({
+        class: "location-axis-inert-zero-matches",
+        severity: "signal",
+        evidence: { shown: n, matched: 0 },
+        ownerTest: "rating.test.ts",
+      });
+    }
+  }
+
+  return defects;
+}
+
+/**
+ * Result-level health: never-fail-closed flags that fired (the user's filter
+ * was silently skipped), and feed degradation that thins the ranker's sample.
+ */
+function classifyResultHealth(
+  result: JobSearchResult,
+  query: { families?: string[] },
+  n: number,
+): Defect[] {
+  const defects: Defect[] = [];
+
+  // Never-fail-closed flags fired: the user's filter was silently skipped.
+  if (result.roleSuppressed) {
+    defects.push({
+      class: "role-filter-suppressed",
+      severity: "signal",
+      evidence: { families: (query.families ?? []).length, shown: n },
+      ownerTest: "refine.test.ts",
+    });
+  }
+  if (result.excludeSuppressed) {
+    defects.push({
+      class: "exclude-filter-suppressed",
+      severity: "signal",
+      evidence: { shown: n },
+      ownerTest: "role-keywords.test.ts",
+    });
+  }
+
+  // Feed health — not a rank bug, but it thins the sample the ranker sees.
+  if (result.degradedProviders.length > 0) {
+    defects.push({
+      class: "providers-degraded",
+      severity: result.degradedProviders.length === result.providerCount ? "blocking" : "info",
+      evidence: {
+        degraded: result.degradedProviders.length,
+        providerCount: result.providerCount,
+      },
+      ownerTest: "(feed health — not a unit-test target)",
+    });
+  }
+
+  return defects;
+}
+
+function collectPiiValues(
+  parsed: { full_name?: string; experience?: Array<{ company?: string; title?: string }> },
+  query: { titles: string[]; skills: string[] },
+  result: JobSearchResult,
+): string[] {
+  const set = new Set<string>();
+  const add = (v: unknown) => {
+    if (typeof v === "string") {
+      const t = v.trim();
+      if (t.length >= 3) set.add(t);
+    }
+  };
+  add(parsed.full_name);
+  for (const part of (parsed.full_name ?? "").split(/\s+/)) add(part);
+  for (const exp of parsed.experience ?? []) {
+    add(exp.company);
+    add(exp.title);
+  }
+  for (const t of query.titles) add(t);
+  for (const s of query.skills) add(s);
+  for (const job of result.jobs) {
+    add((job as RankedJob).posting.company);
+    add((job as RankedJob).posting.title);
+  }
+  return [...set];
+}
+
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
+}
+
+/** The PII-free console read-out. */
+function renderReadout(
+  rows: DecompRow[],
+  defects: Defect[],
+  result: JobSearchResult,
+  query: { titles: string[]; skills: string[]; seniority?: string; location?: string; families?: string[]; compFloor?: number },
+  outFile: string,
+): string {
+  const head =
+    `RL_JOBS_PDF job-search sweep for ${outFile}\n` +
+    `  (PDF path withheld from console — it may carry a name; see the gitignored report)\n\n` +
+    `  QUERY SHAPE (counts only — no values):\n` +
+    `    titles=${query.titles.length}  skills=${query.skills.length}  ` +
+    `seniority=${query.seniority ? "set" : "undefined"}  location=${query.location ? "set" : "undefined"}  ` +
+    `families=${(query.families ?? []).length}  compFloor=${query.compFloor !== undefined ? "set" : "unset"}\n` +
+    `  CAPTURE:\n` +
+    `    raw=${result.rawPostings.length}  shown=${rows.length}  ` +
+    `providers=${result.providerCount}  degraded=${result.degradedProviders.length}  ` +
+    `roleSuppressed=${result.roleSuppressed}  excludeSuppressed=${result.excludeSuppressed}\n`;
+
+  const table =
+    `\n  RANK DECOMPOSITION (top ${Math.min(rows.length, 20)} of ${rows.length}) — ★ = 0–5 stars:\n` +
+    `    idx  score  terms   base   fit★  comp★   loc★  sen★  OVR★   sdst  comp  <floor  locM\n` +
+    rows
+      .slice(0, 20)
+      .map((r) => {
+        const rt = r.rating;
+        return (
+          `    ${pad(r.idx, 3)}  ${pad(r.score, 5)}  ${pad(r.termCount, 5)}  ` +
+          `${pad(round1(r.input.base), 5)}  ${pad(star(rt.fitness), 5)}  ${pad(star(rt.compensation), 5)}  ` +
+          `${pad(star(rt.location), 5)}  ${pad(star(rt.seniority), 4)}  ${pad(star(rt.overall), 4)}  ` +
+          `${pad(r.input.seniorityDistance ?? "—", 4)}  ${pad(r.hasComp ? "y" : "—", 4)}  ` +
+          `${pad(r.belowFloor ? "y" : "—", 6)}  ${r.locationMatch ? "y" : "—"}`
+        );
+      })
+      .join("\n");
+
+  const defectBlock =
+    `\n\n  DEFECTS FOUND (${defects.length}):\n` +
+    (defects.length
+      ? defects
+          .map(
+            (d) =>
+              `    [${d.severity.toUpperCase()}] ${d.class}\n` +
+              `        evidence: ${JSON.stringify(d.evidence)}\n` +
+              `        reproducer owner: ${d.ownerTest}`,
+          )
+          .join("\n")
+      : "    (none — the ranking looks clean on this sample)");
+
+  return (
+    head +
+    table +
+    defectBlock +
+    `\n\n  Full JSON (real titles/companies + piiValues) → ${outFile}` +
+    `\n  ⚠️ gitignored; do NOT commit and do NOT paste onward — it is the candidate's live search surface.\n`
+  );
+}
+
+/** Render a nullable star value: one decimal, or "—" when the axis is absent. */
+function star(v: number | null): string {
+  return v === null ? "—" : String(round1(v));
+}
+
+function pad(v: number | string, w: number): string {
+  return String(v).padStart(w);
+}
+function round1(x: number): number {
+  return Math.round(x * 10) / 10;
+}

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -33,7 +33,20 @@ describe("buildJobQuery", () => {
       skills: [],
       seniority: undefined,
       location: undefined,
+      excludeTerms: [],
     });
+  });
+
+  it("defaults excludeTerms to [] when no seeds are passed (issue 563)", () => {
+    expect(buildJobQuery(baseParsed()).excludeTerms).toEqual([]);
+    expect(
+      buildJobQuery(baseParsed({ skills: ["Python"] })).excludeTerms,
+    ).toEqual([]);
+  });
+
+  it("seeds excludeTerms verbatim from the passed seed list (issue 563)", () => {
+    const query = buildJobQuery(baseParsed(), ["solutions architect"]);
+    expect(query.excludeTerms).toEqual(["solutions architect"]);
   });
 
   it("seeds location from the parsed résumé's top-level location (#545)", () => {
@@ -51,6 +64,18 @@ describe("buildJobQuery", () => {
       "Denver, CO",
     );
     expect(buildJobQuery(baseParsed({ location: "   " })).location).toBeUndefined();
+  });
+
+  it("leaves families undefined when no familySeeds are passed (issue 568)", () => {
+    expect(buildJobQuery(baseParsed()).families).toBeUndefined();
+    expect(buildJobQuery(baseParsed(), ["solutions architect"]).families).toBeUndefined();
+  });
+
+  it("seeds families verbatim from the passed seed list, even an empty one (issue 568)", () => {
+    expect(buildJobQuery(baseParsed(), [], ["backend"]).families).toEqual(["backend"]);
+    // An explicit empty array is a real "user removed every chip" assertion,
+    // distinct from the undefined "never asserted" default above.
+    expect(buildJobQuery(baseParsed(), [], []).families).toEqual([]);
   });
 
   it("derives the distinct titles across experience, most-recent-first", () => {

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -75,6 +75,43 @@ export interface JobQuery {
    *  to union together. Undefined when the parse has no location and the
    *  user hasn't typed one. */
   location?: string;
+  /** Title-only exclude terms (#563) — a posting is dropped when its TITLE
+   *  (never its description) contains one of these as a case-insensitive
+   *  substring. User-editable chips, same interaction as `titles`/`skills`.
+   *  Optional (rather than always-present) so every pre-existing `JobQuery`
+   *  literal across the lane's tests keeps compiling unchanged; every reader
+   *  MUST treat `undefined` the same as `[]` — see `filterPostingsByExcludeTerms`
+   *  in `role-keywords.ts`, the sole place that applies it. Not derived here:
+   *  `buildJobQuery`'s caller (`FindJobsPanel`) seeds it from the role-family
+   *  classification (`seedExcludeTermsForFamilies` in `role-keywords.ts`) and
+   *  passes the result in, so this module stays free of a runtime dependency
+   *  on `role-keywords.ts` (which already depends on this module for
+   *  `parseSeniorityLabel` — importing back would cycle the two). */
+  excludeTerms?: string[];
+  /** Optional user-entered minimum ANNUAL compensation (#564) — a SOFT
+   *  signal only, following the #545/#561/#562 precedent: `rank.ts` reads it
+   *  for a sort-key penalty and `JobResultCard` reads it for a "below your
+   *  floor" badge, but a below-floor posting is never dropped. Undefined
+   *  (the default) means no floor is set, byte-identical to pre-#564
+   *  behavior for every existing caller. Not derived by `buildJobQuery` —
+   *  purely user input, wired from `FindJobsPanel`'s `CompFloorInput`. */
+  compFloor?: number;
+  /** Résumé-derived role families (#568) — seeded from
+   *  `roleFilterForResume(parsed).families` (role-keywords.ts) and rendered as
+   *  REMOVABLE chips by `RoleFamilyChips`; there is no free-text add, since
+   *  the family vocabulary is the fixed `ROLE_FAMILIES` enum, not user text.
+   *  Typed as `string[]` (elements are `RoleFamily` labels) rather than
+   *  importing that type, mirroring `excludeTerms`'s reasoning above — this
+   *  module stays free of a runtime dependency on `role-keywords.ts`.
+   *  TWO distinct states, both load-bearing: `undefined` means "not
+   *  asserted" — every reader falls back to deriving the filter from the
+   *  résumé (`roleFilterForResume`), byte-identical to pre-#568 behavior for
+   *  every existing caller/test. `[]` means "the user removed every seeded
+   *  chip" — readers resolve that to `roleFilterForFamilies([])`, the
+   *  PERMISSIVE "all" filter (never-fail-closed, same floor
+   *  `roleFilterForResume` already guarantees for an unclassified résumé) —
+   *  never to zero results. */
+  families?: string[];
 }
 
 /**
@@ -168,7 +205,16 @@ function deriveTitles(parsed: ResumeQueryInput): string[] {
   return current ? [current] : [];
 }
 
-function deriveSeniority(title: string): string | undefined {
+/**
+ * Parse a single seniority label out of one title by walking `SENIORITY_PATTERNS`
+ * top-to-bottom (first match wins — see that table's ordering notes). Returns
+ * `undefined` when the title carries no recognized level keyword.
+ *
+ * Exported (#562) so the ranker can parse a level out of a *posting* title with
+ * the exact same table the query derivation uses — no second taxonomy. Also the
+ * fn #565/#568 reuse for their own title-side level reads.
+ */
+export function parseSeniorityLabel(title: string): string | undefined {
   for (const { label, pattern } of SENIORITY_PATTERNS) {
     if (pattern.test(title)) return label;
   }
@@ -185,7 +231,7 @@ function deriveSeniority(title: string): string | undefined {
  */
 function deriveSeniorityAcrossTitles(titles: string[]): string | undefined {
   for (const title of titles) {
-    const match = deriveSeniority(title);
+    const match = parseSeniorityLabel(title);
     if (match) return match;
   }
   return undefined;
@@ -240,11 +286,31 @@ function deriveLocation(parsed: ResumeQueryInput): string | undefined {
   return location || undefined;
 }
 
-export function buildJobQuery(parsed: ResumeQueryInput): JobQuery {
+/**
+ * @param excludeTermSeeds Pre-computed exclude-term chips to seed the query
+ *   with (#563) — pass `seedExcludeTermsForFamilies(roleFilterForResume(parsed).families)`
+ *   from the call site (`FindJobsPanel`). Defaults to `[]` (byte-identical to
+ *   pre-#563 behavior) so every other/test caller is unaffected. Kept as a
+ *   plain parameter rather than computed in here — see the `excludeTerms`
+ *   doc on `JobQuery` for why this module doesn't import `role-keywords.ts`.
+ * @param familySeeds The résumé-derived role families (#568) — pass
+ *   `roleFilterForResume(parsed).families` from the call site. Defaults to
+ *   `undefined` (via the empty-array-becomes-undefined normalization below)
+ *   so every other/test caller keeps the pre-#568 "families not asserted"
+ *   behavior on `JobQuery` — see that field's doc for the `undefined` vs `[]`
+ *   distinction.
+ */
+export function buildJobQuery(
+  parsed: ResumeQueryInput,
+  excludeTermSeeds: readonly string[] = [],
+  familySeeds?: readonly string[],
+): JobQuery {
   const titles = deriveTitles(parsed);
   // Primary title first, then fall back across the rest of the titles (#540).
   const seniority = deriveSeniorityAcrossTitles(titles);
   const skills = deriveSkills(parsed);
   const location = deriveLocation(parsed);
-  return { titles, skills, seniority, location };
+  const excludeTerms = [...excludeTermSeeds];
+  const families = familySeeds === undefined ? undefined : [...familySeeds];
+  return { titles, skills, seniority, location, excludeTerms, families };
 }

--- a/src/lib/job-search/rank.test.ts
+++ b/src/lib/job-search/rank.test.ts
@@ -32,6 +32,15 @@ function posting(
   };
 }
 
+/** A posting with an explicit title (so its parsed seniority level matters). */
+function titledPosting(
+  id: string,
+  title: string,
+  description: string,
+): JobPosting {
+  return { ...posting(id, description), title };
+}
+
 describe("rankPostings", () => {
   it("sorts by fit descending", () => {
     const strong = posting("strong", "We need React and TypeScript experts.");
@@ -62,32 +71,60 @@ describe("rankPostings", () => {
     expect(ranked.map((j) => j.posting.id)).toEqual(["strong", "weak"]);
   });
 
-  it("boosts a location-matching posting above a slightly-stronger non-local one (#545)", () => {
-    // "local" has a lower raw coverage score than "faraway" (more uncovered
-    // terms diluting its coverage %), but matches the query location — the
-    // boost (10 points) should move it ahead in sort order without touching
-    // either posting's displayed `score`.
+  it("breaks a genuine fit TIE toward the location-matching posting (#545)", () => {
+    // Location is a minor rating axis (weight 0.1) — it edges an otherwise-equal
+    // race toward the local posting, but (see the #570 test below) can never
+    // overcome a real fit gap. Identical descriptions → identical fitness, so the
+    // location nudge alone decides: the local one leads.
+    const desc =
+      "We need React experts, plus Rust, Kubernetes, Terraform, and GraphQL skills.";
+    const local = posting("local", desc, "Austin, TX");
+    const faraway = posting("faraway", desc, "Berlin, Germany");
+    const ranked = rankPostings(parsed, [local, faraway], { location: "Austin, TX" });
+    // Tied fitness (same description), so the location nudge is the tiebreaker.
+    const localJob = ranked.find((j) => j.posting.id === "local")!;
+    const farawayJob = ranked.find((j) => j.posting.id === "faraway")!;
+    expect(localJob.score).toBe(farawayJob.score);
+    expect(ranked[0].posting.id).toBe("local");
+    // The local posting's location axis is a full 5★; the non-local one's is the
+    // bounded non-match value — the nudge, not a fit difference, ordered them.
+    expect(localJob.rating.location).toBeCloseTo(5, 5);
+    expect(farawayJob.rating.location!).toBeLessThan(5);
+    // Coverage parity is untouched — score still equals coverage.score.
+    expect(localJob.score).toBe(localJob.jdMatch.coverage.score);
+  });
+
+  it("a weak local posting does NOT outrank a clearly-stronger non-local one — location is a minor axis (#570)", () => {
+    // The #570 pathology: the old ranker added a FLAT +10 location boost to a
+    // base that, on real compressed scores, tops out around ~20 — so location
+    // was ~half the range and a weak local posting leapfrogged a much stronger
+    // non-local one. In the star model location is a minor axis (weight 0.1), so
+    // it can only trim the overall by a fraction of a star: "local" has a
+    // distinctly lower fitness than "faraway", and the small location nudge
+    // cannot close that gap — the stronger fit still leads.
     const local = posting(
       "local",
-      "We need React experts, plus Rust, Kubernetes, Terraform, Golang, and GraphQL skills.",
+      "React developer wanted. Also Rust, Kubernetes, Terraform, and Golang.",
       "Austin, TX",
     );
     const faraway = posting(
       "faraway",
-      "We are hiring a React engineer. Familiarity with Rust, Kubernetes, Terraform, GraphQL helpful.",
+      "React and TypeScript engineer. Familiarity with Rust and Kubernetes a plus.",
       "Berlin, Germany",
     );
     const ranked = rankPostings(parsed, [local, faraway], { location: "Austin, TX" });
     const localScore = ranked.find((j) => j.posting.id === "local")!.score;
     const farawayScore = ranked.find((j) => j.posting.id === "faraway")!.score;
-    // Sanity check the fixture: faraway scores at least as high as local on
-    // raw coverage, and the gap is within the location boost, for this to be
-    // a meaningful boost test (not just "local was already winning").
-    expect(farawayScore).toBeGreaterThanOrEqual(localScore);
-    expect(ranked[0].posting.id).toBe("local");
-    // score parity is untouched by the boost — still equals coverage.score.
-    const local2 = ranked.find((j) => j.posting.id === "local")!;
-    expect(local2.score).toBe(local2.jdMatch.coverage.score);
+    // Fixture sanity: faraway is the genuinely stronger fit (covers React AND
+    // TypeScript; local covers only React), so its displayed score is higher —
+    // this is a real fit gap, not a tie the location nudge is meant to break.
+    expect(farawayScore).toBeGreaterThan(localScore);
+    // The stronger non-local fit still leads: the location axis (weight 0.1) can
+    // only trim the overall by a fraction of a star, nowhere near the fitness gap.
+    expect(ranked[0].posting.id).toBe("faraway");
+    // Coverage parity untouched — the rating never edits the displayed score.
+    const localJob = ranked.find((j) => j.posting.id === "local")!;
+    expect(localJob.score).toBe(localJob.jdMatch.coverage.score);
   });
 
   it("does not drop a strong non-local match — soft boost, not a hard filter (#545)", () => {
@@ -102,6 +139,252 @@ describe("rankPostings", () => {
     });
     // The strong non-local match still appears — it isn't filtered out.
     expect(ranked.map((j) => j.posting.id)).toContain("strong-faraway");
+  });
+
+  it("ranks a dense, well-matched posting above a thin fully-covered one (#561)", () => {
+    // A senior résumé covering many technologies.
+    const senior: HeuristicParsedResume = {
+      skills: [
+        "React",
+        "TypeScript",
+        "Node.js",
+        "GraphQL",
+        "PostgreSQL",
+        "Docker",
+        "AWS",
+        "Python",
+        "Kubernetes",
+        "Go",
+      ],
+      experience: [
+        {
+          title: "Staff Engineer",
+          company: "Acme",
+          description:
+            "Built React and TypeScript apps on Node.js with GraphQL, PostgreSQL, Docker, AWS, Python, Kubernetes and Go.",
+        },
+      ],
+      education: [],
+    };
+
+    // Thin posting: a couple of terms, both covered → score 100 on a tiny
+    // denominator.
+    const thin = posting(
+      "thin",
+      "We are looking for a React and TypeScript engineer.",
+    );
+    // Dense, well-specified posting: many extracted terms, most covered, a few
+    // not → a strong-but-sub-100 score over a large denominator.
+    const dense = posting(
+      "dense",
+      "We need React, TypeScript, Node.js, GraphQL, PostgreSQL, Docker, AWS, " +
+        "Python, Kubernetes, and Go. Exposure to Rust, Scala, and Elixir is a plus.",
+    );
+
+    const ranked = rankPostings(senior, [thin, dense]);
+
+    const thinJob = ranked.find((j) => j.posting.id === "thin")!;
+    const denseJob = ranked.find((j) => j.posting.id === "dense")!;
+
+    // Fixture sanity: the thin posting really does score higher on the raw
+    // coverage % (that is the pathology #561 fixes), yet the dense posting has
+    // many more extracted terms.
+    expect(thinJob.score).toBeGreaterThan(denseJob.score);
+    expect(denseJob.jdMatch.terms.length).toBeGreaterThan(
+      thinJob.jdMatch.terms.length,
+    );
+
+    // Despite its lower displayed %, the dense posting sorts first — the
+    // specificity-weighted fitness base demotes the thin 100%.
+    expect(ranked[0].posting.id).toBe("dense");
+
+    // Parity untouched: displayed score still equals coverage.score for both.
+    expect(thinJob.score).toBe(thinJob.jdMatch.coverage.score);
+    expect(denseJob.score).toBe(denseJob.jdMatch.coverage.score);
+  });
+
+  it("keeps a no-extractable-terms posting at the bottom — no-op degenerate case (#561)", () => {
+    const real = posting("real", "We need a React and TypeScript engineer.");
+    // Lowercase filler with no skills, acronyms, or capitalized phrases.
+    const empty = posting(
+      "empty",
+      "we support our people and help them grow a little every single day here.",
+    );
+
+    const ranked = rankPostings(parsed, [empty, real]);
+
+    const emptyJob = ranked.find((j) => j.posting.id === "empty")!;
+    // Degenerate posting yields no terms and a 0 score — unchanged from today.
+    expect(emptyJob.jdMatch.terms.length).toBe(0);
+    expect(emptyJob.score).toBe(0);
+    // It cannot be promoted above a genuinely-matched posting: fitness 0.
+    expect(ranked[ranked.length - 1].posting.id).toBe("empty");
+  });
+
+  it("ranks a level-matching posting above an equal-coverage far-off-level one (issue 562)", () => {
+    // Identical description → identical coverage/base. The ONLY differentiator
+    // is the parsed title level vs the query seniority.
+    const desc = "We need React and TypeScript experts.";
+    const director = titledPosting("director", "Director of Engineering", desc);
+    const junior = titledPosting("junior", "Junior Engineer", desc);
+
+    const ranked = rankPostings(parsed, [junior, director], {
+      seniority: "Director",
+    });
+
+    // Equal base coverage, so the seniority penalty alone orders them.
+    expect(ranked[0].posting.id).toBe("director");
+    // Parity untouched: the penalty lives in the rating, not `score`.
+    const d = ranked.find((j) => j.posting.id === "director")!;
+    expect(d.score).toBe(d.jdMatch.coverage.score);
+  });
+
+  it("leaves ordering byte-identical when the query has no derived seniority (issue 562)", () => {
+    // Titles carry levels, but with no query seniority no penalty is applied,
+    // so ordering is pure coverage — higher-coverage Junior beats weak Director.
+    const strongJunior = titledPosting(
+      "strong-junior",
+      "Junior Engineer",
+      "We need React and TypeScript experts.",
+    );
+    const weakDirector = titledPosting(
+      "weak-director",
+      "Director of Engineering",
+      "We need Rust, Go, and Kubernetes.",
+    );
+
+    const withoutSeniority = rankPostings(parsed, [weakDirector, strongJunior]);
+    const emptySeniority = rankPostings(parsed, [weakDirector, strongJunior], {
+      seniority: undefined,
+    });
+
+    // Higher coverage wins regardless of title level.
+    expect(withoutSeniority.map((j) => j.posting.id)).toEqual([
+      "strong-junior",
+      "weak-director",
+    ]);
+    // Passing an undefined seniority is identical to passing no query at all.
+    expect(emptySeniority.map((j) => j.posting.id)).toEqual(
+      withoutSeniority.map((j) => j.posting.id),
+    );
+  });
+
+  it("treats a posting with no recognizable title level as neutral, not penalized (issue 562)", () => {
+    // Under a Director query: a title with NO level keyword must NOT be
+    // penalized, so it outranks an equal-coverage Junior-titled posting (which
+    // IS penalized for being far below the target).
+    const desc = "We need React and TypeScript experts.";
+    const noLevel = titledPosting("no-level", "Data Analyst", desc);
+    const junior = titledPosting("junior", "Junior Engineer", desc);
+
+    const ranked = rankPostings(parsed, [junior, noLevel], {
+      seniority: "Director",
+    });
+
+    expect(ranked[0].posting.id).toBe("no-level");
+  });
+
+  it("soft-penalizes, never drops: a far-off-level posting still appears (issue 562)", () => {
+    // A heavily level-mismatched posting (Junior under a Director query) is
+    // demoted — a many-rung gap SHOULD sink hard — but it is a penalty, not a
+    // filter: the posting is still in the results, never removed.
+    const junior = titledPosting(
+      "junior",
+      "Junior Engineer",
+      "We need React and TypeScript experts.",
+    );
+    const director = titledPosting(
+      "director",
+      "Director of Engineering",
+      "We need React and TypeScript experts.",
+    );
+
+    const ranked = rankPostings(parsed, [director, junior], {
+      seniority: "Director",
+    });
+
+    // Both survive — nothing is dropped by the soft penalty.
+    expect(ranked).toHaveLength(2);
+    expect(ranked.map((j) => j.posting.id)).toContain("junior");
+    // The level-matched posting still leads.
+    expect(ranked[0].posting.id).toBe("director");
+  });
+
+  it("sinks an adjacent-level posting only mildly — a clear coverage lead holds (issue 562)", () => {
+    // Staff query. The Manager posting (1 rung off, −5) has a decisive coverage
+    // advantage over an exact-level Staff posting with almost no overlap, so the
+    // mild adjacent-level penalty does NOT overturn the coverage order.
+    const rich: HeuristicParsedResume = {
+      skills: ["React", "TypeScript", "Node.js", "GraphQL", "PostgreSQL", "AWS"],
+      experience: [{ title: "Staff Engineer", company: "Acme", description: "" }],
+      education: [],
+    };
+    const managerStrong = titledPosting(
+      "manager-strong",
+      "Engineering Manager",
+      "We need React, TypeScript, Node.js, GraphQL, PostgreSQL, and AWS.",
+    );
+    const staffWeak = titledPosting(
+      "staff-weak",
+      "Staff Engineer",
+      "We need Rust, Go, Kubernetes, Terraform, Scala, and Elixir.",
+    );
+
+    const ranked = rankPostings(rich, [staffWeak, managerStrong], {
+      seniority: "Staff",
+    });
+
+    expect(ranked[0].posting.id).toBe("manager-strong");
+  });
+
+  it("extracts compensation once per posting and exposes it on RankedJob.posting (issue 564)", () => {
+    const p = posting(
+      "comp",
+      "We need React and TypeScript experts. Salary: $180,000 - $240,000.",
+    );
+    const [job] = rankPostings(parsed, [p]);
+    expect(job.posting.compensation).toBeDefined();
+    expect(job.posting.compensation!.min).toBe(180000);
+    expect(job.posting.compensation!.max).toBe(240000);
+    expect(job.posting.compensation!.raw).toContain("180,000");
+  });
+
+  it("SILENCE IS NEUTRAL: a posting with no extractable range ranks unchanged, floor or not (issue 564)", () => {
+    const noComp = posting("no-comp", "We need React and TypeScript experts.");
+    const withoutFloor = rankPostings(parsed, [noComp]);
+    const withFloor = rankPostings(parsed, [noComp], { compFloor: 500000 });
+    expect(withoutFloor[0].belowFloor).toBe(false);
+    expect(withFloor[0].belowFloor).toBe(false);
+    // Sort key is unaffected — same score, same (sole) position either way.
+    expect(withoutFloor[0].score).toBe(withFloor[0].score);
+  });
+
+  it("soft-penalizes a below-floor posting in the rating without dropping it (issue 564)", () => {
+    // Identical descriptions → identical base coverage. The ONLY
+    // differentiator is one posting's stated comp falling below the floor.
+    const desc = "We need React and TypeScript experts.";
+    const belowFloor = posting("below", `${desc} Pay: $80,000 - $90,000.`);
+    const aboveFloor = posting("above", `${desc} Pay: $250,000 - $300,000.`);
+
+    const ranked = rankPostings(parsed, [belowFloor, aboveFloor], {
+      compFloor: 200000,
+    });
+
+    const below = ranked.find((j) => j.posting.id === "below")!;
+    const above = ranked.find((j) => j.posting.id === "above")!;
+    expect(below.belowFloor).toBe(true);
+    expect(above.belowFloor).toBe(false);
+    // Both still present — soft penalty, never a filter.
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0].posting.id).toBe("above");
+    // Ranking parity untouched: displayed score is still coverage.score.
+    expect(below.score).toBe(below.jdMatch.coverage.score);
+  });
+
+  it("never penalizes when no compFloor is set, even for a low-paying posting (issue 564)", () => {
+    const lowPay = posting("low", "We need React and TypeScript experts. Pay: $50,000.");
+    const [job] = rankPostings(parsed, [lowPay]);
+    expect(job.belowFloor).toBe(false);
   });
 
   it("treats a Remote posting as matching any query location (#545)", () => {

--- a/src/lib/job-search/rank.ts
+++ b/src/lib/job-search/rank.ts
@@ -3,28 +3,51 @@
 
 /**
  * Rank fetched postings against the parsed résumé, reusing the jd-match
- * machinery verbatim.
+ * machinery, and attach each posting's 0–5 STAR rating (#561).
  *
- * Ranking parity (acceptance criterion): the fit % on a job card MUST equal
- * what the reused `JdMatch` detail view computes for the SAME posting. We
- * guarantee that by computing coverage ONCE per posting here — `extractJdTerms`
- * + `computeCoverage` — and packaging it into the exact `JdMatchResult` object
- * the `JdMatch` renderer consumes. The card reads `job.jdMatch.coverage` (score
- * + covered/missing) and the detail view is fed that same `job.jdMatch`, so the
- * two can never diverge (there is only one coverage computation).
+ * ── What the card shows (#561): a star rating, not a percentage ──
+ * The old card headline was raw JD-term coverage as a "score/100". Its
+ * denominator is how much the posting SAID, not how well the candidate fits, so
+ * on a real senior résumé it compressed into single digits (max ~57, mean ~10)
+ * and stopped discriminating. It is replaced by a calibrated, set-stretched star
+ * rating computed in `rating.ts` (`rateJobs`) — see that module for the model.
+ * `rank.ts` owns the raw signal extraction (coverage, comp, location, seniority)
+ * and hands it to `rateJobs`; the resulting `JobRating` is attached to every
+ * `RankedJob` and IS the sort order.
  *
- * Location (#545): a SOFT rank boost, never a hard filter — a posting whose
- * location doesn't match the query is still ranked and shown, just lower, so a
- * strong non-local fit is never dropped. The boost is applied ONLY to sort
- * order, never to `RankedJob.score` itself — `score` stays byte-identical to
- * `jdMatch.coverage.score` so the ranking-parity guarantee above (score ===
- * what the card shows === what the detail view computes) holds whether or not
- * a location boost fired. When `query.location` is empty/undefined the sort is
- * byte-identical to pre-#545 behavior (plain coverage-score descending) — no
- * regression for the no-location case. "Remote" (or "Worldwide"/"Anywhere"/
- * "WFH") postings always count as a location match: a remote posting fits any
- * candidate location, so it shouldn't be penalized for lacking a specific
- * city.
+ * ── Coverage parity (unchanged) ──
+ * Coverage is still computed ONCE per posting here (`extractJdTerms` +
+ * `computeCoverage`) and packaged into the exact `JdMatchResult` the `JdMatch`
+ * detail view consumes, so the terms shown on the card and the detail view can
+ * never disagree. `RankedJob.score` is still the raw coverage 0..100 — no longer
+ * the card HEADLINE, but retained as the fitness input (via the
+ * specificity-weighted base) and for the detail view's term legibility.
+ *
+ * ── Rating parity (the invariant that replaces the old "score === coverage") ──
+ * The star rating is computed by `rateJobs` over the WHOLE result set at once
+ * (it needs the set for the hybrid fitness stretch and the floor-less comp
+ * percentile — see `rating.ts`). The card headline, the inline sub-stars, the
+ * detail view, and the sort order all read the SAME attached `JobRating`, so they
+ * cannot diverge. Sorting therefore happens AFTER rating, by `rating.overall`.
+ *
+ * ── The four rating signals this module extracts ──
+ *   - fitness base — `coverage.score × specificityConfidence(termCount)`. The
+ *     specificity factor (#561) discounts a high score resting on few extracted
+ *     terms: a thin vague JD fully covered (100% over 6 terms) yields a smaller
+ *     base than a well-specified JD covered 30/45, so it cannot outrank it.
+ *   - location (#545) — a MATCH flag, remote always matching. Feeds a bounded
+ *     minor axis in `rateJobs`; a non-local strong fit is never dropped, only
+ *     edged by an equal-fit local one. No longer a flat sort-key boost (#570).
+ *   - seniority (#562) — the ladder-rung DISTANCE between the query's derived
+ *     level and the posting title's level, or null when there is no comparison
+ *     (no query seniority, or an unrecognized title level). Feeds a minor axis;
+ *     a level mismatch trims the rating a little, it no longer sinks a strong fit
+ *     (the old flat −5/rung penalty dominated the compressed base — #570/#562).
+ *   - compensation (#564) — `extractCompensation` runs ONCE here (the point
+ *     downstream of board hydration where every posting's `description` is
+ *     present), folded into `posting.compensation`. `belowFloor` is retained for
+ *     the card badge; the comp AXIS in `rateJobs` rates the range vs the floor
+ *     (or set-relative), and an absent comp simply drops out (silence neutral).
  *
  * Dynamic-imported by `search.ts` so jd-match's skill dictionary stays out of
  * the entry chunk.
@@ -36,34 +59,67 @@ import { extractJdTerms } from "../jd-match/extract-jd-terms.ts";
 import { computeCoverage } from "../jd-match/coverage.ts";
 import type { JobPosting } from "./types.ts";
 import type { JobQuery } from "./query-builder.ts";
+import { parseSeniorityLabel } from "./query-builder.ts";
+import { seniorityRung } from "./seniority.ts";
+import { extractCompensation, isBelowFloor, annualizedTop } from "./compensation.ts";
+import { rateJobs, type JobRating, type RatingInput } from "./rating.ts";
 
 /** The keyword arm of `JdMatchResult` — the only shape produced here. */
 export type KeywordJdMatch = Extract<JdMatchResult, { path: "keyword" }>;
 
-/** A posting paired with its (single) coverage computation. */
+/** A posting paired with its coverage computation and its star rating. */
 export interface RankedJob {
   posting: JobPosting;
   /** The exact object handed to `<JdMatch result={...} />` for detail. */
   jdMatch: KeywordJdMatch;
-  /** Weighted coverage 0..100 — the card's "fit %". Mirror of
-   *  `jdMatch.coverage.score`; surfaced flat for sort + card convenience. */
+  /** Raw coverage 0..100 (`jdMatch.coverage.score`), surfaced flat. No longer
+   *  the card headline (that is `rating`), but the fitness input and the detail
+   *  view's term-legibility denominator. */
   score: number;
+  /** The 0–5 star rating shown on the card (overall + sub-axes) — the sort key
+   *  and the single source both card and detail read (#561). */
+  rating: JobRating;
+  /** True when `posting.compensation` is extracted, a query `compFloor` is set,
+   *  AND the posting's top-of-range figure falls below it (#564). A SOFT signal
+   *  — the card reads this to render a "below your floor" badge, never to hide
+   *  the posting. Always false when no comp was extracted or no floor was set. */
+  belowFloor: boolean;
+  /** True when the QUERY carried a compensation floor. Distinct from
+   *  `belowFloor` (which is per-posting and false both for "above the floor" and
+   *  for "no floor at all"): the comp rating axis means two different things
+   *  with and without a floor — measured against it, vs a bonus-only absolute
+   *  curve — so the card must know which regime produced the number before it
+   *  puts words to it (`describeRating`, #569). */
+  compFloorSet: boolean;
 }
 
 /**
- * Points added to a posting's SORT key (never its displayed `score`) when its
- * location matches `query.location` — see the location docblock above. Chosen
- * to outrank a small coverage-score gap between an otherwise-similar local and
- * non-local posting, without letting location swamp a large fit-quality
- * difference (a posting must still be a reasonably close fit to rise above a
- * much stronger non-local match).
+ * Half-saturation constant for the specificity confidence factor (#561): a
+ * posting from which exactly this many terms were extracted has its coverage
+ * score weighted at 0.5 when forming the fitness base. Fewer terms → the
+ * coverage % rests on a thinner denominator, so it is discounted more; many
+ * terms → the factor approaches 1 and the score stands on its own. So a
+ * 100%-on-a-few-terms posting yields a smaller base than a well-specified
+ * posting the résumé matches most of (100% over 6 terms → base ~37 vs 67% over
+ * 45 terms → base ~55), which is what feeds the fitness axis in `rateJobs`.
  */
-const LOCATION_BOOST = 10;
+const SPECIFICITY_HALF_SATURATION = 10;
+
+/**
+ * Confidence multiplier in [0,1) applied to a posting's coverage score to form
+ * its fitness base: `termCount / (termCount + SPECIFICITY_HALF_SATURATION)`.
+ * Monotonically increasing in `termCount`; exactly 0 at `termCount === 0`, so a
+ * posting with no extractable terms has base 0 (fitness 0, per #561's degenerate
+ * case).
+ */
+function specificityConfidence(termCount: number): number {
+  return termCount / (termCount + SPECIFICITY_HALF_SATURATION);
+}
 
 const REMOTE_PATTERN = /\b(remote|worldwide|anywhere|wfh)\b/i;
 
-/** True for a posting location that reads as remote/location-agnostic — see
- *  the location docblock above for why these always count as a match. */
+/** True for a posting location that reads as remote/location-agnostic — a remote
+ *  posting fits any candidate location, so it always counts as a match. */
 function isRemotePosting(location: string): boolean {
   return REMOTE_PATTERN.test(location);
 }
@@ -72,10 +128,10 @@ function isRemotePosting(location: string): boolean {
  * True when `postingLocation` should count as a match for `queryLocation`.
  * Compares the leading city/region token (text before the first comma) so
  * "Austin, TX" matches a feed's "Austin, TX, USA" without requiring an exact
- * string match, and falls back to a loose substring check either direction
- * for postings that don't follow the "City, ST" shape.
+ * string match, and falls back to a loose substring check either direction for
+ * postings that don't follow the "City, ST" shape.
  */
-function locationBoostMatches(queryLocation: string, postingLocation: string): boolean {
+function locationMatches(queryLocation: string, postingLocation: string): boolean {
   if (isRemotePosting(postingLocation)) return true;
   const posting = postingLocation.trim().toLowerCase();
   const query = queryLocation.trim().toLowerCase();
@@ -86,17 +142,64 @@ function locationBoostMatches(queryLocation: string, postingLocation: string): b
 }
 
 /**
- * Score every posting against `parsed` and return them sorted by fit
- * descending, with an optional location boost breaking ties toward postings
- * matching `query.location` (see the location docblock above). Ties keep
- * input order (stable sort), which preserves the provider/dedup order from
- * the fan-out.
+ * The ladder-rung DISTANCE between the query's seniority rung and the level
+ * parsed out of a posting title (#562), or null when there is no comparison to
+ * make: the query carried no derived seniority (`querySeniorityRung` undefined),
+ * or the title carries no recognizable level (its rung is undefined). Null is
+ * NEUTRAL — the seniority axis drops out of the rating rather than being treated
+ * as a worst-case mismatch.
+ */
+function seniorityDistance(
+  postingTitle: string,
+  querySeniorityRung: number | undefined,
+): number | null {
+  if (querySeniorityRung === undefined) return null;
+  const postingRung = seniorityRung(parseSeniorityLabel(postingTitle));
+  if (postingRung === undefined) return null;
+  return Math.abs(querySeniorityRung - postingRung);
+}
+
+/**
+ * Build the raw `RatingInput` for one already-coverage-scored posting — the
+ * bridge between rank.ts's signal extraction and `rateJobs`. Exported so the
+ * `probe-jobs` diagnostic can reconstruct exactly what fed a rating without
+ * re-deriving the constants (the single source of truth for the rating inputs).
+ */
+export function ratingInputFor(
+  job: RankedJob,
+  queryLocation: string | undefined,
+  querySeniorityRung: number | undefined,
+  compFloor: number | undefined,
+): RatingInput {
+  const comp = job.posting.compensation;
+  return {
+    base: job.score * specificityConfidence(job.jdMatch.terms.length),
+    // Annualized top-of-range, or null when absent OR an implausible misparse —
+    // a garbage $300/yr must not tank a strong fit via the comp axis (#561/#564).
+    compMax: comp ? (annualizedTop(comp) ?? null) : null,
+    compFloor,
+    hasQueryLocation: queryLocation !== undefined,
+    locationMatch:
+      queryLocation !== undefined && locationMatches(queryLocation, job.posting.location),
+    seniorityDistance: seniorityDistance(job.posting.title, querySeniorityRung),
+  };
+}
+
+/**
+ * Score every posting against `parsed`, rate it 0–5 stars, and return the
+ * postings sorted by `rating.overall` descending. Coverage + comp are computed
+ * once per posting; the rating is computed once over the whole set (`rateJobs`
+ * needs the set — see `rating.ts`). Ties keep input order (stable sort), which
+ * preserves the provider/dedup order from the fan-out.
  */
 export function rankPostings(
   parsed: HeuristicParsedResume,
   postings: readonly JobPosting[],
-  query?: Pick<JobQuery, "location">,
+  query?: Pick<JobQuery, "location" | "seniority" | "compFloor">,
 ): RankedJob[] {
+  const compFloorSet = (query?.compFloor ?? 0) > 0;
+
+  // Pass 1 — coverage + comp per posting (rating still unset; filled in pass 2).
   const ranked = postings.map((posting): RankedJob => {
     const extracted = extractJdTerms(posting.description);
     const coverage = computeCoverage(parsed, extracted.all);
@@ -106,26 +209,43 @@ export function rankPostings(
       terms: extracted.all,
       nounsDropped: extracted.nounsDropped,
     };
-    return { posting, jdMatch, score: coverage.score };
+    // Extract compensation ONCE here (#564) — the point downstream of hydration
+    // where every posting's `description` is guaranteed present regardless of
+    // source. A posting that already carries `compensation` is left as-is.
+    const compensation = posting.compensation ?? extractCompensation(posting.description);
+    const withComp: JobPosting = compensation ? { ...posting, compensation } : posting;
+    const belowFloor = isBelowFloor(compensation, query?.compFloor);
+    return {
+      posting: withComp,
+      jdMatch,
+      score: coverage.score,
+      // Placeholder; overwritten in pass 2 once the whole set is known.
+      rating: { overall: 0, fitness: 0, compensation: null, location: null, seniority: null },
+      belowFloor,
+      compFloorSet,
+    };
   });
 
-  const queryLocation = query?.location?.trim();
-  if (!queryLocation) {
-    // No location signal → identical to pre-#545 behavior.
-    return ranked.sort((a, b) => b.score - a.score);
-  }
-  // Decorate-sort-undecorate: compute the boosted key ONCE per posting (the
-  // boost does a regex test + two splits), not O(n log n) times inside the
-  // comparator. Sort is stable, so equal keys keep fan-out/dedup order.
+  const queryLocation = query?.location?.trim() || undefined;
+  // Resolve the query's seniority to a ladder rung ONCE. `undefined` here (no
+  // derived seniority, or an unmapped label) makes every posting's seniority
+  // distance null — the axis drops out for the whole set.
+  const querySeniorityRung = seniorityRung(query?.seniority);
+
+  // Pass 2 — rate the whole set at once, attach, then sort by overall. Rating
+  // needs the set (hybrid fitness stretch + floor-less comp percentile), so it
+  // cannot be folded into pass 1.
+  const inputs = ranked.map((job) =>
+    ratingInputFor(job, queryLocation, querySeniorityRung, query?.compFloor),
+  );
+  const ratings = rateJobs(inputs);
+  ranked.forEach((job, i) => {
+    job.rating = ratings[i];
+  });
+
   return ranked
-    .map((job) => ({
-      job,
-      key:
-        job.score +
-        (locationBoostMatches(queryLocation, job.posting.location)
-          ? LOCATION_BOOST
-          : 0),
-    }))
-    .sort((a, b) => b.key - a.key)
+    .map((job, i) => ({ job, i }))
+    // Stable sort by overall rating descending; ties keep fan-out/dedup order.
+    .sort((a, b) => b.job.rating.overall - a.job.rating.overall || a.i - b.i)
     .map(({ job }) => job);
 }

--- a/src/lib/job-search/rating.test.ts
+++ b/src/lib/job-search/rating.test.ts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  rateJobs,
+  describeRating,
+  MAX_STARS,
+  type JobRating,
+  type RatingInput,
+} from "./rating.ts";
+
+/** A minimal input with only fitness present (no comp, no query location/seniority). */
+function fitOnly(base: number): RatingInput {
+  return {
+    base,
+    compMax: null,
+    compFloor: undefined,
+    hasQueryLocation: false,
+    locationMatch: false,
+    seniorityDistance: null,
+  };
+}
+
+describe("rateJobs", () => {
+  it("returns empty for an empty set", () => {
+    expect(rateJobs([])).toEqual([]);
+  });
+
+  it("keeps every rating within [0, MAX_STARS]", () => {
+    const ratings = rateJobs([fitOnly(0), fitOnly(7), fitOnly(21), fitOnly(100)]);
+    for (const r of ratings) {
+      expect(r.overall).toBeGreaterThanOrEqual(0);
+      expect(r.overall).toBeLessThanOrEqual(MAX_STARS);
+      expect(r.fitness).toBeGreaterThanOrEqual(0);
+      expect(r.fitness).toBeLessThanOrEqual(MAX_STARS);
+    }
+  });
+
+  it("with only fitness present, overall equals fitness (absent axes redistribute)", () => {
+    const [r] = rateJobs([fitOnly(15)]);
+    expect(r.compensation).toBeNull();
+    expect(r.location).toBeNull();
+    expect(r.seniority).toBeNull();
+    expect(r.overall).toBeCloseTo(r.fitness, 10);
+  });
+
+  it("fitness is monotonic in the base", () => {
+    const ratings = rateJobs([fitOnly(2), fitOnly(8), fitOnly(20)]);
+    expect(ratings[0].fitness).toBeLessThan(ratings[1].fitness);
+    expect(ratings[1].fitness).toBeLessThan(ratings[2].fitness);
+  });
+
+  it("HYBRID stretch lifts the observed top toward the max even on a compressed set", () => {
+    // Mirror the real distribution: bases compressed into single digits, ceiling
+    // ~21. The absolute curve alone would leave the top around 3.5★; the relative
+    // stretch must pull it clearly higher.
+    const bases = [0, 3, 5, 7, 9, 12, 15, 21];
+    const ratings = rateJobs(bases.map(fitOnly));
+    const top = ratings[ratings.length - 1].fitness;
+    const bottom = ratings[0].fitness;
+    // Top of a compressed set still reaches a strong rating.
+    expect(top).toBeGreaterThan(4);
+    // The degenerate base-0 posting bottoms out at exactly 0 stars.
+    expect(bottom).toBe(0);
+    // The set genuinely spreads (compression no longer flattens the ranking).
+    expect(top - bottom).toBeGreaterThan(3);
+  });
+
+  it("falls back to the absolute curve when the set has no spread (single posting)", () => {
+    const [one] = rateJobs([fitOnly(9)]);
+    // base 9 → absolute 9/18 = 0.5 → 2.5★, no relative stretch to apply.
+    expect(one.fitness).toBeCloseTo(2.5, 5);
+  });
+
+  it("does not penalize a posting for missing compensation — overall stays fitness-driven", () => {
+    const strong = fitOnly(20); // no comp
+    const [r] = rateJobs([strong]);
+    expect(r.compensation).toBeNull();
+    // A strong fit with unknown comp still rates strong, not dragged toward 0.
+    expect(r.overall).toBeGreaterThan(3);
+  });
+
+  it("scores compensation against the floor: at floor ≈ 2.5★, well above ≈ 5★, below < 2.5★", () => {
+    const base = 10;
+    const atFloor: RatingInput = { ...fitOnly(base), compMax: 200000, compFloor: 200000 };
+    const wellAbove: RatingInput = { ...fitOnly(base), compMax: 400000, compFloor: 200000 };
+    const below: RatingInput = { ...fitOnly(base), compMax: 120000, compFloor: 200000 };
+    const [a, w, b] = rateJobs([atFloor, wellAbove, below]);
+    expect(a.compensation).toBeCloseTo(2.5, 5);
+    expect(w.compensation).toBeCloseTo(5, 5);
+    expect(b.compensation!).toBeLessThan(2.5);
+    expect(b.compensation!).toBeGreaterThan(0);
+  });
+
+  it("scores floor-less compensation as a bonus-only absolute curve, never below neutral", () => {
+    const mk = (comp: number): RatingInput => ({ ...fitOnly(10), compMax: comp });
+    // No floor set: comp is a bonus. Higher pay → more stars, monotonically, and
+    // NEVER below the neutral 2.5★ — a lower (but real) salary is not punished
+    // when the user expressed no minimum. Not set-relative: each is scored on its
+    // own absolute magnitude, so the lowest here is still a solid bonus, not 0.
+    const ratings = rateJobs([mk(100000), mk(200000), mk(400000)]);
+    expect(ratings[0].compensation!).toBeGreaterThanOrEqual(2.5);
+    expect(ratings[0].compensation!).toBeLessThan(ratings[1].compensation!);
+    expect(ratings[1].compensation!).toBeLessThan(ratings[2].compensation!);
+    expect(ratings[2].compensation!).toBeLessThan(5);
+  });
+
+  it("does not punish disclosing an average salary vs hiding it (no floor)", () => {
+    // A no-comp posting rates on fitness alone; a posting that DISCLOSES a decent
+    // salary must not thereby rate lower. With the bonus-only curve, comp can only
+    // lift or stay neutral, so the disclosed-comp posting is ≥ the no-comp one.
+    const base = 12;
+    const disclosed: RatingInput = { ...fitOnly(base), compMax: 170000 };
+    const hidden: RatingInput = fitOnly(base);
+    const [d, h] = rateJobs([disclosed, hidden]);
+    expect(d.overall).toBeGreaterThanOrEqual(h.overall);
+  });
+
+  it("gives a lone floor-less comp a solid bonus, not a percentile 2.5★", () => {
+    const [r] = rateJobs([{ ...fitOnly(10), compMax: 180000 }]);
+    // 180k = COMP_HALF_SATURATION → 0.5 + 0.5·0.5 = 0.75 → 3.75★.
+    expect(r.compensation).toBeCloseTo(3.75, 5);
+  });
+
+  it("location: matched = 5★, non-matched = a bounded 2.5★, absent query = null", () => {
+    const base = 10;
+    const matched: RatingInput = { ...fitOnly(base), hasQueryLocation: true, locationMatch: true };
+    const nonMatched: RatingInput = { ...fitOnly(base), hasQueryLocation: true, locationMatch: false };
+    const noQuery: RatingInput = fitOnly(base);
+    const [m, n, q] = rateJobs([matched, nonMatched, noQuery]);
+    expect(m.location).toBeCloseTo(5, 5);
+    expect(n.location).toBeCloseTo(2.5, 5);
+    expect(q.location).toBeNull();
+    // The location nudge is minor: a matched posting edges an identical-fit
+    // non-matched one, but only slightly (weight 0.1).
+    expect(m.overall).toBeGreaterThan(n.overall);
+    expect(m.overall - n.overall).toBeLessThan(0.5);
+  });
+
+  it("seniority: exact level = 5★, each rung of distance drops it, null distance = null", () => {
+    const base = 10;
+    const exact: RatingInput = { ...fitOnly(base), seniorityDistance: 0 };
+    const oneOff: RatingInput = { ...fitOnly(base), seniorityDistance: 1 };
+    const farOff: RatingInput = { ...fitOnly(base), seniorityDistance: 5 };
+    const noLevel: RatingInput = fitOnly(base);
+    const [e, o, f, nl] = rateJobs([exact, oneOff, farOff, noLevel]);
+    expect(e.seniority).toBeCloseTo(5, 5);
+    expect(o.seniority).toBeCloseTo(4, 5); // 1 - 1*0.2 = 0.8 → 4★
+    expect(f.seniority).toBeCloseTo(0, 5); // 1 - 5*0.2 = 0 → 0★
+    expect(nl.seniority).toBeNull();
+  });
+
+  it("a strong fit is NOT sunk by a seniority mismatch — the #562/#570 domination fix", () => {
+    // The real pathology: a top-fit posting (base 21) one level off. Under the
+    // old flat −15 penalty it fell from rank ~1 to rank ~9, below weak local
+    // postings. As a minor fractional axis (weight 0.1) the mismatch can only
+    // trim the overall a little — the strong fit still rates well above a weak
+    // one that happens to be an exact level match.
+    const strongOffLevel: RatingInput = { ...fitOnly(21), seniorityDistance: 2 };
+    const weakExactLevel: RatingInput = { ...fitOnly(4), seniorityDistance: 0 };
+    const [strong, weak] = rateJobs([strongOffLevel, weakExactLevel]);
+    expect(strong.overall).toBeGreaterThan(weak.overall);
+  });
+
+  it("blends fitness and compensation as the two drivers (balanced fit + comp)", () => {
+    // Same fitness; one has a strong comp, one a weak comp. The comp axis
+    // (weight 0.35, second only to fitness) must move the overall meaningfully.
+    const strongComp: RatingInput = { ...fitOnly(10), compMax: 400000, compFloor: 100000 };
+    const weakComp: RatingInput = { ...fitOnly(10), compMax: 90000, compFloor: 100000 };
+    const [s, w] = rateJobs([strongComp, weakComp]);
+    expect(s.overall - w.overall).toBeGreaterThan(0.5);
+  });
+});
+
+describe("describeRating", () => {
+  const base: JobRating = {
+    overall: 3,
+    fitness: 3,
+    compensation: null,
+    location: null,
+    seniority: null,
+  };
+
+  it("always yields a fit phrase, since the fitness axis is always present", () => {
+    expect(describeRating({ ...base, fitness: 4.6 }, { hasCompFloor: false })).toEqual([
+      "Top fit here",
+    ]);
+    expect(describeRating({ ...base, fitness: 3.2 }, { hasCompFloor: false })).toEqual([
+      "Strong fit",
+    ]);
+    expect(describeRating({ ...base, fitness: 2.1 }, { hasCompFloor: false })).toEqual([
+      "Partial fit",
+    ]);
+    expect(describeRating({ ...base, fitness: 0.4 }, { hasCompFloor: false })).toEqual([
+      "Weak fit",
+    ]);
+  });
+
+  it("phrases pay against the floor when the query set one", () => {
+    const withPay = (compensation: number) =>
+      describeRating({ ...base, compensation }, { hasCompFloor: true });
+    expect(withPay(4.8)).toContain("Pay well above your floor");
+    expect(withPay(3.5)).toContain("Pay above your floor");
+    expect(withPay(2.6)).toContain("Pay at your floor");
+  });
+
+  it("says nothing about pay below the floor — the badge already does (issue 564)", () => {
+    // Duplicating the "Below your floor" StatusBadge in words is noise.
+    expect(describeRating({ ...base, compensation: 1.2 }, { hasCompFloor: true })).toEqual([
+      "Strong fit",
+    ]);
+  });
+
+  it("treats a floor-less comp as bonus-only: praise the top, never punish the rest", () => {
+    const withPay = (compensation: number) =>
+      describeRating({ ...base, compensation }, { hasCompFloor: false });
+    expect(withPay(4.5)).toContain("Top pay");
+    expect(withPay(3.4)).toContain("Strong pay");
+    // The floor-less curve bottoms out at 2.5★ and means "nothing to shout
+    // about", NOT "bad pay" — the user set no minimum, so we must not infer one.
+    expect(withPay(2.6)).toEqual(["Strong fit"]);
+  });
+
+  it("speaks only for axes that are present", () => {
+    // A null axis contributed nothing to the blend and must contribute no words.
+    expect(describeRating(base, { hasCompFloor: true })).toEqual(["Strong fit"]);
+  });
+
+  it("names a location match but stays silent on a miss (the card prints the location)", () => {
+    expect(
+      describeRating({ ...base, location: MAX_STARS }, { hasCompFloor: false }),
+    ).toContain("Location match");
+    expect(
+      describeRating({ ...base, location: MAX_STARS / 2 }, { hasCompFloor: false }),
+    ).toEqual(["Strong fit"]);
+  });
+
+  it("flags an exact level match and a multi-rung gap, but not a single rung", () => {
+    const withLevel = (seniority: number) =>
+      describeRating({ ...base, seniority }, { hasCompFloor: false });
+    expect(withLevel(5)).toContain("Level match");
+    expect(withLevel(2)).toContain("Level gap");
+    expect(withLevel(4)).toEqual(["Strong fit"]); // one rung off — not worth saying
+  });
+
+  it("reads every phrase off a real rateJobs result, in axis order", () => {
+    const [rating] = rateJobs([
+      {
+        base: 21,
+        compMax: 400000,
+        compFloor: 100000,
+        hasQueryLocation: true,
+        locationMatch: true,
+        seniorityDistance: 0,
+      },
+    ]);
+    // base 21 is the observed top of the real compressed range → 3.5★ fitness.
+    expect(describeRating(rating, { hasCompFloor: true })).toEqual([
+      "Strong fit",
+      "Pay well above your floor",
+      "Location match",
+      "Level match",
+    ]);
+  });
+});

--- a/src/lib/job-search/rating.ts
+++ b/src/lib/job-search/rating.ts
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Star rating model (#561) — turns a fetched posting's raw signals into a 0–5
+ * star OVERALL rating plus per-axis sub-ratings, replacing the misleading fit
+ * percentage on the job card.
+ *
+ * Why stars, not a percentage: the displayed fit % was raw JD-term coverage,
+ * whose denominator is how much the posting SAID, not how well the candidate
+ * fits. On a real senior résumé that number tops out ~57 and means ~10 — it
+ * compresses into single digits, so the card reads "10% fit" for almost every
+ * posting and stops discriminating. A star rating fixes both halves: it is
+ * calibrated (a strong match reads as ~4–5★, not "57%"), and it is stretched
+ * across the observed set so the good matches actually separate from the noise.
+ *
+ * The OVERALL star is a weighted blend of four axes, each a fraction in [0,1]:
+ *   - fitness      (always present) — hybrid absolute+relative, see below
+ *   - compensation (present iff comp was extracted) — vs floor, or set-relative
+ *   - location     (present iff the query carried a location) — match nudge
+ *   - seniority    (present iff the query + posting title yield a level) — nudge
+ * An ABSENT axis is dropped and its weight redistributed over the present ones,
+ * so a posting with no extracted comp is rated on the axes we actually know, not
+ * penalized for our silence (the #564 "silence is neutral" rule, generalized).
+ *
+ * fitness is HYBRID (the chosen #561 direction): an ABSOLUTE saturating curve of
+ * the specificity-weighted coverage base anchors the meaning (a strong match is
+ * a strong match regardless of the rest of the set), then a set-RELATIVE stretch
+ * lifts the observed top toward 5★ so the ranking still separates the good
+ * matches even when the whole set is compressed. Because both halves are
+ * monotonic in the base, the fitness axis — and thus the fitness-dominant
+ * overall — preserves fit ordering.
+ *
+ * Why the soft axes are now FRACTIONS, weighted small (#570/#562 fix): the old
+ * ranker added a FLAT location boost (+10) and subtracted FLAT seniority (−5/rung)
+ * and comp (−8) penalties to a base that, on real compressed scores, tops out
+ * around ~21. A flat ±10 is half that range, so location and seniority DOMINATED
+ * fit (the probe measured a strong non-local fit sunk from rank ~1 to rank 9 by a
+ * flat seniority penalty, and 446 location-over-fit inversions). Modeling them as
+ * bounded fractions weighted 0.10 each makes them exactly what they were meant to
+ * be — soft nudges that break a near-tie but can never bury a clear fit lead.
+ *
+ * Parity (the invariant that replaces rank.ts's old "score === coverage"):
+ * `rateJobs` is the ONE place a rating is computed, over the whole result set at
+ * once. The card headline, the inline sub-stars, the detail view, and the sort
+ * order all read the SAME `JobRating` object, so they can never diverge. NOTE
+ * the set-dependence this introduces: because the relative stretch reads the
+ * set's min/max base, the identical posting can rate differently in a different
+ * search — that is intended (a 5★ means "the best of what this search found",
+ * not an absolute universal score) and is why the rating is computed per result
+ * set, never cached per posting. That is also why there is no algo-version stamp
+ * here mirroring `ATS_SCORE_ALGO_VERSION`: that constant exists to invalidate a
+ * *stored* score (`resume-library.ts`'s cache key), and nothing stores a rating.
+ * If a rating ever is persisted, add the stamp then, with the consumer.
+ */
+
+/** The star scale. Ratings are real numbers in [0, MAX_STARS]; the display
+ *  component rounds to half-stars, the sort uses the full precision. */
+export const MAX_STARS = 5;
+
+/**
+ * Half-saturation constant for the ABSOLUTE fitness curve:
+ * `base / (base + FIT_HALF_SATURATION)`. A posting whose specificity-weighted
+ * coverage base equals this value scores 0.5 absolute. Sized against the real
+ * compressed base range (ceiling ~21, mean ~7): at 9, a top-of-set base ~21
+ * reaches ~0.7 absolute (→ a strong ~3.5★ before the relative stretch lifts it
+ * toward 5), while a mean base ~7 sits near ~0.44. Not the theoretical 0..100
+ * coverage range — calibrated to what real résumés actually produce.
+ */
+const FIT_HALF_SATURATION = 9;
+
+/**
+ * Blend weight of the set-RELATIVE stretch against the ABSOLUTE curve in the
+ * hybrid fitness fraction: `HYBRID_RELATIVE_WEIGHT · relative + (1 − it) ·
+ * absolute`. At 0.6 the relative stretch leads (so the observed best match is
+ * pulled decisively toward 5★ and the set separates) while the absolute curve
+ * still contributes 40%, keeping a genuinely weak set from having its top posting
+ * inflated to a perfect score purely for being the least-bad option.
+ */
+const HYBRID_RELATIVE_WEIGHT = 0.6;
+
+/** Overall-blend weights per axis (#561 "balanced fit + comp"): fitness and
+ *  compensation are the two drivers, location and seniority are minor nudges.
+ *  Applied only to PRESENT axes, then renormalized — see `rateJobs`. */
+const WEIGHT_FITNESS = 0.45;
+const WEIGHT_COMPENSATION = 0.35;
+const WEIGHT_LOCATION = 0.1;
+const WEIGHT_SENIORITY = 0.1;
+
+/**
+ * Half-saturation constant (annual USD) for the FLOOR-LESS compensation bonus
+ * curve: a posting paying this much reaches the midpoint of the bonus band. At
+ * 180k a typical strong-market salary reads as a solid bonus while a very high
+ * package still has headroom toward the top. Only used when the query set NO
+ * floor — see `compensationFraction`.
+ */
+const COMP_HALF_SATURATION = 180_000;
+
+/** Per-rung falloff of the seniority fraction: an exact-level posting is 1.0,
+ *  each rung of distance drops it by this much (floored at 0). At 0.2 a 1-rung
+ *  miss is 0.8, a 5-rung gulf bottoms out — a gentle slope, because seniority is
+ *  a minor axis (weight 0.1) and a soft nudge, never a filter. */
+const SENIORITY_FRACTION_PER_RUNG = 0.2;
+
+/** Location fraction for a non-matching (non-remote, different-city) posting: not
+ *  zero — a non-local posting still has full fit value, location is only a
+ *  preference — so a matched posting (1.0) edges it by a bounded margin under the
+ *  small location weight. */
+const LOCATION_FRACTION_NONMATCH = 0.5;
+
+/** The per-axis star ratings for one posting. `overall` is the weighted blend;
+ *  a `null` axis was not applicable to this posting/query and did not enter the
+ *  blend (its weight was redistributed). All values are 0..MAX_STARS. */
+export interface JobRating {
+  overall: number;
+  fitness: number;
+  compensation: number | null;
+  location: number | null;
+  seniority: number | null;
+}
+
+/**
+ * The raw per-posting signals the rating is computed from — produced by
+ * `rank.ts` (which owns coverage/comp/location/seniority extraction) and handed
+ * here so this module stays a pure transform with no knowledge of pdfjs, feeds,
+ * or the jd-match dictionary.
+ */
+export interface RatingInput {
+  /** Specificity-weighted coverage base (`coverage.score × specificityConfidence`),
+   *  the same value rank.ts's fitness ordering rides on. */
+  base: number;
+  /** Top of the extracted compensation range (`comp.max ?? comp.min`), or null
+   *  when no comp was extracted for this posting. */
+  compMax: number | null;
+  /** The query's optional compensation floor (annual, USD-assumed) — anchors the
+   *  comp axis when set; when unset the comp axis is scored set-relative. */
+  compFloor: number | undefined;
+  /** True when the query carried a location. `false` → the location axis is
+   *  absent (null in the result) and its weight redistributes. */
+  hasQueryLocation: boolean;
+  /** Whether this posting's location matched the query (remote always matches).
+   *  Only meaningful when `hasQueryLocation`. */
+  locationMatch: boolean;
+  /** Ladder-rung distance between the query's seniority and the posting title's
+   *  level, or null when there is no comparison to make (no query seniority, or
+   *  an unrecognized title level) — in which case the seniority axis is absent. */
+  seniorityDistance: number | null;
+}
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+/** Absolute fitness fraction ∈ [0,1): the saturating curve of the base. */
+function absoluteFitness(base: number): number {
+  return base / (base + FIT_HALF_SATURATION);
+}
+
+/**
+ * The comp fraction ∈ [0,1] for a posting that HAS an extracted (annualized,
+ * plausibility-screened) comp.
+ *
+ * With a floor SET, it is the top-of-range measured against the floor: at the
+ * floor → 0.5, at/above twice the floor → 1.0, below → proportionally under 0.5
+ * (a below-floor posting is a negotiation, not a disqualification — it sinks,
+ * never vanishes). The floor is the user's EXPLICIT minimum, so this is the only
+ * case comp is allowed to drag a posting below neutral.
+ *
+ * With NO floor, comp is a BONUS-ONLY absolute curve into [0.5, 1.0]: a strong
+ * salary lifts the rating, an average/unknown one is neutral, and a merely-lower
+ * salary is NEVER punished — the user set no minimum, so we must not infer one.
+ * This is deliberately not a set-relative percentile: percentile made the
+ * lowest-paying posting ~0★ even at a six-figure salary just because the set had
+ * outliers, which BURIED a strong fit AND penalized a posting for disclosing pay
+ * (a no-comp posting drops the axis and rates on fitness alone — so a disclosed
+ * average salary must not rate below that, or disclosure is punished).
+ */
+function compensationFraction(compMax: number, compFloor: number | undefined): number {
+  if (compFloor !== undefined && compFloor > 0) {
+    return clamp01(compMax / compFloor / 2);
+  }
+  return 0.5 + 0.5 * (compMax / (compMax + COMP_HALF_SATURATION));
+}
+
+/** The seniority fraction ∈ [0,1] from the ladder-rung distance. */
+function seniorityFraction(distance: number): number {
+  return Math.max(0, 1 - Math.abs(distance) * SENIORITY_FRACTION_PER_RUNG);
+}
+
+/**
+ * Rate every posting in a result set at once (the set is required for the hybrid
+ * fitness stretch and the floor-less comp percentile). Returns one `JobRating`
+ * per input, in the same order. This is the SINGLE rating computation the whole
+ * lane reads — card, sub-stars, detail, and sort order — so they cannot diverge.
+ */
+export function rateJobs(inputs: readonly RatingInput[]): JobRating[] {
+  if (inputs.length === 0) return [];
+
+  // Set-level context for the hybrid fitness stretch.
+  const absolutes = inputs.map((i) => absoluteFitness(i.base));
+  const aMax = Math.max(...absolutes);
+  const aMin = Math.min(...absolutes);
+  const spread = aMax - aMin;
+
+  return inputs.map((input, idx): JobRating => {
+    // Fitness — hybrid absolute + set-relative stretch. When the set has no
+    // spread (one posting, or all-equal bases) the stretch is undefined, so fall
+    // back to the pure absolute curve.
+    const absolute = absolutes[idx];
+    const relative = spread > 0 ? (absolute - aMin) / spread : absolute;
+    const fitnessFrac =
+      HYBRID_RELATIVE_WEIGHT * relative + (1 - HYBRID_RELATIVE_WEIGHT) * absolute;
+
+    // Compensation — present only when a comp was extracted.
+    const compFrac =
+      input.compMax !== null
+        ? compensationFraction(input.compMax, input.compFloor)
+        : null;
+
+    // Location — present only when the query carried a location.
+    const locFrac = input.hasQueryLocation
+      ? input.locationMatch
+        ? 1
+        : LOCATION_FRACTION_NONMATCH
+      : null;
+
+    // Seniority — present only when there is a level comparison to make.
+    const senFrac =
+      input.seniorityDistance !== null
+        ? seniorityFraction(input.seniorityDistance)
+        : null;
+
+    // Weighted blend over the PRESENT axes, weights renormalized so an absent
+    // axis neither counts nor penalizes.
+    const axes: Array<[number, number | null]> = [
+      [WEIGHT_FITNESS, fitnessFrac],
+      [WEIGHT_COMPENSATION, compFrac],
+      [WEIGHT_LOCATION, locFrac],
+      [WEIGHT_SENIORITY, senFrac],
+    ];
+    let weighted = 0;
+    let totalWeight = 0;
+    for (const [w, frac] of axes) {
+      if (frac === null) continue;
+      weighted += w * frac;
+      totalWeight += w;
+    }
+    const overallFrac = totalWeight > 0 ? weighted / totalWeight : 0;
+
+    return {
+      overall: MAX_STARS * overallFrac,
+      fitness: MAX_STARS * fitnessFrac,
+      compensation: compFrac === null ? null : MAX_STARS * compFrac,
+      location: locFrac === null ? null : MAX_STARS * locFrac,
+      seniority: senFrac === null ? null : MAX_STARS * senFrac,
+    };
+  });
+}
+
+/* ------------------------------------------------------------------------- *
+ * Reason bands (#569)
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Band cut-points (in stars) for the per-axis WORDS the card shows in place of
+ * per-axis sub-stars. Three reasons the words replaced the stars:
+ *
+ * 1. Three star rows in one card is three identical glyphs carrying three
+ *    different meanings — nothing marks which one is the headline.
+ * 2. `fitness` carries 0.45 of the blend and is the dominant axis, so a fit
+ *    sub-star was ~the overall star shown twice.
+ * 3. `location` and `seniority` were computed and never displayed at all. Words
+ *    fit all four axes on one line where four star rows never could.
+ *
+ * Honesty note: the fitness axis is SET-RELATIVE by construction (the hybrid
+ * stretch reads the set's min/max — see this module's docblock), so the fitness
+ * phrasing is deliberately comparative ("Top fit here"), never an absolute claim
+ * about the posting. The comp axis, by contrast, IS absolute — so its phrasing
+ * may make an absolute claim, but its MEANING flips with `hasCompFloor` (vs the
+ * user's floor when set, bonus-only otherwise), which is why the caller must say
+ * which regime produced the number.
+ */
+const FIT_BAND_TOP = 4;
+const FIT_BAND_STRONG = 3;
+const FIT_BAND_PARTIAL = 2;
+
+/** With a floor set, comp is measured against it: 2.5★ is exactly at the floor
+ *  (`compMax / floor / 2`), so these bands read as multiples of the floor. Below
+ *  the floor gets NO phrase — the card already shows a "Below your floor" badge,
+ *  and saying it twice is noise. */
+const PAY_BAND_WELL_ABOVE_FLOOR = 4.5;
+const PAY_BAND_ABOVE_FLOOR = 3;
+const PAY_BAND_AT_FLOOR = 2.5;
+
+/** With NO floor set, comp is a bonus-only curve into [2.5★, 5★] — a low value
+ *  means "nothing to shout about", never "bad pay" (the user set no minimum, so
+ *  we must not infer one). Only the top of the band earns a phrase; below it the
+ *  axis stays silent, matching the silence-is-neutral rule. */
+const PAY_BAND_TOP = 4;
+const PAY_BAND_STRONG = 3.2;
+
+/** Seniority is 5★ at an exact level match and falls 1★ per ladder rung
+ *  (`SENIORITY_FRACTION_PER_RUNG` × MAX_STARS). So ≥4.5 is an exact match and
+ *  <3 is a gap of 2+ rungs — worth flagging; a single rung stays silent. */
+const SENIORITY_BAND_MATCH = 4.5;
+const SENIORITY_BAND_GAP = 3;
+
+function fitPhrase(fitness: number): string {
+  if (fitness >= FIT_BAND_TOP) return "Top fit here";
+  if (fitness >= FIT_BAND_STRONG) return "Strong fit";
+  if (fitness >= FIT_BAND_PARTIAL) return "Partial fit";
+  return "Weak fit";
+}
+
+function payPhrase(compensation: number, hasCompFloor: boolean): string | null {
+  if (hasCompFloor) {
+    if (compensation >= PAY_BAND_WELL_ABOVE_FLOOR) return "Pay well above your floor";
+    if (compensation >= PAY_BAND_ABOVE_FLOOR) return "Pay above your floor";
+    if (compensation >= PAY_BAND_AT_FLOOR) return "Pay at your floor";
+    return null;
+  }
+  if (compensation >= PAY_BAND_TOP) return "Top pay";
+  if (compensation >= PAY_BAND_STRONG) return "Strong pay";
+  return null;
+}
+
+function levelPhrase(seniority: number): string | null {
+  if (seniority >= SENIORITY_BAND_MATCH) return "Level match";
+  if (seniority < SENIORITY_BAND_GAP) return "Level gap";
+  return null;
+}
+
+/**
+ * Turn a `JobRating` into the short "why" phrases the card renders as one line
+ * in place of per-axis sub-stars (#569).
+ *
+ * Fitness always yields a phrase (the axis is always present). Every other axis
+ * yields one only when it has something non-obvious to say — an absent axis, a
+ * neutral comp, or a non-matching location contributes nothing, so a card with
+ * no signal beyond fit shows exactly one phrase rather than a row of hedges.
+ *
+ * `hasCompFloor` must reflect whether the QUERY carried a floor, not whether
+ * this posting has comp — it selects which of the two comp regimes the number
+ * came from, and the two are not comparable.
+ */
+export function describeRating(
+  rating: JobRating,
+  opts: { hasCompFloor: boolean },
+): string[] {
+  const phrases = [fitPhrase(rating.fitness)];
+
+  if (rating.compensation !== null) {
+    const pay = payPhrase(rating.compensation, opts.hasCompFloor);
+    if (pay) phrases.push(pay);
+  }
+  // Only a MATCH is worth saying: the posting's location is already printed on
+  // the card, so "not where you asked" would be restating what the user can see.
+  if (rating.location !== null && rating.location >= MAX_STARS) {
+    phrases.push("Location match");
+  }
+  if (rating.seniority !== null) {
+    const level = levelPhrase(rating.seniority);
+    if (level) phrases.push(level);
+  }
+
+  return phrases;
+}

--- a/src/lib/job-search/refine.test.ts
+++ b/src/lib/job-search/refine.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import { refineSearchResult } from "./refine.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobPosting } from "./types.ts";
+import type { JobQuery } from "./query-builder.ts";
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [],
+  education: [],
+};
+
+function posting(overrides: Partial<JobPosting>): JobPosting {
+  return {
+    id: "x:1",
+    title: "Frontend Engineer",
+    company: "Acme",
+    location: "Remote",
+    url: "https://x/1",
+    description: "We need React and TypeScript.",
+    source: "Test",
+    ...overrides,
+  };
+}
+
+const query: JobQuery = { titles: ["Frontend Engineer"], skills: ["React"] };
+
+describe("refineSearchResult (issue 568)", () => {
+  it("is the identity pipeline when the query asserts no refinement knobs", async () => {
+    const raw = [posting({ id: "a" }), posting({ id: "b", title: "Backend Engineer" })];
+    const result = await refineSearchResult(raw, parsed, query, [], 1);
+    expect(result.jobs.map((j) => j.posting.id).sort()).toEqual(["a", "b"]);
+    expect(result.excludeSuppressed).toBe(false);
+    expect(result.rawPostings.map((p) => p.id)).toEqual(["a", "b"]);
+  });
+
+  it("narrows by query.families when asserted", async () => {
+    const raw = [
+      posting({ id: "fe", title: "Frontend Engineer" }),
+      posting({ id: "designer", title: "Product Designer" }),
+    ];
+    const result = await refineSearchResult(
+      raw,
+      parsed,
+      { ...query, families: ["frontend"] },
+      [],
+      1,
+    );
+    expect(result.jobs.map((j) => j.posting.id)).toEqual(["fe"]);
+  });
+
+  it("never fails closed: an empty families list keeps every posting", async () => {
+    const raw = [
+      posting({ id: "fe", title: "Frontend Engineer" }),
+      posting({ id: "designer", title: "Product Designer" }),
+    ];
+    const result = await refineSearchResult(raw, parsed, { ...query, families: [] }, [], 1);
+    expect(result.jobs.map((j) => j.posting.id).sort()).toEqual(["designer", "fe"]);
+    expect(result.roleSuppressed).toBe(false);
+  });
+
+  it("never fails closed: a non-empty family matching no posting title keeps them all and flags roleSuppressed (issue 566)", async () => {
+    // Generically-titled postings that pass matchesQuery on skills/description
+    // but match no narrow role-title keyword — the all-generic keyless-feed
+    // regression. Role filtering must be skipped, not empty the panel.
+    const raw = [
+      posting({ id: "a", title: "Software Engineer" }),
+      posting({ id: "b", title: "Senior Developer" }),
+    ];
+    const result = await refineSearchResult(
+      raw,
+      parsed,
+      { ...query, families: ["frontend"] },
+      [],
+      1,
+    );
+    expect(result.jobs.map((j) => j.posting.id).sort()).toEqual(["a", "b"]);
+    expect(result.roleSuppressed).toBe(true);
+  });
+
+  it("does not flag roleSuppressed on a genuinely empty input", async () => {
+    const result = await refineSearchResult([], parsed, { ...query, families: ["frontend"] }, [], 1);
+    expect(result.jobs).toEqual([]);
+    expect(result.roleSuppressed).toBe(false);
+  });
+
+  it("still applies exclude terms and ranking on top of the role-family filter", async () => {
+    const raw = [
+      posting({ id: "kept", title: "Frontend Engineer" }),
+      posting({ id: "excluded", title: "Frontend Engineer (Solutions Architect)" }),
+    ];
+    const result = await refineSearchResult(
+      raw,
+      parsed,
+      { ...query, families: ["frontend"], excludeTerms: ["solutions architect"] },
+      [],
+      1,
+    );
+    expect(result.jobs.map((j) => j.posting.id)).toEqual(["kept"]);
+  });
+
+  it("passes through the degradedProviders/providerCount it was given", async () => {
+    const result = await refineSearchResult([], parsed, query, ["Beta"], 2);
+    expect(result.degradedProviders).toEqual(["Beta"]);
+    expect(result.providerCount).toBe(2);
+  });
+});

--- a/src/lib/job-search/refine.ts
+++ b/src/lib/job-search/refine.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * refineSearchResult — apply the query's LOCAL refinement knobs (role
+ * families #568, exclude terms #563) and rank (#545/#561/#562/#564) over an
+ * already-fetched, already-deduped posting set.
+ *
+ * Pulled out of `searchJobs` (`search.ts`) so `FindJobsPanel` can re-run the
+ * SAME pipeline on every edit to a refinement control (role family, target
+ * level, exclude term, comp floor, location) WITHOUT a new fetch — that's the
+ * #568 "changing any control re-ranks results live" requirement. Re-ranking
+ * already-fetched postings is not a fetch, so this keeps `searchJobs`'s own
+ * "fetch fires ONLY on the Search click" invariant (`FindJobsPanel`'s
+ * docblock) intact — no new egress, `providers/keywords.ts` stays the sole
+ * resume-derived egress helper either way.
+ *
+ * The only I/O this does is the dynamic import of `rank.ts` (the cascade-tier
+ * pattern already used by `search.ts` — jd-match's skill dictionary stays out
+ * of the entry chunk). `searchJobs` calls this once per fetch; `FindJobsPanel`
+ * calls it again, locally, on every subsequent refinement-control edit.
+ */
+
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobPosting } from "./types.ts";
+import type { JobQuery } from "./query-builder.ts";
+import type { RoleFamily } from "./role-keywords.ts";
+import {
+  filterPostingsByRole,
+  filterPostingsByExcludeTerms,
+  roleFilterForFamilies,
+} from "./role-keywords.ts";
+import type { JobSearchResult } from "./search.ts";
+
+export async function refineSearchResult(
+  rawPostings: readonly JobPosting[],
+  parsed: HeuristicParsedResume,
+  query: JobQuery,
+  degradedProviders: readonly string[],
+  providerCount: number,
+): Promise<JobSearchResult> {
+  const { rankPostings } = await import("./rank.ts");
+
+  // Role families (#568): `query.families` elements are `RoleFamily` labels —
+  // FindJobsPanel only ever seeds this from `roleFilterForResume(...).families`
+  // and lets the user REMOVE entries, never add arbitrary text, so the cast is
+  // safe. `undefined` (never asserted — every pre-#568 caller) skips this
+  // filter entirely, byte-identical to prior behavior.
+  //
+  // NEVER FAIL CLOSED (#566), the same floor `filterPostingsByExcludeTerms`
+  // already applies: role keywords are narrow TITLE substrings while
+  // `matchesQuery` admits a posting on title tokens + skills + description, so
+  // a generically-titled keyless-feed posting ("Software Engineer") can pass
+  // the query yet match no role keyword. On an all-generic merged set the role
+  // filter would empty the panel and show only the misleading "broaden the
+  // query" state. So: when a non-empty family filter would reduce a NON-EMPTY
+  // merged set to EMPTY, skip it (keep the input) and flag `roleSuppressed` for
+  // a notice — pointing the user at the Role chips. This wraps the decision at
+  // the merged-set step only; the per-board role filter in `company-boards.ts`
+  // keeps its fail-closed-to-empty contract (a single empty board is normal).
+  let roleFiltered: JobPosting[];
+  let roleSuppressed = false;
+  if (query.families !== undefined) {
+    const candidate = filterPostingsByRole(
+      [...rawPostings],
+      roleFilterForFamilies(query.families as RoleFamily[]),
+    );
+    if (candidate.length === 0 && rawPostings.length > 0) {
+      roleFiltered = [...rawPostings];
+      roleSuppressed = true;
+    } else {
+      roleFiltered = candidate;
+    }
+  } else {
+    roleFiltered = [...rawPostings];
+  }
+
+  const { postings: filtered, suppressed: excludeSuppressed } =
+    filterPostingsByExcludeTerms(roleFiltered, query.excludeTerms);
+
+  return {
+    jobs: rankPostings(parsed, filtered, query),
+    degradedProviders: [...degradedProviders],
+    providerCount,
+    excludeSuppressed,
+    roleSuppressed,
+    rawPostings: [...rawPostings],
+  };
+}

--- a/src/lib/job-search/role-keywords.test.ts
+++ b/src/lib/job-search/role-keywords.test.ts
@@ -6,13 +6,19 @@ import {
   ROLE_KEYWORDS,
   ROLE_FAMILIES,
   roleFilterForResume,
+  roleFilterForFamilies,
   filterPostingsByRole,
+  filterPostingsByExcludeTerms,
+  seedExcludeTermsForFamilies,
   capPerCompany,
+  scoreByTitleAgainstQuery,
+  orderPostingsByTitleScore,
   DEFAULT_PER_COMPANY_CAP,
   type RoleFilter,
 } from "./role-keywords.ts";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { JobPosting } from "./types.ts";
+import type { JobQuery } from "./query-builder.ts";
 
 // Minimal typed stub over the parsed model, like contact.test.ts / sector.test.ts
 // — only the fields role-keywords reads (experience titles + headline/current_title).
@@ -164,6 +170,45 @@ describe("roleFilterForResume — titles, not skills", () => {
   });
 });
 
+describe("roleFilterForFamilies (issue 568)", () => {
+  it("builds a filter from an explicit single family, matching roleFilterForResume's keywords for it", () => {
+    const filter = roleFilterForFamilies(["backend"]);
+    expect(filter.families).toEqual(["backend"]);
+    expect(filter.keywords).toEqual(ROLE_KEYWORDS.backend);
+  });
+
+  it("unions keywords across multiple explicit families, deduped", () => {
+    const filter = roleFilterForFamilies(["frontend", "backend"]);
+    expect(filter.families).toEqual(["frontend", "backend"]);
+    expect(filter.keywords).toEqual(
+      expect.arrayContaining([...ROLE_KEYWORDS.frontend, ...ROLE_KEYWORDS.backend]),
+    );
+    expect(new Set(filter.keywords).size).toBe(filter.keywords.length);
+  });
+
+  it("never fails closed: an empty family list resolves to the permissive 'all' filter", () => {
+    const filter = roleFilterForFamilies([]);
+    expect(filter).toEqual({ families: [], keywords: [], source: "heuristic" });
+    // And that permissive filter is a true no-op through filterPostingsByRole.
+    const postings = [makePosting({ title: "Forklift Operator" })];
+    expect(filterPostingsByRole(postings, filter)).toEqual(postings);
+  });
+
+  it("narrows the same board differently than the union it was drawn from", () => {
+    const postings = [
+      makePosting({ id: "fe", title: "Frontend Engineer" }),
+      makePosting({ id: "be", title: "Backend Engineer" }),
+    ];
+    const both = roleFilterForFamilies(["frontend", "backend"]);
+    expect(filterPostingsByRole(postings, both).map((p) => p.id).sort()).toEqual([
+      "be",
+      "fe",
+    ]);
+    const backendOnly = roleFilterForFamilies(["backend"]);
+    expect(filterPostingsByRole(postings, backendOnly).map((p) => p.id)).toEqual(["be"]);
+  });
+});
+
 describe("filterPostingsByRole", () => {
   const frontendFilter = roleFilterForResume(
     makeParsed({ experience: [{ title: "Frontend Engineer", company: "X" }] }),
@@ -259,5 +304,176 @@ describe("capPerCompany", () => {
   it("keeps none for a non-positive limit", () => {
     const postings = [makePosting({ id: "1", company: "A" })];
     expect(capPerCompany(postings, 0)).toEqual([]);
+  });
+});
+
+describe("scoreByTitleAgainstQuery", () => {
+  it("scores 0 when the query has no derivable titles (degenerate query)", () => {
+    const query: JobQuery = { titles: [], skills: [] };
+    const posting = makePosting({ title: "Backend Engineer" });
+    expect(scoreByTitleAgainstQuery(posting, query)).toBe(0);
+  });
+
+  it("scores higher for more overlapping title words", () => {
+    const query: JobQuery = { titles: ["Senior Backend Engineer"], skills: [] };
+    const strong = makePosting({ title: "Senior Backend Engineer" });
+    const weak = makePosting({ title: "Backend Support Specialist" });
+    const none = makePosting({ title: "Marketing Manager" });
+    expect(scoreByTitleAgainstQuery(strong, query)).toBeGreaterThan(
+      scoreByTitleAgainstQuery(weak, query),
+    );
+    expect(scoreByTitleAgainstQuery(weak, query)).toBeGreaterThan(
+      scoreByTitleAgainstQuery(none, query),
+    );
+  });
+
+  it("reads departments as part of the haystack", () => {
+    const query: JobQuery = { titles: ["Data Scientist"], skills: [] };
+    const posting = makePosting({ title: "Analyst", departments: ["Data Science"] });
+    expect(scoreByTitleAgainstQuery(posting, query)).toBeGreaterThan(0);
+  });
+
+  it("nudges a same-rung seniority match without dominating word overlap", () => {
+    const query: JobQuery = {
+      titles: ["Staff Engineer"],
+      skills: [],
+      seniority: "Staff",
+    };
+    const sameLevel = makePosting({ title: "Staff Engineer" });
+    const offLevel = makePosting({ title: "Junior Engineer" });
+    expect(scoreByTitleAgainstQuery(sameLevel, query)).toBeGreaterThan(
+      scoreByTitleAgainstQuery(offLevel, query),
+    );
+    // A pure title mismatch with no seniority signal never outranks a real
+    // word-overlap match just because the levels happen to line up.
+    const noOverlapSameLevel = makePosting({ title: "Staff Accountant" });
+    expect(scoreByTitleAgainstQuery(sameLevel, query)).toBeGreaterThan(
+      scoreByTitleAgainstQuery(noOverlapSameLevel, query),
+    );
+  });
+});
+
+describe("orderPostingsByTitleScore", () => {
+  it("keeps board order when every score is 0 (never-fail-closed)", () => {
+    const query: JobQuery = { titles: [], skills: [] };
+    const postings = [
+      makePosting({ id: "1" }),
+      makePosting({ id: "2" }),
+      makePosting({ id: "3" }),
+    ];
+    expect(orderPostingsByTitleScore(postings, query).map((p) => p.id)).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("never drops or adds a posting — reorders only", () => {
+    const query: JobQuery = { titles: ["Backend Engineer"], skills: [] };
+    const postings = Array.from({ length: 10 }, (_, i) =>
+      makePosting({ id: `p${i}`, title: i === 3 ? "Backend Engineer" : "Sales Rep" }),
+    );
+    const ordered = orderPostingsByTitleScore(postings, query);
+    expect(ordered).toHaveLength(postings.length);
+    expect(new Set(ordered.map((p) => p.id))).toEqual(new Set(postings.map((p) => p.id)));
+  });
+
+  it("acceptance: the strongest title match at index 30 of 40 survives the per-company cap", () => {
+    const query: JobQuery = { titles: ["Staff Backend Engineer"], skills: [] };
+    const postings: JobPosting[] = Array.from({ length: 40 }, (_, i) =>
+      makePosting({
+        id: `job-${i}`,
+        company: "BigCo",
+        title: i === 30 ? "Staff Backend Engineer" : `Generic Role ${i}`,
+      }),
+    );
+
+    const ordered = orderPostingsByTitleScore(postings, query);
+    const survivors = capPerCompany(ordered, DEFAULT_PER_COMPANY_CAP);
+
+    expect(survivors.some((p) => p.id === "job-30")).toBe(true);
+    // Sanity: a prefix-of-board-order cap (pre-#565 behavior) would have
+    // missed it — index 30 is well past DEFAULT_PER_COMPANY_CAP (8).
+    expect(postings.findIndex((p) => p.id === "job-30")).toBeGreaterThan(
+      DEFAULT_PER_COMPANY_CAP,
+    );
+  });
+});
+
+describe("filterPostingsByExcludeTerms (issue 563)", () => {
+  it("drops a posting whose TITLE matches an exclude term, case-insensitively", () => {
+    const postings = [
+      makePosting({ id: "a", title: "Solutions Architect" }),
+      makePosting({ id: "b", title: "Senior Backend Engineer" }),
+    ];
+    const { postings: kept, suppressed } = filterPostingsByExcludeTerms(
+      postings,
+      ["solutions architect"],
+    );
+    expect(kept.map((p) => p.id)).toEqual(["b"]);
+    expect(suppressed).toBe(false);
+  });
+
+  it("does NOT match a description-only mention of the excluded phrase", () => {
+    const postings = [
+      makePosting({
+        id: "a",
+        title: "Backend Engineer",
+        description: "You will partner with our solutions architect team.",
+      }),
+    ];
+    const { postings: kept } = filterPostingsByExcludeTerms(postings, [
+      "solutions architect",
+    ]);
+    expect(kept.map((p) => p.id)).toEqual(["a"]);
+  });
+
+  it("is a no-op for empty excludeTerms — byte-identical to the input array contents", () => {
+    const postings = [makePosting({ id: "a" }), makePosting({ id: "b" })];
+    expect(filterPostingsByExcludeTerms(postings, [])).toEqual({
+      postings,
+      suppressed: false,
+    });
+    expect(filterPostingsByExcludeTerms(postings, undefined)).toEqual({
+      postings,
+      suppressed: false,
+    });
+  });
+
+  it("never fails closed: skips the exclusion and returns the input when it would empty a non-empty set", () => {
+    const postings = [
+      makePosting({ id: "a", title: "Backend Engineer" }),
+      makePosting({ id: "b", title: "Backend Engineer II" }),
+    ];
+    const { postings: kept, suppressed } = filterPostingsByExcludeTerms(
+      postings,
+      ["engineer"],
+    );
+    expect(kept).toEqual(postings);
+    expect(suppressed).toBe(true);
+  });
+
+  it("an empty input stays empty and unsuppressed", () => {
+    expect(filterPostingsByExcludeTerms([], ["anything"])).toEqual({
+      postings: [],
+      suppressed: false,
+    });
+  });
+});
+
+describe("seedExcludeTermsForFamilies (issue 563)", () => {
+  it("seeds the GTM/field-role negatives for an engineering-adjacent family", () => {
+    const seeds = seedExcludeTermsForFamilies(["backend"]);
+    expect(seeds).toContain("solutions architect");
+    expect(seeds).toContain("forward deployed engineer");
+    expect(seeds).toContain("developer advocate");
+  });
+
+  it("seeds nothing for a sales-family query — must NOT seed engineering negatives against itself", () => {
+    expect(seedExcludeTermsForFamilies(["sales"])).toEqual([]);
+  });
+
+  it("seeds nothing for the permissive 'all' filter (no classified family)", () => {
+    expect(seedExcludeTermsForFamilies([])).toEqual([]);
   });
 });

--- a/src/lib/job-search/role-keywords.ts
+++ b/src/lib/job-search/role-keywords.ts
@@ -10,7 +10,17 @@
  * WHOLE board (100s–1000s of roles). This module is the layer that narrows a
  * board's light-index postings to the ones relevant to the candidate and caps
  * the count, before descriptions are hydrated and `rankPostings` ranks them. It
- * only *narrows and caps*; ranking is out of scope.
+ * only *narrows and caps*; full ranking (coverage against a hydrated
+ * description) is out of scope. `scoreByTitleAgainstQuery` (#565) is the one
+ * exception: a CHEAP, title-only, no-I/O score used solely to pick WHICH
+ * postings survive `capPerCompany`'s slice, not to rank the survivors that
+ * reach `rankPostings`. `filterPostingsByExcludeTerms` (#563) is the sibling
+ * negative filter — user-editable, title-only exclude terms, seeded (visibly
+ * and removably) from the role-family classification via
+ * `seedExcludeTermsForFamilies` — applied in `company-boards.ts` immediately
+ * after `filterPostingsByRole` and strictly BEFORE `orderPostingsByTitleScore`
+ * / `capPerCompany`, so an excluded posting never consumes a company's cap
+ * slot.
  *
  * THREE LOAD-BEARING INVARIANTS:
  *
@@ -49,6 +59,9 @@
 
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { JobPosting } from "./types.ts";
+import type { JobQuery } from "./query-builder.ts";
+import { parseSeniorityLabel } from "./query-builder.ts";
+import { seniorityRungDistance } from "./seniority.ts";
 
 /**
  * Fixed role-family taxonomy — the SINGLE SOURCE OF TRUTH for "which roles
@@ -249,6 +262,66 @@ const FAMILY_ORDER: ReadonlyMap<RoleFamily, number> = new Map(
 );
 
 /**
+ * Families whose boards get flooded by adjacent customer-facing/GTM roles
+ * that share every positive keyword an engineering résumé carries (#563) —
+ * Solutions Architect, Forward Deployed Engineer, Developer Advocate, etc.
+ * are a genuinely different job (GTM, not engineering ownership) that no
+ * amount of positive-keyword tuning separates. `sales` / `marketing` /
+ * `support` / `design` / `pm` are deliberately excluded: a sales-family
+ * query must NOT seed engineering negatives against itself.
+ */
+const ENGINEERING_ADJACENT_FAMILIES: ReadonlySet<RoleFamily> = new Set([
+  "frontend",
+  "backend",
+  "fullstack",
+  "mobile",
+  "data",
+  "ml",
+  "sre-devops",
+  "security",
+  "qa",
+]);
+
+/**
+ * Default exclude-term seeds for an engineering-family query — the exact
+ * adjacent-role list from #563's problem statement. Lowercased; matched as
+ * case-insensitive title substrings by `filterPostingsByExcludeTerms`.
+ */
+const ENGINEERING_EXCLUDE_SEEDS: readonly string[] = [
+  "solutions architect",
+  "solution architect",
+  "deployment architect",
+  "field architect",
+  "forward deployed engineer",
+  "sales engineer",
+  "solutions engineer",
+  "developer advocate",
+  "developer relations",
+  "evangelist",
+  "customer success",
+  "partner engineering",
+  "account executive",
+];
+
+/**
+ * Seed removable exclude-term chips from the resume's classified role
+ * families (#563) — the caller (`FindJobsPanel`, via `buildJobQuery`) renders
+ * these as ordinary removable chips, never applies them invisibly. An
+ * engineering-adjacent family seeds the curated GTM/field-role negatives; any
+ * other family (sales/marketing/support/design/pm) or the permissive "all"
+ * filter (`families: []`) seeds nothing — there is no engineering-negatives
+ * list to seed against a non-engineering search.
+ */
+export function seedExcludeTermsForFamilies(
+  families: readonly RoleFamily[],
+): string[] {
+  const isEngineeringAdjacent = families.some((family) =>
+    ENGINEERING_ADJACENT_FAMILIES.has(family),
+  );
+  return isEngineeringAdjacent ? [...ENGINEERING_EXCLUDE_SEEDS] : [];
+}
+
+/**
  * Collect the lowercased, non-empty TITLE strings the filter reads: every
  * `experience[].title`, plus the standalone `headline` and `current_title`
  * target-role signals when the parsed model carries them. Deliberately does NOT
@@ -311,6 +384,27 @@ export function roleFilterForResume(parsed: HeuristicParsedResume): RoleFilter {
   return { families, keywords, source: "heuristic" };
 }
 
+/**
+ * Build a `RoleFilter` from an EXPLICIT family list rather than deriving one
+ * from the résumé (#568) — the counterpart to `roleFilterForResume` for the
+ * "target level"-style refinement controls: `FindJobsPanel` seeds
+ * `JobQuery.families` from `roleFilterForResume(parsed).families` and lets
+ * the user remove chips from it, and every downstream reader that has an
+ * asserted `query.families` rebuilds its filter from THIS function instead of
+ * re-deriving from the résumé, so a removed chip actually narrows the search.
+ *
+ * NEVER FAIL CLOSED, the same floor `roleFilterForResume` guarantees: an
+ * empty `families` (every seeded chip removed) returns the permissive "all"
+ * filter (`families: []`, `keywords: []`), not a filter that matches nothing.
+ */
+export function roleFilterForFamilies(families: readonly RoleFamily[]): RoleFilter {
+  if (families.length === 0) {
+    return { families: [], keywords: [], source: "heuristic" };
+  }
+  const keywords = dedupe(families.flatMap((family) => [...ROLE_KEYWORDS[family]]));
+  return { families: [...families], keywords, source: "heuristic" };
+}
+
 /** Lowercased haystack a posting is matched against: title + any departments. */
 function postingHaystack(posting: JobPosting): string {
   const departments = posting.departments ?? [];
@@ -334,6 +428,54 @@ export function filterPostingsByRole(
   });
 }
 
+/** Result of `filterPostingsByExcludeTerms` — `suppressed: true` means the
+ *  exclusion was SKIPPED (input returned unchanged) because applying it would
+ *  have emptied a non-empty input; the caller surfaces that as a notice. */
+export interface ExcludeFilterResult {
+  postings: JobPosting[];
+  suppressed: boolean;
+}
+
+/**
+ * Drop a posting whose TITLE — never its description — contains one of
+ * `excludeTerms` as a case-insensitive substring (#563). Deliberately
+ * title-only: a posting whose description merely mentions "customer success"
+ * is not the same job as one titled that, and description-side exclusion
+ * would over-fire (see the issue's problem statement).
+ *
+ * NEVER FAIL CLOSED, same floor as `filterPostingsByRole`: an empty
+ * `excludeTerms` (or one with only blank entries) returns the input
+ * unchanged (`suppressed: false`). And if applying real exclude terms would
+ * drop EVERY posting in a non-empty input, the exclusion is skipped
+ * entirely — the input comes back unchanged with `suppressed: true` — rather
+ * than silently handing the caller an empty result. The caller is expected to
+ * render that as a notice (see `JobSearchResults`), never as a blank panel.
+ */
+export function filterPostingsByExcludeTerms(
+  postings: readonly JobPosting[],
+  excludeTerms: readonly string[] | undefined,
+): ExcludeFilterResult {
+  const terms = (excludeTerms ?? [])
+    .map((term) => term.trim().toLowerCase())
+    .filter((term) => term.length > 0);
+
+  if (terms.length === 0 || postings.length === 0) {
+    return { postings: [...postings], suppressed: false };
+  }
+
+  const filtered = postings.filter((posting) => {
+    const title = posting.title.toLowerCase();
+    return !terms.some((term) => title.includes(term));
+  });
+
+  if (filtered.length === 0) {
+    // Never fail closed: skip the exclusion rather than empty the panel.
+    return { postings: [...postings], suppressed: true };
+  }
+
+  return { postings: filtered, suppressed: false };
+}
+
 /**
  * Bound the kept set to at most `limit` postings per company so hydration and
  * ranking stay cheap. Preserves input order and keeps the first `limit`
@@ -355,4 +497,102 @@ export function capPerCompany(
     kept.push(posting);
   }
   return kept;
+}
+
+/** Split a lowercased string into significant (length > 2) word tokens. */
+const WORD_SPLIT = /[\s/,&()-]+/;
+function tokenizeWords(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(WORD_SPLIT)
+      .filter((word) => word.length > 2),
+  );
+}
+
+/** Points added per query-title word that also appears in the posting's
+ *  title/departments haystack — see `scoreByTitleAgainstQuery`. */
+const TITLE_WORD_OVERLAP_WEIGHT = 10;
+
+/**
+ * Points added when the posting title's parsed seniority level sits at the
+ * SAME rung as `query.seniority`, decaying by rung distance to 0. Sized well
+ * below a single word-overlap hit (`TITLE_WORD_OVERLAP_WEIGHT`) so seniority
+ * only breaks a close race between otherwise similarly-titled postings — it
+ * never lets a level match outrank a genuine title mismatch.
+ */
+const SENIORITY_MATCH_MAX_BONUS = 4;
+
+/**
+ * Cheap, title-only, no-I/O relevance score for one posting against the
+ * query BEFORE `capPerCompany` slices (#565) — the light-index posting
+ * already carries everything this reads (`title` + optional `departments`),
+ * so no hydration or extra fetch is needed to compute it.
+ *
+ * Word-overlap against `query.titles`: every distinct word (length ≥ 3
+ * chars) shared between the posting's title/departments haystack and any of
+ * the candidate's résumé titles adds `TITLE_WORD_OVERLAP_WEIGHT`. Optionally
+ * nudged by `query.seniority` (#562): when both the query and the posting
+ * title carry a recognizable level, the score gets a small bonus that decays
+ * with rung distance — an exact-level match nudges ahead of an
+ * otherwise-tied adjacent-level posting, but never dominates the word-overlap
+ * signal.
+ *
+ * Returns 0 when `query.titles` is empty (a skills-only/degenerate query has
+ * no title signal to score against) or when nothing overlaps — a uniform 0
+ * across a whole board is harmless: `orderPostingsByTitleScore` keeps ties in
+ * their original (board) order, so the never-fail-closed floor holds.
+ */
+export function scoreByTitleAgainstQuery(
+  posting: JobPosting,
+  query: Pick<JobQuery, "titles" | "seniority">,
+): number {
+  if (query.titles.length === 0) return 0;
+
+  const queryWords = new Set<string>();
+  for (const title of query.titles) {
+    for (const word of tokenizeWords(title)) queryWords.add(word);
+  }
+
+  let overlap = 0;
+  for (const word of tokenizeWords(postingHaystack(posting))) {
+    if (queryWords.has(word)) overlap += 1;
+  }
+
+  const seniorityDistance = seniorityRungDistance(
+    query.seniority,
+    parseSeniorityLabel(posting.title),
+  );
+  const seniorityBonus =
+    seniorityDistance === undefined
+      ? 0
+      : Math.max(0, SENIORITY_MATCH_MAX_BONUS - seniorityDistance);
+
+  return overlap * TITLE_WORD_OVERLAP_WEIGHT + seniorityBonus;
+}
+
+/**
+ * Reorder `postings` by `scoreByTitleAgainstQuery` descending so the survivors
+ * `capPerCompany` keeps are the best-matching per company, not the first in
+ * board order (#565). Ties (including the all-zero case — no title signal, or
+ * an empty `query.titles`) keep their original relative order, an explicit
+ * stable sort rather than relying on engine sort stability: the
+ * never-fail-closed floor is that a degenerate query reduces to today's
+ * board-order behavior, never to an empty or reshuffled-for-no-reason result.
+ * Runs strictly BEFORE `capPerCompany` — it reorders the full filtered set,
+ * never trims it, so `capPerCompany`'s own contract (per-company counting,
+ * case-insensitive company key, `limit <= 0` keeps none) is untouched.
+ */
+export function orderPostingsByTitleScore(
+  postings: readonly JobPosting[],
+  query: Pick<JobQuery, "titles" | "seniority">,
+): JobPosting[] {
+  return postings
+    .map((posting, index) => ({
+      posting,
+      index,
+      score: scoreByTitleAgainstQuery(posting, query),
+    }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.posting);
 }

--- a/src/lib/job-search/search.test.ts
+++ b/src/lib/job-search/search.test.ts
@@ -215,6 +215,130 @@ describe("searchJobs", () => {
       expect(job.score).toBe(job.jdMatch.coverage.score);
     }
   });
+
+  it("(issue 563) drops a posting whose TITLE matches an exclude term, keeps a description-only mention", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({
+          id: "alpha:excluded-title",
+          title: "Solutions Architect",
+          description: "React and TypeScript work.",
+        }),
+        posting({
+          id: "alpha:kept-description-mention",
+          title: "Frontend Engineer",
+          description: "We work closely with our solutions architect team.",
+        }),
+      ]),
+    ];
+    const res = await searchJobs(
+      { ...query, excludeTerms: ["solutions architect"] },
+      parsed,
+      new AbortController().signal,
+    );
+    expect(res.jobs.map((j) => j.posting.id)).toEqual([
+      "alpha:kept-description-mention",
+    ]);
+    expect(res.excludeSuppressed).toBe(false);
+  });
+
+  it("(issue 563) empty excludeTerms is byte-identical to no exclusion at all", async () => {
+    holder.providers = [
+      provider("alpha", async () => [posting({ id: "alpha:1" })]),
+    ];
+    const withEmpty = await searchJobs(
+      { ...query, excludeTerms: [] },
+      parsed,
+      new AbortController().signal,
+    );
+    const withoutField = await searchJobs(
+      query,
+      parsed,
+      new AbortController().signal,
+    );
+    expect(withEmpty.jobs.map((j) => j.posting.id)).toEqual(
+      withoutField.jobs.map((j) => j.posting.id),
+    );
+    expect(withEmpty.excludeSuppressed).toBe(false);
+  });
+
+  it("(issue 563) never fails closed: an exclude term matching every result is skipped, not applied", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({ id: "alpha:1", title: "Frontend Engineer" }),
+        posting({ id: "alpha:2", title: "Frontend Engineer II" }),
+      ]),
+    ];
+    const res = await searchJobs(
+      { ...query, excludeTerms: ["engineer"] },
+      parsed,
+      new AbortController().signal,
+    );
+    expect(res.jobs.map((j) => j.posting.id).sort()).toEqual([
+      "alpha:1",
+      "alpha:2",
+    ]);
+    expect(res.excludeSuppressed).toBe(true);
+  });
+
+  it("(issue 568) leaves results unfiltered when query.families is unasserted (undefined)", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({ id: "alpha:eng", title: "Frontend Engineer" }),
+        posting({ id: "alpha:design", title: "Product Designer", company: "Other" }),
+      ]),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.jobs.map((j) => j.posting.id).sort()).toEqual([
+      "alpha:design",
+      "alpha:eng",
+    ]);
+  });
+
+  it("(issue 568) narrows to postings matching the asserted role families", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({ id: "alpha:fe", title: "Frontend Engineer" }),
+        posting({ id: "alpha:designer", title: "Product Designer" }),
+      ]),
+    ];
+    const res = await searchJobs(
+      { ...query, families: ["frontend"] },
+      parsed,
+      new AbortController().signal,
+    );
+    expect(res.jobs.map((j) => j.posting.id)).toEqual(["alpha:fe"]);
+  });
+
+  it("(issue 568) never fails closed: an empty families list is the permissive 'all' filter, not zero results", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({ id: "alpha:fe", title: "Frontend Engineer" }),
+        posting({ id: "alpha:designer", title: "Product Designer", description: "React and TypeScript" }),
+      ]),
+    ];
+    const res = await searchJobs(
+      { ...query, families: [] },
+      parsed,
+      new AbortController().signal,
+    );
+    expect(res.jobs.map((j) => j.posting.id).sort()).toEqual([
+      "alpha:designer",
+      "alpha:fe",
+    ]);
+  });
+
+  it("(issue 568) exposes the deduped, matchesQuery-filtered postings as rawPostings for live re-rank", async () => {
+    holder.providers = [
+      provider("alpha", async () => [
+        posting({ id: "alpha:1" }),
+        // Off-query, dropped by matchesQuery before rawPostings is captured.
+        posting({ id: "alpha:off", title: "Forklift Operator", description: "warehouse work" }),
+      ]),
+    ];
+    const res = await searchJobs(query, parsed, new AbortController().signal);
+    expect(res.rawPostings.map((p) => p.id)).toEqual(["alpha:1"]);
+  });
 });
 
 /**

--- a/src/lib/job-search/search.ts
+++ b/src/lib/job-search/search.ts
@@ -47,6 +47,19 @@
  *    `Promise.allSettled`, because its width grows with the number of selected
  *    companies. `mapWithConcurrency` preserves allSettled's index-ordered,
  *    never-rejecting contract, so the degraded-provider mapping is unchanged.
+ *
+ * Exclude terms (#563): `query.excludeTerms` is applied here too, uniformly
+ * across the FULL merged set (keyless feeds + company boards alike) — the
+ * same "user's editable query is the final say on every source" reasoning as
+ * `matchesQuery` above. Company-board postings already ran through this exact
+ * filter once in `company-boards.ts` (before `capPerCompany`, so an excluded
+ * posting never eats a cap slot); re-applying it here is a no-op for them and
+ * is what makes the filter actually reach the keyless-feed postings, which
+ * never pass through `company-boards.ts` at all. This is also the ONE place
+ * that can see the true whole-panel result count, so it's the one place the
+ * never-fail-closed "skip and notify" decision (`excludeSuppressed` below) is
+ * made — a single board emptying out in `company-boards.ts` is normal, not a
+ * panel-level failure.
  */
 
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
@@ -54,7 +67,9 @@ import type { JobQuery } from "./query-builder.ts";
 import type { JobPosting } from "./types.ts";
 import type { RankedJob } from "./rank.ts";
 import type { CompanyEntry } from "./company-registry.ts";
+import type { RoleFamily } from "./role-keywords.ts";
 import { mapWithConcurrency } from "./concurrency.ts";
+import { refineSearchResult } from "./refine.ts";
 
 /**
  * Providers fetched at once. Bounds the burst when company boards join the
@@ -73,6 +88,27 @@ export interface JobSearchResult {
   degradedProviders: string[];
   /** How many providers were attempted (denominator for the error state). */
   providerCount: number;
+  /** True when `query.excludeTerms` would have emptied the WHOLE merged
+   *  result set (#563) — exclusion was skipped (never-fail-closed) and every
+   *  posting below is un-excluded. The panel surfaces this as a notice rather
+   *  than silently ignoring the user's exclude chips. */
+  excludeSuppressed: boolean;
+  /** True when `query.families` (the role chips) would have emptied the WHOLE
+   *  merged result set (#566) — role filtering was skipped (never-fail-closed,
+   *  the same floor as `excludeSuppressed`) and every posting below is
+   *  un-role-filtered. Role keywords are narrow title substrings while
+   *  `matchesQuery` admits postings on skills/description too, so an
+   *  all-generic keyless feed can pass the query yet match no role title. The
+   *  panel surfaces this as a notice pointing at the Role chips rather than
+   *  showing a misleading empty state. */
+  roleSuppressed: boolean;
+  /** The deduped, `matchesQuery`-filtered postings BEFORE role/exclude
+   *  filtering and ranking (#568) — everything `refineSearchResult` needs to
+   *  redo that local work. `FindJobsPanel` keeps this snapshot from the last
+   *  fetch and re-feeds it through `refineSearchResult` on every refinement-
+   *  control edit (role family, target level, exclude term, comp floor,
+   *  location) for a LIVE re-rank with no new fetch. */
+  rawPostings: JobPosting[];
 }
 
 /** Normalized dedup key: each of title/company lowercased and
@@ -147,17 +183,19 @@ export async function searchJobs(
   signal: AbortSignal,
   companies: readonly CompanyEntry[] = [],
 ): Promise<JobSearchResult> {
-  const [{ getProviders }, { rankPostings }] = await Promise.all([
-    import("./providers/index.ts"),
-    import("./rank.ts"),
-  ]);
+  const { getProviders } = await import("./providers/index.ts");
 
   // Only pull in the company-board tier (and, through it, the role-keyword
   // taxonomy and the board cache) when the user actually selected companies —
   // an empty selection is byte-for-byte the pre-#533 keyless search.
   const companyProviders =
     companies.length > 0
-      ? (await import("./company-boards.ts")).makeBoardProviders(companies, parsed)
+      ? (await import("./company-boards.ts")).makeBoardProviders(
+          companies,
+          parsed,
+          undefined,
+          query.families as RoleFamily[] | undefined,
+        )
       : [];
 
   const providers = getProviders(companyProviders);
@@ -187,9 +225,12 @@ export async function searchJobs(
     }
   });
 
-  return {
-    jobs: rankPostings(parsed, merged, query),
-    degradedProviders,
-    providerCount: providers.length,
-  };
+  // Role families (#568) + title-only exclude terms (#563), applied once over
+  // the FULL merged set, and ranked — see `refine.ts`'s docblock for why this
+  // re-applies (a no-op for company-board postings, which already ran through
+  // the role/exclude filters once in `company-boards.ts`) and is the only
+  // place that reaches keyless-feed postings at all. `FindJobsPanel` calls
+  // `refineSearchResult` again, locally, on every subsequent refinement-
+  // control edit — this is the same pipeline, just the FIRST run of it.
+  return refineSearchResult(merged, parsed, query, degradedProviders, providers.length);
 }

--- a/src/lib/job-search/seniority.test.ts
+++ b/src/lib/job-search/seniority.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import {
+  SENIORITY_LADDER,
+  seniorityRung,
+  seniorityRungDistance,
+} from "./seniority.ts";
+
+describe("seniority ladder (issue 562)", () => {
+  it("orders the IC rungs Intern < Junior < Mid < Senior < Staff < Principal", () => {
+    expect(SENIORITY_LADDER.Intern).toBeLessThan(SENIORITY_LADDER.Junior);
+    expect(SENIORITY_LADDER.Junior).toBeLessThan(SENIORITY_LADDER.Mid);
+    expect(SENIORITY_LADDER.Mid).toBeLessThan(SENIORITY_LADDER.Senior);
+    expect(SENIORITY_LADDER.Senior).toBeLessThan(SENIORITY_LADDER.Staff);
+    expect(SENIORITY_LADDER.Staff).toBeLessThan(SENIORITY_LADDER.Principal);
+  });
+
+  it("offsets management rungs above their IC peers on the SAME ladder", () => {
+    // Manager ≈ Staff + 1, Director ≈ Principal + 1, VP > Director, Exec > VP.
+    expect(SENIORITY_LADDER.Manager).toBe(SENIORITY_LADDER.Staff + 1);
+    expect(SENIORITY_LADDER.Director).toBe(SENIORITY_LADDER.Principal + 1);
+    expect(SENIORITY_LADDER.VP).toBeGreaterThan(SENIORITY_LADDER.Director);
+    expect(SENIORITY_LADDER.Executive).toBeGreaterThan(SENIORITY_LADDER.VP);
+  });
+
+  it("reads a Staff query as ~1 rung from a Manager posting", () => {
+    expect(seniorityRungDistance("Staff", "Manager")).toBe(1);
+  });
+
+  it("reads a Director query as many rungs from a Junior posting", () => {
+    // Director is heavily separated from an IC Junior...
+    expect(seniorityRungDistance("Director", "Junior")).toBeGreaterThanOrEqual(5);
+    // ...but only mildly from an adjacent-tier Manager.
+    expect(seniorityRungDistance("Director", "Manager")).toBeLessThanOrEqual(2);
+  });
+
+  it("is symmetric", () => {
+    expect(seniorityRungDistance("Director", "Junior")).toBe(
+      seniorityRungDistance("Junior", "Director"),
+    );
+  });
+
+  it("returns undefined (neutral) when either side has no recognizable level", () => {
+    expect(seniorityRung(undefined)).toBeUndefined();
+    expect(seniorityRung("Nonsense")).toBeUndefined();
+    expect(seniorityRungDistance(undefined, "Staff")).toBeUndefined();
+    expect(seniorityRungDistance("Staff", undefined)).toBeUndefined();
+    expect(seniorityRungDistance("Staff", "Nonsense")).toBeUndefined();
+  });
+});

--- a/src/lib/job-search/seniority.ts
+++ b/src/lib/job-search/seniority.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The single ordered seniority ladder (#562). One scale, not two — IC and
+ * management rungs are interleaved so any two levels are comparable by a plain
+ * rung distance, which is what lets the ranker apply a *soft* level-mismatch
+ * penalty (a Director query sinks a Junior posting, not "incomparable").
+ *
+ * The labels here are exactly the labels `SENIORITY_PATTERNS`
+ * (`query-builder.ts`) can emit — this module owns no taxonomy of its own, it
+ * only ORDERS the labels that table already produces (the #562 contract: reuse
+ * the existing table, add a level axis, invent no new vocabulary). `parseSeniority
+ * Label` turns a title into one of these labels; this ladder turns a label into
+ * a comparable rung.
+ *
+ * Rung assignment (resolved in the issue before impl):
+ *
+ *   IC:   Intern < Junior < Mid < Senior < (Lead) < Staff < Principal
+ *   Mgmt: Manager ≈ Staff+1, Director ≈ Principal+1, VP > Director, Exec > VP
+ *
+ * Consequences this is chosen to give, all deliberate:
+ *   - A Staff query reads a Manager posting as ~1 rung away (5 vs 6) — a strong
+ *     Manager fit sinks slightly, never vanishes.
+ *   - A Director query reads a Junior IC posting as many rungs away (7 vs 1) —
+ *     heavily demoted — but an adjacent-tier Manager posting as ~1 rung.
+ *   - `Mid` is in the ladder for completeness (it's the conceptual rung between
+ *     Junior and Senior); the current pattern table never emits it, so it's
+ *     documentation of the intended order, not a live entry.
+ *   - `Lead` ("Tech Lead"/"Team Lead") sits between Senior and Staff — above a
+ *     plain Senior, below Staff — the table's own IC ordering.
+ *
+ * Absolute values are meaningless; only DIFFERENCES are used. Tuning the
+ * offsets (if a fixture argues Manager/Director sit wrong) is a data change
+ * here — the single-ladder shape is the decision, not these integers.
+ *
+ * Reused downstream: #565 (optional seniority term in the title-side score) and
+ * #568 (the target-level refinement control) read `seniorityRung` /
+ * `seniorityRungDistance` rather than re-deriving an order.
+ */
+
+/** Label → position on the single ordered ladder. Higher = more senior. */
+export const SENIORITY_LADDER: Readonly<Record<string, number>> = {
+  Intern: 0,
+  Junior: 1,
+  Mid: 2,
+  Senior: 3,
+  Lead: 4,
+  Staff: 5,
+  Principal: 6,
+  Manager: 6, // Staff + 1
+  Director: 7, // Principal + 1
+  VP: 8, // > Director
+  Executive: 9, // > VP
+};
+
+/**
+ * The ladder position of a seniority `label`, or `undefined` when the label is
+ * absent or not a recognized rung. `undefined` is the neutral case the ranker
+ * reads as "no level signal" (no penalty) — never as "lowest rung".
+ */
+export function seniorityRung(label: string | undefined): number | undefined {
+  if (!label) return undefined;
+  return SENIORITY_LADDER[label];
+}
+
+/**
+ * Rung distance between two seniority labels, or `undefined` when EITHER side
+ * carries no recognizable level. Callers treat `undefined` as neutral (skip the
+ * penalty) — a posting whose title has no parseable level, or a query with no
+ * derived seniority, must not be penalized as if it were the bottom rung. The
+ * distance is symmetric and always ≥ 0.
+ */
+export function seniorityRungDistance(
+  a: string | undefined,
+  b: string | undefined,
+): number | undefined {
+  const ra = seniorityRung(a);
+  const rb = seniorityRung(b);
+  if (ra === undefined || rb === undefined) return undefined;
+  return Math.abs(ra - rb);
+}

--- a/src/lib/job-search/types.ts
+++ b/src/lib/job-search/types.ts
@@ -18,6 +18,7 @@
  */
 
 import type { JobQuery } from "./query-builder.ts";
+import type { Compensation } from "./compensation.ts";
 
 /** A single normalized job posting, provider-agnostic. */
 export interface JobPosting {
@@ -40,6 +41,13 @@ export interface JobPosting {
    *  Greenhouse board's `departments[].name`). Optional — most keyless feeds
    *  don't have this axis. Consumed by the #534 title/board-size filter. */
   departments?: string[];
+  /** A pay range regexed out of `description` (#564) — undefined when none
+   *  could be extracted (the common, neutral case; see `compensation.ts`'s
+   *  docblock for the silence-is-neutral invariant). Not set by provider
+   *  adapters directly: `rankPostings` (`rank.ts`) populates it lazily from
+   *  `description`, the one point downstream of hydration where every
+   *  posting's text is guaranteed present regardless of source. */
+  compensation?: Compensation;
 }
 
 /** One keyless job feed, adapted to the normalized shape. */


### PR DESCRIPTION
## Summary

v2 (#528) got company postings **in**; v3 makes them **rank right**. The lane no longer treats cheap funnel signals as verdicts — title-keyword OR-matching, raw ATS board order, and JD word-count-as-fit. Every shown posting now carries one honest, comparable fit number, and **level / compensation / role-type** are in the user's hands as live inline controls.

This is the accumulated batch for epic #566 — all seven sub-issues, one branch, one commit.

### What each sub-issue delivers

- **#561** — the card headline is a **0–5 star rating**, not a coverage percentage. `rateJobs` (`src/lib/job-search/rating.ts`) computes it once over the whole result set as a weighted blend of four fractional axes (fitness 0.45, comp 0.35, location 0.10, seniority 0.10); an absent axis drops out and its weight redistributes. Fitness is hybrid absolute + set-relative, and specificity confidence weights its base so well-specified postings outrank thin ones (fixes JD-word-count-as-fit rewarding thin postings).
- **#570** — location and seniority are bounded minor **fractions**, not the old flat `+10` / per-rung penalties. On the real compressed base (max ~21) a flat ±10 was half the range and dominated ranking, sinking the single best fit from rank 1 to rank 9.
- **#565** — per-company cap now selects on a title-side score *before* slicing, not raw ATS board order.
- **#562** — seniority as a second axis orthogonal to role family; soft rank penalty by rung distance, neutral when the level is undetermined.
- **#563** — title-only exclusion terms, seeded from the role family, removable — keeps adjacent GTM/field roles out of a senior-engineering query.
- **#564** — compensation extracted from the description, shown on the card, with an optional soft floor (below-floor badge + penalty). Extraction attributes a dollar figure to the **nearest salary word within sentence bounds**, so funding / budget / equity dollars are never misread as pay.
- **#567** — weak-match display policy: sub-threshold postings collapse into a labeled section instead of vanishing.
- **#568** — progressive inline refinement: role / level / comp window / exclusions as live editable controls in `FindJobsPanel` that re-rank in place.

### Card layout (post-review pass)

The first cut of the card put the overall stars on top and **fit + pay sub-stars underneath** — three identical glyph rows carrying three different meanings, with nothing marking which was the headline. At `sm` the fractional fill is a two-pixel sliver, so a 4.2 and a 4.6 looked the same, and fitness at 0.45 of the blend made the fit sub-star roughly the overall shown twice. The card also gave compensation its own row, which made every entry six rows tall.

- **One star rating per card**, with its value printed beside it (`RatingStars` gains `showValue`; the numeral is `aria-hidden` because the label already carries it).
- **The sub-axes are words.** New `describeRating` in `rating.ts` bands each *present* axis into a phrase on one reason line. That fits location and seniority — computed on this branch but never displayed — and lets an axis stay silent where a star cannot: below-floor pay is left to its badge rather than said twice, and a floor-less low pay says nothing, since the user set no minimum for us to infer one. Fitness phrasing is deliberately comparative ("Top fit here") because that axis is set-relative by construction.
- **The coverage denominator is visible text** ("12 of 18 terms"), not a `title` tooltip no touch or keyboard user could reach.
- **Four rows, not six.** Company, source, location and pay are all facts about the posting, so they share one meta line. `source` is dropped when it merely repeats `company` — the board adapters set it to the company's own display name, so every Greenhouse/Lever/Ashby hit read "Acme · Acme" — and a multi-location posting collapses to "San Francisco, CA +2". The face shows matched chips only; missing terms stay in the expanded `JdMatch`.

### fallow cleanup

Five `fallow` code-scanning threads, all addressed:

- Three constants the branch added are read only inside their own module — `WEAK_MATCH_STAR_THRESHOLD` (by `WEAK_MATCH_LABEL` + `isWeakMatch`), `PLAUSIBLE_ANNUAL_COMP_MIN` (by `annualizedTop`), `seniorityDistance` (by `rankPostings`). They drop the `export` rather than advertise an API nobody consumes.
- `RATING_ALGO_VERSION` is **deleted**, not un-exported. A version stamp earns its keep by invalidating a *stored* score — `ATS_SCORE_ALGO_VERSION` is half of `resume-library.ts`'s cache key — and nothing stores a rating. The module docblock already explained why it never will (`rateJobs` computes over the whole set, so a rating is only meaningful beside the set it came from); it now records that this is also why there's no stamp, so the constant comes back with its consumer or not at all.
- `probe-jobs`' `classify` (cyclomatic 21 / cognitive 28) splits into four per-concern classifiers — `classifyRating`, `classifyLevelAndComp`, `classifyLocation`, `classifyResultHealth` — leaving only the empty-result guard in `classify` itself. `fallow audit` on the branch is now dead code 0 · complexity 0.

The one remaining `fallow` finding is a duplication clone group across the seven `probe-*.test.ts` harnesses (shared report scaffolding, six of them pre-existing on `main`) — not one of the flagged threads, and the same deliberate-duplication call as the per-vendor adapters.

### Invariants held (per the epic)

- **One fit number.** Every new signal folds into the one rating — never a second parallel score. Note this **replaces** the old `score === coverage.score` form of the invariant: `rateJobs` is now the single place a rating is computed, over the whole result set at once, and the card headline, the reason line, the detail view and the sort order all read that same `job.rating` object, so they cannot diverge. The set-dependence is intended — a 5★ means "the best of what this search found", which is why the rating is computed per result set and never cached per posting.
- **Soft-penalty-and-badge, never hard-drop** (the #545 location precedent). Adjacent-level / under-floor / non-local fits sink and are badged, never vanish.
- **Never fail closed.** A role or exclusion filter that would empty the panel keeps the results and surfaces a notice (`roleSuppressed` / `excludeSuppressed`), rather than showing an empty set.
- **No new egress.** All new logic parses text already fetched or already local. `providers/keywords.ts` remains the sole résumé-derived egress helper; company adapters egress only the public slug.

Closes #561
Closes #562
Closes #563
Closes #564
Closes #565
Closes #567
Closes #568
Closes #570
Closes #566

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (2994 pass / 9 skipped repo-wide; +16 new cases in the card-layout pass on top of the +9 comp regression cases)
- [x] `npm run lint` clean
- [x] `npm run verify` — green locally and in CI (authoritative full gate)
- [x] Manually verified in `npm run dev`

The card-layout pass was verified by test, not by a fresh browser session — the `RatingStars` fill-width regression (a numeral inside the overlay's positioning box would under-fill every rating) and the source-dedup / location-collapse / visible-denominator behaviours each have a pinned case.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #561 (fit score direction) | Claude Opus 4.8 | ultra |
| Implementation — #562 (seniority level axis) | Claude Opus 4.8 | ultra |
| Implementation — #565 (cap-before-rank) | Claude Sonnet 5 | high |
| Implementation — #563 (exclusion terms) | Claude Sonnet 5 | high |
| Implementation — #564 (compensation) | Claude Sonnet 4.6 | high |
| Implementation — #567 (weak-match display) | Claude Sonnet 4.5 | high |
| Implementation — #568 (progressive refinement) | Claude Sonnet 5 | high |
| Adversarial review (round 1) | Claude Opus 4.8 | high |
| Review fixes (round 1) | Claude Opus 4.8 | high |
| Adversarial review (round 2) | Claude Opus 4.8 | high |
| Review fixes (round 2) | Claude Opus 4.8 | high |
| Orchestration + PR | Claude Opus 4.8 | high |
| Card-layout UX pass (one star rating, reason line, density) | Claude Opus 5 | high |
| fallow review pass (unused exports, `classify` decomposition) | Claude Opus 5 | high |
| Verification | `npm run verify` — green in CI | — |

## Adversarial review

Pre-PR self-adversarial review over the accumulated diff, `ecc:react-reviewer` (Claude Opus 4.8), 2 rounds. Reviewer was told to break the change and reproduce suspected bugs end-to-end, not to praise.

**Round 1 — 2 blocking, 4 nits.**
1. *Compensation false-positive (blocking).* `extractCompensation` took the first currency-anchored number anywhere, so `$5M funding`, `$250,000 budget`, `$100,000 equity`, `save $200/month` were misread as salary → wrong "below your floor" badge + `COMP_FLOOR_PENALTY` demotion. **Fixed:** scan all currency matches; magnitude-suffix guard (`M`/`B`/`bn`/`million`), drop the magnitude→hourly inference, salary-context gate for lone singles.
2. *Role-family filter not never-fail-closed (blocking).* `refineSearchResult` hard-filtered the merged keyless-feed set by role family; an over-narrow filter emptied the panel with a misleading "broaden" notice, unlike the `excludeTerms` sibling. **Fixed:** when a non-empty families filter would empty a non-empty set, keep the input and set `roleSuppressed` + a matching notice; empty/undefined families stay safe; genuinely-empty input does not false-flag.
Nits (non-blocking, deferred): `LevelSelect` roving-tabindex, `WeakMatchesSection` `aria-controls`, "Mid" label, `FindJobsPanel` LOC (>200 soft gate, pre-existing debt trajectory).

**Round 2 (cap) — Fix 2 fully resolved; Fix 1 partial, 1 residual blocking.**
The comp fix's `hasSalaryContext` window was position-symmetric, so a non-salary figure whose right window bled into a *later* salary word validated itself and `firstAcceptable` locked it in: `"equity worth $100,000, salary $180,000"` extracted `$100,000` → false below-floor on an above-floor job. **Fixed (root cause):** directional nearest-figure attribution — each salary word binds to the single nearest figure it can reach without crossing a sentence boundary; a salary-attached figure beats a period-only figure; ranges stay exempt and win first. Same change also resolved the two same-root-cause nits (prose hourly rate preceding the real annual; missing `annual` vocabulary). When genuinely ambiguous, extraction returns `undefined` — a false-negative is safe, a false below-floor is not.

Round cap (2) reached with the residual open; rather than halt, the residual was fixed under its exact specified root cause and verified deterministically with regression coverage (no round-3 review). Re-verify over the fixed tree: typecheck clean, 526 tests pass (+9 new comp cases), lint clean. Reviewer re-confirmed clean: ranking parity intact (`score === coverage.score`, all boosts/penalties in `sortKey()` only), no new egress, design-system compliance, SPDX headers, live re-rank dep array correct.

