### PR TITLE
fix(ui): lead with the drop zone before a parse and the score after it

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,11 +108,23 @@ export default function App() {
     state.phase === "authoring" && state.pendingDraft !== null;
 
   return (
-    <PageShell
-      subtitle="A parser audit for your resume — not a judge"
-      badge="alpha"
-      chips={<CapabilityStrip />}
-    >
+    // `chips` is deliberately NOT passed: PageShell renders that slot in the
+    // header on every phase, so the capability strip stayed pinned above the
+    // result for the whole session — three lanes the user had already chosen
+    // between, restated over their score. It now renders once, below the drop
+    // zone, on the pre-drop screen only (see the idle section below).
+    // No `subtitle` either. It read "A parser audit for your resume — not a
+    // judge", which failed three ways at once: "parser audit" is the internal
+    // vocabulary this PR is removing from the tab labels, "not a judge"
+    // defends against an objection the visitor has not formed yet, and on the
+    // idle screen it was a second tagline sitting two inches above the
+    // headline. The one idea worth keeping — the score rates the file, not the
+    // person — now lives as a plain sentence in the block below the drop zone,
+    // next to the score it qualifies. Dropping it also leaves the star CTA
+    // alone on the header-right instead of sharing it. `/jd-fit` and `/jobs`
+    // still pass one: they open straight into a form with no headline of their
+    // own, so there the header line is the only orientation.
+    <PageShell badge="alpha">
       {(state.phase === "idle" ||
         state.phase === "parsing" ||
         state.phase === "error") && (
@@ -126,9 +138,9 @@ export default function App() {
             // One consolidated hero message (internal #265): a single,
             // non-hyperbolic headline — no "they don't read your PDF" claim and
             // no "parser" jargon — that says what OfflineCV does in one angle.
-            // The trust stat is the one supporting line; everything else (the
-            // recruiter-agent context) moves to the quiet block below the drop
-            // zone so the hero isn't three competing messages.
+            // The supporting context (recruiter-agent framing AND the trust
+            // stat that sources it) lives in the quiet block below the drop
+            // zone, so the hero is one message, not three.
             //
             // The headline claims custody, NOT runtime — the distinction is
             // load-bearing and must survive edits. "in your browser" scopes the
@@ -141,8 +153,8 @@ export default function App() {
             //
             // "Browser" is also the noun the sibling surfaces use, and the
             // three are read together on the idle screen: CapabilityStrip's
-            // rail ("Your resume stays in your browser") renders as PageShell's
-            // `chips` a few inches below, and PageShell's footer states its own
+            // rail ("Your resume stays in your browser") renders just below the
+            // drop zone, and PageShell's footer states its own
             // narrower, hedged claim about a different object ("your PDF stays
             // in this browser tab by default"). Same noun, three different
             // sentences — if you change the noun in one, change it in all.
@@ -156,45 +168,77 @@ export default function App() {
             // rescoped in the same PR that ships it. Keep the headline about
             // place and the subhead about the resume; do not merge them into a
             // blanket "everything stays on your device."
-            <Card className="flex flex-col items-center gap-5 bg-surface-card-warm">
-              <div className="flex max-w-2xl flex-col gap-4 text-center">
-                <h2 className="text-balance text-2xl font-semibold leading-snug tracking-tight text-content-primary sm:text-3xl">
-                  Your whole job search — in your browser.
-                </h2>
-                <p className="text-pretty text-base font-medium text-content-secondary sm:text-lg">
-                  OfflineCV is a free, open-source job-search workbench. Drop a
-                  PDF, score it, fix it, match a JD, and find jobs — all without
-                  your resume leaving your browser.
-                </p>
-                <p className="text-sm text-content-muted">
-                  Built in response to a hiring process job seekers say they
-                  can&apos;t see into — source:{" "}
-                  <a
-                    href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
-                    target="_blank"
-                    rel="nofollow noopener noreferrer"
-                    className="hover:underline"
-                  >
-                    Greenhouse, 2025 AI in Hiring Report (4,100+ job seekers and hiring managers)
-                  </a>
-                </p>
-              </div>
-            </Card>
+            // NOT a Card. `bg-surface-card-warm` made this the only tinted
+            // surface on the pre-drop screen, so the block a visitor cannot act
+            // on out-ranked the one they must (user testing, Jul 2026: "it's
+            // kind of hard to find what am I supposed to do here"). Orientation
+            // still comes first — a visitor needs to know what this is before a
+            // drop zone means anything — but as plain text, in two lines, with
+            // the accent reserved for the drop zone directly below.
+            //
+            // The lane list ("score it, fix it, match a JD, and find jobs") is
+            // gone from the subhead because `CapabilityStrip`, a few inches
+            // below, enumerates exactly those lanes with descriptions. The
+            // Greenhouse citation moved down to the recruiter-agent block,
+            // which is the claim it actually sources.
+            <div className="mx-auto flex max-w-2xl flex-col gap-2 text-center">
+              <h2 className="text-balance text-2xl font-semibold leading-snug tracking-tight text-content-primary sm:text-3xl">
+                Your whole job search — in your browser.
+              </h2>
+              <p className="text-pretty text-base text-content-secondary sm:text-lg">
+                A free, open-source job-search workbench — and your resume never
+                leaves your browser.
+              </p>
+            </div>
           )}
 
-          <DropZone
-            onFile={handleFile}
-            disabled={state.phase === "parsing"}
-            status={
-              state.phase === "parsing"
-                ? `Parsing ${state.fileName} (${formatBytes(state.fileSize)})…`
-                : undefined
-            }
-          />
+          {/* Drop zone + its own alternative, in one tight group. The section's
+              `gap-6` is the separation between *topics*; "no resume yet?" is not
+              a topic of its own, it is the other way to answer the question the
+              drop zone asks, so it sits a `gap-3` away from it rather than
+              below the capability strip, the library and the job tracker (user
+              testing, Jul 2026: "it is now separated"). Proximity is the whole
+              point — a fallback a visitor has to scroll past three unrelated
+              blocks to find is a fallback they never see. */}
+          <div className="flex flex-col gap-3">
+            <DropZone
+              onFile={handleFile}
+              disabled={state.phase === "parsing"}
+              status={
+                state.phase === "parsing"
+                  ? `Parsing ${state.fileName} (${formatBytes(state.fileSize)})…`
+                  : undefined
+              }
+            />
+
+            {(state.phase === "idle" || state.phase === "error") && (
+              // "Start from scratch" entry point (#313) — a clearly-secondary
+              // CTA for a user with no resume yet (or who wants a clean start).
+              // Reuses the existing editor/exporter surface (ReconstructedResume
+              // + useEditableParse + useDownloadPdf) via the "authoring" phase
+              // below; no new dropzone/editor/exporter is introduced.
+              <div className="flex justify-center">
+                <Button variant="ghost" onClick={startBlank}>
+                  No resume yet? Build one from scratch →
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {(state.phase === "idle" || state.phase === "error") && (
+            // Capability strip, moved out of PageShell's `chips` header slot.
+            // Below the drop zone, not above it: it answers "what else does
+            // this do?", which is a question a visitor asks *after* the primary
+            // action is legible, not before. Pre-drop only — post-parse the
+            // user has already picked a lane and the tab strip owns navigation.
+            <CapabilityStrip />
+          )}
 
           {(state.phase === "idle" || state.phase === "error") && (
             // Saved-resumes picker (#322) — self-hides when the library is
-            // empty. Sits directly beneath the drop zone; loading one restores
+            // empty, which is why it is not in the drop-zone group above: an
+            // invisible block there would leave a phantom gap between the drop
+            // zone and its "no resume yet?" fallback. Loading an entry restores
             // the results view from its cached parse (no re-upload).
             <ResumeLibrary library={library} onLoad={onLoadSavedResume} />
           )}
@@ -211,44 +255,79 @@ export default function App() {
           )}
 
           {(state.phase === "idle" || state.phase === "error") && (
-            // "Start from scratch" entry point (#313) — a clearly-secondary
-            // CTA for a user with no resume yet (or who wants a clean start).
-            // Reuses the existing editor/exporter surface (ReconstructedResume
-            // + useEditableParse + useDownloadPdf) via the "authoring" phase
-            // below; no new dropzone/editor/exporter is introduced.
-            <div className="flex justify-center">
-              <Button variant="ghost" onClick={startBlank}>
-                No resume yet? Build one from scratch →
-              </Button>
-            </div>
-          )}
-
-          {(state.phase === "idle" || state.phase === "error") && (
-            // "Screened by an agent" framing (internal #21): the recruiter-side
-            // proof point that the mirror positioning stands on. Quiet block
-            // below the drop zone — context, never competing with the primary
-            // action. Claims stay scoped per the fact-check rulings: privacy is
-            // file-scoped, determinism is score-scoped. Per the public-copy
-            // policy (internal #24) we never name other products here — the
-            // trend is described generically, no links to specific tools.
+            // What this is, plainly — plus the three claims displaced from the
+            // old trust-chip row (#517: speed, no-signup, determinism) and the
+            // citation. Quiet block below the drop zone: context, never
+            // competing with the primary action.
             //
-            // #517: this block also now carries the three claims displaced
-            // from the old trust-chip row (speed, no-signup, determinism) —
-            // real differentiators that moved here rather than vanishing when
-            // the chip row became the capability strip above.
+            // Rewritten Jul 2026 (user testing: "too long and not clear of its
+            // value"). The old copy opened on the *trend* — "recruiters are
+            // starting to run AI agents over resumes" — so the first thing a
+            // visitor read was someone else's behaviour, and what they
+            // personally get arrived in clause four, as a metaphor ("the
+            // candidate-side mirror"). It now opens on the three things the
+            // product does, in the order a user does them: parse, edit,
+            // download. 85 words → 27.
+            //
+            // The recruiter-trend sentence was cut outright, not demoted, on a
+            // second pass: an unhedged "recruiters increasingly screen with AI"
+            // is a claim about an industry we would have to defend, and the
+            // Greenhouse report below measures AI *trust* among hiring
+            // managers, not screening prevalence — it never sourced that
+            // sentence as tightly as the old comment here asserted. The
+            // citation now stands on its own weaker, supportable claim
+            // ("a hiring process job seekers say they can't see into").
+            //
+            // ⚠️ Cut with it: "the score rates how readable your file is, not
+            // how good you are." That framing is now nowhere in the app — the
+            // header subtitle that used to carry it ("not a judge") is deleted
+            // in this PR too, and `AtsScoreReadout` never stated it. If it
+            // comes back, it belongs next to the score, not on the landing.
+            //
+            // Both export formats are real, so the remaining claim round-trips:
+            // PDF via `useDownloadPdf.ts` → `render-ats-pdf.ts`, Markdown via
+            // `useDownloadMarkdown.ts` (#552). If either is removed, this
+            // sentence moves in the same PR. "A machine", never "the ATS" — we
+            // run one generic text extractor (pdfjs), so a definite article
+            // would claim a fidelity we have not measured. Determinism stays
+            // scoped to the score, not to the parse.
             <div className="rounded-lg border border-border-light bg-surface-subtle px-4 py-3">
-              <p className="mx-auto max-w-3xl text-pretty text-sm text-content-secondary">
-                <span className="font-medium text-content-primary">
-                  Recruiters are starting to run AI agents over resumes.
-                </span>{" "}
-                Several products score candidates for recruiters. OfflineCV is
-                the candidate-side
-                mirror: it shows you what survives the parse — before you hit
-                submit. The score isn&apos;t a verdict on you as a candidate —
-                it measures how well a machine can read your resume. It takes
-                a few seconds, needs no account or email, and the same PDF
-                always gets the same score.
-              </p>
+              {/* One shared `mx-auto max-w-3xl` wrapper, not three. Applied
+                  per-paragraph, `mx-auto` centres each block independently, so
+                  a paragraph long enough to wrap reads as left-aligned while a
+                  short one visibly centres itself — the three lines rendered
+                  with three different left edges. Centring the group once
+                  gives them one. */}
+              <div className="mx-auto flex max-w-3xl flex-col gap-2">
+                <p className="text-pretty text-sm font-medium text-content-primary">
+                  OfflineCV parses your resume, shows you what a machine read
+                  back, and lets you edit it and download a cleanly formatted
+                  PDF or Markdown file.
+                </p>
+                {/* The three claims displaced from the trust-chip row (#517).
+                    Muted and on their own line: they are reassurance a visitor
+                    scans for, not part of the argument above. */}
+                <p className="text-sm text-content-secondary">
+                  No account, no email, results in seconds — and the same file
+                  always gets the same score.
+                </p>
+                {/* The trust stat, relocated from the hero. It sources the
+                    "recruiters increasingly screen with AI" claim above it,
+                    which is what it was always evidence for — in the hero it
+                    was a third competing message ahead of the primary action. */}
+                <p className="text-sm text-content-muted">
+                  Built in response to a hiring process job seekers say they
+                  can&apos;t see into — source:{" "}
+                  <a
+                    href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
+                    target="_blank"
+                    rel="nofollow noopener noreferrer"
+                    className="hover:underline"
+                  >
+                    Greenhouse, 2025 AI in Hiring Report (4,100+ job seekers and hiring managers)
+                  </a>
+                </p>
+              </div>
             </div>
           )}
         </section>

--- a/src/components/DropZone.test.tsx
+++ b/src/components/DropZone.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Visual-hierarchy guard for the drop zone.
+ *
+ * In user testing (Jul 2026) first-time visitors could not find the primary
+ * action on the pre-drop screen — "everything is the same color, it's kind of
+ * hard to find what am I supposed to do here". The cause was measurable, not
+ * subjective: the drop zone rendered on the default neutral surface with a
+ * `border-border` dashed edge and a `text-sm` prompt, while the hero directly
+ * above it owned the page's only tinted surface (`bg-surface-card-warm`) and a
+ * `text-3xl` headline. The block you cannot act on out-ranked the one you must.
+ *
+ * These assertions pin the inversion, because it is exactly the kind of change
+ * a later "tone this down" edit reverts silently — nothing else in the suite
+ * would go red. They deliberately assert the RELATIVE treatment (accent surface
+ * present, prompt above body size), not specific token values, so a palette
+ * change is still free.
+ *
+ * `renderToStaticMarkup` is enough here — no DOM, no interaction. Drag/drop and
+ * file-accept behaviour are covered by `lib/file-accept.test.ts` and
+ * `useReplaceResumeOnDrop.test.tsx`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DropZone } from "./DropZone.tsx";
+
+const html = () => renderToStaticMarkup(<DropZone onFile={() => {}} />);
+
+describe("DropZone visual hierarchy", () => {
+  it("renders on an accent surface, not the neutral page background", () => {
+    const markup = html();
+    expect(markup).toContain("bg-accent-forward-bg");
+    expect(markup).toContain("border-accent-primary");
+    // The pre-fix neutral edge is what made it recede — it must not come back.
+    expect(markup).not.toContain("border-border ");
+  });
+
+  it("gives the prompt a size step above body copy", () => {
+    const markup = html();
+    // The prompt outranks the supporting lines, which stay at text-sm.
+    expect(markup).toContain("text-lg font-semibold");
+    expect(markup).toContain("Drop your resume here");
+  });
+
+  it("keeps the file-custody line attached to the action", () => {
+    // The privacy claim qualifies THIS control; it is not decoration that can
+    // be relocated to a footer without losing its referent.
+    expect(html()).toContain("Your file stays in this browser tab.");
+  });
+
+  it("still states the accepted formats and the click affordance", () => {
+    const markup = html();
+    expect(markup).toContain("PDF or DOCX");
+    expect(markup).toContain("click to pick a file");
+  });
+
+  it("marks drag state with a border style change, not colour alone", () => {
+    // At rest the border is already accent-coloured, so a colour-only drag
+    // state would be invisible in greyscale. Dashed → solid carries it.
+    expect(html()).toContain("border-dashed");
+  });
+});

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -55,11 +55,20 @@ export function DropZone({ onFile, disabled, status }: DropZoneProps) {
       }}
       className={[
         "flex cursor-pointer flex-col items-center justify-center gap-2",
-        "rounded-xl border-2 border-dashed px-6 py-12 text-center",
+        "rounded-xl border-2 px-6 py-14 text-center",
         "transition-colors",
+        // Accented at rest, not neutral (user testing, Jul 2026): the pre-drop
+        // screen previously rendered every block on the same neutral surface,
+        // so the one thing a first-time visitor must do did not read as the
+        // primary action. This is now the only accent-bordered, accent-filled
+        // surface above the fold — the hero above it is plain text.
+        //
+        // Drag feedback is dashed → solid, not colour alone: the border colour
+        // is already accent at rest, so a colour-only drag state would be
+        // invisible in a greyscale render (and to a red/green-blind user).
         dragOver
-          ? "border-content-primary bg-surface-hover"
-          : "border-border hover:border-border-strong",
+          ? "border-solid border-accent-primary bg-surface-hover"
+          : "border-dashed border-accent-primary bg-accent-forward-bg hover:border-accent-primary-hover",
         disabled && "cursor-not-allowed opacity-60",
       ]
         .filter(Boolean)
@@ -74,8 +83,23 @@ export function DropZone({ onFile, disabled, status }: DropZoneProps) {
         disabled={disabled}
         onChange={(e) => acceptFile(e.target.files?.[0] ?? null)}
       />
-      <p className="text-sm font-medium">
-        Drop a resume PDF or DOCX here, or click to pick one
+      {/* Size/weight step is deliberate: this prompt has to out-rank the hero
+          headline above it, and at `text-sm font-medium` it out-ranked nothing.
+          The privacy line stays attached to the action it qualifies.
+
+          On the repo's type scale, not beside it: `sm:text-xl` (20px) was the
+          only `text-xl` in all of src/ — every other heading in the app steps
+          14 → 16 → 18 → 24 → 30, so a lone 20px was an arbitrary size in the
+          sense the Font Size Scale rule means. `sm:text-2xl` lands on the step
+          the app already uses, and 24px is also what a 56px-padded box needs to
+          stop reading as an empty panel with a caption. The hero headline is
+          still one step above at `sm:text-3xl`; the drop zone leads on colour
+          and fill, which is the contrast that survives a greyscale render. */}
+      <p className="text-lg font-semibold text-content-primary sm:text-2xl">
+        Drop your resume here
+      </p>
+      <p className="text-sm text-content-secondary">
+        PDF or DOCX &middot; or click to pick a file
       </p>
       <p className="text-sm text-content-muted">
         Your file stays in this browser tab.

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -12,7 +12,6 @@ import { AtsScoreReadout } from "./features/AtsScoreReadout.tsx";
 import { isScoreRevealed } from "../lib/contact.ts";
 import { useResumeAnalysisLlm } from "../hooks/useResumeAnalysisLlm.ts";
 import { useLlmEscapeHatch } from "../hooks/useLlmEscapeHatch.ts";
-import { LlmEscapeHatchBanner } from "./features/LlmEscapeHatchBanner.tsx";
 import type { LlmParsedResume } from "../lib/webllm/parse-resume.ts";
 import { mergeLlmParse } from "../lib/webllm/merge-override.ts";
 import { ParsedHeader } from "./features/ParsedHeader.tsx";
@@ -92,7 +91,7 @@ function ParsedCard({
   const triggerCount = result.triggers.length;
 
   // Opt-in combined WebLLM analysis (#262, #273). One controller feeds the
-  // single "Resume Quality" tab (the LLM critique plus "What an ATS misses" as
+  // single on-device-AI tab (the LLM critique plus "What an ATS misses" as
   // a bottom section) from one inference. Lifted here so the tab is only
   // advertised on WebGPU-capable browsers with extractable text; on everything
   // else the tab (and panel) is silently absent. The panel's single CTA triggers
@@ -103,6 +102,17 @@ function ParsedCard({
   // `result.suggestedEscalation === "llm"` AND WebGPU is available AND there is
   // text. When the user opts in and the pass completes, `llmOverride` is set and
   // the entire result surface re-renders from the LLM-parsed fields.
+  //
+  // The controller is created here (it must outlive a tab switch and it feeds
+  // `llmOverride`, which re-grades the score card below) but its BANNER now
+  // renders inside `ResultDetailTabs`' on-device-AI tab, not above this card.
+  // It used to be the first thing on the post-drop screen — a full-width
+  // primary-button banner sitting above the user's own score, so the page
+  // opened on our suggestion instead of their result (user testing, Jul 2026:
+  // "we should not have 'Try a local AI pass' so prominently at the top").
+  // The tab strip already reserves permanent space for the on-device-AI
+  // surface, so the offer moves into space the layout was paying for anyway
+  // and the tab's own label carries the signal. See ResultDetailTabs.
   const escapeHatch = useLlmEscapeHatch(result);
   // `llmOverride` is NOT keyed/reset on `result` change. Safe today because a new
   // file passes through the `parsing` phase, which unmounts `Result` and discards
@@ -163,15 +173,6 @@ function ParsedCard({
     // card below. The gap + each card's own border draws the separator the
     // single-card layout lacked (the tab strip reads as its own section).
     <div className="flex flex-col gap-4">
-      {/* Escape hatch banner — shown above the score card when the cascade
-          flagged a degenerate result and WebGPU is available (#243). */}
-      {escapeHatch.isAvailable && (
-        <LlmEscapeHatchBanner
-          controller={escapeHatch}
-          onRecovered={handleRecovered}
-        />
-      )}
-
       <Card className="flex flex-col gap-6 shadow-xs">
         <ParsedHeader
           isLlmRecovered={isLlmRecovered}
@@ -198,7 +199,7 @@ function ParsedCard({
           </p>
         )}
         {/* Star-rating feedback (#51). The "Report a parsing gap" affordance
-            lives in the "What an ATS misses" bottom section of the Resume Quality
+            lives in the "What an ATS misses" bottom section of the "AI feedback"
             tab (#273), next to the disagreements it characterizes. */}
         <FeedbackPanel />
       </Card>
@@ -212,6 +213,8 @@ function ParsedCard({
         edit={edit}
         jdContext={jdContext}
         analysis={analysis}
+        escapeHatch={escapeHatch}
+        onRecovered={handleRecovered}
         triggerCount={triggerCount}
       />
     </div>

--- a/src/components/features/CritiquePanel.tsx
+++ b/src/components/features/CritiquePanel.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * CritiquePanel — body-only "Resume quality" results (issue #244).
+ * CritiquePanel — body-only "AI feedback" results (issue #244).
  *
  * Exports `CritiqueResults`, a display-only component that renders the
  * on-device LLM content-quality critique body: summary feedback card (if
@@ -16,7 +16,7 @@
  * instead of the overclaiming "All bullets look strong" message (AC #6).
  *
  * Bullet finding rows include a "Rewrite this section →" nudge that
- * navigates to the "Reconstructed resume" tab, where the per-role wand
+ * navigates to the "Your resume" tab, where the per-role wand
  * button (useSectionRewrite) already lives.
  *
  * Design rules (CLAUDE.md):
@@ -51,7 +51,7 @@ function BulletFindingRow({
   onGoToRewrite,
 }: {
   finding: BulletFinding;
-  /** Switch to the "Reconstructed resume" tab where the rewrite affordance lives. */
+  /** Switch to the "Your resume" tab where the rewrite affordance lives. */
   onGoToRewrite?: () => void;
 }) {
   const { issue, bullet, suggestion } = finding;
@@ -81,7 +81,7 @@ function BulletFindingRow({
           size="sm"
           onClick={onGoToRewrite}
           className="self-start text-2xs font-medium text-accent-primary"
-          aria-label="Go to Reconstructed resume tab to rewrite this bullet"
+          aria-label="Go to the Your resume tab to rewrite this bullet"
         >
           Rewrite this section →
         </Button>

--- a/src/components/features/DisagreementPanel.tsx
+++ b/src/components/features/DisagreementPanel.tsx
@@ -11,7 +11,7 @@
  *
  * The shell (header, Analyze CTA, status lifecycle, empty-state copy) moved
  * into `ResumeQualityPanel`, which hosts both this component and
- * `CritiqueResults` under a single "Resume Quality" tab (#273).
+ * `CritiqueResults` under a single on-device-AI tab (#273).
  *
  * All helpers remain here: `DisagreementRow`, `HeuristicVsLlm`,
  * `headlineFor`, `sideValues`, `roleSides`, `pluralize`, and all the

--- a/src/components/features/LlmEscapeHatchPanel.test.tsx
+++ b/src/components/features/LlmEscapeHatchPanel.test.tsx
@@ -4,7 +4,7 @@
 // @vitest-environment jsdom
 
 /**
- * Render coverage for LlmEscapeHatchBanner (#243) — the degenerate-case recovery
+ * Render coverage for LlmEscapeHatchPanel (#243) — the degenerate-case recovery
  * CTA. Drives a fake controller through each status so every render branch plus
  * the `ctaLabel` lookup executes, and asserts the done state fires `onRecovered`.
  * Raw createRoot, matching the other feature render tests.
@@ -14,7 +14,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { createElement } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { LlmEscapeHatchBanner } from "./LlmEscapeHatchBanner.tsx";
+import { LlmEscapeHatchPanel } from "./LlmEscapeHatchPanel.tsx";
 import type { EscapeHatchController } from "../../hooks/useLlmEscapeHatch.ts";
 import type { LlmParsedResume } from "../../lib/webllm/parse-resume.ts";
 
@@ -48,7 +48,7 @@ function render(
   root = createRoot(container);
   act(() => {
     root.render(
-      createElement(LlmEscapeHatchBanner, { controller: controller(status), onRecovered }),
+      createElement(LlmEscapeHatchPanel, { controller: controller(status), onRecovered }),
     );
   });
   return container;
@@ -59,7 +59,7 @@ afterEach(() => {
   container.remove();
 });
 
-describe("LlmEscapeHatchBanner", () => {
+describe("LlmEscapeHatchPanel", () => {
   it("renders the idle CTA", () => {
     expect(render({ kind: "idle" }).textContent).toContain("Try a local AI pass");
   });
@@ -97,5 +97,19 @@ describe("LlmEscapeHatchBanner", () => {
     const onRecovered = vi.fn();
     render({ kind: "done", llmParsed }, onRecovered);
     expect(onRecovered).toHaveBeenCalledWith(llmParsed);
+  });
+
+  it("collapses to a confirmation row once the pass has completed", () => {
+    // `done` hands the tab back to ResumeQualityPanel, so the offer must stop
+    // occupying it — but the component stays MOUNTED (the effect above is what
+    // reports the recovered parse upward), so it has to shrink itself rather
+    // than be unmounted by the caller.
+    const text = render({ kind: "done", llmParsed }).textContent ?? "";
+    expect(text).toContain("Recovered with on-device AI");
+    expect(text).toContain("Re-run AI recovery");
+    // The offer's heading and explainer are gone — no second primary CTA
+    // sitting above the quality panel's own.
+    expect(text).not.toContain("Not everything parsed cleanly");
+    expect(text).not.toContain("One-time");
   });
 });

--- a/src/components/features/LlmEscapeHatchPanel.tsx
+++ b/src/components/features/LlmEscapeHatchPanel.tsx
@@ -2,16 +2,29 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * LlmEscapeHatchBanner — the degenerate-case recovery CTA (issue #243).
+ * LlmEscapeHatchPanel — the degenerate-case recovery offer (issue #243).
  *
- * Shown above the result tabs when the cascade returned a degenerate parse
- * (`suggestedEscalation === "llm"`) and WebGPU is available. Offers the user
- * an opt-in on-device LLM re-parse and renders the download progress while it
- * runs.
+ * Was `LlmEscapeHatchBanner`: a tinted, bordered banner rendered ABOVE the
+ * score card, so the first thing on the post-drop screen was our suggestion
+ * rather than the user's own result. It now renders as the body of the
+ * on-device-AI tab (`ResultDetailTabs`), and while the offer stands it is the
+ * ONLY thing in that tab — `ResumeQualityPanel` is withheld until the pass has
+ * run. Showing both put two model-loading CTAs on one screen, one of them
+ * still wrapped in banner chrome that belonged to the old placement (user
+ * testing, Jul 2026).
+ *
+ * So the shape here is deliberately `ResumeQualityPanel`'s, not a banner's:
+ * same `section` + heading + `max-w-prose` explainer + right-aligned primary
+ * Button. A user switching between the two states should see one surface
+ * change its offer, not two differently-dressed widgets.
  *
  * When the LLM pass completes, calls `onRecovered(llmParsed)` so the parent
  * (`ParsedCard` in `Result.tsx`) can substitute the LLM-parsed fields into the
  * result surface and show the "recovered with on-device AI" provenance badge.
+ * The panel stays mounted through `done` — that transition is what fires the
+ * callback, so a `status.kind !== "done"` mount gate in the parent would swap
+ * the panel out in the same render that produces the result and the callback
+ * would never fire. It collapses to a single confirmation row instead.
  *
  * Reuse analysis (CLAUDE.md 3-tier rule):
  *   - Primitive: `Button` (the opt-in CTA) — no raw `<button>`.
@@ -19,8 +32,8 @@
  *     and SectionRewrite) — no parallel progress component.
  *   - Semantic tokens only; no hardcoded hex or raw palette classes.
  *
- * Returns `null` when the controller flags the feature unavailable. Silent
- * absence — matches the rewrite and disagreement paths.
+ * Rendered only when the controller flags the feature available — the caller
+ * gates on `escapeHatch.isAvailable`, so there is no internal guard.
  */
 
 import { Button, ModelLoadProgress } from "@design-system";
@@ -41,20 +54,16 @@ function ctaLabel(status: EscapeHatchStatus): string {
   return CTA_LABELS[status.kind];
 }
 
-interface LlmEscapeHatchBannerProps {
+interface LlmEscapeHatchPanelProps {
   controller: EscapeHatchController;
   /** Called with the LLM-parsed result once the pass completes. */
   onRecovered: (llmParsed: LlmParsedResume) => void;
 }
 
-/**
- * The banner is only mounted when `controller.isAvailable` (the parent gates
- * on this), so no internal availability guard is needed.
- */
-export function LlmEscapeHatchBanner({
+export function LlmEscapeHatchPanel({
   controller,
   onRecovered,
-}: LlmEscapeHatchBannerProps) {
+}: LlmEscapeHatchPanelProps) {
   const { status } = controller;
 
   // Notify parent once per done-transition. The ref guard makes this one-shot:
@@ -73,14 +82,36 @@ export function LlmEscapeHatchBanner({
     }
   }, [status, onRecovered]);
 
+  // Post-recovery this collapses to one quiet row: the offer has been taken,
+  // the quality panel renders directly below it, and re-running is a rare
+  // repair action — a `link` Button, not a second primary CTA competing with
+  // the one in that panel.
+  if (status.kind === "done") {
+    return (
+      <div
+        role="status"
+        className="flex flex-wrap items-center justify-between gap-2"
+      >
+        <p className="text-sm text-feedback-success-text">
+          Recovered with on-device AI — your score and fields are updated.
+        </p>
+        <Button
+          variant="link"
+          size="sm"
+          onClick={() => void controller.run()}
+          disabled={controller.isBusy}
+          aria-label="Run the on-device AI recovery pass again"
+        >
+          {ctaLabel(status)}
+        </Button>
+      </div>
+    );
+  }
+
   return (
-    <div
-      role="region"
-      aria-label="AI recovery suggestion"
-      className="flex flex-col gap-2 rounded-lg border border-feedback-info-border bg-feedback-info-bg px-4 py-3"
-    >
+    <section aria-label="AI recovery suggestion" className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-3">
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col gap-1">
           {/*
             Headline copy must stay honest across every firing path in
             `chooseEscalation` (confidence.ts): hard failures (missing email,
@@ -93,13 +124,18 @@ export function LlmEscapeHatchBanner({
             neutrally: "not everything parsed cleanly" is true across all
             paths without misattributing content-quality issues to a parser
             failure.
+
+            Heading level and treatment match `ResumeQualityPanel`'s, since
+            the two alternate in the same tab body.
           */}
-          <p className="text-sm font-medium text-content-primary">
-            Not everything parsed cleanly.
-          </p>
-          <p className="text-sm text-content-tertiary">
-            Try a local AI pass? Runs entirely in your browser — nothing leaves
-            this tab. One-time ~1.2&nbsp;GB download, cached for next time.
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
+            Not everything parsed cleanly
+          </h2>
+          <p className="max-w-prose text-sm text-content-tertiary">
+            A small model running in this tab can re-read your file and rebuild
+            the fields the parser got wrong. Runs entirely in your browser —
+            nothing leaves this tab. One-time ~1.2&nbsp;GB download, cached for
+            next time.
           </p>
         </div>
         <Button
@@ -133,12 +169,6 @@ export function LlmEscapeHatchBanner({
           {status.message}
         </p>
       )}
-
-      {status.kind === "done" && (
-        <p className="text-sm text-feedback-success-text">
-          Recovered with on-device AI — result updated below.
-        </p>
-      )}
-    </div>
+    </section>
   );
 }

--- a/src/components/features/ModelSelector.tsx
+++ b/src/components/features/ModelSelector.tsx
@@ -8,7 +8,7 @@
  * picker per page; all rewrite paths consume the persisted selection via
  * `useModelSelection`. Returns `null` when WebGPU is unavailable so the
  * surface stays out of the way for browsers that can't load any model — the
- * "WebGPU unavailable" explainer lives on the "Resume Quality" tab instead
+ * "WebGPU unavailable" explainer lives on the on-device-AI tab instead
  * (#276), the canonical on-device-AI surface.
  *
  * Flow on a user pick (model X ≠ current):
@@ -265,7 +265,7 @@ export function ModelSelector() {
   }, []);
 
   // Picker only shows when WebGPU can actually run a model. When it can't, the
-  // shared explainer lives on the "Resume Quality" tab (the canonical on-device
+  // shared explainer lives on the on-device-AI tab (the canonical on-device
   // AI surface, #276) — not inline here — so the notice isn't buried under
   // Experience or repeated per role. Renders nothing until detection resolves.
   if (capability !== "available") return null;

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -21,8 +21,17 @@ import { useGitHubStars } from "../../hooks/useGitHubStars.ts";
 import { useUpdateChecker } from "../../hooks/useUpdateChecker.ts";
 
 export interface PageShellProps {
-  /** Subtitle shown beside the GitHub-star CTA on wide viewports. */
-  subtitle: string;
+  /**
+   * Optional subtitle shown beside the GitHub-star CTA on wide viewports.
+   *
+   * Optional because a surface that already states what it is in its own body
+   * should not restate it here. `/jd-fit` and `/jobs` open straight into a
+   * form, so the header line is their only orientation and they pass one; `/`
+   * opens with a headline two inches below the header and omits it, which also
+   * lets the star CTA sit alone on the header-right instead of sharing it with
+   * a competing tagline.
+   */
+  subtitle?: string;
   /** Small uppercase badge after the wordmark (e.g. "alpha", "JD Fit"). */
   badge: string;
   /** Optional block rendered under the header (e.g. the capability strip). */
@@ -73,9 +82,11 @@ export function PageShell({
           </div>
           <div className="flex items-center gap-4">
             {headerExtra}
-            <p className="hidden text-sm text-content-muted sm:block">
-              {subtitle}
-            </p>
+            {subtitle && (
+              <p className="hidden text-sm text-content-muted sm:block">
+                {subtitle}
+              </p>
+            )}
             <GitHubStarCta variant="inline" count={starCount} />
           </div>
         </div>

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -1262,8 +1262,13 @@ export function ReconstructedResume({
     >
       <div className="flex flex-col gap-2">
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+          {/* Deliberately NOT the tab label ("Your resume"). A heading that
+              repeats its own tab label is noise, and it makes every
+              `toContain("Your resume")` assertion ambiguous about which
+              element it matched. This states what the section IS; the tab
+              states where you are. */}
           <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-            Reconstructed resume
+            What the parser read
           </h2>
           <div className="flex flex-wrap items-center gap-2">
             <ReportDownloadControl result={result} score={score} />

--- a/src/components/features/ResultDetailTabs.test.tsx
+++ b/src/components/features/ResultDetailTabs.test.tsx
@@ -22,6 +22,7 @@ import { useEditableParse } from "../../hooks/useEditableParse.ts";
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../../lib/score/score.ts";
 import type { AnalysisController } from "../../hooks/useResumeAnalysisLlm.ts";
+import type { EscapeHatchController } from "../../hooks/useLlmEscapeHatch.ts";
 import type { WebGpuCapability } from "../../lib/webllm/types.ts";
 import type { ResumeCritique } from "../../lib/webllm/critique-resume.ts";
 
@@ -60,6 +61,22 @@ interface ControllerOpts {
   isAvailable: boolean;
   capability?: WebGpuCapability | null;
   hasText?: boolean;
+  /** Degenerate-parse recovery offer (#243) — folded into this tab. */
+  escapeHatch?: "offered" | "recovered";
+}
+
+function escapeHatchController(
+  opts: ControllerOpts,
+): EscapeHatchController {
+  return {
+    status:
+      opts.escapeHatch === "recovered"
+        ? { kind: "done", llmParsed: {} }
+        : { kind: "idle" },
+    isAvailable: opts.escapeHatch !== undefined,
+    isBusy: false,
+    run: () => Promise.resolve(),
+  } as unknown as EscapeHatchController;
 }
 
 function controller(opts: ControllerOpts): AnalysisController {
@@ -88,6 +105,8 @@ function Host({ opts, summary }: { opts: ControllerOpts; summary?: string }) {
     sourceKind: "pdf",
     edit,
     analysis: controller(opts),
+    escapeHatch: escapeHatchController(opts),
+    onRecovered: () => {},
     triggerCount: res.triggers.length,
   });
 }
@@ -108,15 +127,15 @@ afterEach(() => {
 });
 
 describe("ResultDetailTabs", () => {
-  it("hides the Resume Quality tab while capability is still detecting / no text", () => {
+  it("hides the on-device-AI tab while capability is still detecting / no text", () => {
     const el = render({ isAvailable: false });
-    expect(el.textContent).toContain("Reconstructed resume");
+    expect(el.textContent).toContain("Your resume");
     expect(el.textContent).toContain("Find jobs");
-    expect(el.textContent).toContain("Source & diagnostics");
-    expect(el.textContent).not.toContain("Resume quality");
+    expect(el.textContent).toContain("Raw text & flags");
+    expect(el.textContent).not.toContain("Local AI feedback");
   });
 
-  it("mounts the single Resume Quality tab (2nd position) when analysis is available", () => {
+  it("mounts the single on-device-AI tab (3rd position) when analysis is available", () => {
     const el = render(
       { isAvailable: true },
       "Senior engineer with a track record of shipping.",
@@ -125,12 +144,57 @@ describe("ResultDetailTabs", () => {
       (t) => t.textContent ?? "",
     );
     // Exactly four tabs: reconstructed, Find jobs (#318, always present),
-    // Resume Quality, diagnostics last.
+    // "Local AI feedback", diagnostics last.
     expect(labels).toHaveLength(4);
-    expect(labels[0]).toContain("Reconstructed resume");
+    expect(labels[0]).toContain("Your resume");
     expect(labels[1]).toContain("Find jobs");
-    expect(labels[2]).toContain("Resume quality");
-    expect(labels[3]).toContain("Source & diagnostics");
+    expect(labels[2]).toContain("Local AI feedback");
+    expect(labels[3]).toContain("Raw text & flags");
+    // No recovery offer, so no warn mark on this tab.
+    expect(labels[2]).not.toContain("parse needs attention");
+  });
+
+  it("turns the on-device-AI tab into the recovery offer when the escape hatch is available", () => {
+    // The banner used to render above the score card; the tab label is now the
+    // whole pre-click signal, so it has to carry both the offer and the warning
+    // (and the warning has to say what it means, not "setup needed").
+    const el = render(
+      { isAvailable: true, escapeHatch: "offered" },
+      "Senior engineer with a track record of shipping.",
+    );
+    const qualityTab = Array.from(el.querySelectorAll('[role="tab"]')).find((t) =>
+      (t.textContent ?? "").includes("local AI pass"),
+    );
+    expect(qualityTab).toBeDefined();
+    expect(qualityTab?.textContent).toContain("didn't parse cleanly");
+    expect(qualityTab?.textContent).toContain("parse needs attention");
+    expect(qualityTab?.textContent).not.toContain("setup needed");
+    // The offer owns the tab body alone — the quality panel's own CTA must not
+    // sit under it, or the tab carries two model-loading CTAs at once.
+    expect(el.textContent).toContain("Not everything parsed cleanly");
+    expect(el.textContent).not.toContain("Analyze with on-device model");
+  });
+
+  it("drops the recovery label once the pass has run, keeping the banner", () => {
+    // The hatch stays `isAvailable` after a successful pass (it is keyed on the
+    // ORIGINAL result so it can be re-run), so without the status gate the tab
+    // would keep inviting a pass the user already took.
+    const el = render(
+      { isAvailable: true, escapeHatch: "recovered" },
+      "Senior engineer with a track record of shipping.",
+    );
+    const labels = Array.from(el.querySelectorAll('[role="tab"]')).map(
+      (t) => t.textContent ?? "",
+    );
+    expect(labels[2]).toContain("Local AI feedback");
+    expect(labels[2]).not.toContain("local AI pass");
+    expect(labels[2]).not.toContain("parse needs attention");
+    // Collapsed confirmation + the quality panel it handed the tab back to.
+    // Assert the PANEL's own heading, not the tab label: those were the same
+    // string until the heading was renamed, so this line passed off `labels[2]`
+    // above and never proved the panel had mounted at all.
+    expect(el.textContent).toContain("Recovered with on-device AI");
+    expect(el.textContent).toContain("What the model checks");
   });
 
   it("reseeds the Find jobs query when the LLM escape hatch swaps activeResult (keyed remount)", () => {
@@ -152,6 +216,8 @@ describe("ResultDetailTabs", () => {
         sourceKind: "pdf",
         edit,
         analysis: controller(opts),
+        escapeHatch: escapeHatchController(opts),
+        onRecovered: () => {},
         triggerCount: heuristic.triggers.length,
       });
     }
@@ -172,13 +238,13 @@ describe("ResultDetailTabs", () => {
     expect(container.textContent).not.toContain("Heuristic Engineer");
   });
 
-  it("keeps the Resume Quality tab (warn-marked) with the notice when WebGPU is unavailable", () => {
+  it("keeps the on-device-AI tab (warn-marked) with the notice when WebGPU is unavailable", () => {
     const el = render(
       { isAvailable: false, capability: "no-webgpu", hasText: true },
       "Senior engineer with a track record of shipping.",
     );
     const qualityTab = Array.from(el.querySelectorAll('[role="tab"]')).find((t) =>
-      (t.textContent ?? "").includes("Resume quality"),
+      (t.textContent ?? "").includes("Local AI feedback"),
     );
     expect(qualityTab).toBeDefined();
     // Warn marker is announced, not colour-only.

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -8,10 +8,13 @@ import { FindJobsLauncher } from "./FindJobsLauncher.tsx";
 import { ResumeQualityPanel } from "./ResumeQualityPanel.tsx";
 import { SourceDiagnosticsPanel } from "./SourceDiagnosticsPanel.tsx";
 import { WebGpuUnavailableNotice } from "./WebGpuUnavailableNotice.tsx";
+import { LlmEscapeHatchPanel } from "./LlmEscapeHatchPanel.tsx";
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../../lib/score/score.ts";
 import type { EditableParse } from "../../hooks/useEditableParse.ts";
 import type { AnalysisController } from "../../hooks/useResumeAnalysisLlm.ts";
+import type { EscapeHatchController } from "../../hooks/useLlmEscapeHatch.ts";
+import type { LlmParsedResume } from "../../lib/webllm/parse-resume.ts";
 
 type SourceKind = "pdf" | "docx" | "markdown";
 
@@ -25,6 +28,14 @@ interface ResultDetailTabsProps {
   edit: EditableParse;
   jdContext?: string;
   analysis: AnalysisController;
+  /**
+   * Degenerate-parse recovery pass (#243), owned by `ParsedCard` because its
+   * result re-grades the score card above this one. Rendered inside the
+   * on-device-AI tab rather than as its own banner — see the label logic below.
+   */
+  escapeHatch: EscapeHatchController;
+  /** Forwarded to the recovery banner; `ParsedCard` swaps in the LLM parse. */
+  onRecovered: (llmParsed: LlmParsedResume) => void;
   triggerCount: number;
 }
 
@@ -37,13 +48,15 @@ export function ResultDetailTabs({
   edit,
   jdContext,
   analysis,
+  escapeHatch,
+  onRecovered,
   triggerCount,
 }: ResultDetailTabsProps) {
   // `tab` state lives here — only used within this component, not in ParsedCard.
   const [tab, setTab] = useState("reconstructed");
 
-  // The "Resume Quality" tab is the canonical on-device-AI surface (#276). It
-  // shows whenever there's résumé text to analyze — either running the live
+  // The on-device-AI tab (id `quality`) is the canonical on-device-AI surface
+  // (#276). It shows whenever there's résumé text to analyze — either running the live
   // analysis (WebGPU available) OR, when WebGPU can't run here, explaining that
   // in place instead of silently vanishing. `capability === null` (still
   // detecting) and "no text" both leave the tab absent, as before.
@@ -53,7 +66,43 @@ export function ResultDetailTabs({
     analysis.capability !== "available"
       ? analysis.capability
       : null;
-  const showQualityTab = analysis.isAvailable || unavailableCapability !== null;
+  // `escapeHatch.isAvailable` already IMPLIES `analysis.isAvailable` — both gate
+  // on `capability === "available"` and on the identical `hasText` expression
+  // over the same `result`, and the hatch adds `suggestedEscalation === "llm"`
+  // on top. The `||` is therefore redundant today and deliberate anyway: the two
+  // gates live in two hooks that can drift, and the failure mode if they do is
+  // an unreachable recovery offer — the exact thing this tab now owns.
+  const showQualityTab =
+    analysis.isAvailable ||
+    unavailableCapability !== null ||
+    escapeHatch.isAvailable;
+
+  // The recovery offer is what this tab LEADS with while it stands, so the tab
+  // label is the offer (user request, Jul 2026: replace the label "when
+  // applicable, and use 'Local AI feedback' when it is not"). That buys the
+  // offer a permanent slot the layout was already paying for, instead of a
+  // banner above the score — but it also means the label is the only pre-click
+  // signal that the parse was degenerate, which is why it takes the warn mark
+  // too.
+  //
+  // Gated on `!== "done"`: the hatch stays `isAvailable` after a successful
+  // recovery (it is keyed on the ORIGINAL result so the pass can be re-run), so
+  // without this the tab would keep inviting a pass the user has already taken.
+  const recoveryOffered =
+    escapeHatch.isAvailable && escapeHatch.status.kind !== "done";
+
+  // "Local AI feedback", not "AI feedback": in the tab strip the word that
+  // matters is the one saying the model runs here. The panel's own heading and
+  // the `description` below carry the rest.
+  const qualityLabel = recoveryOffered
+    ? "Try a local AI pass"
+    : "Local AI feedback";
+
+  const qualityDescription = recoveryOffered
+    ? "some of your file didn't parse cleanly — a local model can re-read it"
+    : analysis.isAvailable
+      ? "on-device AI review of your wording"
+      : "on-device AI review — needs browser support";
 
   return (
     /* Detail sits behind tabs in its own card so only one panel shows at a
@@ -65,16 +114,26 @@ export function ResultDetailTabs({
       <Tabs id="result" value={tab} onValueChange={setTab}>
         {/* Primary tabs ordered by value: insight first, evidence last
             (#263, #273). The evidence tab is always present and always last, so
-            the "Source & diagnostics" tab no longer shifts position when the
-            conditional Resume Quality tab is absent. The layout-flag count badge
+            the "Raw text & flags" tab no longer shifts position when the
+            conditional on-device-AI tab is absent. The layout-flag count badge
             is promoted to this parent tab so the warning count stays visible
-            without opening it. */}
+            without opening it.
+
+            Labels name what the user GETS, in words they arrive with. The
+            previous set — "Reconstructed resume", "Resume quality", "Source &
+            diagnostics" — was our internal vocabulary: in user testing (Jul
+            2026) a reader who knows the product still had to open each tab to
+            learn what it was ("what is a reconstructed resume? what is a
+            parser?"). The `description` subtitle (#519) carries the precise
+            meaning; the label only has to be decodable without clicking. Keep
+            the ids — they are the tab-switch contract with CritiquePanel and
+            ResumeQualityPanel's `onGoToRewrite`. */}
         <TabList aria-label="Parsed result views">
           <Tab
             id="reconstructed"
-            description="what a parser pulled out — edit it here"
+            description="what a parser read from your file — edit it here"
           >
-            Reconstructed resume
+            Your resume
           </Tab>
           <Tab
             id="find-jobs"
@@ -85,14 +144,16 @@ export function ResultDetailTabs({
           {showQualityTab && (
             <Tab
               id="quality"
-              warn={!analysis.isAvailable}
-              description={
-                analysis.isAvailable
-                  ? "on-device critique and rewrites"
-                  : "on-device critique — needs browser support"
+              warn={recoveryOffered || !analysis.isAvailable}
+              // Same dot, two meanings — so it says which. "setup needed" is
+              // right for the WebGPU case and wrong for the recovery one,
+              // where nothing is broken in the browser.
+              warnLabel={
+                recoveryOffered ? "parse needs attention" : "setup needed"
               }
+              description={qualityDescription}
             >
-              Resume quality
+              {qualityLabel}
             </Tab>
           )}
           <Tab
@@ -100,7 +161,7 @@ export function ResultDetailTabs({
             count={triggerCount}
             description="raw text, layout flags, what went wrong"
           >
-            Source &amp; diagnostics
+            Raw text &amp; flags
           </Tab>
         </TabList>
 
@@ -111,7 +172,7 @@ export function ResultDetailTabs({
               score={activeScore}
               edit={edit}
               jdContext={jdContext}
-              // #608: the critique the "Resume quality" tab is already showing
+              // #608: the critique the on-device-AI tab is already showing
               // feeds the rewrite, so clicking Rewrite acts on the findings the
               // user just read instead of discarding them. Only available once
               // the analysis has completed; every other status contributes
@@ -133,7 +194,35 @@ export function ResultDetailTabs({
           </TabPanel>
           {showQualityTab && (
             <TabPanel id="quality">
-              {analysis.isAvailable ? (
+              {/* One offer at a time. While recovery is on the table this tab
+                  shows ONLY the recovery panel: a wording critique of a parse
+                  the parser itself flagged as degenerate is close to
+                  worthless, and stacking both put two model-loading CTAs on
+                  one screen. Once the pass has run (or if it was never
+                  offered), the quality panel takes the tab back — with the
+                  recovery panel collapsed to its one-line confirmation above,
+                  because unmounting it on `done` would kill the effect that
+                  reports the recovered parse upward. */}
+              {/* The wrapper is unconditional on purpose, even though it is
+                  bare when `recoveryOffered`. Only the className varies, so
+                  React keeps the same element at this position and the panel
+                  stays mounted across the `done` transition. Gating the
+                  wrapper itself — rendering the panel bare in one branch and
+                  inside a div in the other — changes the element TYPE at this
+                  position at the moment recovery completes, which unmounts and
+                  remounts the panel in the render that fires `onRecovered`
+                  (see LlmEscapeHatchPanel's docblock). Not worth trading a
+                  documented mount invariant for one empty div. */}
+              {escapeHatch.isAvailable && (
+                <div className={recoveryOffered ? undefined : "mb-4"}>
+                  <LlmEscapeHatchPanel
+                    controller={escapeHatch}
+                    onRecovered={onRecovered}
+                  />
+                </div>
+              )}
+              {!recoveryOffered &&
+                (analysis.isAvailable ? (
                 /* onGoToRewrite: switch back to reconstructed tab where the
                    per-role wand button (#3 / useSectionRewrite) already lives.
                    The quality panel links each flagged bullet to this affordance
@@ -145,12 +234,15 @@ export function ResultDetailTabs({
                 />
               ) : (
                 /* WebGPU can't run here — explain in place instead of hiding
-                   the tab (#276). `unavailableCapability` is non-null whenever
-                   this branch renders (see showQualityTab). */
-                unavailableCapability && (
-                  <WebGpuUnavailableNotice capability={unavailableCapability} />
-                )
-              )}
+                   the tab (#276). Still guarded: `showQualityTab` now has a
+                   third opener (`escapeHatch.isAvailable`), and while that one
+                   implies `analysis.isAvailable` — so it takes the branch above,
+                   never this one — the guard is what makes that reasoning
+                   non-load-bearing. */
+                  unavailableCapability && (
+                    <WebGpuUnavailableNotice capability={unavailableCapability} />
+                  )
+                ))}
             </TabPanel>
           )}
           <TabPanel id="diagnostics">

--- a/src/components/features/ResumeQualityPanel.tsx
+++ b/src/components/features/ResumeQualityPanel.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * ResumeQualityPanel — consolidated "Resume Quality" tab shell (issue #273).
+ * ResumeQualityPanel — consolidated "AI feedback" tab shell (issue #273).
  *
  * Replaces the two separate "What an ATS misses" (DisagreementPanel) and
  * "Resume quality" (CritiquePanel) tabs with a single tab driven by one
@@ -14,7 +14,8 @@
  *   2. "What an ATS misses" bottom section (only when gaps > 0):
  *      heading + intro + DisagreementResults + ReportGapSection.
  *
- * Tab order in Result.tsx: reconstructed → Resume Quality → Source & diagnostics.
+ * Tab order in ResultDetailTabs.tsx (by id): reconstructed → find-jobs →
+ * quality → diagnostics.
  *
  * Design rules (CLAUDE.md):
  *   - Semantic tokens only; no hardcoded hex or raw palette classes.
@@ -41,7 +42,7 @@ export function ResumeQualityPanel({
 }: {
   controller: AnalysisController;
   result: CascadeResult;
-  /** Navigate to the "Reconstructed resume" tab so the user can use the wand. */
+  /** Navigate to the "Your resume" tab so the user can use the wand. */
   onGoToRewrite: () => void;
 }) {
   const { status } = controller;
@@ -50,8 +51,13 @@ export function ResumeQualityPanel({
     <section className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
+          {/* Deliberately NOT the tab label ("Local AI feedback"), same rule
+              ReconstructedResume follows: a heading that repeats its own tab
+              label is noise, and it makes every `toContain("Local AI feedback")`
+              assertion ambiguous about which element it matched. This states
+              what the section DOES; the tab states where you are. */}
           <h2 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-            Resume Quality
+            What the model checks
           </h2>
           <p className="max-w-prose text-sm text-content-tertiary">
             Run a small on-device model to judge bullet quality — weak verbs,

--- a/src/components/features/SourceDiagnosticsPanel.tsx
+++ b/src/components/features/SourceDiagnosticsPanel.tsx
@@ -2,7 +2,8 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * SourceDiagnosticsPanel — the "Source & diagnostics" primary tab body (#263).
+ * SourceDiagnosticsPanel — the "Raw text & flags" primary tab body (#263;
+ * the tab's id is still `diagnostics`).
  *
  * Collapses the three former evidence tabs (Source PDF, Extracted text, Layout
  * flags) into one primary tab. A nested segmented control switches between the
@@ -49,7 +50,7 @@ export function SourceDiagnosticsPanel({
     <div className="flex flex-col gap-4">
       <div
         role="group"
-        aria-label="Source & diagnostics views"
+        aria-label="Raw text & flags views"
         className="inline-flex gap-1 self-start rounded-md border border-border-light bg-surface-subtle p-1"
       >
         <SegmentButton

--- a/src/components/features/WebGpuUnavailableNotice.tsx
+++ b/src/components/features/WebGpuUnavailableNotice.tsx
@@ -5,7 +5,7 @@
  * WebGpuUnavailableNotice — the shared explainer that replaces the silent
  * `return null` when WebGPU isn't available (#276).
  *
- * Rendered as the body of the "Resume Quality" tab (the canonical on-device-AI
+ * Rendered as the body of the on-device-AI tab (the canonical on-device-AI
  * surface) when WebGPU can't run here — the tab used to vanish entirely. Instead
  * of a blank, the user gets: (1) a compact, capability-specific headline, (2)
  * reassurance that the core ATS score + parsed résumé are unaffected (on-device

--- a/src/design-system/shared/CapabilityStrip.tsx
+++ b/src/design-system/shared/CapabilityStrip.tsx
@@ -14,6 +14,13 @@
  * under one persistent local-processing rail. Static and non-interactive: it
  * is a description, not a second entry point competing with the drop zone.
  *
+ * Placement (user testing, Jul 2026): `App` renders this BELOW the drop zone,
+ * on the pre-drop screen only. It used to be passed as PageShell's `chips`,
+ * which renders in the header on every phase — so it sat above the hero before
+ * the drop, and stayed pinned above the score afterwards, restating three lanes
+ * the user had already chosen between. If you move it back into a header slot,
+ * you reintroduce both problems.
+ *
  * Composed entirely from existing `@design-system` exports (Card, StatusBadge,
  * Chip, LockIcon) — no new primitive. `StatusBadge` gives each lane the same
  * small-caps pill treatment a Tab label gets (#516's visual language); `Chip`
@@ -34,7 +41,7 @@
  *
  * The noun is "browser", not "device", and that is deliberate (#537): this
  * rail renders a few inches below `App`'s hero, which says "in your browser"
- * in the headline and "leaving your browser" in the subhead, so a visitor
+ * in the headline and "leaves your browser" in the subhead, so a visitor
  * reads all three at once. "Device" also understates the guarantee — another
  * app on the same device cannot read the resume either. If you change the
  * noun here, change it in `App.tsx`'s hero in the same commit. `PageShell`'s
@@ -61,7 +68,10 @@ const LANES: CapabilityLane[] = [
   {
     label: "Fix it",
     description:
-      "Edit inline, save it in your browser, or export a clean PDF",
+      // "or Markdown" because both exports have shipped since #552
+      // (`useDownloadMarkdown.ts`), and the block a few inches below this strip
+      // now names both — a strip that stops at PDF reads as the narrower truth.
+      "Edit inline, save it in your browser, or export a clean PDF or Markdown",
   },
   {
     label: "Match & find",

--- a/src/design-system/shared/Tabs.tsx
+++ b/src/design-system/shared/Tabs.tsx
@@ -137,6 +137,15 @@ interface TabProps {
    */
   warn?: boolean;
   /**
+   * What the warning dot MEANS, as the visually-hidden addendum to the tab's
+   * accessible name. Defaults to the original "setup needed" (#276's WebGPU
+   * case). Overridable because the same dot now also marks a tab that is
+   * offering an action rather than reporting a broken environment (#243's
+   * recovery pass) — a screen-reader user told "setup needed" there would be
+   * sent looking for a setting that does not exist.
+   */
+  warnLabel?: string;
+  /**
    * Optional one-line subtitle rendered under the label (issue #519), so a
    * tab's purpose is legible without clicking it. Omitting this prop
    * reproduces today's single-line rendering exactly — Tabs is a shared
@@ -157,7 +166,14 @@ interface TabProps {
   description?: string;
 }
 
-export function Tab({ id, children, count, warn, description }: TabProps) {
+export function Tab({
+  id,
+  children,
+  count,
+  warn,
+  warnLabel = "setup needed",
+  description,
+}: TabProps) {
   const { value, onValueChange, baseId } = useTabsContext("Tab");
   const isActive = value === id;
   // Selection carries a real surface (bg-surface-card, matching the panel
@@ -207,7 +223,7 @@ export function Tab({ id, children, count, warn, description }: TabProps) {
               <span aria-hidden="true" className="ml-1.5 text-feedback-warning-text">
                 {"⚠︎"}
               </span>
-              <span className="sr-only"> (setup needed)</span>
+              <span className="sr-only"> ({warnLabel})</span>
             </>
           )}
         </>
@@ -225,7 +241,7 @@ export function Tab({ id, children, count, warn, description }: TabProps) {
                 <span aria-hidden="true" className="text-feedback-warning-text">
                   {"⚠︎"}
                 </span>
-                <span className="sr-only"> (setup needed)</span>
+                <span className="sr-only"> ({warnLabel})</span>
               </>
             )}
           </span>


### PR DESCRIPTION
Closes #676
Follow-ups tracked in #680

Two defects found in user testing on Jul 29 that both read as "the product is
confusing" but were measurable layout and copy problems, not comprehension gaps.

## 1. The pre-drop screen buried its own call to action

`CapabilityStrip` (through PageShell's `chips` slot) and a
`bg-surface-card-warm` hero Card both rendered above the drop zone. The hero
owned the page's only tinted surface and a `text-3xl` headline; the drop zone
sat on the default background behind a `border-border` dashed edge with a
`text-sm` prompt. A first-time visitor read roughly 90 words across three
non-actionable blocks before reaching the one control that does anything.

> "Everything is the same color, so it's kind of hard to find what am I
> supposed to do here. But the first thing you see is *your whole job search in
> your browser*. What does that mean? And I'm not even doing anything."

The hierarchy is now inverted:

- Hero is plain text, two lines, ~20 words — no Card, no tinted surface.
- Drop zone is the only accent surface on the page (`bg-accent-forward-bg` +
  `border-accent-primary`) with a `text-lg` / `sm:text-2xl` prompt.
- `CapabilityStrip` moves below the drop zone and renders pre-drop only. It was
  previously pinned in the header for the entire session, restating three lanes
  over the user's own score after they had already chosen one.
- The Greenhouse citation moves down to the recruiter-agent block — the claim
  it actually sources. In the hero it was a third competing message ahead of
  the primary action.

The privacy copy is unchanged in scope: the headline still claims a *place*,
the subhead still claims the *resume* never leaves the browser, and
`src/lib/job-search/providers/keywords.ts` remains the invariant both depend
on. The subhead drops only its lane list ("score it, fix it, match a JD, and
find jobs"), which `CapabilityStrip` now enumerates a few inches below with
fuller descriptions.

## 2. The tab labels were internal vocabulary

A reader who already knows the product still had to open each tab to find out
what it held.

> "What is a reconstructed resume? What is a parser? What does resume quality
> mean? You have to read a lot of stuff, and it's not clear just seeing it in
> one second."

| Before | After |
|---|---|
| Reconstructed resume | Your resume |
| Find jobs | Find jobs (unchanged) |
| Resume quality | Local AI feedback |
| Source & diagnostics | Raw text & flags |

Tab **ids are untouched**, so the tab-switch contract with `CritiquePanel` and
`ResumeQualityPanel`'s `onGoToRewrite` is unaffected. The `description`
subtitles (#519) still carry the precise meaning — the label only has to be
decodable without clicking.

`ReconstructedResume`'s section heading becomes "What the parser read" rather
than echoing its own tab label. A heading that repeats its tab is noise, and it
would make every `toContain("Your resume")` assertion ambiguous about which
element it matched.

## Testing

New `src/components/DropZone.test.tsx` pins the hierarchy inversion, which
nothing else in the suite would catch. Assertions target the *relative*
treatment — accent surface present, prompt a size step above body copy — not
specific token values, so a palette swap stays free.

Revert-proof, reported honestly: **3 of its 5 assertions fail** against the
pre-fix component. The other two (the file-custody line, `border-dashed`) cover
behaviour this PR deliberately preserves, so they pass either way.

`ResultDetailTabs.test.tsx` updated for the new labels. Full `npm run verify`
green (fallow's 3 complexity findings on `App`, `ModelSelector` and
`AchievementHeader` are pre-existing and report-only).

Browser-verified at 1280x900 and 390x844: the entire landing column now fits
above the fold on desktop, and the drop zone is fully visible on mobile without
scrolling. Post-parse verified too — the capability strip is gone, the score
card is first, and the new labels render with their descriptions.

## 3. Second round (Jul 30)

Four follow-ups on the same screen, after looking at the shipped version.

**The header subtitle is gone.** `PageShell`'s `subtitle` prop becomes optional
and `/` stops passing one. It read *"A parser audit for your resume — not a
judge"*, which failed three ways at once: "parser audit" is exactly the internal
vocabulary this PR removes from the tab labels; "not a judge" is a negation
defending against an objection the visitor has not formed yet; and on the idle
screen it was a second tagline sitting two inches above the headline. Removing
it also leaves the GitHub-star CTA alone on the header-right instead of sharing
it. `/jd-fit` and `/jobs` still pass one — they open straight into a form with
no headline of their own, so there it is the only orientation.

**"No resume yet? Build one from scratch" moved up.** It sat below the
capability strip, the saved-resume library and the job tracker — three
unrelated blocks. It is not a topic of its own; it is the other way to answer
the question the drop zone asks, so it is now in a `gap-3` group with the drop
zone rather than a `gap-6` section apart from it. The library stays outside that
group deliberately: it self-hides when empty, and inside the group an invisible
block would leave a phantom gap.

**Prompt font size.** `sm:text-xl` (20px) was the only `text-xl` in all of
`src/` — every other heading in the app steps 14 → 16 → 18 → 24 → 30. A lone
20px is an arbitrary size in the sense the Font Size Scale rule means, and 20px
also read small inside a 56px-padded box. Now `sm:text-2xl`, a step the app
already uses. The hero headline remains one step above at `sm:text-3xl`; the
drop zone leads on colour and fill, which is the contrast that survives a
greyscale render.

**The block below the drop zone was rewritten, then cut again.** It opened on
the trend — *"Recruiters are starting to run AI agents over resumes"* — so the
first thing a visitor read was someone else's behaviour, and what they
personally get arrived in clause four, as a metaphor ("the candidate-side
mirror"). It now opens on what the product does, in the order a user does it:

> **OfflineCV parses your resume, shows you what a machine read back, and lets
> you edit it and download a cleanly formatted PDF or Markdown file.**

85 words → 27. Both export paths are real, so the claim round-trips to code:
`useDownloadPdf.ts` → `render-ats-pdf.ts` for PDF, `useDownloadMarkdown.ts` for
Markdown (#552). `CapabilityStrip`'s "Fix it" lane now names Markdown too — it
had stopped at PDF since before #552 shipped.

The recruiter-trend sentence was then cut outright rather than demoted: an
unhedged "recruiters increasingly screen with AI" is a claim about an industry
we would have to defend, and the Greenhouse report cited below it measures AI
*trust* among hiring managers, not screening prevalence — it never sourced that
sentence as tightly as the old code comment claimed. The citation now stands on
its own weaker, supportable claim ("a hiring process job seekers say they can't
see into").

⚠️ **One thing left the app entirely.** Cut with that sentence was *"the score
rates how readable your file is, not how good you are"* — and the header
subtitle that used to carry the same idea ("not a judge") is deleted above.
`AtsScoreReadout` never stated it. That framing is now nowhere in the product.
Flagged rather than silently restored: if it comes back it belongs next to the
score, not on the landing page. A code comment in `App.tsx` records this.

Also fixed while in there: the block's three paragraphs each carried their own
`mx-auto max-w-3xl`, so the wrapping paragraph read as left-aligned while the
short ones visibly centred themselves — three lines, three left edges. One
shared wrapper now centres the group once.

Re-verified in a browser at 1280x900 and 390x844. Full suite: 3849 passed, 10
skipped. Branch rebased onto `main` to pick up #675 (`npm run dev:http`, which
is what made the browser pass possible).

## Not in this PR

Three items from the same session were left out; two are now closed by round
3, and the rest are tracked in #680.

- **WebLLM escape-hatch copy.** The complaint was that "Try a local AI pass"
  doesn't explain what it does or why. The label is jargon, but the paragraph
  beside it in `LlmEscapeHatchPanel` already explains the what, the why, the
  privacy scope and the 1.2 GB download. Partly refuted by the code — worth a
  separate look rather than churn here. **Partly addressed in round 3**: the
  label is now the tab, and the explainer sits under it as the tab's whole
  body.
- **"Show the score on top, drop the two boxes."** The score already renders
  above the tabs. Which two boxes were meant is ambiguous from the recording;
  removing `CapabilityStrip` post-parse already removes one candidate.
- **A bug on the Find Jobs surface.** Named in passing with no repro. Needs one
  before it can be fixed.

## 4. Third round (Jul 30) — the post-drop screen

From a screenshot of the post-parse view: the page is busy, and the thing at
the very top is the **recovery banner**, not the score.

- **The recovery offer (#243) moves out of the top banner and into the
  on-device-AI tab.** It was a full-width, tinted, primary-button banner
  rendered above the score card — so the post-drop screen opened on our
  suggestion instead of the user's own result. The score card is now first.
- **The tab label carries the signal.** The tab strip already reserves
  permanent space for this surface, so the offer moves into space the layout
  was paying for anyway: the tab reads **"Try a local AI pass"** (warn-marked)
  while the offer stands, and **"Local AI feedback"** otherwise. That is also
  the whole pre-click signal that the parse was degenerate, which is why it
  takes the warning mark.
- **The panel's heading no longer repeats that label.** `ResumeQualityPanel`'s
  h2 rendered `"Local AI feedback"` — the same string as the tab above it, the
  repetition `ReconstructedResume` already rejected when it renamed its own
  heading to `"What the parser read"`. It now reads **"What the model
  checks"**: the heading says what the section does, the tab says where you
  are. Added in review (thanks @Vaishnavi1709) — the rule had been applied to
  one of the two tabs only.
- **The label reverts once the pass has run.** `escapeHatch.isAvailable` stays
  true after a successful recovery — it is keyed on the *original* result so
  the pass can be re-run — so without a `status.kind !== "done"` gate the tab
  would keep inviting a pass the user already took.
- **One offer at a time.** While recovery is on the table the tab body shows
  only the recovery panel; `ResumeQualityPanel` is withheld. A wording critique
  of a parse the parser itself flagged as degenerate is close to worthless, and
  stacking both put two model-loading CTAs on one screen — the first attempt at
  this shipped the old banner widget as-is *above* the quality panel, which is
  exactly the "two differently-dressed widgets" problem.
- **Restyled into the panel it alternates with**, and renamed
  `LlmEscapeHatchBanner` → `LlmEscapeHatchPanel`: same `section` + uppercase
  heading + `max-w-prose` explainer + right-aligned primary `Button` as
  `ResumeQualityPanel`. A user switching between the two states sees one
  surface change its offer.

### One thing worth reviewing

The panel **stays mounted** on `done` and collapses to a one-line confirmation
(plus a `link` re-run) rather than being unmounted by the caller. That is not a
style choice: the `done` transition is what fires `onRecovered`, and the status
lives in a hook owned by `ParsedCard`, so a `status.kind !== "done"` *mount*
gate would swap the panel out in the same render that produces the result — and
the recovered parse would never reach the score card. Covered by a test.

`Tab` gains a `warnLabel` prop. The dot's `sr-only` addendum was hardcoded to
"setup needed", which is right for the WebGPU case and would send a
screen-reader user looking for a browser setting that does not exist in the
recovery case.

### Verified

Full suite green (3852 passed / 10 skipped), typecheck + lint clean, build
clean. Browser-checked at 1280×900 against `npm run dev:http`, both states: a
clean parse (score at top, tab reads "Local AI feedback") and a degenerate one
(`tests/fixtures/pdfs/unknown/label-rail-grid-fragmented.pdf` — tab reads "Try
a local AI pass ⚠︎", and its body holds the offer alone).

## Provenance

Claude Opus 5, Claude Code. UI recommendations cross-checked against the
`ui-ux-pro-max` rule database (Hero-Centric landing pattern: one primary CTA,
hero minimal-text, CTA at high contrast; Typography/Heading-Clarity: a heading
needs a clear size and weight step over body). Its palette and typography
recommendations were **not** applied — they conflict with this repo's semantic
token system, and its "Exaggerated Minimalism" style suggestion is wrong for a
utility tool.




