### PR TITLE
fix(pdf,score,parser,ui): Summary widow control, plus the #630/#633/#634 review-nit sweep (#635)

### DIFF
--- a/src/components/features/AtsScoreReadout.tsx
+++ b/src/components/features/AtsScoreReadout.tsx
@@ -8,7 +8,11 @@
  */
 
 import type { AnonymousAtsScore } from "../../lib/score/score.ts";
-import { getScoreTier } from "../../lib/score/score.ts";
+import {
+  getScoreTier,
+  BULLET_LENGTH_MIN_WORDS,
+  BULLET_LENGTH_MAX_WORDS,
+} from "../../lib/score/score.ts";
 import type { SectionAnchor } from "../../lib/anchors.ts";
 import { getScoreRecommendation } from "../../lib/score/recommendation.ts";
 import { ScoreRing } from "./ScoreRing.tsx";
@@ -24,6 +28,11 @@ interface DimensionProps {
   max: number;
   gradable: boolean;
   hint: string;
+  /** Spelled-out criterion behind a terse `hint`, surfaced as a tooltip. #624
+   *  shortened the Structure hint to bare counts (`length 13/23`), which no
+   *  longer states what "length" is measured against; this restores the
+   *  criterion without re-lengthening the visible line. */
+  hintTitle?: string;
   /** Hash-prefixed scroll target — narrowed to a known section so a dead link
    *  (a `#foo` with no matching rendered id) is a compile error (#153). */
   anchor: SectionAnchor;
@@ -35,6 +44,7 @@ function Dimension({
   max,
   gradable,
   hint,
+  hintTitle,
   anchor,
 }: DimensionProps) {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
@@ -68,7 +78,9 @@ function Dimension({
           />
         </div>
       )}
-      <p className="text-[11px] text-content-tertiary">{hint}</p>
+      <p className="text-[11px] text-content-tertiary" title={hintTitle}>
+        {hint}
+      </p>
     </a>
   );
 }
@@ -147,6 +159,7 @@ export function AtsScoreReadout({ score }: AtsScoreReadoutProps) {
             max={score.structure.max}
             gradable={score.structure.gradable}
             hint={structureHint}
+            hintTitle={`Verb-led: bullet opens with an action verb. Length: bullet is ${BULLET_LENGTH_MIN_WORDS}–${BULLET_LENGTH_MAX_WORDS} words.`}
             anchor="#reconstructed-resume"
           />
           <Dimension

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -23,7 +23,7 @@ import type {
   AddedEntryField,
 } from "../../hooks/useEditableParse.ts";
 import { buildEducationDates } from "../../lib/score/entry-dates.ts";
-import { EditableField } from "@design-system";
+import { EditableField, SectionHeading } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
 import { AddPill, RemoveButton, sectionExitBlur } from "./ReconstructedAdd.tsx";
 
@@ -41,14 +41,6 @@ const EDUCATION_FIELD_MAP: Record<
 };
 
 // ── Shared section chrome (mirrors ReconstructedResume's local helpers) ────────
-
-function SectionHeading({ children }: { children: React.ReactNode }) {
-  return (
-    <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-      {children}
-    </h2>
-  );
-}
 
 function NotDetected({ what }: { what: string }) {
   return <p className="text-sm text-content-tertiary">No {what} detected.</p>;

--- a/src/components/features/ReconstructedResume.test.ts
+++ b/src/components/features/ReconstructedResume.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import { buildResumeSections, roleLabel } from "./ReconstructedResume.tsx";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import type { BulletObservation } from "../../lib/score/score.ts";
+import { countWords } from "../../lib/score/score.ts";
 
 function bullet(index: number, text: string): BulletObservation {
   return {
@@ -20,7 +21,7 @@ function bullet(index: number, text: string): BulletObservation {
     hasMetric: false,
     startsWithActionVerb: false,
     wellFormedLength: false,
-    wordCount: text.split(/\s+/).length,
+    wordCount: countWords(text),
   };
 }
 

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -111,7 +111,7 @@ import {
 } from "./ReconstructedSummary.tsx";
 import { SkillsSection } from "./ReconstructedSkills.tsx";
 import { SkillTermGuidance } from "./SkillTermGuidance.tsx";
-import { Button, EditableField } from "@design-system";
+import { Button, EditableField, SectionHeading } from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
 import { useDownloadMarkdown } from "../../hooks/useDownloadMarkdown.ts";
@@ -245,14 +245,6 @@ function AttentionStrip({
 }
 
 // ── Section heading + "not detected" gap ──────────────────────────────────────
-
-function SectionHeading({ children }: { children: React.ReactNode }) {
-  return (
-    <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-      {children}
-    </h2>
-  );
-}
 
 /** Explicit gap marker — a section the parser found nothing for. */
 function NotDetected({ what }: { what: string }) {

--- a/src/components/features/ReconstructedSkills.tsx
+++ b/src/components/features/ReconstructedSkills.tsx
@@ -28,7 +28,7 @@
 
 import { useState } from "react";
 import type { SkillCategory } from "../../lib/heuristics/types.ts";
-import { EditableField } from "@design-system";
+import { EditableField, SectionHeading } from "@design-system";
 import {
   AddCategoryInput,
   AddSkillInput,
@@ -39,14 +39,6 @@ import {
 } from "./ReconstructedSkillControls.tsx";
 
 // ── Shared section chrome (mirrors ReconstructedEducationSkills' local helpers) ─
-
-function SectionHeading({ children }: { children: React.ReactNode }) {
-  return (
-    <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-      {children}
-    </h2>
-  );
-}
 
 function NotDetected({ what }: { what: string }) {
   return <p className="text-sm text-content-tertiary">No {what} detected.</p>;

--- a/src/components/features/ReconstructedSummary.tsx
+++ b/src/components/features/ReconstructedSummary.tsx
@@ -29,7 +29,7 @@
  * is always shown the user's latest text rather than the stale parsed one.
  */
 
-import { EditableField } from "@design-system";
+import { EditableField, SectionHeading } from "@design-system";
 import type { SectionInput } from "../../lib/webllm/rewrite-resume.ts";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { roleLabel } from "../../lib/score/group-bullets.ts";
@@ -40,15 +40,6 @@ import type { SectionRewriteApply } from "./SectionRewrite.tsx";
  *  key `buildResumeSections` mints and `summaryRewriteApply` is registered
  *  under, so the proposal panel can join an outcome to its writer. */
 export const SUMMARY_SECTION_ID = "summary";
-
-/** Mirrors ReconstructedResume's local heading (and Education's copy of it). */
-function SectionHeading({ children }: { children: React.ReactNode }) {
-  return (
-    <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-      {children}
-    </h2>
-  );
-}
 
 /**
  * The Summary section: the verbatim source heading (#285, the same one the

--- a/src/components/features/RewriteReviewList.test.tsx
+++ b/src/components/features/RewriteReviewList.test.tsx
@@ -22,7 +22,7 @@ import { act } from "react";
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
 
-import { RewriteReviewList } from "./RewriteReviewList.tsx";
+import { RewriteReviewList, BulletReviewRow } from "./RewriteReviewList.tsx";
 import type { AlignedPair } from "../../lib/rewrite-review/align-bullets.ts";
 import type { RewriteReview } from "../../hooks/useRewriteReview.ts";
 
@@ -178,5 +178,75 @@ describe("RewriteReviewList", () => {
     )!;
     act(() => acceptAll.dispatchEvent(new MouseEvent("click", { bubbles: true })));
     expect(review.acceptMany).toHaveBeenCalledWith(["m:0:0", "add:1", "del:1"]);
+  });
+});
+
+describe("BulletReviewRow — the `noun` prop names the row's content everywhere", () => {
+  // #625 gave the row a `noun` so the whole-résumé review could reuse it for the
+  // one-field summary section. The prop reached the kind label and the two
+  // control `aria-label`s but NOT the editor's placeholder or label, which stayed
+  // hardcoded "bullet" — so accepting a summary rewrite read "Edited summary" in
+  // the header and "edit this bullet" in the textarea, with the same mismatch in
+  // the screen-reader label. Every user-visible noun on the row is asserted here
+  // so a future control added without threading `noun` fails rather than ships.
+  const filled: AlignedPair = {
+    kind: "matched",
+    id: "m:0:0",
+    original: "Engineer with a decade of experience",
+    originalIndex: 0,
+    proposed: "Engineer with a decade of platform experience",
+    proposedIndex: 0,
+  };
+  // The placeholder only paints when the edited side is empty, so it needs its
+  // own pair — asserting it on `filled` would pass vacuously.
+  const empty: AlignedPair = { ...filled, proposed: "" };
+
+  it("names the noun on the kind label, both controls, and the editor label", () => {
+    const el = render(
+      createElement(BulletReviewRow, {
+        pair: filled,
+        review: makeReview(),
+        noun: "summary",
+      }),
+    );
+
+    expect(el.querySelector("li span")?.textContent).toBe("Edited summary");
+    expect(
+      el.querySelector('button[aria-label="Accept this edited summary"]'),
+    ).not.toBeNull();
+    expect(
+      el.querySelector('button[aria-label="Reject this edited summary"]'),
+    ).not.toBeNull();
+    // The editor's own label — half of the pair that stayed hardcoded.
+    expect(
+      el.querySelector('[aria-label="Edit Edit proposed summary"]'),
+    ).not.toBeNull();
+    // Nothing anywhere on the row still calls it a bullet.
+    expect(el.innerHTML).not.toContain("bullet");
+  });
+
+  it("names the noun in the empty-state placeholder — the other half", () => {
+    const el = render(
+      createElement(BulletReviewRow, {
+        pair: empty,
+        review: makeReview(),
+        noun: "summary",
+      }),
+    );
+
+    expect(el.textContent).toContain("edit this summary");
+    expect(el.innerHTML).not.toContain("bullet");
+  });
+
+  it("defaults to \"bullet\", so every caller that omits the prop is unchanged", () => {
+    const el = render(
+      createElement(BulletReviewRow, { pair: empty, review: makeReview() }),
+    );
+
+    expect(el.querySelector("li span")?.textContent).toBe("Edited bullet");
+    expect(
+      el.querySelector('[aria-label="Edit Edit proposed bullet"]'),
+    ).not.toBeNull();
+    expect(el.textContent).toContain("edit this bullet");
   });
 });

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -115,10 +115,13 @@ export function BulletReviewRow({
 }: {
   pair: AlignedPair;
   review: RewriteReview;
-  /** What this row's content IS, for the kind label and the control
-   *  `aria-label`s ("Edited bullet" / "Accept this bullet"). Defaults to
-   *  "bullet"; the whole-résumé review passes "summary" for the one-field
-   *  summary section (#625), whose row is otherwise identical. */
+  /** What this row's content IS, for the kind label, the control
+   *  `aria-label`s ("Edited bullet" / "Accept this bullet") and the editor's
+   *  placeholder + label. Defaults to "bullet"; the whole-résumé review passes
+   *  "summary" for the one-field summary section (#625), whose row is
+   *  otherwise identical. Every user-visible noun on the row routes through
+   *  this — a hardcoded "bullet" left behind reads as the wrong thing on the
+   *  summary row while the header above it says "summary". */
   noun?: string;
 }) {
   const decision = review.decisionOf(pair.id);
@@ -176,9 +179,9 @@ export function BulletReviewRow({
           {/* Primary line: the clean, finished bullet — editable in place. */}
           <EditableField
             value={newSideText(pair, review)}
-            placeholder="edit this bullet"
+            placeholder={`edit this ${noun}`}
             emptyAffordance="plain"
-            label="Edit proposed bullet"
+            label={`Edit proposed ${noun}`}
             textSize="sm"
             display="inline"
             multiline

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -36,3 +36,4 @@ export * from "./shared/UpdateBanner.tsx";
 export * from "./shared/GitHubStarCta.tsx";
 export * from "./shared/InlineDiff.tsx";
 export * from "./shared/RatingStars.tsx";
+export * from "./shared/SectionHeading.tsx";

--- a/src/design-system/shared/SectionHeading.tsx
+++ b/src/design-system/shared/SectionHeading.tsx
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * SectionHeading — the ONE `<h2>` that titles a section of the reconstructed
+ * résumé (Summary, Education, Skills, and the Experience heading inside
+ * `ReconstructedResume`).
+ *
+ * Extracted because it had been copied verbatim into four feature files, each
+ * carrying the same six lines and the same class string. Every copy was already
+ * on semantic tokens and none had local state, so the duplication bought
+ * nothing — it only meant a type-scale or token change had to be made four
+ * times, with a silent visual drift if one was missed. This is the Golden Rule
+ * case in `CLAUDE.md`: exactly one shared piece per concern.
+ *
+ * Deliberately unstyled beyond the heading's own tokens and deliberately not
+ * configurable — callers vary only in their text. A caller needing a different
+ * level or weight wants a different concern, not a variant here.
+ */
+
+import type { ReactNode } from "react";
+
+interface SectionHeadingProps {
+  children: ReactNode;
+}
+
+export function SectionHeading({ children }: SectionHeadingProps) {
+  return (
+    <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
+      {children}
+    </h2>
+  );
+}

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -8,6 +8,7 @@ import { computeAnonymousAtsScore } from "../score/score.ts";
 import { groupBulletsByExperience } from "../score/group-bullets.ts";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { BulletObservation } from "../score/score.ts";
+import { countWords } from "../score/score.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 
 /** Minimal BulletObservation factory — only `text` and `index` matter here. */
@@ -18,7 +19,7 @@ function obs(index: number, text: string): BulletObservation {
     hasMetric: false,
     startsWithActionVerb: false,
     wellFormedLength: false,
-    wordCount: text.split(/\s+/).filter(Boolean).length,
+    wordCount: countWords(text),
   };
 }
 

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -53,9 +53,18 @@ const LEGAL_SUFFIX_RE =
  *  the middle segment stayed whole ("Google, Mountain View" → company). Same
  *  closed-vocab discipline as the pre-existing entries: a real company that
  *  merely contains one of these tokens ("Mountain View Software") still fails
- *  the `^…$`-anchored full-string match. */
+ *  the `^…$`-anchored full-string match.
+ *
+ *  #634 review follow-up: "Santa Clara", "Redwood City" and "Ann Arbor" close
+ *  the three headers the review reproduced as still-broken (Nvidia, Meta, Ford).
+ *  They do NOT make the vocabulary complete — this list is a closed set by
+ *  design, so any multi-word city outside it still folds into `company`. That
+ *  narrowing is the standing limitation of the approach, not a bug to be fixed
+ *  by growing the list without bound; see `experience.multiword-city.test.ts`,
+ *  which pins both halves (a listed city splits; an unlisted one does not, and
+ *  a company merely containing a listed city stays whole). */
 const MULTIWORD_US_CITY_ALT =
-  "New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City|Mountain View|Palo Alto|Menlo Park";
+  "New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City|Mountain View|Palo Alto|Menlo Park|Santa Clara|Redwood City|Ann Arbor";
 
 /** Bare city/region names (no "City, ST" state tail, so `US_LOCATION_RE` misses
  *  them) that show up as a `"Title, Location"` header tail — must NOT be cleaved

--- a/src/lib/heuristics/extract/experience.multiword-city.test.ts
+++ b/src/lib/heuristics/extract/experience.multiword-city.test.ts
@@ -52,6 +52,30 @@ describe("multi-word city on space-folded header (#368)", () => {
     expect(role.title?.toLowerCase()).toContain("intern");
   });
 
+  // The vocabulary is shared between BARE_LOCATION_RE (the middot path, #616)
+  // and KNOWN_MULTIWORD_US_CITY_RE (this space-folded path, #368), so the three
+  // cities added for #634's review improve BOTH — an effect worth pinning
+  // because it was a side effect rather than the goal. A/B against the previous
+  // vocabulary: "Acme Santa Clara, CA" split as company "Acme Santa" /
+  // location "Clara, CA", exactly the Pass B single-token truncation #368
+  // exists to prevent. Untested, this could silently regress.
+  it.each([
+    ["Santa Clara", "CA"],
+    ["Redwood City", "CA"],
+    ["Ann Arbor", "MI"],
+  ])("space-folded `Acme %s, %s` keeps the city whole too", (city, state) => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: `Acme ${city}, ${state}`, fontSize: 11 },
+      { text: "Software Engineer", fontSize: 11 },
+      { text: "May 2023 - Jun. 2024", fontSize: 11 },
+      { text: "• Built a document generator on a hosted LLM API.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Acme");
+    expect(roles[0].location).toBe(`${city}, ${state}`);
+  });
+
   it("still extracts a single-word city (no regression to Pass B)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
@@ -95,26 +119,42 @@ describe("multi-word city on space-folded header (#368)", () => {
 // single-source MULTIWORD_US_CITY_ALT vocab so BARE_LOCATION_RE full-matches it.
 // The trailing-segment case is covered too so behavior is position-independent.
 describe("multi-word city without state/country suffix on middot header (#616)", () => {
-  it("row (b) — middle segment: `Company, MultiWordCity` splits into company + location", () => {
-    // "Google, Mountain View" sits in the MIDDLE middot segment. Before the fix
-    // the whole string landed in `company` and `location` dropped.
-    const roles = roleFromSection([
-      { text: "EXPERIENCE", fontSize: 13 },
-      {
-        text: "Engineering Lead · Google, Mountain View · GFiber",
-        fontSize: 11,
-      },
-      { text: "04/2021 – 12/2023", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
-    ]);
-    expect(roles.length).toBeGreaterThanOrEqual(1);
-    const role = roles[0];
+  // Table-driven so EVERY city added to MULTIWORD_US_CITY_ALT for #616 is
+  // guarded, not just the one the original fix demonstrated. The first five
+  // rows shipped with #634; the last three were added by its review, which
+  // reproduced them as still-broken on that branch. With one row per vocab
+  // entry, dropping an entry from the alternation string fails a test instead
+  // of passing silently.
+  it.each([
+    ["Google", "Mountain View", "GFiber"],
+    ["Meta", "Menlo Park", "Ads"],
+    ["Stanford", "Palo Alto", "SLAC"],
+    ["Nvidia", "Santa Clara", "Compute"],
+    ["Meta", "Redwood City", "Ads"],
+    ["Ford", "Ann Arbor", "Research"],
+  ])(
+    "row (b) — middle segment: `%s, %s` splits into company + location",
+    (company, city, team) => {
+      // The city sits in the MIDDLE middot segment. Before the fix the whole
+      // "Company, City" string landed in `company` and `location` dropped.
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        {
+          text: `Engineering Lead · ${company}, ${city} · ${team}`,
+          fontSize: 11,
+        },
+        { text: "04/2021 – 12/2023", fontSize: 11 },
+        { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      const role = roles[0];
 
-    expect(role.title?.toLowerCase()).toContain("engineering lead");
-    expect(role.company).toBe("Google");
-    expect(role.location).toBe("Mountain View");
-    expect(role.team).toBe("GFiber");
-  });
+      expect(role.title?.toLowerCase()).toContain("engineering lead");
+      expect(role.company).toBe(company);
+      expect(role.location).toBe(city);
+      expect(role.team).toBe(team);
+    },
+  );
 
   it("row (a) unchanged — middle `Company, MultiWordCity, ST` still splits with state suffix", () => {
     const roles = roleFromSection([
@@ -186,5 +226,63 @@ describe("multi-word city without state/country suffix on middot header (#616)",
 
     expect(role.company).toBe("Google");
     expect(role.location).toBe("Mountain View");
+  });
+
+  // The load-bearing safety claim for the whole closed-vocab approach, which
+  // MULTIWORD_US_CITY_ALT's docblock asserts in prose: a real company that
+  // merely CONTAINS a listed city still fails the `^…$`-anchored full-string
+  // match, so the vocabulary can grow without shredding company names. It was
+  // true but tested nowhere (#634 review), and a prose-only invariant drifts
+  // silently — the moment someone relaxes the anchor, these are what break.
+  it.each([
+    // City token leads the company name, alone in its middot segment.
+    ["Engineer · Mountain View Software · Core", "Mountain View Software"],
+    ["Engineer · Redwood City Ventures · Core", "Redwood City Ventures"],
+    ["Engineer · Santa Clara University · Research", "Santa Clara University"],
+  ])(
+    "does not cleave a company that merely contains a vocab city: %s",
+    (header, expectedCompany) => {
+      const roles = roleFromSection([
+        { text: "EXPERIENCE", fontSize: 13 },
+        { text: header, fontSize: 11 },
+        { text: "04/2021 – 12/2023", fontSize: 11 },
+        { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
+      ]);
+      expect(roles.length).toBeGreaterThanOrEqual(1);
+      expect(roles[0].company).toBe(expectedCompany);
+      expect(roles[0].location).toBeUndefined();
+    },
+  );
+
+  it("holds in the comma-tail position too — `Acme, Mountain View Software` stays unsplit", () => {
+    // The tail is where Pass F actually runs BARE_LOCATION_RE, so this is the
+    // position the anchor has to earn its keep in.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Engineer · Acme, Mountain View Software", fontSize: 11 },
+      { text: "04/2021 – 12/2023", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Acme, Mountain View Software");
+    expect(roles[0].location).toBeUndefined();
+  });
+
+  // The standing LIMITATION, pinned so closing #616 cannot be read as a general
+  // guarantee. MULTIWORD_US_CITY_ALT is a closed set by design — an open
+  // "two Title-Case words" rule would split `Acme, Northwind Systems` — so a
+  // multi-word city outside the vocabulary still folds into `company`. This
+  // test failing is the EXPECTED signal when a city is added: move the row up
+  // into the table above rather than deleting it.
+  it("closed vocabulary is closed — an unlisted multi-word city still folds into company", () => {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13 },
+      { text: "Engineering Lead · Vertex Health, Coral Gables · Claims", fontSize: 11 },
+      { text: "04/2021 – 12/2023", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
+    ]);
+    expect(roles.length).toBeGreaterThanOrEqual(1);
+    expect(roles[0].company).toBe("Vertex Health, Coral Gables");
+    expect(roles[0].location).toBeUndefined();
   });
 });

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "../heuristics/types.ts";
 import { ACCOMPLISHMENT_SECTION_NAMES } from "../heuristics/sections.ts";
 import type { AnonymousAtsScore, BulletObservation } from "../score/score.ts";
+import { countWords } from "../score/score.ts";
 
 function bullet(text: string, index: number): BulletObservation {
   return {
@@ -18,7 +19,7 @@ function bullet(text: string, index: number): BulletObservation {
     hasMetric: true,
     startsWithActionVerb: true,
     wellFormedLength: true,
-    wordCount: text.split(/\s+/).length,
+    wordCount: countWords(text),
   };
 }
 

--- a/src/lib/pdf/export-layout-contract.test.ts
+++ b/src/lib/pdf/export-layout-contract.test.ts
@@ -19,14 +19,16 @@
  * the round-trip invariant). PII-free: asserts recognition of heading strings
  * (synthetic-persona fixtures), never dumps field values.
  *
- * It also enforces the PAGINATION half of the contract (#629, #631, #632): a
- * section heading or an entry header may never be the final drawn line on a page;
- * a bullet that wraps may never leave one of its lines alone on a page — neither
- * its first at a page bottom (#629) nor its last at a page top (#631); and an
- * entry may never open a page with its last bullet alone (#632). Those
- * cases are exercised on SYNTHESIZED models (no PDF fixture) — see the second
- * describe block, whose helpers locate the exact filler length that puts the
- * natural page break on the subject line.
+ * It also enforces the PAGINATION half of the contract (#629, #631, #632, #635):
+ * a section heading or an entry header may never be the final drawn line on a
+ * page; a bullet that wraps may never leave one of its lines alone on a page —
+ * neither its first at a page bottom (#629) nor its last at a page top (#631);
+ * an entry may never open a page with its last bullet alone (#632); and the
+ * summary body — the one wrapped block those three left uncovered — may not
+ * widow its last line either (#635). Those cases are exercised on SYNTHESIZED
+ * models (no PDF fixture) — see the second and third describe blocks, whose
+ * helpers locate by bisection the exact input length that puts the natural page
+ * break on the subject line.
  */
 
 import { readFileSync, readdirSync } from "node:fs";
@@ -791,4 +793,91 @@ describe("export layout contract — keep-with-next pagination (#629)", () => {
       ).toBeGreaterThan(densest / 2);
     }
   });
+});
+
+/**
+ * The Summary body is the one wrapped block #629/#631/#632 left uncovered: it is
+ * plain body text on the `drawText` path, so before this it paginated per line
+ * and could widow its last line onto a page of its own.
+ *
+ * Reaching it takes a summary long enough to outrun page one on its own — the
+ * summary is always drawn immediately after the contact block, so nothing can
+ * push a SHORT one across a break. That makes the case remote, not impossible:
+ * the summary is a free-text field the user can edit and paste into (#625), and
+ * the boundary is located here by measurement rather than assumed.
+ *
+ * The ORPHAN half needs no test. `drawSectionHeading` already reserves the
+ * heading plus one body line, and the block can only ever begin on page one's
+ * first content line, so its opening can never sit at a page bottom.
+ */
+describe("export layout contract — the Summary body honours widow control", () => {
+  /** A summary of `words` filler tokens, each wrapped line individually
+   *  identifiable by its token index. No digits-only tokens that would read as a
+   *  metric, and no middot, so it takes the plain wrapped-body path. */
+  function summaryModel(words: number): AtsResumeModel {
+    return {
+      contact: { name: "Jane Candidate", links: [] },
+      summary: Array.from({ length: words }, (_, i) => `token${i}`).join(" "),
+      summaryHeading: "Professional Profile",
+      sections: [],
+    };
+  }
+
+  /** Drawn summary lines per page, in page order — the same shape
+   *  {@link bulletLinesPerPage} returns, so a `1` is the widow. */
+  async function summaryLinesPerPage(words: number): Promise<number[]> {
+    const lines = await extractPdfDrawnLines(
+      await renderAtsResumePdf(summaryModel(words)),
+    );
+    const perPage = new Map<number, number>();
+    for (const line of lines) {
+      if (!/\btoken\d+\b/.test(line.text)) continue;
+      perPage.set(line.page, (perPage.get(line.page) ?? 0) + 1);
+    }
+    return [...perPage.entries()].sort(([a], [b]) => a - b).map(([, n]) => n);
+  }
+
+  /**
+   * The smallest summary that spills onto page two at all. Monotone in `words`
+   * (every extra word only ever pushes the block down), so a bisection is exact.
+   * Bracketed on both sides: the low end must fit page one entirely and the high
+   * end must spill, which is what stops the window below from being vacuous.
+   */
+  async function spillBoundary(max = 800): Promise<number> {
+    expect(
+      (await summaryLinesPerPage(0)).length,
+      "an empty summary must not spill onto page two",
+    ).toBeLessThan(2);
+    expect(
+      (await summaryLinesPerPage(max)).length,
+      `a ${max}-word summary must spill onto page two`,
+    ).toBeGreaterThan(1);
+    let lo = 0;
+    let hi = max;
+    while (hi - lo > 1) {
+      const mid = Math.floor((lo + hi) / 2);
+      if ((await summaryLinesPerPage(mid)).length > 1) hi = mid;
+      else lo = mid;
+    }
+    return hi;
+  }
+
+  it("never leaves the summary's last line alone at the top of a page", async () => {
+    const n = await spillBoundary();
+    // The widow can only occur in the first few words past the boundary — beyond
+    // that the tail is naturally two or more lines — so the window is where the
+    // defect lives, and every count in it must clear the same minimum a wrapped
+    // bullet must (#631).
+    for (let words = n; words <= n + 24; words += 4) {
+      const perPage = await summaryLinesPerPage(words);
+      expect(
+        perPage.length,
+        `words=${words}: summary no longer spans a page break`,
+      ).toBe(2);
+      expect(
+        Math.min(...perPage),
+        `words=${words}: summary widowed ${JSON.stringify(perPage)}`,
+      ).toBeGreaterThanOrEqual(MIN_BULLET_LINES_PER_PAGE);
+    }
+  }, 60000);
 });

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -44,6 +44,14 @@
  * bullets paginate freely and no reservation ever spans the entry — because
  * reserving a whole entry is the density failure #630 measured at ~100pt.
  *
+ * The widow half is not bullets-only. The SUMMARY body is the other wrapped
+ * block on the plain `drawText` path, and it takes the same `widowControl`
+ * (#635). Its orphan half needs no reservation beyond the one line its heading
+ * already keeps: the summary always begins at the top of page one, so it can
+ * only ever straddle a break by outrunning a whole page on its own. The capped
+ * body-header (skills) path is deliberately left uncovered — divisibility past
+ * `BODY_HEADER_KEEP_LINES` is the entire point of the cap.
+ *
  * Two deliberate limits keep those reservations from costing page density: a
  * BODY-TEXT "header" (`headerBold: false` — the skills list) contributes at most
  * `BODY_HEADER_KEEP_LINES`, and a reservation taller than a whole page is
@@ -513,9 +521,10 @@ type DrawTextOpts = {
    *  when the text fits on ONE line, so measured offsets are accurate. */
   linkSpans?: Array<{ display: string; href: string }>;
   /** Paginate the wrapped lines under widow control (#631) — see
-   *  {@link Layout.ensureWrappedLine}. Set only by {@link Layout.drawBullet}; a
-   *  header/contact/summary block keeps the plain per-line behaviour. Not an
-   *  input to wrapping, so {@link Layout.measureTextHeight} ignores it. */
+   *  {@link Layout.ensureWrappedLine}. Set by {@link Layout.drawBullet} and by
+   *  the summary body (#635), the two wrapped free-text blocks; a name/contact/
+   *  header line keeps the plain per-line behaviour. Not an input to wrapping,
+   *  so {@link Layout.measureTextHeight} ignores it. */
   widowControl?: boolean;
   /** Height (pt) that must land on the same page as this block's FINAL drawn
    *  line — the NEXT bullet's keep-opening (#632). Set only by
@@ -630,8 +639,14 @@ class Layout {
    * earlier line breaking naturally leaves the tail intact, and every later line
    * is inside a tail already placed.
    *
-   * The other side of the break is guaranteed by the caller's OPENING
-   * reservation ({@link bulletKeepLines}): it committed `BULLET_KEEP_LINES` lines
+   * The other side of the break is guaranteed by the CALLER's opening
+   * reservation, which is why this method owns only the tail. For a bullet that
+   * is {@link bulletKeepLines}; for the summary body (#635) it is the one line
+   * its section heading keeps, which suffices there because the block always
+   * begins at the top of page one and so never opens at a page bottom.
+   *
+   * For a bullet specifically ({@link bulletKeepLines}): it committed
+   * `BULLET_KEEP_LINES` lines
    * to the page the block starts on, and a block reaching this branch has
    * `total >= 2 * BULLET_KEEP_LINES`, so the lines before the tail are at least
    * that many. A block whose own height exceeds a page simply breaks more than
@@ -1253,7 +1268,17 @@ export async function renderAtsResumePdf(
     // The summary body is plain wrapped text, so the heading must keep one BODY
     // line with it (#629).
     drawSectionHeading(layout, model.summaryHeading ?? "Summary", SIZE_BODY * LINE_GAP);
-    layout.drawText(model.summary, { size: SIZE_BODY });
+    // The body takes `widowControl` for the same reason a bullet does (#631): it
+    // is a wrapped block, so per-line pagination can leave its last line alone at
+    // a page top. It is the only NON-bullet caller — a summary long enough to
+    // outrun page one is remote (the block always starts on page one's first
+    // content line), but it is free text the user can edit and paste into (#625),
+    // and the mechanism costs one option.
+    //
+    // The orphan half needs nothing: the heading above already reserves one body
+    // line, and this block can only ever BEGIN at the top of page one, so its
+    // opening can never sit at a page bottom.
+    layout.drawText(model.summary, { size: SIZE_BODY, widowControl: true });
     layout.advance(GAP_BETWEEN_ENTRIES);
   }
 
@@ -1379,6 +1404,14 @@ function subLineOpts(entry: AtsEntry, mutedColor: RGB): DrawTextOpts {
  * bullet: the block's first line is never left alone at a page bottom. One would
  * add nothing over the plain per-line `ensure`; three or more starts trading real
  * page density for a guarantee body text does not need, since it is divisible.
+ *
+ * NOT pinned by a test, and deliberately so: `1` and `2` produce identical output
+ * on every case the suite measures, so any assertion here would be a tautology.
+ * The load-bearing part of this rule is not the number but the GATE that applies
+ * it — see {@link entryHeadHeight}, where the cap is conditional on the model
+ * declaring the header to be body text. Tune the number here and you change
+ * nothing measurable; move the gate there and you change what a real header
+ * reserves. Read that docblock before touching either.
  */
 const BODY_HEADER_KEEP_LINES = 2;
 

--- a/src/lib/rewrite-review/undo-batch.test.ts
+++ b/src/lib/rewrite-review/undo-batch.test.ts
@@ -24,6 +24,7 @@ import {
 import type { ResolvedWrite } from "./apply-accepted.ts";
 import { applyOverrides } from "../edit/apply-overrides.ts";
 import type { BulletObservation } from "../score/score.ts";
+import { countWords } from "../score/score.ts";
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 
@@ -210,7 +211,7 @@ function obs(index: number, text: string): BulletObservation {
     hasMetric: false,
     startsWithActionVerb: false,
     wellFormedLength: false,
-    wordCount: text.split(/\s+/).filter(Boolean).length,
+    wordCount: countWords(text),
   };
 }
 

--- a/src/lib/score/group-bullets.test.ts
+++ b/src/lib/score/group-bullets.test.ts
@@ -14,6 +14,7 @@ import {
   type BulletExperience,
 } from "./group-bullets.ts";
 import type { BulletObservation } from "./score.ts";
+import { countWords } from "./score.ts";
 import { runCascade } from "../heuristics/cascade.ts";
 import { computeAnonymousAtsScore } from "./score.ts";
 
@@ -33,7 +34,7 @@ function makeBullet(
     hasMetric: false,
     startsWithActionVerb: true,
     wellFormedLength: true,
-    wordCount: text.split(/\s+/).length,
+    wordCount: countWords(text),
     ...overrides,
   };
 }

--- a/src/lib/score/score.test.ts
+++ b/src/lib/score/score.test.ts
@@ -229,6 +229,10 @@ describe("bulletHasMetric — industry-aligned detection", () => {
       "Ran dozens of experiments across the onboarding funnel",
       "Owned twenty-two dashboards across the analytics estate", // compound: "two" closes it
       "Processed two thousand records per day through the ingest path", // year-guard must NOT eat this
+      // The other side of the #633-review widening: the year guard now accepts
+      // hyphens as separators, so it must still require a YEAR TAIL word.
+      // "two-thousand records" is a genuine quantity and survives the strip.
+      "Processed two-thousand records per day through the ingest path",
     ];
     it.each(quantified)("registers as a metric: %s", (bullet) => {
       expect(bulletRegistersAsMetric(bullet)).toBe(true);
@@ -242,6 +246,13 @@ describe("bulletHasMetric — industry-aligned detection", () => {
       "Shipped one-off tooling for the internal support team", // `one` again
       "Joined the company in two thousand nineteen and stayed", // spelled year
       "Hired in nineteen hundred ninety-eight before the merger", // spelled year
+      // Hyphenated spelled years (#633 review). The two rows above bracketed
+      // this bug without crossing it: the guard joined its parts with `\s+`
+      // while QUANTIFYING_CARDINAL accepts a hyphen, so the hyphenated form
+      // escaped the strip and matched off its own leftover ("two-t").
+      "Joined the company in two-thousand-nineteen and stayed",
+      "Joined the company in two thousand-nineteen and stayed", // mixed separators
+      "Hired in nineteen-hundred-ninety-eight before the merger",
       "Led Six Sigma initiatives across the manufacturing org", // proper noun
       "Advised Big Four clients on their reporting stack", // proper noun
       "Reduced the escalation backlog by three", // cardinal modifies nothing

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -91,12 +91,20 @@ const WEIGHTS = {
  *   punctuation-only tokens (a spaced em-dash, mid-dot, etc. no longer counts
  *   as a word), so bullets that use spaced dashes score shorter and more of
  *   them land in the 8–30 well-formed window, raising Structure.
+ * - 1.7 (2026-07-28): the 1.6 spelled-year guard is separator-consistent with
+ *   the cardinal matcher it guards (#633 review). WORD_YEAR_TOKEN joined its
+ *   parts with `\s+` while QUANTIFYING_CARDINAL accepts a hyphen, so a spelled
+ *   year written with hyphens ("two-thousand-nineteen", "nineteen-hundred-
+ *   ninety-eight") escaped the strip and then registered as quantification off
+ *   its own leftover fragment. Both now share CARDINAL_SEPARATOR. Strictly
+ *   removes false Specificity credit; a bullet that genuinely quantifies is
+ *   unaffected, so scores move only DOWN and only on this rare shape.
  */
 // Surfaced to the UI via the `algoVersion` score field, and consumed by the
 // #321 resume-library cache to version persisted parse+score records (a bump
 // here invalidates stale cached snapshots, which then re-parse from the stored
 // PDF blob — see `resume-library.ts`).
-export const ATS_SCORE_ALGO_VERSION = "1.6";
+export const ATS_SCORE_ALGO_VERSION = "1.7";
 
 // ── Shared scoring rules ────────────────────────────────────────────────────
 //
@@ -120,9 +128,13 @@ const BULLET_MARKER_RE = /^[\s ]*[-*•●–▪◦‣▶►·�]\s+/;
 /** Numbered-list prefix: "1." or "1)". */
 const NUMBERED_BULLET_RE = /^[\s ]*\d+[.)]\s+/;
 
-/** Word-count window for a "well-formed" bullet (Structure dimension). */
-const BULLET_LENGTH_MIN_WORDS = 8;
-const BULLET_LENGTH_MAX_WORDS = 30;
+/** Word-count window for a "well-formed" bullet (Structure dimension).
+ *  Exported so the Structure card's tooltip states the criterion from the same
+ *  source that enforces it — #624 shortened the visible hint to bare counts
+ *  (`length 13/23`), and a hand-typed "8–30" in the UI would drift the moment
+ *  the window moves. */
+export const BULLET_LENGTH_MIN_WORDS = 8;
+export const BULLET_LENGTH_MAX_WORDS = 30;
 
 /** A token counts as a word when it contains at least one letter or digit
  *  (#627). `text.split(/\s+/)` alone tokenizes a spaced em-dash, mid-dot, or
@@ -237,9 +249,20 @@ const YEAR_TAIL_WORD =
  *  otherwise trip a cardinal above ("**two thousand** nineteen", "**nineteen
  *  hundred** twelve") need guarding — "twenty twenty-four" contains no accepted
  *  cardinal. The trailing year word is REQUIRED, so a genuine quantity like
- *  "processed two thousand records" survives the strip and still counts. */
+ *  "processed two thousand records" survives the strip and still counts.
+ *
+ *  Separator is CARDINAL_SEPARATOR, NOT `\s`, and that is load-bearing (#633
+ *  review): this guard only works if it recognises every shape the matcher it
+ *  guards against does. QUANTIFYING_CARDINAL accepts a hyphen between the
+ *  cardinal and the next word, so a hyphenated spelled year
+ *  ("two-thousand-nineteen") used to survive the strip and then register as
+ *  quantification off its own leftover fragment. Any future widening of
+ *  CARDINAL_SEPARATOR must stay shared with this constant or the same class of
+ *  false positive reopens. */
+const YEAR_SEPARATOR = `${CARDINAL_SEPARATOR}+`;
 const WORD_YEAR_TOKEN = new RegExp(
-  `\\b(?:two\\s+thousand|nineteen\\s+hundred)(?:\\s+and)?\\s+(?:${YEAR_TAIL_WORD})\\b`,
+  `\\b(?:two${YEAR_SEPARATOR}thousand|nineteen${YEAR_SEPARATOR}hundred)` +
+    `(?:${YEAR_SEPARATOR}and)?${YEAR_SEPARATOR}(?:${YEAR_TAIL_WORD})\\b`,
   "gi",
 );
 

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-honors-subheadings.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-honors-subheadings.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 11,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column-long-role-header.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column-long-role-header.expected.json
@@ -68,7 +68,7 @@
       "scanned": false
     },
     "bulletCount": 14,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -69,7 +69,7 @@
       "scanned": false
     },
     "bulletCount": 52,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -69,7 +69,7 @@
       "scanned": false
     },
     "bulletCount": 30,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 16,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/bare-linkedin-url-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/bare-linkedin-url-roundtrip.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/bulleted-labelled-single-column-skills.expected.json
+++ b/tests/fixtures/pdfs/unknown/bulleted-labelled-single-column-skills.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -70,7 +70,7 @@
       "scanned": false
     },
     "bulletCount": 11,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 27,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/compound-certifications-activities-tail.expected.json
+++ b/tests/fixtures/pdfs/unknown/compound-certifications-activities-tail.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/education-institution-pipe-location.expected.json
+++ b/tests/fixtures/pdfs/unknown/education-institution-pipe-location.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 1,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
+++ b/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/mid-dot-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/mid-dot-header.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
+++ b/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/qualified-experience-relevant-coursework.expected.json
+++ b/tests/fixtures/pdfs/unknown/qualified-experience-relevant-coursework.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/shared-employer-banner-roles.expected.json
+++ b/tests/fixtures/pdfs/unknown/shared-employer-banner-roles.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-endash-title-company.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-endash-title-company.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-intl-role-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-intl-role-headers.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-projects-prose-body.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-projects-prose-body.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 1,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-title-below-anchor.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-title-below-anchor.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
@@ -63,7 +63,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/synthetic-dateless-experience.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-dateless-experience.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/synthetic-degreeless-two-programs.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-degreeless-two-programs.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/title-team-next-line-employer.expected.json
+++ b/tests/fixtures/pdfs/unknown/title-team-next-line-employer.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -71,7 +71,7 @@
       "scanned": false
     },
     "bulletCount": 16,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.6"
+    "algoVersion": "1.7"
   },
   "reproArtifact": {
     "artifactVersion": "v1",


### PR DESCRIPTION
Consolidates the review follow-ups from three PRs that merged in the same window — **#630, #633 and #634** — together with the #635 Summary widow-control fix that #630's review surfaced.

Reviewed across those three by @rohithgollapalli, @Vaishnavi1709, @Samhit21 and @s-annam. Every finding any of them raised is accounted for below: fixed here, filed as a follow-up issue, or declined with a reason on its own thread. Nothing was dropped silently, and the per-item attribution in each section is the record of who found what.

## The defect

#629/#631/#632 gave every wrapped **bullet** both halves of the page-break guarantee. They scope to bullets, entry headers and section headings, and the module docblock was careful not to claim more. The **Summary body** is the one wrapped block left on the plain per-line path:

```ts
layout.drawText(model.summary, { size: SIZE_BODY });
```

`ensureWrappedLine` widens its reservation only under `opts.widowControl`, and `drawBullet` was the only caller setting it. So a summary with N-1 of its N lines fitting leaves the last one alone at the top of the next page.

## Reachability — measured on `main` (`7596161`), not assumed

Synthetic model, summary of `words` filler tokens, counting drawn summary lines per page:

| words | summary lines | per page (before) | per page (after) |
|---|---|---|---|
| 596 | 49 | `[49]` | `[49]` |
| **602** | **50** | **`[49, 1]`** ← widow | `[48, 2]` |
| **608** | **50** | **`[49, 1]`** ← widow | `[48, 2]` |
| 614 | 51 | `[49, 2]` | `[49, 2]` |
| 626 | 52 | `[49, 3]` | `[49, 3]` |

The summary is always drawn immediately after the contact block, so nothing can push a *short* one across a break — it has to outrun a whole page on its own, ~50 wrapped lines / ~600 words. **Remote, and worth saying so plainly** rather than dressing this up as a live bug. Fixed anyway because the summary became a free-text field the user edits and pastes into (#625) — "nobody writes a 600-word summary" is a claim about authorship, not about what the field accepts — and because the mechanism was one option away.

## The orphan half is genuinely not needed

`drawSectionHeading` already reserves the heading plus one body line, and this block can only ever *begin* at the top of page one, so its opening can never sit at a page bottom. That asymmetry is now stated in `ensureWrappedLine`'s docblock, which previously explained the far side of the break purely via `bulletKeepLines` — a path the summary does not take.

The capped body-header (skills) path is left uncovered **deliberately**, exactly as the review recommended: divisibility past `BODY_HEADER_KEEP_LINES` is the entire point of the cap, and covering it would re-introduce the density cost #630 measured at ~100pt.

## The guard

`export-layout-contract.test.ts` gains one test that:

- **bisects** to the spill boundary rather than hard-coding a word count, so it keeps straddling the break if the page geometry or type scale changes;
- **brackets both ends** (empty summary must fit page one; 800 words must spill), so it fails loudly instead of going vacuous;
- asserts the same `MIN_BULLET_LINES_PER_PAGE` minimum a wrapped bullet must meet, across a window past the boundary.

**Proven non-vacuous.** Reverting the one-option change fails exactly this test and nothing else: `words=556: summary widowed [49,1]: expected 1 to be greater than or equal to 2`. Restoring it returns 72/72.

## Second nit — `BODY_HEADER_KEEP_LINES`

Confirmed unpinned: `1` and `2` render identically on every measured case, so an assertion there would be a tautology and none is added. What *is* load-bearing is the **gate** that applies the cap (`headerBold: false`, in `entryHeadHeight`), so the constant now carries a comment pointing at it — the failure mode the nit named is a future reader tuning the number in isolation and assuming the cap is unconditional.

## Docblocks corrected

Three said widow control was bullets-only and would now be false: `DrawTextOpts.widowControl`, `Layout.ensureWrappedLine`, and the module header. Also the test file's contract summary.

## Verification

`npm run typecheck` 0 · `npx eslint src/lib/pdf/` 0 · `npx vitest run src/lib/pdf/` **312 passed / 24 files** · `export-layout-contract.test.ts` **72 passed** (71 before).

**No corpus movement**: `corpus-roundtrip` and `corpus-edit-roundtrip` are unchanged — no fixture has a summary anywhere near the threshold, which is what makes the corpus glyph-diff the review anticipated cheap rather than expensive here.

No fixture binary added or changed. The widow-control change is `src/lib/pdf/` only; the review nits below widen this PR into `src/components/features/`, `src/design-system/` and `src/lib/score/`.

Closes #635

## Also in this PR — the review-nit sweep from #630, #633 and #634

Three PRs merged in the same window (#630, #633, #634), each leaving unresolved review threads behind. Re-pushing to any of those branches would have dismissed their approvals (`main` has `dismiss_stale_reviews: true`), and opening three follow-up PRs would cost three review rounds. This PR had no review yet, so every nit worth fixing is swept here and reviewed once.

**#630's two threads are already satisfied by this PR's own change** — the Summary widow control above *is* @rohithgollapalli's first thread, and the `BODY_HEADER_KEEP_LINES` comment he asked for is the second. Nothing extra was needed for them.

Six items land. Two are behavioural and carry their own proof; four are behaviour-neutral.

### Behavioural — proved, not asserted

**1. The spelled-year guard and the cardinal matcher disagreed about separators.** *(@rohithgollapalli on #633, Secondary — `score.ts:242`)*

`CARDINAL_SEPARATOR` accepts whitespace *or* a hyphen; `WORD_YEAR_TOKEN` joined its parts with `\s+` only. So a spelled year written with hyphens escaped the strip, and `QUANTIFYING_CARDINAL` then matched off its own leftover fragment (`two-t`). Reproduced exactly as reported, through the real scorer:

| Bullet | Before | After |
|---|---|---|
| `…in two thousand nineteen and stayed` | none | none |
| `…in two-thousand-nineteen and stayed` | **METRIC** | none |
| `…in two thousand-nineteen and stayed` | **METRIC** | none |
| `Hired in nineteen-hundred-ninety-eight…` | **METRIC** | none |
| `Hired in nineteen hundred ninety-eight…` | none | none |
| `Processed two thousand records per day` | METRIC | METRIC |
| `Shipped two internal tools` | METRIC | METRIC |
| `Led a four-month migration` | METRIC | METRIC |
| `Owned twenty-two dashboards` | METRIC | METRIC |
| `Processed millions of records nightly` | METRIC | METRIC |

The last row of the "before" set is the one that stung: the un-hyphenated form was already in the `notQuantified` test list and passed, so the existing set bracketed the bug without crossing it. Both constants now share `CARDINAL_SEPARATOR`, and the docblock says why the sharing is load-bearing rather than stylistic.

Six test rows added, not three — the three hyphenated years, plus `Processed two-thousand records per day` on the *accept* side. The widened separator must still require a year **tail** word, or the fix would start eating genuine hyphenated quantities. **Proven non-vacuous:** reverting the separator fails exactly the three new reject rows and nothing else.

**`ATS_SCORE_ALGO_VERSION` 1.6 → 1.7**, which is what kept this out of the earlier batch. The cost is real but bounded, and it is now measured rather than assumed: pinning the version at 1.6 and re-running the corpus, **all 54 snapshots pass unchanged** — so no fixture's parse or score moves, and the only snapshot delta in this diff is the version stamp (54 files, 54 insertions, 54 deletions, zero non-`algoVersion` lines). The bump invalidates persisted `resume-library` cache records, which then re-parse from the stored PDF blob. Scores can only move **down**, only by removing false Specificity credit, and only on this rare shape.

**2. The multi-word-city defect class survived for every city outside the three added.** *(@s-annam on #634, Secondary — `experience-disambiguate.ts:58`)*

The three headers the #634 review reproduced as still-broken, before and after:

| Header | Before | After |
|---|---|---|
| `… · Nvidia, Santa Clara · Compute` | company=`Nvidia, Santa Clara`, location=∅ | company=`Nvidia`, location=`Santa Clara` |
| `… · Meta, Redwood City · Ads` | company=`Meta, Redwood City`, location=∅ | company=`Meta`, location=`Redwood City` |
| `… · Ford, Ann Arbor · Research` | company=`Ford, Ann Arbor`, location=∅ | company=`Ford`, location=`Ann Arbor` |

Three vocabulary entries in `MULTIWORD_US_CITY_ALT`, no logic change. **Proven non-vacuous:** removing the three entries fails exactly the three new table rows.

**One effect I did not set out to get, now pinned.** `MULTIWORD_US_CITY_ALT` is shared with `KNOWN_MULTIWORD_US_CITY_RE`, the space-folded (#368) pass — so the three additions improve that path too. A/B against the previous vocabulary: `Acme Santa Clara, CA` used to split as company `Acme Santa` / location `Clara, CA` — the exact Pass B single-token truncation #368 exists to prevent — and now splits correctly. Three rows added to the #368 block so a side-effect improvement cannot silently regress; reverting the vocabulary fails all six new city rows across both describe blocks.

**This does not make #616's third acceptance criterion true in general, and the code now says so.** The vocabulary is closed by design — an open "two Title-Case words" rule would split `Acme, Northwind Systems` — so an unlisted multi-word city still folds into `company`. That narrowing is recorded in the const's docblock, pinned by a test (`closed vocabulary is closed`, using an unlisted city), and noted on #616 so its closure is not read as a guarantee the code does not make.

**3. The load-bearing safety claim was asserted in prose and tested nowhere.** *(@s-annam on #634, Nit — same file, line 55)*

*"a real company that merely contains one of these tokens (`Mountain View Software`) still fails the `^…$`-anchored full-string match"* is the entire justification for growing a closed vocabulary at all — and nothing enforced it. Four assertions now do, across both positions the anchor has to hold in: `Mountain View Software`, `Redwood City Ventures` and `Santa Clara University` stay whole as leading company names, and `Acme, Mountain View Software` stays unsplit in the comma-tail position, which is where Pass F actually runs `BARE_LOCATION_RE`. Adding `Santa Clara` to the vocabulary would have been reckless without the university case pinned.

**4. Two of #634's three cities shipped untested.** *(@s-annam on #634, Secondary)*

All five of that PR's tests used `Mountain View`; `Palo Alto` and `Menlo Park` had zero coverage, so an edit to the alternation string could drop one and the suite would stay green. Row (b) is now table-driven with **one row per vocabulary entry added for #616** — six rows, exactly the reviewer's suggested shape. Coverage is now structural: adding a city without adding its row is the only way to regress, and that is visible in the diff.

### Behaviour-neutral

**5. `SectionHeading` had four verbatim copies → one shared component.** *(#633's own known-nits list; count corrected by @rohithgollapalli)*
`ReconstructedResume.tsx:249`, `ReconstructedSkills.tsx:43`, `ReconstructedEducationSkills.tsx:45` and `ReconstructedSummary.tsx:45` each carried the same six lines and the same class string. Extracted to `src/design-system/shared/SectionHeading.tsx`, exported through the `@design-system` barrel; all four call sites import it. Same element, same class string, no local state in any copy — the rendered markup is identical. This is the `CLAUDE.md` Golden Rule case: exactly one shared piece per concern. #633's own list called it "a **third** verbatim copy"; it was the fourth, and @rohithgollapalli diffed all four.

**6. Five test helpers still built `wordCount` with the pre-#627 expression.** *(#633's own known-nits list; independently verified inert by @rohithgollapalli and @Vaishnavi1709)*
`apply-overrides.test.ts:21`, `undo-batch.test.ts:213`, `ReconstructedResume.test.ts:23`, `ats-resume-model.test.ts:21`, `group-bullets.test.ts:36` each used `text.split(/\s+/)…`, the expression #627 exists to delete. Both reviewers independently confirmed them inert (nothing reads the field; the stub texts have no punctuation-only tokens), so this is consistency, not correctness — all five now call `countWords`.

**7. The Structure hint stated counts without its criterion.** *(#633's own known-nits list; @rohithgollapalli endorsed the `title`-attribute fix)*
#624 shortened it to `verb-led 0/23 · length 23/23`, which no longer says what "length" is measured against. Adds an optional `hintTitle` to `Dimension`, used only by the Structure card. `BULLET_LENGTH_MIN_WORDS` / `BULLET_LENGTH_MAX_WORDS` are now exported so the tooltip reads the window from the constants that enforce it — a hand-typed "8–30" in the UI would drift the moment the window moves.

**8. The `noun` prop reached the kind label but not the editor.** *(@Vaishnavi1709 on #633, Secondary — the one user-visible UI fix here)*
`RewriteReviewList.tsx:179,181`. `noun` correctly drove `kindLabel` and both control `aria-label`s, then the `EditableField` two lines below hardcoded `placeholder="edit this bullet"` and `label="Edit proposed bullet"`. Accepting a **summary** rewrite (a #625 flow) therefore read "Edited summary" in the header and "edit this bullet" in the textarea, with the same mismatch in the screen-reader label.

Note the substitution is `${noun}`, **not** the row's `lower` — `lower` is the lowercased *kind label* (`"edited bullet"`), so interpolating it would have produced "edit this edited bullet". Three tests cover the passed noun, the empty-state placeholder (which needs its own pair — the placeholder only paints when the edited side is empty, so asserting it on a filled pair would pass vacuously), and the `"bullet"` default. **Proven non-vacuous** — reverting the two interpolations fails exactly the two summary-noun tests and leaves the default-case test passing.

**A pre-existing defect the #634 review flagged now has a home: #641.** That review noted `Palo Alto Networks, CA` → company `Palo Alto` / location `Networks, CA`, A/B'd it against `main`, and flagged it specifically so it would not be misattributed to #634 — but it was never filed. I repeated the A/B against this branch: the shredded rows are byte-identical with and without the new vocabulary entries, so it is Pass B's single-token rule and neither PR's doing. #641 carries the repro, the A/B table, and two candidate directions.

### Deliberately left out

Everything else the three reviews raised, with who raised it. These are not nits — each changes behaviour in a way that needs its own design and its own proof.

- **`ReconstructedRole.tsx:298` undo strip unmounts on prune** — @Vaishnavi1709 on #633, Secondary. Same class as #633's round-1 blocking defect, one lifecycle level up: `pruneEmptyAddedEntries` drops the added role while its undo strip is live, so the undo flashes for a frame and is gone. The fix is architectural — lift the strip host for added-role bullets the way `ExperienceSection` already hosts the Other bucket's, or defer prune while a removed-strip is live. **Filed as a follow-up issue.**
- **`variant="icon"` 24×24 floor belongs on the `Button` primitive** — @Vaishnavi1709 on #633, nit, and she asked for a follow-up issue explicitly. Six call sites still carry the 14×14 hitbox. Layout-affecting, and `ChipListEditor.tsx:45` documents a 5px overlay workaround, so a blanket `min-h` on the primitive would make the chip row worse. **Filed as a follow-up issue.**
- **Inline `text-[11px]` typography** — @Samhit21 on #633, additive nit on `ResumeBulletRow.tsx:156,195`, which he scoped as pre-existing debt for "whenever that file is next touched". Measuring it made it bigger than the two lines: font size is **not tokenised at all** in this repo — `@theme inline` maps `--color-*` only, there is no `tailwind.config.*` (Tailwind v4), and `src/` carries **67** arbitrary sizes (`text-[11px]` ×48, `text-[10px]` ×17, `text-[9px]` ×2). Fixing only these two would mint a token used by 2 of 48 consumers and leave 46 hand-styled — the parallel-copy outcome the Golden Rule exists to prevent. It is a sweep or nothing. **Filed as #640.**
- **`isProseLine` (`line-primitives.ts:83`) still uses the pre-#627 expression** — @Vaishnavi1709 on #633, nit. The one *production* consumer, and the trap in this set: #627 exists because `split(/\s+/).filter(Boolean)` counts punctuation-only tokens as words, so swapping it changes which lines classify as prose. That is parser behaviour with real corpus-movement risk — unlike the two behavioural fixes above, which the corpus proves inert.

Judged not worth fixing, by the reviewer who raised it:

- **`scoreBulletPool` / `analyzeBullets` double-walk bullets** — @Vaishnavi1709 on #633, nit. Her guidance was to fold only if you are in the file anyway, and this PR *is* in `score.ts`. Not taken, and the reason is specific: the cheap fold does not exist. `scoreBulletPool` has two other callers (`score.ts:456`, `:474`) that pass raw strings, so the only way to stop the second walk is to change the shared function's signature to take `BulletObservation[]` — which contradicts the "parallel shape is deliberate" docblock and touches the authed scorer. That is a scorer-core refactor riding along with a scoring change in the same PR, which is exactly the combination worth not making.
- **Proper nouns embedding a cardinal read as quantifications** (`Advised Four Seasons on their loyalty platform`) — @rohithgollapalli on #633, nit. Inherent to a keyword heuristic, the set is unbounded, and the cost is half a Specificity credit on one bullet. Worth recording that the corpus validation reads as stronger coverage than it is: the corpus simply contains no such employer.

Still open from #633's known-nits list, unchanged here and agreed by both reviewers as their own follow-ups: `applyOverrides` at 17 positional params (wants an options-object refactor, which would have buried six fixes in signature churn), and `ResumeBulletRow.tsx` at 300 LOC (debt relocated honestly — `ReconstructedRole.tsx` fell 202 lines in the same change).

### Verification

`npm run verify` **exit 0** — `tsc -b --noEmit` clean · `eslint .` clean · `check:fixtures` green · **3545 passed / 10 skipped** across 244 files · `vite build` 956 modules. **No fixture binary touched** — the 54 `.expected.json` changes are the `algoVersion` stamp and nothing else (54 files, 54 insertions, 54 deletions, zero non-`algoVersion` lines in the diff).

fallow reports 10 findings, none authored here: the complexity list is `mapTitleFirst`, `recoverLocation`, `stripLocationSuffix`, `computeAnonymousAtsScore`, `scoreCompleteness` and the render path, all pre-existing functions this diff does not enter — it adds a vocabulary string and a regex, both at module scope. `experience.multiword-city.test.ts` picks up a unit-size finding for its grown `describe` block, in the same shape as the four other test files already on that list. Report-only per `CLAUDE.md`.
## Provenance

| Stage | Model | Effort |
|---|---|---|
| Repro, fix, test, PR | Claude Opus 5 (1M context) | high |
| Review-nit sweep from #630/#633/#634 | Claude Opus 5 (1M context) | high |

No independent adversarial review round was run on this change. Single-model work, stated rather than implied.



