### PR TITLE
feat(dev): serve the dev server over plain http on demand, for LAN demos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ Release planning runs on GitHub Milestones (P1 Friends & Family → P4 Post-Publ
 Vite 7 + React 19 + TypeScript 5.8 + Tailwind 3.4. Vitest runs against `vite.config.ts` (Node env, globals on). pdfjs-dist 4.x; the worker is configured once at app boot in `src/main.tsx` via Vite's `?url` import. No router (single-page app), no SSR/prerender. Analytics are env-gated (`VITE_POSTHOG_KEY`) and dead-code-eliminated when unset — see `src/lib/analytics.ts`.
 
 ```bash
-npm run dev        # vite dev server (http://localhost:5173)
+npm run dev        # vite dev server (https://localhost:5173 — TLS, self-signed)
+npm run dev:http   # plain http, for LAN demos; costs WebGPU (see README)
 npm run build      # tsc -b && vite build → dist/
 npm run test       # vitest run
 npm run typecheck  # tsc -b --noEmit

--- a/README.md
+++ b/README.md
@@ -25,11 +25,26 @@ branch + commit conventions, and the PR checklist.
 
 ```bash
 npm install
-npm run dev        # vite dev server on http://localhost:5173
+npm run dev        # vite dev server on https://localhost:5173 (self-signed cert)
+npm run dev:http   # same, over plain http — for LAN demos (see below)
 npm run build      # static bundle into dist/
 npm run test       # vitest run
 npm run typecheck  # tsc --noEmit across the project
 ```
+
+`npm run dev` serves **HTTPS**, not http: WebGPU (which the on-device AI
+features need) is only exposed in a [secure context], and `localhost` is the
+only cleartext origin that qualifies. Over TLS every LAN client gets one too —
+at the cost of a one-time "not private" interstitial, since the cert is
+self-signed.
+
+That trade flips when you are showing the app to someone on another machine.
+`npm run dev:http` drops TLS so `http://<your-host>.local:5173/` connects with
+no interstitial. Parse, score, edit, export, JD match and job search all work;
+the on-device AI surfaces detect no WebGPU and say so. Same thing via the
+environment directly: `OFFLINECV_DEV_HTTP=1 npm run dev`.
+
+[secure context]: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
 
 The `npm` scripts above are the supported entry point — everything you
 need to develop, test, and build runs through them on any machine.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prepare": "node scripts/install-git-hooks.mjs",
     "dev": "vite",
+    "dev:http": "OFFLINECV_DEV_HTTP=1 vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,23 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 
+// Dev-server TLS opt-out. `basicSsl()` below makes `npm run dev` serve HTTPS,
+// which is what a LAN client needs for WebGPU (see the plugin's comment) — but
+// it also means a plain `http://<host>.local:5173/` from another machine simply
+// does not connect: the port speaks TLS and the browser is speaking cleartext.
+// The self-signed cert is the other half of the friction — every LAN visitor
+// has to click through an interstitial, which is a bad first ten seconds when
+// you are demoing to someone.
+//
+// `OFFLINECV_DEV_HTTP=1 npm run dev` (or `npm run dev:http`) drops the plugin
+// so the same URL works over http. The trade-off is real and one-directional:
+// over http a non-localhost origin is NOT a secure context, so `navigator.gpu`
+// is hidden and every on-device-AI surface degrades to "no-webgpu" — the "AI
+// feedback" tab renders its unavailable notice instead of running. Parse,
+// score, edit, export, JD-match keyword fallback and job search all work.
+// Default stays HTTPS so nobody loses WebGPU by accident.
+const DEV_HTTP = process.env.OFFLINECV_DEV_HTTP === "1";
+
 // Token-values swap seam. `src/styles.css` imports the raw `--color-*` values
 // via the bare `@design-tokens` specifier; this alias points it at the in-tree
 // default (`src/design-system/styles/tokens.css`), so the standalone build is
@@ -136,7 +153,12 @@ export default defineConfig({
     // disables (detectWebGpu → "no-webgpu"). TLS gives every LAN client a
     // secure context; the cert is untrusted, so each client accepts a one-time
     // browser warning — encryption and the secure-context flag hold regardless.
-    basicSsl(),
+    //
+    // Spread, not a ternary returning `false`: Vite tolerates falsy plugin
+    // entries, but the array type here is `Plugin[]` and a `false` member
+    // fails `tsc -b` in `verify`. See DEV_HTTP at the top of this file for
+    // when and why you would want it gone.
+    ...(DEV_HTTP ? [] : [basicSsl()]),
     tailwindcss(),
     react(),
     emitVersionJson(APP_VERSION),


### PR DESCRIPTION
`vite.config.ts` always loaded `@vitejs/plugin-basic-ssl`, so `npm run dev`
served HTTPS on 5173 and `http://<host>.local:5173/` from another machine on
the network could not connect — the port speaks TLS, the browser speaks
cleartext, and the symptom is a bare `ERR_EMPTY_RESPONSE`. There was no flag to
change it. The self-signed cert is the other half of the friction: every LAN
visitor clicks through a "not private" interstitial first, which is a poor
opening when you are demoing to someone.

`OFFLINECV_DEV_HTTP=1` drops the plugin; `npm run dev:http` is the shorthand.

**The default is unchanged, deliberately.** The plugin exists because WebGPU is
gated behind a [secure context], and over plain http a non-localhost origin is
not one — `navigator.gpu` disappears and every on-device-AI surface degrades to
`no-webgpu`. Parse, score, edit, export, JD match and job search are unaffected.
Opting out of that should be a decision, not something you inherit.

Also corrects the README and CLAUDE.md quick-start blocks, which both
documented the dev server as `http://localhost:5173`. It has served https for as
long as the plugin has been in the tree.

## Testing

Both paths exercised:

- `npm run dev:http` answers **200 over cleartext** at
  `http://Sunroom-Mini.local:<port>/`. The existing `allowedHosts: [".local"]`
  already covers the mDNS name, so no host-check change was needed.
- `npm run dev` still comes up on `https://` and answers 200.

`tsc -b --noEmit` and `eslint .` clean. The plugin is spread into the array
rather than switched with a ternary returning `false` — Vite tolerates falsy
plugin entries at runtime, but the array types as `Plugin[]` and a `false`
member fails the typecheck step in `verify`.

[secure context]: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts

## Provenance

Claude Opus 5, Claude Code.
