### PR TITLE
test(job-search): wait for useCompanyTargets by wall clock, not a tick count

### DIFF
--- a/src/components/features/CompanyTargets.test.tsx
+++ b/src/components/features/CompanyTargets.test.tsx
@@ -88,13 +88,26 @@ async function mount(
     root!.render(createElement(Host, { parsed }));
   });
   // The hook seeds itself from two dynamic imports, so the first render lands
-  // before `ready`. A fixed number of ticks is not enough: the FIRST mount in
-  // the file pays a cold module load while later ones hit the module cache, so
-  // flush until the hook reports ready rather than guessing a tick count.
-  for (let i = 0; i < 50 && !latest?.ready; i += 1) {
+  // before `ready`. Bound the flush by WALL CLOCK, not by a tick count: the
+  // FIRST mount in the file pays a cold module load (~10 ticks / 17ms warm)
+  // while every later one hits the module cache and needs zero, and 50 ticks
+  // is only ~85ms of budget. Under coverage on a loaded CI runner that one
+  // cold load outlasts the budget, the loop gives up with `ready` still false,
+  // and `CompanyTargets` returns null behind its own `ready` guard — so the
+  // next line failed as "no companies disclosure control", blaming the markup
+  // for a wait that ended early. 3s stays under the 5s default `testTimeout`,
+  // so the explicit throw below wins the race against a timeout and says which
+  // of the two actually happened.
+  const deadline = Date.now() + 3_000;
+  while (!latest?.ready && Date.now() < deadline) {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
+  }
+  if (!latest?.ready) {
+    throw new Error(
+      "useCompanyTargets never reported ready within 3s — the lazy registry/taxonomy import never settled",
+    );
   }
   if (options.expand !== false) await expand();
 }
@@ -102,7 +115,16 @@ async function mount(
 /** Clicks the disclosure, the same control a user clicks. */
 async function expand(): Promise<void> {
   const toggle = buttons().find((b) => b.hasAttribute("aria-expanded"));
-  if (!toggle) throw new Error("no companies disclosure control");
+  // With the ready-wait above now hard-failing on its own, the only remaining
+  // way to land here is `ready` with an empty pool — which means the hook's
+  // `catch` swallowed a failed registry/taxonomy import. Say so, rather than
+  // reporting a missing control: the disclosure is correctly absent in that
+  // state, by the `suggested.length > 0` guard in `CompanyTargets`.
+  if (!toggle) {
+    throw new Error(
+      `no companies disclosure control (ready=${latest?.ready}, suggested=${latest?.suggested.length}) — an empty pool means the hook's catch path swallowed the registry import`,
+    );
+  }
   await act(async () => {
     toggle.click();
   });


### PR DESCRIPTION
## Summary

`src/components/features/CompanyTargets.test.tsx` fails intermittently in CI with `no companies disclosure control`, blaming markup that was never the problem. It took down [#572](https://github.com/offlinecv/OfflineCV/pull/572)'s `verify` — a **docs-only** PR that touches no `src/` file — and it will keep hitting unrelated PRs until it lands.

The mount helper waited for the hook by counting ticks:

```ts
for (let i = 0; i < 50 && !latest?.ready; i += 1) { /* setTimeout(resolve, 0) */ }
```

Instrumented, the **first** mount in the file needs ~10 ticks / 17ms to resolve the two dynamic imports `useCompanyTargets` seeds from, while every later one hits the module cache and needs **zero**. So 50 ticks is a ~85ms budget on a warm machine, pinned to nothing in wall-clock time. Under coverage instrumentation on a loaded runner, that one cold load outlasts the budget: the loop gives up with `ready` still false, `CompanyTargets` returns `null` behind its own `ready` guard, and `expand()` finds no disclosure to click.

The helper's own comment already said to *"flush until the hook reports ready rather than guessing a tick count"* — the code guessed a tick count. This makes the code match the comment: a **3s wall-clock deadline**, then a hard failure naming the unsettled import. 3s sits under the 5s default `testTimeout`, so the explicit throw wins the race and says which of the two actually happened.

`expand()` now reports `ready` and `suggested` as well. With the ready-wait failing on its own, the only remaining route to a missing disclosure is a ready hook with an empty pool — the hook's `catch` swallowing a failed registry import — and in that state the control is *correctly* absent, by the `suggested.length > 0` guard in `CompanyTargets`. Naming that keeps the next failure from being misread as a markup regression, the way this one was.

Test-only change; no production code touched.

## Verification of the diagnosis

- Shrinking the bound from 50 to 2 reproduces CI exactly — same message, same first test, other 18 green.
- Forcing the new deadline to expire yields `useCompanyTargets never reported ready within 3s …` instead of the misleading message.
- `main` at `1a785da` runs green locally at 237 files / 3277 tests — the same counts CI reported on the failing run (3266 passed + 1 failed + 10 skipped), so this is timing, not a tree difference.

No issue number — found while triaging the CI failure on #572; happy to file one if you'd rather track it.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 229 passed | 8 skipped (237 files), 3267 passed | 10 skipped
- [x] `npx eslint` clean on the touched file
- [x] Failure mode reproduced and the new diagnostic confirmed (above)

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — green in CI
