### PR TITLE
fix(parser,score,pdf,docs): bulleted role headers, a dateless title's inline year, §7's retracted correction, and a font fallback that refuses instead of mangling a name (#661, #662, #663, #664)

### DIFF
--- a/docs/canonical-resume-model.md
+++ b/docs/canonical-resume-model.md
@@ -2,120 +2,121 @@
 
 Design for [#439](https://github.com/offlinecv/OfflineCV/issues/439), the follow-up to the architecture decision in [#438](https://github.com/offlinecv/OfflineCV/issues/438) ("one canonical representation, staged").
 
-**Status:** design only — no production code changed by this issue (acceptance criterion). Implementation lands as the sequenced, per-stage follow-up issues at the end of this doc. Each stage is separately reviewable and keeps the round-trip invariant green; **nothing here is a big-bang PR.**
+**Status:** the design issue itself was docs-only; its implementation stages have since shipped through the combined Stage D+E cutover (#445). Sections 0–3 and 6 describe the current implementation. Section 4 preserves the staged migration as implementation history.
 
-**Baseline the design is written against:** `main` as of the mapping in this doc. All `file:line` citations are against that baseline. `ATS_SCORE_ALGO_VERSION` is `"1.4"` (`src/lib/score/score.ts:73`); [#435](https://github.com/offlinecv/OfflineCV/issues/435) bumps it to `1.5` in flight — the cache-version hook in §6 keys off whatever value is current at each stage's cutover, not a pinned literal.
-
----
-
-## 0. The thesis, restated precisely
-
-We carry **five** parallel shapes for the same underlying résumé, and every adjacent pair needs a hand-written adapter kept in lockstep by hand:
-
-| # | Shape | Home | Role |
-|---|---|---|---|
-| 1 | `HeuristicParsedResume` / `CascadeResult` | `heuristics/types.ts:121` / `:174` | what the parser produces |
-| 2 | `SectionedResume` | `heuristics/sections.ts:85` | section pools the scorer + editor grade from |
-| 3 | `LlmParsedResume` | `webllm/parse-resume.ts:56` | on-device LLM parse, **field names hand-synced** to #1 |
-| 4 | `AtsResumeModel` / `AtsEntry` / `AtsSection` / `AtsEntryFields` | `pdf/ats-resume-model.ts:181` / `:114` / `:173` / `:87` | render + PDF-export model |
-| 5 | `JsonResume` | `pdf/to-json-resume.ts:113` | JSON Resume export |
-
-The decision (#438) is to collapse these toward **one canonical internal model** with **thin projections** (display / score / render+export / JSON-Resume / llm-diff) derived off it, retiring the N hand-written adapters and the `apply-overrides` lockstep. This doc says *what the canonical model is* and *how we reach it in green stages*.
-
-Two structural costs the canonical model must dissolve, not just relocate:
-
-- **Cost 1 — N peer shapes, N hand-sync adapters.** `apply-overrides.ts` is the sharpest tell: `ApplyOverridesResult` (`edit/apply-overrides.ts:52`) must return `parsed` **and** `rawText` **and** `sections` **and** `fieldConfidence` **together**, because one un-mirrored user edit re-grades or re-parses wrong (comments cite [#133](https://github.com/offlinecv/OfflineCV/issues/133), [#421](https://github.com/offlinecv/OfflineCV/issues/421) Blocking #1/#3). The `LlmParsedResume` hand-sync note (`parse-resume.ts:52-54`: *"Keep field names in sync with that interface"*) is the same cost in a second place.
-- **Cost 2 — the render model encodes re-parse invariants.** `AtsEntry` is doing triple duty (display, PDF layout, **and** export hint via `AtsEntryFields`). Its layout fields exist to satisfy the parse→export→parse identity: `headerLineDate` (#425/#302 entry-boundary date cue), `subLineDate` (#425, avoids the #298 title↔company re-parse swap), `atomicSegments` (#301 skills-middot atomicity), `headerBold` (#425) — each documented in terms of how the exported PDF must re-parse (`ats-resume-model.ts:118-158`). So the renderer knows parser internals, and a fidelity fix touches model + renderer + the parser exemption it leans on + regenerated corpus goldens — four surfaces **by construction**. That is why #425/#434/#435 each landed at 40–54 files.
+**Implementation baseline:** the current source tree. Source citations are symbol-anchored (`path` → `Symbol`) rather than line-anchored, except where a historical line reference is itself the subject. This avoids line drift while preserving an unambiguous source lookup. `ATS_SCORE_ALGO_VERSION` is currently `"1.7"` (`src/lib/score/score.ts` → `ATS_SCORE_ALGO_VERSION`); the persisted-cache key composes it with `CANONICAL_SHAPE_VERSION` (§6).
 
 ---
 
-## 1. The five shapes today (grounded inventory)
+## 0. The thesis and current outcome
 
-### 1 · `HeuristicParsedResume` + `CascadeResult`
-- `HeuristicParsedResume = Partial<ParsedResume> & { skills; experience; education; phoneIsValid? }` — `heuristics/types.ts:121`. `phoneIsValid?` (`:126-129`) precomputes libphonenumber `isValid()` so the scorer skips importing `libphonenumber-js` (entry-chunk budget).
-- `CascadeResult` — `heuristics/types.ts:174`: `parsed`, `rawText` (`:185`), `markdown?` (`:188`), **`sections: SectionedResume`** (`:194`, cites [#132](https://github.com/offlinecv/OfflineCV/issues/132) — replaces the retired `skillsSectionText` side-channel), `linkAnnotations`, `diagnostics.sectionSource`, `timings`.
+The original design identified five peer shapes for the same underlying résumé. That is no longer the current architecture: `CanonicalResume` is now the single parse core, while the remaining shapes are boundary DTOs or one-way projections.
+
+| Shape | Home | Current role |
+|---|---|---|
+| `CanonicalResume` | `heuristics/canonical.ts` → `CanonicalResume` | single parse core: `fields`, `sections`, and `fieldConfidence` |
+| `HeuristicParsedResume` | `heuristics/types.ts` → `HeuristicParsedResume` | field core held at `CanonicalResume.fields` |
+| `SectionedResume` | `heuristics/line-model.ts` → `SectionedResume` | section-membership core held at `CanonicalResume.sections` |
+| `CascadeResult` | `heuristics/types.ts` → `CascadeResult` | cascade envelope with one `canonical` member plus extraction/layout metadata; no top-level `parsed`/`sections`/`fieldConfidence` façade |
+| `LlmParsedResume` | `webllm/parse-resume.ts` → `LlmParsedResume` | on-device LLM boundary DTO; `projectLlmDiff` owns the field-name mapping into a canonical-shaped diff input |
+| `AtsResumeModel` / `JsonResume` | `pdf/ats-resume-model.ts` → `AtsResumeModel`; `pdf/to-json-resume.ts` → `JsonResume` | one-way render/export projections; neither is synchronized back into the parse core |
+
+The decision in #438 was to collapse the peer shapes toward **one canonical internal model** with thin display, score, render/export, JSON-Resume, and LLM-diff projections. The combined D+E cutover completed the ownership change; the stage history below records how it stayed green.
+
+The two original structural costs now have different statuses:
+
+- **Cost 1 — peer shapes and hand-sync adapters: resolved.** `ApplyOverridesResult` is already `CanonicalResume & { rawText: string }` (`edit/apply-overrides.ts` → `ApplyOverridesResult`). `projectLlmDiff` (`heuristics/projections.ts` → `projectLlmDiff`) is the single adapter from `LlmParsedResume`; the old “keep field names in sync” contract is gone.
+- **Cost 2 — render/parser coupling: still explicit.** `AtsEntry` carries parser-sensitive layout fields such as `headerLineDate`, `subLineDate`, `atomicSegments`, and `headerBold` (`pdf/ats-resume-model.ts` → `AtsEntry`). The canonical core is the source, but the render projection still records the layout cues required by parse→export→parse fidelity.
+
+---
+
+## 1. Current shapes and boundaries (grounded inventory)
+
+### 1 · `CanonicalResume` and its field core
+- `CanonicalResume` (`heuristics/canonical.ts` → `CanonicalResume`) owns `fields: HeuristicParsedResume`, `sections: SectionedResume`, and `fieldConfidence: FieldConfidence`.
+- `HeuristicParsedResume = Partial<ParsedResume> & { skills; experience; education; phoneIsValid? }` (`heuristics/types.ts` → `HeuristicParsedResume`). `phoneIsValid?` precomputes libphonenumber `isValid()` so the scorer skips importing `libphonenumber-js` on the entry graph.
 
 ### 2 · `SectionedResume`
-- `heuristics/sections.ts:85` (cites #127 §2.1, #132). `byName: ReadonlyMap<SectionName|"profile", readonly string[]>` (`:89`), `accomplishmentSections` (`:90`, *not yet consumed by pool sourcing*), `sectionHeadings?` (`:94`, #285), `source: "markdown"|"regex"` (`:101`). Built by `toSectionedResume` (`sections.ts:122`) over `PdfSection` (`:62`).
+- `SectionedResume` lives in `heuristics/line-model.ts` → `SectionedResume`. It owns `byName`, `accomplishmentSections`, optional `sectionHeadings`, and splitter `source`. `toSectionedResume` (`heuristics/sections.ts` → `toSectionedResume`) builds it from `PdfSection[]`; `projectScoreSections` exposes the scorer's view.
 
-### 3 · `LlmParsedResume`
-- `webllm/parse-resume.ts:56`. Fields mirror the heuristic parser **by hand** (`:52-54`) so the disagreement detector can diff field-by-field ([#242](https://github.com/offlinecv/OfflineCV/issues/242)). No converter exists between #1 and #3 — the "adapter" is the intentional structural mirror; `diffParses(heuristic, llm)` at `heuristics/disagreement.ts:186` consumes both.
+### 3 · `CascadeResult`
+- `CascadeResult` (`heuristics/types.ts` → `CascadeResult`) has `canonical: CanonicalResume` plus genuinely additional cascade metadata: `confidence`, layout `triggers`, `suggestedEscalation`, `tiers`, `rawText`, optional `markdown`, `linkAnnotations`, `diagnostics`, and `timings`. It does **not** duplicate `canonical.fields`, `canonical.sections`, or `canonical.fieldConfidence` at top level.
 
-### 4 · `AtsResumeModel`
-- `pdf/ats-resume-model.ts:181` (`sections: AtsSection[]` `:188`). `AtsSection` `:173`; `AtsEntry` `:114` with the four round-trip-encoding layout fields above; `AtsEntryFields` `:87` (machine-readable mirror; *"Display/render code never reads this"* `:160`). Built by `buildAtsResumeModel(result, score, edit?)` — `ats-resume-model.ts:425`; date-slot routing to `headerLineDate`/`subLineDate` at `:597-613` cites #425/#302. Round-trip-tradeoff note at `:469`.
+### 4 · `LlmParsedResume`
+- `LlmParsedResume` (`webllm/parse-resume.ts` → `LlmParsedResume`) is the strict DTO produced by on-device JSON coercion. `projectLlmDiff(llm)` (`heuristics/projections.ts` → `projectLlmDiff`) maps it once to a `CanonicalResume`-shaped value; `diffParses` consumes canonical inputs. The type is no longer hand-synchronized with `HeuristicParsedResume`.
 
-### 5 · `JsonResume`
-- `pdf/to-json-resume.ts:113` (jsonresume.org v1.0.0). Produced by `toJsonResume(model: AtsResumeModel)` — `to-json-resume.ts:409` — a **pure** `(model) => JsonResume` adapter (`:5-13`, no `pdf-lib`, no I/O). So JSON-Resume export today reads the **render** model, inheriting its layout coupling.
+### 5 · Render and export projections
+- `buildAtsResumeModel(result, score)` (`pdf/ats-resume-model.ts` → `buildAtsResumeModel`) reads the canonical core through `projectDisplay` and produces `AtsResumeModel` / `AtsEntry` layout data.
+- `toJsonResume(model)` (`pdf/to-json-resume.ts` → `toJsonResume`) is a pure JSON Resume v1.0.0 adapter. It reads the semantic `projectAtsExport(model)` projection (`pdf/ats-export-projection.ts` → `projectAtsExport`), not `AtsEntry` layout fields directly.
 
 ### Adapter chain today
 ```
-PDF ─ runCascade ─▶ CascadeResult ──buildAtsResumeModel──▶ AtsResumeModel ──toJsonResume──▶ JsonResume
-                        │  ▲                                    │
-                        │  └── applyOverrides (edit) ───────────┘ (re-derives parsed+rawText+sections+fieldConfidence)
-                        └── (mirror, no converter) ──▶ LlmParsedResume ──diffParses──▶ disagreement
+PDF ─ runCascade ─▶ CascadeResult.canonical ──projectDisplay──▶ AtsResumeModel ──projectAtsExport/toJsonResume──▶ JsonResume
+                              │
+                              ├── projectScoreSections ──▶ anonymous score
+                              ├── applyOverrides ──▶ CanonicalResume + rawText
+                              └── diffParses ◀── projectLlmDiff(LlmParsedResume)
 ```
 
 ---
 
-## 2. Target representation
+## 2. Implemented canonical representation
 
 ### 2.1 The canonical model + projections
 
-One canonical internal shape, `CanonicalResume`, is the **single source of truth**. Every other shape becomes a **projection** — a pure `(CanonicalResume) => T` function, never a peer shape hand-synced back.
+One canonical internal shape, `CanonicalResume`, is the **single source of truth**. Other internal views are one-way projections; external/parser-boundary DTOs are mapped into it once and are never synchronized back.
 
 ```mermaid
 flowchart TD
     PDF[PDF bytes] --> CASC[runCascade]
     CASC --> CR[("CanonicalResume<br/>(single source of truth)")]
-    EDIT[user edit] -->|mutate one field| CR
-    LLM[on-device LLM parse] -.->|coerced into| CR
+    EDIT[user edit] -->|applyOverrides| CR
+    LLM[on-device LLM parse] --> LDTO[LlmParsedResume]
+    LDTO -->|projectLlmDiff| LCR[canonical-shaped diff input]
 
-    CR --> PD["display projection<br/>(replaces the read side of<br/>HeuristicParsedResume + SectionedResume)"]
-    CR --> PS["score projection<br/>(section pools — replaces<br/>SectionedResume.byName)"]
-    CR --> PR["render+export projection<br/>(replaces AtsResumeModel layout;<br/>round-trip-stable by construction)"]
-    CR --> PJ["JSON-Resume projection<br/>(replaces JsonResume — reads<br/>canonical semantics, not layout)"]
-    CR --> PL["llm-diff projection<br/>(replaces the hand-synced<br/>LlmParsedResume mirror)"]
+    CR --> PD["projectDisplay<br/>(parsed fields + headings)"]
+    CR --> PS["projectScoreSections<br/>(section pools)"]
+    CR --> PR["buildAtsResumeModel<br/>(render projection)"]
+    PR --> PE["projectAtsExport<br/>(semantic export projection)"]
+    PE --> PJ[JsonResume]
 
     PD --> UI[ReconstructedResume / EditableField]
     PS --> SCORE[computeAnonymousAtsScore]
     PR --> RENDER[render-ats-pdf]
     PJ --> JSONEXP[JSON Resume download]
-    PL --> DIS[diffParses / disagreement]
+    CR --> DIS[diffParses / disagreement]
+    LCR --> DIS
 ```
 
-### 2.2 What each of today's five shapes becomes
+### 2.2 Where the original five shapes landed
 
-| Today | Becomes | Note |
+| Original shape | Current state | Note |
 |---|---|---|
-| `HeuristicParsedResume` | the **field core** of `CanonicalResume` | cascade writes it once; nothing else is a peer copy |
-| `SectionedResume` | the **section-membership core** of `CanonicalResume` + a `score` projection | section membership is a property of the model, not re-derived from `rawText` downstream |
-| `LlmParsedResume` | an **input coercion** into `CanonicalResume` + an `llm-diff` projection | the hand-sync note (`parse-resume.ts:52-54`) is deleted — diff reads a projection of the canonical model, not a parallel type |
-| `AtsResumeModel` (`AtsEntry` layout fields) | a **render+export projection** | the four re-parse-encoding fields (`headerLineDate`/`subLineDate`/`atomicSegments`/`headerBold`) move **behind** the projection; see §3 |
-| `JsonResume` | a **JSON-Resume projection off canonical semantics** | stops reading the render model, so it no longer inherits layout coupling |
+| `HeuristicParsedResume` | `CanonicalResume.fields` | cascade writes the field core once |
+| `SectionedResume` | `CanonicalResume.sections` + `projectScoreSections` | section membership is stored once and not re-derived from `rawText` downstream |
+| `LlmParsedResume` | boundary DTO mapped by `projectLlmDiff` | the hand-sync note is gone; disagreement compares canonical-shaped inputs |
+| `AtsResumeModel` (`AtsEntry` layout fields) | one-way render projection built from the canonical core | parser-sensitive layout cues remain behind this projection boundary; see §3 |
+| `JsonResume` | output DTO built through `projectAtsExport` | JSON mapping reads semantic entry fields rather than layout hints |
 
 ### 2.3 Where `apply-overrides` lands
-One user edit mutates **one** field on `CanonicalResume`. `parsed` / `rawText` / `sections` / `fieldConfidence` stop being lockstep return values and become projections read on demand. `ApplyOverridesResult` (`apply-overrides.ts:52`) collapses to `CanonicalResume` (or a thin `{ model }`); the #133 "re-grade a live bullet edit" and #421 "fieldConfidence in step" requirements are satisfied because the projections are *derived*, not *mirrored*.
+`ApplyOverridesResult` is `CanonicalResume & { rawText: string }` (`edit/apply-overrides.ts` → `ApplyOverridesResult`). Edits update the canonical `fields`, `sections`, and `fieldConfidence` members; `rawText` rides alongside because the redacted-date scan still consumes extraction text. There is no separate top-level `parsed`/`sections`/`fieldConfidence` return façade to keep synchronized.
 
 ---
 
 ## 3. Where the round-trip invariant lives
 
-Today the invariant lives in the **renderer** — `AtsEntry`'s layout fields are shaped so the exported PDF re-parses to the same fields (`ats-resume-model.ts:118-158`, `:469`; tests `corpus-roundtrip.test.ts` #293 `:303`, `render-roundtrip.repro.test.ts` #284 `:69`). That is Cost 2: the renderer must know parser internals.
+The canonical field core is the source of truth, but fidelity is enforced across the **canonical-to-render projection and parser**. `buildAtsResumeModel` derives `AtsEntry` values through `projectDisplay`; `AtsEntry` then carries parser-sensitive cues such as `headerLineDate`, `subLineDate`, `atomicSegments`, and `headerBold` (`pdf/ats-resume-model.ts` → `AtsEntry`). `corpus-roundtrip.test.ts` and the focused render round-trip tests pin the resulting parse→export→parse identity.
 
-**Target:** the invariant is a property of `CanonicalResume`. The render+export projection is derived from the canonical model and is round-trip-stable **by construction**, so:
-- the renderer draws from an already-stable shape and stops encoding date-cue / title↔company-swap / middot-atomicity rules (#425/#298/#301/#302 move behind the projection boundary);
-- a fidelity change edits the projection (or the canonical field it reads), **not** model + renderer + parser-exemption + goldens as four coupled surfaces.
-
-The parser-side exemption that today backstops flush-right dates — `columnGapCuts` + `isLoneDateRange` (`sections.ts:264-277`) — becomes an assertion the canonical model satisfies, rather than a rule the renderer must not violate.
+The parser-side flush-right exemption remains `columnGapCuts` + `isLoneDateRange` (`heuristics/line-assembly.ts` → `columnGapCuts`; `heuristics/line-primitives.ts` → `isLoneDateRange`). Stage C localized reads behind projections; it did not eliminate this deliberate render/parser contract.
 
 ---
 
-## 4. Staged migration plan
+## 4. Staged migration history
 
 Ordered stages, shipped as **A / B / C / (D+E)** — the final two were combined into one cutover at implementation time (#445; see the Stage D+E entry below). **Each stage keeps `corpus-roundtrip.test.ts`, `render-roundtrip.repro.test.ts`, and the golden snapshots green** — no half-baked intermediate state. Stages A–C were **additive** (the `AtsResumeModel` shape stayed live so in-flight fidelity PRs kept landing); the combined **D+E** is the one-time cutover that removes the `CascadeResult` façade and versions the persisted cache.
 
 ### Stage A — Split export-semantics from layout inside `AtsEntry`
-Extract `AtsEntryFields` (`ats-resume-model.ts:87`) into a standalone export-semantic projection so `toJsonResume` (`to-json-resume.ts:409`) reads **semantic** fields, not the render model's layout hints (`headerLineDate`/`subLineDate`/`atomicSegments`/`headerBold`). After this, a layout tweak cannot ripple into export mapping.
+Extract `AtsEntryFields` (`ats-resume-model.ts` → `AtsEntryFields`) into a standalone export-semantic projection so `toJsonResume` (`to-json-resume.ts` → `toJsonResume`) reads **semantic** fields, not the render model's layout hints (`headerLineDate`/`subLineDate`/`atomicSegments`/`headerBold`). After this, a layout tweak cannot ripple into export mapping.
 - **Round-trip story:** JSON-Resume output byte-identical (the projection reads the same values `AtsEntryFields` already held); corpus + render round-trip untouched (layout fields unmoved). Pure extraction.
 - **Blast radius:** `ats-resume-model.ts`, `to-json-resume.ts`, their tests. Small.
 
@@ -125,8 +126,8 @@ Define `CanonicalResume` (field core from `HeuristicParsedResume` + section core
 - **Blast radius:** new `canonical.ts`, `cascade.ts` wiring, `score.ts` + `ReconstructedResume` read-site swap. Medium.
 
 ### Stage C — Move the round-trip invariant onto the canonical model
-Make the render+export projection derive from `CanonicalResume` and be round-trip-stable by construction (§3). Renderer draws from the projection; `buildAtsResumeModel` (`ats-resume-model.ts:425`) becomes `canonical → render-projection`.
-- **Round-trip story:** this is the delicate stage — land it behind the projection with the corpus + render round-trip tests as the gate, and only flip the renderer's source once the projection reproduces every current golden. The `columnGapCuts`/`isLoneDateRange` exemption (`sections.ts:264-277`) becomes a canonical-model assertion.
+Make the render+export projection derive from `CanonicalResume` and be round-trip-stable by construction (§3). Renderer draws from the projection; `buildAtsResumeModel` (`ats-resume-model.ts` → `buildAtsResumeModel`) becomes `canonical → render-projection`.
+- **Round-trip story:** this is the delicate stage — land it behind the projection with the corpus + render round-trip tests as the gate, and only flip the renderer's source once the projection reproduces every current golden. The `columnGapCuts`/`isLoneDateRange` exemption (`heuristics/line-assembly.ts` → `columnGapCuts`; `heuristics/line-primitives.ts` → `isLoneDateRange`) becomes a canonical-model assertion.
 - **Blast radius:** `ats-resume-model.ts`, `render-ats-pdf.ts`, projection module, goldens. Medium-large, but **one-time** — it buys down every future fidelity PR.
 
 ### Stage D+E — Collapse the remaining peer shapes + cutover + cache migration (shipped as one, #445)
@@ -153,31 +154,35 @@ Per-stage implementation issues were minted from **this** list once it was fixed
 
 ## 6. Hard constraint — #321 parse-result cache
 
-The `resumes` IndexedDB store caches a **pre-canonical `CascadeResult`**: `SavedResumeSnapshot { result: CascadeResult; score; sourceKind }` (`resume-library.ts:37`), written in `saveResumeToLibrary` (`:90-99`), read via `readSnapshot` (`:66`); it round-trips through IndexedDB structured clone, which preserves the `sections` `Map` (`:6-13`, #321).
+The `resumes` IndexedDB store caches the **current canonical cascade envelope** in `SavedResumeSnapshot { result: CascadeResult; score; sourceKind; shapeVersion? }` (`resume-library.ts` → `SavedResumeSnapshot`). `result.canonical.sections.byName` survives IndexedDB structured clone as a `Map`; the storage layer continues to treat the parse as opaque.
 
-Any stage that changes the **persisted** shape (Stage E, and Stage B if the façade is persisted) MUST invalidate or migrate that cache — not only the in-memory model + corpus goldens. **Cheapest hook:** version the cached record by `ATS_SCORE_ALGO_VERSION` (`score.ts:73`, currently `"1.4"`, →`1.5` via #435) **plus a new parser-shape version constant**, so a representation change auto-invalidates on read and re-parses from the stored PDF `Blob` (#321 keeps the blob). A stale-shape read must **re-parse**, never silently deserialize an old shape into the canonical model. Refs [#321](https://github.com/offlinecv/OfflineCV/issues/321), [#401](https://github.com/offlinecv/OfflineCV/issues/401).
+`CACHE_SHAPE_VERSION` (`resume-library.ts` → `CACHE_SHAPE_VERSION`) composes `ATS_SCORE_ALGO_VERSION` (`score.ts` → `ATS_SCORE_ALGO_VERSION`, currently `"1.7"`) with `CANONICAL_SHAPE_VERSION` (`heuristics/canonical.ts` → `CANONICAL_SHAPE_VERSION`, currently `"2"`). `saveResumeToLibrary` stamps every snapshot. On a mismatch, `loadResumeFromLibrary` re-parses from the stored PDF `Blob`, recomputes the score, and re-stamps the record; if no source bytes exist, it refuses to hydrate the stale shape. A stale record is never silently deserialized as the current canonical model. Refs [#321](https://github.com/offlinecv/OfflineCV/issues/321), [#401](https://github.com/offlinecv/OfflineCV/issues/401).
 
 ---
 
-## 7. Hard constraint — header-vs-entry regression case (with a correction)
+## 7. Hard constraint — header-vs-entry regression case
 
-**Correction to #438/#439 as written.** Both issues cite `classifyLine` at `sections.ts:1854` with `lineLooksLikeDatedEntry = hasDateRange(line) || hasDateRange(nextLine)`. That identifier and that `hasDateRange` function **do not exist in the codebase.** `classifyLine` is really at `sections.ts:1829`; line 1854 sits inside its `isInstitutionRepeat` suppression branch. The **actual** one-line `Title  Dates` header-vs-entry mechanism is the #425 flush-right-date exemption in `columnGapCuts`:
+**#438/#439 were right, and this section's earlier "correction" of them is retracted.** Both issues attribute `lineLooksLikeDatedEntry = hasDateRange(line) || hasDateRange(nextLine)` to `classifyLine`. This section used to answer that neither identifier existed. **Both exist, verbatim and exactly as attributed:** `heuristics/sections.ts` → `classifyLine` computes `const lineLooksLikeDatedEntry = hasDateRange(line) || hasDateRange(nextLine)` and passes it to `isInstitutionRepeat`, over `heuristics/sections.ts` → `hasDateRange`.
+
+The retracted claim was true against the baseline it was written on, and stopped being true on the next parser merge. This doc landed in #440; **#435** (`fix(parser,score): experience field-mapping, section routing, bullet pooling, abbreviated dates`) introduced both identifiers afterwards, and §0 flagged #435 as in flight at the time. So a source claim written in the present tense outlived its baseline by one merge — which is why every citation in this doc is now symbol-anchored (`path` → `Symbol`) rather than line-anchored, and why a *negative* claim about the codebase ("X does not exist") does not belong in a document that is not re-verified on every merge.
+
+A second, adjacent mechanism is also real: the #425 flush-right-date exemption in `heuristics/line-assembly.ts` → `columnGapCuts` (not `sections.ts`, where an earlier revision of this section placed it):
 
 ```ts
-// sections.ts:264-277
+// src/lib/heuristics/line-assembly.ts → columnGapCuts
 if (cuts.length > 0 &&
     isLoneDateRange(mergeItemText(sorted.slice(cuts[cuts.length - 1])))) {
   cuts.pop();   // trailing lone-date segment stays merged into its org text
 }
 ```
 
-The *problem class* named in #438 is real — "is this line a category header or a dated entry?" is decided from **adjacent raw-line signals** (`isLoneDateRange` on the trailing segment) rather than from a structured field on a canonical model. The cited symbol is just wrong.
+The *problem class* named in #438 is real, and the live code makes the case more plainly than the issue did: "is this line a category header or a dated entry?" is decided from **adjacent raw-line signals** — `hasDateRange(nextLine)` reaching forward one raw line in `classifyLine`, and `isLoneDateRange` on the trailing segment in `columnGapCuts` — rather than from a structured field on a canonical model.
 
 **Acceptance test the canonical model must pass:** a one-line `Title  Dates` role under a section header routes as a **dated entry**, not a sub-section boundary, with the header-vs-entry call keyed off a **derived** `isDatedEntry` predicate over the entry's structured dates — not off `isLoneDateRange`/`hasDateRange` re-scanning neighboring raw lines.
 
 > **§7 correction (folded in at Stage C, #444).** Earlier this read "keyed off a structured `isDatedEntry` **property** on `CanonicalResume`." That over-specified: the structure (`start_date` / `end_date` + precision) is **already** on the entry (`fields.experience[]` / `fields.education[]`). A stored `isDatedEntry` field would be a second entries representation parallel to the field core — exactly the parallel-shape lockstep cost this epic removes (considered and **rejected** via `/clarify`, 2026-07-11). So `isDatedEntry` is a **derived predicate** — `Boolean(start_date || end_date)` — over the dates the entry already holds (`isDatedEntry` in `pdf/ats-resume-model.ts`), never a new core or field. It answers §7's coarse "is this a dated entry at all"; the finer flush-right routing (`headerLineDate` / `subLineDate`) stays on `isLoneDateRange` over the *formatted* range, a render-shape concern Stage C keeps byte-identical.
 
-Capture it as a fixture + assertion at Stage C (where the render+export projection takes over) and carry it green through the combined D+E cutover (#445).
+This remains the standing requirement rather than a shipped guarantee: the raw-line reads named above are still live, so the acceptance test above is the bar the header-vs-entry routing is held to, not a property the cutover established. Refs [#438](https://github.com/offlinecv/OfflineCV/issues/438), [#445](https://github.com/offlinecv/OfflineCV/issues/445).
 
 ---
 
@@ -215,27 +220,27 @@ passes through verbatim and may contain any glyph.
 
 | Join | Separator | Site |
 |---|---|---|
-| `Title · Company, Location · Team` | `" · "` | `ats-resume-model.ts:583`, `:608` (`joinHeader`) |
-| `Company, Location` | `", "` | `ats-resume-model.ts:580-582` |
-| `Title, Team` (empty-company branch, #466) | `", "` | `ats-resume-model.ts:605` |
-| `Institution · Location` | `" · "` | `ats-resume-model.ts:720` |
-| `Degree, Field` | `", "` | `ats-resume-model.ts:719` |
-| `Type · Title` (achievement) | `" · "` | `ats-resume-model.ts:441` |
-| Skills, within a category | `" · "` | `ats-resume-model.ts:829`, `:838` |
-| Header ↔ trailing single-token date | `"  "` (two spaces) | `ats-resume-model.ts:641`, `:780`, `:796`, `:808` |
-| Experience/education date **range** | `" – "` spaced en dash | `ats-resume-model.ts:368` (`experienceDateRange`) |
-| Project/education-fallback date **range** | `"–"` unspaced en dash | `score/entry-dates.ts:19` (`buildProjectDates`), `:33` (`buildEducationDates`) |
+| `Title · Company, Location · Team` | `" · "` | `ats-resume-model.ts` → `joinHeader` |
+| `Company, Location` | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (experience mapping) |
+| `Title, Team` (empty-company branch, #466) | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (empty-company branch) |
+| `Institution · Location` | `" · "` | `ats-resume-model.ts` → `buildAtsResumeModel` (education mapping) |
+| `Degree, Field` | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (education mapping) |
+| `Type · Title` (achievement) | `" · "` | `ats-resume-model.ts` → `buildAtsResumeModel` (achievement mapping) |
+| Skills, within a category | `" · "` | `ats-resume-model.ts` → `buildAtsResumeModel` (skills mapping) |
+| Header ↔ trailing single-token date | `"  "` (two spaces) | `ats-resume-model.ts` → `buildAtsResumeModel` |
+| Experience/education date **range** | `" – "` spaced en dash | `ats-resume-model.ts` → `experienceDateRange` |
+| Project/education-fallback date **range** | `"–"` unspaced en dash | `score/entry-dates.ts` → `buildProjectDates` / `buildEducationDates` |
 
 Every `ats-resume-model.ts` row above is `src/lib/pdf/ats-resume-model.ts`; the date-range
 row is `src/lib/score/entry-dates.ts`, a different directory.
 
 Plus one deliberate exception: an **achievement's** title↔year separator echoes the
-*source's own* punctuation (`achievementYearJoiner`, `score/entry-dates.ts:57`, #380) — a hyphen
+*source's own* punctuation (`score/entry-dates.ts` → `achievementYearJoiner`, #380) — a hyphen
 there is also user-sourced, by design, so the export re-parses to the same `year_separator`
 it came from.
 
 `render-ats-pdf.ts` holds exactly one separator constant of its own —
-`MIDDOT_SEGMENT_SEP = " · "` (`render-ats-pdf.ts:176`) — used only to keep a middot-joined
+`MIDDOT_SEGMENT_SEP = " · "` (`render-ats-pdf.ts` → `MIDDOT_SEGMENT_SEP`) — used only to keep a middot-joined
 segment atomic across a wrap point; it does not choose which fields get middot-joined.
 
 There is **no** ASCII hyphen anywhere in this set. A `Role - Subtitle` header is a title

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -113,7 +113,12 @@ import {
 } from "./ReconstructedSummary.tsx";
 import { SkillsSection } from "./ReconstructedSkills.tsx";
 import { SkillTermGuidance } from "./SkillTermGuidance.tsx";
-import { Button, EditableField, SectionHeading } from "@design-system";
+import {
+  Button,
+  EditableField,
+  ErrorState,
+  SectionHeading,
+} from "@design-system";
 import { SECTION_IDS } from "../../lib/anchors.ts";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
 import { useDownloadMarkdown } from "../../hooks/useDownloadMarkdown.ts";
@@ -1150,7 +1155,10 @@ export function ReconstructedResume({
   // Download the reconstructed (possibly edited) résumé as an ATS-safe,
   // text-only PDF — built fully client-side from the already-parsed fields,
   // so no PDF bytes ever leave the browser (#171).
-  const { download, isGenerating } = useDownloadPdf(result, score);
+  const { download, isGenerating, error: downloadError } = useDownloadPdf(
+    result,
+    score,
+  );
 
   // Download the same reconstructed résumé as a career-ops-shaped `cv.md`
   // (#552) — a plain-text sibling artifact, not a competing "primary" export.
@@ -1281,6 +1289,7 @@ export function ReconstructedResume({
             </Button>
           </div>
         </div>
+        {downloadError && <ErrorState>{downloadError}</ErrorState>}
         <p className="max-w-prose text-sm text-content-tertiary">
           What the parser recognized, in resume shape. Each bullet is checked
           against three rules — an action verb, the 8–30-word length window, and

--- a/src/hooks/useDownloadPdf.test.tsx
+++ b/src/hooks/useDownloadPdf.test.tsx
@@ -17,7 +17,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { useDownloadPdf, type UseDownloadPdf } from "./useDownloadPdf.ts";
+import {
+  glyphLossMessage,
+  useDownloadPdf,
+  type UseDownloadPdf,
+} from "./useDownloadPdf.ts";
 import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import { computeAnonymousAtsScore } from "../lib/score/score.ts";
@@ -145,5 +149,93 @@ describe("useDownloadPdf — download-source tagging (#313)", () => {
     });
 
     expect(localStorage.getItem(BLANK_DRAFT_STORAGE_KEY)).not.toBeNull();
+  });
+});
+
+/**
+ * #664 — refuse rather than silently substituting "?" in the user's own fields.
+ *
+ * These cases need no font stub: under Node the Poppins `?url` asset is a bare
+ * path that `fetch` cannot resolve, so the export ALWAYS takes the Helvetica
+ * fallback here. That is the same condition a browser hits when the font fetch
+ * fails, which makes this environment the natural place to test the refusal —
+ * the ASCII cases above prove the same path still downloads normally.
+ */
+describe("useDownloadPdf — glyph-loss refusal (#664)", () => {
+  function namedResult(fullName: string): CascadeResult {
+    const base = uploadedResult();
+    return {
+      ...base,
+      canonical: {
+        ...base.canonical,
+        fields: { ...base.canonical.fields, full_name: fullName },
+      },
+    };
+  }
+
+  it("refuses the download and names the field when the fallback would mangle the name", async () => {
+    mount(namedResult("ANNA WIŚNIEWSKA"));
+
+    await act(async () => {
+      await api.download();
+    });
+
+    expect(api.error).toContain("Name");
+    // The value itself must not be echoed back — a résumé's own text does not
+    // belong in an error banner.
+    expect(api.error).not.toContain("WIŚNIEWSKA");
+    expect(api.isGenerating).toBe(false);
+  });
+
+  it("fires no download and no analytics event when it refuses", async () => {
+    mount(namedResult("ANNA WIŚNIEWSKA"));
+
+    await act(async () => {
+      await api.download();
+    });
+
+    // A refused export is not a completed one — counting it would inflate the
+    // download metric with PDFs that were never produced.
+    expect(tracked).toEqual([]);
+    expect(HTMLAnchorElement.prototype.click).not.toHaveBeenCalled();
+  });
+
+  it("still downloads a pure-ASCII résumé on the same failing-font path", async () => {
+    // The gate that keeps a font problem from blocking everyone: this is the
+    // identical code path as the refusal above, differing only in the data.
+    mount(namedResult("Jane Candidate"));
+
+    await act(async () => {
+      await api.download();
+    });
+
+    expect(api.error).toBeNull();
+    expect(tracked).toEqual([{ source: "upload", format: "pdf" }]);
+  });
+});
+
+describe("glyphLossMessage (#664)", () => {
+  it("collapses duplicate fields so a repeated loss reads as one item", () => {
+    const msg = glyphLossMessage([
+      { where: "Experience", original: "a→b", degraded: "a->b" },
+      { where: "Experience", original: "c→d", degraded: "c->d" },
+      { where: "Experience", original: "e→f", degraded: "e->f" },
+    ]);
+
+    expect(msg).toContain("your Experience.");
+    // Not "Experience, Experience and Experience".
+    expect(msg.match(/Experience/g)).toHaveLength(1);
+  });
+
+  it("joins multiple fields readably and never echoes the values", () => {
+    const msg = glyphLossMessage([
+      { where: "Name", original: "WIŚNIEWSKA", degraded: "WI?NIEWSKA" },
+      { where: "Location", original: "Kraków", degraded: "Krak?w" },
+      { where: "Experience", original: "★", degraded: "?" },
+    ]);
+
+    expect(msg).toContain("your Name, Location and Experience.");
+    expect(msg).not.toContain("WIŚNIEWSKA");
+    expect(msg).not.toContain("Kraków");
   });
 });

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -5,17 +5,38 @@
  * useDownloadPdf — drives the "Download PDF" action on the reconstructed-resume
  * surface (#171).
  *
- * Flow: build the flat ATS model from the surface's own props → render bytes
- * with the pdf-lib draw engine → wrap in a Blob → trigger a same-document
- * download via a temporary object URL. Everything is client-side; no network
- * request is made (no font fetch, no upload), satisfying the zero-egress AC.
+ * Flow: build the flat ATS model from the surface's own props → check that the
+ * export font can draw every character (#664) → render bytes with the pdf-lib
+ * draw engine → wrap in a Blob → trigger a same-document download via a
+ * temporary object URL.
+ *
+ * Zero-egress holds, but not because nothing is fetched: the renderer DOES issue
+ * a `fetch` for the vendored Poppins TTFs, and this docblock previously claimed
+ * "no network request is made (no font fetch, no upload)", which was false. The
+ * fetch targets the app's own bundled-asset origin — never a font CDN — so no
+ * résumé bytes leave the browser, which is the actual guarantee. Say custody,
+ * not runtime.
+ *
+ * This hook owns the refusal for #664. When the Poppins fetch fails, the
+ * renderer falls back to Helvetica, whose WinAnsi codec replaces anything
+ * outside it with `?` — including a candidate's own name. Rather than hand back
+ * a PDF reading `ANNA WI?NIEWSKA`, the hook probes first and refuses, because
+ * the trigger is the network rather than the user's data and a retry usually
+ * clears it. The refusal lives here and not in `renderAtsResumePdf` so that the
+ * renderer's ~35 other call sites — every round-trip and export test, plus the
+ * corpus oracle, which must keep rendering the degraded value to measure it —
+ * are unaffected.
  */
 
 import { useCallback, useState } from "react";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../lib/score/score.ts";
 import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
-import { renderAtsResumePdf } from "../lib/pdf/render-ats-pdf.ts";
+import {
+  findExportGlyphLosses,
+  renderAtsResumePdf,
+  type ExportGlyphLoss,
+} from "../lib/pdf/render-ats-pdf.ts";
 import { slugifyName, triggerBlobDownload } from "../lib/download/blob-download.ts";
 import { trackDownloadCompleted, type DownloadSource } from "../lib/analytics.ts";
 import { clearBlankDraft } from "./useResumeAnalysis.ts";
@@ -32,6 +53,29 @@ function filenameFromName(name: string | undefined): string {
   return slug ? `${slug}-resume-ats.pdf` : "resume-ats.pdf";
 }
 
+/**
+ * The message shown when the export font is unavailable and the fallback would
+ * mangle real characters (#664).
+ *
+ * Exported for its own test: the field list is the part a user acts on, and it
+ * has to name the fields WITHOUT echoing their values — a résumé's own text does
+ * not belong in an error banner. `where` labels are already user-facing (a
+ * contact field name or the section's own heading), and duplicates collapse so a
+ * résumé with forty arrow bullets does not produce a forty-item sentence.
+ */
+export function glyphLossMessage(losses: readonly ExportGlyphLoss[]): string {
+  const fields = [...new Set(losses.map((l) => l.where))];
+  const list =
+    fields.length === 1
+      ? fields[0]
+      : `${fields.slice(0, -1).join(", ")} and ${fields[fields.length - 1]}`;
+  return (
+    `Could not load the résumé font, so this export would fall back to a font ` +
+    `that cannot draw every character in your ${list}. Downloading now would ` +
+    `replace those characters with "?". Check your connection and try again.`
+  );
+}
+
 export function useDownloadPdf(
   result: CascadeResult,
   score: AnonymousAtsScore,
@@ -44,6 +88,18 @@ export function useDownloadPdf(
     setError(null);
     try {
       const model = buildAtsResumeModel(result, score);
+
+      // #664: refuse rather than silently substituting "?" in the user's own
+      // fields. Returns [] whenever the embedded font loaded OR nothing would
+      // actually be lost, so a pure-ASCII résumé downloads exactly as before
+      // even when the font fetch fails. Returning early skips the download and
+      // the analytics event; `finally` still clears `isGenerating`.
+      const losses = await findExportGlyphLosses(model);
+      if (losses.length > 0) {
+        setError(glyphLossMessage(losses));
+        return;
+      }
+
       const bytes = await renderAtsResumePdf(model);
       // `bytes.slice()` copies into a fresh ArrayBuffer-backed view so Blob gets
       // a clean buffer.

--- a/src/lib/heuristics/corpus-edit-roundtrip.known-failures.json
+++ b/src/lib/heuristics/corpus-edit-roundtrip.known-failures.json
@@ -44,14 +44,6 @@
         "status": "accepted",
         "note": "The one fixture Group A's deletion did not clear, for an unrelated reason. Its first pooled bullet IS a title-only achievement's whole header line ('Patent · … [2019]'): the parser stores it as type/title/year with an EMPTY description while the scorer still pools the raw line, so the synthesized edit lands in the section pool but the achievement ENTRY it belongs to is untouched and the exporter renders that entry from its fields. #224 fixed the PRODUCT path — `ReconstructedResume` runs `suppressTitleOwnedBullets` over the 'Other bullets' group, the only group this line can land in, so no editable row is ever offered for it. What remains is reachable only from this gate, which synthesizes an edit the surface does not offer; `accepted` records that, and it is deliberately NOT 'fixed' by teaching `synthesizeOverrides` to skip such a bullet — moving a gate's INPUT until it passes is how a gate stops meaning anything."
       }
-    ],
-    "unknown/date-heading-bulleted-roles.pdf": [
-      {
-        "category": "bullets",
-        "issue": 662,
-        "status": "open",
-        "note": "COLLATERAL of the fixture's own defect, not a separate edit bug: this fixture parses ZERO experience entries (it is the corpus's reproducer for `experience-parser-miss`), so the pooled bullet the gate edits belongs to no entry and the exporter has nothing to render it under. Clears when #662 does. Previously cited #492 with a prose caveat saying #492 did NOT cover this shape — that citation was wrong and is exactly the failure mode issue-linked baselines exist to prevent: check:baselines judges the issue NUMBER and cannot read a caveat, so the gate certified an attribution the fixture's own generator docblock contradicts ('NOT #492')."
-      }
     ]
   }
 }

--- a/src/lib/heuristics/corpus-roundtrip.known-failures.json
+++ b/src/lib/heuristics/corpus-roundtrip.known-failures.json
@@ -43,14 +43,6 @@
         "note": "Same single-glyph toWinAnsi() substitution as google-docs-skia-proxy-classic; see #326's decision record."
       }
     ],
-    "unknown/openresume-react-pdf.pdf": [
-      {
-        "category": "experience",
-        "issue": 663,
-        "status": "open",
-        "note": "A dateless role whose TITLE carries an inline year ('Software Engineer Intern Summer 2022') round-trips with the year split out as start_date ('… Summer' + 2022) — an asymmetry between what the exporter composes and what the parser splits. Previously cited #649; that was the wrong owner, because #649 is a pure extraction whose own acceptance criterion is 'changes ZERO rendered bytes' and whose plan explicitly defers the date dialect to a separate PR — so it could never clear this line and this entry would have orphaned the day it merged. Not the #298 title/company swap and not the #436 one-line header."
-      }
-    ],
     "google-docs/google-docs-skia-proxy-honors-subheadings.pdf": [
       {
         "category": "experience",
@@ -63,8 +55,8 @@
       {
         "category": "contact",
         "issue": 664,
-        "status": "open",
-        "note": "full_name 'ANNA WIŚNIEWSKA' → 'ANNA WI?NIEWSKA'. ś (U+015B) is Latin Extended-A, outside WinAnsi, so toWinAnsi() degrades it to '?' on the standard-font path (always under Node/CI; in the browser only when the Poppins fetch fails). Minted under #654 as the corpus's first evidence for roundtrip-contact-value-changed. The MECHANISM is #326's, but this is filed OPEN under #664 rather than accepted under #326 on purpose: #326 weighed a punctuation glyph in a role TITLE against a crash, and nobody has weighed a candidate's own NAME being mangled in a PDF they send to employers. Marking it accepted would permanently exempt it from CI on a decision no one made."
+        "status": "accepted",
+        "note": "full_name 'ANNA WIŚNIEWSKA' → 'ANNA WI?NIEWSKA'. ś (U+015B) is Latin Extended-A, outside WinAnsi, so toWinAnsi() degrades it to '?' on the standard-font path. ACCEPTED under #664 with an explicit written decision — not inherited from #326, whose recorded tradeoff covers a punctuation glyph in a role TITLE and does not extend to an identity field. The decision: the USER-FACING export refuses rather than degrading. useDownloadPdf calls findExportGlyphLosses() before rendering and, on the Helvetica fallback, blocks the download and names the affected fields instead of handing back a mangled name. That refusal deliberately does NOT live in renderAtsResumePdf, so this corpus row keeps exercising the un-refused path: the round-trip oracle needs a rendered PDF to measure, and it is the only fixture in the corpus with a character outside WinAnsi (verified: 0 of 57 expected snapshots contain one). So the '?' recorded here is the intentional Node/CI behaviour, not an open defect. Delete this row if a Unicode-capable font ever removes the fallback entirely. Minted under #654 as the corpus's first evidence for roundtrip-contact-value-changed."
       }
     ]
   }

--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -196,6 +196,17 @@ export interface EntryBlockConfig {
    * it. Experience uses 2.
    */
   headerLookback?: number;
+  /**
+   * Which anchor lines may have date-looking text parsed and stripped.
+   *
+   * `"all"` (the default) preserves the date-optional project/achievement
+   * contract: their `first_line` anchor may carry a lone date. Experience uses
+   * `"date_anchors_only"` so a line recovered by the DATELESS-role boundary
+   * keeps title text such as `"Software Engineer Intern Summer 2022"` intact.
+   * A genuine year-only experience date still qualifies through the guarded
+   * `date_range` anchor (`"Title · Company  2022"`, #358).
+   */
+  dateParsing?: "all" | "date_anchors_only";
 }
 
 /**
@@ -283,6 +294,28 @@ function isAnchorLine(line: PdfLine, anchor: EntryAnchor): boolean {
       // a new entry.
       return !isBulletLine(line);
   }
+}
+
+/**
+ * Whether `buildEntryBlock` may interpret date-shaped text on this anchor.
+ *
+ * A `date_range` parse can contain anchors from two disjoint sources: genuine
+ * date syntax (`isAnchorLine`) and the conservative dateless-role recovery
+ * (`collectDatelessAnchors`). Issue #663 exposed the provenance loss between
+ * those stages: every recovered dateless line was later fed to
+ * `parseDateRange`, synthesizing a date from a year that belonged to the title.
+ * Re-checking the same date-anchor predicate preserves that distinction. The
+ * inverse is deliberate: #358's terminal `Title · Company  2022` shape passes
+ * the predicate and therefore remains a real `start_date`.
+ */
+function shouldParseAnchorDate(
+  line: PdfLine,
+  cfg: EntryBlockConfig,
+): boolean {
+  return (
+    cfg.dateParsing !== "date_anchors_only" ||
+    isAnchorLine(line, "date_range")
+  );
 }
 
 /**
@@ -1271,8 +1304,13 @@ function buildEntryBlock(
   );
 
   const anchorLine = lines[anchorIdx];
-  const dates = parseDateRange(anchorLine.text);
-  const anchorTextWithoutDates = stripDateRange(anchorLine.text);
+  const parseAnchorDate = shouldParseAnchorDate(anchorLine, cfg);
+  const dates: EntryBlock["dates"] = parseAnchorDate
+    ? parseDateRange(anchorLine.text)
+    : {};
+  const anchorTextWithoutDates = parseAnchorDate
+    ? stripDateRange(anchorLine.text)
+    : anchorLine.text;
 
   // Header candidates below the anchor (e.g. "Company <dates>\nTitle"):
   // consecutive non-bullet lines until the body begins or the next anchor. The
@@ -1404,7 +1442,9 @@ function buildEntryBlock(
     headerLines,
     anchorHeaderIndex,
     dates,
-    dateSeparator: dateSeparator(anchorLine.text),
+    dateSeparator: parseAnchorDate
+      ? dateSeparator(anchorLine.text)
+      : undefined,
     body,
     bulletCount: bodyUnits.length,
   };

--- a/src/lib/heuristics/extract/dateless-entries.test.ts
+++ b/src/lib/heuristics/extract/dateless-entries.test.ts
@@ -163,6 +163,39 @@ describe("dateless trailing experience role (#219)", () => {
     );
   });
 
+  it("keeps an inline year in a dateless title but parses a terminal year-date (#663)", () => {
+    const { value } = extractExperience(
+      mkSection("experience", [
+        ["Staff Engineer · Acme Corp  Jan 2020 - Present", 0, 100],
+        ["• Led the platform migration", 10, 90],
+        [
+          "Software Engineer Intern Summer 2022 · DEF Organization",
+          0,
+          70,
+        ],
+        ["• Built the release dashboard", 10, 60],
+        ["Research Assistant · XYZ University  2021", 0, 40],
+        ["• Evaluated the ranking model", 10, 30],
+      ]),
+    );
+
+    expect(value).toHaveLength(3);
+    expect(value[1]).toMatchObject({
+      title: "Software Engineer Intern Summer 2022",
+      company: "DEF Organization",
+    });
+    expect(value[1].start_date).toBeUndefined();
+    expect(value[1].end_date).toBeUndefined();
+
+    // Deliberate inverse: a terminal year after the canonical middot-bearing
+    // org segment is #358's real year-only date shape, not title text.
+    expect(value[2]).toMatchObject({
+      title: "Research Assistant",
+      company: "XYZ University",
+      start_date: "2021",
+    });
+  });
+
   it("opens a dateless role whose predecessor bullet WRAPPED onto a continuation line (#239)", () => {
     // The previous role's last bullet wraps onto a marker-less continuation line
     // ("millions of users…") that ends on a period — so the dateless header sits
@@ -215,6 +248,27 @@ describe("dateless trailing experience role (#219)", () => {
     );
     expect(value).toHaveLength(1);
     expect(value[0].title).toBe("Volunteer Lead");
+    expect(value[0].start_date).toBeUndefined();
+    expect(value[0].end_date).toBeUndefined();
+  });
+
+  it("keeps an inline title year in the all-dateless first_line fallback (#663)", () => {
+    const { value } = extractExperience(
+      mkSection("experience", [
+        [
+          "Software Engineer Intern Summer 2022 · DEF Organization",
+          0,
+          100,
+        ],
+        ["• Built the release dashboard", 10, 90],
+      ]),
+    );
+
+    expect(value).toHaveLength(1);
+    expect(value[0]).toMatchObject({
+      title: "Software Engineer Intern Summer 2022",
+      company: "DEF Organization",
+    });
     expect(value[0].start_date).toBeUndefined();
     expect(value[0].end_date).toBeUndefined();
   });

--- a/src/lib/heuristics/extract/experience.bulleted-role-header.test.ts
+++ b/src/lib/heuristics/extract/experience.bulleted-role-header.test.ts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Regression tests for #662: a date range is the role heading and the first
+ * bullet below it carries `Title, Company` before the accomplishment bullets.
+ *
+ * Recovery must stay narrower than "promote the first bullet". A date-only
+ * block containing ordinary achievement prose is the #145 phantom shape and
+ * must still be dropped, even when that prose happens to mention a title word.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toCanonicalResume } from "../canonical.ts";
+import { mkItems } from "../__test-utils__/mkItem.ts";
+import { extractExperience } from "../extract-fields.ts";
+import {
+  findSection,
+  groupIntoLines,
+  splitIntoSections,
+  toSectionedResume,
+} from "../sections.ts";
+import type { CascadeResult, HeuristicParsedResume } from "../types.ts";
+import { buildAtsResumeModel } from "../../pdf/ats-resume-model.ts";
+import { computeAnonymousAtsScore } from "../../score/score.ts";
+
+function parseExperienceSection(
+  specs: Array<{ text: string; fontSize?: number }>,
+) {
+  const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
+  const experience = findSection(sections, "experience");
+  expect(experience).toBeDefined();
+  return {
+    roles: extractExperience(experience).value,
+    sections: toSectionedResume(sections, "regex"),
+  };
+}
+
+function rolesFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+  return parseExperienceSection(specs).roles;
+}
+
+describe("date-heading roles with a bulleted header (#662)", () => {
+  it("recovers two roles without grading or exporting the promoted header bullets", () => {
+    const specs = [
+      { text: "Experience", fontSize: 13 },
+      { text: "Mar 2021 - Present" },
+      { text: "• Staff Engineer, Globex Systems LLC" },
+      { text: "• Led the payments platform migration across 14 services" },
+      { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+      { text: "Jun 2017 - Feb 2021" },
+      { text: "• Senior Engineer, Initech Analytics" },
+      { text: "• Rebuilt the ingest pipeline handling 3M events per day" },
+      { text: "• Mentored four engineers through the on-call rotation" },
+    ];
+    const { roles, sections } = parseExperienceSection(specs);
+
+    expect(roles).toHaveLength(2);
+    expect(roles[0]).toMatchObject({
+      title: "Staff Engineer",
+      company: "Globex Systems LLC",
+      start_date: "Mar 2021",
+      is_current: true,
+    });
+    expect(roles[0].end_date).toBeUndefined();
+    expect(roles[0].description?.split("\n")).toEqual([
+      "Led the payments platform migration across 14 services",
+      "Cut median deploy time from 42 minutes to 9 minutes",
+    ]);
+
+    expect(roles[1]).toMatchObject({
+      title: "Senior Engineer",
+      company: "Initech Analytics",
+      start_date: "Jun 2017",
+      end_date: "Feb 2021",
+    });
+    expect(roles[1].description?.split("\n")).toEqual([
+      "Rebuilt the ingest pipeline handling 3M events per day",
+      "Mentored four engineers through the on-call rotation",
+    ]);
+
+    const parsed = {
+      skills: [],
+      experience: roles,
+      education: [],
+    } satisfies HeuristicParsedResume;
+    const score = computeAnonymousAtsScore({
+      parsed,
+      fieldConfidence: {},
+      triggers: [],
+      rawText: specs.map((spec) => spec.text).join("\n"),
+      sections,
+    });
+    const achievementBullets = [
+      "Led the payments platform migration across 14 services",
+      "Cut median deploy time from 42 minutes to 9 minutes",
+      "Rebuilt the ingest pipeline handling 3M events per day",
+      "Mentored four engineers through the on-call rotation",
+    ];
+    expect(score.bullets?.map((bullet) => bullet.text)).toEqual(
+      achievementBullets,
+    );
+
+    const cascade: CascadeResult = {
+      canonical: toCanonicalResume(parsed, sections, {}),
+      confidence: 1,
+      triggers: [],
+      suggestedEscalation: "none",
+      tiers: ["t1_openresume"],
+      rawText: specs.map((spec) => spec.text).join("\n"),
+      linkAnnotations: [],
+      diagnostics: {
+        rawCharCount: 0,
+        extractedCharCount: 0,
+        pages: 1,
+        elapsedMs: 0,
+        sectionSource: "regex",
+      },
+      timings: { t0_layout_ms: 0, t1_openresume_ms: 0 },
+    };
+    const model = buildAtsResumeModel(cascade, score);
+    const exported = model.sections.find(
+      (section) => section.kind === "experience",
+    );
+    expect(exported?.entries.flatMap((entry) => entry.bullets)).toEqual(
+      achievementBullets,
+    );
+  });
+
+  // The suppression keys are matched against the WHOLE pooled bullet set, so
+  // scoping it to promoted entries is what keeps it from reaching across
+  // sections. Here nothing is promoted: an ordinary header line parses normally
+  // and an authored Achievements line restates it. Before the
+  // `header_from_bullet` gate that line was filtered out of `score.bullets` —
+  // losing both its editable row and, via `resolveBullets`, its exported slot,
+  // because the entry beside it still had a graded bullet so the raw
+  // `description` fallback never fired.
+  it("keeps an authored line that restates a NORMALLY-parsed header (#662 review)", () => {
+    const specs = [
+      { text: "Experience", fontSize: 13 },
+      { text: "Staff Engineer, Globex Systems LLC" },
+      { text: "Mar 2021 - Present" },
+      { text: "• Led the payments platform migration across 14 services" },
+      { text: "Achievements", fontSize: 13 },
+      { text: "• Staff Engineer, Globex Systems LLC" },
+      { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+    ];
+    const allSections = splitIntoSections(groupIntoLines(mkItems(specs)));
+    const roles = extractExperience(findSection(allSections, "experience")).value;
+    const sections = toSectionedResume(allSections, "regex");
+
+    // Parsed from a header line, so the promotion path never ran.
+    expect(roles).toHaveLength(1);
+    expect(roles[0]).toMatchObject({
+      title: "Staff Engineer",
+      company: "Globex Systems LLC",
+    });
+    expect(roles[0].header_from_bullet).toBeUndefined();
+
+    const score = computeAnonymousAtsScore({
+      parsed: {
+        skills: [],
+        experience: roles,
+        education: [],
+      } satisfies HeuristicParsedResume,
+      fieldConfidence: {},
+      triggers: [],
+      rawText: specs.map((spec) => spec.text).join("\n"),
+      sections,
+    });
+    expect(score.bullets?.map((bullet) => bullet.text)).toContain(
+      "Staff Engineer, Globex Systems LLC",
+    );
+  });
+
+  it("does not revive a date-only phantom from achievement prose", () => {
+    const roles = rolesFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Mar 2021 - Present" },
+      { text: "• Led Engineering Team, North America" },
+      { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+    ]);
+
+    expect(roles).toEqual([]);
+  });
+
+  it("does not treat a lowercase prose tail as a company suffix", () => {
+    const roles = rolesFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Mar 2021 - Present" },
+      { text: "• Engineering Roadmap, improving Distributed Systems" },
+      { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+    ]);
+
+    expect(roles).toEqual([]);
+  });
+
+  // "Owned Developer Platform" is rejected by the role-noun grammar alone
+  // ("Platform" is not a role noun), so it cannot prove the verb gate. Each of
+  // the others ends in a genuine role noun and carries header casing, so the
+  // ONLY thing standing between them and a fabricated role — plus the silent
+  // loss of the staffing/mentoring bullet they were built from — is
+  // `startsWithActionVerb`.
+  for (const prose of [
+    "Owned Developer Platform, Cloud Infrastructure",
+    "Hired Staff Engineer, Cloud Infrastructure",
+    "Managed Senior Engineer, Payments Platform LLC",
+    "Mentored Junior Developer, Core Services Inc",
+  ]) {
+    it(`does not promote title-keyword accomplishment prose: "${prose}" (#145)`, () => {
+      const roles = rolesFromSection([
+        { text: "Experience", fontSize: 13 },
+        { text: "Mar 2021 - Present" },
+        { text: `• ${prose}` },
+        { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+      ]);
+
+      expect(roles).toEqual([]);
+    });
+  }
+
+  it("accepts Latin Extended casing in a genuine role header", () => {
+    const roles = rolesFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Mar 2021 - Present" },
+      { text: "• Élite Staff Engineer, Société Générale LLC" },
+      { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+    ]);
+
+    expect(roles).toMatchObject([
+      {
+        title: "Élite Staff Engineer",
+        company: "Société Générale LLC",
+        description: "Cut median deploy time from 42 minutes to 9 minutes",
+      },
+    ]);
+  });
+
+  it("does not revive a date-only phantom without both role fields", () => {
+    const roles = rolesFromSection([
+      { text: "Experience", fontSize: 13 },
+      { text: "Mar 2021 - Present" },
+      { text: "• Staff Engineer" },
+      { text: "• Cut median deploy time from 42 minutes to 9 minutes" },
+    ]);
+
+    expect(roles).toEqual([]);
+  });
+});

--- a/src/lib/heuristics/extract/experience.ts
+++ b/src/lib/heuristics/extract/experience.ts
@@ -5,8 +5,13 @@ import type { ResumeExperience } from "../../score/types.ts";
 import type { PdfSection } from "../sections.ts";
 import { parseEntryBlocks } from "../entry-blocks.ts";
 import type { EntryBlock } from "../entry-blocks.ts";
-import { finalizeEntries, looksLikeCompany } from "./shared.ts";
+import {
+  finalizeEntries,
+  looksLikeCompany,
+  looksLikeTitle,
+} from "./shared.ts";
 import { disambiguateCompanyTitle } from "./experience-disambiguate.ts";
+import { startsWithActionVerb } from "../../lexicon/action-verbs.ts";
 
 // ── Experience ──────────────────────────────────────────────────────────────
 
@@ -40,6 +45,7 @@ export function extractExperience(
     anchor: "date_range",
     collectBody: true,
     headerLookback: 2,
+    dateParsing: "date_anchors_only",
   });
   // A dateless experience section yields zero `date_range` blocks. Fall back to
   // the `"first_line"` anchor so each header-run + bullet-group is recovered as
@@ -52,6 +58,7 @@ export function extractExperience(
     blocks = parseEntryBlocks(experience, {
       anchor: "first_line",
       collectBody: true,
+      dateParsing: "date_anchors_only",
     });
   }
   // Map each block, then carry a shared-employer banner down to the roles that
@@ -166,6 +173,144 @@ function propagateSharedEmployer(
   }
 }
 
+const HEADER_CONNECTOR_RE = /^(?:and|at|for|in|of|on|the)$/i;
+
+/**
+ * A promoted title must read as a standalone role designation, not merely
+ * contain a title keyword somewhere in accomplishment prose. Most titles end
+ * in the role noun ("Staff Engineer", "Product Manager"); executive titles
+ * may lead with it ("Director of Product", "Head of Engineering"). Keeping
+ * that grammar positive is what carries most of the work: it needs no verb list
+ * to reject "Engineering Roadmap, improving Distributed Systems".
+ *
+ * It is necessary but NOT sufficient, because the role noun it anchors on ends a
+ * sentence as readily as a title ("Hired Staff Engineer"). The verb-lead check
+ * in `looksLikeRoleHeaderTitle` covers that residue; keep both.
+ */
+const ROLE_TITLE_EDGE_RE =
+  /(?:^(?:ceo|cfo|chief|cio|co-?founder|coo|cto|director|founder|head|lead|manager|president|vice\s+president|vp)\b|\b(?:accountant|administrator|advisor|adviser|agent|ambassador|analyst|apprentice|architect|assistant|associate|auditor|ceo|cfo|cio|clerk|consultant|coordinator|coo|counselor|cto|designer|developer|devops|director|editor|engineer|fellow|founder|instructor|intern|internship|lead|lecturer|manager|officer|pm|president|principal|producer|professor|recruiter|representative|researcher|scientist|specialist|sre|strategist|supervisor|teacher|technician|tpm|trainee|tutor|volunteer|writer)(?:\s+(?:i{1,4}|l\d+|\d+))?$)/iu;
+
+/** True when every substantive token has header casing. Connectors may remain
+ * lowercase; brands such as iOS/eBay qualify through an internal capital. */
+function hasHeaderCase(text: string): boolean {
+  return text.split(/\s+/).every((raw) => {
+    const token = raw.replace(
+      /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu,
+      "",
+    );
+    if (!token || HEADER_CONNECTOR_RE.test(token)) return true;
+    return (
+      /^[\p{Lu}\p{Lt}\p{N}]/u.test(token) ||
+      /^\p{Ll}+\p{Lu}/u.test(token)
+    );
+  });
+}
+
+/**
+ * Reject a candidate that LEADS with an action verb, however title-shaped its
+ * tail is.
+ *
+ * `ROLE_TITLE_EDGE_RE` is deliberately positive grammar, but positive grammar
+ * alone is not sufficient here: the role noun it anchors on can sit at the end
+ * of a *sentence* as easily as at the end of a title. "Hired Staff Engineer,
+ * Cloud Infrastructure" satisfies every other gate — the tail matches
+ * `engineer$`, every token has header casing, and the comma splits it into a
+ * plausible `Title, Company` pair — so it promoted to a fabricated role AND was
+ * then suppressed from the description, score pool, and export as "metadata".
+ * A staffing achievement disappeared and a role nobody held took its place.
+ *
+ * "Owned Developer Platform" was the only case covered before, and it failed for
+ * the wrong reason: "Platform" is not a role noun. Swap the noun for one that is
+ * and the guard evaporates. The verb, not the noun, is the discriminator, so
+ * this asks about the verb.
+ *
+ * The list is the shared `ACTION_VERBS` lexicon — the same set the scorer grades
+ * bullet specificity against — rather than a denylist maintained here, so a verb
+ * added for scoring cannot leave this gate behind. Accepted cost: a genuine
+ * title whose first word is in that set ("Managed Services Engineer") is
+ * rejected. That is the safe direction — dropping a real role is #145's
+ * long-standing date-only behavior, while fabricating one both invents history
+ * and deletes the bullet it was made from.
+ */
+function looksLikeRoleHeaderTitle(text: string): boolean {
+  return (
+    looksLikeTitle(text) &&
+    hasHeaderCase(text) &&
+    ROLE_TITLE_EDGE_RE.test(text) &&
+    !startsWithActionVerb(text)
+  );
+}
+
+interface PromotedRoleHeader {
+  fields: ReturnType<typeof disambiguateCompanyTitle>;
+  description: string | undefined;
+}
+
+/**
+ * Recover fields from the first source bullet of an otherwise date-only block.
+ *
+ * The narrow gates preserve #145's date-only-phantom contract:
+ * - the anchor carried a complete range but no header text;
+ * - another body bullet follows, distinguishing `role bullet + achievements`
+ *   from a lone achievement;
+ * - the candidate independently resolves to BOTH a title-like role and an
+ *   organization-shaped company; and
+ * - the title has a positive standalone-role shape rather than a title keyword
+ *   embedded in sentence-led accomplishment prose.
+ *
+ * Once promoted, the first body unit is metadata rather than an achievement.
+ * Remove it from the description so display and export do not duplicate the
+ * reconstructed role header. The scorer independently suppresses the matching
+ * source bullet from its section-derived observation pool — gated on the
+ * `header_from_bullet` flag this promotion stamps, so the suppression cannot
+ * reach a normally-parsed role's bullets.
+ *
+ * `block.bulletCount` and `block.body`'s line count are the same counter, not
+ * two that happen to agree: the anchored builder in `entry-blocks.ts` derives
+ * both from one `bodyUnits` array — `body` is `bodyUnits.join("\n")` and
+ * `bulletCount` is `bodyUnits.length` — and a wrapped tail is appended onto its
+ * unit with a space, never as a new line, so no unit contains a `\n`. Empty
+ * units are skipped before the push, so the `.trim()` on the join cannot shift
+ * index 0 either. The `anchorHeaderIndex !== -1` gate above keeps this exact:
+ * `parseBulletList`'s builder leaves `anchorHeaderIndex` undefined and is
+ * rejected before we ever split its body. So the `>= 2` gate guarantees
+ * `bodyLines[0]` is a whole bullet and `slice(1)` strands nothing.
+ */
+function promoteBulletedRoleHeader(
+  block: EntryBlock,
+): PromotedRoleHeader | undefined {
+  if (
+    block.headerLines.length !== 0 ||
+    block.anchorHeaderIndex !== -1 ||
+    block.bulletCount < 2 ||
+    !block.dates.start_date ||
+    (!block.dates.end_date && !block.dates.is_current)
+  ) {
+    return undefined;
+  }
+
+  const bodyLines = block.body?.split("\n") ?? [];
+  const candidate = bodyLines[0]?.trim();
+  if (!candidate) return undefined;
+
+  const fields = disambiguateCompanyTitle([candidate]);
+  if (
+    !fields.title ||
+    !fields.company ||
+    !looksLikeRoleHeaderTitle(fields.title)
+  ) {
+    return undefined;
+  }
+  if (!hasHeaderCase(fields.company)) {
+    return undefined;
+  }
+  const remainingBody = bodyLines.slice(1).join("\n").trim();
+  return {
+    fields,
+    description: remainingBody || undefined,
+  };
+}
+
 /** Map one dated entry block to a `ResumeExperience` and its confidence score.
  *  Extracted from `extractExperience` to keep each function below the
  *  complexity threshold; mirrors `projectFromBlock` / `achievementFromBlock`. */
@@ -174,11 +319,16 @@ function experienceFromBlock(block: EntryBlock): {
   score: number;
 } {
   const { dates } = block;
-  const { title, company, team, location } = disambiguateCompanyTitle(
+  const parsedFields = disambiguateCompanyTitle(
     block.headerLines,
     block.anchorHeaderIndex,
   );
-  const description = block.body;
+  const promoted =
+    parsedFields.title || parsedFields.company
+      ? undefined
+      : promoteBulletedRoleHeader(block);
+  const { title, company, team, location } = promoted?.fields ?? parsedFields;
+  const description = promoted ? promoted.description : block.body;
 
   // Score the entry.
   let score = 0;
@@ -197,6 +347,7 @@ function experienceFromBlock(block: EntryBlock): {
       ...(dates.start_date ? { start_date: dates.start_date } : {}),
       ...(dates.end_date ? { end_date: dates.end_date } : {}),
       ...(dates.is_current ? { is_current: true } : {}),
+      ...(promoted ? { header_from_bullet: true as const } : {}),
       description: description || undefined,
     },
     score: Math.min(score, 1),

--- a/src/lib/lexicon/action-verbs.ts
+++ b/src/lib/lexicon/action-verbs.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Shared action-verb lexicon — zero dependencies, no domain imports.
+ *
+ * Two unrelated layers need the same question answered: "does this line lead
+ * with an action verb?"
+ *
+ * - the **scorer** grades a bullet's specificity by it (`score.ts`), and the
+ *   rewrite eval extends the set for its `actionVerbLead` criterion
+ *   (`webllm/eval/verbs.ts`);
+ * - the **parser** uses it as a negative guard: an action-verb lead is the tell
+ *   that a candidate role header is really accomplishment prose
+ *   (`heuristics/extract/experience.ts` → `looksLikeRoleHeaderTitle`, #662).
+ *
+ * The set previously lived in `score.ts`, which made the parser's only route to
+ * it an import of the whole scorer — pulling the scoring module into the tier-1
+ * parse chunk for one `Set` membership test. It lives here instead so both
+ * layers share one list without either depending on the other.
+ */
+
+/**
+ * Curated past-tense action verbs.
+ *
+ * Kept narrow on purpose: weak generic verbs ("worked", "helped", "supported",
+ * "responsible", "assisted", "participated") are deliberately NOT here. A
+ * bullet leading with one of those SHOULD fail the scorer's specificity check.
+ */
+export const ACTION_VERBS: ReadonlySet<string> = new Set([
+  "led", "managed", "developed", "built", "designed", "implemented",
+  "created", "launched", "drove", "increased", "reduced", "improved",
+  "delivered", "established", "optimized", "architected", "scaled",
+  "automated", "streamlined", "coordinated", "negotiated", "achieved",
+  "spearheaded", "mentored", "transformed", "pioneered", "orchestrated",
+  "accelerated", "consolidated", "eliminated", "enhanced", "executed",
+  "facilitated", "generated", "integrated", "migrated", "overhauled",
+  "redesigned", "refactored", "resolved", "revamped", "simplified",
+  "supervised", "trained", "unified", "upgraded",
+  // Promoted from the eval-only extension (#622) — past-tense, general
+  // register, and squarely in the eng/PM lane this base set already covers.
+  "shipped", "owned", "secured", "deployed", "engineered", "rewrote",
+  "authored", "analyzed", "conducted", "identified", "presented",
+  "produced", "published", "planned",
+  // Newly added (#622) — strong outcome verbs missing from both this set
+  // and the eval extension.
+  "won", "ran", "grew", "founded", "hired", "partnered", "defined", "cut",
+  "ported", "rebuilt", "advised", "shaped", "standardized", "instrumented",
+]);
+
+/**
+ * True when `text`'s first whitespace-delimited token is an action verb.
+ *
+ * Lowercase the token and strip everything outside `a-z`, so trailing
+ * punctuation (`Led,`, `Shipped:`) matches without expanding the set with
+ * decorated variants. Returns `false` for empty input.
+ *
+ * The strip is ASCII-only by design: it is a *first-token* normalizer for an
+ * ASCII verb list, not a general folder. A non-ASCII lead ("Élite") reduces to
+ * a residue that is simply absent from the set, which is the correct answer.
+ */
+export function startsWithActionVerb(text: string): boolean {
+  const firstWord = text.split(/\s/)[0]?.toLowerCase().replace(/[^a-z]/g, "");
+  if (!firstWord) return false;
+  return ACTION_VERBS.has(firstWord);
+}

--- a/src/lib/pdf/render-ats-pdf.fonts.test.ts
+++ b/src/lib/pdf/render-ats-pdf.fonts.test.ts
@@ -38,20 +38,49 @@ function stubFetchSucceeds() {
     expect(url).not.toMatch(/^https?:\/\//);
     expect(url.toLowerCase()).not.toContain("fonts.gstatic.com");
     const bytes = url.includes("Bold") ? BOLD_BYTES : REGULAR_BYTES;
-    return { arrayBuffer: async () => toArrayBuffer(bytes) } as Response;
+    // `ok: true` is not decoration — `fetchFontBytes` rejects a non-ok response
+    // (#664), and a mock that omits `ok` reads as `undefined`/falsy, which would
+    // send every case in this file down the Helvetica path while claiming to
+    // test the embedded one.
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      arrayBuffer: async () => toArrayBuffer(bytes),
+    } as Response;
   });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
 
-/** Stub `fetch` to fail, forcing the Helvetica-fallback path. */
+/** Stub `fetch` to fail at the network layer, forcing the Helvetica fallback. */
 function stubFetchFails() {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async () => {
-      throw new Error("network unavailable (simulated)");
-    }),
+  const fetchMock = vi.fn(async () => {
+    throw new Error("network unavailable (simulated)");
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/**
+ * Stub `fetch` to RESOLVE with an HTTP error — the case `fetch` itself does not
+ * reject on (#664). Before the status check this reached the Helvetica fallback
+ * anyway, but only because fontkit choked on the error page's bytes.
+ */
+function stubFetchHttpError(status = 404) {
+  // The body reader is a spy, because it is the ONLY observable difference the
+  // status check makes. Without the check the fallback is still reached — via
+  // fontkit failing on the error page's bytes — so asserting "we fell back"
+  // passes either way. Asserting the body was never read is what distinguishes
+  // "rejected on the status" from "rejected on corrupt bytes".
+  const arrayBuffer = vi.fn(
+    async () => new TextEncoder().encode("<html>nope</html>").buffer,
   );
+  const fetchMock = vi.fn(async () => {
+    return { ok: false, status, statusText: "Not Found", arrayBuffer } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, arrayBuffer };
 }
 
 /**
@@ -248,6 +277,174 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
       expect(text).not.toContain("\0");
       expect(text).toContain("Engineer");
       expect(text).toContain("Acme");
+    });
+  });
+
+  // The two failure-handling defects behind #664's refusal. Both are about the
+  // LOAD path, not the sanitizers — a refusal the user cannot clear is worse
+  // than the silent degradation it replaces.
+  describe("font-load failure handling (#664)", () => {
+    it("rejects an HTTP error response without reading its body, which `fetch` alone does not do", async () => {
+      const { fetchMock, arrayBuffer } = stubFetchHttpError(404);
+      vi.resetModules();
+      const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
+
+      const bytes = await renderAtsResumePdf(model("http error check"));
+
+      expect(fetchMock).toHaveBeenCalled();
+      // The load bailed on the status. Without the check we would have read the
+      // error page and handed it to fontkit — reaching the same fallback, but
+      // reporting a font-parse failure instead of a 404.
+      expect(arrayBuffer).not.toHaveBeenCalled();
+      // The fallback is still intact: a bad status must not break the download.
+      await expect(hasEmbeddedFontFile2(bytes)).resolves.toBe(false);
+    });
+
+    it("re-fetches after a failure instead of replaying the cached rejection", async () => {
+      // The defect: `poppinsBytesPromise` is memoized and the guard is
+      // `!poppinsBytesPromise`, so a REJECTED promise used to stay cached for
+      // the life of the page. Every later download replayed it without issuing
+      // a request, which silently made "check your connection and try again"
+      // impossible to satisfy.
+      const failing = stubFetchFails();
+      vi.resetModules();
+      const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
+
+      const first = await renderAtsResumePdf(model("attempt one"));
+      await expect(hasEmbeddedFontFile2(first)).resolves.toBe(false);
+      const callsWhileFailing = failing.mock.calls.length;
+      expect(callsWhileFailing).toBeGreaterThan(0);
+
+      // Network recovers. NOTE: no `vi.resetModules()` here — that is the whole
+      // point. The same module instance, with its cache already poisoned by the
+      // failure above, must issue a fresh request.
+      const recovered = stubFetchSucceeds();
+      const second = await renderAtsResumePdf(model("attempt two"));
+
+      expect(recovered).toHaveBeenCalled();
+      await expect(hasEmbeddedFontFile2(second)).resolves.toBe(true);
+    });
+
+    it("keeps memoizing a SUCCESSFUL fetch — only the failure path is cleared", async () => {
+      const fetchMock = stubFetchSucceeds();
+      vi.resetModules();
+      const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
+
+      await renderAtsResumePdf(model("first"));
+      const afterFirst = fetchMock.mock.calls.length;
+      await renderAtsResumePdf(model("second"));
+
+      // Two assets, fetched once between them — clearing the memo on success
+      // too would turn every repeat download into a re-download.
+      expect(afterFirst).toBe(2);
+      expect(fetchMock.mock.calls.length).toBe(2);
+    });
+  });
+
+  // The probe behind the refusal. It must be silent for the common case and
+  // specific for the rare one.
+  describe("findExportGlyphLosses (#664)", () => {
+    const polish = (): AtsResumeModel => ({
+      contact: { name: "ANNA WIŚNIEWSKA", links: [] },
+      sections: [],
+    });
+
+    it("reports nothing when the embedded font loads, even with Latin-Extended text", async () => {
+      // Poppins covers ś/ł, so there is no loss to refuse over — the whole
+      // reason this issue's original framing stopped being accurate.
+      stubFetchSucceeds();
+      vi.resetModules();
+      const { findExportGlyphLosses } = await import("./render-ats-pdf.ts");
+
+      await expect(findExportGlyphLosses(polish())).resolves.toEqual([]);
+    });
+
+    it("reports nothing for a pure-ASCII résumé even when the font fetch fails", async () => {
+      // The gate that keeps a font hiccup from blocking every user: Helvetica
+      // draws ASCII perfectly, so there is nothing to warn about.
+      stubFetchFails();
+      vi.resetModules();
+      const { findExportGlyphLosses } = await import("./render-ats-pdf.ts");
+
+      await expect(
+        findExportGlyphLosses({
+          contact: {
+            name: "Jane Candidate",
+            email: "jane@example.com",
+            links: ["linkedin.com/in/jane"],
+          },
+          summary: "Shipped things. Cut deploy time from 42 minutes to 9.",
+          sections: [
+            {
+              kind: "experience",
+              heading: "Experience",
+              entries: [
+                { headerLine: "Engineer · Acme", bullets: ["Did the work"] },
+              ],
+            },
+          ],
+        }),
+      ).resolves.toEqual([]);
+    });
+
+    it("names the contact field when the fallback would mangle the candidate's name", async () => {
+      stubFetchFails();
+      vi.resetModules();
+      const { findExportGlyphLosses } = await import("./render-ats-pdf.ts");
+
+      const losses = await findExportGlyphLosses(polish());
+
+      expect(losses).toEqual([
+        {
+          where: "Name",
+          original: "ANNA WIŚNIEWSKA",
+          degraded: "ANNA WI?NIEWSKA",
+        },
+      ]);
+    });
+
+    it("labels a loss inside a section by that section's own heading", async () => {
+      // The label is shown to the user, so it must be their heading — not an
+      // index into a model they have never seen.
+      stubFetchFails();
+      vi.resetModules();
+      const { findExportGlyphLosses } = await import("./render-ats-pdf.ts");
+
+      const losses = await findExportGlyphLosses({
+        contact: { name: "Jane Candidate", links: [] },
+        sections: [
+          {
+            kind: "experience",
+            heading: "Work History",
+            entries: [
+              {
+                headerLine: "Engineer · Acme",
+                bullets: ["Migrated ★ to ✓"],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(losses.map((l) => l.where)).toEqual(["Work History"]);
+      expect(losses[0].degraded).toBe("Migrated ? to ?");
+    });
+
+    it("does not report a WinAnsi-representable glyph that merely looks exotic", async () => {
+      // An em dash, curly quotes and a bullet ARE valid WinAnsi (cp1252's upper
+      // range assigns them), so refusing over them would be a false positive on
+      // text the fallback draws correctly.
+      stubFetchFails();
+      vi.resetModules();
+      const { findExportGlyphLosses } = await import("./render-ats-pdf.ts");
+
+      await expect(
+        findExportGlyphLosses({
+          contact: { name: "Jane “Jay” Candidate — Engineer", links: [] },
+          summary: "Led • owned • shipped … end",
+          sections: [],
+        }),
+      ).resolves.toEqual([]);
     });
   });
 });

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -392,17 +392,141 @@ let poppinsBytesPromise: Promise<{
   bold: ArrayBuffer;
 }> | null = null;
 
+/**
+ * Fetch one font asset, failing loudly on an HTTP error (#664).
+ *
+ * `fetch` rejects only on a *network* failure — a 404 or 500 RESOLVES, so
+ * `res.arrayBuffer()` would hand the error page's bytes to `embedFont` and
+ * fontkit would throw on the unparseable input. The fallback was still reached,
+ * but by way of a font-parse error, which reports the wrong cause. The status
+ * check matters because {@link findExportGlyphLosses}' caller shows the reason
+ * to a user, and "you appear to be offline" and "the font asset is missing"
+ * have different remedies.
+ */
+async function fetchFontBytes(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`font asset responded ${res.status} ${res.statusText}`);
+  }
+  return res.arrayBuffer();
+}
+
 function loadPoppinsBytes(): Promise<{
   regular: ArrayBuffer;
   bold: ArrayBuffer;
 }> {
   if (!poppinsBytesPromise) {
     poppinsBytesPromise = Promise.all([
-      fetch(poppinsRegularUrl).then((res) => res.arrayBuffer()),
-      fetch(poppinsBoldUrl).then((res) => res.arrayBuffer()),
-    ]).then(([regular, bold]) => ({ regular, bold }));
+      fetchFontBytes(poppinsRegularUrl),
+      fetchFontBytes(poppinsBoldUrl),
+    ])
+      .then(([regular, bold]) => ({ regular, bold }))
+      .catch((err: unknown) => {
+        // Clear the memo on failure so the NEXT call re-fetches (#664).
+        //
+        // The guard above is `!poppinsBytesPromise`, so without this the
+        // REJECTED promise stays cached forever: one transient blip degraded
+        // every subsequent download for the life of the page, even after the
+        // network recovered. That also made a user-facing "try again" a lie —
+        // the retry resolved to the same stored rejection without issuing a
+        // request. Only the failure path is cleared; a successful fetch stays
+        // memoized, which is what this cache is for.
+        poppinsBytesPromise = null;
+        throw err;
+      });
   }
   return poppinsBytesPromise;
+}
+
+/** One field whose text the Helvetica fallback cannot draw intact (#664). */
+export interface ExportGlyphLoss {
+  /** User-facing label for where the loss is — a contact field name, "Summary",
+   *  or the section's own heading. Not a code path; it is shown to the user. */
+  where: string;
+  /** The text as authored. */
+  original: string;
+  /** What the fallback font would draw instead. */
+  degraded: string;
+}
+
+/**
+ * Report the fields the Helvetica fallback would silently mangle (#664).
+ *
+ * This is the probe behind the Download-PDF refusal. `useDownloadPdf` calls it
+ * BEFORE rendering and refuses when it returns a non-empty list, so the user is
+ * never handed a PDF in which their own name has quietly become `WI?NIEWSKA`.
+ *
+ * Three design points, each load-bearing:
+ *
+ *  1. **It lives here, not in `renderAtsResumePdf`.** An earlier design gave the
+ *     renderer a policy parameter so the browser could ask to refuse while the
+ *     corpus harness asked to degrade. `renderAtsResumePdf` has ~35 call sites,
+ *     all typed `Promise<Uint8Array>` — every round-trip, export-layout and
+ *     repro test in the repo. A separate probe leaves all of them untouched, and
+ *     leaves the corpus round-trip oracle (which needs a rendered PDF, degraded
+ *     or not) working by construction rather than by opt-out.
+ *  2. **Empty when the embedded font loads.** It shares the memoized
+ *     {@link loadPoppinsBytes}, so the probe and the subsequent render make one
+ *     fetch attempt between them, not two. On the failure path the memo is
+ *     cleared (that is what makes Retry work), so a *no-loss* résumé costs a
+ *     second failing attempt when the render then re-tries — acceptable, since
+ *     it only happens when the font is already unavailable.
+ *  3. **It gates on actual loss, not on "the font failed."** Most résumés are
+ *     pure ASCII, and Helvetica draws them perfectly. Refusing on the font
+ *     failure alone would block every user to protect the few with a character
+ *     outside WinAnsi.
+ *
+ * Deliberate limit: this covers the **fallback** path only. On the embedded path
+ * `toEmbeddedFontSafe` can still emit `?` for a code point Poppins lacks (`★`,
+ * `✓`) — decorative symbols, not identity fields, and outside #664's scope. It
+ * is also mildly conservative: headings are uppercased before sanitizing at draw
+ * time, and this probe reads the un-cased text, so a character that would
+ * upper-case into WinAnsi could be reported as a loss it isn't. That errs toward
+ * asking the user, which is the safe direction.
+ */
+export async function findExportGlyphLosses(
+  model: AtsResumeModel,
+): Promise<ExportGlyphLoss[]> {
+  try {
+    await loadPoppinsBytes();
+    return [];
+  } catch {
+    // The embedded font is unavailable, so the render below would fall back to
+    // Helvetica/WinAnsi. Fall through and measure what that would cost.
+  }
+
+  const losses: ExportGlyphLoss[] = [];
+  const check = (where: string, text: string | undefined): void => {
+    if (!text) return;
+    const degraded = toWinAnsi(text);
+    if (degraded !== text) losses.push({ where, original: text, degraded });
+  };
+
+  const { contact } = model;
+  check("Name", contact.name);
+  check("Headline", contact.headline);
+  check("Email", contact.email);
+  check("Phone", contact.phone);
+  check("Location", contact.location);
+  for (const link of contact.links) check("Links", link);
+  check(model.summaryHeading || "Summary", model.summary);
+
+  for (const section of model.sections) {
+    // The section's own heading labels its entries, so a loss inside Experience
+    // reads as "Experience" rather than as an index into a model the user has
+    // never seen.
+    const where = section.heading || "Section";
+    check(where, section.heading);
+    for (const entry of section.entries) {
+      check(where, entry.headerLine);
+      check(where, entry.headerLineDate);
+      check(where, entry.subLine);
+      check(where, entry.subLineDate);
+      for (const bullet of entry.bullets) check(where, bullet);
+    }
+  }
+
+  return losses;
 }
 
 /**
@@ -419,6 +543,15 @@ function loadPoppinsBytes(): Promise<{
  * embedded path it is {@link toEmbeddedFontSafe} bound to Poppins' own glyph
  * coverage, because an embedded font silently emits `.notdef` (extracting as
  * U+0000) for a glyph it lacks rather than throwing.
+ *
+ * "A font problem never blocks the download" is deliberately still true HERE
+ * and is not the product behaviour (#664). Falling back silently is right for
+ * the ~35 non-user callers — every round-trip and export test, and the corpus
+ * oracle, which must render the degraded output in order to measure it. The
+ * user-facing refusal lives one layer up in `useDownloadPdf`, which asks
+ * {@link findExportGlyphLosses} whether the fallback would actually cost the
+ * user a character and stops before rendering if it would. Keep the split: a
+ * refusal wired in here would break every one of those callers to serve one.
  */
 async function loadFonts(
   doc: Doc,

--- a/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
@@ -2,9 +2,9 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * Round-trip regression for #358 — a single-column experience role whose ONLY
- * date is a bare YEAR ("Company · Location  2022") lost both its identity and
- * its date on the Download-PDF round-trip.
+ * Round-trip regressions for the two sides of a bare-year experience header:
+ * #358 keeps a genuine year-only date, while #663 keeps a year that belongs to
+ * a dateless role's title.
  *
  * Pipeline: build the ATS model from a parsed résumé → `renderAtsResumePdf`
  * → RE-parse the rendered bytes with `runCascade`. Before the fix, the
@@ -45,6 +45,12 @@ function makeResult(): CascadeResult {
           { title: "Composer", company: "Northwind Ensemble", location: "Boston, MA", start_date: "2022", description: "• Scored the winter program." },
           // Year-only, no location (org-signature form).
           { title: "Lecturer", company: "Fabrikam Institute", start_date: "2019", description: "• Taught the seminar." },
+          // Dateless title whose final segment happens to carry a year (#663).
+          {
+            title: "Software Engineer Intern Summer 2022",
+            company: "DEF Organization",
+            description: "• Built the release dashboard.",
+          },
         ],
         education: [],
         projects: [],
@@ -93,5 +99,14 @@ describe("#358 — year-only experience role round-trips (no title/company swap,
     expect(lecturer).toBeDefined();
     expect(lecturer!.company).toBe("Fabrikam Institute");
     expect(lecturer!.start_date).toBe("2019");
+  });
+
+  it("keeps a dateless role's inline year in its title (#663)", () => {
+    const exp = reparsed.canonical.fields.experience ?? [];
+    const intern = exp.find((e) => e.company === "DEF Organization");
+    expect(intern).toBeDefined();
+    expect(intern!.title).toBe("Software Engineer Intern Summer 2022");
+    expect(intern!.start_date).toBeUndefined();
+    expect(intern!.end_date).toBeUndefined();
   });
 });

--- a/src/lib/score/score.ts
+++ b/src/lib/score/score.ts
@@ -17,6 +17,7 @@ import type {
 } from "./types.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 import { assignBulletIds } from "./bullet-id.ts";
+import { startsWithActionVerb } from "../lexicon/action-verbs.ts";
 import {
   deriveContactProfiles,
   isProfileConfident,
@@ -100,12 +101,20 @@ const WEIGHTS = {
  *   its own leftover fragment. Both now share CARDINAL_SEPARATOR. Strictly
  *   removes false Specificity credit; a bullet that genuinely quantifies is
  *   unaffected, so scores move only DOWN and only on this rare shape.
+ * - 1.8 (2026-07-30): a role header the parser recovered from its block's first
+ *   body bullet (#662, `header_from_bullet`) no longer enters the graded pool.
+ *   Date-heading templates write `Title, Company` in bullet position; once
+ *   `promoteBulletedRoleHeader` promotes that unit to a structured header,
+ *   grading it as an accomplishment double-counts it. This changes WHICH
+ *   bullets are graded — observable as a lower `bulletCount` — so Specificity /
+ *   Structure move on résumés of that shape. Same class as 1.5. Scoped to
+ *   promoted entries; a normally-parsed role's bullets are untouched.
  */
 // Surfaced to the UI via the `algoVersion` score field, and consumed by the
 // #321 resume-library cache to version persisted parse+score records (a bump
 // here invalidates stale cached snapshots, which then re-parse from the stored
 // PDF blob — see `resume-library.ts`).
-export const ATS_SCORE_ALGO_VERSION = "1.7";
+export const ATS_SCORE_ALGO_VERSION = "1.8";
 
 // ── Shared scoring rules ────────────────────────────────────────────────────
 //
@@ -278,44 +287,6 @@ function bulletHasMetric(text: string): boolean {
   return QUANTIFYING_CARDINAL.test(
     stripped.replace(WORD_YEAR_TOKEN, " ").replace(NON_QUANTIFYING_PHRASE, " "),
   );
-}
-
-/**
- * Curated past-tense action verbs used to grade the user's *existing*
- * bullets. Exported so the rewrite eval (`src/lib/webllm/eval/verbs.ts`)
- * can reuse this as the base set without duplicating it — the eval set
- * adds present-tense and IC-discipline verbs on top, but the scorer's
- * specificity-dimension semantics stay anchored here.
- *
- * Kept narrow on purpose: weak generic verbs ("worked", "helped",
- * "supported", "responsible", "assisted", "participated") are deliberately
- * NOT here. A bullet leading with one of those SHOULD fail the
- * specificity check.
- */
-export const ACTION_VERBS: ReadonlySet<string> = new Set([
-  "led", "managed", "developed", "built", "designed", "implemented",
-  "created", "launched", "drove", "increased", "reduced", "improved",
-  "delivered", "established", "optimized", "architected", "scaled",
-  "automated", "streamlined", "coordinated", "negotiated", "achieved",
-  "spearheaded", "mentored", "transformed", "pioneered", "orchestrated",
-  "accelerated", "consolidated", "eliminated", "enhanced", "executed",
-  "facilitated", "generated", "integrated", "migrated", "overhauled",
-  "redesigned", "refactored", "resolved", "revamped", "simplified",
-  "supervised", "trained", "unified", "upgraded",
-  // Promoted from the eval-only extension (#622) — past-tense, general
-  // register, and squarely in the eng/PM lane this base set already covers.
-  "shipped", "owned", "secured", "deployed", "engineered", "rewrote",
-  "authored", "analyzed", "conducted", "identified", "presented",
-  "produced", "published", "planned",
-  // Newly added (#622) — strong outcome verbs missing from both this set
-  // and the eval extension.
-  "won", "ran", "grew", "founded", "hired", "partnered", "defined", "cut",
-  "ported", "rebuilt", "advised", "shaped", "standardized", "instrumented",
-]);
-
-function startsWithActionVerb(bullet: string): boolean {
-  const firstWord = bullet.split(/\s/)[0]?.toLowerCase().replace(/[^a-z]/g, "");
-  return ACTION_VERBS.has(firstWord);
 }
 
 /**
@@ -728,6 +699,8 @@ export interface AnonymousAtsScoreInput {
     experience?: {
       title?: string;
       company?: string;
+      location?: string;
+      team?: string;
       start_date?: string;
       end_date?: string;
       is_current?: boolean;
@@ -919,6 +892,80 @@ function poolExperienceDescriptions(
   return out;
 }
 
+interface ExperienceHeaderSource {
+  title?: string;
+  company?: string;
+  location?: string;
+  team?: string;
+  header_from_bullet?: boolean;
+}
+
+/** Normalize only for exact role-header ownership checks. Punctuation is a
+ * separator here because source headers may use comma, middot, dash, pipe, or
+ * `@` while resolving to the same structured fields. */
+function normalizeExperienceHeaderUnit(text: string): string {
+  return text
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Remove marker bullets that are already represented by a structured
+ * experience header. Date-heading templates put `Title, Company` in the first
+ * bullet position; once the parser promotes that unit, grading it as an
+ * accomplishment would duplicate it in editor observations and PDF export.
+ *
+ * SCOPED TO PROMOTED ENTRIES ONLY — `header_from_bullet` (#662). Do not widen
+ * this to every experience entry: the keys are matched against the WHOLE pooled
+ * bullet set, so an unscoped filter reaches across sections. A résumé with an
+ * ordinary parsed header and an authored Achievements line that restates it
+ * ("Staff Engineer, Globex Systems LLC") would lose that line with no promotion
+ * anywhere in the parse — and losing it is not cosmetic. Dropping a bullet here
+ * drops it from `score.bullets`, which costs it its editable row on the
+ * reconstructed surface AND its slot in the exported PDF, because
+ * `resolveBullets` in `ats-resume-model.ts` falls back to the raw `description`
+ * split only when an entry has NO graded bullets — a restatement sitting beside
+ * real achievements is simply gone. For a promoted entry the line is genuinely
+ * parser-owned metadata, so suppression is correct there and only there.
+ *
+ * Both title/company orders are accepted because the disambiguator supports
+ * company-first source headers. Optional location/team suffixes are exact: an
+ * achievement with any additional prose cannot collide with these keys.
+ */
+function suppressExperienceHeaderBullets(
+  bullets: string[],
+  experience: readonly ExperienceHeaderSource[] | undefined,
+): string[] {
+  const headerKeys = new Set<string>();
+  const addKey = (parts: Array<string | undefined>) => {
+    const key = normalizeExperienceHeaderUnit(
+      parts.filter((part): part is string => Boolean(part?.trim())).join(" "),
+    );
+    if (key) headerKeys.add(key);
+  };
+
+  for (const entry of experience ?? []) {
+    if (!entry.header_from_bullet) continue;
+    if (!entry.title?.trim() || !entry.company?.trim()) continue;
+    const suffixes: Array<Array<string | undefined>> = [
+      [],
+      [entry.location],
+      [entry.team],
+      [entry.location, entry.team],
+    ];
+    for (const suffix of suffixes) {
+      addKey([entry.title, entry.company, ...suffix]);
+      addKey([entry.company, entry.title, ...suffix]);
+    }
+  }
+
+  if (headerKeys.size === 0) return bullets;
+  return bullets.filter(
+    (bullet) => !headerKeys.has(normalizeExperienceHeaderUnit(bullet)),
+  );
+}
+
 export function computeAnonymousAtsScore(
   input: AnonymousAtsScoreInput,
 ): AnonymousAtsScore {
@@ -936,7 +983,10 @@ export function computeAnonymousAtsScore(
   // pool, so a résumé whose OTHER accomplishment sections (e.g. Achievements)
   // still carry glyph bullets doesn't mask a glyph-less Experience section —
   // see `poolExperienceDescriptions` for the full rationale.
-  const bullets = extractBulletsFromSections(input.sections);
+  const bullets = suppressExperienceHeaderBullets(
+    extractBulletsFromSections(input.sections),
+    input.parsed.experience,
+  );
   if (extractExperienceSectionBullets(input.sections).length === 0) {
     bullets.push(...poolExperienceDescriptions(input.parsed.experience));
   }

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -144,6 +144,17 @@ export interface ResumeExperience {
   seniority_level?: string;
   /** Optional extraction-quality score in [0, 1]. Missing means "trust it". */
   confidence?: number;
+  /** True when `title`/`company` were recovered from this block's FIRST BODY
+   *  BULLET rather than from a header line (#662, `promoteBulletedRoleHeader`) —
+   *  the date-heading templates that put `Title, Company` in bullet position.
+   *  Parser-internal provenance, not résumé content: it exists so the scorer can
+   *  suppress the source bullet from the graded pool for THESE entries only.
+   *  Suppressing on every entry silently deletes an authored line that merely
+   *  restates a normally-parsed header — it leaves `score.bullets`, so it loses
+   *  both its editable row and (via `resolveBullets`) its slot in the exported
+   *  PDF. Absent for every normally-parsed role, so consumers that ignore it
+   *  behave exactly as before. */
+  header_from_bullet?: boolean;
 }
 
 export interface ResumeEducation {

--- a/src/lib/webllm/eval/verbs.test.ts
+++ b/src/lib/webllm/eval/verbs.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { ACTION_VERBS as SCORER_ACTION_VERBS } from "../../score/score.ts";
+import { ACTION_VERBS as SCORER_ACTION_VERBS } from "../../lexicon/action-verbs.ts";
 import { EVAL_ONLY_EXTENSIONS, startsWithActionVerb } from "./verbs.ts";
 
 // #622: the whole point of promoting a verb out of EVAL_ONLY_EXTENSIONS and

--- a/src/lib/webllm/eval/verbs.ts
+++ b/src/lib/webllm/eval/verbs.ts
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
-import { ACTION_VERBS as SCORER_ACTION_VERBS } from "../../score/score.ts";
+import { ACTION_VERBS as SCORER_ACTION_VERBS } from "../../lexicon/action-verbs.ts";
 
 /**
  * Action-verb list used by the eval rubric's `actionVerbLead` criterion.
  *
  * Built as the scorer's curated past-tense set + a small eval-only
- * extension. The scorer set lives in `src/lib/score/score.ts` so when a
- * verb is added there it lights up here automatically — single source of
+ * extension. The base set lives in `src/lib/lexicon/action-verbs.ts` so when
+ * a verb is added there it lights up here automatically — single source of
  * truth, no drift.
  *
  * The extension covers two cases the scorer set doesn't:
@@ -34,8 +34,8 @@ import { ACTION_VERBS as SCORER_ACTION_VERBS } from "../../score/score.ts";
  * those SHOULD fail the criterion. That's the whole point.
  */
 
-// Exported so `verbs.test.ts` can assert this set stays disjoint from
-// `score.ts`'s `ACTION_VERBS` (#622) — everything else in this module stays
+// Exported so `verbs.test.ts` can assert this set stays disjoint from the
+// shared `ACTION_VERBS` (#622) — everything else in this module stays
 // module-internal.
 export const EVAL_ONLY_EXTENSIONS: readonly string[] = [
   // Eng / data IC verbs the scorer set doesn't cover.
@@ -49,15 +49,15 @@ export const EVAL_ONLY_EXTENSIONS: readonly string[] = [
 ];
 
 // Module-internal: only `startsWithActionVerb` is consumed by the rubric.
-// Not exported — keeping it local avoids a dead public export and a
-// name collision with `score.ts`'s `ACTION_VERBS` (both flagged by fallow).
+// Not exported — keeping it local avoids a dead public export and a name
+// collision with the shared `ACTION_VERBS` (both flagged by fallow).
 const ACTION_VERBS: ReadonlySet<string> = new Set([
   ...SCORER_ACTION_VERBS,
   ...EVAL_ONLY_EXTENSIONS,
 ]);
 
 /**
- * First-token check that mirrors `score.ts::startsWithActionVerb`:
+ * First-token check that mirrors the shared `startsWithActionVerb`:
  * lowercase the first whitespace-delimited token, strip everything that
  * isn't a-z, and look up in the union set. The strip handles trailing
  * punctuation (`Led,`, `Shipped:`) without expanding the set with

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-achievements-oneline.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-additional-skills.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-certifications.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-classic.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-coursework-dup.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-honors-subheadings.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-honors-subheadings.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-nonstandard-headers.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-programs-skills-software.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 11,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column-long-role-header.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column-long-role-header.expected.json
@@ -68,7 +68,7 @@
       "scanned": false
     },
     "bulletCount": 14,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-cv.expected.json
@@ -69,7 +69,7 @@
       "scanned": false
     },
     "bulletCount": 52,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/awesome-cv-resume.expected.json
@@ -69,7 +69,7 @@
       "scanned": false
     },
     "bulletCount": 30,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
+++ b/tests/fixtures/pdfs/latex/header-as-name-functional-resume.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 16,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/bare-linkedin-url-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/bare-linkedin-url-roundtrip.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/bulleted-labelled-single-column-skills.expected.json
+++ b/tests/fixtures/pdfs/unknown/bulleted-labelled-single-column-skills.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-asymmetric-sidebar.expected.json
@@ -70,7 +70,7 @@
       "scanned": false
     },
     "bulletCount": 11,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-qualified-experience-headers.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/chromium-two-column-sidebar.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 27,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/compound-certifications-activities-tail.expected.json
+++ b/tests/fixtures/pdfs/unknown/compound-certifications-activities-tail.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/date-heading-bulleted-roles.expected.json
+++ b/tests/fixtures/pdfs/unknown/date-heading-bulleted-roles.expected.json
@@ -1,16 +1,19 @@
 {
   "schemaVersion": 5,
   "cascade": {
-    "confidence": 0,
+    "confidence": 0.87,
     "triggers": [],
     "tiers": [
       "t0_layout",
       "t1_openresume"
     ],
-    "suggestedEscalation": "llm",
+    "suggestedEscalation": "none",
     "fieldsPopulated": [
+      "current_company",
+      "current_title",
       "education",
       "email",
+      "experience",
       "family_name",
       "full_name",
       "given_name",
@@ -20,7 +23,7 @@
       "skills"
     ],
     "skillsCount": 4,
-    "experienceCount": 0,
+    "experienceCount": 2,
     "educationCount": 1,
     "projectsCount": 0,
     "achievementsCount": 0,
@@ -31,24 +34,24 @@
     "sectionSource": "markdown"
   },
   "score": {
-    "overall": 83,
-    "preLayoutOverall": 83,
+    "overall": 94,
+    "preLayoutOverall": 94,
     "specificity": {
       "score": 40,
       "max": 40,
       "gradable": true,
       "metricBullets": 4,
-      "totalBullets": 6
+      "totalBullets": 4
     },
     "structure": {
-      "score": 20,
+      "score": 30,
       "max": 30,
       "gradable": true,
       "goodBullets": 4,
-      "totalBullets": 6
+      "totalBullets": 4
     },
     "completeness": {
-      "score": 23,
+      "score": 24,
       "max": 30,
       "gradable": true,
       "missing": [
@@ -61,8 +64,8 @@
       "multiplier": 1,
       "scanned": false
     },
-    "bulletCount": 6,
-    "algoVersion": "1.7"
+    "bulletCount": 4,
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",
@@ -71,7 +74,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 570,
-    "extractedCharCount": 145,
+    "extractedCharCount": 440,
     "sections": [
       {
         "name": "profile",
@@ -96,7 +99,7 @@
       "hasPhone": true,
       "hasLocation": true,
       "hasSummary": false,
-      "experienceCount": 0,
+      "experienceCount": 2,
       "educationCount": 1,
       "skillsCount": 4
     },
@@ -111,7 +114,7 @@
     "educationHeaderCandidateRejected": false,
     "educationEntriesFewerThanDegreeTokens": false,
     "experienceRegionHasDateRangeLines": true,
-    "experienceEntriesFewerThanDateRangeLines": true,
+    "experienceEntriesFewerThanDateRangeLines": false,
     "achievementsParsedEmpty": true,
     "achievementsEntriesFewerThanHeaderLines": false,
     "fullNameChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/date-heading-bulleted-roles.truth.json
+++ b/tests/fixtures/pdfs/unknown/date-heading-bulleted-roles.truth.json
@@ -30,22 +30,5 @@
     "Kubernetes",
     "Terraform",
     "PostgreSQL"
-  ],
-  "knownWrong": {
-    "experience.title": {
-      "issue": 662,
-      "status": "open",
-      "note": "ZERO experience entries parsed from two plainly dated roles — the defect this fixture exists to exhibit (experience-parser-miss). #662 owns this shape specifically: a date-range HEADING with the role line bulleted under it. Previously cited #492 with a prose caveat; that citation was wrong — #492's trigger is a HEADERLESS section and its acceptance criteria do not cover this fixture, as this fixture's own generator docblock states. A caveat in prose is invisible to check:baselines, which certifies the issue NUMBER."
-    },
-    "experience.company": {
-      "issue": 662,
-      "status": "open",
-      "note": "Same drop as experience.title — zero entries parsed. See that entry."
-    },
-    "experience.dates": {
-      "issue": 662,
-      "status": "open",
-      "note": "Same drop as experience.title — zero entries parsed. See that entry."
-    }
-  }
+  ]
 }

--- a/tests/fixtures/pdfs/unknown/education-institution-pipe-location.expected.json
+++ b/tests/fixtures/pdfs/unknown/education-institution-pipe-location.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 1,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/education-lone-year-flush-right.expected.json
+++ b/tests/fixtures/pdfs/unknown/education-lone-year-flush-right.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 1,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/extended-latin-name-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/extended-latin-name-roundtrip.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/label-rail-inline-headers.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
+++ b/tests/fixtures/pdfs/unknown/letter-spaced-name-heading.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/mid-dot-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/mid-dot-header.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
+++ b/tests/fixtures/pdfs/unknown/name-set-apart-tagline.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
+++ b/tests/fixtures/pdfs/unknown/openresume-react-pdf.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",
@@ -127,7 +127,7 @@
     "phoneChangedAcrossRoundtrip": false,
     "locationChangedAcrossRoundtrip": false,
     "linkedinUrlChangedAcrossRoundtrip": false,
-    "experienceChangedAcrossRoundtrip": true,
+    "experienceChangedAcrossRoundtrip": false,
     "educationChangedAcrossRoundtrip": false,
     "skillsChangedAcrossRoundtrip": false,
     "summaryChangedAcrossRoundtrip": false,

--- a/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 2,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/qualified-experience-relevant-coursework.expected.json
+++ b/tests/fixtures/pdfs/unknown/qualified-experience-relevant-coursework.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/shared-employer-banner-roles.expected.json
+++ b/tests/fixtures/pdfs/unknown/shared-employer-banner-roles.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-endash-title-company.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-endash-title-company.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-intl-role-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-intl-role-headers.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-projects-prose-body.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-projects-prose-body.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 1,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-title-below-anchor.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-title-below-anchor.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-column-year-only-roundtrip.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
+++ b/tests/fixtures/pdfs/unknown/single-word-name-mononym.expected.json
@@ -63,7 +63,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/synthetic-dateless-experience.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-dateless-experience.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/synthetic-degreeless-two-programs.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-degreeless-two-programs.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 4,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
+++ b/tests/fixtures/pdfs/unknown/synthetic-two-experience-sections.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 0,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/title-team-next-line-employer.expected.json
+++ b/tests/fixtures/pdfs/unknown/title-team-next-line-employer.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 5,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/top-skills-header-unrecognized.expected.json
+++ b/tests/fixtures/pdfs/unknown/top-skills-header-unrecognized.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
+++ b/tests/fixtures/pdfs/unknown/two-column-achievements-sidebar.expected.json
@@ -71,7 +71,7 @@
       "scanned": false
     },
     "bulletCount": 16,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-classic.expected.json
@@ -64,7 +64,7 @@
       "scanned": false
     },
     "bulletCount": 8,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-minimal.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 7,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-nonstandard-headers.expected.json
@@ -66,7 +66,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
+++ b/tests/fixtures/pdfs/unknown/weasyprint-cairo-two-column.expected.json
@@ -72,7 +72,7 @@
       "scanned": false
     },
     "bulletCount": 13,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-bulleted-skills.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
+++ b/tests/fixtures/pdfs/word/chanchal-sharma-sample.expected.json
@@ -67,7 +67,7 @@
       "scanned": false
     },
     "bulletCount": 3,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -65,7 +65,7 @@
       "scanned": false
     },
     "bulletCount": 6,
-    "algoVersion": "1.7"
+    "algoVersion": "1.8"
   },
   "reproArtifact": {
     "artifactVersion": "v1",


### PR DESCRIPTION
## Summary

Three defects surfaced by re-reading the corpus gates' own baselines. Each one had a baseline entry or a doc paragraph asserting something the code contradicted — the failure mode `check:baselines` cannot catch, because it certifies an issue *number* and cannot read prose.

### #662 — a date-range heading with bulleted role lines parsed zero entries

```
Mar 2021 - Present
• Staff Engineer, Globex Systems LLC     ← the role header, bulleted
• Led the payments platform migration…
```

`parseEntryBlocks` anchors on the date, finds no header lines above it, and #145's date-only-phantom contract drops the whole block. The first body bullet is now promoted to the role header behind four narrow gates: the anchor carried a **complete** range, another body bullet follows, the candidate resolves to **both** a title-like role and an organization-shaped company, and the title reads as a standalone role. Once promoted it is metadata — it leaves the description, and the scorer suppresses the matching source bullet from its observation pool, so it is neither graded as an achievement nor re-exported as one.

**The standalone-role test is two gates, not one.** `ROLE_TITLE_EDGE_RE` is positive grammar (a title ends in its role noun, or an executive title leads with one) and needs no verb list to reject `Engineering Roadmap, improving Distributed Systems`. But it is **necessary, not sufficient** — a role noun ends a sentence as readily as a title:

| Candidate | Ends in role noun | Header casing | Splits on comma | Promoted before this PR |
|---|---|---|---|---|
| `Staff Engineer, Globex Systems LLC` | ✅ | ✅ | ✅ | ✅ correct |
| `Hired Staff Engineer, Cloud Infrastructure` | ✅ | ✅ | ✅ | ❌ **fabricated a role, and deleted the staffing bullet it was built from** |
| `Owned Developer Platform, Cloud Infrastructure` | ❌ | ✅ | ✅ | ✅ rejected — but only because "Platform" is not a role noun |

`Owned …` was the only case covered, and it passed **for the wrong reason**: swap the noun for a real role noun and the guard evaporates. The verb is the discriminator, so `looksLikeRoleHeaderTitle` now asks about the verb.

That check reuses the scorer's `ACTION_VERBS` rather than a denylist maintained at the call site, so a verb added for bullet grading cannot leave the parser gate behind. The set moves to a new zero-dep leaf, `src/lib/lexicon/action-verbs.ts` — it lived in `score.ts`, which made the parser's only route to it an import of the whole scoring module into the tier-1 parse chunk for one `Set` membership test.

**Accepted cost, stated plainly:** a genuine title whose first word is in that set (`Managed Services Engineer`) is now rejected. That is the safe direction — dropping a real role is #145's long-standing date-only behavior, whereas fabricating one both invents history *and* deletes a real bullet.

### #663 — a dateless role's inline year was split out as `start_date`

`Software Engineer Intern Summer 2022` round-tripped as title `… Summer` + `start_date: 2022`. `collectDatelessAnchors` lost the provenance distinguishing a date the exporter *composed* from one that was always part of the title, so the re-parse could not tell them apart.

### #661 — §7 of `docs/canonical-resume-model.md` asserted two symbols don't exist

§7 claimed `lineLooksLikeDatedEntry` and `hasDateRange` "do not exist in the codebase", correcting #438/#439 for citing them. **Both exist, verbatim and exactly as attributed** — `heuristics/sections.ts` → `classifyLine` computes `const lineLooksLikeDatedEntry = hasDateRange(line) || hasDateRange(nextLine)`. The correction is retracted.

It was true when written and stopped being true on the next parser merge: this doc landed in #440, and **#435** introduced both identifiers afterwards — having been flagged in the doc's own §0 as *in flight at the time*. So the whole doc is re-anchored from `path:line` to `path` → `Symbol`, and the retraction records the general lesson: a **negative** claim about the codebase does not belong in a document nothing re-verifies on merge.

The problem class #438 named survives intact — and the live code states it more plainly than the issue did. The header-vs-entry call is made from **adjacent raw-line signals** (`hasDateRange(nextLine)` reaching forward one line; `isLoneDateRange` on the trailing segment in `columnGapCuts`), not from a structured field. §7's acceptance test is therefore restated as a standing bar, not a property the D+E cutover established.

### Baselines deleted, not re-noted

Both defects are fixed, so their exemptions go rather than acquiring a new citation: #662's `corpus-edit-roundtrip` entry (collateral of the zero-entry parse) and #663's `corpus-roundtrip` entry. `date-heading-bulleted-roles.truth.json` loses its three `knownWrong` entries for the same reason.

### Independently: a failed PDF download was silent

`useDownloadPdf` has always returned an `error`, and no surface rendered it — so a pdf-lib or font-load failure left the user with a button that did nothing. `ReconstructedResume` now shows it through the shared `ErrorState`. Originally scope-adjacent; #664's refusal is what makes it reachable and reviewable.

## #664 — the export refuses instead of mangling a name

The batch originally carried a #664 slice, and it was **removed** before the first push: it decided a product question the issue had explicitly reserved, and it collided with #667. Both are now resolved — #667 merged, and #664's product decision is recorded on the issue — so #664 lands here, rewritten from scratch rather than restored.

**The decision: refuse.** When the Poppins fetch fails, the fallback's WinAnsi codec replaces anything outside it with `?`, so `ANNA WIŚNIEWSKA` round-tripped as `ANNA WI?NIEWSKA`. `useDownloadPdf` now asks `findExportGlyphLosses()` whether the fallback would actually cost a character; if so it names the affected fields and stops before rendering. Transliterating (`WISNIEWSKA`) was rejected — it produces a wrong name with no signal — and so was `?`, which ships a document the user would call broken. **The trigger is the network, not the user's data.** Accepted cost: someone genuinely offline with a non-WinAnsi character cannot export until they reconnect.

**Why it lands in this PR and not its own.** #670 already added the `downloadError` → `ErrorState` surface, and nothing in #670 could trigger it — the error is near-unreachable on `main`, so the affordance shipped unexercised and unreviewable. This refusal is its first real consumer. The earlier "keep them apart" argument rested on the two changes touching disjoint files, which shows they *can* be split, not that they should be — and it structurally hides the case where one PR adds a seam the other consumes.

**Why the renderer is untouched.** An earlier design (written into #664, since corrected there) gave `renderAtsResumePdf` a policy parameter so the browser could refuse while the corpus harness degraded. It has **~35 call sites, all typed `Promise<Uint8Array>`** — every round-trip, export-layout and repro test, plus the corpus oracle, which must render the degraded output in order to measure it. A separate probe leaves all of them untouched: the oracle keeps working by construction rather than by opt-out, and **no test call site changes.** The probe also gates on actual loss rather than on the font failing, so a pure-ASCII résumé — most of them — downloads exactly as before even when the fetch fails.

### Two load-path defects, without which the refusal is not actionable

- **`loadPoppinsBytes()` memoized its own rejection and never cleared it.** The guard is `!poppinsBytesPromise`, so one transient failure degraded every later download for the life of the page, even after the network recovered — silently making "try again" impossible to satisfy, since the retry replayed the stored rejection without issuing a request.
- **The fetch never checked response status.** `fetch` rejects only on a network failure, so a 404 *resolved* and the error page's bytes went to `embedFont`; the fallback was reached only because fontkit choked on them, reporting a font-parse failure instead of a 404.

`stubFetchSucceeds` gained `ok: true`. It had returned only `{ arrayBuffer }`, which reads as falsy — without that, every case in `render-ats-pdf.fonts.test.ts` would have taken the Helvetica path while claiming to test the embedded one.

### Baseline

#664's `extended-latin-name-roundtrip` → `contact` entry moves from `open` to **`accepted`**, with the decision written into the note: the corpus deliberately keeps exercising the *un-refused* path so the round-trip oracle survives. Measured: **0 of 57** corpus `expected.json` snapshots contain a character outside WinAnsi — this was one fixture, never a defect class. `check:baselines` warns that #664 is still open; the `Closes #664` below resolves that on merge.

## Review focus

- `src/lib/lexicon/action-verbs.ts` — is a new top-level `lexicon/` leaf the right home, or should this live under `heuristics/`? It is shared by the parser, the scorer, and the eval rubric, so it belongs to none of them; the leaf exists so the parser doesn't import `score.ts`.
- `looksLikeRoleHeaderTitle` — the `Managed Services Engineer` false negative is the accepted cost. Is the safe direction the right call, or is a first-token carve-out (verb followed by a role noun **and** a comma-split company) worth the extra surface?
- `docs/canonical-resume-model.md` §7 — the retraction is prose about prose. Does it earn its length, or should it be one sentence plus the corrected citations?
- `findExportGlyphLosses` covers the **fallback** path only. On the embedded path `toEmbeddedFontSafe` can still emit `?` for a code point Poppins lacks (`★`, `✓`) — decorative symbols rather than identity fields, and deliberately out of #664's scope. Is that the right line?
- The probe re-reads the model's strings rather than observing what `drawText` actually sanitized, so it is mildly conservative: headings are uppercased before sanitizing and the probe reads un-cased text. It errs toward asking the user. Acceptable?

## Test plan

- [x] `npm run verify` green end to end — typecheck, eslint, `check:fixtures`, `check:baselines`, coverage, build
- [x] `npm run test` — **3807 passed, 10 skipped, 0 failed** (+20 from the base: 13 new here, 7 arriving with #667)
- [x] `✓ fixture PII: 57 PDFs and 15 ground-truth sidecars — all personas synthetic`
- [x] `✓ issue-linked baselines: 6 citations across 2 gate baselines and 15 truth files`
- [x] **Revert-proofed the verb gate on its own.** Reverting only `!startsWithActionVerb(text)` fails the three new cases (`Hired` / `Managed` / `Mentored`) while `Owned Developer Platform` **still passes** — confirming the old case was passing for the wrong reason — and both genuine-promotion cases stay green, confirming the gate does not over-reject.
- [x] Verified every symbol the rewritten doc cites actually resolves (`ATS_SCORE_ALGO_VERSION` = `1.7`, `CANONICAL_SHAPE_VERSION` = `2`, `isDatedEntry`, `projectAtsExport`, `projectDisplay`, `projectLlmDiff`, `projectScoreSections`)
- [x] **Both #664 load-path fixes revert-proofed.** Removing the cache reset fails `re-fetches after a failure…` and nothing else. The status check needed a better assertion first: asserting "we fell back" passed with the check removed, because fontkit chokes on the error page anyway — so it now asserts the response **body is never read**, which is the only observable difference.
- [x] **Verified in a real browser** (the refusal is unreachable from Vitest). With the Poppins requests aborted, `Download resume` refuses and names `Name`; with them allowed through and **no reload** — same module instance, poisoned memo — the same page exports `anna-wisniewska-resume-ats.pdf`, and `pdftotext` shows `ANNA WIŚNIEWSKA` intact.
- [x] fallow reports 10 complexity findings / 7 clone groups, **all inherited** (report-only inside `verify`). Both clone groups sit above line 282 of `render-ats-pdf.fonts.test.ts`; this diff's additions to that file start at 282, so they are re-attributed, not introduced.

Closes #661
Closes #662
Closes #663
Closes #664

## Provenance
Code implementation: Codex (GPT-5.x, 2 review rounds; stopped before PR on its own blocking findings)
Blocker fixes, #664 re-scope + implementation, commit + PR: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — green locally; also runs in CI

