### PR TITLE
fix(parser): flatten every markdown link shape, and stop body URLs hijacking the contact card

### DIFF
--- a/src/lib/heuristics/extract/contact.test.ts
+++ b/src/lib/heuristics/extract/contact.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { extractContact } from "./contact.ts";
+import { isStandaloneUrl } from "./shared.ts";
 import type { PdfLinkAnnotation } from "../types.ts";
 import type { PdfLine, PdfSection } from "../sections.ts";
 
@@ -119,18 +120,28 @@ describe("extractContact — mid-sentence domain is not promoted to website_url 
   // fallback scan and promoted to website_url. The standalone check in
   // extractOtherUrls now rejects domains that appear mid-sentence.
 
+  // Both prose lines are kept IN the profile section, the same treatment the
+  // positive test below already applies. #610 banded the website/portfolio text
+  // tier to the profile, so a prose line parked in the body would make these
+  // pass no matter what `isStandaloneUrl` does — the doc-wide fallback is never
+  // consulted for those two fields, so the assertion would hold vacuously and
+  // #237's guard would be pinned nowhere.
+
   it("does not promote a domain mid-sentence to website_url", () => {
     const contactLine = mkLine(
       "Jane Doe | jane@example.com | (312) 555-0123",
       0,
     );
-    // Body line that contains a domain mid-sentence
-    const bodyLine = mkLine(
+    // Prose line that contains a domain mid-sentence
+    const proseLine = mkLine(
       "Exit · Founded and sold return2india.com to Satyam Infoway (NASDAQ: SIFY). 200K monthly visits.",
-      100,
+      1,
     );
-    const profile: PdfSection = { name: "profile", lines: [contactLine] };
-    const allLines: PdfLine[] = [contactLine, bodyLine];
+    const profile: PdfSection = {
+      name: "profile",
+      lines: [contactLine, proseLine],
+    };
+    const allLines: PdfLine[] = [contactLine, proseLine];
 
     const result = extractContact(profile, allLines);
 
@@ -139,13 +150,30 @@ describe("extractContact — mid-sentence domain is not promoted to website_url 
 
   it("does not promote a domain with surrounding words to website_url", () => {
     const contactLine = mkLine("Jane Doe | jane@example.com", 0);
-    const bodyLine = mkLine("Launched mysite.com for 10K users in 2023", 100);
-    const profile: PdfSection = { name: "profile", lines: [contactLine] };
-    const allLines: PdfLine[] = [contactLine, bodyLine];
+    const proseLine = mkLine("Launched mysite.com for 10K users in 2023", 1);
+    const profile: PdfSection = {
+      name: "profile",
+      lines: [contactLine, proseLine],
+    };
+    const allLines: PdfLine[] = [contactLine, proseLine];
 
     const result = extractContact(profile, allLines);
 
     expect(result.website_url).toBeUndefined();
+  });
+
+  // Direct unit test of the guard itself — `isStandaloneUrl` is exported from
+  // `./shared.ts`, so it needs no test-only export. The two cases above run it
+  // through `extractContact`; these pin the predicate's own contract.
+  it("isStandaloneUrl rejects a bare domain flanked by words and accepts a schemed one", () => {
+    const prose = "Launched mysite.com for 10K users in 2023";
+    expect(isStandaloneUrl("mysite.com", prose)).toBe(false);
+    expect(
+      isStandaloneUrl("https://mysite.com", "Launched https://mysite.com for"),
+    ).toBe(true);
+    expect(
+      isStandaloneUrl("janedoe.com", "Jane Doe | jane@example.com | janedoe.com"),
+    ).toBe(true);
   });
 
   it("still promotes a standalone domain on its own line to website_url", () => {
@@ -162,9 +190,34 @@ describe("extractContact — mid-sentence domain is not promoted to website_url 
 
   it("still promotes an https:// URL even when mid-sentence text surrounds it", () => {
     const contactLine = mkLine("Jane Doe | jane@example.com", 0);
-    // An explicit https:// URL is always a link regardless of surrounding text
+    // An explicit https:// URL is always a link regardless of surrounding text.
+    // Kept IN the profile section: #610 banded the website/portfolio text tier
+    // to the profile, so putting this line in the body would now assert the
+    // banding rather than the `isStandaloneUrl` scheme rule it exists to pin.
+    const proseLine = mkLine("Sold https://return2india.com to Satyam Infoway", 1);
+    const profile: PdfSection = {
+      name: "profile",
+      lines: [contactLine, proseLine],
+    };
+    const allLines: PdfLine[] = [contactLine, proseLine];
+
+    const result = extractContact(profile, allLines);
+
+    expect(result.website_url).toBe("https://return2india.com");
+  });
+});
+
+describe("extractContact — body-section URLs never reach the contact card (#610)", () => {
+  // The doc-wide text tier made `website_url` — an explicit catch-all — claim
+  // the first scheme-bearing URL ANYWHERE in the résumé. #237's guard cannot
+  // stop it: a scheme-bearing URL is unconditionally `isStandaloneUrl`. The
+  // portfolio/website text tier is now banded to the profile section, matching
+  // what the annotation tier already did via `inProfileSection`.
+
+  it("does not promote a scheme-bearing URL that lives in a body section", () => {
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
     const bodyLine = mkLine(
-      "Sold https://return2india.com to Satyam Infoway",
+      "Led the catalog migration https://example.org/eng-blog/catalog-migration that cut checkout latency 40%",
       100,
     );
     const profile: PdfSection = { name: "profile", lines: [contactLine] };
@@ -172,7 +225,35 @@ describe("extractContact — mid-sentence domain is not promoted to website_url 
 
     const result = extractContact(profile, allLines);
 
-    expect(result.website_url).toBe("https://return2india.com");
+    expect(result.website_url).toBeUndefined();
+    expect(result.profiles).toEqual([]);
+  });
+
+  it("does not promote a portfolio-shaped body URL to portfolio_url", () => {
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
+    const bodyLine = mkLine("Shipped the redesign at https://acme.io/case-study", 100);
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const allLines: PdfLine[] = [contactLine, bodyLine];
+
+    const result = extractContact(profile, allLines);
+
+    expect(result.portfolio_url).toBeUndefined();
+    expect(result.website_url).toBeUndefined();
+  });
+
+  it("still promotes linkedin/github identity links found outside the profile", () => {
+    const contactLine = mkLine("Jane Doe | jane@example.com", 0);
+    const footerLine = mkLine(
+      "Links: https://linkedin.com/in/janedoe · github.com/janedoe",
+      100,
+    );
+    const profile: PdfSection = { name: "profile", lines: [contactLine] };
+    const allLines: PdfLine[] = [contactLine, footerLine];
+
+    const result = extractContact(profile, allLines);
+
+    expect(result.linkedin_url).toBe("https://linkedin.com/in/janedoe");
+    expect(result.github_url).toBe("https://github.com/janedoe");
   });
 });
 

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -215,6 +215,57 @@ function findConsumedLines(
 }
 
 /**
+ * Band `portfolio_url` / `website_url` to the profile section on the TEXT tier
+ * as well as the annotation tier (#610) — option (a) of the two the issue put
+ * up. When true, `pickUrl` skips the doc-wide text fallback for those two
+ * fields; `linkedin_url` / `github_url` keep theirs.
+ *
+ * WHY THIS EXISTS. `website_url` is the explicit catch-all — "any remaining URL
+ * not already claimed by linkedin/github/portfolio". Run over a doc-wide join
+ * of every line, catch-all semantics degrade to *the first scheme-bearing URL
+ * anywhere in the résumé*, so a link that lives in an Achievements entry or an
+ * Experience bullet renders on the contact line. #237's guard does not stop it:
+ * that fixed the scheme-LESS case, and a `https://` URL is unconditionally
+ * `isStandaloneUrl`. This also makes the #134 docblock claim below
+ * ("portfolio/website stay header-banded") true on BOTH tiers rather than only
+ * the annotation one, which is what it already asserted.
+ *
+ * WHY NOT OPTION (b) — subtract URLs already claimed by an achievement/project
+ * entry. It cannot satisfy the issue's own acceptance criterion, which names
+ * *Experience* alongside Achievements and Projects: an Experience bullet has no
+ * `url` slot, so its link is never "claimed by a body entry" and there is
+ * nothing to subtract. Generalising (b) to "any URL on a non-profile line" is
+ * option (a) wearing a post-pass, at the cost of re-ordering extraction.
+ *
+ * COST, MEASURED. The stated risk was a résumé that genuinely prints its
+ * personal site in a footer, which would now be lost. Ran the banded build over
+ * all 54 corpus fixtures: exactly ONE snapshot moves —
+ * `tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.pdf` drops
+ * `website_url` from `fieldsPopulated` — and it is a false positive being
+ * removed, not a footer site: the value was `LaunchPadCart.com`, lifted out of
+ * a STRENGTHS-sidebar sentence ("Successfully launched and sold a consumer
+ * website LaunchPadCart.com."). That is a product the candidate sold, not their
+ * contact website, and it is #237's own defect class reaching the card by the
+ * one route #237 left open. No fixture in the corpus sources either field
+ * legitimately from below the profile band, so the footer shape the issue
+ * worried about is not represented and is not being traded away here.
+ *
+ * WHAT THIS COSTS, STATED PLAINLY. A personal site printed in a FOOTER is lost.
+ * The text tier no longer reaches it, and the annotation tier does not rescue
+ * it either: `pdf-extract.ts` flips pdfjs' bottom-origin y to top-origin
+ * (`yTop = viewport.height - yBottom`), so y grows DOWNWARD, and
+ * `inProfileSection` accepts `ann.yTop <= profileLineMaxY + 12` — at or above
+ * the last profile line plus about one line-height of slack. That band is the
+ * header, the opposite end of the page from a footer. The only surviving route
+ * is the résumé hyperlinking the site from its header block, where the
+ * annotation lands inside the band. That is the accepted cost of option (a),
+ * which #610 explicitly permits; no corpus fixture exercises the footer shape.
+ * (`linkedin_url` / `github_url` are unaffected — their doc-wide `anywhereOnDoc`
+ * fallback is deliberately kept, so a footer profile icon still resolves.)
+ */
+const PORTFOLIO_WEBSITE_BAND_TO_PROFILE = true;
+
+/**
  * Scans `lines` for a candidate location string, checking US patterns first
  * then international. Returns the first match found, or `undefined`.
  *
@@ -444,14 +495,20 @@ export function extractContact(
   // `/in/` redirect printed as its own label (LaTeX `\href{url}{url}`) fills
   // `linkedin_url` from the annotation AND `website_url` from the text scan —
   // the exact double-render this PR removes (#378).
+  //
+  // `bandToProfileSection` (#610) drops the doc-wide TEXT tier for a field,
+  // leaving only the profile-band text scan and the profile-band annotation
+  // lookup — see `PORTFOLIO_WEBSITE_BAND_TO_PROFILE` for why the two link
+  // catch-alls opt in and the two identity links do not.
   const pickUrl = <K extends "linkedin_url" | "github_url" | "portfolio_url" | "website_url">(
     key: K,
     resolveAnnotation: () => string | undefined,
     reject?: (url: string) => boolean,
+    bandToProfileSection = false,
   ): { value: string | undefined; confidence: number } => {
     if (primary[key] && !reject?.(primary[key]!))
       return { value: primary[key], confidence: primary.confidence[key] };
-    if (fallback[key] && !reject?.(fallback[key]!))
+    if (!bandToProfileSection && fallback[key] && !reject?.(fallback[key]!))
       return {
         value: fallback[key],
         confidence: fallback.confidence[key] * 0.9,
@@ -503,6 +560,7 @@ export function extractContact(
         inProfileSection,
       ),
     (u) => claimedByIdentity.has(claimKey(u)),
+    PORTFOLIO_WEBSITE_BAND_TO_PROFILE,
   );
   // Website is the catch-all: any remaining URL not already claimed by
   // linkedin/github/portfolio — on ANY tier (text scan or annotation), so a
@@ -525,6 +583,7 @@ export function extractContact(
         inProfileSection,
       ),
     (u) => claimedUrls.has(claimKey(u)),
+    PORTFOLIO_WEBSITE_BAND_TO_PROFILE,
   );
 
   // Ownership (#134): claim the document-wide body lines that are nothing but a

--- a/src/lib/heuristics/markdown-inline-links.repro.test.ts
+++ b/src/lib/heuristics/markdown-inline-links.repro.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * End-to-end repro for #610 — dropping a `.md` whose body carries markdown
+ * inline links.
+ *
+ * Runs the REAL drop path (`parseMarkdownFile` → `runCascadeFromMarkdown`) over
+ * `tests/fixtures/markdown/inline-links.md` so both halves of the fix are
+ * pinned where the user actually sees them:
+ *
+ *   - Step 1 (`markdown-lines.ts`): `[label](url)` and `<url>` are flattened to
+ *     `label url`, so no bracket-paren syntax reaches an extractor. Before the
+ *     fix, an Experience bullet rendered the raw markdown into the exported PDF
+ *     and `liftHeaderLabel` left an orphaned `[label]()` in an achievement
+ *     title (it spliced out the URL and nothing else).
+ *   - Step 2 (`contact.ts`): a URL that lives only in a body section never
+ *     becomes the contact `website_url` / `portfolio_url`. Flattening alone
+ *     does not fix this — it leaves a scheme-bearing URL in body text, which
+ *     the doc-wide catch-all would still steal.
+ *
+ * The fixture is a synthetic persona (see `tests/fixtures/markdown/README.md`);
+ * `npm run check:fixtures` does not cover `.md`, so treat it manually.
+ */
+
+import { promises as fsp } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runCascadeFromMarkdown } from "./cascade.ts";
+import { parseMarkdownFile } from "../ingest/markdown.ts";
+import type { CascadeResult } from "./types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(HERE, "../../../tests/fixtures/markdown/inline-links.md");
+
+let result: CascadeResult;
+
+beforeAll(async () => {
+  const { rawText, markdown } = parseMarkdownFile(
+    await fsp.readFile(FIXTURE, "utf8"),
+  );
+  result = await runCascadeFromMarkdown(rawText, markdown);
+});
+
+/** Every string the parse produced that a reader could see in the export. */
+function visibleStrings(r: CascadeResult): string[] {
+  const f = r.canonical.fields;
+  return [
+    f.summary ?? "",
+    ...(f.skills ?? []),
+    ...(f.experience ?? []).flatMap((e) => [
+      e.title ?? "",
+      e.company ?? "",
+      e.description ?? "",
+    ]),
+    ...(f.projects ?? []).flatMap((p) => [p.name ?? "", p.description ?? ""]),
+    ...(f.heuristic_achievements ?? []).flatMap((a) => [
+      a.title ?? "",
+      a.type ?? "",
+    ]),
+    ...(f.education ?? []).flatMap((e) => [e.institution ?? "", e.degree ?? ""]),
+  ];
+}
+
+describe("#610 — inline link syntax never survives the .md drop path", () => {
+  it("leaves no markdown link syntax in any user-visible field", () => {
+    for (const s of visibleStrings(result)) {
+      // `[2019]`-style bracketed years are fine — it is the LINK shape
+      // (`](`, or a bracket immediately followed by parens) that must be gone.
+      expect(s).not.toMatch(/\]\s*\(/);
+      expect(s).not.toMatch(/\]\s*\(\s*\)/);
+      expect(s).not.toMatch(/<https?:/);
+    }
+  });
+
+  it("keeps the Experience bullet's label text AND its target, unbracketed", () => {
+    // Reproduction 2 — an Experience bullet never passes through
+    // `liftHeaderLabel`, so before the fix the whole `[label](url)` rendered
+    // verbatim into the exported PDF.
+    const roles = result.canonical.fields.experience ?? [];
+    const migration = roles.find((e) =>
+      /catalog migration/.test(e.description ?? ""),
+    )?.description;
+    expect(migration).toBeDefined();
+    expect(migration).not.toContain("[catalog migration]");
+    expect(migration).toContain(
+      "Led the catalog migration https://example.org/eng-blog/catalog-migration that cut",
+    );
+
+    // The titled form `[label](url "Title")` drops the title and keeps both
+    // halves of the link.
+    const writeup = roles.find((e) => /writeup/.test(e.description ?? ""))
+      ?.description;
+    expect(writeup).toContain("the writeup https://example.net/pricing-writeup");
+    expect(writeup).not.toContain("Pricing rebuild");
+  });
+
+  it("leaves no orphaned `[label]()` in the achievement title, and keeps the URL as data", () => {
+    const achievements = result.canonical.fields.heuristic_achievements ?? [];
+    const patent = achievements.find((a) => /Issued Patent/.test(a.title ?? ""));
+    expect(patent).toBeDefined();
+    // `liftHeaderLabel` spliced the URL out and left the syntax behind.
+    expect(patent!.title).not.toMatch(/\[|\]\(|\(\)/);
+    expect(patent!.title).toContain("Issued Patent XX0000000A0");
+    // The target is preserved as structured data, not discarded.
+    //
+    // `startsWith`, not equality: the fixture writes the repro's `…A0;` shape,
+    // and `URL_RE` treats a trailing `;` as part of the URL. That is
+    // pre-existing, path-agnostic behavior — a PLAIN-TEXT résumé line reading
+    // "Patent A0 https://example.org/x; more prose" lifts the same `;`-suffixed
+    // URL today, because `liftHeaderLabel` is shared with the PDF path. Making
+    // the `.md` path agree with the plain-text path is exactly what #610
+    // restores, so the suffix is in-contract here; trimming sentence
+    // punctuation off `URL_RE` would move every corpus fixture and is a
+    // separate change.
+    expect(patent!.url).toMatch(/^https:\/\/example\.org\/patents\/XX0000000A0/);
+  });
+
+  it("lifts the Projects entry URL without leaving link syntax in the name", () => {
+    const project = (result.canonical.fields.projects ?? [])[0];
+    expect(project).toBeDefined();
+    expect(project!.name).not.toMatch(/\[|\]\(/);
+    expect(project!.url).toBe("https://example.org/ledger-toolkit");
+  });
+});
+
+describe("#610 — a body-section URL never reaches the contact card", () => {
+  it("does not promote any body URL to website_url or portfolio_url", () => {
+    expect(result.canonical.fields.website_url).toBeUndefined();
+    expect(result.canonical.fields.portfolio_url).toBeUndefined();
+  });
+
+  it("carries only genuine contact links in profiles[]", () => {
+    const profiles = result.canonical.fields.profiles ?? [];
+    expect(profiles.map((p) => p.url)).toEqual([
+      "https://linkedin.com/in/rileynakamura",
+      "https://github.com/rileynakamura",
+    ]);
+    expect(profiles.every((p) => p.kind !== "other")).toBe(true);
+  });
+
+  it("still resolves the autolinked LinkedIn and the bare GitHub from the header", () => {
+    expect(result.canonical.fields.linkedin_url).toBe(
+      "https://linkedin.com/in/rileynakamura",
+    );
+    expect(result.canonical.fields.github_url).toBe(
+      "https://github.com/rileynakamura",
+    );
+  });
+
+  it("still holds #237's line — a bare domain mid-sentence is not a website", () => {
+    // "sold sidebiz.example.com to a buyer" sits in the Summary. It must not
+    // surface as a contact link on ANY tier.
+    const links = [
+      result.canonical.fields.website_url,
+      result.canonical.fields.portfolio_url,
+      result.canonical.fields.linkedin_url,
+      result.canonical.fields.github_url,
+    ];
+    expect(links.some((u) => u?.includes("sidebiz.example.com"))).toBe(false);
+  });
+});

--- a/src/lib/heuristics/markdown-lines.test.ts
+++ b/src/lib/heuristics/markdown-lines.test.ts
@@ -106,3 +106,133 @@ describe("sectionizeMarkdown — rawHeading capture (#285)", () => {
     expect(profile?.rawHeading).toBeUndefined();
   });
 });
+
+describe("sectionizeMarkdown — inline link flattening (#610)", () => {
+  /** Convenience: the text of the single line produced by `md`. */
+  const lineText = (md: string): string => {
+    const { lines } = sectionizeMarkdown(md);
+    expect(lines).toHaveLength(1);
+    return lines[0].text;
+  };
+
+  it("flattens `[label](url)` to `label url`, matching mdToPlainText", () => {
+    expect(lineText("Led the [catalog migration](https://example.org/blog/x) last year")).toBe(
+      "Led the catalog migration https://example.org/blog/x last year",
+    );
+  });
+
+  it("drops the optional CommonMark link title", () => {
+    expect(lineText('See the [writeup](https://example.net/w "Pricing rebuild").')).toBe(
+      "See the writeup https://example.net/w.",
+    );
+  });
+
+  it("flattens every link on a line, not just the first", () => {
+    expect(
+      lineText("[one](https://example.org/1) and [two](https://example.org/2)"),
+    ).toBe("one https://example.org/1 and two https://example.org/2");
+  });
+
+  it("flattens a link inside a bullet, keeping the bullet glyph", () => {
+    expect(lineText("- Led the [migration](https://example.org/m) work")).toBe(
+      "- Led the migration https://example.org/m work",
+    );
+  });
+
+  it("emits the bare target for a degenerate empty label", () => {
+    expect(lineText("Portfolio [](https://example.org/p) here")).toBe(
+      "Portfolio https://example.org/p here",
+    );
+  });
+
+  it("flattens a bare URI autolink to the URL itself", () => {
+    expect(lineText("Site: <https://example.org/me>")).toBe(
+      "Site: https://example.org/me",
+    );
+  });
+
+  it("flattens an email autolink to the address itself", () => {
+    expect(lineText("<riley.nakamura@example.com>")).toBe(
+      "riley.nakamura@example.com",
+    );
+  });
+
+  it("leaves a stray HTML-ish angle token alone — an autolink needs a scheme or an @", () => {
+    expect(lineText("Wrote <b>bold</b> copy for the landing page")).toBe(
+      "Wrote <b>bold</b> copy for the landing page",
+    );
+  });
+
+  it("still strips markdown IMAGES entirely rather than flattening them", () => {
+    // The `!`-prefixed form must never start reading as `alt url`: `stripImages`
+    // runs first, so by the time `flattenLinks` sees the text the image is gone.
+    expect(lineText("Headshot ![Riley Nakamura](https://example.org/me.png) here")).toBe(
+      "Headshot  here",
+    );
+    expect(lineText("Logo ![logo](data:image/png;base64,AAAA) here")).toBe(
+      "Logo  here",
+    );
+  });
+
+});
+
+describe("sectionizeMarkdown — reference-link flattening (#611)", () => {
+  /** Convenience: the text of the single NON-blank line produced by `md`. */
+  const lineText = (md: string): string => {
+    const { lines } = sectionizeMarkdown(md);
+    expect(lines).toHaveLength(1);
+    return lines[0].text;
+  };
+
+  const DEFS = [
+    "",
+    "[cat]: https://example.org/eng-blog/catalog-migration",
+    "[pricing rebuild]: https://example.net/pricing-rebuild",
+  ].join("\n");
+
+  it("flattens `[label][ref]` to `label url`, matching the inline shape", () => {
+    // Was `leaves reference-style links unflattened` — #610 deferred this shape
+    // and #611 claims it, so the assertion inverts rather than being deleted.
+    expect(lineText(`Led the [catalog migration][cat] work${DEFS}`)).toBe(
+      "Led the catalog migration https://example.org/eng-blog/catalog-migration work",
+    );
+  });
+
+  it("flattens the collapsed `[label][]` and shortcut `[label]` forms too", () => {
+    expect(lineText(`Wrote the [Pricing Rebuild][] doc${DEFS}`)).toBe(
+      "Wrote the Pricing Rebuild https://example.net/pricing-rebuild doc",
+    );
+    expect(lineText(`Wrote the [Pricing Rebuild] doc${DEFS}`)).toBe(
+      "Wrote the Pricing Rebuild https://example.net/pricing-rebuild doc",
+    );
+  });
+
+  it("drops the `[ref]: url` definition lines entirely", () => {
+    const { lines } = sectionizeMarkdown(
+      `Led the [catalog migration][cat] work${DEFS}`,
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines.map((l) => l.text).join("\n")).not.toContain("]:");
+  });
+
+  it("leaves an undefined reference — and plain bracketed prose — untouched", () => {
+    expect(lineText(`Owned the [warehouse indexer][missing] rewrite${DEFS}`)).toBe(
+      "Owned the [warehouse indexer][missing] rewrite",
+    );
+    // `[2019]` is a shortcut-reference SHAPE, but nothing defines it, so it
+    // stays the year marker the achievements extractor reads.
+    expect(lineText(`Issued a patent. [2019]${DEFS}`)).toBe(
+      "Issued a patent. [2019]",
+    );
+  });
+
+  it("still flattens an INLINE link when the same line also holds a reference", () => {
+    // Inline flattening runs first and consumes its own brackets, so the
+    // shortcut rule can never re-read `[label](url)` as `[label]`.
+    expect(
+      lineText(`See [the post](https://example.org/p) and [catalog migration][cat]${DEFS}`),
+    ).toBe(
+      "See the post https://example.org/p and catalog migration https://example.org/eng-blog/catalog-migration",
+    );
+  });
+});

--- a/src/lib/heuristics/markdown-lines.ts
+++ b/src/lib/heuristics/markdown-lines.ts
@@ -16,6 +16,16 @@
  *   - Strip base64 data URIs in `![...](data:...)` — mammoth+turndown emits
  *     embedded images this way and they can bloat markdown 3× with zero
  *     signal for parsing.
+ *   - Flatten inline links `[label](url)` and autolinks `<url>` to `label url`
+ *     (#610). Without this the bracket-paren syntax reaches every extractor
+ *     verbatim, so a `.md` renders literal markdown in the exported PDF and
+ *     `liftHeaderLabel` leaves an orphaned `[label]()` behind.
+ *   - Resolve reference-style links — `[label][ref]`, `[label][]` and bare
+ *     `[label]` — against the document's `[ref]: url` definition table, and
+ *     blank the definition lines themselves (#611). Same `label url` output as
+ *     the inline shape; the table and the reasoning live in
+ *     `src/lib/markdown-link-refs.ts`, shared with `mdToPlainText` so the
+ *     `rawText` and `markdown` readings of one `.md` stay in agreement.
  *   - Unescape turndown's backslash-escapes (`\_`, `\*`, `\[`, `\.`). These
  *     would otherwise break email / URL regex (e.g. `Jordan\_Lee@foo`
  *     parses as `_Lee@foo`).
@@ -38,6 +48,12 @@
  * " | "; rare in resumes and not worth a dedicated extractor today.
  */
 
+import {
+  extractLinkDefinitions,
+  flattenAutolinks,
+  resolveReferenceLinks,
+  stripReferenceImages,
+} from "../markdown-link-refs.ts";
 import type { PdfLine, PdfSection } from "./sections.ts";
 import {
   matchSectionHeaderDetailed,
@@ -81,6 +97,27 @@ const DATA_URI_IMAGE_RE = /!\[[^\]]*\]\(data:[^)]*\)/g;
 // it doesn't pollute the line text.
 const ANY_IMAGE_RE = /!\[[^\]]*\]\([^)]*\)/g;
 
+// Reference-style images (`![alt][ref]`, `![alt][]`, `![alt]`) cannot be
+// stripped here: unlike the two shapes above they are not self-identifying —
+// whether `![great]` is an image or literal prose depends on the document's
+// `[ref]: url` definition table, which does not exist yet at this point in the
+// pipeline. They are handled inside `flattenLinks` via the shared
+// `stripReferenceImages`, one step later, once the table has been built.
+
+// Inline markdown links: `[label](url)`, optionally with a CommonMark title
+// (`[label](url "Title")`). Unlike images, BOTH halves carry signal — the label
+// is the visible résumé text and the target is a real link — so we flatten to
+// `label url` rather than dropping the ref (#610). The label class excludes
+// newlines so an unmatched `[` on one line can never pair with a `](url)` on a
+// later one; the target class excludes whitespace, which is also what makes a
+// `)`-bearing URL out of scope (CommonMark requires those be angle-bracketed or
+// escaped, and neither shape appears in a résumé).
+const INLINE_LINK_RE = /\[([^\]\n]*)\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
+
+// Autolinks (`<https://…>`, `<jane@example.com>`) flatten through the shared
+// `flattenAutolinks` in `../markdown-link-refs.ts` — see the import above. The
+// rule lives there so `mdToPlainText` applies the identical one to `rawText`.
+
 // Turndown backslash-escapes characters that have markdown meaning: `_`,
 // `*`, `[`, `]`, `(`, `)`, `.`, `+`, `-`, `!`, `` ` ``, `#`, `>`. Undo the
 // escapes that appear in contact data / prose. We keep `\n` as-is.
@@ -91,6 +128,56 @@ function stripImages(markdown: string): string {
   return markdown
     .replace(DATA_URI_IMAGE_RE, "")
     .replace(ANY_IMAGE_RE, "");
+}
+
+/**
+ * Flatten every markdown link shape to its plain-text reading — inline links
+ * and autolinks (#610), then reference-style links (#611).
+ *
+ * Also where the REFERENCE-style image shape is dropped, because this is the
+ * first point that has the definition table `stripReferenceImages` needs to
+ * tell an image (`![badge][ci]`, with `[ci]` defined) from prose that merely
+ * puts a `!` beside a bracket (`Grew revenue 40%![details][cat]`, with nothing
+ * defining `[cat]`). Deciding it a step earlier, in `stripImages`, is not
+ * possible without the table and deleted the prose.
+ *
+ * An image that the table does NOT resolve therefore survives into
+ * `resolveReferenceLinks` — as does every image on `mdToPlainText`'s path,
+ * which has no strip pass at all. Both are safe: the image alternative in that
+ * scan consumes the whole usage and returns it untouched, so no image can
+ * start flattening to `alt url` on either path.
+ *
+ * `label url` (not bare `label`) is deliberate: it mirrors the `$1 $2` rewrite
+ * `mdToPlainText` (`src/lib/ingest/markdown.ts`) already applies to the
+ * `rawText` half of a dropped `.md`, so the two representations of the same
+ * file finally agree — that convergence is the actual invariant this restores.
+ * (A degenerate empty-label `[](url)` emits the bare target rather than a
+ * leading space, which is the only place the two rewrites differ.)
+ * It also keeps the target visible to `liftHeaderLabel`, which lifts it into
+ * `project.url` / `achievement.url` exactly as it does for a plain-text
+ * résumé; emitting bare `label` would silently discard structured data.
+ *
+ * The internal ORDER is load-bearing (#611). Definition lines are blanked
+ * first, so a `[ref]: <https://…>` target can never be mistaken for an
+ * autolink and a definition label can never be resolved as a shortcut
+ * reference against itself. Inline links go next, because they are the one
+ * shape identified by a token the reference rule cannot see (`](`) — flattening
+ * them first consumes their brackets, so `[label](url)` is never re-read as the
+ * shortcut reference `[label]`. Reference resolution runs last, over text that
+ * by then holds only brackets no other rule claimed.
+ */
+function flattenLinks(markdown: string): string {
+  const { definitions, body } = extractLinkDefinitions(markdown);
+  return resolveReferenceLinks(
+    flattenAutolinks(
+      stripReferenceImages(body, definitions).replace(
+        INLINE_LINK_RE,
+        (_m, label: string, url: string) =>
+          label.trim() ? `${label} ${url}` : url,
+      ),
+    ),
+    definitions,
+  );
 }
 
 /** Undo turndown's backslash-escapes of markdown-meaningful characters. */
@@ -155,6 +242,7 @@ function normalizeSplitLetterHeaders(markdown: string): string {
 function preprocessMarkdown(markdown: string): string {
   let out = markdown;
   out = stripImages(out);
+  out = flattenLinks(out);
   out = unescapeBackslashes(out);
   out = normalizeSplitLetterHeaders(out);
   return out;

--- a/src/lib/heuristics/markdown-reference-links.repro.test.ts
+++ b/src/lib/heuristics/markdown-reference-links.repro.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * End-to-end repro for #611 — dropping a `.md` whose body carries
+ * reference-style links.
+ *
+ * Sibling of `markdown-inline-links.repro.test.ts`: same real drop path
+ * (`parseMarkdownFile` → `runCascadeFromMarkdown`), over
+ * `tests/fixtures/markdown/reference-links.md`, pinning the three distinct
+ * leaks measured on the pre-#611 baseline. #611 was filed as a hypothesis, so
+ * what that baseline actually did is worth recording:
+ *
+ *   1. `[label][ref]`, `[label][]` and `[label]` all survived verbatim into
+ *      `PdfLine.text`, and from there into `experience[].description` and
+ *      `heuristic_achievements[].title` — as the issue presumed.
+ *   2. The `[ref]: url` DEFINITION line's fate turned out to depend on where it
+ *      sat, which the issue did not anticipate. Under a prose section it was
+ *      appended verbatim to `summary`. Above the first section header it became
+ *      the contact `website_url` PLUS a bogus `kind: "other"` profile entry —
+ *      the one placement #610's profile-banding cannot stop, which is why this
+ *      fixture puts `[handbook]:` in the profile band. Under Education or
+ *      Skills it was silently swallowed by the section extractor and left no
+ *      trace in the canonical fields at all — but it still printed into
+ *      `rawText`, which `EvidencePanel` shows the user verbatim. (On plain
+ *      `main`, before #610's banding, ALL THREE placements leaked
+ *      `website_url`.)
+ *
+ * The fixture is a synthetic persona (see `tests/fixtures/markdown/README.md`);
+ * `npm run check:fixtures` does not cover `.md`, so treat it manually.
+ */
+
+import { promises as fsp } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runCascadeFromMarkdown } from "./cascade.ts";
+import { parseMarkdownFile } from "../ingest/markdown.ts";
+import type { CascadeResult } from "./types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(HERE, "../../../tests/fixtures/markdown/reference-links.md");
+
+let result: CascadeResult;
+
+beforeAll(async () => {
+  const { rawText, markdown } = parseMarkdownFile(
+    await fsp.readFile(FIXTURE, "utf8"),
+  );
+  result = await runCascadeFromMarkdown(rawText, markdown);
+});
+
+/** Every string the parse produced that a reader could see in the export. */
+function visibleStrings(r: CascadeResult): string[] {
+  const f = r.canonical.fields;
+  return [
+    f.summary ?? "",
+    ...(f.skills ?? []),
+    ...(f.experience ?? []).flatMap((e) => [
+      e.title ?? "",
+      e.company ?? "",
+      e.description ?? "",
+    ]),
+    ...(f.projects ?? []).flatMap((p) => [p.name ?? "", p.description ?? ""]),
+    ...(f.heuristic_achievements ?? []).flatMap((a) => [
+      a.title ?? "",
+      a.type ?? "",
+    ]),
+    ...(f.education ?? []).flatMap((e) => [e.institution ?? "", e.degree ?? ""]),
+  ];
+}
+
+describe("#611 — link-definition lines are never résumé content", () => {
+  it("leaves no `[ref]: url` line in any user-visible field", () => {
+    // The bare TARGET is expected to appear — `[handbook]` is used in a bullet
+    // and resolves to it. What must not appear is the definition SYNTAX.
+    for (const s of visibleStrings(result)) {
+      expect(s).not.toMatch(/\]\s*:\s*(?:https?:|www\.)/);
+    }
+  });
+
+  it("leaves no `[ref]: url` line in rawText either", () => {
+    // `rawText` is not merely scorer input — `EvidencePanel` prints it back to
+    // the user verbatim, so a surviving definition line is visible markdown.
+    expect(result.rawText).not.toMatch(/^\s*\[[^\]]+\]:\s/m);
+  });
+
+  it("does not promote a definition-only URL to website_url or portfolio_url", () => {
+    // `[handbook]:` sits ABOVE the first section header, i.e. inside the
+    // profile band that #610's contact fix deliberately still trusts.
+    expect(result.canonical.fields.website_url).toBeUndefined();
+    expect(result.canonical.fields.portfolio_url).toBeUndefined();
+  });
+
+  it("carries only genuine contact links in profiles[]", () => {
+    const profiles = result.canonical.fields.profiles ?? [];
+    expect(profiles.map((p) => p.url)).toEqual([
+      "https://linkedin.com/in/averyokonkwo",
+      "https://github.com/averyokonkwo",
+    ]);
+    expect(profiles.every((p) => p.kind !== "other")).toBe(true);
+  });
+});
+
+describe("#611 — reference-link usages flatten to `label url`", () => {
+  it("resolves the full, collapsed, and shortcut forms in Experience bullets", () => {
+    const staff = (result.canonical.fields.experience ?? []).find(
+      (e) => e.company === "Example Corp",
+    )?.description;
+    expect(staff).toBeDefined();
+    // `[label][ref]`
+    expect(staff).toContain(
+      "Led the catalog migration https://example.org/eng-blog/catalog-migration that cut",
+    );
+    // `[label][]`, matched case-insensitively against `[pricing rebuild]:`
+    expect(staff).toContain(
+      "Wrote the Pricing Rebuild https://example.net/pricing-rebuild design doc",
+    );
+    // bare `[label]`
+    expect(staff).toContain(
+      "Maintained the handbook https://example.org/platform-handbook every platform team",
+    );
+  });
+
+  it("lifts the Projects entry URL from an angle-wrapped definition", () => {
+    const project = (result.canonical.fields.projects ?? [])[0];
+    expect(project).toBeDefined();
+    expect(project!.name).not.toMatch(/\[|\]/);
+    expect(project!.url).toBe("https://example.org/ledger-toolkit");
+  });
+
+  it("leaves no bracket residue in the achievement title, and keeps the URL as data", () => {
+    const patent = (result.canonical.fields.heuristic_achievements ?? []).find(
+      (a) => /Issued Patent/.test(a.title ?? ""),
+    );
+    expect(patent).toBeDefined();
+    expect(patent!.title).not.toMatch(/\[|\]/);
+    expect(patent!.title).toContain("Issued Patent XX0000000A0");
+    // `startsWith`, not equality: `URL_RE` treats the fixture's trailing `;` as
+    // part of the URL. That is pre-existing and path-agnostic — see the same
+    // note in `markdown-inline-links.repro.test.ts`.
+    expect(patent!.url).toMatch(/^https:\/\/example\.org\/patents\/XX0000000A0/);
+    // The `[2019]` year marker is a shortcut-reference SHAPE that nothing
+    // defines, so it stayed literal and the extractor could still read it.
+    expect(patent!.year).toBe("2019");
+  });
+
+  it("leaves an UNDEFINED reference exactly as the author wrote it", () => {
+    // CommonMark's own reading: `[warehouse indexer][missing]` has no
+    // definition, so it IS literal text. Rewriting it would be inventing data.
+    const senior = (result.canonical.fields.experience ?? []).find(
+      (e) => e.company === "Northwind Systems",
+    )?.description;
+    expect(senior).toContain("[warehouse indexer][missing]");
+  });
+});

--- a/src/lib/ingest/markdown.test.ts
+++ b/src/lib/ingest/markdown.test.ts
@@ -60,3 +60,30 @@ describe("mdToPlainText", () => {
     );
   });
 });
+
+describe("mdToPlainText — reference-style links (#611)", () => {
+  // `rawText` is rendered verbatim by `EvidencePanel`, so these two rewrites
+  // are user-visible in their own right — and they are what keeps this reading
+  // of a `.md` in agreement with the `markdown-lines.ts` one (#610).
+  it("expands [text][ref] to 'text url' and drops the definition line", () => {
+    expect(
+      mdToPlainText("- Led the [catalog migration][cat] work\n\n[cat]: https://example.org/c"),
+    ).toBe("Led the catalog migration https://example.org/c work\n\n");
+  });
+
+  it("expands the collapsed and shortcut forms as well", () => {
+    const defs = "\n\n[handbook]: https://example.org/h";
+    expect(mdToPlainText(`The [Handbook][] page${defs}`)).toBe(
+      "The Handbook https://example.org/h page\n\n",
+    );
+    expect(mdToPlainText(`The [handbook] page${defs}`)).toBe(
+      "The handbook https://example.org/h page\n\n",
+    );
+  });
+
+  it("leaves an undefined reference — and bracketed prose — untouched", () => {
+    expect(mdToPlainText("Owned the [warehouse indexer][missing] rewrite. [2019]")).toBe(
+      "Owned the [warehouse indexer][missing] rewrite. [2019]",
+    );
+  });
+});

--- a/src/lib/ingest/markdown.ts
+++ b/src/lib/ingest/markdown.ts
@@ -13,6 +13,12 @@
  * no I/O: the caller reads the File via `file.text()` before calling this.
  */
 
+import {
+  extractLinkDefinitions,
+  flattenAutolinks,
+  resolveReferenceLinks,
+} from "../markdown-link-refs.ts";
+
 export interface MarkdownParseResult {
   rawText: string;
   markdown: string;
@@ -29,15 +35,43 @@ export interface MarkdownParseResult {
  * underscores (`snake_case_name`, an SDK symbol, a slug) survive verbatim —
  * matching CommonMark, which disallows single-underscore emphasis mid-word.
  * Asterisk emphasis has no intraword ambiguity and is stripped directly.
+ *
+ * EVERY link rule here is shared with `markdown-lines.ts` or mirrors it exactly,
+ * because the two readings of one `.md` must agree: `rawText` is not merely
+ * scorer input — `EvidencePanel` prints it back to the user verbatim — so any
+ * shape this misses is raw markdown shown to the user AND a disagreement with
+ * what the extractors saw.
+ *
+ *   - Autolinks (`<https://…>`) flatten through the shared `flattenAutolinks`
+ *     (#610). Skipping them here left `<https://linkedin.com/in/…>` — angle
+ *     brackets and all — in the panel while the extractors read the bare URL.
+ *   - Reference-style links are the one shape that cannot be handled
+ *     line-by-line, so their `[ref]: url` definition table is built over the
+ *     whole document first (#611). A definition line surviving here is a
+ *     visible markdown artifact; a `[label][ref]` surviving here disagrees with
+ *     the `label url` the other reading produces.
+ *   - The inline rule is title-aware, matching `markdown-lines.ts`'s
+ *     `INLINE_LINK_RE`. Without that, `[writeup](url "Pricing rebuild")`
+ *     swallowed the CommonMark title into the target and printed
+ *     `writeup url "Pricing rebuild"`.
  */
 export function mdToPlainText(text: string): string {
-  return text
+  const { definitions, body } = extractLinkDefinitions(text);
+  return body
     .split("\n")
     .map((line) =>
-      line
-        .replace(/^\s{0,3}#{1,6}\s+/, "") // heading markers
-        .replace(/^\s*[-*+]\s+/, "") // list bullet markers
-        .replace(/\[([^\]]*)\]\(([^)]+)\)/g, "$1 $2") // [text](url) → text url
+      // Reference resolution runs with the link rules, before emphasis: it
+      // must see the brackets that `[text](url)` has already surrendered.
+      resolveReferenceLinks(
+        flattenAutolinks(
+          line
+            .replace(/^\s{0,3}#{1,6}\s+/, "") // heading markers
+            .replace(/^\s*[-*+]\s+/, "") // list bullet markers
+            // [text](url) → text url, dropping an optional CommonMark title
+            .replace(/\[([^\]]*)\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g, "$1 $2"),
+        ),
+        definitions,
+      )
         .replace(/\*\*(.+?)\*\*/g, "$1") // bold (asterisk)
         .replace(/\*(.+?)\*/g, "$1") // italic (asterisk)
         .replace(/(^|\W)__(\S(?:.*?\S)?)__(?=\W|$)/g, "$1$2") // bold (underscore, word-boundary)

--- a/src/lib/markdown-link-refs.test.ts
+++ b/src/lib/markdown-link-refs.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit tests for the reference-link table (#611). The two consumers
+ * (`markdown-lines.ts`, `ingest/markdown.ts`) are covered where they are, so
+ * this file owns the shapes neither of them can reach through its own surface:
+ * definition-line recognition and, above all, the NON-recognition that keeps
+ * ordinary bracketed résumé prose from being read as a link.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  extractLinkDefinitions,
+  resolveReferenceLinks,
+  stripReferenceImages,
+} from "./markdown-link-refs.ts";
+
+/** Round-trip helper: strip definitions, then resolve usages against them. */
+const flatten = (md: string): string => {
+  const { definitions, body } = extractLinkDefinitions(md);
+  return resolveReferenceLinks(body, definitions);
+};
+
+describe("extractLinkDefinitions", () => {
+  it("collects a definition and blanks the line it came from", () => {
+    const { definitions, body } = extractLinkDefinitions(
+      "Prose line\n\n[cat]: https://example.org/c\n",
+    );
+    expect(definitions.get("cat")).toBe("https://example.org/c");
+    expect(body).toBe("Prose line\n\n\n");
+  });
+
+  it("accepts the three CommonMark title delimiters and an angle-wrapped target", () => {
+    const { definitions } = extractLinkDefinitions(
+      [
+        '[a]: https://example.org/a "double"',
+        "[b]: https://example.org/b 'single'",
+        "[c]: https://example.org/c (paren)",
+        "[d]: <https://example.org/d>",
+      ].join("\n"),
+    );
+    expect([...definitions.values()]).toEqual([
+      "https://example.org/a",
+      "https://example.org/b",
+      "https://example.org/c",
+      "https://example.org/d",
+    ]);
+  });
+
+  it("matches labels case-insensitively with internal whitespace collapsed", () => {
+    const { definitions } = extractLinkDefinitions(
+      "[Pricing   Rebuild]: https://example.net/p",
+    );
+    expect(definitions.get("pricing rebuild")).toBe("https://example.net/p");
+  });
+
+  it("keeps the FIRST definition when a label is defined twice", () => {
+    const { definitions } = extractLinkDefinitions(
+      "[a]: https://example.org/first\n[a]: https://example.org/second",
+    );
+    expect(definitions.get("a")).toBe("https://example.org/first");
+  });
+
+  it("tolerates CRLF without swallowing the carriage return", () => {
+    const { definitions, body } = extractLinkDefinitions(
+      "Prose\r\n[a]: https://example.org/a\r\nMore\r\n",
+    );
+    expect(definitions.get("a")).toBe("https://example.org/a");
+    expect(body).toBe("Prose\r\n\r\nMore\r\n");
+  });
+
+  it("does NOT eat a prose line whose target has no scheme", () => {
+    // The scheme requirement is the whole guard against reading a colon-bearing
+    // résumé line as document metadata.
+    const md = "[2019]: awarded the Northwind engineering prize";
+    const { definitions, body } = extractLinkDefinitions(md);
+    expect(definitions.size).toBe(0);
+    expect(body).toBe(md);
+  });
+
+  it("does NOT eat a definition-shaped line that continues into a sentence", () => {
+    const md = "[a]: https://example.org/a and then some prose";
+    const { definitions, body } = extractLinkDefinitions(md);
+    expect(definitions.size).toBe(0);
+    expect(body).toBe(md);
+  });
+
+  it("does NOT eat a line indented four spaces (a code block, not a definition)", () => {
+    const md = "    [a]: https://example.org/a";
+    expect(extractLinkDefinitions(md).definitions.size).toBe(0);
+  });
+});
+
+describe("resolveReferenceLinks", () => {
+  it("resolves a full reference to `label url`", () => {
+    expect(flatten("Led the [catalog migration][cat] work\n\n[cat]: https://example.org/c")).toBe(
+      "Led the catalog migration https://example.org/c work\n\n",
+    );
+  });
+
+  it("resolves a collapsed reference `[label][]` off its own label", () => {
+    expect(flatten("The [Pricing Rebuild][] doc\n\n[pricing rebuild]: https://example.net/p")).toBe(
+      "The Pricing Rebuild https://example.net/p doc\n\n",
+    );
+  });
+
+  it("resolves a shortcut reference `[label]` off its own label", () => {
+    expect(flatten("The [handbook] page\n\n[handbook]: https://example.org/h")).toBe(
+      "The handbook https://example.org/h page\n\n",
+    );
+  });
+
+  it("emits the bare target for a degenerate empty label", () => {
+    expect(flatten("Portfolio [][p] here\n\n[p]: https://example.org/p")).toBe(
+      "Portfolio https://example.org/p here\n\n",
+    );
+  });
+
+  it("leaves an UNDEFINED reference exactly as written", () => {
+    // CommonMark's own reading: an undefined reference is literal text.
+    expect(flatten("Owned the [warehouse indexer][missing] rewrite")).toBe(
+      "Owned the [warehouse indexer][missing] rewrite",
+    );
+  });
+
+  it("leaves bracketed prose alone — a shortcut ref needs a definition", () => {
+    // `[2019]` is the year marker the achievements extractor reads. Nothing
+    // defines it, so the shortcut rule must never claim it.
+    expect(flatten("Bulk editor. [2019]\n\n[cat]: https://example.org/c")).toBe(
+      "Bulk editor. [2019]\n\n",
+    );
+  });
+
+  it("does not let a DEFINED label bleed into an unresolvable neighbouring reference", () => {
+    // The single-scan regex exists for this: were shortcuts resolved in a
+    // second pass, `[a][nope]` would come back as `a https://…][nope]`.
+    expect(flatten("[a][nope] here\n\n[a]: https://example.org/a")).toBe(
+      "[a][nope] here\n\n",
+    );
+  });
+
+  it("resolves every reference on a line, not just the first", () => {
+    expect(
+      flatten("[one][a] and [two][b]\n\n[a]: https://example.org/1\n[b]: https://example.org/2"),
+    ).toBe("one https://example.org/1 and two https://example.org/2\n\n\n");
+  });
+
+  it("never pairs a `[` with a `]` on a later line", () => {
+    expect(flatten("Opened [ a bracket\nand closed ] here\n\n[a]: https://example.org/a")).toBe(
+      "Opened [ a bracket\nand closed ] here\n\n",
+    );
+  });
+
+  it("is a no-op when the document defines nothing", () => {
+    const text = "Owned the [warehouse indexer] rewrite [2019]";
+    expect(resolveReferenceLinks(text, new Map())).toBe(text);
+  });
+});
+
+describe("stripReferenceImages", () => {
+  const defs = new Map([["logo", "https://example.org/logo.png"]]);
+
+  it.each([
+    ["full", "A ![Company logo][logo] B"],
+    ["collapsed", "A ![logo][] B"],
+    ["shortcut", "A ![logo] B"],
+    ["bracket-bearing alt", "A ![a [b] c][logo] B"],
+    ["empty alt", "A ![][logo] B"],
+  ])("drops a %s reference the table defines", (_label, text) => {
+    expect(stripReferenceImages(text, defs)).toBe("A  B");
+  });
+
+  it.each([
+    ["shortcut", "Wow![great] news"],
+    ["full", "Grew revenue 40%![details][cat]"],
+    ["collapsed", "Sold 3x![units][] last year"],
+  ])("leaves an UNDEFINED %s reference as literal text", (_label, text) => {
+    expect(stripReferenceImages(text, defs)).toBe(text);
+  });
+
+  it("does not claim a non-image reference of the same shape", () => {
+    expect(stripReferenceImages("A [Company logo][logo] B", defs)).toBe(
+      "A [Company logo][logo] B",
+    );
+  });
+
+  it("assumes the INLINE image shape is already gone — an ordering contract", () => {
+    // Pinning the contract, not endorsing the output: `![logo](url)` opens with
+    // the same `![alt]` token, so handed one raw this leaves the bare `(url)`
+    // behind. It never gets one — `markdown-lines.ts` runs `stripImages` (which
+    // owns `![alt](url)`) before `flattenLinks` calls this. A future caller that
+    // reorders the two would see the mess below rather than silence.
+    expect(
+      stripReferenceImages("A ![logo](https://example.org/x.png) B", defs),
+    ).toBe("A (https://example.org/x.png) B");
+  });
+
+  it("is a no-op when the document defines nothing", () => {
+    const text = "Wow![great] news and ![logo][]";
+    expect(stripReferenceImages(text, new Map())).toBe(text);
+  });
+});

--- a/src/lib/markdown-link-refs.ts
+++ b/src/lib/markdown-link-refs.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Shared markdown link flattening — autolinks (#610) and the doc-wide
+ * reference-link table (#611).
+ *
+ * #610 flattened the link shapes that are self-contained on one line
+ * (`[label](url)`, `<url>`). Reference-style links are not: `[label][ref]`,
+ * `[label][]` and bare `[label]` all carry their target on a separate
+ * `[ref]: https://…` *definition* line, conventionally at the bottom of the
+ * document. Resolving them therefore needs a document-wide index, which is why
+ * this lives in its own zero-dep module rather than inside either consumer.
+ *
+ * Two consumers, one table — that shared table is the point. A dropped `.md`
+ * is parsed twice: `markdown-lines.ts` turns the markdown into `PdfLine[]` for
+ * the extractors, and `ingest/markdown.ts`'s `mdToPlainText` flattens the same
+ * file into the `rawText` the scorer scans and `EvidencePanel` renders
+ * verbatim. #610 established that those two readings must agree; duplicating
+ * the definition table would be the fastest way to break that agreement again.
+ *
+ * `flattenAutolinks` lives here for the same reason, even though an autolink
+ * needs no table: it is a #610 rule, and leaving it in `markdown-lines.ts`
+ * meant only ONE of the two readings applied it — a dropped `.md` rendered
+ * `<https://linkedin.com/in/…>` verbatim in the Evidence panel while the
+ * extractors saw the bare URL. One definition, both readings.
+ *
+ * The operations this module exposes are load-bearing:
+ *
+ *   - `extractLinkDefinitions` blanks every definition line. A `[ref]: url`
+ *     line is document metadata, never résumé content, and left in place it
+ *     leaks three different ways depending on where it sits (measured on the
+ *     #610 baseline): appended verbatim into `summary` when it trails a prose
+ *     section, promoted to the contact `website_url` **plus** a bogus
+ *     `kind: "other"` profile entry when it sits above the first section
+ *     header — the one placement #610's profile-banding does not cover — and,
+ *     everywhere, printed into `rawText` for the user to read in the Evidence
+ *     panel. Blanking rather than deleting keeps line positions stable, and
+ *     `classifyMarkdownLine` already drops blank lines.
+ *   - `resolveReferenceLinks` rewrites the usage to `label url`.
+ *
+ * WHY `label url` AND NOT BARE `label`. The corpus argues for the cheap option
+ * and against it at the same time. No fixture, and no `.md` in the tree, uses
+ * the reference shape at all, so this is a rare shape and a big pre-pass would
+ * not be worth it — hence one regex and a `Map`, not a CommonMark parser. But
+ * rarity says nothing about which *output* is right, and bare `label` would be
+ * strictly worse than shipping nothing: today the target at least survives as
+ * literal text on the definition line, whereas blanking definitions (which is
+ * mandatory) and emitting bare `label` would erase the URL from the document
+ * entirely, so `liftHeaderLabel` could never lift `project.url` /
+ * `achievement.url` from it. `label url` is also exactly what #610's
+ * `flattenLinks` and `mdToPlainText` already emit for the inline shape.
+ *
+ * WHY SHORTCUT AND COLLAPSED REFS ARE IN SCOPE. `[label]` on its own is a
+ * *shortcut* reference link, and `[label][]` a *collapsed* one; excluding them
+ * would leave the exact `[`/`]` residue this change exists to remove. They are
+ * safe to claim precisely because resolution is table-driven: a label with no
+ * matching definition is returned untouched, which is both CommonMark's own
+ * reading (an undefined reference IS literal text) and what protects ordinary
+ * bracketed prose — the `[2019]` year marker the achievements extractor reads
+ * is never a link here, because nothing defines `[2019]`.
+ *
+ * DELIBERATE CommonMark SUBSET. A definition must fit on one line and its
+ * target must carry a scheme (`https:`, `mailto:`) or start `www.`. Multi-line
+ * definitions and titles-on-the-next-line are not recognized, and the
+ * scheme requirement is what stops a prose line like
+ * `[2019]: awarded the prize` from being eaten as metadata. Label matching
+ * follows CommonMark: case-insensitive, internal whitespace collapsed.
+ */
+
+/**
+ * A one-line link definition: `[label]: <target> "optional title"`.
+ *
+ * `^ {0,3}` mirrors CommonMark's indent allowance. The target class rejects
+ * whitespace and angle brackets so an angle-wrapped target unwraps cleanly,
+ * and the trailing group tolerates all three CommonMark title delimiters. The
+ * line must end after the title — a trailing sentence means this was prose.
+ * The end anchor is a LOOKAHEAD so a CRLF document keeps its `\r`: the match is
+ * replaced with the empty string, and consuming the `\r` would silently
+ * downgrade that one line ending to a bare `\n`.
+ */
+const LINK_DEFINITION_RE =
+  /^ {0,3}\[([^\]\n]+)\]:[ \t]*<?((?:[A-Za-z][A-Za-z0-9+.-]*:|www\.)[^\s<>]*)>?[ \t]*(?:"[^"]*"|'[^']*'|\([^)]*\))?[ \t]*(?=\r?$)/gm;
+
+/**
+ * CommonMark autolinks: `<https://example.com>` and `<jane@example.com>`. There
+ * is no separate label, so the visible text becomes the target itself — which
+ * is exactly how a bare URL already reads today. Both alternatives require a
+ * `scheme:` or an `@`, so an HTML tag that survived into the markdown (`<b>`,
+ * `<br/>`) is never touched (#610).
+ */
+const AUTOLINK_URI_RE = /<([A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\s]*)>/g;
+const AUTOLINK_EMAIL_RE = /<([^<>\s@]+@[^<>\s@]+\.[^<>\s@]+)>/g;
+
+/**
+ * A reference-style IMAGE usage: `![alt][ref]`, `![alt][]`, `![alt]`.
+ *
+ * The alt class admits ONE level of nested brackets — `[^[\]\n]` for ordinary
+ * characters, `\[[^[\]\n]*\]` for a balanced inner pair — because CommonMark
+ * reads `![a [b] c][logo]` as a single image, and a flat `[^\]\n]*` class does
+ * not: it stops at the inner `]`, consuming only `![a [b]` and leaving a
+ * `[logo]` tail that shortcut resolution then turns back into a URL in body
+ * text. The nesting is deliberately bounded rather than recursive — deeper
+ * nesting is not expressible as a regex, and no résumé carries it.
+ *
+ * A genuinely UNBALANCED alt (`![a ] b][logo]`) still leaves a tail, and that
+ * is correct: CommonMark reads that as literal text followed by a real
+ * shortcut link, which is exactly what resolution then produces.
+ */
+const REFERENCE_IMAGE_RE =
+  /!\[((?:[^[\]\n]|\[[^[\]\n]*\])*)\](?:\[([^\]\n]*)\])?/g;
+
+/**
+ * Every reference usage, in ONE alternation-free scan per shape: `[label][ref]`,
+ * `[label][]` and `[label]`. The optional second group is what makes the
+ * single scan necessary rather than merely tidy — matching full references in
+ * one pass and shortcuts in another would let an *unresolvable* `[a][nope]`
+ * be re-entered by the shortcut pass and rewritten to `a url][nope]`.
+ * Consuming both bracket pairs as one match makes that unreachable.
+ *
+ * Newlines are excluded from both label classes for the same reason #610's
+ * `INLINE_LINK_RE` excludes them: an unmatched `[` can never pair with a `]`
+ * on a later line.
+ *
+ * The leading image alternative is what keeps a reference-style IMAGE out of
+ * link resolution, honouring #610's rule that an image never flattens to
+ * `alt url`. It is an ALTERNATIVE that consumes the whole usage rather than a
+ * `(?<!!)` lookbehind on purpose: a lookbehind would reject the `[alt]` bracket
+ * pair but leave the scan free to re-enter at `[ref]` and resolve THAT as a
+ * shortcut reference, emitting `![alt]ref url`. Consuming the `!` and both
+ * bracket pairs in one match is the only shape that makes the whole image
+ * inert — including the bracket-bearing alt the flat class used to split.
+ *
+ * Ordering the image alternative FIRST is what makes it win: JavaScript
+ * alternation is leftmost-first, so at a `!` the image branch is tried before
+ * the plain-link branch. The image branch captures nothing, so an `undefined`
+ * label group is the signal that it matched — `undefined`, not falsy: a
+ * degenerate `[][ref]` captures the empty string and is still a link.
+ */
+const REFERENCE_LINK_RE =
+  /!\[(?:[^[\]\n]|\[[^[\]\n]*\])*\](?:\[[^\]\n]*\])?|\[([^\]\n]*)\](?:\[([^\]\n]*)\])?/g;
+
+/** CommonMark label matching: case-insensitive, internal whitespace collapsed. */
+function normalizeLabel(label: string): string {
+  return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/**
+ * Pull the link-definition table out of `markdown` and blank the lines it came
+ * from, returning both. The newline is left in place, so line numbering and
+ * paragraph structure are untouched.
+ */
+export function extractLinkDefinitions(markdown: string): {
+  definitions: ReadonlyMap<string, string>;
+  body: string;
+} {
+  const definitions = new Map<string, string>();
+  const body = markdown.replace(
+    LINK_DEFINITION_RE,
+    (_m, label: string, target: string) => {
+      // First definition wins, as in CommonMark.
+      const key = normalizeLabel(label);
+      if (!definitions.has(key)) definitions.set(key, target);
+      return "";
+    },
+  );
+  return { definitions, body };
+}
+
+/**
+ * Rewrite reference-link usages in `text` to `label url` using `definitions`.
+ * A usage whose label is not defined is left exactly as it was found.
+ *
+ * A degenerate empty label (`[][ref]`) emits the bare target rather than a
+ * leading space — the same carve-out #610's inline flattening makes.
+ */
+export function resolveReferenceLinks(
+  text: string,
+  definitions: ReadonlyMap<string, string>,
+): string {
+  if (definitions.size === 0) return text;
+  return text.replace(
+    REFERENCE_LINK_RE,
+    (match, label: string | undefined, ref: string | undefined) => {
+      // A reference-style image matched the image alternative, which captures
+      // nothing: consumed whole and returned untouched.
+      if (label === undefined) return match;
+      // `[label][ref]` uses `ref`; `[label][]` and `[label]` use the label.
+      const url = definitions.get(normalizeLabel(ref?.trim() ? ref : label));
+      if (!url) return match;
+      return label.trim() ? `${label} ${url}` : url;
+    },
+  );
+}
+
+/**
+ * Drop reference-style images — `![alt][ref]`, `![alt][]`, `![alt]` — whose
+ * reference the definition table actually RESOLVES. Alt text alone carries no
+ * résumé signal, so the same rule `markdown-lines.ts` applies to the inline
+ * shape (`![alt](url)`) applies here; the difference is that the inline shape
+ * is self-identifying and this one is not.
+ *
+ * WHY THE TABLE IS A PARAMETER AND NOT AN IMPLEMENTATION DETAIL. `![great]`
+ * with nothing defining `[great]` is not an image — CommonMark says an image
+ * reference with no matching definition is literal text, the identical rule
+ * `resolveReferenceLinks` already applies to an undefined LINK label and the
+ * identical rule that keeps a bracketed `[2019]` year marker out of link
+ * resolution. Stripping unconditionally deleted résumé content for any prose
+ * that happened to put a `!` next to a bracket (`Wow![great] news`,
+ * `Grew revenue 40%![details][cat]`), and deleted it from only ONE of the two
+ * readings of the file. The lookup is the whole point of the function.
+ *
+ * Callers that do NOT strip are still safe: `resolveReferenceLinks` consumes
+ * any surviving image whole, so no image ever emits its URL into text.
+ */
+export function stripReferenceImages(
+  text: string,
+  definitions: ReadonlyMap<string, string>,
+): string {
+  if (definitions.size === 0) return text;
+  return text.replace(
+    REFERENCE_IMAGE_RE,
+    (match, alt: string, ref: string | undefined) =>
+      definitions.has(normalizeLabel(ref?.trim() ? ref : alt)) ? "" : match,
+  );
+}
+
+/**
+ * Flatten CommonMark autolinks — `<https://…>`, `<jane@example.com>` — to their
+ * bare target (#610). Shared by both readings of a dropped `.md`: the
+ * `markdown-lines.ts` reading that feeds the extractors and the `mdToPlainText`
+ * reading that feeds the scorer and `EvidencePanel`.
+ */
+export function flattenAutolinks(text: string): string {
+  return text
+    .replace(AUTOLINK_URI_RE, (_m, url: string) => url)
+    .replace(AUTOLINK_EMAIL_RE, (_m, email: string) => email);
+}

--- a/src/lib/markdown-readings-agree.test.ts
+++ b/src/lib/markdown-readings-agree.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The "two readings of one `.md` agree" invariant, asserted directly.
+ *
+ * A dropped `.md` is read twice: `markdown-lines.ts` turns it into `PdfLine[]`
+ * for the extractors, and `ingest/markdown.ts`'s `mdToPlainText` flattens it
+ * into the `rawText` the scorer scans and `EvidencePanel` prints back to the
+ * user verbatim. Three docblocks assert those readings agree (#610, #611) — and
+ * nothing checked it. The gap was real: `mdToPlainText` had the reference rules
+ * but not the autolink rule and its inline rule was not title-aware, so the
+ * SAME fixture line read `<https://linkedin.com/in/…>` and
+ * `…/pricing-writeup "Pricing rebuild"` on the `rawText` side while the
+ * extractors saw the flattened form.
+ *
+ * The existing repro tests could not catch it: they scan `visibleStrings()`,
+ * which is built from the parsed canonical fields and so never touches
+ * `rawText`. This compares the two readings against each other, line for line,
+ * over both markdown fixtures.
+ *
+ * THE ONE DELIBERATE DIFFERENCE. `markdown-lines.ts` keeps a bullet's leading
+ * `- ` so the shared `isBulletLine` extractor matches; `mdToPlainText` strips it
+ * because the scorer wants prose. Normalizing that marker away is therefore
+ * part of the invariant, not a concession to it — every other character must
+ * match exactly.
+ */
+
+import { promises as fsp } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { sectionizeMarkdown } from "./heuristics/markdown-lines.ts";
+import { mdToPlainText } from "./ingest/markdown.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(HERE, "../../tests/fixtures/markdown");
+
+/** Drop the bullet marker and blank lines — the only sanctioned divergence. */
+function normalize(lines: string[]): string[] {
+  return lines
+    .map((l) => l.replace(/^\s*[-*+]\s+/, "").trim())
+    .filter((l) => l.length > 0);
+}
+
+function readings(markdown: string): { mdLines: string[]; rawText: string[] } {
+  return {
+    mdLines: normalize(sectionizeMarkdown(markdown).lines.map((l) => l.text)),
+    rawText: normalize(mdToPlainText(markdown).split("\n")),
+  };
+}
+
+describe.each(["inline-links", "reference-links"])(
+  "%s.md — the PdfLine reading and the rawText reading agree",
+  (name) => {
+    let markdown: string;
+
+    beforeAll(async () => {
+      markdown = await fsp.readFile(join(FIXTURE_DIR, `${name}.md`), "utf8");
+    });
+
+    it("produces identical lines from both readings", () => {
+      const { mdLines, rawText } = readings(markdown);
+      expect(rawText).toEqual(mdLines);
+    });
+
+    it("leaves no link syntax in either reading", () => {
+      const { mdLines, rawText } = readings(markdown);
+      for (const line of [...mdLines, ...rawText]) {
+        expect(line).not.toMatch(/<https?:/); // autolink
+        expect(line).not.toMatch(/<[^<>\s@]+@[^<>\s@]+>/); // email autolink
+        expect(line).not.toMatch(/\]\s*\(/); // inline link
+        expect(line).not.toMatch(/^\s{0,3}\[[^\]\n]+\]:/); // definition line
+        expect(line).not.toMatch(/"Pricing rebuild"/); // CommonMark title
+      }
+    });
+  },
+);
+
+describe("a DEFINED reference-style image never leaks its URL in EITHER reading", () => {
+  // #610's criterion "images still strip entirely" holds for the inline shape
+  // `![alt](url)`; #611's reference table reopened it in the reference shape,
+  // which resolved to `!alt url` and injected an image URL into body text.
+  //
+  // The title says DEFINED because that is the whole population this covers: an
+  // image reference with no matching definition is literal text, not an image
+  // (see the sibling describe below). Within that population the cases are the
+  // full alt-text alphabet — plain, empty, and BRACKET-BEARING, the last being
+  // where an alt class that stops at the first inner `]` left a `[logo]` tail
+  // behind for shortcut resolution to turn back into a URL.
+  const DEF = "\n\n[logo]: https://example.org/logo.png";
+
+  it.each([
+    ["full reference", `![Company logo][logo]${DEF}`],
+    ["collapsed reference", `![logo][]${DEF}`],
+    ["shortcut reference", `![logo]${DEF}`],
+    ["bracketed alt text", `![a [b] c][logo]${DEF}`],
+    ["empty alt text", `![][logo]${DEF}`],
+  ])("%s never flattens to `alt url` (PdfLine reading)", (_label, markdown) => {
+    const texts = sectionizeMarkdown(markdown).lines.map((l) => l.text);
+    // The image is stripped outright and the definition line is blanked, so
+    // the document has no content lines at all.
+    expect(texts).toEqual([]);
+  });
+
+  it.each([
+    ["full reference", `![Company logo][logo]${DEF}`, "![Company logo][logo]"],
+    ["collapsed reference", `![logo][]${DEF}`, "![logo][]"],
+    ["shortcut reference", `![logo]${DEF}`, "![logo]"],
+    ["bracketed alt text", `![a [b] c][logo]${DEF}`, "![a [b] c][logo]"],
+    ["empty alt text", `![][logo]${DEF}`, "![][logo]"],
+  ])(
+    "%s stays literal, URL-free markdown (rawText reading)",
+    (_label, markdown, literal) => {
+      const raw = mdToPlainText(markdown);
+      expect(raw).toContain(literal);
+      // Neither the image URL nor a stray `!alt url` reaches the text.
+      expect(raw).not.toContain("https://example.org/logo.png");
+    },
+  );
+
+  it("keeps a bracket-bearing alt inert INSIDE a prose line", () => {
+    // Standalone, the leak shows up as a whole line; mid-sentence it shows up
+    // as a URL spliced into résumé body text, which is the shape that reaches
+    // the scorer and the Evidence panel.
+    const markdown = `Team ![a [b] c][logo] shipped${DEF}`;
+    const mdLine = sectionizeMarkdown(markdown).lines.map((l) => l.text);
+    const raw = mdToPlainText(markdown);
+    expect(mdLine.join("\n")).not.toContain("https://example.org/logo.png");
+    expect(raw).not.toContain("https://example.org/logo.png");
+  });
+
+  it("still resolves a NON-image reference sharing the shape", () => {
+    // Guards the `(!?)` capture against over-claiming: drop the `!` and the
+    // very same input must resolve.
+    expect(mdToPlainText(`[Company logo][logo]${DEF}`)).toContain(
+      "Company logo https://example.org/logo.png",
+    );
+    expect(
+      sectionizeMarkdown(`[Company logo][logo]${DEF}`).lines.map((l) => l.text),
+    ).toEqual(["Company logo https://example.org/logo.png"]);
+  });
+});
+
+describe("an UNDEFINED reference-style image is literal text, not an image", () => {
+  // The image strip deleted `![anything]` outright, with no definition-table
+  // lookup — so ordinary prose carrying a `!` next to a bracket silently lost
+  // characters the PDF/plain-text paths keep, and the two readings disagreed
+  // about it (`rawText` kept the text; the `PdfLine` reading deleted it).
+  //
+  // CommonMark is explicit that an image reference with no matching definition
+  // IS literal text — the same rule `resolveReferenceLinks` already applies to
+  // an undefined LINK label, and the same rule that protects a bracketed year
+  // marker like `[2019]` from being read as a link.
+  it.each([
+    ["shortcut", "Wow![great] news"],
+    ["full", "Grew revenue 40%![details][cat]"],
+    ["collapsed", "Sold 3x![units][] last year"],
+  ])("%s reference survives verbatim in both readings", (_label, markdown) => {
+    expect(sectionizeMarkdown(markdown).lines.map((l) => l.text)).toEqual([
+      markdown,
+    ]);
+    expect(mdToPlainText(markdown)).toBe(markdown);
+  });
+
+  it("resolves only the ones the definition table actually defines", () => {
+    // Same document, same shape, one defined and one not: the defined image
+    // strips, the undefined one stays as the author typed it.
+    const markdown =
+      "Wow![great] news ![badge][ci]\n\n[ci]: https://example.org/ci.svg";
+    const mdLine = sectionizeMarkdown(markdown).lines.map((l) => l.text);
+    expect(mdLine.join("\n")).toContain("Wow![great] news");
+    expect(mdLine.join("\n")).not.toContain("![badge][ci]");
+    expect(mdLine.join("\n")).not.toContain("https://example.org/ci.svg");
+    expect(mdToPlainText(markdown)).not.toContain("https://example.org/ci.svg");
+  });
+});

--- a/tests/fixtures/markdown/README.md
+++ b/tests/fixtures/markdown/README.md
@@ -1,0 +1,22 @@
+# Markdown ingest fixtures
+
+`.md` résumés for the **markdown import path** (`#552`) — dropped-file text that
+feeds `parseMarkdownFile` → `runCascadeFromMarkdown`. These are NOT part of the
+PDF corpus: `corpus.test.ts` walks `tests/fixtures/pdfs/` for `*.pdf` only, so
+nothing here is snapshot-baked and nothing here needs a `.expected.json`.
+
+**PII — hard rule.** Same rule as the PDF corpus (`../pdfs/CLAUDE.md`): every
+fixture uses a synthetic persona — fake name, `@example.com` email, and a phone
+with a **real area code + `555` exchange + `0100`–`0199` subscriber**, e.g.
+`(312) 555-0123`. Never an area-code-`555` number like `(555) 010-0123`: `555`
+is an invalid NANP area code, so `libphonenumber-js` rejects it and the phone
+silently drops out of the score.
+
+`npm run check:fixtures` scans **PDFs under `tests/fixtures/pdfs/` only**, so
+files in this directory are **not** covered by that gate. The judgement is
+manual — read the fixture before you add or change one.
+
+| Fixture | Guards |
+|---|---|
+| `inline-links.md` | `#610` — inline `[label](url)` / autolink flattening, and that a body-section URL never reaches the contact card |
+| `reference-links.md` | `#611` — reference-style `[label][ref]` / `[label][]` / `[label]` resolution, that `[ref]: url` definition lines never become content (including from the profile band, where they otherwise become `website_url`), and that an *undefined* reference stays literal |

--- a/tests/fixtures/markdown/inline-links.md
+++ b/tests/fixtures/markdown/inline-links.md
@@ -1,0 +1,38 @@
+# Riley Nakamura
+
+riley.nakamura@example.com · (312) 555-0123 · Chicago, IL
+
+<https://linkedin.com/in/rileynakamura> · github.com/rileynakamura
+
+## Summary
+
+Platform engineer who ships checkout and catalog systems. Earlier, sold sidebiz.example.com to a buyer after four years of operating it.
+
+## Experience
+
+**Staff Engineer**, Example Corp — 2020–2024
+
+- Led the [catalog migration](https://example.org/eng-blog/catalog-migration) that cut checkout latency 40%.
+- Ran the on-call rotation for six services across two regions.
+
+**Senior Engineer**, Northwind Systems — 2016–2020
+
+- Rebuilt the pricing service; see the [writeup](https://example.net/pricing-writeup "Pricing rebuild").
+
+## Projects
+
+**Ledger Toolkit** — [ledger-toolkit](https://example.org/ledger-toolkit)
+
+- Double-entry bookkeeping library used by three internal teams.
+
+## Achievements
+
+- **Patent** · Issued Patent [XX0000000A0](https://example.org/patents/XX0000000A0); expression-language bulk editor for product catalogs. [2019]
+
+## Education
+
+Example State University — B.S. Computer Science — 2016
+
+## Skills
+
+TypeScript, Go, Postgres, Kubernetes, AWS, React

--- a/tests/fixtures/markdown/reference-links.md
+++ b/tests/fixtures/markdown/reference-links.md
@@ -1,0 +1,47 @@
+# Avery Okonkwo
+
+avery.okonkwo@example.com · (312) 555-0155 · Austin, TX
+
+<https://linkedin.com/in/averyokonkwo> · github.com/averyokonkwo
+
+[handbook]: https://example.org/platform-handbook
+
+## Summary
+
+Platform engineer who ships checkout and catalog systems.
+
+## Experience
+
+**Staff Engineer**, Example Corp — 2020–2024
+
+- Led the [catalog migration][cat] that cut checkout latency 40%.
+- Wrote the [Pricing Rebuild][] design doc for the payments group.
+- Maintained the [handbook] every platform team onboards from.
+- Ran the on-call rotation for six services across two regions.
+
+**Senior Engineer**, Northwind Systems — 2016–2020
+
+- Owned the [warehouse indexer][missing] rewrite end to end.
+
+## Projects
+
+**Ledger Toolkit** — [ledger-toolkit][ledger]
+
+- Double-entry bookkeeping library used by three internal teams.
+
+## Achievements
+
+- **Patent** · Issued Patent [XX0000000A0][patent]; expression-language bulk editor for product catalogs. [2019]
+
+## Education
+
+Example State University — B.S. Computer Science — 2016
+
+## Skills
+
+TypeScript, Go, Postgres, Kubernetes
+
+[cat]: https://example.org/eng-blog/catalog-migration
+[pricing rebuild]: https://example.net/pricing-rebuild "Payments design doc"
+[ledger]: <https://example.org/ledger-toolkit>
+[patent]: https://example.org/patents/XX0000000A0

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -24,8 +24,7 @@
       "phone",
       "phoneIsValid",
       "skills",
-      "summary",
-      "website_url"
+      "summary"
     ],
     "skillsCount": 18,
     "experienceCount": 4,


### PR DESCRIPTION
## Summary

Dropping a `.md` left markdown link syntax intact all the way to the field extractors. Two visible defects followed, both shipping into the exported Download PDF: a body URL was claimed as the candidate's contact `website_url`, and the entry title kept an orphaned `[label]()`. Root cause was an asymmetry — `rawText` was flattened by `mdToPlainText`, but the cascade consumed the verbatim `markdown`. Both readings now share one set of link rules.

- **#610** — inline links, CommonMark titles and bare autolinks flatten to `label url`, preserving the target so `liftHeaderLabel` still populates `achievement.url` / `project.url`. Step 2 chose **option (a)**, banding `website_url`/`portfolio_url` to the profile section on the text tier.
- **#611** — reference-style links resolve against the document's definition table, and the `[ref]: url` definition lines are blanked. The table lives in a shared `src/lib/markdown-link-refs.ts` consumed by both readings, which is what keeps them in agreement.

Closes #610
Closes #611

## Notable decisions

- **Step 2 option (a) over (b).** Option (b) — subtract URLs already claimed by a body entry — cannot satisfy #610's own acceptance criterion, which names *Experience* alongside Achievements and Projects: an Experience bullet has no `url` slot, so there is nothing to subtract.
- **Accepted cost, stated plainly.** A personal site printed in a page **footer** is now lost on the text tier. The annotation tier does not rescue it — `pdf-extract.ts` flips pdfjs' y to top-origin, so `inProfileSection`'s `ann.yTop <= profileLineMaxY + 12` band is the *header*, the opposite end of the page. Recorded verbatim in the `contact.ts` docblock. `linkedin_url`/`github_url` are unaffected.
- **Undefined references stay literal.** An image or link reference with no matching definition is left untouched, which is CommonMark's own reading and what protects the `[2019]` year marker the achievements extractor depends on.

## Corpus snapshot

Exactly one moves: `two-column-achievements-sidebar` drops `website_url` from `fieldsPopulated`. The value was `LaunchPadCart.com`, lifted from the STRENGTHS sidebar sentence "Successfully launched and sold a consumer website LaunchPadCart.com." — a product the candidate sold, not their contact site. 9 corpus fixtures carried `website_url` before, 8 after; no fixture sources the field legitimately from below the profile band. Score is unaffected (`website_url` is not scored).

## Known limitations (not fixed here)

- `mdToPlainText` has no image strip, so an **inline** `![alt](url)` still reads `!alt url` in `rawText`, which `EvidencePanel` prints verbatim. **Pre-existing on `main`** (shipped with #552) — not introduced here, and neither markdown fixture contains an image. Follow-up candidate.
- `achievement.url` keeps a trailing `;` (`URL_RE` treats sentence punctuation as part of the URL), leaving a double space in the title. Pre-existing and path-agnostic, but newly *visible* in the export — `main` showed `[XX0000000A0]();`.
- `#611`'s "no `[`/`]` residue" criterion holds for **defined** references only; an undefined one deliberately stays literal per CommonMark. Disclosed rather than checked off silently.
- No code-span or fenced-block awareness: a link inside backticks flattens, and a definition inside a fence is blanked. Documented in the module's stated CommonMark subset.
- Link scanning is **quadratic**, not exponential — an unbounded label class restarts at every `[`. Measured 3.1 s on 80 000 `[`. `main` already carries the identical shape in `ANY_IMAGE_RE` and `mdToPlainText`; asymptotics unchanged, so no input cap was added.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — `Test Files 238 passed | 8 skipped`, `Tests 3391 passed | 10 skipped`
- [x] `fallow audit --base origin/main` — report-only findings only: 7 clone groups in *test* files, and 2 complexity findings on `normalizeSplitLetterHeaders` / `classifyMarkdownLine`, both verified unchanged from `main` (line-shifted, not introduced)
- [x] Fixture personas verified synthetic — no real PII. `npm run check:fixtures` green on all 54 PDFs; the two new `.md` fixtures fall outside that gate and were judged manually (Riley Nakamura / Avery Okonkwo, `@example.com`, `(312) 555-0123` and `(312) 555-0155` — real area code, `555` exchange, subscriber in `0100`–`0199`)
- [x] Every new test proven to fail before its fix — no vacuously-baked fixture

## Adversarial review

Two bounded rounds ran against the accumulated diff before this PR opened.

**Round 1 — 4 blocking findings, all fixed:**

1. `ingest/markdown.ts` — the "two readings agree" invariant, asserted in three docblocks, was **false**: `mdToPlainText` never received #610's autolink rule and its inline regex swallowed the CommonMark title into the URL. The existing repro tests could not catch it — they scan only the parsed canonical fields, never `rawText`. Fixed by single-sourcing the autolink rules and adding `markdown-readings-agree.test.ts`, which compares the two readings line-for-line.
2. `markdown-link-refs.ts` — reference-style **images** flattened: `![alt][ref]` emitted `!alt url`, injecting an image URL into résumé body text. New behaviour, and a violation of #610's "images must still strip entirely" criterion.
3. `contact.ts` — the docblock **falsely claimed** a footer site stayed reachable via the annotation band. It does not; the band is the header. Comment-only, but it would have landed in `main`, the squash message and this PR body simultaneously. Replaced with the honest statement now quoted above.
4. `contact.test.ts` — #237's bare-domain guard had become **vacuous**: under banding the doc-wide fallback is never consulted, so the negative tests passed regardless of what `isStandaloneUrl` did. The regression criterion was pinned nowhere. Both prose lines moved into the profile section, plus a direct unit test; proven non-vacuous by defeating the guard and observing red.

**Round 2 — `clean: true`**, all four confirmed closed, no new blocking findings. Two of its nits were behaviour **regressions versus `main`** and were fixed rather than deferred: a reference image with bracketed alt text still leaked its URL, and `![anything]` was deleted unconditionally, so ordinary prose (`Wow![great] news`) lost text. The image-reference drop now consults the definition table, and `stripImages` is byte-identical to `main` again.

Surviving nits are the "Known limitations" above.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #610 | Claude Opus 5 (1M context) | ultra |
| Implementation — #611 | Claude Opus 4.5 (1M context) | ultra |
| Adversarial review — round 1 | Claude Opus 5 (1M context) | ultra |
| Review fixes — round 1 | Claude Opus 5 (1M context) | ultra |
| Adversarial review — round 2 | Claude Opus 5 (1M context) | ultra |
| Review fixes — round 2 | Claude Opus 5 (1M context) | ultra |
| Orchestration + PR | Claude Opus 5 (1M context) | ultra |
| Verification | `npm run verify` — green in CI | — |
