### PR TITLE
test(parser): use the house synthetic persona in the middot-header fixtures

### DIFF
--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -175,7 +175,7 @@ describe("applyOverrides", () => {
 
   it("applies an experience team override and clears it on empty string", () => {
     const parsed = baseParsed();
-    parsed.experience[0].team = "Enterprise Platforms";
+    parsed.experience[0].team = "Payments Platform";
     const { fields: out } = applyOverrides(
       parsed,
       "raw",
@@ -199,7 +199,7 @@ describe("applyOverrides", () => {
     // A cleared team drops off entirely so the render/PDF emits no "· Team".
     expect(cleared.experience[0].team).toBeUndefined();
     // Original untouched.
-    expect(parsed.experience[0].team).toBe("Enterprise Platforms");
+    expect(parsed.experience[0].team).toBe("Payments Platform");
   });
 
   it("propagates a bullet edit to rawText, sections, and the matching description", () => {

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -610,9 +610,9 @@ function mapSegmentsToFields(
   // own company via the `Title · Team · Company` middot shape (rows a/b/c/e of
   // the issue's condition matrix), the anchor line's middot is not the export
   // signature at all. It is data noise on the date sub-line — a role scope
-  // tail like `dates · L7 · 18 engineers, 2 TLMs`, whose post-`stripDateRange`
-  // residue `L7 · 18 engineers, ...` also trips {@link anchorCarriesOrgSignal}.
-  // Without this narrowing, `L7` was picked as the company via the else-if
+  // tail like `dates · M4 · 22 engineers, 3 squads`, whose post-`stripDateRange`
+  // residue `M4 · 22 engineers, ...` also trips {@link anchorCarriesOrgSignal}.
+  // Without this narrowing, `M4` was picked as the company via the else-if
   // branch below, silently discarding the real trailing-segment company on
   // the title line and dropping location.
   //
@@ -932,8 +932,8 @@ function mapWithoutCompanyMatch(
     splits[0].source === splits[1].source
   ) {
     // #614 — a three-segment middot header where the MIDDLE segment is
-    // title-keyword-shaped ("Site Lead, Enterprise Platforms") and the
-    // TRAILING segment is not ("Google") reads as the OTHER canonical ordering:
+    // title-keyword-shaped ("Site Lead, Payments Platform") and the
+    // TRAILING segment is not ("Globex") reads as the OTHER canonical ordering:
     // `Title · Team · Company` (rows a/b/c/e of the issue), not `Title ·
     // Company · Team`. Detect the ordering by the title-keyword split:
     // `secondLooksTitle && !thirdLooksTitle` → the trailing segment is the

--- a/src/lib/heuristics/extract/experience.date-subline-extra-tokens.test.ts
+++ b/src/lib/heuristics/extract/experience.date-subline-extra-tokens.test.ts
@@ -12,9 +12,9 @@
  * (`anchorCarriesOrgSignal`) checked only for a `·` on the anchor line,
  * without distinguishing the export's own signature from a real-résumé date
  * sub-line whose post-strip residue happens to contain middots — so a date
- * line like `01/2024 – 12/2024 · L7 · 18 engineers, 2 TLMs` reduced to
- * `L7 · 18 engineers, 2 TLMs`, tripped the check, and the branch took the
- * first anchor-line token (`L7`) as the company — silently discarding the
+ * line like `01/2024 – 12/2024 · M4 · 22 engineers, 3 squads` reduced to
+ * `M4 · 22 engineers, 3 squads`, tripped the check, and the branch took the
+ * first anchor-line token (`M4`) as the company — silently discarding the
  * real company on the title line above and dropping the location.
  *
  * The fix narrows the gate: the reconstructed-export shape emits a BARE title
@@ -48,93 +48,93 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Google, Hyderabad",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Hyderabad");
-    expect(role.team).toBe("Site Lead, Enterprise Platforms");
+    expect(role.team).toBe("Site Lead, Payments Platform");
   });
 
   it("row (b) — extra `·`-tokens on the date line MUST NOT become the company", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Google, Hyderabad",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad",
         fontSize: 11,
       },
-      { text: "01/2024 – 12/2024 · L7 · 18 engineers, 2 TLMs", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Hyderabad");
-    expect(role.team).toBe("Site Lead, Enterprise Platforms");
+    expect(role.team).toBe("Site Lead, Payments Platform");
     // The date-line data token must not appear in any parsed field.
-    expect(role.company).not.toBe("L7");
-    expect(role.team).not.toContain("L7");
+    expect(role.company).not.toBe("M4");
+    expect(role.team).not.toContain("M4");
   });
 
   it("row (c) — same as (b) with a country-suffixed location", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Google, Hyderabad, India",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad, India",
         fontSize: 11,
       },
-      { text: "01/2024 – 12/2024 · L7 · 18 engineers, 2 TLMs", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Hyderabad, India");
-    expect(role.team).toBe("Site Lead, Enterprise Platforms");
+    expect(role.team).toBe("Site Lead, Payments Platform");
   });
 
   it("row (d) unchanged — MIDDLE-segment company with extra date tokens still parses", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Google, Hyderabad, India · Site Lead, Enterprise Platforms",
+        text: "Sr. Engineering Manager · Globex, Hyderabad, India · Site Lead, Payments Platform",
         fontSize: 11,
       },
-      { text: "01/2024 – 12/2024 · L7 · 18 engineers, 2 TLMs", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Hyderabad, India");
-    expect(role.team).toBe("Site Lead, Enterprise Platforms");
+    expect(role.team).toBe("Site Lead, Payments Platform");
   });
 
   it("row (e) — trailing-segment BARE company (no location) survives extra date tokens", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Google",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex",
         fontSize: 11,
       },
-      { text: "01/2024 – 12/2024 · L7 · 18 engineers, 2 TLMs", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
-    expect(role.team).toBe("Site Lead, Enterprise Platforms");
-    expect(role.company).not.toBe("L7");
+    expect(role.company).toBe("Globex");
+    expect(role.team).toBe("Site Lead, Payments Platform");
+    expect(role.company).not.toBe("M4");
   });
 
   // Negative case (#639 review): the rotate that fixes rows b/c/e must NOT
@@ -150,7 +150,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
       { text: "EXPERIENCE", fontSize: 13 },
       { text: "Engineer · Team Lead · New York, NY", fontSize: 11 },
       { text: "01/2024 – 12/2024", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
@@ -190,11 +190,11 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Hyderabad, India",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Hyderabad, India",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024", fontSize: 11 },
-      { text: "• Built an 18-engineer org in under 6 months.", fontSize: 11 },
+      { text: "• Ran a cross-team migration to a shared platform.", fontSize: 11 },
     ]);
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];

--- a/src/lib/heuristics/extract/experience.multiword-city.test.ts
+++ b/src/lib/heuristics/extract/experience.multiword-city.test.ts
@@ -178,7 +178,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Google, Hyderabad · Enterprise Platforms",
+        text: "Sr. Engineering Manager · Globex, Hyderabad · Payments Platform",
         fontSize: 11,
       },
       { text: "04/2021 – 12/2023", fontSize: 11 },
@@ -187,16 +187,16 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Hyderabad");
-    expect(role.team).toBe("Enterprise Platforms");
+    expect(role.team).toBe("Payments Platform");
   });
 
   it("row (d) unchanged — trailing `Company, SingleWordCity` still splits", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Google, Hyderabad",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad",
         fontSize: 11,
       },
       { text: "04/2021 – 12/2023", fontSize: 11 },
@@ -205,7 +205,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Hyderabad");
   });
 
@@ -215,7 +215,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Enterprise Platforms · Google, Mountain View",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Mountain View",
         fontSize: 11,
       },
       { text: "04/2021 – 12/2023", fontSize: 11 },
@@ -224,7 +224,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Mountain View");
   });
 


### PR DESCRIPTION
## Summary

The `#614` and `#616` middot-header regression fixtures were written with recognisable real-world employer, team, level and headcount strings instead of the synthetic vocabulary the rest of the suite already uses (`Globex`, `CloudWave`, `Jordan Lee`, `Rivertown, CA`). This brings them in line, in the two test files and in the three `experience-disambiguate.ts` docblocks that quote them:

Rename only. No production behaviour changes, no expectation was relaxed, and no test was added or removed.

## Why the substitutions are shape-preserving

This is the part worth checking, since a careless swap here silently turns a regression test into a test of something else:

- **`Globex`** carries no `COMPANY_SUFFIX_RE` token, so `looksLikeCompany` / `looksLikeTitle` classify it exactly as the string it replaced did.
- **`Site Lead, Payments Platform`** keeps the `Lead` title keyword and introduces no company suffix, so it still satisfies the `looksLikeTitle(s1) && !looksLikeTitle(s2)` gate that the trailing-company rotate keys on. `Platform Group` was rejected for this reason — `Group` is in `COMPANY_SUFFIX_RE`, which would have flipped `looksLikeTitle` to `false` and made the gate stop firing.
- **`squads`** was chosen over the more natural `leads` / `managers` for the same reason in reverse: both of those are in `TITLE_KEYWORDS_RE`, and either would have made the post-`stripDateRange` date-line residue title-shaped.
- **`Hyderabad` stays.** It is a single-word city already in the `BARE_LOCATION_RE` vocab, several older fixtures pair it with `Globex` already, and swapping it would move `#616`'s coverage onto a different vocabulary path than the one the issue is about.

## Test plan

- [x] `npx vitest run src/lib/heuristics/extract/` — 295 pass across 21 files; same 8 tests in `experience.date-subline-extra-tokens.test.ts` and same 21 in `experience.multiword-city.test.ts` as before the rename
- [x] `npm run verify` — green (typecheck, lint, coverage, build; fallow reports only the 4 pre-existing inherited complexity findings in `experience-disambiguate.ts`, none newly attributed to this diff)

Refs #614

## Provenance

Authored by Claude Opus 5 (1M context).

