### PR TITLE
chore(skills): shrink the pr-ready ping, make pr-review adversarial, let revise-pr import feedback

### DIFF
--- a/.claude/pr-ready.local.json.example
+++ b/.claude/pr-ready.local.json.example
@@ -5,5 +5,6 @@
   ],
   "reminder_at_minutes": 60,
   "default_deadline_minutes": 90,
-  "ack_reactions": ["eyes", "white_check_mark", "raising_hand"]
+  "hold_grace_minutes": 60,
+  "ack_reactions": ["+1", "thumbsup"]
 }

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -218,6 +218,13 @@ gh pr create --repo "$REPO" --base "$BASE" --head "$BRANCH" \
 
 Closes #<N>   <!-- omit if not fully resolving an issue; use "Refs #<N>" if partial -->
 
+## Review focus
+
+<!-- OPTIONAL — include only when the risk isn't obvious from the diff. Omit entirely
+     (heading and all) on a small or self-evident change. Max ~4 entries. -->
+
+- `src/lib/<file>.ts:<line>` — <the question to ask of it, not a claim about it>
+
 ## Test plan
 
 - [ ] `npm run typecheck` clean
@@ -234,6 +241,28 @@ BODY
 
 If the PR adds fixtures, add a line to the Test plan:
 `- [ ] Fixture personas verified synthetic — no real PII (Step 3.5)`.
+
+**`## Review focus` is optional, and it belongs here rather than in the review
+request.** `pr-ready` used to carry these pointers in its chat ping; they now live
+in the body, where the reviewer already is when they start reading — a pointer in
+a chat message costs them a context switch to act on, and costs everyone else in
+the channel the tokens to scroll past.
+
+Three rules for writing one, all of them about not doing the reviewer's thinking
+for them:
+
+- **Ask, don't assert.** "does the guard fire on the `Title · Team · City` shape
+  too?" — not "the guard handles all header shapes." An assertion invites the
+  reviewer to confirm it; a question invites them to check.
+- **Name the risk, not the change.** The diff already says what changed. This
+  section says where you'd look first if it were wrong.
+- **Omit it when it's obvious.** A one-file test fix has no review focus. An empty
+  or padded section trains reviewers to skip the heading entirely, which costs you
+  the one time it mattered.
+
+It is explicitly **not** a scope bound. `pr-review` treats it as the author's
+hypothesis — a lead to check and then audit for accuracy — and reviews the whole
+diff regardless. Do not use it to steer attention away from anything.
 
 `gh pr create --fill` derives title/body from the commits — fine for small PRs,
 but it won't produce a `## Provenance` block — append one (Step 5.5) if you use it.
@@ -303,6 +332,10 @@ merge their own PR via admin bypass.)
   `Claude-Session:` URL or `🤖 Generated with …` badge anywhere (this repo is
   public; a session URL is an account-scoped identifier with no reader value).
   Declare the models in the PR body instead (Step 5.5).
+- **Review pointers go in the body, never in a chat ping.** `## Review focus` is
+  optional and phrased as questions; omit the heading when the risk is obvious.
+  It is a lead for the reviewer, never a scope bound — `pr-review` audits it for
+  accuracy and reviews the whole diff either way.
 - **Every provenance row is self-reported or first-hand.** Name your own model
   from your system prompt; take a subagent's from what it reported. Never infer a
   version string from a `model:` alias, and never invent a row — omit it instead.

--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,26 +1,35 @@
 ---
 name: pr-ready
-description: Solicit review on one or more open PRs — post one ping with an explicit ack mechanism and an absolute deadline, wait, send at most one reminder, and report per PR whether anyone engaged. Detects the ack across chat and GitHub. Never changes a PR's merge state. Use when the user says "pr-ready", "/pr-ready", "ask for review on this PR", "ping reviewers", or has open PRs nobody has looked at yet.
+description: Solicit review on one or more open PRs — post one short ping asking for a single explicit 👍 by an absolute merge time, wait, send at most one reminder, and report per PR which of SILENT / ACKED / REVIEWING / REVIEWED was reached and by whom. Detects an in-progress review from GitHub (the 👀 /pr-review posts) and grants it one bounded grace extension. Carries no review guidance — that lives in the PR body. Never changes a PR's merge state. Use when the user says "pr-ready", "/pr-ready", "ask for review on this PR", "ping reviewers", or has open PRs nobody has looked at yet.
 argument-hint: [<pr-number>[,<pr-number>...]]
 ---
 
 # PR Ready
 
 Take a PR — or a list of them — from "open and silent" to "a human has visibly
-engaged, or the author knows exactly who to nudge": preflight → post one ping
-with a stated ack mechanism and an absolute-time deadline → wait → check once
-at the reminder checkpoint and send at most one reminder if still silent →
-wait to the deadline → report. A list is **one** ask: one ping, one deadline,
-one reminder, one report that breaks down per PR. This skill only ever produces a **report** — the merge decision stays
-with a human, made outside this skill, every time.
+engaged, or the author knows exactly who to nudge": preflight → post one **short**
+ping asking for a single 👍 by an absolute merge time → wait → check once at the
+reminder checkpoint and send at most one reminder if still silent → wait to the
+deadline, plus one bounded grace window if someone is demonstrably mid-review →
+report. A list is **one** ask: one ping, one deadline, one reminder, one report
+that breaks down per PR. This skill only ever produces a **report** — the merge
+decision stays with a human, made outside this skill, every time.
 
 This is the missing middle of the review loop: `open-pr` creates the PR and
 stops; `pr-review` is the reviewer performing a review; `revise-pr` is the
 author closing out threads afterward. Nothing today owns "did anyone actually
 pick this up" — silence reads identically whether a reviewer is mid-review or
-not looking at all, and the parts that make an ask work (a one-click ack, a
-stated deadline, an escape hatch for late review, named entry points into a
-large diff) are exactly what get dropped when the ask is typed by hand.
+not looking at all, and the parts that make an ask work (one unambiguous ack, a
+stated merge time, an escape hatch for late review) are exactly what get dropped
+when the ask is typed by hand.
+
+Two things this skill deliberately does **not** do, both of them things an earlier
+version did: it does not brief the reviewer (that's the PR body's
+`## Review focus`), and it does not accept "any signal at all" as an ack. The
+second was the more expensive mistake — accepting a reaction *or* a reply *or* any
+comment meant no state distinguished "someone is reading this right now" from
+"nobody has looked", so a second person with approval rights had no way to tell
+whether merging would cut across a review in flight.
 
 ## One-time setup
 
@@ -44,6 +53,16 @@ identifiers, and nothing can infer the link, so it must be declared. If
 `.claude/pr-ready.local.json` is missing, stop and point at this section; do
 not guess a channel or roster.
 
+**`ack_reactions` must contain the emoji your reviewers actually send.** It is an
+allowlist, so an entry that nobody uses is inert and an emoji in use that is
+missing from it is invisible — the predicate reports SILENT while the reaction sits
+on the message in plain sight, and the reminder fires at people who already
+answered. The example ships `["+1", "thumbsup"]` because 👍 is what reviewers
+reach for unprompted; `thumbsup` is Slack's alias for the same glyph and both
+spellings appear in the API depending on how it was sent, so keep both. Before
+trusting a SILENT verdict on a checkout you didn't configure, read the channel and
+check what emoji are actually on the ping.
+
 ## Non-goals — read before running
 
 - **This skill never changes what a PR can do next.** Its terminal state is
@@ -59,7 +78,18 @@ not guess a channel or roster.
   outlives it. A scheduled/headless variant is a different tool, not this one.
 - **At most one reminder, ever**, regardless of how long the wait runs — and
   one per *ask*, not one per PR. A list of three PRs is one ping, one
-  checkpoint, one reminder, one report.
+  checkpoint, one reminder, one report. The Phase 5.1 grace extension posts
+  nothing at all.
+- **The ping carries no review guidance.** Where to look lives in the PR body's
+  `## Review focus` (`open-pr` Step 5), never in the chat message. This skill
+  asks for attention; it does not brief the reviewer, and it must not grow a
+  summary or a file list back into the template.
+- **One asked-for signal: 👍.** No second emoji convention for "I'm reviewing" —
+  that state is detected from GitHub (`/pr-review` posts 👀 when a review starts),
+  so it costs a reviewer nothing to emit and cannot fall out of use.
+- **No indefinite hold.** A claim buys exactly one grace window measured from the
+  claim itself, and then the run terminates with a report. There is no state in
+  which this skill waits forever for a reviewer who went quiet.
 - **No cross-PR judgement.** With a list, this skill reports which PRs were
   acked and which weren't. It does not rank them, decide which deserves review
   first, or drop one for being less important — the order is the author's, and
@@ -287,6 +317,15 @@ Falling through to Phase 4 in that state posts a reminder quoting a deadline
 that already elapsed, which reads as noise to every reviewer it @-mentions. If
 the deadline is still ahead, continue to Phase 3 as normal.
 
+**This shortcut deliberately ignores the grace window** — it compares against the
+base `default_deadline_minutes` only, and reports even if a claim's
+`hold_grace_minutes` has not run out. That is the right call for an adopted ping:
+the original session's wait already ended when that session closed, so there is no
+wait in progress to resume, and re-entering one would restart a clock the
+reviewer never agreed to. Phase 6 still reports the claim as REVIEWING with its
+timestamp, so the author sees the in-flight review — they just get the report now
+instead of after another wait.
+
 Use `slack_read_channel`, not a search tool. `slack_search_public` covers
 public channels only, and its consent-gated sibling can be declined — either
 way a private-channel run would silently have **no** existing-ping check and
@@ -297,40 +336,50 @@ If no existing ping is found, compose the message from the fixed template —
 but do not send it yet:
 
 ```
-:mag: Review requested — <PR title, or "<n> PRs" when the ask covers a list>
+:mag: Review requested
 
-<for EACH eligible PR, in the order given:>
+<for EACH eligible PR, in the order given — exactly two lines each:>
 *<PR title>* (<+adds/-dels>, <n> files)
 <PR url>
-<1–2 sentence summary: what changed and why it's worth a look>
-- `<path 1>` — <the question to ask of it>
-- `<path 2>` — <the question to ask of it>
 
 <@reviewer 1> <@reviewer 2>
 
-*Ack:* react <ack emoji — render from the config's `ack_reactions`, not a
-fixed list> on this message, reply in the thread, or leave any comment/review
-on any of the PRs — any of those counts.
-*Deadline:* <absolute local time, e.g. "Thu Jul 24, 4:30 PM PT">. Review after
-the deadline still counts — findings become issues, treated the same as PR
-comments. (One reminder at most, and only while my session stays open — no
-bot is watching this thread.)
+Merging *<absolute local time, e.g. "Thu Jul 24, 4:30 PM PT">* — late findings
+still welcome, they become issues.
+*React :+1: if you'll review before then* — that's the one signal I read.
+Where to look is in the PR description; `/pr-review` is the review itself.
 ```
 
-**One PR keeps one block; the shape doesn't change.** A single-PR ask renders
-exactly one of these and reads as it always did — the list case is the same
-template repeated, not a second format to maintain.
+**That is the entire message. Do not add to it.** No per-PR summary, no file
+slices, no "here's what changed and why" — every one of those was moved into the
+PR body's `## Review focus` (see `open-pr` Step 5), which is where the reviewer
+already is when they act on it. A pointer delivered in chat costs the reviewer a
+context switch to use and costs everyone else in the channel the scroll to get
+past it. The ping's only job is **"this exists, here's when it merges, say if
+you're on it."**
 
-**Every PR carries its own size and its own slices.** They are what let a
-reviewer triage the ask instead of reading it front-to-back: a one-file test
-fix and a 23-file feature want different amounts of attention, and saying so is
-what makes it reasonable to put them in one message. A list with no per-PR
-slices is just a pile of links, and it costs the reviewer the very thing this
-message exists to give them — a place to start.
+**One PR keeps its two lines; the shape doesn't change.** A single-PR ask renders
+one title/url pair; a list renders several. Same template either way.
 
 **Order the blocks as the user passed them** (Input), and don't fold two PRs
 into one block even when they're related — each needs its own URL on its own
 line, because the ack predicate and the report both key off individual PRs.
+
+**Render the ack emoji from the config's `ack_reactions`, not a fixed list**, and
+name exactly one — the message asks for a single unambiguous signal, so listing
+three alternatives reintroduces the ambiguity this template exists to remove.
+Render the first entry; the predicate still accepts every entry (`thumbsup` is
+just Slack's alias for `+1`, and a reviewer may send either).
+
+**Why the ask is 👍 and nothing else.** The old template accepted a reaction *or*
+a thread reply *or* any comment on any PR — "any of those counts". That made the
+absence of a signal unreadable: silence and mid-review looked identical, so
+nobody could tell whether an approval was still coming. One asked-for signal, with
+one stated meaning, is the fix. **Do not ask reviewers for a second emoji to mean
+"I'm reviewing"** — that state is now detected from GitHub without anyone opting
+in (see the ack predicate: `/pr-review` posts 👀 on the PR when a review starts).
+Asking humans to hand-maintain a signal a machine already emits is how conventions
+die.
 
 Render `*Deadline:*` as an absolute local time, not a duration — "in 90
 minutes" is useless to someone reading the message an hour later. Compute it
@@ -397,9 +446,9 @@ ping sorts as after it, and the skill reports an ack nobody gave — the exact
 "silence counted as engagement" this skill exists to prevent. The `||` is the
 same BSD-vs-GNU portability pair as the deadline render above.
 
-Both the reactions list and the review slices come from the config /
-diff — never invent placeholder reviewers or slices if the config or diff
-doesn't supply them; ask instead.
+The reviewer mentions and the ack emoji come from the config, and the sizes come
+from the diff — never invent a placeholder reviewer or a made-up size; ask
+instead.
 
 ### Phase 3: Wait to the reminder checkpoint
 
@@ -416,6 +465,11 @@ a team can nudge at 60 of 90 minutes rather than at some fixed midpoint. Assert
 stop if it doesn't hold: a checkpoint at or past the deadline means Phase 3
 falls through, Phase 4 fires the reminder, and Phase 5's wait is already over —
 the reminder and the report land together, which is not a reminder at all.
+
+Assert `hold_grace_minutes > 0` in the same place, and default it to 60 if the
+key is absent (an older config predates it). A zero or negative grace makes
+Phase 5.1's extension a no-op while still reporting a claim as held, so the
+report would promise a wait that never happened.
 
 A Slack `ts` is **already epoch seconds** with a fractional part
 (`1721862000.123456`) — no date parsing is involved, and none should be
@@ -455,12 +509,13 @@ manually. When it returns, proceed to Phase 4.
 
 ### Phase 4: Check + at most one reminder
 
-Evaluate the **ack predicate** (below). If acked, skip straight to Phase 6
-and report who. If still silent, compose the reminder — a short "still open,
-deadline is `<time>`" message — and **confirm it the same way as the Phase 2
-ping**: show the exact text and wait for an explicit go-ahead, since
-`reply_broadcast` puts it in the shared channel, not just the thread. Use
-`slack_send_message_draft` if the user hasn't reviewed the text.
+Evaluate the **ack predicate** (below). If **any** state above SILENT was
+reached, skip straight to Phase 6 and report who and which. If still SILENT,
+compose the reminder — a short "still open, merging `<time>`" message — and
+**confirm it the same way as the Phase 2 ping**: show the exact text and wait
+for an explicit go-ahead, since `reply_broadcast` puts it in the shared channel,
+not just the thread. Use `slack_send_message_draft` if the user hasn't reviewed
+the text.
 
 **With a list, the reminder fires only when NOTHING has been acked** — no chat
 ack on the ping, and no post-ping GitHub activity on **any** listed PR. Once a
@@ -469,6 +524,11 @@ says "you still haven't looked at #605" to someone who just reviewed #606 reads
 as being chased, not nudged. Chasing the remaining PRs is the author's call,
 made from the Phase 6 report with a name attached — not something a skill
 should do automatically to a person who already showed up.
+
+**ACKED suppresses the reminder without moving the deadline.** That is the whole
+point of the state: the reminder's job is to break silence, and a 👍 broke it, so
+re-asking is pure noise — but a promise is not evidence of reading, so it buys no
+time. The deadline in the reminder-suppressed case is still the original one.
 
 When it does fire, the reminder **names only the still-unacked PRs**, which in
 this branch is all of them; it never re-lists a PR that has activity, even
@@ -501,92 +561,212 @@ validates its own input instead of trusting a caller — a bad `PING_TS` that
 slipped through would put the checkpoint in Jan 1970 and drop straight through
 the loop.
 
+#### Phase 5.1: The grace extension — at most one
+
+When the loop returns, re-evaluate the predicate. If **any** PR reached
+**REVIEWING** (input 3 or 4) and **no** review has been submitted yet, extend
+once — `hold_grace_minutes` measured from the **earliest claim's** `created_at`,
+not from now:
+
+```bash
+CLAIM_ISO="<the earliest REVIEWING created_at, UTC Z-form>"
+CLAIM_EPOCH=$(date -u -j -f %Y-%m-%dT%H:%M:%SZ "$CLAIM_ISO" +%s 2>/dev/null \
+           || date -u -d "$CLAIM_ISO" +%s)          # BSD/macOS, then GNU
+GRACE_EPOCH=$(( CLAIM_EPOCH + <hold_grace_minutes>*60 ))
+if [ "$GRACE_EPOCH" -gt "$(date +%s)" ]; then
+  until [ "$(date +%s)" -ge "$GRACE_EPOCH" ]; do sleep 60; done
+fi
+```
+
+**From the claim, not from now** — measuring from the current moment lets a claim
+that landed one minute after the ping buy the *full* grace on top of the *full*
+deadline. From the claim, a reviewer who started early has usually already spent
+their window by the time the deadline arrives, and the `-gt` test skips the wait
+entirely in that case.
+
+**Extend exactly once, ever.** Do not re-check for new claims after the grace
+loop and extend again — a window that renews on each check is an indefinite hold
+with extra steps, and an indefinite hold is the thing this design refuses. If the
+grace lapses with still no submitted review, that is the terminal state
+`HELD BUT STALE`, and Phase 6 reports it with the claimant's login so the author
+has a specific person to nudge rather than an open-ended wait.
+
+**No message is posted at the grace boundary.** The reminder budget is one per
+ask and Phase 4 owns it; a second "still waiting?" is exactly the chasing this
+skill refuses to do to someone who demonstrably showed up.
+
 Then Phase 6.
 
 ### Phase 6: Final check + report
 
-Re-evaluate the ack predicate one last time and print a terminal summary:
-acked or not, by whom and through which channel (reaction / thread reply /
-GitHub activity), each PR's current `state`/`mergeable`/check status, and the
-author's options ("nobody's engaged — nudge directly, extend the deadline, or
-proceed with your own judgment"). Stop there. Nothing after this phase runs
-automatically.
+Re-evaluate the ack predicate one last time and print a terminal summary: the
+state reached per PR, by whom and through which signal, each PR's current
+`state`/`mergeable`/check status, and the author's options. Stop there. Nothing
+after this phase runs automatically.
 
-**With a list, report per PR — one row each, never one verdict for the set.**
+**Report per PR — one row each, never one verdict for the set.**
 
-| PR | Acked by | How | State / checks |
-|---|---|---|---|
-| #606 | `<login>` | GitHub review comment | OPEN / green |
-| #605 | — | — | OPEN / green |
+| PR | State | Who | Signal | Since | State / checks |
+|---|---|---|---|---|---|
+| #606 | REVIEWED (`APPROVED`) | `<login>` | submitted review | 15:42 | OPEN / green |
+| #607 | REVIEWING | `<login>` | 👀 on the PR | 16:10 | OPEN / green |
+| #608 | HELD BUT STALE | `<login>` | 👀 at 14:05, grace lapsed 15:05 | — | OPEN / green |
+| #605 | SILENT | — | — | — | OPEN / green |
+
+Above the table, on their own line, name the **ask-level** acks — a 👍 or a thread
+reply on the ping. They say someone picked up the ask, but they cannot say which
+PR they picked up, and the table must not imply otherwise by attributing them to
+a row.
 
 A rolled-up "2 of 3 acked" hides exactly the thing the author needs to act on:
 *which* PR is still unread, and *who* has already spent attention elsewhere and
-shouldn't be asked again first. Name the ask-level chat acks (a reaction or
-thread reply on the ping) in their own line above the table — they say someone
-picked up the ask, but they cannot say which PR they picked up, and the table
-must not imply otherwise by attributing them to a row.
+shouldn't be asked again first.
+
+**Then state the author's options, keyed to the worst state in the table** — and
+state them as options, never as a recommendation to merge:
+
+- any **SILENT** → "nobody engaged on #N — nudge directly, re-run with a later
+  deadline, or proceed on your own judgment."
+- any **REVIEWING** → "`<login>` is mid-review on #N as of `<time>`. Merging now
+  discards work someone is actively doing."
+- any **HELD BUT STALE** → "`<login>` started #N at `<t>` and posted nothing by
+  `<t+grace>` — ask them directly whether they're still on it."
+- **REVIEWED / `CHANGES_REQUESTED`** → "#N has requested changes; that is a
+  blocking review, not an ack to merge past."
+
+**The merge decision is still not this skill's, in any state.** Even an
+all-`APPROVED` table is a report that approvals exist, not an instruction — see
+Non-goals.
 
 **Repeat the Phase 1 exclusions below the table**, with their reasons. The
 report is the artifact that outlives the session; a table of three PRs that
 never mentions the fourth reads as complete coverage of what was asked.
 
+**Say that the wait was session-bound here**, since the ping no longer carries
+that caveat: the deadline held only while this session stayed open, and no bot
+was watching the thread after it closed.
+
 ## The ack predicate
 
-Acked if **any** of the following holds for **any** configured reviewer,
-**timestamped strictly after the ping**:
+Every input below counts only for a **configured reviewer** and only when
+**timestamped strictly after the ping**. What differs is *which of three states*
+each input establishes.
 
-**Two scopes, and the difference is not cosmetic.** Inputs 1 and 2 are
-**ask-level**: a reaction or a thread reply lands on the *ping*, which names
-every PR in the list, so nothing about it identifies which PR the reviewer
-opened. Input 3 is **per PR**: it reads that PR's own activity. So evaluate
-input 3 once per listed PR and keep the results separate, and never spread an
-ask-level ack across the rows — a 👀 means "I'm on it", not "I read all three".
-Phases 4 and 6 consume the two scopes differently: the reminder needs the union
-(has *anything* been acked?), the report needs them apart (which PR is still
+### Three states, not one boolean
+
+| State | Established by | Effect on the deadline |
+|---|---|---|
+| **SILENT** | nothing | reminder fires at the checkpoint; deadline stands |
+| **ACKED** | input 1 (👍 on the ping) or input 2 (thread reply) | reminder suppressed; **deadline unchanged** |
+| **REVIEWING** | input 3 (👀 on the PR) or input 4 (a post-ping PR comment) | **one** grace extension of `hold_grace_minutes` from the claim |
+| **REVIEWED** | input 5 (a submitted review) | terminal — the ask worked |
+
+The states are ordered; report the **strongest** one reached per reviewer. A 👍
+followed by a real review reports as REVIEWED, not both.
+
+**Why ACKED does not move the deadline.** A 👍 is a promise, and a promise is
+exactly enough to stop the nagging — the reminder exists to break silence, and the
+silence is broken. It is not evidence that any reading has happened, so it must
+not buy time. Only input 3/4 — evidence a review is genuinely underway — earns the
+grace window. Collapsing the two would let a one-second reaction extend every
+deadline indefinitely, which is the failure mode the deadline exists to prevent.
+
+**Grace is one-shot, never rolling.** Extend from the *first* claim only. If the
+window lapses with no submitted review, that is its own reportable state:
+`HELD BUT STALE — <login> started at <t>, nothing posted by <t+grace>`. Naming the
+person is the point — the author now has a specific human to nudge instead of an
+open-ended wait. Never extend a second time; a hold that renews itself on every
+check is an indefinite hold with extra steps.
+
+### Two scopes, and the difference is not cosmetic
+
+Inputs 1 and 2 are **ask-level**: a reaction or a thread reply lands on the
+*ping*, which names every PR in the list, so nothing about it identifies which PR
+the reviewer opened. Inputs 3–5 are **per PR**: they read that PR's own activity.
+So evaluate them once per listed PR and keep the results separate, and never
+spread an ask-level ack across the rows — a 👍 means "I'm on it", not "I read all
+three". Phases 4 and 6 consume the scopes differently: the reminder needs the
+union (has *anything* been acked?), the report needs them apart (which PR is still
 unread, and who is already busy elsewhere?).
 
 1. **A reaction on the ping message**, from that reviewer's `chat_id`, whose
-   emoji is in the config's `ack_reactions` allowlist.
+   emoji is in the config's `ack_reactions` allowlist. → **ACKED**
    > **Chat seam.** `slack_get_reactions` on the ping's `channel_id` +
    > `message_ts`; check the `users` list under each allowlisted emoji for the
    > reviewer's `chat_id`. A reaction can only exist on a message that already
    > posted, so it is inherently after the ping — no separate timestamp check
    > needed. Caveat: each emoji's `users` list is truncated at 50, so on a
    > heavily-reacted message a reviewer's ack can fall outside it — treat a
-   > miss there as inconclusive, not as "not acked", and let inputs 2 and 3
+   > miss there as inconclusive, not as "not acked", and let inputs 2–5
    > decide.
 2. **Any threaded reply on the ping**, from that reviewer's `chat_id`.
+   → **ACKED**
    > **Chat seam.** `slack_read_thread` on the ping's `channel_id` +
    > `message_ts`; any reply whose `user` is the reviewer's `chat_id` counts.
    > Same reasoning — a thread reply cannot predate its parent.
-3. **Any PR activity by that reviewer's `gh_login`** — a review of any state,
-   a review comment, or an issue-level PR comment — with a timestamp after
-   the ping's wall-clock time (`PING_ISO`, the UTC Z-form value pinned once in
-   Phase 2 when the `ts` is recorded or adopted — reuse it for every
-   comparison, and never re-derive it in local time here).
 
-   Both exclusions below are already folded into these three commands — run
-   them as written, don't strip the `select(...)`. **Run all three per listed
-   PR**, tagging each result with its `<PR_NUM>` so the Phase 6 table can
-   attribute it; a flat merged list answers "did anyone review anything", which
-   is the one question the report is not allowed to stop at:
+Inputs 3–5 are GitHub, evaluated **per listed PR**, and every one of them
+compares against `PING_ISO` — the UTC Z-form value pinned once in Phase 2 when
+the `ts` is recorded or adopted. Reuse it for every comparison; never re-derive
+it in local time here. Both exclusions described below are already folded into
+the commands — run them as written, don't strip the `select(...)`. **Tag every
+result with its `<PR_NUM>`** so the Phase 6 table can attribute it; a flat merged
+list answers "did anyone review anything", which is the one question the report is
+not allowed to stop at.
+
+3. **A 👀 reaction on the PR** from that reviewer's `gh_login`, created after
+   the ping. → **REVIEWING** (starts the grace window at its `created_at`)
 
    ```bash
-   gh api repos/$REPO/pulls/<PR_NUM>/reviews \
-     --jq ".[] | select(.user.type != \"Bot\" and .user.login != \"$AUTHOR\") | {login:.user.login, at:.submitted_at}"
+   gh api "repos/$REPO/issues/<PR_NUM>/reactions" --paginate \
+     --jq ".[] | select(.content == \"eyes\" and .user.type != \"Bot\" and .user.login != \"$AUTHOR\") | {login:.user.login, at:.created_at}"
+   ```
+
+   **This is the machine-emitted claim, and it is the reason this skill asks
+   humans for only one signal.** `/pr-review` posts this reaction at Step 0.6, the
+   moment a review actually starts — so "someone is reading this right now" is
+   detected from a byproduct of the work instead of from a convention a reviewer
+   has to remember. Nothing else on GitHub reports it: a *pending* review is
+   invisible to everyone but its author.
+
+   `issues/` is correct — reactions on a PR's top-level body live on the issues
+   endpoint; `pulls/<N>/reactions` 404s.
+
+   **The `created_at > PING_ISO` filter is what keeps this honest.** The reaction
+   is never removed once posted, so last week's review leaves a 👀 sitting on the
+   PR forever. Without the timestamp filter, every re-run of this skill against
+   that PR would read a months-old marker as a live hold and extend the deadline
+   for a review nobody is doing.
+
+4. **A post-ping comment by that reviewer** — a review comment on the diff, or an
+   issue-level comment on the PR. → **REVIEWING**
+
+   ```bash
    gh api repos/$REPO/pulls/<PR_NUM>/comments \
      --jq ".[] | select(.user.type != \"Bot\" and .user.login != \"$AUTHOR\") | {login:.user.login, at:.created_at}"
    gh api repos/$REPO/issues/<PR_NUM>/comments \
      --jq ".[] | select(.user.type != \"Bot\" and .user.login != \"$AUTHOR\") | {login:.user.login, at:.created_at}"
    ```
 
-   Then keep only rows whose `at` is later than `PING_ISO`, and whose `login`
-   equals a configured reviewer's `gh_login`. Both sides are UTC Z-form of the
-   same width, so a plain string `>` is a correct time comparison — that is the
-   only reason no date parsing is needed on this path.
+5. **A submitted review by that reviewer**, of any state. → **REVIEWED**
+
+   ```bash
+   gh api repos/$REPO/pulls/<PR_NUM>/reviews \
+     --jq ".[] | select(.user.type != \"Bot\" and .user.login != \"$AUTHOR\") | {login:.user.login, at:.submitted_at, state:.state}"
+   ```
+
+   Carry the `state` through to the report: `APPROVED`, `CHANGES_REQUESTED`, and
+   `COMMENTED` are all REVIEWED for this skill's purposes — the ask worked — but
+   they mean very different things for what the author does next, and the report
+   is where that distinction has to survive.
+
+For 3–5, keep only rows whose `at` is later than `PING_ISO` and whose `login`
+equals a configured reviewer's `gh_login`. Both sides are UTC Z-form of the same
+width, so a plain string `>` is a correct time comparison — that is the only
+reason no date parsing is needed on this path.
 
 **Why those two `select(...)` clauses are there** — they are the exclusions,
-and they must stay inside every one of the three queries above. Filtering
+and they must stay inside every one of the queries above. Filtering
 "afterwards, by eye" is how the author's own comment gets counted as an ack:
 
 - **Bots** — `.user.type == "Bot"` (the checks app, the deploy-preview bot,
@@ -658,7 +838,11 @@ be added later, not as work to do now.
   than starting the deadline over.
 - **Ack predicate can't reach GitHub** (rate limit, auth) → report that the
   GitHub half of the predicate couldn't be evaluated and fall back to the
-  chat-only signals; don't report "not acked" on a check that didn't run.
+  chat-only signals; don't report "not acked" on a check that didn't run. Note
+  specifically that **REVIEWING and REVIEWED are undetectable in this state** —
+  inputs 3–5 are all GitHub — so the run can distinguish only SILENT from ACKED,
+  and no grace extension can be granted. Say that rather than reporting SILENT,
+  which would read as "nobody looked" when the truth is "nobody could check."
 
 ## Rules
 
@@ -675,10 +859,23 @@ be added later, not as work to do now.
   state is always a report, and the decision that follows it is a human's,
   made outside this skill.
 - **At most one reminder per run**, regardless of how long the wait runs, and
-  regardless of how many PRs the run covers.
-- **The wait is session-bound.** Say so in the ping and in the report — this
-  is not a durable/background timer, and closing the session cancels
-  whatever wait phase is in flight.
+  regardless of how many PRs the run covers. The grace extension is silent.
+- **Keep the ping short and signal-only.** Two lines per PR, the mentions, the
+  merge time, the 👍 ask. Review guidance belongs in the PR body — a reviewer
+  who has to read a chat message to know where to look pays a context switch to
+  use it, and everyone else in the channel pays the scroll.
+- **One human signal, one meaning.** Ask for 👍 and nothing else; detect
+  "reviewing" from GitHub rather than asking for it. An allowlist that omits the
+  emoji people actually send reports SILENT while the reaction sits in plain
+  sight — check `ack_reactions` against real channel behaviour before trusting a
+  silent verdict.
+- **A claim extends once, from the claim.** `hold_grace_minutes` measured from the
+  earliest 👀/comment, never from now, never renewed. Then report — `HELD BUT
+  STALE` names the person to nudge instead of waiting on them indefinitely.
+- **The wait is session-bound.** Say so in the report — this is not a
+  durable/background timer, and closing the session cancels whatever wait phase
+  is in flight. (It is deliberately *not* in the ping any more; the ping is for
+  reviewers, and this is the author's operational caveat.)
 - **Idempotent posting.** Always scan the channel for an existing ping
   (Phase 2, via `slack_read_channel`) before sending a new one; adopt it and
   resume instead of double-posting. With a list, adopt only on an **exact**

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,19 +1,41 @@
 ---
 name: pr-review
-description: Review an offlinecv pull request the way a maintainer does — pull the diff, run the generic /code-review correctness pass, then layer offlinecv's own gates (fixture PII, design-system reuse, style tokens, fallow dead-code, command-level bugs in skill/script files), structure the findings Blocking / Secondary / Nits, and post a PR review whose verdict matches what was found. Use when the user says "review PR #N", "/pr-review", "review this PR", or hands you a PR to critique before merge.
+description: Review an offlinecv pull request adversarially, the way a maintainer does — signal 👀 that review started, judge the diff against the linked issue's acceptance criteria, run the generic /code-review correctness pass, layer offlinecv's own gates (fixture PII, design-system reuse, style tokens, fallow dead-code, command-level bugs in skill/script files), then read the PR description LAST and audit it for claims the code doesn't back, structure the findings Blocking / Secondary / Nits, and post a PR review whose verdict matches what was found. Use when the user says "review PR #N", "/pr-review", "review this PR", or hands you a PR to critique before merge.
 argument-hint: <#|#N> [--repo owner/repo] [--post|--local] [--effort low|medium|high]
 ---
 
 # Review PR
 
 Take an offlinecv PR from "someone opened it" to "a maintainer-grade review is on
-the thread": check out the diff → run the built-in `/code-review` for the generic
-correctness pass → **layer the offlinecv-specific gates** → structure findings
+the thread": check out the diff → **signal that review started** → read the
+**issue**, not the PR's prose → run the built-in `/code-review` for the generic
+correctness pass → **layer the offlinecv-specific gates** → **then** read the PR
+description and audit it against what the code actually does → structure findings
 **Blocking / Secondary / Nits** → draft the review → confirm → post a `gh` PR
 review whose **verdict matches the findings**.
 
 This is the **reviewer-side** sibling of the author-side loop: `open-pr` creates
 the PR, `revise-pr` addresses the review — this skill *is* the review in between.
+
+## The review is adversarial — read the description LAST
+
+**The spec is the issue. The code is the evidence. The PR description is a claim
+to falsify.** That ordering is the whole stance, and it is not a formality:
+
+A description read *first* becomes the map — you check the three things it points
+at, find them fine, and approve. Every defect it failed to mention is now
+invisible, and the author's blind spots have silently become the reviewer's.
+Worse, a description that *misdescribes* the change can only be caught by someone
+who formed an independent picture of the change first; read it up front and you
+will read the diff through it, confirming rather than checking. So Steps 1–3 form
+findings from the diff and the issue alone, and Step 3f is where the description
+finally gets read — as a **hypothesis to test against what you already found**,
+never as a guide to what to look at.
+
+`## Review focus` in the body is subject to exactly the same treatment. It is the
+author's guess at where the risk is: a useful lead, and a real signal when it
+turns out to be wrong. **A review that visits only the files it names is not a
+review.**
 
 ## Why this skill exists
 
@@ -57,6 +79,96 @@ gh pr view "$PR_NUM" --repo "$REPO" \
 
 If the PR is not `OPEN`, stop and say so. Note the **author login** — it tunes the
 review stance (see the careful-review note in Rules).
+
+**Note what this call deliberately does not fetch: `body`.** The field list above
+is title/state/refs/author/files and nothing else, so the PR's prose never enters
+the review until Step 3f. Don't add `body` to it "while you're there."
+
+### Step 0.5 — Read the issue, not the PR's prose
+
+The linked issue is the spec this PR is judged against. Get the issue *numbers*
+without pulling the description's prose into the review — pipe the body straight
+through a matcher so only digits come back:
+
+```bash
+# auto-closing links, resolved by GitHub itself
+gh pr view "$PR_NUM" --repo "$REPO" --json closingIssuesReferences \
+  -q '.closingIssuesReferences[].number'
+# plus partial links GitHub does not resolve (`Refs #N`), matched out of the body
+gh pr view "$PR_NUM" --repo "$REPO" --json body -q .body \
+  | grep -oiE '\b(closes|fixes|resolves|refs?):? +#[0-9]+' | grep -oE '[0-9]+' | sort -u
+```
+
+**The `grep` is load-bearing, not decoration.** You cannot un-read prose once it
+is in the transcript, so the discipline has to be enforced at the tool boundary
+rather than by intention: piping through `grep -o` means the tool result is a list
+of numbers and the description is never rendered. Run it as written — a bare
+`--json body` here defeats the entire ordering rule three steps before Step 3f.
+
+**The `:?` covers the colon form** — `Closes: #123` is valid GitHub syntax and the
+whitespace-only pattern misses it. For the *closing* keywords that costs nothing
+in practice, since GitHub's own resolver picks them up and they arrive via
+`closingIssuesReferences` above; the two commands are belt-and-braces and their
+union covers it. The one shape that falls through **both** is `Refs: #N` — a
+non-closing keyword in colon form, which GitHub never resolves. `closes#789`
+staying unmatched is correct: GitHub doesn't accept that form either.
+
+Then read each issue in full, and write down its acceptance criteria before you
+look at any code:
+
+```bash
+for N in $ISSUE_NUMS; do gh issue view "$N" --repo "$REPO" --comments; done
+```
+
+Carry those ACs into Step 4 as a checklist. **An unimplemented AC on a PR that
+says `Closes #N` is Blocking** — the merge closes the issue, so the gap ships as
+"done" and nothing will ever re-open it. If the PR links no issue at all, say so
+in the report and review against the diff alone; don't invent a spec.
+
+### Step 0.6 — Signal that the review has started
+
+Post a 👀 reaction on the PR. Do this **now**, before the slow work, not at the
+end — its entire value is telling everyone else that this PR is being read *while*
+you read it:
+
+```bash
+gh api "repos/$REPO/issues/$PR_NUM/reactions" -f content=eyes --silent
+```
+
+No confirmation needed for this one write (it is the exception to the
+confirm-before-posting rule): it is a single reversible reaction, it notifies
+nobody, and it carries no prose that could be wrong. Say you posted it in the
+Step 7 report.
+
+`issues/` is correct — reactions on a PR's top-level body go through the issues
+endpoint; `pulls/$PR_NUM/reactions` does not exist and 404s. Re-reacting is
+idempotent (GitHub returns the existing reaction), so a re-run of this skill will
+not double-post or fail.
+
+**Why this reaction exists.** `pr-ready` reads it as the machine-emitted "someone
+is actually reviewing this" signal, and extends its deadline by a grace window
+when it sees one. Nothing else on GitHub carries that information: a *pending*
+review is invisible to everyone but its author, and the alternatives that are
+visible (a `COMMENT` review, a label, a self-assign) all cost a notification or a
+repo-config change to say the same thing. Leave the reaction in place when the
+review is submitted — it is then a permanent marker of who read this PR, and
+`pr-ready` only counts reactions newer than its own ping, so a stale one from an
+earlier cycle can never read as a live hold.
+
+A review abandoned *within* a cycle is the case that filter doesn't cover — Step
+0.6 posts 👀 before the slow work, so a run that dies, or one where the user
+declines to post at Step 6, leaves a reaction genuinely newer than the ping that
+does read as `REVIEWING`. That is bounded rather than unhandled: `pr-ready` grants
+one grace window from the claim and then reports `HELD BUT STALE` with your login.
+It is also the honest argument for posting 👀 early and unconfirmed — an abandoned
+claim degrades to naming a person to nudge, which beats a reaction that is
+worthless because it landed after the review was already done.
+
+**Honest limit, so nobody over-trusts it:** 👀 does not *block* anything. `main`
+requires one approving review, and any approver can merge over a 👀. The only
+merge-blocking signal GitHub offers is `REQUEST_CHANGES`, which is far too heavy
+to mean "wait for me." This is a social hold that `pr-ready` surfaces by name, not
+enforcement.
 
 ### Step 1 — Get the diff onto disk
 
@@ -199,6 +311,41 @@ shown command for:
 Severity: a bug that fires on **normal** invocation → **Blocking**; one that fires
 only on an edge (bad `--order`, partial-failure re-run) → **Secondary/Nit**.
 
+#### 3f — Description accuracy (the LAST gate — read the body only now)
+
+Your findings are formed. **Now** read the PR description, and audit it as a claim
+about a change you already understand:
+
+```bash
+gh pr view "$PR_NUM" --repo "$REPO" --json body -q .body
+```
+
+Take every checkable statement in `## Summary`, `## Review focus`, and
+`## Test plan` and round-trip it to the diff you just read:
+
+| Finding | Severity |
+|---|---|
+| Claims a behaviour the code does not implement | **Blocking** |
+| `Closes #N` while an AC of #N is unimplemented (Step 0.5) | **Blocking** |
+| Test plan box ticked for a gate that demonstrably didn't run or isn't green | **Blocking** |
+| Omits a behaviour change the diff makes — especially one outside the stated scope | **Secondary** |
+| Describes the change accurately but the *rationale* is wrong (cites a constraint that doesn't exist) | **Secondary** |
+| `## Review focus` points at a file the diff barely touches, or misses the riskiest hunk | **Nit** |
+
+**A wrong description is a real defect, not a documentation nit.** It is the
+artifact the next reader — a bisecting maintainer, a reviewer of the follow-up,
+the squash message in `main` — trusts when the code has stopped being fresh in
+anyone's mind. And a description that overclaims is how an unimplemented AC gets
+merged as `Closes`.
+
+**The asymmetry to hold onto:** the description can *add* findings, never subtract
+them. If it explains away something you found, that explanation is itself a claim
+to check against the code — not permission to drop the finding. Dropping a
+verified finding because the body says it's fine is the exact failure this gate's
+placement exists to prevent.
+
+Skip this gate only if the body is empty, and say so in the report.
+
 ### Step 4 — Structure the findings
 
 Merge `/code-review`'s findings with the gate results into three buckets. **Verify
@@ -206,9 +353,14 @@ each finding against the file first** — read the code at the cited line; drop
 anything that doesn't reproduce (a plausible-but-wrong finding erodes the whole
 review):
 
+Run the **AC checklist from Step 0.5** here as its own pass: for each acceptance
+criterion of each linked issue, point at the code that satisfies it or record it as
+unmet. An unmet AC under a `Closes #N` is Blocking (3f).
+
 - **Blocking** — must fix before merge: correctness bugs that fire on normal use,
   real PII, hardcoded colors / wrong component tier, a command bug that breaks every
-  invocation, a missing gate CI will fail on.
+  invocation, a missing gate CI will fail on, an unimplemented AC under `Closes`,
+  or a description that claims behaviour the code doesn't have.
 - **Secondary** — a consistent pattern worth fixing but not a merge-blocker; prose
   vs behaviour mismatches; edge-case bugs.
 - **Nits** — style, idempotency niceties, doc polish. Explicitly labelled
@@ -319,15 +471,29 @@ and stop.
 ### Step 7 — Report
 
 Print: the verdict + the rule that produced it, the finding counts
-(Blocking/Secondary/Nits), **how many landed inline vs stayed in the body** (and why
-the body ones had no anchor), the head SHA reviewed, which gates ran vs were skipped,
-and the review URL (or "local only"). If any gate couldn't run (missing `pdftotext`,
+(Blocking/Secondary/Nits), **the AC checklist result per linked issue** (met /
+unmet / no issue linked), **the 3f description-accuracy verdict** (accurate /
+overclaims / omits — with what), **how many landed inline vs stayed in the body**
+(and why the body ones had no anchor), that the 👀 start-signal was posted
+(Step 0.6), the head SHA reviewed, which gates ran vs were skipped, and the review
+URL (or "local only"). If any gate couldn't run (missing `pdftotext`,
 `fallow` not installed), say so — a skipped gate is not a passed gate. If you fell
 back to body-only after a `422`, say that too — the author should know the anchors
 were lost to a mid-review push, not to laziness.
 
 ## Rules
 
+- **Issue first, code second, description last.** The issue is the spec, the code
+  is the evidence, the body is a claim to falsify (gate 3f). Never let the
+  description set the scope of the review, and never drop a verified finding
+  because the body explains it away — that explanation is one more claim to check.
+- **`## Review focus` is a lead, not a boundary.** Check what it names, then review
+  everything else too. A focus section that points at the wrong place is itself a
+  finding (3f), which is only visible to a reviewer who looked elsewhere.
+- **Signal the start (Step 0.6).** Post 👀 on the PR before the slow work — it is
+  the only visible "review in progress" marker GitHub has, `pr-ready` reads it, and
+  it is worthless posted at the end. It is advisory, not a merge block; don't
+  describe it as one.
 - **Wrap, don't duplicate.** `/code-review` owns the generic correctness pass; this
   skill owns the offlinecv gates + workflow + posting. Don't re-litigate what
   `/code-review` already found — fold it in.
@@ -351,7 +517,9 @@ were lost to a mid-review push, not to laziness.
 - **One `422` is information, not a puzzle.** It almost always means the author pushed
   mid-review. Re-anchor against the fresh patch once; if that fails, post body-only
   and move on. Never loop on anchoring.
-- Confirm before posting to a public PR.
+- Confirm before posting to a public PR — with one carve-out: the Step 0.6 👀
+  reaction posts unconfirmed (single reversible reaction, no notification, no
+  prose). Everything with words in it gets confirmed.
 - **Tune stance to the author** — historically complex/untested contributions get an
   extra-careful pass; don't relax the gates because a diff "looks" clean.
 - Pure `gh` + `git` + `npm`/`npx` — no external services, no machine-specific paths.

--- a/.claude/skills/revise-pr/SKILL.md
+++ b/.claude/skills/revise-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: revise-pr
-description: Revise a pull request in response to review — check out the PR branch, fix what each unresolved thread asks for (or reply explaining why not), run the gates, commit + push to the PR branch, then reply to and resolve the threads on GitHub. Use when the user says "revise the PR", "/revise-pr", "address the review comments", "fix the review feedback", "clear the comments so it's ready to merge", or a reviewer left changes to act on.
+description: Revise a pull request in response to review — check out the PR branch, fix what each unresolved thread asks for (or reply explaining why not), run the gates, commit + push to the PR branch, then reply to and resolve the threads on GitHub. Feedback can be imported from another PR (--from-pr), a single comment URL (--from-comment), or free prose (--notes), re-verified against this branch before anything is changed. Use when the user says "revise the PR", "/revise-pr", "address the review comments", "fix the review feedback", "apply another PR's review comments here", "clear the comments so it's ready to merge", or a reviewer left changes to act on.
+argument-hint: "[<pr-number>] [--repo owner/repo] [--from-pr <n>]... [--from-comment <url>]... [--notes <file>]"
 ---
 
 # Revise PR
@@ -16,8 +17,9 @@ this one closes the loop *after* review.
 
 ## Input
 
-Parse the argument for a **PR number** (`100`, `#100`) and optionally
-`--repo owner/repo`. If no PR number is given, infer it from the current branch:
+Parse the argument for a **PR number** (`100`, `#100`) — the **target**, the PR
+whose branch gets the code changes — and optionally `--repo owner/repo`. If no PR
+number is given, infer it from the current branch:
 
 ```bash
 gh pr view --json number,headRefName,state -q '{n:.number,head:.headRefName,state:.state}'
@@ -26,6 +28,61 @@ gh pr view --json number,headRefName,state -q '{n:.number,head:.headRefName,stat
 If that finds no PR for the current branch and none was passed, list open PRs and
 ask which one. Never guess.
 
+### Where the feedback comes from — three sources, not one
+
+By default the work items are the target PR's own unresolved threads. But review
+feedback does not always arrive on the PR that should carry the fix: a reviewer
+finds a pattern bug on PR #A that also exists in the sibling #B, or a review lands
+in chat, or the same defect class shows up across a batch. These flags widen the
+source without moving the target:
+
+| Flag | Source | Reply lands on |
+|---|---|---|
+| *(none)* | the target PR's unresolved threads | the target's own threads |
+| `--from-pr <N>` | every unresolved thread on PR `<N>` | `<N>`'s threads |
+| `--from-comment <url>` | one specific review thread, by comment URL | that thread |
+| `--notes <file>` | free prose — a review that arrived over chat or in person | nowhere; report only |
+
+Flags are repeatable and combine: `--from-pr 640 --from-pr 641 --notes /tmp/x.md`
+is one run. **The target PR is always the one from the argument** — an imported
+thread never redirects where the code lands.
+
+**A zero-thread run is legal.** With `--notes` or `--from-pr` supplying the work,
+the target can have no unresolved threads of its own, and that is not an error —
+say so and proceed. (The reverse is also fine: a target whose threads are all
+resolved and no import flags means there is nothing to do; report that and stop
+rather than inventing work.)
+
+Extract the PR and comment ids from a `--from-comment` URL — GitHub spells a
+review-thread comment as `…/pull/<N>#discussion_r<COMMENT_ID>`:
+
+**Shape-check the URL before extracting, not after.** `sed` passes its input
+through unchanged when the pattern doesn't match, so an unguarded extraction
+turns `https://example.com/not-a-pr` into `SRC_PR=https://example.com/not-a-pr`,
+which then lands in `repos/$REPO/pulls/$SRC_PR/comments` and 404s. That fails
+loudly and can never write to the wrong PR — but the user sees a 404 on a
+nonsense path instead of "that isn't a review-thread comment URL." Match first,
+extract second:
+
+```bash
+# https://github.com/<owner>/<repo>/pull/640#discussion_r123456789
+case "$URL" in
+  *"/pull/"*"#discussion_r"*) ;;
+  *"/pull/"*"#issuecomment-"*)
+    echo "issue-level comment, not a review thread — treat as a --notes item: $URL" >&2
+    exit 1 ;;
+  *) echo "not a review-thread comment URL: $URL" >&2; exit 1 ;;
+esac
+SRC_PR="$(sed -E 's|.*/pull/([0-9]+).*|\1|' <<<"$URL")"
+SRC_COMMENT="$(sed -E 's|.*#discussion_r([0-9]+).*|\1|' <<<"$URL")"
+```
+
+An `#issuecomment-<id>` URL is an issue-level comment, not a review thread — it
+has no thread to resolve, so treat it like a `--notes` item: usable as a work
+item, replied to via `issues/<N>/comments` if at all, never resolved. The `case`
+above rejects it by name rather than letting the extraction run and produce a
+`SRC_COMMENT` that is the whole URL.
+
 ## Why this skill exists
 
 `main` is protected with **dismiss-stale-reviews-on-push**: pushing new commits
@@ -33,6 +90,13 @@ to a PR branch *dismisses any existing approval*. So the order matters — addre
 everything in one pass, push once, then re-request review. This skill encodes
 that order so a contributor doesn't push piecemeal and burn approvals, and so
 every thread gets a visible reply (the PR-author signal norm: don't push silent).
+
+It also owns the case where the feedback isn't on this PR. A reviewer who finds a
+pattern bug on one PR of a batch has found it on all of them, but the fix belongs
+wherever the code is — so `--from-pr` / `--from-comment` / `--notes` let one run
+pull a finding in from elsewhere, re-verify it here (Step 2.5), fix it here, and
+reply *there*. Without that, the alternative is hand-copying a finding across
+branches, which loses both the re-verification and the reply.
 
 ## Process
 
@@ -61,10 +125,16 @@ command (do **not** compound it with a later `git commit` in one `&&` line — t
 `block_commit` hook evaluates the branch at the *start* of the command, so a
 compound `switch && commit` is judged on the pre-switch branch).
 
-### Step 2: Fetch the unresolved review threads
+### Step 2: Collect the work items
 
 Threads, not flat comments: only GraphQL exposes `isResolved`, the thread node
 `id` (needed to resolve), and each comment's `databaseId` (needed to reply).
+
+Run the query below **once per source PR** — the target, plus every `--from-pr`
+(and the `SRC_PR` behind a `--from-comment`, filtered to that one comment id).
+**Tag every item with the PR it came from**; the reply routing in Step 6 and the
+report both key off it, and a merged untagged list will send replies to the wrong
+thread.
 
 ```bash
 gh api graphql -f query='
@@ -87,12 +157,47 @@ query($owner:String!,$name:String!,$pr:Int!){
 ```
 
 Work only the threads where `isResolved==false`. For each, note `threadId` (to
-resolve) and `replyTo` (the first comment's `databaseId`, to reply).
+resolve), `replyTo` (the first comment's `databaseId`, to reply), and the
+**source PR number**.
+
+`--notes` items have none of those three — read the file and treat each item as a
+work item with `source: notes`. They can produce code changes like any other, but
+there is nothing to reply to and nothing to resolve.
+
+### Step 2.5: Re-verify every IMPORTED item against this branch
+
+**Skip this step for the target's own threads** — a comment on this PR is already
+about this code. It applies to everything from `--from-pr`, `--from-comment`, and
+`--notes`.
+
+An imported finding is a claim about *another* branch's code. It may be true
+there and false here: the file may not exist, the pattern may already be fixed,
+the surrounding code may make the concern moot, or the fix may have to take a
+different shape. So read the relevant code **on this branch** and classify each
+import before changing anything:
+
+| Verdict | Meaning | Do |
+|---|---|---|
+| `reproduces` | the same defect is present here | fix it |
+| `partially applies` | related but the shape differs | fix what's real; say in the reply how it differed |
+| `does not apply` | not present on this branch | **change nothing**; record the reason |
+
+**Never fix a non-reproducing import.** A finding that arrived with a reviewer's
+authority attached is the easiest kind to apply on faith, and applying it on faith
+is how a fix for #A's code becomes an unrequested, untested edit to #B — a change
+nobody reviewed, justified by a comment that was never about this file. The whole
+value of importing is that the *finding* travels; the *verdict* has to be
+re-earned here.
+
+Carry each verdict into Step 6 — a `does not apply` still gets a reply on its
+source thread, because the reviewer is owed the reason their finding was not
+acted on.
 
 ### Step 3: Address each thread
 
-For every unresolved thread, read the file at `path` (the code may have moved
-since the comment), decide, and act:
+For every work item that survived Step 2.5, read the file at `path` (the code may
+have moved since the comment — and for an import, `path` is the *source*
+branch's), decide, and act:
 
 - **Actionable change requested** → make the fix in code. Keep the diff scoped to
   what the thread asks; don't fold in unrelated cleanup.
@@ -156,12 +261,19 @@ message concatenated as `* ` bullets — which is how `fix lint` and
 So the PR should reach the queue as one commit. But **do not collapse on every
 round.** Gate it:
 
-- **Leaving any thread open** (you pushed back, or deferred to a follow-up
-  issue) → the reviewer is coming back for another round. **Keep the fixup commit
-  separate.** They need to diff *just your delta*, not re-read the whole change.
-- **Every unresolved thread is now addressed** and you're re-requesting a clean
-  approval → **collapse.** This is the last round; the branch's single commit is
-  what lands in `main`.
+- **Leaving any thread open *on the target*** (you pushed back, or deferred to a
+  follow-up issue) → the reviewer is coming back for another round. **Keep the
+  fixup commit separate.** They need to diff *just your delta*, not re-read the
+  whole change.
+- **Every unresolved thread on the target is now addressed** and you're
+  re-requesting a clean approval → **collapse.** This is the last round; the
+  branch's single commit is what lands in `main`.
+
+**Judge the gate on the target's threads only.** An imported thread left open on
+its *source* PR is the normal, correct outcome (Step 6) — it says nothing about
+whether this PR is getting another review round, and letting it block the collapse
+would strand a finished PR on a multi-commit branch waiting for a thread on a
+different PR that nobody is going to close.
 
 When the gate passes:
 
@@ -215,13 +327,43 @@ retrofit provenance you can't establish for work you didn't do.
 
 ### Step 6: Reply to each thread, then resolve what you fixed
 
-Reply on the same thread (uses `in_reply_to`, so no inline-line 422 risk):
+Reply on the same thread (uses `in_reply_to`, so no inline-line 422 risk). **The
+PR number in the path is the thread's SOURCE PR, not the target** — that is the
+one line in this skill where a merged, untagged work-list silently posts replies
+to the wrong PR:
 
 ```bash
-gh api "repos/$REPO/pulls/$PR_NUM/comments" \
+gh api "repos/$REPO/pulls/$SRC_PR/comments" \
   -f body="<concise reply: what changed + commit sha, or why deferred + issue link>" \
   -F in_reply_to="$REPLY_TO"
 ```
+
+For an imported thread, the reply must name **where** the fix landed, because the
+reader is looking at a different PR than the one that changed:
+
+> Fixed in #<target> (`<sha>`) — the same missing guard was present in
+> `src/lib/<file>.ts`. Leaving this thread open for #<source>'s own copy.
+
+**Routing by source and verdict:**
+
+| Item | Reply on | Resolve? |
+|---|---|---|
+| Target's own thread, fixed | target thread | **yes** |
+| Target's own thread, deferred / pushed back | target thread | no — leave for the reviewer |
+| Imported, `reproduces`, fixed in target | source thread | **only** if the source PR's own copy of the defect is also gone; otherwise no |
+| Imported, `does not apply` | source thread, with the reason | **no** |
+| Source PR is merged or closed | source thread (replies still work) | **never** |
+| `--notes` item | nowhere — no thread exists | n/a; report only |
+
+**Fixing a defect in #B does not resolve it in #A.** The source thread is about
+the source PR's code, which your commit did not touch — resolving it there would
+mark a live defect as handled and it would merge. Resolve a source thread only
+when the source's own copy is genuinely gone (the source PR was closed in favour
+of this one, or the code moved wholesale), and say which in the reply.
+
+Resolving another PR's thread also needs write access on that PR; a fork-based
+source will simply fail the mutation. That is non-blocking — the reply is the
+load-bearing part — but note it in the report.
 
 Then resolve **only** the threads you actually addressed or that are outdated:
 
@@ -231,13 +373,17 @@ mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved
   -f id="$THREAD_ID"
 ```
 
-- Reply to **every** unresolved thread — addressed or deferred. Silence isn't an
-  option (PR-author signal norm).
+- Reply to **every** unresolved thread — addressed, deferred, or non-reproducing.
+  Silence isn't an option (PR-author signal norm), and that includes a reviewer on
+  another PR whose finding you imported and then didn't act on.
 - Resolve threads you fixed or that are outdated. **Don't** resolve a thread where
   you pushed back or deferred — leave it open for the reviewer to close, with your
   rationale visible.
 - The reply must match what you did: "Fixed in `<sha>`" only if the code changed;
-  "Deferred to #N because …" otherwise. No claiming a fix you didn't make.
+  "Deferred to #N because …" otherwise. No claiming a fix you didn't make. For an
+  imported fix, the sha lives in a different PR — name that PR in the reply, or
+  the reviewer is sent looking for a commit that isn't on the branch they're
+  reading.
 - If `resolveReviewThread` fails (you may lack write on a fork), that's
   non-blocking — the reply is the load-bearing part. Note it in the report.
 
@@ -249,9 +395,20 @@ The push dismissed the prior approval, so ask the reviewers back:
 gh pr edit "$PR_NUM" --repo "$REPO" --add-reviewer <reviewer-login>
 ```
 
-Then report: each thread and how it was handled (fixed / answered / deferred +
-issue), the commit sha pushed, gates status (typecheck + test), and that review
-was re-requested. Link the PR.
+Then report **one row per work item**, with its source — a run that pulled from
+three places and reports one flat list leaves the author unable to tell which
+reviewer is still owed something:
+
+| Source | Item | Verdict | Handled |
+|---|---|---|---|
+| #<target> thread | `<path>:<line>` | — | fixed, resolved |
+| #<source> thread (imported) | `<path>:<line>` | reproduces | fixed in `<sha>`, replied on #<source>, left open |
+| #<source> thread (imported) | `<path>:<line>` | does not apply | replied with reason, not resolved |
+| `--notes` | "<the note>" | reproduces | fixed in `<sha>`, no thread to reply to |
+
+Plus: the commit sha pushed, gates status (typecheck + test), that review was
+re-requested, and any `resolveReviewThread` that failed for lack of write access
+on a source PR. Link the target PR.
 
 ## Rules
 
@@ -264,6 +421,16 @@ was re-requested. Link the PR.
   back for.
 - **Reply to every unresolved thread**, even deferred ones. Resolve only the ones
   you actually fixed (or that are outdated); leave pushback/deferred threads open.
+- **Feedback can come from elsewhere; the code always lands on the target.**
+  `--from-pr` / `--from-comment` / `--notes` widen the source, never the
+  destination. A run with no unresolved threads of its own is legal.
+- **Re-verify every import on this branch before touching code (Step 2.5).** A
+  finding from another PR is a claim about another branch — fix it only if it
+  reproduces here, and reply with the reason when it doesn't. A reviewer's
+  authority does not transfer across branches; the verdict has to be re-earned.
+- **Reply on the SOURCE thread, resolve only where the defect is actually gone.**
+  Fixing #A's finding in #B leaves #A's copy live — resolving it there marks a
+  real defect handled and it merges.
 - **Replies must round-trip to the code.** "Fixed in `<sha>`" requires a real
   change in that sha; otherwise say what you deferred and why.
 - **Gates are green before push** — `npm run typecheck` clean and `npm run test`


### PR DESCRIPTION
## Summary

Four coupled changes to the review loop. `pr-ready`'s ping was long enough that reviewers skimmed it, and the review pointers it carried biased the review they were meant to help. Its ack accepted "a reaction *or* a reply *or* any comment" — so silence and mid-review were indistinguishable, and a second person with approval rights could not tell whether merging would cut across someone's work.

- **`open-pr`** — optional `## Review focus` in the PR body: ≤4 entries, phrased as questions, omitted when the risk is obvious. Review pointers now live where the reviewer already is.
- **`pr-ready`** — ping cut to two lines per PR + mentions + merge time + one asked-for signal (👍). Ack becomes four states: `ACKED` suppresses the reminder but does **not** move the deadline (a promise is not evidence of reading); `REVIEWING` earns one `hold_grace_minutes` window measured from the claim, never renewed; a lapsed window reports `HELD BUT STALE` with the claimant's login.
- **`pr-review`** — issue → code → description, in that order. The linked issue's ACs are the spec; the body is read **last** and audited in new gate 3f (an unbacked claim, or an unimplemented AC under `Closes`, is Blocking). New Step 0.6 posts a 👀 reaction, which is what `pr-ready` reads as the "review in progress" signal.
- **`revise-pr`** — `--from-pr` / `--from-comment` / `--notes` import feedback from elsewhere; the code always lands on the target. New Step 2.5 re-verifies each import against this branch before anything changes.

No issue — process-surface change, filed straight as a PR.

## Review focus

- `.claude/skills/pr-ready/SKILL.md` (ack predicate, input 3) — the 👀 reaction is never removed, so a stale one must not read as a live hold. Is `created_at > PING_ISO` actually applied on **every** path that reaches input 3, including the Phase 2 adopted-ping branch?
- `.claude/skills/pr-ready/SKILL.md` (Phase 5.1) — grace is measured from the claim, not from now. Does the `-gt "$(date +%s)"` guard skip the wait correctly when the window already elapsed, and is there any path that extends twice?
- `.claude/skills/revise-pr/SKILL.md` (Step 6) — the reply path is `pulls/$SRC_PR/comments`. Is there a path where the target's number reaches an imported thread's reply, or where a source thread gets resolved while its own copy of the defect is still live?
- `.claude/skills/pr-review/SKILL.md` (Step 0.5) — the whole ordering rule depends on issue *numbers* reaching the review without the description's prose. Does anything upstream of gate 3f pull the body in?

## Test plan

- [x] No `src/` changes — `git diff --stat` is five files under `.claude/`, so `typecheck` / `test` / the corpus are untouched and the suite is inert against this diff. Not claiming green boxes for gates that have nothing to run against.
- [x] Every `gh` command added was executed against the live API before being written down, not pattern-matched: the reactions endpoint shape (`content` / `created_at` / `user.type`), `--silent`, `closingIssuesReferences` (returned `629 631 632` on #630, matching the body-grep exactly), the author-excluded `jq` filter, and the `#discussion_r` URL parse.
- [x] The `date -u -j -f` (BSD) / `date -u -d` (GNU) pair round-trips an ISO-Z string to epoch.
- [x] Markdown structure linted across all four skills — code fences balanced, frontmatter intact, table rows consistent.
- [x] Not exercised end-to-end: no live `/pr-ready` run has posted the new ping, and no `/revise-pr --from-pr` run has imported a real thread. First real use is the test.

## Notes for the reviewer

One change is **not** in this diff and should be, in the sense that it matters: `ack_reactions` in the git-ignored `.claude/pr-ready.local.json` was `["eyes","white_check_mark","raising_hand"]` — none of which reviewers here actually use. Every ack was being reported as silence. It is now `["+1","thumbsup"]`, plus `hold_grace_minutes: 60`. The committed `.example` reflects both, but the live config is per-checkout and will need the same edit anywhere else it exists.

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: no `src/` changes — CI `verify` runs, but has nothing in this diff to exercise
