### PR TITLE
fix(pdf): never strand a header, heading, or lone line at a page break (#629, #631, #632)

### DIFF
--- a/src/lib/pdf/export-layout-contract.test.ts
+++ b/src/lib/pdf/export-layout-contract.test.ts
@@ -18,6 +18,15 @@
  * the parser would fail to re-open as a section on re-upload (which would break
  * the round-trip invariant). PII-free: asserts recognition of heading strings
  * (synthetic-persona fixtures), never dumps field values.
+ *
+ * It also enforces the PAGINATION half of the contract (#629, #631, #632): a
+ * section heading or an entry header may never be the final drawn line on a page;
+ * a bullet that wraps may never leave one of its lines alone on a page — neither
+ * its first at a page bottom (#629) nor its last at a page top (#631); and an
+ * entry may never open a page with its last bullet alone (#632). Those
+ * cases are exercised on SYNTHESIZED models (no PDF fixture) — see the second
+ * describe block, whose helpers locate the exact filler length that puts the
+ * natural page break on the subject line.
  */
 
 import { readFileSync, readdirSync } from "node:fs";
@@ -29,7 +38,13 @@ import { matchSectionHeader } from "../heuristics/regex.ts";
 import { runCascade } from "../heuristics/cascade.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
 import type { CascadeResult } from "../heuristics/types.ts";
+import type { AtsEntry, AtsResumeModel } from "./ats-resume-model.ts";
 import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+import {
+  extractPdfDrawnLines,
+  type PdfDrawnLine,
+} from "./render-ats-pdf.test-utils.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = join(HERE, "../../..", "tests/fixtures/pdfs");
@@ -101,4 +116,679 @@ describe("export layout contract — canonical headers re-recognize (#334)", () 
       }
     });
   }
+});
+
+// ── Pagination half of the contract: keep-with-next (#629) ───────────────────
+//
+// Content is SYNTHESIZED (no PDF fixture, per #629): a "filler" entry of N
+// single-line bullets pushes a "subject" line down the page one line at a time,
+// so some N puts the natural page break exactly on that subject line. `boundaryN`
+// finds that N by bisection instead of hard-coding it, so the tests keep
+// straddling the break if the page geometry / type scale ever changes — and fail
+// LOUDLY (its bracket assertions) rather than going vacuous if they stop.
+
+/** A filler bullet short enough to occupy exactly one drawn line. No digits, so
+ *  `autoBoldMetrics` finds no metric and the plain single-string path is used. */
+const FILLER_BULLET = "Filler bullet kept deliberately short.";
+
+function fillerEntry(bullets: number): AtsEntry {
+  return {
+    headerLine: "Filler Role · Filler Company, Springfield, IL",
+    bullets: Array.from({ length: bullets }, () => FILLER_BULLET),
+  };
+}
+
+/**
+ * A bullet wrapping to exactly THREE drawn lines under the Helvetica fallback,
+ * carrying one distinctive token per line. Three is the canonical widow case
+ * (#631): it is the shortest bullet with NO legal split position — either half
+ * of a 2/1 or 1/2 break strands a lone line — so it can only move whole.
+ */
+const THREE_LINE_BULLET =
+  "BULLETSTART partnered across engineering, product and design to land a " +
+  "platform initiative that measurably improved customer outcomes BULLETMID " +
+  "and then carried the same practice into the wider organisation BULLETEND";
+const THREE_LINE_TOKENS = ["BULLETSTART", "BULLETMID", "BULLETEND"];
+
+/** A bullet wrapping to exactly FOUR drawn lines, one token per line. Four is
+ *  the shortest bullet that CAN legally split (2/2), so it is the case that
+ *  exercises break placement rather than a whole-bullet reservation (#631). */
+const FOUR_LINE_BULLET =
+  "BULLETSTART partnered across engineering, product and design to land a " +
+  "platform initiative that measurably improved customer outcomes BULLETTWO " +
+  "and then carried the same practice into the wider organisation, writing " +
+  "the runbooks BULLETTHREE and training the on-call rotation before handing " +
+  "the whole programme over to its permanent owners BULLETEND";
+const FOUR_LINE_TOKENS = [
+  "BULLETSTART",
+  "BULLETTWO",
+  "BULLETTHREE",
+  "BULLETEND",
+];
+
+/** Build a model whose `sections` are pushed down by `filler` one-line bullets. */
+type ModelBuilder = (filler: number) => AtsResumeModel;
+
+/** One Experience section: the filler entry, then the subject entry. */
+const withFillerBefore =
+  (subject: AtsEntry): ModelBuilder =>
+  (filler) => ({
+    contact: { name: "Jane Candidate", links: [] },
+    sections: [
+      { heading: "Experience", entries: [fillerEntry(filler), subject] },
+    ],
+  });
+
+async function drawnLines(
+  build: ModelBuilder,
+  filler: number,
+): Promise<PdfDrawnLine[]> {
+  return extractPdfDrawnLines(await renderAtsResumePdf(build(filler)));
+}
+
+/** Index of the single drawn line containing `token` (fails if 0 or 2+ match). */
+function lineIndexOf(lines: PdfDrawnLine[], token: string): number {
+  const hits = lines
+    .map((l, i) => (l.text.includes(token) ? i : -1))
+    .filter((i) => i >= 0);
+  expect(hits, `expected "${token}" on exactly one drawn line`).toHaveLength(1);
+  return hits[0];
+}
+
+/** The page (1-based) the line containing `token` landed on. */
+function pageOf(lines: PdfDrawnLine[], token: string): number {
+  return lines[lineIndexOf(lines, token)].page;
+}
+
+/** How many text lines were drawn on `page` — the density measure a "wasted
+ *  page" / "de-densified page" assertion is about (#629). */
+function linesOnPage(lines: PdfDrawnLine[], page: number): number {
+  return lines.filter((l) => l.page === page).length;
+}
+
+/**
+ * The smallest filler-bullet count that pushes `token` off page 1. Monotone by
+ * construction — every filler bullet is exactly one line, so the subject only
+ * ever moves down — so a bisection is exact. The two bracket assertions are the
+ * non-vacuity gate: they prove the break really is inside the searched range.
+ */
+async function boundaryN(
+  build: ModelBuilder,
+  token: string,
+  max = 80,
+): Promise<number> {
+  expect(
+    pageOf(await drawnLines(build, 0), token),
+    `"${token}" must start on page 1 with no filler`,
+  ).toBe(1);
+  expect(
+    pageOf(await drawnLines(build, max), token),
+    `"${token}" must be pushed off page 1 by ${max} filler bullets`,
+  ).toBeGreaterThan(1);
+  let lo = 0;
+  let hi = max;
+  while (hi - lo > 1) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (pageOf(await drawnLines(build, mid), token) > 1) hi = mid;
+    else lo = mid;
+  }
+  return hi;
+}
+
+/** Filler counts to assert over: the break lands on the subject line inside this
+ *  window, so it covers "just fits", "exactly on the boundary", and "just past". */
+const windowAround = (n: number) => [n - 2, n - 1, n, n + 1];
+
+/** The minimum drawn lines of one wrapped bullet that must land on each side of
+ *  a page break it straddles — `BULLET_KEEP_LINES` in render-ats-pdf.ts. Kept as
+ *  a local literal rather than an import so the test states the CONTRACT and
+ *  cannot be silently relaxed by editing the implementation's constant. */
+const MIN_BULLET_LINES_PER_PAGE = 2;
+
+/**
+ * How many of one bullet's drawn lines landed on each page it occupies, in page
+ * order — `tokens` names those lines, one distinctive token per wrapped line, in
+ * draw order.
+ *
+ * A single count of `1` IS the whole page-break defect family: on the first page
+ * of the pair it is #629's orphan (a lone first line at a page bottom), on the
+ * second it is #631's widow (a lone last line at a page top). Asserting every
+ * count `>= MIN_BULLET_LINES_PER_PAGE` therefore states both halves at once, and
+ * for a bullet too short to admit any legal split it collapses to the stronger
+ * "all on one page" — the only arrangement that satisfies it.
+ */
+function bulletLinesPerPage(
+  lines: PdfDrawnLine[],
+  tokens: string[],
+): number[] {
+  const perPage = new Map<number, number>();
+  for (const token of tokens) {
+    const page = pageOf(lines, token);
+    perPage.set(page, (perPage.get(page) ?? 0) + 1);
+  }
+  return [...perPage.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, count]) => count);
+}
+
+/** Assert `tokens`' drawn lines are contiguous, in order, at `filler = 0` — the
+ *  non-vacuity gate for a break-position test, whether the tokens name one
+ *  bullet's wrapped lines (#631) or one bullet each (#632). Without it, content
+ *  that laid out differently than intended would make the page assertions pass
+ *  for the wrong reason. */
+function expectWrapsTo(lines: PdfDrawnLine[], tokens: string[]) {
+  const first = lineIndexOf(lines, tokens[0]);
+  tokens.forEach((token, i) => {
+    expect(
+      lineIndexOf(lines, token),
+      `expected "${token}" on wrapped line ${i + 1} of the bullet`,
+    ).toBe(first + i);
+  });
+}
+
+describe("export layout contract — keep-with-next pagination (#629)", () => {
+  it("never leaves an entry header as the last line on a page", async () => {
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: ["ALPHABULLET drove the platform migration end to end."],
+    });
+    const n = await boundaryN(build, "SUBJECTROLE");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      expect(
+        pageOf(lines, "SUBJECTROLE"),
+        `filler=${filler}: header stranded away from its first bullet`,
+      ).toBe(pageOf(lines, "ALPHABULLET"));
+    }
+  });
+
+  it("moves ALL of a wrapped entry header with its first bullet", async () => {
+    const build = withFillerBefore({
+      headerLine:
+        "SUBJECTROLE Senior Staff Engineering Manager · Subject Company, " +
+        "Springfield, Illinois · Platform Infrastructure, Developer " +
+        "Experience, Release Engineering HEADEREND",
+      headerHangingIndent: 12,
+      bullets: ["ALPHABULLET drove the platform migration end to end."],
+    });
+    // Non-vacuity: the header really does wrap, and to exactly two lines — so
+    // reserving one header line (the pre-#629 behaviour) is provably not enough.
+    const unbroken = await drawnLines(build, 0);
+    expect(lineIndexOf(unbroken, "HEADEREND")).toBe(
+      lineIndexOf(unbroken, "SUBJECTROLE") + 1,
+    );
+
+    const n = await boundaryN(build, "SUBJECTROLE");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      const headPage = pageOf(lines, "SUBJECTROLE");
+      expect(
+        pageOf(lines, "HEADEREND"),
+        `filler=${filler}: wrapped header split across pages`,
+      ).toBe(headPage);
+      expect(
+        pageOf(lines, "ALPHABULLET"),
+        `filler=${filler}: wrapped header stranded from its first bullet`,
+      ).toBe(headPage);
+    }
+  });
+
+  it("keeps a bullet-less entry's header and sub-line together, reserving no phantom bullet line", async () => {
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company",
+      subLine: "SUBLINETOKEN Springfield, Illinois",
+      bullets: [],
+    });
+    const n = await boundaryN(build, "SUBJECTROLE");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      expect(
+        pageOf(lines, "SUBLINETOKEN"),
+        `filler=${filler}: bullet-less header split from its sub-line`,
+      ).toBe(pageOf(lines, "SUBJECTROLE"));
+    }
+  });
+
+  it("never splits a wrapped bullet one line / rest across a page break", async () => {
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: [
+        "ALPHABULLET short first bullet.",
+        "BULLETSTART partnered across engineering, product and design to land " +
+          "an initiative that measurably improved customer outcomes BULLETEND",
+      ],
+    });
+    // Non-vacuity: the subject bullet wraps to exactly two drawn lines, so
+    // "first line and last line on the same page" IS the no-split assertion.
+    const unbroken = await drawnLines(build, 0);
+    expect(lineIndexOf(unbroken, "BULLETEND")).toBe(
+      lineIndexOf(unbroken, "BULLETSTART") + 1,
+    );
+
+    const n = await boundaryN(build, "BULLETSTART");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      expect(
+        pageOf(lines, "BULLETEND"),
+        `filler=${filler}: wrapped bullet orphaned its first line`,
+      ).toBe(pageOf(lines, "BULLETSTART"));
+    }
+  });
+
+  it("never leaves a section heading as the last line on a page", async () => {
+    const build: ModelBuilder = (filler) => ({
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [
+        { heading: "Experience", entries: [fillerEntry(filler)] },
+        {
+          heading: "Achievements",
+          entries: [
+            {
+              headerLine: "SUBJECTROLE · Subject Company",
+              bullets: ["ALPHABULLET led the standards working group."],
+            },
+          ],
+        },
+      ],
+    });
+    const n = await boundaryN(build, "ACHIEVEMENTS");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      const headingPage = pageOf(lines, "ACHIEVEMENTS");
+      expect(
+        pageOf(lines, "SUBJECTROLE"),
+        `filler=${filler}: section heading stranded from its first entry`,
+      ).toBe(headingPage);
+      expect(
+        pageOf(lines, "ALPHABULLET"),
+        `filler=${filler}: section heading kept only a header, not a content line`,
+      ).toBe(headingPage);
+    }
+  });
+
+  it("never splits an entry's FIRST wrapped bullet one line / rest", async () => {
+    // The first bullet is the one `drawEntry` marks `alreadyReserved`, so its
+    // orphan control comes entirely from the entry's keep-block. Reserving
+    // "header + ONE bullet line" there let the break land at header + 1 line and
+    // split this bullet 1 / rest — the same defect the standalone-bullet case
+    // above forbids, on the one bullet that case cannot reach.
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: [
+        "BULLETSTART partnered across engineering, product and design to land " +
+          "an initiative that measurably improved customer outcomes BULLETEND",
+        "Second bullet kept deliberately short.",
+      ],
+    });
+    // Non-vacuity: the FIRST bullet wraps to exactly two drawn lines, immediately
+    // after the header — so "all three on one page" IS the no-split assertion.
+    const unbroken = await drawnLines(build, 0);
+    expect(lineIndexOf(unbroken, "BULLETSTART")).toBe(
+      lineIndexOf(unbroken, "SUBJECTROLE") + 1,
+    );
+    expect(lineIndexOf(unbroken, "BULLETEND")).toBe(
+      lineIndexOf(unbroken, "BULLETSTART") + 1,
+    );
+
+    const n = await boundaryN(build, "BULLETSTART");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      const startPage = pageOf(lines, "BULLETSTART");
+      expect(
+        pageOf(lines, "BULLETEND"),
+        `filler=${filler}: entry's first wrapped bullet orphaned its first line`,
+      ).toBe(startPage);
+      expect(
+        pageOf(lines, "SUBJECTROLE"),
+        `filler=${filler}: header stranded from its first bullet`,
+      ).toBe(startPage);
+    }
+  });
+
+  it("never leaves a THREE-line bullet's last line alone at a page top", async () => {
+    // The widow half (#631). A three-line bullet has no legal split: the 2/1
+    // break a two-line reservation permits leaves its tail alone at the next
+    // page's top, and the 1/2 alternative is #629's orphan. So it must move
+    // whole — the reservation is its full height, not a fixed two lines.
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: ["ALPHABULLET short first bullet.", THREE_LINE_BULLET],
+    });
+    // Non-vacuity: the subject bullet really does wrap to three drawn lines, in
+    // token order — so a page-count of 1 or 2 for its tail is a real split.
+    expectWrapsTo(await drawnLines(build, 0), THREE_LINE_TOKENS);
+
+    const n = await boundaryN(build, "BULLETSTART");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      for (const count of bulletLinesPerPage(lines, THREE_LINE_TOKENS)) {
+        expect(
+          count,
+          `filler=${filler}: three-line bullet split across pages`,
+        ).toBeGreaterThanOrEqual(MIN_BULLET_LINES_PER_PAGE);
+      }
+    }
+  });
+
+  it("never leaves an entry's FIRST THREE-line bullet's last line alone at a page top", async () => {
+    // The first bullet is the one `drawEntry` marks `alreadyReserved`, so its
+    // whole break-position guarantee comes from the entry's keep-block. A block
+    // reserving "header + two bullet lines" lets the break land after line two
+    // and widows line three — the same defect the standalone case above forbids,
+    // on the one bullet that case cannot reach.
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: [THREE_LINE_BULLET, "Second bullet kept deliberately short."],
+    });
+    // Non-vacuity: the bullet wraps to three lines AND sits immediately under
+    // the header, so the keep-block really is what places it.
+    const unbroken = await drawnLines(build, 0);
+    expectWrapsTo(unbroken, THREE_LINE_TOKENS);
+    expect(lineIndexOf(unbroken, "BULLETSTART")).toBe(
+      lineIndexOf(unbroken, "SUBJECTROLE") + 1,
+    );
+
+    const n = await boundaryN(build, "BULLETSTART");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      for (const count of bulletLinesPerPage(lines, THREE_LINE_TOKENS)) {
+        expect(
+          count,
+          `filler=${filler}: entry's first three-line bullet split across pages`,
+        ).toBeGreaterThanOrEqual(MIN_BULLET_LINES_PER_PAGE);
+      }
+      expect(
+        pageOf(lines, "SUBJECTROLE"),
+        `filler=${filler}: header stranded from its first bullet`,
+      ).toBe(pageOf(lines, "BULLETSTART"));
+    }
+  });
+
+  it("splits a FOUR-line bullet so neither page gets a lone line", async () => {
+    // A four-line bullet stays DIVISIBLE — reserving it whole would de-densify
+    // pages, the failure mode #630 measured. Instead the break is placed: when
+    // three lines would fit, the third is pushed forward so the tail carries two
+    // lines rather than widowing the fourth.
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: ["ALPHABULLET short first bullet.", FOUR_LINE_BULLET],
+    });
+    // Non-vacuity: the subject bullet really does wrap to four drawn lines, so a
+    // 3/1 split is reachable and is what this asserts against.
+    expectWrapsTo(await drawnLines(build, 0), FOUR_LINE_TOKENS);
+
+    const n = await boundaryN(build, "BULLETSTART");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      for (const count of bulletLinesPerPage(lines, FOUR_LINE_TOKENS)) {
+        expect(
+          count,
+          `filler=${filler}: four-line bullet left a lone line on a page`,
+        ).toBeGreaterThanOrEqual(MIN_BULLET_LINES_PER_PAGE);
+      }
+    }
+  });
+
+  it("never leaves an entry's LAST bullet alone at a page top", async () => {
+    // #632. Once the header is safely placed, nothing constrained how an entry's
+    // bullets distributed among THEMSELVES — so a four-bullet entry rendered 3/1
+    // and the fourth bullet opened the next page with no other trace of its entry
+    // above it. The rule pushes the third forward with it, so at least two travel
+    // together. Single-line bullets on purpose: the defect does not need a wrapped
+    // bullet, and a wrapped-only rule would not reach this repro.
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: [
+        "ONEBULLET drove the platform migration.",
+        "TWOBULLET rebuilt the release pipeline.",
+        "THREEBULLET mentored the on-call rotation.",
+        "FOURBULLET owned the incident review process.",
+      ],
+    });
+    // Non-vacuity: all four bullets really are one drawn line each and contiguous
+    // in order, so "the last two share a page" IS the no-lone-bullet assertion.
+    expectWrapsTo(await drawnLines(build, 0), [
+      "ONEBULLET",
+      "TWOBULLET",
+      "THREEBULLET",
+      "FOURBULLET",
+    ]);
+
+    const n = await boundaryN(build, "FOURBULLET");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      expect(
+        pageOf(lines, "FOURBULLET"),
+        `filler=${filler}: entry's last bullet left alone at a page top`,
+      ).toBe(pageOf(lines, "THREEBULLET"));
+    }
+  });
+
+  it("never leaves the SECOND bullet of a two-bullet entry alone at a page top", async () => {
+    // The hard case. Here the second-to-last bullet IS the first bullet — the one
+    // `drawEntry` marks `alreadyReserved` — so the hand-off has nowhere to ride
+    // and `entryKeepHeight` must carry it. That makes this the one shape where the
+    // rule grows the entry's own keep-block, which is why it is bounded to the
+    // trailing bullet's keep-opening and dropped outright if it would push the
+    // block past a page (#629 outranks #632).
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: [
+        "ONEBULLET drove the platform migration.",
+        "TWOBULLET rebuilt the release pipeline.",
+      ],
+    });
+    // Non-vacuity: both bullets are one drawn line each, immediately under the
+    // header — so the keep-block really is what places them.
+    const unbroken = await drawnLines(build, 0);
+    expectWrapsTo(unbroken, ["ONEBULLET", "TWOBULLET"]);
+    expect(lineIndexOf(unbroken, "ONEBULLET")).toBe(
+      lineIndexOf(unbroken, "SUBJECTROLE") + 1,
+    );
+
+    const n = await boundaryN(build, "TWOBULLET");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      const firstPage = pageOf(lines, "ONEBULLET");
+      expect(
+        pageOf(lines, "TWOBULLET"),
+        `filler=${filler}: two-bullet entry's second bullet left alone at a page top`,
+      ).toBe(firstPage);
+      expect(
+        pageOf(lines, "SUBJECTROLE"),
+        `filler=${filler}: header stranded from its first bullet`,
+      ).toBe(firstPage);
+    }
+  });
+
+  it("keeps the last bullet with the TAIL of a wrapped second-to-last bullet", async () => {
+    // The interaction with #631. When the second-to-last bullet is itself long
+    // enough to split, the reservation covering its final line is the TAIL
+    // reservation, not its opening — so that is where the last bullet's
+    // keep-opening rides. Either the tail and the last bullet both fit here, or
+    // the break moves up and they travel forward together. The four-line bullet
+    // must also stay divisible: reserving it whole is the density failure #630
+    // measured, so this asserts placement, not a whole-bullet move.
+    const build = withFillerBefore({
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: [
+        "ALPHABULLET short first bullet.",
+        FOUR_LINE_BULLET,
+        "TAILBULLET owned the incident review process.",
+      ],
+    });
+    // Non-vacuity: the middle bullet really does wrap to four drawn lines, so its
+    // tail is a real, separately-placed unit.
+    expectWrapsTo(await drawnLines(build, 0), FOUR_LINE_TOKENS);
+
+    const n = await boundaryN(build, "TAILBULLET");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      expect(
+        pageOf(lines, "TAILBULLET"),
+        `filler=${filler}: last bullet left alone at a page top, away from the wrapped bullet's tail`,
+      ).toBe(pageOf(lines, "BULLETEND"));
+      // #631 still holds: the wrapped bullet is not pulled forward whole, and
+      // neither side of any break it straddles gets a lone line.
+      for (const count of bulletLinesPerPage(lines, FOUR_LINE_TOKENS)) {
+        expect(
+          count,
+          `filler=${filler}: four-line bullet left a lone line on a page`,
+        ).toBeGreaterThanOrEqual(MIN_BULLET_LINES_PER_PAGE);
+      }
+    }
+  });
+
+  it("moves ALL of a genuine THREE-line entry header with its first bullet", async () => {
+    // The B2 cap on body-text headers must not reach a real header: a role header
+    // that wraps to three lines still reserves all three.
+    const build = withFillerBefore({
+      headerLine:
+        "HEADSTART Senior Staff Engineering Manager and Principal Technical " +
+        "Program Lead · Subject Company Incorporated, Springfield, Illinois · " +
+        "Platform Infrastructure, Developer Experience, Release Engineering, " +
+        "Observability and Reliability Engineering HEADEREND",
+      headerHangingIndent: 12,
+      bullets: ["ALPHABULLET drove the platform migration end to end."],
+    });
+    // Non-vacuity: the header really does wrap to THREE lines, so a two-line cap
+    // (what a body-text header gets) is provably not enough to hold it.
+    const unbroken = await drawnLines(build, 0);
+    expect(lineIndexOf(unbroken, "HEADEREND")).toBe(
+      lineIndexOf(unbroken, "HEADSTART") + 2,
+    );
+
+    const n = await boundaryN(build, "HEADSTART");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      const headPage = pageOf(lines, "HEADSTART");
+      expect(
+        pageOf(lines, "HEADEREND"),
+        `filler=${filler}: three-line header split across pages`,
+      ).toBe(headPage);
+      expect(
+        pageOf(lines, "ALPHABULLET"),
+        `filler=${filler}: three-line header stranded from its first bullet`,
+      ).toBe(headPage);
+    }
+  });
+
+  it("does not pull a long skills list forward as one indivisible block", async () => {
+    // The skills list is a SINGLE `headerLine` (`skills.join(" · ")` with no
+    // bullets — `ats-resume-model.ts`), marked `headerBold: false` because it
+    // reads as body text. Reserving every one of its wrapped lines as a
+    // keep-with-next unit moves the WHOLE list to the next page and leaves a
+    // half-empty page behind, which `drawSectionHeading` inherits through
+    // `followHeight`. Body text is divisible; it must flow.
+    const skillsSection = (skills: string[]) => ({
+      heading: "Skills",
+      entries: [
+        {
+          headerLine: skills.join(" · "),
+          headerBold: false,
+          atomicSegments: true,
+          bullets: [],
+        } satisfies AtsEntry,
+      ],
+    });
+    const longSkills = [
+      "FIRSTSKILL",
+      ...Array.from({ length: 120 }, (_, i) => `Skill${i}`),
+      "LASTSKILL",
+    ];
+    const buildFor =
+      (skills: string[]): ModelBuilder =>
+      (filler) => ({
+        contact: { name: "Jane Candidate", links: [] },
+        sections: [
+          { heading: "Experience", entries: [fillerEntry(filler)] },
+          skillsSection(skills),
+        ],
+      });
+    const build = buildFor(longSkills);
+    // A one-line control list: same document, same filler, a skills block that
+    // cannot possibly be pulled forward. Page 1 of the long variant must be at
+    // least as full as page 1 of the control — that is the density claim, and it
+    // is what a whole-block reservation breaks.
+    const control = buildFor(["FIRSTSKILL", "Skill0", "LASTSKILL"]);
+
+    // Non-vacuity: the long list really does wrap far past the two-line cap.
+    const unbroken = await drawnLines(build, 0);
+    expect(
+      lineIndexOf(unbroken, "LASTSKILL") - lineIndexOf(unbroken, "FIRSTSKILL"),
+    ).toBeGreaterThan(2);
+
+    const n = await boundaryN(build, "LASTSKILL");
+    for (const filler of windowAround(n)) {
+      const lines = await drawnLines(build, filler);
+      expect(
+        pageOf(lines, "FIRSTSKILL"),
+        `filler=${filler}: whole skills list pulled off the heading's page`,
+      ).toBe(pageOf(lines, "SKILLS"));
+      expect(
+        linesOnPage(lines, 1),
+        `filler=${filler}: skills block de-densified page 1`,
+      ).toBeGreaterThanOrEqual(
+        linesOnPage(await drawnLines(control, filler), 1),
+      );
+    }
+  });
+
+  it("wastes no page on a keep-block taller than a whole page", async () => {
+    // An entry whose header alone outruns a full page makes BOTH the section
+    // heading's reservation and the entry's own reservation unsatisfiable. If
+    // `ensureBlock` were a bare `ensure`, each would break in turn: the heading
+    // lands alone on a fresh page and the entry starts on the one after — a wasted
+    // page AND the very stranding the reservation exists to prevent (#629 AC3).
+    //
+    // The header is a GENUINE (bold) one on purpose. A body-text header — the
+    // skills list — is capped at two lines and so can no longer reach this case at
+    // all; only an uncapped real header can, which is what makes it the honest
+    // exercise of `ensureBlock`'s unsatisfiable branch.
+    const model: AtsResumeModel = {
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [
+        { heading: "Experience", entries: [fillerEntry(10)] },
+        {
+          heading: "Achievements",
+          entries: [
+            {
+              headerLine: [
+                "FIRSTHEAD",
+                ...Array.from({ length: 900 }, (_, i) => `Award${i}`),
+                "LASTHEAD",
+              ].join(" · "),
+              bullets: ["ALPHABULLET led the standards working group."],
+            },
+          ],
+        },
+      ],
+    };
+    const lines = await extractPdfDrawnLines(await renderAtsResumePdf(model));
+    const pages = Math.max(...lines.map((l) => l.page));
+    const densest = Math.max(
+      ...Array.from({ length: pages }, (_, i) => linesOnPage(lines, i + 1)),
+    );
+    // Non-vacuity: the block really is taller than a whole page — it draws more
+    // lines than the densest page can hold, so NO page could ever satisfy its
+    // reservation. Measured on the drawn output, not asserted from the input size.
+    expect(
+      lineIndexOf(lines, "LASTHEAD") - lineIndexOf(lines, "FIRSTHEAD") + 1,
+    ).toBeGreaterThan(densest);
+
+    expect(
+      pageOf(lines, "FIRSTHEAD"),
+      "ACHIEVEMENTS heading stranded alone; its entry starts on the next page",
+    ).toBe(pageOf(lines, "ACHIEVEMENTS"));
+    // No page before the last is wasted. A page consumed by an unsatisfiable
+    // reservation is grossly under-filled (a heading and nothing else), so
+    // comparing against half the densest page separates "wasted" from the few
+    // lines a heading + rule + section gaps legitimately cost.
+    for (let page = 1; page < pages; page++) {
+      expect(
+        linesOnPage(lines, page),
+        `page ${page} was wasted by an unsatisfiable reservation`,
+      ).toBeGreaterThan(densest / 2);
+    }
+  });
 });

--- a/src/lib/pdf/render-ats-pdf.test-utils.ts
+++ b/src/lib/pdf/render-ats-pdf.test-utils.ts
@@ -2,10 +2,66 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * Shared test helper for render-ats-pdf's test files (render-ats-pdf.test.ts,
- * render-ats-pdf.fonts.test.ts) — NOT itself a `*.test.ts` file, so it isn't
- * picked up as a test suite.
+ * Shared test helpers for render-ats-pdf's test files (render-ats-pdf.test.ts,
+ * render-ats-pdf.fonts.test.ts, export-layout-contract.test.ts) — NOT itself a
+ * `*.test.ts` file, so it isn't picked up as a test suite.
  */
+
+/** One drawn text line: the page it landed on (1-based) and its joined text. */
+export interface PdfDrawnLine {
+  page: number;
+  text: string;
+}
+
+/**
+ * Extract the drawn text LINE by LINE, top-to-bottom within each page and pages
+ * in order, each line tagged with its 1-based page number. Lines are recovered by
+ * grouping text items on a shared baseline `y` (the renderer draws every item of
+ * one line at the same `y`) and joining them left-to-right.
+ *
+ * Unlike {@link extractPdfText}, this preserves the two things a pagination
+ * contract is about: which page a line landed on, and which line follows which
+ * (#629).
+ */
+export async function extractPdfDrawnLines(
+  bytes: Uint8Array,
+): Promise<PdfDrawnLine[]> {
+  const pdfjs = await import("pdfjs-dist");
+  const doc = await pdfjs.getDocument({
+    data: bytes.slice(),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+    useSystemFonts: false,
+  }).promise;
+  const out: PdfDrawnLine[] = [];
+  for (let p = 1; p <= doc.numPages; p++) {
+    const page = await doc.getPage(p);
+    const content = await page.getTextContent();
+    const rows = new Map<string, Array<{ x: number; y: number; str: string }>>();
+    for (const raw of content.items) {
+      if (!("str" in raw)) continue;
+      const item = raw as { str: string; transform: number[] };
+      if (item.str.trim() === "") continue;
+      const x = item.transform[4];
+      const y = item.transform[5];
+      const key = y.toFixed(1);
+      const row = rows.get(key);
+      if (row) row.push({ x, y, str: item.str });
+      else rows.set(key, [{ x, y, str: item.str }]);
+    }
+    const ordered = [...rows.values()].sort((a, b) => b[0].y - a[0].y);
+    for (const row of ordered) {
+      out.push({
+        page: p,
+        text: row
+          .sort((a, b) => a.x - b.x)
+          .map((i) => i.str)
+          .join(" "),
+      });
+    }
+  }
+  return out;
+}
 
 /** Extract all selectable text from PDF bytes using pdfjs-dist. */
 export async function extractPdfText(bytes: Uint8Array): Promise<string> {

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -19,6 +19,40 @@
  * word-wrapped by measuring with `font.widthOfTextAtSize`; bullets get a "• "
  * marker with a hanging indent.
  *
+ * Pagination is per line (`ensure`) PLUS keep-with-next reservations
+ * (`ensureBlock`, #629): a section heading reserves its rule and the first
+ * entry's keep-block, an entry header reserves all its wrapped header/sub-line
+ * lines plus its first bullet's keep-opening, and a standalone bullet that wraps
+ * reserves that same opening. So a heading or header can never be the last drawn
+ * line on a page.
+ *
+ * A wrapped bullet gets BOTH halves of the break-position guarantee: at least
+ * `BULLET_KEEP_LINES` of its lines sit on each side of any page break it
+ * straddles — never one line alone at a page bottom (#629, the orphan half) and
+ * never one line alone at a page top (#631, the widow half). The opening
+ * reservation (`bulletKeepLines`) covers the first side and, for a bullet too
+ * short to admit any legal split, the whole bullet; `ensureWrappedLine` places
+ * the break for the second side, pushing the trailing lines forward together
+ * rather than reserving the entire bullet — long bullets must stay divisible or
+ * pages de-densify.
+ *
+ * The same "never exactly one alone" rule applies one level up, to the BULLETS of
+ * an entry (#632): a page never opens on an entry's last bullet with nothing else
+ * of that entry above it. The second-to-last bullet carries the last one's
+ * keep-opening (`followKeepHeight`), so a break at that boundary moves both
+ * bullets forward together. Only that one boundary is constrained — earlier
+ * bullets paginate freely and no reservation ever spans the entry — because
+ * reserving a whole entry is the density failure #630 measured at ~100pt.
+ *
+ * Two deliberate limits keep those reservations from costing page density: a
+ * BODY-TEXT "header" (`headerBold: false` — the skills list) contributes at most
+ * `BODY_HEADER_KEEP_LINES`, and a reservation taller than a whole page is
+ * unsatisfiable and ignored outright. Every reservation is MEASURED by the same
+ * wrapping code that draws it (`measureTextHeight` / `measureBulletLines` /
+ * `measureHeaderRunsHeight` all share the draw path's line breaking), never
+ * estimated. This is manual pdf-lib layout, not an HTML/Chromium print path —
+ * CSS `break-after: avoid` / `orphans` / `widows` do not apply here.
+ *
  * The `rgb()` colors here are PDF graphics-state values (black text, a muted
  * gray rule) — NOT Tailwind tokens. The style guard scans component/feature
  * code, not this draw module.
@@ -43,6 +77,11 @@ const PAGE_HEIGHT = 792;
 const MARGIN = 54;
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
 const CONTENT_BOTTOM = MARGIN;
+// Drawable height of a FRESH page — `newPage()` resets the cursor to
+// `PAGE_HEIGHT - MARGIN` and `ensure` stops at `CONTENT_BOTTOM`. This is exactly
+// the tallest reservation {@link Layout.ensureBlock} can satisfy, so anything
+// taller is unsatisfiable and must not be reserved (#629).
+const USABLE_PAGE_HEIGHT = PAGE_HEIGHT - MARGIN - CONTENT_BOTTOM;
 
 // ── Type scale (points) ───────────────────────────────────────────────────────
 //
@@ -79,9 +118,41 @@ const GAP_BEFORE_SECTION = 12;
 const GAP_AFTER_RULE = 6;
 const GAP_BETWEEN_ENTRIES = 7;
 const GAP_AFTER_HEADER = 2;
+// Vertical space the section-heading rule consumes (`drawRule`). Named because
+// the keep-with-next reservation for a section heading must include it (#629) —
+// the heading, its rule, and the first line of its content move as one unit.
+const RULE_HEIGHT = 2;
 
 const BULLET_MARKER = "• ";
 const BULLET_INDENT = 12; // hanging-indent width for wrapped bullet lines
+
+// Minimum drawn lines of a wrapped bullet that must land on EACH side of a page
+// break it straddles — the orphan half (#629, no lone line at a page bottom) and
+// the widow half (#631, no lone line at a page top) of one symmetric rule. It
+// follows that the legal split positions of an N-line bullet are exactly
+// `[BULLET_KEEP_LINES, N - BULLET_KEEP_LINES]`, an interval that is EMPTY when
+// `N < 2 * BULLET_KEEP_LINES` — which is why a three-line bullet is indivisible
+// and has to move whole (see `bulletKeepLines`).
+const BULLET_KEEP_LINES = 2;
+
+/**
+ * How many of a bullet's `total` drawn lines its OPENING reservation must keep
+ * together (#629/#631).
+ *
+ * A bullet with no legal split position (`total < 2 * BULLET_KEEP_LINES`) is
+ * indivisible: every break inside it would strand fewer than `BULLET_KEEP_LINES`
+ * lines on one side, so the reservation is the whole bullet and the break falls
+ * before it. That is the three-line case #631 is about — reserving two lines
+ * draws two and leaves the third alone at the next page's top.
+ *
+ * A longer bullet reserves ONLY its orphan-safe opening and stays divisible;
+ * {@link Layout.ensureWrappedLine} then places the break so the tail keeps
+ * `BULLET_KEEP_LINES` lines too. Reserving such a bullet whole would de-densify
+ * pages by its full height — the failure mode #630 measured on the skills list.
+ */
+function bulletKeepLines(total: number): number {
+  return total < 2 * BULLET_KEEP_LINES ? total : BULLET_KEEP_LINES;
+}
 
 // Minimum blank gutter (pt) kept between the wrapped header text and the
 // flush-right date tail (#436). Without a reserve the header text wraps to the
@@ -417,6 +488,43 @@ function groupRunsIntoWords(
 }
 
 /**
+ * Options for {@link Layout.drawText}. Named (rather than inlined in the
+ * signature) so {@link Layout.measureTextHeight} can take the IDENTICAL options
+ * — a keep-with-next reservation (#629) is only sound if it is measured by the
+ * same wrapping decision that will draw it.
+ */
+type DrawTextOpts = {
+  bold?: boolean;
+  size?: number;
+  color?: RGB;
+  x?: number;
+  hangingIndent?: number;
+  uppercase?: boolean;
+  atomicSegments?: boolean;
+  /** A short tail (a role/degree date range) drawn FLUSH-RIGHT, regular
+   *  weight, on the first wrapped line's baseline (#425). */
+  rightText?: string;
+  rightColor?: RGB;
+  rightSize?: number;
+  /** Register a clickable URI annotation over the whole first line (#425). */
+  linkUrl?: string;
+  /** Register a clickable URI annotation over each `display` substring found
+   *  in the first line (#425 — the contact line's link slugs). Applied only
+   *  when the text fits on ONE line, so measured offsets are accurate. */
+  linkSpans?: Array<{ display: string; href: string }>;
+  /** Paginate the wrapped lines under widow control (#631) — see
+   *  {@link Layout.ensureWrappedLine}. Set only by {@link Layout.drawBullet}; a
+   *  header/contact/summary block keeps the plain per-line behaviour. Not an
+   *  input to wrapping, so {@link Layout.measureTextHeight} ignores it. */
+  widowControl?: boolean;
+  /** Height (pt) that must land on the same page as this block's FINAL drawn
+   *  line — the NEXT bullet's keep-opening (#632). Set only by
+   *  {@link Layout.drawBullet}, and only for an entry's second-to-last bullet.
+   *  Like `widowControl`, not an input to wrapping. */
+  followKeepHeight?: number;
+};
+
+/**
  * Mutable cursor + page state threaded through the draw routines. We keep one
  * "current page" and append new pages as the cursor overflows.
  */
@@ -480,6 +588,81 @@ class Layout {
   /** Ensure room for `height` pt; add a page if the cursor would overflow. */
   private ensure(height: number) {
     if (this.y - height < CONTENT_BOTTOM) this.newPage();
+  }
+
+  /**
+   * Reserve `height` pt for an INDIVISIBLE block — a keep-with-next group such
+   * as "entry header + its first bullet line" or "section heading + rule + one
+   * line of content" (#629). Arithmetically identical to the per-line
+   * {@link ensure}; the difference is the caller's contract, not the maths.
+   * `ensure` is handed one line and may legitimately break right after it,
+   * whereas this is handed a whole group and guarantees the group STARTS on a
+   * page that can hold all of it — so the per-line `ensure` calls that draw the
+   * group cannot fire a second break inside it.
+   *
+   * A reservation TALLER than a whole empty page is UNSATISFIABLE, and is
+   * therefore ignored outright rather than broken to (#629). Deferring it cannot
+   * make it fit, and doing so actively causes the defect this method exists to
+   * prevent: on a "heading + oversized first entry" pair, the heading's
+   * reservation breaks to a fresh page, the entry's own equally-unsatisfiable
+   * reservation immediately breaks again, and the heading is left alone on a page
+   * of its own — a wasted page plus the exact stranding AC3 forbids. Ignoring it
+   * hands the block back to the per-line {@link ensure} calls that draw it, which
+   * fill the current page and break naturally. The comparison is against
+   * {@link USABLE_PAGE_HEIGHT}, so a block exactly that tall still counts as
+   * satisfiable.
+   */
+  ensureBlock(height: number) {
+    if (height > USABLE_PAGE_HEIGHT) return;
+    this.ensure(height);
+  }
+
+  /**
+   * Paginate ONE line (`index` of `total`) of a wrapped block, honouring widow
+   * control (#631).
+   *
+   * Without it, or on a block too short to split legally, this is the plain
+   * per-line {@link ensure}. With it, the line `BULLET_KEEP_LINES` from the end
+   * reserves the whole TAIL rather than itself: if the tail fits, the block
+   * cannot end with fewer than `BULLET_KEEP_LINES` lines on the next page; if it
+   * does not, the break happens HERE instead of one line later, carrying the tail
+   * forward as a unit. Only that one line needs the wider reservation — every
+   * earlier line breaking naturally leaves the tail intact, and every later line
+   * is inside a tail already placed.
+   *
+   * The other side of the break is guaranteed by the caller's OPENING
+   * reservation ({@link bulletKeepLines}): it committed `BULLET_KEEP_LINES` lines
+   * to the page the block starts on, and a block reaching this branch has
+   * `total >= 2 * BULLET_KEEP_LINES`, so the lines before the tail are at least
+   * that many. A block whose own height exceeds a page simply breaks more than
+   * once; a fresh page always holds a tail this short, so the reservation here
+   * can never be unsatisfiable.
+   *
+   * `followKeep` (#632) is height that must land on the SAME page as this block's
+   * FINAL line — the next bullet's keep-opening. The tail reservation is the one
+   * that covers that final line for a DIVISIBLE block, so it is also the one that
+   * must carry the follow: either both fit here, or the break moves up and the
+   * tail travels forward together with what follows it. An indivisible block
+   * never reaches this branch — its opening reservation covers its final line, so
+   * {@link drawBullet} folds the follow in there instead. Bounded by construction:
+   * `BULLET_KEEP_LINES` plus at most `2 * BULLET_KEEP_LINES - 1` follow lines,
+   * far under a page, so this stays satisfiable.
+   */
+  private ensureWrappedLine(
+    index: number,
+    total: number,
+    lineHeight: number,
+    opts: { widowControl?: boolean; followKeepHeight?: number },
+  ) {
+    const startsTail =
+      (opts.widowControl ?? false) &&
+      total >= 2 * BULLET_KEEP_LINES &&
+      index === total - BULLET_KEEP_LINES;
+    this.ensure(
+      startsTail
+        ? BULLET_KEEP_LINES * lineHeight + (opts.followKeepHeight ?? 0)
+        : lineHeight,
+    );
   }
 
   advance(points: number) {
@@ -564,41 +747,28 @@ class Layout {
   }
 
   /**
-   * Draw a wrapped block of text. `x` is the left edge; `hangingIndent`
-   * indents continuation lines (for bullet hanging indent). `atomicSegments`
-   * opts into segment-atomic middot wrapping (see `wrap()` above) — leave it
-   * unset/`false` for ordinary header/entry lines; the skills entry is the
-   * only caller that sets it `true` (#307).  Returns nothing; mutates the
-   * cursor and paginates as needed.
+   * Resolve everything a {@link drawText} call needs BEFORE it touches the page:
+   * the font, the sanitized value, the flush-right tail, and the wrapped lines.
+   * Shared with {@link measureTextHeight} so a keep-with-next reservation (#629)
+   * is measured by exactly the wrapping that will draw it — one layout pass'
+   * worth of logic, called once per measure and once per draw, never forked into
+   * a second implementation that could disagree.
    */
-  drawText(
+  private resolveDrawLines(
     text: string,
-    opts: {
-      bold?: boolean;
-      size?: number;
-      color?: RGB;
-      x?: number;
-      hangingIndent?: number;
-      uppercase?: boolean;
-      atomicSegments?: boolean;
-      /** A short tail (a role/degree date range) drawn FLUSH-RIGHT, regular
-       *  weight, on the first wrapped line's baseline (#425). */
-      rightText?: string;
-      rightColor?: RGB;
-      rightSize?: number;
-      /** Register a clickable URI annotation over the whole first line (#425). */
-      linkUrl?: string;
-      /** Register a clickable URI annotation over each `display` substring found
-       *  in the first line (#425 — the contact line's link slugs). Applied only
-       *  when the text fits on ONE line, so measured offsets are accurate. */
-      linkSpans?: Array<{ display: string; href: string }>;
-    } = {},
-  ) {
+    opts: DrawTextOpts,
+  ): {
+    lines: string[];
+    font: PdfFont;
+    size: number;
+    x: number;
+    lineHeight: number;
+    rValue: string;
+    rSize: number;
+  } {
     const size = opts.size ?? SIZE_BODY;
     const font = opts.bold ? this.fonts.bold : this.fonts.regular;
-    const color = opts.color ?? this.black;
     const x = opts.x ?? MARGIN;
-    const hanging = opts.hangingIndent ?? 0;
     // Sanitize LAST — after the case transform — so a case-expansion can never
     // produce an un-encodable glyph downstream. `toUpperCase()` maps some
     // WinAnsi-native lowercase letters to glyphs with NO WinAnsi representation
@@ -633,10 +803,36 @@ class Layout {
       atomic,
       rightReserve,
     );
-    const lineHeight = size * LINE_GAP;
+    return { lines, font, size, x, lineHeight: size * LINE_GAP, rValue, rSize };
+  }
+
+  /**
+   * Height (pt) a {@link drawText} call with the SAME `text`/`opts` will
+   * occupy — its wrapped line count times its line height. Pure: measures
+   * without touching the page or the cursor. The keep-with-next reservations
+   * (#629) are built from this, so a reservation can never be a guess.
+   */
+  measureTextHeight(text: string, opts: DrawTextOpts = {}): number {
+    const { lines, lineHeight } = this.resolveDrawLines(text, opts);
+    return lines.length * lineHeight;
+  }
+
+  /**
+   * Draw a wrapped block of text. `x` is the left edge; `hangingIndent`
+   * indents continuation lines (for bullet hanging indent). `atomicSegments`
+   * opts into segment-atomic middot wrapping (see `wrap()` above) — leave it
+   * unset/`false` for ordinary header/entry lines; the skills entry is the
+   * only caller that sets it `true` (#307).  Returns nothing; mutates the
+   * cursor and paginates as needed.
+   */
+  drawText(text: string, opts: DrawTextOpts = {}) {
+    const { lines, font, size, x, lineHeight, rValue, rSize } =
+      this.resolveDrawLines(text, opts);
+    const color = opts.color ?? this.black;
+    const hanging = opts.hangingIndent ?? 0;
     const singleLine = lines.length === 1;
     for (let i = 0; i < lines.length; i++) {
-      this.ensure(lineHeight);
+      this.ensureWrappedLine(i, lines.length, lineHeight, opts);
       const lineX = i === 0 ? x : x + hanging;
       const topY = this.y;
       this.page.drawText(lines[i], {
@@ -647,48 +843,85 @@ class Layout {
         color,
       });
       if (i === 0) {
-        // Flush-right date tail on the first line's baseline (#425), right-
-        // aligned to the content margin and drawn regular-weight/muted.
-        if (opts.rightText) {
-          const rFont = this.fonts.regular;
-          const rX = PAGE_WIDTH - MARGIN - rFont.widthOfTextAtSize(rValue, rSize);
-          this.page.drawText(rValue, {
-            x: rX,
-            y: topY - size,
-            size: rSize,
-            font: rFont,
-            color: opts.rightColor ?? color,
-          });
-        }
-        // Clickable annotation over the whole first line (#425).
-        if (opts.linkUrl) {
-          const w = font.widthOfTextAtSize(lines[0], size);
-          this.registerLink(lineX, topY - size, lineX + w, topY, opts.linkUrl);
-        }
-        // Per-substring link annotations (#425 contact-line slugs). Measure
-        // against the DRAWN first line (whitespace already collapsed by wrap);
-        // skip if the text wrapped so offsets stay accurate. Drawn glyphs are
-        // untouched either way, so the text round-trip is unaffected.
-        //
-        // Search from a running offset that advances past each matched span, so
-        // a display that is a SUBSTRING of an earlier part (e.g. website slug
-        // `example.com` inside email `jane@example.com`, and the email is drawn
-        // first) can't match inside that earlier part and land the rect on the
-        // wrong text. The spans are supplied in draw order, so a monotonic offset
-        // maps each to its own occurrence.
-        if (opts.linkSpans && singleLine) {
-          let searchFrom = 0;
-          for (const span of opts.linkSpans) {
-            const idx = lines[0].indexOf(span.display, searchFrom);
-            if (idx < 0) continue;
-            const x0 = lineX + font.widthOfTextAtSize(lines[0].slice(0, idx), size);
-            const x1 = x0 + font.widthOfTextAtSize(span.display, size);
-            this.registerLink(x0, topY - size, x1, topY, span.href);
-            searchFrom = idx + span.display.length;
-          }
-        }
+        this.decorateFirstLine(opts, {
+          line: lines[0],
+          lineX,
+          topY,
+          font,
+          size,
+          color,
+          rValue,
+          rSize,
+          singleLine,
+        });
       }
       this.advance(lineHeight);
+    }
+  }
+
+  /**
+   * Draw the first line's optional decorations: the flush-right date tail, a
+   * whole-line link annotation, and per-substring link annotations (#425).
+   *
+   * Split out of {@link drawText} purely to keep that method's line loop
+   * readable — all three apply only to `i === 0`, none touches the cursor, and
+   * none participates in wrapping or pagination. Extracting them therefore
+   * cannot drift measurement from drawing (the #629 invariant): the geometry
+   * they consume is passed in, already resolved by `resolveDrawLines`.
+   */
+  private decorateFirstLine(
+    opts: DrawTextOpts,
+    geom: {
+      line: string;
+      lineX: number;
+      topY: number;
+      font: PdfFont;
+      size: number;
+      color: RGB;
+      rValue: string;
+      rSize: number;
+      singleLine: boolean;
+    },
+  ) {
+    const { line, lineX, topY, font, size, color, rValue, rSize } = geom;
+    // Flush-right date tail on the first line's baseline (#425), right-aligned
+    // to the content margin and drawn regular-weight/muted.
+    if (opts.rightText) {
+      const rFont = this.fonts.regular;
+      const rX = PAGE_WIDTH - MARGIN - rFont.widthOfTextAtSize(rValue, rSize);
+      this.page.drawText(rValue, {
+        x: rX,
+        y: topY - size,
+        size: rSize,
+        font: rFont,
+        color: opts.rightColor ?? color,
+      });
+    }
+    // Clickable annotation over the whole first line (#425).
+    if (opts.linkUrl) {
+      const w = font.widthOfTextAtSize(line, size);
+      this.registerLink(lineX, topY - size, lineX + w, topY, opts.linkUrl);
+    }
+    // Per-substring link annotations (#425 contact-line slugs). Measure against
+    // the DRAWN first line (whitespace already collapsed by wrap); skip if the
+    // text wrapped so offsets stay accurate. Drawn glyphs are untouched either
+    // way, so the text round-trip is unaffected.
+    //
+    // Search from a running offset that advances past each matched span, so a
+    // display that is a SUBSTRING of an earlier part (e.g. website slug
+    // `example.com` inside email `jane@example.com`, and the email is drawn
+    // first) can't match inside that earlier part and land the rect on the wrong
+    // text. The spans are supplied in draw order, so a monotonic offset maps each
+    // to its own occurrence.
+    if (!opts.linkSpans || !geom.singleLine) return;
+    let searchFrom = 0;
+    for (const span of opts.linkSpans) {
+      const idx = line.indexOf(span.display, searchFrom);
+      if (idx < 0) continue;
+      const x0 = lineX + font.widthOfTextAtSize(line.slice(0, idx), size);
+      const x1 = x0 + font.widthOfTextAtSize(span.display, size);
+      this.registerLink(x0, topY - size, x1, topY, span.href);
+      searchFrom = idx + span.display.length;
     }
   }
 
@@ -701,13 +934,85 @@ class Layout {
    * sentinel markers, so the round-trip text is byte-identical to the source —
    * including any literal `**` a user typed, which is drawn verbatim (#284/#425).
    */
-  drawBullet(text: string, size: number, hangingIndent: number) {
+  drawBullet(
+    text: string,
+    size: number,
+    hangingIndent: number,
+    opts: { alreadyReserved?: boolean; followKeepHeight?: number } = {},
+  ) {
+    // Break-position control (#629 orphan half, #631 widow half): a wrapped
+    // bullet reserves `bulletKeepLines` lines before it starts, so it can never
+    // leave its first line alone at a page bottom — and, when it is too short to
+    // split legally at all, that reservation IS its full height, so it can never
+    // leave its last line alone at a page top either. A longer bullet stays
+    // divisible; `widowControl` below places its break so the tail keeps
+    // `BULLET_KEEP_LINES` lines too. A one-line bullet keeps the plain per-line
+    // behaviour.
+    //
+    // `alreadyReserved` is the entry header's first bullet — `entryKeepHeight`
+    // already folded THIS reservation into the keep-block, so re-reserving here
+    // would move the bullet and STRAND the header that reservation just
+    // guaranteed against. Per #629's composition decision the two rules compose
+    // rather than sum: both call `bulletKeepLines`, so neither reserves a long
+    // bullet's FULL height. Widow control is unaffected either way — it lives in
+    // the draw loop, not the reservation, so the first bullet gets it too.
+    //
+    // `followKeepHeight` (#632) is the NEXT bullet's keep-opening, and the rule
+    // placing it is one line: whichever reservation covers THIS bullet's final
+    // drawn line must also cover the follow. For an INDIVISIBLE bullet
+    // (`bulletKeepLines(total) === total`) that is this opening reservation, so it
+    // is added here; for a divisible one it is the tail reservation, so
+    // {@link ensureWrappedLine} adds it instead and this opening stays exactly
+    // what #629/#631 made it. The two cases are exclusive — never summed — so the
+    // follow is reserved once and the reservation stays bounded to two bullets'
+    // keep-openings, never the whole entry.
+    const lineHeight = size * LINE_GAP;
+    const followKeep = opts.followKeepHeight ?? 0;
+    if (!opts.alreadyReserved) {
+      const total = this.measureBulletLines(text, size, hangingIndent);
+      const keep = bulletKeepLines(total);
+      const height = keep * lineHeight + (keep === total ? followKeep : 0);
+      // A bare one-line reservation is what the first line's own `ensure` already
+      // does, so reserve only when the block asks for more than that.
+      if (height > lineHeight) this.ensureBlock(height);
+    }
     const marked = autoBoldMetrics(text);
     if (!marked.includes(EMPHASIS_OPEN)) {
-      this.drawText(`${BULLET_MARKER}${text}`, { size, hangingIndent });
+      this.drawText(`${BULLET_MARKER}${text}`, {
+        size,
+        hangingIndent,
+        widowControl: true,
+        followKeepHeight: followKeep,
+      });
       return;
     }
-    this.drawRuns(parseBoldRuns(marked), size, hangingIndent);
+    this.drawRuns(parseBoldRuns(marked), size, hangingIndent, {
+      widowControl: true,
+      followKeepHeight: followKeep,
+    });
+  }
+
+  /**
+   * How many lines {@link drawBullet} will draw for the same arguments, counted
+   * through whichever wrapping path will draw it (#629). A LINE COUNT rather
+   * than a height because both reservation rules are stated in lines
+   * ({@link bulletKeepLines}), and deriving the count back out of a height would
+   * put a division between the measurement and the decision it feeds.
+   */
+  measureBulletLines(
+    text: string,
+    size: number,
+    hangingIndent: number,
+  ): number {
+    const marked = autoBoldMetrics(text);
+    if (!marked.includes(EMPHASIS_OPEN)) {
+      return this.resolveDrawLines(`${BULLET_MARKER}${text}`, {
+        size,
+        hangingIndent,
+      }).lines.length;
+    }
+    return this.wrapRuns(parseBoldRuns(marked), size, hangingIndent, BULLET_MARKER)
+      .length;
   }
 
   /**
@@ -721,29 +1026,30 @@ class Layout {
     this.drawRuns(parseBoldRuns(text), size, 0, { marker: "", color: this.black });
   }
 
+  /** Height (pt) {@link drawHeaderRuns} will occupy for the same text (#629). */
+  measureHeaderRunsHeight(text: string, size: number): number {
+    return (
+      this.wrapRuns(parseBoldRuns(text), size, 0, "").length * (size * LINE_GAP)
+    );
+  }
+
   /**
-   * Draw a sequence of `{ text, bold }` runs with word-level wrapping. A "word"
-   * is a run of non-whitespace that may span a bold→regular boundary (so mid-
-   * word emphasis draws correctly); words are separated by a single space. A
-   * leading `marker` (the bullet "• " by default, "" for a header) leads the
-   * first line; continuation lines use `hangingIndent`. Bold is preserved across
-   * wraps because it is tracked per chunk, not per line.
+   * Break `runs` into drawn lines WITHOUT touching the page — the pure half of
+   * {@link drawRuns}, so a reservation and the draw that follows it agree by
+   * construction (#629). A "word" is a run of non-whitespace that may span a
+   * bold→regular boundary (so mid-word emphasis draws correctly); words are
+   * separated by a single space. The `marker` (the bullet "• ", or "" for a
+   * header) occupies the start of the first line; continuation lines start at
+   * `hangingIndent`. An empty run list yields one empty line, matching what the
+   * draw loop emits.
    */
-  private drawRuns(
+  private wrapRuns(
     runs: Array<{ text: string; bold: boolean }>,
     size: number,
     hangingIndent: number,
-    opts: { marker?: string; color?: RGB } = {},
-  ) {
-    const marker = opts.marker ?? BULLET_MARKER;
-    const color = opts.color ?? this.black;
-    const words = groupRunsIntoWords(
-      runs,
-      size,
-      this.fonts,
-      this.sanitize,
-    );
-
+    marker: string,
+  ): WordChunk[][][] {
+    const words = groupRunsIntoWords(runs, size, this.fonts, this.sanitize);
     const wordWidth = (w: WordChunk[]) =>
       w.reduce((sum, c) => sum + c.width, 0);
     const space = this.fonts.regular.widthOfTextAtSize(" ", size);
@@ -751,32 +1057,94 @@ class Layout {
       ? this.fonts.regular.widthOfTextAtSize(marker, size)
       : 0;
     const rightEdge = PAGE_WIDTH - MARGIN;
-    const lineHeight = size * LINE_GAP;
 
-    this.ensure(lineHeight);
-    if (marker) {
-      this.page.drawText(marker, {
-        x: MARGIN,
-        y: this.y - size,
-        size,
-        font: this.fonts.regular,
-        color,
-      });
-    }
+    const lines: WordChunk[][][] = [];
+    let current: WordChunk[][] = [];
     let x = MARGIN + markerWidth;
     let atLineStart = true;
-
     for (const word of words) {
       const ww = wordWidth(word);
       // Wrap before a word (never the first on a line) that would overflow.
       if (!atLineStart && x + space + ww > rightEdge) {
-        this.advance(lineHeight);
-        this.ensure(lineHeight);
+        lines.push(current);
+        current = [];
         x = MARGIN + hangingIndent;
         atLineStart = true;
       }
       if (!atLineStart) x += space;
-      for (const chunk of word) {
+      x += ww;
+      current.push(word);
+      atLineStart = false;
+    }
+    lines.push(current);
+    return lines;
+  }
+
+  /**
+   * Draw a sequence of `{ text, bold }` runs with word-level wrapping, breaking
+   * to a new page between lines as needed. Line breaking itself lives in
+   * {@link wrapRuns}; this walks the resulting lines and draws them. Bold is
+   * preserved across wraps because it is tracked per chunk, not per line.
+   */
+  private drawRuns(
+    runs: Array<{ text: string; bold: boolean }>,
+    size: number,
+    hangingIndent: number,
+    opts: {
+      marker?: string;
+      color?: RGB;
+      widowControl?: boolean;
+      followKeepHeight?: number;
+    } = {},
+  ) {
+    const marker = opts.marker ?? BULLET_MARKER;
+    const color = opts.color ?? this.black;
+    const lines = this.wrapRuns(runs, size, hangingIndent, marker);
+    const space = this.fonts.regular.widthOfTextAtSize(" ", size);
+    const markerWidth = marker
+      ? this.fonts.regular.widthOfTextAtSize(marker, size)
+      : 0;
+    const lineHeight = size * LINE_GAP;
+
+    for (let i = 0; i < lines.length; i++) {
+      this.ensureWrappedLine(i, lines.length, lineHeight, opts);
+      if (i === 0 && marker) {
+        this.page.drawText(marker, {
+          x: MARGIN,
+          y: this.y - size,
+          size,
+          font: this.fonts.regular,
+          color,
+        });
+      }
+      this.drawRunWords(
+        lines[i],
+        i === 0 ? MARGIN + markerWidth : MARGIN + hangingIndent,
+        { size, color, space },
+      );
+      this.advance(lineHeight);
+    }
+  }
+
+  /**
+   * Draw one already-wrapped line of runs, left to right from `startX`, switching
+   * font per chunk so bold survives a wrap.
+   *
+   * Split out of {@link drawRuns} to flatten its loop nest; this walks words and
+   * their chunks at a fixed baseline and never paginates or moves the cursor, so
+   * line breaking stays wholly in {@link wrapRuns} and cannot drift from what was
+   * measured (#629).
+   */
+  private drawRunWords(
+    words: Array<Array<{ str: string; bold: boolean; width: number }>>,
+    startX: number,
+    opts: { size: number; color: RGB; space: number },
+  ) {
+    const { size, color, space } = opts;
+    let x = startX;
+    for (let w = 0; w < words.length; w++) {
+      if (w > 0) x += space;
+      for (const chunk of words[w]) {
         this.page.drawText(chunk.str, {
           x,
           y: this.y - size,
@@ -786,20 +1154,18 @@ class Layout {
         });
         x += chunk.width;
       }
-      atLineStart = false;
     }
-    this.advance(lineHeight);
   }
 
   drawRule() {
-    this.ensure(2);
+    this.ensure(RULE_HEIGHT);
     this.page.drawLine({
       start: { x: MARGIN, y: this.y },
       end: { x: PAGE_WIDTH - MARGIN, y: this.y },
       thickness: 0.75,
       color: this.gray,
     });
-    this.advance(2);
+    this.advance(RULE_HEIGHT);
   }
 }
 
@@ -884,14 +1250,26 @@ export async function renderAtsResumePdf(
 
   // ── Summary ──
   if (model.summary) {
-    drawSectionHeading(layout, model.summaryHeading ?? "Summary");
+    // The summary body is plain wrapped text, so the heading must keep one BODY
+    // line with it (#629).
+    drawSectionHeading(layout, model.summaryHeading ?? "Summary", SIZE_BODY * LINE_GAP);
     layout.drawText(model.summary, { size: SIZE_BODY });
     layout.advance(GAP_BETWEEN_ENTRIES);
   }
 
   // ── Sections ──
   for (const section of model.sections) {
-    drawSectionHeading(layout, section.heading);
+    // Keep-with-next (#629): the heading reserves its rule, its trailing gap AND
+    // the whole keep-block of its first entry. Reserving only "heading + one
+    // line" would let the entry's own reservation fire immediately afterwards and
+    // move the entry to the next page, stranding the heading it just committed.
+    drawSectionHeading(
+      layout,
+      section.heading,
+      section.entries.length > 0
+        ? entryKeepHeight(layout, section.entries[0], muted)
+        : 0,
+    );
     for (let i = 0; i < section.entries.length; i++) {
       drawEntry(layout, section.entries[i], muted);
       if (i < section.entries.length - 1) layout.advance(GAP_BETWEEN_ENTRIES);
@@ -928,14 +1306,233 @@ export async function renderAtsResumePdf(
   return doc.save();
 }
 
-function drawSectionHeading(layout: Layout, heading: string) {
+/** The `drawText` options for a section/summary heading — shared by the draw and
+ *  its keep-with-next measurement (#629) so the two cannot drift. */
+const HEADING_OPTS = {
+  bold: true,
+  size: SIZE_SECTION,
+  uppercase: true,
+} as const;
+
+/**
+ * Draw a section (or Summary) heading plus its rule. `followHeight` is the
+ * keep-with-next payload — the height of the first thing that must land on the
+ * SAME page as the heading (#629), i.e. the first entry's keep-block, or one body
+ * line for the Summary. Passing `0` (an empty section) degrades to the plain
+ * "heading must itself fit" behaviour.
+ */
+function drawSectionHeading(
+  layout: Layout,
+  heading: string,
+  followHeight: number,
+) {
   layout.advance(GAP_BEFORE_SECTION);
-  layout.drawText(heading, { bold: true, size: SIZE_SECTION, uppercase: true });
+  layout.ensureBlock(
+    layout.measureTextHeight(heading, HEADING_OPTS) +
+      RULE_HEIGHT +
+      GAP_AFTER_RULE +
+      followHeight,
+  );
+  layout.drawText(heading, HEADING_OPTS);
   layout.drawRule();
   layout.advance(GAP_AFTER_RULE);
 }
 
+/** The `drawText` options for an entry's header line — shared by the draw and its
+ *  keep-with-next measurement (#629). */
+function headerLineOpts(entry: AtsEntry, mutedColor: RGB): DrawTextOpts {
+  return {
+    // Every header is bold EXCEPT where the model opts out — the skills list,
+    // which reads as regular-weight body text (#425).
+    bold: entry.headerBold ?? true,
+    size: SIZE_HEADER,
+    atomicSegments: entry.atomicSegments,
+    hangingIndent: entry.headerHangingIndent,
+    // Flush-right date on the header line (#425) — set for a title-less role /
+    // degree-less program, where the org/date anchor lives on the header.
+    rightText: entry.headerLineDate,
+    rightColor: mutedColor,
+    rightSize: SIZE_SUB,
+  };
+}
+
+/** The `drawText` options for an entry's sub-line — shared by the draw and its
+ *  keep-with-next measurement (#629). See `drawEntry` for why the middot
+ *  segments are atomic here. */
+function subLineOpts(entry: AtsEntry, mutedColor: RGB): DrawTextOpts {
+  return {
+    size: SIZE_SUB,
+    color: mutedColor,
+    atomicSegments: true,
+    // Flush-right date on the sub-line (#425) — set for a titled role /
+    // degreed entry, where the org anchor lives on the sub-line.
+    rightText: entry.subLineDate,
+    rightColor: mutedColor,
+    rightSize: SIZE_SUB,
+  };
+}
+
+/**
+ * How many header lines a BODY-TEXT header line contributes to a keep-with-next
+ * reservation, at most (#629). Two, because that is the smallest unit with any
+ * widow value — it is the same orphan rule `drawBullet` applies to a wrapped
+ * bullet: the block's first line is never left alone at a page bottom. One would
+ * add nothing over the plain per-line `ensure`; three or more starts trading real
+ * page density for a guarantee body text does not need, since it is divisible.
+ */
+const BODY_HEADER_KEEP_LINES = 2;
+
+/**
+ * The entry header block's contribution (pt) to the keep-with-next reservation —
+ * its (possibly wrapped) header line plus, when present, the gap and its
+ * (possibly wrapped) sub-line. `0` for a bullets-only entry. Measured through the
+ * SAME option builders the draw uses, so a multi-line header reserves ALL of its
+ * wrapped lines, not one (#629).
+ *
+ * ALL of them, that is, for a real header. `headerBold: false` is the model saying
+ * this entry's "header" is regular-weight BODY text, not a header — set only by
+ * the two skills paths in `ats-resume-model.ts` (the flat `skills.join(" · ")`
+ * entry and one per category), whose single header line carries the entire skills
+ * list and can wrap to dozens of lines. Reserving every one of those would make an
+ * arbitrarily tall body block indivisible, and `drawSectionHeading` inherits that
+ * through `followHeight` — de-densifying real pages by up to ~100pt and, past a
+ * page, hitting {@link Layout.ensureBlock}'s unsatisfiable case. Body text is
+ * divisible, so it is capped at {@link BODY_HEADER_KEEP_LINES}.
+ *
+ * The achievement headers that also set `headerBold: false` are NOT caught by
+ * this: they set it because their per-run sentinels carry the weight instead
+ * (`buildAchievementHeader` returns `emphasized` iff the line contains
+ * `EMPHASIS_OPEN`), so they take the run-measuring branch above and keep the full
+ * multi-line reservation a genuine header deserves.
+ *
+ * The `bullets.length === 0` half of the gate is what makes the cap SAFE rather
+ * than merely correct-today. `headerBold` is a styling flag, so on its own it
+ * would let a capped entry keep bullets: reserving 2 header lines + 1 bullet line
+ * for a 3-line header leaves the per-line `ensure` free to draw header line 3 and
+ * break before the bullet — page ends on header text, bullet orphaned, AC1
+ * violated. Capping only a BULLETLESS entry gates on the property that actually
+ * licenses the cap (nothing must be kept with it), so AC1 holds unconditionally
+ * instead of "unless `headerBold === false`". Both skills paths hard-code
+ * `bullets: []`, so this changes no output today.
+ */
+function entryHeadHeight(
+  layout: Layout,
+  entry: AtsEntry,
+  mutedColor: RGB,
+): number {
+  let height = 0;
+  if (entry.headerLine) {
+    if (entry.headerLine.includes(EMPHASIS_OPEN)) {
+      height += layout.measureHeaderRunsHeight(entry.headerLine, SIZE_HEADER);
+    } else {
+      const full = layout.measureTextHeight(
+        entry.headerLine,
+        headerLineOpts(entry, mutedColor),
+      );
+      height +=
+        entry.headerBold === false && entry.bullets.length === 0
+          ? Math.min(full, BODY_HEADER_KEEP_LINES * SIZE_HEADER * LINE_GAP)
+          : full;
+    }
+  }
+  if (entry.subLine) {
+    height +=
+      GAP_AFTER_HEADER +
+      layout.measureTextHeight(entry.subLine, subLineOpts(entry, mutedColor));
+  }
+  return height;
+}
+
+/**
+ * Height (pt) of the entry's keep-with-next group — the indivisible unit that
+ * must start on a page able to hold all of it (#629):
+ *
+ *   - header block (all wrapped header + sub-line lines) + the first bullet's own
+ *     keep-opening, so a header can never be the last thing on a page;
+ *   - a header block with NO bullets reserves just the header block — no phantom
+ *     bullet line;
+ *   - a bullets-only entry (no header, no sub-line) reduces to exactly that first
+ *     bullet reservation, since its head measures `0`;
+ *   - an entirely empty entry reserves nothing.
+ *
+ * The first bullet's reservation is exactly {@link bulletKeepLines} of its lines
+ * — the same opening {@link Layout.drawBullet} reserves for a bullet it starts on
+ * its own, so the two agree by construction rather than by coincidence. That is
+ * what lets `drawEntry` pass `alreadyReserved` for the first bullet: the lines
+ * really are reserved here, so suppressing the bullet's own reservation cannot
+ * re-orphan its first line (#629) nor widow its last (#631 — a first bullet
+ * wrapping to three lines is indivisible, so all three are reserved here). It
+ * does not violate #629's "compose rather than sum" decision either: a first
+ * bullet long enough to split still reserves only its opening, never its full
+ * height.
+ *
+ * Used both by the entry itself and by the section heading above it, so the two
+ * agree on what "the first thing that must stay with the heading" costs.
+ */
+function entryKeepHeight(
+  layout: Layout,
+  entry: AtsEntry,
+  mutedColor: RGB,
+): number {
+  const bulletLine = SIZE_BODY * LINE_GAP;
+  const head = entryHeadHeight(layout, entry, mutedColor);
+  if (entry.bullets.length === 0) return head;
+  const firstBulletLines = layout.measureBulletLines(
+    entry.bullets[0],
+    SIZE_BODY,
+    BULLET_INDENT,
+  );
+  const keep = bulletKeepLines(firstBulletLines);
+  const base = head + keep * bulletLine;
+  // #632, and ONLY for a two-bullet entry whose first bullet is INDIVISIBLE. In
+  // that one shape the reservation covering the first bullet's final line is its
+  // opening — which `drawEntry` suppresses via `alreadyReserved` — so the
+  // trailing bullet's keep-opening has nowhere else to ride and must be folded in
+  // here. Every other shape reserves the follow later and cheaper: a divisible
+  // first bullet carries it on its tail reservation (not suppressed, it lives in
+  // the draw loop), and a 3+ bullet entry carries it on a bullet this block never
+  // covers at all. So the entry-level cost of the rule is at most one trailing
+  // bullet's keep-opening (≤ `2 * BULLET_KEEP_LINES - 1` lines), never the entry.
+  if (entry.bullets.length !== 2 || keep !== firstBulletLines) return base;
+  const withFollow = base + trailingBulletKeepHeight(layout, entry);
+  // #629 outranks #632. Growing this block past a page would make it
+  // UNSATISFIABLE, and `ensureBlock` then ignores it outright — surrendering the
+  // header-stranding guarantee to buy a lone-bullet one. Drop the follow instead:
+  // the lone trailing bullet degrades, the header keep-with-next does not.
+  return withFollow > USABLE_PAGE_HEIGHT ? base : withFollow;
+}
+
+/**
+ * The keep-opening (pt) of an entry's LAST bullet — what must fit after the
+ * second-to-last bullet's final line so the last bullet is never left alone at a
+ * page top (#632).
+ *
+ * It is exactly the reservation that bullet will make for itself when
+ * {@link Layout.drawBullet} starts it ({@link bulletKeepLines} of its measured
+ * lines), so reserving it in advance is exact rather than approximate: the
+ * trailing bullet's own reservation is then guaranteed to be already satisfied
+ * and cannot fire a second page break that would undo the placement. Measured
+ * through {@link Layout.measureBulletLines}, the same wrapping that draws it.
+ */
+function trailingBulletKeepHeight(layout: Layout, entry: AtsEntry): number {
+  const lines = layout.measureBulletLines(
+    entry.bullets[entry.bullets.length - 1],
+    SIZE_BODY,
+    BULLET_INDENT,
+  );
+  return bulletKeepLines(lines) * SIZE_BODY * LINE_GAP;
+}
+
 function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
+  // Keep-with-next (#629): commit to this page only if the header AND its first
+  // bullet's keep-opening (`bulletKeepLines` of its lines — all of them when it
+  // is too short to split) fit together, so the header is never the final drawn
+  // line on a page. The
+  // reservation covers everything the draws below consume up to that point, so
+  // their own per-line `ensure` calls cannot fire a second page break inside the
+  // group.
+  const keepHeight = entryKeepHeight(layout, entry, mutedColor);
+  if (keepHeight > 0) layout.ensureBlock(keepHeight);
   if (entry.headerLine) {
     if (entry.headerLine.includes(EMPHASIS_OPEN)) {
       // Mixed-weight header (#425 — an achievement "type" label bolded, the rest
@@ -943,19 +1540,7 @@ function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
       // date, so the marker-less run path covers them.
       layout.drawHeaderRuns(entry.headerLine, SIZE_HEADER);
     } else {
-      layout.drawText(entry.headerLine, {
-        // Every header is bold EXCEPT where the model opts out — the skills list,
-        // which reads as regular-weight body text (#425).
-        bold: entry.headerBold ?? true,
-        size: SIZE_HEADER,
-        atomicSegments: entry.atomicSegments,
-        hangingIndent: entry.headerHangingIndent,
-        // Flush-right date on the header line (#425) — set for a title-less role /
-        // degree-less program, where the org/date anchor lives on the header.
-        rightText: entry.headerLineDate,
-        rightColor: mutedColor,
-        rightSize: SIZE_SUB,
-      });
+      layout.drawText(entry.headerLine, headerLineOpts(entry, mutedColor));
     }
   }
   if (entry.subLine) {
@@ -966,21 +1551,33 @@ function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
     // inside a multi-word location (e.g. "San Francisco Bay Area") re-parses it
     // into fragmented location tokens (#301). Unlike the 3+ segment achievement
     // HEADER lines (#307), these must stay atomic, so opt in unconditionally.
-    layout.drawText(entry.subLine, {
-      size: SIZE_SUB,
-      color: mutedColor,
-      atomicSegments: true,
-      // Flush-right date on the sub-line (#425) — set for a titled role /
-      // degreed entry, where the org anchor lives on the sub-line.
-      rightText: entry.subLineDate,
-      rightColor: mutedColor,
-      rightSize: SIZE_SUB,
-    });
+    layout.drawText(entry.subLine, subLineOpts(entry, mutedColor));
   }
-  for (const bullet of entry.bullets) {
+  // #632: the LAST bullet of a multi-bullet entry must never be the only thing
+  // its page opens with. The whole rule is one hand-off — the SECOND-TO-LAST
+  // bullet carries the last one's keep-opening as `followKeepHeight`, so the only
+  // page break the pair admits is one that moves BOTH forward. It is deliberately
+  // not an entry-level reservation: only this one boundary is constrained, the
+  // earlier bullets paginate freely, and the extra height is one bullet's opening
+  // — the blanket "keep the whole entry together" alternative is what cost a real
+  // fixture ~100pt of page-1 density in #630.
+  const trailingKeep =
+    entry.bullets.length >= 2 ? trailingBulletKeepHeight(layout, entry) : 0;
+  for (let i = 0; i < entry.bullets.length; i++) {
     // Auto-bold quantified metrics inside the bullet, then draw per-word runs
     // (#425). Markers are stripped before drawing, so the round-trip text is
     // unchanged; a metric-free bullet takes the legacy single-string path.
-    layout.drawBullet(bullet, SIZE_BODY, BULLET_INDENT);
+    //
+    // The FIRST bullet is already covered by the keep-block reserved above, so it
+    // must not re-reserve for its own orphan rule — that would move it and strand
+    // the header (#629's composition decision). When it is ALSO the second-to-last
+    // bullet, `entryKeepHeight` has already folded `trailingKeep` into that block
+    // for the one shape where it must (see there), and passing it on here is
+    // harmless: `drawBullet` uses it only on the reservation covering the bullet's
+    // final line, which for a divisible bullet is its tail — not suppressed.
+    layout.drawBullet(entry.bullets[i], SIZE_BODY, BULLET_INDENT, {
+      alreadyReserved: i === 0 && keepHeight > 0,
+      followKeepHeight: i === entry.bullets.length - 2 ? trailingKeep : 0,
+    });
   }
 }


### PR DESCRIPTION
## Summary

The ATS PDF export paginated one text line at a time — `ensure()` was the only page-break decision and it was always handed a single `lineHeight`. So a header fit whenever one line's worth of space remained, regardless of whether anything belonging with it also fit. This adds a block-aware reservation (`ensureBlock`) plus the measurement needed to make a reservation exact, and applies keep-with-next at four sites: entry headers, wrapped bullets, an entry's bullet list, and section headings.

It now carries **#631 and #632** as well. Those were filed as follow-ups off #629 and implemented onto this branch rather than a second PR, because all three are the same rule at three scales — *never leave exactly one of anything alone* — and splitting them would have meant three separate corpus-density arguments over the same code.

The measurement is why the diff is larger than the fix sketch implies. Line breaking lived *inside* two draw loops, so it could not be called without drawing. It is split into a pure half and a draw half (`resolveDrawLines`, `wrapRuns`), letting `measureTextHeight` / `measureBulletHeight` / `measureHeaderRunsHeight` measure through the exact wrapping that will draw. The alternative — a second, parallel measurement implementation — is the precise failure mode that makes a reservation a guess. Drawn output is unchanged except where a reservation moves a block; this was verified rather than asserted (below).

Closes #629
Closes #631
Closes #632

## Verification

Every corpus fixture was compared **glyph-run by glyph-run** (`page | x | y | str`) against `main`, not just by page count:

- **4 fixtures fixed** — a stranded header or heading moved off a page bottom. e.g. `latex/deedy-resume-macfonts.pdf` no longer ends page 1 on the stranded header `MA, RTINIERE FOR BOYS`; `latex/multi-degree-coursework.pdf` no longer ends it on `B.S., Computer Science` + its sub-line.
- **0 fixtures regressed**, no page-count changes, no blank pages, and zero intra-line or x-position differences — which is also the proof that the `drawRuns` → `wrapRuns` refactor is behaviour-preserving.
- A synthesized genuine 3-line role header strands three ways on `main` (`filler=44,45,46`) and zero ways here.

**For #631 and #632** the same method was re-run against baseline `78a924c` (this PR's #629 commit), since #629's own corpus effect was already vetted against `main`:

- **#631 alone: byte-identical** across all 1542 drawn lines — the widow rule changes no corpus fixture.
- **#632: exactly one line moves.** `unknown/chromium-two-column-sidebar.pdf` goes p1 43→42, p2 17→18, page count unchanged. Inspected line-by-line: on the baseline that fixture ends page 1 with two bullets of a 3-bullet entry and opens page 2 on the third **alone**, immediately followed by the next role. That is a genuine instance of the #632 defect in the real corpus, and the one lost page-1 line is the cost of correcting it — not spurious de-densification.
- The complexity refactor (`decorateFirstLine` / `drawRunWords`) was diffed separately and is **byte-identical**, which is the proof it is behaviour-preserving.

Each of the four keep-with-next rules was reverted **individually** to confirm its own test fails — so no test passes on another rule's back. Sample failures: `filler=46: header stranded away from its first bullet: expected 1 to be 2`; `filler=34: skills block de-densified page 1: expected 37 to be greater than or equal to 39`.

## Notable design decisions

**A skills entry's header is body text, not a header.** The flat skills list carries the entire `·`-joined list on a single `headerLine` with `bullets: []`, so "reserve all wrapped header lines" turned an arbitrarily tall body block into a keep-with-next unit — costing 8 lines on one real fixture and ~100pt of page density. It is capped at two lines, gated on a **bullet-less** `headerBold: false` entry. Gating on `headerBold` alone would have been unsafe: a `headerBold: false` entry *with* bullets and a 3-line header reserves 2 header lines + 1 bullet line, letting the per-line `ensure` draw header line 3 and break before the bullet — violating the very criterion this issue is about. Gating additionally on `bullets.length === 0` keys the cap to the property that actually licenses it. Both skills paths hard-code `bullets: []`, so this changes no output today.

**An unsatisfiable reservation is ignored, not deferred.** A keep-block taller than one page previously fired `newPage()` twice with only the heading drawn between, producing `[13, 1, 52, 37]` — a page holding *only* the `SKILLS` heading, plus a wasted page. Now `[47, 52, 4]`, matching `main`.

## Known gaps (deliberate, not oversights)

> **Both gaps previously listed here are now closed in this PR** — #631 (widow half) and #632 (lone trailing bullet). They were filed as follow-ups when this PR covered only #629, then implemented onto the same branch. The two bullets that described them as unfixed have been removed rather than left to read as current.
- An entry with an empty `headerLine`, no sub-line and no bullets yields a zero-height keep-block, so a heading could strand. Unreachable from `buildAtsResumeModel` today (`"Education"` is a hard fallback and both skills paths have a non-empty `headerLine`); noted as defensive only.
- The new pagination tests run under the **Helvetica fallback** — the Poppins embed fails in Node (`Failed to parse URL from /src/assets/fonts/Poppins-Regular.ttf`), so every filler boundary is Helvetica geometry, not the browser's Poppins. Inherent to the harness.

`fallow` now reports **2** complexity findings, down from 4. The two that this PR's threads flagged are fixed: `drawText` (cognitive 29 → below threshold) and `drawRuns` (23 → below threshold), by extracting `decorateFirstLine` and `drawRunWords`. Both extractions move only drawing, never measurement, so the measure-and-draw-share-one-wrapper invariant is untouched — proven by the corpus diff being byte-identical across the refactor. The 2 survivors (`toWinAnsi` 20, `renderAtsResumePdf` 16) are pre-existing on `main` and were not what either thread cited.

`fallow` also reports 9 clone groups (up from 7), the added pair being boundary-sweep scaffolding in the new tests. **Deliberately not refactored:** `main` already carries 2 groups of the identical scaffolding and posted no duplication thread, so this class does not surface as a review comment here; `CLAUDE.md` classifies it as never-blocking; and collapsing 14 proven test bodies to save 19 lines would void the revert-based guard proofs for an advisory finding.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 3406 passed / 10 skipped repo-wide; 311 across `src/lib/pdf/`. No `KNOWN_FAILURES` entry added or changed.
- [x] `npm run verify` green locally (fallow report-only, as configured)
- [x] Corpus glyph-position diff vs `main` — 4 fixed, 0 regressed; vs `78a924c` for #631/#632 — 1 lone-bullet case fixed, 0 regressed
- [x] Guard proofs re-run against the **final** code after the complexity refactor: reverting #631 alone fails 4 tests, reverting #632 alone fails 3, and neither breaks the other's
- [x] No fixture binary added or changed — nothing for the fixture-PII surface

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #629 | Claude Opus 5 (1M context) | ultra |
| Adversarial review — #629 (2 rounds) | Claude Opus 5 (1M context) | inherited session effort |
| Review fixes — B1/B2/B3 | Claude Opus 5 (1M context) | ultra |
| Implementation — #631 | unreported (requested: opus) | ultra |
| Implementation — #632 | unreported (requested: opus) | ultra |
| Adversarial review — #631/#632 | unreported (requested: opus) — returned no findings, see below | ultra |
| Complexity refactor (`drawText`/`drawRuns`) | Claude Opus 5 (1M context) | inherited session effort |
| Verification of #631/#632 | Claude Opus 5 (1M context) | inherited session effort |
| Orchestration + PR | Claude Opus 5 (1M context) | inherited session effort |
| Verification | `npm run verify` — green in CI | — |

Every model string above is self-reported by the agent that ran the stage, or first-hand for orchestration. **Three rows read `unreported`**: those subagents completed their work but went idle without returning their structured report, and were re-prompted for the model name without answering. A requested alias is not evidence of what it resolved to, so the rows are left unresolved rather than filled with a guess.

The B2 gating decision and the final one-line hardening were made by the orchestrator, overriding the reviewer's proposed fix.

## Adversarial review — #629

Two bounded rounds ran pre-PR against the local diff, by an independent adversarial reviewer prompted to break the change rather than praise it, with instructions to **reproduce** suspected defects end-to-end rather than reason about the code. Round 1 returned `clean: false` with three blocking findings; round 2 returned `clean: true`.

### Round 1 — 3 blocking, all reproduced and all fixed

| # | Finding | Reproduction | Resolution |
|---|---|---|---|
| **B1** | Acceptance criterion 2 violated for the **first** bullet of every entry: `entryKeepHeight` reserved `head + 1` bullet line while `alreadyReserved` suppressed that bullet's own 2-line orphan reservation, so it split 1 line / rest. | `filler=45`, with the page-1/page-2 tails quoted. Also reproduces on `main`, so this was an **inherited** defect, not one this PR introduced. | Reserve two bullet lines when the first bullet wraps. Violation window `[45]` → `[]`. |
| **B2** | Reserving *all* wrapped header lines made the skills list indivisible and de-densified real pages. | Two corpus fixtures regressed: `…two-column-long-role-header.pdf` 40 → **32** page-1 lines (~100pt of new whitespace), `two-column-achievements-sidebar.pdf` 40 → 37. | Cap at two lines — see *Notable design decisions*. Both fixtures restored to `main`'s exact pagination. |
| **B3** | A keep-block taller than a page fired `newPage()` twice, stranding the heading on a page of its own — the exact case the reservation exists to prevent. The docblock asserted the opposite. | `[13, 1, 52, 37]` vs `main`'s `[47, 52, 4]`; page 2 held only the `SKILLS` heading. | Ignore an unsatisfiable reservation; docblock corrected. Restored to `[47, 52, 4]`. |

**The reviewer's B2 fix was rejected and replaced.** It proposed capping *every* header at two lines, which would have re-stranded a genuine 3-line role header — trading an AC1 regression for the B2 fix. Gating the cap on `headerBold === false` fixes skills while leaving real headers fully reserved; round 2 confirmed with a reproduction that the unconditional cap breaks `main`'s own 3-line-header case at three filler values while the gated one does not.

### Round 2 — clean, plus one hardening taken

No blocking findings. The reviewer additionally showed that `headerBold` alone is a **styling flag doing load-bearing layout work**: a `headerBold: false` entry *with* bullets and a 3-line header violates AC1 (reproduced at `filler=44`), unreachable today but guarded by nothing. It declined to call this blocking. It was taken anyway as a validated one-liner — `&& entry.bullets.length === 0` — so the invariant reads "AC1 holds" rather than "AC1 holds unless `headerBold === false`". Corpus output is byte-identical.

It also confirmed the reservation-vs-consumption arithmetic balances exactly (including float exactness: `LINE_GAP = 1.25` and all four font sizes are dyadic), that `resolveDrawLines` is genuinely pure so measure-then-draw cannot double-register a link annotation, and that `ats-resume-model.ts` is the sole `AtsEntry` producer reaching the render path.

### A vacuous test, caught

The B3 regression test's first version drove a 900-item skills list and **did not fail** when B3 was reverted — because the B2 cap makes the skills path satisfiable, so skills can no longer reach the unsatisfiable branch at all. It was reworked onto a genuine oversized bold achievement header, the only path that still reaches it. B3 is therefore defence-in-depth against an oversized real header, not a fix for a currently-reachable case. Recorded because a test that passes for the wrong reason is worse than no test.

### Surviving nits for the human reviewer

- `BODY_HEADER_KEEP_LINES = 2` and a value of `1` produce **identical output on every measured case** — the value is a semantic choice, not a measured one.
- `EMPHASIS_OPEN` is `U+E000`, a private-use codepoint that icon fonts commonly map into. A source PDF whose extracted skills text contains it would silently un-cap that entry. Pre-existing hazard of the sentinel design, noted only because `includes(EMPHASIS_OPEN)` is now load-bearing for a *layout* decision and not just a styling one.
- `render-ats-pdf.test-utils.ts:40` is now prettier-dirty (an 82-char line) where it was clean at `main`. No prettier gate in `verify`, so cosmetic.
- The remaining widow / lone-trailing-bullet / zero-keep-height gaps are listed under *Known gaps* above.



---

## Adversarial review — #631 / #632 (this round)

**Stated plainly: the independent reviewer for this round returned nothing.** It was spawned against the accumulated diff with the same adversarial brief as the #629 rounds, ran for ~12 minutes, then went idle without emitting its structured findings; a follow-up request for the report went unanswered. It produced **no** `clean: true`, no findings, and no model string. This section does not claim a clean independent review, because one did not complete.

Every acceptance criterion was therefore re-verified first-hand by the orchestrator rather than taken on an agent's word — the same posture used when the #629 implementation agent vanished:

- **Guard proofs, run twice each.** Once when each fix landed, and again against the *final* code after the complexity refactor (a refactor after a proof invalidates the proof). Reverting only #631 fails exactly its 3 tests plus the #631/#632 interaction test, with 67 passing; reverting only #632 fails exactly its 3 tests with 68 passing. Neither rule props up the other's tests, and none of the six is vacuous.
- **The `followKeepHeight` hand-off invariant was enumerated by hand**, since it is where a silent double- or zero-reservation would hide. The opening reservation carries the follow only when `bulletKeepLines(total) === total` (⇒ `total < 4`); `ensureWrappedLine`'s tail fires only when `total >= 4`. Disjoint, so the follow is never summed. The one shape whose opening is suppressed (`alreadyReserved` — a two-bullet entry's first bullet) is exactly the shape `entryKeepHeight` folds it into, and that fold's `keep === firstBulletLines` condition is the same indivisibility test, so it cannot coexist with a tail reservation either. The single uncovered case is `withFollow > USABLE_PAGE_HEIGHT`, where the follow is dropped **deliberately** so #629's header guarantee outranks #632's.
- **Regression classes from the #629 round were re-checked specifically.** The fold falls back to `base`, so it can never turn a satisfiable keep-block unsatisfiable and forfeit the header guarantee (the B2/B3 failure shape). `ensureWrappedLine` reserves at most ~5 lines against 684pt of usable page, so it cannot reproduce B3's double-`newPage()`.
- **Corpus density** measured by drawn-line position across all 54 fixtures, not page count — the method that caught B2's 8-line regression last round.

### Design decision recorded

#632's issue body listed three candidate rules and explicitly deferred the choice. **The maintainer chose "never leave exactly one bullet alone"**, rejecting "keep the whole entry together" (the ~100pt density trap from B2) and "only for wrapped bullets" (too narrow — #632's own reproduction uses four *single-line* bullets). The implementation is a single hand-off at one boundary, not an entry-level reservation, so the bounded cost is one bullet's keep-opening.

### Surviving nits for the human reviewer

- The one moved corpus line is a **real behaviour change**, not a no-op: `chromium-two-column-sidebar.pdf` loses a page-1 line so a lone third bullet rejoins its entry. Worth an eyeball to confirm the trade reads correctly.
- Test duplication grew by 2 clone groups; deliberately not refactored (rationale under *Known gaps*).
- `BULLET_KEEP_LINES = 2` is asserted as a local literal in the test file rather than imported, so the contract cannot be silently relaxed by editing the implementation constant. Intentional, but it does mean the two can drift apart into a *failing* test rather than a silently-passing one.
