### PR TITLE
fix(skills): leadership aliases so the advisory stops suggesting skills the résumé already has (#594, #607)

### DIFF
--- a/src/components/features/JobQueryEditor.test.tsx
+++ b/src/components/features/JobQueryEditor.test.tsx
@@ -730,11 +730,18 @@ describe("JobQueryEditor — title/skill coherence (issue 587)", () => {
    * heading text appears somewhere on the page.
    */
   describe("grouped suggestions", () => {
-    /** The group element whose heading starts with `heading`, or undefined. */
+    /** The group element whose heading starts with `heading`, or undefined.
+     *
+     *  Takes the INNERMOST match, not the first: any ancestor whose leading child
+     *  is this group satisfies the same predicate, and picking it would sweep the
+     *  other group's pills in too — making the `not.toContain` assertions below
+     *  vacuous. `querySelectorAll` is document order, so the ancestor comes
+     *  first and the group itself comes last. */
     function group(el: HTMLElement, heading: string): Element | undefined {
-      return [...el.querySelectorAll("div")].find(
+      const matches = [...el.querySelectorAll("div")].filter(
         (node) => node.firstElementChild?.textContent?.startsWith(heading) === true,
       );
+      return matches[matches.length - 1];
     }
 
     it("puts each suggestion under a heading that names the field it writes to", () => {

--- a/src/components/features/TermQualityAdvisory.tsx
+++ b/src/components/features/TermQualityAdvisory.tsx
@@ -69,7 +69,13 @@ import type {
 import { AddPill } from "./ReconstructedAdd.tsx";
 
 /** The display text for a missing term — the term itself for a title, or the
- *  skill's human label (falling back to the id) for a skill. */
+ *  skill's human label (falling back to the id) for a skill.
+ *
+ *  The label is the dictionary's `label` verbatim, which is also what a click
+ *  appends to `query.skills` — so a pill and the chip it creates read
+ *  identically, and both match the chips `deriveSkills` already produced. That
+ *  only holds because every authored `label` is title-cased (#607); a lowercase
+ *  one would render `+ people management` beside title-cased chips. */
 export function missingTermLabel(term: MissingTerm): string {
   if (term.kind === "title") return term.term;
   return getSkillIndex().idToLabel.get(term.term) ?? term.term;

--- a/src/lib/jd-match/extract-jd-terms.test.ts
+++ b/src/lib/jd-match/extract-jd-terms.test.ts
@@ -117,7 +117,7 @@ Kubernetes is a core piece of the platform.
   it("renders a human label for skills whose id reads poorly, not the kebab id", () => {
     const { skills } = extractJdTerms("Experience running A/B testing and CI/CD pipelines.");
     const abTest = skills.find((s) => s.id === "a-b-testing");
-    expect(abTest?.display).toBe("A/B testing");
+    expect(abTest?.display).toBe("A/B Testing");
     const cicd = skills.find((s) => s.id === "ci-cd");
     expect(cicd?.display).toBe("CI/CD");
   });

--- a/src/lib/jd-match/skills.test.ts
+++ b/src/lib/jd-match/skills.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
-import { SKILLS, getSkillIndex, skillCount } from "./skills.ts";
+import { SKILLS, SKILLS_DICTIONARY_VERSION, getSkillIndex, skillCount } from "./skills.ts";
 
 describe("skills dictionary", () => {
   it("ships at least 100 canonical skills (issue acceptance criterion)", () => {
@@ -39,6 +39,33 @@ describe("skills dictionary", () => {
     const captured = matches.map((m) => m[1].toLowerCase());
     expect(captured).toContain("ruby on rails");
     expect(captured).not.toContain("ruby");
+  });
+
+  it("starts every authored label with a capital or a digit (#607)", () => {
+    // A `label` is rendered verbatim beside chips `deriveSkills` title-cased
+    // itself, so a lowercase one puts two casings in one sentence — and the
+    // recognized skill is the one that looks unpolished. Checked on the first
+    // character only: inside the label the entry's own house casing rules
+    // ("iOS", "P&L Ownership", "A/B Testing"), which no rule can derive.
+    const offenders = SKILLS.filter((s) => s.label && !/^[A-Z0-9]/.test(s.label)).map(
+      (s) => `${s.id}: "${s.label}"`,
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every alias lowercase — aliases are matched, never shown", () => {
+    // The matcher lowercases both sides, so an uppercase alias is not wrong so
+    // much as a sign someone pasted a display string into the wrong field.
+    for (const entry of SKILLS) {
+      for (const alias of entry.aliases) {
+        expect(alias).toBe(alias.toLowerCase());
+      }
+    }
+  });
+
+  it("pins the dictionary data version so an alias edit is a conscious bump", () => {
+    // Upstream of `term-quality.ts`'s answer, which no other version covers.
+    expect(SKILLS_DICTIONARY_VERSION).toBe("1.1");
   });
 
   it("matches aliases case-insensitively at word boundaries", () => {
@@ -110,6 +137,19 @@ describe("leadership/management competencies (#583)", () => {
         }
       }
     }
+  });
+
+  it("recognizes the skills-row phrasings a leadership résumé actually uses (#594)", () => {
+    // Not bullet prose: these are the literal chips off a real leadership
+    // résumé's SKILLS row. `deriveSkills` canonicalizes by EXACT full-string
+    // lookup, so each spelling has to be its own alias — a near miss leaves the
+    // chip as free text and the advisory then offers a skill the chip states.
+    const { aliasToId } = getSkillIndex();
+    expect(aliasToId.get("engineering leadership")).toBe("people-management");
+    expect(aliasToId.get("engineering management")).toBe("people-management");
+    expect(aliasToId.get("hiring & talent acquisition")).toBe("technical-recruiting");
+    expect(aliasToId.get("hiring and talent acquisition")).toBe("technical-recruiting");
+    expect(aliasToId.get("talent acquisition")).toBe("technical-recruiting");
   });
 
   it("matches realistic bullet phrasing for a sample of the new competencies", () => {

--- a/src/lib/jd-match/skills.ts
+++ b/src/lib/jd-match/skills.ts
@@ -34,10 +34,40 @@ export interface SkillEntry {
   readonly aliases: readonly string[];
   /** Human display form. Omit when the `id` already reads cleanly (`react`,
    *  `kubernetes`); set it where the kebab/lowercased id reads poorly in the
-   *  UI (`a-b-testing` → `A/B testing`, `ci-cd` → `CI/CD`). Falls back to
-   *  `id`. */
+   *  UI (`a-b-testing` → `A/B Testing`, `ci-cd` → `CI/CD`). Falls back to
+   *  `id`.
+   *
+   *  MUST START WITH A CAPITAL (or a digit) — `skills.test.ts` enforces it.
+   *  A `label` is rendered verbatim: `deriveSkills`
+   *  (`job-search/query-builder.ts`) uses it for a recognized résumé skill and
+   *  title-cases the free-text ones itself, so a lowercase label put two casings
+   *  in one sentence — "cross-functional collaboration, Team Building &
+   *  Mentorship" — and it was the RECOGNIZED skill that looked unpolished (#607).
+   *  Inside the label, follow the entry's own house casing (`iOS`, `P&L
+   *  Ownership`); only the first character is machine-checked. Aliases stay
+   *  lowercase — they are matched, never shown. */
   readonly label?: string;
 }
+
+/**
+ * Version of the dictionary's DATA — the entries, their aliases, their labels.
+ *
+ * Exists because this table is upstream of an answer that is versioned
+ * elsewhere: `job-search/term-quality.ts` reproduces a query's advice from
+ * `TERM_QUALITY_VERSION` (its rules) + `ROLE_PROFILES_VERSION` (which terms a
+ * role expects), and neither moves when an alias here does — yet an added alias
+ * changes which suggestions that module emits for an unchanged résumé, because
+ * `deriveSkills` canonicalizes a chip through `aliasToId` before the advice is
+ * computed. Without this number that class of change is unreproducible.
+ *
+ * Changelog:
+ * - 1.0: initial curated dictionary, plus the #583 leadership/management block.
+ * - 1.1 (2026-07-29): leadership aliases widened to the phrasings a leadership
+ *   résumé's SKILLS ROW actually uses, and every authored `label` title-cased
+ *   (#594, #607). Moves both the canonicalization of a chip and its display
+ *   text; no entry was removed and no `id` renamed.
+ */
+export const SKILLS_DICTIONARY_VERSION = "1.1";
 
 export const SKILLS: readonly SkillEntry[] = [
   // ── Languages ────────────────────────────────────────────────────────────
@@ -153,8 +183,8 @@ export const SKILLS: readonly SkillEntry[] = [
   { id: "git", aliases: ["git"] },
 
   // ── Data / ML ────────────────────────────────────────────────────────────
-  { id: "machine-learning", label: "machine learning", aliases: ["machine learning", "ml"] },
-  { id: "deep-learning", label: "deep learning", aliases: ["deep learning"] },
+  { id: "machine-learning", label: "Machine Learning", aliases: ["machine learning", "ml"] },
+  { id: "deep-learning", label: "Deep Learning", aliases: ["deep learning"] },
   { id: "pytorch", aliases: ["pytorch"] },
   { id: "tensorflow", aliases: ["tensorflow"] },
   { id: "keras", aliases: ["keras"] },
@@ -166,14 +196,14 @@ export const SKILLS: readonly SkillEntry[] = [
   { id: "langchain", aliases: ["langchain", "lang chain"] },
   { id: "llm", aliases: ["llm", "large language model", "large language models"] },
   { id: "nlp", aliases: ["nlp", "natural language processing"] },
-  { id: "computer-vision", label: "computer vision", aliases: ["computer vision", "cv (computer vision)"] },
+  { id: "computer-vision", label: "Computer Vision", aliases: ["computer vision", "cv (computer vision)"] },
   { id: "rag", aliases: ["rag", "retrieval augmented generation", "retrieval-augmented generation"] },
   { id: "etl", aliases: ["etl", "elt"] },
   { id: "dbt", aliases: ["dbt"] },
   { id: "tableau", aliases: ["tableau"] },
   { id: "looker", aliases: ["looker"] },
   { id: "power-bi", label: "Power BI", aliases: ["power bi", "powerbi"] },
-  { id: "data-warehouse", label: "data warehouse", aliases: ["data warehouse", "data warehousing"] },
+  { id: "data-warehouse", label: "Data Warehouse", aliases: ["data warehouse", "data warehousing"] },
 
   // ── Mobile ──────────────────────────────────────────────────────────────
   { id: "ios", aliases: ["ios"] },
@@ -201,9 +231,9 @@ export const SKILLS: readonly SkillEntry[] = [
   { id: "confluence", aliases: ["confluence"] },
   { id: "figma", aliases: ["figma"] },
   { id: "sketch", aliases: ["sketch"] },
-  { id: "product-management", label: "product management", aliases: ["product management", "product manager"] },
-  { id: "a-b-testing", label: "A/B testing", aliases: ["a/b testing", "ab testing", "a/b test"] },
-  { id: "user-research", label: "user research", aliases: ["user research", "user interviews"] },
+  { id: "product-management", label: "Product Management", aliases: ["product management", "product manager"] },
+  { id: "a-b-testing", label: "A/B Testing", aliases: ["a/b testing", "ab testing", "a/b test"] },
+  { id: "user-research", label: "User Research", aliases: ["user research", "user interviews"] },
   { id: "okrs", aliases: ["okrs", "okr"] },
 
   // ── Security / misc ─────────────────────────────────────────────────────
@@ -220,29 +250,44 @@ export const SKILLS: readonly SkillEntry[] = [
   // is exactly the noisy single-word alias the docblock above warns against
   // — it would fire on ordinary bullet prose. Every alias here is a
   // multi-word phrase (see `skills.test.ts` for the enforcing check).
-  { id: "people-management", label: "people management", aliases: ["people management", "managed a team", "managing a team", "team management"] },
-  { id: "technical-recruiting", label: "technical recruiting", aliases: ["technical recruiting", "led hiring", "technical hiring"] },
-  { id: "performance-management", label: "performance management", aliases: ["performance management", "performance reviews", "performance review"] },
-  { id: "coaching-mentorship", label: "coaching / mentorship", aliases: ["coaching and mentorship", "coaching & mentorship", "mentoring engineers"] },
-  { id: "career-development", label: "career development", aliases: ["career development", "career growth planning"] },
-  { id: "org-design", label: "org design", aliases: ["org design", "organizational design", "organization design"] },
-  { id: "team-building", label: "team building", aliases: ["team building", "built and scaled a team", "grew the team"] },
-  { id: "roadmap-ownership", label: "roadmap ownership", aliases: ["roadmap ownership", "owned the roadmap", "product roadmap ownership"] },
-  { id: "project-delivery", label: "project delivery", aliases: ["project delivery", "delivery leadership"] },
-  { id: "program-management", label: "program management", aliases: ["program management", "technical program management"] },
-  { id: "agile-leadership", label: "agile / scrum leadership", aliases: ["scrum leadership", "agile leadership", "agile transformation"] },
-  { id: "incident-management", label: "incident management", aliases: ["incident management", "incident commander", "incident response leadership"] },
-  { id: "on-call-ownership", label: "on-call ownership", aliases: ["on-call ownership", "owned on-call", "on-call rotation ownership"] },
-  { id: "technical-strategy", label: "technical strategy", aliases: ["technical strategy", "engineering strategy"] },
-  { id: "architecture-review", label: "architecture review", aliases: ["architecture review", "architectural review board"] },
-  { id: "platform-ownership", label: "platform ownership", aliases: ["platform ownership", "owned the platform"] },
-  { id: "vendor-management", label: "vendor management", aliases: ["vendor management", "vendor negotiations"] },
-  { id: "budget-headcount-planning", label: "budget / headcount planning", aliases: ["budget planning", "headcount planning", "budget and headcount planning"] },
-  { id: "pnl-ownership", label: "P&L ownership", aliases: ["p&l ownership", "profit and loss ownership", "p and l ownership"] },
-  { id: "stakeholder-management", label: "stakeholder management", aliases: ["stakeholder management", "stakeholder alignment"] },
-  { id: "cross-functional-collaboration", label: "cross-functional collaboration", aliases: ["cross-functional collaboration", "cross functional collaboration"] },
-  { id: "executive-communication", label: "executive communication", aliases: ["executive communication", "executive presentations", "communicating with executives"] },
-  { id: "technical-writing", label: "technical writing", aliases: ["technical writing", "wrote technical documentation"] },
+  //
+  // THE SKILLS-ROW PHRASINGS ARE LOAD-BEARING, NOT DECORATION (#594, #607). Most
+  // aliases here are BULLET phrasings ("managed a team"); the ones that read like
+  // a section heading — "engineering leadership", "hiring & talent acquisition",
+  // "talent acquisition" — are how a leadership résumé's SKILLS ROW spells the
+  // same competency, and they earn their place for a second reason. `deriveSkills`
+  // (`job-search/query-builder.ts`) canonicalizes a chip by EXACT full-string
+  // alias lookup, so an unlisted spelling stays raw free text; `term-quality.ts`
+  // may not import jd-match at runtime and so compares word-wise, finds no overlap
+  // between {hiring} and {technical, recruiting}, and offers the person a skill
+  // their own chip already states. Add the spelling here; never loosen that
+  // comparison. The cost is that the chip then RENDERS as the canonical label —
+  // "Engineering Leadership" shows up as "People Management" — which is the same
+  // trade "k8s" → "kubernetes" already makes, and is why an alias must be a true
+  // synonym of the entry, not merely adjacent to it.
+  { id: "people-management", label: "People Management", aliases: ["people management", "managed a team", "managing a team", "team management", "engineering leadership", "engineering management", "people leadership"] },
+  { id: "technical-recruiting", label: "Technical Recruiting", aliases: ["technical recruiting", "led hiring", "technical hiring", "talent acquisition", "hiring & talent acquisition", "hiring and talent acquisition"] },
+  { id: "performance-management", label: "Performance Management", aliases: ["performance management", "performance reviews", "performance review"] },
+  { id: "coaching-mentorship", label: "Coaching / Mentorship", aliases: ["coaching and mentorship", "coaching & mentorship", "mentoring engineers"] },
+  { id: "career-development", label: "Career Development", aliases: ["career development", "career growth planning"] },
+  { id: "org-design", label: "Org Design", aliases: ["org design", "organizational design", "organization design", "organizational leadership"] },
+  { id: "team-building", label: "Team Building", aliases: ["team building", "built and scaled a team", "grew the team"] },
+  { id: "roadmap-ownership", label: "Roadmap Ownership", aliases: ["roadmap ownership", "owned the roadmap", "product roadmap ownership"] },
+  { id: "project-delivery", label: "Project Delivery", aliases: ["project delivery", "delivery leadership", "delivery management", "project execution"] },
+  { id: "program-management", label: "Program Management", aliases: ["program management", "technical program management"] },
+  { id: "agile-leadership", label: "Agile / Scrum Leadership", aliases: ["scrum leadership", "agile leadership", "agile transformation"] },
+  { id: "incident-management", label: "Incident Management", aliases: ["incident management", "incident commander", "incident response leadership"] },
+  { id: "on-call-ownership", label: "On-Call Ownership", aliases: ["on-call ownership", "owned on-call", "on-call rotation ownership"] },
+  { id: "technical-strategy", label: "Technical Strategy", aliases: ["technical strategy", "engineering strategy"] },
+  { id: "architecture-review", label: "Architecture Review", aliases: ["architecture review", "architectural review board"] },
+  { id: "platform-ownership", label: "Platform Ownership", aliases: ["platform ownership", "owned the platform"] },
+  { id: "vendor-management", label: "Vendor Management", aliases: ["vendor management", "vendor negotiations"] },
+  { id: "budget-headcount-planning", label: "Budget / Headcount Planning", aliases: ["budget planning", "headcount planning", "budget and headcount planning"] },
+  { id: "pnl-ownership", label: "P&L Ownership", aliases: ["p&l ownership", "profit and loss ownership", "p and l ownership"] },
+  { id: "stakeholder-management", label: "Stakeholder Management", aliases: ["stakeholder management", "stakeholder alignment"] },
+  { id: "cross-functional-collaboration", label: "Cross-Functional Collaboration", aliases: ["cross-functional collaboration", "cross functional collaboration"] },
+  { id: "executive-communication", label: "Executive Communication", aliases: ["executive communication", "executive presentations", "communicating with executives"] },
+  { id: "technical-writing", label: "Technical Writing", aliases: ["technical writing", "wrote technical documentation"] },
 ];
 
 /**
@@ -271,7 +316,7 @@ interface CompiledIndex {
   readonly idToAliases: ReadonlyMap<string, readonly string[]>;
   /** Canonical ID → human display label (falls back to the id when an entry
    *  has no explicit `label`). Lets the extractor render a clean term name
-   *  instead of the kebab id (`a-b-testing` → `A/B testing`). */
+   *  instead of the kebab id (`a-b-testing` → `A/B Testing`). */
   readonly idToLabel: ReadonlyMap<string, string>;
   /** Per-canonical-ID mention probe — `mentionPatterns.get("kubernetes")`
    *  returns a single regex that fires on any of {"kubernetes", "k8s"}. */

--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -307,22 +307,24 @@ describe("buildJobQuery", () => {
     // free-text phrase is indistinguishable from a canonical label downstream,
     // and judging one as the other is what marked real skills weak.
     const parsed = baseParsed({
-      skills: ["JS", "Team Building & Mentorship", "python3", "Engineering Leadership"],
+      skills: ["JS", "Team Building & Mentorship", "python3", "Competitive Juggling"],
     });
     const query = buildJobQuery(parsed);
     expect(query.skills).toEqual([
       "javascript",
       "python",
       "Team Building & Mentorship",
-      "Engineering Leadership",
+      "Competitive Juggling",
     ]);
     expect(query.canonicalSkills).toEqual(["javascript", "python"]);
   });
 
   it("leaves canonicalSkills absent when no skill is a canonical name", () => {
     // Absent means "not asserted", which readers treat as no standing to judge —
-    // never as "none are canonical, so all are weak".
-    const query = buildJobQuery(baseParsed({ skills: ["Engineering Leadership"] }));
+    // never as "none are canonical, so all are weak". "Engineering Leadership"
+    // used to be the example here and stopped working as one: #594 made it an
+    // alias of `people-management`, which is the whole point of that change.
+    const query = buildJobQuery(baseParsed({ skills: ["Underwater Basket Weaving"] }));
     expect(query.canonicalSkills).toBeUndefined();
   });
 
@@ -387,7 +389,10 @@ describe("buildJobQuery", () => {
     // unrecognized entries that were typed first.
     // Pin the #583 canonicality: the leadership skill the taxonomy now
     // recognizes leads the ranked list, ahead of the AI/ML cluster.
-    expect(query.skills[0]).toBe("stakeholder management");
+    // The canonical label verbatim — title-cased in the dictionary since #607,
+    // so a recognized skill no longer renders lowercase beside a title-cased
+    // free-text one.
+    expect(query.skills[0]).toBe("Stakeholder Management");
     const aiClusterIndex = query.skills.indexOf("python");
     const incidentalIndex = query.skills.indexOf("Team Leadership");
     expect(aiClusterIndex).toBeGreaterThanOrEqual(0);
@@ -397,7 +402,7 @@ describe("buildJobQuery", () => {
     expect(query.skills).toEqual(
       expect.arrayContaining([
         "python",
-        "machine learning",
+        "Machine Learning",
         "pytorch",
         "tensorflow",
         "nlp",
@@ -435,15 +440,15 @@ describe("buildJobQuery", () => {
     // The leadership competencies now resolve to canonical labels...
     expect(query.skills).toEqual(
       expect.arrayContaining([
-        "people management",
-        "technical recruiting",
-        "roadmap ownership",
-        "cross-functional collaboration",
+        "People Management",
+        "Technical Recruiting",
+        "Roadmap Ownership",
+        "Cross-Functional Collaboration",
       ]),
     );
     // ...and rank ahead of the one entry that still has no canonical match,
     // proving the sort is no longer a tie.
-    const firstCanonicalIndex = query.skills.indexOf("people management");
+    const firstCanonicalIndex = query.skills.indexOf("People Management");
     const incidentalIndex = query.skills.indexOf("Public Speaking");
     expect(firstCanonicalIndex).toBeGreaterThanOrEqual(0);
     expect(incidentalIndex).toBeGreaterThanOrEqual(0);

--- a/src/lib/job-search/query-builder.ts
+++ b/src/lib/job-search/query-builder.ts
@@ -378,6 +378,11 @@ function deriveSkills(parsed: ResumeQueryInput): string[] {
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
     ranked.push({
+      // A recognized skill renders the dictionary's own `label`, a free-text one
+      // is title-cased here. Those two only agree on casing because #607
+      // title-cased every authored `label` in `jd-match/skills.ts` — before
+      // that, recognition status leaked into casing and the card read
+      // "cross-functional collaboration, Team Building & Mentorship".
       label: canonicalId ? (index.idToLabel.get(canonicalId) ?? trimmed) : titleCase(trimmed),
       isCanonical: Boolean(canonicalId),
       index: order++,

--- a/src/lib/job-search/term-quality.test.ts
+++ b/src/lib/job-search/term-quality.test.ts
@@ -8,6 +8,7 @@ import {
   TERM_QUALITY_VERSION,
 } from "./term-quality.ts";
 import type { TermVerdict } from "./term-quality.ts";
+import { buildJobQuery } from "./query-builder.ts";
 import type { JobQuery } from "./query-builder.ts";
 import { roleProfileById } from "./role-profiles.ts";
 
@@ -437,6 +438,26 @@ describe("assessQueryTerms — missing terms", () => {
     ).not.toContain("executive-communication");
   });
 
+  it("still suggests a leadership skill the query only says in a spelling jd-match does not know", () => {
+    // The pre-#594 state of the world, pinned so the fix is attributable to the
+    // alias data and not to some coincidence downstream: this module compares
+    // word-wise and cannot see jd-match's aliases (its docblock forbids the
+    // import), so a RAW skills-row phrasing shares no word with the expected id
+    // and is correctly — from this module's point of view — not a match.
+    // `buildJobQuery` is what makes the end-to-end case below pass, by rewriting
+    // the chip to the canonical label first. Delete the alias and that test goes
+    // red while this one keeps passing.
+    const { missing } = assessQueryTerms(
+      makeQuery({
+        titles: ["Senior Engineering Manager"],
+        skills: ["Hiring & Talent Acquisition", "Engineering Leadership"],
+      }),
+    );
+    const skills = missing.filter((entry) => entry.kind === "skill").map((e) => e.term);
+    expect(skills).toContain("technical-recruiting");
+    expect(skills).toContain("people-management");
+  });
+
   it("never suggests a wordier spelling of a title the query already carries, but keeps a different market phrasing", () => {
     // The reproduction's titles. "+ engineering team lead" was offered to
     // someone titled "Engineering Lead" — {engineering, lead} ⊂ {engineering,
@@ -474,6 +495,101 @@ describe("assessQueryTerms — missing terms", () => {
     expect(missing.filter((e) => e.kind === "title").map((e) => e.term)).toContain(
       "machine learning engineer",
     );
+  });
+});
+
+/**
+ * The #594/#607 reproduction, end to end — the only level at which it reproduces.
+ *
+ * A hand-built `JobQuery` cannot show the fix: this module compares word-wise and
+ * may not read jd-match's aliases, so the bridge is `buildJobQuery` canonicalizing
+ * "Hiring & Talent Acquisition" to the chip "Technical Recruiting" BEFORE the
+ * advice is computed. Both halves of the pipe therefore have to be in the test.
+ *
+ * Each case asserts `missing` is still `MAX_MISSING_SKILLS` long alongside the
+ * `not.toContain`, because suppression back-fills: without that, an assertion
+ * passes when the term merely fell off the tail of a re-ordered head-cap, which
+ * is exactly the wrong reason.
+ */
+describe("assessQueryTerms + buildJobQuery — a suggestion the résumé already states (#594, #607)", () => {
+  function queryFor(skills: string[], titles = ["Engineering Lead", "Sr. Engineering Manager"]): JobQuery {
+    return buildJobQuery({
+      skills,
+      experience: titles.map((title, i) => ({ title, company: i ? "Globex" : "Acme Corp" })),
+    });
+  }
+
+  function missingSkills(skills: string[], titles?: string[]): string[] {
+    return assessQueryTerms(queryFor(skills, titles))
+      .missing.filter((entry) => entry.kind === "skill")
+      .map((entry) => entry.term);
+  }
+
+  it("does not offer '+ technical recruiting' beside a 'Hiring & Talent Acquisition' chip", () => {
+    // Titled into `senior-engineering-manager` on purpose: that is the profile
+    // whose prevalence-ranked head CARRIES `technical-recruiting` (asserted
+    // below, not assumed), so the term had a place in `missing` to lose. Run
+    // against `engineering-manager` this would pass whether the fix exists or
+    // not, because the term never reaches the head-cap there.
+    const titles = ["Senior Engineering Manager"];
+    const head = (roleProfileById("senior-engineering-manager")?.skills ?? []).slice(
+      0,
+      MAX_MISSING_SKILLS,
+    );
+    expect(head).toContain("technical-recruiting");
+    expect(missingSkills([], titles)).toContain("technical-recruiting");
+
+    const skills = missingSkills(["Hiring & Talent Acquisition"], titles);
+    expect(skills).not.toContain("technical-recruiting");
+    expect(skills).toHaveLength(MAX_MISSING_SKILLS);
+  });
+
+  it("does not offer '+ people management' beside an 'Engineering Leadership' chip", () => {
+    // On its own, so the suppression cannot be riding on "Team Building &
+    // Mentorship" happening to sit in the same query. Same non-vacuity check:
+    // the same résumé without that chip IS told to add the skill.
+    expect(missingSkills([])).toContain("people-management");
+    const skills = missingSkills(["Engineering Leadership"]);
+    expect(skills).not.toContain("people-management");
+    expect(skills).toHaveLength(MAX_MISSING_SKILLS);
+  });
+
+  it("suppresses both across the full reproduction résumé, and still fills the row", () => {
+    const skills = missingSkills([
+      "Engineering Leadership",
+      "Technical Architecture & System Design",
+      "Distributed Systems & Cloud Computing",
+      "Team Building & Mentorship",
+      "Hiring & Talent Acquisition",
+      "Cross-functional Collaboration",
+      "Product Development & Strategy",
+      "Performance Optimization",
+      "AI / LLM Orchestration",
+      "Prompt Engineering & Evals",
+    ]);
+    // Not asserted for `technical-recruiting`: these titles resolve to
+    // `engineering-manager`, whose head-cap never reaches it, so the assertion
+    // would pass without the fix. It is asserted where it bites, above.
+    expect(skills).not.toContain("people-management");
+    expect(skills).not.toContain("team-building");
+    expect(skills).not.toContain("cross-functional-collaboration");
+    expect(skills).toHaveLength(MAX_MISSING_SKILLS);
+    // The advice that WAS right stays right: that résumé never says agile,
+    // scrum, or sprints, and "Performance Optimization" is latency work, not
+    // performance management.
+    expect(skills).toContain("agile-leadership");
+    expect(skills).toContain("performance-management");
+  });
+
+  it("never lets a recognized leadership chip read weak", () => {
+    // The #585 standing rule, re-asserted on the chips canonicalization now
+    // produces: recognition must upgrade a verdict, never manufacture a "this is
+    // not what the role is hired on" about a skill the role plainly expects.
+    const query = queryFor(["Engineering Leadership", "Hiring & Talent Acquisition"]);
+    const { verdicts } = assessQueryTerms(query);
+    expect(verdicts.filter((v) => v.kind === "skill" && v.quality === "weak")).toEqual([]);
+    expect(qualityOf(verdicts, "People Management")).toBe("strong");
+    expect(qualityOf(verdicts, "Technical Recruiting")).toBe("strong");
   });
 });
 

--- a/src/lib/job-search/term-quality.ts
+++ b/src/lib/job-search/term-quality.ts
@@ -135,10 +135,13 @@ import {
  * regenerable snapshot. Folding that into this number would mean bumping it on
  * every mining run with no rule changed, which makes it useless as a marker of
  * "the rules moved". That data carries its own versions and this one does not
- * shadow them: reproduce an answer from the pair `TERM_QUALITY_VERSION` +
- * `ROLE_PROFILES_VERSION`, plus `PREVALENCE_SNAPSHOT.generatedAt` for the exact
- * ordering. #588 accordingly bumped `ROLE_PROFILES_VERSION` (1.0 → 1.1) and left
- * this at 1.2.
+ * shadow them: reproduce an answer from the triple `TERM_QUALITY_VERSION` +
+ * `ROLE_PROFILES_VERSION` + `SKILLS_DICTIONARY_VERSION` (jd-match's alias table,
+ * which decides whether a chip arrives here canonicalized at all), plus
+ * `PREVALENCE_SNAPSHOT.generatedAt` for the exact ordering. #588 accordingly
+ * bumped `ROLE_PROFILES_VERSION` (1.0 → 1.1) and left this at 1.2; #594/#607
+ * bumped `SKILLS_DICTIONARY_VERSION` (1.0 → 1.1) and left this at 1.2 again —
+ * both dropped suggestions for an unchanged résumé without touching a rule here.
  *
  * Changelog:
  * - 1.0 (2026-07-25): initial classifier (#584).


### PR DESCRIPTION
Closes #594. Closes #607. Closes #644 (batch epic).

## What was wrong

`src/lib/jd-match/skills.ts` is IC/tool-shaped. Its leadership block carried bullet phrasings ("managed a team") but none of the wordings a leadership résumé's **skills row** uses, so `Hiring & Talent Acquisition` and `Engineering Leadership` reached `term-quality.ts` as raw free text. That module compares word-wise and may not import jd-match (its docblock forbids the runtime import), so `{hiring}` shares nothing with `{technical, recruiting}` and the card offered:

> **Not in your résumé yet — add the ones you actually have:** `+ people management` … `+ technical recruiting`

…to someone whose own chips said both.

## The fix is data, not rule

`skillCovers` / `anySkillCovers` are untouched — loosening them resurrects the false-suppression bug clause 3's opt-in note exists to prevent. Instead:

- **Aliases added.** `deriveSkills` canonicalizes a chip by **exact full-string** lookup, so every spelling is listed verbatim: `engineering leadership`, `engineering management`, `people leadership` → `people-management`; `talent acquisition`, `hiring & talent acquisition`, `hiring and talent acquisition` → `technical-recruiting`. Swept the rest of the block for the same class of gap: `organizational leadership` → `org-design`; `delivery management`, `project execution` → `project-delivery`. Every alias is multi-word, per the block's own rule.
- **Judgement call, stated explicitly:** `engineering leadership` is an alias of `people-management`. There is no `engineering-leadership` id, and the phrase connotes people leadership rather than IC depth. The alternative — a new id — also requires `ROLE_PROFILES` to list it or the term becomes unmatched free text again, a strictly larger change. Consequence worth seeing: the chip then **renders as the canonical label**, so "Engineering Leadership" displays as "People Management". That is the same trade `k8s` → `kubernetes` already makes, and it is why an alias must be a true synonym, not merely adjacent.

## Folded in (#607's casing nit)

Same screenshot: *"Already in your résumé: cross-functional collaboration, Team Building & Mentorship"* — two casings in one sentence, with the **recognized** skill the one that looked unpolished. Every authored `label` is now title-cased (28 of them), which is the fix the issue specified. Aliases stay lowercase; they are matched, never shown.

**Not done, deliberately:** the ~150 entries with *no* `label` still fall back to their lowercase `id`, so a recognized `sql` chip renders `sql`. The alternative considered was title-casing at render time; it is worse — it turns `iOS` into `IOS` and `sql` into `Sql`. Giving the whole dictionary authored display labels is a separate, larger polish task; happy to file it.

## Versions

- `SKILLS_DICTIONARY_VERSION` is **new** (1.1). This table is upstream of an answer that `TERM_QUALITY_VERSION` + `ROLE_PROFILES_VERSION` claim to reproduce, and neither moves when an alias does — yet an added alias changes which suggestions ship for an unchanged résumé. `term-quality.ts`'s reproducibility docblock now names the triple.
- `TERM_QUALITY_VERSION` stays **1.2** — no rule in that module changed. Same call #588 made.
- `ROLE_PROFILES_VERSION` untouched — no profile data changed.

## Tests

- Suppression is pinned **end-to-end through `buildJobQuery`**, the only level at which it reproduces (a hand-built `JobQuery` cannot show it — the bridge is canonicalization). Each case asserts the row is still `MAX_MISSING_SKILLS` long alongside the `not.toContain`, so a pass cannot come from the head-cap dropping the term.
- The `technical-recruiting` case titles into `senior-engineering-manager` **on purpose** and asserts that profile's head carries the term; under `engineering-manager` it never reaches the cap and the assertion would pass with or without the fix.
- Non-vacuity proven both ways: the raw-phrasing query is asserted to *still* get the suggestion, and deleting the four new aliases turns exactly the four new end-to-end tests red (verified locally, restored).
- `skills.test.ts`: labels must start with a capital/digit, aliases must be lowercase, dictionary version pinned, and the new skills-row spellings resolve to the right ids.
- `JobQueryEditor.test.tsx`'s `group()` helper now takes the **innermost** match. The title-cased label exposed that it was matching an ancestor containing both groups, which made its `not.toContain` assertions vacuous.

## Gates

`npm run typecheck`, `npx eslint src`, `npx vitest run` (3565 passed / 10 skipped), `npm run build` — all green locally.

## Provenance

Implemented by Claude Code (Opus 5) with maintainer review.
