### PR TITLE
feat(jobs): give job search its own page and real paging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,11 @@ There is **no BYOK LLM provider in the tree** — `#320` is future; App.tsx / Ca
 
 ### Product lanes and entry points
 
-The build ships exactly two HTML entries (`vite.config.ts` `rollupOptions.input`):
+The build ships exactly three HTML entries (`vite.config.ts` `rollupOptions.input`):
 
 - **`/` (index.html)** — the parser-audit lane: drop → parse cascade → score → editable reconstructed resume (`ReconstructedResume` + `EditableField`) → Download PDF (`src/lib/pdf/render-ats-pdf.ts`). On-device WebLLM insights (parse disagreement, resume-quality critique, rewrite) layer on top when WebGPU is available (`src/lib/webllm/`).
 - **`/jd-fit/` (jd-fit/index.html)** — the JD-match lane: paste a JD, get requirement/evidence coverage (`src/lib/jd-match/`, semantic via WebLLM with keyword fallback) and JD-driven section rewrites. Resume state hands off from `/` via `src/lib/jd-fit-handoff.ts`.
-- The **job-search lane** (`src/lib/job-search/`: query builder → provider search → rank by resume fit → deep links) rides inside the main page (`FindJobsPanel`), not a third entry.
+- **`/jobs/` (jobs/index.html)** — the job-search lane (`src/lib/job-search/`: query builder → provider search → rank by resume fit → deep links). `FindJobsPanel` is the whole page: a full-width query form that folds into a sticky one-line summary (`JobQuerySummary`) the moment Search is clicked, with the paged ranked results owning the full width below it. The parsed résumé arrives from `/` via `src/lib/jobs-handoff.ts` (sessionStorage, read but NOT consumed, so a reload survives); `/` keeps only `FindJobsLauncher`, which stashes the parse and navigates. This surface has no DropZone — parsing is `/`'s job.
 
 `jd-spike.html` and `eval-rewrite.html` are dev-only harnesses, deliberately excluded from the production build.
 

--- a/README.md
+++ b/README.md
@@ -346,9 +346,9 @@ is the custom domain **<https://offlinecv.org>**; the project-Pages URL
 <https://offlinecv.github.io/OfflineCV/> remains as a fallback (built
 with `VITE_BASE_PATH=/OfflineCV/`).
 
-The build emits two root pages — `/` (the parser audit) and `/jd-fit`
-(JD-match + JD-driven rewrite) — as a multi-entry Vite build, so both ship
-in the same self-contained `dist/`.
+The build emits three root pages — `/` (the parser audit), `/jd-fit`
+(JD-match + JD-driven rewrite), and `/jobs` (the job-search workbench) — as a
+multi-entry Vite build, so all of them ship in the same self-contained `dist/`.
 
 To bake telemetry into a deployed build, set `VITE_POSTHOG_KEY` (and
 optionally `VITE_POSTHOG_HOST`) in the build environment — see the

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OfflineCV — Find Jobs</title>
+    <meta
+      name="description"
+      content="Search job boards from the search we built out of your resume, and page through every match ranked by fit."
+    />
+    <meta name="color-scheme" content="light dark" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/jobs/main.tsx"></script>
+  </body>
+</html>

--- a/src/components/features/CompanyTargets.tsx
+++ b/src/components/features/CompanyTargets.tsx
@@ -96,12 +96,15 @@ export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
       {/* #542: large employers with self-hosted careers sites (Apple, Google,
        *  Meta, …) aren't on Greenhouse/Lever/Ashby, so they can never appear
        *  in this list — a structural boundary of the three-vendor design, not
-       *  a curation gap. "Search external boards" above (LinkedIn / Indeed /
-       *  Google Jobs) is the intended path to those. */}
+       *  a curation gap. "Search external boards" (LinkedIn / Indeed / Google
+       *  Jobs) is the intended path to those. No "above"/"below" here: this
+       *  block is pinned to the top of `/jobs/` while the board links live in
+       *  the foldable search details, so any direction word would be wrong
+       *  half the time. */}
       <p className="max-w-prose text-xs text-content-tertiary">
         Large employers with their own careers site (e.g. Apple, Google,
-        Meta) aren&apos;t reachable here — find them via the external boards
-        above.
+        Meta) aren&apos;t reachable here — find them via the external board
+        links in the search details.
       </p>
     </div>
   );

--- a/src/components/features/ExternalBoardLinks.tsx
+++ b/src/components/features/ExternalBoardLinks.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ExternalBoardLinks — the "Search external boards" row of the job-search
+ * workbench. Inert: each link is an ordinary `<a target="_blank">`, so the
+ * navigation is the user's own and nothing here fetches. Only the query
+ * keywords ride in the URL, never the résumé text.
+ *
+ * Split out of `FindJobsPanel` in the `/jobs/` move so the workbench file stays
+ * a layout shell (same reason `JobResultCard` and `LevelSelect` were split).
+ *
+ * Not a `<Button>`: these are real cross-origin navigations, so an anchor is the
+ * correct element — the design system's Button primitive renders a `<button>`
+ * and would need a link-as-button escape hatch for no benefit.
+ */
+
+import type { JobBoardLink } from "../../lib/job-search/deep-links.ts";
+
+export function ExternalBoardLinks({ links }: { links: readonly JobBoardLink[] }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs text-content-tertiary">
+        Search external boards
+      </span>
+      <div className="flex flex-wrap gap-2">
+        {links.map((link) => (
+          <a
+            key={link.label}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
+          >
+            {link.label}
+            <span aria-hidden="true">↗</span>
+          </a>
+        ))}
+      </div>
+      <p className="text-xs text-content-tertiary">
+        Only your search keywords are sent, and only when you click a link above.
+      </p>
+    </div>
+  );
+}

--- a/src/components/features/FindJobsLauncher.test.tsx
+++ b/src/components/features/FindJobsLauncher.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the Find Jobs tab on `/` after the search moved to `/jobs/`.
+ *
+ * The contract that matters: clicking the button STASHES the parse before it
+ * navigates. If the write were skipped or ordered after the navigation, `/jobs/`
+ * would load with no résumé and show its empty state — the failure the split
+ * made possible, so it is the thing under test.
+ *
+ * jsdom implements no navigation, so the `window.location.href` assignment logs
+ * a "Not implemented: navigation" notice from the virtual console. That is
+ * expected noise, not a failure; the assertion is on sessionStorage.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { FindJobsLauncher } from "./FindJobsLauncher.tsx";
+import { readJobsHandoff } from "../../lib/jobs-handoff.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  skills: ["React", "TypeScript", "GraphQL"],
+  experience: [{ company: "Acme", title: "Staff Frontend Engineer" }],
+  education: [],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(props: { parsed: HeuristicParsedResume }) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(FindJobsLauncher, props));
+  });
+  return container;
+}
+
+function launchButton(el: HTMLElement): HTMLButtonElement {
+  const button = [...el.querySelectorAll("button")].find((b) =>
+    b.textContent?.includes("Open job workbench"),
+  );
+  if (!button) throw new Error("no launch button rendered");
+  return button as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("FindJobsLauncher", () => {
+  it("previews the derived query terms without an editor", () => {
+    const el = render({ parsed });
+    expect(el.textContent).toContain("Starting from these terms");
+    // `buildJobQuery` lowercases skill terms, so the preview shows what will
+    // actually be searched, not the résumé's casing.
+    expect(el.textContent).toContain("Staff Frontend Engineer");
+    expect(el.textContent).toContain("react");
+    // No chip-add inputs here — editing belongs to /jobs/ only.
+    expect(el.querySelectorAll("input").length).toBe(0);
+  });
+
+  it("stashes the parse before navigating", () => {
+    const el = render({ parsed });
+    act(() => launchButton(el).click());
+
+    const handoff = readJobsHandoff();
+    expect(handoff).not.toBeNull();
+    expect(handoff?.parsed.full_name).toBe("Dana Fixture");
+    expect(handoff?.parsed.skills).toContain("GraphQL");
+  });
+
+  it("still offers the jump when no query could be derived", () => {
+    // The workbench is where titles/skills get added, so a degenerate parse
+    // must not disable the only route to it.
+    const el = render({
+      parsed: { skills: [], experience: [], education: [] },
+    });
+    expect(el.textContent).toContain("couldn't derive a search");
+    expect(launchButton(el).disabled).toBe(false);
+  });
+});

--- a/src/components/features/FindJobsLauncher.tsx
+++ b/src/components/features/FindJobsLauncher.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * FindJobsLauncher — what the Find Jobs tab on `/` shows now that the search
+ * itself lives on `/jobs/`.
+ *
+ * Deliberately thin: a preview of the query terms we derived plus one button.
+ * The whole point of the move is that a ranked posting list is a destination
+ * with its own URL and its own scroll, so duplicating the editable query here
+ * would recreate the "two places to edit one search" problem the split removed.
+ * Anything editable belongs on `/jobs/`.
+ *
+ * The button writes the parse to sessionStorage and then navigates — a full
+ * document navigation, base-aware via `import.meta.env.BASE_URL` so it works
+ * under both the custom-domain "/" base and the "/OfflineCV/" Pages-fallback
+ * base (same pattern as `App.tsx`'s /jd-fit cross-link).
+ *
+ * Nothing here fetches, and the navigation is same-origin, so no résumé data
+ * leaves the browser at this step.
+ */
+
+import { useMemo } from "react";
+import { Button } from "@design-system";
+import { buildJobQuery } from "../../lib/job-search/query-builder.ts";
+import { roleFilterForResume, seedExcludeTermsForFamilies } from "../../lib/job-search/role-keywords.ts";
+import { writeJobsHandoff } from "../../lib/jobs-handoff.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+
+/** Terms previewed before the jump. Enough to show the derivation worked
+ *  without reproducing the full editor. */
+const PREVIEW_LIMIT = 6;
+
+export function FindJobsLauncher({ parsed }: { parsed: HeuristicParsedResume }) {
+  // Same seed `/jobs/` will compute from the same parse — this is a preview of
+  // that query, not a second source of truth. Recomputed there on arrival.
+  const query = useMemo(() => {
+    const roleFilter = roleFilterForResume(parsed);
+    return buildJobQuery(
+      parsed,
+      seedExcludeTermsForFamilies(roleFilter.families),
+      roleFilter.families,
+    );
+  }, [parsed]);
+
+  const isDegenerate = query.titles.length === 0 && query.skills.length === 0;
+  const preview = [...query.titles, ...query.skills].slice(0, PREVIEW_LIMIT);
+
+  const go = () => {
+    writeJobsHandoff({ parsed });
+    window.location.href = `${import.meta.env.BASE_URL}jobs/`;
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
+            Find jobs
+          </h2>
+          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
+            alpha
+          </span>
+        </div>
+        <p className="max-w-prose text-xs text-content-tertiary">
+          We built a search from your parsed resume. Open the job workbench to
+          edit it, search job boards, and page through every match ranked by
+          fit. Your resume text never leaves this browser — only the keywords
+          are sent.
+        </p>
+      </header>
+
+      {preview.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-content-tertiary">
+            Starting from these terms
+          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {preview.map((term) => (
+              <span
+                key={term}
+                className="rounded bg-surface-subtle px-2 py-0.5 text-xs text-content-secondary"
+              >
+                {term}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* A degenerate query does NOT gate the jump: the workbench is where
+       *  titles and skills are added, so blocking here would leave the user
+       *  with a dead tab and no control to fix it. The button opens the same
+       *  editor, which shows its own "add a title or skills" hint. */}
+      {isDegenerate && (
+        <p className="text-xs text-content-tertiary">
+          We couldn&apos;t derive a search from this resume — add a title or
+          skills in the workbench and search from there.
+        </p>
+      )}
+      <div>
+        <Button variant="primary" size="md" onClick={go}>
+          Open job workbench <span aria-hidden="true">▸</span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -2,41 +2,70 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * FindJobsPanel — first slice of the job-search lane (#318). Builds a search
- * query from the parsed resume, lets the user edit it, and renders inert
- * deep-link buttons to major job boards. Zero network calls: deep links open
- * in a new tab under the user's own navigation; nothing here fetches.
+ * FindJobsPanel — the job-search workbench body, the whole of `/jobs/`.
  *
- * This is the STABLE SKELETON for the whole "Find Jobs" panel arc (epic
- * #317): header + Query block + Actions row (see the UX spec at
- * `find-jobs-ux-spec.md`). Slice #319 appends a Search button + Results
- * region below the Actions row; slice #320 appends a BYOK footer. Neither
- * restructures what this slice ships — only append here.
+ * It used to be a tab on `/` with the results stacked underneath the query, at
+ * the bottom of a long parser-audit page. Results moved to their own entry
+ * (`jobs/index.html`) because a ranked list of dozens of postings is a
+ * destination, not a footnote: it needs a URL you can reload, its own scroll,
+ * and the full page width. `/` keeps `FindJobsLauncher`, which hands the parse
+ * over via `lib/jobs-handoff.ts`.
  *
- * The query is local, scratch-editable state seeded once from the parse; it
- * intentionally does NOT write back into the résumé override model
- * (useEditableParse) — editing the search query is not editing the résumé.
+ * LAYOUT: full-width bands stacked down the page, never a sidebar. Reading order
+ * is the order of the work — who we search, then what we search for, then what we
+ * found:
+ *
+ *  1. **Company targets, permanent.** The one query control that stays visible
+ *     with the results. It's the axis users retune WHILE reading postings ("drop
+ *     that one, add this one"), and #533's toggle is now live against an existing
+ *     result set, so hiding it behind a fold would bury the panel's most
+ *     immediate feedback loop.
+ *  2. **The rest of the query, foldable.** Titles, skills, location, level,
+ *     excludes, pay floor, external boards — a form, worth the full page width
+ *     while being filled in and worth none of it afterwards. Folded, it is a
+ *     one-line `JobQuerySummary` + Search again.
+ *  3. **Results**, owning the full width.
+ *
+ * Folding on submit rather than on the first successful result is deliberate:
+ * the transition is then tied to the user's own click, so it never happens under
+ * their cursor a second later, and the loading skeleton already gets the full
+ * width it will render results into. A failed search stays folded too — its
+ * error state carries Retry, and Edit search is one click away.
+ *
+ * Nothing is sticky. With the company chips permanently on top, a pinned band
+ * would be ~3 chip rows tall and would cost more viewport on every scroll than
+ * the Search button it keeps in reach is worth.
+ *
+ * #568's live re-rank means a refinement chip edited while the panel is open
+ * updates the results with no refetch, so re-opening the form over a results set
+ * is a cheap, non-destructive thing to do. The company selector is the one
+ * control that can outrun the results — removing a target re-filters live, but
+ * ADDING one needs its board fetched, which is what `PendingCompaniesNotice`
+ * offers rather than doing on the checkbox click.
+ *
+ * Still a layout shell: the query fields are `JobQueryEditor`, the deep links
+ * `ExternalBoardLinks`, the fetch lifecycle `useJobSearch`, the company picker
+ * `useCompanyTargets`. The query state is owned HERE because the editor, the
+ * ranking, and the re-rank effect all read it.
  */
 
 import { useMemo, useState } from "react";
-import { Button, EditableField } from "@design-system";
+import { Button } from "@design-system";
 import { buildJobQuery, type JobQuery } from "../../lib/job-search/query-builder.ts";
 import { buildDeepLinks } from "../../lib/job-search/deep-links.ts";
 import {
   roleFilterForResume,
   seedExcludeTermsForFamilies,
-  type RoleFamily,
 } from "../../lib/job-search/role-keywords.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import { JobSearchResults } from "./JobSearchResults.tsx";
-import { ChipListEditor } from "./ChipListEditor.tsx";
-import { CompFloorInput } from "./CompFloorInput.tsx";
-import { RoleFamilyChips } from "./RoleFamilyChips.tsx";
-import { LevelSelect } from "./LevelSelect.tsx";
+import { JobQueryEditor } from "./JobQueryEditor.tsx";
+import { JobQuerySummary } from "./JobQuerySummary.tsx";
+import { ExternalBoardLinks } from "./ExternalBoardLinks.tsx";
+import { PendingCompaniesNotice } from "./PendingCompaniesNotice.tsx";
 import { CompanyTargets } from "./CompanyTargets.tsx";
 import { useCompanyTargets } from "../../hooks/useCompanyTargets.ts";
 import { useJobSearch } from "../../hooks/useJobSearch.ts";
-import { AddPill } from "./ReconstructedAdd.tsx";
 
 interface FindJobsPanelProps {
   /** The live cascade's parsed résumé. `buildJobQuery` reads only titles/skills;
@@ -51,7 +80,7 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   // on mount); the user edits it from here. Exclude-term chips (#563) AND
   // role-family chips (#568) are seeded from the SAME role-family
   // classification the company-board pipeline derives — visibly, as ordinary
-  // removable chips below, never applied invisibly.
+  // removable chips, never applied invisibly.
   const [query, setQuery] = useState<JobQuery>(() => {
     const roleFilter = roleFilterForResume(parsed);
     return buildJobQuery(
@@ -60,190 +89,104 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
       roleFilter.families,
     );
   });
-  // Progressive disclosure for Seniority (#540): a résumé whose titles carry
-  // no recognized seniority keyword renders no inert placeholder field — the
-  // row appears only once a seniority was derived, or the user opts in via
-  // the "+ Seniority" pill.
-  const [seniorityExpanded, setSeniorityExpanded] = useState(false);
+
+  // Open until the first Search, then folded — see the docblock. Purely
+  // presentational, so it stays local rather than moving to a hook.
+  const [open, setOpen] = useState(true);
 
   const links = useMemo(() => buildDeepLinks(query), [query]);
   const isDegenerate = query.titles.length === 0 && query.skills.length === 0;
 
-  // ChipListEditor already trims + case-insensitively dedups before calling
-  // onAdd, so these handlers just append / filter the controlled list.
-  const addTitle = (title: string) =>
-    setQuery((q) => ({ ...q, titles: [...q.titles, title] }));
-  const removeTitle = (title: string) =>
-    setQuery((q) => ({ ...q, titles: q.titles.filter((t) => t !== title) }));
-
-  const addSkill = (skill: string) =>
-    setQuery((q) => ({ ...q, skills: [...q.skills, skill] }));
-  const removeSkill = (skill: string) =>
-    setQuery((q) => ({ ...q, skills: q.skills.filter((s) => s !== skill) }));
-
-  const addExcludeTerm = (term: string) =>
-    setQuery((q) => ({ ...q, excludeTerms: [...(q.excludeTerms ?? []), term] }));
-  const removeExcludeTerm = (term: string) =>
-    setQuery((q) => ({
-      ...q,
-      excludeTerms: (q.excludeTerms ?? []).filter((t) => t !== term),
-    }));
-
-  // Role families (#568): REMOVAL only — see RoleFamilyChips' doc for why
-  // there's no free-text add. Narrowing to an empty list is safe: readers
-  // resolve `families: []` to the permissive "all" filter, never zero results.
-  const removeRoleFamily = (family: RoleFamily) =>
-    setQuery((q) => ({
-      ...q,
-      families: (q.families ?? []).filter((f) => f !== family),
-    }));
-
-  const setLevel = (level: string | undefined) =>
-    setQuery((q) => ({ ...q, seniority: level }));
-
   // Sector-suggested companies whose ATS boards join the fan-out. Selecting
   // none is a supported state: the search falls back to the keyless feeds
-  // alone, exactly as it behaved before #533.
+  // alone, the same way it behaved before #533.
   const companyTargets = useCompanyTargets(parsed);
   const selectedCompanies = companyTargets.selected;
 
-  // Fetch lifecycle + #568's live re-rank — see the hook's own docblock.
-  const { phase, runSearch, isLoading } = useJobSearch(query, parsed, selectedCompanies);
+  // Fetch lifecycle, #568's live re-rank, and the asymmetric company handling
+  // (remove = live, add = a prompt) — see the hook's own docblock.
+  const {
+    phase,
+    runSearch,
+    isLoading,
+    pendingCompanies,
+    searchPendingCompanies,
+    isUpdating,
+  } = useJobSearch(query, parsed, selectedCompanies);
+  const hasSearched = phase.kind !== "idle";
+
+  const submit = () => {
+    setOpen(false);
+    runSearch();
+  };
 
   return (
     <div className="flex flex-col gap-4">
-      <header className="flex flex-col gap-1">
-        <div className="flex items-baseline gap-2">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-content-muted">
-            Find jobs
-          </h2>
-          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
-            alpha
-          </span>
-        </div>
-        <p className="max-w-prose text-xs text-content-tertiary">
-          We built this search from your parsed resume. Edit it, then search
-          job boards. Your resume text never leaves this browser — only the
-          keywords below are sent.
-        </p>
-      </header>
-
-      <div className="flex flex-col gap-3">
-        <ChipListEditor
-          label="Titles"
-          items={query.titles}
-          onAdd={addTitle}
-          onRemove={removeTitle}
-          placeholder="Add a title…"
-          addAriaLabel="Add title"
-        />
-        {/* Role families (#568): seeded from the same classification the
-         *  company-board pipeline uses, removable so a fullstack résumé that
-         *  also matched `data` can drop it. */}
-        <RoleFamilyChips
-          families={(query.families ?? []) as RoleFamily[]}
-          onRemove={removeRoleFamily}
-        />
-        {/* Location (#545): always shown, unlike the target level's
-         *  AddPill-gated disclosure — location is a primary axis of every
-         *  job-board search form (not an auxiliary facet the way level is),
-         *  and a résumé with no parsed location still needs a visible place
-         *  to type one to get any location-aware ranking or deep-link
-         *  behavior at all. */}
-        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-          <span className="text-xs text-content-tertiary">Location</span>
-          <EditableField
-            value={query.location}
-            placeholder="location"
-            label="Location"
-            onCommit={(v) =>
-              setQuery((q) => ({ ...q, location: v || undefined }))
-            }
-          />
-        </div>
-        {/* Target level (#562/#568): progressive disclosure, same pattern as
-         *  pre-#568 free-text Seniority — a résumé whose titles carry no
-         *  recognized level renders no inert control until the user opts in
-         *  via "+ Seniority". Changing the level re-runs the #562 rung-
-         *  distance penalty (live, via the refinement effect above). */}
-        {query.seniority || seniorityExpanded ? (
-          <LevelSelect value={query.seniority} onChange={setLevel} />
-        ) : (
-          <AddPill label="Target level" onClick={() => setSeniorityExpanded(true)} />
-        )}
-        <ChipListEditor
-          label="Skills"
-          items={query.skills}
-          onAdd={addSkill}
-          onRemove={removeSkill}
-          placeholder="Add a skill…"
-          addAriaLabel="Add skill"
-        />
-        {/* Exclude (#563): title-only — a posting is dropped when its TITLE
-         *  contains one of these, never when only its description does.
-         *  Removable chips may already be seeded from the role-family
-         *  classification (e.g. GTM/field roles for an engineering search). */}
-        <ChipListEditor
-          label="Exclude (title only)"
-          items={query.excludeTerms ?? []}
-          onAdd={addExcludeTerm}
-          onRemove={removeExcludeTerm}
-          placeholder="Add a title to exclude…"
-          addAriaLabel="Add exclude term"
-        />
-        <CompFloorInput
-          value={query.compFloor}
-          onCommit={(v) => setQuery((q) => ({ ...q, compFloor: v }))}
-        />
-        {isDegenerate && (
-          <p className="text-xs text-content-tertiary">
-            We couldn&apos;t derive a search from this resume — add a title or
-            skills above to search.
-          </p>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-xs text-content-tertiary">
-          Search external boards
-        </span>
-        <div className="flex flex-wrap gap-2">
-          {links.map((link) => (
-            <a
-              key={link.label}
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
-            >
-              {link.label}
-              <span aria-hidden="true">↗</span>
-            </a>
-          ))}
-        </div>
-        <p className="text-xs text-content-tertiary">
-          Only your search keywords are sent, and only when you click a link
-          above.
-        </p>
-      </div>
-
+      {/* Band 1 — the only query control that outlives the fold. */}
       <CompanyTargets targets={companyTargets} />
 
-      <div className="flex flex-col gap-2">
-        <div>
+      <section
+        aria-label="Job search query"
+        className="flex flex-col gap-3 border-y border-border-light py-3"
+      >
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? "Hide search details" : "Edit search"}
+          </Button>
+          {!open && (
+            <JobQuerySummary
+              query={query}
+              companyCount={selectedCompanies.length}
+            />
+          )}
           <Button
             variant="primary"
             size="md"
-            onClick={runSearch}
+            className="ml-auto"
+            onClick={submit}
             disabled={isDegenerate || isLoading}
           >
-            {isLoading ? "Searching…" : "Search jobs"}
+            {isLoading
+              ? "Searching…"
+              : hasSearched
+                ? "Search again"
+                : "Search jobs"}
           </Button>
         </div>
+
+        {/* Sits under the Search button rather than at the foot of the section:
+         *  the claim is about what THAT button does, and `ExternalBoardLinks`
+         *  carries its own (different) claim about the deep links. */}
         <p className="text-xs text-content-tertiary">
           Only your search keywords are sent, and only when you click Search.
         </p>
-      </div>
+
+        {open && (
+          <div className="flex flex-col gap-4">
+            <JobQueryEditor
+              query={query}
+              onChange={setQuery}
+              isDegenerate={isDegenerate}
+            />
+            <ExternalBoardLinks links={links} />
+          </div>
+        )}
+      </section>
+
+      {/* Only over an existing result set: before the first search every
+       *  selected company is unsearched, which is not news. */}
+      {phase.kind === "loaded" && (
+        <PendingCompaniesNotice
+          companies={pendingCompanies}
+          onSearch={searchPendingCompanies}
+          isUpdating={isUpdating}
+        />
+      )}
 
       <JobSearchResults phase={phase} onRetry={runSearch} />
     </div>

--- a/src/components/features/JobQueryEditor.tsx
+++ b/src/components/features/JobQueryEditor.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobQueryEditor — the editable search query of the job-search workbench.
+ *
+ * Extracted verbatim out of `FindJobsPanel` when the results moved to their own
+ * `/jobs/` page: the panel became a foldable full-width search form above the
+ * results, and the fields shouldn't own the layout that folds them. Nothing
+ * about the controls changed in the move.
+ *
+ * The fields lay themselves out across the full width rather than stacking in one
+ * narrow column: the panel hands this component the whole page, and a single
+ * column would leave a ~470px form on a 1080px page — which is what the layout
+ * looked like when the neighbouring blocks owned the other columns.
+ *
+ * Grouping is by how the fields are used, not by size: what you SEARCH FOR
+ * (titles + role) and what you're MADE OF (skills) get a column each, because
+ * both are long removable-chip lists; the narrow modifiers (location, exclude,
+ * pay floor) share the third. Target level spans the full width on its own row —
+ * it's a 12-rung segmented control that would wrap into three ragged lines inside
+ * a third of the page.
+ *
+ * Controlled by the parent through `query` / `onChange` — the query is the
+ * workbench's single source of truth (the fit ranking and the #568 live re-rank
+ * both read it), so it cannot live here. Every mutation is a whole-query
+ * replacement, which keeps the "one Search click = one fetch" invariant in
+ * `useJobSearch` unaffected by editing.
+ *
+ * The query is scratch state seeded from the parse; it intentionally does NOT
+ * write back into the résumé override model — editing a search is not editing
+ * the résumé.
+ */
+
+import { useState } from "react";
+import { EditableField } from "@design-system";
+import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+import type { RoleFamily } from "../../lib/job-search/role-keywords.ts";
+import { ChipListEditor } from "./ChipListEditor.tsx";
+import { CompFloorInput } from "./CompFloorInput.tsx";
+import { RoleFamilyChips } from "./RoleFamilyChips.tsx";
+import { LevelSelect } from "./LevelSelect.tsx";
+import { AddPill } from "./ReconstructedAdd.tsx";
+
+export function JobQueryEditor({
+  query,
+  onChange,
+  isDegenerate,
+}: {
+  query: JobQuery;
+  onChange: (next: (q: JobQuery) => JobQuery) => void;
+  /** True when the parse yielded neither a title nor a skill — the search
+   *  cannot run, and the hint below tells the user what to type. */
+  isDegenerate: boolean;
+}) {
+  // Progressive disclosure for Seniority (#540): a résumé whose titles carry
+  // no recognized seniority keyword renders no inert placeholder field — the
+  // row appears only once a seniority was derived, or the user opts in via
+  // the "+ Seniority" pill. Purely presentational, so it stays local here.
+  const [seniorityExpanded, setSeniorityExpanded] = useState(false);
+
+  // ChipListEditor already trims + case-insensitively dedups before calling
+  // onAdd, so these handlers just append / filter the controlled list.
+  const addTitle = (title: string) =>
+    onChange((q) => ({ ...q, titles: [...q.titles, title] }));
+  const removeTitle = (title: string) =>
+    onChange((q) => ({ ...q, titles: q.titles.filter((t) => t !== title) }));
+
+  const addSkill = (skill: string) =>
+    onChange((q) => ({ ...q, skills: [...q.skills, skill] }));
+  const removeSkill = (skill: string) =>
+    onChange((q) => ({ ...q, skills: q.skills.filter((s) => s !== skill) }));
+
+  const addExcludeTerm = (term: string) =>
+    onChange((q) => ({ ...q, excludeTerms: [...(q.excludeTerms ?? []), term] }));
+  const removeExcludeTerm = (term: string) =>
+    onChange((q) => ({
+      ...q,
+      excludeTerms: (q.excludeTerms ?? []).filter((t) => t !== term),
+    }));
+
+  // Role families (#568): REMOVAL only — see RoleFamilyChips' doc for why
+  // there's no free-text add. Narrowing to an empty list is safe: readers
+  // resolve `families: []` to the permissive "all" filter, never zero results.
+  const removeRoleFamily = (family: RoleFamily) =>
+    onChange((q) => ({
+      ...q,
+      families: (q.families ?? []).filter((f) => f !== family),
+    }));
+
+  const setLevel = (level: string | undefined) =>
+    onChange((q) => ({ ...q, seniority: level }));
+
+  return (
+    <div className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="flex flex-col gap-3">
+        <ChipListEditor
+          label="Titles"
+          items={query.titles}
+          onAdd={addTitle}
+          onRemove={removeTitle}
+          placeholder="Add a title…"
+          addAriaLabel="Add title"
+        />
+        {/* Role families (#568): seeded from the same classification the
+         *  company-board pipeline uses, removable so a fullstack résumé that
+         *  also matched `data` can drop it. */}
+        <RoleFamilyChips
+          families={(query.families ?? []) as RoleFamily[]}
+          onRemove={removeRoleFamily}
+        />
+      </div>
+
+      <ChipListEditor
+        label="Skills"
+        items={query.skills}
+        onAdd={addSkill}
+        onRemove={removeSkill}
+        placeholder="Add a skill…"
+        addAriaLabel="Add skill"
+      />
+
+      <div className="flex flex-col gap-3">
+        {/* Location (#545): always shown, unlike the target level's
+         *  AddPill-gated disclosure — location is a primary axis of every
+         *  job-board search form (not an auxiliary facet the way level is),
+         *  and a résumé with no parsed location still needs a visible place
+         *  to type one to get any location-aware ranking or deep-link
+         *  behavior at all. */}
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+          <span className="text-xs text-content-tertiary">Location</span>
+          <EditableField
+            value={query.location}
+            placeholder="location"
+            label="Location"
+            onCommit={(v) => onChange((q) => ({ ...q, location: v || undefined }))}
+          />
+        </div>
+        {/* Exclude (#563): title-only — a posting is dropped when its TITLE
+         *  contains one of these, never when only its description does.
+         *  Removable chips may already be seeded from the role-family
+         *  classification (e.g. GTM/field roles for an engineering search). */}
+        <ChipListEditor
+          label="Exclude (title only)"
+          items={query.excludeTerms ?? []}
+          onAdd={addExcludeTerm}
+          onRemove={removeExcludeTerm}
+          placeholder="Add a title to exclude…"
+          addAriaLabel="Add exclude term"
+        />
+        <CompFloorInput
+          value={query.compFloor}
+          onCommit={(v) => onChange((q) => ({ ...q, compFloor: v }))}
+        />
+      </div>
+
+      {/* Target level (#562/#568): progressive disclosure, same pattern as
+       *  pre-#568 free-text Seniority — a résumé whose titles carry no
+       *  recognized level renders no inert control until the user opts in
+       *  via "+ Seniority". Changing the level re-runs the #562 rung-
+       *  distance penalty (live, via the workbench's refinement effect).
+       *  Full-width row: 12 rungs wrap badly inside a third of the page. */}
+      <div className="sm:col-span-2 lg:col-span-3">
+        {query.seniority || seniorityExpanded ? (
+          <LevelSelect value={query.seniority} onChange={setLevel} />
+        ) : (
+          <AddPill label="Target level" onClick={() => setSeniorityExpanded(true)} />
+        )}
+      </div>
+
+      {isDegenerate && (
+        <p className="text-xs text-content-tertiary sm:col-span-2 lg:col-span-3">
+          We couldn&apos;t derive a search from this resume — add a title or
+          skills to search.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/JobQuerySummary.test.ts
+++ b/src/components/features/JobQuerySummary.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `summarizeQuery` is what the user reads once `/jobs/` folds the search form
+ * away, so the assertions here are about it not LYING: a filter that is doing
+ * work must appear, and one that is not must not.
+ */
+
+import { describe, it, expect } from "vitest";
+import { summarizeQuery } from "./JobQuerySummary.tsx";
+import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+
+const base: JobQuery = { titles: [], skills: [] };
+
+describe("summarizeQuery", () => {
+  it("names the titles, location and company count", () => {
+    expect(
+      summarizeQuery(
+        { ...base, titles: ["Staff Engineer", "Principal Engineer"], location: "Austin, TX" },
+        9,
+      ),
+    ).toEqual(["Staff Engineer / Principal Engineer", "Austin, TX", "9 companies"]);
+  });
+
+  it("says 'anywhere' rather than omitting an unset location", () => {
+    // A location-blind search is the one silent axis a user reads as a bug, so
+    // it is the one default that still gets a segment.
+    expect(summarizeQuery({ ...base, titles: ["Designer"] }, 0)).toEqual([
+      "Designer",
+      "anywhere",
+      "0 companies",
+    ]);
+  });
+
+  it("omits the filters that are not filtering", () => {
+    const summary = summarizeQuery({ ...base, titles: ["Designer"] }, 1);
+    expect(summary.join(" · ")).not.toMatch(/excluded|\$|skill/);
+    // Singular company, not "1 companies".
+    expect(summary).toContain("1 company");
+  });
+
+  it("counts skills and exclusions and rounds the comp floor to $k", () => {
+    expect(
+      summarizeQuery(
+        {
+          titles: ["SRE"],
+          skills: ["go", "k8s", "terraform"],
+          excludeTerms: ["sales"],
+          seniority: "senior",
+          compFloor: 185_000,
+          location: "Remote",
+        },
+        4,
+      ),
+    ).toEqual([
+      "SRE",
+      "Remote",
+      "senior",
+      "3 skills",
+      "1 excluded",
+      "≥ $185k",
+      "4 companies",
+    ]);
+  });
+
+  it("does not report a location that is only whitespace", () => {
+    expect(summarizeQuery({ ...base, titles: ["PM"], location: "   " }, 2)).toContain(
+      "anywhere",
+    );
+  });
+});

--- a/src/components/features/JobQuerySummary.tsx
+++ b/src/components/features/JobQuerySummary.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobQuerySummary — one line describing the query behind the results shown.
+ *
+ * `/jobs/` gives the results the full page width by FOLDING the query controls
+ * away once a search has run (`FindJobsPanel`). Folding a form the user has just
+ * filled in is only safe if what it contained stays legible — otherwise the
+ * collapsed state is amnesia, and the user re-expands the panel just to remember
+ * what they searched for. This is that legibility: every axis that can change the
+ * result set gets a segment, so the summary and the ranking can't silently
+ * disagree.
+ *
+ * Silent axes are OMITTED rather than rendered as "none" — an unset comp floor or
+ * an empty exclude list is the neutral default, and printing it would imply a
+ * filter is doing work when it isn't. Location is the one exception: it always
+ * shows ("anywhere" when unset), because a location-blind search is a result the
+ * user will otherwise read as a bug.
+ *
+ * `summarizeQuery` is exported separately from the component so the segment logic
+ * is testable without a DOM.
+ */
+
+import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+
+/**
+ * Human-readable segments describing `query`, in the order the fields appear in
+ * the editor. `companyCount` is the number of selected company boards, which is
+ * part of the query's reach but lives outside `JobQuery` (`useCompanyTargets`).
+ */
+export function summarizeQuery(
+  query: JobQuery,
+  companyCount: number,
+): string[] {
+  const parts: string[] = [];
+  if (query.titles.length > 0) parts.push(query.titles.join(" / "));
+  const location = query.location?.trim();
+  parts.push(location ? location : "anywhere");
+  if (query.seniority) parts.push(query.seniority);
+  if (query.skills.length > 0) {
+    parts.push(`${query.skills.length} skill${query.skills.length === 1 ? "" : "s"}`);
+  }
+  const excluded = query.excludeTerms?.length ?? 0;
+  if (excluded > 0) parts.push(`${excluded} excluded`);
+  if (query.compFloor !== undefined) {
+    parts.push(`≥ $${Math.round(query.compFloor / 1000)}k`);
+  }
+  parts.push(
+    `${companyCount} compan${companyCount === 1 ? "y" : "ies"}`,
+  );
+  return parts;
+}
+
+export function JobQuerySummary({
+  query,
+  companyCount,
+}: {
+  query: JobQuery;
+  companyCount: number;
+}) {
+  return (
+    <p className="min-w-0 text-xs text-content-tertiary">
+      {summarizeQuery(query, companyCount).join(" · ")}
+    </p>
+  );
+}

--- a/src/components/features/JobSearchResults.test.tsx
+++ b/src/components/features/JobSearchResults.test.tsx
@@ -6,8 +6,10 @@
 /**
  * Render coverage for JobSearchResults (#319) — the five-state Results region.
  * Drives each SearchPhase directly (idle / loading / failed / loaded) plus the
- * loaded sub-branches inside `Loaded` (results, capped list, empty, partial
+ * loaded sub-branches inside `Loaded` (results, paged list, empty, partial
  * degrade, total degrade → hard error) so every state from UX spec §2 renders.
+ * The paging assertions are the regression guard for the old `RENDER_CAP`: they
+ * check the 21st match is REACHABLE, not merely that a footnote counts it.
  * Real `RankedJob`s built via `rankPostings`; raw createRoot + act.
  */
 
@@ -82,6 +84,19 @@ function loaded(
 let container: HTMLDivElement;
 let root: Root;
 
+/** Pagination controls, found by their visible label inside the results nav. */
+function navButton(el: HTMLElement, text: string): HTMLButtonElement {
+  const nav = el.querySelector("nav");
+  const button = [...(nav?.querySelectorAll("button") ?? [])].find((b) =>
+    b.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`no "${text}" button in the pagination nav`);
+  return button as HTMLButtonElement;
+}
+
+const prevButton = (el: HTMLElement) => navButton(el, "Prev");
+const nextButton = (el: HTMLElement) => navButton(el, "Next");
+
 function render(phase: SearchPhase) {
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -122,10 +137,68 @@ describe("JobSearchResults", () => {
     expect(el.querySelectorAll("h3").length).toBe(2);
   });
 
-  it("caps the rendered list at 20 and notes the cap", () => {
+  it("pages the list instead of capping it — page 1 shows the first 20 of 25", () => {
     const el = render({ kind: "loaded", result: loaded(25) });
     expect(el.querySelectorAll("h3").length).toBe(20);
-    expect(el.textContent).toContain("Showing the top 20 of 25");
+    expect(el.textContent).toContain("Showing 1–20 of 25 matches");
+    // No "narrow the query" instruction: every match is reachable by paging.
+    expect(el.textContent).not.toContain("Narrow the query");
+    const nav = el.querySelector("nav");
+    expect(nav?.getAttribute("aria-label")).toContain("page 1 of 2");
+    // Prev is unreachable on the first page; Next is not.
+    expect(prevButton(el).disabled).toBe(true);
+    expect(nextButton(el).disabled).toBe(false);
+  });
+
+  it("Next reveals the REMAINING matches — the tail is not discarded", () => {
+    const el = render({ kind: "loaded", result: loaded(25) });
+    act(() => nextButton(el).click());
+
+    expect(el.querySelectorAll("h3").length).toBe(5);
+    expect(el.textContent).toContain("Showing 21–25 of 25 matches");
+    // Postings 20–24 are exactly the ones page 1 could never show.
+    expect(el.textContent).toContain("React Engineer 20");
+    expect(el.textContent).toContain("React Engineer 24");
+    expect(el.textContent).not.toContain("React Engineer 0★");
+    expect(nextButton(el).disabled).toBe(true);
+    expect(prevButton(el).disabled).toBe(false);
+  });
+
+  it("a numbered jump goes straight to that page", () => {
+    const el = render({ kind: "loaded", result: loaded(45) });
+    const page3 = [...el.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === "Page 3",
+    ) as HTMLButtonElement;
+    act(() => page3.click());
+
+    expect(el.textContent).toContain("Showing 41–45 of 45 matches");
+    expect(page3.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("a single page renders no pagination control at all", () => {
+    const el = render({ kind: "loaded", result: loaded(20) });
+    expect(el.querySelectorAll("h3").length).toBe(20);
+    expect(el.querySelector("nav")).toBeNull();
+    expect(el.textContent).not.toContain("Showing 1–20");
+  });
+
+  it("a new, shorter result set resets the page instead of showing nothing", () => {
+    const el = render({ kind: "loaded", result: loaded(45) });
+    act(() => nextButton(el).click());
+    expect(el.textContent).toContain("Showing 21–40 of 45");
+
+    // Same component, new result identity (a fresh Search or a live re-rank).
+    act(() => {
+      root.render(
+        createElement(JobSearchResults, {
+          phase: { kind: "loaded", result: loaded(3) },
+          onRetry: () => {},
+        }),
+      );
+    });
+
+    expect(el.querySelectorAll("h3").length).toBe(3);
+    expect(el.querySelector("nav")).toBeNull();
   });
 
   it("loaded with a partial degrade notes the missing feed", () => {

--- a/src/components/features/JobSearchResults.tsx
+++ b/src/components/features/JobSearchResults.tsx
@@ -11,16 +11,29 @@
  *
  * The whole region is `aria-live="polite"` so a screen reader hears
  * "N jobs found" / "search failed" without stealing focus.
+ *
+ * Paging (not capping): `searchJobs` already returns the FULL ranked set, so
+ * the old `RENDER_CAP` slice discarded results the user had already paid the
+ * fetch for and told them to narrow the query instead — the wrong instruction,
+ * since narrowing cannot surface match #21. The list is cut into pages of
+ * `PAGE_SIZE` and every match is reachable. Nothing here fetches, so a page
+ * change is pure render work.
+ *
+ * The page resets whenever the identity of the result set changes (a fresh
+ * Search, or #568's live re-rank), otherwise page 3 of an old 80-match set
+ * would silently show page 3 of a new 25-match one — or nothing at all.
  */
 
-import { Button, ErrorState, StatusBadge } from "@design-system";
+import { useEffect, useRef, useState } from "react";
+import { Button, ErrorState, Pagination, StatusBadge } from "@design-system";
 import { JobResultCard } from "./JobResultCard.tsx";
 import { WeakMatchesSection } from "./WeakMatchesSection.tsx";
 import { isWeakMatch } from "./weakMatchThreshold.ts";
 import type { JobSearchResult } from "../../lib/job-search/search.ts";
 
-/** Cap on rendered cards — the sample is a taster, not a firehose (spec §4). */
-const RENDER_CAP = 20;
+/** Cards per page. Matches the pre-paging render cap, so a first screenful of
+ *  results is unchanged — what changed is that page 2 now exists. */
+const PAGE_SIZE = 20;
 
 export type SearchPhase =
   | { kind: "idle" }
@@ -30,7 +43,8 @@ export type SearchPhase =
 
 const SAMPLE_LABEL =
   "These come from a few free, keyless job feeds that skew remote and tech — " +
-  "a sample, not every job. Use the external board links above for broader coverage.";
+  "a sample, not every job. Use the external board links in the search details " +
+  "for broader coverage.";
 
 export function JobSearchResults({
   phase,
@@ -88,6 +102,35 @@ function Loaded({
   onRetry: () => void;
 }) {
   const { jobs, degradedProviders, providerCount, excludeSuppressed, roleSuppressed } = result;
+  const [page, setPage] = useState(1);
+  // Anchor for the scroll-to-top on a page change. A numbered jump replaces the
+  // whole list under a scroll position that was meaningful for the old page, so
+  // without this the user lands mid-page-4 with no idea the content moved.
+  const topRef = useRef<HTMLDivElement | null>(null);
+  const jumpedRef = useRef(false);
+
+  // A new result set (fresh fetch or live re-rank) invalidates the page index.
+  // Keyed on the array identity — `refineSearchResult` returns a new array on
+  // every re-rank, which is exactly when the ordering changed.
+  useEffect(() => {
+    setPage(1);
+  }, [jobs]);
+
+  // Scroll only for a user-driven page change, never for the reset above or the
+  // first render — yanking the viewport on a fresh Search would fight the
+  // user's own scroll into the results.
+  useEffect(() => {
+    if (!jumpedRef.current) return;
+    jumpedRef.current = false;
+    // Optional call: jsdom (and any non-browser host) does not implement
+    // scrollIntoView, and a page change must not throw in a test.
+    topRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
+  }, [page]);
+
+  const goToPage = (next: number) => {
+    jumpedRef.current = true;
+    setPage(next);
+  };
 
   // Every provider rejected → hard error (with retry). Guarded on a non-zero
   // provider count so an empty registry (possible once #320 makes the set
@@ -100,23 +143,29 @@ function Loaded({
   if (jobs.length === 0) {
     return (
       <ErrorState tone="warning">
-        No matching postings on the feeds we can search. Broaden the query above
-        or try the external board links.
+        No matching postings on the feeds we can search. Open Edit search to
+        broaden the query, or try the external board links.
       </ErrorState>
     );
   }
 
-  const shown = jobs.slice(0, RENDER_CAP);
-  // Split BENEATH the cap, not the ranking — #561's star rating is the only fit
-  // number, this just partitions the already-ranked, already-capped list on it.
-  // Never-empty-by-construction (issue 567): if every shown posting is weak,
-  // the strong list renders nothing, so the weak section is auto-expanded
+  const pageCount = Math.ceil(jobs.length / PAGE_SIZE);
+  // Clamp rather than trust `page`: the reset effect above runs AFTER this
+  // render when the result set shrinks, so for one commit `page` can point past
+  // the end and an unclamped slice would render an empty results region.
+  const current = Math.min(page, pageCount);
+  const start = (current - 1) * PAGE_SIZE;
+  const shown = jobs.slice(start, start + PAGE_SIZE);
+  // Split WITHIN the page, not across the ranking — #561's star rating is the
+  // only fit number, this just partitions the already-ranked page on it.
+  // Never-empty-by-construction (issue 567): if every posting on this page is
+  // weak, the strong list renders nothing, so the weak section is auto-expanded
   // instead of leaving the page looking result-free behind a click.
   const strong = shown.filter((job) => !isWeakMatch(job.rating));
   const weak = shown.filter((job) => isWeakMatch(job.rating));
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1.5">
+      <div ref={topRef} className="flex flex-col gap-1.5">
         <div className="flex flex-wrap items-center gap-2">
           <StatusBadge tone="info">sample</StatusBadge>
           <span className="text-xs text-content-tertiary">
@@ -133,15 +182,15 @@ function Loaded({
         {excludeSuppressed && (
           <p className="text-xs text-content-tertiary">
             Your exclude terms would have removed every match, so we skipped
-            them for this search — remove or narrow a term above to apply
-            exclusion again.
+            them for this search — open Edit search to remove or narrow a term
+            and apply exclusion again.
           </p>
         )}
         {roleSuppressed && (
           <p className="text-xs text-content-tertiary">
             Role filter skipped — it would have hidden every result, so we kept
-            them all for this search. Adjust the Role chips above to apply role
-            filtering again.
+            them all for this search. Open Edit search to adjust the Role chips
+            and apply role filtering again.
           </p>
         )}
       </div>
@@ -156,11 +205,19 @@ function Loaded({
 
       <WeakMatchesSection jobs={weak} defaultOpen={strong.length === 0} />
 
-      {jobs.length > RENDER_CAP && (
-        <p className="text-xs text-content-muted">
-          Showing the top {RENDER_CAP} of {jobs.length} matches. Narrow the query
-          above for a tighter set.
-        </p>
+      {pageCount > 1 && (
+        <div className="flex flex-col gap-2 border-t border-border-light pt-3">
+          <p className="text-xs text-content-muted">
+            Showing {start + 1}–{Math.min(start + PAGE_SIZE, jobs.length)} of{" "}
+            {jobs.length} matches, ranked by fit.
+          </p>
+          <Pagination
+            page={current}
+            pageCount={pageCount}
+            onPageChange={goToPage}
+            label="Job matches"
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/features/PendingCompaniesNotice.tsx
+++ b/src/components/features/PendingCompaniesNotice.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * PendingCompaniesNotice — "you selected companies these results don't include".
+ *
+ * Removing a company target updates the results live (`useJobSearch` filters the
+ * snapshot), but ADDING one can't: the last fetch has none of that board's
+ * postings. Two ways to resolve that gap, and this is the honest one — say the
+ * results are behind the selection and offer the fetch — rather than either
+ * silently refetching on a checkbox click (the panel promises keywords leave only
+ * on a Search click) or leaving the user to guess why the new company produced
+ * nothing.
+ *
+ * Names the companies instead of counting them: "Ramp, Vanta" tells the user
+ * whether the pending set is the one they just clicked, which "+2 companies"
+ * doesn't. The list is bounded by the company picker itself (14, `COMPANY_LIMIT`).
+ *
+ * Rendered only over an existing result set — before the first search EVERY
+ * selected company is unsearched, which is not news.
+ */
+
+import { Button, StatusBadge } from "@design-system";
+import type { CompanyEntry } from "../../lib/job-search/company-registry.ts";
+
+export function PendingCompaniesNotice({
+  companies,
+  onSearch,
+  isUpdating,
+}: {
+  companies: readonly CompanyEntry[];
+  onSearch: () => void;
+  /** True while the incremental fetch runs — the results below stay visible. */
+  isUpdating: boolean;
+}) {
+  if (companies.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-border-light bg-surface-subtle px-3 py-2">
+      <StatusBadge tone="info">not searched yet</StatusBadge>
+      <p className="min-w-0 text-xs text-content-secondary">
+        These results don&apos;t include{" "}
+        {companies.map((entry) => entry.name).join(", ")}.
+      </p>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="ml-auto"
+        onClick={onSearch}
+        disabled={isUpdating}
+      >
+        {isUpdating ? "Adding…" : "Add to results"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -4,7 +4,7 @@
 import { useState } from "react";
 import { Card, Tabs, TabList, Tab, TabPanel } from "@design-system";
 import { ReconstructedResume } from "./ReconstructedResume.tsx";
-import { FindJobsPanel } from "./FindJobsPanel.tsx";
+import { FindJobsLauncher } from "./FindJobsLauncher.tsx";
 import { ResumeQualityPanel } from "./ResumeQualityPanel.tsx";
 import { SourceDiagnosticsPanel } from "./SourceDiagnosticsPanel.tsx";
 import { WebGpuUnavailableNotice } from "./WebGpuUnavailableNotice.tsx";
@@ -114,16 +114,12 @@ export function ResultDetailTabs({
             />
           </TabPanel>
           <TabPanel id="find-jobs">
-            {/* Key on parse identity so the LLM escape hatch (activeResult !==
-                result) remounts the panel and reseeds its once-seeded local
-                query from the recovered parse. Without this the panel keeps the
-                garbage-derived query while runSearch ranks against the fresh
-                parse — result set and fit scores would answer different
-                questions (PR #337 review). */}
-            <FindJobsPanel
-              key={activeResult === result ? "heuristic" : "recovered"}
-              parsed={activeResult.canonical.fields}
-            />
+            {/* The search itself lives on `/jobs/` now; this tab hands the
+                parse over and navigates (see FindJobsLauncher). The launcher
+                derives its preview query from `parsed` on every change, so the
+                PR #337 remount key is no longer needed — a recovered parse
+                cannot leave a stale query behind here. */}
+            <FindJobsLauncher parsed={activeResult.canonical.fields} />
           </TabPanel>
           {showQualityTab && (
             <TabPanel id="quality">

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -25,6 +25,7 @@ export * from "./shared/CapabilityStrip.tsx";
 export * from "./shared/Card.tsx";
 export * from "./shared/InlineResult.tsx";
 export * from "./shared/ModelLoadProgress.tsx";
+export * from "./shared/Pagination.tsx";
 export * from "./shared/StatusBadge.tsx";
 export * from "./shared/Tabs.tsx";
 export * from "./shared/CountBadge.tsx";

--- a/src/design-system/shared/Pagination.test.ts
+++ b/src/design-system/shared/Pagination.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit coverage for `pageWindow` — the only logic in Pagination. Asserts the
+ * two properties the control depends on rather than exact strips for their own
+ * sake: first and last are ALWAYS reachable, and the rendered slot count stays
+ * bounded no matter how many pages exist. Rendering is covered through
+ * `JobSearchResults.test.tsx`, its only consumer.
+ */
+
+import { describe, it, expect } from "vitest";
+import { pageWindow } from "./Pagination.tsx";
+
+describe("pageWindow", () => {
+  it("lists every page, gap-free, for a short set", () => {
+    expect(pageWindow(1, 1)).toEqual([1]);
+    expect(pageWindow(2, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(pageWindow(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("elides on the right when the current page is near the start", () => {
+    expect(pageWindow(1, 20)).toEqual([1, 2, 3, 4, 5, 6, null, 20]);
+  });
+
+  it("elides on the left when the current page is near the end", () => {
+    expect(pageWindow(20, 20)).toEqual([1, null, 15, 16, 17, 18, 19, 20]);
+  });
+
+  it("elides on both sides and centres the window mid-set", () => {
+    expect(pageWindow(10, 20)).toEqual([1, null, 8, 9, 10, 11, 12, null, 20]);
+  });
+
+  it("always keeps first, last, and the current page reachable", () => {
+    for (const pageCount of [1, 2, 6, 7, 8, 9, 40, 500]) {
+      // Only in-range pages: the caller clamps `page` to [1, pageCount] before
+      // rendering, so an out-of-range index is not a contract this must honour.
+      const pages = [1, 2, Math.ceil(pageCount / 2), pageCount].filter(
+        (p) => p <= pageCount,
+      );
+      for (const page of pages) {
+        const slots = pageWindow(page, pageCount);
+        expect(slots).toContain(1);
+        expect(slots).toContain(pageCount);
+        expect(slots).toContain(page);
+        // Bounded strip: 5 windowed slots + first + last + up to 2 ellipses.
+        expect(slots.length).toBeLessThanOrEqual(9);
+        // Strictly ascending page numbers — no duplicate or out-of-order slot.
+        const numbers = slots.filter((s): s is number => s !== null);
+        expect([...numbers].sort((a, b) => a - b)).toEqual(numbers);
+        expect(new Set(numbers).size).toBe(numbers.length);
+      }
+    }
+  });
+});

--- a/src/design-system/shared/Pagination.tsx
+++ b/src/design-system/shared/Pagination.tsx
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Pagination — numbered page control for a long, already-materialised list.
+ *
+ * Domain-agnostic and display-only: it owns no page state. The caller holds
+ * `page` and slices its own data, so the same control drives a client-side
+ * slice (job search) or, later, a fetch-per-page list without changing shape.
+ *
+ * Lives in `shared/` rather than a feature folder because "cut a list into
+ * pages" is not job-search-specific, and the repo's rule is one component per
+ * concern — a second hand-rolled Prev/Next row in another feature would be the
+ * duplication CLAUDE.md's Golden Rule forbids.
+ *
+ * Windowing: the number strip is bounded to `WINDOW` slots so a 40-page set
+ * doesn't render 40 buttons. First and last are always reachable; an elided
+ * run renders as a non-interactive ellipsis (`aria-hidden`, since the adjacent
+ * numbers already describe the jump). Screen readers get the authoritative
+ * "Page N of M" from the nav's own label, not from the ellipsis.
+ *
+ * Pages are 1-indexed here — it is user-facing text as much as an index, and
+ * a 0-indexed `page` that renders as `page + 1` invites the off-by-one at
+ * every callsite.
+ */
+
+import { Button } from "../primitives/Button.tsx";
+
+/** Numbered slots rendered at once, excluding Prev/Next. Odd, so the current
+ *  page sits centred when it is not near either end. */
+const WINDOW = 5;
+
+/**
+ * The page numbers to render, in order, with `null` marking an elided run.
+ * Exported for direct unit testing — the windowing is the only logic here and
+ * asserting it through the DOM would test React, not the algorithm.
+ */
+export function pageWindow(page: number, pageCount: number): (number | null)[] {
+  if (pageCount <= WINDOW + 2) {
+    return Array.from({ length: pageCount }, (_, i) => i + 1);
+  }
+  // Centre the window on `page`, then clamp it inside [2, pageCount - 1] so
+  // first/last always render as their own explicit slots.
+  const half = Math.floor(WINDOW / 2);
+  let start = Math.max(2, page - half);
+  let end = Math.min(pageCount - 1, start + WINDOW - 1);
+  start = Math.max(2, end - WINDOW + 1);
+  if (end < start) end = start;
+
+  const slots: (number | null)[] = [1];
+  if (start > 2) slots.push(null);
+  for (let p = start; p <= end; p += 1) slots.push(p);
+  if (end < pageCount - 1) slots.push(null);
+  slots.push(pageCount);
+  return slots;
+}
+
+export function Pagination({
+  page,
+  pageCount,
+  onPageChange,
+  label = "Results",
+}: {
+  /** Current page, 1-indexed. */
+  page: number;
+  /** Total pages. The control renders nothing when this is 1 or less. */
+  pageCount: number;
+  onPageChange: (page: number) => void;
+  /** Names what is being paged, for the nav's accessible label. */
+  label?: string;
+}) {
+  if (pageCount <= 1) return null;
+
+  return (
+    <nav
+      aria-label={`${label} pagination — page ${page} of ${pageCount}`}
+      className="flex flex-wrap items-center gap-1"
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        <span aria-hidden="true">‹</span> Prev
+      </Button>
+      {pageWindow(page, pageCount).map((slot, i) =>
+        slot === null ? (
+          <span
+            // Slot index is the only stable key for an ellipsis — there can be
+            // one on each side and neither carries a page number.
+            key={`gap-${i}`}
+            aria-hidden="true"
+            className="px-1 text-xs text-content-muted"
+          >
+            …
+          </span>
+        ) : (
+          <Button
+            key={slot}
+            variant={slot === page ? "primary" : "ghost"}
+            size="sm"
+            aria-label={`Page ${slot}`}
+            aria-current={slot === page ? "page" : undefined}
+            onClick={() => onPageChange(slot)}
+          >
+            {slot}
+          </Button>
+        ),
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={page >= pageCount}
+        onClick={() => onPageChange(page + 1)}
+      >
+        Next <span aria-hidden="true">›</span>
+      </Button>
+    </nav>
+  );
+}

--- a/src/hooks/useJobSearch.test.tsx
+++ b/src/hooks/useJobSearch.test.tsx
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The asymmetric company selector. What matters is the asymmetry itself:
+ * removing a company must NOT refetch, and adding one must fetch exactly the
+ * added board — not the whole fan-out — and only when asked.
+ *
+ * `searchJobs`/`searchCompanyBoards` are mocked; `refineSearchResult` is the real
+ * module, so the ranked counts asserted here come from the same pipeline the app
+ * runs.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useJobSearch } from "./useJobSearch.ts";
+import type { CompanyEntry } from "../lib/job-search/company-registry.ts";
+import type { JobPosting } from "../lib/job-search/types.ts";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { JobQuery } from "../lib/job-search/query-builder.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function posting(id: string, title: string, company: string): JobPosting {
+  return {
+    id,
+    title,
+    company,
+    location: "Remote",
+    url: "https://example.com/job",
+    description: `${title} — build and operate services.`,
+    source: company,
+  };
+}
+
+const FEED_JOB = posting("remotive:1", "Platform Engineer", "Globex");
+const ACME_JOB = posting("greenhouse:acme:9", "Platform Engineer", "Acme");
+const RAMP_JOB = posting("lever:ramp:4", "Platform Engineer", "Ramp");
+
+const searchJobs = vi.fn();
+const searchCompanyBoards = vi.fn();
+
+vi.mock("../lib/job-search/search.ts", () => ({
+  searchJobs: (...args: unknown[]) => searchJobs(...args),
+  searchCompanyBoards: (...args: unknown[]) => searchCompanyBoards(...args),
+}));
+
+const ACME: CompanyEntry = {
+  name: "Acme",
+  ats: "greenhouse",
+  slug: "acme",
+  sectors: ["fintech"],
+};
+const RAMP: CompanyEntry = {
+  name: "Ramp",
+  ats: "lever",
+  slug: "ramp",
+  sectors: ["fintech"],
+};
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  skills: ["kubernetes", "go"],
+  experience: [{ company: "Initech", title: "Platform Engineer" }],
+  education: [],
+};
+const query: JobQuery = { titles: ["Platform Engineer"], skills: ["go"] };
+
+type Hook = ReturnType<typeof useJobSearch>;
+let latest: Hook;
+
+function Harness({ companies }: { companies: readonly CompanyEntry[] }) {
+  latest = useJobSearch(query, parsed, companies);
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(companies: readonly CompanyEntry[]) {
+  container = document.createElement("div");
+  root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(Harness, { companies }));
+  });
+}
+
+async function rerender(companies: readonly CompanyEntry[]) {
+  await act(async () => {
+    root.render(createElement(Harness, { companies }));
+  });
+  await flush();
+}
+
+/**
+ * Let the re-rank settle. `refineSearchResult` dynamic-imports `rank.ts`, so the
+ * chain is `setPhase` behind a module resolution behind a promise — a microtask
+ * flush alone leaves the pre-re-rank phase in place, which reads as "the effect
+ * never ran" rather than as a timing miss. Several macrotasks because the FIRST
+ * test to reach the real `rank.ts` pays an uncached resolution that later ones
+ * don't; without this the suite passes or fails by test order.
+ */
+async function flush() {
+  for (let i = 0; i < 5; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+// `refineSearchResult` reaches the ranking tier through a dynamic import, and
+// the FIRST resolution costs real transform time — more than any bounded tick
+// loop will wait. Warming the module here makes every in-test import a cache
+// hit, so `flush()` only has to drain promises. Without it the suite passes or
+// fails by test order: whichever test paid the cold import loses.
+beforeAll(async () => {
+  await import("../lib/job-search/rank.ts");
+});
+
+beforeEach(() => {
+  searchJobs.mockReset();
+  searchCompanyBoards.mockReset();
+  searchJobs.mockResolvedValue({
+    // The mock stands in for the real fan-out, so its `jobs` are the ranked
+    // form of its own `rawPostings` — only `.posting` is read here.
+    jobs: [{ posting: FEED_JOB }, { posting: ACME_JOB }],
+    degradedProviders: [],
+    providerCount: 4,
+    excludeSuppressed: false,
+    roleSuppressed: false,
+    rawPostings: [FEED_JOB, ACME_JOB],
+  });
+  searchCompanyBoards.mockResolvedValue({
+    postings: [RAMP_JOB],
+    degradedProviders: [],
+    providerCount: 1,
+  });
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+});
+
+function loadedCompanies(): string[] {
+  if (latest.phase.kind !== "loaded") throw new Error("not loaded");
+  return latest.phase.result.jobs.map((job) => job.posting.company);
+}
+
+describe("useJobSearch — company selection", () => {
+  it("ranks the fetched snapshot and reports nothing pending", async () => {
+    await render([ACME]);
+    await act(async () => latest.runSearch());
+    await flush();
+    expect(loadedCompanies()).toEqual(expect.arrayContaining(["Globex", "Acme"]));
+    expect(latest.pendingCompanies).toEqual([]);
+  });
+
+  it("drops a deselected company's postings WITHOUT refetching", async () => {
+    await render([ACME]);
+    await act(async () => latest.runSearch());
+    await flush();
+    expect(searchJobs).toHaveBeenCalledTimes(1);
+
+    await rerender([]);
+    expect(loadedCompanies()).toEqual(["Globex"]);
+    // The whole point: local set arithmetic, no network.
+    expect(searchJobs).toHaveBeenCalledTimes(1);
+    expect(searchCompanyBoards).not.toHaveBeenCalled();
+  });
+
+  it("reports a newly selected company as pending and does not fetch it yet", async () => {
+    await render([ACME]);
+    await act(async () => latest.runSearch());
+    await flush();
+
+    await rerender([ACME, RAMP]);
+    expect(latest.pendingCompanies.map((c) => c.name)).toEqual(["Ramp"]);
+    // A checkbox is not a Search click.
+    expect(searchCompanyBoards).not.toHaveBeenCalled();
+    expect(loadedCompanies()).not.toContain("Ramp");
+  });
+
+  it("fetches ONLY the pending board on request and merges it in", async () => {
+    await render([ACME]);
+    await act(async () => latest.runSearch());
+    await flush();
+    await rerender([ACME, RAMP]);
+
+    await act(async () => latest.searchPendingCompanies());
+    await flush();
+
+    expect(searchCompanyBoards).toHaveBeenCalledTimes(1);
+    // Fourth argument is the company list — just the addition, not the selection.
+    expect(searchCompanyBoards.mock.calls[0][3]).toEqual([RAMP]);
+    // Still one full search: the keyless feeds were never refetched.
+    expect(searchJobs).toHaveBeenCalledTimes(1);
+    expect(loadedCompanies()).toContain("Ramp");
+    expect(latest.pendingCompanies).toEqual([]);
+  });
+
+  it("keeps the existing results when the incremental fetch fails", async () => {
+    await render([ACME]);
+    await act(async () => latest.runSearch());
+    await flush();
+    await rerender([ACME, RAMP]);
+    searchCompanyBoards.mockRejectedValue(new Error("board down"));
+
+    await act(async () => latest.searchPendingCompanies());
+    await flush();
+
+    expect(loadedCompanies()).toEqual(expect.arrayContaining(["Globex", "Acme"]));
+    expect(latest.isUpdating).toBe(false);
+  });
+
+  it("re-adding a deselected company needs a fetch, since its postings are gone", async () => {
+    await render([ACME]);
+    await act(async () => latest.runSearch());
+    await flush();
+    await rerender([]);
+    expect(loadedCompanies()).toEqual(["Globex"]);
+
+    await rerender([ACME]);
+    expect(latest.pendingCompanies.map((c) => c.name)).toEqual(["Acme"]);
+  });
+});

--- a/src/hooks/useJobSearch.ts
+++ b/src/hooks/useJobSearch.ts
@@ -7,13 +7,13 @@
  * CLAUDE.md's "hooks own modals/drop zones/locks" rule — this is the same
  * shape (a fetch + a derived recompute), just for the search panel.
  *
- * TWO responsibilities, one hook, because they share state a split would
+ * THREE responsibilities, one hook, because they share state a split would
  * have to duplicate (the abort controller, the raw-postings snapshot):
  *
- * 1. `runSearch` — the ONLY thing that fetches. Never fires on mount, drop,
- *    tab open, or a query edit — only an explicit caller invocation (the
- *    panel's Search button). `searchJobs` dynamic-imports the provider/rank
- *    tiers, so nothing job-fetch-related sits in the entry chunk.
+ * 1. `runSearch` — the full fan-out. Never fires on mount, drop, tab open, or a
+ *    query edit — only an explicit caller invocation (the panel's Search
+ *    button). `searchJobs` dynamic-imports the provider/rank tiers, so nothing
+ *    job-fetch-related sits in the entry chunk.
  * 2. The live re-rank effect (#568) — re-runs `refineSearchResult` (the SAME
  *    role/exclude filter + rank pipeline `searchJobs` used) over the last
  *    fetch's raw postings whenever a refinement control changes, with NO new
@@ -23,6 +23,23 @@
  *    location); a titles/skills edit still requires a fresh Search, since
  *    `matchesQuery` already ran against the OLD titles/skills when the
  *    snapshot was taken.
+ * 3. The company selection, which is deliberately ASYMMETRIC because the two
+ *    directions are not the same kind of operation:
+ *
+ *     - **Deselecting** is local set arithmetic over the snapshot
+ *       (`dropCompanyPostings`) and re-ranks live, no fetch, no button. Making
+ *       the user click Search to remove rows we can already identify would be
+ *       asking them to pay for nothing.
+ *     - **Selecting** a company that wasn't in the last fetch cannot be served
+ *       locally — the snapshot contains none of its postings. Rather than
+ *       silently refetching (the panel promises keywords leave "only when you
+ *       click Search", and a checkbox is not that click), the addition is
+ *       reported as `pendingCompanies` for the UI to offer, and
+ *       `searchPendingCompanies` fetches JUST those boards and merges them in.
+ *       One board, usually an IndexedDB cache hit — not the whole fan-out.
+ *
+ *    `fetchedCompanyKeys` is state, not a ref, precisely because the pending
+ *    count is rendered.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -31,6 +48,11 @@ import type { JobQuery } from "../lib/job-search/query-builder.ts";
 import type { JobPosting } from "../lib/job-search/types.ts";
 import type { CompanyEntry } from "../lib/job-search/company-registry.ts";
 import { refineSearchResult } from "../lib/job-search/refine.ts";
+import {
+  dropCompanyPostings,
+  mergeRawPostings,
+} from "../lib/job-search/raw-postings.ts";
+import { companyKey } from "./useCompanyTargets.ts";
 import type { SearchPhase } from "../components/features/JobSearchResults.tsx";
 
 interface RawFetchSnapshot {
@@ -45,13 +67,24 @@ export function useJobSearch(
   selectedCompanies: readonly CompanyEntry[],
 ) {
   const [phase, setPhase] = useState<SearchPhase>({ kind: "idle" });
+  const [isUpdating, setIsUpdating] = useState(false);
+  /** Company keys whose boards are IN the current snapshot. */
+  const [fetchedCompanyKeys, setFetchedCompanyKeys] = useState<readonly string[]>(
+    [],
+  );
   const abortRef = useRef<AbortController | null>(null);
   // Snapshot of the last fetch's raw (deduped, matchesQuery-filtered but not
   // yet role/exclude-filtered or ranked) postings — kept OUTSIDE `phase` so
   // the re-rank effect below doesn't feed back into its own trigger.
-  // `undefined` until the first successful search; the effect is a no-op
+  // `undefined` until the first successful search; the effects are a no-op
   // until then.
   const rawFetchRef = useRef<RawFetchSnapshot | undefined>(undefined);
+  // Latest query/parsed for the deselect effect, which is keyed on the company
+  // selection alone and would otherwise re-rank against a stale query.
+  const queryRef = useRef(query);
+  queryRef.current = query;
+  const parsedRef = useRef(parsed);
+  parsedRef.current = parsed;
 
   // Abort any in-flight search on unmount so a late response can't try to
   // update state on an unmounted component.
@@ -63,6 +96,8 @@ export function useJobSearch(
     const ctrl = new AbortController();
     abortRef.current = ctrl;
     setPhase({ kind: "loading" });
+    setIsUpdating(false);
+    const companyKeys = selectedCompanies.map(companyKey);
     void (async () => {
       try {
         const { searchJobs } = await import("../lib/job-search/search.ts");
@@ -73,6 +108,7 @@ export function useJobSearch(
           degradedProviders: result.degradedProviders,
           providerCount: result.providerCount,
         };
+        setFetchedCompanyKeys(companyKeys);
         setPhase({ kind: "loaded", result });
       } catch {
         if (ctrl.signal.aborted) return;
@@ -80,6 +116,114 @@ export function useJobSearch(
       }
     })();
   };
+
+  /** Selected companies whose boards are NOT in the snapshot yet. */
+  const pendingCompanies = selectedCompanies.filter(
+    (entry) => !fetchedCompanyKeys.includes(companyKey(entry)),
+  );
+
+  /**
+   * Fetch only `pendingCompanies` and merge them into the snapshot. Keeps the
+   * current results on screen while it runs (`isUpdating`) rather than dropping
+   * to the loading skeleton — this adds to a result set the user is reading, so
+   * blanking it would be a bigger interruption than the wait.
+   */
+  const searchPendingCompanies = () => {
+    const snapshot = rawFetchRef.current;
+    if (!snapshot || pendingCompanies.length === 0) return;
+    const additions = pendingCompanies;
+    const addedKeys = additions.map(companyKey);
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setIsUpdating(true);
+    void (async () => {
+      try {
+        const { searchCompanyBoards } = await import("../lib/job-search/search.ts");
+        const added = await searchCompanyBoards(
+          queryRef.current,
+          parsedRef.current,
+          ctrl.signal,
+          additions,
+        );
+        if (ctrl.signal.aborted) return;
+        const next: RawFetchSnapshot = {
+          raw: mergeRawPostings(snapshot.raw, added.postings),
+          degradedProviders: [
+            ...snapshot.degradedProviders,
+            ...added.degradedProviders,
+          ],
+          providerCount: snapshot.providerCount + added.providerCount,
+        };
+        rawFetchRef.current = next;
+        // Recorded even for a board that failed: the user asked for it and we
+        // tried, so it must leave the pending list — otherwise the "not searched
+        // yet" prompt reappears forever on a board that will keep failing. The
+        // failure is already visible in the degraded-providers notice.
+        setFetchedCompanyKeys((current) => [...current, ...addedKeys]);
+        const result = await refineSearchResult(
+          next.raw,
+          parsedRef.current,
+          queryRef.current,
+          next.degradedProviders,
+          next.providerCount,
+        );
+        if (ctrl.signal.aborted) return;
+        setPhase({ kind: "loaded", result });
+      } catch {
+        // The incremental fetch is additive: on failure the existing results
+        // stay exactly as they were, which is strictly better than replacing a
+        // readable list with an error state.
+      } finally {
+        if (!ctrl.signal.aborted) setIsUpdating(false);
+      }
+    })();
+  };
+
+  // Deselection → drop that company's postings and re-rank locally. Keyed on a
+  // joined key list rather than the array (a new array identity every render).
+  // Additions are NOT handled here on purpose — they need a fetch, which is
+  // `searchPendingCompanies`'s job.
+  const selectedKeyList = selectedCompanies.map(companyKey).join(" ");
+  useEffect(() => {
+    const snapshot = rawFetchRef.current;
+    if (!snapshot) return;
+    const selected = new Set(
+      selectedKeyList === "" ? [] : selectedKeyList.split(" "),
+    );
+    const removed = fetchedCompanyKeys.filter((key) => !selected.has(key));
+    if (removed.length === 0) return;
+    // `providerCount` and `degradedProviders` are left alone: they are the
+    // denominator and labels of what was ATTEMPTED, and a removed board was
+    // still attempted. Shrinking the denominator here could flip a partially
+    // degraded search into the "every provider failed" hard error.
+    const next: RawFetchSnapshot = {
+      ...snapshot,
+      raw: dropCompanyPostings(snapshot.raw, removed),
+    };
+    rawFetchRef.current = next;
+    setFetchedCompanyKeys((current) =>
+      current.filter((key) => selected.has(key)),
+    );
+    let cancelled = false;
+    void (async () => {
+      const result = await refineSearchResult(
+        next.raw,
+        parsedRef.current,
+        queryRef.current,
+        next.degradedProviders,
+        next.providerCount,
+      );
+      if (!cancelled) setPhase({ kind: "loaded", result });
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // `exhaustive-deps` is NOT lint-enforced here (no react-hooks plugin).
+    // Deliberately keyed on the selection only: `fetchedCompanyKeys` is read,
+    // not watched — this effect is the only thing that shrinks it, so adding it
+    // would re-fire the effect on its own write for no new work.
+  }, [selectedKeyList]);
 
   useEffect(() => {
     const snapshot = rawFetchRef.current;
@@ -104,5 +248,14 @@ export function useJobSearch(
     // (stable per panel mount — the résumé isn't edited from here).
   }, [query.families, query.excludeTerms, query.seniority, query.compFloor, query.location]);
 
-  return { phase, runSearch, isLoading: phase.kind === "loading" };
+  return {
+    phase,
+    runSearch,
+    isLoading: phase.kind === "loading",
+    /** Selected companies not yet represented in the results, if any. */
+    pendingCompanies,
+    searchPendingCompanies,
+    /** True while an incremental company fetch is in flight. */
+    isUpdating,
+  };
 }

--- a/src/jobs/JobsApp.tsx
+++ b/src/jobs/JobsApp.tsx
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobsApp — the `/jobs` root surface: the job-search workbench.
+ *
+ * Third entry beside `/` (parser audit) and `/jd-fit` (JD match). It exists so
+ * a ranked posting list has a URL of its own, its own scroll, and the full page
+ * width — rather than being the tail of the parser page, below the fold, capped
+ * at a screenful.
+ *
+ * Résumé source: the sessionStorage handoff written by `FindJobsLauncher` on `/`
+ * (`lib/jobs-handoff.ts`). Unlike `/jd-fit`, this surface has NO DropZone of its
+ * own — the job-search lane consumes a parsed résumé, and the parse pipeline
+ * (with its cascade, score, and edit layer) is `/`'s job. Adding a second parse
+ * entry point here would be the parallel surface CLAUDE.md's Reuse Gate exists
+ * to prevent. With no handoff, this renders a pointer back to `/`.
+ *
+ * Because the handoff is read but not consumed, a reload of `/jobs` keeps
+ * working — see the handoff module for why that differs from `/jd-fit`.
+ *
+ * Shares chrome with the other surfaces via <PageShell>; no PDF bytes and no
+ * résumé text reach this page's network calls (only query keywords do, on an
+ * explicit Search — see `lib/job-search/providers/keywords.ts`).
+ */
+
+import { useState } from "react";
+import { Button, ErrorState } from "@design-system";
+import { PageShell } from "../components/features/PageShell.tsx";
+import { FindJobsPanel } from "../components/features/FindJobsPanel.tsx";
+import { readJobsHandoff } from "../lib/jobs-handoff.ts";
+
+function backToResume() {
+  window.location.href = import.meta.env.BASE_URL;
+}
+
+export default function JobsApp() {
+  // Read once, on first render (lazy initializer): the payload is inert JSON and
+  // the read is non-destructive, so there is no StrictMode double-invoke hazard
+  // of the kind `useJdFitResume` needs a ref for.
+  const [handoff] = useState(() => readJobsHandoff());
+
+  return (
+    <PageShell
+      subtitle="Find jobs that fit your resume"
+      badge="Jobs"
+      headerExtra={
+        <Button variant="link" size="sm" onClick={backToResume}>
+          <span aria-hidden="true">‹</span> Back to your resume
+        </Button>
+      }
+    >
+      {handoff === null ? (
+        <div className="flex flex-col items-start gap-3">
+          <ErrorState tone="warning">
+            No resume loaded in this tab. The job search ranks postings against
+            your parsed resume, so start on the main page — drop your PDF there,
+            then open the job workbench from the Find jobs tab.
+          </ErrorState>
+          <Button variant="primary" size="md" onClick={backToResume}>
+            Go to your resume
+          </Button>
+        </div>
+      ) : (
+        <FindJobsPanel parsed={handoff.parsed} />
+      )}
+    </PageShell>
+  );
+}

--- a/src/jobs/main.tsx
+++ b/src/jobs/main.tsx
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import JobsApp from "./JobsApp.tsx";
+import { initAnalytics, setAnalyticsSurface } from "../lib/analytics";
+import "@fontsource/poppins/400.css";
+import "@fontsource/poppins/500.css";
+import "@fontsource/poppins/600.css";
+import "@fontsource/poppins/700.css";
+import "../styles.css";
+
+// No pdfjs worker configuration here (unlike src/main.tsx and jd-fit/main.tsx):
+// this surface never parses a PDF — it receives an already-parsed résumé through
+// the sessionStorage handoff — so importing pdfjs would pull a large chunk into
+// the entry for nothing.
+setAnalyticsSurface("jobs");
+void initAnalytics();
+
+// Stale-deploy safety net (mirrors src/main.tsx). A tab loaded before a deploy
+// holds the old jobs/index.html, whose hashed tier chunks are gone after the site
+// snapshot is replaced. The failing import fires `vite:preloadError`; reload
+// pulls the fresh build. The sessionStorage guard prevents a reload loop.
+window.addEventListener("vite:preloadError", () => {
+  if (sessionStorage.getItem("vite-preload-reloaded")) return;
+  sessionStorage.setItem("vite-preload-reloaded", "1");
+  window.location.reload();
+});
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("#root not found");
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <JobsApp />
+  </StrictMode>,
+);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -25,13 +25,13 @@ const queue: Array<[string, Record<string, unknown>]> = [];
 /**
  * Which root surface emitted an event (#226 / #52). `/` (main.tsx) is the
  * parser audit; `/jd-fit` (jd-fit/main.tsx) is the JD-match + JD-driven rewrite
- * surface. Each entry calls `setAnalyticsSurface` once at boot; every `track()`
- * stamps the value so the two products are distinguishable in PostHog without a
- * whole event-category system. Defaults to "parser" so an un-tagged caller (or
+ * surface; `/jobs` (jobs/main.tsx) is the job-search workbench. Each entry calls
+ * `setAnalyticsSurface` once at boot; every `track()` stamps the value so the
+ * surfaces are distinguishable in PostHog without a whole event-category system. Defaults to "parser" so an un-tagged caller (or
  * a test) attributes to the original surface. Dead-code-safe: when
  * VITE_POSTHOG_KEY is unset, `track()` short-circuits before reading this.
  */
-export type AnalyticsSurface = "parser" | "jd-fit";
+export type AnalyticsSurface = "parser" | "jd-fit" | "jobs";
 let surface: AnalyticsSurface = "parser";
 
 /** Tag every subsequent event with the emitting surface. Call once at boot. */

--- a/src/lib/job-search/CLAUDE.md
+++ b/src/lib/job-search/CLAUDE.md
@@ -1,9 +1,11 @@
 # CLAUDE.md — job-search lane
 
-Query builder → provider search → rank by resume fit → deep links. Rides inside the
-main page (`FindJobsPanel`), not a separate HTML entry. Consumes the parsed resume,
-never the raw PDF. Read the root `CLAUDE.md` first; this file adds only the
-lane-specific rules that are silent to break.
+Query builder → provider search → rank by resume fit → deep links. Owns its own HTML
+entry, `/jobs/` (`jobs/index.html` → `src/jobs/JobsApp.tsx` → `FindJobsPanel`); `/`
+keeps only `FindJobsLauncher`, which hands the parse over through
+`src/lib/jobs-handoff.ts`. Consumes the parsed resume, never the raw PDF — this
+surface cannot parse a PDF at all. Read the root `CLAUDE.md` first; this file adds
+only the lane-specific rules that are silent to break.
 
 ## Privacy invariant (hard)
 

--- a/src/lib/job-search/raw-postings.test.ts
+++ b/src/lib/job-search/raw-postings.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The snapshot arithmetic behind the asymmetric company selector: removing a
+ * company target must be free and exact, and adding one must not duplicate a
+ * posting the original fan-out already admitted.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  dedupKey,
+  dropCompanyPostings,
+  mergeRawPostings,
+} from "./raw-postings.ts";
+import type { JobPosting } from "./types.ts";
+
+function posting(id: string, title: string, company: string): JobPosting {
+  return {
+    id,
+    title,
+    company,
+    location: "Remote",
+    url: "https://example.com/job",
+    description: "",
+    source: id.split(":")[0],
+  };
+}
+
+describe("dedupKey", () => {
+  it("collapses case and whitespace differences between feeds", () => {
+    expect(dedupKey(posting("a:1", "Staff  Engineer ", "Acme"))).toBe(
+      dedupKey(posting("b:2", "staff engineer", "acme")),
+    );
+  });
+
+  it("normalizes the fields independently, so the join can't shift", () => {
+    // "ab" + "" must not collide with "a" + "b".
+    expect(dedupKey(posting("a:1", "ab", ""))).not.toBe(
+      dedupKey(posting("a:2", "a", "b")),
+    );
+  });
+});
+
+describe("mergeRawPostings", () => {
+  it("appends only the postings that are new", () => {
+    const existing = [posting("remotive:1", "SRE", "Acme")];
+    const merged = mergeRawPostings(existing, [
+      posting("greenhouse:acme:9", "sre", "ACME"),
+      posting("greenhouse:acme:10", "Platform Engineer", "Acme"),
+    ]);
+    expect(merged.map((p) => p.id)).toEqual([
+      "remotive:1",
+      "greenhouse:acme:10",
+    ]);
+  });
+
+  it("keeps the existing copy of a duplicate, not the incoming one", () => {
+    // The existing copy may already be hydrated and already ranked on screen.
+    const existing = [
+      { ...posting("remotive:1", "SRE", "Acme"), description: "hydrated" },
+    ];
+    const merged = mergeRawPostings(existing, [posting("lever:acme:2", "SRE", "Acme")]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].description).toBe("hydrated");
+  });
+
+  it("dedups within the incoming batch too", () => {
+    const merged = mergeRawPostings([], [
+      posting("greenhouse:a:1", "SRE", "Acme"),
+      posting("greenhouse:b:1", "SRE", "Acme"),
+    ]);
+    expect(merged).toHaveLength(1);
+  });
+
+  it("does not mutate either input", () => {
+    const existing = [posting("remotive:1", "SRE", "Acme")];
+    mergeRawPostings(existing, [posting("lever:x:2", "PM", "Other")]);
+    expect(existing).toHaveLength(1);
+  });
+});
+
+describe("dropCompanyPostings", () => {
+  const raw = [
+    posting("remotive:1", "SRE", "Acme"),
+    posting("greenhouse:acme:9", "SRE", "Acme Corp"),
+    posting("lever:acme-labs:3", "SRE", "Acme Labs"),
+  ];
+
+  it("removes only the named company's board postings", () => {
+    expect(dropCompanyPostings(raw, ["greenhouse:acme"]).map((p) => p.id)).toEqual([
+      "remotive:1",
+      "lever:acme-labs:3",
+    ]);
+  });
+
+  it("does not let one slug strip a longer slug that starts with it", () => {
+    // The prefix must be `lever:acme:`, not `lever:acme` — otherwise
+    // deselecting `lever:acme` would silently drop `lever:acme-labs` too.
+    expect(dropCompanyPostings(raw, ["lever:acme"]).map((p) => p.id)).toContain(
+      "lever:acme-labs:3",
+    );
+  });
+
+  it("never touches keyless-feed postings", () => {
+    const kept = dropCompanyPostings(raw, [
+      "greenhouse:acme",
+      "lever:acme-labs",
+    ]);
+    expect(kept.map((p) => p.id)).toEqual(["remotive:1"]);
+  });
+
+  it("is a copy, not the same array, when nothing is removed", () => {
+    const kept = dropCompanyPostings(raw, []);
+    expect(kept).toEqual(raw);
+    expect(kept).not.toBe(raw);
+  });
+});

--- a/src/lib/job-search/raw-postings.ts
+++ b/src/lib/job-search/raw-postings.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Set operations on the raw-postings snapshot `searchJobs` returns.
+ *
+ * #568 let the refinement controls (role chips, level, excludes, comp floor,
+ * location) re-rank a result set with no refetch, because all of them are pure
+ * functions of a snapshot the last fetch already produced. The COMPANY selector
+ * is different in kind: a company that wasn't selected at fetch time has no
+ * postings in the snapshot at all, so no amount of local recomputation can
+ * conjure them. That asymmetry is what these helpers exist to serve:
+ *
+ *  - **Removing** a company is pure snapshot arithmetic and free. A board
+ *    posting's id is `{ats}:{slug}:{jobId}` (`company-boards.ts`), whose prefix
+ *    is the same `{ats}:{slug}` string `companyKey()` builds — so its postings
+ *    are identifiable without adding an attribution field to `JobPosting`.
+ *  - **Adding** one needs that board fetched, and `mergeRawPostings` is where the
+ *    result rejoins the snapshot under the SAME dedup rule the original fan-out
+ *    used. Sharing `dedupKey` with `search.ts` is the point: a second dedup
+ *    definition would let an incrementally-added board duplicate a posting the
+ *    keyless feeds already carried.
+ *
+ * Leaf module — types only, no provider/rank imports — so a caller can hold the
+ * snapshot logic without pulling the search tier into its chunk.
+ */
+
+import type { JobPosting } from "./types.ts";
+
+/** Lowercased, whitespace-collapsed — so spacing differences between feeds
+ *  don't read as two different postings. */
+function normalizeField(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Cross-provider dedup key: normalized title + company. Each field is
+ *  normalized independently, then joined, so a trailing space in one feed's
+ *  title can't shift the boundary. */
+export function dedupKey(posting: JobPosting): string {
+  return `${normalizeField(posting.title)}::${normalizeField(posting.company)}`;
+}
+
+/**
+ * `existing` plus every posting in `incoming` that isn't already present under
+ * `dedupKey`. Existing postings win: they may have been hydrated (descriptions
+ * filled in) and already carry a rank the user has seen, so replacing one with a
+ * fresh-but-equivalent row would reshuffle the list for no gain.
+ *
+ * Order is append-only for the same reason — ranking happens downstream in
+ * `refineSearchResult`, so this only has to be stable, not sorted.
+ */
+export function mergeRawPostings(
+  existing: readonly JobPosting[],
+  incoming: readonly JobPosting[],
+): JobPosting[] {
+  const seen = new Set(existing.map(dedupKey));
+  const merged = [...existing];
+  for (const posting of incoming) {
+    const key = dedupKey(posting);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(posting);
+  }
+  return merged;
+}
+
+/**
+ * `raw` without the postings that came from any of `companyKeys` (each an
+ * `{ats}:{slug}` string from `companyKey()`).
+ *
+ * Matches on the `{key}:` prefix, not `startsWith(key)`, so `lever:acme` cannot
+ * also strip `lever:acme-labs`. Keyless-feed postings are never touched: their
+ * ids are prefixed with a feed slug (`remotive:…`), which no company key equals.
+ *
+ * One deliberate consequence: when a company board and a keyless feed both
+ * carried the same posting, dedup kept whichever arrived first. If that was the
+ * board's copy, deselecting the company drops the posting even though a feed also
+ * had it. That is the honest reading of the action — the user said "don't show me
+ * this company" — and re-selecting refetches, so nothing is lost permanently.
+ */
+export function dropCompanyPostings(
+  raw: readonly JobPosting[],
+  companyKeys: readonly string[],
+): JobPosting[] {
+  if (companyKeys.length === 0) return [...raw];
+  const prefixes = companyKeys.map((key) => `${key}:`);
+  return raw.filter(
+    (posting) => !prefixes.some((prefix) => posting.id.startsWith(prefix)),
+  );
+}

--- a/src/lib/job-search/search.ts
+++ b/src/lib/job-search/search.ts
@@ -64,12 +64,13 @@
 
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { JobQuery } from "./query-builder.ts";
-import type { JobPosting } from "./types.ts";
+import type { JobPosting, JobProvider } from "./types.ts";
 import type { RankedJob } from "./rank.ts";
 import type { CompanyEntry } from "./company-registry.ts";
 import type { RoleFamily } from "./role-keywords.ts";
 import { mapWithConcurrency } from "./concurrency.ts";
 import { refineSearchResult } from "./refine.ts";
+import { dedupKey } from "./raw-postings.ts";
 
 /**
  * Providers fetched at once. Bounds the burst when company boards join the
@@ -109,17 +110,6 @@ export interface JobSearchResult {
    *  control edit (role family, target level, exclude term, comp floor,
    *  location) for a LIVE re-rank with no new fetch. */
   rawPostings: JobPosting[];
-}
-
-/** Normalized dedup key: each of title/company lowercased and
- *  whitespace-collapsed independently, then joined — so trailing/among-word
- *  spacing differences between feeds collapse to the same key. */
-function normalizeField(value: string): string {
-  return value.toLowerCase().replace(/\s+/g, " ").trim();
-}
-
-function dedupKey(posting: JobPosting): string {
-  return `${normalizeField(posting.title)}::${normalizeField(posting.company)}`;
 }
 
 /** Only ever render feed-supplied urls that are plain web links. */
@@ -172,6 +162,50 @@ function matchesQuery(posting: JobPosting, patterns: RegExp[]): boolean {
 }
 
 /**
+ * Fetch `providers` concurrently and reduce them to one deduped, url-safe,
+ * query-matched posting list plus the labels that failed.
+ *
+ * Shared by the full search and the incremental company-board fetch so both
+ * apply the SAME three admission rules (url trust boundary, `matchesQuery`,
+ * cross-provider dedup). A second copy of this loop is how an incrementally
+ * added board would start admitting postings the main search would have
+ * rejected.
+ */
+async function fanOut(
+  providers: readonly JobProvider[],
+  query: JobQuery,
+  signal: AbortSignal,
+): Promise<{ merged: JobPosting[]; degradedProviders: string[] }> {
+  const settled = await mapWithConcurrency(
+    providers,
+    PROVIDER_CONCURRENCY,
+    (p) => p.search(query, signal),
+  );
+
+  const degradedProviders: string[] = [];
+  const seen = new Set<string>();
+  const merged: JobPosting[] = [];
+  const termPatterns = buildQueryTermPatterns(query);
+
+  settled.forEach((outcome, i) => {
+    if (outcome.status === "rejected") {
+      degradedProviders.push(providers[i].label);
+      return;
+    }
+    for (const posting of outcome.value) {
+      if (!isSafeUrl(posting.url)) continue;
+      if (!matchesQuery(posting, termPatterns)) continue;
+      const key = dedupKey(posting);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(posting);
+    }
+  });
+
+  return { merged, degradedProviders };
+}
+
+/**
  * Run the search. Never rejects on a provider failure — inspect the returned
  * `degradedProviders` / `providerCount` for partial or total failure. May
  * reject only if the dynamic chunk import itself fails (offline first-load);
@@ -199,31 +233,7 @@ export async function searchJobs(
       : [];
 
   const providers = getProviders(companyProviders);
-  const settled = await mapWithConcurrency(
-    providers,
-    PROVIDER_CONCURRENCY,
-    (p) => p.search(query, signal),
-  );
-
-  const degradedProviders: string[] = [];
-  const seen = new Set<string>();
-  const merged: JobPosting[] = [];
-  const termPatterns = buildQueryTermPatterns(query);
-
-  settled.forEach((outcome, i) => {
-    if (outcome.status === "rejected") {
-      degradedProviders.push(providers[i].label);
-      return;
-    }
-    for (const posting of outcome.value) {
-      if (!isSafeUrl(posting.url)) continue;
-      if (!matchesQuery(posting, termPatterns)) continue;
-      const key = dedupKey(posting);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      merged.push(posting);
-    }
-  });
+  const { merged, degradedProviders } = await fanOut(providers, query, signal);
 
   // Role families (#568) + title-only exclude terms (#563), applied once over
   // the FULL merged set, and ranked — see `refine.ts`'s docblock for why this
@@ -233,4 +243,49 @@ export async function searchJobs(
   // `refineSearchResult` again, locally, on every subsequent refinement-
   // control edit — this is the same pipeline, just the FIRST run of it.
   return refineSearchResult(merged, parsed, query, degradedProviders, providers.length);
+}
+
+/** What an incremental company-board fetch adds to an existing snapshot. */
+export interface CompanyBoardFetch {
+  /** Url-safe, `matchesQuery`-passing, internally-deduped postings from the
+   *  requested boards — NOT yet merged against the caller's snapshot
+   *  (`mergeRawPostings` in `raw-postings.ts` does that). */
+  postings: JobPosting[];
+  /** Labels of the requested boards that failed, to append to the snapshot's. */
+  degradedProviders: string[];
+  /** How many boards were attempted, to add to the snapshot's denominator. */
+  providerCount: number;
+}
+
+/**
+ * Fetch ONLY the given company boards — no keyless feeds, no ranking.
+ *
+ * The narrow counterpart to `searchJobs`, for the case where a result set already
+ * exists and the user selected a company that wasn't part of it. Re-running the
+ * whole search would refetch every keyless feed and every already-searched board
+ * to learn one board's postings; this fetches the one board (usually from the
+ * IndexedDB board cache — see `makeBoardProvider`) and leaves merging and ranking
+ * to the caller, which already holds the snapshot.
+ *
+ * Same never-rejects-on-provider-failure contract as `searchJobs`: a board that
+ * fails comes back as a label in `degradedProviders`.
+ */
+export async function searchCompanyBoards(
+  query: JobQuery,
+  parsed: HeuristicParsedResume,
+  signal: AbortSignal,
+  companies: readonly CompanyEntry[],
+): Promise<CompanyBoardFetch> {
+  if (companies.length === 0) {
+    return { postings: [], degradedProviders: [], providerCount: 0 };
+  }
+  const { makeBoardProviders } = await import("./company-boards.ts");
+  const providers = makeBoardProviders(
+    companies,
+    parsed,
+    undefined,
+    query.families as RoleFamily[] | undefined,
+  );
+  const { merged, degradedProviders } = await fanOut(providers, query, signal);
+  return { postings: merged, degradedProviders, providerCount: providers.length };
 }

--- a/src/lib/jobs-handoff.test.ts
+++ b/src/lib/jobs-handoff.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Round-trip + rejection coverage for the `/` → `/jobs/` résumé handoff.
+ *
+ * The load-bearing assertion is the one that differs from `jd-fit-handoff`:
+ * reading is NON-destructive, so a reload of `/jobs/` still finds the parse.
+ * `/jobs/` has no DropZone to fall back to, so a one-shot read would strand the
+ * user on a dead page.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  JOBS_HANDOFF_KEY,
+  readJobsHandoff,
+  writeJobsHandoff,
+} from "./jobs-handoff.ts";
+import type { HeuristicParsedResume } from "./heuristics/types.ts";
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  skills: ["React", "TypeScript"],
+  experience: [{ company: "Acme", title: "Staff Engineer" }],
+  education: [],
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("jobs handoff", () => {
+  it("round-trips the parsed résumé", () => {
+    writeJobsHandoff({ parsed });
+    const read = readJobsHandoff();
+    expect(read?.parsed.full_name).toBe("Dana Fixture");
+    expect(read?.parsed.skills).toEqual(["React", "TypeScript"]);
+    expect(read?.parsed.experience[0]?.title).toBe("Staff Engineer");
+  });
+
+  it("is NOT consumed on read — a reload of /jobs/ still finds the parse", () => {
+    writeJobsHandoff({ parsed });
+    expect(readJobsHandoff()).not.toBeNull();
+    expect(readJobsHandoff()).not.toBeNull();
+    expect(sessionStorage.getItem(JOBS_HANDOFF_KEY)).not.toBeNull();
+  });
+
+  it("a second launch overwrites the stashed parse", () => {
+    writeJobsHandoff({ parsed });
+    writeJobsHandoff({
+      parsed: { ...parsed, full_name: "Robin Fixture", skills: ["Go"] },
+    });
+    const read = readJobsHandoff();
+    expect(read?.parsed.full_name).toBe("Robin Fixture");
+    expect(read?.parsed.skills).toEqual(["Go"]);
+  });
+
+  it("returns null when absent", () => {
+    expect(readJobsHandoff()).toBeNull();
+  });
+
+  it("rejects malformed JSON rather than throwing", () => {
+    sessionStorage.setItem(JOBS_HANDOFF_KEY, "{not json");
+    expect(readJobsHandoff()).toBeNull();
+  });
+
+  it("rejects a payload missing the guaranteed array fields", () => {
+    // `HeuristicParsedResume` guarantees skills/experience/education as arrays;
+    // ranking against a payload without them would throw downstream instead.
+    sessionStorage.setItem(
+      JOBS_HANDOFF_KEY,
+      JSON.stringify({ parsed: { full_name: "Dana Fixture", skills: ["React"] } }),
+    );
+    expect(readJobsHandoff()).toBeNull();
+
+    sessionStorage.setItem(JOBS_HANDOFF_KEY, JSON.stringify({}));
+    expect(readJobsHandoff()).toBeNull();
+  });
+});

--- a/src/lib/jobs-handoff.ts
+++ b/src/lib/jobs-handoff.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Résumé handoff from `/` (parser audit) to `/jobs/` (the job-search workbench).
+ *
+ * `/` no longer hosts the search itself — its Find Jobs tab is a launcher that
+ * stashes the EDITED parsed résumé here and navigates. `/jobs/` seeds its query
+ * from that parse (`buildJobQuery`) and ranks postings against it.
+ *
+ * What crosses is ONLY `HeuristicParsedResume` — no PDF bytes, no raw text, no
+ * `CascadeResult`. That is the whole input the job-search lane consumes
+ * (`FindJobsPanel` already took exactly this prop), so widening the payload
+ * would hand `/jobs/` data it has no use for. Unlike the JD-fit handoff there
+ * is no edit-layer replay to arrange: `/jobs/` runs no edit layer at all, so the
+ * APPLIED parse is the correct thing to send — the user's corrections are what
+ * they want searched against.
+ *
+ * `sessionStorage`, per the repo's `ocv_*` convention, so the parse dies with
+ * the tab and cannot leak into a later, unrelated session.
+ *
+ * Deliberately NOT one-shot — this is where it diverges from
+ * `jd-fit-handoff.ts`. `/jd-fit` clears on read because it owns a DropZone to
+ * fall back to; `/jobs/` has none, so consuming the key would turn an ordinary
+ * browser reload (or a Back into the results page) into a dead end with no way
+ * to recover but returning to `/`. The key is overwritten on each launch, so a
+ * newer parse always wins, and it dies with the tab either way.
+ */
+
+import type { HeuristicParsedResume } from "./heuristics/types.ts";
+
+/** sessionStorage key for the parser-audit → job-search handoff payload. */
+export const JOBS_HANDOFF_KEY = "ocv_jobs_handoff";
+
+export interface JobsHandoff {
+  /** The EDITED parsed résumé — `buildJobQuery` seeds the query from its titles
+   *  and skills, and the fit ranking reads its fuller shape (summary,
+   *  education). */
+  parsed: HeuristicParsedResume;
+}
+
+/** Write the handoff payload before navigating to /jobs/. */
+export function writeJobsHandoff(payload: JobsHandoff): void {
+  try {
+    sessionStorage.setItem(JOBS_HANDOFF_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota / private-mode / disabled storage — the navigation still proceeds
+    // and /jobs/ renders its "no résumé yet" state pointing back at `/`.
+  }
+}
+
+/**
+ * Read the handoff payload. Returns null when absent or malformed so `/jobs/`
+ * falls back to its empty state instead of rendering a broken query.
+ *
+ * Non-destructive: see the module docblock for why this does not clear the key.
+ */
+export function readJobsHandoff(): JobsHandoff | null {
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(JOBS_HANDOFF_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const payload = JSON.parse(raw) as JobsHandoff;
+    if (!payload || typeof payload !== "object") return null;
+    const { parsed } = payload;
+    if (!parsed || typeof parsed !== "object") return null;
+    // `HeuristicParsedResume` guarantees these three as arrays (empty when the
+    // parse found nothing). A payload missing them is not a parse we can rank.
+    if (
+      !Array.isArray(parsed.skills) ||
+      !Array.isArray(parsed.experience) ||
+      !Array.isArray(parsed.education)
+    ) {
+      return null;
+    }
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -157,6 +157,7 @@ export default defineConfig({
       input: {
         main: fileURLToPath(new URL("./index.html", import.meta.url)),
         jdFit: fileURLToPath(new URL("./jd-fit/index.html", import.meta.url)),
+        jobs: fileURLToPath(new URL("./jobs/index.html", import.meta.url)),
       },
     },
   },


### PR DESCRIPTION
## Summary

Two problems with Find Jobs, both reported from using it:

1. **Only 20 results, with the wrong instruction.** `JobSearchResults` sliced the
   ranked set at a `RENDER_CAP = 20` and the footer asked the user to narrow the
   query — but `searchJobs` had already fetched and ranked everything, so
   narrowing can never surface match #21. The list is now paged at 20 per page
   over the full set (numbered pages + Prev/Next), so every match is reachable
   and nothing new is fetched.
2. **Results were at the bottom of `/`.** Job search now owns its own entry,
   `/jobs/`, laid out as **full-width bands in the order of the work**: company
   targets pinned at the top, the rest of the query a full-width form that folds
   to a one-line summary on the Search click, then the ranked postings owning the
   full width. `/`'s Find Jobs tab is a launcher: it previews the derived terms,
   stashes the edited parse and navigates.

Filed as a PR rather than an issue on purpose — the Cloudflare preview makes it
easier to keep iterating on the lane from here.

**Privacy unchanged.** The handoff carries only `HeuristicParsedResume` — no PDF
bytes, no raw text — in `sessionStorage`, so it dies with the tab. Egress is
still just the keyword string from `providers/keywords.ts`, still only on an
explicit Search click.

Note for #576 (deprecate `/jd-fit/`): this adds a third entry rather than
removing one. It doesn't conflict — the consolidation target there is the JD
paste + JD-driven rewrite, and `/jobs/` is now the obvious surface to fold them
into.

## Notable decisions

- **No sidebar, and no sticky bar.** A 20rem query rail would have charged every
  posting card for a form that only matters while it's being filled in. Bands
  instead: companies, then the foldable form, then results — all full width.
  Nothing is sticky, because with the company chips permanently on top a pinned
  band is ~3 chip rows tall and costs more viewport on every scroll than the
  Search button it keeps in reach is worth.
- **Company targets are the one control that outlives the fold** — they're the
  axis you retune *while reading* postings, and the toggle is now live against an
  existing result set, so folding them away would bury the panel's tightest
  feedback loop.
- **Folds on the Search click, not on the first result** — the transition is tied
  to the user's own action instead of happening under their cursor a second later,
  and the loading skeleton already occupies the width the results will land in.
- Query fields lay out across the page (titles+role / skills / location+exclude+pay,
  with the 12-rung level control spanning the full width) rather than stacking in
  one ~470px column on a 1080px page.
- Copy that used to say "the query **above**" now says "open Edit search" — with a
  foldable form, a direction word points at a collapsed bar half the time.
- `JobQuerySummary` omits filters that aren't filtering (unset comp floor, empty
  exclude list) so the folded line can't imply a filter is doing work. Location is
  the one exception — it always shows, `anywhere` when unset, because a
  location-blind search otherwise reads as a bug.
- `Pagination` is a new **shared** design-system component (windowed page strip,
  first/last always reachable, `aria-current="page"`), not hand-rolled buttons in
  the feature. The disclosure reuses the house `<Button aria-expanded>` idiom from
  `WeakMatchesSection` rather than adding a Disclosure primitive.
- The page index resets on a new result set (fresh search or #568's live re-rank)
  and is **clamped** — the reset effect runs a render late, so an unclamped slice
  would flash an empty results region when the set shrinks.
- The handoff is deliberately **not** one-shot, unlike `jd-fit-handoff.ts`:
  `/jobs/` has no DropZone, so consuming the key would make a reload a dead end.
- `src/jobs/main.tsx` configures **no** pdfjs worker — that surface never parses
  a PDF, so the entry chunk stays small.

## Company targets now reach existing results (asymmetrically)

Toggling a company used to require a whole new search. It doesn't now — but the
two directions are not the same operation, so they don't behave the same:

| Action | Behaviour | Cost |
|---|---|---|
| **Remove** a company | Results update live | Zero. `dropCompanyPostings` filters the snapshot by the `{ats}:{slug}:` id prefix — board postings are self-attributing, no new `JobPosting` field |
| **Add** a company | `PendingCompaniesNotice`: "These results don't include Ramp — [Add to results]" | One board on click. `searchCompanyBoards` fetches only the added boards (usually an IndexedDB cache hit via `makeBoardProvider`), merges under `search.ts`'s own dedup key, re-ranks |

Adding can't be served locally at all — the snapshot has none of that board's
postings — and auto-fetching on a checkbox click would contradict *"only your
search keywords are sent, and only when you click Search."* So the addition is
surfaced and the fetch stays behind an explicit click. The keyless feeds are
never refetched either way.

A board that fails still leaves the pending list, so a permanently-failing board
can't re-prompt forever; the failure shows up in the existing degraded-providers
notice. An incremental fetch that throws leaves the current results untouched.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 3033 passed / 9 skipped (216 files)
- [x] `npm run verify` green (fallow findings are report-only: JSX-dense
      `JobQueryEditor` + `FindJobsPanel`, 0.1% duplication)
- [x] `npm run build` emits `dist/jobs/index.html` alongside `dist/jd-fit/`
- [x] **Verified in a real browser** against the production build (Playwright over
      the built `dist/`): 268 matches, `Showing 1–20 of 268` + `‹ Prev 1 2 3 4 5 6 … 14 Next ›`,
      form folds on Search to `Founder & CEO / Sr. Engineering Manager · Santa Clara, CA · Executive · 11 skills · 14 companies`,
      deselecting Databricks dropped 268 → 260 with **no** refetch, re-selecting
      showed the pending notice, and Add to results merged it back
- [x] Cloudflare preview: same flow starting from `/` (the sessionStorage handoff
      leg), which the local run stubbed by writing the key directly
- No fixture binaries added or changed, so the PII preflight is a no-op here

New tests assert reachability, not just counts — page 2 checks that matches 21–25
actually render, and the launcher test asserts the parse is stashed *before* the
navigation.

## Provenance

Code implementation via: Claude Opus 5 (1M context), high effort
Verification: `npm run verify` — green locally, and in CI on this PR
