### PR TITLE
test(job-search): pin the skills half of the advisory adjacency claim (#595)

### DIFF
--- a/src/components/features/JobQueryEditor.test.tsx
+++ b/src/components/features/JobQueryEditor.test.tsx
@@ -303,6 +303,30 @@ describe("JobQueryEditor — dropped terms and in-column suggestions (issue 597)
     expect(rolePanel?.textContent).toContain("Add to your titles");
     expect(skillsPanel?.textContent).not.toContain("Add to your titles");
   });
+
+  it("renders the skill suggestions inside the Skills step, and no pill in Review (#595)", () => {
+    // The other half of the adjacency claim, and the one #595 was filed about:
+    // every pill has to be visible with the field it writes into. Asserted per
+    // panel, because the failure mode is a pill drifting back into the trailing
+    // Review block — which is page-wide text a whole-page search would still find.
+    const query: JobQuery = { titles: ["Engineering Manager"], skills: [] };
+    const missing = assessQueryTerms(query).missing.filter((t) => t.kind === "skill");
+    expect(missing.length).toBeGreaterThan(0);
+
+    const el = render(query, () => query);
+    const skillsPanel = el.querySelector("#test-steppanel-skills");
+    const rolePanel = el.querySelector("#test-steppanel-role");
+    const reviewPanel = el.querySelector("#test-steppanel-review");
+    // Asserted, not assumed: a renamed panel id would turn every `not.toContain`
+    // below into a check against `undefined`.
+    expect(reviewPanel).not.toBeNull();
+    expect(skillsPanel?.textContent).toContain("Add to your skills");
+    expect(rolePanel?.textContent).not.toContain("Add to your skills");
+    // Review carries whole-query findings only — the coherence note and the
+    // dropped terms — so neither suggestion heading may appear there.
+    expect(reviewPanel?.textContent).not.toContain("Add to your skills");
+    expect(reviewPanel?.textContent).not.toContain("Add to your titles");
+  });
 });
 
 /**

--- a/src/components/features/TermQualityAdvisory.tsx
+++ b/src/components/features/TermQualityAdvisory.tsx
@@ -15,10 +15,12 @@
  * GROUPED BY KIND (see {@link GROUPS}), because the two kinds write to two
  * different fields of the query and a flat row said nothing about which.
  *
- * TWO PLACEMENTS, one component (#597). Passing `kind` puts ONE group inline
- * under its own chip column — the suggestion pills belong beside the list they
- * write into, not in a trailing section at the foot of the page the user has to
- * connect back up. Omitting `kind` keeps the original full-width block, which is
+ * TWO PLACEMENTS, one component (#597) — and the split is what closed #595, which
+ * reported the full-width block rendering two sections away from the fields its
+ * pills write into. Adjacency is therefore a requirement here, not a preference:
+ * passing `kind` puts ONE group inline under its own chip column, because the
+ * suggestion pills belong beside the list they write into, not in a trailing
+ * section at the foot of the page the user has to connect back up. Omitting `kind` keeps the original full-width block, which is
  * where the findings that are ABOUT the query as a whole live: the coherence
  * note and the dropped terms. The full-width mode is the only one that spans the
  * grid, so a column instance can never break its parent's layout.


### PR DESCRIPTION
Closes #595.

## What I found

The advisory is **already adjacent** on `main`. #595 described the pre-#602 layout — a full-width block below the Target level ladder — and #597/#602 (merged ~21h after #595 was filed, which is why the issue was never closed) implemented **option 2**, the split the issue ranked best:

- `TermQualityAdvisory kind="title"` renders inside the Titles `QueryStepSection`, directly under the chip list it writes into (`JobQueryEditor.tsx:198`).
- `TermQualityAdvisory kind="skill"` renders inside the Skills section, same shape (`JobQueryEditor.tsx:262`).
- The Review step keeps only the **whole-query** findings — the #587 coherence note and the #597 dropped terms — and is deliberately not passed `missing`, so it carries no pill at all (`JobQueryEditor.tsx:343`).

The grouped headings survived the move rather than becoming redundant, because a pill's destination is still worth naming in words at the moment of the click.

## What this PR adds

Only what was missing: the **regression test for the skills half**. Adjacency was pinned per-panel for titles (`"renders the title suggestions inside the Role step"`) and not for skills, so a pill drifting back into the trailing Review block would have been caught on one side only. The new case asserts, scoped to each mounted `StepPanel`:

- the skill suggestions are inside the Skills panel and not in Role,
- neither suggestion heading appears in Review,
- and that the Review panel element actually exists — without that, the `not.toContain` assertions would be checks against `undefined`.

Plus one docblock line in `TermQualityAdvisory.tsx` tying the split placement to the issue it closed, so the next person reading "TWO PLACEMENTS" knows adjacency is a requirement and not a style preference.

## Verification, stated honestly

Panel-scoped DOM assertions over a fully mounted stepper (inactive panels stay mounted, only `hidden`), not a browser screenshot at a laptop viewport. The acceptance criterion's "visible together without scrolling" is satisfied structurally — the pills are inside the same section as their field, which is stronger than a single viewport measurement — but I did not re-measure it in a browser. The folded-summary state is unaffected: the pills live inside the form, so they fold with it, and `JobQuerySummary` is untouched.

## Gates

`npm run typecheck`, `npx eslint src`, `npx vitest run`, `npm run build` — all green locally.

## Provenance

Implemented by Claude Code (Opus 5) with maintainer review.
