### PR TITLE
feat: order role-profile titles and skills by mined prevalence

### DIFF
--- a/src/lib/job-search/mine-prevalence.test.ts
+++ b/src/lib/job-search/mine-prevalence.test.ts
@@ -1,0 +1,680 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Prevalence mining harness (#588) — inert in CI, runs ONLY when
+ * `RL_MINE_PREVALENCE=1` is set:
+ *
+ *   RL_MINE_PREVALENCE=1 npx vitest run \
+ *     src/lib/job-search/mine-prevalence.test.ts
+ *
+ * WHY THIS EXISTS. `ROLE_PROFILES` promises its `titles` are "most-used first"
+ * and its `skills` "most-expected first". Curation can assert that ordering; it
+ * cannot *measure* it, so the product would be making a market claim off one
+ * person's judgement. The job feeds we already query carry the market's own
+ * vocabulary in their posting titles and descriptions. This harness reads that
+ * vocabulary back and emits a frequency ranking, which `role-profiles.ts` bakes
+ * in as `prevalence-snapshot.ts` and applies as an ORDERING ONLY.
+ *
+ * ── NO NEW EGRESS (the property the privacy copy depends on) ────────────────
+ * Nothing résumé-derived is involved anywhere in this loop. The queries are
+ * seeded from `CURATED_ROLE_PROFILES`' OWN titles — public, committed strings —
+ * so the egress is a strict SUBSET of what a normal in-app search already
+ * sends (`providers/keywords.ts`: a short keyword string; company adapters: a
+ * public slug). No PDF, no parsed résumé, no user text. `keywords.ts` is
+ * untouched and remains the sole résumé-derived egress helper.
+ *
+ * The mined result is COMMITTED as a static TS module, never fetched at
+ * runtime: a "prevalence service" call from the browser would be a brand-new
+ * egress path, which #588 puts explicitly out of scope. `role-profiles.ts`
+ * therefore still fetches nothing.
+ *
+ * Node has no CORS, so a run from here may reach feeds a browser's CORS set
+ * cannot, and live postings drift run to run. That asymmetry is exactly why the
+ * output is a snapshot rather than a runtime computation — the committed file
+ * is the record of what one dated run saw, reviewable in a diff.
+ *
+ * ── CURATION STAYS AUTHORITATIVE ON MEMBERSHIP ──────────────────────────────
+ * The harness only ever *counts*. For titles it counts how often each of a
+ * profile's CURATED surface forms is observed in real posting titles (via the
+ * shared `profileTitleMatches` relation), deliberately NOT harvesting new forms:
+ * harvesting would be adding membership, and a junk title form that trends in a
+ * feed must never be able to write itself into a profile.
+ *
+ * Skills are TALLIED over the whole jd-match dictionary — the raw market
+ * vocabulary, whatever it says — and then narrowed to curated membership at
+ * EMIT time. The narrowing is a snapshot-size decision, not the guard rail:
+ * `applyPrevalenceOrder` filters again and structurally cannot add, so the
+ * committed file stays reviewable in a diff and free of ~20× dead entries the
+ * consumer would discard at module init anyway. Narrowing before the cut is also
+ * the correct order — capping a raw tally first would drop a curated skill that
+ * happened to rank below a pile of ids no profile carries, silently losing its
+ * ranking. The unfiltered tally is preserved in the gitignored JSON report.
+ *
+ * ── Sampling shape (stated so a reader can calibrate the numbers) ───────────
+ * Keyless feeds only (`KEYLESS_PROVIDERS`). Company ATS boards are deliberately
+ * excluded: their pool is derived from a *sector* classification that has no
+ * profile-level equivalent, their light index carries no description (so the
+ * skill axis would be blind for them), and several Lever registry slugs are
+ * known-wrong. Adding them would widen the run without deepening the sample.
+ * The `providerMix` in the snapshot header names exactly which feeds answered.
+ *
+ * | Var | Default | Meaning |
+ * |---|---|---|
+ * | `RL_MINE_PREVALENCE` | *(unset)* | Set to any value to run. Unset → inert. |
+ * | `RL_MINE_OUT` | `internal/job-search/` | Directory for the JSON report + the generated snapshot module. |
+ * | `RL_MINE_SEEDS` | *(all)* | Cap on curated titles per profile used as feed queries. Lower it for a smoke run, never for a snapshot you intend to commit. |
+ *
+ * ── SEEDING IS SNAPSHOT-INDEPENDENT, ON PURPOSE ─────────────────────────────
+ * The seed loop reads `CURATED_ROLE_PROFILES`, the hand-written table, NOT the
+ * prevalence-reordered `ROLE_PROFILES` it is about to regenerate. Seeding from
+ * the ranked table is a ratchet: the corpus becomes a function of the previous
+ * run, so a title that sank to the tail once is never queried again and is
+ * pinned there permanently — and a profile whose bucket got filled by a
+ * neighbouring role would then seed that neighbour's name first and be filled
+ * even harder next time. Bucketing is stable under reordering (see `bucketFor`);
+ * seeding is a different question and is answered here.
+ *
+ * ── Baking the result (the two-step, on purpose) ────────────────────────────
+ * The run writes `prevalence-snapshot.generated.ts` into the gitignored output
+ * dir; a human copies it over `src/lib/job-search/prevalence-snapshot.ts` and
+ * reviews the diff. The harness never writes into a tracked path, for the same
+ * reason `probe-jobs` doesn't: a networked, non-deterministic step must not be
+ * able to mutate committed source without a human reading the change.
+ *
+ * ASSERTS NOTHING ABOUT WHAT IT FINDS. It fails only if it could not run at all
+ * (every feed down), so a thin corpus is reported honestly instead of inflated.
+ * Every bucketed profile is baked with an `audit` — the consumer's own per-axis
+ * verdict, computed here by calling `auditPrevalence` rather than re-deriving
+ * the rule — so "ranked", "declined for a thin sample", "declined because the
+ * bucket is a different role" and "declined for want of readable descriptions"
+ * are four visibly different outcomes in the committed diff. Profiles no posting
+ * reached at all are listed separately as `unobservedProfiles`: measured-and-
+ * declined and never-seen are not the same finding.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import { REPO_ROOT } from "../heuristics/__test-utils__/corpus-snapshots.ts";
+import { getSkillIndex } from "../jd-match/skills.ts";
+import { KEYLESS_PROVIDERS } from "./providers/index.ts";
+import type { JobQuery } from "./query-builder.ts";
+import { dedupKey } from "./raw-postings.ts";
+import {
+  CURATED_ROLE_PROFILES,
+  auditPrevalence,
+  normalizeSkillKey,
+  profileTitleMatches,
+  resolveProfilesByTitles,
+  type PrevalenceAudit,
+  type RoleProfile,
+} from "./role-profiles.ts";
+import type { JobPosting } from "./types.ts";
+
+/**
+ * The output directory, validated exactly the way `probe-jobs` validates its
+ * own: the default (`internal/`) is gitignored, and an override that lands
+ * inside the repo but is NOT gitignored is a hard failure. `git check-ignore` is
+ * the authority. The stake here is different from probe-jobs' (no PII is in
+ * play) but the rule is the same one: a networked run may not deposit a file
+ * into a tracked path.
+ */
+function resolveOutDir(): string {
+  const override = process.env.RL_MINE_OUT;
+  if (!override) return join(REPO_ROOT, "internal/job-search");
+
+  const dir = isAbsolute(override) ? override : resolve(process.cwd(), override);
+  const rel = relative(REPO_ROOT, dir);
+  const insideRepo = rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  if (!insideRepo) return dir;
+
+  try {
+    execFileSync("git", ["check-ignore", "-q", "--", dir], { cwd: REPO_ROOT });
+    return dir;
+  } catch {
+    throw new Error(
+      `RL_MINE_OUT="${override}" resolves inside the repo at "${rel}" and is NOT ` +
+        `gitignored. This harness is networked and non-deterministic; its output ` +
+        `must be reviewed and copied in by a human, never written straight into a ` +
+        `tracked path. Point RL_MINE_OUT at a gitignored path (the default ` +
+        `"internal/job-search/") or somewhere outside the repo.`,
+    );
+  }
+}
+
+/**
+ * Curated titles per profile used as feed queries. ALL of them by default.
+ *
+ * Capping the seeds was a fan-out saving that quietly decided what the corpus
+ * could contain: a title never queried is a title that can only ever be observed
+ * incidentally, so it sinks to the tail and — if the seeds were taken from a
+ * ranked table — stays there across every future run. Seeding every curated
+ * title is what makes the corpus a function of curation rather than of the
+ * previous snapshot. `RL_MINE_SEEDS` still caps it for a quick smoke run; a cap
+ * makes the run faster and the ranking narrower, and should not be used to
+ * produce a snapshot that gets committed.
+ */
+const DEFAULT_SEEDS_PER_PROFILE = Number.POSITIVE_INFINITY;
+/**
+ * Pause between seed queries. These are free, keyless, unauthenticated public
+ * feeds and this harness is the heaviest thing in the tree that touches them —
+ * every curated title in the table × 3 providers in one run (113 × 3 as of the
+ * committed snapshot). Without pacing they throttle partway through and the
+ * corpus silently halves, which looks like a thin market rather than a thin
+ * sample. If a run reports many `providerFailures`, wait for the window to clear
+ * and re-run; do not read a throttled corpus as data. Raised from 400ms when
+ * seeding went from 3 titles per profile to all of them (#588 review), and
+ * again to 1200ms after a 600ms run drew 72 `arbeitnow` rejections across 113
+ * queries — the pacing is per seed while the providers are queried in parallel,
+ * so each provider sees one request per interval and this is the knob that
+ * moves.
+ */
+const QUERY_PACING_MS = 1200;
+/** A posting whose description is shorter than this carries no usable skill
+ *  vocabulary (a feed that returned a stub). Counted in the corpus, skipped for
+ *  the skill axis, so the sample size stays honest about what was read. */
+const MIN_DESCRIPTION_CHARS = 80;
+
+/** One observed term with its raw count. Mirrors `PrevalenceEntry`. */
+interface MinedEntry {
+  form: string;
+  count: number;
+}
+
+/** Per-profile accumulator during the run. */
+interface ProfileTally {
+  sampleSize: number;
+  titles: Map<string, number>;
+  skills: Map<string, number>;
+}
+
+describe.runIf(process.env.RL_MINE_PREVALENCE)(
+  "role-profile prevalence mining (RL_MINE_PREVALENCE)",
+  () => {
+    // Deliberate monolithic diagnostic harness (mirrors probe-jobs): one linear
+    // read-out of seed → capture → bucket → tally → emit, in a single scroll.
+    // Not production logic; it never asserts on what it finds.
+    // fallow-ignore-next-line complexity
+    it("mines title + skill prevalence from live feeds and emits a snapshot module", async () => {
+      const outDir = resolveOutDir();
+      const seedsPerProfile = Number(
+        process.env.RL_MINE_SEEDS ?? DEFAULT_SEEDS_PER_PROFILE,
+      );
+
+      // ── Capture. One query per (profile, seed title), fanned across the
+      //    keyless feeds. Deduped cross-provider under the SAME rule the app's
+      //    fan-out uses, so a posting carried by two feeds counts once. ────────
+      const corpus = new Map<string, JobPosting>();
+      const providerMix: Record<string, number> = {};
+      const failures: Record<string, number> = {};
+      const signal = new AbortController().signal;
+
+      // Seeds come from CURATED_ROLE_PROFILES, never from the reordered
+      // `ROLE_PROFILES` — see that constant's docblock. Seeding from the ranked
+      // table would make each corpus a function of the previous snapshot, which
+      // is a ratchet: a title that fell to the tail once would never be queried
+      // again. Seeding is deliberately snapshot-independent.
+      for (const profile of CURATED_ROLE_PROFILES) {
+        for (const seed of profile.titles.slice(0, seedsPerProfile)) {
+          await new Promise((r) => setTimeout(r, QUERY_PACING_MS));
+          const query: JobQuery = { titles: [seed], skills: [] };
+          const settled = await Promise.allSettled(
+            KEYLESS_PROVIDERS.map((provider) => provider.search(query, signal)),
+          );
+          settled.forEach((outcome, idx) => {
+            const provider = KEYLESS_PROVIDERS[idx];
+            if (outcome.status === "rejected") {
+              failures[provider.id] = (failures[provider.id] ?? 0) + 1;
+              return;
+            }
+            for (const posting of outcome.value) {
+              const key = dedupKey(posting);
+              if (corpus.has(key)) continue;
+              corpus.set(key, posting);
+              providerMix[provider.id] = (providerMix[provider.id] ?? 0) + 1;
+            }
+          });
+        }
+      }
+
+      // ── Bucket + tally. ──────────────────────────────────────────────────────
+      const { tallies, unbucketed } = tally([...corpus.values()]);
+
+      // ── Emit. ────────────────────────────────────────────────────────────────
+      const snapshot = renderSnapshotModule({
+        generatedAt: new Date().toISOString().slice(0, 10),
+        corpusSize: corpus.size,
+        providerMix,
+        tallies,
+      });
+      mkdirSync(outDir, { recursive: true });
+      const tsFile = join(outDir, "prevalence-snapshot.generated.ts");
+      const jsonFile = join(outDir, "prevalence-mining-report.json");
+      writeFileSync(tsFile, snapshot);
+      writeFileSync(
+        jsonFile,
+        JSON.stringify(
+          {
+            corpusSize: corpus.size,
+            providerMix,
+            providerFailures: failures,
+            unbucketed,
+            seedsPerProfile,
+            unobservedProfiles: CURATED_ROLE_PROFILES.map((p) => p.id)
+              .filter((id) => !tallies.has(id))
+              .sort(),
+            profiles: Object.fromEntries(
+              [...tallies].map(([id, t]) => [
+                id,
+                {
+                  sampleSize: t.sampleSize,
+                  titles: sortEntries(t.titles),
+                  skills: sortEntries(t.skills),
+                },
+              ]),
+            ),
+          },
+          null,
+          2,
+        ),
+      );
+
+      console.log(
+        renderReadout(
+          corpus.size,
+          providerMix,
+          failures,
+          unbucketed,
+          tallies,
+          tsFile,
+          jsonFile,
+        ),
+      );
+
+      // Diagnostic: never fails on findings, but must fail if it could not run.
+      expect(corpus.size).toBeGreaterThan(0);
+    }, 900_000); // live network fan-out over the whole table — minutes, not seconds.
+  },
+);
+
+/**
+ * Bucket every posting into ONE profile and count what it says.
+ *
+ * One posting, one bucket: `resolveProfilesByTitles` returns a ranked list, and
+ * crediting every member would let a single posting inflate five sample sizes
+ * at once, making `sampleSize` a number no reader could interpret. The head is
+ * the resolver's own best answer, which is the same answer the product uses.
+ */
+function tally(postings: readonly JobPosting[]): {
+  tallies: Map<string, ProfileTally>;
+  unbucketed: number;
+} {
+  const byId = new Map(CURATED_ROLE_PROFILES.map((p) => [p.id, p] as const));
+  const tallies = new Map<string, ProfileTally>();
+  let unbucketed = 0;
+
+  for (const posting of postings) {
+    const profile = bucketFor(posting, byId);
+    if (!profile) {
+      unbucketed += 1;
+      continue;
+    }
+    const tallyForProfile = tallies.get(profile.id) ?? {
+      sampleSize: 0,
+      titles: new Map<string, number>(),
+      skills: new Map<string, number>(),
+    };
+    tallies.set(profile.id, tallyForProfile);
+    tallyForProfile.sampleSize += 1;
+
+    // Titles: which CURATED forms does this real posting title exhibit? A
+    // posting can exhibit several ("Senior Engineering Manager" is both
+    // "engineering manager" and "senior engineering manager"); each is a real
+    // observation of that form, so each is counted.
+    for (const curated of profile.titles) {
+      if (profileTitleMatches(curated, posting.title)) {
+        bump(tallyForProfile.titles, curated);
+      }
+    }
+
+    for (const id of skillsMentionedIn(posting.description)) {
+      bump(tallyForProfile.skills, id);
+    }
+  }
+
+  return { tallies, unbucketed };
+}
+
+/**
+ * Canonical jd-match skill ids mentioned in a posting description, deduped.
+ *
+ * One pass of jd-match's own combined alias regex, so the mined vocabulary is
+ * the SAME vocabulary the JD-match lane extracts — a skill this can see is a
+ * skill the product can already reason about. Deduped within a posting: a
+ * description repeating "Kubernetes" eight times is one posting asking for
+ * Kubernetes, not eight. A too-short description (a feed that returned a stub)
+ * yields nothing rather than a fake zero-skill observation.
+ */
+function skillsMentionedIn(description: string): ReadonlySet<string> {
+  const ids = new Set<string>();
+  if (description.length < MIN_DESCRIPTION_CHARS) return ids;
+  const { pattern, aliasToId } = getSkillIndex();
+  for (const match of description.matchAll(pattern)) {
+    const id = aliasToId.get((match[1] ?? "").toLowerCase());
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+/**
+ * The single profile this posting's title resolves to, or undefined.
+ *
+ * `resolveProfilesByTitles` reads the ALREADY-ORDERED `ROLE_PROFILES`, but
+ * ordering can never change membership or the subset relation a title match is
+ * decided by — only the small prevalence nudge that breaks otherwise-equal ties.
+ * BUCKETING is therefore stable across regenerations. That claim covers
+ * bucketing and nothing else; SEEDING, which decides what the corpus contains in
+ * the first place, is a separate question and is answered separately — the seed
+ * loop reads `CURATED_ROLE_PROFILES` precisely so the corpus does not chase the
+ * previous run's output.
+ *
+ * Bucketing is stable, not correct. Every posting lands in exactly one profile,
+ * so a posting for a neighbouring role whose market name happens to be a curated
+ * title of some profile is counted as evidence about THAT profile. The consumer
+ * gate `MIN_CURATED_HEAD_TITLE_SHARE` catches the resulting contamination at
+ * apply time, and the baked `audit` reports it; the harness itself, as ever,
+ * asserts nothing about what it finds.
+ */
+function bucketFor(
+  posting: JobPosting,
+  byId: ReadonlyMap<string, RoleProfile>,
+): RoleProfile | undefined {
+  const id = resolveProfilesByTitles([posting.title])[0]?.id;
+  return id ? byId.get(id) : undefined;
+}
+
+function bump(counts: Map<string, number>, key: string): void {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+}
+
+/** Count desc, then insertion order — a deterministic, reproducible ranking. */
+function sortEntries(counts: ReadonlyMap<string, number>): MinedEntry[] {
+  const keys = [...counts.keys()];
+  return keys
+    .map((form, index) => ({ form, count: counts.get(form) ?? 0, index }))
+    .sort((a, b) => b.count - a.count || a.index - b.index)
+    .map(({ form, count }) => ({ form, count }));
+}
+
+/**
+ * Render the generated `prevalence-snapshot.ts`. The header this writes is the
+ * file's provenance — generation date, corpus size, provider mix, and the exact
+ * command that rebuilds it — because a snapshot nobody can regenerate rots
+ * silently and a snapshot with no dated header rots invisibly.
+ */
+function renderSnapshotModule(input: {
+  generatedAt: string;
+  corpusSize: number;
+  providerMix: Record<string, number>;
+  tallies: Map<string, ProfileTally>;
+}): string {
+  const { generatedAt, corpusSize, providerMix, tallies } = input;
+  const unobserved = CURATED_ROLE_PROFILES.map((p) => p.id)
+    .filter((id) => !tallies.has(id))
+    .sort();
+  const mixLine = Object.entries(providerMix)
+    .map(([id, n]) => `${id}=${n}`)
+    .join(", ");
+  const dominantLine = describeDominantFeed(providerMix, corpusSize);
+
+  const byId = new Map(CURATED_ROLE_PROFILES.map((p) => [p.id, p] as const));
+
+  const profileBlocks = [...tallies]
+    .sort((a, b) => b[1].sampleSize - a[1].sampleSize || a[0].localeCompare(b[0]))
+    .map(([id, t]) => {
+      const profile = byId.get(id);
+      const curated = new Set((profile?.skills ?? []).map(normalizeSkillKey));
+      const titles = sortEntries(t.titles);
+      const skills = sortEntries(t.skills).filter((e) =>
+        curated.has(normalizeSkillKey(e.form)),
+      );
+      // The verdict is computed by the CONSUMER's own `auditPrevalence`, not
+      // re-derived here, so the baked `audit` and what `applyPrevalenceOrder`
+      // will actually do cannot drift. A test asserts the two still agree on the
+      // committed file — which also catches a hand-edited count.
+      const audit = profile
+        ? auditPrevalence(profile, { sampleSize: t.sampleSize, titles, skills })
+        : undefined;
+      return (
+        `    ${JSON.stringify(id)}: {\n` +
+        `      sampleSize: ${t.sampleSize},\n` +
+        `      titles: [\n${renderEntries(titles)}      ],\n` +
+        `      skills: [\n${renderEntries(skills)}      ],\n` +
+        (audit ? `      audit: ${renderAudit(audit)},\n` : "") +
+        `    },`
+      );
+    })
+    .join("\n");
+
+  return `// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * prevalence-snapshot.ts — GENERATED. Do not hand-edit the data body (#588).
+ *
+ * Baked frequency counts mined from real job postings, consumed by
+ * \`role-profiles.ts\` to ORDER each profile's curated \`titles\` / \`skills\`.
+ * Ordering only: an entry naming a term the curated table does not carry is
+ * dropped by \`applyPrevalenceOrder\`, never added. Editing these numbers by hand
+ * is how a snapshot rots — regenerate instead.
+ *
+ * NO RUNTIME FETCH. This is a static module in the bundle; nothing here or in
+ * \`role-profiles.ts\` calls the network. The mining that produced it ran offline
+ * in a dev harness seeded from the curated titles themselves — no résumé, no new
+ * egress. See \`mine-prevalence.test.ts\`.
+ *
+ * ── WHOSE VOICE THIS IS ─────────────────────────────────────────────────────
+ * ${dominantLine}
+ * These are keyless remote-jobs aggregators, which over-represent remote-first,
+ * English-language and often smaller-company listings. Read a ranking as "what
+ * these feeds said on this date", not as a market-wide measurement.
+ *
+ * COMPANY ATS BOARDS (greenhouse / lever / ashby) ARE EXCLUDED BY DESIGN, not
+ * missing because they were down. Their pool is drawn from a *sector*
+ * classification with no profile-level equivalent, their light index carries no
+ * description at all (so the skill axis would be blind for every posting they
+ * contributed), and several Lever registry slugs are known-wrong. A provider
+ * absent from \`providerMix\` below is either one of those three or a feed that
+ * genuinely failed; the run's JSON report records the failures.
+ *
+ * Regenerate with:
+ *
+ *   RL_MINE_PREVALENCE=1 npx vitest run src/lib/job-search/mine-prevalence.test.ts
+ *
+ * then copy \`internal/job-search/prevalence-snapshot.generated.ts\` over this
+ * file and review the diff. Read each entry's \`audit\` first: it says whether
+ * each AXIS was ranked or declined and why, and it names the modal observed
+ * title — a modal title that is not the role is the tell that the bucket was
+ * filled by a neighbour and that curated MEMBERSHIP, not ordering, needs work.
+ *
+ * generatedAt:  ${generatedAt}
+ * corpusSize:   ${corpusSize} deduped postings
+ * providerMix:  ${mixLine || "(none)"}
+ */
+
+import type { PrevalenceAudit } from "./role-profiles.ts";
+
+/** One observed surface form (title) or canonical id (skill) with its count. */
+export interface PrevalenceEntry {
+  readonly form: string;
+  readonly count: number;
+}
+
+/** What one profile's postings said, ranked count-desc. */
+export interface ProfilePrevalence {
+  /**
+   * Postings that bucketed to this profile. This is the TITLE axis's evidence
+   * and only the title axis's: a posting joins the corpus on its title, and a
+   * posting whose description was a stub contributes to this number while
+   * contributing nothing to \`skills\`. \`audit.skillObservations\` is the skill
+   * axis's own denominator — see \`MIN_PREVALENCE_SKILL_OBSERVATIONS\`.
+   */
+  readonly sampleSize: number;
+  readonly titles: readonly PrevalenceEntry[];
+  /**
+   * Curated skills observed at least once, count-desc. A curated skill missing
+   * from this list scored zero, which is AMBIGUOUS: postings may genuinely never
+   * ask for it, or jd-match's alias regex may be unable to see the phrasing they
+   * asked for it with. The ranking cannot distinguish the two and treats both as
+   * "unobserved", sinking the term to the tail of the curated order — never
+   * dropping it, which is what keeps the ambiguity survivable.
+   */
+  readonly skills: readonly PrevalenceEntry[];
+  /** Per-axis verdict + the measurements behind it, computed at bake time by
+   *  the consumer's own \`auditPrevalence\`. Present for every mined profile. */
+  readonly audit: PrevalenceAudit;
+}
+
+/** The whole baked corpus summary. */
+export interface PrevalenceSnapshot {
+  /** ISO date (YYYY-MM-DD) of the mining run. */
+  readonly generatedAt: string;
+  /** Deduped postings read across every feed. */
+  readonly corpusSize: number;
+  /** Provider id → postings contributed (first-seen wins under dedup). */
+  readonly providerMix: Readonly<Record<string, number>>;
+  readonly profiles: Readonly<Record<string, ProfilePrevalence>>;
+  /**
+   * Curated profile ids for which the corpus contained NO posting at all —
+   * distinct from a profile that bucketed too few, which appears in \`profiles\`
+   * with a declining \`audit\`. The distinction matters: a thin profile was
+   * measured and declined, an unobserved one was never seen, and only the second
+   * says the seeds or the feeds could not reach that role.
+   */
+  readonly unobservedProfiles: readonly string[];
+}
+
+export const PREVALENCE_SNAPSHOT: PrevalenceSnapshot = {
+  generatedAt: ${JSON.stringify(generatedAt)},
+  corpusSize: ${corpusSize},
+  providerMix: ${JSON.stringify(providerMix)},
+  profiles: {
+${profileBlocks}
+  },
+  unobservedProfiles: ${JSON.stringify(unobserved)},
+};
+`;
+}
+
+function renderEntries(entries: readonly MinedEntry[]): string {
+  return entries
+    .map((e) => `        { form: ${JSON.stringify(e.form)}, count: ${e.count} },\n`)
+    .join("");
+}
+
+/** One line, so a reviewer reads the verdict without unfolding an object. */
+function renderAudit(audit: PrevalenceAudit): string {
+  return (
+    `{ titles: ${JSON.stringify(audit.titles)}, skills: ${JSON.stringify(audit.skills)}, ` +
+    `sampleSize: ${audit.sampleSize}, ` +
+    `modalTitle: ${JSON.stringify(audit.modalTitle)}, ` +
+    `modalTitleShare: ${audit.modalTitleShare}, ` +
+    `curatedHeadTitleShare: ${audit.curatedHeadTitleShare}, ` +
+    `skillObservations: ${audit.skillObservations}, ` +
+    `skillHeadCount: ${audit.skillHeadCount} }`
+  );
+}
+
+/**
+ * The one sentence a reader needs before believing any count in this file: how
+ * lopsided the corpus is. A snapshot that only lists `providerMix` lets a
+ * reader assume three feeds contributed comparably when in practice one
+ * aggregator has supplied four fifths of every run so far.
+ */
+function describeDominantFeed(
+  providerMix: Readonly<Record<string, number>>,
+  corpusSize: number,
+): string {
+  const entries = Object.entries(providerMix).sort((a, b) => b[1] - a[1]);
+  const top = entries[0];
+  if (!top || corpusSize <= 0) return "No feed answered; the corpus is empty.";
+  const pct = Math.round((top[1] / corpusSize) * 100);
+  const others = entries.slice(1).map(([id, n]) => `${id} ${n}`).join(", ");
+  return (
+    `THIS CORPUS IS NOT EVENLY SOURCED: "${top[0]}" alone supplied\n` +
+    ` * ${top[1]} of ${corpusSize} postings (${pct}%)` +
+    (others ? `, against ${others}.` : ".")
+  );
+}
+
+/** The console read-out. No PII is in play here — the corpus is public postings
+ *  and the seeds are committed strings — so this prints real counts and ids. */
+function renderReadout(
+  corpusSize: number,
+  providerMix: Record<string, number>,
+  failures: Record<string, number>,
+  unbucketed: number,
+  tallies: Map<string, ProfileTally>,
+  tsFile: string,
+  jsonFile: string,
+): string {
+  const byId = new Map(CURATED_ROLE_PROFILES.map((p) => [p.id, p] as const));
+  const audits = [...tallies].map(([id, t]) => {
+    const profile = byId.get(id);
+    const audit = profile
+      ? auditPrevalence(profile, {
+          sampleSize: t.sampleSize,
+          titles: sortEntries(t.titles),
+          skills: sortEntries(t.skills),
+        })
+      : undefined;
+    return { id, tally: t, audit };
+  });
+
+  const rows = audits
+    .sort((a, b) => b.tally.sampleSize - a.tally.sampleSize)
+    .map(({ id, tally: t, audit }) => {
+      // The modal is printed for both verdicts that turn on it — the refusal,
+      // and the near-tie where it led but not by enough to take the head.
+      const modalMatters =
+        audit?.titles === "bucket-not-this-role" ||
+        audit?.titles === "ranked-head-pinned";
+      const verdict = audit
+        ? `titles=${audit.titles} skills=${audit.skills}` +
+          (modalMatters
+            ? `  modal="${audit.modalTitle}" ${Math.round(audit.modalTitleShare * 100)}%`
+            : "")
+        : "(not a curated profile)";
+      return (
+        `    ${id.padEnd(30)} n=${String(t.sampleSize).padStart(4)}` +
+        `  skillObs=${String(audit?.skillObservations ?? 0).padStart(4)}  ${verdict}`
+      );
+    })
+    .join("\n");
+
+  const rankedTitles = audits.filter((a) => a.audit?.titles === "ranked").length;
+  const pinnedTitles = audits.filter(
+    (a) => a.audit?.titles === "ranked-head-pinned",
+  ).length;
+  const rankedSkills = audits.filter((a) => a.audit?.skills === "ranked").length;
+  const unobserved = CURATED_ROLE_PROFILES.filter((p) => !tallies.has(p.id)).length;
+
+  return (
+    `\nprevalence mining run\n` +
+    `  corpus=${corpusSize} deduped postings  unbucketed=${unbucketed}\n` +
+    `  providerMix=${JSON.stringify(providerMix)}\n` +
+    `  providerFailures=${JSON.stringify(failures)}\n` +
+    `  profiles bucketed=${tallies.size}  unobserved=${unobserved}\n` +
+    `  ranked TITLE axis=${rankedTitles} (+${pinnedTitles} head-pinned)` +
+    `  ranked SKILL axis=${rankedSkills}\n\n` +
+    `  PER PROFILE:\n${rows}\n\n` +
+    `  generated snapshot → ${tsFile}\n` +
+    `  full report        → ${jsonFile}\n` +
+    `  Copy the generated module over src/lib/job-search/prevalence-snapshot.ts ` +
+    `and review the diff.\n`
+  );
+}

--- a/src/lib/job-search/prevalence-snapshot.ts
+++ b/src/lib/job-search/prevalence-snapshot.ts
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * prevalence-snapshot.ts — GENERATED. Do not hand-edit the data body (#588).
+ *
+ * Baked frequency counts mined from real job postings, consumed by
+ * `role-profiles.ts` to ORDER each profile's curated `titles` / `skills`.
+ * Ordering only: an entry naming a term the curated table does not carry is
+ * dropped by `applyPrevalenceOrder`, never added. Editing these numbers by hand
+ * is how a snapshot rots — regenerate instead.
+ *
+ * NO RUNTIME FETCH. This is a static module in the bundle; nothing here or in
+ * `role-profiles.ts` calls the network. The mining that produced it ran offline
+ * in a dev harness seeded from the curated titles themselves — no résumé, no new
+ * egress. See `mine-prevalence.test.ts`.
+ *
+ * ── WHOSE VOICE THIS IS ─────────────────────────────────────────────────────
+ * THIS CORPUS IS NOT EVENLY SOURCED: "jobicy" alone supplied
+ * 1002 of 1139 postings (88%), against arbeitnow 99, remotive 38.
+ * These are keyless remote-jobs aggregators, which over-represent remote-first,
+ * English-language and often smaller-company listings. Read a ranking as "what
+ * these feeds said on this date", not as a market-wide measurement.
+ *
+ * COMPANY ATS BOARDS (greenhouse / lever / ashby) ARE EXCLUDED BY DESIGN, not
+ * missing because they were down. Their pool is drawn from a *sector*
+ * classification with no profile-level equivalent, their light index carries no
+ * description at all (so the skill axis would be blind for every posting they
+ * contributed), and several Lever registry slugs are known-wrong. A provider
+ * absent from `providerMix` below is either one of those three or a feed that
+ * genuinely failed; the run's JSON report records the failures.
+ *
+ * Regenerate with:
+ *
+ *   RL_MINE_PREVALENCE=1 npx vitest run src/lib/job-search/mine-prevalence.test.ts
+ *
+ * then copy `internal/job-search/prevalence-snapshot.generated.ts` over this
+ * file and review the diff. Read each entry's `audit` first: it says whether
+ * each AXIS was ranked or declined and why, and it names the modal observed
+ * title — a modal title that is not the role is the tell that the bucket was
+ * filled by a neighbour and that curated MEMBERSHIP, not ordering, needs work.
+ *
+ * generatedAt:  2026-07-26
+ * corpusSize:   1139 deduped postings
+ * providerMix:  remotive=38, arbeitnow=99, jobicy=1002
+ */
+
+import type { PrevalenceAudit } from "./role-profiles.ts";
+
+/** One observed surface form (title) or canonical id (skill) with its count. */
+export interface PrevalenceEntry {
+  readonly form: string;
+  readonly count: number;
+}
+
+/** What one profile's postings said, ranked count-desc. */
+export interface ProfilePrevalence {
+  /**
+   * Postings that bucketed to this profile. This is the TITLE axis's evidence
+   * and only the title axis's: a posting joins the corpus on its title, and a
+   * posting whose description was a stub contributes to this number while
+   * contributing nothing to `skills`. `audit.skillObservations` is the skill
+   * axis's own denominator — see `MIN_PREVALENCE_SKILL_OBSERVATIONS`.
+   */
+  readonly sampleSize: number;
+  readonly titles: readonly PrevalenceEntry[];
+  /**
+   * Curated skills observed at least once, count-desc. A curated skill missing
+   * from this list scored zero, which is AMBIGUOUS: postings may genuinely never
+   * ask for it, or jd-match's alias regex may be unable to see the phrasing they
+   * asked for it with. The ranking cannot distinguish the two and treats both as
+   * "unobserved", sinking the term to the tail of the curated order — never
+   * dropping it, which is what keeps the ambiguity survivable.
+   */
+  readonly skills: readonly PrevalenceEntry[];
+  /** Per-axis verdict + the measurements behind it, computed at bake time by
+   *  the consumer's own `auditPrevalence`. Present for every mined profile. */
+  readonly audit: PrevalenceAudit;
+}
+
+/** The whole baked corpus summary. */
+export interface PrevalenceSnapshot {
+  /** ISO date (YYYY-MM-DD) of the mining run. */
+  readonly generatedAt: string;
+  /** Deduped postings read across every feed. */
+  readonly corpusSize: number;
+  /** Provider id → postings contributed (first-seen wins under dedup). */
+  readonly providerMix: Readonly<Record<string, number>>;
+  readonly profiles: Readonly<Record<string, ProfilePrevalence>>;
+  /**
+   * Curated profile ids for which the corpus contained NO posting at all —
+   * distinct from a profile that bucketed too few, which appears in `profiles`
+   * with a declining `audit`. The distinction matters: a thin profile was
+   * measured and declined, an unobserved one was never seen, and only the second
+   * says the seeds or the feeds could not reach that role.
+   */
+  readonly unobservedProfiles: readonly string[];
+}
+
+export const PREVALENCE_SNAPSHOT: PrevalenceSnapshot = {
+  generatedAt: "2026-07-26",
+  corpusSize: 1139,
+  providerMix: {"remotive":38,"arbeitnow":99,"jobicy":1002},
+  profiles: {
+    "account-executive": {
+      sampleSize: 75,
+      titles: [
+        { form: "account executive", count: 25 },
+        { form: "sales engineer", count: 16 },
+        { form: "account manager", count: 11 },
+        { form: "business development manager", count: 10 },
+        { form: "solutions engineer", count: 7 },
+        { form: "sales development representative", count: 7 },
+      ],
+      skills: [
+        { form: "sql", count: 5 },
+        { form: "executive-communication", count: 4 },
+        { form: "cross-functional-collaboration", count: 1 },
+      ],
+      audit: { titles: "ranked", skills: "thin-observations", sampleSize: 75, modalTitle: "account executive", modalTitleShare: 0.329, curatedHeadTitleShare: 0.329, skillObservations: 10, skillHeadCount: 5 },
+    },
+    "support-engineer": {
+      sampleSize: 66,
+      titles: [
+        { form: "customer success manager", count: 56 },
+        { form: "customer support specialist", count: 6 },
+        { form: "support engineer", count: 4 },
+      ],
+      skills: [
+        { form: "stakeholder-management", count: 9 },
+        { form: "linux", count: 7 },
+        { form: "jira", count: 6 },
+        { form: "cross-functional-collaboration", count: 2 },
+        { form: "sql", count: 1 },
+      ],
+      audit: { titles: "bucket-not-this-role", skills: "thin-observations", sampleSize: 66, modalTitle: "customer success manager", modalTitleShare: 0.848, curatedHeadTitleShare: 0.061, skillObservations: 25, skillHeadCount: 9 },
+    },
+    "software-engineer": {
+      sampleSize: 49,
+      titles: [
+        { form: "software engineer", count: 42 },
+        { form: "software developer", count: 7 },
+      ],
+      skills: [
+        { form: "python", count: 21 },
+        { form: "rest", count: 18 },
+        { form: "java", count: 16 },
+        { form: "typescript", count: 15 },
+        { form: "sql", count: 8 },
+        { form: "docker", count: 6 },
+        { form: "javascript", count: 5 },
+        { form: "git", count: 5 },
+      ],
+      audit: { titles: "ranked", skills: "ranked", sampleSize: 49, modalTitle: "software engineer", modalTitleShare: 0.857, curatedHeadTitleShare: 0.857, skillObservations: 94, skillHeadCount: 21 },
+    },
+    "product-manager": {
+      sampleSize: 38,
+      titles: [
+        { form: "product manager", count: 33 },
+        { form: "senior product manager", count: 17 },
+        { form: "technical product manager", count: 6 },
+        { form: "product owner", count: 5 },
+      ],
+      skills: [
+        { form: "product-management", count: 27 },
+        { form: "agile", count: 8 },
+        { form: "user-research", count: 6 },
+        { form: "stakeholder-management", count: 6 },
+        { form: "sql", count: 5 },
+        { form: "jira", count: 1 },
+        { form: "okrs", count: 1 },
+      ],
+      audit: { titles: "ranked", skills: "ranked", sampleSize: 38, modalTitle: "product manager", modalTitleShare: 0.541, curatedHeadTitleShare: 0.541, skillObservations: 54, skillHeadCount: 27 },
+    },
+    "engineering-manager": {
+      sampleSize: 37,
+      titles: [
+        { form: "engineering manager", count: 32 },
+        { form: "engineering lead", count: 5 },
+        { form: "software engineering manager", count: 1 },
+      ],
+      skills: [
+        { form: "career-development", count: 11 },
+        { form: "people-management", count: 6 },
+        { form: "project-delivery", count: 2 },
+        { form: "team-building", count: 2 },
+        { form: "stakeholder-management", count: 2 },
+        { form: "performance-management", count: 1 },
+      ],
+      audit: { titles: "ranked", skills: "thin-observations", sampleSize: 37, modalTitle: "engineering manager", modalTitleShare: 0.842, curatedHeadTitleShare: 0.842, skillObservations: 24, skillHeadCount: 11 },
+    },
+    "machine-learning-engineer": {
+      sampleSize: 37,
+      titles: [
+        { form: "ai engineer", count: 14 },
+        { form: "machine learning engineer", count: 11 },
+        { form: "data scientist", count: 8 },
+        { form: "ml engineer", count: 3 },
+        { form: "applied scientist", count: 2 },
+        { form: "research scientist", count: 2 },
+      ],
+      skills: [
+        { form: "machine-learning", count: 29 },
+        { form: "python", count: 28 },
+        { form: "pytorch", count: 13 },
+        { form: "llm", count: 11 },
+        { form: "tensorflow", count: 11 },
+        { form: "deep-learning", count: 7 },
+        { form: "scikit-learn", count: 5 },
+        { form: "nlp", count: 5 },
+        { form: "pandas", count: 2 },
+        { form: "numpy", count: 1 },
+      ],
+      audit: { titles: "ranked-head-pinned", skills: "ranked", sampleSize: 37, modalTitle: "ai engineer", modalTitleShare: 0.35, curatedHeadTitleShare: 0.275, skillObservations: 112, skillHeadCount: 29 },
+    },
+    "site-reliability-engineer": {
+      sampleSize: 34,
+      titles: [
+        { form: "site reliability engineer", count: 11 },
+        { form: "cloud engineer", count: 10 },
+        { form: "devops engineer", count: 9 },
+        { form: "platform engineer", count: 7 },
+      ],
+      skills: [
+        { form: "ci-cd", count: 22 },
+        { form: "aws", count: 19 },
+        { form: "kubernetes", count: 19 },
+        { form: "linux", count: 17 },
+        { form: "terraform", count: 15 },
+        { form: "grafana", count: 11 },
+        { form: "prometheus", count: 10 },
+        { form: "bash", count: 8 },
+        { form: "docker", count: 7 },
+        { form: "ansible", count: 4 },
+      ],
+      audit: { titles: "ranked", skills: "ranked", sampleSize: 34, modalTitle: "site reliability engineer", modalTitleShare: 0.297, curatedHeadTitleShare: 0.297, skillObservations: 132, skillHeadCount: 22 },
+    },
+    "technical-program-manager": {
+      sampleSize: 27,
+      titles: [
+        { form: "project manager", count: 15 },
+        { form: "program manager", count: 12 },
+        { form: "technical program manager", count: 4 },
+        { form: "senior technical program manager", count: 1 },
+      ],
+      skills: [
+        { form: "program-management", count: 7 },
+        { form: "stakeholder-management", count: 6 },
+        { form: "project-delivery", count: 4 },
+        { form: "cross-functional-collaboration", count: 4 },
+        { form: "incident-management", count: 1 },
+        { form: "jira", count: 1 },
+      ],
+      audit: { titles: "bucket-not-this-role", skills: "thin-observations", sampleSize: 27, modalTitle: "project manager", modalTitleShare: 0.469, curatedHeadTitleShare: 0.125, skillObservations: 23, skillHeadCount: 7 },
+    },
+    "marketing-manager": {
+      sampleSize: 25,
+      titles: [
+        { form: "marketing manager", count: 25 },
+        { form: "content marketing manager", count: 4 },
+        { form: "product marketing manager", count: 2 },
+        { form: "growth marketing manager", count: 1 },
+      ],
+      skills: [
+        { form: "cross-functional-collaboration", count: 5 },
+        { form: "a-b-testing", count: 2 },
+      ],
+      audit: { titles: "ranked", skills: "thin-observations", sampleSize: 25, modalTitle: "marketing manager", modalTitleShare: 0.781, curatedHeadTitleShare: 0.781, skillObservations: 7, skillHeadCount: 5 },
+    },
+    "data-engineer": {
+      sampleSize: 20,
+      titles: [
+        { form: "data engineer", count: 11 },
+        { form: "data analyst", count: 9 },
+        { form: "data platform engineer", count: 4 },
+      ],
+      skills: [
+        { form: "sql", count: 13 },
+        { form: "python", count: 12 },
+        { form: "airflow", count: 7 },
+        { form: "etl", count: 5 },
+        { form: "dbt", count: 5 },
+        { form: "spark", count: 4 },
+        { form: "snowflake", count: 4 },
+        { form: "bigquery", count: 4 },
+        { form: "data-warehouse", count: 3 },
+        { form: "tableau", count: 3 },
+      ],
+      audit: { titles: "thin-sample", skills: "ranked", sampleSize: 20, modalTitle: "data engineer", modalTitleShare: 0.458, curatedHeadTitleShare: 0.458, skillObservations: 60, skillHeadCount: 13 },
+    },
+    "security-engineer": {
+      sampleSize: 15,
+      titles: [
+        { form: "security engineer", count: 14 },
+        { form: "application security engineer", count: 3 },
+        { form: "security architect", count: 1 },
+      ],
+      skills: [
+        { form: "python", count: 12 },
+        { form: "aws", count: 8 },
+        { form: "linux", count: 4 },
+        { form: "saml", count: 3 },
+        { form: "soc2", count: 3 },
+        { form: "hipaa", count: 2 },
+        { form: "oauth", count: 1 },
+        { form: "sso", count: 1 },
+        { form: "gdpr", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 15, modalTitle: "security engineer", modalTitleShare: 0.778, curatedHeadTitleShare: 0.778, skillObservations: 35, skillHeadCount: 12 },
+    },
+    "fullstack-engineer": {
+      sampleSize: 11,
+      titles: [
+        { form: "fullstack engineer", count: 11 },
+        { form: "fullstack software engineer", count: 3 },
+      ],
+      skills: [
+        { form: "react", count: 9 },
+        { form: "rest", count: 6 },
+        { form: "postgresql", count: 5 },
+        { form: "typescript", count: 5 },
+        { form: "node.js", count: 5 },
+        { form: "aws", count: 5 },
+        { form: "javascript", count: 3 },
+        { form: "docker", count: 2 },
+        { form: "next.js", count: 2 },
+        { form: "graphql", count: 2 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 11, modalTitle: "fullstack engineer", modalTitleShare: 0.786, curatedHeadTitleShare: 0.786, skillObservations: 44, skillHeadCount: 9 },
+    },
+    "qa-engineer": {
+      sampleSize: 10,
+      titles: [
+        { form: "automation engineer", count: 5 },
+        { form: "qa engineer", count: 4 },
+        { form: "quality engineer", count: 3 },
+        { form: "quality assurance engineer", count: 1 },
+        { form: "test engineer", count: 1 },
+      ],
+      skills: [
+        { form: "ci-cd", count: 4 },
+        { form: "python", count: 4 },
+        { form: "cypress", count: 2 },
+        { form: "selenium", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 10, modalTitle: "automation engineer", modalTitleShare: 0.357, curatedHeadTitleShare: 0.286, skillObservations: 11, skillHeadCount: 4 },
+    },
+    "backend-engineer": {
+      sampleSize: 8,
+      titles: [
+        { form: "backend engineer", count: 7 },
+        { form: "backend developer", count: 1 },
+      ],
+      skills: [
+        { form: "docker", count: 4 },
+        { form: "rest", count: 4 },
+        { form: "go", count: 3 },
+        { form: "postgresql", count: 2 },
+        { form: "grpc", count: 2 },
+        { form: "python", count: 2 },
+        { form: "kafka", count: 1 },
+        { form: "java", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 8, modalTitle: "backend engineer", modalTitleShare: 0.875, curatedHeadTitleShare: 0.875, skillObservations: 19, skillHeadCount: 4 },
+    },
+    "frontend-engineer": {
+      sampleSize: 7,
+      titles: [
+        { form: "frontend engineer", count: 6 },
+        { form: "react developer", count: 1 },
+      ],
+      skills: [
+        { form: "react", count: 6 },
+        { form: "typescript", count: 5 },
+        { form: "css", count: 4 },
+        { form: "javascript", count: 4 },
+        { form: "tailwind", count: 1 },
+        { form: "html", count: 1 },
+        { form: "jest", count: 1 },
+        { form: "next.js", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 7, modalTitle: "frontend engineer", modalTitleShare: 0.857, curatedHeadTitleShare: 0.857, skillObservations: 23, skillHeadCount: 6 },
+    },
+    "mobile-engineer": {
+      sampleSize: 7,
+      titles: [
+        { form: "android engineer", count: 3 },
+        { form: "mobile engineer", count: 1 },
+        { form: "ios developer", count: 1 },
+        { form: "android developer", count: 1 },
+        { form: "ios engineer", count: 1 },
+      ],
+      skills: [
+        { form: "android", count: 5 },
+        { form: "ios", count: 4 },
+        { form: "kotlin", count: 4 },
+        { form: "swift", count: 3 },
+        { form: "xcode", count: 2 },
+        { form: "react-native", count: 1 },
+        { form: "java", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 7, modalTitle: "android engineer", modalTitleShare: 0.429, curatedHeadTitleShare: 0.143, skillObservations: 20, skillHeadCount: 5 },
+    },
+    "product-designer": {
+      sampleSize: 7,
+      titles: [
+        { form: "product designer", count: 7 },
+      ],
+      skills: [
+        { form: "product-management", count: 3 },
+        { form: "figma", count: 2 },
+        { form: "user-research", count: 1 },
+        { form: "html", count: 1 },
+        { form: "css", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 7, modalTitle: "product designer", modalTitleShare: 1, curatedHeadTitleShare: 1, skillObservations: 8, skillHeadCount: 3 },
+    },
+    "senior-engineering-manager": {
+      sampleSize: 4,
+      titles: [
+        { form: "senior engineering manager", count: 4 },
+      ],
+      skills: [
+        { form: "cross-functional-collaboration", count: 1 },
+        { form: "people-management", count: 1 },
+        { form: "career-development", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 4, modalTitle: "senior engineering manager", modalTitleShare: 1, curatedHeadTitleShare: 1, skillObservations: 3, skillHeadCount: 1 },
+    },
+    "director-of-engineering": {
+      sampleSize: 3,
+      titles: [
+        { form: "director of engineering", count: 3 },
+        { form: "engineering director", count: 3 },
+        { form: "director of software engineering", count: 1 },
+      ],
+      skills: [
+        { form: "executive-communication", count: 1 },
+        { form: "performance-management", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 3, modalTitle: "director of engineering", modalTitleShare: 0.857, curatedHeadTitleShare: 0.857, skillObservations: 2, skillHeadCount: 1 },
+    },
+    "founder-ceo": {
+      sampleSize: 2,
+      titles: [
+        { form: "ceo", count: 2 },
+        { form: "chief executive officer", count: 2 },
+      ],
+      skills: [
+        { form: "stakeholder-management", count: 1 },
+        { form: "executive-communication", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 2, modalTitle: "ceo", modalTitleShare: 1, curatedHeadTitleShare: 0, skillObservations: 2, skillHeadCount: 1 },
+    },
+    "cto": {
+      sampleSize: 1,
+      titles: [
+        { form: "cto", count: 1 },
+        { form: "chief technology officer", count: 1 },
+        { form: "chief technical officer", count: 1 },
+      ],
+      skills: [
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 1, modalTitle: "cto", modalTitleShare: 1, curatedHeadTitleShare: 1, skillObservations: 0, skillHeadCount: 0 },
+    },
+    "site-lead": {
+      sampleSize: 1,
+      titles: [
+        { form: "site director", count: 1 },
+      ],
+      skills: [
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 1, modalTitle: "site director", modalTitleShare: 1, curatedHeadTitleShare: 0, skillObservations: 0, skillHeadCount: 0 },
+    },
+    "vp-engineering": {
+      sampleSize: 1,
+      titles: [
+        { form: "vp of engineering", count: 1 },
+        { form: "vp engineering", count: 1 },
+        { form: "vice president of engineering", count: 1 },
+      ],
+      skills: [
+        { form: "stakeholder-management", count: 1 },
+      ],
+      audit: { titles: "thin-sample", skills: "thin-observations", sampleSize: 1, modalTitle: "vp of engineering", modalTitleShare: 1, curatedHeadTitleShare: 1, skillObservations: 1, skillHeadCount: 1 },
+    },
+  },
+  unobservedProfiles: ["head-of-engineering"],
+};

--- a/src/lib/job-search/role-profiles.test.ts
+++ b/src/lib/job-search/role-profiles.test.ts
@@ -3,12 +3,26 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  CURATED_ROLE_PROFILES,
+  MAX_FOREIGN_MODAL_TITLE_SHARE,
+  MIN_CURATED_HEAD_TITLE_SHARE,
+  MIN_PREVALENCE_SAMPLE,
+  MIN_PREVALENCE_SKILL_HEAD_COUNT,
+  MIN_PREVALENCE_SKILL_OBSERVATIONS,
   ROLE_PROFILES,
   ROLE_PROFILES_VERSION,
+  applyPrevalenceOrder,
+  auditPrevalence,
   resolveProfilesByTitles,
   resolveProfilesBySkills,
   roleProfileById,
+  type RoleProfile,
 } from "./role-profiles.ts";
+import {
+  PREVALENCE_SNAPSHOT,
+  type PrevalenceSnapshot,
+  type ProfilePrevalence,
+} from "./prevalence-snapshot.ts";
 import { ROLE_FAMILIES } from "./role-keywords.ts";
 import { SENIORITY_LADDER } from "./seniority.ts";
 // jd-match is imported by the TEST ONLY — the shipped module keeps the
@@ -25,7 +39,7 @@ function familiesOf(profiles: readonly { family: string }[]): string[] {
 
 describe("ROLE_PROFILES table integrity", () => {
   it("is versioned", () => {
-    expect(ROLE_PROFILES_VERSION).toBe("1.0");
+    expect(ROLE_PROFILES_VERSION).toBe("1.1");
   });
 
   it("has a unique kebab id per profile", () => {
@@ -276,6 +290,566 @@ describe("the two resolvers are separate questions", () => {
       "coaching-mentorship",
     ]);
     expect(byTitle[0].id).toBe(bySkill[0].id);
+  });
+});
+
+// ── #588 prevalence ordering ────────────────────────────────────────────────
+// Tested against FABRICATED snapshots only, with one exception at the bottom
+// that checks the committed snapshot for INTERNAL CONSISTENCY rather than for
+// content. Asserting on `PREVALENCE_SNAPSHOT`'s counts would bake one mining
+// run's live-feed sample into the suite, so every regeneration would break tests
+// that are not about the change.
+describe("applyPrevalenceOrder", () => {
+  const curated: readonly RoleProfile[] = [
+    {
+      id: "alpha",
+      label: "Alpha",
+      family: "backend",
+      rungs: [1],
+      titles: ["first title", "second title", "third title"],
+      skills: ["python", "java", "go"],
+    },
+    {
+      id: "beta",
+      label: "Beta",
+      family: "frontend",
+      rungs: [1],
+      titles: ["beta lead", "beta engineer"],
+      skills: ["react", "css"],
+    },
+  ];
+
+  /** A skill tally that clears both skill-axis floors, ranked as given. */
+  const RANKABLE_SKILLS = [
+    { form: "go", count: 70 },
+    { form: "java", count: 12 },
+  ];
+  /** A title tally that clears EVERY title-axis gate, with room on each so a
+   *  test using it fails on the behaviour it names and not on a boundary:
+   *  the curated head ("first title") holds 40/160 = 25% (floor 20%), the
+   *  foreign modal holds 70/160 ≈ 44% (ceiling 50%), and the modal's lead over
+   *  the head is 30 against a noise floor of √110 ≈ 10.5. */
+  const RANKABLE_TITLES = [
+    { form: "third title", count: 70 },
+    { form: "first title", count: 40 },
+    { form: "second title", count: 50 },
+  ];
+
+  function snapshotOf(
+    profiles: Record<string, Omit<ProfilePrevalence, "audit">>,
+    unobserved: readonly string[] = [],
+  ): PrevalenceSnapshot {
+    return {
+      generatedAt: "2026-07-25",
+      corpusSize: 1000,
+      providerMix: { remotive: 1000 },
+      // The `audit` field is what the harness BAKES; `applyPrevalenceOrder`
+      // recomputes it and never reads the baked copy, so the fixtures below can
+      // omit it. `auditPrevalence` fills it in for the assertions that need it.
+      profiles: Object.fromEntries(
+        Object.entries(profiles).map(([id, entry]) => {
+          const profile = curated.find((p) => p.id === id);
+          return [
+            id,
+            { ...entry, audit: auditPrevalence(profile ?? curated[0], entry) },
+          ];
+        }),
+      ),
+      unobservedProfiles: unobserved,
+    };
+  }
+
+  it("reorders a healthy profile on both axes by observed count", () => {
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: MIN_PREVALENCE_SAMPLE,
+          titles: RANKABLE_TITLES,
+          skills: RANKABLE_SKILLS,
+        },
+      }),
+    );
+    expect(alpha.titles).toEqual(["third title", "second title", "first title"]);
+    // "python" was never observed, so it falls to the tail — behind every
+    // observed skill, but keeping its curated position relative to other
+    // unobserved terms.
+    expect(alpha.skills).toEqual(["go", "java", "python"]);
+  });
+
+  it("leaves a profile absent from the snapshot exactly as curated", () => {
+    const ordered = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: 500,
+          titles: RANKABLE_TITLES,
+          skills: RANKABLE_SKILLS,
+        },
+      }),
+    );
+    const beta = ordered[1];
+    expect(beta.titles).toEqual(curated[1].titles);
+    expect(beta.skills).toEqual(curated[1].skills);
+    // Untouched by reference — the fallback does not rebuild the object.
+    expect(beta).toBe(curated[1]);
+  });
+
+  it("returns a profile by reference when NEITHER axis clears its gate", () => {
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: MIN_PREVALENCE_SAMPLE - 1,
+          titles: [{ form: "third title", count: 999 }],
+          skills: [{ form: "go", count: 9 }],
+        },
+      }),
+    );
+    expect(alpha).toBe(curated[0]);
+  });
+
+  // ── The two axes are gated independently (#588 review, B1) ────────────────
+  // `sampleSize` counts postings, and a posting joins on its TITLE. Its skills
+  // come from its description, which a feed may not have supplied at all — so
+  // one gate over both axes lets the title axis's evidence authorise the skill
+  // ranking. These two tests pin that each axis stands or falls on its own.
+
+  it("ranks skills while declining titles when only the skill axis has evidence", () => {
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: MIN_PREVALENCE_SAMPLE - 1,
+          titles: [{ form: "third title", count: 999 }],
+          skills: RANKABLE_SKILLS,
+        },
+      }),
+    );
+    expect(alpha.titles).toBe(curated[0].titles);
+    expect(alpha.skills).toEqual(["go", "java", "python"]);
+  });
+
+  it("ranks titles while declining skills when the descriptions were unreadable", () => {
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: 500,
+          titles: RANKABLE_TITLES,
+          // A whole profile's worth of postings, five skill observations
+          // between them: enough to name a head, nowhere near enough to rank.
+          skills: [
+            { form: "go", count: 4 },
+            { form: "java", count: 1 },
+          ],
+        },
+      }),
+    );
+    expect(alpha.titles).toEqual(["third title", "second title", "first title"]);
+    expect(alpha.skills).toBe(curated[0].skills);
+  });
+
+  it("declines the skill axis on a flat tally that clears the total but not the head", () => {
+    // Five skills at nine observations apiece: 45 clears the total floor, but
+    // no single term is a repeated ask, so the "ranking" is five coin flips and
+    // its head is what would ship as advice.
+    const wide = ["python", "java", "go", "rust", "kotlin"];
+    const audit = auditPrevalence(
+      { ...curated[0], skills: wide },
+      {
+        sampleSize: 500,
+        titles: RANKABLE_TITLES,
+        skills: wide.map((form) => ({ form, count: 9 })),
+      },
+    );
+    expect(audit.skillObservations).toBeGreaterThanOrEqual(
+      MIN_PREVALENCE_SKILL_OBSERVATIONS,
+    );
+    expect(audit.skillHeadCount).toBeLessThan(MIN_PREVALENCE_SKILL_HEAD_COUNT);
+    expect(audit.skills).toBe("thin-observations");
+  });
+
+  it("declines the skill axis on a strong head with too few observations behind it", () => {
+    // The mirror of the test above, and the reason `MIN_PREVALENCE_SKILL_
+    // OBSERVATIONS` needs a fixture of its own: with only the head-count floor
+    // in play, twelve mentions of one term and five of another would authorise
+    // a ranking of the whole list — including the terms nobody mentioned, whose
+    // order would then be pure curation wearing a measured label.
+    const thin = {
+      sampleSize: 500,
+      titles: RANKABLE_TITLES,
+      skills: [
+        { form: "go", count: 12 },
+        { form: "java", count: 5 },
+      ],
+    };
+    const audit = auditPrevalence(curated[0], thin);
+    expect(audit.skillHeadCount).toBeGreaterThanOrEqual(
+      MIN_PREVALENCE_SKILL_HEAD_COUNT,
+    );
+    expect(audit.skillObservations).toBeLessThan(MIN_PREVALENCE_SKILL_OBSERVATIONS);
+    expect(audit.skills).toBe("thin-observations");
+
+    const [alpha] = applyPrevalenceOrder(curated, snapshotOf({ alpha: thin }));
+    // Curated skill order ships untouched, even though "go" led decisively.
+    expect(alpha.skills).toBe(curated[0].skills);
+    // The title axis still ranked, so this is the skill gate firing alone.
+    expect(alpha.titles).toEqual(["third title", "second title", "first title"]);
+  });
+
+  // ── The bucketing-concentration guard (#588 review, B2) ───────────────────
+
+  it("refuses the title ranking when the bucket is mostly a different role", () => {
+    // The `support-engineer` shape: `resolveProfilesByTitles` routes every
+    // Customer Success Manager posting to the Support Engineer profile because
+    // CSM is one of its curated titles, so 85% of a healthy-looking sample is a
+    // different job — and the counts would then make "Customer Success Manager"
+    // the answer to "what is this role commonly called". A bigger sample makes
+    // this worse, not better, so the guard is on composition, not size.
+    const contaminated = {
+      sampleSize: 500,
+      titles: [
+        { form: "third title", count: 90 },
+        { form: "first title", count: 4 },
+        { form: "second title", count: 2 },
+      ],
+      skills: RANKABLE_SKILLS,
+    };
+    const audit = auditPrevalence(curated[0], contaminated);
+    expect(audit.modalTitle).toBe("third title");
+    expect(audit.curatedHeadTitleShare).toBeLessThan(MIN_CURATED_HEAD_TITLE_SHARE);
+
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({ alpha: contaminated }),
+    );
+    expect(alpha.titles).toBe(curated[0].titles);
+    expect(alpha.titles[0]).toBe("first title");
+    // Only the TITLE axis is refused — the descriptions were still readable.
+    expect(alpha.skills).toEqual(["go", "java", "python"]);
+  });
+
+  it("allows a genuine rename: modal is not the head, but the head still holds", () => {
+    // The `machine-learning-engineer` shape — "AI Engineer" really did overtake
+    // "Machine Learning Engineer" while the latter stayed a strong runner-up.
+    // That is the market renaming a role, and refusing it would throw away the
+    // measurement this whole mechanism exists to make.
+    const renamed = {
+      sampleSize: 500,
+      titles: [
+        { form: "third title", count: 35 },
+        { form: "first title", count: 25 },
+        { form: "second title", count: 40 },
+      ],
+      skills: RANKABLE_SKILLS,
+    };
+    const audit = auditPrevalence(curated[0], renamed);
+    expect(audit.modalTitle).toBe("second title");
+    expect(audit.curatedHeadTitleShare).toBeGreaterThanOrEqual(
+      MIN_CURATED_HEAD_TITLE_SHARE,
+    );
+
+    const [alpha] = applyPrevalenceOrder(curated, snapshotOf({ alpha: renamed }));
+    expect(alpha.titles).toEqual(["second title", "third title", "first title"]);
+  });
+
+  // ── The modal ceiling (#588 round 2, S-B) ────────────────────────────────
+
+  it("refuses a bucket whose foreign modal is an outright majority, however well the head polls", () => {
+    // The half of the stated standard `MIN_CURATED_HEAD_TITLE_SHARE` cannot
+    // reach. Its docblock promises a two-sided test — "a rename leaves the
+    // curated head a strong runner-up" — but it only floors the loser, so a
+    // head at 21% passes while a foreign form owns 70% of the bucket and would
+    // become this role's name.
+    const dominated = {
+      sampleSize: 500,
+      titles: [
+        { form: "third title", count: 70 },
+        { form: "first title", count: 21 },
+        { form: "second title", count: 9 },
+      ],
+      skills: RANKABLE_SKILLS,
+    };
+    const audit = auditPrevalence(curated[0], dominated);
+    // Both the reasons it is NOT refused for, so the ceiling is what fired:
+    expect(audit.curatedHeadTitleShare).toBeGreaterThanOrEqual(
+      MIN_CURATED_HEAD_TITLE_SHARE,
+    );
+    expect(audit.modalTitleShare).toBeGreaterThan(MAX_FOREIGN_MODAL_TITLE_SHARE);
+    expect(audit.titles).toBe("bucket-not-this-role");
+
+    const [alpha] = applyPrevalenceOrder(curated, snapshotOf({ alpha: dominated }));
+    expect(alpha.titles).toBe(curated[0].titles);
+  });
+
+  it("is not made redundant by the margin gate: a dominant modal's lead is huge", () => {
+    // The reason the ceiling is a separate constant rather than a corollary.
+    // 70 vs 21 is a 49-observation lead against a noise floor of √91 ≈ 9.5, so
+    // the margin gate would wave it straight through — it asks whether the flip
+    // is REAL, which it is. The ceiling asks a different question: whether the
+    // bucket is this role's to flip.
+    const lead = 70 - 21;
+    expect(lead).toBeGreaterThan(Math.sqrt(70 + 21));
+  });
+
+  // ── The head-flip margin gate (#588 round 2) ──────────────────────────────
+
+  it("pins the curated head when the modal's lead is inside the noise", () => {
+    // The `machine-learning-engineer` shape: "ai engineer" 14 against "machine
+    // learning engineer" 11 out of 40 observations. Both existing gates pass —
+    // a healthy sample, and the head is a strong runner-up — and yet a 3-count
+    // lead over 25 observations is what a fair coin produces routinely
+    // (√25 = 5). Calling that an ORDER, and then quoting its head as a common
+    // title for the role, over-asserts what was measured.
+    const nearTie = {
+      sampleSize: 500,
+      titles: [
+        { form: "third title", count: 14 },
+        { form: "first title", count: 11 },
+        { form: "second title", count: 13 },
+      ],
+      skills: RANKABLE_SKILLS,
+    };
+    const audit = auditPrevalence(curated[0], nearTie);
+    expect(audit.modalTitle).toBe("third title");
+    expect(audit.titles).toBe("ranked-head-pinned");
+
+    const [alpha] = applyPrevalenceOrder(curated, snapshotOf({ alpha: nearTie }));
+    // Position 0 is held at the curated head — NOT the modal, which is what an
+    // unguarded ranking would have put there.
+    expect(alpha.titles[0]).toBe("first title");
+    // The tail is still measured: "third title" (14) now precedes "second
+    // title" (13), which is neither the curated order nor the ranked order.
+    expect(alpha.titles).toEqual(["first title", "third title", "second title"]);
+    expect(alpha.titles).not.toEqual(curated[0].titles);
+    // Membership is untouched by the pin.
+    expect([...alpha.titles].sort()).toEqual([...curated[0].titles].sort());
+    // The skill axis is unaffected — this gate is about position 0 of `titles`.
+    expect(alpha.skills).toEqual(["go", "java", "python"]);
+  });
+
+  it("lets the head flip when the lead is bigger than the noise", () => {
+    // The other side of the same gate, and the reason it is one sigma rather
+    // than a blanket "never flip the head": 30 against 20 is a 10-observation
+    // lead over 50, and √50 ≈ 7.07. A market that really did rename a role
+    // clears this, and the measurement is allowed to stand.
+    const renamedHard = {
+      sampleSize: 500,
+      titles: [
+        { form: "third title", count: 30 },
+        { form: "first title", count: 20 },
+        { form: "second title", count: 25 },
+      ],
+      skills: RANKABLE_SKILLS,
+    };
+    const audit = auditPrevalence(curated[0], renamedHard);
+    expect(audit.titles).toBe("ranked");
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({ alpha: renamedHard }),
+    );
+    expect(alpha.titles).toEqual(["third title", "second title", "first title"]);
+  });
+
+  it("never lets a one-posting lead flip the head, at any sample size", () => {
+    // The property the sqrt derivation buys, stated as a property rather than
+    // as a case: a margin of 1 is below √n for every n ≥ 2, so this holds for a
+    // bucket of 30 observations and for one of 30,000 alike.
+    for (const modalCount of [3, 40, 400, 4000]) {
+      const audit = auditPrevalence(curated[0], {
+        sampleSize: 500,
+        titles: [
+          { form: "third title", count: modalCount },
+          { form: "first title", count: modalCount - 1 },
+          // A third term carrying its share, purely so the modal is not
+          // trivially a majority of a two-horse bucket and this test exercises
+          // the noise floor rather than `MAX_FOREIGN_MODAL_TITLE_SHARE`.
+          { form: "second title", count: modalCount - 1 },
+        ],
+        skills: [],
+      });
+      expect(audit.modalTitle).toBe("third title");
+      expect(audit.titles).toBe("ranked-head-pinned");
+    }
+  });
+
+  it("never asks for permission when the curated head already leads the bucket", () => {
+    const audit = auditPrevalence(curated[0], {
+      sampleSize: 500,
+      titles: [{ form: "first title", count: 3 }],
+      skills: [],
+    });
+    // A one-in-one share is trivially above the floor, but the point is the
+    // branch: a profile whose own head is modal is never subject to the guard.
+    expect(audit.modalTitle).toBe("first title");
+    expect(audit.titles).toBe("ranked");
+  });
+
+  it("never ADDS a term the curated list does not carry", () => {
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: 500,
+          // Both of these outrank every curated term by count. Neither may appear.
+          titles: [
+            { form: "rockstar ninja guru", count: 100_000 },
+            { form: "first title", count: 50 },
+            { form: "second title", count: 90 },
+            { form: "third title", count: 70 },
+          ],
+          skills: [
+            { form: "cobol", count: 100_000 },
+            { form: "java", count: 30 },
+            { form: "go", count: 20 },
+          ],
+        },
+      }),
+    );
+    expect(alpha.titles).not.toContain("rockstar ninja guru");
+    expect(alpha.skills).not.toContain("cobol");
+    expect([...alpha.titles].sort()).toEqual([...curated[0].titles].sort());
+    expect([...alpha.skills].sort()).toEqual([...curated[0].skills].sort());
+    // The curated terms the snapshot DID name still moved, so the drop is a
+    // membership filter, not the whole snapshot being ignored.
+    expect(alpha.titles[0]).toBe("second title");
+    expect(alpha.skills[0]).toBe("java");
+  });
+
+  it("does not count an uncurated term towards either gate", () => {
+    // The membership filter and the gates must agree on what counts as
+    // evidence: a snapshot stuffed with terms this profile does not carry must
+    // not be able to buy itself a ranking it has no curated evidence for.
+    const audit = auditPrevalence(curated[0], {
+      sampleSize: 500,
+      titles: [{ form: "rockstar ninja guru", count: 100_000 }],
+      skills: [{ form: "cobol", count: 100_000 }],
+    });
+    expect(audit.skillObservations).toBe(0);
+    expect(audit.skills).toBe("thin-observations");
+    expect(audit.modalTitle).toBe("");
+    expect(audit.titles).toBe("bucket-not-this-role");
+  });
+
+  it("joins titles on the token SET, not the literal string", () => {
+    const [, beta] = applyPrevalenceOrder(
+      [
+        curated[0],
+        { ...curated[1], titles: ["director of engineering", "beta engineer"] },
+      ],
+      snapshotOf({
+        beta: {
+          sampleSize: 500,
+          // Same token set, written the other way round.
+          titles: [{ form: "Engineering Director", count: 400 }],
+          skills: [],
+        },
+      }),
+    );
+    expect(beta.titles[0]).toBe("director of engineering");
+  });
+
+  it("keeps curated order for terms observed the same number of times", () => {
+    // Ties keep the curated order — the only ordering information left once the
+    // counts say nothing.
+    //
+    // Honest about what this does and does not prove: deleting the
+    // `|| a.index - b.index` clause from the comparator does NOT fail this test,
+    // because `Array.prototype.sort` has been stable since ES2019 and produces
+    // the same answer without it. The clause is belt-and-braces and the coverage
+    // here is of the PROPERTY, not of the clause — no test can distinguish them.
+    // What this does catch is a comparator that stops falling back to curated
+    // order at all: an added third key, a `Math.random()` shuffle, a switch to
+    // an unstable hand-rolled sort.
+    const [alpha] = applyPrevalenceOrder(
+      curated,
+      snapshotOf({
+        alpha: {
+          sampleSize: 500,
+          titles: [
+            { form: "third title", count: 60 },
+            { form: "second title", count: 60 },
+            { form: "first title", count: 60 },
+          ],
+          skills: [
+            { form: "go", count: 20 },
+            { form: "java", count: 20 },
+            { form: "python", count: 20 },
+          ],
+        },
+      }),
+    );
+    expect(alpha.titles).toEqual(curated[0].titles);
+    expect(alpha.skills).toEqual(curated[0].skills);
+  });
+
+  it("is total over a degenerate snapshot", () => {
+    const empty = snapshotOf({});
+    expect(applyPrevalenceOrder(curated, empty)).toEqual(curated);
+    expect(applyPrevalenceOrder([], empty)).toEqual([]);
+    expect(() =>
+      applyPrevalenceOrder(
+        curated,
+        snapshotOf({
+          alpha: {
+            sampleSize: 500,
+            titles: [{ form: "", count: 5 }],
+            skills: [{ form: "", count: 5 }],
+          },
+        }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      auditPrevalence(
+        { ...curated[0], titles: [], skills: [] },
+        { sampleSize: 500, titles: [], skills: [] },
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("the committed prevalence snapshot", () => {
+  // Content-free by design: these assert the committed file is internally
+  // consistent, which survives every regeneration. A hand-edited count — the
+  // one thing the GENERATED banner cannot prevent — desynchronises the baked
+  // `audit` from what `applyPrevalenceOrder` will actually do, and that is what
+  // fails here.
+  const byId = new Map(CURATED_ROLE_PROFILES.map((p) => [p.id, p] as const));
+
+  it("bakes an audit that matches what the consumer recomputes", () => {
+    for (const [id, entry] of Object.entries(PREVALENCE_SNAPSHOT.profiles)) {
+      const profile = byId.get(id);
+      expect(profile, `snapshot names unknown profile "${id}"`).toBeDefined();
+      expect(entry.audit, `no baked audit for "${id}"`).toEqual(
+        auditPrevalence(profile as RoleProfile, entry),
+      );
+    }
+  });
+
+  it("separates profiles that were never observed from those that were declined", () => {
+    for (const id of PREVALENCE_SNAPSHOT.unobservedProfiles) {
+      expect(byId.has(id)).toBe(true);
+      expect(PREVALENCE_SNAPSHOT.profiles[id]).toBeUndefined();
+    }
+  });
+
+  it("only ever reordered the profiles its own audit says it ranked", () => {
+    for (const profile of CURATED_ROLE_PROFILES) {
+      const audit = PREVALENCE_SNAPSHOT.profiles[profile.id]?.audit;
+      const shipped = ROLE_PROFILES.find((p) => p.id === profile.id) as RoleProfile;
+      if (audit?.titles === "ranked-head-pinned") {
+        // The tail moved, position 0 did not.
+        expect(shipped.titles[0]).toBe(profile.titles[0]);
+      } else if (audit?.titles !== "ranked") {
+        expect(shipped.titles).toEqual(profile.titles);
+      }
+      if (audit?.skills !== "ranked") expect(shipped.skills).toEqual(profile.skills);
+      // Whatever happened, membership is untouched — the permutation invariant
+      // over the real table, not a fabricated one.
+      expect([...shipped.titles].sort()).toEqual([...profile.titles].sort());
+      expect([...shipped.skills].sort()).toEqual([...profile.skills].sort());
+    }
   });
 });
 

--- a/src/lib/job-search/role-profiles.ts
+++ b/src/lib/job-search/role-profiles.ts
@@ -29,7 +29,8 @@
  * answers a different question — *"what do people in this role call
  * themselves, and in what order of prevalence"* — so it carries surface forms
  * `ROLE_KEYWORDS` must not carry, and its head element is the one term we can
- * honestly call "the common title for this role". Merging the two would break
+ * honestly call "a common title for this role" — measured where the sample
+ * supports it, curated otherwise. Merging the two would break
  * posting matching. They stay reconcilable through `RoleProfile.family`, which
  * is a real `RoleFamily`; `role-profiles.test.ts` asserts that, so the two
  * assets cannot drift into contradiction.
@@ -90,8 +91,50 @@
  * Curation: hand-written on 2026-07-25 from common software job-title
  * phrasings. Staleness is tolerable in the same way `ROLE_KEYWORDS`' is — a
  * missing surface form narrows an answer, it never makes one wrong.
+ *
+ * ORDERING IS MEASURED WHERE IT CAN BE, MEMBERSHIP IS CURATED (#588). The two
+ * docstrings above — "most-used first", "most-expected first" — used to be one
+ * person's judgement of what the market says. Where the evidence supports it
+ * they are now backed by counts mined from real postings and baked into
+ * `prevalence-snapshot.ts`: `applyPrevalenceOrder` re-sorts a profile's `titles`
+ * and `skills` by observed frequency, and `ROLE_PROFILES` is that reordering of
+ * `CURATED_ROLE_PROFILES`. The split of authority is strict and
+ * one-directional — the snapshot may only REORDER what curation admitted. A
+ * snapshot term with no curated counterpart is dropped, so a junk title form
+ * trending in some feed can never write itself into a profile.
+ *
+ * IT IS A MINORITY OF THE TABLE. The two axes are gated separately and most
+ * profiles clear neither, keeping their curated order verbatim; read each
+ * snapshot entry's `audit` to see which way a given profile went and why. And
+ * the corpus is not "the market": it is what a handful of keyless remote-jobs
+ * aggregators answered on one dated run, with one of them supplying the large
+ * majority of postings (the snapshot header names it and its share). Remote-first
+ * aggregators over-represent remote-friendly, English-language, often
+ * smaller-company listings. Treat a ranked ordering as "what these feeds said",
+ * which is still strictly more than the previous "what one curator assumed", and
+ * not as a market-wide measurement.
+ *
+ * NO NEW EGRESS. This module still fetches nothing: the snapshot is a static
+ * committed module, not a runtime call to a prevalence service (which would be a
+ * brand-new egress path). The mining itself is offline and dev-only — the
+ * harness is a `.test.ts` excluded from the production build, and it seeds its
+ * feed queries from `CURATED_ROLE_PROFILES` below (the hand-written table, NOT
+ * the reordered export — see that constant for why), so no résumé is anywhere in
+ * that loop and `providers/keywords.ts` remains the sole résumé-derived egress
+ * helper. Regenerate the snapshot with:
+ *
+ *   RL_MINE_PREVALENCE=1 npx vitest run src/lib/job-search/mine-prevalence.test.ts
+ *
+ * then copy `internal/job-search/prevalence-snapshot.generated.ts` over
+ * `prevalence-snapshot.ts` and review the diff.
  */
 
+import {
+  PREVALENCE_SNAPSHOT,
+  type PrevalenceEntry,
+  type PrevalenceSnapshot,
+  type ProfilePrevalence,
+} from "./prevalence-snapshot.ts";
 import type { RoleFamily } from "./role-keywords.ts";
 import { SENIORITY_LADDER } from "./seniority.ts";
 
@@ -103,8 +146,21 @@ import { SENIORITY_LADDER } from "./seniority.ts";
  * Changelog:
  * - 1.0 (2026-07-25): initial table (#582) — leadership ladder + one profile
  *   per existing role family.
+ * - 1.1 (2026-07-25): `titles` / `skills` ordering is prevalence-ranked from a
+ *   mined snapshot (#588) for the profiles whose evidence clears the per-axis
+ *   gates; the rest keep their curated order, and a ranked profile whose modal
+ *   title only tied with its curated head keeps that head at position 0
+ *   (`ranked-head-pinned`). Membership is unchanged, but both
+ *   resolvers' prevalence nudges read position, so a tie can now break
+ *   differently — and downstream `term-quality.ts` head-caps `missing` at
+ *   `MAX_MISSING_TITLES` / `MAX_MISSING_SKILLS`, so the advice that ships
+ *   selects different terms. This version covers the MECHANISM; regenerating
+ *   the snapshot changes the data under it without changing these rules, which
+ *   is why `term-quality.ts` does not bump on a mining run — an answer for a
+ *   given query is a function of both this version and
+ *   `PREVALENCE_SNAPSHOT.generatedAt`.
  */
-export const ROLE_PROFILES_VERSION = "1.0";
+export const ROLE_PROFILES_VERSION = "1.1";
 
 /** One curated role: the titles it is called by and the skills it is described with. */
 export interface RoleProfile {
@@ -117,8 +173,10 @@ export interface RoleProfile {
   readonly family: RoleFamily;
   /** Seniority rungs this profile normally spans (see seniority.ts). */
   readonly rungs: readonly number[];
-  /** Title surface forms, most-used first. The head of this list is what we
-   *  can honestly call "the common title for this role". */
+  /** Title surface forms, most-used first. The head of this list is what we can
+   *  honestly call "a common title for this role" — measured where the sample
+   *  supports it (#588), curated otherwise; never "the" one, and never a term
+   *  the observations only tied with. */
   readonly titles: readonly string[];
   /** Canonical skill IDs (keys into jd-match SKILLS) this role is normally
    *  described with, most-expected first. */
@@ -155,10 +213,37 @@ const PROGRAM_RUNGS: readonly number[] = [
 ];
 
 /**
- * The curated table — the SINGLE SOURCE OF TRUTH for "what is this role called
- * and what is it described with". DECLARATION ORDER IS THE DETERMINISTIC
- * TIE-BREAK for both resolvers (same contract as `ROLE_FAMILIES`), so entries
- * are ordered by `ROLE_FAMILIES` and, within a family, most-common role first.
+ * The curated table — the SINGLE SOURCE OF TRUTH for MEMBERSHIP: "what is this
+ * role called and what is it described with". DECLARATION ORDER IS THE
+ * DETERMINISTIC TIE-BREAK for both resolvers (same contract as `ROLE_FAMILIES`),
+ * so entries are ordered by `ROLE_FAMILIES` and, within a family, most-common
+ * role first.
+ *
+ * EXPORTED FOR THE MINING HARNESS ONLY, and consumers must not read it. The
+ * table the lane reads is `ROLE_PROFILES`, this one passed through
+ * `applyPrevalenceOrder`; two consumer-facing tables that agree on membership
+ * and disagree on order is exactly the drift #588's single-table rule exists to
+ * prevent. The harness is the one legitimate reader, because it must SEED its
+ * feed queries from an order that does not depend on the snapshot it is about to
+ * overwrite — seeding from `ROLE_PROFILES` makes the corpus a function of the
+ * previous run, so a title that fell to the tail is never queried again and is
+ * pinned there permanently. Seeding here is snapshot-independent by construction.
+ *
+ * WITHIN a profile, the order of `titles` / `skills` here is the order that
+ * SHIPS for every profile the snapshot could not rank — which, on the committed
+ * run, is most of them. Write them most-plausible-first and treat that as the
+ * answer, not as a placeholder.
+ *
+ * The mining can also be WRONG about a profile rather than merely thin, and the
+ * curator needs to be able to tell the two apart. The failure mode is bucket
+ * contamination: `resolveProfilesByTitles` routes each posting to exactly one
+ * profile, so a neighbouring role whose market name is a curated title here
+ * arrives in this profile's bucket and its counts redefine the role.
+ * `MIN_CURATED_HEAD_TITLE_SHARE` refuses the ranking when that happens, and the
+ * snapshot's per-profile `audit` names the modal observed title and its share —
+ * so a `bucket-not-this-role` verdict, or a modal title that is not the role,
+ * is the signal that the curated MEMBERSHIP here is too wide, not that the
+ * ordering needs another run.
  *
  * Depth is deliberately uneven. The leadership ladder is the gap this asset was
  * built to close and carries full title + competency lists; the pre-existing IC
@@ -168,7 +253,7 @@ const PROGRAM_RUNGS: readonly number[] = [
  * thinnest `skills` because jd-match `SKILLS` is itself engineering-shaped;
  * that is a known limitation of the source dictionary, not an omission here.
  */
-export const ROLE_PROFILES: readonly RoleProfile[] = [
+export const CURATED_ROLE_PROFILES: readonly RoleProfile[] = [
   {
     id: "frontend-engineer",
     label: "Frontend Engineer",
@@ -810,6 +895,437 @@ function profileTitleTokens(raw: string): ReadonlySet<string> {
 export function normalizeSkillKey(raw: string): string {
   return String(raw).toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
+
+// ── Prevalence ordering (#588) ──────────────────────────────────────────────
+
+/**
+ * THE TWO AXES ARE GATED SEPARATELY, and the reason is that they do not share
+ * an evidence base. A posting joins the corpus on its TITLE, so every bucketed
+ * posting is one observation of the title axis; but its skills come from its
+ * DESCRIPTION, and a feed that returned a title with a stub description
+ * contributes nothing to the skill axis at all. Gating both on the posting
+ * count therefore authorises a skill ranking with the title axis's evidence —
+ * which is how a profile with 37 postings but 5 skill observations came to
+ * offer a single 4-count term as the head of its expected skills.
+ *
+ * So each axis clears its own floor, independently: a profile may have its
+ * `titles` ranked while its `skills` stay curated, or the reverse.
+ * `auditPrevalence` is the one place both decisions are made, and the harness
+ * bakes its verdict into every snapshot entry so the split is legible in a diff
+ * rather than reconstructible only by rerunning the code.
+ */
+
+/**
+ * Postings a profile needs before its mined TITLE counts may reorder anything.
+ *
+ * A floor on *interpretability*, not a statistical result: ranking six title
+ * forms off four postings is noise dressed as data, and the element at risk is
+ * the head — the one element the product quotes as a common title for this
+ * role. Twenty-five is the point where one unusual listing can no longer move
+ * that head by itself.
+ *
+ * What it does NOT do, and what the sibling constants exist for: it says nothing
+ * about whether the postings are of the right ROLE (see
+ * `MIN_CURATED_HEAD_TITLE_SHARE`) and nothing about whether any of them carried
+ * a readable description (see `MIN_PREVALENCE_SKILL_OBSERVATIONS`). On the run
+ * that produced the committed snapshot only a minority of the table cleared it,
+ * and most of the leadership ladder did not — that is the honest shape of a
+ * corpus mined from remote-jobs aggregators, not a threshold to lower.
+ */
+export const MIN_PREVALENCE_SAMPLE = 25;
+
+/**
+ * Share of a profile's TITLE observations that must land on the profile's OWN
+ * curated head title before a ranking is trusted, in the case where the modal
+ * observed form is something else.
+ *
+ * This is the bucketing-concentration guard. `resolveProfilesByTitles` assigns
+ * every posting to exactly one profile, so a neighbouring role whose market name
+ * happens to be a curated title of this profile fills this profile's bucket —
+ * and the counts then redefine the role. Raising `MIN_PREVALENCE_SAMPLE` cannot
+ * help: the failure is a systematic majority, not an outlier.
+ *
+ * The distinction the number has to draw is "the market renamed this role"
+ * versus "this bucket is mostly a different job". A rename leaves the curated
+ * head a strong runner-up; a takeover leaves it a rounding error. One in five is
+ * where those separate on the observed corpus, and it is not a knife edge —
+ * nothing that clears `MIN_PREVALENCE_SAMPLE` lands between 12.5% and 27.5%:
+ *
+ * - `machine-learning-engineer` — modal "ai engineer" at 35%, own head
+ *   "machine learning engineer" still 27.5%. A rename, not a takeover, so this
+ *   guard passes it — `headFlipBeatsNoise` is what then decides whether the
+ *   14-vs-11 lead is big enough to actually move the head.
+ * - `technical-program-manager` — modal "project manager" at 47%, own head
+ *   12.5%. Two neighbouring roles collapsed into one bucket. DECLINED.
+ * - `support-engineer` — modal "customer success manager" at 84.8%, own head
+ *   6.1%. A different job wearing this profile's id. DECLINED.
+ *
+ * The guard only applies when the modal form is NOT the curated head: a profile
+ * whose own head leads its bucket needs no permission to sort the tail.
+ */
+export const MIN_CURATED_HEAD_TITLE_SHARE = 0.2;
+
+/**
+ * The other half of the same standard: the largest share a FOREIGN modal title
+ * may hold before the bucket is refused outright, whatever the curated head's
+ * own share is.
+ *
+ * `MIN_CURATED_HEAD_TITLE_SHARE` alone only floors the loser, and the docblock
+ * above states a two-sided test it cannot actually run — "a rename leaves the
+ * curated head a strong runner-up" is a claim about the RELATION between the two
+ * forms. A bucket at head 21% / foreign modal 70% clears the floor and is
+ * plainly not a runner-up story; it is a neighbouring role that brought a long
+ * tail with it. Nothing in the committed snapshot is near this (`support-engineer`
+ * at 84.8% is already refused on the head's 6.1%), but a regeneration can reach
+ * it, and the failure is silent: the profile ranks and adopts the other role's
+ * name as its head.
+ *
+ * The margin gate below does NOT subsume this. That gate asks whether the LEAD
+ * is bigger than noise, and a dominant modal's lead is enormous — 70 vs 21 beats
+ * its 9.5-observation noise floor many times over, so it would rank. The two
+ * measure different things: one that the flip is real, this one that the bucket
+ * is ours to flip.
+ *
+ * One half is the line because a majority is the point where the foreign form is
+ * no longer competing with the curated head for the role's identity — it simply
+ * IS the bucket's identity. Compared strictly, so an even split is not a
+ * majority.
+ */
+export const MAX_FOREIGN_MODAL_TITLE_SHARE = 0.5;
+
+/**
+ * Skill observations a profile needs before its mined SKILL counts may reorder
+ * anything. Counted over observations that join to a curated skill — the
+ * evidence that actually drives the sort — not over postings.
+ *
+ * `MAX_MISSING_SKILLS` (5) of the ranked list becomes user-facing advice, so the
+ * ranking must have resolution across at least five positions. Forty is eight
+ * observations per surviving slot: enough that a slot is a pattern rather than a
+ * coincidence, while still well inside what a profile with readable descriptions
+ * supplies. On the committed run the technical profiles cleared it with room
+ * (site-reliability-engineer 132, machine-learning-engineer 112,
+ * software-engineer 94, data-engineer 60, product-manager 54) and the profiles
+ * whose vocabulary the jd-match dictionary barely reads did not
+ * (account-executive 10, marketing-manager 7). Nor did `engineering-manager`,
+ * at 24, whose people-leadership vocabulary is exactly the gap jd-match's
+ * engineering-shaped `SKILLS` has. Its curated order therefore ships, which is
+ * the correct answer: a measured ranking off 24 observations of a six-skill
+ * list would have replaced a considered order with a coin toss.
+ */
+export const MIN_PREVALENCE_SKILL_OBSERVATIONS = 40;
+
+/**
+ * Observations the most-observed curated skill must itself carry before the
+ * SKILL ranking is trusted. Guards the shape a bare total cannot: forty
+ * observations spread four-apiece across ten skills ranks nothing, it just
+ * arranges ten coin flips, and the top of that arrangement is what ships as
+ * advice. Ten is the point where a term is a repeated ask rather than one
+ * unusual posting's vocabulary.
+ */
+export const MIN_PREVALENCE_SKILL_HEAD_COUNT = 10;
+
+/**
+ * Why the TITLE axis did or did not rank.
+ *
+ * `ranked-head-pinned` is a THIRD state, not a flavour of either: the tail was
+ * prevalence-ordered but the curated head kept position 0 because the observed
+ * lead over it was inside the noise (`headFlipBeatsNoise`). It exists as its own
+ * verdict because #588's whole design is that every decision is legible in the
+ * snapshot diff, and a head that was silently held in place is the one decision
+ * a reader of that diff could not otherwise see.
+ */
+export type TitleAxisVerdict =
+  | "ranked"
+  | "ranked-head-pinned"
+  | "thin-sample"
+  | "bucket-not-this-role";
+/** Why the SKILL axis did or did not rank. */
+export type SkillAxisVerdict = "ranked" | "thin-observations";
+
+/**
+ * The per-axis decision plus the measurements it was made from. Baked into every
+ * snapshot entry so a human reading the generated diff sees WHY a profile was
+ * ranked or declined — and, in the `bucket-not-this-role` case, sees the modal
+ * title that would otherwise have silently become the role's identity.
+ */
+export interface PrevalenceAudit {
+  readonly titles: TitleAxisVerdict;
+  readonly skills: SkillAxisVerdict;
+  /** Postings that bucketed here. Denominator for nothing — see the shares. */
+  readonly sampleSize: number;
+  /** The profile's most-observed CURATED title (the snapshot's surface forms
+   *  folded onto the terms they join to); `""` when nothing was observed. */
+  readonly modalTitle: string;
+  /** `modalTitle`'s share of all title observations, 0–1, 3dp. */
+  readonly modalTitleShare: number;
+  /** The profile's own curated HEAD title's share of the same, 0–1, 3dp. */
+  readonly curatedHeadTitleShare: number;
+  /** Observations joining a curated skill — the skill axis's real evidence. */
+  readonly skillObservations: number;
+  /** The largest single such observation count. */
+  readonly skillHeadCount: number;
+}
+
+/**
+ * Canonical comparison key for a title surface form: its `profileTitleTokens`
+ * SET, order-normalised. Set equality is the right join here because it is the
+ * same relation the title matcher works in — "Director of Engineering" and
+ * "Engineering Director" are one form, so a snapshot naming either ranks the
+ * curated entry regardless of which way round it was written.
+ */
+function titlePrevalenceKey(raw: string): string {
+  return [...profileTitleTokens(raw)].sort().join(" ");
+}
+
+/**
+ * Does the modal title's lead over the curated head EXCEED THE NOISE in the
+ * split that produced it? Only asked when the two are different terms, and only
+ * about position 0.
+ *
+ * WHAT IT GUARDS. The gates above floor the loser's share and the denominator;
+ * neither floors the SEPARATION, so a head flip can ride on one posting. Thirty
+ * observations split 8 (modal) to 7 (head) clears both, and the head — the term
+ * the product turns into advice — changes hands on a coin toss. That is not a
+ * measurement of which title is more common; it is a measurement that they are
+ * comparably common, which is a different claim and not one that should reorder
+ * anything.
+ *
+ * WHY `sqrt`, AND NOT A CHOSEN RATIO. Take the null hypothesis this has to rule
+ * out: the two forms are equally prevalent and each of the `modal + head`
+ * observations landed on one of them by a fair coin. The DIFFERENCE between the
+ * two counts is then a symmetric random walk over that many steps, whose
+ * standard deviation is exactly the square root of it. So `sqrt(modal + head)`
+ * is not a tuned number at all — it is one sigma of the very hypothesis being
+ * rejected, and it falls out of the counts rather than out of a judgement about
+ * them. A fitted constant (`0.2` of the total, "at least 5 more") would carry
+ * the objection that it was picked to make some particular case decline; this
+ * cannot, because there was nothing to pick.
+ *
+ * Consequences, all intended: a one-posting lead never flips the head at any
+ * sample size; a genuine rename at 30-vs-10 clears it comfortably (20 > 6.32);
+ * and the bar scales with the evidence, so a bigger corpus buys a flip with a
+ * proportionally smaller lead rather than a bigger one.
+ *
+ * ONE SIGMA, not two or three, and deliberately so: this is a tie-breaker
+ * between two curated terms that both stay in the list either way, so the cost
+ * of a wrong call is one position in an ordering, not a false claim. A stricter
+ * bar would pin heads that the corpus really did move.
+ */
+function headFlipBeatsNoise(modalCount: number, headCount: number): boolean {
+  return modalCount - headCount > Math.sqrt(modalCount + headCount);
+}
+
+/** Shares are stored, so they must round-trip a JSON bake exactly. */
+function share(part: number, whole: number): number {
+  return whole > 0 ? Math.round((part / whole) * 1000) / 1000 : 0;
+}
+
+/**
+ * Snapshot counts folded onto the CURATED terms they join to, keyed by `keyOf`.
+ * Entries with no curated counterpart are dropped here for the same reason
+ * `rankByPrevalence` cannot use them: they are not evidence about this profile.
+ * Keeping the two in step is what stops a gate being cleared by observations the
+ * ranking then ignores.
+ */
+function joinToCurated(
+  curated: readonly string[],
+  entries: readonly PrevalenceEntry[] | undefined,
+  keyOf: (raw: string) => string,
+): Map<string, number> {
+  const wanted = new Set(curated.map(keyOf));
+  const counts = new Map<string, number>();
+  for (const entry of entries ?? []) {
+    const key = keyOf(entry.form);
+    if (key.length === 0 || !wanted.has(key)) continue;
+    counts.set(key, (counts.get(key) ?? 0) + entry.count);
+  }
+  return counts;
+}
+
+/**
+ * Decide both axes for one profile against its snapshot entry, and report the
+ * numbers behind the decision. Pure and total: an absent, empty or degenerate
+ * entry yields a fully-declined audit rather than throwing.
+ *
+ * `profile` must be the CURATED profile — the guard reads `titles[0]` as the
+ * role's declared identity, and reading it off an already-reordered table would
+ * make the guard agree with whatever the last run produced.
+ */
+export function auditPrevalence(
+  profile: RoleProfile,
+  // Structurally typed, not `ProfilePrevalence`: the harness calls this while
+  // BUILDING an entry, before the `audit` field it is about to compute exists.
+  mined: Omit<ProfilePrevalence, "audit"> | undefined,
+): PrevalenceAudit {
+  // Aggregated by KEY, not per entry, so the audit measures exactly what
+  // `rankByPrevalence` sorts on — two entries that normalise to one curated term
+  // are one term's evidence in both places.
+  const titleCounts = joinToCurated(profile.titles, mined?.titles, titlePrevalenceKey);
+  const titleTotal = [...titleCounts.values()].reduce((a, b) => a + b, 0);
+  const headKey = titlePrevalenceKey(profile.titles[0] ?? "");
+  const headCount = titleCounts.get(headKey) ?? 0;
+  let modalTitle = "";
+  let modalCount = 0;
+  for (const term of profile.titles) {
+    const count = titleCounts.get(titlePrevalenceKey(term)) ?? 0;
+    if (count > modalCount) {
+      modalCount = count;
+      modalTitle = term;
+    }
+  }
+
+  const skillCounts = joinToCurated(profile.skills, mined?.skills, normalizeSkillKey);
+  const skillObservations = [...skillCounts.values()].reduce((a, b) => a + b, 0);
+  const skillHeadCount = Math.max(0, ...skillCounts.values());
+
+  const sampleSize = mined?.sampleSize ?? 0;
+  const curatedHeadTitleShare = share(headCount, titleTotal);
+  const modalTitleShare = share(modalCount, titleTotal);
+  const modalIsCuratedHead =
+    modalTitle.length > 0 && titlePrevalenceKey(modalTitle) === headKey;
+
+  // Three questions in order of how much they disqualify: is there enough
+  // evidence at all, is this bucket even this role, and only then — is the one
+  // position the product quotes actually changing hands, or is it a coin toss?
+  let titles: TitleAxisVerdict;
+  if (sampleSize < MIN_PREVALENCE_SAMPLE) {
+    titles = "thin-sample";
+  } else if (
+    !modalIsCuratedHead &&
+    (curatedHeadTitleShare < MIN_CURATED_HEAD_TITLE_SHARE ||
+      modalTitleShare > MAX_FOREIGN_MODAL_TITLE_SHARE)
+  ) {
+    titles = "bucket-not-this-role";
+  } else if (!modalIsCuratedHead && !headFlipBeatsNoise(modalCount, headCount)) {
+    titles = "ranked-head-pinned";
+  } else {
+    titles = "ranked";
+  }
+
+  const skills: SkillAxisVerdict =
+    skillObservations >= MIN_PREVALENCE_SKILL_OBSERVATIONS &&
+    skillHeadCount >= MIN_PREVALENCE_SKILL_HEAD_COUNT
+      ? "ranked"
+      : "thin-observations";
+
+  return {
+    titles,
+    skills,
+    sampleSize,
+    modalTitle,
+    modalTitleShare,
+    curatedHeadTitleShare,
+    skillObservations,
+    skillHeadCount,
+  };
+}
+
+/**
+ * Re-sort `curated` by the counts in `entries`, most-observed first.
+ *
+ * THE MEMBERSHIP GUARD RAIL LIVES HERE and is structural rather than checked:
+ * the output is built by sorting `curated` itself, and `entries` is only ever
+ * read through a lookup keyed off a curated term. A snapshot entry with no
+ * curated counterpart therefore has nothing to attach to and cannot appear in
+ * the result — there is no code path that appends. Curated terms the snapshot
+ * never observed score 0 and keep their relative curated order at the tail,
+ * because the sort is stable via the index tie-break (`Array.sort` is spec-
+ * stable since ES2019; the explicit index compare states the contract rather
+ * than relying on it).
+ *
+ * A ZERO IS NOT A MEASUREMENT OF ABSENCE. A curated skill scores 0 both when
+ * postings genuinely never ask for it and when jd-match's alias regex simply
+ * cannot see the phrasing they asked for it with — the mining reads descriptions
+ * through that dictionary and inherits its blind spots. The sort treats the two
+ * identically, so an unobserved term sinking to the tail is weak evidence, which
+ * is tolerable only because sinking to the tail is all it does: membership is
+ * curated and nothing here can drop a term.
+ */
+function rankByPrevalence(
+  curated: readonly string[],
+  entries: readonly PrevalenceEntry[],
+  keyOf: (raw: string) => string,
+): readonly string[] {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    const key = keyOf(entry.form);
+    if (key.length === 0) continue;
+    counts.set(key, (counts.get(key) ?? 0) + entry.count);
+  }
+  return curated
+    .map((term, index) => ({ term, index, count: counts.get(keyOf(term)) ?? 0 }))
+    .sort((a, b) => b.count - a.count || a.index - b.index)
+    .map(({ term }) => term);
+}
+
+/**
+ * `ranked` order with the curated head put back at position 0. Everything below
+ * it keeps the ranked order it was given, so this is the narrowest possible
+ * intervention: the ONE position the product converts into a claim is protected,
+ * the tail — which nothing quotes — is still measured.
+ *
+ * Total: an empty `head` cannot be pinned (and cannot occur — a profile with no
+ * titles has no head to flip, so it is refused upstream), and the result is a
+ * permutation of `ranked` either way.
+ */
+function pinHead(head: string, ranked: readonly string[]): readonly string[] {
+  const key = titlePrevalenceKey(head);
+  if (key.length === 0) return ranked;
+  return [head, ...ranked.filter((term) => titlePrevalenceKey(term) !== key)];
+}
+
+/**
+ * The curated table with each profile's `titles` / `skills` reordered by mined
+ * prevalence, PER AXIS. Pure, total, and exported so the guard rails above are
+ * testable against fabricated snapshots rather than against the committed one,
+ * whose contents change on every regeneration.
+ *
+ * A profile is returned BY REFERENCE, untouched, when NEITHER axis clears its
+ * gate — the snapshot does not mention it, or it failed both. That is the
+ * fallback and it is deliberately identity-preserving, so a caller can tell
+ * "unranked" from "ranked to the same order" if it ever needs to. A profile that
+ * clears one axis is rebuilt with the other axis's curated list copied across
+ * unchanged.
+ *
+ * `ranked-head-pinned` counts as clearing the title axis: the tail is sorted by
+ * prevalence and only position 0 is held at its curated term. See `pinHead`.
+ */
+export function applyPrevalenceOrder(
+  curated: readonly RoleProfile[],
+  snapshot: PrevalenceSnapshot,
+): readonly RoleProfile[] {
+  const profiles = snapshot?.profiles ?? {};
+  return curated.map((profile) => {
+    const audit = auditPrevalence(profile, profiles[profile.id]);
+    const titlesRanked =
+      audit.titles === "ranked" || audit.titles === "ranked-head-pinned";
+    if (!titlesRanked && audit.skills !== "ranked") return profile;
+    const mined = profiles[profile.id];
+    const rankedTitles = titlesRanked
+      ? rankByPrevalence(profile.titles, mined?.titles ?? [], titlePrevalenceKey)
+      : profile.titles;
+    return {
+      ...profile,
+      titles:
+        audit.titles === "ranked-head-pinned"
+          ? pinHead(profile.titles[0] ?? "", rankedTitles)
+          : rankedTitles,
+      skills:
+        audit.skills === "ranked"
+          ? rankByPrevalence(profile.skills, mined?.skills ?? [], normalizeSkillKey)
+          : profile.skills,
+    };
+  });
+}
+
+/**
+ * The table every consumer reads: curated membership, measured order. The one
+ * exported table — see `CURATED_ROLE_PROFILES` for why there is not a second.
+ */
+export const ROLE_PROFILES: readonly RoleProfile[] = applyPrevalenceOrder(
+  CURATED_ROLE_PROFILES,
+  PREVALENCE_SNAPSHOT,
+);
 
 // ── Scoring weights ─────────────────────────────────────────────────────────
 // Integers throughout: a resolver whose ordering depends on float accumulation

--- a/src/lib/job-search/term-quality.test.ts
+++ b/src/lib/job-search/term-quality.test.ts
@@ -2,9 +2,14 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
-import { assessQueryTerms, TERM_QUALITY_VERSION } from "./term-quality.ts";
+import {
+  assessQueryTerms,
+  MAX_MISSING_SKILLS,
+  TERM_QUALITY_VERSION,
+} from "./term-quality.ts";
 import type { TermVerdict } from "./term-quality.ts";
 import type { JobQuery } from "./query-builder.ts";
+import { roleProfileById } from "./role-profiles.ts";
 
 /** Minimal typed query stub — only the fields the classifier reads. */
 function makeQuery(overrides: Partial<JobQuery> = {}): JobQuery {
@@ -322,7 +327,30 @@ describe("assessQueryTerms — missing terms", () => {
     const titles = missing.filter((entry) => entry.kind === "title").map((e) => e.term);
     const skills = missing.filter((entry) => entry.kind === "skill").map((e) => e.term);
     expect(titles).toContain("engineering team lead");
-    expect(skills).toContain("coaching-mentorship");
+    // Not asserted by naming one skill: since #588 the head of
+    // `RoleProfile.skills` is prevalence-ranked from a regenerable snapshot, and
+    // `MAX_MISSING_SKILLS` keeps only that head — so naming a single expected
+    // term would fail on a mining run that reordered it, for no behavioural
+    // reason.
+    //
+    // Asserted instead as a PREFIX, which is ordering-insensitive in the same
+    // way but is NOT satisfied by an arbitrary subset: the suggestions must be
+    // the profile's own leading skills, in the profile's own order, minus only
+    // the ones the query already carries. That pins the thing the cap actually
+    // promises — that it keeps the HEAD — so a change that made the cap sample
+    // from the tail fails here.
+    //
+    // It does NOT pin that the prevalence ordering reaches this module: both
+    // sides read `roleProfileById`, so they move together. (Concretely:
+    // `engineering-manager`'s skill axis is `thin-observations`, so its shipped
+    // order IS its curated order.) The ordering's arrival is covered where it
+    // belongs, in `role-profiles.test.ts`.
+    const expected = roleProfileById("engineering-manager")?.skills ?? [];
+    expect(skills.length).toBeGreaterThan(0);
+    const covered = new Set(["people-management"]);
+    const wanted = expected.filter((s) => !covered.has(s)).slice(0, MAX_MISSING_SKILLS);
+    expect(skills).toEqual(wanted);
+    expect(skills).not.toContain("people-management");
   });
 
   it("never names a term the résumé already carries", () => {
@@ -374,12 +402,39 @@ describe("assessQueryTerms — missing terms", () => {
   });
 
   it("still suggests a skill that only shares a qualifier with one the query has", () => {
-    // The over-suppression guard. "Performance Optimization" is not
-    // `performance-management`, and suppressing it would hide a real gap.
-    const { missing } = assessQueryTerms(
-      makeQuery({ titles: ["Engineering Manager"], skills: ["Performance Optimization"] }),
+    // The over-suppression guard. The reproduction was "Performance
+    // Optimization" against the expected `performance-management`: a shared
+    // qualifier word is not the same skill, and suppressing on it hides a real
+    // gap. Asserted here on the SAME relation but through `account-executive`,
+    // whose curated skill list is exactly `MAX_MISSING_SKILLS` long, so nothing
+    // can fall out of `missing` via the head-cap. That matters since #588 made
+    // the head a function of a regenerable prevalence snapshot: run against a
+    // longer profile, this assertion would report the snapshot's ordering
+    // instead of the suppression rule, and pass or fail for the wrong reason.
+    // The precondition, asserted rather than assumed: a sixth curated skill on
+    // `account-executive` would push a term past the head-cap and this test
+    // would start reporting the cap instead of the suppression rule — silently,
+    // and in whichever direction the snapshot happened to order things.
+    expect(roleProfileById("account-executive")?.skills).toHaveLength(
+      MAX_MISSING_SKILLS,
     );
-    expect(missing.map((entry) => entry.term)).toContain("performance-management");
+    const query = makeQuery({
+      titles: ["Account Executive"],
+      skills: ["Executive Search"],
+    });
+    expect(assessQueryTerms(query).missing.map((entry) => entry.term)).toContain(
+      "executive-communication",
+    );
+    // Not vacuous: the query saying the skill FOR REAL does suppress it, so the
+    // assertion above is evidence the guard held rather than evidence that
+    // nothing is ever suppressed.
+    const saidForReal = makeQuery({
+      titles: ["Account Executive"],
+      skills: ["Executive Communication"],
+    });
+    expect(
+      assessQueryTerms(saidForReal).missing.map((entry) => entry.term),
+    ).not.toContain("executive-communication");
   });
 
   it("never suggests a wordier spelling of a title the query already carries, but keeps a different market phrasing", () => {

--- a/src/lib/job-search/term-quality.ts
+++ b/src/lib/job-search/term-quality.ts
@@ -123,9 +123,22 @@ import {
 } from "./role-profiles.ts";
 
 /**
- * Version of the classification rules + the copy they emit. Bump when a change
- * can move what `assessQueryTerms` returns for the same query — a rule change,
- * a cap change, or a `reason` rewrite (the strings are user-visible).
+ * Version of THIS MODULE'S classification rules + the copy they emit. Bump when
+ * a change here can move what `assessQueryTerms` returns for the same query — a
+ * rule change, a cap change, or a `reason` rewrite (the strings are
+ * user-visible).
+ *
+ * DELIBERATELY NOT A VERSION OF THE ANSWER. The output is also a function of the
+ * upstream data this module reads — chiefly `ROLE_PROFILES`, whose `titles` /
+ * `skills` ORDER decides which terms survive `MAX_MISSING_TITLES` /
+ * `MAX_MISSING_SKILLS`, and which since #588 is prevalence-ranked from a
+ * regenerable snapshot. Folding that into this number would mean bumping it on
+ * every mining run with no rule changed, which makes it useless as a marker of
+ * "the rules moved". That data carries its own versions and this one does not
+ * shadow them: reproduce an answer from the pair `TERM_QUALITY_VERSION` +
+ * `ROLE_PROFILES_VERSION`, plus `PREVALENCE_SNAPSHOT.generatedAt` for the exact
+ * ordering. #588 accordingly bumped `ROLE_PROFILES_VERSION` (1.0 → 1.1) and left
+ * this at 1.2.
  *
  * Changelog:
  * - 1.0 (2026-07-25): initial classifier (#584).
@@ -243,9 +256,20 @@ const COHERENCE_NOTES: Readonly<Record<CoherenceDirection, (titles: string) => s
 // Small on purpose: `missing` is advice, and a list of fifteen things a résumé
 // "should" say is not advice. Both lists are already most-expected-first in
 // `ROLE_PROFILES`, so the cap keeps the head and drops the tail.
+//
+// That "already most-expected-first" is where these caps meet #588: for the
+// profiles whose evidence cleared the prevalence gates the head is measured, and
+// for the rest it is the curator's ordering. Either way the caps read POSITION,
+// so a change to `ROLE_PROFILES`' ordering changes which terms ship as advice
+// without changing a single rule in this module.
+//
+// `MAX_MISSING_SKILLS` is exported for the tests only: a test that needs a
+// profile short enough that nothing falls out of the head has to be able to
+// assert that precondition rather than assume it, or a sixth curated skill
+// voids it silently.
 
 const MAX_MISSING_TITLES = 3;
-const MAX_MISSING_SKILLS = 5;
+export const MAX_MISSING_SKILLS = 5;
 
 /** How many of the query's own titles the coherence sentence names before it
  *  stops listing — a sentence quoting six titles is not readable. */


### PR DESCRIPTION
## Summary

Ranks each `ROLE_PROFILES` entry's expected titles and skills by prevalence mined from real job
postings, baked as a committed static snapshot. **Ordering is measured; curated membership is
untouched** — mining can only reorder terms curation already admitted, never add or drop one.

Two deliberately separated pieces: a dev-only, env-gated offline mining harness
(`mine-prevalence.test.ts`), and the generated-then-committed counts it produces
(`prevalence-snapshot.ts`), consumed by `role-profiles.ts` for ordering only.

**No new egress.** The snapshot is a static module — nothing fetches at runtime, and
`providers/keywords.ts` (the sole résumé-derived egress helper) is byte-identical to `main`. The
harness egresses only curated title strings and public company slugs; no résumé text, no PDF bytes.

Closes #588

## What the guards do

Each axis is gated independently on its own evidence — a profile can rank titles while its skills
fall back to curated order, and vice versa. Guards **decline** a reorder rather than assert on thin
evidence:

| Guard | Refuses when |
|---|---|
| `MIN_PREVALENCE_SAMPLE` | too few postings bucketed to the profile |
| `MIN_PREVALENCE_SKILL_OBSERVATIONS` / `..._HEAD_COUNT` | too few skill mentions behind the ranking |
| `MIN_CURATED_HEAD_TITLE_SHARE` / `MAX_FOREIGN_MODAL_TITLE_SHARE` | the bucket is dominated by a different role |
| `headFlipBeatsNoise` | a head flip sits inside statistical noise (`modal − head ≤ √(modal + head)`) |

Net effect on the committed corpus (1139 postings): **6 title lists and 5 skill lists reordered out
of 24**, 1 head-pinned, 2 declined for bucket contamination, 1 profile unobserved. Every decision is
recorded in the snapshot's `audit` block, so it stays legible in a diff. The verdict is
**re-derived from the raw counts at runtime** — a stale or hand-edited `audit` cannot re-enable a
refused reorder.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 3208 passed / 10 skipped
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Permutation verified against `main`: same multiset per profile, all 24 — nothing added or dropped
- [x] Guards mutation-tested (see below)

## Adversarial review

Two rounds, plus a third repair round for a design decision. Findings were verified against the
code and the committed data, not taken from prose.

**Round 1 — 5 blocking, all fixed:**

1. **Wrong denominator on the skills axis.** One `sampleSize` gate authorised both axes, so skills
   reordered on the titles axis's evidence. `account-executive` ranked `sql` first off **4**
   observations at n=37, and `term-quality` then offered `+ sql` as the top suggestion for an
   Account Executive. → split into independent per-axis gates measured on skill observations.
2. **No bucketing-concentration guard.** `support-engineer` was 28 of 34 postings titled "customer
   success manager", so the profile's head — the term the product quotes — became a different job.
   → concentration guard; it also caught `technical-program-manager` (modal "project manager" 47%).
3. **Seed ratchet.** The harness seeded from its own already-reordered output, so dropped titles
   were never queried again and pinned to the tail permanently. → seeds from curated declaration
   order; corpus grew 763 → 1139.
4. **Undisclosed feed skew** (one aggregator supplied 88% of the corpus). → stated in the snapshot
   header and the `ROLE_PROFILES` docblock, with the by-design ATS exclusion distinguished from an
   outage.
5. **Four false claims in comments**, incl. "the leadership ladder still clears it on a normal run"
   (only 1 of 8 cleared). → rewritten to what is true of the current code and data.

**Round 2 — 4 blocking, all fixed:** three incorrect numbers written by the first repair round
(113 curated titles stated as 115; 84.8% stated as 82%; a test comment claiming a guarantee that an
identity mutation proved it did not have), plus the margin defect below.

**The margin defect and its resolution.** Nothing constrained the *separation* between the winning
title and the curated head — only the loser's share and the denominator. Reachable case: 30
observations, modal 8 vs head 7, both gates pass, head flips on one posting. It bit
`machine-learning-engineer`, which flipped to "ai engineer" on **14 vs 11** (p ≈ 0.69 against equal
prevalence — "comparably common", not an order). Resolved two ways: a derived margin gate
(`√(modal + head)`, one sigma of the null hypothesis being rejected — not a fitted constant) with a
third `ranked-head-pinned` verdict so the decision is visible; **and** softening the claim itself
from "*the* common title for this role" to "*a* common title — measured where the sample supports
it, curated otherwise."

**Mutation results** (each guard proven load-bearing): identity `applyPrevalenceOrder` → 9 failures;
margin gate → 4; concentration ceiling → 1; skill-observation floor → 3; `pinHead` → 2.

**Surviving advisories (not blocking):** `auditPrevalence` cyclomatic 19 — a flat decision ladder;
splitting it would put the three-question ordering in two places. Clone groups across the three
dev-harness files are the established house pattern (each harness independently proves its own
output path is gitignored). `fallow` is report-only in `verify`. Dead code: 0.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Orchestration, verification + PR | Claude Opus 5 (1M context) | high |
| Implementation | subagent via `model: opus` alias — version not self-reported | high (`--quality`) |
| Adversarial review (2 rounds) | subagent via `model: opus` alias — version not self-reported | high |
| Review fixes (2 rounds) | subagent via `model: opus` alias — version not self-reported | high |
| Commit message | subagent via `model: sonnet` alias — version not self-reported | medium |
| Verification | `npm run verify` — green in CI | — |

Subagent rows name the spawn alias rather than a version string: the alias's resolved model is known
only to the subagent, and none reported it back. Stating the alias is true; inferring a version
would not be.
