### PR TITLE
fix(edit,docs): make "Remove bullet" real on user-added roles, and record the exporter's separator contract (#637, #620)

### DIFF
--- a/docs/canonical-resume-model.md
+++ b/docs/canonical-resume-model.md
@@ -199,3 +199,75 @@ Minted **after** this plan is accepted, one per stage, each with its round-trip-
 4. **Stage D+E** (shipped combined, #445 — supersedes the separate #446) — collapse `LlmParsedResume` + `ApplyOverridesResult` into projections and delete the hand-sync note, **and** cut over: remove the `CascadeResult` façade + ship #321 cache versioning/invalidation (§6). Combined so the façade removal is provable in one round-trip gate rather than two.
 
 Refs [#438](https://github.com/offlinecv/OfflineCV/issues/438), [#321](https://github.com/offlinecv/OfflineCV/issues/321), [#401](https://github.com/offlinecv/OfflineCV/issues/401), [#425](https://github.com/offlinecv/OfflineCV/issues/425), [#434](https://github.com/offlinecv/OfflineCV/issues/434), [#435](https://github.com/offlinecv/OfflineCV/issues/435).
+
+---
+
+## 10. Separator contract
+
+Dogfooding once read a role header as `Role - Subtitle · Company, Location` and asked
+whether the ASCII hyphen was a bug or a deliberate parser constraint. It is neither: the
+exporter never chooses a hyphen. Every separator `AtsResumeModel` emits is a fixed literal;
+the hyphen came from the **role title string itself** — user-authored text, passed through
+verbatim.
+
+**The invariant:** the exporter's separator set is fixed and parser-coupled; user text
+passes through verbatim and may contain any glyph.
+
+| Join | Separator | Site |
+|---|---|---|
+| `Title · Company, Location · Team` | `" · "` | `ats-resume-model.ts:583`, `:608` (`joinHeader`) |
+| `Company, Location` | `", "` | `ats-resume-model.ts:580-582` |
+| `Title, Team` (empty-company branch, #466) | `", "` | `ats-resume-model.ts:605` |
+| `Institution · Location` | `" · "` | `ats-resume-model.ts:720` |
+| `Degree, Field` | `", "` | `ats-resume-model.ts:719` |
+| `Type · Title` (achievement) | `" · "` | `ats-resume-model.ts:441` |
+| Skills, within a category | `" · "` | `ats-resume-model.ts:829`, `:838` |
+| Header ↔ trailing single-token date | `"  "` (two spaces) | `ats-resume-model.ts:641`, `:780`, `:796`, `:808` |
+| Experience/education date **range** | `" – "` spaced en dash | `ats-resume-model.ts:368` (`experienceDateRange`) |
+| Project/education-fallback date **range** | `"–"` unspaced en dash | `score/entry-dates.ts:19` (`buildProjectDates`), `:33` (`buildEducationDates`) |
+
+Every `ats-resume-model.ts` row above is `src/lib/pdf/ats-resume-model.ts`; the date-range
+row is `src/lib/score/entry-dates.ts`, a different directory.
+
+Plus one deliberate exception: an **achievement's** title↔year separator echoes the
+*source's own* punctuation (`achievementYearJoiner`, `score/entry-dates.ts:57`, #380) — a hyphen
+there is also user-sourced, by design, so the export re-parses to the same `year_separator`
+it came from.
+
+`render-ats-pdf.ts` holds exactly one separator constant of its own —
+`MIDDOT_SEGMENT_SEP = " · "` (`render-ats-pdf.ts:176`) — used only to keep a middot-joined
+segment atomic across a wrap point; it does not choose which fields get middot-joined.
+
+There is **no** ASCII hyphen anywhere in this set. A `Role - Subtitle` header is a title
+field whose value literally contains `" - "`, drawn verbatim.
+
+**Why it's load-bearing, not cosmetic:**
+
+- `joinHeader([title, org], " · ")` is what the re-parser's `mapTitleFirst` splits on to
+  recover title / company / location / team.
+- The **#466 empty-company branch** exists precisely because swapping one separator changes
+  the parse: a naive `"Title · Team"` middot join re-parses as a `Title · Company` shape and
+  mislabels the team as the company. The fix emits a **comma** instead (`"Title, Team"`), so
+  the parser's role-comma split routes it back to `team`.
+- The `", "` in `Company, Location` and the `" · "` before `Team` are load-bearing the same
+  way — the comma marks the location boundary, the middot marks the team boundary.
+- The two-space header↔date join is also a contract: the wide same-`y` gap is what
+  `columnGapCuts` / `flush()` in `sections.ts` read as a flush-right date rail (#425).
+- The en dash in a date range feeds `DATE_RANGE_RE` / `isLoneDateRange`
+  (`line-primitives.ts`), the shared discriminator between the exporter's flush-right
+  decision and the splitter's exemption.
+
+Widening the accepted charset — teaching the exporter to emit `-` or `|` where it emits
+`·`, or teaching the parser to treat them as equivalent — changes field routing on real
+fixtures. §7 above documents an adjacent tradeoff of this class (the one-line header
+removing the title/company structural signal, baselined in `KNOWN_FAILURES`).
+
+**Explicitly out of scope for this contract:**
+
+- Normalizing user-authored hyphens inside a title. `Role - Subtitle` is the user's text;
+  rewriting it would be the exporter editing résumé content, which it must never do.
+- Widening the parser to accept alternative separators (a source résumé using `|` or `—`
+  between title and company parses worse today) — a parser-input question, separate from
+  this export-side contract.
+
+Refs [#620](https://github.com/offlinecv/OfflineCV/issues/620), [#466](https://github.com/offlinecv/OfflineCV/issues/466), [#425](https://github.com/offlinecv/OfflineCV/issues/425), [#380](https://github.com/offlinecv/OfflineCV/issues/380).

--- a/src/components/features/BulletRemoveStatus.tsx
+++ b/src/components/features/BulletRemoveStatus.tsx
@@ -37,8 +37,11 @@ import {
 } from "./ApplyConfirmation.tsx";
 
 export interface BulletRemoveControl {
-  /** Drop one bullet by its `BulletObservation.index` and arm the strip. */
-  removeBullet: (index: number) => void;
+  /** Drop one bullet by its `BulletObservation.index` and arm the strip. `text`
+   *  is the bullet's observation text, which the owner forwards so a USER-ADDED
+   *  bullet can be located in its `addedBullets` bucket — the index alone
+   *  cannot reach one (#637, see `added-bullets.ts`). */
+  removeBullet: (index: number, text: string) => void;
   /** True while a confirmation is showing. Callers use it to suppress an
    *  "empty section" note that would otherwise contradict the strip. */
   pending: boolean;
@@ -48,13 +51,14 @@ export interface BulletRemoveControl {
 }
 
 /**
- * @param onRemoveBullet Drop a bullet by `BulletObservation.index`. Absent →
- *   `removeBullet` is inert (the caller renders no remove control either).
+ * @param onRemoveBullet Drop a bullet by `BulletObservation.index`, plus its
+ *   text for the added-bullet path (#637). Absent → `removeBullet` is inert
+ *   (the caller renders no remove control either).
  * @param captureUndo Snapshot the slot the remove will clear, BEFORE the write
  *   (issue 510). Absent → the confirmation renders without an Undo action.
  */
 export function useBulletRemoveStatus(
-  onRemoveBullet?: (index: number) => void,
+  onRemoveBullet?: (index: number, text: string) => void,
   captureUndo?: SectionRewriteApply["captureUndo"],
 ): BulletRemoveControl {
   const [status, setStatus] = useState<
@@ -64,12 +68,14 @@ export function useBulletRemoveStatus(
   >({ kind: "idle" });
 
   const removeBullet = useCallback(
-    (index: number) => {
+    (index: number, text: string) => {
       if (!onRemoveBullet) return;
       // Snapshot BEFORE the write — once it lands the prior value is gone
-      // (issue 510, same rule the rewrite-review Apply follows).
+      // (issue 510, same rule the rewrite-review Apply follows). For an added
+      // bullet the snapshotted slot is the entry's `addedBullets` bucket, which
+      // `batchUndoTargets` now records for a `remove` too (#637).
       const undo = captureUndo?.([{ kind: "remove", obsIndex: index }]);
-      onRemoveBullet(index);
+      onRemoveBullet(index, text);
       setStatus({ kind: "removed", undo });
     },
     [onRemoveBullet, captureUndo],

--- a/src/components/features/ExperienceSection.prune-hold.test.tsx
+++ b/src/components/features/ExperienceSection.prune-hold.test.tsx
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Regression test for #637 half 2 — the section-exit prune used to unmount the
+ * `RoleEntry` hosting a just-armed "Removed 1 change · Undo" strip.
+ *
+ * This repro is only REACHABLE once half 1 lands. Before it, removing a user-
+ * added role's bullet never shrank `addedBullets`, so `isAddedEntryEmpty` stayed
+ * false, so `pruneEmptyAddedEntries` never touched the role and the strip was
+ * never at risk. The test therefore drives the REAL `useEditableParse` and the
+ * REAL `applyOverrides` → `computeAnonymousAtsScore` → `groupBulletsByExperience`
+ * chain: the entry becomes empty because the shipped code emptied it, not
+ * because the harness staged it.
+ *
+ * The second case is what makes the hold PER ENTRY rather than per section: an
+ * empty SIBLING added role with no live undo must still be dropped by the very
+ * same prune pass that spares the held one.
+ *
+ * jsdom + raw `createRoot` + fake timers, matching `ExperienceSection.test.tsx`.
+ */
+
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { createElement, useMemo } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ExperienceSection } from "./ReconstructedResume.tsx";
+import { useEditableParse, type EditableParse } from "../../hooks/useEditableParse.ts";
+import { applyOverrides } from "../../lib/edit/apply-overrides.ts";
+import { computeAnonymousAtsScore } from "../../lib/score/score.ts";
+import { groupBulletsByExperience } from "../../lib/score/group-bullets.ts";
+import type { BulletGroup } from "../../lib/score/group-bullets.ts";
+import { projectScoreSections } from "../../lib/heuristics/projections.ts";
+import { buildBlankResult } from "../../lib/heuristics/empty-result.ts";
+import { toCanonicalResume } from "../../lib/heuristics/canonical.ts";
+import type { SectionedResume } from "../../lib/heuristics/sections.ts";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+import { batchUndoTargets } from "../../lib/rewrite-review/undo-batch.ts";
+import { UNDO_HOLD_MS } from "./ApplyConfirmation.tsx";
+
+const PARSED_BULLET = "Cut p99 checkout latency by 38% via edge caching.";
+const HELD_BULLET = "Shipped a design system used by 40 engineers.";
+
+/**
+ * One PARSED role, so the EXPERIENCE section pool is non-empty. That matters:
+ * with an empty one, `computeAnonymousAtsScore`'s glyph-less fallback (#365)
+ * re-pools every role DESCRIPTION, and an added bullet — which lives in both
+ * the description and the appended pool lines — would be graded twice.
+ */
+function baseResult(): CascadeResult {
+  const blank = buildBlankResult();
+  const byName = new Map<string, readonly string[]>([
+    ["experience", [`• ${PARSED_BULLET}`]],
+  ]);
+  const sections: SectionedResume = {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+  return {
+    ...blank,
+    rawText: `• ${PARSED_BULLET}`,
+    canonical: toCanonicalResume(
+      {
+        full_name: "Robin Vasquez",
+        email: "robin.vasquez@example.com",
+        skills: ["typescript"],
+        education: [],
+        experience: [
+          {
+            title: "Staff Engineer",
+            company: "Northwind Systems",
+            description: PARSED_BULLET,
+          },
+        ],
+      },
+      sections,
+      {},
+    ),
+  };
+}
+
+let api: EditableParse;
+
+/**
+ * Mounts `ExperienceSection` over the real edit hook and the real re-grade
+ * pipeline: one parsed role, plus whatever the test adds through "+ Add
+ * experience". Only the ADDED ones can be pruned.
+ */
+function Harness() {
+  const edit = useEditableParse();
+  api = edit;
+
+  const groups = useMemo<BulletGroup[]>(() => {
+    const base = baseResult();
+    const core = applyOverrides(
+      base.canonical.fields,
+      base.rawText,
+      base.canonical.sections,
+      edit.contactOverrides,
+      edit.experienceOverrides,
+      edit.bulletOverrides,
+      [],
+      edit.educationOverrides,
+      edit.skillsOverride,
+      edit.addedEntries,
+      edit.addedBullets,
+      edit.removedBullets,
+      edit.profileOverrides,
+      base.canonical.fieldConfidence,
+      edit.achievementOverrides,
+      edit.descriptionOverrides,
+      edit.summaryOverride,
+    );
+    const score = computeAnonymousAtsScore({
+      parsed: core.fields,
+      fieldConfidence: core.fieldConfidence,
+      triggers: base.triggers,
+      rawText: core.rawText,
+      sections: projectScoreSections(core),
+    });
+    const experiences = core.fields.experience;
+    const byIndex = new Map(
+      groupBulletsByExperience([...(score.bullets ?? [])], experiences)
+        .filter((g) => g.experienceIndex !== null)
+        .map((g) => [g.experienceIndex, g] as const),
+    );
+    // `buildEntryGroups`' `sliceGroups` fallback: every entry renders, even
+    // with zero matched bullets.
+    return experiences.map(
+      (exp, i) =>
+        byIndex.get(i) ?? { experienceIndex: i, experience: exp, bullets: [] },
+    );
+  }, [edit]);
+
+  return createElement(ExperienceSection, {
+    groups,
+    resumeSections: [],
+    // false → no ModelSelector / rewrite CTA chrome in the test DOM.
+    hasBullets: false,
+    experienceOverrides: {},
+    onExperienceFieldChange: () => {},
+    bulletOverrides: edit.bulletOverrides,
+    onBulletChange: edit.setBulletField,
+    onRemoveBullet: edit.removeBullet,
+    addedExperience: edit.addedEntries.filter((e) => e.section === "experience"),
+    // Index 0 is the parsed role; indices 1+ are the user-added ones.
+    originalCount: 1,
+    onAddEntry: () => edit.addEntry("experience"),
+    onRemoveEntry: edit.removeEntry,
+    onEntryField: edit.setEntryField,
+    onAddBullet: edit.addBullet,
+    captureBulletUndo: edit.captureBulletUndo,
+    summaryApply: {
+      obsIndices: [],
+      onReplace: () => {},
+      onRemove: () => {},
+      onAdd: () => {},
+    },
+    onPruneEmpty: (isHeld) => edit.pruneEmptyAddedEntries("experience", isHeld),
+  });
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function render(): Promise<HTMLDivElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(Harness));
+  });
+  await act(async () => {});
+  return container;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: [
+      "setTimeout",
+      "clearTimeout",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+    ],
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+  vi.useRealTimers();
+});
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+/** The real section-exit blur (#379): focus leaves the section entirely, then
+ *  the deferred prune fires one macrotask later. */
+async function exitSection(el: HTMLDivElement) {
+  const section = el.querySelector("section")!;
+  await act(async () => {
+    section.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: null }),
+    );
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(1);
+  });
+}
+
+function removeBulletButtons(el: HTMLDivElement): HTMLButtonElement[] {
+  return Array.from(
+    el.querySelectorAll<HTMLButtonElement>('[aria-label="Remove bullet"]'),
+  );
+}
+
+const UNDO_LABEL = "Undo the changes just applied to the résumé";
+
+/**
+ * Two blank-header added roles; the first gets a bullet. Blank headers are
+ * load-bearing: `isAddedEntryEmpty` is `headerEmpty && no bullets`, so a role
+ * with a typed title is never prunable and a test built on one would pass with
+ * the hold ripped out. Here the bullet is the ONLY thing keeping `held` alive,
+ * and removing it hands the entry straight to the prune.
+ */
+function seedRoles(): { held: string; sibling: string } {
+  let held = "";
+  let sibling = "";
+  act(() => {
+    held = api.addEntry("experience");
+    sibling = api.addEntry("experience");
+  });
+  act(() => api.addBullet(held, HELD_BULLET));
+  return { held, sibling };
+}
+
+describe("ExperienceSection — the prune must not eat a live undo (#637 half 2)", () => {
+  it("keeps the added role and its Undo strip alive across the prune tick", async () => {
+    const el = await render();
+    seedRoles();
+    await act(async () => {});
+
+    expect(el.textContent).toContain(HELD_BULLET);
+    // The parsed role's bullet, then the added role's.
+    const buttons = removeBulletButtons(el);
+    expect(buttons).toHaveLength(2);
+
+    // Blank-commit's destination: the per-bullet remove.
+    await click(buttons[1]!);
+    expect(el.textContent).toContain("Removed 1 change");
+
+    // The role is NOW genuinely empty — half 1 emptied its bucket — so the
+    // prune would drop it and take the strip with it.
+    expect(api.addedBullets).toEqual({});
+    expect(el.textContent).not.toContain(HELD_BULLET);
+
+    await exitSection(el);
+
+    expect(el.textContent).toContain("Removed 1 change");
+    expect(el.querySelector(`[aria-label="${UNDO_LABEL}"]`)).not.toBeNull();
+  });
+
+  it("that surviving Undo still works after the prune tick", async () => {
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await click(removeBulletButtons(el)[1]!);
+    await exitSection(el);
+
+    await click(el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`)!);
+
+    expect(el.textContent).toContain(HELD_BULLET);
+    expect(el.textContent).toContain("Reverted 1 change");
+    expect(removeBulletButtons(el)).toHaveLength(2);
+    expect(api.addedBullets[held]).toEqual([HELD_BULLET]);
+  });
+
+  it("still drops an empty SIBLING added role in the same prune pass", async () => {
+    const el = await render();
+    const { held, sibling } = seedRoles();
+    await act(async () => {});
+    expect(api.addedEntries.map((e) => e.id)).toEqual([held, sibling]);
+
+    await click(removeBulletButtons(el)[1]!);
+    await exitSection(el);
+
+    // Per-entry, not per-section: the held role survives, its blank sibling
+    // — which has no live undo to protect — does not.
+    expect(api.addedEntries.map((e) => e.id)).toEqual([held]);
+  });
+
+  it("prunes the held role once its strip is gone and focus leaves again", async () => {
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await click(removeBulletButtons(el)[1]!);
+    await exitSection(el);
+    expect(api.addedEntries.map((e) => e.id)).toContain(held);
+
+    // The hold is a lease on the LIVE strip, not a permanent exemption: once
+    // the confirmation collapses, the next section exit drops the ghost.
+    // Two advances, not one: `ApplyConfirmation` chains hold → collapsing →
+    // exit, and the exit timer is not SCHEDULED until the effect reacting to
+    // `collapsing` runs, so a single advance would never reach `onCollapse`.
+    await act(async () => {
+      vi.advanceTimersByTime(UNDO_HOLD_MS);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(el.textContent).not.toContain("Removed 1 change");
+
+    await exitSection(el);
+
+    expect(api.addedEntries).toHaveLength(0);
+  });
+});
+
+describe("useEditableParse.pruneEmptyAddedEntries — isHeld (#637 half 2)", () => {
+  it("spares only the held id, and keeps identity when it spares everything", async () => {
+    await render();
+    let a = "";
+    let b = "";
+    act(() => {
+      a = api.addEntry("experience");
+      b = api.addEntry("experience");
+    });
+    // Flush the WebGPU-capability probe each freshly-mounted RoleEntry kicks
+    // off, so its setState lands inside act().
+    await act(async () => {});
+    const before = api.addedEntries;
+
+    act(() => api.pruneEmptyAddedEntries("experience", (id) => id === a || id === b));
+    expect(api.addedEntries).toBe(before);
+
+    act(() => api.pruneEmptyAddedEntries("experience", (id) => id === a));
+    expect(api.addedEntries.map((e) => e.id)).toEqual([a]);
+    expect(b).not.toBe(a);
+  });
+
+  it("prunes everything empty when no hold is supplied (#379 unchanged)", async () => {
+    await render();
+    act(() => {
+      api.addEntry("experience");
+      api.addEntry("experience");
+    });
+    await act(async () => {});
+    act(() => api.pruneEmptyAddedEntries("experience"));
+    expect(api.addedEntries).toHaveLength(0);
+  });
+});
+
+describe("batchUndoTargets records the bucket for a remove (#637 half 1)", () => {
+  it("carries addedEntryKey for a remove-only batch", () => {
+    expect(
+      batchUndoTargets([{ kind: "remove", obsIndex: 3 }], "added:7"),
+    ).toEqual({ replaced: [], removed: [3], addedEntryKey: "added:7" });
+  });
+
+  it("still omits it for a replace-only batch", () => {
+    expect(
+      batchUndoTargets([{ kind: "replace", obsIndex: 3, text: "x" }], "added:7"),
+    ).toEqual({ replaced: [3], removed: [] });
+  });
+});

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -81,8 +81,10 @@ import type {
   AddedEntry,
   AddedEntryField,
   AchievementFieldOverrides,
+  AddedBulletRef,
 } from "../../hooks/useEditableParse.ts";
 import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
+import { useAddedEntryPruneHold } from "../../hooks/useAddedEntryPruneHold.ts";
 import {
   batchUndoTargets,
   type BulletUndoTargets,
@@ -437,8 +439,10 @@ export function ExperienceSection({
   ) => void;
   bulletOverrides: BulletOverrides;
   onBulletChange: (index: number, value: string) => void;
-  /** Drop a parsed bullet by BulletObservation.index (rewrite-review apply, #211). */
-  onRemoveBullet: (index: number) => void;
+  /** Drop a bullet by BulletObservation.index (rewrite-review apply, #211),
+   *  plus the optional added-bullets bucket + line that is the only way to
+   *  reach a USER-ADDED bullet (#637). */
+  onRemoveBullet: (index: number, added?: AddedBulletRef) => void;
   /** User-added experience entries, append-aligned to indices ≥ originalCount. */
   addedExperience: AddedEntry[];
   /** Count of PARSED experience roles; indices at/above this are user-added. */
@@ -454,8 +458,10 @@ export function ExperienceSection({
    *  an accepted summary rewrite lands in `summaryOverride` — the slot the
    *  inline Summary field writes — instead of being read-only redline. */
   summaryApply: SectionRewriteApply;
-  /** Drop a blank added entry when focus leaves the section (#379). */
-  onPruneEmpty: () => void;
+  /** Drop a blank added entry when focus leaves the section (#379). `isHeld`
+   *  spares individual entries whose remove-undo strip is still live — see
+   *  {@link useAddedEntryPruneHold} (#637). */
+  onPruneEmpty: (isHeld?: (entryId: string) => boolean) => void;
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
@@ -475,7 +481,29 @@ export function ExperienceSection({
       captureBulletUndo(batchUndoTargets(writes, "other-bullets")),
     [captureBulletUndo],
   );
-  const otherRemove = useBulletRemoveStatus(onRemoveBullet, otherCaptureUndo);
+  // The "Other bullets" bucket owns no entry, so in practice it does not carry
+  // an added bullet: `applyAddedEntriesAndBullets` writes every added line into
+  // its entry's own description, and `buildEntryGroups` grades experiences,
+  // projects and achievements against one combined index space — so an added
+  // line normally matches its entry and never falls through to "Other". The
+  // row's `text` is therefore dropped rather than forwarded as an
+  // `AddedBulletRef` that would almost always miss (#637).
+  //
+  // Not an absolute, though: `groupBulletsByExperience` keys on
+  // `normalizeBulletText` and skips a line whose key is empty, while `addBullet`
+  // only rejects blank-after-`trim()`. So a degenerate added line that is pure
+  // punctuation ("•", "-", "–") IS accepted and DOES land here, where its Remove
+  // is inert. Tracked separately rather than widened here.
+  const otherRemoveBullet = useCallback(
+    (index: number) => onRemoveBullet(index),
+    [onRemoveBullet],
+  );
+  const otherRemove = useBulletRemoveStatus(otherRemoveBullet, otherCaptureUndo);
+
+  // Per-entry prune hold (#637 half 2). Created HERE — the ids it holds are
+  // only meaningful to this section's `pruneEmptyAddedEntries` call, and the
+  // holders are the `RoleEntry`s rendered below.
+  const pruneHold = useAddedEntryPruneHold();
 
   const { topHeading, inlineHeadings } = computeExperienceHeadings(
     groups,
@@ -502,7 +530,16 @@ export function ExperienceSection({
       map.set(`experience:${idx}`, {
         obsIndices: group.bullets.map((b) => b.index),
         onReplace: (obsIndex, text) => onBulletChange(obsIndex, text),
-        onRemove: (obsIndex) => onRemoveBullet(obsIndex),
+        // Entry-aware like the per-role path (#637): a removal accepted on a
+        // user-added role has to splice that role's bucket, since the bullet
+        // has no base-parse observation for `removedBullets` to key on.
+        onRemove: (obsIndex) => {
+          const text = group.bullets.find((b) => b.index === obsIndex)?.text;
+          onRemoveBullet(
+            obsIndex,
+            text === undefined ? undefined : { entryKey, text },
+          );
+        },
         onAdd: (text) => onAddBullet(entryKey, text),
         // Adds land in THIS role's bucket, so the entry key the snapshot
         // records is the same one `onAdd` writes to (issue 510).
@@ -532,7 +569,7 @@ export function ExperienceSection({
   return (
     <section
       className="flex flex-col gap-3"
-      onBlur={sectionExitBlur(onPruneEmpty)}
+      onBlur={sectionExitBlur(() => onPruneEmpty(pruneHold.isHeld))}
     >
       {/* Heading row: the flag legend sits beside the Experience title (next to
           where the inline glyphs actually appear), not at the top of the
@@ -583,6 +620,12 @@ export function ExperienceSection({
               idx >= originalCount
                 ? addedExperience[idx - originalCount]
                 : undefined;
+            // The one bucket this role owns — its added id, or its parsed-entry
+            // key. Adds append to it, a rewrite batch's undo snapshots it, and
+            // (since #637) a remove of a user-added bullet splices it.
+            const roleEntryKey = added
+              ? added.id
+              : parsedEntryKey("experience", idx);
             const entry = (
               <RoleEntry
                 key={added ? added.id : idx}
@@ -597,21 +640,13 @@ export function ExperienceSection({
                 bulletOverrides={bulletOverrides}
                 onBulletChange={onBulletChange}
                 onRemoveBullet={onRemoveBullet}
-                onAddBullet={(text) =>
-                  onAddBullet(
-                    added ? added.id : parsedEntryKey("experience", idx),
-                    text,
-                  )
-                }
+                onAddBullet={(text) => onAddBullet(roleEntryKey, text)}
                 captureUndo={(writes) =>
-                  captureBulletUndo(
-                    batchUndoTargets(
-                      writes,
-                      added ? added.id : parsedEntryKey("experience", idx),
-                    ),
-                  )
+                  captureBulletUndo(batchUndoTargets(writes, roleEntryKey))
                 }
                 onRemove={added ? () => onRemoveEntry(added.id) : undefined}
+                entryKey={roleEntryKey}
+                pruneHold={pruneHold}
               />
             );
             return subHeading ? (
@@ -1309,11 +1344,11 @@ export function ReconstructedResume({
         }
         bulletOverrides={bulletOverrides}
         onBulletChange={(index, value) => setBulletField(index, value)}
-        onRemoveBullet={(index) => removeBullet(index)}
+        onRemoveBullet={removeBullet}
         addedExperience={addedExperience}
         originalCount={originalExpCount}
         onAddEntry={() => addEntry("experience")}
-        onPruneEmpty={() => pruneEmptyAddedEntries("experience")}
+        onPruneEmpty={(isHeld) => pruneEmptyAddedEntries("experience", isHeld)}
         onRemoveEntry={removeEntry}
         onEntryField={setEntryField}
         onAddBullet={addBullet}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -24,15 +24,21 @@
  * passed in as `removeControl`. See that module's docblock for why.
  */
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { roleLabel } from "../../lib/score/group-bullets.ts";
 import { EditableField } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
 import type {
+  AddedBulletRef,
   ExperienceFieldOverrides,
   BulletOverrides,
 } from "../../hooks/useEditableParse.ts";
+import { isAddedEntryKey } from "../../hooks/useEditableParse.ts";
+import {
+  useHoldWhile,
+  type AddedEntryPruneHold,
+} from "../../hooks/useAddedEntryPruneHold.ts";
 import {
   useSectionRewrite,
   type SectionRewriteApply,
@@ -253,10 +259,20 @@ interface RoleEntryProps {
   /** Append a new bullet to this role (#180-followup). Renders a "+ Add bullet"
    *  affordance under the bullet list when provided. */
   onAddBullet?: (text: string) => void;
-  /** Drop a parsed bullet by its BulletObservation.index (#211). Required —
-   *  alongside onBulletChange + onAddBullet — to wire the section-rewrite
-   *  per-bullet Apply (accept/reject/edit writes back here). */
-  onRemoveBullet?: (index: number) => void;
+  /** Drop a bullet by its BulletObservation.index (#211). Required — alongside
+   *  onBulletChange + onAddBullet — to wire the section-rewrite per-bullet
+   *  Apply (accept/reject/edit writes back here). The optional second argument
+   *  identifies the added-bullets bucket + line, which is the ONLY way to reach
+   *  a user-ADDED bullet (#637); this component supplies it from `entryKey`. */
+  onRemoveBullet?: (index: number, added?: AddedBulletRef) => void;
+  /** This role's `addedBullets` bucket — its `AddedEntry.id` when the user
+   *  added the role, else its `parsedEntryKey`. Absent for the "Other bullets"
+   *  bucket, which owns no entry. */
+  entryKey?: string;
+  /** Per-entry stay of execution over the section's empty-added-entry prune
+   *  (#637). This role registers its own strip's pending state; the section
+   *  hands the same registry's `isHeld` to `pruneEmptyAddedEntries`. */
+  pruneHold?: AddedEntryPruneHold;
   /** Snapshot the slots a rewrite batch will write, so the whole batch can be
    *  reversed in one action (issue 510). Omitted → no Undo is offered. */
   captureUndo?: SectionRewriteApply["captureUndo"];
@@ -288,16 +304,38 @@ export function RoleEntry({
   captureUndo,
   onRemove,
   removeControl,
+  entryKey,
+  pruneHold,
 }: RoleEntryProps) {
+  // Tag every remove issued from this role's own rows with the bucket that
+  // owns them, so a USER-ADDED bullet is spliced out of `addedBullets` rather
+  // than filed under an observation index that reaches nothing (#637).
+  const removeOwnBullet = useCallback(
+    (index: number, text: string) =>
+      onRemoveBullet?.(
+        index,
+        entryKey === undefined ? undefined : { entryKey, text },
+      ),
+    [onRemoveBullet, entryKey],
+  );
   // Per-bullet remove confirmation (#626), mirroring SectionRewrite's own
   // applied/undone strip so a mis-click (or an empty-commit auto-remove, see
   // ResumeBulletRow) is recoverable the same way a rewrite-review batch is.
   // Owned by an ancestor for a group that can vanish on its last remove; owned
   // here otherwise. The hook runs unconditionally either way (hooks rule); its
   // result is simply unused when the ancestor supplied one.
-  const ownRemove = useBulletRemoveStatus(onRemoveBullet, captureUndo);
+  const ownRemove = useBulletRemoveStatus(removeOwnBullet, captureUndo);
   const removes = removeControl ?? ownRemove;
   const hostsStrip = removeControl === undefined;
+
+  // Half 2 of #637: hold this entry back from the section-exit prune while its
+  // own strip is live, so the undo the remove just armed survives the tick.
+  // Only a user-ADDED entry can be pruned at all, so only its id is ever held.
+  useHoldWhile(
+    pruneHold,
+    entryKey !== undefined && isAddedEntryKey(entryKey) ? entryKey : undefined,
+    hostsStrip && removes.pending,
+  );
 
   // Bullet display text honors #82 overrides — section rewrite must see the
   // text the user actually edited, not the stale parsed text.
@@ -310,17 +348,35 @@ export function RoleEntry({
   // Memoized so the proposal's decision state doesn't reset on every render.
   const obsIndices = group.bullets.map((b) => b.index);
   const obsIndicesKey = obsIndices.join(",");
+  // Latest bullets, read at CALL time by the rewrite-apply below: the memo is
+  // keyed on `obsIndicesKey`, which cannot see a text change that leaves the
+  // index set alone, and the added-bullet splice matches on text (#637).
+  const bulletsRef = useRef(group.bullets);
+  bulletsRef.current = group.bullets;
   const rewriteApply = useMemo<SectionRewriteApply | undefined>(() => {
     if (!onBulletChange || !onAddBullet || !onRemoveBullet) return undefined;
     return {
       obsIndices,
       onReplace: (index, text) => onBulletChange(index, text),
-      onRemove: (index) => onRemoveBullet(index),
+      // Same entry-aware removal the per-row control uses (#637) — an accepted
+      // "remove this bullet" on a user-added role must splice the bucket too.
+      onRemove: (index) => {
+        const text = bulletsRef.current.find((b) => b.index === index)?.text;
+        if (text === undefined) onRemoveBullet(index);
+        else removeOwnBullet(index, text);
+      },
       onAdd: (text) => onAddBullet(text),
       captureUndo,
     };
     // obsIndices identity churns each render; key on its stable string form.
-  }, [obsIndicesKey, onBulletChange, onAddBullet, onRemoveBullet, captureUndo]);
+  }, [
+    obsIndicesKey,
+    onBulletChange,
+    onAddBullet,
+    onRemoveBullet,
+    removeOwnBullet,
+    captureUndo,
+  ]);
   // The "Rewrite section" trigger sits on the header row (right of the title);
   // its result panel renders full-width below the bullet list.
   const { trigger: rewriteTrigger, panel: rewritePanel } = useSectionRewrite(
@@ -358,7 +414,7 @@ export function RoleEntry({
                 }
                 onRemove={
                   onRemoveBullet
-                    ? () => removes.removeBullet(b.index)
+                    ? () => removes.removeBullet(b.index, b.text)
                     : undefined
                 }
               />

--- a/src/hooks/useAddedEntryPruneHold.ts
+++ b/src/hooks/useAddedEntryPruneHold.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useAddedEntryPruneHold — a per-entry stay of execution over
+ * `pruneEmptyAddedEntries` (#637).
+ *
+ * Once removing a user-added role's last bullet ACTUALLY empties it (#637 half
+ * 1 — before that the bucket never shrank, so the entry was never empty and the
+ * prune never fired), the section-exit prune (#379) unmounts that `RoleEntry`
+ * one tick after the blur — and with it the "Removed 1 change · Undo" strip
+ * the removal just armed. The undo flashes for a frame and the user has no way
+ * back.
+ *
+ * The hold is PER ENTRY, deliberately. A section-wide "something is pending, do
+ * not prune" flag would also spare an unrelated SIBLING added role that is
+ * genuinely empty and has no live undo — exactly the ghost entry #379 exists to
+ * drop. Keying by entry id means only the role hosting a live strip survives.
+ *
+ * REF-backed, not state: a hold is read by the deferred prune, never rendered.
+ * Storing it in state would re-render every role in the section on each strip
+ * arm/collapse, and — worse — the prune runs a macrotask after the blur, so it
+ * needs the value as of THEN, which a render closure cannot give it.
+ *
+ * A hold is a lease, not a latch: {@link useHoldWhile} releases it on unmount,
+ * so a role that disappears for any other reason (an explicit "Remove role", a
+ * fresh parse) cannot leave its id held forever.
+ *
+ * Scope note (bounded, deliberate): the prune is only ever CALLED on section
+ * exit, so an entry held through one blur is not re-examined when its strip
+ * later collapses — it survives until the next section exit. Re-running the
+ * prune on release was rejected: the strip collapses on a timer, which can fire
+ * while the user is typing inside that very entry, and pruning then would yank
+ * the row out from under them.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+export interface AddedEntryPruneHold {
+  /** Take or release `id`'s hold. Idempotent; safe to call every render. */
+  setHold: (id: string, held: boolean) => void;
+  /** The predicate to hand `pruneEmptyAddedEntries`. Stable identity. */
+  isHeld: (id: string) => boolean;
+}
+
+/** Create a registry. One per section that prunes — the ids it holds are only
+ *  meaningful to that section's `pruneEmptyAddedEntries` call. */
+export function useAddedEntryPruneHold(): AddedEntryPruneHold {
+  const held = useRef<Set<string>>(new Set());
+
+  const setHold = useCallback((id: string, hold: boolean) => {
+    if (hold) held.current.add(id);
+    else held.current.delete(id);
+  }, []);
+
+  const isHeld = useCallback((id: string) => held.current.has(id), []);
+
+  // Memoized, not a fresh literal: this object is a dep of every holder's
+  // effect, so a churning identity would tear the hold down and re-take it on
+  // every single render of the section.
+  return useMemo(() => ({ setHold, isHeld }), [setHold, isHeld]);
+}
+
+/**
+ * Register `id`'s hold for as long as `held` is true, releasing it on unmount.
+ *
+ * Split from the registry so the holder (a `RoleEntry`, which knows whether it
+ * hosts a live strip) and the pruner (the section) each touch only their half
+ * of the contract. No-ops when the caller has no registry or no id — a parsed
+ * role has no added-entry id to hold, and nothing outside the editable
+ * experience section supplies a registry at all.
+ */
+export function useHoldWhile(
+  registry: AddedEntryPruneHold | undefined,
+  id: string | undefined,
+  held: boolean,
+): void {
+  useEffect(() => {
+    if (registry === undefined || id === undefined) return;
+    registry.setHold(id, held);
+    return () => registry.setHold(id, false);
+  }, [registry, id, held]);
+}

--- a/src/hooks/useEditableParse.added-bullet-remove.test.tsx
+++ b/src/hooks/useEditableParse.added-bullet-remove.test.tsx
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Regression test for #637 half 1 — "Remove bullet" was inert on every
+ * user-added bullet.
+ *
+ * The removal has to be proven end-to-end, not at the hook boundary: the whole
+ * defect was that the hook DID record something (`removedBullets`) and nothing
+ * downstream could resolve it. So each case drives the REAL `useEditableParse`
+ * and then folds its state through the REAL `applyOverrides` →
+ * `computeAnonymousAtsScore` → `buildAtsResumeModel` chain that `/` runs, and
+ * asserts against all three of the issue's surfaces: the rendered bullet pool,
+ * the score, and the exported PDF model.
+ *
+ * `observations` is the FROZEN base-parse pool (`doneScoreBullets` in
+ * `useAnalyzedResume`), deliberately built from the parsed role alone — that
+ * asymmetry IS the bug: an added bullet never appears there, so an
+ * index-keyed removal could never reach it.
+ *
+ * Mounted with raw `createRoot`, matching `useEditableParse.test.tsx` (the
+ * project has no @testing-library/react).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useEditableParse, type EditableParse } from "./useEditableParse.ts";
+import { applyOverrides } from "../lib/edit/apply-overrides.ts";
+import {
+  computeAnonymousAtsScore,
+  countWords,
+  type AnonymousAtsScore,
+  type BulletObservation,
+} from "../lib/score/score.ts";
+import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
+import { projectScoreSections } from "../lib/heuristics/projections.ts";
+import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
+import { toCanonicalResume } from "../lib/heuristics/canonical.ts";
+import type { SectionedResume } from "../lib/heuristics/sections.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import { batchUndoTargets } from "../lib/rewrite-review/undo-batch.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const PARSED_BULLET = "Cut p99 checkout latency by 38% via edge caching.";
+const ADDED_BULLET = "Shipped a design system used by 40 engineers.";
+
+function sections(experience: readonly string[]): SectionedResume {
+  const byName = new Map<string, readonly string[]>([["experience", experience]]);
+  return {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
+
+/** One PARSED role carrying `PARSED_BULLET`. The added role arrives via the
+ *  hook's own `addEntry`, exactly as "+ Add experience" produces it. */
+function baseResult(): CascadeResult {
+  const blank = buildBlankResult();
+  return {
+    ...blank,
+    rawText: `• ${PARSED_BULLET}`,
+    canonical: toCanonicalResume(
+      {
+        full_name: "Robin Vasquez",
+        email: "robin.vasquez@example.com",
+        skills: ["typescript"],
+        education: [],
+        experience: [
+          {
+            title: "Staff Engineer",
+            company: "Northwind Systems",
+            start_date: "2020",
+            end_date: "2024",
+            description: PARSED_BULLET,
+          },
+        ],
+      },
+      sections([`• ${PARSED_BULLET}`]),
+      {},
+    ),
+  };
+}
+
+/** The frozen base-parse observation pool — the parsed bullet ONLY. */
+const OBSERVATIONS: readonly BulletObservation[] = [
+  {
+    text: PARSED_BULLET,
+    index: 0,
+    hasMetric: true,
+    startsWithActionVerb: true,
+    wellFormedLength: true,
+    wordCount: countWords(PARSED_BULLET),
+  },
+];
+
+/** Run the exact `/` pipeline over the hook's current override state. */
+function regrade(api: EditableParse): {
+  score: AnonymousAtsScore;
+  bulletTexts: string[];
+  roleDescriptions: (string | undefined)[];
+  /** Every bullet the Download PDF would draw, across all entries. */
+  exportedBullets: string[];
+} {
+  const base = baseResult();
+  const core = applyOverrides(
+    base.canonical.fields,
+    base.rawText,
+    base.canonical.sections,
+    api.contactOverrides,
+    api.experienceOverrides,
+    api.bulletOverrides,
+    OBSERVATIONS,
+    api.educationOverrides,
+    api.skillsOverride,
+    api.addedEntries,
+    api.addedBullets,
+    api.removedBullets,
+    api.profileOverrides,
+    base.canonical.fieldConfidence,
+    api.achievementOverrides,
+    api.descriptionOverrides,
+    api.summaryOverride,
+  );
+  const score = computeAnonymousAtsScore({
+    parsed: core.fields,
+    fieldConfidence: core.fieldConfidence,
+    triggers: base.triggers,
+    rawText: core.rawText,
+    sections: projectScoreSections(core),
+  });
+  const display: CascadeResult = {
+    ...base,
+    canonical: {
+      ...base.canonical,
+      fields: core.fields,
+      fieldConfidence: core.fieldConfidence,
+    },
+  };
+  const model = buildAtsResumeModel(display, score, {
+    contactOverrides: api.contactOverrides,
+    bulletOverrides: api.bulletOverrides,
+  });
+  return {
+    score,
+    bulletTexts: (score.bullets ?? []).map((b) => b.text),
+    roleDescriptions: core.fields.experience.map((e) => e.description),
+    exportedBullets: model.sections.flatMap((s) =>
+      s.entries.flatMap((e) => e.bullets),
+    ),
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let api: EditableParse;
+
+function Probe() {
+  api = useEditableParse();
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Probe />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** Add a role via "+ Add experience" and give it one bullet. Returns its id. */
+function addRoleWithBullet(): string {
+  let id = "";
+  act(() => {
+    id = api.addEntry("experience");
+    api.setEntryField(id, "title", "Principal Engineer");
+    api.setEntryField(id, "subtitle", "Cascadia Analytics");
+  });
+  act(() => api.addBullet(id, ADDED_BULLET));
+  return id;
+}
+
+/** The added bullet's index in the RE-GRADED pool (never in OBSERVATIONS). */
+function addedObsIndex(): number {
+  const at = regrade(api).bulletTexts.indexOf(ADDED_BULLET);
+  expect(at).toBeGreaterThanOrEqual(0);
+  return regrade(api).score.bullets![at].index;
+}
+
+describe("removeBullet on a user-ADDED role (#637 half 1)", () => {
+  it("drops the bullet from the pool, the score and the exported PDF", () => {
+    const id = addRoleWithBullet();
+
+    const before = regrade(api);
+    expect(before.bulletTexts).toEqual([PARSED_BULLET, ADDED_BULLET]);
+    expect(before.exportedBullets).toContain(ADDED_BULLET);
+
+    const obsIndex = addedObsIndex();
+    act(() =>
+      api.removeBullet(obsIndex, { entryKey: id, text: ADDED_BULLET }),
+    );
+
+    const after = regrade(api);
+    // 1. Gone from the rendered/graded bullet pool.
+    expect(after.bulletTexts).toEqual([PARSED_BULLET]);
+    // 2. Gone from the added role's own description (what the UI renders).
+    expect(after.roleDescriptions[1]).toBeUndefined();
+    // 3. Gone from the exported PDF model.
+    expect(after.exportedBullets).not.toContain(ADDED_BULLET);
+    expect(after.exportedBullets).toContain(PARSED_BULLET);
+    // 4. The score actually moved — the whole point of "it stays in the score".
+    expect(after.score.specificity).not.toEqual(before.score.specificity);
+  });
+
+  it("empties the bucket so the now-blank-bodied role is prunable", () => {
+    const id = addRoleWithBullet();
+    const obsIndex = addedObsIndex();
+
+    act(() =>
+      api.removeBullet(obsIndex, { entryKey: id, text: ADDED_BULLET }),
+    );
+
+    // The bucket is DELETED, not left as `{id: []}` — `hasEdits` and
+    // `isAddedEntryEmpty` both key off its presence/length.
+    expect(id in api.addedBullets).toBe(false);
+  });
+
+  it("restores the bullet through the captured undo", () => {
+    const id = addRoleWithBullet();
+    const obsIndex = addedObsIndex();
+
+    // Exactly the capture-then-write order `useBulletRemoveStatus` performs.
+    let undo = () => {};
+    act(() => {
+      undo = api.captureBulletUndo(
+        batchUndoTargets([{ kind: "remove", obsIndex }], id),
+      );
+      api.removeBullet(obsIndex, { entryKey: id, text: ADDED_BULLET });
+    });
+    expect(regrade(api).bulletTexts).toEqual([PARSED_BULLET]);
+
+    act(() => undo());
+
+    const restored = regrade(api);
+    expect(restored.bulletTexts).toEqual([PARSED_BULLET, ADDED_BULLET]);
+    expect(restored.exportedBullets).toContain(ADDED_BULLET);
+    expect(api.addedBullets[id]).toEqual([ADDED_BULLET]);
+  });
+
+  it("removes each of two added bullets independently, in one tick", () => {
+    const id = addRoleWithBullet();
+    act(() => api.addBullet(id, "Mentored 6 engineers to promotion."));
+    expect(api.addedBullets[id]).toHaveLength(2);
+
+    // Both removes land in ONE act(), so the second reads the ref rather than
+    // a committed render — the case a render closure would get wrong.
+    act(() => {
+      api.removeBullet(99, { entryKey: id, text: ADDED_BULLET });
+      api.removeBullet(98, {
+        entryKey: id,
+        text: "Mentored 6 engineers to promotion.",
+      });
+    });
+
+    expect(id in api.addedBullets).toBe(false);
+    expect(regrade(api).bulletTexts).toEqual([PARSED_BULLET]);
+    // Neither stale index leaked into the observation-keyed set.
+    expect(api.removedBullets.size).toBe(0);
+  });
+
+  it("keeps an add made in the SAME tick as a splicing remove", () => {
+    // The add-before-remove order `resolveSectionWrites` emits in ordinary pair
+    // order, run synchronously by the rewrite-apply loops. A literal
+    // `setAddedBullets(next)` in the remove path discards the add's queued
+    // update, so `writeAddedBullets` must make the ref — not the committed
+    // state — the base every writer composes on.
+    const id = addRoleWithBullet();
+
+    act(() => {
+      api.addBullet(id, "Cut infra spend 22% by right-sizing clusters.");
+      api.removeBullet(99, { entryKey: id, text: ADDED_BULLET });
+    });
+
+    expect(api.addedBullets[id]).toEqual([
+      "Cut infra spend 22% by right-sizing clusters.",
+    ]);
+    expect(regrade(api).bulletTexts).toEqual([
+      PARSED_BULLET,
+      "Cut infra spend 22% by right-sizing clusters.",
+    ]);
+  });
+
+  it("keeps a CROSS-BUCKET add made in the same tick as a splicing remove", () => {
+    // The whole-résumé rewrite path applies every section in one synchronous
+    // loop, so the add and the remove routinely land on different entries.
+    const a = addRoleWithBullet();
+    let b = "";
+    act(() => {
+      b = api.addEntry("experience");
+      api.setEntryField(b, "title", "Engineering Manager");
+    });
+
+    act(() => {
+      api.addBullet(b, "Grew the platform team from 4 to 11.");
+      api.removeBullet(99, { entryKey: a, text: ADDED_BULLET });
+    });
+
+    expect(api.addedBullets[b]).toEqual(["Grew the platform team from 4 to 11."]);
+    expect(a in api.addedBullets).toBe(false);
+  });
+
+  it("keeps a same-tick add against a PARSED role's bucket", () => {
+    // Not confined to added entries: a parsed role's bucket is written by the
+    // same pair of setters, so the clobber reached it too.
+    act(() => api.addBullet("experience:0", ADDED_BULLET));
+
+    act(() => {
+      api.addBullet("experience:0", "Owned the migration to Postgres 16.");
+      api.removeBullet(1, { entryKey: "experience:0", text: ADDED_BULLET });
+    });
+
+    expect(api.addedBullets["experience:0"]).toEqual([
+      "Owned the migration to Postgres 16.",
+    ]);
+    expect(api.removedBullets.size).toBe(0);
+  });
+
+  it("never files a removal under an observation index for an added entry", () => {
+    const id = addRoleWithBullet();
+    const obsIndex = addedObsIndex();
+
+    act(() =>
+      api.removeBullet(obsIndex, { entryKey: id, text: ADDED_BULLET }),
+    );
+    // A repeat click (the row is already gone) must NOT fall through: index 0
+    // is the PARSED bullet's observation, and filing it there would remove an
+    // unrelated bullet.
+    act(() => api.removeBullet(0, { entryKey: id, text: ADDED_BULLET }));
+
+    expect(api.removedBullets.size).toBe(0);
+    expect(regrade(api).bulletTexts).toEqual([PARSED_BULLET]);
+  });
+});
+
+describe("removeBullet still reaches PARSED bullets (#637 scoping)", () => {
+  it("falls through to removedBullets for a parsed role's own bullet", () => {
+    act(() =>
+      api.removeBullet(0, {
+        entryKey: "experience:0",
+        text: PARSED_BULLET,
+      }),
+    );
+
+    expect(api.removedBullets.has(0)).toBe(true);
+    const after = regrade(api);
+    expect(after.bulletTexts).toEqual([]);
+    expect(after.exportedBullets).not.toContain(PARSED_BULLET);
+  });
+
+  it("removes an ADDED bullet on a PARSED role without touching its parsed one", () => {
+    act(() => api.addBullet("experience:0", ADDED_BULLET));
+    expect(regrade(api).bulletTexts).toEqual([PARSED_BULLET, ADDED_BULLET]);
+
+    act(() =>
+      api.removeBullet(1, { entryKey: "experience:0", text: ADDED_BULLET }),
+    );
+
+    // Spliced from the bucket, NOT filed as observation 1 (which does not
+    // exist in the base pool at all).
+    expect(api.removedBullets.size).toBe(0);
+    expect(regrade(api).bulletTexts).toEqual([PARSED_BULLET]);
+  });
+
+  it("still works with no ref at all (the 'Other bullets' call path)", () => {
+    act(() => api.removeBullet(0));
+    expect(api.removedBullets.has(0)).toBe(true);
+    expect(regrade(api).bulletTexts).toEqual([]);
+  });
+});

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -18,6 +18,13 @@
  * skills one — the Summary was parsed, scored and exported but had no edit
  * channel at all, so a mis-segmented summary was uncorrectable and an emptied
  * one uncleanable.
+ * Issue #637 makes `removeBullet` ENTRY-AWARE. Every other override map is
+ * keyed by `BulletObservation.index` against the FROZEN base parse, which a
+ * user-ADDED bullet has no entry in — so removing one was silently inert. It
+ * now splices the bullet out of its `addedBullets` bucket instead, which is the
+ * only place an added bullet exists, and `pruneEmptyAddedEntries` grew a
+ * per-entry hold so the removal's Undo strip survives the newly-reachable
+ * prune.
  * Overrides are held in component state and lost on reset — no persistence
  * is expected or provided.
  *
@@ -32,6 +39,7 @@ import {
   type BulletUndoTargets,
 } from "../lib/rewrite-review/undo-batch.ts";
 import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
+import { removeAddedBulletLine } from "../lib/edit/added-bullets.ts";
 import {
   addCategory as addSkillCategoryTx,
   addSkillToCategory as addSkillToCategoryTx,
@@ -281,9 +289,42 @@ export function isAddedEntryEmpty(
  */
 export type AddedBullets = Record<string, string[]>;
 
+/** Prefix of every ADDED entry's id. The one place the two bullet-key
+ *  namespaces are told apart — see {@link isAddedEntryKey}. */
+const ADDED_ENTRY_ID_PREFIX = "added:";
+
 /** The stable bullet key for a PARSED entry at `index` within `section`. */
 export function parsedEntryKey(section: AddableSection, index: number): string {
   return `${section}:${index}`;
+}
+
+/**
+ * True when `entryKey` names a user-ADDED entry rather than a parsed one.
+ *
+ * Load-bearing for bullet removal (#637): an added entry's description is built
+ * SOLELY from its `addedBullets` bucket (`pushAddedEntry`), so every bullet
+ * rendered under it is an added bullet and a removal there must never fall
+ * through to the observation-indexed `removedBullets` path. A parsed entry
+ * carries both kinds, so a removal there falls through when the bucket has no
+ * matching line.
+ */
+export function isAddedEntryKey(entryKey: string): boolean {
+  return entryKey.startsWith(ADDED_ENTRY_ID_PREFIX);
+}
+
+/**
+ * Identifies the user-ADDED bullet line a removal targets: the bucket its entry
+ * owns, plus the bullet's own (pre-override) text. `removeBullet` takes this
+ * alongside the `BulletObservation.index` because the index alone cannot reach
+ * an added bullet — see `added-bullets.ts`.
+ */
+export interface AddedBulletRef {
+  /** The `addedBullets` bucket this row's entry owns — an added entry's `id`,
+   *  or the entry's {@link parsedEntryKey}. */
+  entryKey: string;
+  /** The bullet's `BulletObservation.text`, i.e. the line as it sits in the
+   *  bucket. NOT the `bulletOverrides` display text. */
+  text: string;
 }
 
 // ── Profile-link overrides (#427, consolidates #335) ──────────────────────────
@@ -401,8 +442,17 @@ export interface EditableParse {
    *  keyed by BulletObservation.index — folded by applyOverrides to drop the
    *  line from the graded pool, rawText, and the role description. */
   removedBullets: ReadonlySet<number>;
-  /** Drop a parsed bullet by its BulletObservation.index. Idempotent. */
-  removeBullet: (index: number) => void;
+  /**
+   * Drop one bullet.
+   *
+   * `index` is its `BulletObservation.index`, which reaches PARSED bullets only
+   * — `applyOverrides` resolves it against the frozen base-parse observations.
+   * `added` additionally identifies the row's `addedBullets` bucket + line, so a
+   * user-ADDED bullet (which has no base observation) is spliced out of that
+   * bucket instead; without it such a removal is silently inert (#637). Pass it
+   * whenever the caller knows which entry owns the row. Idempotent.
+   */
+  removeBullet: (index: number, added?: AddedBulletRef) => void;
   /** Override map for education entries, keyed by education array index. */
   educationOverrides: Record<number, EducationFieldOverrides>;
   /** Update one field on a specific education entry by its array index.
@@ -433,8 +483,17 @@ export interface EditableParse {
   /** Drop every EMPTY user-added entry in a section — one the user opened with
    *  "+ Add …" and left with no populated field and no bullets (#379). Called
    *  when focus leaves the section, so a blank ghost entry never persists in the
-   *  list, the score, or the exported PDF. No-op when nothing is empty. */
-  pruneEmptyAddedEntries: (section: AddableSection) => void;
+   *  list, the score, or the exported PDF. No-op when nothing is empty.
+   *
+   *  `isHeld` spares individual entries by id (#637): once removing an added
+   *  role's last bullet genuinely empties it, this prune would unmount the very
+   *  `RoleEntry` hosting that removal's "Removed · Undo" strip, taking the undo
+   *  with it. The hold is PER ENTRY, not per section, so an empty SIBLING with
+   *  no live undo is still dropped in the same pass. */
+  pruneEmptyAddedEntries: (
+    section: AddableSection,
+    isHeld?: (entryId: string) => boolean,
+  ) => void;
   /** Edit one header field on an added entry. */
   setEntryField: (id: string, field: AddedEntryField, value: string) => void;
   /** Bullet lines appended to entries, keyed by entry key (parsedEntryKey or
@@ -566,14 +625,33 @@ export function useEditableParse(): EditableParse {
   );
   const [addedEntries, setAddedEntries] = useState<AddedEntry[]>([]);
   const [addedBullets, setAddedBullets] = useState<AddedBullets>({});
-  // Latest bullets, readable synchronously inside `pruneEmptyAddedEntries` —
-  // which is called deferred (a tick after a blur), by which point an in-flight
-  // add-bullet may have landed. A render-time closure would read a stale map.
+  // Latest bullets, readable synchronously by every writer and by
+  // `pruneEmptyAddedEntries` — which is called deferred (a tick after a blur),
+  // by which point an in-flight add-bullet may have landed. A render-time
+  // closure would read a stale map. See `writeAddedBullets` below: this ref, not
+  // the state, is the source of PENDING truth. The render-phase assignment only
+  // re-syncs it with what React committed, which the writer already matches.
   const addedBulletsRef = useRef(addedBullets);
   addedBulletsRef.current = addedBullets;
   const [profileOverrides, setProfileOverrides] = useState<ProfileOverride[]>(
     [],
   );
+
+  // The ONE writer of `addedBullets`. The ref — not React state — is the source
+  // of pending truth: it is assigned synchronously here, before the setState, so
+  // a second write in the SAME tick composes on top of the first instead of on
+  // the last committed render. Mixing this with a functional updater elsewhere
+  // is what silently loses an edit: a literal write lands last and discards the
+  // queued updater, so `addBullet(id, x)` followed in one handler by a splicing
+  // `removeBullet(...)` dropped `x` entirely. `resolveSectionWrites` emits an
+  // `add` before a `remove` in ordinary pair order and the rewrite-apply loops
+  // (`SectionRewrite`, `ResumeRewriteProposed`) run every write synchronously,
+  // so that ordering is not exotic. Every writer routes through here and every
+  // one computes its `next` from `addedBulletsRef.current`.
+  const writeAddedBullets = useCallback((next: AddedBullets) => {
+    addedBulletsRef.current = next;
+    setAddedBullets(next);
+  }, []);
   // Monotonic source of stable added-entry ids. A ref (not state) because a new
   // id must not itself trigger a re-render, and the value need only be unique
   // within the session — never reset, even across resetAll.
@@ -643,14 +721,36 @@ export function useEditableParse(): EditableParse {
     [],
   );
 
-  const removeBullet = useCallback((index: number) => {
-    setRemovedBullets((prev) => {
-      if (prev.has(index)) return prev;
-      const next = new Set(prev);
-      next.add(index);
-      return next;
-    });
-  }, []);
+  const removeBullet = useCallback(
+    (index: number, added?: AddedBulletRef) => {
+      if (added !== undefined) {
+        // Try the added-bullets bucket FIRST: an added bullet exists nowhere
+        // else, so `index` (a re-graded observation index) cannot reach it
+        // (#637).
+        const prev = addedBulletsRef.current;
+        const next = removeAddedBulletLine(prev, added.entryKey, added.text);
+        if (next !== prev) {
+          writeAddedBullets(next);
+          return;
+        }
+        // No matching line. Under an ADDED entry that means the bullet is
+        // already gone (its description is built solely from this bucket), so
+        // there is nothing left to remove — and falling through would push a
+        // now-stale observation index into `removedBullets`, where it can
+        // collide with an UNRELATED base-parse bullet once earlier removals
+        // have re-indexed the pool. A parsed entry legitimately carries
+        // non-added bullets too, so only that case falls through.
+        if (isAddedEntryKey(added.entryKey)) return;
+      }
+      setRemovedBullets((prev) => {
+        if (prev.has(index)) return prev;
+        const next = new Set(prev);
+        next.add(index);
+        return next;
+      });
+    },
+    [writeAddedBullets],
+  );
 
   const setEducationField = useCallback(
     (
@@ -780,33 +880,41 @@ export function useEditableParse(): EditableParse {
   );
 
   const addEntry = useCallback((section: AddableSection) => {
-    const id = `added:${idCounter.current++}`;
+    const id = `${ADDED_ENTRY_ID_PREFIX}${idCounter.current++}`;
     setAddedEntries((prev) => [...prev, { id, section, title: "" }]);
     return id;
   }, []);
 
-  const removeEntry = useCallback((id: string) => {
-    setAddedEntries((prev) => prev.filter((e) => e.id !== id));
-    setAddedBullets((prev) => {
-      if (!(id in prev)) return prev;
+  const removeEntry = useCallback(
+    (id: string) => {
+      setAddedEntries((prev) => prev.filter((e) => e.id !== id));
+      const prev = addedBulletsRef.current;
+      if (!(id in prev)) return;
       const next = { ...prev };
       delete next[id];
-      return next;
-    });
-  }, []);
+      writeAddedBullets(next);
+    },
+    [writeAddedBullets],
+  );
 
-  const pruneEmptyAddedEntries = useCallback((section: AddableSection) => {
-    const bullets = addedBulletsRef.current;
-    setAddedEntries((prev) => {
-      const kept = prev.filter(
-        (e) => e.section !== section || !isAddedEntryEmpty(e, bullets),
-      );
-      // An empty entry has no bullets by definition, so `addedBullets` needs no
-      // cleanup here (unlike `removeEntry`). Preserve identity when nothing
-      // changed so an idle blur doesn't churn a re-render.
-      return kept.length === prev.length ? prev : kept;
-    });
-  }, []);
+  const pruneEmptyAddedEntries = useCallback(
+    (section: AddableSection, isHeld?: (entryId: string) => boolean) => {
+      const bullets = addedBulletsRef.current;
+      setAddedEntries((prev) => {
+        const kept = prev.filter(
+          (e) =>
+            e.section !== section ||
+            !isAddedEntryEmpty(e, bullets) ||
+            isHeld?.(e.id) === true,
+        );
+        // An empty entry has no bullets by definition, so `addedBullets` needs
+        // no cleanup here (unlike `removeEntry`). Preserve identity when nothing
+        // changed so an idle blur doesn't churn a re-render.
+        return kept.length === prev.length ? prev : kept;
+      });
+    },
+    [],
+  );
 
   const setEntryField = useCallback(
     (id: string, field: AddedEntryField, value: string) => {
@@ -817,14 +925,18 @@ export function useEditableParse(): EditableParse {
     [],
   );
 
-  const addBullet = useCallback((entryKey: string, text: string) => {
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    setAddedBullets((prev) => ({
-      ...prev,
-      [entryKey]: [...(prev[entryKey] ?? []), trimmed],
-    }));
-  }, []);
+  const addBullet = useCallback(
+    (entryKey: string, text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const prev = addedBulletsRef.current;
+      writeAddedBullets({
+        ...prev,
+        [entryKey]: [...(prev[entryKey] ?? []), trimmed],
+      });
+    },
+    [writeAddedBullets],
+  );
 
   // ── Rewrite-batch undo primitives (issue 510) ─────────────────────────────
   // The inverses of removeBullet / addBullet. Deliberately NOT on the public
@@ -844,17 +956,15 @@ export function useEditableParse(): EditableParse {
 
   const replaceAddedBullets = useCallback(
     (entryKey: string, bullets: readonly string[]) => {
-      setAddedBullets((prev) => {
-        const next = { ...prev };
-        // An empty list must DELETE the bucket, not leave `{key: []}` behind —
-        // `hasEdits` keys off `Object.keys(addedBullets).length`, so a stray
-        // empty bucket would leave the résumé permanently "dirty" after undo.
-        if (bullets.length === 0) delete next[entryKey];
-        else next[entryKey] = [...bullets];
-        return next;
-      });
+      const next = { ...addedBulletsRef.current };
+      // An empty list must DELETE the bucket, not leave `{key: []}` behind —
+      // `hasEdits` keys off `Object.keys(addedBullets).length`, so a stray
+      // empty bucket would leave the résumé permanently "dirty" after undo.
+      if (bullets.length === 0) delete next[entryKey];
+      else next[entryKey] = [...bullets];
+      writeAddedBullets(next);
     },
-    [],
+    [writeAddedBullets],
   );
 
   // Live edit state readable synchronously at capture time. Refs, not the
@@ -952,9 +1062,12 @@ export function useEditableParse(): EditableParse {
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
     setSummaryOverride(undefined);
     setAddedEntries([]);
-    setAddedBullets({});
+    // Through the writer, so the ref is cleared too — otherwise a reset leaves
+    // the pending-truth ref holding the pre-reset buckets, and the next
+    // `addBullet`/`removeBullet` in that same tick would resurrect them.
+    writeAddedBullets({});
     setProfileOverrides([]);
-  }, []);
+  }, [writeAddedBullets]);
 
   const snapshot = useMemo<EditSnapshot>(
     () => ({

--- a/src/lib/edit/added-bullets.test.ts
+++ b/src/lib/edit/added-bullets.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Tests for `removeAddedBulletLine` (#637) — the splice that makes removing a
+ * user-added bullet real.
+ *
+ * The identity contract is the load-bearing one: the caller distinguishes
+ * "spliced" from "no such line" by reference, and that distinction is what
+ * decides whether a removal falls through to the observation-indexed
+ * `removedBullets` path.
+ */
+
+import { describe, it, expect } from "vitest";
+import { removeAddedBulletLine } from "./added-bullets.ts";
+
+describe("removeAddedBulletLine", () => {
+  it("splices the matching line out of the entry's bucket", () => {
+    const before = { "added:0": ["First line", "Second line", "Third line"] };
+    const after = removeAddedBulletLine(before, "added:0", "Second line");
+    expect(after["added:0"]).toEqual(["First line", "Third line"]);
+    // The input is never mutated.
+    expect(before["added:0"]).toHaveLength(3);
+  });
+
+  it("DELETES an emptied bucket rather than leaving `{key: []}`", () => {
+    const after = removeAddedBulletLine(
+      { "added:0": ["Only line"] },
+      "added:0",
+      "Only line",
+    );
+    // `hasEdits` keys off Object.keys(addedBullets).length, so a stray empty
+    // bucket would leave the résumé permanently "dirty" after the removal.
+    expect("added:0" in after).toBe(false);
+    expect(Object.keys(after)).toHaveLength(0);
+  });
+
+  it("leaves sibling buckets untouched", () => {
+    const after = removeAddedBulletLine(
+      { "added:0": ["Gone"], "experience:2": ["Kept"] },
+      "added:0",
+      "Gone",
+    );
+    expect(after).toEqual({ "experience:2": ["Kept"] });
+  });
+
+  it("matches on the normalised form (marker, case, inner whitespace)", () => {
+    const after = removeAddedBulletLine(
+      { "added:0": ["Cut  p99 latency by 38%"] },
+      "added:0",
+      "• cut p99 latency by 38%",
+    );
+    expect("added:0" in after).toBe(false);
+  });
+
+  it("removes only the FIRST of two identical lines", () => {
+    const after = removeAddedBulletLine(
+      { "added:0": ["Same", "Same", "Other"] },
+      "added:0",
+      "Same",
+    );
+    expect(after["added:0"]).toEqual(["Same", "Other"]);
+  });
+
+  it("returns the input BY REFERENCE when the bucket is absent", () => {
+    const before = { "added:0": ["Present"] };
+    expect(removeAddedBulletLine(before, "added:9", "Present")).toBe(before);
+  });
+
+  it("returns the input BY REFERENCE when no line matches", () => {
+    const before = { "added:0": ["Present"] };
+    expect(removeAddedBulletLine(before, "added:0", "Absent")).toBe(before);
+  });
+});

--- a/src/lib/edit/added-bullets.ts
+++ b/src/lib/edit/added-bullets.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * added-bullets.ts — the inverse of `addBullet` for a USER-ADDED bullet line
+ * (#637).
+ *
+ * Every other bullet removal in the app is recorded as a
+ * `BulletObservation.index` in `removedBullets`, and `applyOverrides` resolves
+ * that index against `observations` — the FROZEN base-parse bullet pool. A
+ * user-added bullet has no observation in that pool (it was minted by
+ * `applyAddedEntriesAndBullets` *after* the parse), so its index resolves to
+ * nothing and the removal is silently dropped: the bullet stayed on screen, in
+ * the score, and in the exported PDF (#637). The only place an added bullet
+ * actually lives is its `addedBullets` bucket, so the only removal that can
+ * work is a splice out of that bucket — which is what this module does.
+ *
+ * Matching is by NORMALISED text, via the same {@link normalizeBulletText} the
+ * grouping (`groupBulletsByExperience`) and `applyOverrides`' own line-matching
+ * helpers use. Position can't be used: the caller holds a `BulletObservation`
+ * from the RE-GRADED pool, whose ordering is the section pool's, not the
+ * bucket's.
+ *
+ * The tiebreak is therefore the FIRST normalised match in the bucket, which is
+ * not necessarily the row the user clicked. `normalizeBulletText` lowercases and
+ * collapses whitespace, so two lines that differ only in case or spacing are one
+ * target here; on a PARSED entry — whose bucket sits alongside parsed bullets —
+ * an added line normalising equal to an earlier duplicate is the one spliced.
+ * The removal is still correct in effect (the surviving text is identical), but
+ * the row identity is not preserved.
+ *
+ * A second, CROSS-ENTRY tiebreak exists upstream and is not this module's to
+ * fix: `groupBulletsByExperience`'s `lineToExpIdx` is first-match-wins across
+ * entries, so when two entries carry a normalise-equal line, both group under
+ * the first. A bullet added to the second entry then renders under the first and
+ * arrives here tagged with the FIRST entry's key — so the splice misses. When
+ * that key is a parsed entry the caller deliberately falls through to
+ * `removedBullets` (see `useEditableParse.removeBullet`), which is the stale-index
+ * hazard documented there. Strictly better than before #637 (every added-bullet
+ * remove pushed a stray index), but not eliminated.
+ *
+ * Pure: no React, no mutation of the input. Returns the input map by REFERENCE
+ * when nothing matched, so the caller can tell "spliced" from "no such line"
+ * without a second lookup — that distinction is what decides whether a removal
+ * falls through to the observation-indexed `removedBullets` path.
+ */
+
+import { normalizeBulletText } from "../score/group-bullets.ts";
+import type { AddedBullets } from "../../hooks/useEditableParse.ts";
+
+/**
+ * Drop the first line of `addedBullets[entryKey]` whose normalised text equals
+ * `text`, returning the next map. Returns `addedBullets` ITSELF (same
+ * reference) when the bucket is absent or carries no matching line.
+ *
+ * An emptied bucket is DELETED rather than left as `{key: []}` — `hasEdits`
+ * keys off `Object.keys(addedBullets).length`, so a stray empty bucket would
+ * leave the résumé permanently "dirty", and `isAddedEntryEmpty` reads
+ * `(addedBullets[id] ?? []).length` so either shape would prune the same. This
+ * mirrors `replaceAddedBullets`' identical rule.
+ */
+export function removeAddedBulletLine(
+  addedBullets: AddedBullets,
+  entryKey: string,
+  text: string,
+): AddedBullets {
+  const lines = addedBullets[entryKey];
+  if (lines === undefined) return addedBullets;
+  const target = normalizeBulletText(text);
+  const at = lines.findIndex((line) => normalizeBulletText(line) === target);
+  if (at < 0) return addedBullets;
+  const next = { ...addedBullets };
+  const remaining = [...lines.slice(0, at), ...lines.slice(at + 1)];
+  if (remaining.length === 0) delete next[entryKey];
+  else next[entryKey] = remaining;
+  return next;
+}

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -419,6 +419,62 @@ describe("buildAtsResumeModel", () => {
     expect(exp.entries[0].subLine).toBeUndefined();
   });
 
+  it("pins the separator contract: middot header join vs comma empty-company join (#620)", () => {
+    // Standard shape: title/company-location/team all join with " · ", and
+    // company/location join with ", " — the exporter's fixed, parser-coupled
+    // separator set (docs/canonical-resume-model.md §10). A future "normalize
+    // the separators" refactor should fail THIS assertion, not silently
+    // re-route fields on a real résumé.
+    const standard = buildAtsResumeModel(
+      makeResult({
+        experience: [
+          {
+            title: "Senior PM",
+            company: "Acme",
+            location: "Chicago, IL",
+            team: "Growth",
+            start_date: "2021",
+            end_date: "2024",
+            description: "Owned the roadmap",
+          },
+        ],
+      }),
+      makeScore([]),
+    );
+    const standardExp = standard.sections.find(
+      (s) => s.heading === "Experience",
+    )!;
+    expect(standardExp.entries[0].headerLine).toBe(
+      "Senior PM · Acme, Chicago, IL · Growth",
+    );
+
+    // #466 empty-company branch: with `company` empty and `team` set, the
+    // header joins Title and Team with a COMMA (not " · ") so the re-parser's
+    // role-comma split routes the segment back into `team` instead of
+    // mislabeling it as the company.
+    const emptyCompany = buildAtsResumeModel(
+      makeResult({
+        experience: [
+          {
+            title: "Chair",
+            company: "",
+            team: "Leadership Council",
+            start_date: "2021",
+            end_date: "2024",
+            description: "Ran the committee",
+          },
+        ],
+      }),
+      makeScore([]),
+    );
+    const emptyCompanyExp = emptyCompany.sections.find(
+      (s) => s.heading === "Experience",
+    )!;
+    expect(emptyCompanyExp.entries[0].headerLine).toBe(
+      "Chair, Leadership Council",
+    );
+  });
+
   it("fully display-formats contact links (scheme + www stripped) so the www round-trip holds (#425)", () => {
     const result = makeResult({
       linkedin_url: "https://www.linkedin.com/in/janesmith",

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -16,6 +16,11 @@
  * Section order is standard ATS top-to-bottom:
  *   Summary → (Achievements if "above_experience") → Experience → Projects →
  *   Achievements (default placement) → Education → Skills.
+ *
+ * Every join literal below (` · `, `, `, two-space date gap, en dash) is a
+ * parser-coupled separator, not a cosmetic choice — see the #466 empty-company
+ * branch and the #425 flush-right-date notes inline, and the full table in
+ * "Separator contract" (docs/canonical-resume-model.md §10, #620).
  */
 
 import type { CascadeResult } from "../heuristics/types.ts";

--- a/src/lib/rewrite-review/undo-batch.test.ts
+++ b/src/lib/rewrite-review/undo-batch.test.ts
@@ -104,15 +104,26 @@ describe("batchUndoTargets", () => {
     expect(targets.removed).toEqual([7]);
   });
 
-  it("records the added-bullet entry key only when the batch adds", () => {
+  it("records the added-bullet entry key when the batch adds OR removes", () => {
+    // #637 widened this from "adds" to "touches the bucket". A remove can now
+    // be a splice out of `addedBullets` (a user-ADDED bullet has no base-parse
+    // observation for `removedBullets` to key on), so `restore` alone can no
+    // longer undo it — the bucket has to be in the snapshot too.
     expect(
       batchUndoTargets([{ kind: "remove", obsIndex: 1 }], "experience:0")
         .addedEntryKey,
-    ).toBeUndefined();
+    ).toBe("experience:0");
     expect(
       batchUndoTargets([{ kind: "add", text: "new" }], "experience:0")
         .addedEntryKey,
     ).toBe("experience:0");
+    // A replace-only batch still snapshots no array.
+    expect(
+      batchUndoTargets(
+        [{ kind: "replace", obsIndex: 1, text: "x" }],
+        "experience:0",
+      ).addedEntryKey,
+    ).toBeUndefined();
   });
 });
 

--- a/src/lib/rewrite-review/undo-batch.ts
+++ b/src/lib/rewrite-review/undo-batch.ts
@@ -48,16 +48,23 @@ export interface BulletUndoTargets {
   replaced: readonly number[];
   /** BulletObservation indices a `remove` will drop. */
   removed: readonly number[];
-  /** The added-bullet entry key an `add` appends to — set iff the batch has
-   *  at least one `add` write. */
+  /** The added-bullet entry key an `add` appends to — or a `remove` splices out
+   *  of (#637). Set iff the batch has at least one `add` or `remove` write. */
   addedEntryKey?: string;
 }
 
 /**
  * Which slots `writes` will touch. `entryKey` is the caller's own added-bullet
  * bucket (the role's `AddedEntry.id` or its `parsedEntryKey`); it is recorded
- * only when the batch actually adds, so a replace-only batch snapshots no
- * array.
+ * when the batch adds — and, since #637, when it removes, because a remove of a
+ * USER-ADDED bullet is a splice out of that same bucket rather than an entry in
+ * the observation-indexed `removedBullets` set, so `restore` alone cannot undo
+ * it. A replace-only batch still snapshots no array.
+ *
+ * Recording the bucket for a remove that turns out to have targeted a PARSED
+ * bullet is harmless: the snapshot then holds the bucket's unchanged value and
+ * restoring writes it straight back (and an absent bucket snapshots as `[]`,
+ * which restores as a delete — a no-op).
  */
 export function batchUndoTargets(
   writes: readonly ResolvedWrite[],
@@ -65,13 +72,17 @@ export function batchUndoTargets(
 ): BulletUndoTargets {
   const replaced: number[] = [];
   const removed: number[] = [];
-  let adds = false;
+  let touchesBucket = false;
   for (const write of writes) {
     if (write.kind === "replace") replaced.push(write.obsIndex);
-    else if (write.kind === "remove") removed.push(write.obsIndex);
-    else adds = true;
+    else if (write.kind === "remove") {
+      removed.push(write.obsIndex);
+      touchesBucket = true;
+    } else touchesBucket = true;
   }
-  return adds ? { replaced, removed, addedEntryKey: entryKey } : { replaced, removed };
+  return touchesBucket
+    ? { replaced, removed, addedEntryKey: entryKey }
+    : { replaced, removed };
 }
 
 /** The live edit state the snapshot reads. Structural on purpose — this module


### PR DESCRIPTION
## Summary

Two issues on one branch.

**#637 — "Remove bullet" was inert on every user-added role.** `applyRemovedBulletOverrides` resolves indices against the frozen base-parse observations, where an added bullet has no entry, so the removal was dropped: the bullet stayed in the list, the score and the exported PDF while the UI rendered "Removed 1 change · Undo" for a change that never happened. `removeBullet` is now entry-aware and splices the owning `addedBullets` bucket; `batchUndoTargets` records that bucket on a remove so Undo restores it. Making the removal real also made the original undo-strip defect reachable for the first time, so its fix lands alongside as a per-entry prune hold.

**#620 — the exporter's separator set is a parser contract** that existed only implicitly across scattered docblocks. Now recorded in `docs/canonical-resume-model.md` §10, with a test pinning the standard and empty-company header shapes. No rendered byte changes.

Closes #620
Closes #637

## Behaviour change (intended, pre-authorized)

Removing or blank-committing a bullet on a user-added role now **moves the score and changes the exported PDF**. Before, it was byte-identical to not removing it. Parsed-bullet removal is unchanged — it still routes through `removedBullets`.

## Review focus

- `src/hooks/useEditableParse.ts` — every `addedBullets` writer now goes through one `writeAddedBullets` helper that sets a ref before `setState`, replacing React-managed update ordering with a hand-rolled source of truth for that field. Does any path still write the state without the ref, or read the ref where the committed value was wanted?
- `src/hooks/useEditableParse.ts` (`removeBullet`) — on a splice miss under a **parsed** entry the call deliberately falls through to the observation-indexed `removedBullets`. Is the `isAddedEntryKey` guard the right discriminator, and can a mis-tagged `entryKey` reach it?
- `src/hooks/useAddedEntryPruneHold.ts` — the hold is released on unmount. Does that ordering hold against the `setTimeout(0)` section-exit prune it exists to survive, in both directions (early release / permanent leak)?
- `docs/canonical-resume-model.md` §10 — every `ats-resume-model.ts` line citation. This PR's own docblock shifted them once already.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run` — 251 files / 3608 tests passed, 8 files / 10 skipped, 0 failed
- [x] `npm run check:fixtures` — 54 PDFs, all personas synthetic (no fixture touched by this PR)
- [x] `corpus-roundtrip` + `render-roundtrip-*` families untouched and green (#620 requires no rendered byte to change)
- [x] Whole-tree `fallow audit --base origin/main` — 0 dead files, 0 dead exports; complexity + duplication findings all verified inherited, not introduced by this diff
- [x] Manually verified in `npm run dev`

## Non-vacuity proofs

Each half of #637 was proven by reverting **that half alone** — reverting one half of a two-part fix shows the rule fires, not that it is correctly scoped.

- **Half 1 reverted alone** (added-bucket branch disabled, half 2 left intact): 8 failed / 8 passed. `expected [ …(2) ] to deeply equal [ Array(1) ]` — the removed bullet still present. The two parsed-bullet tests still passed, confirming scope.
- **Half 2 reverted alone** (`pruneEmptyAddedEntries` ignores `isHeld`, half 1 restored): 5 failed / 11 passed, every failure inside the half-2 suite. `expected '…' to contain 'Removed 1 change'`, and `Cannot read properties of null (reading 'dispatchEvent')` — the Undo button no longer exists to click.
- **The `writeAddedBullets` regression tests**, reverted against a pre-fix mutant of the hook: 10 of 28 scenarios fail, including `expected {} to deeply equal { 'added:0': [ 'B' ] }`.

## Adversarial review

Two rounds before this PR existed. Round 1 returned **2 blocking findings**, both reproduced end-to-end rather than reasoned about; round 2 returned **clean** after verifying the fixes against a purpose-built pre-fix mutant.

**Blocking 1 — `addedBullets` literal-vs-functional `setState` clobber.** The new splice wrote state with a literal value derived from a ref while four pre-existing writers used functional updaters and never touched that ref. In one synchronous handler the literal write landed last and discarded the queued update — wiping the whole map, not just one bullet. Reachable through the ordinary rewrite-apply path, which emits writes in pair order, so add-before-remove is normal; Undo did not rescue it. The shipped test missed it because the *passing* order is remove-then-add. Fixed by routing all five writers through one `writeAddedBullets` helper. Notably the ref/updater divergence was **pre-existing and systemic** — `captureBulletUndo` already snapshotted a stale bucket; this diff introduced the first literal-value writer, which is what made it destructive. The fix repairs both.

**Blocking 2 — every `ats-resume-model.ts` citation in the new §10 table was 5 lines short**, because #620's own docblock addition shifted the lines its table cites. The table was correct when written and wrong by the time it was saved, in the same commit. All 20 citations corrected and individually re-read against the source.

**Surviving nits, for the reviewer's eye:** the `text === undefined` fallbacks in `ReconstructedRole.tsx` / `ReconstructedResume.tsx` (practically unreachable); the render-phase `bulletsRef` assignment; `ReconstructedResume.tsx` LOC debt. The 81-line test-harness clone between `ExperienceSection.prune-hold.test.tsx` and `ExperienceSection.test.tsx` was judged **leave it** — the two are independent regression proofs, and a shared harness would let a future edit for one silently weaken the other.

## Known residuals — not fixed here, each now has its own issue

1. **#657** — **`bulletOverrides` is still inert on an added bullet.** `applyBulletTextOverrides` uses the same frozen `byIndex`, so a *non-blank edit* of an added bullet still silently does nothing. Only the blank-commit/remove path was in scope. Root cause #1 from #637's body is bypassed by this fix, not repaired.
2. **#658** — **A held added-entry is not re-examined when its strip collapses** — it survives until the next section exit. Deliberate: the collapse is timer-driven and could fire while the user is typing in that entry. Strictly better than before (such a role was previously never prunable at all).
3. **#659** — **The strip confirms a removal that provably did nothing** — `setStatus({kind:"removed"})` is unconditional, but `removeBullet` now has a deliberate silent early return on a bucket miss. Pre-existing, but the new return makes it a designed path.
4. **#660** — **A degenerate pure-punctuation added bullet** (`"•"`, `"-"`) normalises to an empty grouping key and lands in the "Other bullets" bucket, where its Remove is inert. `addBullet` only rejects blank-after-`trim()`.
5. **#661** — **`docs/canonical-resume-model.md`'s citations outside §10 are stale** (doc lines 20/28/45/103/118/128). Verified pre-existing — `AtsResumeModel` is cited as `:181`, was `:210` at `25dde7c`, is `:215` now. Never correct; a separate sweep.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #620 | Claude Sonnet 5 | medium |
| Implementation — #637 | Claude Opus 5 (1M context) | ultra |
| Adversarial review — round 1 | Claude Opus 5 (1M context) | — |
| Review fixes | Claude Opus 5 (1M context) | — |
| Adversarial review — round 2 | Claude Opus 5 (1M context) | — |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |

