### PR TITLE
fix(parser,a11y,design-system): corporate tails before a state suffix, the icon-variant target floor, and the font-size token sweep (#641, #638, #640)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,40 @@ const PALETTE_PROPS = "bg|text|border|ring|shadow|fill|stroke";
 
 const PALETTE_RE = `(${PALETTE_PROPS})-(${PALETTE_COLOURS})-[0-9]`;
 const DARK_RE = `dark:[a-z]+-[a-z]+-[0-9]`;
-const HEX_RE = `#[0-9a-fA-F]{3,6}\\b`;
+/** Hardcoded hex colours, e.g. #ef4444, #fff, bg-[#f00], #334155cc.
+ *
+ *  `#638` is simultaneously a valid 3-digit hex colour and a valid GitHub issue
+ *  reference, and this rule matches `Literal`/`TemplateElement` VALUES — so an
+ *  unanchored `#[0-9a-fA-F]{3,6}` reported every `describe("… (#638)")` in the
+ *  suite as a hardcoded colour. (Comments are neither node type, which is why
+ *  the contrast-ratio docblocks in `CountBadge.tsx`/`Tabs.tsx` were never hit
+ *  and the trap only ever bites test/UI STRINGS.) Same unanchored-substring
+ *  defect as ARBITRARY_TEXT_SIZE_RE below — fixed the same way, positionally.
+ *
+ *  The two hex shapes live in different positions, and that is what separates
+ *  them from an issue number:
+ *   - 6- or 8-digit form is unambiguous at any length, so it matches anywhere;
+ *   - 3- or 4-digit form only where a colour can actually START — at the
+ *     beginning of the string value (`"#fff"`, `color: "#f00"` as a whole
+ *     value) or straight after Tailwind's arbitrary-value `[` (`bg-[#f00]`).
+ *  An issue reference is always preceded by a space or `(`, so it matches
+ *  neither branch. A string whose ENTIRE value is `#638` is still reported:
+ *  genuinely ambiguous, and a false positive there is cheaper than letting
+ *  `"#fff"` through. */
+const HEX_RE = `(?:(?:^|\\[)#[0-9a-fA-F]{3,4}\\b|#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?\\b)`;
+/** Arbitrary Tailwind font-size values, e.g. text-[11px], text-[0.6875rem],
+ *  text-[10pt], text-[2vw] or the explicit `text-[length:12px]` form.
+ *
+ *  Left boundary is load-bearing (#640 review): without it the pattern is a
+ *  bare substring match, so ANY class ending in "text-" fires it — `context-`,
+ *  `subtext-`, a data attribute — and the rule reports a violation on a line
+ *  that has no arbitrary font size at all.
+ *
+ *  The unit alternation covers every CSS length unit Tailwind will accept here,
+ *  not just the two the #640 sweep happened to use. Arbitrary values that are
+ *  NOT sizes stay legal — `text-[color:var(--x)]` and `text-[#abc]` are colour
+ *  values, governed by the palette/hex rules above, and neither matches. */
+const ARBITRARY_TEXT_SIZE_RE = `(^|[\\s:'"\`])text-\\[(length:)?[0-9.]+(px|rem|em|pt|vw|vh|ch|ex|%)\\]`;
 
 /** no-restricted-syntax selectors that catch both string literals and
  *  template-literal chunks (so cn()/clsx template strings are covered). */
@@ -54,6 +87,17 @@ function restrictedSyntaxRules() {
       selector: `TemplateElement[value.raw=/${HEX_RE}/]`,
       message:
         "No hardcoded hex colours in feature code — use semantic tokens.",
+    },
+    // Arbitrary font-size values
+    {
+      selector: `Literal[value=/${ARBITRARY_TEXT_SIZE_RE}/]`,
+      message:
+        "Use a named type-ramp step (text-4xs, text-3xs, text-2xs, text-xs, text-sm, …) instead of an arbitrary font size.",
+    },
+    {
+      selector: `TemplateElement[value.raw=/${ARBITRARY_TEXT_SIZE_RE}/]`,
+      message:
+        "Use a named type-ramp step (text-4xs, text-3xs, text-2xs, text-xs, text-sm, …) instead of an arbitrary font size.",
     },
   ];
 }
@@ -95,14 +139,26 @@ export default [
     rules: {},
   },
 
-  // ── Architecture guard: components + App.tsx ────────────────────────────
+  // ── Architecture guard: components + the three lane roots ───────────────
   // These rules encode the same checks style_guard.sh runs (non-blocking,
   // advisory). Here they are BLOCKING (error) and run in CI.
+  //
+  // The scope is every surface that WRITES markup: the component tiers, plus
+  // the ROOT of each of the three HTML entries the build ships (vite.config.ts
+  // `rollupOptions.input`). `src/App.tsx` was listed alone, which left its two
+  // peers — `JobsApp` (`/jobs/`) and `JdFitApp` (`/jd-fit/`) — writing JSX
+  // outside every token rule (#640 review). Listed as the three files rather
+  // than as `src/jobs/**`+`src/jd-fit/**` so the scope stays "the entry roots",
+  // matching how `src/App.tsx` is named; `main.tsx` and the lane hooks/tests
+  // hold no markup. `src/lib/**` and `src/hooks/**` stay out for the same
+  // reason.
   {
     files: [
       "src/components/**/*.{ts,tsx}",
       "src/design-system/**/*.{ts,tsx}",
       "src/App.tsx",
+      "src/jobs/JobsApp.tsx",
+      "src/jd-fit/JdFitApp.tsx",
     ],
     rules: {
       // Raw <button> outside the Button primitive is forbidden in feature code.

--- a/src/components/features/ApplyConfirmation.tsx
+++ b/src/components/features/ApplyConfirmation.tsx
@@ -114,7 +114,7 @@ export function ApplyConfirmation({
         <StatusBadge tone="ok" aria-hidden>
           {verb}
         </StatusBadge>
-        <span className="text-[11px] text-content-secondary">
+        <span className="text-2xs text-content-secondary">
           {verb} {count} change{count === 1 ? "" : "s"}
           {/* No trailing "— " when nothing was named; an empty list left a
               dangling em dash. */}
@@ -138,7 +138,7 @@ export function UndoBatchButton({ onUndo }: { onUndo: () => void }) {
       variant="link"
       size="sm"
       onClick={onUndo}
-      className="text-[11px] font-medium text-content-secondary"
+      className="text-2xs font-medium text-content-secondary"
       aria-label="Undo the changes just applied to the résumé"
     >
       Undo

--- a/src/components/features/AtsScoreReadout.tsx
+++ b/src/components/features/AtsScoreReadout.tsx
@@ -57,7 +57,7 @@ function Dimension({
       href={anchor}
       className="block flex flex-col gap-1.5 rounded-lg border border-border-light bg-surface-subtle p-3 hover:border-border-light"
     >
-      <dt className="text-[11px] font-semibold uppercase tracking-wider text-content-muted">
+      <dt className="text-2xs font-semibold uppercase tracking-wider text-content-muted">
         {label}
       </dt>
       <dd className="text-sm font-medium">
@@ -78,7 +78,7 @@ function Dimension({
           />
         </div>
       )}
-      <p className="text-[11px] text-content-tertiary" title={hintTitle}>
+      <p className="text-2xs text-content-tertiary" title={hintTitle}>
         {hint}
       </p>
     </a>
@@ -120,7 +120,7 @@ export function AtsScoreReadout({ score }: AtsScoreReadoutProps) {
         <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
           Your resume score
         </h2>
-        <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-content-secondary">
+        <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wider text-content-secondary">
           alpha
         </span>
       </div>
@@ -173,12 +173,12 @@ export function AtsScoreReadout({ score }: AtsScoreReadoutProps) {
         </dl>
       </div>
       {score.layout.multiplier < 1 && (
-        <p className="text-[11px] text-feedback-warning-text">
+        <p className="text-2xs text-feedback-warning-text">
           Layout penalty applied (multiplier {score.layout.multiplier.toFixed(2)}
           ): pre-layout score was {score.preLayoutOverall}.
         </p>
       )}
-      <p className="text-[11px] text-content-muted">
+      <p className="text-2xs text-content-muted">
         {score.algoVersion && <>algo v{score.algoVersion} · </>}Built{" "}
         <span title={buildDate}>{buildAgo}</span>
       </p>

--- a/src/components/features/ChipListEditor.tsx
+++ b/src/components/features/ChipListEditor.tsx
@@ -42,7 +42,9 @@
  * target size is what the current spacing supports, not the reverse. Both
  * controls meet 24x24 via an invisible `after:` overlay that expands only the
  * CLICKABLE area, not the visual box or the chip's layout: `Chip`'s remove
- * control (`variant="icon"`, ~14px visible) gets a 5px overlay on every side;
+ * control (`variant="icon"`, ~14px visible) gets the fixed, centred 24x24
+ * overlay the `icon` variant itself carries (`Button.tsx`, #638 — moved off
+ * `Chip` so every `variant="icon"` caller gets the floor, not just this one);
  * the promote control (`Button variant="link"`, ~16px tall, its width is
  * already the item text) gets a 4px vertical-only overlay — sized to reach the
  * chip's own top/bottom edge and no further, so it cannot cross the 6px wrap

--- a/src/components/features/ConsentDialog.tsx
+++ b/src/components/features/ConsentDialog.tsx
@@ -73,7 +73,7 @@ export function ConsentDialog({
           on your device, but downloading the model means accepting those
           terms.
         </p>
-        <p className="text-[11px] leading-relaxed text-content-tertiary">
+        <p className="text-2xs leading-relaxed text-content-tertiary">
           You only need to accept once per license type — switching to
           another model under the same license won't re-prompt you.
         </p>

--- a/src/components/features/CritiquePanel.tsx
+++ b/src/components/features/CritiquePanel.tsx
@@ -80,7 +80,7 @@ function BulletFindingRow({
           variant="link"
           size="sm"
           onClick={onGoToRewrite}
-          className="self-start text-[11px] font-medium text-accent-primary"
+          className="self-start text-2xs font-medium text-accent-primary"
           aria-label="Go to Reconstructed resume tab to rewrite this bullet"
         >
           Rewrite this section →
@@ -123,7 +123,7 @@ export function CritiqueResults({
     <div className="flex flex-col gap-4">
       {critique.summaryFeedback && (
         <Card className="flex flex-col gap-1 p-3">
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+          <span className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
             Summary
           </span>
           <p className="text-sm text-content-secondary">{critique.summaryFeedback}</p>

--- a/src/components/features/FindJobsLauncher.tsx
+++ b/src/components/features/FindJobsLauncher.tsx
@@ -54,7 +54,7 @@ export function FindJobsLauncher({ parsed }: { parsed: HeuristicParsedResume }) 
           <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
             Find jobs
           </h2>
-          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
+          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-4xs font-semibold uppercase tracking-wider text-content-secondary">
             alpha
           </span>
         </div>

--- a/src/components/features/JdMatch.tsx
+++ b/src/components/features/JdMatch.tsx
@@ -33,7 +33,7 @@ export function JdMatch({ result }: JdMatchProps) {
           <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
             JD match
           </h2>
-          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
+          <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-4xs font-semibold uppercase tracking-wider text-content-secondary">
             alpha
           </span>
         </div>
@@ -70,7 +70,7 @@ export function JdMatch({ result }: JdMatchProps) {
       </div>
 
       {nounsDropped > 0 && (
-        <p className="text-[11px] text-content-muted">
+        <p className="text-2xs text-content-muted">
           +{nounsDropped} more capitalized phrase{nounsDropped === 1 ? "" : "s"}{" "}
           in this JD weren't surfaced — the noun-phrase pass ranks hits by how
           often they recur (weighting the requirements section) and keeps the
@@ -130,7 +130,7 @@ function TermRow({
     >
       <span className={`text-sm font-semibold ${markerCls}`}>{marker}</span>
       <span className="text-sm text-content-primary">{term.display}</span>
-      <span className="ml-auto font-mono text-[10px] uppercase tracking-wider text-content-muted">
+      <span className="ml-auto font-mono text-3xs uppercase tracking-wider text-content-muted">
         {sourceLabel}
       </span>
     </li>

--- a/src/components/features/ModelSelector.tsx
+++ b/src/components/features/ModelSelector.tsx
@@ -285,10 +285,10 @@ export function ModelSelector() {
       {showRows ? (
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <div className="flex flex-wrap items-baseline gap-2">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-content-muted">
+            <h3 className="text-2xs font-semibold uppercase tracking-wider text-content-muted">
               Rewrite model
             </h3>
-            <p className="text-[11px] text-content-tertiary">
+            <p className="text-2xs text-content-tertiary">
               Picks here apply to every "Rewrite" button below.
             </p>
           </div>
@@ -315,7 +315,7 @@ export function ModelSelector() {
             {loadState.kind === "error" &&
             loadState.modelId === selectedModel.id ? (
               <span className="flex items-baseline gap-2">
-                <span className="text-[11px] text-feedback-error-text">
+                <span className="text-2xs text-feedback-error-text">
                   Couldn't download.
                 </span>
                 <Button
@@ -328,7 +328,7 @@ export function ModelSelector() {
                 </Button>
               </span>
             ) : cachedIds.has(selectedModel.id) ? (
-              <span className="text-[11px] text-feedback-success-text">
+              <span className="text-2xs text-feedback-success-text">
                 ✓ Ready · runs offline
               </span>
             ) : (
@@ -446,19 +446,19 @@ export function ModelRow({
           <span className="text-sm font-semibold text-content-primary">
             {model.name}
             {isDefault && (
-              <span className="ml-1.5 text-[10px] font-normal text-content-tertiary">
+              <span className="ml-1.5 text-3xs font-normal text-content-tertiary">
                 default
               </span>
             )}
           </span>
-          <span className="text-[10px] uppercase tracking-wider text-content-muted">
+          <span className="text-3xs uppercase tracking-wider text-content-muted">
             {model.tier} tier · {licenseLabel(model)}
           </span>
         </div>
-        <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] text-content-tertiary">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-2xs text-content-tertiary">
           <span>{downloadLabel}</span>
           {selected && (
-            <span className="text-[10px] uppercase tracking-wider text-feedback-success-text">
+            <span className="text-3xs uppercase tracking-wider text-feedback-success-text">
               ✓ Selected
             </span>
           )}
@@ -477,13 +477,13 @@ export function ModelRow({
 
       {error && (
         <div role="alert" className="mt-1 flex flex-col gap-0.5">
-          <p className="text-[11px] text-feedback-error-text">{error.message}</p>
+          <p className="text-2xs text-feedback-error-text">{error.message}</p>
           {error.detail && (
             <details>
-              <summary className="cursor-pointer text-[10px] text-content-tertiary hover:underline">
+              <summary className="cursor-pointer text-3xs text-content-tertiary hover:underline">
                 Technical details
               </summary>
-              <pre className="mt-1 max-w-prose overflow-x-auto whitespace-pre-wrap text-[10px] text-content-tertiary">
+              <pre className="mt-1 max-w-prose overflow-x-auto whitespace-pre-wrap text-3xs text-content-tertiary">
                 {error.detail}
               </pre>
             </details>
@@ -493,7 +493,7 @@ export function ModelRow({
 
       {cached && !disabled && (
         confirming ? (
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px]">
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-2xs">
             <span className="text-content-tertiary">
               Remove {model.name}? Frees ~{sizeGb} GB · re-downloads next use.
             </span>
@@ -501,7 +501,7 @@ export function ModelRow({
               variant="link"
               size="sm"
               onClick={onClear}
-              className="text-[11px] text-feedback-error-text"
+              className="text-2xs text-feedback-error-text"
             >
               Remove
             </Button>
@@ -509,7 +509,7 @@ export function ModelRow({
               variant="link"
               size="sm"
               onClick={() => setConfirming(false)}
-              className="text-[11px] text-content-tertiary"
+              className="text-2xs text-content-tertiary"
             >
               Cancel
             </Button>
@@ -519,7 +519,7 @@ export function ModelRow({
             variant="link"
             size="sm"
             onClick={() => setConfirming(true)}
-            className="mt-1 text-[11px] text-content-tertiary"
+            className="mt-1 text-2xs text-content-tertiary"
           >
             Clear download
           </Button>

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -67,7 +67,7 @@ export function PageShell({
               O
             </a>
             <h1 className="text-2xl font-semibold tracking-tight">offlinecv</h1>
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+            <span className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
               {badge}
             </span>
           </div>

--- a/src/components/features/ReconstructedAdd.remove-button.test.tsx
+++ b/src/components/features/ReconstructedAdd.remove-button.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Structural test pinning `RemoveButton`'s VISIBLE 24×24 box (#638 review).
+ *
+ * `Button.test.tsx` pins the `icon` variant's invisible `after:` overlay — the
+ * TOUCH TARGET. That overlay is fixed at 24×24 and centred, so it says nothing
+ * about the size of the box the user can SEE, and it reads as making a caller's
+ * `min-h-6 min-w-6` redundant. It is not: #638 deleted that minimum on exactly
+ * that reasoning, which shrank the painted `hover:bg-surface-subtle` rectangle
+ * and the `focus-visible` ring from 24×24 to ~14×14 at all eight `RemoveButton`
+ * call sites, and — because a 14px box under a fixed 24px overlay overhangs 5px
+ * per side, wider than the `gap-1` (4px) in `ReconstructedRole`'s and
+ * `ContactExtraLinks`' action rows — reintroduced the #581/#591 neighbour-target
+ * overlap the overlay was designed to avoid.
+ *
+ * A docblock alone did not survive that round, so the invariant is asserted
+ * here. jsdom does no layout (`getBoundingClientRect()` is all zeros), so this
+ * asserts the classes, not measured pixels — same limitation and same
+ * `renderToStaticMarkup` pattern as `Button.test.tsx` and `Chip.test.tsx`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { RemoveButton } from "./ReconstructedAdd.tsx";
+
+describe("RemoveButton visible box (#638 review)", () => {
+  const html = renderToStaticMarkup(
+    createElement(RemoveButton, { label: "Remove role", onClick: () => {} }),
+  );
+
+  it("sizes its own visible box to the 24x24 the overlay targets", () => {
+    // Zero overflow depends on the visible box being >= the fixed 24x24
+    // overlay. Dropping either class is the regression this pins.
+    expect(html).toContain("min-h-6");
+    expect(html).toContain("min-w-6");
+  });
+
+  it("still routes through the icon variant that owns the touch target", () => {
+    // The minimum above is additive to the overlay, never a replacement for
+    // it — if the variant were swapped out, the target floor would be lost on
+    // any caller that did not repeat the sizing.
+    expect(html).toContain("after:h-6");
+    expect(html).toContain("after:w-6");
+    expect(html).toContain("relative");
+  });
+});

--- a/src/components/features/ReconstructedAdd.tsx
+++ b/src/components/features/ReconstructedAdd.tsx
@@ -107,12 +107,27 @@ export function AddPill({
 /**
  * A quiet remove (X) control for a user-added entry or bullet.
  *
- * `min-h-6 min-w-6` is the 24×24 CSS-px target WCAG 2.2 AA SC 2.5.8 asks for
- * (24, not 44 — see #581/#591). The `CloseIcon` glyph is 10×10 and the `icon`
- * Button variant adds only `p-0.5`, so without the minimum the hit box is
- * 14×14; the `inline-flex items-center justify-center` in Button's BASE keeps
- * the glyph centred as the box grows. Set here rather than on the variant so
- * the change stays scoped to the controls this file owns.
+ * The `icon` Button variant carries the 24×24 CSS-px WCAG 2.2 AA SC 2.5.8 TOUCH
+ * TARGET (24, not 44 — see #581/#591) on its own, via a fixed, centred invisible
+ * `after:` overlay (`Button.tsx`, #638). `min-h-6 min-w-6` here is NOT redundant
+ * with that overlay — it sizes the VISIBLE box, and it is what makes the overlay
+ * cost zero overflow:
+ *
+ *   - Visible affordance. `variant="icon"` paints `hover:bg-surface-subtle` and
+ *     a `focus-visible` ring on the real box. The `CloseIcon` glyph is 10×10 and
+ *     the variant adds only `p-0.5`, so without the minimum the hover rectangle
+ *     and the focus ring shrink to ~14×14 — a ~40%-per-dimension regression in
+ *     the affordance the user actually sees and aims at (#638 review).
+ *   - Zero overflow. A 24×24 visible box means the centred 24×24 overlay lands
+ *     entirely inside it, so the target never bleeds past the button. At 14×14 it
+ *     overhangs 5px per side, which is wider than the `gap-1` (4px) separating
+ *     this control from its neighbour in `ReconstructedRole`'s and
+ *     `ContactExtraLinks`' action rows — and, being DOM-later, it would win
+ *     hit-testing over that neighbour's visible box (the #581/#591 class).
+ *
+ * `inline-flex items-center justify-center` in Button's BASE keeps the glyph
+ * centred as the box grows. Set here rather than on the variant so the change
+ * stays scoped to the controls this file owns.
  */
 export function RemoveButton({
   label,

--- a/src/components/features/ReconstructedSkillControls.tsx
+++ b/src/components/features/ReconstructedSkillControls.tsx
@@ -41,7 +41,24 @@ function MoveMenu({
         size="sm"
         aria-label="Move to another category"
         onClick={() => setOpen(true)}
-        className="text-content-muted hover:text-accent-primary"
+        // `mr-2` separates this trigger from the Remove control beside it
+        // (#638). Both are `variant="icon"` ~14px boxes and the variant's 24x24
+        // target overlay extends 5px past each box on every side, so at the
+        // row's own `gap-1` (4px) the two overlays overlapped by 6px AND
+        // Remove's overlay covered ~1px of THIS button's visible glyph — a tap
+        // on the Move icon fired Remove. Measured in a browser, not reasoned
+        // about. 8px takes the real gap to 12px = a 26px centre-to-centre
+        // distance; WCAG 2.2 AA SC 2.5.8's spacing exception only needs 24, but
+        // at exactly 24 the overlays abut and hit-testing on the shared
+        // boundary pixel still resolved to the later-painted sibling. 26 leaves
+        // 2px of daylight.
+        //
+        // The margin lives HERE rather than on Remove because this trigger is
+        // the conditional one: `MoveMenu` renders nothing without `moveTargets`
+        // and returns null at `targets.length === 0`, so an uncategorised chip
+        // has no Move control and needs no separation. Putting it on Remove
+        // added 8px of dead space to every chip in the ungrouped `SkillChipRow`.
+        className="mr-2 text-content-muted hover:text-accent-primary"
       >
         <svg
           aria-hidden="true"
@@ -67,7 +84,7 @@ function MoveMenu({
           setOpen(false);
       }}
     >
-      <span className="text-[11px] text-content-muted">Move to</span>
+      <span className="text-2xs text-content-muted">Move to</span>
       {targets.map((t) => (
         <Button
           key={t.index}
@@ -82,7 +99,7 @@ function MoveMenu({
           onKeyDown={(e) => {
             if (e.key === "Escape") setOpen(false);
           }}
-          className="rounded-full bg-surface-subtle px-2 py-0.5 text-[11px] text-content-tertiary hover:text-accent-primary"
+          className="rounded-full bg-surface-subtle px-2 py-0.5 text-2xs text-content-tertiary hover:text-accent-primary"
         >
           {t.label}
         </Button>
@@ -130,6 +147,10 @@ export function SkillChip({
         variant="icon"
         aria-label={`Remove ${skill}`}
         onClick={onRemove}
+        // Separation from the `MoveMenu` trigger is owned by that trigger's own
+        // `mr-2` (#638) — see the rationale there. It lives on the conditional
+        // control so an uncategorised chip, which renders no Move trigger, gets
+        // no dead space.
         className="shrink-0 text-content-muted hover:text-content-secondary"
       >
         <svg

--- a/src/components/features/ResumeBulletRow.tsx
+++ b/src/components/features/ResumeBulletRow.tsx
@@ -153,7 +153,7 @@ export function BulletFlagLegend() {
           ariaLabel="Word count outside 8–30"
           decorative
         >
-          <span className="text-[11px] font-medium tabular-nums">#w</span>
+          <span className="text-2xs font-medium tabular-nums">#w</span>
         </FlagChip>
         length (8–30 words)
       </li>
@@ -192,7 +192,7 @@ function BulletFlagsInline({ bullet }: { bullet: BulletObservation }) {
           ariaLabel={lengthTitle(bullet)}
           className="ml-1 align-middle"
         >
-          <span className="text-[11px] font-medium tabular-nums">
+          <span className="text-2xs font-medium tabular-nums">
             {lengthToken(bullet)}
           </span>
         </FlagChip>

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -201,7 +201,7 @@ function RewriteSteeringBox({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-[11px] font-medium text-content-secondary">
+        <span className="text-2xs font-medium text-content-secondary">
           Target length:
         </span>
         {PAGE_PRESETS.map((preset) => {
@@ -214,7 +214,7 @@ function RewriteSteeringBox({
               disabled={disabled}
               aria-pressed={selected}
               onClick={() => onChipClick(preset)}
-              className="rounded-full border border-border-light px-2.5 py-0.5 text-[11px]"
+              className="rounded-full border border-border-light px-2.5 py-0.5 text-2xs"
             >
               {preset.label}
             </Button>
@@ -339,7 +339,7 @@ export function StepIndicator({
         <span>
           Rewriting {Math.min(currentIndex + 1, totalSections)} of {totalSections}: {label}
         </span>
-        <span className="font-mono text-[11px]">{pct}%</span>
+        <span className="font-mono text-2xs">{pct}%</span>
       </div>
       <div
         role="progressbar"
@@ -373,7 +373,7 @@ function CompletedList({
           <span>{outcome.input.label}</span>
           {!outcome.data.numbersPreserved && (
             <span
-              className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-[10px] text-feedback-warning-text"
+              className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-3xs text-feedback-warning-text"
               title="A metric was altered or removed"
             >
               metric drift

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -243,7 +243,7 @@ export function ProposedPanel({
           variant="link"
           size="sm"
           onClick={onDismiss}
-          className="text-[11px] font-medium text-content-tertiary"
+          className="text-2xs font-medium text-content-tertiary"
         >
           Discard
         </Button>
@@ -266,7 +266,7 @@ function ReviewSectionGroup({
   return (
     <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+        <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
           {section.label}
         </h4>
         <div className="flex shrink-0 items-center gap-1">
@@ -274,7 +274,7 @@ function ReviewSectionGroup({
             variant="ghost"
             size="sm"
             onClick={() => review.acceptMany(ids)}
-            className="rounded-md px-2 py-0.5 text-[11px]"
+            className="rounded-md px-2 py-0.5 text-2xs"
           >
             Accept all
           </Button>
@@ -282,7 +282,7 @@ function ReviewSectionGroup({
             variant="ghost"
             size="sm"
             onClick={() => review.rejectMany(ids)}
-            className="rounded-md px-2 py-0.5 text-[11px] text-content-tertiary"
+            className="rounded-md px-2 py-0.5 text-2xs text-content-tertiary"
           >
             Reject all
           </Button>
@@ -337,7 +337,7 @@ function SectionResult({ outcome }: { outcome: SectionOutcome }) {
   if (outcome.kind === "summary") {
     return (
       <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
-        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+        <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
           {outcome.input.label}
         </h4>
         <InlineDiff
@@ -354,7 +354,7 @@ function SectionResult({ outcome }: { outcome: SectionOutcome }) {
   );
   return (
     <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
-      <h4 className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+      <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
         {outcome.input.label}
       </h4>
       <InlineDiff

--- a/src/components/features/RewriteReviewList.tsx
+++ b/src/components/features/RewriteReviewList.tsx
@@ -141,7 +141,7 @@ export function BulletReviewRow({
   return (
     <li className="flex flex-col gap-1.5 rounded border border-border-light bg-surface-card p-2.5">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-content-muted">
+        <span className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
           {kindLabel}
         </span>
         <div className="flex shrink-0 items-center gap-0.5">
@@ -190,7 +190,7 @@ export function BulletReviewRow({
           {/* Secondary: the redline, collapsed by default. Word-level so it
               reads as whole words, not the char-level "SupportLed" mash-up. */}
           <details className="mt-0.5">
-            <summary className="inline-flex cursor-pointer select-none items-center gap-1 text-[11px] text-content-tertiary hover:text-content-secondary list-none [&::-webkit-details-marker]:hidden">
+            <summary className="inline-flex cursor-pointer select-none items-center gap-1 text-2xs text-content-tertiary hover:text-content-secondary list-none [&::-webkit-details-marker]:hidden">
               <DisclosureChevron />
               Show changes
             </summary>
@@ -237,7 +237,7 @@ export function RewriteReviewList({
       {warning}
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="text-[11px] text-content-secondary">
+        <span className="text-2xs text-content-secondary">
           {total} change{total === 1 ? "" : "s"} proposed — review each below.
         </span>
         <div className="flex shrink-0 items-center gap-1">
@@ -245,7 +245,7 @@ export function RewriteReviewList({
             variant="ghost"
             size="sm"
             onClick={() => review.acceptMany(ids)}
-            className="rounded-md px-2 py-0.5 text-[11px]"
+            className="rounded-md px-2 py-0.5 text-2xs"
           >
             Accept all
           </Button>
@@ -253,7 +253,7 @@ export function RewriteReviewList({
             variant="ghost"
             size="sm"
             onClick={() => review.rejectMany(ids)}
-            className="rounded-md px-2 py-0.5 text-[11px] text-content-tertiary"
+            className="rounded-md px-2 py-0.5 text-2xs text-content-tertiary"
           >
             Reject all
           </Button>
@@ -280,7 +280,7 @@ export function RewriteReviewList({
           variant="link"
           size="sm"
           onClick={onDiscard}
-          className="text-[11px] font-medium text-content-tertiary"
+          className="text-2xs font-medium text-content-tertiary"
         >
           Discard
         </Button>

--- a/src/components/features/ScoreRing.tsx
+++ b/src/components/features/ScoreRing.tsx
@@ -60,7 +60,7 @@ export function ScoreRing({ score, max = 100 }: ScoreRingProps) {
         <span className={`text-3xl font-semibold leading-none ${ringColorCls}`}>
           {score}
         </span>
-        <span className="text-[11px] text-content-muted">/ {max}</span>
+        <span className="text-2xs text-content-muted">/ {max}</span>
       </div>
     </div>
   );

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -421,7 +421,7 @@ export function useSectionRewrite(
         )}
 
         {status.kind === "rewriting" && (
-          <p className="text-[11px] text-content-muted">
+          <p className="text-2xs text-content-muted">
             Rewriting the section…
           </p>
         )}
@@ -496,7 +496,7 @@ export function useSectionRewrite(
         )}
 
         {status.kind === "error" && (
-          <p role="alert" className="text-[11px] text-feedback-error-text">
+          <p role="alert" className="text-2xs text-feedback-error-text">
             {status.message}
           </p>
         )}
@@ -564,7 +564,7 @@ export function ProposedSection({
           variant="ghost"
           size="sm"
           onClick={onCopyAll}
-          className="rounded-md border border-border-light bg-surface-card px-2.5 py-1 text-[11px] text-content-primary hover:border-border hover:bg-surface-hover"
+          className="rounded-md border border-border-light bg-surface-card px-2.5 py-1 text-2xs text-content-primary hover:border-border hover:bg-surface-hover"
         >
           {copied ? "Copied" : "Use this — copy all bullets"}
         </Button>
@@ -572,7 +572,7 @@ export function ProposedSection({
           variant="link"
           size="sm"
           onClick={onReject}
-          className="text-[11px] font-medium text-content-tertiary"
+          className="text-2xs font-medium text-content-tertiary"
         >
           Discard
         </Button>
@@ -595,7 +595,7 @@ export function NumberPreservationWarning({
   return (
     <p
       role="alert"
-      className="text-[11px] leading-snug text-feedback-warning-text"
+      className="text-2xs leading-snug text-feedback-warning-text"
     >
       <span aria-hidden="true">⚠ </span>
       AI altered a metric — {detail}. Review before saving.

--- a/src/components/features/WebGpuUnavailableNotice.tsx
+++ b/src/components/features/WebGpuUnavailableNotice.tsx
@@ -89,7 +89,7 @@ export function WebGpuUnavailableNotice({ capability }: Props) {
       >
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wider text-content-muted">
+            <p className="text-2xs font-semibold uppercase tracking-wider text-content-muted">
               {guidance.platformLabel}
             </p>
             <ol className="flex list-decimal flex-col gap-1 pl-4 text-sm text-content-secondary">
@@ -130,7 +130,7 @@ export function WebGpuUnavailableNotice({ capability }: Props) {
             <summary className="cursor-pointer text-sm text-content-tertiary hover:underline">
               Using a different browser?
             </summary>
-            <ul className="mt-1.5 flex flex-col gap-1 pl-1 text-[11px] text-content-tertiary list-none">
+            <ul className="mt-1.5 flex flex-col gap-1 pl-1 text-2xs text-content-tertiary list-none">
               <li>
                 <span className="font-semibold text-content-secondary">
                   Chrome / Edge:
@@ -192,9 +192,9 @@ function CopyablePath({ path }: { path: CopyPath }) {
 
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[11px] text-content-tertiary">{path.label}</span>
+      <span className="text-2xs text-content-tertiary">{path.label}</span>
       <div className="flex items-center gap-2 rounded border border-border-light bg-surface-subtle px-2 py-1">
-        <code className="flex-1 overflow-x-auto text-[11px] text-content-primary">
+        <code className="flex-1 overflow-x-auto text-2xs text-content-primary">
           {path.value}
         </code>
         <Button
@@ -202,7 +202,7 @@ function CopyablePath({ path }: { path: CopyPath }) {
           size="sm"
           onClick={onCopy}
           aria-label={`Copy ${path.value}`}
-          className="shrink-0 text-[11px] text-accent-primary"
+          className="shrink-0 text-2xs text-accent-primary"
         >
           {copied ? "Copied ✓" : "Copy"}
         </Button>

--- a/src/design-system/CLAUDE.md
+++ b/src/design-system/CLAUDE.md
@@ -41,9 +41,11 @@ adjacent `U+FE0E` and an `aria-hidden`/`sr-only` pair.
 
 ## Type ramp
 
-Audit sizes by consumption: `rg -o 'text-(xs|sm|base|lg|xl|2xl|3xl)' src/ | sort | uniq -c`.
+Audit sizes by consumption: `rg -o 'text-(4xs|3xs|2xs|xs|sm|base|lg|xl|2xl|3xl)' src/ | sort | uniq -c`.
+- `text-2xs` / `text-3xs` / `text-4xs`: **Below `text-xs` — never for body prose.** Named descending from `text-xs` (0.75rem/12px) the way the built-in scale ascends from it: `2xs` (0.6875rem/11px), `3xs` (0.625rem/10px), `4xs` (0.5625rem/9px). Declared in `theme.css`'s `@theme inline` block. Reserved for the same kind of subordinate metadata as `text-xs` but smaller still — badge/pill labels, footer captions, model-load progress detail — never a step chosen to squeeze more text into a fixed box.
 - `text-xs`: **Never for body prose.** Allowed only for metadata that sits alongside stronger text: a chip's quality mark, a units suffix, a count badge, a timestamp.
 - `text-sm`: The default body text size.
 - `text-base`: Subheadings or large body prose.
 - `text-lg`: Primary headings for cards/sections.
 - `text-2xl`+: Page-level headings.
+- **No arbitrary sizes.** An arbitrary font size in any CSS length unit — `text-[11px]`, `text-[0.6875rem]`, `text-[1.2em]`, `text-[10pt]`, `text-[2vw]`, or the explicit `text-[length:12px]` form — is blocked by ESLint (`no-restricted-syntax` in `eslint.config.js`) — add a named step above instead of reaching for an arbitrary value. Arbitrary *non-size* values (`text-[color:var(--x)]`) are not this rule's business. The `files:` scope is every surface that writes markup: `src/components/**`, `src/design-system/**`, and the three shipped entry roots `src/App.tsx`, `src/jobs/JobsApp.tsx`, `src/jd-fit/JdFitApp.tsx`. Keep this sentence and the config's `files:` block in step — they drifted once already.

--- a/src/design-system/primitives/Button.test.tsx
+++ b/src/design-system/primitives/Button.test.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Structural test pinning the `icon` variant's 24x24 CSS-px touch-target
+ * floor (WCAG 2.2 AA SC 2.5.8, #638). jsdom does not do layout —
+ * `getBoundingClientRect()` returns zeros here, so a real pixel measurement
+ * is NOT possible in this suite (see the actual browser measurement recorded
+ * for `Chip` in #591). This asserts the CSS technique itself is present: a
+ * fixed, centred invisible `after:` overlay (`h-6 w-6`, `left-1/2 top-1/2`
+ * `-translate-x-1/2 -translate-y-1/2`) on a `relative` button — NOT an
+ * inset-based overlay, which would scale with (and overshoot) a caller's own
+ * `h-`/`w-` sizing (see `Button.tsx`'s docblock). A future token edit that
+ * drops `relative`, the fixed `h-6 w-6`, or the centring classes fails this
+ * test even though every existing snapshot/behavioural test stays green,
+ * because none of them can see an invisible overlay. Matches
+ * `Chip.test.tsx`'s `renderToStaticMarkup` pattern; no jsdom needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Button } from "./Button.tsx";
+
+function render(props: Parameters<typeof Button>[0]): string {
+  return renderToStaticMarkup(createElement(Button, props));
+}
+
+describe("Button icon variant target size", () => {
+  it("carries a fixed, centred 24x24 invisible overlay on top of its own ~14px box", () => {
+    const html = render({ variant: "icon", "aria-label": "Remove" });
+    expect(html).toContain("relative");
+    // `after:absolute` is load-bearing, not decoration: without it the
+    // pseudo-element is a non-replaced INLINE box, where `width`/`height` do
+    // not apply at all. Drop it and the overlay silently becomes a no-op while
+    // every `after:h-6`/`after:w-6` assertion below still passes.
+    expect(html).toContain("after:absolute");
+    expect(html).toContain("after:h-6");
+    expect(html).toContain("after:w-6");
+    expect(html).toContain("after:left-1/2");
+    expect(html).toContain("after:top-1/2");
+    expect(html).toContain("after:-translate-x-1/2");
+    expect(html).toContain("after:-translate-y-1/2");
+    expect(html).toContain("after:content-[&#x27;&#x27;]");
+  });
+
+  it("does not carry the overlay on other variants", () => {
+    const html = render({ variant: "ghost", children: "Cancel" });
+    expect(html).not.toContain("after:h-6");
+    expect(html).not.toContain("after:w-6");
+  });
+});

--- a/src/design-system/primitives/Button.tsx
+++ b/src/design-system/primitives/Button.tsx
@@ -10,7 +10,37 @@
  *             (text-content-secondary, hover:bg-surface-subtle)
  *   link    — looks like an inline anchor (text-content-tertiary, hover:underline)
  *   icon    — compact icon-only affordance (same hover as ghost, no padding
- *             beyond the affordance area, square touch target)
+ *             beyond the affordance area, square touch target). Carries the
+ *             24×24 CSS-px WCAG 2.2 AA SC 2.5.8 floor itself via an invisible
+ *             `after:` pseudo-element fixed at `h-6 w-6` and centred on the
+ *             button (`relative` + `after:absolute` + `left-1/2 top-1/2`
+ *             `-translate-x-1/2 -translate-y-1/2`) — NOT via inset percentages
+ *             or a `min-h`/`min-w` on the real box. A fixed, centred 24×24
+ *             overlay only ever *adds* click area when the button's own box
+ *             is smaller than 24px (e.g. the bare `p-0.5` ~14px case below);
+ *             on a caller that already sizes itself ≥24px (e.g. `h-7 w-7`),
+ *             the overlay lands entirely inside the visible box and changes
+ *             nothing. An inset-based overlay (`after:-inset-[5px]`) would
+ *             instead scale WITH the box, so a 28px button flanked by a 2px
+ *             gap (see `RewriteReviewList`'s Accept/Reject pair) would gain a
+ *             38px hit area and overlap its neighbour — the exact #581/#591
+ *             failure mode.
+ *
+ *             The primitive owns the TOUCH TARGET; a caller still owns its
+ *             VISIBLE box. So caller-side `min-h`/`min-w`/`h-`/`w-` is not
+ *             forbidden — it is simply not the way to reach SC 2.5.8, which
+ *             the overlay already guarantees on its own. Add it when the box
+ *             you can SEE matters: `variant="icon"` paints
+ *             `hover:bg-surface-subtle` and the `focus-visible` ring on the
+ *             real box, so a bare `p-0.5` around a 10×10 glyph gives a ~14×14
+ *             hover/focus affordance. `min-h-6 min-w-6` (see
+ *             `features/ReconstructedAdd.tsx`'s `RemoveButton`) makes that
+ *             affordance match the target — and, because the overlay is a
+ *             FIXED 24×24, a ≥24px visible box also means zero target overflow
+ *             past the button, which is what keeps a tight `gap-1` action row
+ *             free of the #581/#591 neighbour overlap. Do NOT delete such a
+ *             minimum as "redundant with the overlay": the two sizes govern
+ *             different boxes (#638 review).
  *   tab     — segmented-control trigger for `Tabs` (`shared/Tabs.tsx`). Owns its
  *             own size (`text-sm`, one step up from `sm`) and shape (`rounded-md`)
  *             so the caller only layers the active/inactive surface + text
@@ -18,7 +48,7 @@
  *             corners, hover surface, or size the way the pre-#516 Tab did.
  *
  * Sizes:
- *   sm  — default; covers most usage (text-xs/[11px], compact touch area)
+ *   sm  — default; covers most usage (text-sm, compact padding)
  *   md  — larger label CTAs when more visual weight is needed
  *   (the `tab` variant opts out of the size map — see below)
  *
@@ -49,7 +79,8 @@ const VARIANT: Record<ButtonVariant, string> = {
   ghost:
     "text-content-secondary hover:bg-surface-subtle px-2 py-0.5",
   link: "text-content-tertiary hover:underline underline-offset-2 p-0",
-  icon: "text-content-secondary hover:bg-surface-subtle p-0.5",
+  icon:
+    "relative text-content-secondary hover:bg-surface-subtle p-0.5 after:absolute after:left-1/2 after:top-1/2 after:h-6 after:w-6 after:-translate-x-1/2 after:-translate-y-1/2 after:content-['']",
   tab:
     "rounded-md px-3 py-1.5 text-sm duration-200 motion-reduce:transition-none motion-reduce:duration-0",
 };

--- a/src/design-system/primitives/Chip.test.tsx
+++ b/src/design-system/primitives/Chip.test.tsx
@@ -2,14 +2,16 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * Structural test for the `Chip` remove control's expanded hit area (#591).
+ * Structural test for the `Chip` remove control's visible box (#591, #638).
  * jsdom does not do layout — `getBoundingClientRect()` returns zeros here, so
  * a real pixel measurement is NOT possible in this suite (see the actual
- * browser measurement recorded in #591 instead). This asserts the CSS
- * technique that produces the 24x24 CSS px hit area is present — an invisible
- * `after:` overlay inset -5px on every side around the ~14px visible control
- * — as a structural proxy, not a rendered measurement. Matches
- * `EditableField.test.tsx`'s `renderToStaticMarkup` pattern; no jsdom needed.
+ * browser measurement recorded in #591 instead). The 24x24 hit-area floor
+ * itself now lives on the `icon` Button variant and is pinned by
+ * `Button.test.tsx` — this test only guards that `Chip` stays a plain
+ * consumer of that variant and does not reintroduce its own redundant
+ * `min-h`/`min-w`/overlay, which would double up on (or fight) the
+ * primitive's own floor. Matches `EditableField.test.tsx`'s
+ * `renderToStaticMarkup` pattern; no jsdom needed.
  */
 
 import { describe, it, expect } from "vitest";
@@ -22,18 +24,28 @@ function render(props: Parameters<typeof Chip>[0]): string {
 }
 
 describe("Chip remove control target size", () => {
-  it("expands the remove control's hit area to 24x24 via an invisible overlay, not a layout change", () => {
+  it("keeps the remove control's own box unexpanded, relying on the icon variant's floor", () => {
     const html = render({
       children: "React",
       onRemove: () => {},
       removeLabel: "Remove React",
     });
-    // `relative` positions the button as the overlay's containing block;
-    // `after:-inset-[5px]` grows the clickable area 5px on every side of the
-    // ~14px visible control (14 + 5 + 5 = 24), meeting WCAG 2.2 SC 2.5.8 (AA)
-    // without touching the button's own visual box.
-    expect(html).toContain("relative");
-    expect(html).toContain("after:-inset-[5px]");
-    expect(html).toContain("after:content-[&#x27;&#x27;]");
+    // POSITIVE assertion first, and it is the load-bearing one: it pins that
+    // Chip is still an `icon`-variant CONSUMER. `Button` defaults to
+    // `variant = "ghost"`, so deleting the one `variant="icon"` token in
+    // Chip.tsx would drop the whole SC 2.5.8 floor — and `ghost` and `icon`
+    // render near-identically in jsdom, so an all-negative test would stay
+    // green through exactly that edit. The overlay classes only ever reach the
+    // markup via the `icon` variant, so asserting one of them asserts the
+    // variant.
+    expect(html).toContain("after:absolute");
+    expect(html).toContain("after:h-6");
+    // No per-caller min-h/min-w/overlay — the `icon` variant supplies the
+    // 24x24 floor (see Button.test.tsx). These stay NEGATIVE: their job is to
+    // catch a reintroduced per-caller mechanism that would double up on (or
+    // fight) the primitive's floor.
+    expect(html).not.toContain("min-h-6");
+    expect(html).not.toContain("min-w-6");
+    expect(html).not.toContain("after:-inset-[5px]");
   });
 });

--- a/src/design-system/primitives/Chip.tsx
+++ b/src/design-system/primitives/Chip.tsx
@@ -79,14 +79,13 @@ export function Chip({
           variant="icon"
           aria-label={removeLabel ?? "Remove"}
           onClick={onRemove}
-          // WCAG 2.2 SC 2.5.8 Target Size (Minimum, AA) needs a 24x24 CSS px
-          // hit area; the visible glyph + `icon` variant padding is ~14px
-          // (10px svg + p-0.5). `relative` + an invisible `after:` overlay
-          // expand the CLICKABLE area to 24x24 (5px on every side) without
-          // touching the control's visual size or the chip's layout box, so
-          // no row re-spacing is needed (#591). Measured zero-overlap against
-          // neighbouring chips in a real browser — see #591.
-          className="relative shrink-0 text-content-muted hover:text-content-secondary after:absolute after:-inset-[5px] after:content-['']"
+          // The `icon` variant itself carries the 24x24 CSS-px WCAG 2.2 SC
+          // 2.5.8 (AA) floor via a fixed, centred invisible `after:` overlay
+          // (`Button.tsx`) — this control's visible glyph + padding stays
+          // ~14px (10px svg + p-0.5) and its layout box is untouched, so no
+          // row re-spacing is needed (#591, #638). Measured zero-overlap
+          // against neighbouring chips in a real browser — see #591.
+          className="shrink-0 text-content-muted hover:text-content-secondary"
         >
           <ChipRemoveIcon />
         </Button>

--- a/src/design-system/shared/GitHubStarCta.tsx
+++ b/src/design-system/shared/GitHubStarCta.tsx
@@ -89,7 +89,7 @@ function StarLink({ count }: { count?: number }) {
       {showCount && (
         <span
           aria-hidden="true"
-          className="rounded bg-surface-subtle px-1 py-0.5 text-[10px] font-semibold tabular-nums text-content-tertiary"
+          className="rounded bg-surface-subtle px-1 py-0.5 text-3xs font-semibold tabular-nums text-content-tertiary"
         >
           {formatCount(count)}
         </span>

--- a/src/design-system/shared/ModelLoadProgress.tsx
+++ b/src/design-system/shared/ModelLoadProgress.tsx
@@ -53,7 +53,7 @@ export function ModelLoadProgress({
   const pct = Math.max(0, Math.min(100, Math.round(progress * 100)));
   return (
     <div className="flex flex-col gap-1 rounded border border-border-light bg-surface-subtle p-2">
-      <div className="flex items-center justify-between text-[11px] text-content-secondary">
+      <div className="flex items-center justify-between text-2xs text-content-secondary">
         <span>{label}</span>
         <span className="font-mono">{pct}%</span>
       </div>
@@ -71,14 +71,14 @@ export function ModelLoadProgress({
         />
       </div>
       {text && (
-        <p className="font-mono text-[10px] text-content-muted">{text}</p>
+        <p className="font-mono text-3xs text-content-muted">{text}</p>
       )}
       {showExplainer && (
         <details className="mt-1">
-          <summary className="cursor-pointer text-[10px] text-content-tertiary hover:underline">
+          <summary className="cursor-pointer text-3xs text-content-tertiary hover:underline">
             What's happening?
           </summary>
-          <p className="mt-1 max-w-prose text-[10px] leading-relaxed text-content-tertiary">
+          <p className="mt-1 max-w-prose text-3xs leading-relaxed text-content-tertiary">
             A small open-source language model is downloading to your
             browser. It runs entirely on your device — your text never
             leaves this tab. The download is cached for next time.

--- a/src/design-system/shared/StatusBadge.tsx
+++ b/src/design-system/shared/StatusBadge.tsx
@@ -45,7 +45,7 @@ export function StatusBadge({
   return (
     <span
       aria-hidden={ariaHidden}
-      className={`inline-flex w-fit rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider ${TONE_CLS[tone]}`}
+      className={`inline-flex w-fit rounded-full px-2 py-0.5 text-2xs font-semibold uppercase tracking-wider ${TONE_CLS[tone]}`}
     >
       {children}
     </span>

--- a/src/design-system/styles/theme.css
+++ b/src/design-system/styles/theme.css
@@ -20,6 +20,17 @@
     Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
+  /*
+   * Font sizes below Tailwind's own `text-xs` (0.75rem / 12px) — see
+   * "Type ramp" in design-system/CLAUDE.md. Named descending from `xs` like
+   * the built-in scale ascends from it: 2xs, 3xs, 4xs. Values only (no
+   * paired --text-*--line-height): the sites these replace set line-height
+   * separately, so pairing one here would be a retune, not a rename.
+   */
+  --text-2xs: 0.6875rem; /* 11px */
+  --text-3xs: 0.625rem; /* 10px */
+  --text-4xs: 0.5625rem; /* 9px */
+
   /* Surface colors */
   --color-surface-base: var(--color-bg-base);
   --color-surface-card: var(--color-bg-card);

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -99,6 +99,9 @@ function looksLikeLocationTail(after: string): boolean {
  *     multi-word ("Mountain View", "Santa Clara").
  *   Pass B — space-delimited US "Role … City, ST": single-token city only (no
  *     comma boundary means greedy multi-word would consume role keywords).
+ *     Defers on a `COMPANY_TAIL_TOKENS_RE` "city" (#641) — a corporate tail noun
+ *     immediately before ", ST" is the company's last word, not a city — and
+ *     peels only the state code in that case.
  *   Pass C — comma-delimited international "…, City, Country": validates the
  *     trailing token against `COUNTRY_GAZETTEER` (closed ~249-entry ISO set +
  *     colloquial aliases) to avoid false-matching any capitalized word.
@@ -159,9 +162,28 @@ const LOCALITY_SUFFIX_RE =
  *  the current false-positive silently steals the company's tail into location.
  *  Deliberately closed-set (open-shape "single-word remnant looks wrong" would
  *  over-correct: `Citi Bank` legitimately reduces to `Citi Bank`, and `Citi`
- *  alone is a real company — a one-token-remnant rule would be unsafe.) */
+ *  alone is a real company — a one-token-remnant rule would be unsafe.)
+ *
+ *  Shared with Pass B (#641): the identical failure exists on the US
+ *  "…Company <word>, ST" space fold ("Palo Alto Networks, CA"), so the same
+ *  vocabulary gates both. Keeping ONE list means a corporate tail added for
+ *  either path protects both; it also means an entry that is a real single-word
+ *  place ("Media, PA") is deliberately traded away in favour of the company, per
+ *  the deferral rationale above.
+ *
+ *  The trailing `\.?` is load-bearing (#641 review): the captured "city" comes
+ *  from `[A-Z][A-Za-z.\-]+`, which INCLUDES the period, so the abbreviated —
+ *  and canonical written — forms `Corp.` / `Inc.` / `Ltd.` / `Labs.` reach this
+ *  test with the dot attached and a bare `$` anchor rejected every one of them.
+ *  Matches the sibling {@link COMPANY_LEGAL_TAIL_RE}, which already writes
+ *  `Inc\.?|Ltd\.?|Corp\.?`. `Co` is here for the same reason `LEGAL_SUFFIX_RE`
+ *  carries `co\.?` — "Acme Co, CA" is the same cleave — and is safe despite
+ *  being short: it is a two-letter *word* before the comma, never the `, ST`
+ *  state code (that is group 2), and no US or gazetteer locality is named "Co".
+ *  A deferral misfire is harmless by construction anyway: the whole string
+ *  stays company and the state/country is still peeled on its own. */
 const COMPANY_TAIL_TOKENS_RE =
-  /^(?:Bank|Corp|Corporation|Group|Systems|Solutions|Technologies|Studios|Media|Software|Consulting|Partners|Ventures|Holdings|Industries|Financial|Health|Healthcare|Networks|Digital|Analytics|Labs|Ltd|LLC|Inc|GmbH|SA|PLC)$/i;
+  /^(?:Bank|Co|Corp|Corporation|Group|Systems|Solutions|Technologies|Studios|Media|Software|Consulting|Partners|Ventures|Holdings|Industries|Financial|Health|Healthcare|Networks|Digital|Analytics|Labs|Ltd|LLC|Inc|GmbH|SA|PLC)\.?$/i;
 
 /** Unambiguous LEGAL-ENTITY markers — a strictly narrower closed vocabulary
  *  than {@link COMPANY_TAIL_TOKENS_RE}, used by `mapTitleFirst` case 3a to
@@ -232,14 +254,46 @@ function stripLocationSuffix(s: string): {
   // Pass B — space-delimited "Role … City, ST": single-token city only.
   const SPACE_LOCATION_RE = /\s+([A-Z][A-Za-z.\-]+),\s*([A-Z]{2})$/;
 
-  const mUS =
-    s.match(COMMA_LOCATION_RE) ??
-    s.match(SPACE_MULTIWORD_LOCATION_RE) ??
-    s.match(SPACE_LOCATION_RE);
+  // Evaluated in order, but kept as separate bindings (not a `??` chain over
+  // `s.match(...)`) so the branch below can tell WHICH pass matched: the
+  // corporate-tail deferral applies to the single-token space fold ONLY.
+  const mComma = s.match(COMMA_LOCATION_RE);
+  const mMultiword =
+    mComma === null ? s.match(SPACE_MULTIWORD_LOCATION_RE) : null;
+  const mSpace =
+    mComma === null && mMultiword === null ? s.match(SPACE_LOCATION_RE) : null;
+  const mUS = mComma ?? mMultiword ?? mSpace;
   if (mUS && US_STATE_CODE_RE.test(mUS[2])) {
-    // Guard: stripping must leave a non-empty remainder.
-    const before = stripDanglingSeparator(s.slice(0, mUS.index));
-    if (before) return { text: before, location: `${mUS[1]}, ${mUS[2]}` };
+    // #641 — Pass B's single-token rule calls the last space-delimited word
+    // before the comma the city, so a company whose LAST word is a corporate
+    // noun that precedes a state tail gets cleaved and that word is promoted to
+    // a location: "Palo Alto Networks, CA" → company "Palo Alto" + location
+    // "Networks, CA". Both halves are wrong. Apply the same closed-vocabulary
+    // deferral Pass D already uses (COMPANY_TAIL_TOKENS_RE): a corporate tail
+    // noun immediately before ", ST" is company text, not a city.
+    //
+    // Scoped to `mSpace` — the comma-delimited Pass A has a real comma boundary
+    // before its city, and Pass B-multi's city comes from the closed
+    // MULTIWORD_US_CITY_ALT vocabulary (no entry of which is a corporate tail),
+    // so neither can produce this cleave and neither is narrowed here. That
+    // keeps `Acme Palo Alto, CA` / `Acme Santa Clara, CA` splitting exactly as
+    // #636 made them.
+    //
+    // The state tail is still peeled on its own, mirroring Pass E's
+    // trailing-country-only strip after the identical Pass D deferral
+    // ("Deutsche Bank, India" → "Deutsche Bank" + "India"): the company keeps
+    // every one of its words and the location survives as the bare state code,
+    // rather than the ", CA" residue staying glued to the company name.
+    if (mSpace !== null && COMPANY_TAIL_TOKENS_RE.test(mUS[1])) {
+      // The match is end-anchored on ", ST", and a state code carries no comma,
+      // so the last comma in `s` is exactly the city/state boundary.
+      const beforeState = stripDanglingSeparator(s.slice(0, s.lastIndexOf(",")));
+      if (beforeState) return { text: beforeState, location: mUS[2] };
+    } else {
+      // Guard: stripping must leave a non-empty remainder.
+      const before = stripDanglingSeparator(s.slice(0, mUS.index));
+      if (before) return { text: before, location: `${mUS[1]}, ${mUS[2]}` };
+    }
   }
 
   // Pass C — comma-delimited "…, City, Country" (international). Only fires

--- a/src/lib/heuristics/extract/experience.company-tail-state.test.ts
+++ b/src/lib/heuristics/extract/experience.company-tail-state.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression tests for the Pass B corporate-tail deferral (#641).
+ *
+ * Pass B of `stripLocationSuffix` is a SINGLE-TOKEN space-delimited city rule:
+ * it takes the last whitespace-delimited word before the comma and calls it the
+ * city. When a company's own last word precedes a `, ST` tail, the company was
+ * cleaved and a company word promoted to a location:
+ *
+ *   "Palo Alto Networks, CA"  → company "Palo Alto"   + location "Networks, CA"
+ *   "Santa Clara Systems, CA" → company "Santa Clara" + location "Systems, CA"
+ *
+ * Both halves are wrong: `Networks, CA` is not a location and `Palo Alto` is not
+ * the employer. The fix has two halves, and each is pinned separately below:
+ *   (a) a `COMPANY_TAIL_TOKENS_RE` deferral so the corporate noun is never taken
+ *       as the city, and
+ *   (b) a state-code-only peel in that deferral branch, mirroring Pass E's
+ *       trailing-country-only strip, so the company keeps every word AND the
+ *       location still surfaces.
+ *
+ * The closed city vocabulary cannot decide this on its own — `Palo Alto` is in
+ * `MULTIWORD_US_CITY_ALT` in BOTH "Palo Alto Networks, CA" (company) and
+ * "Acme Palo Alto, CA" (company + city); only POSITION relative to the comma
+ * differentiates them. So the "already works" rows are pinned here too: the
+ * deferral is scoped to Pass B and must not trade away the Pass B-multi split
+ * #636 delivered.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
+import { extractExperience } from "../extract-fields.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+
+function roleFromHeader(header: string) {
+  const sections = splitIntoSections(
+    groupIntoLines(
+      mkItems([
+        { text: "EXPERIENCE", fontSize: 13 },
+        { text: header, fontSize: 11 },
+        { text: "04/2021 – 12/2023", fontSize: 11 },
+        {
+          text: "• Ran a cross-team migration to a shared platform.",
+          fontSize: 11,
+        },
+      ]),
+    ),
+  );
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  const roles = extractExperience(experience).value;
+  expect(roles.length).toBeGreaterThanOrEqual(1);
+  return roles[0];
+}
+
+describe("company tail before a state suffix (#641)", () => {
+  // Half (a) + (b) together: the exact rows the issue reproduces. Reverting the
+  // deferral guard restores `company: "Palo Alto"` / `location: "Networks, CA"`;
+  // reverting only the state-code peel leaves `company: "Palo Alto Networks, CA"`
+  // with no location. Both assertions are therefore load-bearing.
+  it.each([
+    ["Palo Alto Networks", "CA"],
+    ["Santa Clara Systems", "CA"],
+    ["Redwood City Ventures", "CA"],
+    // A company whose tail noun is not preceded by a vocabulary city — the same
+    // defect without any MULTIWORD_US_CITY_ALT involvement.
+    ["Acme Networks", "CA"],
+  ])("`%s, %s` keeps the company whole", (company, state) => {
+    const role = roleFromHeader(`Engineer · ${company}, ${state}`);
+    expect(role.company).toBe(company);
+    expect(role.location).toBe(state);
+    // No company word may end up in the location.
+    for (const word of company.split(" ")) {
+      expect(role.location).not.toContain(word);
+    }
+  });
+
+  // The period-bearing forms (#641 review). `Corp.` / `Inc.` / `Ltd.` /
+  // `Labs.` are the CANONICAL written spelling of the commonest corporate
+  // tails, and Pass B's capture group `[A-Z][A-Za-z.\-]+` includes the period —
+  // so a `$`-anchored vocabulary with no optional dot never fired for any of
+  // them and the deferral silently skipped exactly the shape it exists for.
+  // `Co` is the same defect one token shorter: absent from the vocabulary
+  // entirely, though `LEGAL_SUFFIX_RE` has carried `co\.?` all along.
+  it.each([
+    ["Acme Corp.", "CA"],
+    ["Acme Inc.", "NY"],
+    ["Acme Ltd.", "TX"],
+    ["Acme Labs.", "CA"],
+    ["Acme Co", "CA"],
+    ["Acme Co.", "CA"],
+  ])("`%s, %s` keeps the abbreviated corporate tail", (company, state) => {
+    const role = roleFromHeader(`Engineer · ${company}, ${state}`);
+    expect(role.company).toBe(company);
+    expect(role.location).toBe(state);
+  });
+
+  // The improvement #636 delivered as a side effect of the shared city
+  // vocabulary. The deferral is scoped to Pass B precisely so these keep
+  // splitting through Pass B-multi; if the guard ever leaks into Pass B-multi
+  // these fail rather than silently regressing.
+  it.each([
+    ["Palo Alto", "CA"],
+    ["Santa Clara", "CA"],
+    ["Redwood City", "CA"],
+  ])("`Acme %s, %s` still splits company from city", (city, state) => {
+    const role = roleFromHeader(`Engineer · Acme ${city}, ${state}`);
+    expect(role.company).toBe("Acme");
+    expect(role.location).toBe(`${city}, ${state}`);
+  });
+
+  // Pass B itself must still fire for a single-token city that is NOT a
+  // corporate tail noun — the deferral is a narrowing, and a narrowing that
+  // swallowed the whole pass would pass every test above while breaking these.
+  it.each([
+    ["Northwind Labs", "Bellevue", "WA"],
+    ["Acme Corp", "Austin", "TX"],
+  ])("`%s %s, %s` still strips the city", (company, city, state) => {
+    const role = roleFromHeader(`Engineer · ${company} ${city}, ${state}`);
+    expect(role.company).toBe(company);
+    expect(role.location).toBe(`${city}, ${state}`);
+  });
+
+  it("comma-delimited Pass A is untouched", () => {
+    const role = roleFromHeader("Engineer · Acme, Springfield, IL");
+    expect(role.company).toBe("Acme");
+    expect(role.location).toBe("Springfield, IL");
+  });
+
+  it("Pass B-multi is untouched on a corporate-tail company", () => {
+    // "Analytics" IS a corporate tail token, but it is not adjacent to the
+    // comma — the vocabulary city is — so Pass B-multi wins and the deferral
+    // never runs.
+    const role = roleFromHeader("Engineer · Acme Analytics New York, NY");
+    expect(role.company).toBe("Acme Analytics");
+    expect(role.location).toBe("New York, NY");
+  });
+
+  it("the intl sibling shape is unchanged", () => {
+    // Pass D defers on "Group" and Pass E peels the bare country — the exact
+    // behaviour the US branch now mirrors.
+    const role = roleFromHeader("Engineer · Acme Group, India");
+    expect(role.company).toBe("Acme Group");
+    expect(role.location).toBe("India");
+  });
+
+  // `COMPANY_TAIL_TOKENS_RE` is SHARED with Pass D, so the optional-period
+  // widening reaches the international path too. Pinned here so a future
+  // narrowing of the vocabulary can't quietly regress Pass D while the US rows
+  // above stay green.
+  it.each([
+    ["Acme Group", "India"],
+    ["Acme Group.", "India"],
+    ["Acme Ltd.", "India"],
+  ])("Pass D still defers on `%s, %s`", (company, country) => {
+    const role = roleFromHeader(`Engineer · ${company}, ${country}`);
+    expect(role.company).toBe(company);
+    expect(role.location).toBe(country);
+  });
+});


### PR DESCRIPTION
## Summary

Three independent issues, batched onto one branch and hardened by two adversarial review rounds before this PR existed. Each is described below with what it fixed and what it deliberately did not.

Closes #641
Closes #638
Closes #640

### #641 — parser: a corporate tail before a state suffix cleaved the company

Pass B of `stripLocationSuffix` is a **single-token** space-delimited city rule, so a company whose last word preceded a `, ST` tail was split and that word promoted to a location:

| Header | Before | After |
|---|---|---|
| `Palo Alto Networks, CA` | `Palo Alto` / `Networks, CA` | `Palo Alto Networks` / `CA` |
| `Santa Clara Systems, CA` | `Santa Clara` / `Systems, CA` | `Santa Clara Systems` / `CA` |
| `Acme Corp., CA` | `Acme` / `Corp., CA` | `Acme Corp.` / `CA` |

The US match chain is split into named bindings so the branch can tell **which** pass matched, and the `COMPANY_TAIL_TOKENS_RE` deferral is scoped to the single-token space fold only — the comma-delimited pass has a real comma boundary, and the multi-word pass draws its city from a closed vocabulary, so neither can produce the cleave and neither is narrowed. `Acme Palo Alto, CA` and `Acme Santa Clara, CA` still split exactly as #636 left them, pinned by their own test table.

Round-1 review caught that the `$`-anchored vocabulary was **defeated by a trailing period** — Pass B's capture group `([A-Z][A-Za-z.\-]+)` includes it, so `Corp.` / `Inc.` / `Ltd.` failed the test. Those are the canonical written forms, i.e. the most common instance of the very defect being fixed. Resolved with an optional trailing period and `Co`.

**Deliberate trade:** `Media` is in the vocabulary, so `Globex Media, PA` now yields `Globex Media` / `PA`. Media, PA is a real borough — but a false negative leaves recoverable company text, where a false positive silently steals it. Documented at the constant.

**Not fixed, by design:** the comma-delimited pass has the same ambiguity (`Acme Group, Networks, CA`). Pre-existing, and a real comma boundary is a genuine signal; narrowing it was out of scope.

**Blast radius: zero.** No corpus fixture or snapshot moved — verified independently by scanning every parsed `experience` role in the corpus for a company or location ending in any vocabulary token: no matches exist, so the change is inert by construction.

### #638 — a11y: the 24×24 target floor belongs on the primitive

The WCAG 2.2 AA SC 2.5.8 floor now lives on `Button`'s `icon` variant rather than being re-applied per caller. It is a **fixed, centred overlay**, not a minimum size: it only ever adds hit area to a box under 24px and never grows a caller's layout box. An inset overlay would have scaled with the caller and pushed already-conformant 28px controls into their neighbours. `Chip`'s geometry is unchanged (14px visible / 24px hit area) — only the technique producing it moved, so #591's browser measurement still holds.

The floor is not free at every surface: a 14px box with a 24×24 overlay overhangs **5px per side**, wider than a 4px row gap. Three adjacencies were measured in a browser and corrected:

- **Skills chip Move/Remove** — overlays overlapped by 6px, and Remove's overlay covered ~1px of Move's *visible* glyph, so a tap on the Move icon fired the destructive Remove. Fixed to 12px gap / 26px centre-to-centre / 2px daylight. The spacing sits on the **Move trigger**, which is the conditional control, so an uncategorised chip gains no dead space.
- **Role row** and **contact-link row** — same class, found in review, and both resolved by keeping `RemoveButton`'s own 24px visible box so the overlay is contained exactly (which also restores the hover/focus affordance at 8 consumer sites).

The primitive owns the **touch target**; a caller may still size its **visible box**. Both docblocks now say so, and a test pins it — because a docblock is precisely what failed here the first time.

### #640 — design system: font size had no token vocabulary

`@theme inline` mapped colours only, so 67 call sites across 19 files hand-wrote an arbitrary size. Three steps below `text-xs` are now declared once and consumed by name — `text-2xs` (11px), `text-3xs` (10px), `text-4xs` (9px) — with a `no-restricted-syntax` rule blocking new ones. The rule pairs a `Literal` selector with a `TemplateElement` one so class strings built in template literals are covered, and matches every CSS length unit rather than only the two the sweep happened to use.

**Rename, not retune.** Token values equal the px they replace, the emitted CSS is `font-size` only (no paired line-height, matching what `text-[11px]` emitted), and `html { font-size: 16px }` is pinned, so the rem values are exact. Rendered output is unchanged at every site.

## Adversarial review

Two bounded rounds against the local diff, before this PR existed, so the loop could iterate freely and push once. Reviewer was independent and prompted to falsify, not to approve.

### Round 1 — 4 blocking

| # | Finding | Resolution |
|---|---|---|
| 1 | `COMPANY_TAIL_TOKENS_RE` is `$`-anchored with no optional period, but Pass B's capture group includes it — so `Acme Corp.` / `Inc.` / `Ltd.`, the canonical written forms and the most common instance of the defect, were still cleaved | added `\.?` and `Co`; 7 new test rows, each proven to fail on revert |
| 2 | New target overlap at `ReconstructedRole.tsx:339` — the icon overlay overhangs 5px into a 4px `gap-1`, and Remove is DOM-later so it wins the seam over the rewrite trigger | fixed at the root (below) |
| 3 | Same at `ContactExtraLinks.tsx:49`, stealing from the external-link anchor | fixed at the root (below) |
| 4 | Dropping `min-h-6 min-w-6` from `RemoveButton` shrank the visible hover/focus box from 24×24 to ~14×14 at 8 consumer sites — the per-caller sizing was not redundant with the overlay; it governed a different box | restored it, which resolves 2, 3 and 4 together: a real 24px box contains the 24×24 overlay exactly, so overflow is zero |

Also fixed, as defects in guards this batch itself shipped: the new lint regex both **over**-matched (unanchored left — `context-[11px]` flagged) and **under**-matched (`em` / `pt` / `vw` / `length:` missed); a stale `Button` docblock still citing the `[11px]` notation the sweep retires; and a doc/config disagreement about the rule's `files:` scope.

### Round 2 — 1 blocking

Round 2 caught a defect **introduced by round 1's own fix**: `Chip.test.tsx` had been rewritten to be entirely negative (three `not.toContain`). Since `Button` defaults to `variant = "ghost"`, deleting the single `variant="icon"` token in `Chip.tsx` would drop the whole SC 2.5.8 floor while every one of the 3573 tests stayed green — and `ghost`/`icon` render near-identically in jsdom. Fixed by adding a positive assertion that pins Chip as an `icon`-variant consumer; verified it now fails on exactly that one-token edit.

Two round-2 nits were treated as blocking and fixed for the same reason — a test that cannot fail on the thing it guards:

- `Button.test.tsx` asserted `after:h-6`/`after:w-6` but not **`after:absolute`**, without which the pseudo-element is a non-replaced inline box where width/height do not apply — the overlay silently becomes a no-op and the test still passes.
- `ml-2` was unconditional while `MoveMenu` is not, so every chip in the ungrouped row gained 8px of dead space. Moved onto the Move trigger, which only exists when there is a neighbour to separate from. Re-measured in a browser: categorised chip 12px gap / 26px centres / 2px daylight / 0 mis-targeted px; uncategorised chip back to a 4px `gap-1` with no dead space.

### Surviving nits — not fixed, for the human reviewer

- `Button.tsx` has a second stale comment naming `text-xs`/`text-sm` where the size map reads `text-sm`/`text-base` (pre-existing sibling of one that was corrected).
- The lint `files:` list names two app roots by path; a new markup component under `src/jobs/` or `src/jd-fit/` would escape the token rules with no signal.
- `ARBITRARY_TEXT_SIZE_RE`'s left boundary does not admit a leading `!`. Not a hole on Tailwind 4 (where `!` is a suffix, and the suffixed form **is** caught) — noted so the omission is a decision rather than an oversight.
- `Acme Ltd., India` in the Pass D test table cannot fail — an independent guard already rejects it. The load-bearing row there is `Acme Group.`, which reaches the widened vocabulary. Worth a comment marking which is which.
- The `#641` shape survives on two sibling paths the issue did not scope: `Acme Group, Networks, CA` (comma-delimited) and `Acme Group | Networks, CA` (pipe anchor-cell).

### What the reviewer tried to break and could not

The `??`→named-bindings refactor preserves short-circuit order exactly (no input makes two bindings non-null). `s.lastIndexOf(",")` is provably the city/state boundary in the deferral branch, and a company-internal comma routes to the comma-delimited pass where the deferral never runs. `Co` cannot collide with Colorado — a state code can only land in the second capture group. No US or gazetteer locality is spelled `Co`, `Co.`, or with a trailing dot on any vocabulary word, so the widening adds zero new place-name false deferrals beyond the documented `Media, PA`. Pass D was probed with six international shapes, all unchanged. No `variant="icon"` sits inside any `overflow-hidden` container, so the floor is not silently clipped anywhere. The px→rem rename was proven neutral by compiling Tailwind against the real theme and diffing the emitted CSS, and every removed `text-[…]` line was machine-paired to its replacement — 0 unmatched, 0 mis-mapped. The diff adds no hook code at all, so the repo's unenforced `exhaustive-deps` has no surface here.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean — whole repo, with the new rule active
- [x] `npm run test` — 3573 passed / 10 skipped / 0 failed (255 files)
- [x] `npm run check:fixtures` clean — 54 PDFs, none added or changed by this PR
- [x] Zero `text-[Npx]` remaining in `.ts` / `.tsx` / `.css`
- [x] Corpus snapshots unchanged (no fixture movement)
- [x] Target geometry measured in a real browser at all three corrected adjacencies
- [x] `fallow` — 7 complexity findings, 9 clone groups, all 9 excluded as inherited (report-only per `CLAUDE.md`)

## Notes for the reviewer

- **#637 was dropped from this batch and rewritten, not closed.** Implementation found its repro is unreachable on `main`: `removeBullet` never splices `addedBullets`, so an added role that ever had a bullet is permanently non-empty to `isAddedEntryEmpty` and the prune never fires. The reason it is unreachable is a larger defect — **"Remove bullet" is inert on every user-added role**, surviving into the score and the exported PDF. #637 now describes that, as two independently revert-provable halves. It is not in this diff.
- **`stripLocationSuffix` is now fallow-CRITICAL** (29 cyclomatic / 41 cognitive / 160 lines); #641 added ~34 lines to an already-over-threshold function. Left alone on purpose: a behaviour-preserving extraction would void the revert-proof that certifies this implementation, and "tests still green" is not the same claim. Report-only per `CLAUDE.md`.
- **`HEX_RE` was anchored in this PR, for the same reason as the font-size rule.** It was `#[0-9a-fA-F]{3,6}\b`, unanchored — and because these selectors match string VALUES, a bare issue reference like `#638` in a test name was reported as a hardcoded hex colour. The new `ReconstructedAdd.remove-button.test.tsx` shipped a comment routing around it, which is what made it worth fixing here rather than filing: the same unanchored-substring defect, in the same file, twelve lines from its already-fixed sibling. Hex now matches positionally — 6- and 8-digit forms anywhere, 3- and 4-digit forms only at a value start or after Tailwind's `[`. Verified both directions against a throwaway probe (`#fff`, `#ef4444`, `bg-[#f00]`, `text-[#abc]`, `#12345678`, `#fffa`, a template literal and a mid-string 6-digit all still error; five issue-reference strings clean), then proven by deleting the workaround comment and restoring `#638` to the `describe` string — whole-repo `npm run lint` stays green.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #641 | Claude Opus 5 (1M context) | ultra |
| Implementation — #638 | Claude Sonnet 4.6 | high |
| Implementation — #640 | Claude Sonnet 5 | high |
| Adversarial review — round 1 | Claude Opus 5 (1M context) | high |
| Review fixes | Claude Opus 5 (1M context) | high |
| Adversarial review — round 2 | Claude Opus 5 (1M context) | high |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |

Every model string above is self-reported by the agent that ran, or first-hand. #638 and #640 ran under the same requested `sonnet` alias yet reported different names; both are recorded as reported rather than reconciled, since inferring either would be a guess.


