### PR TITLE
feat: primary role targeting, editable headline, and job-search handoff (#598)

### DIFF
--- a/src/components/features/ChipListEditor.test.tsx
+++ b/src/components/features/ChipListEditor.test.tsx
@@ -79,3 +79,24 @@ describe("ChipListEditor promote label", () => {
     expect(html).toContain('aria-label="Make TypeScript the primary title"');
   });
 });
+
+describe("ChipListEditor optional add and remove (issue 599)", () => {
+  it("renders with no add input when onAdd is omitted", () => {
+    const html = render({
+      label: "Role Titles",
+      items: ["Engineering Lead"],
+    });
+    expect(html).not.toContain("<input");
+    expect(html).not.toContain("Add");
+  });
+
+  it("renders non-removable chips when onRemove is omitted", () => {
+    const html = render({
+      label: "Role Titles",
+      items: ["Engineering Lead", "Senior Developer"],
+    });
+    expect(html).not.toContain("Remove Engineering Lead");
+    expect(html).not.toContain("Remove Senior Developer");
+  });
+});
+

--- a/src/components/features/ChipListEditor.tsx
+++ b/src/components/features/ChipListEditor.tsx
@@ -2,10 +2,14 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * ChipListEditor — a labelled list of removable chips plus an "add" input, the
- * shared editing surface for both the Titles and Skills rows of `FindJobsPanel`
- * (#539). Extracted so the two lists share one implementation rather than the
- * panel hand-rolling a second copy of the chip + add-input pattern for titles.
+ * ChipListEditor — a labelled list of chips with opt-in add input, removal controls,
+ * and primary promotion controls. The shared editing surface for `JobQueryEditor`
+ * (#539, #581, #597) and `RolesPanel` (#599).
+ *
+ * Supports three shapes:
+ *  1. Removable chips + add input + optional promote/quality controls (used by `JobQueryEditor` on `/jobs/`).
+ *  2. Non-removable chips + promote control + no add input (used by `RolesPanel` on `/`).
+ *  3. Non-removable chips + add input (or removable chips without add input).
  *
  * Owns only its own draft-input state; the chip list itself is fully
  * controlled by the parent (`items` / `onAdd` / `onRemove`). Adds are
@@ -72,7 +76,26 @@ export const QUALITY_MARK: Record<TermQuality, { glyph: string; className: strin
   noise: { glyph: "⚠︎", className: "text-feedback-warning-text" },
 };
 
-interface ChipListEditorProps {
+/**
+ * The add-input trio, as a discriminated union rather than three independent
+ * optionals (#605 review). "`placeholder`/`addAriaLabel` are required when
+ * `onAdd` is set" used to live only in a doc comment, so a caller that passed
+ * `onAdd` and forgot `addAriaLabel` rendered `<input aria-label="">` — an
+ * unlabelled text input (WCAG 4.1.2) — with `tsc` green. Here the compiler
+ * rejects it, and the `""` defaults that used to paper over it are gone.
+ */
+type AddProps =
+  | {
+      /** Called with a trimmed, non-duplicate value when the user adds one. */
+      onAdd: (value: string) => void;
+      /** Placeholder for the add input. */
+      placeholder: string;
+      /** Accessible label for the add input. */
+      addAriaLabel: string;
+    }
+  | { onAdd?: undefined; placeholder?: never; addAriaLabel?: never };
+
+interface ChipListEditorBaseProps {
   /** Row label shown above the chips (e.g. "Titles", "Skills"). */
   label: string;
   /** Render `label` for screen readers only (#602). For a caller whose own
@@ -82,14 +105,8 @@ interface ChipListEditorProps {
   labelHidden?: boolean;
   /** The controlled chip values, in display order. */
   items: string[];
-  /** Called with a trimmed, non-duplicate value when the user adds one. */
-  onAdd: (value: string) => void;
-  /** Called with the exact item string to remove. */
-  onRemove: (value: string) => void;
-  /** Placeholder for the add input. */
-  placeholder: string;
-  /** Accessible label for the add input. */
-  addAriaLabel: string;
+  /** Called with the exact item string to remove. Omit for non-removable chips. */
+  onRemove?: (value: string) => void;
   /** Opt-in (#581): index of the primary chip. Omit to render plain chips. */
   primaryIndex?: number;
   /** Opt-in (#581): called with the item to promote to primary. Required
@@ -104,6 +121,8 @@ interface ChipListEditorProps {
    *  term with no verdict was not judgeable, see `term-quality.ts`. */
   qualityFor?: (value: string) => TermVerdict | undefined;
 }
+
+type ChipListEditorProps = ChipListEditorBaseProps & AddProps;
 
 export function ChipListEditor({
   label,
@@ -121,6 +140,7 @@ export function ChipListEditor({
   const [draft, setDraft] = useState("");
 
   const commit = () => {
+    if (!onAdd) return;
     const trimmed = draft.trim();
     if (!trimmed) return;
     const alreadyPresent = items.some(
@@ -148,8 +168,8 @@ export function ChipListEditor({
             return (
               <Chip
                 key={item}
-                onRemove={() => onRemove(item)}
-                removeLabel={`Remove ${item}`}
+                onRemove={onRemove ? () => onRemove(item) : undefined}
+                removeLabel={onRemove ? `Remove ${item}` : undefined}
               >
                 {mark && (
                   <span aria-hidden="true" className={mark.className} title={verdict!.reason}>
@@ -186,30 +206,32 @@ export function ChipListEditor({
           })}
         </div>
       )}
-      <div className="flex items-center gap-2">
-        <input
-          type="text"
-          value={draft}
-          aria-label={addAriaLabel}
-          placeholder={placeholder}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              commit();
-            }
-          }}
-          className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
-        />
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={commit}
-          disabled={draft.trim().length === 0}
-        >
-          Add
-        </Button>
-      </div>
+      {onAdd && (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={draft}
+            aria-label={addAriaLabel}
+            placeholder={placeholder}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commit();
+              }
+            }}
+            className="min-w-0 max-w-56 flex-1 rounded border border-border-light bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={commit}
+            disabled={draft.trim().length === 0}
+          >
+            Add
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -28,6 +28,7 @@
  */
 
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
+import type { ContactDisplayField } from "../../lib/contact.ts";
 import { applyContactOverrides, buildContactFields } from "../../lib/contact.ts";
 import { Card, EditableField } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
@@ -37,6 +38,7 @@ import type {
 } from "../../hooks/useEditableParse.ts";
 import type { LegacyLinkKey } from "../../lib/score/types.ts";
 import { ContactDetails } from "./ContactDetails.tsx";
+import { headlineRoundTripWarning } from "../../lib/edit/headline.ts";
 
 interface ContactCardProps {
   result: CascadeResult;
@@ -58,6 +60,48 @@ interface ContactCardProps {
   onRemoveProfile?: (id: string) => void;
 }
 
+/**
+ * The tagline line under the name (#599) — the user's chosen primary role when
+ * one is set, otherwise the standalone title the parser lifted from the profile
+ * block. Rendered as its own component rather than inline in `ContactCard`
+ * because the gated-vs-editable-vs-absent branching is what pushed the card's
+ * cognitive complexity past the bar; `ContactCard` is already at the top of the
+ * repo's ~200 LOC budget, so the house rule is to extract into a sibling.
+ *
+ * Renders nothing when there is no headline AND the card is display-only — a
+ * blank editable slot is the affordance that lets a user add one, but on a
+ * read-only card it would just be dead space.
+ */
+function HeadlineField({
+  headline,
+  editable,
+  onCommit,
+}: {
+  headline: ContactDisplayField | undefined;
+  editable: boolean;
+  onCommit: (value: string) => void;
+}) {
+  const shown = headline && !headline.gated ? headline.value : undefined;
+  if (!editable) {
+    return shown ? (
+      <div className="mt-1 text-sm font-normal text-content-muted">{shown}</div>
+    ) : null;
+  }
+  return (
+    <div className="mt-1 text-sm font-normal text-content-muted">
+      <EditableField
+        value={shown}
+        placeholder="headline"
+        label="Headline"
+        textSize="sm"
+        textWeight="normal"
+        onCommit={onCommit}
+        validate={headlineRoundTripWarning}
+      />
+    </div>
+  );
+}
+
 export function ContactCard({
   result,
   overrides,
@@ -77,7 +121,8 @@ export function ContactCard({
     editable ? overrides : undefined,
   );
 
-  const name = displayFields.find((f) => f.group === "identity");
+  const name = displayFields.find((f) => f.key === "full_name");
+  const headline = displayFields.find((f) => f.key === "headline");
   const contactLine = displayFields.filter((f) => f.group === "contact");
   const links = displayFields.filter((f) => f.group === "link");
 
@@ -105,6 +150,12 @@ export function ContactCard({
           </span>
         )}
       </h2>
+
+      <HeadlineField
+        headline={headline}
+        editable={editable}
+        onCommit={(v) => commit("headline", v)}
+      />
 
       <ContactDetails
         contactLine={contactLine}

--- a/src/components/features/JobQueryEditor.tsx
+++ b/src/components/features/JobQueryEditor.tsx
@@ -45,6 +45,7 @@
 import { useState } from "react";
 import { EditableField, StepPanel } from "@design-system";
 import type { JobQuery } from "../../lib/job-search/query-builder.ts";
+import { ROLE_HINT } from "../../lib/job-search/query-steps.ts";
 import {
   canonicalSkillLabels,
   parseSeniorityLabel,
@@ -177,7 +178,7 @@ export function JobQueryEditor({
       <StepPanel id="role">
         <QueryStepSection
           title="Titles"
-          hint="The starred title is the one sent to the job feeds. Everything else narrows and ranks on your device."
+          hint={ROLE_HINT}
         >
           <ChipListEditor
             label="Your titles"

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -45,6 +45,8 @@ import {
   toBulletExperience,
 } from "../../lib/score/group-bullets.ts";
 import { ContactCard } from "./ContactCard.tsx";
+import { RolesPanel } from "./RolesPanel.tsx";
+import { deriveTitles } from "../../lib/job-search/query-builder.ts";
 import {
   applyContactOverrides,
   buildContactFields,
@@ -1014,6 +1016,7 @@ export function ReconstructedResume({
   // section headings, read off the canonical model rather than `result` directly.
   const display = projectDisplay(result.canonical);
   const parsed = display.parsed;
+  const titles = deriveTitles(result.canonical.fields);
   const bullets = score.bullets ?? [];
   const projects = parsed.projects ?? [];
   const achievements = parsed.heuristic_achievements ?? [];
@@ -1259,6 +1262,22 @@ export function ReconstructedResume({
         onEditProfile={setProfileUrl}
         onRemoveProfile={removeProfile}
       />
+      {/* Decision zone (#605 review), in order: what needs fixing
+       *  (AttentionStrip, above) → who you are (ContactCard) → what you're
+       *  aiming at (RolesPanel) → what that target expects (SkillTermGuidance).
+       *  The last two are adjacent on purpose: the guidance is derived from the
+       *  starred title, via buildJobQuery → deriveTitles → titles[0]. Below
+       *  this line the page is the résumé document itself. */}
+      <RolesPanel
+        titles={titles}
+        primary={contactOverrides.headline ?? result.canonical.fields.headline}
+        onPrimaryChange={(value) => setContactField("headline", value)}
+      />
+      {/* Term-quality guidance (#586): same classifier as `/jobs/`'s
+       *  `TermQualityAdvisory`, résumé-framed copy, writes only through the
+       *  existing `addSkill` inline-edit path. Renders nothing when there's
+       *  no suggestion, including the unresolved-role case. */}
+      <SkillTermGuidance parsed={parsed} onAddSkill={addSkill} />
       {achievementsAbove && achievementsSection}
       <ExperienceSection
         heading={display.sectionHeadings?.get("experience")}
@@ -1341,11 +1360,6 @@ export function ReconstructedResume({
           removeCategorySkill(parsed.skillCategories ?? [], skill)
         }
       />
-      {/* Term-quality guidance (#586): same classifier as `/jobs/`'s
-       *  `TermQualityAdvisory`, résumé-framed copy, writes only through the
-       *  existing `addSkill` inline-edit path. Renders nothing when there's
-       *  no suggestion, including the unresolved-role case. */}
-      <SkillTermGuidance parsed={parsed} onAddSkill={addSkill} />
     </section>
   );
 }

--- a/src/components/features/RolesPanel.test.tsx
+++ b/src/components/features/RolesPanel.test.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Render and interaction tests for RolesPanel (#599).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createElement, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RolesPanel } from "./RolesPanel.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(
+  titles: string[],
+  primary?: string,
+  onPrimaryChange: (val: string) => void = () => {},
+) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(RolesPanel, { titles, primary, onPrimaryChange }),
+    );
+  });
+  return container;
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+function expectPrimary(el: Element, expectedText: string) {
+  const primaryEl = el.querySelector('[aria-current="true"]');
+  expect(primaryEl).not.toBeNull();
+  expect(primaryEl?.textContent).toContain("★");
+  expect(primaryEl?.textContent).toContain(expectedText);
+}
+
+describe("RolesPanel", () => {
+  it("renders nothing when titles is empty", () => {
+    const el = render([]);
+    expect(el.firstElementChild).toBeNull();
+  });
+
+  // #605 review: this used to assert `titles[0]` was starred by default, which
+  // was the defect — `render-ats-pdf.ts` guards on `model.contact.headline`, so
+  // with no headline the export draws NOTHING under the name while the ★ and
+  // its copy claimed otherwise. Only 8 of 54 corpus fixtures parse a headline,
+  // so the over-claim hit ~85% of the corpus. No headline → no ★.
+  it("marks no title as primary when there is no headline at all", () => {
+    const el = render(["Engineering Lead", "Senior Developer"]);
+    expect(el.textContent).toContain("Engineering Lead");
+    expect(el.textContent).toContain("Senior Developer");
+
+    expect(el.querySelector('[aria-current="true"]')).toBeNull();
+    expect(el.textContent).toContain(
+      "Nothing picked yet, so no role prints under your name.",
+    );
+    // Every chip is a promote control in this state — including the first.
+    expect(
+      el.querySelector('button[aria-label="Make Engineering Lead the primary title"]'),
+    ).not.toBeNull();
+  });
+
+  it("marks the specified primary title when primary is set", () => {
+    const el = render(
+      ["Engineering Lead", "Senior Developer"],
+      "Senior Developer",
+    );
+    expectPrimary(el, "Senior Developer");
+  });
+
+  it("calls onPrimaryChange with title when a non-primary title is clicked", () => {
+    let chosen = "";
+    const el = render(
+      ["Engineering Lead", "Senior Developer"],
+      "Engineering Lead",
+      (val) => {
+        chosen = val;
+      },
+    );
+
+    const button = el.querySelector(
+      'button[aria-label="Make Senior Developer the primary title"]',
+    ) as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    act(() => button.click());
+    expect(chosen).toBe("Senior Developer");
+  });
+
+  // BOTH consequences of promoting must be stated, and the egress one is the
+  // load-bearing half: `titles[0]` is what `providers/keywords.ts` sends as the
+  // feeds' `search=` param. Assert each clause separately — a single
+  // `toContain` over the shared "prints under your name" substring would stay
+  // green if the egress sentence were dropped.
+  it("states both consequences of promoting a title", () => {
+    const el = render(["Engineering Lead"]);
+    // Collapse whitespace: JSX line-wrapping puts newlines + indentation inside
+    // these sentences, so a raw `textContent` match would be asserting the
+    // source's formatting rather than the copy.
+    const text = (el.textContent ?? "").replace(/\s+/g, " ");
+    expect(text).toContain("print it under your name on the PDF you download");
+    expect(text).toContain("A single title is sent to the job feeds");
+    expect(text).toContain("The rest stay on your device");
+    // The egress happens with or without a pick — `titles[0]` is sent either
+    // way — so the copy must not condition it on picking (#605 review).
+    expect(text).not.toContain("only title sent to the job feeds");
+  });
+
+  it("reports a headline that is not one of the chips instead of claiming nothing prints", () => {
+    const el = render(["Engineering Lead", "Senior Developer"], "CTO");
+    // Not one of the chips, so no ★ — but it DOES print, so the empty-state
+    // sentence would be a false claim here.
+    expect(el.querySelector('[aria-current="true"]')).toBeNull();
+    expect(el.textContent).toContain("CTO");
+    expect(el.textContent).toContain("prints under your name right now");
+    expect(el.textContent).not.toContain(
+      "Nothing picked yet, so no role prints under your name.",
+    );
+  });
+});

--- a/src/components/features/RolesPanel.tsx
+++ b/src/components/features/RolesPanel.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * RolesPanel — "which role are you targeting?" (#599). Renders the candidate's
+ * derived role titles (most-recent-first) as `ChipListEditor` chips; clicking a
+ * non-primary title promotes it, setting the `headline` override.
+ *
+ * WHY IT SITS WHERE IT SITS. This is the third beat of the page's decision zone
+ * — what needs fixing (AttentionStrip), who you are (ContactCard), what you're
+ * aiming at (here) — and it is immediately followed by `SkillTermGuidance`,
+ * whose suggestions are a FUNCTION of the promoted title: that component runs
+ * `buildJobQuery` → `deriveTitles`, whose `titles[0]` is this ★. Change the
+ * star, the suggestions below change. Adjacency is what makes that causal;
+ * separating them (the guidance used to render below the Skills section) left
+ * the output four sections away from its own input.
+ *
+ * TWO CONSEQUENCES, NOT ONE — both are stated in the help copy because both are
+ * true and neither is guessable: the promoted title is drawn under the name on
+ * the downloaded PDF (`render-ats-pdf.ts` guards on `model.contact.headline`),
+ * AND it is `titles[0]`, which `providers/keywords.ts` sends verbatim as the
+ * feeds' `search=` param — the one audited resume-derived egress. Every other
+ * title filters locally in `matchesQuery` and never leaves.
+ *
+ * The copy leads with the egress, and states it UNCONDITIONALLY (#605 review).
+ * A `titles[0]` is sent whether or not the user picks anything — with no pick
+ * it is the most-recent experience title — so copy reading "the picked title is
+ * the only one sent" implies no pick means nothing is sent. Picking changes
+ * WHICH title goes, not whether one does; only the PDF consequence is gated on
+ * picking.
+ *
+ * NO DEFAULT ★ (#605 review). `primaryIndex` is undefined until a headline
+ * actually exists — the parser's or the user's. Defaulting to index 0 starred
+ * `titles[0]` on every résumé under copy saying it prints, while the export
+ * drew nothing: only 8 of 54 corpus fixtures parse a headline at all.
+ *
+ * A headline that is not one of the chips is a real state, not a bug: the chip
+ * list comes from `deriveTitles`, which splits a stacked tagline and dedups
+ * against experience titles, so a user-typed headline ("Chief Widget Officer")
+ * prints without matching any chip. That case gets its own line rather than
+ * the "nothing prints" one, which would be a false claim.
+ */
+
+import { Card } from "@design-system";
+import { ChipListEditor } from "./ChipListEditor.tsx";
+
+interface RolesPanelProps {
+  /** Distinct role titles, most-recent-first, from `deriveTitles`. */
+  titles: string[];
+  /** The currently chosen primary — the `headline` override, or undefined. */
+  primary?: string;
+  /** Commit a new primary (or "" to clear back to the parser's default). */
+  onPrimaryChange: (value: string) => void;
+}
+
+export function RolesPanel({
+  titles,
+  primary,
+  onPrimaryChange,
+}: RolesPanelProps) {
+  if (titles.length === 0) return null;
+
+  const effectivePrimary = primary && primary.trim() ? primary.trim() : undefined;
+  const matchedIndex =
+    effectivePrimary === undefined ? -1 : titles.indexOf(effectivePrimary);
+  const primaryIndex = matchedIndex >= 0 ? matchedIndex : undefined;
+
+  return (
+    <Card className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold text-content-primary">
+          Which role are you targeting?
+        </h2>
+        <p className="max-w-prose text-sm text-content-tertiary">
+          A single title is sent to the job feeds when you search. The rest stay
+          on your device and just widen the matching. Pick one of your titles to
+          make it that one — and to print it under your name on the PDF you
+          download.
+        </p>
+      </div>
+
+      <ChipListEditor
+        label="Your role titles"
+        labelHidden
+        items={titles}
+        primaryIndex={primaryIndex}
+        onPromote={onPrimaryChange}
+        primaryNoun="title"
+      />
+
+      {primaryIndex === undefined && (
+        <p className="text-sm text-content-tertiary">
+          {effectivePrimary === undefined ? (
+            <>Nothing picked yet, so no role prints under your name.</>
+          ) : (
+            <>
+              <span className="font-medium text-content-secondary">
+                {effectivePrimary}
+              </span>{" "}
+              prints under your name right now. Pick a title above to replace
+              it, or edit it directly in the card above.
+            </>
+          )}
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/src/components/features/SkillTermGuidance.test.tsx
+++ b/src/components/features/SkillTermGuidance.test.tsx
@@ -56,13 +56,40 @@ function resolvableParsed(): ResumeQueryInput {
 describe("SkillTermGuidance", () => {
   it("renders recognized and not-recognized skills for a role-resolvable résumé", () => {
     const el = render(resolvableParsed(), () => {});
-    expect(el.textContent).toContain("Terms worth adding");
+    expect(el.textContent).toContain("Skills this role usually asks for");
+    // The subhead names the ROLE as the source, which is what makes the panel's
+    // new position (directly under RolesPanel) legible — its content is derived
+    // from `titles[0]`. Worded "first", not "starred": `titles[0]` drives this
+    // list whether or not it carries a ★ (a résumé with no headline has no ★
+    // at all, by design — see RolesPanel).
+    expect(el.textContent).toContain("Based on the first role title above");
     // `query.skills` canonicalizes through the jd-match skill index
     // (`buildJobQuery` → `getSkillIndex`), so the rendered term is the
     // canonical id/label ("postgresql", "csharp"), not the résumé's raw
     // casing — same behaviour `/jobs/` renders.
-    expect(el.textContent).toContain("Recognized in your résumé: postgresql");
-    expect(el.textContent).toContain("Not recognized by matchers: csharp");
+    expect(el.textContent).toContain("Already in your résumé: postgresql");
+    expect(el.textContent).toContain(
+      "We could not match these to a known skill: csharp",
+    );
+    // The old wording blamed the user's term rather than our index; assert it
+    // is gone, not merely that the new sentence is present.
+    expect(el.textContent).not.toContain("Not recognized by matchers");
+  });
+
+  it("confirms in place where an added term landed", () => {
+    const el = render(resolvableParsed(), () => {});
+    const pill = el.querySelector("button[aria-label]") as HTMLButtonElement;
+    const label = pill.getAttribute("aria-label")!;
+
+    expect(el.textContent).not.toContain("to your Skills section");
+    act(() => pill.click());
+
+    // This panel now sits far above the Skills section it writes into, so the
+    // add needs an acknowledgement the vanishing pill alone cannot give.
+    expect(el.textContent).toContain(`to your Skills section: ${label}`);
+    const live = el.querySelector('[aria-live="polite"]');
+    expect(live).not.toBeNull();
+    expect(live?.textContent).toContain(label);
   });
 
   it("renders the reason for an unrecognized skill verbatim from the classifier", () => {

--- a/src/components/features/SkillTermGuidance.tsx
+++ b/src/components/features/SkillTermGuidance.tsx
@@ -5,10 +5,27 @@
  * SkillTermGuidance — surfaces the term-quality classifier's verdict on the
  * résumé's OWN skills, in the résumé review lane (#586). `TermQualityAdvisory`
  * (#585) does the equivalent job on `/jobs/`, but that surface can only edit
- * the search *query* — it has no DropZone and no editor. This one sits beside
- * `SkillsSection` on `/`, where `onAddSkill` writes through the existing
- * inline-edit path (`useEditableParse`), so a suggestion here can actually
- * land in the document.
+ * the search *query* — it has no DropZone and no editor. This one lives on `/`,
+ * where `onAddSkill` writes through the existing inline-edit path
+ * (`useEditableParse`), so a suggestion here can actually land in the document.
+ *
+ * PLACEMENT: directly under `RolesPanel`, above Experience (#605 review). It
+ * used to render last, below `SkillsSection`. Two reasons it moved up:
+ *
+ *  1. Its content is a FUNCTION of the starred role. `buildJobQuery` →
+ *     `deriveTitles` puts the promoted headline at `titles[0]`, and
+ *     `assessQueryTerms` resolves the role profile from it. Star a different
+ *     title and this whole list changes. Cause and effect have to be adjacent
+ *     or the dependency is invisible; four résumé sections apart, it read as a
+ *     static footer.
+ *  2. It is advice about the document, not part of the document. Sitting last
+ *     among the résumé sections framed it as one.
+ *
+ * The cost of moving is that its `onAddSkill` target — `SkillsSection` — is now
+ * off-screen, so the general "put feedback next to the thing it affects" rule
+ * is being paid for rather than followed. It is paid with a confirm-in-place
+ * trail plus an `aria-live` announcement (there is no toast primitive in this
+ * design system), so an add still reports where it landed.
  *
  * SAME CLASSIFIER, NO SECOND JUDGEMENT. Builds a `JobQuery` from the current
  * parse with `buildJobQuery` and reads it through `assessQueryTerms` — the
@@ -47,6 +64,8 @@
  * So this is a new, narrowly-scoped sibling, not a parallel copy of either.
  */
 
+import { useState } from "react";
+import { Card } from "@design-system";
 import { assessQueryTerms } from "../../lib/job-search/term-quality.ts";
 import { buildJobQuery, type ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
 import { missingTermLabel } from "./TermQualityAdvisory.tsx";
@@ -62,6 +81,12 @@ export function SkillTermGuidance({
    *  way a suggestion here reaches the résumé. */
   onAddSkill: (skill: string) => void;
 }) {
+  // Terms added from this panel, in click order. Purely a confirmation trail:
+  // the résumé itself is written by `onAddSkill`, and an added term leaves
+  // `missing` on the next assessment anyway — so the pill vanishing is the state
+  // change, and this is the acknowledgement that the vanish alone can't give.
+  const [added, setAdded] = useState<string[]>([]);
+
   const query = buildJobQuery(parsed);
   const assessment = assessQueryTerms(query);
 
@@ -74,37 +99,60 @@ export function SkillTermGuidance({
     return null;
   }
 
+  const add = (label: string) => {
+    onAddSkill(label);
+    setAdded((prev) => (prev.includes(label) ? prev : [...prev, label]));
+  };
+
   return (
-    <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-subtle p-3">
-      <p className="flex items-start gap-1.5 text-sm font-semibold text-content-secondary">
-        <span aria-hidden="true">⚠︎</span>
-        <span>
-          <span className="sr-only">Term guidance: </span>
-          Terms worth adding
-        </span>
-      </p>
+    <Card className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold text-content-primary">
+          Skills this role usually asks for
+        </h2>
+        <p className="max-w-prose text-sm text-content-tertiary">
+          Based on the first role title above. Star a different one and this
+          list changes with it.
+        </p>
+      </div>
 
       {missingSkills.length > 0 && (
         <div className="flex flex-col gap-1.5">
-          <span className="text-sm text-content-tertiary">
-            Roles like yours are usually described with terms not in your résumé
+          <span className="text-sm text-content-secondary">
+            Not in your résumé yet — add the ones you actually have:
           </span>
           <div className="flex flex-wrap gap-1.5">
             {missingSkills.map((term) => (
               <AddPill
                 key={term.term}
                 label={missingTermLabel(term)}
-                onClick={() => onAddSkill(missingTermLabel(term))}
+                onClick={() => add(missingTermLabel(term))}
               />
             ))}
           </div>
         </div>
       )}
 
+      {/* Confirm in place — there is no toast primitive here, and this panel now
+       *  sits far above the Skills section it writes into, so an add would
+       *  otherwise have no visible destination. `aria-live` announces it once;
+       *  the text carries the meaning, never colour alone. */}
+      <p aria-live="polite" className="sr-only">
+        {added.length > 0
+          ? `Added to your skills: ${added.join(", ")}.`
+          : ""}
+      </p>
+      {added.length > 0 && (
+        <p className="text-sm text-content-tertiary">
+          <span className="font-medium text-feedback-success-text">Added</span>{" "}
+          to your Skills section: {added.join(", ")}.
+        </p>
+      )}
+
       {recognized.length > 0 && (
         <p className="text-sm text-content-tertiary">
           <span className="font-medium text-content-secondary">
-            Recognized in your résumé:
+            Already in your résumé:
           </span>{" "}
           {recognized.map((v) => v.term).join(", ")}
         </p>
@@ -114,7 +162,7 @@ export function SkillTermGuidance({
         <div className="flex flex-col gap-1">
           <p className="text-sm text-content-tertiary">
             <span className="font-medium text-content-secondary">
-              Not recognized by matchers:
+              We could not match these to a known skill:
             </span>{" "}
             {unrecognized.map((v) => v.term).join(", ")}
           </p>
@@ -129,6 +177,6 @@ export function SkillTermGuidance({
           </ul>
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -217,4 +217,16 @@ describe("useEditableParse — Skills category edits (#476)", () => {
       "Go",
     ]);
   });
+
+  it("headline override flips hasEdits to true and is cleared by resetAll (issue 599)", () => {
+    expect(api.hasEdits).toBe(false);
+    act(() => api.setContactField("headline", "Staff Engineer"));
+    expect(api.contactOverrides.headline).toBe("Staff Engineer");
+    expect(api.hasEdits).toBe(true);
+
+    act(() => api.resetAll());
+    expect(api.contactOverrides.headline).toBeUndefined();
+    expect(api.hasEdits).toBe(false);
+  });
 });
+

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -52,6 +52,7 @@ export interface ContactOverrides {
   email?: string;
   phone?: string;
   location?: string;
+  headline?: string;
 }
 
 // ── Experience overrides ──────────────────────────────────────────────────────

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -47,6 +47,7 @@ const CONTACT_ROWS: readonly {
   optional?: boolean;
 }[] = [
   { key: "full_name", label: "Name", group: "identity" },
+  { key: "headline", label: "Headline", group: "identity", optional: true },
   { key: "email", label: "Email", group: "contact" },
   { key: "phone", label: "Phone", group: "contact" },
   // Brand-neutral required row (#335): a "Professional profile" gap, satisfied
@@ -64,6 +65,7 @@ const CONTACT_ROWS: readonly {
 // TypeScript trick: enumerate the valid keys for indexing `parsed`.
 const FIELD_KEYS = {
   full_name: true,
+  headline: true,
   email: true,
   phone: true,
   linkedin_url: true,
@@ -140,13 +142,31 @@ export function applyContactOverrides(
   overrides: ContactOverrides | undefined,
 ): ContactDisplayField[] {
   if (overrides === undefined) return fields;
-  return fields.map((field): ContactDisplayField => {
+  const result = fields.map((field): ContactDisplayField => {
     const ov = overrides[field.key as keyof ContactOverrides];
     if (ov === undefined) return field;
     if (ov === "")
       return { ...field, value: "", gated: true, reason: "absent" };
     return { ...field, value: ov, gated: false, reason: undefined };
   });
+
+  // Optional fields dropped by buildContactFields might have been overridden.
+  // Add them back to the display list so the UI can render the user's edit.
+  for (const row of CONTACT_ROWS) {
+    if (row.optional && overrides[row.key as keyof ContactOverrides]) {
+      const exists = result.some((f) => f.key === row.key);
+      if (!exists) {
+        result.push({
+          key: row.key,
+          label: row.label,
+          group: row.group,
+          value: overrides[row.key as keyof ContactOverrides]!,
+          gated: false,
+        });
+      }
+    }
+  }
+  return result;
 }
 
 export interface ContactCompleteness {

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -89,6 +89,7 @@ const CONTACT_KEYS: readonly (keyof ContactOverrides)[] = [
   "email",
   "phone",
   "location",
+  "headline",
 ];
 
 /** Leading bullet/numbered markers — mirrors group-bullets.ts LEADING_MARKER_RE. */

--- a/src/lib/edit/headline.ts
+++ b/src/lib/edit/headline.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Imported from the LEAF `extract/title-shape.ts`, never from `extract/shared.ts`
+// (#605 review). `ContactCard` imports this module eagerly on `/`, and
+// `shared.ts` pulls in `heuristics/regex.ts` — 672 lines of parser regexes that
+// are otherwise reached only through `cascade.ts`'s dynamic imports. Keep this
+// import pointing at the leaf or the whole parser regex table lands back on the
+// entry graph for one predicate.
+import { looksLikeTitle } from "../heuristics/extract/title-shape.ts";
+
+/** Longest headline `extractHeadline` will recover — mirrors its `text.length > 60`
+ *  gate exactly. A longer value prints on the PDF and does not come back whole. */
+export const MAX_HEADLINE_LENGTH = 60;
+
+/** A message when this headline will not survive parse → export → re-parse,
+ *  or `null` when it will. Shaped for `EditableField`'s `validate` hook. */
+export function headlineRoundTripWarning(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.length > MAX_HEADLINE_LENGTH) {
+    return "A long headline wraps on the PDF and only its first line reads back.";
+  }
+
+  if (!looksLikeTitle(trimmed)) {
+    return "This reads as a sentence, and re-import only recovers a job-title-shaped line.";
+  }
+
+  return null;
+}

--- a/src/lib/heuristics/extract/name.ts
+++ b/src/lib/heuristics/extract/name.ts
@@ -10,6 +10,7 @@ import {
   INSTITUTION_HINTS,
 } from "../regex.ts";
 import { looksLikeTitle } from "./shared.ts";
+import { MAX_HEADLINE_LENGTH } from "../../edit/headline.ts";
 
 // ── Name ────────────────────────────────────────────────────────────────────
 
@@ -385,7 +386,7 @@ export function extractHeadline(
     if (isNameLine(text, name)) continue; // the name is not its own headline
     if (matchSectionHeader(text)) break; // reached a section — header block over
     if (startsContactCluster(text)) break; // contact cluster — header block over
-    if (text.length > 60) continue;
+    if (text.length > MAX_HEADLINE_LENGTH) continue;
     if (!looksLikeTitle(text)) continue;
     return { value: text, confidence: 0.7 };
   }

--- a/src/lib/heuristics/extract/shared.ts
+++ b/src/lib/heuristics/extract/shared.ts
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
-import {
-  COMPANY_SUFFIX_RE,
-  INSTITUTION_HINTS,
-} from "../regex.ts";
+import { INSTITUTION_HINTS } from "../regex.ts";
+import { COMPANY_SUFFIX_RE, looksLikeTitle } from "./title-shape.ts";
+// Re-exported so the ~dozen parser call sites that import `looksLikeTitle`
+// from here are unchanged; the definition moved to the leaf `title-shape.ts`
+// so `edit/headline.ts` can use it without pulling `regex.ts` onto `/`'s
+// eager graph (#605 review).
+export { looksLikeTitle };
 
 /** First regex hit as trimmed string, or undefined. */
 export function firstMatch(re: RegExp, text: string): string | undefined {
@@ -91,24 +94,6 @@ export function isStandaloneUrl(
   const wordBefore = /\w$/.test(before);
   const wordAfter = /^\w/.test(after);
   return !(wordBefore && wordAfter);
-}
-
-/**
- * Keywords that commonly appear in a job title. Used as a tiebreaker when
- * neither header line carries a company suffix:
- * modern resumes often flip the "Company first, then Title" convention
- * and put Title on the top (H2) with Company below (H3). Without this
- * heuristic the default fallback misattributes a `**Sr. Engineering
- * Manager (L7)**` header as the company and `**Globex / CloudWave**`
- * as the title.
- */
-const TITLE_KEYWORDS_RE =
-  /\b(Engineer|Engineering|Developer|Manager|Director|Lead|Consultant|Analyst|Specialist|Associate|Architect|Principal|Officer|Designer|Scientist|Researcher|Administrator|Founder|Co-?founder|President|VP|Vice President|Head|Chief|CTO|CEO|COO|CFO|CIO|PM|TPM|SRE|DevOps|Assistant|Intern|Internship|Trainee|Apprentice|Coordinator|Technician|Representative|Supervisor|Strategist|Advisor|Adviser|Counselor|Recruiter|Accountant|Auditor|Editor|Writer|Producer|Teacher|Instructor|Lecturer|Professor|Tutor|Agent|Clerk|Ambassador|Volunteer|Fellow)\b/i;
-
-/** Heuristic: text contains title-like keywords but no company suffix. */
-export function looksLikeTitle(text: string): boolean {
-  if (COMPANY_SUFFIX_RE.test(text)) return false;
-  return TITLE_KEYWORDS_RE.test(text);
 }
 
 /** Employer signal: a legal suffix ("Inc", "LLC") OR an institution word

--- a/src/lib/heuristics/extract/title-shape.ts
+++ b/src/lib/heuristics/extract/title-shape.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * title-shape — "does this line read as a job title?", and the two regexes that
+ * answer it. A LEAF module: it imports nothing, and nothing may be added here
+ * that does.
+ *
+ * WHY IT IS ITS OWN FILE (#605 review). `looksLikeTitle` used to live in
+ * `extract/shared.ts`, which imports `heuristics/regex.ts` (672 lines of parser
+ * regexes). That was free while only the parser tiers called it — they are all
+ * dynamic-imported from `cascade.ts`. It stopped being free when
+ * `edit/headline.ts` started calling it for `headlineRoundTripWarning`, because
+ * `ContactCard` imports THAT eagerly on `/`: the whole chain
+ * `ContactCard → edit/headline → extract/shared → heuristics/regex` landed on
+ * the entry graph, for one predicate over two regexes.
+ *
+ * Splitting the predicate out — rather than duplicating the constant, which
+ * would leave two sources of truth for what a title looks like — keeps
+ * `COMPANY_SUFFIX_RE` defined exactly once. `extract/shared.ts` re-exports
+ * `looksLikeTitle` so its existing parser import sites are unchanged;
+ * `COMPANY_SUFFIX_RE` needs no such shim because `extract/shared.ts` was its
+ * only importer and now takes it from here directly.
+ */
+
+/** Legal-entity suffixes that mark a line as an employer, not a role. */
+export const COMPANY_SUFFIX_RE =
+  /\b(Inc\.?|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?|GmbH|S\.A\.?|Pty\.?|plc|Group|Holdings|Technologies|Systems|Labs|Solutions)\b/i;
+
+/**
+ * Keywords that commonly appear in a job title. Used as a tiebreaker when
+ * neither header line carries a company suffix:
+ * modern resumes often flip the "Company first, then Title" convention
+ * and put Title on the top (H2) with Company below (H3). Without this
+ * heuristic the default fallback misattributes a `**Sr. Engineering
+ * Manager (L7)**` header as the company and `**Globex / CloudWave**`
+ * as the title.
+ */
+const TITLE_KEYWORDS_RE =
+  /\b(Engineer|Engineering|Developer|Manager|Director|Lead|Consultant|Analyst|Specialist|Associate|Architect|Principal|Officer|Designer|Scientist|Researcher|Administrator|Founder|Co-?founder|President|VP|Vice President|Head|Chief|CTO|CEO|COO|CFO|CIO|PM|TPM|SRE|DevOps|Assistant|Intern|Internship|Trainee|Apprentice|Coordinator|Technician|Representative|Supervisor|Strategist|Advisor|Adviser|Counselor|Recruiter|Accountant|Auditor|Editor|Writer|Producer|Teacher|Instructor|Lecturer|Professor|Tutor|Agent|Clerk|Ambassador|Volunteer|Fellow)\b/i;
+
+/** Heuristic: text contains title-like keywords but no company suffix. */
+export function looksLikeTitle(text: string): boolean {
+  if (COMPANY_SUFFIX_RE.test(text)) return false;
+  return TITLE_KEYWORDS_RE.test(text);
+}

--- a/src/lib/heuristics/regex.ts
+++ b/src/lib/heuristics/regex.ts
@@ -667,6 +667,9 @@ export const PROGRAM_NOTE_RE =
   /^(?:GPA[:\s]|Minor\b|Major\b|Concentration\b|Relevant Coursework\b|Coursework\b)/i;
 
 // ── Company suffix hints ────────────────────────────────────────────────────
-
-export const COMPANY_SUFFIX_RE =
-  /\b(Inc\.?|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?|GmbH|S\.A\.?|Pty\.?|plc|Group|Holdings|Technologies|Systems|Labs|Solutions)\b/i;
+//
+// `COMPANY_SUFFIX_RE` used to live here. It moved to the leaf
+// `extract/title-shape.ts` alongside `looksLikeTitle`, the only predicate that
+// pairs with it, so `ContactCard → edit/headline` no longer drags this whole
+// file onto the entry graph. `extract/shared.ts` — its sole importer — now
+// imports it from there directly, so no re-export shim is left behind here.

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -2,7 +2,13 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
-import { buildJobQuery, MAX_SKILLS, MAX_TITLES } from "./query-builder.ts";
+import {
+  buildJobQuery,
+  splitHeadline,
+  MAX_SKILLS,
+  MAX_TITLES,
+} from "./query-builder.ts";
+import { searchPhrase } from "./providers/keywords.ts";
 import type { ParsedResume, ResumeExperience } from "../score/types.ts";
 
 function baseParsed(overrides: Partial<ParsedResume> = {}): ParsedResume {
@@ -541,5 +547,159 @@ describe("buildJobQuery titleNoise (issue 579)", () => {
     expect(query.titleNoise).toContain("datadog");
     expect(query.titleNoise).toContain("seoul");
     expect(query.titleNoise).toContain("salesforce");
+  });
+
+  // ── The stated target (#599) and the audited egress (#605 review) ──────────
+  //
+  // `titles[0]` is not just a display slot: `providers/keywords.ts` sends it
+  // verbatim as the keyless feeds' `search=` param — the single resume-derived
+  // egress in the app. So what lands at index 0 is a privacy-surface decision,
+  // and these assert it through `searchPhrase` rather than through `titles`
+  // alone, so a change to that mapping cannot pass them silently.
+
+  it("leads titles with the stated target so it becomes the egress phrase", () => {
+    const query = buildJobQuery(
+      baseParsed({
+        headline: "Platform Engineer",
+        experience: [experience({ title: "Software Engineer" })],
+      }),
+    );
+    expect(query.titles[0]).toBe("Platform Engineer");
+    expect(searchPhrase(query)).toBe("Platform Engineer");
+  });
+
+  // A headline is a tagline, not a title: `extractHeadline` routinely lifts
+  // "DevOps Engineer · Software Architect" off a real résumé. Sent whole it is
+  // a single-intent full-text query naming two intents — exactly what
+  // `keywords.ts`'s docblock says it avoids — and it returns near-nothing.
+  it("splits a separator-stacked headline so only ONE role reaches the feeds", () => {
+    const query = buildJobQuery(
+      baseParsed({
+        headline: "DevOps Engineer · Software Architect",
+        experience: [experience({ title: "Site Reliability Engineer" })],
+      }),
+    );
+    expect(query.titles[0]).toBe("DevOps Engineer");
+    expect(searchPhrase(query)).toBe("DevOps Engineer");
+    expect(searchPhrase(query)).not.toContain("·");
+    // The second role is not discarded — it still widens the LOCAL
+    // `matchesQuery` broadening, it just never leaves the browser.
+    expect(query.titles).toContain("Software Architect");
+    expect(query.titles).toContain("Site Reliability Engineer");
+  });
+
+  // The split must not manufacture the egress phrase. Before the space guard,
+  // "React/Node Engineer" left the browser as "React" and "VP, Engineering" as
+  // "VP" — a term the user never held, and one `looksLikeTitle` would have
+  // rejected outright had anything re-checked the parts (#605 review).
+  it.each([
+    "React/Node Engineer",
+    "VP, Engineering",
+    "Engineer, Data Platform",
+  ])("egresses %s whole, not a fragment of it", (headline) => {
+    const query = buildJobQuery(
+      baseParsed({
+        headline,
+        experience: [experience({ title: "Software Engineer" })],
+      }),
+    );
+    expect(query.titles[0]).toBe(headline);
+    expect(searchPhrase(query)).toBe(headline);
+  });
+
+  it("keeps the split titles within MAX_TITLES", () => {
+    const query = buildJobQuery(
+      baseParsed({
+        headline: "Engineer / Architect / Manager",
+        experience: [
+          experience({ title: "Staff Engineer" }),
+          experience({ title: "Principal Engineer" }),
+          experience({ title: "Director of Engineering" }),
+        ],
+      }),
+    );
+    expect(query.titles.length).toBeLessThanOrEqual(MAX_TITLES);
+  });
+
+  it("does not duplicate a headline that repeats an experience title", () => {
+    const query = buildJobQuery(
+      baseParsed({
+        headline: "Software Engineer",
+        experience: [experience({ title: "Software Engineer" })],
+      }),
+    );
+    expect(query.titles).toEqual(["Software Engineer"]);
+  });
+
+  describe("splitHeadline", () => {
+    it("returns a single entry for a plain headline", () => {
+      expect(splitHeadline("Engineering Lead")).toEqual(["Engineering Lead"]);
+    });
+
+    it("splits on every stacking separator and trims the parts", () => {
+      expect(
+        splitHeadline("Engineer · Architect | Consultant / Manager - Director"),
+      ).toEqual([
+        "Engineer",
+        "Architect",
+        "Consultant",
+        "Manager",
+        "Director",
+      ]);
+    });
+
+    // `titles[0]` is what `keywords.ts` sends verbatim as the feeds' `search=`
+    // param, so an unguarded `/` or `,` does not merely mis-chip — it egresses
+    // "React" or "VP" in place of the role the user actually holds (#605
+    // review). Both characters appear INSIDE a single role far more often than
+    // they stack two.
+    it("does NOT split a single role on an unspaced / or on a comma", () => {
+      expect(splitHeadline("React/Node Engineer")).toEqual([
+        "React/Node Engineer",
+      ]);
+      expect(splitHeadline("VP, Engineering")).toEqual(["VP, Engineering"]);
+      expect(splitHeadline("Engineer, Data Platform")).toEqual([
+        "Engineer, Data Platform",
+      ]);
+      // A genuinely stacked pair still splits — the space is the signal.
+      expect(splitHeadline("Product Manager / Data Analyst")).toEqual([
+        "Product Manager",
+        "Data Analyst",
+      ]);
+    });
+
+    // The shape gates upstream run on the COMPOUND; the split invents parts
+    // nothing has checked. `looksLikeTitle("Software Engineer · Coffee Lover")`
+    // is true, `looksLikeTitle("Coffee Lover")` is not.
+    it("drops a manufactured part that does not read as a title", () => {
+      expect(splitHeadline("Software Engineer · Coffee Lover")).toEqual([
+        "Software Engineer",
+      ]);
+      expect(splitHeadline("Engineer | Globex Labs")).toEqual(["Engineer"]);
+    });
+
+    it("keeps the whole headline when NO part reads as a title", () => {
+      expect(splitHeadline("Coffee Lover · Dog Dad")).toEqual([
+        "Coffee Lover · Dog Dad",
+      ]);
+    });
+
+    // "&"/"and" join ONE compound role ("Founding Member & Site Reliability
+    // Engineer"), so splitting on them would mint titles nobody holds.
+    it("does NOT split a compound role joined by & or a hyphenated word", () => {
+      expect(splitHeadline("Founding Member & Site Reliability Engineer")).toEqual([
+        "Founding Member & Site Reliability Engineer",
+      ]);
+      expect(splitHeadline("Full-Stack Engineer")).toEqual(["Full-Stack Engineer"]);
+    });
+
+    it("is empty for absent or blank input, and drops empty parts", () => {
+      expect(splitHeadline(undefined)).toEqual([]);
+      expect(splitHeadline("   ")).toEqual([]);
+      expect(splitHeadline("Engineer ·  · Architect")).toEqual([
+        "Engineer",
+        "Architect",
+      ]);
+    });
   });
 });

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -70,19 +70,21 @@ import { parseSeniorityLabel } from "./seniority.ts";
 export { parseSeniorityLabel };
 import { ROLE_KEYWORDS, tokenizeWords } from "./role-keywords.ts";
 import { normalizeSkillKey } from "./role-profiles.ts";
+import { looksLikeTitle } from "../heuristics/extract/title-shape.ts";
 
 export interface JobQuery {
   /** Distinct role titles, most-recent-first, deduped case-insensitively and
    *  capped at MAX_TITLES. Empty when none could be derived (skills-only /
-   *  degenerate query). `titles[0]` is the primary (most-recent) title. */
+   *  degenerate query). `titles[0]` is the stated target when there is one,
+   *  or the primary (most-recent) title. */
   titles: string[];
   /** Top-ranked skills, canonicalized + deduped, capped at MAX_SKILLS. */
   skills: string[];
   /** Seniority keyword found across the résumé's titles (Executive/VP/
    *  Director/Manager/Staff/Principal/Lead/Senior/Junior/Intern) — the
-   *  PRIMARY title wins when it has a keyword, otherwise the first match
-   *  scanning the rest of `titles` in order (#540) — or undefined when none
-   *  of them carries a recognized keyword. */
+   *  PRIMARY title (titles[0], which may be the headline) wins when it has
+   *  a keyword, otherwise the first match scanning the rest of `titles` in
+   *  order (#540) — or undefined when none of them carries a recognized keyword. */
   seniority?: string;
   /** Candidate location, seeded from the parsed résumé's top-level
    *  `location` (contact address, e.g. "Austin, TX") when present (#545).
@@ -180,7 +182,7 @@ export interface JobQuery {
  */
 export type ResumeQueryInput = Pick<
   ParsedResume,
-  "skills" | "experience" | "current_title" | "location"
+  "skills" | "experience" | "current_title" | "location" | "headline"
 >;
 
 /**
@@ -206,6 +208,59 @@ export const MAX_SKILLS = 12;
  */
 export const MAX_TITLES = 4;
 
+/** Separators a headline stacks distinct roles on.
+ *
+ *  `·`, `•` and `|` split bare — none of them occurs inside a single role.
+ *  `-` and `/` do occur inside one, so both split only when a space sits on
+ *  each side, the way a person writes a genuine stack ("Product Manager /
+ *  Data Analyst"). Unguarded, `/` turns "React/Node Engineer" into `React` +
+ *  `Node Engineer`, and `titles[0]` is what egresses (#605 review).
+ *
+ *  `,` is absent from the set entirely rather than space-guarded. Nobody
+ *  writes " , ", so a guarded comma would never fire — a dead branch — while
+ *  a bare one splits "VP, Engineering" and "Engineer, Data Platform", which
+ *  are single roles, into fragments.
+ *
+ *  `&` and `and` are excluded for the same reason: "Founding Member & Site
+ *  Reliability Engineer" is one compound role, not two, and splitting it
+ *  would mint titles nobody holds. */
+const HEADLINE_SEPARATOR_RE = /[·•|]|\s[-–—/]\s/;
+
+/**
+ * The distinct role titles a headline names, in stated order — one entry for a
+ * plain headline, N for a separator-stacked tagline. Empty for absent/blank,
+ * and any part that reduces to nothing is dropped rather than emitted as "".
+ *
+ * A MANUFACTURED PART IS RE-SHAPE-GATED (#605 review). Both routes into a
+ * headline shape the WHOLE string — `extractHeadline` admits a parsed one only
+ * past `looksLikeTitle`, and a user-typed one is warned by
+ * `headlineRoundTripWarning` — and neither says anything about a fragment this
+ * split invents. `looksLikeTitle("Software Engineer · Coffee Lover")` is true;
+ * `looksLikeTitle("Coffee Lover")` is not. Since `titles[0]` is the one audited
+ * resume-derived egress (`providers/keywords.ts`) and every part also renders
+ * as a chip in `RolesPanel`, a part that does not read as a title is dropped
+ * rather than egressed and shown as a chip the user never typed.
+ *
+ * A single part is NOT re-gated: it is the caller's own headline unchanged, and
+ * this function is not the place to overrule a headline the user typed.
+ */
+export function splitHeadline(headline: string | undefined): string[] {
+  const whole = (headline ?? "").trim();
+  if (!whole) return [];
+
+  const parts = whole
+    .split(HEADLINE_SEPARATOR_RE)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  if (parts.length <= 1) return parts;
+
+  const titled = parts.filter(looksLikeTitle);
+  // Every part failing means the string read as a title only in aggregate.
+  // Keep it whole rather than dropping the headline outright: it is still the
+  // user's stated target, and `RolesPanel` needs it among the chips to star it.
+  return titled.length > 0 ? titled : [whole];
+}
+
 // Order matters throughout this table: every row is checked top-to-bottom and
 // the FIRST match wins, so a more specific keyword must sit above the more
 // general one it would otherwise be swallowed by. Two ordering constraints in
@@ -218,23 +273,64 @@ export const MAX_TITLES = 4;
 //     above the generic VP row, and the whole leadership tier sits above the
 //     IC tier so a compound title like "Senior Director" reads as Director,
 //     not Senior (#540).
-function deriveTitles(parsed: ResumeQueryInput): string[] {
+export function deriveTitles(parsed: ResumeQueryInput): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const exp of parsed.experience ?? []) {
-    const title = exp.title?.trim();
-    if (!title) continue;
-    const key = title.toLowerCase();
-    if (seen.has(key)) continue; // dedup case-insensitively, keep first-seen casing
-    seen.add(key);
-    out.push(title);
-    if (out.length >= MAX_TITLES) break; // most-recent-first, so we keep the recent ones
+
+  /**
+   * Admits one candidate title. Trims, drops blanks, dedups case-insensitively
+   * (keeping first-seen casing), and enforces `MAX_TITLES`. Returns `false` once
+   * the list is full, so each source below stops at the cap without repeating
+   * the check — three loops applying the same three rules inline is what pushed
+   * this function over the cognitive-complexity bar.
+   */
+  const push = (raw: string | undefined): boolean => {
+    if (out.length >= MAX_TITLES) return false;
+    const title = raw?.trim();
+    if (title && !seen.has(title.toLowerCase())) {
+      seen.add(title.toLowerCase());
+      out.push(title);
+    }
+    return out.length < MAX_TITLES;
+  };
+
+  // The stated target (#599) leads, because `titles[0]` is what `searchPhrase`
+  // sends as the feeds' `search=` param — the one audited resume-derived egress.
+  //
+  // SPLIT IT FIRST. A headline is a tagline, not a title: `extractHeadline`
+  // routinely lifts "DevOps Engineer · Software Architect" — two roles stacked
+  // on a separator. Sent whole, that is a single-intent full-text query naming
+  // two intents, which is exactly what `keywords.ts`'s own docblock says it
+  // avoids ("stacking distinct titles … would over-constrain the feed"), and it
+  // returns near-nothing. Splitting is preferred over gating the compound out:
+  // each part IS a real title, so the first becomes a clean egress phrase and
+  // the rest still widen the local `matchesQuery` broadening.
+  //
+  // The WHOLE headline arrives already shaped — `extractHeadline` admits a
+  // parsed one only past `looksLikeTitle`, and a user-typed one is warned by
+  // `headlineRoundTripWarning` in the ContactCard editor. The PARTS do not
+  // inherit that: the split invents them, so `splitHeadline` re-gates them
+  // itself. See its docblock.
+  for (const part of splitHeadline(parsed.headline)) {
+    if (!push(part)) break;
   }
-  if (out.length > 0) return out;
+
+  // `hasExpTitle` is set before the cap check on purpose: a résumé whose
+  // experience titles were all crowded out by the headline still HAS experience
+  // titles, so it must not fall through to the `current_title` fallback below.
+  // Most-recent-first, so the cap keeps the recent ones.
+  let hasExpTitle = false;
+  for (const exp of parsed.experience ?? []) {
+    if (!exp.title?.trim()) continue;
+    hasExpTitle = true;
+    if (!push(exp.title)) break;
+  }
+  if (hasExpTitle) return out;
+
   // No experience title at all → fall back to the top-level current_title, or
   // an empty set (skills-only / degenerate query).
-  const current = parsed.current_title?.trim();
-  return current ? [current] : [];
+  push(parsed.current_title);
+  return out;
 }
 
 /**

--- a/src/lib/job-search/query-steps.ts
+++ b/src/lib/job-search/query-steps.ts
@@ -57,6 +57,22 @@ const NO_SKILLS = "No skills yet";
 const NO_FILTERS = "Anywhere, nothing ruled out";
 const NOTHING_TO_SEND = "Nothing to search for yet";
 
+/**
+ * The one hint on the Titles step. Two facts, in the order they matter:
+ * what leaves the browser, and where the starred title came from.
+ *
+ * Both are verified, not assumed. `providers/keywords.ts` sends `titles[0]`
+ * as the feeds' `search=` param and nothing else résumé-derived; every other
+ * title filters locally in `search.ts`'s `matchesQuery`. And the star does
+ * survive the handoff: `useAnalyzedResume` folds the `headline` override into
+ * `canonical.fields` (it is in `applyOverrides`' `CONTACT_KEYS`), that becomes
+ * `displayResult`, and `ResultDetailTabs` hands exactly those fields to
+ * `FindJobsLauncher` — so re-launching from `/` does re-seed from the role
+ * marked there, replacing a title edited only here.
+ */
+export const ROLE_HINT =
+  "Only the starred title is sent to the job feeds. Every other title narrows and ranks the results right here on your device. The star starts from the role you marked on the résumé page, so going back and launching again will replace a title you changed here.";
+
 /** `n` of a thing, pluralised — the whole of a count summary's grammar. */
 function count(n: number, singular: string): string {
   return `${n} ${singular}${n === 1 ? "" : "s"}`;
@@ -99,6 +115,7 @@ export const QUERY_STEP_COPY: readonly string[] = [
   NO_SKILLS,
   NO_FILTERS,
   NOTHING_TO_SEND,
+  ROLE_HINT,
 ];
 
 /**

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -57,10 +57,10 @@ const HEADER_WRAP_INDENT = 12;
 
 export interface AtsContact {
   name: string;
-  /** Professional headline shown regular-weight under the name (#425). Absent
-   *  until the parser surfaces a genuine headline distinct from the most-recent
-   *  role title — see the follow-up note in `buildContact`. When present, the
-   *  renderer draws it between the name and the contact line. */
+  /** Professional headline shown regular-weight under the name (#425, #599). Set to
+   *  the candidate's chosen primary role title when selected (#599), falling back to
+   *  the standalone title tagline the parser lifted from the profile block. When
+   *  present, the renderer draws it between the name and the contact line. */
   headline?: string;
   email?: string;
   phone?: string;
@@ -256,10 +256,19 @@ export function buildContact(
   };
 
   const name = valueFor("full_name") || result.canonical.fields.full_name || "";
-  // Header headline (#425 follow-up): the standalone title tagline the parser
-  // lifted from the profile block ("Engineering Lead"), redrawn under the name.
-  // Not inline-editable (no ContactOverrides key), so read straight off parsed.
-  const headline = (result.canonical.fields.headline ?? "").trim();
+  // Header headline (#425, #599): the user's chosen primary role title when set,
+  // falling back to the standalone title tagline the parser lifted from the profile
+  // block ("Engineering Lead"), redrawn under the name.
+  //
+  // Read through `valueFor` like its five siblings rather than off
+  // `canonical.fields` directly. Both resolve to the same string on the app path
+  // — `useAnalyzedResume` folds `contactOverrides` into `canonical.fields` via
+  // `applyOverrides` before `displayResult` reaches this builder, and `headline`
+  // is in that fold's `CONTACT_KEYS` — so this is not a behaviour fix. It closes
+  // the gap between the two: a caller that hands `buildContact` a RAW cascade
+  // result plus overrides (as a unit test naturally does) would otherwise get
+  // the parsed headline back while every other field honoured the override.
+  const headline = valueFor("headline");
   const email = valueFor("email");
   const phone = valueFor("phone");
   const location = valueFor("location");

--- a/src/lib/pdf/render-roundtrip-headline.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-headline.repro.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+import { MAX_HEADLINE_LENGTH, headlineRoundTripWarning } from "../edit/headline.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/latex/awesome-cv-resume.pdf",
+);
+
+function scoreFor(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: cascade.canonical.fields,
+    fieldConfidence: cascade.canonical.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.canonical.sections,
+  });
+}
+
+describe("Headline round-trip", () => {
+  let baseCascade: CascadeResult;
+
+  beforeAll(async () => {
+    baseCascade = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+  });
+
+  /**
+   * Round-trip the fixture with `headline` substituted, returning BOTH the
+   * recovered headline and a witness that the rest of the parse survived.
+   *
+   * The witness exists because `not.toBe(tooLong)` — the shape this file used
+   * to assert — is satisfied by a truncation, by `undefined`, and equally by
+   * the fixture having stopped parsing altogether (#605 review). Pinning the
+   * name + experience count makes a broken fixture fail loudly instead of
+   * passing green for the wrong reason.
+   */
+  async function roundTripWithHeadline(headline: string): Promise<{
+    headline: string | undefined;
+    name: string | undefined;
+    experienceCount: number;
+  }> {
+    const canonical = {
+      ...baseCascade.canonical,
+      fields: {
+        ...baseCascade.canonical.fields,
+        headline,
+      },
+    };
+    const modifiedCascade = { ...baseCascade, canonical };
+    const model = buildAtsResumeModel(modifiedCascade, scoreFor(modifiedCascade));
+    const bytes = await renderAtsResumePdf(model);
+    const reparsed = await runCascade(bytes);
+    return {
+      headline: reparsed.canonical.fields.headline,
+      name: reparsed.canonical.fields.full_name,
+      experienceCount: reparsed.canonical.fields.experience.length,
+    };
+  }
+
+  /** The rest of the résumé came back — so a headline assertion below is
+   *  reporting on the headline, not on a fixture that failed to parse. */
+  function expectParseSurvived(result: { name: string | undefined; experienceCount: number }) {
+    expect(result.name).toBe(baseCascade.canonical.fields.full_name);
+    expect(result.experienceCount).toBe(baseCascade.canonical.fields.experience.length);
+  }
+
+  it("round-trips a headline at exactly MAX_HEADLINE_LENGTH characters", async () => {
+    const headlineBase = "Director Of Engineering Product Management And Development";
+    const exactHeadline = headlineBase.padEnd(MAX_HEADLINE_LENGTH, "X");
+
+    expect(exactHeadline.length).toBe(MAX_HEADLINE_LENGTH);
+    expect(headlineRoundTripWarning(exactHeadline)).toBeNull();
+
+    const result = await roundTripWithHeadline(exactHeadline);
+    expectParseSurvived(result);
+    expect(result.headline).toBe(exactHeadline);
+  });
+
+  it("truncates and warns on a headline exceeding MAX_HEADLINE_LENGTH", async () => {
+    const tooLong = "Director Of Engineering Product Management And Development And More";
+    expect(tooLong.length).toBeGreaterThan(MAX_HEADLINE_LENGTH);
+
+    expect(headlineRoundTripWarning(tooLong)).not.toBeNull();
+
+    const result = await roundTripWithHeadline(tooLong);
+    expectParseSurvived(result);
+    // What the warning promises: an over-long headline does not come back
+    // whole. Assert the recovered VALUE is either absent or within the limit —
+    // `not.toBe(tooLong)` would also pass on a garbled 200-char line.
+    expect(
+      result.headline === undefined ||
+        result.headline.length <= MAX_HEADLINE_LENGTH,
+    ).toBe(true);
+  });
+
+  it("warns on a prose-shaped headline that fails looksLikeTitle", async () => {
+    const proseHeadline = "A driven professional looking for opportunities";
+    expect(proseHeadline.length).toBeLessThanOrEqual(MAX_HEADLINE_LENGTH);
+
+    expect(headlineRoundTripWarning(proseHeadline)).not.toBeNull();
+
+    const result = await roundTripWithHeadline(proseHeadline);
+    expectParseSurvived(result);
+    // A prose line fails `extractHeadline`'s own `looksLikeTitle` gate, so it
+    // is not recovered as a headline at all. Assert that, not mere inequality.
+    expect(result.headline).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the candidate's target role on the reconstructed résumé page (`/`), makes the headline a first-class editable field with round-trip validation, and carries that target into the job-search lane.

Closes #598
Closes #599
Closes #600
Closes #601

**What lands:**

- **`RolesPanel`** — a "Which role are you targeting?" card over the titles `deriveTitles` derives. Promoting a chip sets the `headline` override, which is drawn under the name on the downloaded PDF **and** leads the job-feed query. Both consequences are stated in the help copy because neither is guessable from the UI.
- **`ContactCard`** gains an inline-editable headline, validated by `headlineRoundTripWarning` so a user-typed tagline the parser would not read back is flagged before it reaches the export.
- **`SkillTermGuidance`** moves from the page footer to directly under `RolesPanel`, above Experience.

## Egress correctness

`titles[0]` is what `providers/keywords.ts` sends verbatim as the feeds' `search=` param — the one audited resume-derived egress. A parsed headline is a *tagline*, not a title: `extractHeadline` routinely lifts `"DevOps Engineer · Software Architect"`, and sending that whole is a single-intent query naming two intents.

`splitHeadline` now breaks a stacked headline on `· • | / ,` and spaced dashes, so the first part becomes a clean egress phrase and the rest still widen the local `matchesQuery` filter. `&` and `and` are deliberately **not** separators — "Founding Member & Site Reliability Engineer" is one compound role, and splitting it would mint titles nobody holds.

No title is starred until a headline actually exists. Defaulting the star to `titles[0]` claimed a role printed under the name while `render-ats-pdf.ts` — which guards on `model.contact.headline` — drew nothing; only 8 of 54 corpus fixtures parse a headline at all.

## Section order on `/`

AttentionStrip → ContactCard → **RolesPanel → SkillTermGuidance** → the résumé document.

`SkillTermGuidance` moved up because its content is a *function* of the starred role (`buildJobQuery` → `deriveTitles` → `titles[0]` → role profile). Star a different title and the whole suggestion list changes; four sections apart, that dependency was invisible and the panel read as a static footer. AttentionStrip and ContactCard were left in place — the strip's "N contact fields missing" segment points at the card directly beneath it.

The cost of the move is that `onAddSkill`'s target (`SkillsSection`) is now off-screen, so the "put feedback next to the thing it affects" rule is being *paid for* rather than followed. It is paid with a confirm-in-place trail plus an `aria-live` announcement (this design system has no toast primitive), so an add still reports where it landed.

## Supporting changes

- `looksLikeTitle` + `COMPANY_SUFFIX_RE` move to a new leaf module `heuristics/extract/title-shape.ts`. `ContactCard → edit/headline → extract/shared → heuristics/regex` had dragged 672 lines of parser regex onto the entry graph for one predicate.
- `ChipListEditor`'s add affordance becomes a discriminated union, so `placeholder`/`addAriaLabel` are required exactly when `onAdd` is passed.
- `deriveTitles` folds its three trim/dedup/cap loops into a single `push` helper.

## Test plan

- [x] `npm run verify` — exit 0 (typecheck, lint, 3288 tests / 231 files, build)
- [x] Manual browser pass on `/` — promote a role, confirm the printed headline and the `+skill` confirmation trail
- [x] `npm run check:fixtures` — no fixture binaries added or changed by this PR

## fallow

Two complexity findings this PR genuinely introduced were fixed, not suppressed:

| Function | Before | After |
|---|---|---|
| `deriveTitles` (`query-builder.ts`) | cognitive 16 | below threshold |
| `ContactCard` (`ContactCard.tsx`) | cognitive 16 | below threshold |

A dead re-export of `COMPANY_SUFFIX_RE` left behind by the leaf split was removed.

Four findings that `fallow audit` still labels `introduced: true` are **misattributions** — `educationEntries`, `experienceEntries` (`ats-resume-model.ts`), `applyExperienceHeaderOverrides` (`apply-overrides.ts`), and `AchievementHeader` (`ReconstructedResume.tsx`). Verified by running `fallow health` on `origin/main` with the identical `--coverage` input: all four report byte-identical `cyclomatic`/`cognitive`/`crap` on both branches, and none of their bodies appear in this diff. The attribution appears to key on line number, which this PR shifted. The remaining duplication findings carry no `introduced` flag at all.

`fallow` is report-only inside `npm run verify`, so this does not gate CI.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #599 | Gemini 3.5 Flash (High) | high |
| Implementation — #600 | Claude 3.5 Sonnet | ultra |
| Implementation — #601 | Claude 3.5 Sonnet | ultra |
| Adversarial review | Gemini 2.5 Pro | ultra |
| Review fixes | Claude 3.5 Sonnet | ultra |
| Review revisions — #605 threads, section order, copy, fallow | Claude Opus 5 (1M context) | high |
| Orchestration + PR | Gemini 3.5 Flash (High) | high |
| Verification | `npm run verify` — exit 0 | — |

