### PR TITLE
feat(job-search): judge résumé terms and say what's missing (#584)

### DIFF
--- a/src/components/features/ChipListEditor.test.tsx
+++ b/src/components/features/ChipListEditor.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Structural test for the promote control's expanded hit area (#591). Same
+ * jsdom caveat as `design-system/primitives/Chip.test.tsx`: no layout engine,
+ * so this asserts the CSS technique (an invisible vertical-only `after:`
+ * overlay) is present rather than measuring rendered pixels. Real-browser
+ * measurement is recorded in #591.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ChipListEditor } from "./ChipListEditor.tsx";
+
+function render(props: Parameters<typeof ChipListEditor>[0]): string {
+  return renderToStaticMarkup(createElement(ChipListEditor, props));
+}
+
+describe("ChipListEditor promote control target size", () => {
+  it("expands the non-primary promote control's hit area vertically to reach 24x24, without a horizontal overlay that could cross into the remove control", () => {
+    const html = render({
+      label: "Titles",
+      items: ["Frontend Engineer", "Fullstack Engineer"],
+      onAdd: () => {},
+      onRemove: () => {},
+      placeholder: "Add a title",
+      addAriaLabel: "Add title",
+      primaryIndex: 0,
+      onPromote: () => {},
+    });
+    // The ~16px-tall `Button variant="link"` promote control gets a 4px
+    // vertical-only overlay (16 + 4 + 4 = 24) — `after:inset-x-0` keeps the
+    // horizontal edges unchanged so the overlay can't reach across the 4px
+    // `gap-1` into the neighbouring remove control's hit area.
+    expect(html).toContain("after:-inset-y-[4px]");
+    expect(html).toContain("after:inset-x-0");
+  });
+
+  it("renders the primary chip's star mark without a promote control", () => {
+    const html = render({
+      label: "Titles",
+      items: ["Frontend Engineer"],
+      onAdd: () => {},
+      onRemove: () => {},
+      placeholder: "Add a title",
+      addAriaLabel: "Add title",
+      primaryIndex: 0,
+      onPromote: () => {},
+    });
+    expect(html).toContain('aria-current="true"');
+  });
+});

--- a/src/components/features/ChipListEditor.tsx
+++ b/src/components/features/ChipListEditor.tsx
@@ -24,22 +24,46 @@
  * becomes a second control — "Make X the primary title" — beside the
  * existing remove button.
  *
- * KNOWN GAP — chip-control touch targets are under 44×44 (#581 AC8, deferred).
- * The promote control is `Button variant="link"` (`p-0` + `text-xs`, ~16px tall)
- * and `Chip`'s remove is `variant="icon"` (`p-0.5` around a 10px glyph, ~14px),
- * sitting `gap-1` (4px) apart. Growing either to 44px is NOT a contained change:
- * `min-h`/`min-w` re-lays out every chip row, and the zero-layout-cost
- * alternative (a transparent `::after` overlay) makes the hit areas overlap the
- * NEIGHBOURING chips — the chip row is 24px tall with a 6px wrap gap and a 6px
- * horizontal gap, so a 44px overlay reaches ~4px into the next row and ~5px into
- * the next chip, and the later-painted remove overlay would win those taps.
- * Trading a small target for a destructive mis-tap is worse. Raising both
- * controls to 44px needs a Chip/Button hit-area redesign sized as its own issue;
- * keyboard tab order (the other half of AC8) is verified and correct.
+ * TARGET SIZE (#591, resolves the #581 AC8 gap). WCAG 2.2 SC 2.5.8 Target Size
+ * (Minimum) is level AA at 24x24 CSS px — the AAA figure some UIs use (44x44,
+ * SC 2.5.5) is explicitly NOT the bar here: chasing it forces a row-spacing
+ * redesign (chips wrap at `gap-1.5` = 6px, so a 44px hit area would reach
+ * ~4px into the next wrapped row and ~5px into the neighbouring chip, letting
+ * a tap near one chip's edge fire a NEIGHBOUR's remove control). The chosen
+ * target size is what the current spacing supports, not the reverse. Both
+ * controls meet 24x24 via an invisible `after:` overlay that expands only the
+ * CLICKABLE area, not the visual box or the chip's layout: `Chip`'s remove
+ * control (`variant="icon"`, ~14px visible) gets a 5px overlay on every side;
+ * the promote control (`Button variant="link"`, ~16px tall, its width is
+ * already the item text) gets a 4px vertical-only overlay — sized to reach the
+ * chip's own top/bottom edge and no further, so it cannot cross the 6px wrap
+ * gap into the next row. Measured zero-overlap against neighbouring chips and
+ * against each other in a real browser — see #591. Keyboard tab order is
+ * verified and correct.
+ *
+ * QUALITY MARK (#585). Opt-in `qualityFor` looks up a `TermVerdict` (from
+ * `term-quality.ts`) by the chip's own text. A term with no verdict — not
+ * judgeable, per that module's contract — renders as a plain chip; this
+ * component substitutes no default. When a verdict exists it renders as a
+ * DECORATIVE sibling of the chip's existing content (glyph + `title` tooltip,
+ * `aria-hidden`) plus a separate `sr-only` span carrying `reason` verbatim —
+ * the same "new child, not inside the interactive control" placement the
+ * `isPrimary` star already uses, and deliberately outside the promote
+ * `Button` so the mark's reason is never swallowed by that button's own
+ * `aria-label` (an inner `sr-only` node cannot contribute to a labelled
+ * button's accessible name). No classification logic lives here — the glyph
+ * is a pure function of `verdict.quality`.
  */
 
 import { useState } from "react";
 import { Button, Chip } from "@design-system";
+import type { TermQuality, TermVerdict } from "../../lib/job-search/term-quality.ts";
+
+const QUALITY_MARK: Record<TermQuality, { glyph: string; className: string }> = {
+  strong: { glyph: "✓", className: "text-feedback-success-text" },
+  weak: { glyph: "○", className: "text-content-tertiary" },
+  noise: { glyph: "⚠︎", className: "text-feedback-warning-text" },
+};
 
 interface ChipListEditorProps {
   /** Row label shown above the chips (e.g. "Titles", "Skills"). */
@@ -59,6 +83,10 @@ interface ChipListEditorProps {
   /** Opt-in (#581): called with the item to promote to primary. Required
    *  alongside `primaryIndex` to make a chip's body clickable. */
   onPromote?: (value: string) => void;
+  /** Opt-in (#585): looks up the `TermVerdict` for a chip's own text. Omit
+   *  (or return `undefined` for a given item) to render that chip plain — a
+   *  term with no verdict was not judgeable, see `term-quality.ts`. */
+  qualityFor?: (value: string) => TermVerdict | undefined;
 }
 
 export function ChipListEditor({
@@ -70,6 +98,7 @@ export function ChipListEditor({
   addAriaLabel,
   primaryIndex,
   onPromote,
+  qualityFor,
 }: ChipListEditorProps) {
   const [draft, setDraft] = useState("");
 
@@ -90,12 +119,19 @@ export function ChipListEditor({
         <div className="flex flex-wrap gap-1.5">
           {items.map((item, index) => {
             const isPrimary = onPromote !== undefined && index === primaryIndex;
+            const verdict = qualityFor?.(item);
+            const mark = verdict && QUALITY_MARK[verdict.quality];
             return (
               <Chip
                 key={item}
                 onRemove={() => onRemove(item)}
                 removeLabel={`Remove ${item}`}
               >
+                {mark && (
+                  <span aria-hidden="true" className={mark.className} title={verdict!.reason}>
+                    {mark.glyph}
+                  </span>
+                )}
                 {onPromote === undefined ? (
                   item
                 ) : isPrimary ? (
@@ -107,13 +143,20 @@ export function ChipListEditor({
                   <Button
                     variant="link"
                     size="sm"
-                    className="p-0 text-content-secondary hover:text-content-primary"
+                    // See TARGET SIZE docblock above: vertical-only overlay
+                    // reaches the chip's own edge (24px chip, ~16px control)
+                    // without crossing into the wrap gap or the neighbouring
+                    // remove control's horizontal hit area.
+                    className="relative p-0 text-content-secondary hover:text-content-primary after:absolute after:-inset-y-[4px] after:inset-x-0 after:content-['']"
                     onClick={() => onPromote(item)}
                     aria-label={`Make ${item} the primary title`}
                   >
                     {item}
                   </Button>
                 )}
+                {/* Outside the (possibly labelled) promote button on purpose —
+                 *  see the QUALITY MARK docblock note above. */}
+                {mark && <span className="sr-only"> — {verdict!.reason}</span>}
               </Chip>
             );
           })}

--- a/src/components/features/JobQueryEditor.test.tsx
+++ b/src/components/features/JobQueryEditor.test.tsx
@@ -18,6 +18,9 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { JobQueryEditor } from "./JobQueryEditor.tsx";
 import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+import { assessQueryTerms } from "../../lib/job-search/term-quality.ts";
+import { missingTermLabel, TermQualityAdvisory } from "./TermQualityAdvisory.tsx";
+import type { CoherenceFinding } from "../../lib/job-search/term-quality.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -25,16 +28,116 @@ import type { JobQuery } from "../../lib/job-search/query-builder.ts";
 let container: HTMLDivElement;
 let root: Root;
 
-function render(query: JobQuery, onChange: (next: (q: JobQuery) => JobQuery) => void) {
+function render(
+  query: JobQuery,
+  onChange: (next: (q: JobQuery) => JobQuery) => void,
+  isDegenerate = false,
+) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
     root.render(
-      createElement(JobQueryEditor, { query, onChange, isDegenerate: false }),
+      createElement(JobQueryEditor, { query, onChange, isDegenerate }),
     );
   });
   return container;
+}
+
+/** Re-renders the same root with a new query/isDegenerate, mirroring how the
+ *  parent workbench flows a fresh `JobQuery` back down after `onChange`. */
+function rerender(
+  query: JobQuery,
+  onChange: (next: (q: JobQuery) => JobQuery) => void,
+  isDegenerate = false,
+) {
+  act(() => {
+    root.render(
+      createElement(JobQueryEditor, { query, onChange, isDegenerate }),
+    );
+  });
+  return container;
+}
+
+/** Deep-freezes an object and every plain-object/array value it holds, so an
+ *  in-place mutation (`push`, `arr[i] = x`, `obj.field = x`) throws a
+ *  TypeError in strict mode instead of silently succeeding. Only reaches
+ *  plain objects/arrays — it would not, for example, protect a Map or a
+ *  class instance nested inside, but `JobQuery` is a plain record of
+ *  strings/numbers/string-arrays, which this covers completely. */
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const key of Object.getOwnPropertyNames(value)) {
+      deepFreeze((value as Record<string, unknown>)[key]);
+    }
+  }
+  return value;
+}
+
+function findButton(el: HTMLElement, matchLabel: string): HTMLButtonElement {
+  const btn = [...el.querySelectorAll("button")].find(
+    (b) => b.getAttribute("aria-label") === matchLabel,
+  );
+  if (!btn) throw new Error(`no button labelled "${matchLabel}"`);
+  return btn as HTMLButtonElement;
+}
+
+/** Sets an input's value the way a user would, as far as React can tell.
+ *  Assigning `input.value` directly is swallowed by React's value tracker —
+ *  it compares against its own cached value and concludes nothing changed, so
+ *  no `onChange` fires. Going through the prototype's native setter updates the
+ *  DOM without touching the tracker, and the bubbled `input` event then reads
+ *  as a genuine edit. */
+function setNativeValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/**
+ * Types `value` into the chip input named `ariaLabel` and clicks that row's
+ * Add button.
+ *
+ * `addIndex` selects among the identically-labelled "Add" buttons in DOM order
+ * and is passed to `Array.at`, so a negative index counts from the end: the
+ * editor renders Titles (0), Skills (1), … and Exclude last (-1). Indexing is
+ * what the tests already did inline; naming it here is the only reason the
+ * convention is legible, so keep the comment with it.
+ */
+function typeAndAdd(el: HTMLElement, ariaLabel: string, value: string, addIndex: number) {
+  const input = el.querySelector(`input[aria-label="${ariaLabel}"]`) as HTMLInputElement;
+  if (!input) throw new Error(`no input labelled "${ariaLabel}"`);
+  setNativeValue(input, value);
+  const addBtns = [...el.querySelectorAll("button")].filter((b) => b.textContent === "Add");
+  const btn = addBtns.at(addIndex);
+  if (!btn) throw new Error(`no Add button at index ${addIndex} (found ${addBtns.length})`);
+  act(() => btn.click());
+}
+
+/** Clicks the read-mode `EditableField` span identified by its accessible
+ *  name, types `text` into the input it reveals, then commits by pressing
+ *  Enter (single-line `EditableField` also commits on blur, but Enter is
+ *  the deterministic path in jsdom). */
+function editField(el: HTMLElement, openLabel: string, fieldLabel: string, text: string) {
+  const opener = [...el.querySelectorAll('[role="button"]')].find(
+    (b) => b.getAttribute("aria-label") === openLabel,
+  ) as HTMLElement;
+  if (!opener) throw new Error(`no editable field opener labelled "${openLabel}"`);
+  act(() => opener.click());
+  const input = el.querySelector(`input[aria-label="${fieldLabel}"]`) as HTMLInputElement;
+  if (!input) throw new Error(`no input labelled "${fieldLabel}" after opening editor`);
+  setNativeValue(input, text);
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+  });
 }
 
 afterEach(() => {
@@ -90,5 +193,510 @@ describe("JobQueryEditor — primary title promotion", () => {
 
     const current = el.querySelector('[aria-current="true"]');
     expect(current?.textContent).toContain("Staff Engineer");
+  });
+});
+
+/**
+ * Coverage for #589: `JobQueryEditor` is the single write path into
+ * `JobQuery`, and every mutation is supposed to be a whole-query
+ * replacement — never an in-place edit, never a dropped sibling field. This
+ * block asserts that per handler: the object passed to `onChange` is a NEW
+ * object, it carries only the intended change, and it is not just the
+ * component's own internal state (props-in / callback-out, no mocks).
+ */
+describe("JobQueryEditor — query mutation contract (issue 589)", () => {
+  const fullQuery: JobQuery = {
+    titles: ["Staff Engineer"],
+    skills: ["TypeScript"],
+    location: "Austin, TX",
+    excludeTerms: ["Manager"],
+    compFloor: 150_000,
+    families: ["fullstack"],
+    seniority: "Staff",
+  };
+
+  const noOptionalFieldsQuery: JobQuery = {
+    titles: ["Staff Engineer"],
+    skills: ["TypeScript"],
+    // location / excludeTerms / compFloor / families / seniority all absent.
+  };
+
+  it("adds a title via the Titles chip input, producing a new object with every other field untouched", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    typeAndAdd(el, "Add title", "Principal Engineer", 0);
+
+    expect(captured).not.toBe(fullQuery);
+    expect(captured?.titles).toEqual(["Staff Engineer", "Principal Engineer"]);
+    expect(captured?.skills).toBe(fullQuery.skills);
+    expect(captured?.location).toBe(fullQuery.location);
+    expect(captured?.excludeTerms).toBe(fullQuery.excludeTerms);
+    expect(captured?.compFloor).toBe(fullQuery.compFloor);
+    expect(captured?.families).toBe(fullQuery.families);
+    expect(captured?.seniority).toBe(fullQuery.seniority);
+  });
+
+  it("removes a title via its chip's Remove control", () => {
+    const twoTitles: JobQuery = { ...fullQuery, titles: ["Staff Engineer", "Tech Lead"] };
+    let captured: JobQuery | undefined;
+    const el = render(twoTitles, (next) => {
+      captured = next(twoTitles);
+    });
+    act(() => findButton(el, "Remove Tech Lead").click());
+
+    expect(captured).not.toBe(twoTitles);
+    expect(captured?.titles).toEqual(["Staff Engineer"]);
+  });
+
+  it("adds and removes a skill", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    typeAndAdd(el, "Add skill", "Rust", 1); // Titles' Add is index 0
+    expect(captured).not.toBe(fullQuery);
+    expect(captured?.skills).toEqual(["TypeScript", "Rust"]);
+    expect(captured?.titles).toBe(fullQuery.titles);
+
+    const afterAdd = rerender(captured!, (next) => {
+      captured = next(captured!);
+    });
+    act(() => findButton(afterAdd, "Remove TypeScript").click());
+    expect(captured?.skills).toEqual(["Rust"]);
+  });
+
+  it("adds and removes an exclude term", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    typeAndAdd(el, "Add exclude term", "Recruiter", -1); // Exclude row is the last chip list
+    expect(captured).not.toBe(fullQuery);
+    expect(captured?.excludeTerms).toEqual(["Manager", "Recruiter"]);
+    expect(captured?.titles).toBe(fullQuery.titles);
+    expect(captured?.skills).toBe(fullQuery.skills);
+
+    const afterAdd = rerender(captured!, (next) => {
+      captured = next(captured!);
+    });
+    act(() => findButton(afterAdd, "Remove Manager").click());
+    expect(captured?.excludeTerms).toEqual(["Recruiter"]);
+  });
+
+  it("adding an exclude term when excludeTerms is undefined produces [term], not a crash on the ?? [] path", () => {
+    let captured: JobQuery | undefined;
+    const el = render(noOptionalFieldsQuery, (next) => {
+      captured = next(noOptionalFieldsQuery);
+    });
+    typeAndAdd(el, "Add exclude term", "Recruiter", -1);
+
+    expect(captured).not.toBe(noOptionalFieldsQuery);
+    expect(captured?.excludeTerms).toEqual(["Recruiter"]);
+    expect(captured?.titles).toBe(noOptionalFieldsQuery.titles);
+    expect(captured?.skills).toBe(noOptionalFieldsQuery.skills);
+  });
+
+  it("removing a role family narrows to an EMPTY ARRAY, not undefined — readers resolve [] to the permissive 'all' filter", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    act(() => findButton(el, "Remove fullstack").click());
+
+    expect(captured).not.toBe(fullQuery);
+    expect(captured?.families).toEqual([]);
+    expect(Array.isArray(captured?.families)).toBe(true);
+    expect(captured?.families).not.toBeUndefined();
+    // Every other field survives untouched.
+    expect(captured?.titles).toBe(fullQuery.titles);
+    expect(captured?.skills).toBe(fullQuery.skills);
+    expect(captured?.location).toBe(fullQuery.location);
+    expect(captured?.excludeTerms).toBe(fullQuery.excludeTerms);
+    expect(captured?.compFloor).toBe(fullQuery.compFloor);
+    expect(captured?.seniority).toBe(fullQuery.seniority);
+  });
+
+  it("renders 'no role narrowing' with families undefined, exercising the (families ?? []) read path without crashing", () => {
+    // NOTE (drift from the issue checklist): `removeRoleFamily`'s own
+    // `(q.families ?? []).filter(...)` write-side branch has no reachable UI
+    // path when `families` is undefined — `RoleFamilyChips` renders its
+    // remove buttons from the same `query.families ?? []` list the row
+    // displays, so an undefined `families` renders zero chips and there is
+    // nothing to click. The write-side `?? []` is defensive-only under the
+    // current render logic. What IS reachable and asserted here is the
+    // READ-side `?? []` (the row renders the empty-state copy instead of
+    // throwing on `undefined.map`), plus the narrow-to-`[]` write path
+    // above, which is exercised from a non-empty `families` fixture.
+    const el = render(noOptionalFieldsQuery, () => noOptionalFieldsQuery);
+    expect(el.textContent).toContain("No role narrowing");
+  });
+
+  it("commits an edited location", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    editField(el, "Edit Location", "Location", "Denver, CO");
+
+    expect(captured).not.toBe(fullQuery);
+    expect(captured?.location).toBe("Denver, CO");
+    expect(captured?.titles).toBe(fullQuery.titles);
+    expect(captured?.skills).toBe(fullQuery.skills);
+  });
+
+  it("committing an empty location produces undefined, not an empty string", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    editField(el, "Edit Location", "Location", "");
+
+    expect(captured?.location).toBeUndefined();
+    expect(captured?.location).not.toBe("");
+  });
+
+  it("commits a comp floor value", () => {
+    let captured: JobQuery | undefined;
+    const el = render(fullQuery, (next) => {
+      captured = next(fullQuery);
+    });
+    editField(el, "Edit Minimum annual pay", "Minimum annual pay", "180000");
+
+    expect(captured).not.toBe(fullQuery);
+    expect(captured?.compFloor).toBe(180_000);
+    expect(captured?.titles).toBe(fullQuery.titles);
+  });
+
+  it("shows LevelSelect when query.seniority is set, and the '+ Target level' pill when it is not", () => {
+    const withLevel = render(fullQuery, () => fullQuery);
+    expect(withLevel.querySelectorAll('[role="radio"]').length).toBeGreaterThan(0);
+    expect(
+      [...withLevel.querySelectorAll("button")].some(
+        (b) => b.getAttribute("aria-label") === "Target level",
+      ),
+    ).toBe(false);
+
+    const withoutLevel = render(noOptionalFieldsQuery, () => noOptionalFieldsQuery);
+    expect(withoutLevel.querySelectorAll('[role="radio"]').length).toBe(0);
+    expect(
+      [...withoutLevel.querySelectorAll("button")].some(
+        (b) => b.getAttribute("aria-label") === "Target level",
+      ),
+    ).toBe(true);
+  });
+
+  it("clicking the '+ Target level' pill reveals LevelSelect", () => {
+    const el = render(noOptionalFieldsQuery, () => noOptionalFieldsQuery);
+    act(() => findButton(el, "Target level").click());
+    expect(el.querySelectorAll('[role="radio"]').length).toBeGreaterThan(0);
+  });
+
+  it("renders the degenerate-query hint only when isDegenerate is true", () => {
+    const hintText = "We couldn't derive a search from this resume";
+    const withHint = render(noOptionalFieldsQuery, () => noOptionalFieldsQuery, true);
+    expect(withHint.textContent).toContain(hintText);
+
+    const withoutHint = render(noOptionalFieldsQuery, () => noOptionalFieldsQuery, false);
+    expect(withoutHint.textContent).not.toContain(hintText);
+  });
+
+  it("never mutates the input query object in place — a frozen fixture throws on any in-place write", () => {
+    const frozen = deepFreeze({
+      titles: ["Staff Engineer"],
+      skills: ["TypeScript"],
+      location: "Austin, TX",
+      excludeTerms: ["Manager"],
+      compFloor: 150_000,
+      families: ["fullstack"],
+      seniority: "Staff",
+    }) as JobQuery;
+    const snapshotJSON = JSON.stringify(frozen);
+
+    let latest: JobQuery = frozen;
+    const el = render(frozen, (next) => {
+      // A handler that mutated `latest` in place (e.g. `latest.titles.push`)
+      // would throw a TypeError here, synchronously, since `latest` starts
+      // out frozen — the assertion IS that none of the interactions below
+      // throw.
+      latest = next(latest);
+    });
+
+    // Exercise several handlers in sequence; each replaces `latest` with a
+    // freshly spread (unfrozen) object, so later handlers operate on a
+    // non-frozen query — this only proves the FIRST handler touching each
+    // frozen array/object doesn't write through it in place.
+    const titleInput = el.querySelector('input[aria-label="Add title"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    expect(() => {
+      act(() => {
+        setter.call(titleInput, "Principal Engineer");
+        titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      const addBtn = [...el.querySelectorAll("button")].find((b) => b.textContent === "Add")!;
+      act(() => addBtn.click());
+    }).not.toThrow();
+    expect(latest.titles).toEqual(["Staff Engineer", "Principal Engineer"]);
+
+    expect(() => {
+      act(() => findButton(el, "Remove fullstack").click());
+    }).not.toThrow();
+
+    // The original fixture is byte-identical to before any interaction —
+    // freezing already guarantees this structurally, but the JSON diff
+    // makes the intent explicit for a reader.
+    expect(JSON.stringify(frozen)).toBe(snapshotJSON);
+  });
+});
+
+/**
+ * Coverage for #585: `JobQueryEditor` renders `assessQueryTerms`'s judgement
+ * on the query it already owns — a chip's quality mark, and an add-able row
+ * for what the resolved role is missing. `assessQueryTerms` itself is
+ * `term-quality.test.ts`'s job; these tests only check the RENDERING
+ * contract (mark + accessible label present/absent, click adds the exact
+ * term via `onChange`), computing expected verdicts from the same classifier
+ * rather than hardcoding its output, so they don't drift if #584's rules
+ * change.
+ */
+describe("JobQueryEditor — term quality (issue 585)", () => {
+  it("marks a strong title with a text glyph and a screen-reader-legible reason, verbatim from the lib", () => {
+    const query: JobQuery = { titles: ["Engineering Manager"], skills: [] };
+    const { verdicts } = assessQueryTerms(query);
+    const verdict = verdicts.find((v) => v.term === "Engineering Manager");
+    expect(verdict?.quality).toBe("strong");
+
+    const el = render(query, () => query);
+    // The glyph is decorative (aria-hidden); the accessible label is the
+    // separate sr-only span carrying `reason` unchanged.
+    expect(el.querySelector('[aria-hidden="true"].text-feedback-success-text')).not.toBeNull();
+    expect(el.textContent).toContain(verdict!.reason);
+  });
+
+  it("renders a term with no verdict as a plain, unmarked chip", () => {
+    // No role resolves for this title (rule 1 in term-quality.ts): NOTHING is
+    // judged without a basis, so this term gets no verdict at all.
+    const query: JobQuery = { titles: ["Zzyzx Wobble Frobnicator"], skills: [] };
+    const { verdicts } = assessQueryTerms(query);
+    expect(verdicts).toHaveLength(0);
+
+    const el = render(query, () => query);
+    const marks = [...el.querySelectorAll('[aria-hidden="true"]')].filter(
+      (node) =>
+        node.classList.contains("text-feedback-success-text") ||
+        node.classList.contains("text-feedback-warning-text") ||
+        node.classList.contains("text-content-tertiary"),
+    );
+    expect(marks).toHaveLength(0);
+  });
+
+  it("renders nothing for missing terms when the query is empty (no role resolved)", () => {
+    const query: JobQuery = { titles: [], skills: [] };
+    expect(assessQueryTerms(query).missing).toEqual([]);
+
+    const el = render(query, () => query);
+    expect(el.textContent).not.toContain("Add to your titles");
+    expect(el.textContent).not.toContain("Add to your skills");
+  });
+
+  it("clicking a missing-term suggestion adds it to the query via onChange, with every sibling field untouched and no mutation of the input", () => {
+    const query: JobQuery = deepFreeze({
+      titles: ["Engineering Manager"],
+      skills: [],
+      location: "Remote",
+    }) as JobQuery;
+    const { missing } = assessQueryTerms(query);
+    expect(missing.length).toBeGreaterThan(0);
+    const target = missing[0]!;
+
+    let captured: JobQuery | undefined;
+    const el = render(query, (next) => {
+      captured = next(query);
+    });
+
+    // `TermQualityAdvisory` renders each pill's label through the same
+    // `missingTermLabel` — a skill's canonical id (e.g. `ci-cd`) maps to its
+    // human label there, never the raw id.
+    const pillLabel = missingTermLabel(target);
+    const pill = findButton(el, pillLabel);
+    expect(() => act(() => pill.click())).not.toThrow();
+
+    expect(captured).not.toBe(query);
+    if (target.kind === "title") {
+      expect(captured?.titles).toEqual([...query.titles, pillLabel]);
+      expect(captured?.skills).toBe(query.skills);
+    } else {
+      expect(captured?.skills).toEqual([...query.skills, pillLabel]);
+      expect(captured?.titles).toBe(query.titles);
+    }
+    expect(captured?.location).toBe(query.location);
+  });
+});
+
+/**
+ * Coverage for the title/skill coherence advisory (issue 587). The DETECTION is
+ * `term-quality.test.ts`'s job; these check only that the finding reaches the
+ * user — inside the existing advisory, never as a fourth panel — and that its
+ * two render conditions are independent, since a mismatched résumé can easily
+ * have nothing missing.
+ */
+describe("JobQueryEditor — title/skill coherence (issue 587)", () => {
+  /** Renders the advisory alone, the one way to drive `missing` and
+   *  `coherence` independently — `assessQueryTerms` never produces a firing
+   *  finding with an empty `missing`, but the component must not depend on
+   *  that coincidence. */
+  function renderAdvisory(
+    missing: Parameters<typeof TermQualityAdvisory>[0]["missing"],
+    coherence?: CoherenceFinding,
+  ) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(TermQualityAdvisory, { missing, coherence, onAdd: () => {} }),
+      );
+    });
+    return container;
+  }
+
+  const mismatched: JobQuery = {
+    titles: ["Engineering Manager"],
+    skills: ["Java", "Python", "Kubernetes", "Docker", "Terraform"],
+  };
+
+  it("renders the lib's sentence verbatim, under an accessible name, with a text-presentation mark", () => {
+    const { coherence } = assessQueryTerms(mismatched);
+    expect(coherence).toBeDefined();
+
+    const el = render(mismatched, () => mismatched);
+    expect(el.textContent).toContain(coherence!.note);
+    // Named for a screen reader by the sr-only prefix, not by the glyph — the
+    // mark is decorative and colour is never the only carrier.
+    expect(el.textContent).toContain("Check these terms:");
+    const mark = [...el.querySelectorAll('[aria-hidden="true"]')].find(
+      (node) => node.textContent === "⚠︎",
+    );
+    expect(mark).toBeDefined();
+  });
+
+  it("renders no note for a coherent query", () => {
+    const coherent: JobQuery = {
+      titles: ["Engineering Manager"],
+      skills: ["People Management", "Coaching Mentorship", "Team Building", "Project Delivery"],
+    };
+    expect(assessQueryTerms(coherent).coherence).toBeUndefined();
+
+    const el = render(coherent, () => coherent);
+    expect(el.textContent).not.toContain("Check these terms:");
+  });
+
+  it("renders the note even when there is nothing missing to add", () => {
+    const coherence = assessQueryTerms(mismatched).coherence!;
+    const el = renderAdvisory([], coherence);
+    expect(el.textContent).toContain(coherence.note);
+    expect(el.textContent).not.toContain("Add to your titles");
+    expect(el.textContent).not.toContain("Add to your skills");
+  });
+
+  it("renders nothing at all when there is no finding and nothing missing", () => {
+    expect(renderAdvisory([], undefined).innerHTML).toBe("");
+  });
+
+  /**
+   * A suggestion pill writes into `query.titles` or into `query.skills`
+   * depending on its kind, and in one flat row the two were visually identical —
+   * nothing on screen said what a click would do. The grouping is the fix, so
+   * these assert the pill is INSIDE its own labelled group, not merely that the
+   * heading text appears somewhere on the page.
+   */
+  describe("grouped suggestions", () => {
+    /** The group element whose heading starts with `heading`, or undefined. */
+    function group(el: HTMLElement, heading: string): Element | undefined {
+      return [...el.querySelectorAll("div")].find(
+        (node) => node.firstElementChild?.textContent?.startsWith(heading) === true,
+      );
+    }
+
+    it("puts each suggestion under a heading that names the field it writes to", () => {
+      const el = renderAdvisory([
+        { term: "engineering team lead", kind: "title" },
+        { term: "people-management", kind: "skill" },
+      ]);
+      const titles = group(el, "Add to your titles");
+      const skills = group(el, "Add to your skills");
+      expect(titles?.textContent).toContain("engineering team lead");
+      expect(titles?.textContent).not.toContain("People Management");
+      expect(skills?.textContent).toContain(
+        missingTermLabel({ term: "people-management", kind: "skill" }),
+      );
+      expect(skills?.textContent).not.toContain("engineering team lead");
+    });
+
+    it("renders only the group it has terms for", () => {
+      const el = renderAdvisory([{ term: "people-management", kind: "skill" }]);
+      expect(el.textContent).toContain("Add to your skills");
+      expect(el.textContent).not.toContain("Add to your titles");
+    });
+  });
+});
+
+/**
+ * Coverage for the `canonicalSkills` annotation the classifier reads. The
+ * classifier's own use of it is `term-quality.test.ts`'s job; this pins the
+ * editor's half of the contract — a chip the USER adds is annotated exactly like
+ * one `buildJobQuery` derived, so the annotation never goes stale against the
+ * list it describes.
+ */
+describe("JobQueryEditor — skill edits keep the canonicality annotation in step", () => {
+  function addSkillValue(el: HTMLElement, value: string) {
+    const input = el.querySelector('input[aria-label="Add skill"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    act(() => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const addBtn = [...el.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Add",
+    )[1]!;
+    act(() => addBtn.click());
+  }
+
+  it("annotates a canonical skill the user types, and leaves a free-text one unannotated", () => {
+    const query: JobQuery = { titles: ["Engineering Manager"], skills: [] };
+    let captured: JobQuery | undefined;
+    const el = render(query, (next) => {
+      captured = next(query);
+    });
+
+    addSkillValue(el, "Kubernetes");
+    expect(captured?.skills).toEqual(["Kubernetes"]);
+    expect(captured?.canonicalSkills).toEqual(["Kubernetes"]);
+
+    addSkillValue(el, "Team Building & Mentorship");
+    expect(captured?.skills).toEqual(["Team Building & Mentorship"]);
+    expect(captured?.canonicalSkills).toEqual([]);
+  });
+
+  it("drops a removed skill from the annotation too", () => {
+    const query: JobQuery = {
+      titles: ["Engineering Manager"],
+      skills: ["Kubernetes", "Team Building & Mentorship"],
+      canonicalSkills: ["Kubernetes"],
+    };
+    let captured: JobQuery | undefined;
+    const el = render(query, (next) => {
+      captured = next(query);
+    });
+    act(() => findButton(el, "Remove Kubernetes").click());
+    expect(captured?.skills).toEqual(["Team Building & Mentorship"]);
+    expect(captured?.canonicalSkills).toEqual([]);
   });
 });

--- a/src/components/features/JobQueryEditor.tsx
+++ b/src/components/features/JobQueryEditor.tsx
@@ -35,14 +35,19 @@
 import { useState } from "react";
 import { EditableField } from "@design-system";
 import type { JobQuery } from "../../lib/job-search/query-builder.ts";
-import { parseSeniorityLabel } from "../../lib/job-search/query-builder.ts";
+import {
+  canonicalSkillLabels,
+  parseSeniorityLabel,
+} from "../../lib/job-search/query-builder.ts";
 import { searchPhrase } from "../../lib/job-search/providers/keywords.ts";
 import type { RoleFamily } from "../../lib/job-search/role-keywords.ts";
+import { assessQueryTerms, type MissingTerm } from "../../lib/job-search/term-quality.ts";
 import { ChipListEditor } from "./ChipListEditor.tsx";
 import { CompFloorInput } from "./CompFloorInput.tsx";
 import { RoleFamilyChips } from "./RoleFamilyChips.tsx";
 import { LevelSelect } from "./LevelSelect.tsx";
 import { AddPill } from "./ReconstructedAdd.tsx";
+import { missingTermLabel, TermQualityAdvisory } from "./TermQualityAdvisory.tsx";
 
 /**
  * The title that produced `query.seniority`, or `undefined` when the level
@@ -95,10 +100,21 @@ export function JobQueryEditor({
       };
     });
 
+  // Skills carry a second, derived field: `canonicalSkills`, the subset the
+  // shared dictionary recognizes, which is what gives `assessQueryTerms` standing
+  // to call a skill weak. Recomputed from the whole list on every edit through
+  // the same `canonicalSkillLabels` `buildJobQuery` used, so a chip the user
+  // types is annotated exactly like a derived one and the annotation can never
+  // describe only the original parse.
+  const withSkills = (q: JobQuery, skills: string[]): JobQuery => ({
+    ...q,
+    skills,
+    canonicalSkills: canonicalSkillLabels(skills),
+  });
   const addSkill = (skill: string) =>
-    onChange((q) => ({ ...q, skills: [...q.skills, skill] }));
+    onChange((q) => withSkills(q, [...q.skills, skill]));
   const removeSkill = (skill: string) =>
-    onChange((q) => ({ ...q, skills: q.skills.filter((s) => s !== skill) }));
+    onChange((q) => withSkills(q, q.skills.filter((s) => s !== skill)));
 
   const addExcludeTerm = (term: string) =>
     onChange((q) => ({ ...q, excludeTerms: [...(q.excludeTerms ?? []), term] }));
@@ -120,6 +136,31 @@ export function JobQueryEditor({
   const setLevel = (level: string | undefined) =>
     onChange((q) => ({ ...q, seniority: level }));
 
+  // Term quality (#585): pure classification, computed fresh each render off
+  // the current `query` — `assessQueryTerms` is total and cheap (no I/O), so
+  // no memoization is warranted. `ChipListEditor` stays display-only: it
+  // looks up a verdict by chip text, it never classifies.
+  const assessment = assessQueryTerms(query);
+  const titleVerdicts = new Map(
+    assessment.verdicts.filter((v) => v.kind === "title").map((v) => [v.term, v]),
+  );
+  const skillVerdicts = new Map(
+    assessment.verdicts.filter((v) => v.kind === "skill").map((v) => [v.term, v]),
+  );
+  // Adding a missing term to the QUERY, never the résumé (#585) — a plain
+  // whole-query replacement through the same `onChange` every other handler
+  // here uses, so it rides the live re-rank with no refetch. `missingTermLabel`
+  // is the same mapping `TermQualityAdvisory` rendered the pill with, so the
+  // text the user clicked is exactly the text that lands in the query.
+  const addMissingTerm = (term: MissingTerm) => {
+    const label = missingTermLabel(term);
+    onChange((q) =>
+      term.kind === "title"
+        ? { ...q, titles: [...q.titles, label] }
+        : withSkills(q, [...q.skills, label]),
+    );
+  };
+
   /** The literal string that egresses to the keyless feeds — empty when the
    *  query carries neither a title nor a skill. */
   const egressPhrase = searchPhrase(query);
@@ -136,6 +177,7 @@ export function JobQueryEditor({
           addAriaLabel="Add title"
           primaryIndex={query.titles.length > 0 ? 0 : undefined}
           onPromote={promoteTitle}
+          qualityFor={(item) => titleVerdicts.get(item)}
         />
         {/* #581: this reads the SAME `searchPhrase` the keyless feeds are
          *  called with, rather than a copy, so it can never drift from what
@@ -164,6 +206,7 @@ export function JobQueryEditor({
         onRemove={removeSkill}
         placeholder="Add a skill…"
         addAriaLabel="Add skill"
+        qualityFor={(item) => skillVerdicts.get(item)}
       />
 
       <div className="flex flex-col gap-3">
@@ -221,6 +264,16 @@ export function JobQueryEditor({
           </p>
         )}
       </div>
+
+      {/* Term-quality advisory (#585 missing terms + #587 title/skill
+       *  coherence): renders nothing when it has nothing to say, including the
+       *  unresolved-role case — no fourth panel, no "we couldn't identify your
+       *  role" nag, no all-clear. */}
+      <TermQualityAdvisory
+        missing={assessment.missing}
+        coherence={assessment.coherence}
+        onAdd={addMissingTerm}
+      />
 
       {isDegenerate && (
         <p className="text-xs text-content-tertiary sm:col-span-2 lg:col-span-3">

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -98,6 +98,7 @@ import {
 import { validateDate } from "../../lib/edit/field-validators.ts";
 import { EducationSection } from "./ReconstructedEducationSkills.tsx";
 import { SkillsSection } from "./ReconstructedSkills.tsx";
+import { SkillTermGuidance } from "./SkillTermGuidance.tsx";
 import { Button, EditableField } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
@@ -1340,6 +1341,11 @@ export function ReconstructedResume({
           removeCategorySkill(parsed.skillCategories ?? [], skill)
         }
       />
+      {/* Term-quality guidance (#586): same classifier as `/jobs/`'s
+       *  `TermQualityAdvisory`, résumé-framed copy, writes only through the
+       *  existing `addSkill` inline-edit path. Renders nothing when there's
+       *  no suggestion, including the unresolved-role case. */}
+      <SkillTermGuidance parsed={parsed} onAddSkill={addSkill} />
     </section>
   );
 }

--- a/src/components/features/SkillTermGuidance.test.tsx
+++ b/src/components/features/SkillTermGuidance.test.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render coverage for SkillTermGuidance (#586). Raw createRoot + act,
+ * matching the other feature render tests in this lane (no
+ * @testing-library here — see RoleFamilyChips.test.tsx).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SkillTermGuidance } from "./SkillTermGuidance.tsx";
+import type { ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(parsed: ResumeQueryInput, onAddSkill: (skill: string) => void) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(SkillTermGuidance, { parsed, onAddSkill }));
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** A résumé whose title resolves the backend-engineer profile: PostgreSQL is
+ *  canonical for that role (strong), C# is recognized but not what the role
+ *  is usually hired on (weak), and "People Management" is a high-value skill
+ *  the profile expects but the résumé never uses (missing). */
+function resolvableParsed(): ResumeQueryInput {
+  return {
+    skills: ["PostgreSQL", "C#"],
+    experience: [
+      {
+        title: "Backend Engineer",
+        company: "Acme Corp",
+      },
+    ],
+  };
+}
+
+describe("SkillTermGuidance", () => {
+  it("renders recognized and not-recognized skills for a role-resolvable résumé", () => {
+    const el = render(resolvableParsed(), () => {});
+    expect(el.textContent).toContain("Terms worth adding");
+    // `query.skills` canonicalizes through the jd-match skill index
+    // (`buildJobQuery` → `getSkillIndex`), so the rendered term is the
+    // canonical id/label ("postgresql", "csharp"), not the résumé's raw
+    // casing — same behaviour `/jobs/` renders.
+    expect(el.textContent).toContain("Recognized in your résumé: postgresql");
+    expect(el.textContent).toContain("Not recognized by matchers: csharp");
+  });
+
+  it("renders the reason for an unrecognized skill verbatim from the classifier", () => {
+    const el = render(resolvableParsed(), () => {});
+    // REASONS.skillWeak in term-quality.ts.
+    expect(el.textContent).toContain(
+      "Not what this role is usually hired on, so it adds little.",
+    );
+  });
+
+  it("calls onAddSkill through the existing inline-edit path when a missing term is clicked", () => {
+    const added: string[] = [];
+    const el = render(resolvableParsed(), (skill) => added.push(skill));
+    const pill = el.querySelector("button[aria-label]") as HTMLButtonElement;
+    expect(pill).not.toBeNull();
+    const label = pill.getAttribute("aria-label");
+    act(() => pill.click());
+    expect(added).toEqual([label]);
+  });
+
+  it("never auto-edits: no onAddSkill call happens on render alone", () => {
+    let called = false;
+    render(resolvableParsed(), () => {
+      called = true;
+    });
+    expect(called).toBe(false);
+  });
+
+  it("renders nothing for a résumé whose role never resolves", () => {
+    const el = render(
+      {
+        skills: [],
+        experience: [
+          { title: "Chief Happiness Officer", company: "Acme Corp" },
+        ],
+      },
+      () => {},
+    );
+    expect(el.textContent).toBe("");
+  });
+
+  it("renders nothing for an entirely empty résumé", () => {
+    const el = render({ skills: [], experience: [] }, () => {});
+    expect(el.textContent).toBe("");
+  });
+});

--- a/src/components/features/SkillTermGuidance.tsx
+++ b/src/components/features/SkillTermGuidance.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * SkillTermGuidance — surfaces the term-quality classifier's verdict on the
+ * résumé's OWN skills, in the résumé review lane (#586). `TermQualityAdvisory`
+ * (#585) does the equivalent job on `/jobs/`, but that surface can only edit
+ * the search *query* — it has no DropZone and no editor. This one sits beside
+ * `SkillsSection` on `/`, where `onAddSkill` writes through the existing
+ * inline-edit path (`useEditableParse`), so a suggestion here can actually
+ * land in the document.
+ *
+ * SAME CLASSIFIER, NO SECOND JUDGEMENT. Builds a `JobQuery` from the current
+ * parse with `buildJobQuery` and reads it through `assessQueryTerms` — the
+ * same function `/jobs/` calls. This component adds no rule of its own; it
+ * only decides what to show and how to phrase the surrounding copy.
+ *
+ * COPY IS DELIBERATELY NOT `/jobs/`'S COPY. `TermQualityAdvisory` frames
+ * everything as "your query" (heading: "Commonly expected for this role, not
+ * in your query") because that surface edits a search. Here the framing is
+ * always "your résumé" / "in your résumé" — the document, not a query — per
+ * the issue's instruction that an identically-reading sentence belongs on
+ * only one surface. `TermVerdict.reason` is the one exception: it is
+ * written once in `term-quality.ts` and rendered verbatim on both surfaces on
+ * purpose, so the same skill can never be explained two different ways.
+ *
+ * "NOISE" SKILLS ARE DELIBERATELY OMITTED. A "noise" verdict's reason talks
+ * about search admission ("Too common as a search term to narrow your
+ * results") — a query concept with nothing to say about a résumé. Only
+ * "strong" (recognized) and "weak" (not recognized by matchers, but not
+ * struck as worthless — term-quality.ts's central rule) skill verdicts, plus
+ * `missing` skills, render here. Both are `[]`/absent whenever no role
+ * resolved (term-quality.ts rule 1), which is what makes this component
+ * return `null` for an unresolvable résumé too — no separate check is needed
+ * for that case.
+ *
+ * NEVER AUTO-EDITS. `onAddSkill` fires only from a user click on an `AddPill`
+ * (the same primitive `TermQualityAdvisory` reuses) — this component reads
+ * the parse, it never writes to it on its own.
+ *
+ * Reuse Gate (PR body): no existing résumé-review surface fit. `CritiquePanel`
+ * is WebLLM-gated content critique (prose/bullet quality), not vocabulary
+ * matching, and lives in a different tab entirely. The skills-ordering
+ * critique issue (#544) is unimplemented — there is no surface to extend.
+ * `TermQualityAdvisory` itself can't be reused as-is: it writes into a
+ * `JobQuery`, not the résumé model, and its copy is query-framed throughout.
+ * So this is a new, narrowly-scoped sibling, not a parallel copy of either.
+ */
+
+import { assessQueryTerms } from "../../lib/job-search/term-quality.ts";
+import { buildJobQuery, type ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
+import { missingTermLabel } from "./TermQualityAdvisory.tsx";
+import { AddPill } from "./ReconstructedAdd.tsx";
+
+export function SkillTermGuidance({
+  parsed,
+  onAddSkill,
+}: {
+  /** The current parse — same shape `FindJobsPanel` feeds `buildJobQuery`. */
+  parsed: ResumeQueryInput;
+  /** The existing inline-edit path (`useEditableParse.addSkill`) — the ONLY
+   *  way a suggestion here reaches the résumé. */
+  onAddSkill: (skill: string) => void;
+}) {
+  const query = buildJobQuery(parsed);
+  const assessment = assessQueryTerms(query);
+
+  const skillVerdicts = assessment.verdicts.filter((v) => v.kind === "skill");
+  const recognized = skillVerdicts.filter((v) => v.quality === "strong");
+  const unrecognized = skillVerdicts.filter((v) => v.quality === "weak");
+  const missingSkills = assessment.missing.filter((m) => m.kind === "skill");
+
+  if (recognized.length === 0 && unrecognized.length === 0 && missingSkills.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-subtle p-3">
+      <p className="flex items-start gap-1.5 text-xs font-semibold text-content-secondary">
+        <span aria-hidden="true">⚠︎</span>
+        <span>
+          <span className="sr-only">Term guidance: </span>
+          Terms worth adding
+        </span>
+      </p>
+
+      {missingSkills.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-content-tertiary">
+            Roles like yours are usually described with terms not in your résumé
+          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {missingSkills.map((term) => (
+              <AddPill
+                key={term.term}
+                label={missingTermLabel(term)}
+                onClick={() => onAddSkill(missingTermLabel(term))}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {recognized.length > 0 && (
+        <p className="text-xs text-content-tertiary">
+          <span className="font-medium text-content-secondary">
+            Recognized in your résumé:
+          </span>{" "}
+          {recognized.map((v) => v.term).join(", ")}
+        </p>
+      )}
+
+      {unrecognized.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <p className="text-xs text-content-tertiary">
+            <span className="font-medium text-content-secondary">
+              Not recognized by matchers:
+            </span>{" "}
+            {unrecognized.map((v) => v.term).join(", ")}
+          </p>
+          {/* `reason` rendered verbatim, per term-quality.ts's contract — the
+           *  same explanation `/jobs/` would show for the same skill. */}
+          <ul className="flex flex-col gap-0.5 pl-4 text-xs text-content-tertiary">
+            {unrecognized.map((v) => (
+              <li key={v.term} className="list-disc">
+                <span className="font-medium">{v.term}</span> — {v.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/TermQualityAdvisory.tsx
+++ b/src/components/features/TermQualityAdvisory.tsx
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * TermQualityAdvisory — the "here's what's missing" half of the term-quality
+ * surface (#585). `JobQueryEditor` marks the chips that already exist; this
+ * renders `QueryTermAssessment.missing` (`term-quality.ts`) as an add-able
+ * row beneath the relevant chip list.
+ *
+ * Deliberately its own component, not inline in `JobQueryEditor` (already
+ * near the ~200 LOC gate) or a fourth panel: this is the one place a grouped
+ * term advisory lives, so #587's title/skill coherence note renders INSIDE it
+ * rather than as a second advisory surface next to it.
+ *
+ * GROUPED BY KIND (see {@link GROUPS}), because the two kinds write to two
+ * different fields of the query and a flat row said nothing about which.
+ *
+ * Renders nothing when it has nothing to say — `missing` empty AND no
+ * coherence finding, which covers the unresolved-role case where
+ * `assessQueryTerms` returns `[]`/`undefined` by contract. No empty-state box,
+ * no "we couldn't identify your role" nag, and no "your résumé looks
+ * consistent" all-clear (term-quality docblock, rule 1). The two conditions
+ * are INDEPENDENT: a mismatched résumé routinely has no missing terms, and the
+ * note must survive that.
+ *
+ * The coherence note is a block, not a pill, so it competes with nothing for
+ * the missing-term caps (3 titles / 5 skills, `term-quality.ts`) — those keep
+ * the advisory short on their own.
+ *
+ * `note` is rendered VERBATIM from the lib. The sentence is written once in
+ * `term-quality.ts` so `/jobs/` and the résumé lane cannot describe the same
+ * finding differently; this component never composes copy of its own.
+ *
+ * Reuse Gate: each suggestion is the existing `AddPill` "+ <label>"
+ * progressive-disclosure pill (`ReconstructedAdd.tsx`) — the shared piece
+ * this exact shape already has — not a new pill component.
+ *
+ * `MissingTerm.term` for `kind: "skill"` is a canonical jd-match id (e.g.
+ * `ci-cd`), not a display label (`term-quality.ts` module docblock).
+ * {@link missingTermLabel} is the one place that mapping happens, so the
+ * text a user clicks and the text `JobQueryEditor` appends to `query.skills`
+ * (which expects the same canonical labels `buildJobQuery` already produces)
+ * can never drift apart — both read through this same helper.
+ */
+
+import { getSkillIndex } from "../../lib/jd-match/skills.ts";
+import type { CoherenceFinding, MissingTerm } from "../../lib/job-search/term-quality.ts";
+import { AddPill } from "./ReconstructedAdd.tsx";
+
+/** The display text for a missing term — the term itself for a title, or the
+ *  skill's human label (falling back to the id) for a skill. */
+export function missingTermLabel(term: MissingTerm): string {
+  if (term.kind === "title") return term.term;
+  return getSkillIndex().idToLabel.get(term.term) ?? term.term;
+}
+
+/**
+ * One group per `MissingTerm.kind`, in render order. The grouping is not
+ * cosmetic: a click on "+ software engineering manager" writes into
+ * `query.titles` and a click on "+ people management" writes into
+ * `query.skills`, and in one flat row those two pills were indistinguishable —
+ * a user could not tell what a click would do. The heading names the
+ * destination first, then the consequence.
+ *
+ * Query-framed throughout ("your search"), like the rest of `/jobs/`. The `/`
+ * lane's `SkillTermGuidance` deliberately says "your résumé" for the same
+ * classifier output — same judgement, two different things a click can change,
+ * so the copy may not be shared (see that component).
+ */
+const GROUPS: readonly { kind: MissingTerm["kind"]; heading: string }[] = [
+  { kind: "title", heading: "Add to your titles — employers post these for this role" },
+  { kind: "skill", heading: "Add to your skills — this role is usually hired on these" },
+];
+
+export function TermQualityAdvisory({
+  missing,
+  coherence,
+  onAdd,
+}: {
+  missing: readonly MissingTerm[];
+  /** A confident title/skill mismatch (#587), or `undefined` — the normal
+   *  state, which renders nothing rather than an all-clear. */
+  coherence?: CoherenceFinding;
+  /** Called with the term the user clicked to add; `JobQueryEditor` maps it
+   *  through {@link missingTermLabel} before writing it into the query, the
+   *  same way this component renders it. */
+  onAdd: (term: MissingTerm) => void;
+}) {
+  if (missing.length === 0 && !coherence) return null;
+
+  return (
+    <div className="flex flex-col gap-3 sm:col-span-2 lg:col-span-3">
+      {/* #587. The mark is decorative (it repeats what the sentence says, so
+       *  colour and glyph are never the only carriers); the sr-only prefix is
+       *  what gives the block an accessible name in the reading order. */}
+      {coherence && (
+        <p className="flex items-start gap-1.5 text-xs text-feedback-warning-text">
+          <span aria-hidden="true">⚠︎</span>
+          <span>
+            <span className="sr-only">Check these terms: </span>
+            {coherence.note}
+          </span>
+        </p>
+      )}
+      {GROUPS.map(({ kind, heading }) => {
+        const terms = missing.filter((term) => term.kind === kind);
+        if (terms.length === 0) return null;
+        return (
+          <div key={kind} className="flex flex-col gap-1.5">
+            <span className="text-xs text-content-tertiary">{heading}</span>
+            <div className="flex flex-wrap gap-1.5">
+              {terms.map((term) => (
+                <AddPill
+                  key={term.term}
+                  label={missingTermLabel(term)}
+                  onClick={() => onAdd(term)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/design-system/primitives/Chip.test.tsx
+++ b/src/design-system/primitives/Chip.test.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Structural test for the `Chip` remove control's expanded hit area (#591).
+ * jsdom does not do layout — `getBoundingClientRect()` returns zeros here, so
+ * a real pixel measurement is NOT possible in this suite (see the actual
+ * browser measurement recorded in #591 instead). This asserts the CSS
+ * technique that produces the 24x24 CSS px hit area is present — an invisible
+ * `after:` overlay inset -5px on every side around the ~14px visible control
+ * — as a structural proxy, not a rendered measurement. Matches
+ * `EditableField.test.tsx`'s `renderToStaticMarkup` pattern; no jsdom needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Chip } from "./Chip.tsx";
+
+function render(props: Parameters<typeof Chip>[0]): string {
+  return renderToStaticMarkup(createElement(Chip, props));
+}
+
+describe("Chip remove control target size", () => {
+  it("expands the remove control's hit area to 24x24 via an invisible overlay, not a layout change", () => {
+    const html = render({
+      children: "React",
+      onRemove: () => {},
+      removeLabel: "Remove React",
+    });
+    // `relative` positions the button as the overlay's containing block;
+    // `after:-inset-[5px]` grows the clickable area 5px on every side of the
+    // ~14px visible control (14 + 5 + 5 = 24), meeting WCAG 2.2 SC 2.5.8 (AA)
+    // without touching the button's own visual box.
+    expect(html).toContain("relative");
+    expect(html).toContain("after:-inset-[5px]");
+    expect(html).toContain("after:content-[&#x27;&#x27;]");
+  });
+});

--- a/src/design-system/primitives/Chip.tsx
+++ b/src/design-system/primitives/Chip.tsx
@@ -79,7 +79,14 @@ export function Chip({
           variant="icon"
           aria-label={removeLabel ?? "Remove"}
           onClick={onRemove}
-          className="shrink-0 text-content-muted hover:text-content-secondary"
+          // WCAG 2.2 SC 2.5.8 Target Size (Minimum, AA) needs a 24x24 CSS px
+          // hit area; the visible glyph + `icon` variant padding is ~14px
+          // (10px svg + p-0.5). `relative` + an invisible `after:` overlay
+          // expand the CLICKABLE area to 24x24 (5px on every side) without
+          // touching the control's visual size or the chip's layout box, so
+          // no row re-spacing is needed (#591). Measured zero-overlap against
+          // neighbouring chips in a real browser — see #591.
+          className="relative shrink-0 text-content-muted hover:text-content-secondary after:absolute after:-inset-[5px] after:content-['']"
         >
           <ChipRemoveIcon />
         </Button>

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -296,6 +296,30 @@ describe("buildJobQuery", () => {
     expect(query.skills).toEqual(["javascript", "react", "python"]);
   });
 
+  it("annotates which of the emitted skills are canonical names, and only those", () => {
+    // The fact `term-quality.ts` cannot recover on its own: a title-cased
+    // free-text phrase is indistinguishable from a canonical label downstream,
+    // and judging one as the other is what marked real skills weak.
+    const parsed = baseParsed({
+      skills: ["JS", "Team Building & Mentorship", "python3", "Engineering Leadership"],
+    });
+    const query = buildJobQuery(parsed);
+    expect(query.skills).toEqual([
+      "javascript",
+      "python",
+      "Team Building & Mentorship",
+      "Engineering Leadership",
+    ]);
+    expect(query.canonicalSkills).toEqual(["javascript", "python"]);
+  });
+
+  it("leaves canonicalSkills absent when no skill is a canonical name", () => {
+    // Absent means "not asserted", which readers treat as no standing to judge —
+    // never as "none are canonical, so all are weak".
+    const query = buildJobQuery(baseParsed({ skills: ["Engineering Leadership"] }));
+    expect(query.canonicalSkills).toBeUndefined();
+  });
+
   it("passes through an unrecognized skill verbatim (title-cased)", () => {
     const parsed = baseParsed({ skills: ["underwater basket weaving"] });
     const query = buildJobQuery(parsed);

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -33,7 +33,10 @@
  * alias the same canonical skill (e.g. "JS" and "Javascript") collapse into
  * one. Skills that don't match a known canonical alias pass through verbatim
  * (title-cased raw string) rather than being dropped, so an unusual but real
- * skill still surfaces.
+ * skill still surfaces. Which of them were recognized is no longer discarded:
+ * it ships as `canonicalSkills`, because a title-cased free-text phrase is
+ * indistinguishable from a canonical label downstream and being judged as one
+ * is what made `term-quality.ts` call a real skill weak. See that field.
  *
  * Ranking (#541): a résumé's skills section is typically NOT already ordered
  * by relevance — an incidental early entry (a soft skill, a one-off tool) can
@@ -66,6 +69,7 @@ import { getSkillIndex } from "../jd-match/skills.ts";
 import { parseSeniorityLabel } from "./seniority.ts";
 export { parseSeniorityLabel };
 import { ROLE_KEYWORDS, tokenizeWords } from "./role-keywords.ts";
+import { normalizeSkillKey } from "./role-profiles.ts";
 
 export interface JobQuery {
   /** Distinct role titles, most-recent-first, deduped case-insensitively and
@@ -126,6 +130,29 @@ export interface JobQuery {
    *  `roleFilterForResume` already guarantees for an unclassified résumé) —
    *  never to zero results. */
   families?: string[];
+  /** The subset of `skills` — verbatim, same strings — that jd-match's canonical
+   *  skill index recognizes (#584 follow-up). It is the ANSWER TO ONE QUESTION a
+   *  downstream classifier cannot ask for itself: *is this chip a canonical skill
+   *  name, or free résumé prose?* `deriveSkills` already computes it (that is what
+   *  ranks canonical entries first) and used to throw it away, emitting a
+   *  title-cased raw phrase that looks exactly like a canonical label — so
+   *  `term-quality.ts` judged "Team Building & Mentorship" as if it were one and
+   *  called a real, on-role skill weak.
+   *
+   *  It travels on the query rather than being recomputed downstream because
+   *  `term-quality.ts` must not gain a runtime import of jd-match (its own
+   *  docblock and `role-profiles.ts`'s draw that boundary — it keeps the skill
+   *  dictionary out of the `/` entry chunk). Data, not a dependency.
+   *
+   *  `undefined` ⇒ NOT ASSERTED, and every reader must treat that as "no basis to
+   *  judge any skill", never as "none are canonical and all are therefore weak" —
+   *  see `assessQueryTerms`. Emitted only when non-empty, the same optional-field
+   *  contract as `titleNoise`, so a hand-built query literal keeps compiling and
+   *  an existing whole-object assertion keeps passing.
+   *
+   *  NOT EGRESS. `providers/keywords.ts` — the sole resume-derived egress helper —
+   *  reads `titles` and `skills` only; no adapter serializes the query object. */
+  canonicalSkills?: string[];
   /** Lowercased tokens that appear in the résumé's own experience LOCATIONS and
    *  COMPANY names — geography/employer words that ride along inside a role
    *  title ("Berlin Site Lead", "Acme Cloud Lead") and would otherwise score as
@@ -270,6 +297,60 @@ function deriveSkills(parsed: ResumeQueryInput): string[] {
   return ranked.slice(0, MAX_SKILLS).map((entry) => entry.label);
 }
 
+/**
+ * Every comparison key jd-match's dictionary recognizes — each alias, each
+ * canonical id, and each display label, all through `normalizeSkillKey`. Built
+ * once, lazily, so importing this module still costs nothing until a query is
+ * actually built.
+ *
+ * Keyed rather than looked up through `aliasToId` directly on purpose: that map
+ * is keyed on the RAW lowercased alias, so it misses a label that is not itself
+ * an alias ("CI/CD" for `ci-cd`) and any separator variant ("Team-Building").
+ * `normalizeSkillKey` is the same folding `term-quality.ts` compares with, so
+ * "is this canonical" and "does this match what the role expects" can never
+ * disagree about whether two spellings are the same skill.
+ */
+let canonicalSkillKeys: ReadonlySet<string> | undefined;
+function getCanonicalSkillKeys(): ReadonlySet<string> {
+  if (!canonicalSkillKeys) {
+    const index = getSkillIndex();
+    const keys = new Set<string>();
+    const add = (value: string) => {
+      const key = normalizeSkillKey(value);
+      if (key) keys.add(key);
+    };
+    for (const [alias, id] of index.aliasToId) {
+      add(alias);
+      add(id);
+    }
+    for (const label of index.idToLabel.values()) add(label);
+    canonicalSkillKeys = keys;
+  }
+  return canonicalSkillKeys;
+}
+
+/**
+ * The entries of `skills` that name a canonical jd-match skill, verbatim and in
+ * input order — the value of `JobQuery.canonicalSkills` (see that field for why
+ * the fact travels on the query at all).
+ *
+ * Exported because the query is EDITABLE: a chip the user types has to be
+ * annotated the same way a derived one was, or the annotation would silently
+ * describe only the original parse. `JobQueryEditor` recomputes the whole list
+ * through this same function on every skill add, so there is one rule, not two.
+ * Pure and total — non-string entries are dropped rather than coerced.
+ */
+export function canonicalSkillLabels(skills: readonly string[] | undefined): string[] {
+  const keys = getCanonicalSkillKeys();
+  const out: string[] = [];
+  for (const skill of skills ?? []) {
+    if (typeof skill !== "string") continue;
+    const key = normalizeSkillKey(skill);
+    if (key && keys.has(key)) out.push(skill);
+  }
+  return out;
+}
+
 function deriveLocation(parsed: ResumeQueryInput): string | undefined {
   const location = parsed.location?.trim();
   return location || undefined;
@@ -380,9 +461,23 @@ export function buildJobQuery(
   // Primary title first, then fall back across the rest of the titles (#540).
   const seniority = deriveSeniorityAcrossTitles(titles);
   const skills = deriveSkills(parsed);
+  // Annotated from the EMITTED labels, not from `deriveSkills`' internal flag:
+  // that flag reads `aliasToId` on the raw résumé string, while every downstream
+  // comparison is against the label this function actually ships. Annotating the
+  // shipped value is what makes the two agree by construction.
+  const canonical = canonicalSkillLabels(skills);
   const location = deriveLocation(parsed);
   const excludeTerms = [...excludeTermSeeds];
   const families = familySeeds === undefined ? undefined : [...familySeeds];
   const titleNoise = deriveTitleNoise(parsed);
-  return { titles, skills, seniority, location, excludeTerms, families, titleNoise };
+  return {
+    titles,
+    skills,
+    canonicalSkills: canonical.length > 0 ? canonical : undefined,
+    seniority,
+    location,
+    excludeTerms,
+    families,
+    titleNoise,
+  };
 }

--- a/src/lib/job-search/query-terms.ts
+++ b/src/lib/job-search/query-terms.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * query-terms.ts — the ONE definition of "which words of a `JobQuery` actually
+ * do anything", shared by the code that applies them and the code that explains
+ * them.
+ *
+ * WHY THIS MODULE EXISTS. These four helpers were private to `search.ts`, where
+ * they decide posting admission (`buildQueryTermPatterns` → `matchesQuery`).
+ * `term-quality.ts` has to answer the user-facing half of the same question —
+ * *"is this chip of mine pulling any weight?"* — and the only honest answer is
+ * the one admission actually uses. A second copy of these rules would let the
+ * explanation drift from the behaviour it explains: the UI would mark a term
+ * significant while the search silently ignored it, which is worse than saying
+ * nothing. So the rules moved DOWN here, to a leaf module, and both callers
+ * import them. There is still exactly one copy.
+ *
+ * WHY A NEW MODULE RATHER THAN EXPORTING FROM `search.ts`. `search.ts` statically
+ * imports the ranking tier, which reaches jd-match's skill dictionary. Importing
+ * it from a classifier that the `/` lane renders would drag that whole graph into
+ * the entry chunk. This module imports NOTHING — that is its point, and the
+ * property to preserve when adding to it.
+ */
+
+/** Tokens too generic to carry query intent on their own. Module-private: the
+ *  predicates below are the supported surface, so callers share the RULE rather
+ *  than re-deriving it from the raw word list. */
+const STOPWORDS = new Set([
+  "and", "or", "the", "of", "for", "with", "in", "at", "to", "on", "an", "a",
+]);
+
+/**
+ * A skill term is significant enough to filter on when it is 3+ chars, or
+ * shorter but symbol-bearing (`c#`, `c++`, `f#`, `.net`) — those are
+ * unambiguous, whereas a bare 2-char alpha token (`ai`, `go`, `ml`) matches
+ * most of a tech feed's prose and reduces `matchesQuery` to a pass-through.
+ *
+ * Accepted cost: bare `Go`, `R`, `AI`, `ML` stop contributing to admission.
+ * This is acceptable because admission is an OR across all terms (dropping
+ * one rarely empties a result set), `matchesQuery` never fails closed (an
+ * empty pattern list admits everything), and the dropped term is still
+ * rendered as a chip and still reaches the deep links — only its filtering
+ * role is removed.
+ *
+ * Expects an already-trimmed, lowercased term, exactly as `search.ts` calls it.
+ */
+export function isSignificantSkillTerm(term: string): boolean {
+  if (STOPWORDS.has(term)) return false;
+  if (term.length >= 3) return true;
+  return /[^a-z0-9]/.test(term);
+}
+
+/**
+ * Split one title-ish string into this filter's title tokens: lowercased, split
+ * on everything outside `a-z0-9+#.`, with leading/trailing dots stripped so
+ * "Node.js." reads as `node.js`.
+ *
+ * Used for BOTH `query.titles` (the admission terms) and `query.titleNoise`
+ * (#579, the tokens that must NOT admit), so the two are compared in exactly the
+ * same token space. That matters: `titleNoise` is derived with
+ * `role-keywords.ts`'s `tokenizeWords`, whose punctuation rule differs — "Acme
+ * Corp." tokenizes as `corp.` there and `corp` here, and "Yahoo!" as `yahoo!`
+ * there and `yahoo` here — so comparing the raw noise strings against these
+ * tokens would silently miss every employer name carrying punctuation.
+ */
+export function titleTokens(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9+#.]+/)
+    .map((token) => token.replace(/^\.+|\.+$/g, ""))
+    .filter(Boolean);
+}
+
+/**
+ * `query.titleNoise` re-tokenized into this module's token space — the set a
+ * title token must NOT be in to admit anything. `undefined` ⇒ empty set, the
+ * pre-#579 behaviour.
+ */
+export function titleNoiseTokens(titleNoise: readonly string[] | undefined): Set<string> {
+  return new Set((titleNoise ?? []).flatMap(titleTokens));
+}
+
+/**
+ * True when a token drawn from a query TITLE contributes to posting admission:
+ * long enough, not a stopword, and not résumé geography/employer noise (#579).
+ * The title-side counterpart of `isSignificantSkillTerm` — deliberately a
+ * different rule (no symbol-bearing escape hatch, plus the noise subtraction),
+ * because titles and skills are different signals; see `buildQueryTermPatterns`.
+ */
+export function isAdmittingTitleTerm(term: string, noise: ReadonlySet<string>): boolean {
+  return term.length >= 3 && !STOPWORDS.has(term) && !noise.has(term);
+}

--- a/src/lib/job-search/role-profiles.ts
+++ b/src/lib/job-search/role-profiles.ts
@@ -807,7 +807,7 @@ function profileTitleTokens(raw: string): ReadonlySet<string> {
  * every separator removed, so "People Management", "people-management" and
  * "people management" collide, and "CI/CD" meets "ci-cd". Total.
  */
-function normalizeSkillKey(raw: string): string {
+export function normalizeSkillKey(raw: string): string {
   return String(raw).toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
 
@@ -872,6 +872,23 @@ function isSubset(needle: ReadonlySet<string>, haystack: ReadonlySet<string>): b
     if (!haystack.has(token)) return false;
   }
   return true;
+}
+
+/**
+ * The TITLE-MATCHING RULE (module docblock) as a public predicate: true when
+ * `profileTitle`'s token set is a SUBSET of `resumeTitle`'s, both normalized by
+ * `profileTitleTokens`. Note the asymmetry — the résumé side may carry extra
+ * words, the profile side may not.
+ *
+ * Exported for consumers that need the per-TITLE answer rather than the
+ * per-PROFILE one the resolvers give: `term-quality.ts` asks both "does this
+ * résumé title match anything the resolved role is called?" and its inverse,
+ * "does the résumé already cover this expected title?" — the same relation read
+ * in both directions. Sharing this predicate is what keeps those answers from
+ * drifting from the resolvers'. Total; never throws.
+ */
+export function profileTitleMatches(profileTitle: string, resumeTitle: string): boolean {
+  return isSubset(profileTitleTokens(profileTitle), profileTitleTokens(resumeTitle));
 }
 
 /** Sort scored entries by score desc, then declaration order asc, then cap. */

--- a/src/lib/job-search/search.ts
+++ b/src/lib/job-search/search.ts
@@ -69,6 +69,12 @@ import type { RankedJob } from "./rank.ts";
 import type { CompanyEntry } from "./company-registry.ts";
 import type { RoleFamily } from "./role-keywords.ts";
 import { mapWithConcurrency } from "./concurrency.ts";
+import {
+  isAdmittingTitleTerm,
+  isSignificantSkillTerm,
+  titleNoiseTokens,
+  titleTokens,
+} from "./query-terms.ts";
 import { refineSearchResult } from "./refine.ts";
 import { dedupKey } from "./raw-postings.ts";
 
@@ -117,53 +123,8 @@ function isSafeUrl(url: string): boolean {
   return /^https?:\/\//i.test(url);
 }
 
-/** Tokens too generic to carry query intent on their own. */
-const STOPWORDS = new Set([
-  "and", "or", "the", "of", "for", "with", "in", "at", "to", "on", "an", "a",
-]);
-
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * A skill term is significant enough to filter on when it is 3+ chars, or
- * shorter but symbol-bearing (`c#`, `c++`, `f#`, `.net`) — those are
- * unambiguous, whereas a bare 2-char alpha token (`ai`, `go`, `ml`) matches
- * most of a tech feed's prose and reduces `matchesQuery` to a pass-through.
- *
- * Accepted cost: bare `Go`, `R`, `AI`, `ML` stop contributing to admission.
- * This is acceptable because admission is an OR across all terms (dropping
- * one rarely empties a result set), `matchesQuery` never fails closed (an
- * empty pattern list admits everything), and the dropped term is still
- * rendered as a chip and still reaches the deep links — only its filtering
- * role is removed.
- */
-function isSignificantSkillTerm(term: string): boolean {
-  if (STOPWORDS.has(term)) return false;
-  if (term.length >= 3) return true;
-  return /[^a-z0-9]/.test(term);
-}
-
-/**
- * Split one title-ish string into this filter's title tokens: lowercased, split
- * on everything outside `a-z0-9+#.`, with leading/trailing dots stripped so
- * "Node.js." reads as `node.js`.
- *
- * Used for BOTH `query.titles` (the admission terms) and `query.titleNoise`
- * (#579, the tokens that must NOT admit), so the two are compared in exactly the
- * same token space. That matters: `titleNoise` is derived with
- * `role-keywords.ts`'s `tokenizeWords`, whose punctuation rule differs — "Acme
- * Corp." tokenizes as `corp.` there and `corp` here, and "Yahoo!" as `yahoo!`
- * there and `yahoo` here — so comparing the raw noise strings against these
- * tokens would silently miss every employer name carrying punctuation.
- */
-function titleTokens(text: string): string[] {
-  return text
-    .toLowerCase()
-    .split(/[^a-z0-9+#.]+/)
-    .map((token) => token.replace(/^\.+|\.+$/g, ""))
-    .filter(Boolean);
 }
 
 /**
@@ -183,13 +144,17 @@ function titleTokens(text: string): string[] {
  * they are user-editable chips carrying a different signal, and the noise set is
  * derived from experience places/companies, not from the skills section.
  * `undefined` ⇒ no noise, byte-identical to pre-#579 admission.
+ *
+ * The token rules themselves live in `query-terms.ts` (a leaf module) rather
+ * than here, because `term-quality.ts` explains this admission decision to the
+ * user and must read the SAME rule — see that module's docblock.
  */
 function buildQueryTermPatterns(query: JobQuery): RegExp[] {
   const terms = new Set<string>();
-  const noise = new Set((query.titleNoise ?? []).flatMap(titleTokens));
+  const noise = titleNoiseTokens(query.titleNoise);
   for (const title of query.titles) {
     for (const term of titleTokens(title)) {
-      if (term.length < 3 || STOPWORDS.has(term) || noise.has(term)) continue;
+      if (!isAdmittingTitleTerm(term, noise)) continue;
       terms.add(term);
     }
   }

--- a/src/lib/job-search/term-quality.test.ts
+++ b/src/lib/job-search/term-quality.test.ts
@@ -1,0 +1,623 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import { assessQueryTerms, TERM_QUALITY_VERSION } from "./term-quality.ts";
+import type { TermVerdict } from "./term-quality.ts";
+import type { JobQuery } from "./query-builder.ts";
+
+/** Minimal typed query stub — only the fields the classifier reads. */
+function makeQuery(overrides: Partial<JobQuery> = {}): JobQuery {
+  return { titles: [], skills: [], ...overrides };
+}
+
+function verdictFor(verdicts: readonly TermVerdict[], term: string): TermVerdict | undefined {
+  return verdicts.find((verdict) => verdict.term === term);
+}
+
+function qualityOf(verdicts: readonly TermVerdict[], term: string): string | undefined {
+  return verdictFor(verdicts, term)?.quality;
+}
+
+describe("assessQueryTerms — totality", () => {
+  it("is versioned", () => {
+    expect(TERM_QUALITY_VERSION).toBe("1.2");
+  });
+
+  it("returns empty results for an empty query", () => {
+    expect(assessQueryTerms(makeQuery())).toEqual({ verdicts: [], missing: [] });
+  });
+
+  it("does not throw on a query missing every optional field", () => {
+    // A hand-built or storage-restored query, the shape the type does not stop.
+    expect(() => assessQueryTerms({} as JobQuery)).not.toThrow();
+    expect(assessQueryTerms({} as JobQuery)).toEqual({ verdicts: [], missing: [] });
+  });
+
+  it("drops blank and non-string chips instead of judging them", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager", "   "],
+        skills: [null as unknown as string, "People Management"],
+      }),
+    );
+    expect(verdicts.map((verdict) => verdict.term)).toEqual([
+      "Engineering Manager",
+      "People Management",
+    ]);
+  });
+
+  it("emits one verdict per distinct term, case-insensitively", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager", "engineering manager"] }),
+    );
+    expect(verdicts).toHaveLength(1);
+  });
+
+  it("is deterministic across calls", () => {
+    const query = makeQuery({
+      titles: ["Engineering Manager", "Acme Berlin"],
+      skills: ["People Management", "Go", "Photoshop"],
+      titleNoise: ["Acme", "Berlin"],
+    });
+    expect(assessQueryTerms(query)).toEqual(assessQueryTerms(query));
+  });
+});
+
+describe("assessQueryTerms — noise", () => {
+  it("marks a title whose every word is the résumé's own geography or employer", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Acme Berlin"], titleNoise: ["Acme Corp.", "Berlin"] }),
+    );
+    const verdict = verdictFor(verdicts, "Acme Berlin");
+    expect(verdict?.quality).toBe("noise");
+    expect(verdict?.reason).toMatch(/place or an employer/);
+  });
+
+  it("keeps a title that carries a real role word alongside a noise word", () => {
+    // "Berlin Site Lead" still admits on `site`/`lead` — only `berlin` is noise,
+    // so the title as a whole is not.
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Berlin Site Lead"], titleNoise: ["Berlin"] }),
+    );
+    // Asserted as the exact quality, not `not.toBe("noise")` — an unjudged term
+    // has no verdict at all, so the negative form would pass vacuously.
+    expect(qualityOf(verdicts, "Berlin Site Lead")).toBe("strong");
+  });
+
+  it("gives a different reason for a title with no searchable word at all", () => {
+    const { verdicts } = assessQueryTerms(makeQuery({ titles: ["IC 3"] }));
+    const verdict = verdictFor(verdicts, "IC 3");
+    expect(verdict?.quality).toBe("noise");
+    expect(verdict?.reason).not.toMatch(/place or an employer/);
+  });
+
+  it("marks a skill below the significance gate", () => {
+    const { verdicts } = assessQueryTerms(makeQuery({ skills: ["Go", "AI"] }));
+    expect(qualityOf(verdicts, "Go")).toBe("noise");
+    expect(qualityOf(verdicts, "AI")).toBe("noise");
+  });
+
+  it("keeps a short symbol-bearing skill out of noise", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({
+        titles: ["Backend Engineer"],
+        skills: ["C#"],
+        // Canonical, so the classifier has standing to call it off-role — see
+        // the "weak needs standing" test below for what happens without it.
+        canonicalSkills: ["C#"],
+      }),
+    );
+    expect(qualityOf(verdicts, "C#")).toBe("weak");
+  });
+
+  it("reports noise ahead of strong for a term that cannot narrow anything", () => {
+    // `go` IS canonical for the resolved backend role and still admits nothing.
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Backend Engineer"], skills: ["Go", "PostgreSQL"] }),
+    );
+    expect(qualityOf(verdicts, "Go")).toBe("noise");
+    expect(qualityOf(verdicts, "PostgreSQL")).toBe("strong");
+  });
+
+  it("judges noise without any resolved role, since noise does not depend on one", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Acme Berlin"], titleNoise: ["Acme", "Berlin"] }),
+    );
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0].quality).toBe("noise");
+  });
+});
+
+describe("assessQueryTerms — strong and weak", () => {
+  it("marks a title the resolved role is actually called", () => {
+    const { verdicts } = assessQueryTerms(makeQuery({ titles: ["Engineering Manager"] }));
+    expect(qualityOf(verdicts, "Engineering Manager")).toBe("strong");
+  });
+
+  it("tolerates decoration on the résumé side of a strong title", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Senior Engineering Manager, Payments"] }),
+    );
+    expect(qualityOf(verdicts, "Senior Engineering Manager, Payments")).toBe("strong");
+  });
+
+  it("marks a recognized but off-role title weak", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager", "Chief Happiness Officer"] }),
+    );
+    expect(qualityOf(verdicts, "Engineering Manager")).toBe("strong");
+    expect(qualityOf(verdicts, "Chief Happiness Officer")).toBe("weak");
+  });
+
+  it("marks a skill the resolved role is described with", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager"], skills: ["People Management"] }),
+    );
+    expect(qualityOf(verdicts, "People Management")).toBe("strong");
+  });
+
+  it("marks a lone off-role tool weak", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["Figma", "Tableau"],
+        canonicalSkills: ["Figma", "Tableau"],
+      }),
+    );
+    expect(qualityOf(verdicts, "Figma")).toBe("weak");
+    expect(qualityOf(verdicts, "Tableau")).toBe("weak");
+  });
+
+  it("reads a coherent off-role cluster as a real second facet, not as weak", () => {
+    // The failure this guards: judging an EM's ML stack against the manager
+    // profile alone would call three sharp, narrowing terms worthless.
+    const { verdicts } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["People Management", "Python", "PyTorch", "TensorFlow"],
+      }),
+    );
+    expect(qualityOf(verdicts, "People Management")).toBe("strong");
+    expect(qualityOf(verdicts, "PyTorch")).toBe("strong");
+    expect(qualityOf(verdicts, "TensorFlow")).toBe("strong");
+  });
+
+  it("compares skills case- and separator-insensitively", () => {
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Site Reliability Engineer"], skills: ["CI/CD", "kubernetes"] }),
+    );
+    expect(qualityOf(verdicts, "CI/CD")).toBe("strong");
+    expect(qualityOf(verdicts, "kubernetes")).toBe("strong");
+  });
+});
+
+/**
+ * The manual-testing reproduction that motivated the standing rule, verbatim: a
+ * real leadership résumé whose role resolved CONFIDENTLY (engineering-manager,
+ * senior-engineering-manager, founder-ceo) and which was then told that nine of
+ * its eleven skills — "Engineering Leadership", "Team Building & Mentorship",
+ * "Hiring & Talent Acquisition" among them — are "not what this role is usually
+ * hired on". That is the one thing `term-quality.ts` exists not to do.
+ */
+describe("assessQueryTerms — a free-text skill is never called weak", () => {
+  const LEADERSHIP_SKILLS = [
+    "cross-functional collaboration",
+    "Engineering Leadership",
+    "Technical Architecture & System Design",
+    "Distributed Systems & Cloud Computing",
+    "Team Building & Mentorship",
+    "Hiring & Talent Acquisition",
+    "Product Development & Strategy",
+    "Performance Optimization",
+    "AI",
+    "LLM Orchestration",
+    "Prompt Engineering & Evals",
+  ];
+  const leadership = makeQuery({
+    titles: ["Engineering Lead", "Founder & CEO", "India Lead", "Sr. Engineering Manager"],
+    skills: LEADERSHIP_SKILLS,
+    // What `buildJobQuery` ships for this résumé: exactly one of the eleven
+    // phrases is a canonical skill name. `query-builder.test.ts` pins that.
+    canonicalSkills: ["cross-functional collaboration"],
+  });
+
+  it("marks no skill of the reproduction weak", () => {
+    const { verdicts } = assessQueryTerms(leadership);
+    const weak = verdicts.filter((v) => v.kind === "skill" && v.quality === "weak");
+    expect(weak).toEqual([]);
+  });
+
+  it("says nothing at all about a phrase it has no canonical name for", () => {
+    const { verdicts } = assessQueryTerms(leadership);
+    expect(verdictFor(verdicts, "Engineering Leadership")).toBeUndefined();
+    expect(verdictFor(verdicts, "Hiring & Talent Acquisition")).toBeUndefined();
+  });
+
+  it("still marks the canonical skill strong, and reads a multi-concept phrase that names an expected skill", () => {
+    const { verdicts } = assessQueryTerms(leadership);
+    expect(qualityOf(verdicts, "cross-functional collaboration")).toBe("strong");
+    // "Team Building & Mentorship" names `team-building`, which this role expects.
+    expect(qualityOf(verdicts, "Team Building & Mentorship")).toBe("strong");
+  });
+
+  it("keeps the role-independent noise verdict, which does not need standing", () => {
+    expect(qualityOf(assessQueryTerms(leadership).verdicts, "AI")).toBe("noise");
+  });
+
+  it("withholds every skill verdict when canonicality is not asserted at all", () => {
+    // A hand-built or storage-restored query. Absent data is read as "no
+    // standing", never as "nothing is canonical, so everything is weak".
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager"], skills: ["Figma", "Tableau"] }),
+    );
+    expect(verdicts.filter((v) => v.kind === "skill")).toEqual([]);
+  });
+
+  it("does not manufacture a strong verdict from a merely shared qualifier", () => {
+    // "Performance Optimization" and `performance-management` share
+    // "performance" and disagree on the head noun — different skills.
+    const { verdicts } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["Performance Optimization"],
+        canonicalSkills: [],
+      }),
+    );
+    expect(verdictFor(verdicts, "Performance Optimization")).toBeUndefined();
+  });
+
+  it("does not manufacture a strong verdict from a bare head noun", () => {
+    // A less-qualified form suppresses a SUGGESTION but is not evidence for a
+    // verdict — "Strategy" is not "technical strategy".
+    const { verdicts } = assessQueryTerms(
+      makeQuery({ titles: ["CTO"], skills: ["Strategy"], canonicalSkills: [] }),
+    );
+    expect(verdictFor(verdicts, "Strategy")).toBeUndefined();
+  });
+
+  it("never matches a skill on a substring of a word", () => {
+    // `java` must not be read out of "JavaScript", nor `sql` out of "MySQL".
+    const { verdicts } = assessQueryTerms(
+      makeQuery({
+        titles: ["Backend Engineer"],
+        skills: ["JavaScript", "MySQL"],
+        canonicalSkills: ["JavaScript", "MySQL"],
+      }),
+    );
+    expect(qualityOf(verdicts, "JavaScript")).toBe("weak");
+    expect(qualityOf(verdicts, "MySQL")).toBe("weak");
+  });
+});
+
+describe("assessQueryTerms — unresolved role", () => {
+  const unresolved = makeQuery({
+    titles: ["Chief Happiness Officer"],
+    skills: ["Excel", "Go"],
+  });
+
+  it("returns no missing terms", () => {
+    expect(assessQueryTerms(unresolved).missing).toEqual([]);
+  });
+
+  it("marks nothing weak on the basis of a role it could not identify", () => {
+    const { verdicts } = assessQueryTerms(unresolved);
+    expect(verdicts.every((verdict) => verdict.quality !== "weak")).toBe(true);
+  });
+
+  it("returns no verdict at all for a term it cannot judge", () => {
+    const { verdicts } = assessQueryTerms(unresolved);
+    expect(verdictFor(verdicts, "Chief Happiness Officer")).toBeUndefined();
+    expect(verdictFor(verdicts, "Excel")).toBeUndefined();
+    // …while the role-independent verdict still lands.
+    expect(qualityOf(verdicts, "Go")).toBe("noise");
+  });
+});
+
+describe("assessQueryTerms — missing terms", () => {
+  it("names titles and skills the resolved role expects and the résumé lacks", () => {
+    const { missing } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager"], skills: ["People Management"] }),
+    );
+    const titles = missing.filter((entry) => entry.kind === "title").map((e) => e.term);
+    const skills = missing.filter((entry) => entry.kind === "skill").map((e) => e.term);
+    expect(titles).toContain("engineering team lead");
+    expect(skills).toContain("coaching-mentorship");
+  });
+
+  it("never names a term the résumé already carries", () => {
+    const { missing } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager"], skills: ["People Management"] }),
+    );
+    expect(missing.map((entry) => entry.term)).not.toContain("engineering manager");
+    expect(missing.map((entry) => entry.term)).not.toContain("people-management");
+  });
+
+  it("counts a decorated résumé title as already covering the expected one", () => {
+    const { missing } = assessQueryTerms(
+      makeQuery({ titles: ["Senior Software Engineering Manager"] }),
+    );
+    expect(missing.map((entry) => entry.term)).not.toContain("senior engineering manager");
+  });
+
+  it("caps each kind so the advice stays readable", () => {
+    const { missing } = assessQueryTerms(makeQuery({ titles: ["Frontend Engineer"] }));
+    expect(missing.filter((entry) => entry.kind === "title").length).toBeLessThanOrEqual(3);
+    expect(missing.filter((entry) => entry.kind === "skill").length).toBeLessThanOrEqual(5);
+  });
+
+  it("never suggests a term it would itself mark noise", () => {
+    // `go` is canonical for the backend role and cannot narrow a search, so the
+    // advice must skip it and back-fill from the next expected skill.
+    const { missing } = assessQueryTerms(makeQuery({ titles: ["Backend Engineer"] }));
+    const skills = missing.filter((entry) => entry.kind === "skill").map((e) => e.term);
+    expect(skills).not.toContain("go");
+    expect(skills).toHaveLength(5);
+  });
+
+  it("never suggests a skill the query already says in different words", () => {
+    // The second half of the reproduction: "+ team building" was offered while
+    // "Team Building & Mentorship" sat as a chip on the same screen, and
+    // "+ coaching / mentorship" beside it.
+    const { missing } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Lead", "Sr. Engineering Manager"],
+        skills: ["Team Building & Mentorship", "Hiring & Talent Acquisition"],
+      }),
+    );
+    const skills = missing.filter((entry) => entry.kind === "skill").map((e) => e.term);
+    expect(skills).not.toContain("team-building");
+    expect(skills).not.toContain("coaching-mentorship");
+    // Suppression costs the advice nothing: the cap back-fills from the next
+    // most-expected entry, so the row is still full.
+    expect(skills).toHaveLength(5);
+  });
+
+  it("still suggests a skill that only shares a qualifier with one the query has", () => {
+    // The over-suppression guard. "Performance Optimization" is not
+    // `performance-management`, and suppressing it would hide a real gap.
+    const { missing } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager"], skills: ["Performance Optimization"] }),
+    );
+    expect(missing.map((entry) => entry.term)).toContain("performance-management");
+  });
+
+  it("never suggests a wordier spelling of a title the query already carries, but keeps a different market phrasing", () => {
+    // The reproduction's titles. "+ engineering team lead" was offered to
+    // someone titled "Engineering Lead" — {engineering, lead} ⊂ {engineering,
+    // team, lead}, the same phrase padded. Both assertions are load-bearing and
+    // must be read together: suppressing on any resemblance would also kill
+    // "software engineering manager", which boards really do post and this
+    // résumé really does not say.
+    const { missing } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Lead", "Founder & CEO", "India Lead", "Sr. Engineering Manager"],
+      }),
+    );
+    const titles = missing.filter((entry) => entry.kind === "title").map((e) => e.term);
+    expect(titles).not.toContain("engineering team lead");
+    expect(titles).toContain("software engineering manager");
+    // The cap is full, so the suppressed entry cost the advice nothing.
+    expect(titles).toHaveLength(3);
+  });
+
+  it("draws from ONE profile, so it never suggests the rung above", () => {
+    const { missing } = assessQueryTerms(makeQuery({ titles: ["Engineering Manager"] }));
+    const terms = missing.map((entry) => entry.term);
+    expect(terms).not.toContain("director of engineering");
+    expect(terms).not.toContain("vp of engineering");
+  });
+
+  it("falls back to the skill-implied role when no title resolves", () => {
+    const { missing } = assessQueryTerms(
+      makeQuery({
+        titles: ["Chief Happiness Officer"],
+        skills: ["Python", "PyTorch", "TensorFlow"],
+      }),
+    );
+    expect(missing.some((entry) => entry.kind === "title")).toBe(true);
+    expect(missing.filter((e) => e.kind === "title").map((e) => e.term)).toContain(
+      "machine learning engineer",
+    );
+  });
+});
+
+/**
+ * Coverage for the title/skill coherence check (issue 587). The failure mode
+ * this guards is a FALSE POSITIVE — telling someone their résumé is broken when
+ * it isn't — so the silence cases outnumber the firing ones on purpose, and
+ * every one of them is a résumé shape a real person has.
+ */
+describe("assessQueryTerms — title/skill coherence", () => {
+  // ── Fires ────────────────────────────────────────────────────────────────
+
+  it("reports leadership titles backed by exclusively hands-on technical skills", () => {
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["Java", "Python", "Kubernetes", "Docker", "Terraform", "AWS"],
+      }),
+    );
+    expect(coherence?.direction).toBe("leadership-titles-ic-skills");
+    // Names the user's own title, the skill shape, and what would close the gap.
+    expect(coherence?.titles).toEqual(["Engineering Manager"]);
+    expect(coherence?.offAxisSkills).toContain("Kubernetes");
+    expect(coherence?.missingSkills).toContain("people-management");
+    expect(coherence?.note).toContain("Engineering Manager");
+  });
+
+  it("reports the inverse — individual-contributor titles backed by exclusively managerial skills", () => {
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Senior Software Engineer"],
+        skills: [
+          "People Management",
+          "Org Design",
+          "Budget Headcount Planning",
+          "Executive Communication",
+          "Performance Management",
+        ],
+      }),
+    );
+    expect(coherence?.direction).toBe("ic-titles-leadership-skills");
+    expect(coherence?.titles).toEqual(["Senior Software Engineer"]);
+    expect(coherence?.offAxisSkills).toContain("Org Design");
+    // The competencies the IC titles' own role expects — the other direction.
+    expect(coherence?.missingSkills).toContain("python");
+  });
+
+  it("names several titles when several resolved", () => {
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Director of Engineering", "Senior Engineering Manager"],
+        skills: ["Python", "PyTorch", "TensorFlow", "Machine Learning", "Deep Learning"],
+      }),
+    );
+    expect(coherence?.titles).toEqual(["Director of Engineering", "Senior Engineering Manager"]);
+  });
+
+  // ── Stays silent ─────────────────────────────────────────────────────────
+
+  it("stays silent for a senior IC who also lists mentorship skills", () => {
+    // THE named false positive. Their skills resolve BOTH an IC role and a
+    // manager, so the skill side is mixed — a person who is genuinely both is
+    // coherent, not mismatched.
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Senior Software Engineer"],
+        skills: ["Python", "Java", "TypeScript", "React", "Coaching Mentorship", "Team Building"],
+      }),
+    );
+    expect(coherence).toBeUndefined();
+  });
+
+  it("stays silent for a manager who kept their engineering skills", () => {
+    // The multi-facet shape rule 2 protects: an EM who was an ML engineer.
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["People Management", "Coaching Mentorship", "PyTorch", "Python", "Machine Learning"],
+      }),
+    );
+    expect(coherence).toBeUndefined();
+  });
+
+  it("stays silent for a promoted IC whose titles span both ladders", () => {
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager", "Senior Software Engineer"],
+        skills: ["Java", "Python", "Kubernetes", "Docker", "Terraform"],
+      }),
+    );
+    expect(coherence).toBeUndefined();
+  });
+
+  it("stays silent when the titles resolve nothing", () => {
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Zzyzx Wobble Frobnicator"],
+        skills: ["Java", "Python", "Kubernetes", "Docker", "Terraform"],
+      }),
+    );
+    expect(coherence).toBeUndefined();
+  });
+
+  it("stays silent when the skills resolve nothing", () => {
+    const { coherence } = assessQueryTerms(
+      makeQuery({ titles: ["Engineering Manager"], skills: ["Photoshop"] }),
+    );
+    expect(coherence).toBeUndefined();
+  });
+
+  it("stays silent when even one skill is what the titles' own role expects", () => {
+    // One managerial skill is below the resolver's own two-hit floor, so the
+    // axis gate cannot see it — this is the gap the "every" gate closes, and
+    // it is what keeps the sentence literally true.
+    const { coherence } = assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["Java", "Python", "Kubernetes", "Docker", "Terraform", "Stakeholder Management"],
+      }),
+    );
+    expect(coherence).toBeUndefined();
+  });
+
+  it("stays silent on an empty query", () => {
+    expect(assessQueryTerms(makeQuery()).coherence).toBeUndefined();
+    expect(assessQueryTerms({} as JobQuery).coherence).toBeUndefined();
+  });
+
+  // ── The threshold does real work ─────────────────────────────────────────
+
+  it("stays silent below the off-axis skill threshold and reports above it", () => {
+    const titles = ["Senior Software Engineer"];
+    const marginal = ["Coaching Mentorship", "Team Building"];
+    expect(assessQueryTerms(makeQuery({ titles, skills: marginal })).coherence).toBeUndefined();
+
+    const clears = [...marginal, "People Management", "Performance Management"];
+    const { coherence } = assessQueryTerms(makeQuery({ titles, skills: clears }));
+    expect(coherence?.offAxisSkills).toHaveLength(4);
+    expect(coherence?.direction).toBe("ic-titles-leadership-skills");
+  });
+});
+
+describe("coherence copy", () => {
+  const notes = [
+    assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager"],
+        skills: ["Java", "Python", "Kubernetes", "Docker", "Terraform"],
+      }),
+    ).coherence?.note,
+    assessQueryTerms(
+      makeQuery({
+        titles: ["Senior Software Engineer"],
+        skills: ["People Management", "Org Design", "Team Building", "Performance Management"],
+      }),
+    ).coherence?.note,
+  ];
+
+  it("covers both directions", () => {
+    expect(notes.filter(Boolean)).toHaveLength(2);
+    expect(new Set(notes).size).toBe(2);
+  });
+
+  it("names a consequence, never the mechanism", () => {
+    for (const note of notes) {
+      expect(note).toBeDefined();
+      expect(note).not.toMatch(/tokenizer|filter|regex|gate|profile|resolver|admission|#/i);
+    }
+  });
+});
+
+describe("reason copy", () => {
+  // Every reason string the module can emit, gathered from queries that trigger
+  // each branch — a denylist over REASONS itself would not prove the branches
+  // reach these strings.
+  const everyReason = [
+    ...assessQueryTerms(
+      makeQuery({ titles: ["Acme Berlin", "IC 3"], titleNoise: ["Acme", "Berlin"] }),
+    ).verdicts,
+    ...assessQueryTerms(
+      makeQuery({
+        titles: ["Engineering Manager", "Chief Happiness Officer"],
+        skills: ["People Management", "Figma", "Go"],
+        canonicalSkills: ["People Management", "Figma"],
+      }),
+    ).verdicts,
+  ].map((verdict) => verdict.reason);
+
+  it("covers all seven branches", () => {
+    expect(new Set(everyReason).size).toBe(7);
+  });
+
+  it("is never empty", () => {
+    for (const reason of everyReason) expect(reason.trim().length).toBeGreaterThan(0);
+  });
+
+  it("names a consequence, never the mechanism", () => {
+    for (const reason of everyReason) {
+      expect(reason).not.toMatch(/tokenizer|filter|regex|gate|profile|admission|#/i);
+    }
+  });
+});

--- a/src/lib/job-search/term-quality.ts
+++ b/src/lib/job-search/term-quality.ts
@@ -1,0 +1,777 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * term-quality.ts — judges every term of a `JobQuery` (#584): which of the
+ * user's own titles and skills carry weight, and which high-value terms for
+ * their role the résumé never uses.
+ *
+ * WHY THIS MODULE EXISTS. Three separate surfaces ask the same three questions
+ * — *which of my titles is a good search term*, *which of my skills are pulling
+ * weight*, *what am I missing* — so the judgement lives in one pure module and
+ * the surfaces render it. The copy in `reason` is part of that: it is written
+ * here, once, and shown verbatim, so `/jobs/` and `/` cannot describe the same
+ * chip differently.
+ *
+ * THE CONSTRAINT THIS GUARDS: **never tell a user a real term is worthless.**
+ * A false "noise" or "weak" verdict is not a cosmetic miss — it invites someone
+ * to delete a term that was working. Three rules follow from that and are the
+ * reason the code is shaped the way it is:
+ *
+ *  1. NOTHING IS JUDGED WITHOUT A BASIS. When no role profile resolves, this
+ *     returns NO verdict at all for terms whose quality depends on the role —
+ *     not a defaulted "weak". Only the role-independent noise verdicts survive,
+ *     because those are true regardless of who the candidate is. `missing` is
+ *     `[]` for the same reason: inventing "you're missing X" for a role we could
+ *     not identify is worse than saying nothing. A surface renders an
+ *     unjudged term as a plain chip; absence of a verdict is the honest state
+ *     and consumers MUST treat it that way rather than substituting a default.
+ *  2. THE EXPECTED SET IS THE UNION OF EVERY RESOLVED PROFILE, from BOTH
+ *     resolvers. A résumé is usually more than one facet — an EM who was an ML
+ *     engineer has both, and judging their PyTorch against the manager profile
+ *     alone would call a sharp, narrowing term "weak". Resolving by skills too
+ *     costs nothing in false-strongs, because `resolveProfilesBySkills` needs
+ *     two hits before it reports anything: a lone off-role tool still reads as
+ *     weak, while a coherent off-role cluster reads as the real second facet it
+ *     is. This does NOT preempt the title/skill coherence check — that compares
+ *     the two resolvers' answers independently, which is exactly why
+ *     `role-profiles.ts` keeps them separate.
+ *  3. `missing` COMES FROM ONE PROFILE, not the union. Profiles are per-rung, so
+ *     unioning would hand a manager a director's titles — advice that reads as
+ *     "apply one level up" when we meant "here is what your role is called".
+ *
+ * DERIVED, NOT INVENTED. Every input is an asset that already ships. "Noise" is
+ * whatever `search.ts` already refuses to admit postings on, read through the
+ * shared rules in `query-terms.ts`; "strong"/"weak"/"missing" come from
+ * `role-profiles.ts` and its own matching predicates. This module adds no fourth
+ * vocabulary and no second copy of either rule — if it did, the explanation
+ * would drift from the behaviour it claims to explain.
+ *
+ * NOISE OUTRANKS STRONG, deliberately. `Go` is a canonical backend skill AND a
+ * bare two-char token the admission filter drops, so it is reported as noise:
+ * admission happens upstream of relevance, and a term that admits nothing
+ * narrows nothing no matter how apt it is. The copy is scoped to that
+ * consequence ("can't narrow your results") and never says the skill does not
+ * belong on the résumé — because it does, it still renders as a chip, and it
+ * still reaches the deep links.
+ *
+ * STRONG NEEDS EVIDENCE; WEAK NEEDS STANDING. The two skill verdicts are NOT
+ * two halves of one boolean, and treating them as one is what let this module
+ * violate its own constraint. "Strong" is a positive claim — this term is one
+ * the role expects — and any term that demonstrably matches an expected skill
+ * earns it. "Weak" is the destructive claim — *this term is not what your role
+ * is hired on* — and it may only be said about a term we are entitled to judge:
+ * a CANONICAL skill name, one the shared dictionary knows. A free-text résumé
+ * phrase ("Team Building & Mentorship") is not a canonical name, so a failure to
+ * match it proves nothing about the term and everything about our vocabulary; it
+ * gets NO verdict, exactly like rule 1's unresolved role. Before this asymmetry
+ * existed, nine of eleven skills on a leadership résumé whose role resolved
+ * confidently were marked weak — including "Engineering Leadership" and "Hiring
+ * & Talent Acquisition".
+ *
+ * WHICH SKILLS ARE CANONICAL ARRIVES AS DATA, on `JobQuery.canonicalSkills`,
+ * because this module must not gain a runtime import of jd-match (see the
+ * boundary note below). `undefined` there means NOT ASSERTED — a hand-built or
+ * storage-restored query — and is read as "no standing to call anything weak",
+ * never as "nothing is canonical, so everything is weak". That is the only
+ * reading of absent data that cannot resurrect the false-weak bug; the cost is
+ * silence on a query nobody annotated, which is the honest state.
+ *
+ * MATCHING IS WORD-WISE, NOT KEY-EQUAL (`skillCovers`). A canonical id is one
+ * concept; a résumé phrase is often several ("Team Building & Mentorship"), and
+ * comparing whole normalized keys makes the two never equal. The same predicate
+ * answers both questions that need it — *is this chip strong* and *does the
+ * query already carry this expected skill* — so a term can never be suggested
+ * and marked at odds with itself. It is deliberately word-level, never
+ * substring: "javascript" is one word and so never covers "java".
+ *
+ * CLASSIFIES ONLY. Nothing here mutates a query or removes a term. Removal is a
+ * user action on a surface, always.
+ *
+ * THE COHERENCE CHECK (#587) IS A FOURTH JUDGEMENT, and the strictest one. It
+ * compares the two resolvers' answers — what the person calls themselves vs what
+ * their evidence describes — and reports a leadership/IC axis disagreement. It
+ * deliberately does NOT read the union rule 2 builds: the union exists to stop a
+ * genuine second facet reading as weak, and folding it in here would erase the
+ * very disagreement this looks for. Its false-positive cost is higher than any
+ * verdict's — "your résumé does not match your titles" is a claim about the
+ * document, not about one chip — so it clears four gates, not one; see
+ * `assessCoherence`.
+ *
+ * NO jd-match RUNTIME IMPORT, the same boundary `role-profiles.ts` draws. Two
+ * consequences for callers: `query.skills` are expected to be the canonical
+ * labels `buildJobQuery` already produces (a raw alias like "k8s" is nobody's
+ * canonical id and would read as unexpected), and `MissingTerm.term` for a skill
+ * is a canonical jd-match id (`ci-cd`), not a display label — a surface wanting
+ * "CI/CD" maps it through jd-match's `getSkillIndex().idToLabel`.
+ */
+
+import type { JobQuery } from "./query-builder.ts";
+import type { RoleFamily } from "./role-keywords.ts";
+import {
+  isAdmittingTitleTerm,
+  isSignificantSkillTerm,
+  titleNoiseTokens,
+  titleTokens,
+} from "./query-terms.ts";
+import {
+  normalizeSkillKey,
+  profileTitleMatches,
+  resolveProfilesBySkills,
+  resolveProfilesByTitles,
+  type RoleProfile,
+} from "./role-profiles.ts";
+
+/**
+ * Version of the classification rules + the copy they emit. Bump when a change
+ * can move what `assessQueryTerms` returns for the same query — a rule change,
+ * a cap change, or a `reason` rewrite (the strings are user-visible).
+ *
+ * Changelog:
+ * - 1.0 (2026-07-25): initial classifier (#584).
+ * - 1.1 (2026-07-25): title/skill coherence finding (#587) — an added optional
+ *   `coherence` field; no existing field changed shape or value.
+ * - 1.2 (2026-07-25): a skill verdict now needs standing before it can read
+ *   "weak" (`query.canonicalSkills`), skill matching is word-wise rather than
+ *   key-equal, and a `missing` entry is suppressed when the query already
+ *   covers it. Moves verdicts (weak → none, none → strong) and drops
+ *   suggestions for the same query; no field changed shape.
+ */
+export const TERM_QUALITY_VERSION = "1.2";
+
+export type TermQuality =
+  /** Canonical for the resolved role — a market term that narrows well. */
+  | "strong"
+  /** Recognized but weak: too generic, or peripheral to the resolved role. */
+  | "weak"
+  /** Not a role signal at all — geography, employer, or a token below the
+   *  significance gate that contributes nothing to admission. */
+  | "noise";
+
+export interface TermVerdict {
+  /** The term verbatim as it appears in the query (and as the chip renders). */
+  readonly term: string;
+  readonly kind: "title" | "skill";
+  readonly quality: TermQuality;
+  /** One short user-facing consequence — never the mechanism. Rendered as-is;
+   *  no issue numbers, no "tokenizer", no "admission filter". */
+  readonly reason: string;
+}
+
+export interface MissingTerm {
+  /** A high-value term for the resolved role that the résumé does not use.
+   *  For `kind: "skill"` this is a canonical jd-match id, not a display label
+   *  (module docblock). */
+  readonly term: string;
+  readonly kind: "title" | "skill";
+}
+
+/** Which way round a coherence disagreement runs. */
+export type CoherenceDirection =
+  /** Leadership titles, exclusively individual-contributor skills. */
+  | "leadership-titles-ic-skills"
+  /** Individual-contributor titles, exclusively people-leadership skills. */
+  | "ic-titles-leadership-skills";
+
+/**
+ * A CONFIDENT title/skill disagreement (#587). Present only when every gate in
+ * {@link assessCoherence} cleared; its absence is the overwhelmingly common —
+ * and correct — case, and means nothing about the résumé.
+ */
+export interface CoherenceFinding {
+  readonly direction: CoherenceDirection;
+  /** The query's own titles that resolved the title side, verbatim, capped at
+   *  {@link MAX_NAMED_TITLES}. Never empty. */
+  readonly titles: readonly string[];
+  /** The query's own skills that back the OTHER side of the axis, verbatim.
+   *  Length is the evidence the threshold is measured in. */
+  readonly offAxisSkills: readonly string[];
+  /** Canonical jd-match ids the titles' own role expects and the query lacks —
+   *  the competencies that would close the gap. Ids, not labels (module
+   *  docblock); a surface wanting "People Management" maps them through
+   *  jd-match's `getSkillIndex().idToLabel`. */
+  readonly missingSkills: readonly string[];
+  /** The one user-facing sentence, written here so `/jobs/` and `/` cannot
+   *  describe the same finding differently. Consequence only, no mechanism. */
+  readonly note: string;
+}
+
+export interface QueryTermAssessment {
+  /** One verdict per judgeable term, query order, titles before skills. A term
+   *  with NO verdict was not judgeable — see rule 1 in the module docblock. */
+  readonly verdicts: readonly TermVerdict[];
+  /** High-value terms for the resolved role that the query lacks. Always `[]`
+   *  when no role resolved. */
+  readonly missing: readonly MissingTerm[];
+  /** A confident title/skill mismatch, or `undefined` — which is the normal
+   *  state and must render as nothing at all, never as an "all clear". */
+  readonly coherence?: CoherenceFinding;
+}
+
+// ── Copy ────────────────────────────────────────────────────────────────────
+// Consequence only. These strings ship to the user unchanged on two surfaces,
+// so they carry no mechanism vocabulary and no internal noun — a reader must
+// never need to know what a token, a gate or a profile is. `term-quality.test.ts`
+// asserts the absence of that vocabulary; keep new entries inside the same rule.
+
+const REASONS = {
+  /** The title's every word is a place or a former employer. */
+  titleNoisePlace: "Names a place or an employer, so it won't find roles.",
+  /** The title has no word long enough to search on at all. */
+  titleNoiseEmpty: "Has no words a job search can look for.",
+  titleStrong: "A title employers post, so it narrows your results.",
+  titleWeak: "Not a common posting title for this role, so it finds fewer jobs.",
+  skillNoise: "Too common as a search term to narrow your results.",
+  skillStrong: "Expected for this role, so it sharpens your matches.",
+  skillWeak: "Not what this role is usually hired on, so it adds little.",
+} as const;
+
+/**
+ * The coherence sentence, per direction (#587). Takes the query's own titles so
+ * the claim is anchored to words the user can see on screen rather than to an
+ * abstraction. Same rule as `REASONS`: consequence only — what the postings
+ * behind these titles ask for — never how the finding was reached.
+ */
+const COHERENCE_NOTES: Readonly<Record<CoherenceDirection, (titles: string) => string>> = {
+  "leadership-titles-ic-skills": (titles) =>
+    `You're searching with leadership titles (${titles}), but every skill you list is a hands-on technical one. Postings for these titles usually ask for people management, hiring, and roadmap ownership.`,
+  "ic-titles-leadership-skills": (titles) =>
+    `You're searching with individual-contributor titles (${titles}), but every skill you list is a people-leadership one. Postings for these titles usually ask for hands-on depth in specific languages and tools.`,
+};
+
+// ── Caps ────────────────────────────────────────────────────────────────────
+// Small on purpose: `missing` is advice, and a list of fifteen things a résumé
+// "should" say is not advice. Both lists are already most-expected-first in
+// `ROLE_PROFILES`, so the cap keeps the head and drops the tail.
+
+const MAX_MISSING_TITLES = 3;
+const MAX_MISSING_SKILLS = 5;
+
+/** How many of the query's own titles the coherence sentence names before it
+ *  stops listing — a sentence quoting six titles is not readable. */
+const MAX_NAMED_TITLES = 3;
+
+// ── The coherence threshold (#587) ──────────────────────────────────────────
+
+/**
+ * THE THRESHOLD. How many of the query's OWN SKILLS must sit on the wrong side
+ * of the leadership/IC axis before the disagreement is reported at all.
+ *
+ * Unit: distinct skills in `query.skills` (deduped by `normalizeSkillKey`) that
+ * a role on the *skill-resolved* side is normally described with. Countable by
+ * hand from the chips on screen — that is the point of choosing skills as the
+ * unit rather than an opaque score.
+ *
+ * Why 4. `resolveProfilesBySkills` already refuses to name a role on fewer than
+ * two shared skills, because one is a coincidence. Four is double that floor:
+ * one cluster is a role, two clusters' worth is a *shape*, and only a shape
+ * justifies telling someone their document disagrees with itself. Concretely,
+ * it is what separates an engineer who lists "Coaching" and "Team Building"
+ * beside nothing else (2 — silent) from one whose entire skills row is people
+ * management (5+ — reported).
+ *
+ * Raising it makes this quieter and never wronger; lowering it below the
+ * resolver's own floor of 2 would let a single coincidental pair speak.
+ */
+const MIN_OFF_AXIS_SKILLS = 4;
+
+/**
+ * The one `RoleFamily` that means *running* an engineering organisation rather
+ * than building inside one. This is READ from the shipped taxonomy, not a second
+ * hand-maintained list of which roles are "leadership": every leadership rung in
+ * `ROLE_PROFILES` already declares this family and no IC profile does, so the
+ * axis cannot drift from the table. Typed as `RoleFamily` on purpose — renaming
+ * the family in `role-keywords.ts` breaks the build here instead of silently
+ * turning this check off.
+ *
+ * `pm` is deliberately NOT here. A product or program manager leads work, not an
+ * engineering org, and their expected skills overlap both sides; counting them as
+ * leadership would fire on every PM résumé that lists SQL.
+ */
+const LEADERSHIP_FAMILY: RoleFamily = "eng-leadership";
+
+/**
+ * Trimmed, non-blank, case-insensitively deduped terms in input order. Runtime
+ * non-strings are dropped rather than coerced: `assessQueryTerms` is total on
+ * any `JobQuery` shape, including one built by hand or restored from storage,
+ * and a stray `null` chip should vanish rather than become the verdict `"null"`.
+ */
+function cleanTerms(raw: readonly string[] | undefined): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of raw ?? []) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+// ── Skill matching (word-wise) ──────────────────────────────────────────────
+
+/**
+ * Words that carry no skill signal, dropped so "Coaching and Mentorship" and
+ * "Coaching & Mentorship" are the same phrase. Same shape and reasoning as
+ * `role-profiles.ts`'s title stop words, and kept just as short: every word
+ * removed is a word the subset rules below can no longer tell two skills apart
+ * with.
+ */
+const SKILL_STOP_WORDS: ReadonlySet<string> = new Set([
+  "a", "an", "and", "at", "for", "in", "of", "on", "or", "the", "to", "with",
+]);
+
+/**
+ * The separators a résumé uses to cram several concepts into one skill entry.
+ * Splitting on them is what lets "Team Building & Mentorship" be read as the two
+ * skills it names rather than one skill nobody has.
+ *
+ * `+` is deliberately NOT one: it would tear "C++" into a bare "c", and it buys
+ * nothing — clause 2 already reads `react` out of an unsplit "React + Redux",
+ * since an expected skill only has to be contained in the concept.
+ */
+const SKILL_CONCEPT_SEPARATORS = /\s*(?:&|\/|,|\band\b)\s*/i;
+
+/** One skill concept: its canonical key, its words in order, and their set. */
+interface SkillPhrase {
+  readonly key: string;
+  readonly words: readonly string[];
+  readonly set: ReadonlySet<string>;
+}
+
+function skillPhrase(raw: string): SkillPhrase {
+  const words = String(raw)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length > 0 && !SKILL_STOP_WORDS.has(word));
+  return { key: normalizeSkillKey(raw), words, set: new Set(words) };
+}
+
+/** The concepts one query skill names — one for an ordinary skill, several for
+ *  a multi-concept résumé phrase. Empty concepts (a trailing "&") are dropped. */
+function skillConcepts(raw: string): SkillPhrase[] {
+  return String(raw)
+    .split(SKILL_CONCEPT_SEPARATORS)
+    .map(skillPhrase)
+    .filter((phrase) => phrase.words.length > 0);
+}
+
+/** True when every member of `needle` is in `haystack`. Empty needle ⇒ false —
+ *  an empty set is a subset of everything, which here would match everything. */
+function isSubsetOf(needle: ReadonlySet<string>, haystack: ReadonlySet<string>): boolean {
+  if (needle.size === 0 || needle.size > haystack.size) return false;
+  for (const word of needle) {
+    if (!haystack.has(word)) return false;
+  }
+  return true;
+}
+
+/**
+ * THE SKILL-MATCHING RULE: does the query skill `skill` carry the expected
+ * canonical skill `expected`? Two consumers read it — a chip matching something
+ * expected is "strong", and an expected term the query already carries is not
+ * "missing" — so a term can never be suggested and marked at odds with itself.
+ *
+ * Three ways to match, narrowest first. Each is a separate claim, and each was
+ * chosen against a specific wrong answer:
+ *
+ *  1. SAME KEY. `normalizeSkillKey` equality — "CI/CD" is `ci-cd`. This is the
+ *     pre-existing rule and must stay FIRST: concept splitting would otherwise
+ *     tear "CI/CD" into `ci` and `cd` and lose the match it already had.
+ *  2. SPELLED OUT INSIDE A CONCEPT (`expected ⊆ concept`). "Team Building &
+ *     Mentorship" carries `team-building`; "AWS Lambda" carries `aws`. The
+ *     concept may say MORE than the expected skill; it may not say less.
+ *  3. THE SAME THING, LESS QUALIFIED (`concept ⊆ expected`, sharing the HEAD) —
+ *     `allowLessQualified` only. "Mentorship" is what `coaching-mentorship` is
+ *     about, so a résumé listing it is not missing that skill. The head word (the
+ *     last — the noun a phrase is ABOUT) must be the shared one, which is what
+ *     keeps "Performance Optimization" from covering `performance-management`:
+ *     they share "performance", a qualifier, and disagree on the head. Without
+ *     that guard any incidental shared word would suppress a real gap.
+ *
+ * WHY CLAUSE 3 IS OPT-IN, AND OFF FOR VERDICTS. It is a weaker claim than the
+ * other two: the query term is a bare head noun, so it names the general activity
+ * without the qualifier that makes the expected skill what it is ("Strategy" is
+ * not "technical strategy"). That is enough to stop us telling someone to add
+ * what they arguably already said — a suppressed suggestion costs nothing, the
+ * cap back-fills — but not enough to tell them the term is "expected for this
+ * role, so it sharpens your matches", which would be a false strong. The two
+ * verdicts have different error costs, so they get different thresholds; the
+ * shared clauses stay shared.
+ *
+ * Word-level throughout, never substring: "javascript" is one word, so it never
+ * covers "java", and "mysql" never covers "sql". Total; never throws.
+ */
+function skillCovers(
+  expected: SkillPhrase,
+  skill: string,
+  allowLessQualified: boolean,
+): boolean {
+  if (expected.key.length > 0 && expected.key === normalizeSkillKey(skill)) return true;
+  if (expected.words.length === 0) return false;
+  const head = expected.words[expected.words.length - 1];
+  for (const concept of skillConcepts(skill)) {
+    if (isSubsetOf(expected.set, concept.set)) return true;
+    if (
+      allowLessQualified &&
+      expected.words.length > 1 &&
+      concept.set.has(head) &&
+      isSubsetOf(concept.set, expected.set)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Clauses 1–2: strong enough to base a VERDICT on. */
+function skillIsExpected(expected: SkillPhrase, skill: string): boolean {
+  return skillCovers(expected, skill, false);
+}
+
+/** The expected canonical ids as phrases, deduped by key — the union of every
+ *  resolved profile's skills, ready to match query chips against. */
+function dedupePhrases(ids: readonly string[]): SkillPhrase[] {
+  const seen = new Set<string>();
+  const out: SkillPhrase[] = [];
+  for (const id of ids) {
+    const phrase = skillPhrase(id);
+    if (phrase.key.length === 0 || seen.has(phrase.key)) continue;
+    seen.add(phrase.key);
+    out.push(phrase);
+  }
+  return out;
+}
+
+/** All three clauses, across the whole query: is this expected skill already
+ *  said, in whatever words? The SUPPRESSION side of the rule. */
+function anySkillCovers(expected: SkillPhrase, skills: readonly string[]): boolean {
+  return skills.some((skill) => skillCovers(expected, skill, true));
+}
+
+/**
+ * Whether a query title already covers an expected one, in EITHER direction —
+ * the narrow near-identity relation, not a general similarity.
+ *
+ * Forward (`expected ⊆ résumé title`) is the pre-existing rule: "Senior
+ * Engineering Manager, Payments" already says "engineering manager". Reverse
+ * (`résumé title ⊆ expected`) is the fix: a résumé saying "Engineering Lead" was
+ * being told to add "engineering team lead", a strictly wordier spelling of what
+ * it already says. The reverse direction is safe precisely because the résumé
+ * side must be a token SUBSET — the résumé already says a shorter version of the
+ * same phrase, not merely a related one. "Sr. Engineering Manager" is NOT a
+ * subset of "software engineering manager" (senior ≠ software), so that genuinely
+ * different market phrasing still gets suggested, which is the point of the
+ * advice.
+ */
+function titleCovers(expected: string, title: string): boolean {
+  return profileTitleMatches(expected, title) || profileTitleMatches(title, expected);
+}
+
+/** Profiles from both resolvers, title answers first, deduped by id. */
+function unionProfiles(
+  byTitles: readonly RoleProfile[],
+  bySkills: readonly RoleProfile[],
+): RoleProfile[] {
+  const seen = new Set<string>();
+  const out: RoleProfile[] = [];
+  for (const profile of [...byTitles, ...bySkills]) {
+    if (seen.has(profile.id)) continue;
+    seen.add(profile.id);
+    out.push(profile);
+  }
+  return out;
+}
+
+/**
+ * The high-value terms `primary` expects that the query does not already carry.
+ * "Already carry" is `titleCovers` / `skillCovers`, not string equality — see
+ * those two and the note below. `undefined` primary ⇒ `[]` — the unresolved-role
+ * contract.
+ *
+ * A suggestion also has to survive the SAME admission rules the verdicts apply.
+ * `ROLE_PROFILES` legitimately carries canonical terms that narrow nothing —
+ * `go` is a real backend skill and a token the search cannot filter on — and
+ * telling someone to add a term we would immediately mark noise is advice that
+ * does nothing. Whatever is suppressed here, the cap simply back-fills from the
+ * next-most-expected entry, so suppression costs the advice nothing.
+ *
+ * "ALREADY CARRIES IT" IS NOT KEY EQUALITY, on either kind. Offering someone
+ * "+ team building" while "Team Building & Mentorship" sits as a chip on the same
+ * screen, or "+ engineering team lead" to someone titled "Engineering Lead",
+ * reads as a broken product — and it was the same root cause both times: a
+ * whole-string comparison cannot see a phrase that already says the thing.
+ * `skillCovers` and `titleCovers` are the two relations, and both are shared with
+ * the verdict pass rather than re-derived here.
+ */
+function missingTerms(
+  primary: RoleProfile | undefined,
+  titles: readonly string[],
+  skills: readonly string[],
+  noise: ReadonlySet<string>,
+): MissingTerm[] {
+  if (!primary) return [];
+  const missing: MissingTerm[] = [];
+
+  let titleCount = 0;
+  for (const expected of primary.titles) {
+    if (titleCount >= MAX_MISSING_TITLES) break;
+    if (!titleTokens(expected).some((token) => isAdmittingTitleTerm(token, noise))) continue;
+    if (titles.some((title) => titleCovers(expected, title))) continue;
+    missing.push({ term: expected, kind: "title" });
+    titleCount += 1;
+  }
+
+  let skillCount = 0;
+  for (const expected of primary.skills) {
+    if (skillCount >= MAX_MISSING_SKILLS) break;
+    if (!isSignificantSkillTerm(expected.toLowerCase())) continue;
+    if (anySkillCovers(skillPhrase(expected), skills)) continue;
+    missing.push({ term: expected, kind: "skill" });
+    skillCount += 1;
+  }
+
+  return missing;
+}
+
+/**
+ * Which side of the leadership/IC axis a whole resolved side sits on, or
+ * `undefined` when it sits on BOTH.
+ *
+ * "Both" is not a weak answer, it is a disqualifying one: a résumé that resolves
+ * an engineering-manager AND a backend-engineer genuinely describes both, and the
+ * mixed case covers the two shapes we most need to never accuse — the promoted
+ * IC whose titles span the ladder, and the manager who kept their engineering
+ * skills (rule 2's EM-who-was-an-ML-engineer). Reading only the top profile of
+ * each side would report both of them.
+ */
+function sharedAxis(profiles: readonly RoleProfile[]): "leadership" | "ic" | undefined {
+  if (profiles.length === 0) return undefined;
+  const leadership = profiles.filter((profile) => profile.family === LEADERSHIP_FAMILY).length;
+  if (leadership === profiles.length) return "leadership";
+  if (leadership === 0) return "ic";
+  return undefined;
+}
+
+/** Distinct canonical keys of `terms` that appear in `expected`. */
+function overlap(terms: readonly string[], expected: ReadonlySet<string>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const term of terms) {
+    const key = normalizeSkillKey(term);
+    if (seen.has(key) || !expected.has(key)) continue;
+    seen.add(key);
+    out.push(term);
+  }
+  return out;
+}
+
+/**
+ * The title/skill coherence check (#587): does what this person calls themselves
+ * disagree with what their evidence describes?
+ *
+ * FOUR GATES, every one of which must clear. Each exists to kill a specific
+ * false positive, because the cost of a wrong finding here is telling someone
+ * their résumé is broken when it isn't:
+ *
+ *  1. BOTH SIDES RESOLVED. An unresolved side is ignorance, not evidence. A
+ *     résumé whose titles we cannot place says nothing about its skills.
+ *  2. NEITHER SIDE IS MIXED (`sharedAxis`). A person who is genuinely both is
+ *     coherent — see that function.
+ *  3. THE SIDES DISAGREE on the axis. Same axis ⇒ nothing to say, whatever the
+ *     family: a frontend engineer whose skills read fullstack is not mismatched,
+ *     and firing on that alone would make this a noise generator. Family-only
+ *     disagreement is deliberately NOT reported (see the issue's "family or the
+ *     leadership/IC axis" — we take the confident intersection).
+ *  4. THE CLAIM IS LITERALLY TRUE AND NOT MARGINAL. "every skill you list is X"
+ *     is only said when the query carries ZERO skills the titles' own role
+ *     expects — one managerial skill on an engineer's résumé is enough to keep
+ *     us quiet, and it lands in the gap gate 2 cannot see because the resolver
+ *     needs two hits to name a role. And the other side must be backed by at
+ *     least {@link MIN_OFF_AXIS_SKILLS} skills.
+ *
+ * A skill counts as evidence even when it is too generic to filter on ("go"):
+ * this describes the SHAPE of the document, which is true regardless of what the
+ * search can narrow with.
+ *
+ * Total and deterministic; returns `undefined` far more often than not, which is
+ * the designed outcome.
+ */
+function assessCoherence(
+  byTitles: readonly RoleProfile[],
+  bySkills: readonly RoleProfile[],
+  titles: readonly string[],
+  skills: readonly string[],
+): CoherenceFinding | undefined {
+  const titleAxis = sharedAxis(byTitles); // gates 1 and 2
+  const skillAxis = sharedAxis(bySkills);
+  if (!titleAxis || !skillAxis || titleAxis === skillAxis) return undefined; // gate 3
+
+  const expectedByTitleSide = new Set(
+    byTitles.flatMap((profile) => profile.skills.map(normalizeSkillKey)),
+  );
+  if (overlap(skills, expectedByTitleSide).length > 0) return undefined; // gate 4, "every"
+
+  const expectedBySkillSide = new Set(
+    bySkills.flatMap((profile) => profile.skills.map(normalizeSkillKey)),
+  );
+  const offAxisSkills = overlap(skills, expectedBySkillSide);
+  if (offAxisSkills.length < MIN_OFF_AXIS_SKILLS) return undefined; // gate 4, threshold
+
+  // The user's own words for the finding to name. Non-empty whenever `byTitles`
+  // is, since a profile only resolves off a matching title; guarded anyway so
+  // the copy can never quote an empty list.
+  const namedTitles = titles
+    .filter((title) =>
+      byTitles.some((profile) =>
+        profile.titles.some((expected) => profileTitleMatches(expected, title)),
+      ),
+    )
+    .slice(0, MAX_NAMED_TITLES);
+  if (namedTitles.length === 0) return undefined;
+
+  // What would close the gap: the titles' own role's expected skills, minus what
+  // the query already has (nothing, by gate 4) and minus anything the search
+  // could not use anyway — the same suppression `missingTerms` applies.
+  const missingSkills = byTitles[0].skills
+    .filter((skill) => isSignificantSkillTerm(skill.toLowerCase()))
+    .slice(0, MAX_MISSING_SKILLS);
+
+  const direction: CoherenceDirection =
+    titleAxis === "leadership" ? "leadership-titles-ic-skills" : "ic-titles-leadership-skills";
+
+  return {
+    direction,
+    titles: namedTitles,
+    offAxisSkills,
+    missingSkills,
+    note: COHERENCE_NOTES[direction](namedTitles.map((title) => `"${title}"`).join(", ")),
+  };
+}
+
+/**
+ * Verdicts for the title half of a query.
+ *
+ * Split out of {@link assessQueryTerms} so each verdict rule reads on its own:
+ * the two halves share no state, and the asymmetry between them — a title is
+ * judged as soon as a role resolves, a skill additionally needs standing — is
+ * the module's central claim, easiest to check when neither loop is nested
+ * inside the wiring that calls it.
+ */
+function titleVerdicts(
+  titles: readonly string[],
+  resolved: readonly RoleProfile[],
+  noise: ReadonlySet<string>,
+): TermVerdict[] {
+  const verdicts: TermVerdict[] = [];
+  for (const term of titles) {
+    const tokens = titleTokens(term);
+    if (!tokens.some((token) => isAdmittingTitleTerm(token, noise))) {
+      // Two ways to admit nothing, and they are different news for the user:
+      // every word was their own city/employer, or there was no real word at all.
+      verdicts.push({
+        term,
+        kind: "title",
+        quality: "noise",
+        reason: tokens.some((token) => noise.has(token))
+          ? REASONS.titleNoisePlace
+          : REASONS.titleNoiseEmpty,
+      });
+      continue;
+    }
+    if (resolved.length === 0) continue; // no basis — say nothing (rule 1)
+    const strong = resolved.some((profile) =>
+      profile.titles.some((expected) => profileTitleMatches(expected, term)),
+    );
+    verdicts.push({
+      term,
+      kind: "title",
+      quality: strong ? "strong" : "weak",
+      reason: strong ? REASONS.titleStrong : REASONS.titleWeak,
+    });
+  }
+  return verdicts;
+}
+
+/**
+ * Verdicts for the skill half of a query — the half with the extra gate.
+ *
+ * "Strong" is earned by evidence (an expected skill covers the term).
+ * "Weak" additionally requires STANDING: the term must be a canonical skill
+ * name, per `canonicalSkills`. A free-text phrase that matches nothing tells us
+ * about our vocabulary, not about the term, so it leaves with no verdict at all.
+ * See the module docblock — this is the rule the first draft got wrong.
+ */
+function skillVerdicts(
+  skills: readonly string[],
+  resolved: readonly RoleProfile[],
+  expectedSkills: readonly SkillPhrase[],
+  canonicalSkills: ReadonlySet<string>,
+): TermVerdict[] {
+  const verdicts: TermVerdict[] = [];
+  for (const term of skills) {
+    if (!isSignificantSkillTerm(term.toLowerCase())) {
+      verdicts.push({ term, kind: "skill", quality: "noise", reason: REASONS.skillNoise });
+      continue;
+    }
+    if (resolved.length === 0) continue; // no basis — say nothing (rule 1)
+    if (expectedSkills.some((expected) => skillIsExpected(expected, term))) {
+      verdicts.push({ term, kind: "skill", quality: "strong", reason: REASONS.skillStrong });
+      continue;
+    }
+    // Nothing expected matched. Whether that is news about the TERM or only
+    // about our vocabulary depends on standing — see the module docblock.
+    if (!canonicalSkills.has(normalizeSkillKey(term))) continue;
+    verdicts.push({ term, kind: "skill", quality: "weak", reason: REASONS.skillWeak });
+  }
+  return verdicts;
+}
+
+/**
+ * Classify every term of `query` and name what the résumé is missing.
+ *
+ * Total and deterministic: no I/O, no clock, no randomness, and no throw on any
+ * `JobQuery` shape — empty titles, empty skills, absent optional fields, or a
+ * bare `{}`. Two contracts consumers depend on, both tested:
+ *
+ *  - a term absent from `verdicts` was NOT judgeable; render it unmarked. That
+ *    now includes a free-text skill on a query with no `canonicalSkills`
+ *    annotation — silence, never a defaulted "weak".
+ *  - `missing` is `[]` whenever no role resolved, and never names something the
+ *    query already covers in different words.
+ *  - `coherence` is `undefined` unless a mismatch cleared every gate; that
+ *    absence is the normal state and renders as nothing, not as an "all clear".
+ */
+export function assessQueryTerms(query: JobQuery): QueryTermAssessment {
+  const titles = cleanTerms(query.titles);
+  const skills = cleanTerms(query.skills);
+  const noise = titleNoiseTokens(query.titleNoise);
+
+  const byTitles = resolveProfilesByTitles(titles);
+  const bySkills = resolveProfilesBySkills(skills);
+  const resolved = unionProfiles(byTitles, bySkills);
+  // Most-confident answer to "who is this" — the title answer when there is
+  // one, since a title is what a person IS and a skill only implies it.
+  const primary = byTitles[0] ?? bySkills[0];
+  const expectedSkills = dedupePhrases(resolved.flatMap((profile) => profile.skills));
+  // Standing to say "weak", per the module docblock. `undefined` and "annotated,
+  // none canonical" collapse to the same empty set on purpose: both mean no skill
+  // here is one we may call worthless.
+  const canonicalSkills = new Set(cleanTerms(query.canonicalSkills).map(normalizeSkillKey));
+
+  return {
+    // Titles first, then skills — `verdicts` order is the render order on the
+    // chip rows, and the two loops are independent.
+    verdicts: [
+      ...titleVerdicts(titles, resolved, noise),
+      ...skillVerdicts(skills, resolved, expectedSkills, canonicalSkills),
+    ],
+    missing: missingTerms(primary, titles, skills, noise),
+    // The two resolvers' answers compared INDEPENDENTLY, never through
+    // `resolved` — see the module docblock and `assessCoherence`'s gates.
+    coherence: assessCoherence(byTitles, bySkills, titles, skills),
+  };
+}


### PR DESCRIPTION
## Summary

Every term on a résumé was treated as equal — an internal title like "Berlin Site Lead" looked
exactly like a market title, and a two-character token looked exactly like a canonical skill. This
adds one pure classifier that judges each term (strong / weak / noise) and names the high-value
terms the résumé is missing, then renders that judgement on the three surfaces where a user can act
on it.

The classifier derives from assets that already ship — the noise set, the skill significance gate,
and the role-profile map — rather than introducing a second vocabulary. The gate moved into a new
zero-import leaf (`query-terms.ts`) so `search.ts` and the classifier share one rule instead of
drifting apart.

The constraint the module guards: **a real term must never be called worthless.** When no role
resolves there is no basis to judge, so it returns *no verdict at all* rather than a defaulted
"weak", and no suggestions rather than invented ones.

Closes #584
Closes #585
Closes #586
Closes #587
Closes #589
Closes #591

`Closes` on all six. #591 in particular: its own acceptance criteria offer the choice explicitly —
*"either rows re-space to accommodate the chosen target size, or the target size is set to what the
current spacing supports"* — and AA (24×24) is the second branch. The AAA 44×44 belongs to #581,
the parent #591 was split out of and replaced.

## What shipped, per issue

- **#584** — new pure lib `src/lib/job-search/term-quality.ts` (`assessQueryTerms`) classifying
  every query term strong/weak/noise and naming missing high-value terms. Derived from shipped
  assets only (`titleNoise`, the skill significance gate, `role-profiles.ts`); the gate was
  extracted into a new zero-import leaf `query-terms.ts` and shared with `search.ts` rather than
  duplicated. Contract: an unresolved role yields **no** verdict (never a defaulted "weak") and
  `missing: []`. 46 unit tests.
- **#589** — `JobQueryEditor.test.tsx` gains 14 tests for the single write path into the query
  object: per-handler whole-query replacement, `families: []` produced as an empty array not
  `undefined`, location empty-string → `undefined`, and a deep-frozen fixture proving no handler
  mutates its input. Falsifiability-checked — both load-bearing assertions were made to go red,
  then restored. No production code touched.
- **#591** — `Chip`'s remove control and `ChipListEditor`'s promote control reach the WCAG 2.2 **AA**
  target size (SC 2.5.8, 24×24) via an invisible `after:` overlay, with zero layout change and no row
  re-spacing. AAA (SC 2.5.5, 44×44) is deliberately declined: 44px areas overlap neighbouring chips
  at the current `gap-1.5`/`gap-1`, so a tap on one chip's label would fire the **previous** chip's
  Remove. Zero overlap verified by real-browser geometry, not inspection. The `KNOWN GAP` docblock is
  rewritten to state what is met, what is declined, and why.
- **#585** — `/jobs/` chips carry a text-presentation quality mark plus an `sr-only` reason (never
  colour alone), and a new `TermQualityAdvisory` renders missing terms as add-able `AddPill`s that
  ride the existing live re-rank with no refetch. Canonical jd-match skill ids map to display labels
  through one shared helper, so the text a user clicks and the text written into the query cannot
  drift apart.
- **#587** — title↔skill coherence: fires only on a confident disagreement between
  `resolveProfilesByTitles` and `resolveProfilesBySkills`. The threshold is a named constant
  `MIN_OFF_AXIS_SKILLS = 4` (double the resolver's own 2-skill floor), and the leadership/IC axis is
  **read from the shipped `RoleFamily` taxonomy** (`eng-leadership`), typed so renaming the family
  breaks the build instead of silently disabling the check. Renders inside the existing advisory,
  not a fourth panel. Tested in both fire directions plus 5 explicit silence cases — including the
  senior-IC-with-mentorship false positive the issue names.
- **#586** — new `SkillTermGuidance` sibling on `/`, rendered after `SkillsSection`. Suggests only:
  never auto-edits, never touches the ATS score (`src/lib/score/` untouched; its 145 tests re-run
  unchanged). Copy is document-framed so it does not duplicate `/jobs/`'s query-framed sentences.

## Reuse analysis

Required by #586, quoted verbatim from the implementing agent:

> No existing résumé-review surface fit. `CritiquePanel` is WebLLM-gated content critique
> (prose/bullet quality, requires model load, lives in the separate 'Resume quality' tab) — a
> different judgement entirely from vocabulary/term matching, and it's gated behind model
> availability while term-quality guidance must always render when applicable. The skills-ordering
> critique issue (#544) is open but UNIMPLEMENTED — grepped the tree for any
> 544/skills-order/SkillsOrder surface and found none, so there is nothing to extend.
> `TermQualityAdvisory` (#585, the /jobs/ sibling) can't be reused as-is either: it writes into a
> `JobQuery` via `onAdd`, not the résumé model, and its copy is query-framed throughout
> ('Commonly expected for this role, not in your query'). So this is a new, narrowly-scoped sibling
> component (not a parallel copy of any of the three) placed directly after `SkillsSection` in
> `ReconstructedResume.tsx`, the section it refers to.

## Orchestrator notes

- **Privacy: no new egress.** `assessQueryTerms` is pure and local;
  `src/lib/job-search/providers/keywords.ts` remains the sole resume-derived egress helper.
- **fallow** is clean for this PR. Dead-code clean after un-exporting an unused `STOPWORDS` from
  `query-terms.ts`. The code-scanning alert on `assessQueryTerms` (cognitive complexity 22 vs a
  threshold of 15) is **fixed, not waived** — the two verdict loops are now `titleVerdicts` and
  `skillVerdicts`, and the function no longer appears in `fallow audit --base origin/main`. The
  duplication a review round would have flagged in `JobQueryEditor.test.tsx` is gone too: the
  repeated native-setter-plus-click-Add boilerplate is one `typeAndAdd` helper, proven
  load-bearing by deleting its body and watching exactly the 4 dependent tests go red.
  What remains is inherited and untouched by this PR: `AchievementHeader`
  (`ReconstructedResume.tsx:745`, 72.0 CRAP — that score is 0% coverage, not tangled code) and the
  `ReconstructedResume`/`ReconstructedSkills` clone pair. This PR touches that file at exactly two
  places, an import and a 5-line render; fallow lists the function because the *file* changed.
- **A subagent's self-report was wrong and was corrected.** #586's agent reported "typecheck clean"
  when it was not: 7 real type errors in its own new test file (`null` supplied for optional
  `string` fields, plus a `bullets` property that does not exist on `ResumeExperience`). Fixed
  during orchestration; the corrected fixtures are in this diff.
- **Deliberately not attempted:** wiring a suggested term into the on-device rewrite lane as an
  input hint (#586's "optional, only if it falls out cleanly"). It needs a new prop threaded through
  the `SectionRewrite` / `useSectionRewriteLock` request shape — a follow-up, not a half-wire.
- **#591 blast radius correction:** the issue lists 4 non-primitive `Chip` call sites and states none
  passes `onRemove`. `RoleFamilyChips.tsx` is a 5th that does. The fix lives inside the `Chip`
  primitive with zero layout change, so it applies there safely too.
- **Manual testing found three defects in the first push; all are fixed in this diff.** On a real
  leadership résumé whose role resolved confidently, **nine of eleven skills were marked "weak"** —
  "Engineering Leadership" and "Hiring & Talent Acquisition" among them — which is precisely the
  claim `term-quality.ts`'s own docblock forbids. Root cause: skills were compared by whole-string
  key equality while titles used a token-subset rule, so only a skill jd-match had already
  canonicalized could ever score. The fix splits the two verdicts by what they claim — *strong needs
  evidence, weak needs standing* — and only a canonical skill name may be called weak; anything else
  gets no verdict, per the module's existing rule 1. The canonicality fact is one `buildJobQuery`
  already computed and discarded; it now ships as `JobQuery.canonicalSkills`, so `term-quality.ts`
  still has no runtime import of jd-match. Two consequences of the same root cause went with it:
  `+ team building` was offered beside a "Team Building & Mentorship" chip (matching is now word-wise
  and shared between the verdict and suggestion passes, so they cannot disagree), and the pill row
  mixed title-writing and skill-writing pills with no visual difference (now grouped by destination).
  Verified by re-running the reproducing query end-to-end: 9 false "weak" verdicts → 0.
- Adversarial review was skipped at the maintainer's request; it is being run separately.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 3183 passed, 9 skipped
- [x] `npm run lint` clean
- [x] `npm run verify` green locally — run explicitly, not via the pre-push hook (this clone's
      `core.hooksPath` points at a path left over from the repo rename, so no git hook fires here)
- [x] `npm run check:fixtures` — 54 PDFs, all personas synthetic (no fixtures added by this PR)
- [x] Manually verified in `npm run dev` on a real leadership résumé — this is what found the three
      defects recorded in Orchestrator notes; the fixes are in this diff and the reproducing query
      was re-run end-to-end afterwards

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #584 | unreported (requested: opus) | ultra |
| Implementation — #589 | Claude Sonnet 5 | medium |
| Implementation — #591 | Claude Sonnet 5 | high |
| Implementation — #585 | Claude Sonnet 4.5 | high |
| Implementation — #587 | unreported (requested: opus) | ultra |
| Implementation — #586 | Claude Sonnet 5 | high |
| Manual-test fixes (round 1) | unreported (requested: opus) | ultra |
| Orchestration, verification + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |

Three rows read `unreported`: those subagents never answered the model self-report request, and a
`model:` alias is not evidence of what it resolved to. Not guessed. The round-1 fix agent was asked
twice and stayed silent; its work was verified independently rather than taken on report.

