### PR TITLE
feat(job-search): state the search contract, and walk the query in four steps (#597)

### DIFF
--- a/src/components/features/ChipListEditor.test.tsx
+++ b/src/components/features/ChipListEditor.test.tsx
@@ -52,3 +52,30 @@ describe("ChipListEditor promote control target size", () => {
     expect(html).toContain('aria-current="true"');
   });
 });
+
+/**
+ * #597 extends the promote control to Skills, where `primaryKeyword` sends
+ * `skills[0]`. The label was hardcoded to "title", which would have told a
+ * screen-reader user that a skill chip promotes a title.
+ */
+describe("ChipListEditor promote label", () => {
+  const base = {
+    items: ["Kubernetes", "TypeScript"],
+    onAdd: () => {},
+    onRemove: () => {},
+    placeholder: "Add a skill",
+    addAriaLabel: "Add skill",
+    primaryIndex: 0,
+    onPromote: () => {},
+  };
+
+  it("names the list's own noun", () => {
+    const html = render({ ...base, label: "Skills", primaryNoun: "skill" });
+    expect(html).toContain('aria-label="Make TypeScript the primary skill"');
+  });
+
+  it("defaults to 'title' so the original Titles call site is unchanged", () => {
+    const html = render({ ...base, label: "Titles" });
+    expect(html).toContain('aria-label="Make TypeScript the primary title"');
+  });
+});

--- a/src/components/features/ChipListEditor.tsx
+++ b/src/components/features/ChipListEditor.tsx
@@ -16,12 +16,17 @@
  * removable chips are the `Chip` primitive's `onRemove` variant, not a copy).
  *
  * `onPromote` + `primaryIndex` (#581) are an opt-in pair, not baked into the
- * shared surface: only the Titles call site (`JobQueryEditor`) passes them,
- * because only titles have a "which one is searched" axis (`searchPhrase`
- * sends `titles[0]`). Skills and Exclude leave both undefined and render
- * unchanged. When set, the chip at `primaryIndex` gets a `★` text
+ * shared surface: a list qualifies only when ONE of its entries is singled out
+ * by what actually leaves the browser. Titles qualify because `searchPhrase`
+ * sends `titles[0]` to the keyless feeds; Skills qualify too (#597) because
+ * `primaryKeyword` sends `skills[0]` as Jobicy's tag — both are `keywords.ts`
+ * reading index 0 of one list. `primaryNoun` is what the promote control calls
+ * that list's entries, so the label reads "the primary skill" on one and "the
+ * primary title" on the other. Exclude has no such axis — it filters locally,
+ * every entry equally — so it leaves both undefined and renders unchanged.
+ * When set, the chip at `primaryIndex` gets a `★` text
  * mark (never colour alone) + `aria-current="true"`; every other chip's body
- * becomes a second control — "Make X the primary title" — beside the
+ * becomes a second control — "Make X the primary {primaryNoun}" — beside the
  * existing remove button.
  *
  * TARGET SIZE (#591, resolves the #581 AC8 gap). WCAG 2.2 SC 2.5.8 Target Size
@@ -59,7 +64,9 @@ import { useState } from "react";
 import { Button, Chip } from "@design-system";
 import type { TermQuality, TermVerdict } from "../../lib/job-search/term-quality.ts";
 
-const QUALITY_MARK: Record<TermQuality, { glyph: string; className: string }> = {
+/** The glyph + token for each verdict. Exported so `TermGlyphLegend` (#597)
+ *  explains the SAME marks this renders rather than a second copy of them. */
+export const QUALITY_MARK: Record<TermQuality, { glyph: string; className: string }> = {
   strong: { glyph: "✓", className: "text-feedback-success-text" },
   weak: { glyph: "○", className: "text-content-tertiary" },
   noise: { glyph: "⚠︎", className: "text-feedback-warning-text" },
@@ -68,6 +75,11 @@ const QUALITY_MARK: Record<TermQuality, { glyph: string; className: string }> = 
 interface ChipListEditorProps {
   /** Row label shown above the chips (e.g. "Titles", "Skills"). */
   label: string;
+  /** Render `label` for screen readers only (#602). For a caller whose own
+   *  section heading already names the row — two visible names for one control
+   *  is worse than none, and dropping the label outright would leave the chip
+   *  list unnamed in the accessibility tree. */
+  labelHidden?: boolean;
   /** The controlled chip values, in display order. */
   items: string[];
   /** Called with a trimmed, non-duplicate value when the user adds one. */
@@ -83,6 +95,10 @@ interface ChipListEditorProps {
   /** Opt-in (#581): called with the item to promote to primary. Required
    *  alongside `primaryIndex` to make a chip's body clickable. */
   onPromote?: (value: string) => void;
+  /** What one entry of this list is called in the promote control's accessible
+   *  label ("Make X the primary title"). Only meaningful alongside
+   *  `onPromote`; defaults to `"title"`, the original #581 call site. */
+  primaryNoun?: string;
   /** Opt-in (#585): looks up the `TermVerdict` for a chip's own text. Omit
    *  (or return `undefined` for a given item) to render that chip plain — a
    *  term with no verdict was not judgeable, see `term-quality.ts`. */
@@ -91,6 +107,7 @@ interface ChipListEditorProps {
 
 export function ChipListEditor({
   label,
+  labelHidden = false,
   items,
   onAdd,
   onRemove,
@@ -98,6 +115,7 @@ export function ChipListEditor({
   addAriaLabel,
   primaryIndex,
   onPromote,
+  primaryNoun = "title",
   qualityFor,
 }: ChipListEditorProps) {
   const [draft, setDraft] = useState("");
@@ -114,7 +132,13 @@ export function ChipListEditor({
 
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-xs text-content-tertiary">{label}</span>
+      <span
+        className={
+          labelHidden ? "sr-only" : "text-sm font-medium text-content-secondary"
+        }
+      >
+        {label}
+      </span>
       {items.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {items.map((item, index) => {
@@ -149,7 +173,7 @@ export function ChipListEditor({
                     // remove control's horizontal hit area.
                     className="relative p-0 text-content-secondary hover:text-content-primary after:absolute after:-inset-y-[4px] after:inset-x-0 after:content-['']"
                     onClick={() => onPromote(item)}
-                    aria-label={`Make ${item} the primary title`}
+                    aria-label={`Make ${item} the primary ${primaryNoun}`}
                   >
                     {item}
                   </Button>
@@ -175,7 +199,7 @@ export function ChipListEditor({
               commit();
             }
           }}
-          className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-xs text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+          className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
         />
         <Button
           variant="ghost"

--- a/src/components/features/CompFloorInput.tsx
+++ b/src/components/features/CompFloorInput.tsx
@@ -26,7 +26,10 @@ interface CompFloorInputProps {
 export function CompFloorInput({ value, onCommit }: CompFloorInputProps) {
   return (
     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-      <span className="text-xs text-content-tertiary">Minimum pay ($/yr)</span>
+      {/* Named visibly by the caller's section heading (#602); the units stay
+          here, where the value is typed. */}
+      <span className="sr-only">Minimum pay</span>
+      <span className="text-sm text-content-secondary">$/yr</span>
       <EditableField
         value={value !== undefined ? String(value) : undefined}
         placeholder="minimum pay"

--- a/src/components/features/CompanyTargets.test.tsx
+++ b/src/components/features/CompanyTargets.test.tsx
@@ -71,7 +71,16 @@ function Host({ parsed }: { parsed: HeuristicParsedResume }) {
   return createElement(CompanyTargets, { targets });
 }
 
-async function mount(parsed: HeuristicParsedResume): Promise<void> {
+/**
+ * Mounts and, by default, EXPANDS the block: #597 collapsed it to a single
+ * summary line, and everything that asserts on the per-company toggles has to
+ * open it the way a user would. Pass `{ expand: false }` to assert the
+ * collapsed default itself.
+ */
+async function mount(
+  parsed: HeuristicParsedResume,
+  options: { expand?: boolean } = {},
+): Promise<void> {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -87,6 +96,16 @@ async function mount(parsed: HeuristicParsedResume): Promise<void> {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
   }
+  if (options.expand !== false) await expand();
+}
+
+/** Clicks the disclosure, the same control a user clicks. */
+async function expand(): Promise<void> {
+  const toggle = buttons().find((b) => b.hasAttribute("aria-expanded"));
+  if (!toggle) throw new Error("no companies disclosure control");
+  await act(async () => {
+    toggle.click();
+  });
 }
 
 function buttons(): HTMLButtonElement[] {
@@ -219,16 +238,50 @@ describe("CompanyTargets rendering", () => {
   it("degrades to a plain explanation when no sector companies exist", async () => {
     // An unclassifiable resume falls to the "other" sector, which by design has
     // no registry entries.
-    await mount({ skills: [], experience: [], education: [] });
+    await mount({ skills: [], experience: [], education: [] }, { expand: false });
     expect(latest?.suggested).toEqual([]);
     expect(companyButtons()).toHaveLength(0);
-    expect(container?.textContent).toContain("job feeds only");
+    // NOT merely "job feeds only" — both this state and a user who deselected
+    // every board end in those words, so that substring alone cannot tell them
+    // apart and would pass even if this said "No companies selected".
+    expect(container?.textContent).toContain(
+      "couldn't match your resume to a sector",
+    );
+    expect(container?.textContent).not.toContain("No companies selected");
+  });
+
+  // #597: with nothing to choose from, the disclosure would open onto its own
+  // apology — so there is no disclosure.
+  it("offers no expand control when no sector companies exist", async () => {
+    await mount({ skills: [], experience: [], education: [] }, { expand: false });
+    expect(buttons().filter((b) => b.hasAttribute("aria-expanded"))).toHaveLength(0);
   });
 
   // #542
   it("notes that self-hosted-careers employers aren't reachable here", async () => {
     await mount(fintechResume);
     expect(container?.textContent).toContain("their own careers site");
+  });
+});
+
+/** #597: the block leads `/jobs/` but is not what the page is for, so it opens
+ *  as one line that still makes the whole claim. */
+describe("CompanyTargets disclosure", () => {
+  it("renders collapsed by default, with the count and the sent-data claim intact", async () => {
+    await mount(fintechResume, { expand: false });
+    expect(companyButtons()).toHaveLength(0);
+    expect(container?.textContent).toContain("public job boards");
+    expect(container?.textContent).toContain("only the company name is sent");
+    const toggle = buttons().find((b) => b.hasAttribute("aria-expanded"));
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("reveals the per-company toggles on expand", async () => {
+    await mount(fintechResume, { expand: false });
+    await expand();
+    expect(companyButtons().length).toBe(latest!.suggested.length);
+    const toggle = buttons().find((b) => b.hasAttribute("aria-expanded"));
+    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
   });
 });
 

--- a/src/components/features/CompanyTargets.tsx
+++ b/src/components/features/CompanyTargets.tsx
@@ -15,8 +15,19 @@
  * "×" would imply it's gone. `aria-pressed` carries the state to a screen
  * reader, and a "✓" text mark carries it visually, so selection is never
  * signalled by colour alone.
+ *
+ * COLLAPSED BY DEFAULT (#597). This block sits above the query form and used to
+ * open as three wrapped rows of chips plus two paragraphs — the first thing on
+ * `/jobs/` and the last thing a user came to read. Collapsed it is one line
+ * that still makes the whole claim (how many boards, and that only the company
+ * name is sent), so nothing load-bearing is hidden behind the disclosure; what
+ * expands is the per-company retuning, which is a deliberate act. The
+ * disclosure is a `Button` with `aria-expanded` + local state — the house
+ * pattern (`FindJobsPanel`'s own fold); there is no Disclosure primitive in the
+ * `@design-system` barrel and this is not the reason to add one.
  */
 
+import { useState } from "react";
 import { Button } from "@design-system";
 import type { CompanyEntry } from "../../lib/job-search/company-registry.ts";
 import type { CompanyTargets as CompanyTargetsState } from "../../hooks/useCompanyTargets.ts";
@@ -28,8 +39,31 @@ function sectorLabel(sector: string): string {
   return sector.replace(/-/g, " / ");
 }
 
+/** The one line that survives the collapse — it must carry the whole claim on
+ *  its own, since it is all most users will read.
+ *
+ *  `hasSuggestions` separates two states a bare count cannot tell apart: a user
+ *  who reviewed the suggested boards and kept none, versus a résumé we could
+ *  match to no sector at all. Both end at "the job feeds only", but only the
+ *  first is a choice, and calling the second "no companies selected" would
+ *  blame the user for a gap in our registry. */
+function summaryLine(selectedCount: number, hasSuggestions: boolean): string {
+  if (!hasSuggestions) {
+    return "We couldn't match your resume to a sector we have companies for, so this search uses the job feeds only.";
+  }
+  if (selectedCount === 0) {
+    return "No companies selected — this search uses the job feeds only.";
+  }
+  return `We'll check ${selectedCount} ${
+    selectedCount === 1 ? "company's" : "companies'"
+  } public job ${selectedCount === 1 ? "board" : "boards"} — only the company name is sent, never your resume.`;
+}
+
 export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
   const { ready, sector, runnerUp, suggested, selected } = targets;
+  // Purely presentational, so it stays local — same as `FindJobsPanel`'s fold.
+  // Declared above the `ready` guard: a hook may not sit behind a return.
+  const [expanded, setExpanded] = useState(false);
 
   // Before the registry chunk resolves there is nothing truthful to say, and
   // a spinner for a lazy import that usually takes a frame would flicker.
@@ -38,29 +72,48 @@ export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <span className="text-xs text-content-tertiary">
-          {suggested.length > 0 && sector
-            ? `Companies we matched to your background (${sectorLabel(sector)})`
-            : "Companies"}
-        </span>
-        {runnerUp && (
+        <p className="max-w-prose text-sm text-content-secondary">
+          {summaryLine(selected.length, suggested.length > 0)}
+        </p>
+        {/* No disclosure when there is nothing to disclose: "Choose companies"
+         *  over an empty registry match is a control that opens onto its own
+         *  apology. The summary line above already says the whole truth in
+         *  that state. */}
+        {suggested.length > 0 && (
           <Button
             variant="link"
             size="sm"
-            onClick={targets.switchToRunnerUp}
+            aria-expanded={expanded}
+            onClick={() => setExpanded((v) => !v)}
           >
-            Not right? Try {sectorLabel(runnerUp)}
+            {expanded ? "Hide companies" : "Choose companies"}
           </Button>
         )}
       </div>
 
-      {suggested.length === 0 ? (
-        <p className="max-w-prose text-xs text-content-tertiary">
-          We couldn&apos;t match your resume to a sector we have companies for,
-          so this search uses the job feeds only.
-        </p>
-      ) : (
+      {expanded && suggested.length > 0 && (
         <>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span className="text-sm text-content-secondary">
+              {suggested.length > 0 && sector
+                ? `Companies we matched to your background (${sectorLabel(sector)})`
+                : "Companies"}
+            </span>
+            {runnerUp && (
+              <Button
+                variant="link"
+                size="sm"
+                onClick={targets.switchToRunnerUp}
+              >
+                Not right? Try {sectorLabel(runnerUp)}
+              </Button>
+            )}
+          </div>
+
+          {/* The selection state itself is the collapsed summary line above —
+           *  repeating it here would be the same sentence twice on one screen.
+           *  The empty case never reaches this branch: with no suggestions
+           *  there is no disclosure to open. */}
           <div className="flex flex-wrap gap-1.5">
             {suggested.map((entry: CompanyEntry) => {
               const isOn = targets.isSelected(entry);
@@ -74,7 +127,7 @@ export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
                   className={
                     isOn
                       ? "rounded-full border border-accent-primary px-2.5 py-1"
-                      : "rounded-full border border-border-light px-2.5 py-1 text-content-tertiary"
+                      : "rounded-full border border-border-light px-2.5 py-1 text-content-secondary"
                   }
                 >
                   <span aria-hidden="true">{isOn ? "✓︎" : "+"}</span>
@@ -83,29 +136,22 @@ export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
               );
             })}
           </div>
-          <p className="max-w-prose text-xs text-content-tertiary">
-            {selected.length === 0
-              ? "No companies selected — this search uses the job feeds only."
-              : `We'll read ${selected.length} ${
-                  selected.length === 1 ? "company's" : "companies'"
-                } public job board directly. Only the company name is sent — never your resume.`}
+
+          {/* #542: large employers with self-hosted careers sites (Apple,
+           *  Google, Meta, …) aren't on Greenhouse/Lever/Ashby, so they can
+           *  never appear in this list — a structural boundary of the
+           *  three-vendor design, not a curation gap. "Search external boards"
+           *  (LinkedIn / Indeed / Google Jobs) is the intended path to those.
+           *  No "above"/"below" here: this block is pinned to the top of
+           *  `/jobs/` while the board links live in the foldable search
+           *  details, so any direction word would be wrong half the time. */}
+          <p className="max-w-prose text-sm text-content-secondary">
+            Large employers with their own careers site (e.g. Apple, Google,
+            Meta) aren&apos;t reachable here — find them via the external board
+            links in the search details.
           </p>
         </>
       )}
-
-      {/* #542: large employers with self-hosted careers sites (Apple, Google,
-       *  Meta, …) aren't on Greenhouse/Lever/Ashby, so they can never appear
-       *  in this list — a structural boundary of the three-vendor design, not
-       *  a curation gap. "Search external boards" (LinkedIn / Indeed / Google
-       *  Jobs) is the intended path to those. No "above"/"below" here: this
-       *  block is pinned to the top of `/jobs/` while the board links live in
-       *  the foldable search details, so any direction word would be wrong
-       *  half the time. */}
-      <p className="max-w-prose text-xs text-content-tertiary">
-        Large employers with their own careers site (e.g. Apple, Google,
-        Meta) aren&apos;t reachable here — find them via the external board
-        links in the search details.
-      </p>
     </div>
   );
 }

--- a/src/components/features/ExternalBoardLinks.tsx
+++ b/src/components/features/ExternalBoardLinks.tsx
@@ -20,9 +20,9 @@ import type { JobBoardLink } from "../../lib/job-search/deep-links.ts";
 export function ExternalBoardLinks({ links }: { links: readonly JobBoardLink[] }) {
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-xs text-content-tertiary">
-        Search external boards
-      </span>
+      {/* Named visibly by the caller's section heading (#602); kept so the
+          link row is still named in the accessibility tree. */}
+      <span className="sr-only">Search external boards</span>
       <div className="flex flex-wrap gap-2">
         {links.map((link) => (
           <a
@@ -30,14 +30,14 @@ export function ExternalBoardLinks({ links }: { links: readonly JobBoardLink[] }
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
+            className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-sm font-medium text-content-secondary transition-colors hover:bg-surface-subtle focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
           >
             {link.label}
             <span aria-hidden="true">↗</span>
           </a>
         ))}
       </div>
-      <p className="text-xs text-content-tertiary">
+      <p className="max-w-prose text-sm text-content-secondary">
         Only your search keywords are sent, and only when you click a link above.
       </p>
     </div>

--- a/src/components/features/FindJobsPanel.tsx
+++ b/src/components/features/FindJobsPanel.tsx
@@ -11,20 +11,39 @@
  * and the full page width. `/` keeps `FindJobsLauncher`, which hands the parse
  * over via `lib/jobs-handoff.ts`.
  *
- * LAYOUT: full-width bands stacked down the page, never a sidebar. Reading order
- * is the order of the work — who we search, then what we search for, then what we
- * found:
+ * LAYOUT: full-width bands stacked down the page, never a sidebar.
  *
- *  1. **Company targets, permanent.** The one query control that stays visible
- *     with the results. It's the axis users retune WHILE reading postings ("drop
- *     that one, add this one"), and #533's toggle is now live against an existing
- *     result set, so hiding it behind a fold would bury the panel's most
- *     immediate feedback loop.
- *  2. **The rest of the query, foldable.** Titles, skills, location, level,
- *     excludes, pay floor, external boards — a form, worth the full page width
- *     while being filled in and worth none of it afterwards. Folded, it is a
- *     one-line `JobQuerySummary` + Search again.
- *  3. **Results**, owning the full width.
+ *  1. **The query, as an ordered four-step walk** (#602) — Role → Skills →
+ *     Narrow → Review, on the `Stepper` composition. The pre-#602 form put
+ *     every field on screen at once in a three-column grid: ~40 chips, a
+ *     12-rung level rail, a mark legend, an advisory block, the deep links and
+ *     the outbound contract, all at one typographic weight with no headings.
+ *     Everything was reachable and nothing was findable. The steps ARE the
+ *     reading order of the work, and each rail entry states its own current
+ *     value (`describeQuerySteps`), so a closed step is still legible.
+ *  2. **Results**, owning the full width.
+ *
+ * The whole query folds to a one-line `JobQuerySummary` + Search again on
+ * submit — the rail included, since a form worth the full page width while
+ * being filled in is worth none of it afterwards.
+ *
+ * ORDER IS CAUSE → CONTRACT → ACTION (#597, kept by #602). The fields come
+ * first, then `SearchPlanCard` at the head of the Review step — which single
+ * title and which single skill will actually leave the browser, with a
+ * **change** control on each — and then Search. Before #597 the button floated
+ * top-right, where a user read the outbound terms (if at all) after clicking
+ * rather than before; before #602 the contract card rendered at the FOOT of the
+ * form, below every field it describes.
+ *
+ * The Search button is mounted on every step (`StepperNav`'s `finalAction`), not
+ * gated behind reaching Review: the query arrives already seeded, so a user who
+ * is happy with it must never have to walk four steps to run it. Its fixed
+ * position at the end of the nav row is what marks it as the end of the flow.
+ *
+ * The plan card carries the ONE form-level statement of what is sent and when.
+ * `ExternalBoardLinks` and `CompanyTargets` keep their own sentences — those are
+ * different triggers (clicking a deep link; reading a company board), and
+ * deleting them would leave those egress paths unexplained.
  *
  * Folding on submit rather than on the first successful result is deliberate:
  * the transition is then tied to the user's own click, so it never happens under
@@ -32,9 +51,9 @@
  * width it will render results into. A failed search stays folded too — its
  * error state carries Retry, and Edit search is one click away.
  *
- * Nothing is sticky. With the company chips permanently on top, a pinned band
- * would be ~3 chip rows tall and would cost more viewport on every scroll than
- * the Search button it keeps in reach is worth.
+ * Nothing is sticky: a pinned band tall enough to hold the rail and the nav row
+ * would cost more viewport on every scroll than the Search button it keeps in
+ * reach is worth.
  *
  * #568's live re-rank means a refinement chip edited while the panel is open
  * updates the results with no refetch, so re-opening the form over a results set
@@ -50,9 +69,13 @@
  */
 
 import { useMemo, useState } from "react";
-import { Button } from "@design-system";
+import { Button, Stepper, StepperNav, StepperRail } from "@design-system";
 import { buildJobQuery, type JobQuery } from "../../lib/job-search/query-builder.ts";
 import { buildDeepLinks } from "../../lib/job-search/deep-links.ts";
+import {
+  describeQuerySteps,
+  type QueryStepId,
+} from "../../lib/job-search/query-steps.ts";
 import {
   roleFilterForResume,
   seedExcludeTermsForFamilies,
@@ -61,9 +84,7 @@ import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import { JobSearchResults } from "./JobSearchResults.tsx";
 import { JobQueryEditor } from "./JobQueryEditor.tsx";
 import { JobQuerySummary } from "./JobQuerySummary.tsx";
-import { ExternalBoardLinks } from "./ExternalBoardLinks.tsx";
 import { PendingCompaniesNotice } from "./PendingCompaniesNotice.tsx";
-import { CompanyTargets } from "./CompanyTargets.tsx";
 import { useCompanyTargets } from "../../hooks/useCompanyTargets.ts";
 import { useJobSearch } from "../../hooks/useJobSearch.ts";
 
@@ -94,6 +115,10 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   // presentational, so it stays local rather than moving to a hook.
   const [open, setOpen] = useState(true);
 
+  // Which step of the query walk is showing (#602). Also presentational; the
+  // query itself is the state that matters and lives above.
+  const [step, setStep] = useState<QueryStepId>("role");
+
   const links = useMemo(() => buildDeepLinks(query), [query]);
   const isDegenerate = query.titles.length === 0 && query.skills.length === 0;
 
@@ -102,6 +127,11 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
   // alone, the same way it behaved before #533.
   const companyTargets = useCompanyTargets(parsed);
   const selectedCompanies = companyTargets.selected;
+
+  // Pure string assembly over already-derived values (see `query-steps.ts`), so
+  // no memoization is warranted; it must recompute on every query edit anyway,
+  // which is what makes a closed step's summary trustworthy.
+  const steps = describeQuerySteps(query, selectedCompanies.length);
 
   // Fetch lifecycle, #568's live re-rank, and the asymmetric company handling
   // (remove = live, add = a prompt) — see the hook's own docblock.
@@ -120,11 +150,21 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
     runSearch();
   };
 
+  // One Search button, rendered in two different places by the fold — declared
+  // once so the disabled rule and the label cannot drift between them.
+  const searchButton = (
+    <Button
+      variant="primary"
+      size="md"
+      onClick={submit}
+      disabled={isDegenerate || isLoading}
+    >
+      {isLoading ? "Searching…" : hasSearched ? "Search again" : "Search jobs"}
+    </Button>
+  );
+
   return (
     <div className="flex flex-col gap-4">
-      {/* Band 1 — the only query control that outlives the fold. */}
-      <CompanyTargets targets={companyTargets} />
-
       <section
         aria-label="Job search query"
         className="flex flex-col gap-3 border-y border-border-light py-3"
@@ -132,49 +172,40 @@ export function FindJobsPanel({ parsed }: FindJobsPanelProps) {
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           <Button
             variant="ghost"
-            size="sm"
+            size="md"
             aria-expanded={open}
             onClick={() => setOpen((v) => !v)}
           >
             {open ? "Hide search details" : "Edit search"}
           </Button>
           {!open && (
-            <JobQuerySummary
-              query={query}
-              companyCount={selectedCompanies.length}
-            />
+            <>
+              <JobQuerySummary
+                query={query}
+                companyCount={selectedCompanies.length}
+              />
+              <div className="ml-auto">{searchButton}</div>
+            </>
           )}
-          <Button
-            variant="primary"
-            size="md"
-            className="ml-auto"
-            onClick={submit}
-            disabled={isDegenerate || isLoading}
-          >
-            {isLoading
-              ? "Searching…"
-              : hasSearched
-                ? "Search again"
-                : "Search jobs"}
-          </Button>
         </div>
 
-        {/* Sits under the Search button rather than at the foot of the section:
-         *  the claim is about what THAT button does, and `ExternalBoardLinks`
-         *  carries its own (different) claim about the deep links. */}
-        <p className="text-xs text-content-tertiary">
-          Only your search keywords are sent, and only when you click Search.
-        </p>
-
         {open && (
-          <div className="flex flex-col gap-4">
+          <Stepper
+            id="job-query"
+            value={step}
+            onValueChange={(next) => setStep(next as QueryStepId)}
+            steps={steps}
+          >
+            <StepperRail aria-label="Search steps" />
             <JobQueryEditor
               query={query}
               onChange={setQuery}
               isDegenerate={isDegenerate}
+              links={links}
+              companyTargets={companyTargets}
             />
-            <ExternalBoardLinks links={links} />
-          </div>
+            <StepperNav finalAction={searchButton} />
+          </Stepper>
         )}
       </section>
 

--- a/src/components/features/JobQueryEditor.test.tsx
+++ b/src/components/features/JobQueryEditor.test.tsx
@@ -4,29 +4,74 @@
 // @vitest-environment jsdom
 
 /**
- * Coverage for the #581 primary-title marker + click-to-promote: the property
- * under test is that promoting a chip is a plain reorder of `query.titles`
- * flowing through the existing `onChange` — the "Searching feeds for …" line
- * (which reads `searchPhrase`, i.e. `titles[0]`) must follow the reorder, and
- * `titleNoise` — a derived, non-user-facing field on the same `JobQuery` —
- * must survive the promotion untouched.
+ * Coverage for the #581 primary-title marker + click-to-promote, extended to
+ * skills in #597: the property under test is that promoting a chip is a plain
+ * reorder of the relevant list flowing through the existing `onChange`, and
+ * that `titleNoise` — a derived, non-user-facing field on the same `JobQuery` —
+ * survives the promotion untouched. The old "Searching feeds for …" line is
+ * gone: `SearchPlanCard` states the outbound terms now (#597), and it is
+ * `FindJobsPanel` that renders it, so the assertion moved with the surface.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
 import { createElement } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { Stepper } from "@design-system";
 import { JobQueryEditor } from "./JobQueryEditor.tsx";
 import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+import { describeQuerySteps } from "../../lib/job-search/query-steps.ts";
 import { assessQueryTerms } from "../../lib/job-search/term-quality.ts";
 import { missingTermLabel, TermQualityAdvisory } from "./TermQualityAdvisory.tsx";
 import type { CoherenceFinding } from "../../lib/job-search/term-quality.ts";
+import type { CompanyTargets } from "../../hooks/useCompanyTargets.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
 
 let container: HTMLDivElement;
 let root: Root;
+
+/** A company picker that never resolved its registry — `CompanyTargets`
+ *  renders nothing until `ready`, so the Filters step reduces to the fields
+ *  these tests are actually about. `FindJobsPanel` owns the real hook. */
+const NO_COMPANIES: CompanyTargets = {
+  ready: false,
+  sector: null,
+  runnerUp: null,
+  suggested: [],
+  selected: [],
+  isSelected: () => false,
+  toggle: () => {},
+  switchToRunnerUp: () => {},
+};
+
+/**
+ * `JobQueryEditor` emits `StepPanel`s (#602), which read their position from
+ * `Stepper`'s context, so every render goes through the same host the panel
+ * uses. Inactive panels stay MOUNTED (only `hidden`), which is what keeps these
+ * tests able to assert across all four steps from one render — the same
+ * property that lets a half-typed chip draft survive stepping away.
+ */
+function element(
+  query: JobQuery,
+  onChange: (next: (q: JobQuery) => JobQuery) => void,
+  isDegenerate: boolean,
+) {
+  return createElement(Stepper, {
+    id: "test",
+    value: "role",
+    onValueChange: () => {},
+    steps: describeQuerySteps(query, 0),
+    children: createElement(JobQueryEditor, {
+      query,
+      onChange,
+      isDegenerate,
+      links: [],
+      companyTargets: NO_COMPANIES,
+    }),
+  });
+}
 
 function render(
   query: JobQuery,
@@ -37,9 +82,7 @@ function render(
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root.render(
-      createElement(JobQueryEditor, { query, onChange, isDegenerate }),
-    );
+    root.render(element(query, onChange, isDegenerate));
   });
   return container;
 }
@@ -52,9 +95,7 @@ function rerender(
   isDegenerate = false,
 ) {
   act(() => {
-    root.render(
-      createElement(JobQueryEditor, { query, onChange, isDegenerate }),
-    );
+    root.render(element(query, onChange, isDegenerate));
   });
   return container;
 }
@@ -156,7 +197,9 @@ describe("JobQueryEditor — primary title promotion", () => {
       query = next(query);
     });
 
-    expect(el.textContent).toContain('Searching feeds for "Berlin Site Lead"');
+    // Superseded by `SearchPlanCard` (#597) — the editor no longer states what
+    // egresses, so a duplicate here would be a second place to keep in sync.
+    expect(el.textContent).not.toContain("Searching feeds for");
 
     const promote = [...el.querySelectorAll("button")].find((b) =>
       b.getAttribute("aria-label")?.includes("Make VP Engineering the primary title"),
@@ -175,16 +218,36 @@ describe("JobQueryEditor — primary title promotion", () => {
 
     act(() => {
       root.render(
-        createElement(JobQueryEditor, {
+        element(
           query,
-          onChange: (next) => {
+          (next) => {
             query = next(query);
           },
-          isDegenerate: false,
-        }),
+          false,
+        ),
       );
     });
-    expect(el.textContent).toContain('Searching feeds for "VP Engineering"');
+    // The star follows the reorder, which is what the plan card reads.
+    expect(el.querySelector('[aria-current="true"]')?.textContent).toContain(
+      "VP Engineering",
+    );
+  });
+
+  it("promotes a skill through the same whole-query replacement, recomputing canonicalSkills", () => {
+    let query: JobQuery = {
+      titles: [],
+      skills: ["Team Building & Mentorship", "TypeScript"],
+      canonicalSkills: ["TypeScript"],
+    };
+    const el = render(query, (next) => {
+      query = next(query);
+    });
+
+    const promote = findButton(el, "Make TypeScript the primary skill");
+    act(() => promote.click());
+
+    expect(query.skills).toEqual(["TypeScript", "Team Building & Mentorship"]);
+    expect(query.canonicalSkills).toEqual(["TypeScript"]);
   });
 
   it("marks the primary chip with a star and aria-current", () => {
@@ -193,6 +256,52 @@ describe("JobQueryEditor — primary title promotion", () => {
 
     const current = el.querySelector('[aria-current="true"]');
     expect(current?.textContent).toContain("Staff Engineer");
+  });
+});
+
+/**
+ * #597's information-architecture claims, each of which is a placement the user
+ * can see: a term that reaches nothing is named in words rather than only as a
+ * chip mark, and a suggestion sits under the list it writes into instead of in
+ * a trailing section at the foot of the form.
+ */
+describe("JobQueryEditor — dropped terms and in-column suggestions (issue 597)", () => {
+  it("names a term that narrows nothing, with the lib's own reason verbatim", () => {
+    const query: JobQuery = {
+      titles: ["Berlin", "Engineering Manager"],
+      skills: [],
+      titleNoise: ["berlin"],
+    };
+    const verdict = assessQueryTerms(query).verdicts.find((v) => v.term === "Berlin");
+    expect(verdict?.quality).toBe("noise");
+
+    const el = render(query, () => query);
+    expect(el.textContent).toContain("aren't narrowing your search");
+    // Verbatim from `term-quality.ts`, not a second sentence written here.
+    expect(el.textContent).toContain(verdict!.reason);
+  });
+
+  it("says nothing about the terms it is entitled to judge but not to call dropped", () => {
+    // A clean query has no noise verdict, so the block must not appear at all —
+    // no empty state, no all-clear.
+    const query: JobQuery = { titles: ["Engineering Manager"], skills: [] };
+    const el = render(query, () => query);
+    expect(el.textContent).not.toContain("aren't narrowing your search");
+  });
+
+  it("renders the title suggestions inside the Role step, not in a trailing block", () => {
+    const query: JobQuery = { titles: ["Engineering Manager"], skills: [] };
+    const missing = assessQueryTerms(query).missing.filter((t) => t.kind === "title");
+    expect(missing.length).toBeGreaterThan(0);
+
+    const el = render(query, () => query);
+    // Scoped to the panel, not merely "appears somewhere on the page" — with
+    // every step mounted (see `element`), a page-wide text search would pass
+    // even if the suggestions had drifted back into a trailing section.
+    const rolePanel = el.querySelector("#test-steppanel-role");
+    const skillsPanel = el.querySelector("#test-steppanel-skills");
+    expect(rolePanel?.textContent).toContain("Add to your titles");
+    expect(skillsPanel?.textContent).not.toContain("Add to your titles");
   });
 });
 
@@ -473,7 +582,12 @@ describe("JobQueryEditor — term quality (issue 585)", () => {
     const el = render(query, () => query);
     // The glyph is decorative (aria-hidden); the accessible label is the
     // separate sr-only span carrying `reason` unchanged.
-    expect(el.querySelector('[aria-hidden="true"].text-feedback-success-text')).not.toBeNull();
+    // Scoped by `title`: only a CHIP's quality mark carries the reason as a
+    // tooltip, so this can't be satisfied by the glyph legend (#597), which
+    // reuses the same tokens with no per-term reason behind them.
+    expect(
+      el.querySelector('[aria-hidden="true"][title].text-feedback-success-text'),
+    ).not.toBeNull();
     expect(el.textContent).toContain(verdict!.reason);
   });
 
@@ -485,7 +599,8 @@ describe("JobQueryEditor — term quality (issue 585)", () => {
     expect(verdicts).toHaveLength(0);
 
     const el = render(query, () => query);
-    const marks = [...el.querySelectorAll('[aria-hidden="true"]')].filter(
+    // Same `title` scoping as above — the glyph legend is not a chip mark.
+    const marks = [...el.querySelectorAll('[aria-hidden="true"][title]')].filter(
       (node) =>
         node.classList.contains("text-feedback-success-text") ||
         node.classList.contains("text-feedback-warning-text") ||

--- a/src/components/features/JobQueryEditor.tsx
+++ b/src/components/features/JobQueryEditor.tsx
@@ -2,24 +2,34 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * JobQueryEditor — the editable search query of the job-search workbench.
+ * JobQueryEditor — the editable search query of the job-search workbench,
+ * emitted as the four panels of `FindJobsPanel`'s `Stepper` (#602).
  *
- * Extracted verbatim out of `FindJobsPanel` when the results moved to their own
- * `/jobs/` page: the panel became a foldable full-width search form above the
- * results, and the fields shouldn't own the layout that folds them. Nothing
- * about the controls changed in the move.
+ * WHAT CHANGED IN #602 AND WHY. This used to be a three-column grid that put
+ * every field on screen at once: ~40 chips at one visual weight, a 12-rung
+ * level rail, a mark legend, the whole-query advisory and (via the panel) the
+ * outbound contract and the external-board links. Everything was reachable and
+ * nothing was findable — and the contract card, which the form exists to lead
+ * up to, rendered LAST, about a thousand pixels below the chips it describes.
+ * The fields are now grouped into an ordered walk whose reading order is the
+ * order of the work:
  *
- * The fields lay themselves out across the full width rather than stacking in one
- * narrow column: the panel hands this component the whole page, and a single
- * column would leave a ~470px form on a 1080px page — which is what the layout
- * looked like when the neighbouring blocks owned the other columns.
+ *   1. **Role** — the titles, one of which is what actually leaves the browser.
+ *   2. **Skills** — the second egressing term, and the fit evidence.
+ *   3. **Narrow** — the narrowing axes: where, what to drop, a pay floor, and
+ *      which company boards to check.
+ *   4. **Review** — the pre-flight contract (`SearchPlanCard`), the whole-query
+ *      findings, and the external deep links, immediately above the button they
+ *      describe.
  *
- * Grouping is by how the fields are used, not by size: what you SEARCH FOR
- * (titles + role) and what you're MADE OF (skills) get a column each, because
- * both are long removable-chip lists; the narrow modifiers (location, exclude,
- * pay floor) share the third. Target level spans the full width on its own row —
- * it's a 12-rung segmented control that would wrap into three ragged lines inside
- * a third of the page.
+ * The per-kind suggestions and the mark legend moved to sit under the chip rows
+ * they belong to; a key to marks a screen away was decoration.
+ *
+ * This component does NOT own the `Stepper` — `FindJobsPanel` does, because the
+ * rail's summaries need the selected-company count and the terminal action is
+ * that panel's Search button. `StepPanel` reads its position from context, so
+ * emitting the panels from here costs no wiring. Panels stay mounted when
+ * inactive (see `Stepper`), so a half-typed chip draft survives stepping away.
  *
  * Controlled by the parent through `query` / `onChange` — the query is the
  * workbench's single source of truth (the fit ranking and the #568 live re-rank
@@ -33,20 +43,27 @@
  */
 
 import { useState } from "react";
-import { EditableField } from "@design-system";
+import { EditableField, StepPanel } from "@design-system";
 import type { JobQuery } from "../../lib/job-search/query-builder.ts";
 import {
   canonicalSkillLabels,
   parseSeniorityLabel,
 } from "../../lib/job-search/query-builder.ts";
-import { searchPhrase } from "../../lib/job-search/providers/keywords.ts";
+import { promoteSkill, promoteTitle } from "../../lib/job-search/search-plan.ts";
 import type { RoleFamily } from "../../lib/job-search/role-keywords.ts";
 import { assessQueryTerms, type MissingTerm } from "../../lib/job-search/term-quality.ts";
+import type { JobBoardLink } from "../../lib/job-search/deep-links.ts";
+import type { CompanyTargets as CompanyTargetsState } from "../../hooks/useCompanyTargets.ts";
 import { ChipListEditor } from "./ChipListEditor.tsx";
+import { CompanyTargets } from "./CompanyTargets.tsx";
 import { CompFloorInput } from "./CompFloorInput.tsx";
+import { ExternalBoardLinks } from "./ExternalBoardLinks.tsx";
 import { RoleFamilyChips } from "./RoleFamilyChips.tsx";
 import { LevelSelect } from "./LevelSelect.tsx";
 import { AddPill } from "./ReconstructedAdd.tsx";
+import { QueryStepSection } from "./QueryStepSection.tsx";
+import { SearchPlanCard } from "./SearchPlanCard.tsx";
+import { TermGlyphLegend } from "./TermGlyphLegend.tsx";
 import { missingTermLabel, TermQualityAdvisory } from "./TermQualityAdvisory.tsx";
 
 /**
@@ -66,17 +83,23 @@ export function JobQueryEditor({
   query,
   onChange,
   isDegenerate,
+  links,
+  companyTargets,
 }: {
   query: JobQuery;
   onChange: (next: (q: JobQuery) => JobQuery) => void;
   /** True when the parse yielded neither a title nor a skill — the search
    *  cannot run, and the hint below tells the user what to type. */
   isDegenerate: boolean;
+  /** Deep links for the Review step, built by the parent from the same query. */
+  links: readonly JobBoardLink[];
+  /** The company-board picker's state, rendered in the Narrow step (#602). */
+  companyTargets: CompanyTargetsState;
 }) {
   // Progressive disclosure for Seniority (#540): a résumé whose titles carry
   // no recognized seniority keyword renders no inert placeholder field — the
   // row appears only once a seniority was derived, or the user opts in via
-  // the "+ Seniority" pill. Purely presentational, so it stays local here.
+  // the "+ Target level" pill. Purely presentational, so it stays local here.
   const [seniorityExpanded, setSeniorityExpanded] = useState(false);
 
   // ChipListEditor already trims + case-insensitively dedups before calling
@@ -85,20 +108,6 @@ export function JobQueryEditor({
     onChange((q) => ({ ...q, titles: [...q.titles, title] }));
   const removeTitle = (title: string) =>
     onChange((q) => ({ ...q, titles: q.titles.filter((t) => t !== title) }));
-  // Promote (#581): move-to-front of `titles`, a whole-query replacement that
-  // touches nothing else on `q` — `titleNoise` (#579) is a derived,
-  // non-user-facing field on the same object and must survive untouched, so
-  // this spreads `q` rather than rebuilding it. Rides the existing `onChange`
-  // → live re-rank path, so promoting never refetches.
-  const promoteTitle = (title: string) =>
-    onChange((q) => {
-      const index = q.titles.indexOf(title);
-      if (index <= 0) return q; // already primary, or not found
-      return {
-        ...q,
-        titles: [title, ...q.titles.slice(0, index), ...q.titles.slice(index + 1)],
-      };
-    });
 
   // Skills carry a second, derived field: `canonicalSkills`, the subset the
   // shared dictionary recognizes, which is what gives `assessQueryTerms` standing
@@ -161,126 +170,196 @@ export function JobQueryEditor({
     );
   };
 
-  /** The literal string that egresses to the keyless feeds — empty when the
-   *  query carries neither a title nor a skill. */
-  const egressPhrase = searchPhrase(query);
+  const hasChips = query.titles.length > 0 || query.skills.length > 0;
 
   return (
-    <div className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
-      <div className="flex flex-col gap-3">
-        <ChipListEditor
-          label="Titles"
-          items={query.titles}
-          onAdd={addTitle}
-          onRemove={removeTitle}
-          placeholder="Add a title…"
-          addAriaLabel="Add title"
-          primaryIndex={query.titles.length > 0 ? 0 : undefined}
-          onPromote={promoteTitle}
-          qualityFor={(item) => titleVerdicts.get(item)}
-        />
-        {/* #581: this reads the SAME `searchPhrase` the keyless feeds are
-         *  called with, rather than a copy, so it can never drift from what
-         *  actually egresses. Gated on the phrase itself being non-empty, NOT
-         *  on `titles.length` — with no title `searchPhrase` falls back to
-         *  `skills.slice(0, 3)`, so gating on titles hid this line in the one
-         *  case where skills are what egress. */}
-        {egressPhrase.length > 0 && (
-          <p className="text-xs text-content-tertiary">
-            Searching feeds for &quot;{egressPhrase}&quot;
-          </p>
-        )}
+    <>
+      <StepPanel id="role">
+        <QueryStepSection
+          title="Titles"
+          hint="The starred title is the one sent to the job feeds. Everything else narrows and ranks on your device."
+        >
+          <ChipListEditor
+            label="Your titles"
+            labelHidden
+            items={query.titles}
+            onAdd={addTitle}
+            onRemove={removeTitle}
+            placeholder="Add a title…"
+            addAriaLabel="Add title"
+            primaryIndex={query.titles.length > 0 ? 0 : undefined}
+            onPromote={(title) => onChange((q) => promoteTitle(q, title))}
+            qualityFor={(item) => titleVerdicts.get(item)}
+          />
+          {query.titles.length > 0 && <TermGlyphLegend />}
+          {/* #597: the suggestions sit under the list they write into, not in a
+           *  trailing section the user has to connect back up. */}
+          <TermQualityAdvisory
+            kind="title"
+            missing={assessment.missing}
+            onAdd={addMissingTerm}
+          />
+        </QueryStepSection>
+
+        {/* Target level (#562/#568): progressive disclosure, same pattern as
+         *  pre-#568 free-text Seniority — a résumé whose titles carry no
+         *  recognized level renders no inert control until the user opts in.
+         *  Changing the level re-runs the #562 rung-distance penalty (live, via
+         *  the workbench's refinement effect). It sits with Role rather than in
+         *  Narrow because it is derived FROM a title and its provenance line
+         *  names that title — the two are unreadable apart. */}
+        <QueryStepSection title="Target level">
+          {query.seniority || seniorityExpanded ? (
+            <LevelSelect value={query.seniority} onChange={setLevel} />
+          ) : (
+            <AddPill label="Target level" onClick={() => setSeniorityExpanded(true)} />
+          )}
+          {/* #581: names the title `deriveSeniorityAcrossTitles` matched, so an
+           *  overridable derived value is explicable rather than a new lever.
+           *  Absent once the user overrides to a level no title produces. */}
+          {seniorityProvenance(query) && (
+            <p className="text-sm text-content-secondary">
+              {query.seniority} — from &quot;{seniorityProvenance(query)}&quot;
+            </p>
+          )}
+        </QueryStepSection>
+
         {/* Role families (#568): seeded from the same classification the
          *  company-board pipeline uses, removable so a fullstack résumé that
          *  also matched `data` can drop it. */}
-        <RoleFamilyChips
-          families={(query.families ?? []) as RoleFamily[]}
-          onRemove={removeRoleFamily}
-        />
-      </div>
+        <QueryStepSection title="Role family">
+          <RoleFamilyChips
+            families={(query.families ?? []) as RoleFamily[]}
+            onRemove={removeRoleFamily}
+          />
+        </QueryStepSection>
+      </StepPanel>
 
-      <ChipListEditor
-        label="Skills"
-        items={query.skills}
-        onAdd={addSkill}
-        onRemove={removeSkill}
-        placeholder="Add a skill…"
-        addAriaLabel="Add skill"
-        qualityFor={(item) => skillVerdicts.get(item)}
-      />
+      <StepPanel id="skills">
+        <QueryStepSection
+          title="Skills"
+          hint="The starred skill is sent as the topic tag. The rest rank how well each posting fits you, on your device."
+        >
+          {/* Skills carry a primary too (#597): `primaryKeyword` sends
+           *  `skills[0]` as the topic tag, so the `★` control means the same
+           *  thing here as on Titles — hence the same opt-in pair, with the noun
+           *  the label needs. */}
+          <ChipListEditor
+            label="Your skills"
+            labelHidden
+            items={query.skills}
+            onAdd={addSkill}
+            onRemove={removeSkill}
+            placeholder="Add a skill…"
+            addAriaLabel="Add skill"
+            primaryIndex={query.skills.length > 0 ? 0 : undefined}
+            onPromote={(skill) => onChange((q) => promoteSkill(q, skill))}
+            primaryNoun="skill"
+            qualityFor={(item) => skillVerdicts.get(item)}
+          />
+          {query.skills.length > 0 && <TermGlyphLegend />}
+          <TermQualityAdvisory
+            kind="skill"
+            missing={assessment.missing}
+            onAdd={addMissingTerm}
+          />
+        </QueryStepSection>
+      </StepPanel>
 
-      <div className="flex flex-col gap-3">
+      <StepPanel id="filters">
         {/* Location (#545): always shown, unlike the target level's
          *  AddPill-gated disclosure — location is a primary axis of every
          *  job-board search form (not an auxiliary facet the way level is),
          *  and a résumé with no parsed location still needs a visible place
          *  to type one to get any location-aware ranking or deep-link
          *  behavior at all. */}
-        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-          <span className="text-xs text-content-tertiary">Location</span>
-          <EditableField
-            value={query.location}
-            placeholder="location"
-            label="Location"
-            onCommit={(v) => onChange((q) => ({ ...q, location: v || undefined }))}
-          />
-        </div>
+        <QueryStepSection title="Location">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm">
+            <EditableField
+              value={query.location}
+              placeholder="location"
+              label="Location"
+              onCommit={(v) => onChange((q) => ({ ...q, location: v || undefined }))}
+            />
+          </div>
+        </QueryStepSection>
+
         {/* Exclude (#563): title-only — a posting is dropped when its TITLE
          *  contains one of these, never when only its description does.
          *  Removable chips may already be seeded from the role-family
          *  classification (e.g. GTM/field roles for an engineering search). */}
-        <ChipListEditor
-          label="Exclude (title only)"
-          items={query.excludeTerms ?? []}
-          onAdd={addExcludeTerm}
-          onRemove={removeExcludeTerm}
-          placeholder="Add a title to exclude…"
-          addAriaLabel="Add exclude term"
-        />
-        <CompFloorInput
-          value={query.compFloor}
-          onCommit={(v) => onChange((q) => ({ ...q, compFloor: v }))}
-        />
-      </div>
+        <QueryStepSection
+          title="Exclude"
+          hint="A posting is dropped when its title contains one of these — its description is not checked."
+        >
+          <ChipListEditor
+            label="Excluded titles"
+            labelHidden
+            items={query.excludeTerms ?? []}
+            onAdd={addExcludeTerm}
+            onRemove={removeExcludeTerm}
+            placeholder="Add a title to exclude…"
+            addAriaLabel="Add exclude term"
+          />
+        </QueryStepSection>
 
-      {/* Target level (#562/#568): progressive disclosure, same pattern as
-       *  pre-#568 free-text Seniority — a résumé whose titles carry no
-       *  recognized level renders no inert control until the user opts in
-       *  via "+ Seniority". Changing the level re-runs the #562 rung-
-       *  distance penalty (live, via the workbench's refinement effect).
-       *  Full-width row: 12 rungs wrap badly inside a third of the page. */}
-      <div className="sm:col-span-2 lg:col-span-3 flex flex-col gap-1">
-        {query.seniority || seniorityExpanded ? (
-          <LevelSelect value={query.seniority} onChange={setLevel} />
-        ) : (
-          <AddPill label="Target level" onClick={() => setSeniorityExpanded(true)} />
-        )}
-        {/* #581: names the title `deriveSeniorityAcrossTitles` matched, so an
-         *  overridable derived value is explicable rather than a new lever.
-         *  Absent once the user overrides to a level no title produces. */}
-        {seniorityProvenance(query) && (
-          <p className="text-xs text-content-tertiary">
-            {query.seniority} — from &quot;{seniorityProvenance(query)}&quot;
+        <QueryStepSection title="Minimum pay">
+          <CompFloorInput
+            value={query.compFloor}
+            onCommit={(v) => onChange((q) => ({ ...q, compFloor: v }))}
+          />
+        </QueryStepSection>
+
+        {/* #602: the company picker moved from a permanent band above the form
+         *  into the step it belongs to. It was pinned there (pre-#602) so it
+         *  would survive the post-search fold; `JobQuerySummary` already
+         *  carries the selected count through that fold, so the readout it was
+         *  protecting is not lost — and as a lone unheaded grey sentence at the
+         *  top of the page it was the least legible control on the form. */}
+        <QueryStepSection title="Company boards">
+          <CompanyTargets targets={companyTargets} />
+        </QueryStepSection>
+      </StepPanel>
+
+      <StepPanel id="review">
+        {/* Contract first: this is the block the whole form leads up to, and
+         *  before #602 it rendered below every field instead of above the
+         *  button it describes. The pickers call the SAME promote reducers the
+         *  chip rows' `★` control calls — one mutation path, and every reorder
+         *  is a click the user made. */}
+        <SearchPlanCard
+          query={query}
+          companyCount={companyTargets.selected.length}
+          onPromoteTitle={(title) => onChange((q) => promoteTitle(q, title))}
+          onPromoteSkill={(skill) => onChange((q) => promoteSkill(q, skill))}
+        />
+
+        {/* Whole-query findings: the #587 coherence note and the #597 dropped
+         *  terms. The per-kind suggestions render in their own steps instead,
+         *  so `missing` is deliberately not passed here. Renders nothing when
+         *  it has nothing to say, including the unresolved-role case — no
+         *  "we couldn't identify your role" nag, no all-clear. */}
+        <TermQualityAdvisory
+          coherence={assessment.coherence}
+          dropped={assessment.verdicts}
+          onAdd={addMissingTerm}
+        />
+
+        {/* Legend repeated here only when the findings above can render a mark
+         *  the user has not seen in context. */}
+        {hasChips && <TermGlyphLegend />}
+
+        <QueryStepSection title="Search somewhere else">
+          <ExternalBoardLinks links={links} />
+        </QueryStepSection>
+
+        {isDegenerate && (
+          <p className="max-w-prose text-sm text-content-secondary">
+            We couldn&apos;t derive a search from this resume — add a title or
+            skills to search.
           </p>
         )}
-      </div>
-
-      {/* Term-quality advisory (#585 missing terms + #587 title/skill
-       *  coherence): renders nothing when it has nothing to say, including the
-       *  unresolved-role case — no fourth panel, no "we couldn't identify your
-       *  role" nag, no all-clear. */}
-      <TermQualityAdvisory
-        missing={assessment.missing}
-        coherence={assessment.coherence}
-        onAdd={addMissingTerm}
-      />
-
-      {isDegenerate && (
-        <p className="text-xs text-content-tertiary sm:col-span-2 lg:col-span-3">
-          We couldn&apos;t derive a search from this resume — add a title or
-          skills to search.
-        </p>
-      )}
-    </div>
+      </StepPanel>
+    </>
   );
 }

--- a/src/components/features/JobQuerySummary.tsx
+++ b/src/components/features/JobQuerySummary.tsx
@@ -66,7 +66,7 @@ export function JobQuerySummary({
   companyCount?: number;
 }) {
   return (
-    <p className="min-w-0 text-xs text-content-tertiary">
+    <p className="min-w-0 text-sm text-content-secondary">
       {summarizeQuery(query, companyCount).join(" · ")}
     </p>
   );

--- a/src/components/features/LevelSelect.tsx
+++ b/src/components/features/LevelSelect.tsx
@@ -43,7 +43,9 @@ export function LevelSelect({ value, onChange }: LevelSelectProps) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-center gap-2">
-        <span id="level-select-label" className="text-xs text-content-tertiary">
+        {/* Named visibly by the caller's section heading (#602); kept here so
+            the radiogroup still has an accessible name. */}
+        <span id="level-select-label" className="sr-only">
           Target level
         </span>
         {value !== undefined && (

--- a/src/components/features/PendingCompaniesNotice.tsx
+++ b/src/components/features/PendingCompaniesNotice.tsx
@@ -38,7 +38,7 @@ export function PendingCompaniesNotice({
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-border-light bg-surface-subtle px-3 py-2">
       <StatusBadge tone="info">not searched yet</StatusBadge>
-      <p className="min-w-0 text-xs text-content-secondary">
+      <p className="min-w-0 text-sm text-content-secondary">
         These results don&apos;t include{" "}
         {companies.map((entry) => entry.name).join(", ")}.
       </p>

--- a/src/components/features/QueryStepSection.tsx
+++ b/src/components/features/QueryStepSection.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * QueryStepSection — a titled block inside one step of the `/jobs/` query form
+ * (#602).
+ *
+ * WHY IT EXISTS. Every label on the pre-#602 form — "Titles", "Skills",
+ * "Location", "Target level", the advisory headings — was rendered at the same
+ * `text-xs text-content-tertiary` as the body copy beneath it. With no weight,
+ * size or colour step anywhere, the page had ~40 chips and zero headings: no
+ * scanning order, and nothing for a screen reader's heading navigation to land
+ * on either. This is the one heading level the form uses, so the step of one
+ * block cannot drift from the next.
+ *
+ * Feature-local rather than a `@design-system` export: it is a heading + hint
+ * pair for one form's steps, and the shared layer already owns the generic
+ * surface chrome (`Card`). Promote it only when a second lane needs it.
+ *
+ * Renders a real `<h3>` (the page's `<h1>` is the site header and each step's
+ * rail entry is its `<h2>`-equivalent label), so the outline is ordered rather
+ * than styled text pretending to be one.
+ */
+
+import type { ReactNode } from "react";
+
+export function QueryStepSection({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  /** One line under the heading saying what this block changes. Omit when the
+   *  fields say it themselves — an obvious hint is noise at heading weight. */
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-0.5">
+        <h3 className="text-base font-semibold text-content-primary">{title}</h3>
+        {hint != null && (
+          <p className="max-w-prose text-sm text-content-secondary">{hint}</p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/features/RoleFamilyChips.tsx
+++ b/src/components/features/RoleFamilyChips.tsx
@@ -31,7 +31,8 @@ interface RoleFamilyChipsProps {
 export function RoleFamilyChips({ families, onRemove }: RoleFamilyChipsProps) {
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-xs text-content-tertiary">Role</span>
+      {/* Named visibly by the caller's section heading (#602). */}
+      <span className="sr-only">Role family</span>
       {families.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">
           {families.map((family) => (
@@ -45,7 +46,7 @@ export function RoleFamilyChips({ families, onRemove }: RoleFamilyChipsProps) {
           ))}
         </div>
       ) : (
-        <p className="text-xs text-content-tertiary">
+        <p className="text-sm text-content-secondary">
           No role narrowing — searching every role.
         </p>
       )}

--- a/src/components/features/SearchPlanCard.test.tsx
+++ b/src/components/features/SearchPlanCard.test.tsx
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The card's claim is that what it shows is what will be sent, and that the
+ * **change** control is a real correction path rather than decoration. These
+ * assert both from the outside: props in, callback out, no mocks — a click on a
+ * picked chip must reach the parent's promote handler with that chip's own text.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SearchPlanCard } from "./SearchPlanCard.tsx";
+import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(props: Parameters<typeof SearchPlanCard>[0]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(SearchPlanCard, props));
+  });
+  return container;
+}
+
+function buttonByLabel(el: HTMLElement, label: string): HTMLButtonElement {
+  const btn = [...el.querySelectorAll("button")].find(
+    (b) => b.getAttribute("aria-label") === label,
+  );
+  if (!btn) throw new Error(`no button labelled "${label}"`);
+  return btn as HTMLButtonElement;
+}
+
+const noop = () => {};
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("SearchPlanCard", () => {
+  const query: JobQuery = {
+    titles: ["Founder & CEO", "VP Engineering", "Engineering Manager"],
+    skills: ["cross-functional collaboration", "TypeScript"],
+  };
+
+  it("names the one title and the one skill that will be sent, and the company boards", () => {
+    const el = render({
+      query,
+      companyCount: 14,
+      onPromoteTitle: noop,
+      onPromoteSkill: noop,
+    });
+    expect(el.textContent).toContain('"Founder & CEO"');
+    expect(el.textContent).toContain('"cross-functional collaboration"');
+    expect(el.textContent).toContain("14 company boards");
+    expect(el.textContent).toContain("company name only");
+    // The other half of the model: everything else stays here.
+    expect(el.textContent).toMatch(/on your device/);
+  });
+
+  it("promotes the picked title through the parent handler", () => {
+    let promoted: string | undefined;
+    const el = render({
+      query,
+      companyCount: 0,
+      onPromoteTitle: (t) => {
+        promoted = t;
+      },
+      onPromoteSkill: noop,
+    });
+
+    act(() => buttonByLabel(el, "Change what Job feeds is searched for").click());
+    const pick = [...el.querySelectorAll("button")].find(
+      (b) => b.textContent === "VP Engineering",
+    );
+    if (!pick) throw new Error("no picker option for VP Engineering");
+    act(() => pick.click());
+
+    expect(promoted).toBe("VP Engineering");
+  });
+
+  it("promotes the picked skill through the parent handler", () => {
+    let promoted: string | undefined;
+    const el = render({
+      query,
+      companyCount: 0,
+      onPromoteTitle: noop,
+      onPromoteSkill: (s) => {
+        promoted = s;
+      },
+    });
+
+    act(() => buttonByLabel(el, "Change what Topic tag is searched for").click());
+    const pick = [...el.querySelectorAll("button")].find((b) => b.textContent === "TypeScript");
+    if (!pick) throw new Error("no picker option for TypeScript");
+    act(() => pick.click());
+
+    expect(promoted).toBe("TypeScript");
+  });
+
+  it("renders no change control when there is nothing else to pick", () => {
+    const el = render({
+      query: { titles: ["Staff Engineer"], skills: ["Kubernetes"] },
+      companyCount: 1,
+      onPromoteTitle: noop,
+      onPromoteSkill: noop,
+    });
+    const labels = [...el.querySelectorAll("button")].map((b) =>
+      b.getAttribute("aria-label"),
+    );
+    expect(labels.some((l) => l?.startsWith("Change what"))).toBe(false);
+  });
+
+  // With no title, `searchPhrase` falls back to the first three skills joined,
+  // so the feeds row's displayed term matches no single chip. Filtering the
+  // picker by that string would leave the already-primary skill on offer, and
+  // promoting index 0 is a no-op — a control that does nothing when clicked.
+  it("offers no no-op option on the title-less fallback", () => {
+    const el = render({
+      query: { titles: [], skills: ["Go", "Kubernetes", "Terraform"] },
+      companyCount: 0,
+      onPromoteTitle: noop,
+      onPromoteSkill: noop,
+    });
+    const change = buttonByLabel(el, "Change what Job feeds is searched for");
+    act(() => change.click());
+
+    const options = [...el.querySelectorAll("button")]
+      .map((b) => b.textContent)
+      .filter((text) => text === "Go" || text === "Kubernetes");
+    // "Go" is already `skills[0]`; picking it would change nothing.
+    expect(options).not.toContain("Go");
+    expect(options).toContain("Kubernetes");
+  });
+
+  it("renders a reason instead of empty quotes for a degenerate query", () => {
+    const el = render({
+      query: { titles: [], skills: [] },
+      companyCount: 0,
+      onPromoteTitle: noop,
+      onPromoteSkill: noop,
+    });
+    expect(el.textContent).not.toContain('""');
+    expect(el.textContent).toContain("add a title or a skill");
+  });
+});

--- a/src/components/features/SearchPlanCard.tsx
+++ b/src/components/features/SearchPlanCard.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * SearchPlanCard — the pre-flight contract of `/jobs/` (#597): the one block
+ * that says, before Search is clicked, which single title and which single
+ * skill leave the browser, that a company board gets only a public name, and
+ * that every other chip works on the user's own device.
+ *
+ * Reuse analysis (CLAUDE.md's Reuse Gate). This is a new CAPABILITY, not a
+ * second copy of an existing surface: no surface in the tree states the
+ * outbound contract BEFORE a search. `JobQuerySummary` was the closest
+ * candidate and is post-search by construction — it exists to make the FOLDED
+ * state legible and renders only after the fold. `JobQueryEditor` owns the
+ * fields and is already at ~286 LOC, over the ~200 guide, so the block that
+ * supersedes its grey "Searching feeds for …" line is extracted here rather
+ * than grown into it. The **change** picker is NOT a new mutation path — it
+ * calls the same `promoteTitle` / `promoteSkill` reducers the chip rows' `★`
+ * control calls (`lib/job-search/search-plan.ts`).
+ *
+ * Display-only. Every string comes from `buildSearchPlan`, which reads through
+ * `searchPhrase` / `primaryKeyword` — this component composes no copy of its
+ * own and re-derives nothing, so it cannot drift from what egresses.
+ *
+ * THE PICKER IS AN INLINE DISCLOSURE, not the `Dialog` primitive: a modal to
+ * choose one of ~5 chips already on screen is disproportionate, and a second
+ * modal picker beside the chip rows' promote control is exactly the parallel
+ * surface the golden rule forbids. It is ABSENT — not disabled — when the
+ * source list holds one item, because there is nothing to change to.
+ */
+
+import { useState } from "react";
+import { Button } from "@design-system";
+import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+import {
+  buildSearchPlan,
+  type SearchPlanRow,
+  type SearchPlanSource,
+} from "../../lib/job-search/search-plan.ts";
+
+export function SearchPlanCard({
+  query,
+  companyCount,
+  onPromoteTitle,
+  onPromoteSkill,
+}: {
+  query: JobQuery;
+  /** Selected company boards — outside `JobQuery`, same as `JobQuerySummary`. */
+  companyCount: number;
+  /** Make this title the one the feeds are searched for. */
+  onPromoteTitle: (title: string) => void;
+  /** Make this skill the one the topic tag is set to. */
+  onPromoteSkill: (skill: string) => void;
+}) {
+  // Which row's picker is open, or null. One at a time, and purely
+  // presentational, so it stays local rather than moving to a hook.
+  const [openRow, setOpenRow] = useState<string | null>(null);
+
+  const plan = buildSearchPlan(query, companyCount);
+  const optionsFor = (source: SearchPlanSource): string[] =>
+    source === "title" ? query.titles : query.skills;
+  const promote = (source: SearchPlanSource, value: string) => {
+    if (source === "title") onPromoteTitle(value);
+    else onPromoteSkill(value);
+    setOpenRow(null);
+  };
+
+  return (
+    <div
+      aria-label={plan.heading}
+      // CONTRAST (#602). `bg-surface-subtle` is the wrong surface for a block
+      // of explanatory prose: against it, `content-tertiary` measures 4.04:1 and
+      // `accent-primary` 4.07:1 in dark mode, both under WCAG 1.4.3's 4.5:1 for
+      // body text. On `bg-surface-card` the same tokens are 5.71:1 and 5.75:1
+      // (13.35:1 for the heading). The card still reads as its own block via
+      // the border + the accent left rule, which cost nothing in contrast.
+      className="flex flex-col gap-2 rounded border border-l-4 border-border-light border-l-accent-primary bg-surface-card p-4"
+    >
+      <h3 className="text-base font-semibold text-content-primary">{plan.heading}</h3>
+
+      <dl className="flex flex-col gap-2">
+        {plan.rows.map((row) => (
+          <PlanRow
+            key={row.id}
+            row={row}
+            options={row.source ? optionsFor(row.source) : []}
+            isOpen={openRow === row.id}
+            onToggle={() => setOpenRow((v) => (v === row.id ? null : row.id))}
+            onPick={(value) => row.source && promote(row.source, value)}
+          />
+        ))}
+      </dl>
+
+      <p className="max-w-prose text-sm text-content-secondary">{plan.localNote}</p>
+      <p className="max-w-prose text-sm text-content-secondary">{plan.privacyNote}</p>
+    </div>
+  );
+}
+
+function PlanRow({
+  row,
+  options,
+  isOpen,
+  onToggle,
+  onPick,
+}: {
+  row: SearchPlanRow;
+  options: readonly string[];
+  isOpen: boolean;
+  onToggle: () => void;
+  onPick: (value: string) => void;
+}) {
+  // A dead "change" control is worse than none: with one item there is nothing
+  // to change to, and with no term there is nothing being sent to change.
+  const canChange = row.term !== undefined && options.length > 1;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <dt className="text-sm text-content-secondary">{row.label}</dt>
+        <dd className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm font-medium text-content-primary">
+          {/* A row either sends a term or explains why it doesn't — never a
+           *  bare pair of empty quotes (`search-plan.ts`). */}
+          {row.term !== undefined ? (
+            <span>&quot;{row.term}&quot;</span>
+          ) : (
+            <span className="font-normal text-content-secondary">{row.detail}</span>
+          )}
+          {canChange && (
+            <Button
+              variant="link"
+              size="md"
+              aria-expanded={isOpen}
+              aria-label={`Change what ${row.label} is searched for`}
+              onClick={onToggle}
+            >
+              {isOpen ? "close" : "change"}
+            </Button>
+          )}
+        </dd>
+      </div>
+      {canChange && isOpen && (
+        <div className="flex flex-wrap gap-1.5">
+          {/* Drop index 0, not the displayed term. They are the same chip on
+           *  the common path, but not on `searchPhrase`'s title-less fallback,
+           *  where the row shows several skills joined — there, filtering by
+           *  the displayed string matches nothing and the picker would offer
+           *  the already-primary skill, whose promote reducer is a no-op. A
+           *  control that does nothing when clicked is worse than an absent
+           *  one. */}
+          {options
+            .filter((option) => option !== options[0])
+            .map((option) => (
+              <Button
+                key={option}
+                variant="ghost"
+                size="md"
+                className="rounded-full border border-border-light px-2.5 py-1"
+                onClick={() => onPick(option)}
+              >
+                {option}
+              </Button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/TermGlyphLegend.test.tsx
+++ b/src/components/features/TermGlyphLegend.test.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The legend's job is to make four marks readable (#597), so what is worth
+ * asserting is the PAIRING — every glyph the chips can render appears here next
+ * to words, and the words are what a screen reader gets. A test that only
+ * counted spans would pass on a legend that showed the glyphs alone, which is
+ * the exact failure the component exists to prevent.
+ *
+ * The copy denylist lives in `job-search-copy.test.ts` with the other surfaces'.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QUALITY_MARK } from "./ChipListEditor.tsx";
+import { TermGlyphLegend } from "./TermGlyphLegend.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root | undefined;
+
+function render(): HTMLElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(createElement(TermGlyphLegend));
+  });
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("TermGlyphLegend", () => {
+  it("shows every quality mark the chips can render", () => {
+    const el = render();
+    for (const { glyph } of Object.values(QUALITY_MARK)) {
+      expect(el.textContent).toContain(glyph);
+    }
+    expect(el.textContent).toContain("★");
+  });
+
+  it("pairs each glyph with words, so meaning is never the mark alone", () => {
+    const el = render();
+    // Every glyph is aria-hidden — the accessible text is the sentence beside
+    // it. Strip the hidden nodes and the legend must still say everything.
+    for (const hidden of el.querySelectorAll("[aria-hidden='true']")) {
+      hidden.remove();
+    }
+    const readable = el.textContent ?? "";
+    expect(readable).toContain("the one that is searched");
+    expect(readable).toContain("sharpens your matches");
+    expect(readable).toContain("adds little");
+    expect(readable).toContain("narrows nothing");
+    for (const { glyph } of Object.values(QUALITY_MARK)) {
+      expect(readable).not.toContain(glyph);
+    }
+  });
+});

--- a/src/components/features/TermGlyphLegend.tsx
+++ b/src/components/features/TermGlyphLegend.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * TermGlyphLegend — one line naming what the chip marks mean (#597).
+ *
+ * `/jobs/` grew four marks on its chips over three issues — `★` for the term
+ * that is actually searched (#581) and `✓ / ○ / ⚠︎` for term quality (#585) —
+ * each self-evident to whoever added it and none of them explained on screen.
+ * A mark nobody can read is decoration, so this states the mapping once,
+ * adjacent to the chip rows.
+ *
+ * Its own file rather than inline in `JobQueryEditor`, which is already ~286
+ * LOC against the ~200 guide: per CLAUDE.md, extend a sibling instead of
+ * growing that file.
+ *
+ * The glyphs come from `ChipListEditor`'s own {@link QUALITY_MARK} table, not a
+ * second copy — change a mark there and this legend follows. Each entry pairs
+ * the glyph with words, so meaning is never carried by colour alone, and the
+ * glyphs themselves are `aria-hidden`: a screen reader gets the sentence, which
+ * is the part that means something.
+ */
+
+import { QUALITY_MARK } from "./ChipListEditor.tsx";
+import type { TermQuality } from "../../lib/job-search/term-quality.ts";
+
+/** Consequence only, matching `term-quality.ts`'s `REASONS` register: what the
+ *  mark tells you about your results, never how the mark was decided. */
+const QUALITY_MEANING: Record<TermQuality, string> = {
+  strong: "sharpens your matches",
+  weak: "adds little",
+  noise: "narrows nothing",
+};
+
+const PRIMARY_GLYPH = "★";
+const PRIMARY_MEANING = "the one that is searched";
+
+/** Every string this component can put on screen, so the copy rule above is
+ *  assertable — see `job-search-copy.test.ts`. Same purpose as
+ *  `search-plan.ts`'s `SEARCH_PLAN_COPY`: a new phrase cannot quietly escape
+ *  the denylist by living in a component instead of a lib module. */
+export const TERM_GLYPH_LEGEND_COPY: readonly string[] = [
+  PRIMARY_MEANING,
+  ...Object.values(QUALITY_MEANING),
+];
+
+export function TermGlyphLegend() {
+  return (
+    <p className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm text-content-secondary">
+      <span>
+        <span aria-hidden="true">{PRIMARY_GLYPH} </span>
+        {PRIMARY_MEANING}
+      </span>
+      {(Object.keys(QUALITY_MEANING) as TermQuality[]).map((quality) => (
+        <span key={quality}>
+          <span aria-hidden="true" className={QUALITY_MARK[quality].className}>
+            {QUALITY_MARK[quality].glyph}{" "}
+          </span>
+          {QUALITY_MEANING[quality]}
+        </span>
+      ))}
+    </p>
+  );
+}

--- a/src/components/features/TermQualityAdvisory.tsx
+++ b/src/components/features/TermQualityAdvisory.tsx
@@ -15,8 +15,25 @@
  * GROUPED BY KIND (see {@link GROUPS}), because the two kinds write to two
  * different fields of the query and a flat row said nothing about which.
  *
+ * TWO PLACEMENTS, one component (#597). Passing `kind` puts ONE group inline
+ * under its own chip column — the suggestion pills belong beside the list they
+ * write into, not in a trailing section at the foot of the page the user has to
+ * connect back up. Omitting `kind` keeps the original full-width block, which is
+ * where the findings that are ABOUT the query as a whole live: the coherence
+ * note and the dropped terms. The full-width mode is the only one that spans the
+ * grid, so a column instance can never break its parent's layout.
+ *
+ * DROPPED TERMS (#597) are the chips that narrow nothing — the `noise` verdicts
+ * `term-quality.ts` already produces, rendered with their `reason` VERBATIM.
+ * There is no second scoring path and no new reason string: the glyph on the
+ * chip said this already, but only as a mark and a tooltip, which is not an
+ * answer to "why do my results look wrong". Only `noise` is listed, not `weak`:
+ * a weak term still participates in local matching, so calling it dropped would
+ * be false — and "weak" is the destructive verdict this lane is careful with
+ * (`term-quality.ts`, STRONG NEEDS EVIDENCE; WEAK NEEDS STANDING).
+ *
  * Renders nothing when it has nothing to say — `missing` empty AND no
- * coherence finding, which covers the unresolved-role case where
+ * coherence finding AND no dropped term, which covers the unresolved-role case where
  * `assessQueryTerms` returns `[]`/`undefined` by contract. No empty-state box,
  * no "we couldn't identify your role" nag, and no "your résumé looks
  * consistent" all-clear (term-quality docblock, rule 1). The two conditions
@@ -44,7 +61,11 @@
  */
 
 import { getSkillIndex } from "../../lib/jd-match/skills.ts";
-import type { CoherenceFinding, MissingTerm } from "../../lib/job-search/term-quality.ts";
+import type {
+  CoherenceFinding,
+  MissingTerm,
+  TermVerdict,
+} from "../../lib/job-search/term-quality.ts";
 import { AddPill } from "./ReconstructedAdd.tsx";
 
 /** The display text for a missing term — the term itself for a title, or the
@@ -72,21 +93,52 @@ const GROUPS: readonly { kind: MissingTerm["kind"]; heading: string }[] = [
   { kind: "skill", heading: "Add to your skills — this role is usually hired on these" },
 ];
 
+/** The one heading over the dropped-term list. Names the consequence the
+ *  verdicts' own `reason` strings then explain per term — the reasons stay
+ *  verbatim from the lib, so this component still composes no per-term copy. */
+const DROPPED_HEADING = "These terms aren't narrowing your search";
+
+/** The copy this component composes itself — the group headings and the
+ *  dropped-term heading. Per-term text is NOT here on purpose: `reason` and
+ *  `note` come verbatim from `term-quality.ts`, which asserts its own strings.
+ *  Exported so the denylist covers these too (`job-search-copy.test.ts`). */
+export const TERM_ADVISORY_COPY: readonly string[] = [
+  DROPPED_HEADING,
+  ...GROUPS.map((group) => group.heading),
+];
+
 export function TermQualityAdvisory({
-  missing,
+  missing = [],
   coherence,
+  dropped = [],
+  kind,
   onAdd,
 }: {
-  missing: readonly MissingTerm[];
+  missing?: readonly MissingTerm[];
   /** A confident title/skill mismatch (#587), or `undefined` — the normal
    *  state, which renders nothing rather than an all-clear. */
   coherence?: CoherenceFinding;
+  /** Verdicts to surface as dropped terms (#597). Only `noise` entries are
+   *  rendered — see the docblock; the caller may pass the whole verdict list. */
+  dropped?: readonly TermVerdict[];
+  /** Set to render ONLY that group, inline under its own chip column (#597).
+   *  Omit for the full-width block, the only mode that shows `coherence` and
+   *  `dropped`. */
+  kind?: MissingTerm["kind"];
   /** Called with the term the user clicked to add; `JobQueryEditor` maps it
    *  through {@link missingTermLabel} before writing it into the query, the
    *  same way this component renders it. */
   onAdd: (term: MissingTerm) => void;
 }) {
-  if (missing.length === 0 && !coherence) return null;
+  if (kind !== undefined) {
+    const group = GROUPS.find((g) => g.kind === kind);
+    const terms = missing.filter((term) => term.kind === kind);
+    if (!group || terms.length === 0) return null;
+    return <MissingGroup heading={group.heading} terms={terms} onAdd={onAdd} />;
+  }
+
+  const noise = dropped.filter((verdict) => verdict.quality === "noise");
+  if (missing.length === 0 && !coherence && noise.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-3 sm:col-span-2 lg:col-span-3">
@@ -94,7 +146,7 @@ export function TermQualityAdvisory({
        *  colour and glyph are never the only carriers); the sr-only prefix is
        *  what gives the block an accessible name in the reading order. */}
       {coherence && (
-        <p className="flex items-start gap-1.5 text-xs text-feedback-warning-text">
+        <p className="flex items-start gap-1.5 text-sm text-feedback-warning-text">
           <span aria-hidden="true">⚠︎</span>
           <span>
             <span className="sr-only">Check these terms: </span>
@@ -102,24 +154,59 @@ export function TermQualityAdvisory({
           </span>
         </p>
       )}
-      {GROUPS.map(({ kind, heading }) => {
-        const terms = missing.filter((term) => term.kind === kind);
+      {/* The terms that reach nothing, said in words rather than only as the
+       *  chip's `⚠︎` mark. `reason` is the lib's own string, verbatim. */}
+      {noise.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm font-medium text-content-secondary">{DROPPED_HEADING}</span>
+          <ul className="flex flex-col gap-0.5">
+            {noise.map((verdict) => (
+              <li
+                key={`${verdict.kind}:${verdict.term}`}
+                className="text-sm text-content-secondary"
+              >
+                <span className="text-content-secondary">{verdict.term}</span>
+                {" — "}
+                {verdict.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {GROUPS.map(({ kind: groupKind, heading }) => {
+        const terms = missing.filter((term) => term.kind === groupKind);
         if (terms.length === 0) return null;
         return (
-          <div key={kind} className="flex flex-col gap-1.5">
-            <span className="text-xs text-content-tertiary">{heading}</span>
-            <div className="flex flex-wrap gap-1.5">
-              {terms.map((term) => (
-                <AddPill
-                  key={term.term}
-                  label={missingTermLabel(term)}
-                  onClick={() => onAdd(term)}
-                />
-              ))}
-            </div>
-          </div>
+          <MissingGroup key={groupKind} heading={heading} terms={terms} onAdd={onAdd} />
         );
       })}
+    </div>
+  );
+}
+
+/** One heading + its add-pill row. Shared by both placements so the inline
+ *  column and the full-width block cannot render the suggestion differently. */
+function MissingGroup({
+  heading,
+  terms,
+  onAdd,
+}: {
+  heading: string;
+  terms: readonly MissingTerm[];
+  onAdd: (term: MissingTerm) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium text-content-secondary">{heading}</span>
+      <div className="flex flex-wrap gap-1.5">
+        {terms.map((term) => (
+          <AddPill
+            key={term.term}
+            label={missingTermLabel(term)}
+            onClick={() => onAdd(term)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/features/job-search-copy.test.ts
+++ b/src/components/features/job-search-copy.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The copy rule for `/jobs/`, in one place (#597).
+ *
+ * `term-quality.ts` established the rule and asserts its own `REASONS` /
+ * `COHERENCE_NOTES`: a string that ships to a user names a CONSEQUENCE and
+ * never the mechanism behind it — no "token", no "gate", no "profile", no
+ * issue numbers. #597 added user-facing copy on three more surfaces, and a rule
+ * enforced only where it was born is a rule that decays: the next phrase gets
+ * written in a component, where nothing checks it.
+ *
+ * So every module that composes its own copy for this lane exports the strings
+ * it can render, and this file is the single assertion over all of them. Adding
+ * a surface means adding its export here — which is the point. Copy that comes
+ * VERBATIM from `term-quality.ts` (`TermVerdict.reason`, `CoherenceFinding.note`)
+ * is deliberately absent: that module already asserts it, and re-asserting it
+ * here would imply these components may edit it, which they may not.
+ */
+
+import { describe, expect, it } from "vitest";
+import { QUERY_STEP_COPY } from "../../lib/job-search/query-steps.ts";
+import { SEARCH_PLAN_COPY } from "../../lib/job-search/search-plan.ts";
+import { TERM_GLYPH_LEGEND_COPY } from "./TermGlyphLegend.tsx";
+import { TERM_ADVISORY_COPY } from "./TermQualityAdvisory.tsx";
+
+/** The same denylist `term-quality.test.ts` applies, plus the internal nouns
+ *  #597 names explicitly (`token`, `provider`, `egress`). */
+const MECHANISM =
+  /tokenizer|token|filter|regex|gate|profile|resolver|admission|provider|egress|#/i;
+
+const SURFACES: readonly { name: string; copy: readonly string[] }[] = [
+  { name: "search plan card", copy: SEARCH_PLAN_COPY },
+  { name: "term glyph legend", copy: TERM_GLYPH_LEGEND_COPY },
+  { name: "term quality advisory", copy: TERM_ADVISORY_COPY },
+  { name: "query step rail", copy: QUERY_STEP_COPY },
+];
+
+describe("job-search copy", () => {
+  for (const { name, copy } of SURFACES) {
+    describe(name, () => {
+      it("names a consequence, never the mechanism", () => {
+        for (const line of copy) expect(line).not.toMatch(MECHANISM);
+      });
+
+      it("is never empty", () => {
+        expect(copy.length).toBeGreaterThan(0);
+        for (const line of copy) expect(line.trim().length).toBeGreaterThan(0);
+      });
+    });
+  }
+
+  it("would catch a mechanism word, so the assertion is load-bearing", () => {
+    expect("we ran your résumé through the role profile").toMatch(MECHANISM);
+    expect("only your search keywords are sent").not.toMatch(MECHANISM);
+  });
+});

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -27,6 +27,7 @@ export * from "./shared/InlineResult.tsx";
 export * from "./shared/ModelLoadProgress.tsx";
 export * from "./shared/Pagination.tsx";
 export * from "./shared/StatusBadge.tsx";
+export * from "./shared/Stepper.tsx";
 export * from "./shared/Tabs.tsx";
 export * from "./shared/CountBadge.tsx";
 export * from "./shared/ErrorState.tsx";

--- a/src/design-system/shared/Stepper.test.tsx
+++ b/src/design-system/shared/Stepper.test.tsx
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Coverage for `Stepper` (#602) — the four properties a consumer depends on and
+ * that a refactor could silently break:
+ *
+ *  1. Inactive panels stay MOUNTED, only `hidden`. This is what lets a
+ *     half-typed chip draft survive stepping away, so "renders nothing" would be
+ *     a regression that no visual check catches.
+ *  2. The current step carries `aria-current="step"` and exactly one does — the
+ *     established pattern for an ordered progress trail, and the only thing
+ *     telling a screen reader where the user is.
+ *  3. The position is stated in WORDS, not left to the visual numerals.
+ *  4. Back/Next move by one, and the terminal action is reachable from every
+ *     step (see the component's docblock — a seeded query must be runnable
+ *     without walking the whole flow).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Stepper, StepPanel, StepperNav, StepperRail } from "./Stepper.tsx";
+import { Button } from "../primitives/Button.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const STEPS = [
+  { id: "one", label: "One", summary: "1 thing" },
+  { id: "two", label: "Two", summary: "2 things" },
+  { id: "three", label: "Three" },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let value: string;
+
+function render(initial = "one", finalAction?: ReactNode) {
+  value = initial;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(tree(finalAction)));
+  return container;
+}
+
+function tree(finalAction?: ReactNode) {
+  return createElement(Stepper, {
+    id: "s",
+    value,
+    onValueChange: (next: string) => {
+      value = next;
+      act(() => root.render(tree(finalAction)));
+    },
+    steps: STEPS,
+    children: [
+      createElement(StepperRail, { key: "rail", "aria-label": "Steps" }),
+      ...STEPS.map((s) =>
+        createElement(StepPanel, { key: s.id, id: s.id, children: `body ${s.id}` }),
+      ),
+      createElement(StepperNav, { key: "nav", finalAction }),
+    ],
+  });
+}
+
+const panel = (el: HTMLElement, id: string) =>
+  el.querySelector<HTMLElement>(`#s-steppanel-${id}`)!;
+const buttonWithText = (el: HTMLElement, text: string) =>
+  [...el.querySelectorAll("button")].find((b) => b.textContent?.includes(text));
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+});
+
+describe("Stepper", () => {
+  it("keeps every panel mounted and hides all but the current one", () => {
+    const el = render("two");
+    for (const s of STEPS) {
+      // Mounted: the node and its children exist regardless of position.
+      expect(panel(el, s.id).textContent).toBe(`body ${s.id}`);
+    }
+    expect(panel(el, "two").hidden).toBe(false);
+    expect(panel(el, "one").hidden).toBe(true);
+    expect(panel(el, "three").hidden).toBe(true);
+  });
+
+  it("marks exactly one step aria-current='step'", () => {
+    const el = render("two");
+    const current = el.querySelectorAll('[aria-current="step"]');
+    expect(current).toHaveLength(1);
+    expect(current[0]?.textContent).toContain("Two");
+  });
+
+  it("states the position in words, not only as numerals", () => {
+    const el = render("two");
+    expect(el.textContent).toContain("Step 2 of 3");
+  });
+
+  it("renders each step's summary when it has one, and nothing extra when it doesn't", () => {
+    const el = render();
+    expect(el.textContent).toContain("1 thing");
+    expect(el.textContent).toContain("2 things");
+    // "Three" has no summary — its rail entry is the label alone.
+    const third = [...el.querySelectorAll('[role="listitem"], li')].find((n) =>
+      n.textContent?.includes("Three"),
+    );
+    expect(third?.textContent?.trim()).toBe("3. Three");
+  });
+
+  it("moves one step at a time with Back and Next", () => {
+    const el = render("one");
+    // First step has no Back.
+    expect(buttonWithText(el, "Back to")).toBeUndefined();
+
+    act(() => buttonWithText(el, "Next: Two")!.click());
+    expect(value).toBe("two");
+
+    act(() => buttonWithText(container, "Back to One")!.click());
+    expect(value).toBe("one");
+  });
+
+  it("drops Next on the last step but keeps the terminal action reachable from every step", () => {
+    const action = createElement(Button, { children: "Do it" });
+    const el = render("one", action);
+    expect(buttonWithText(el, "Do it")).toBeDefined();
+
+    act(() => buttonWithText(el, "Next: Two")!.click());
+    act(() => buttonWithText(container, "Next: Three")!.click());
+    expect(value).toBe("three");
+    expect(buttonWithText(container, "Next:")).toBeUndefined();
+    expect(buttonWithText(container, "Do it")).toBeDefined();
+  });
+
+  it("jumps to any step from the rail — the steps are all optional", () => {
+    const el = render("one");
+    const third = [...el.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("Three"),
+    )!;
+    act(() => third.click());
+    expect(value).toBe("three");
+  });
+
+  /** Arrow/Home/End on the rail. Keyboard is the only way some users move
+   *  between steps, and it is invisible to every visual check — so it gets its
+   *  own block rather than one representative key. */
+  describe("keyboard", () => {
+    function press(el: HTMLElement, key: string) {
+      const nav = el.querySelector("nav")!;
+      act(() => {
+        nav.dispatchEvent(
+          new window.KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+        );
+      });
+    }
+
+    it("walks right and left one step at a time", () => {
+      const el = render("one");
+      press(el, "ArrowRight");
+      expect(value).toBe("two");
+      press(container, "ArrowLeft");
+      expect(value).toBe("one");
+    });
+
+    it("wraps at both ends rather than dead-ending", () => {
+      const el = render("one");
+      press(el, "ArrowLeft");
+      expect(value).toBe("three");
+      press(container, "ArrowRight");
+      expect(value).toBe("one");
+    });
+
+    it("jumps to the first and last step with Home and End", () => {
+      const el = render("two");
+      press(el, "End");
+      expect(value).toBe("three");
+      press(container, "Home");
+      expect(value).toBe("one");
+    });
+
+    it("ignores a key it does not handle, leaving the step and the event alone", () => {
+      const el = render("two");
+      const nav = el.querySelector("nav")!;
+      const event = new window.KeyboardEvent("keydown", {
+        key: "a",
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => {
+        nav.dispatchEvent(event);
+      });
+      expect(value).toBe("two");
+      // Not swallowed — a typed character must still reach a field inside a panel.
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("moves focus with the selection, so the next arrow press continues from there", () => {
+      const el = render("one");
+      press(el, "ArrowRight");
+      expect(document.activeElement?.id).toBe("s-step-two");
+    });
+  });
+
+  it("throws when a part is used outside the provider, rather than rendering a broken shell", () => {
+    const orphan = document.createElement("div");
+    const orphanRoot = createRoot(orphan);
+    expect(() =>
+      act(() => orphanRoot.render(createElement(StepPanel, { id: "x", children: null }))),
+    ).toThrow(/must be used within <Stepper>/);
+  });
+});

--- a/src/design-system/shared/Stepper.tsx
+++ b/src/design-system/shared/Stepper.tsx
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Stepper — the ONE ordered, multi-step navigation composition.
+ *
+ * Reuse analysis (CLAUDE.md's Reuse Gate). `Tabs` was the only candidate and
+ * models a DIFFERENT concern: lateral browsing of peer views, where no order
+ * exists, nothing is "next", and arriving at the last tab means nothing. A
+ * stepper models a sequence that terminates in one commit action — the user
+ * needs to know how far through they are and what finishes the flow. Reusing
+ * `Tabs` for that leaves the terminal button ("Search jobs") with no visible
+ * relationship to the steps, which is exactly the ambiguity this exists to
+ * remove. So this is a missing concern, not a second copy of `Tabs`; the two
+ * stay separate and neither absorbs the other.
+ *
+ * Composition (mirrors `Tabs`' shape so the two read alike):
+ *   <Stepper value onValueChange id steps>   context provider
+ *     <StepperRail aria-label>               <nav><ol>, numbered, aria-current
+ *     <StepPanel id>…</StepPanel>            role="group", hidden when inactive
+ *     <StepperNav finalAction>               Back / Next, terminal action last
+ *
+ * Accessibility. There is no ARIA `stepper` role; the established pattern for
+ * an ordered progress trail is a `<nav>` + ordered list whose current item
+ * carries `aria-current="step"`, which is what `StepperRail` renders. The
+ * count is ALSO stated in words ("Step 2 of 4") rather than left to the visual
+ * numerals — a screen reader gets the position without having to count the
+ * list. Panels are `role="group"` labelled by their rail entry, not
+ * `role="tabpanel"`: they are not controlled by tabs, and mislabelling them
+ * would promise arrow-key tab semantics this does not implement.
+ *
+ * Inactive panels stay MOUNTED (`hidden`), same as `Tabs` — child UI state
+ * (a half-typed chip draft, an open disclosure) must survive stepping away and
+ * back, and the parent owns the real data anyway.
+ *
+ * Selection affordance follows `Tabs`' #516 decision: the rail is a recessed
+ * track (`bg-surface-subtle`) and the current step sits on `bg-surface-card`
+ * with a font-weight step — a real surface change, never colour alone, so the
+ * rail still resolves in a greyscale render. Text on the recessed track is
+ * `content-secondary`, not `content-tertiary`/`content-muted`: those two land
+ * at 4.04:1 against `--color-bg-subtle` in dark mode, under the 4.5:1 of
+ * WCAG 1.4.3.
+ *
+ * Design rules (CLAUDE.md): semantic tokens only, `Button` primitive for every
+ * control, no raw `<button>`.
+ */
+
+import {
+  createContext,
+  useContext,
+  type ReactNode,
+  type KeyboardEvent,
+} from "react";
+import { Button } from "../primitives/Button.tsx";
+
+export interface StepDefinition {
+  /** Stable id, used for `value` and to wire label ↔ panel. */
+  id: string;
+  /** Short step name shown in the rail. */
+  label: string;
+  /**
+   * Optional one-line state of that step ("4 titles", "Santa Clara, CA"), shown
+   * under the label. A rail that names only the steps tells you where you are
+   * but not what you already set — with the panels closed that is the only
+   * place the answer can live. Hidden below `sm`, like `Tab`'s `description`,
+   * so a 375px viewport degrades to a single-line rail.
+   */
+  summary?: string;
+}
+
+interface StepperContextValue {
+  value: string;
+  onValueChange: (value: string) => void;
+  baseId: string;
+  steps: readonly StepDefinition[];
+}
+
+const StepperContext = createContext<StepperContextValue | null>(null);
+
+function useStepperContext(component: string): StepperContextValue {
+  const ctx = useContext(StepperContext);
+  if (ctx == null) throw new Error(`${component} must be used within <Stepper>`);
+  return ctx;
+}
+
+const stepId = (baseId: string, id: string) => `${baseId}-step-${id}`;
+const stepPanelId = (baseId: string, id: string) => `${baseId}-steppanel-${id}`;
+
+export function Stepper({
+  value,
+  onValueChange,
+  id,
+  steps,
+  children,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  /** Stable prefix for step/panel id wiring. */
+  id: string;
+  steps: readonly StepDefinition[];
+  children: ReactNode;
+}) {
+  return (
+    <StepperContext.Provider value={{ value, onValueChange, baseId: id, steps }}>
+      <div className="flex flex-col gap-4">{children}</div>
+    </StepperContext.Provider>
+  );
+}
+
+export function StepperRail({
+  "aria-label": ariaLabel,
+}: {
+  "aria-label": string;
+}) {
+  const { value, onValueChange, baseId, steps } = useStepperContext("StepperRail");
+  const currentIndex = steps.findIndex((s) => s.id === value);
+
+  // Left/Right (+ Home/End) walk the rail, matching `TabList`. Unlike a
+  // tablist there is no roving tabindex to maintain: every step stays
+  // focusable, because jumping straight to step 4 is a legitimate move in a
+  // flow whose steps are all optional.
+  function onKeyDown(event: KeyboardEvent<HTMLElement>) {
+    const delta =
+      event.key === "ArrowLeft" ? -1 : event.key === "ArrowRight" ? 1 : 0;
+    let next = currentIndex;
+    if (delta !== 0) next = (currentIndex + delta + steps.length) % steps.length;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = steps.length - 1;
+    else return;
+    const target = steps[next];
+    if (target == null) return;
+    event.preventDefault();
+    onValueChange(target.id);
+    document.getElementById(stepId(baseId, target.id))?.focus();
+  }
+
+  return (
+    <nav aria-label={ariaLabel} onKeyDown={onKeyDown} className="flex flex-col gap-1.5">
+      <ol className="flex gap-1 overflow-x-auto overflow-y-hidden rounded-md border border-border-light bg-surface-subtle p-1">
+        {steps.map((step, index) => {
+          const isCurrent = step.id === value;
+          return (
+            <li key={step.id} className="min-w-0 flex-1">
+              <Button
+                variant="tab"
+                id={stepId(baseId, step.id)}
+                aria-current={isCurrent ? "step" : undefined}
+                aria-controls={stepPanelId(baseId, step.id)}
+                onClick={() => onValueChange(step.id)}
+                className={[
+                  "w-full flex-col items-start gap-0 text-left",
+                  isCurrent
+                    ? "bg-surface-card text-content-primary font-semibold shadow-xs"
+                    : "bg-transparent text-content-secondary font-medium hover:bg-surface-hover hover:text-content-primary hover:ring-1 hover:ring-inset hover:ring-border-strong",
+                ].join(" ")}
+              >
+                <span className="truncate">
+                  <span aria-hidden="true" className="tabular-nums">
+                    {index + 1}.{" "}
+                  </span>
+                  {step.label}
+                </span>
+                {step.summary != null && (
+                  <span className="hidden max-w-full truncate text-xs font-normal text-content-secondary sm:block">
+                    {step.summary}
+                  </span>
+                )}
+              </Button>
+            </li>
+          );
+        })}
+      </ol>
+      <p className="text-sm text-content-secondary">
+        Step {currentIndex + 1} of {steps.length}
+      </p>
+    </nav>
+  );
+}
+
+export function StepPanel({ id, children }: { id: string; children: ReactNode }) {
+  const { value, baseId } = useStepperContext("StepPanel");
+  return (
+    <section
+      role="group"
+      id={stepPanelId(baseId, id)}
+      aria-labelledby={stepId(baseId, id)}
+      hidden={value !== id}
+      className="flex flex-col gap-4"
+    >
+      {children}
+    </section>
+  );
+}
+
+export function StepperNav({ finalAction }: { finalAction?: ReactNode }) {
+  const { value, onValueChange, steps } = useStepperContext("StepperNav");
+  const index = steps.findIndex((s) => s.id === value);
+  const previous = index > 0 ? steps[index - 1] : undefined;
+  const next = index >= 0 && index < steps.length - 1 ? steps[index + 1] : undefined;
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-t border-border-light pt-3">
+      {previous && (
+        <Button size="md" onClick={() => onValueChange(previous.id)}>
+          ‹ Back to {previous.label}
+        </Button>
+      )}
+      <div className="ml-auto flex flex-wrap items-center gap-3">
+        {next && (
+          <Button size="md" onClick={() => onValueChange(next.id)}>
+            Next: {next.label} ›
+          </Button>
+        )}
+        {/* The terminal action stays mounted on every step — a user who is
+         *  happy with the seeded query must never have to walk to the last
+         *  step to run a search. Its position (always last in the row) is what
+         *  marks it as the end of the flow, not its presence. */}
+        {finalAction}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/job-search/query-steps.test.ts
+++ b/src/lib/job-search/query-steps.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Coverage for the step rail's summaries (#602). A summary is the ONLY readout
+ * of a step whose panel is closed, so the property under test is that it states
+ * what the user has already set and nothing else — every assertion here is
+ * about a claim a user could check by opening the step.
+ *
+ * The review summary is the sharp one: it must quote what actually egresses,
+ * which means it is asserted against `searchPhrase`'s own output rather than a
+ * hardcoded string. A test that hardcoded the phrase would keep passing if the
+ * summary drifted away from the egress helper, which is the exact failure the
+ * module exists to prevent.
+ */
+
+import { describe, expect, it } from "vitest";
+import { describeQuerySteps } from "./query-steps.ts";
+import { searchPhrase } from "./providers/keywords.ts";
+import type { JobQuery } from "./query-builder.ts";
+
+const summaryOf = (query: JobQuery, id: string, companyCount = 0) =>
+  describeQuerySteps(query, companyCount).find((s) => s.id === id)!.summary;
+
+describe("describeQuerySteps", () => {
+  it("returns the four steps in the order of the work", () => {
+    const steps = describeQuerySteps({ titles: [], skills: [] }, 0);
+    expect(steps.map((s) => s.id)).toEqual(["role", "skills", "filters", "review"]);
+  });
+
+  it("counts titles and skills, singular and plural", () => {
+    expect(summaryOf({ titles: ["Staff Engineer"], skills: [] }, "role")).toContain(
+      "1 title",
+    );
+    expect(
+      summaryOf({ titles: ["Staff Engineer", "Tech Lead"], skills: [] }, "role"),
+    ).toContain("2 titles");
+    expect(summaryOf({ titles: [], skills: ["Rust"] }, "skills")).toContain("1 skill");
+    expect(summaryOf({ titles: [], skills: ["Rust", "Go"] }, "skills")).toContain(
+      "2 skills",
+    );
+  });
+
+  it("says what is absent rather than showing a zero", () => {
+    const empty: JobQuery = { titles: [], skills: [] };
+    expect(summaryOf(empty, "role")).toBe("No title yet");
+    expect(summaryOf(empty, "skills")).toBe("No skills yet");
+    expect(summaryOf(empty, "filters")).toBe("Anywhere, nothing ruled out");
+    expect(summaryOf(empty, "review")).toBe("Nothing to search for yet");
+    for (const step of describeQuerySteps(empty, 0)) {
+      expect(step.summary).not.toMatch(/\b0\b/);
+    }
+  });
+
+  it("names the target level alongside the title count, only when one is set", () => {
+    const titles = ["Staff Engineer"];
+    expect(summaryOf({ titles, skills: [], seniority: "Staff" }, "role")).toContain(
+      "Staff",
+    );
+    expect(summaryOf({ titles, skills: [] }, "role")).not.toContain("Staff ·");
+  });
+
+  it("assembles the filters summary from only the axes that are set", () => {
+    const query: JobQuery = {
+      titles: [],
+      skills: [],
+      location: "Austin, TX",
+      excludeTerms: ["Recruiter", "Sales Engineer"],
+      compFloor: 180_000,
+    };
+    const summary = summaryOf(query, "filters", 3);
+    expect(summary).toContain("Austin, TX");
+    expect(summary).toContain("2 excluded");
+    expect(summary).toContain("$180,000");
+    expect(summary).toContain("3 company boards");
+
+    // A query with only a location says only the location — no empty segments,
+    // no "0 excluded".
+    expect(summaryOf({ titles: [], skills: [], location: "Remote" }, "filters")).toBe(
+      "Remote",
+    );
+  });
+
+  it("quotes the review step from the egress helper itself, not a copy", () => {
+    const query: JobQuery = {
+      titles: ["Founder & CEO", "Engineering Lead"],
+      skills: ["Kubernetes"],
+    };
+    const phrase = searchPhrase(query);
+    expect(phrase.length).toBeGreaterThan(0);
+    expect(summaryOf(query, "review")).toContain(phrase);
+  });
+
+  it("follows a promotion, because it reads the same list order the feeds do", () => {
+    const before: JobQuery = { titles: ["Founder & CEO", "Engineering Lead"], skills: [] };
+    const after: JobQuery = { titles: ["Engineering Lead", "Founder & CEO"], skills: [] };
+    expect(summaryOf(before, "review")).toContain(searchPhrase(before));
+    expect(summaryOf(after, "review")).toContain(searchPhrase(after));
+    expect(summaryOf(before, "review")).not.toBe(summaryOf(after, "review"));
+  });
+});

--- a/src/lib/job-search/query-steps.ts
+++ b/src/lib/job-search/query-steps.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * query-steps.ts — the ordered steps of the `/jobs/` query form, and the
+ * one-line state of each (#602).
+ *
+ * WHY THIS MODULE EXISTS. `/jobs/` used to present its whole query at once:
+ * ~40 chips over three columns, a 12-rung level rail, a mark legend, an
+ * advisory block, the external-board links and the outbound contract, all at
+ * one visual weight with no headings. Everything was reachable and nothing was
+ * findable. Splitting the form into steps needs two things kept out of the
+ * component: the step ORDER (which is the reading order of the work — who you
+ * are, what you're made of, how to narrow it, what gets sent) and each step's
+ * SUMMARY, which is what a collapsed step shows instead of its fields.
+ *
+ * THE CONSTRAINT THIS GUARDS: a summary states what the user has already set,
+ * never what we inferred or what we will do with it. It is the only readout of
+ * a step whose panel is closed, so an over-claiming summary is a lie the user
+ * cannot check without opening the step. Counts are counts; the review step
+ * quotes {@link searchPhrase}'s own output rather than re-deriving it, exactly
+ * as `search-plan.ts` does, so it cannot drift from what egresses.
+ *
+ * Pure and zero-I/O. The returned objects are structurally the design system's
+ * `StepDefinition` but this module does not import it — domain modules do not
+ * depend on the UI layer (CLAUDE.md), and structural typing makes the handoff
+ * free.
+ */
+
+import type { JobQuery } from "./query-builder.ts";
+import { searchPhrase } from "./providers/keywords.ts";
+
+export type QueryStepId = "role" | "skills" | "filters" | "review";
+
+/** One entry of the step rail. Structurally `StepDefinition` (`@design-system`). */
+export interface QueryStep {
+  readonly id: QueryStepId;
+  readonly label: string;
+  readonly summary: string;
+}
+
+// ── Copy ────────────────────────────────────────────────────────────────────
+// Same rule as `search-plan.ts` and `term-quality.ts`: these ship to a user
+// unchanged, so consequence only — no mechanism vocabulary, no internal noun.
+// `job-search-copy.test.ts` asserts the absence of that vocabulary over
+// QUERY_STEP_COPY below.
+
+const STEP_LABELS: Record<QueryStepId, string> = {
+  role: "Role",
+  skills: "Skills",
+  filters: "Narrow",
+  review: "Review",
+};
+
+const NO_TITLES = "No title yet";
+const NO_SKILLS = "No skills yet";
+const NO_FILTERS = "Anywhere, nothing ruled out";
+const NOTHING_TO_SEND = "Nothing to search for yet";
+
+/** `n` of a thing, pluralised — the whole of a count summary's grammar. */
+function count(n: number, singular: string): string {
+  return `${n} ${singular}${n === 1 ? "" : "s"}`;
+}
+
+function roleSummary(query: JobQuery): string {
+  if (query.titles.length === 0) return NO_TITLES;
+  const parts = [count(query.titles.length, "title")];
+  if (query.seniority) parts.push(query.seniority);
+  return parts.join(" · ");
+}
+
+function skillsSummary(query: JobQuery): string {
+  return query.skills.length === 0 ? NO_SKILLS : count(query.skills.length, "skill");
+}
+
+function filtersSummary(query: JobQuery, companyCount: number): string {
+  const parts: string[] = [];
+  if (query.location) parts.push(query.location);
+  const excluded = query.excludeTerms?.length ?? 0;
+  if (excluded > 0) parts.push(`${excluded} excluded`);
+  if (query.compFloor) parts.push(`from $${query.compFloor.toLocaleString("en-US")}`);
+  if (companyCount > 0) parts.push(count(companyCount, "company board"));
+  return parts.length === 0 ? NO_FILTERS : parts.join(" · ");
+}
+
+/** Quotes what actually egresses, by CALLING the sole egress helper — the same
+ *  no-drift discipline `search-plan.ts` documents at length. */
+function reviewSummary(query: JobQuery): string {
+  const phrase = searchPhrase(query);
+  return phrase.length > 0 ? `Sends “${phrase}”` : NOTHING_TO_SEND;
+}
+
+/** Every string this module can put on screen, for the copy test. Counts and
+ *  user-supplied values (a location, a promoted title) are excluded on
+ *  purpose — they are the user's own words, not ours to police. */
+export const QUERY_STEP_COPY: readonly string[] = [
+  ...Object.values(STEP_LABELS),
+  NO_TITLES,
+  NO_SKILLS,
+  NO_FILTERS,
+  NOTHING_TO_SEND,
+];
+
+/**
+ * The steps in reading order, each carrying the current state of its own
+ * fields. Recomputed on every query edit — all four summaries are string
+ * concatenation over already-derived values, so no memoization is warranted.
+ *
+ * `companyCount` is the selected-board count, which lives outside `JobQuery`
+ * (same reason `buildSearchPlan` takes it as a second argument).
+ */
+export function describeQuerySteps(
+  query: JobQuery,
+  companyCount: number,
+): readonly QueryStep[] {
+  return [
+    { id: "role", label: STEP_LABELS.role, summary: roleSummary(query) },
+    { id: "skills", label: STEP_LABELS.skills, summary: skillsSummary(query) },
+    {
+      id: "filters",
+      label: STEP_LABELS.filters,
+      summary: filtersSummary(query, companyCount),
+    },
+    { id: "review", label: STEP_LABELS.review, summary: reviewSummary(query) },
+  ];
+}

--- a/src/lib/job-search/search-plan.test.ts
+++ b/src/lib/job-search/search-plan.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The plan card's whole value is that it cannot lie about what leaves the
+ * browser, so these assert the two properties that would make it lie: the rows
+ * read through `searchPhrase` / `primaryKeyword` (including their FALLBACKS, the
+ * cases a hand-written "titles[0] / skills[0]" copy would get wrong), and a
+ * query with nothing to send renders a reason rather than an empty term.
+ */
+
+import { describe, it, expect } from "vitest";
+import { canonicalSkillLabels, type JobQuery } from "./query-builder.ts";
+import { primaryKeyword, searchPhrase } from "./providers/keywords.ts";
+import {
+  buildSearchPlan,
+  COMPANY_DETAIL,
+  COMPANY_DETAIL_NONE,
+  NO_TERM_DETAIL,
+  promoteSkill,
+  promoteTitle,
+  SEARCH_PLAN_COPY,
+  type SearchPlan,
+} from "./search-plan.ts";
+
+function row(plan: SearchPlan, id: "feeds" | "topic" | "companies") {
+  const found = plan.rows.find((r) => r.id === id);
+  if (!found) throw new Error(`no ${id} row`);
+  return found;
+}
+
+describe("buildSearchPlan — the outbound rows", () => {
+  it("shows the primary title on the feeds row and the primary skill on the topic row", () => {
+    const query: JobQuery = {
+      titles: ["Founder & CEO", "VP Engineering"],
+      skills: ["cross-functional collaboration", "TypeScript"],
+    };
+    const plan = buildSearchPlan(query, 14);
+
+    expect(row(plan, "feeds").term).toBe("Founder & CEO");
+    expect(row(plan, "feeds").source).toBe("title");
+    expect(row(plan, "topic").term).toBe("cross-functional collaboration");
+    expect(row(plan, "topic").source).toBe("skill");
+  });
+
+  it("reads index 0, not any other title — a reorder moves the feeds term", () => {
+    const query: JobQuery = {
+      titles: ["Founder & CEO", "VP Engineering"],
+      skills: [],
+    };
+    expect(row(buildSearchPlan(query, 0), "feeds").term).toBe("Founder & CEO");
+    const promoted = promoteTitle(query, "VP Engineering");
+    expect(row(buildSearchPlan(promoted, 0), "feeds").term).toBe("VP Engineering");
+  });
+
+  it("matches the egress helpers verbatim, fallbacks included", () => {
+    const cases: JobQuery[] = [
+      { titles: ["Staff Engineer"], skills: ["Kubernetes"] },
+      { titles: [], skills: ["React", "Node.js", "TypeScript", "GraphQL"] },
+      { titles: ["Staff Engineer"], skills: [] },
+    ];
+    for (const query of cases) {
+      const plan = buildSearchPlan(query, 3);
+      expect(row(plan, "feeds").term).toBe(searchPhrase(query));
+      expect(row(plan, "topic").term).toBe(primaryKeyword(query));
+    }
+  });
+
+  it("attributes a title-less query's feeds term to the skills it fell back to", () => {
+    const query: JobQuery = { titles: [], skills: ["React", "Node.js", "TypeScript", "Go"] };
+    const feeds = row(buildSearchPlan(query, 0), "feeds");
+    // `searchPhrase` joins the top three skills when there is no title.
+    expect(feeds.term).toBe("React Node.js TypeScript");
+    expect(feeds.source).toBe("skill");
+  });
+
+  it("attributes a skill-less query's topic term to the title it fell back to", () => {
+    const query: JobQuery = { titles: ["Staff Engineer"], skills: [] };
+    const topic = row(buildSearchPlan(query, 0), "topic");
+    expect(topic.term).toBe("Staff Engineer");
+    expect(topic.source).toBe("title");
+  });
+
+  it("renders a reason, never an empty term, for a degenerate query", () => {
+    const plan = buildSearchPlan({ titles: [], skills: [] }, 0);
+    for (const id of ["feeds", "topic"] as const) {
+      expect(row(plan, id).term).toBeUndefined();
+      expect(row(plan, id).source).toBeUndefined();
+      expect(row(plan, id).detail).toBe(NO_TERM_DETAIL);
+    }
+  });
+});
+
+describe("buildSearchPlan — the company row", () => {
+  it("says only the company name is sent, and counts the boards", () => {
+    expect(row(buildSearchPlan({ titles: ["X"], skills: [] }, 14), "companies")).toMatchObject({
+      label: "14 company boards",
+      detail: COMPANY_DETAIL,
+    });
+    expect(row(buildSearchPlan({ titles: ["X"], skills: [] }, 1), "companies").label).toBe(
+      "1 company board",
+    );
+  });
+
+  it("says none are selected at zero rather than printing '0 company boards'", () => {
+    const companies = row(buildSearchPlan({ titles: ["X"], skills: [] }, 0), "companies");
+    expect(companies.detail).toBe(COMPANY_DETAIL_NONE);
+    expect(companies.label).not.toMatch(/^0 /);
+  });
+});
+
+describe("promote reducers", () => {
+  it("promoteTitle is a whole-query replacement that keeps derived siblings", () => {
+    const query: JobQuery = {
+      titles: ["Berlin Site Lead", "VP Engineering"],
+      skills: [],
+      titleNoise: ["berlin"],
+    };
+    const next = promoteTitle(query, "VP Engineering");
+    expect(next).not.toBe(query);
+    expect(next.titles).toEqual(["VP Engineering", "Berlin Site Lead"]);
+    expect(next.titleNoise).toEqual(["berlin"]);
+  });
+
+  it("promoteSkill recomputes canonicalSkills so a moved chip keeps its standing", () => {
+    const query: JobQuery = {
+      titles: [],
+      skills: ["Team Building & Mentorship", "TypeScript"],
+      canonicalSkills: ["TypeScript"],
+    };
+    const next = promoteSkill(query, "TypeScript");
+    expect(next.skills).toEqual(["TypeScript", "Team Building & Mentorship"]);
+    // Recomputed from the whole reordered list through the same helper
+    // `buildJobQuery` uses — the free-text phrase is still not canonical.
+    expect(next.canonicalSkills).toEqual(canonicalSkillLabels(next.skills));
+    expect(next.canonicalSkills).toEqual(["TypeScript"]);
+  });
+
+  it("returns the SAME object for a no-op promotion", () => {
+    const query: JobQuery = { titles: ["A", "B"], skills: ["S"] };
+    expect(promoteTitle(query, "A")).toBe(query);
+    expect(promoteTitle(query, "missing")).toBe(query);
+    expect(promoteSkill(query, "S")).toBe(query);
+    expect(promoteSkill(query, "missing")).toBe(query);
+  });
+});
+
+describe("search-plan copy", () => {
+  // The same denylist `term-quality.test.ts` applies to `REASONS`, plus the
+  // internal nouns #597 named. A user must never have to know what a token, a
+  // provider or a query profile is to read this card.
+  it("carries no mechanism vocabulary", () => {
+    for (const text of SEARCH_PLAN_COPY) {
+      expect(text).not.toMatch(/tokenizer|filter|regex|gate|profile|resolver|admission|#/i);
+      expect(text).not.toMatch(/\btokens?\b|\bproviders?\b|\begress\b/i);
+    }
+  });
+
+  it("states what leaves and when, exactly once", () => {
+    const plan = buildSearchPlan({ titles: ["Staff Engineer"], skills: [] }, 2);
+    expect(plan.privacyNote).toMatch(/only when you click Search/i);
+    expect(plan.localNote).toMatch(/on your device/i);
+  });
+});

--- a/src/lib/job-search/search-plan.ts
+++ b/src/lib/job-search/search-plan.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * search-plan.ts — the pre-flight contract for a job search (#597): which ONE
+ * title and which ONE skill actually leave the browser, before Search is
+ * clicked.
+ *
+ * WHY THIS MODULE EXISTS. `/jobs/` shows the user ~40 equally-weighted chips,
+ * but only two of them egress: `searchPhrase(query)` goes out as `search=` to
+ * the keyless feeds, and `primaryKeyword(query)` goes out as `tag=` to Jobicy.
+ * Every other chip narrows and ranks ON DEVICE (`matchesQuery` in `search.ts`).
+ * A résumé whose most-recent title is a founder title therefore searches the
+ * feeds for that title and looks broken when it is merely mis-seeded. This
+ * module states the two outbound terms as data so a surface can show them and
+ * hand the user the control that fixes them.
+ *
+ * THE CONSTRAINT THIS GUARDS: **the plan may never drift from what actually
+ * egresses.** It does not re-derive, copy, or paraphrase the derivation — it
+ * CALLS `searchPhrase` / `primaryKeyword` from `providers/keywords.ts`, the
+ * sole résumé-derived egress helper, exactly as the adapters do. Change what
+ * goes out and this card changes with it, by construction. Nothing here issues
+ * a request or mutates a query.
+ *
+ * The user-facing copy lives here as named constants rather than inline in the
+ * component, for the same reason `term-quality.ts`'s `REASONS` do: the strings
+ * ship to a user, so they are assertable in a unit test — consequence only, no
+ * mechanism vocabulary and no internal noun.
+ *
+ * THE CORRECTION PATH IS A PLAIN REORDER. {@link promoteTitle} /
+ * {@link promoteSkill} are the one implementation of "make this chip the one
+ * that is searched", shared by the chip rows' `★` control and the plan card's
+ * **change** picker so the two can never diverge. Both are pure whole-query
+ * replacements: they spread `q` so derived siblings (`titleNoise`) survive, and
+ * the skill one recomputes `canonicalSkills` through the same
+ * `canonicalSkillLabels` `buildJobQuery` used, so a promoted skill is annotated
+ * exactly as it was before it moved.
+ */
+
+import { canonicalSkillLabels, type JobQuery } from "./query-builder.ts";
+import { primaryKeyword, searchPhrase } from "./providers/keywords.ts";
+
+/** Which chip list a plan row's term was taken from — the list a **change**
+ *  control reorders. `undefined` when the query has no term to send at all. */
+export type SearchPlanSource = "title" | "skill";
+
+export interface SearchPlanRow {
+  /** Stable key; also what a surface keys its disclosure state on. */
+  readonly id: "feeds" | "topic" | "companies";
+  /** What receives the term. */
+  readonly label: string;
+  /** The term that will be sent, or `undefined` when there is none — a row
+   *  with no term must never render as an empty pair of quotes. */
+  readonly term?: string;
+  /** Said instead of a term when `term` is absent, or alongside a count for
+   *  the company row. Always present, so a row is never blank. */
+  readonly detail?: string;
+  /** The chip list that produced `term`, so a surface knows which list to
+   *  offer and which promote reducer to call. Absent when `term` is. */
+  readonly source?: SearchPlanSource;
+}
+
+export interface SearchPlan {
+  readonly heading: string;
+  readonly rows: readonly SearchPlanRow[];
+  /** What every OTHER chip does — the half of the model the chip wall hides. */
+  readonly localNote: string;
+  /** The single form-level statement of what leaves and when. */
+  readonly privacyNote: string;
+}
+
+// ── Copy ────────────────────────────────────────────────────────────────────
+// Consequence only, same rule as `term-quality.ts`'s `REASONS`: these ship to a
+// user unchanged, so no mechanism vocabulary and no internal noun — a reader
+// must never need to know what a token, a provider or a query profile is.
+// `search-plan.test.ts` asserts the absence of that vocabulary.
+
+const SEARCH_PLAN_HEADING = "What will be searched";
+const FEEDS_ROW_LABEL = "Job feeds";
+const TOPIC_ROW_LABEL = "Topic tag";
+/** Shown on either outbound row when the query carries nothing to send. */
+export const NO_TERM_DETAIL = "nothing yet — add a title or a skill";
+/** What a company board receives: never a résumé term, only a public name. */
+export const COMPANY_DETAIL = "company name only";
+const COMPANY_ROW_LABEL_NONE = "Company boards";
+export const COMPANY_DETAIL_NONE = "none selected — the job feeds only";
+const LOCAL_NOTE =
+  "Your other titles and skills narrow and rank results on your device.";
+const PRIVACY_NOTE =
+  "Only your search keywords are sent, and only when you click Search.";
+
+/**
+ * Every string this module can put on screen — the assertion surface for the
+ * copy rule above, and the reason a new constant cannot quietly escape it. The
+ * individual strings are deliberately NOT exported: a surface reads them off
+ * the built plan, so a second import path would let a component render a
+ * constant the plan never chose. */
+export const SEARCH_PLAN_COPY: readonly string[] = [
+  SEARCH_PLAN_HEADING,
+  FEEDS_ROW_LABEL,
+  TOPIC_ROW_LABEL,
+  NO_TERM_DETAIL,
+  COMPANY_DETAIL,
+  COMPANY_ROW_LABEL_NONE,
+  COMPANY_DETAIL_NONE,
+  LOCAL_NOTE,
+  PRIVACY_NOTE,
+];
+
+/** Which list `searchPhrase` read to build its phrase — titles when there is
+ *  one, else the skills it falls back to (`keywords.ts`). */
+function feedsSource(query: JobQuery): SearchPlanSource | undefined {
+  if (query.titles.length > 0) return "title";
+  return query.skills.length > 0 ? "skill" : undefined;
+}
+
+/** Which list `primaryKeyword` read — skills first, title as the fallback. */
+function topicSource(query: JobQuery): SearchPlanSource | undefined {
+  if (query.skills.length > 0) return "skill";
+  return query.titles.length > 0 ? "title" : undefined;
+}
+
+function outboundRow(
+  id: "feeds" | "topic",
+  label: string,
+  term: string,
+  source: SearchPlanSource | undefined,
+): SearchPlanRow {
+  const trimmed = term.trim();
+  if (trimmed.length === 0 || source === undefined) {
+    return { id, label, detail: NO_TERM_DETAIL };
+  }
+  return { id, label, term: trimmed, source };
+}
+
+function companyRow(companyCount: number): SearchPlanRow {
+  if (companyCount <= 0) {
+    return {
+      id: "companies",
+      label: COMPANY_ROW_LABEL_NONE,
+      detail: COMPANY_DETAIL_NONE,
+    };
+  }
+  return {
+    id: "companies",
+    label: `${companyCount} company board${companyCount === 1 ? "" : "s"}`,
+    detail: COMPANY_DETAIL,
+  };
+}
+
+/**
+ * The destination-by-destination plan for `query`.
+ *
+ * Total and deterministic: no I/O, no throw on any `JobQuery` shape, including
+ * a fully degenerate one (no titles and no skills), which yields two rows with
+ * no term rather than two empty quotes.
+ *
+ * `companyCount` is the number of selected company boards — it lives outside
+ * `JobQuery` (`useCompanyTargets`), the same way `JobQuerySummary` takes it.
+ */
+export function buildSearchPlan(query: JobQuery, companyCount: number): SearchPlan {
+  return {
+    heading: SEARCH_PLAN_HEADING,
+    rows: [
+      outboundRow("feeds", FEEDS_ROW_LABEL, searchPhrase(query), feedsSource(query)),
+      outboundRow("topic", TOPIC_ROW_LABEL, primaryKeyword(query), topicSource(query)),
+      companyRow(companyCount),
+    ],
+    localNote: LOCAL_NOTE,
+    privacyNote: PRIVACY_NOTE,
+  };
+}
+
+/**
+ * Move `title` to index 0. Returns `q` UNCHANGED when it is already primary or
+ * absent, so a no-op click cannot make the workbench re-render a new query
+ * object. Spreads `q` so `titleNoise` — derived and non-user-facing — survives.
+ */
+export function promoteTitle(q: JobQuery, title: string): JobQuery {
+  const index = q.titles.indexOf(title);
+  if (index <= 0) return q;
+  return {
+    ...q,
+    titles: [title, ...q.titles.slice(0, index), ...q.titles.slice(index + 1)],
+  };
+}
+
+/**
+ * Move `skill` to index 0. Same no-op guard as {@link promoteTitle}, plus the
+ * `canonicalSkills` recompute every other skill mutation does: that field is
+ * what gives `term-quality.ts` standing to call a skill weak, so it may never
+ * be carried across an edit stale.
+ */
+export function promoteSkill(q: JobQuery, skill: string): JobQuery {
+  const index = q.skills.indexOf(skill);
+  if (index <= 0) return q;
+  const skills = [skill, ...q.skills.slice(0, index), ...q.skills.slice(index + 1)];
+  return { ...q, skills, canonicalSkills: canonicalSkillLabels(skills) };
+}


### PR DESCRIPTION
## Summary

`/jobs/` stated what actually reaches a job feed only after the fact, or not at all — one grey "Searching feeds for …" line and a legend-less `★` on a wall of ~40 equally-weighted chips. A résumé whose most-recent role is a founder title therefore searched the feeds for that title and looked broken when it was merely mis-seeded.

This makes the outbound terms a **pre-flight contract**, and turns the form into an ordered four-step walk that ends on it. Derivation and egress are untouched — `keywords.ts`, `buildJobQuery` and `matchesQuery` do not change; the correction path is an ordinary chip reorder the user performs.

### The contract

- `lib/job-search/search-plan.ts` — `buildSearchPlan` states the two egressing terms by **calling** `searchPhrase` / `primaryKeyword` (no re-derivation, so the card cannot drift from what is sent), plus `promoteTitle` / `promoteSkill` as the single "make this the searched chip" reducer, shared by the card's **change** picker and the chip rows' `★`.
- `SearchPlanCard` — new capability (no surface stated the contract pre-search; `JobQuerySummary` is post-fold by construction). Inline disclosure, not a second modal picker.
- `TermGlyphLegend` — names what `★ ✓ ○ ⚠︎` mean, reading glyphs from `ChipListEditor`'s own `QUALITY_MARK` table rather than a second copy; glyphs `aria-hidden`, meaning never carried by colour alone.
- `CompanyTargets` distinguishes "no companies selected" (a choice) from "no sector matched" (a registry gap).
- `job-search-copy.test.ts` — one assertion over every surface's exported copy, so the consequence-not-mechanism rule no longer decays outside `term-quality.ts`.

### The walk

A first pass put all of the above on one screen, which made the page worse rather than better. Three columns of chips, a 12-rung level rail, a legend, an advisory block, the deep links and the contract card — every one of them at `text-xs text-content-tertiary`, so the page had **no headings and no scanning order**. And the contract card, which the form exists to lead up to, rendered at the *foot* of the form, ~1100px below the chips it describes, despite the IA claim being "cause → contract → action".

- `design-system/shared/Stepper.tsx` — the one ordered multi-step composition: `<nav><ol>` rail with `aria-current="step"`, position stated in words ("Step 2 of 4"), Back/Next, arrow/Home/End keyboard walk, and panels that stay **mounted** so a half-typed chip draft survives stepping away.

  **Reuse analysis (Reuse Gate).** `Tabs` was the only candidate and models a different concern: lateral browsing of peer views, where no order exists, nothing is "next", and reaching the last tab means nothing. That leaves a terminal Search button with no visible relationship to the steps — the exact ambiguity this removes. A missing concern, not a second copy; the two stay separate.

- `lib/job-search/query-steps.ts` — the step order and each step's one-line summary. A summary is the **only** readout of a closed step, so the review summary quotes `searchPhrase`'s own output rather than re-deriving it (same no-drift discipline as `search-plan.ts`).
- `JobQueryEditor` regrouped into **Role → Skills → Narrow → Review**, with the contract card at the head of Review, immediately above the button it describes, and the per-kind suggestions and legend under the chip rows they belong to.
- `QueryStepSection` — the form's one heading level (a real `<h3>`). Inner control labels become `sr-only` so nothing is named twice on screen.
- The company picker moves from its permanent top band into Narrow. It was pinned there to survive the post-search fold; `JobQuerySummary` already carries the selected count through that fold, so the readout it was protecting is not lost.

Search stays mounted on every step (`StepperNav`'s `finalAction`) — the query arrives seeded, so a user happy with it must never walk four steps to run it.

`Filters` is labelled **Narrow** because "filter" trips `job-search-copy.test.ts`'s mechanism denylist. That is the rule working, not a false positive.

### Contrast

`SearchPlanCard`'s prose was `text-content-tertiary` on `bg-surface-subtle` — **4.04:1 in dark mode**, under WCAG 1.4.3's 4.5:1 for body text. Measured across the whole token set, the failing pairs are:

| Pair | Light | Dark |
|---|---|---|
| `content-muted` on `surface-subtle` | **4.34** ✗ | **4.04** ✗ |
| `content-muted` on `surface-hover` | **3.86** ✗ | **4.04** ✗ |
| `content-tertiary` on `surface-subtle` / `-hover` | pass | **4.04** ✗ |
| `accent-primary` on `surface-subtle` | pass | **4.07** ✗ |

The card moves to `bg-surface-card` (5.71:1 / 5.75:1) and keeps its block identity from a border plus an accent left rule. Body copy across the lane goes 12px → 14px.

**Font size is not itself a WCAG criterion** — WCAG 2.2 has no minimum-font-size SC, and the page already meets 1.4.4 at 200%. The small type here is a legibility and hierarchy problem, which is reason enough; it should not be argued on compliance grounds it cannot carry. `text-xs` is nonetheless the app-wide body default (147 uses across 59 files vs 95 `text-sm`), so the ramp and the two failing token pairs are **#603**, deliberately not swept into this PR — retyping 59 files across all three lanes inside a job-search change would make the diff unreviewable.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (3244 passed / 9 skipped)
- [x] `npm run verify` green locally — exit 0, incl. `check:fixtures`, coverage, build; fallow's one remaining finding is pre-existing `FindJobsPanel` complexity (report-only)
- [x] Manually driven in a browser against this branch's HEAD (`0bbadcc`) on a seeded leadership-shaped parse: all four steps, rail summaries, Back/Next, rail jump, and the Review contract card

New coverage: `Stepper.test.tsx` (13 — mount-not-unmount, single `aria-current`, spoken position, Back/Next bounds, keyboard walk + wrap + unhandled-key passthrough + focus follow, provider guard), `query-steps.test.ts` (7 — counts, absent-state copy, filter assembly, review summary asserted against `searchPhrase` itself rather than a hardcoded string, and that it follows a promotion).

## Notes for the reviewer

- Docblocks in the new files cite `#602`, which is **this PR**, not an issue — the redesign has no separate issue. GitHub shares the number space, so the reference resolves; say the word if you would rather it read `#597`.
- `LevelSelect`, `RoleFamilyChips`, `CompFloorInput` and `ExternalBoardLinks` keep their labels as `sr-only` rather than dropping them: the visible name now comes from the section heading, but the control still needs a name in the accessibility tree.

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — exit 0 locally; CI pending
