### PR TITLE
chore(tooling): point the Codex CLI at the repo's own skills

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary

One file, one line: `.codex/skills` → a relative symlink to `.claude/skills`.

Running the Codex CLI in this repo previously picked up **none** of the repo's skills — it looks for `.codex/skills`, found nothing, and all seventeen checked-in skills were invisible to it: `open-pr`, `revise-pr`, `pr-review`, `pr-ready`, `triage-issue`, `batch-issues`, `implement-batch`, and the ten `probe-*` parser harnesses. That is how a batch run reinvents the PR path instead of following the one the repo documents.

**Why a symlink, and why relative:** the alternative is two divergent copies of the same seventeen files, where a rename in one silently doesn't reach the other. The target is tracked, so the link resolves for anyone who clones.

## Two limits, stated up front

- **`oss-translate` won't resolve for everyone.** `/.claude/skills/oss-translate` is gitignored (it belongs to the internal repo), so `.codex/skills/oss-translate` works only on a workstation that has it. Every *tracked* skill is unaffected.
- **Windows.** Git stores this as mode `120000`. Without `core.symlinks=true` or Developer Mode, the checkout materializes a one-line text file containing `../.claude/skills` instead of a link. Harmless — nothing in the build or CI reads this path — but a Windows contributor gets a stray file rather than working skills.

## Review focus

- Is `.codex/` the right convention, or should this be gitignored as per-workstation tooling? Tracking it makes the skills work on a fresh clone with no setup step; ignoring it keeps the repo agnostic about which CLI a contributor uses. I went with tracked because the skills themselves are already tracked — this only changes *who can see them*.
- No doc note accompanies it. There is no existing "agent tooling" section in `CONTRIBUTING.md` or `docs/CONTRIBUTING-PROCESS.md`, and the commit message is the durable record. Say the word if you'd rather have a line in one of them, so a future cleanup doesn't delete an unexplained symlink.

## Test plan

- [x] `git ls-files -s .codex` → `120000 … .codex/skills`, blob content `../.claude/skills` — a real symlink, not a copied tree
- [x] Target confirmed tracked: 17 skill files under `.claude/skills/`
- [x] No source, build, or test input touched — nothing for `verify` to exercise beyond confirming it stays green

## Provenance
Change authored by: Claude Opus 5 (1M context) (high)
