### PR TITLE
fix(edit,export): an experience role's lone end date no longer comes back as a start date (#672)

### DIFF
--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -348,7 +348,7 @@ function buildEntryGroups(
 
 /** Map a RoleHeader field name to the flat AddedEntry field it edits. */
 const EXPERIENCE_FIELD_MAP: Record<
-  keyof ExperienceFieldOverrides,
+  Exclude<keyof ExperienceFieldOverrides, "is_current">,
   AddedEntryField
 > = {
   title: "title",
@@ -641,11 +641,13 @@ export function ExperienceSection({
                 group={group}
                 experienceIndex={idx}
                 overrides={added ? undefined : experienceOverrides[idx]}
-                onFieldChange={(field, value) =>
-                  added
-                    ? onEntryField(added.id, EXPERIENCE_FIELD_MAP[field], value)
-                    : onExperienceFieldChange(idx, field, value)
-                }
+                onFieldChange={(field, value) => {
+                  if (added) {
+                    onEntryField(added.id, EXPERIENCE_FIELD_MAP[field], value);
+                  } else {
+                    onExperienceFieldChange(idx, field, value);
+                  }
+                }}
                 onBulletChange={onBulletChange}
                 onRemoveBullet={onRemoveBullet}
                 onAddBullet={(text) => onAddBullet(roleEntryKey, text)}
@@ -1356,8 +1358,14 @@ export function ReconstructedResume({
         critique={critique}
         hasBullets={bullets.length > 0}
         experienceOverrides={experienceOverrides}
+        // The 4th argument is the RESOLVED entry, not the pristine parse:
+        // `parsed` is `display.parsed`, i.e. `applyOverrides` output, so it
+        // already carries every earlier edit — which is exactly what the #672
+        // rule has to resolve `??` against. `setExperienceField` pairs it with
+        // the pre-write override map so the sparse write-back does not compare a
+        // previously-overridden key against a base that contains it.
         onExperienceFieldChange={(index, field, value) =>
-          setExperienceField(index, field, value)
+          setExperienceField(index, field, value, parsed.experience[index])
         }
         onBulletChange={(index, value, original) =>
           setBulletField(index, value, original)

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -29,6 +29,10 @@ import type { BulletGroup } from "../../lib/score/group-bullets.ts";
 import { roleLabel } from "../../lib/score/group-bullets.ts";
 import { EditableField } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
+import {
+  normalizeExperienceDates,
+  formatExperienceDateRange,
+} from "../../lib/edit/experience-dates.ts";
 import type {
   AddedBulletRef,
   ExperienceFieldOverrides,
@@ -55,8 +59,10 @@ interface RoleHeaderProps {
   group: BulletGroup;
   /** Present only when the role is editable (experience has a parsed index). */
   overrides?: ExperienceFieldOverrides;
+  /** `is_current` is excluded by type: it is derived from the date pair by
+   *  `edit/experience-dates.ts`, so no cell may commit it directly (#672). */
   onFieldChange?: (
-    field: keyof ExperienceFieldOverrides,
+    field: Exclude<keyof ExperienceFieldOverrides, "is_current">,
     value: string,
   ) => void;
 }
@@ -101,15 +107,10 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
     const location = exp.location || undefined;
     const team = exp.team || undefined;
 
-    // Build date segment.
-    let dates: string | undefined;
-    const start = exp.start_date || undefined;
-    const end = exp.is_current
-      ? "Present"
-      : (exp.end_date || undefined);
-    if (start && end) dates = `${start} – ${end}`;
-    else if (start) dates = start;
-    else if (end) dates = end;
+    // Build date segment. Through the #672 rule, so a role whose only date is an
+    // end date reads the same here, in the edit card, and in the exported PDF.
+    const dateFields = normalizeExperienceDates(exp);
+    const dates = formatExperienceDateRange(dateFields) || undefined;
 
     // Location rides inline with the company, comma-joined ("Company, City, ST");
     // the team/department (when present) trails after a "·", mirroring the
@@ -150,13 +151,16 @@ function RoleHeader({ group, overrides, onFieldChange }: RoleHeaderProps) {
     ov.location !== undefined ? ov.location : exp.location,
   );
   const team = toDisplay(ov.team !== undefined ? ov.team : exp.team);
-  const startDate = toDisplay(
-    ov.start_date !== undefined ? ov.start_date : exp.start_date,
-  );
-  const endDate =
-    exp.is_current && ov.end_date === undefined
-      ? "Present"
-      : toDisplay(ov.end_date !== undefined ? ov.end_date : exp.end_date);
+  // Dates read directly from the overrides or parsed fields. The normalization
+  // is performed on commit (in useEditableParse / setExperienceField) rather than
+  // on render, so the card always displays the normalized state and subsequent
+  // edits resolve from it. Undo and snapshots restore the normalized dates rather
+  // than raw keystrokes, ensuring consistency across all edit phases.
+  const startVal = ov.start_date !== undefined ? ov.start_date : exp.start_date;
+  const endVal = ov.end_date !== undefined ? ov.end_date : exp.end_date;
+  const isCurrent = ov.is_current !== undefined ? ov.is_current : exp.is_current;
+  const startDate = toDisplay(startVal);
+  const endDate = isCurrent ? "Present" : toDisplay(endVal);
 
   return (
     <div className="flex min-w-0 grow flex-col gap-0.5">
@@ -246,9 +250,10 @@ interface RoleEntryProps {
   experienceIndex: number | null;
   /** Editable overrides for this role's header fields (from useEditableParse). */
   overrides?: ExperienceFieldOverrides;
-  /** Called when the user commits a field edit. */
+  /** Called when the user commits a field edit. `is_current` is excluded by
+   *  type — see `RoleHeaderProps`. */
   onFieldChange?: (
-    field: keyof ExperienceFieldOverrides,
+    field: Exclude<keyof ExperienceFieldOverrides, "is_current">,
     value: string,
   ) => void;
   /** Commit a bullet edit, keyed by BulletObservation.id (#82, #648). The

--- a/src/hooks/useEditableParse.date-slot-sequence.repro.test.tsx
+++ b/src/hooks/useEditableParse.date-slot-sequence.repro.test.tsx
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Regression for the SECOND date edit on one role (#672).
+ *
+ * `applyNormalizedDateOverrides`'s own unit tests pass the same pristine pair on
+ * both steps, which is not what production does and is why they could not see
+ * this: `ReconstructedResume` hands `setExperienceField` `display.parsed`, the
+ * overrides-APPLIED entry, so on the second edit the first edit's value is inside
+ * the "base" the sparse write-back compares against — and the key deletes itself.
+ *
+ * Concretely, on a role parsed `{2019, 2022}`:
+ *
+ * ```
+ *                     override map                       applied
+ * step 1 clear Start  {start_date:"2022", end_date:""}   {s:"2022"}           ok
+ * step 2 End = 2024   {end_date:"2024"}                  {s:"2019", e:"2024"} BUG
+ * ```
+ *
+ * The 2019 the user cleared is back and the card re-renders it — #672's own
+ * corruption, one edit later.
+ *
+ * So this drives the REAL hook and the REAL `applyOverrides`, re-deriving the
+ * resolved entry between commits exactly as a re-render does. Every assertion is
+ * on the APPLIED entry rather than on the override map, because the map is an
+ * implementation detail and the applied entry is what the card renders and what
+ * the exporter draws.
+ *
+ * Probe-component harness (the project has no @testing-library/react) — same
+ * pattern as `useEditableParse.test.tsx`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useEditableParse, type EditableParse } from "./useEditableParse.ts";
+import { applyOverrides } from "../lib/edit/apply-overrides.ts";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { SectionedResume } from "../lib/heuristics/sections.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function makeSections(): SectionedResume {
+  return {
+    byName: new Map() as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
+
+function parsedWith(
+  dates: { start_date?: string; end_date?: string; is_current?: boolean },
+): HeuristicParsedResume {
+  return {
+    full_name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    location: "Chicago, IL",
+    skills: ["TypeScript"],
+    experience: [
+      {
+        title: "Alpha Analyst",
+        company: "Contoso",
+        description: "Ran the alpha ledger.",
+        ...dates,
+      },
+    ],
+    education: [],
+  };
+}
+
+/** What `ReconstructedResume` renders and hands back on the next commit: the
+ *  overrides-APPLIED role, re-derived from the current map. */
+function appliedRole(parsed: HeuristicParsedResume, api: EditableParse) {
+  const applied = applyOverrides(
+    parsed,
+    "raw",
+    makeSections(),
+    {},
+    api.experienceOverrides,
+    {},
+    [],
+  );
+  return applied.fields.experience[0];
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let api: EditableParse;
+
+function Probe() {
+  api = useEditableParse();
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Probe />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** One date-cell commit, wired the way the component wires it: the resolved
+ *  entry is read off the CURRENT map, not captured once up front. */
+function commit(
+  parsed: HeuristicParsedResume,
+  field: "start_date" | "end_date",
+  value: string,
+) {
+  const resolved = appliedRole(parsed, api);
+  act(() => api.setExperienceField(0, field, value, resolved));
+}
+
+describe("#672 — a second date edit resolves from what the card shows", () => {
+  it("keeps the re-anchored start date when an end date is typed after it", () => {
+    const parsed = parsedWith({ start_date: "2019", end_date: "2022" });
+
+    // Step 1 — clear the Start cell. The end date becomes the anchor.
+    commit(parsed, "start_date", "");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2022" });
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+
+    // Step 2 — type 2024 into the now-empty End cell. "2022 – 2024" is what the
+    // card showed and what the user meant. The bug resurrected the cleared 2019.
+    commit(parsed, "end_date", "2024");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2022",
+      end_date: "2024",
+    });
+  });
+
+  it("clears the Start cell a second time instead of no-opping", () => {
+    // Same aliasing, plainer symptom: with the previous override inside the
+    // comparison base, the second clear wrote a key equal to "base" and deleted
+    // itself, so the card snapped back to the value the user had just removed.
+    const parsed = parsedWith({ start_date: "2019", end_date: "2022" });
+
+    commit(parsed, "start_date", "");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2022" });
+
+    commit(parsed, "start_date", "");
+    // Nothing is left to anchor the role, so both slots go.
+    expect("start_date" in appliedRole(parsed, api)).toBe(false);
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+  });
+
+  it("still drops an override that lands back on the parsed value", () => {
+    // The sparse write-back is what keeps `hasEdits` honest, and the fix must not
+    // cost it: a first edit that re-types the parsed value stores nothing.
+    const parsed = parsedWith({ start_date: "2019", end_date: "2022" });
+    commit(parsed, "start_date", "2019");
+    expect(api.experienceOverrides[0]).toEqual({});
+  });
+
+  it("gives up 'ongoing' when an end date is typed, and keeps it thereafter", () => {
+    const parsed = parsedWith({ start_date: "2019", is_current: true });
+
+    commit(parsed, "end_date", "2022");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+    // The flag is DELETED, not stored as false: `applyExperienceHeaderOverrides`
+    // drops the key, and `"is_current" in role` is what the round-trip gates and
+    // `toJsonResume` read.
+    expect("is_current" in appliedRole(parsed, api)).toBe(false);
+
+    // A follow-up correction to the same cell must not resurrect the flag — the
+    // second commit resolves against a pair the first one already collapsed.
+    commit(parsed, "end_date", "2023");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2019",
+      end_date: "2023",
+    });
+    expect("is_current" in appliedRole(parsed, api)).toBe(false);
+  });
+});
+
+describe("#814 — End typed before Start keeps both dates", () => {
+  it("puts the re-anchored end date back when the real start date arrives", () => {
+    // The regression this file exists to stop, one ordering later. On a role the
+    // parser produced with NO dates, committing End first re-anchors 2022 into
+    // the Start slot (#672's rule — a lone end date is not representable). The
+    // user then types the start date they meant into the Start cell they can
+    // see, and before #814 that overwrote the anchor: the 2022 was gone, with no
+    // undo affordance pointing at it. `main` accumulated both, so this ordering
+    // was a REGRESSION, not a pre-existing gap.
+    const parsed = parsedWith({});
+
+    commit(parsed, "end_date", "2022");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2022" });
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+
+    commit(parsed, "start_date", "2019");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+
+  it("puts it back after a cleared start re-anchored the pair", () => {
+    // Same rule, reached from the other direction: clearing Start on {2019,2022}
+    // re-anchors the 2022 exactly as an End-first commit does, so typing the
+    // start date back in has to restore the end date rather than consume it.
+    const parsed = parsedWith({ start_date: "2019", end_date: "2022" });
+
+    commit(parsed, "start_date", "");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2022" });
+
+    commit(parsed, "start_date", "2020");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2020",
+      end_date: "2022",
+    });
+  });
+
+  it("does not invent an end date from a start date the user typed as one", () => {
+    // The control that makes the restore a rule rather than a guess: a Start
+    // value the user typed into the Start cell was never relocated, so
+    // correcting it is a plain overwrite. Only a value the rule MOVED out of the
+    // End cell is owed a way back.
+    const parsed = parsedWith({});
+
+    commit(parsed, "start_date", "2022");
+    commit(parsed, "start_date", "2019");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2019" });
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+  });
+
+  it("does not resurrect an end date the user deliberately cleared", () => {
+    // Nothing was relocated here either: the pair had a real start date all
+    // along, so clearing End is a clear, and the next Start edit must not undo
+    // it.
+    const parsed = parsedWith({ start_date: "2019", end_date: "2022" });
+
+    commit(parsed, "end_date", "");
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+
+    commit(parsed, "start_date", "2020");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2020" });
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+  });
+
+  it("does not turn the anchor into a range when the Start cell is blurred untouched", () => {
+    // `EditableField.commit` (primitives/EditableField.tsx:208) fires from
+    // onBlur with the untouched draft — no dirty check — so focusing the Start
+    // cell and clicking away re-commits the value it is already showing. That is
+    // the natural next click here, since the cell is showing a value the user
+    // typed as an END date. A restore on that commit writes the anchor into both
+    // slots and the export draws "2022 – 2022", which the parser reads back as a
+    // real two-sided range.
+    const parsed = parsedWith({});
+
+    commit(parsed, "end_date", "2022");
+    commit(parsed, "start_date", "2022");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2022" });
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+  });
+
+  it("keeps the parking across an untouched blur, so the next real edit still restores", () => {
+    // The other half: a stray blur must not DISARM the restore either, or the
+    // start date typed after it loses the end date exactly as before.
+    const parsed = parsedWith({});
+
+    commit(parsed, "end_date", "2022");
+    commit(parsed, "start_date", "2022"); // blur, nothing typed
+    commit(parsed, "end_date", ""); // blur on the empty End cell too
+    commit(parsed, "start_date", "2019");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+
+  it("does not restore against a pair another writer has replaced", () => {
+    // The parking is keyed by the role's index, and a write that bypasses the
+    // rule (`replay`, which passes no resolved entry) can leave the parked value
+    // describing a pair that is no longer on screen. The restore is gated on the
+    // parked value still BEING the anchor, so a stale one is dropped rather than
+    // pushed into the End cell of a pair it never came from.
+    const parsed = parsedWith({});
+
+    commit(parsed, "end_date", "2022");
+    act(() => api.setExperienceField(0, "start_date", "2020"));
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2020" });
+
+    commit(parsed, "start_date", "2019");
+    expect(appliedRole(parsed, api)).toMatchObject({ start_date: "2019" });
+    expect("end_date" in appliedRole(parsed, api)).toBe(false);
+  });
+
+  it("keeps Start-first ordering unchanged", () => {
+    // The ordering that always worked, asserted beside the one that did not.
+    const parsed = parsedWith({});
+
+    commit(parsed, "start_date", "2019");
+    commit(parsed, "end_date", "2022");
+    expect(appliedRole(parsed, api)).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+});

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -133,6 +133,110 @@ describe("useEditableParse — pruneEmptyAddedEntries (#379)", () => {
   });
 });
 
+describe("useEditableParse — added-role date slots (#672)", () => {
+  it("re-anchors an end date typed into a role that has no start date", () => {
+    // An added entry never reaches the override map, so `setEntryField` carries
+    // the one-anchor rule itself. This is the path a user hits FIRST: "+ Add
+    // role", then only the End cell — the role exported with its year in
+    // `start_date` and re-parsed as a start date.
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+    });
+
+    act(() => api.setEntryField(id, "end_date", "2022"));
+    expect(api.addedEntries[0]).toMatchObject({
+      start_date: "2022",
+      end_date: "",
+    });
+  });
+
+  it("leaves a two-sided pair alone", () => {
+    // The control: normalising on every date write must not disturb the pair a
+    // user fills in the usual order.
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+    });
+
+    act(() => api.setEntryField(id, "start_date", "2019"));
+    act(() => api.setEntryField(id, "end_date", "2022"));
+    expect(api.addedEntries[0]).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+
+  it("keeps the end date when the start date is typed second (#814)", () => {
+    // The same End-before-Start ordering as the parsed-role path, on the surface
+    // that has no override map behind it. The re-anchored 2022 has to move back
+    // into the End cell when the real start date lands, or the value the user
+    // typed first is destroyed by the value they type second.
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+    });
+
+    act(() => api.setEntryField(id, "end_date", "2022"));
+    act(() => api.setEntryField(id, "start_date", "2019"));
+    expect(api.addedEntries[0]).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+
+  it("survives an untouched blur on the Start cell (#814)", () => {
+    // `EditableField` commits on blur whether or not the draft changed, so the
+    // Start cell re-commits the re-anchored value. That must not become a
+    // two-sided `2022 – 2022`, and it must not disarm the restore either.
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+    });
+
+    act(() => api.setEntryField(id, "end_date", "2022"));
+    act(() => api.setEntryField(id, "start_date", "2022"));
+    expect(api.addedEntries[0]).toMatchObject({
+      start_date: "2022",
+      end_date: "",
+    });
+
+    act(() => api.setEntryField(id, "start_date", "2019"));
+    expect(api.addedEntries[0]).toMatchObject({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+
+  it("does not invent an end date from a corrected start date (#814)", () => {
+    // Control: nothing was relocated, so the second Start commit is an overwrite.
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+    });
+
+    act(() => api.setEntryField(id, "start_date", "2022"));
+    act(() => api.setEntryField(id, "start_date", "2019"));
+    expect(api.addedEntries[0]).toMatchObject({
+      start_date: "2019",
+      end_date: "",
+    });
+  });
+
+  it("does not normalise a section that has no date pair", () => {
+    // Education's lone date is a GRADUATION date and belongs in `end_date`
+    // (#97) — the rule is experience-only, and `setEntryField` gates on section.
+    let id = "";
+    act(() => {
+      id = api.addEntry("education");
+    });
+
+    act(() => api.setEntryField(id, "end_date", "2022"));
+    expect(api.addedEntries[0]).toMatchObject({ end_date: "2022" });
+    expect(api.addedEntries[0].start_date).toBeUndefined();
+  });
+});
+
 describe("useEditableParse — Skills category edits (#476)", () => {
   const cats: SkillCategory[] = [
     { label: "Frontend", skills: ["React", "TypeScript"] },

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -55,6 +55,12 @@
 
 import { useState, useCallback, useMemo, useRef } from "react";
 import {
+  applyNormalizedDateOverrides,
+  normalizeExperienceDates,
+  relocatedEndAnchor,
+  type ExperienceDateFields,
+} from "../lib/edit/experience-dates.ts";
+import {
   captureBulletUndoSnapshot,
   restoreBulletUndoSnapshot,
   type BulletUndoTargets,
@@ -116,6 +122,7 @@ export interface ExperienceFieldOverrides {
   team?: string;
   start_date?: string;
   end_date?: string;
+  is_current?: boolean;
 }
 
 // ── Bullet overrides ──────────────────────────────────────────────────────────
@@ -306,6 +313,17 @@ export interface AddedEntry {
  * {@link AddedEntryField} FROM the tuple is what keeps the two in lockstep: a
  * new field can only join the union by joining the replay. Not exported — replay
  * lives in this module now, so nothing outside it needs the tuple.
+ *
+ * ORDER is load-bearing for the date pair, unlike the rest of this list:
+ * `setEntryField` normalises on every date write (#672), so replaying
+ * `{start_date: "2019", end_date: "2022"}` end-first would collapse the lone end
+ * date to `{start_date: "2022"}` and then overwrite it, restoring the entry as
+ * `{start_date: "2019", end_date: ""}`. Keep `start_date` ahead of `end_date`.
+ *
+ * #814's parking does NOT rescue that ordering, deliberately: replay writes every
+ * field of a fresh entry in ONE synchronous burst, so `addedEntriesRef` has not
+ * re-rendered and `setEntryField` sees no entry to park against. Replay stays
+ * verbatim — the same reason it passes no `resolvedEntry` on the override path.
  */
 const ADDED_ENTRY_FIELDS = [
   "title",
@@ -497,11 +515,25 @@ export interface EditableParse {
   ) => void;
   /** Override map for experience entries, keyed by experience array index. */
   experienceOverrides: Record<number, ExperienceFieldOverrides>;
-  /** Update one field on a specific experience entry by its array index. */
-  setExperienceField: (
+  /**
+   * Update one field on a specific experience entry by its array index.
+   *
+   * `resolvedEntry` is the entry as the map currently resolves it — the
+   * overrides-APPLIED experience entry the caller is rendering, NOT the pristine
+   * parse. Passing it opts this commit into the #672 date rule
+   * ({@link applyNormalizedDateOverrides}); omitting it writes the raw value, which
+   * is what `replay` wants — a snapshot's keys are already normalised, and
+   * re-resolving them one at a time would mix a half-applied pair.
+   *
+   * Passing it also opts into #814's restore: a date this rule relocated out of
+   * the End cell earlier in the session is written back to `end_date` when a real
+   * start date arrives, instead of being overwritten by it.
+   */
+  setExperienceField: <K extends keyof ExperienceFieldOverrides>(
     index: number,
-    field: keyof ExperienceFieldOverrides,
-    value: string | undefined,
+    field: K,
+    value: ExperienceFieldOverrides[K],
+    resolvedEntry?: ExperienceDateFields,
   ) => void;
   /** Override map for bullet text, keyed by {@link BulletObservation.id}. */
   bulletOverrides: BulletOverrides;
@@ -728,6 +760,84 @@ export interface EditableParse {
   resetAll: () => void;
 }
 
+/** Parking key for a parsed role (its override-map index). */
+function roleAnchorKey(index: number): string {
+  return `role:${index}`;
+}
+
+/** Parking key for an added entry (its stable id). */
+function addedAnchorKey(id: string): string {
+  return `added:${id}`;
+}
+
+/** What one date-cell commit owes the relocation memory. */
+interface DateCommitRelocation {
+  /** End value to write back alongside this commit — the parked value, when a
+   *  real start date has arrived to displace it. */
+  restoredEnd?: string;
+  /** The value parked AFTER this commit; absent clears the entry's parking. */
+  parked?: string;
+}
+
+/**
+ * Decide the #814 restore and the new parking for one date-cell commit, from the
+ * pair the card is currently showing (`current`) and the value parked for this
+ * entry.
+ *
+ * Module scope and pure, so both writers — the override map
+ * (`setExperienceField`) and the added-entry list (`setEntryField`) — apply the
+ * same rule, and so neither has to run it inside a state updater.
+ *
+ * `current` is the pair as RESOLVED for display: `applyOverrides` output for a
+ * parsed role, the `AddedEntry` itself for an added one. Both have already been
+ * through {@link normalizeExperienceDates}, which is what makes
+ * `current.start_date === parked` a sound test for "the parked value is still
+ * the anchor on screen" — if the user has since replaced it, nothing is owed.
+ */
+function resolveDateCommit(
+  field: "start_date" | "end_date",
+  value: string | undefined,
+  current: ExperienceDateFields,
+  parked: string | undefined,
+): DateCommitRelocation {
+  // `undefined` clears the override rather than writing a blank, so the pair
+  // falls back to what the card is showing for that cell.
+  const committed = (value ?? current[field] ?? "").trim();
+
+  // A commit that re-writes what the cell is already showing displaces nothing,
+  // and BOTH halves of that matter. `EditableField.commit`
+  // (design-system/primitives/EditableField.tsx) fires from `onBlur` with the
+  // untouched draft — there is no dirty check — so clicking into a date cell and
+  // clicking away commits its own value back. Restoring on such a commit would
+  // write the anchor into both slots: one typed date becomes "2022 – 2022",
+  // which the exporter draws and the parser reads back as a genuine two-sided
+  // range — a tenure nobody entered, and exactly the shape
+  // `normalizeExperienceDates` refuses to produce. Consuming the parking on it
+  // is the opposite failure: one stray blur would disarm the restore and the
+  // next real Start commit would lose the end date just as it did before #814.
+  // The Start cell is where this bites (it is the cell holding the relocated
+  // value, so it is the natural next click), but the End cell blurs the same
+  // way, so the guard is on the commit rather than on the field.
+  if (committed === (current[field] ?? "").trim()) return { parked };
+
+  const restoredEnd =
+    field === "start_date" &&
+    parked !== undefined &&
+    Boolean(committed) &&
+    current.start_date === parked
+      ? parked
+      : undefined;
+
+  return {
+    restoredEnd,
+    parked: relocatedEndAnchor({
+      start_date: field === "start_date" ? committed : current.start_date,
+      end_date:
+        field === "end_date" ? committed : (restoredEnd ?? current.end_date),
+    }),
+  };
+}
+
 export function useEditableParse(): EditableParse {
   const [contactOverrides, setContactOverrides] = useState<ContactOverrides>(
     {},
@@ -754,6 +864,13 @@ export function useEditableParse(): EditableParse {
     undefined,
   );
   const [addedEntries, setAddedEntries] = useState<AddedEntry[]>([]);
+  // The committed added entries, readable synchronously by `setEntryField` so it
+  // can decide the #814 restore OUTSIDE its state updater — see
+  // {@link relocatedEndsRef}. Date cells commit one at a time (change/blur on a
+  // single input), so the render-phase assignment is current by the next commit;
+  // unlike `addedBulletsRef` this is a mirror, not a pending-truth channel.
+  const addedEntriesRef = useRef(addedEntries);
+  addedEntriesRef.current = addedEntries;
   const [addedBullets, setAddedBullets] = useState<AddedBullets>({});
   // Latest bullets, readable synchronously by every writer and by
   // `pruneEmptyAddedEntries` — which is called deferred (a tick after a blur,
@@ -780,6 +897,41 @@ export function useEditableParse(): EditableParse {
   bulletOverridesRef.current = bulletOverrides;
   const removedBulletsRef = useRef(removedBullets);
   removedBulletsRef.current = removedBullets;
+
+  /**
+   * Date values the one-anchor rule MOVED out of an End cell and into a Start
+   * cell, keyed by the entry the move happened on (#814).
+   *
+   * WHY THIS EXISTS. `normalizeExperienceDates` re-anchors a lone end date into
+   * `start_date` because that is the only shape the export/parse pair can
+   * represent (#672). The card then shows the value in the Start cell, so a user
+   * filling the pair End-first types the real start date straight over it and the
+   * end date they typed FIRST is destroyed. Before #672 the two commits
+   * accumulated into a two-sided range, which makes that a regression, not a gap
+   * — so the relocated value is parked here and put back into `end_date` the
+   * moment a real start date arrives.
+   *
+   * WHY IT IS A REF AND NOT PART OF THE OVERRIDE MAP. This is provenance about
+   * the edit SEQUENCE, not a field value: `{start_date: "2022"}` typed into the
+   * Start cell and the same pair relocated out of the End cell are identical
+   * objects, and only the second is owed a restore (the "does not invent an end
+   * date" cases in the repro tests are the ones that fall to the difference). It
+   * is therefore not derivable from `prior` or the resolved entry. Keeping it out
+   * of `ExperienceFieldOverrides` also keeps it out of `EditSnapshot`, which
+   * crosses to `/jobs/` through `jd-fit-handoff.ts` — a session-local editing
+   * affordance has no business widening a persisted payload. The cost is that a
+   * replayed snapshot forgets the parking (`resetAll`/`replay` clear it), which
+   * degrades to the pre-#814 behaviour for that one entry rather than to
+   * anything worse.
+   *
+   * Read and written OUTSIDE the state updaters, never inside: an updater that
+   * both reads and clears this would not be idempotent, and React invokes
+   * updaters twice under StrictMode.
+   *
+   * Keys are `roleAnchorKey(index)` for a parsed role's override map and
+   * `addedAnchorKey(id)` for an added entry, which cannot collide.
+   */
+  const relocatedEndsRef = useRef<Record<string, string>>({});
 
   // The ONE writer of `addedBullets`. The ref — not React state — is the source
   // of pending truth: it is assigned synchronously here, before the setState, so
@@ -817,18 +969,55 @@ export function useEditableParse(): EditableParse {
   );
 
   const setExperienceField = useCallback(
-    (
+    <K extends keyof ExperienceFieldOverrides>(
       index: number,
-      field: keyof ExperienceFieldOverrides,
-      value: string | undefined,
+      field: K,
+      value: ExperienceFieldOverrides[K],
+      resolvedEntry?: ExperienceDateFields,
     ) => {
+      const isDateField = field === "start_date" || field === "end_date";
+
+      // #814, decided BEFORE the updater so the read-then-clear of the parking
+      // memory happens exactly once. `restoredEnd` is the end date this rule
+      // relocated into the Start cell earlier in the session, now displaced by a
+      // real start date and owed its slot back.
+      let restoredEnd: string | undefined;
+      if (resolvedEntry && isDateField) {
+        const key = roleAnchorKey(index);
+        const next = resolveDateCommit(
+          field,
+          // A runtime check on `field` cannot narrow `K`, so the value's type
+          // has to be stated. `isDateField` is what makes it true — the only
+          // non-string member of the union is `is_current`.
+          value as string | undefined,
+          resolvedEntry,
+          relocatedEndsRef.current[key],
+        );
+        restoredEnd = next.restoredEnd;
+        if (next.parked === undefined) delete relocatedEndsRef.current[key];
+        else relocatedEndsRef.current[key] = next.parked;
+      }
+
       setExperienceOverrides((prev) => {
-        const entry = { ...prev[index] };
+        const prior = prev[index] ?? {};
+        const entry = { ...prior };
         if (value === undefined) {
           delete entry[field];
         } else {
           entry[field] = value;
         }
+        if (restoredEnd !== undefined) entry.end_date = restoredEnd;
+
+        // Normalise on COMMIT, not at render: the #672 rule runs where the
+        // override is WRITTEN, so the map and the card can never hold different
+        // pairs. `prior` — the map BEFORE this write — is what keeps the sparse
+        // write-back honest: `resolvedEntry` already carries every earlier edit,
+        // so a key that has one may not be compared against it. See
+        // `applyNormalizedDateOverrides`.
+        if (resolvedEntry && isDateField) {
+          applyNormalizedDateOverrides(entry, resolvedEntry, prior);
+        }
+
         return { ...prev, [index]: entry };
       });
     },
@@ -1188,10 +1377,60 @@ export function useEditableParse(): EditableParse {
     [],
   );
 
+  /**
+   * Commit one header field of an added entry.
+   *
+   * An added entry has no override map behind it, so the one-anchor rule (#672)
+   * runs HERE for the same reason `applyNormalizedDateOverrides` runs at the
+   * override seam: without it, filling only the End cell of a freshly added role
+   * shows an end date the exported file would draw as a start date. It carries
+   * #814's other half too — the relocated value is parked in
+   * {@link relocatedEndsRef} and handed back to `end_date` when a real start date
+   * displaces it, so filling the pair End-first no longer destroys the End value.
+   *
+   * A cleared slot is spelled `""`, not a deleted key — the opposite of
+   * {@link applyNormalizedExperienceDates}, which deletes precisely because
+   * `"end_date" in entry` is load-bearing on the parsed-resume shape.
+   * `AddedEntry`'s fields are plain strings and `pushAddedEntry` re-normalises
+   * downstream, so the two conventions are each right for their own container.
+   */
   const setEntryField = useCallback(
     (id: string, field: AddedEntryField, value: string) => {
+      const isDateField = field === "start_date" || field === "end_date";
+      const current = addedEntriesRef.current.find((e) => e.id === id);
+
+      // #814, the same parking the override map does — see `relocatedEndsRef`.
+      // Decided out here for the same reason: reading and clearing the memory
+      // inside the updater would break under a double-invoked updater.
+      let restoredEnd: string | undefined;
+      if (current?.section === "experience" && isDateField) {
+        const key = addedAnchorKey(id);
+        const next = resolveDateCommit(
+          field,
+          value,
+          current,
+          relocatedEndsRef.current[key],
+        );
+        restoredEnd = next.restoredEnd;
+        if (next.parked === undefined) delete relocatedEndsRef.current[key];
+        else relocatedEndsRef.current[key] = next.parked;
+      }
+
       setAddedEntries((prev) =>
-        prev.map((e) => (e.id === id ? { ...e, [field]: value } : e)),
+        prev.map((e) => {
+          if (e.id !== id) return e;
+          const nextEntry = { ...e, [field]: value };
+          if (restoredEnd !== undefined) nextEntry.end_date = restoredEnd;
+          if (e.section === "experience" && isDateField) {
+            const norm = normalizeExperienceDates({
+              start_date: nextEntry.start_date,
+              end_date: nextEntry.end_date,
+            });
+            nextEntry.start_date = norm.start_date ?? "";
+            nextEntry.end_date = norm.end_date ?? "";
+          }
+          return nextEntry;
+        }),
       );
     },
     [],
@@ -1336,6 +1575,8 @@ export function useEditableParse(): EditableParse {
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
     setSummaryOverride(undefined);
     setAddedEntries([]);
+    // The relocation memory is about entries that no longer exist (#814).
+    relocatedEndsRef.current = {};
     // Through the writer, so the ref is cleared too — otherwise a reset leaves
     // the pending-truth ref holding the pre-reset buckets, and the next
     // `addBullet`/`removeBullet` in that same tick would resurrect them.
@@ -1376,6 +1617,13 @@ export function useEditableParse(): EditableParse {
 
   const replay = useCallback(
     (snap: EditSnapshot) => {
+      // A snapshot restores a whole edit state, so any value parked from the
+      // state being replaced is provenance about commits this one never made
+      // (#814). Dropping it costs the restore for that entry until its next date
+      // commit re-parks; keeping it would offer a value the snapshot's own pair
+      // never contained.
+      relocatedEndsRef.current = {};
+
       (
         Object.entries(snap.contactOverrides) as [
           keyof ContactOverrides,
@@ -1383,11 +1631,25 @@ export function useEditableParse(): EditableParse {
         ][]
       ).forEach(([key, value]) => setContactField(key, value));
 
+      // No `resolvedEntry`, deliberately: a snapshot's date keys were normalised
+      // when they were written, and replaying them one at a time against a
+      // half-applied pair would re-resolve each against the other and can produce
+      // "2022 – 2022". Replay is verbatim; the rule runs at commit time only.
+      // The value type is `string | boolean` since #672 widened
+      // `ExperienceFieldOverrides` with `is_current` — a snapshot is JSON, so the
+      // boolean round-trips, but the cast has to say so.
       Object.entries(snap.experienceOverrides).forEach(([index, fields]) => {
         (
-          Object.entries(fields) as [keyof ExperienceFieldOverrides, string][]
+          Object.entries(fields) as [
+            keyof ExperienceFieldOverrides,
+            string | boolean,
+          ][]
         ).forEach(([field, value]) =>
-          setExperienceField(Number(index), field, value),
+          setExperienceField(
+            Number(index),
+            field,
+            value as ExperienceFieldOverrides[typeof field],
+          ),
         );
       });
 

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -206,6 +206,99 @@ describe("applyOverrides", () => {
     expect(parsed.experience[0].location).toBe("Springfield, IL");
   });
 
+  it("re-anchors a role whose start date the user cleared (#672)", () => {
+    // The reproduction: a correction ("I don't know when I joined") left
+    // `start_date: ""` beside a live `end_date`, which Download-PDF exported as a
+    // bare "2022" and the re-parse read back as a START date — silently, and in a
+    // direction that IMPROVES the score, since the date-completeness check reads
+    // `start_date` alone.
+    const parsed = baseParsed();
+    const { fields: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      { 0: { start_date: "" } },
+      {},
+      [],
+    );
+    expect(out.experience[0].start_date).toBe("2022");
+    expect("end_date" in out.experience[0]).toBe(false);
+    // Original untouched.
+    expect(parsed.experience[0].start_date).toBe("2020");
+    expect(parsed.experience[0].end_date).toBe("2022");
+  });
+
+  it("drops is_current when the start date that anchored it is cleared (#672)", () => {
+    const parsed = baseParsed();
+    parsed.experience[0] = {
+      ...parsed.experience[0],
+      start_date: "2020",
+      end_date: undefined,
+      is_current: true,
+    };
+    const { fields: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      { 0: { start_date: "" } },
+      {},
+      [],
+    );
+    // A bare "Present" draws into the header and re-parses to nothing at all, so
+    // the flag cannot survive the round trip either way — it goes here, where the
+    // card shows the change, rather than inside the downloaded file.
+    expect("start_date" in out.experience[0]).toBe(false);
+    expect("is_current" in out.experience[0]).toBe(false);
+  });
+
+  it("drops is_current when the user types an end date onto a current role (#672)", () => {
+    // The opposite direction from the case above, and it fails the opposite way:
+    // `experienceDateRange` and the `AtsEntryFields` builder both let `is_current`
+    // WIN, so a surviving flag draws "2020 – Present" and the end date the user
+    // just typed never reaches the file.
+    const parsed = baseParsed();
+    parsed.experience[0] = {
+      ...parsed.experience[0],
+      start_date: "2020",
+      end_date: undefined,
+      is_current: true,
+    };
+    const { fields: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      { 0: { end_date: "2022" } },
+      {},
+      [],
+    );
+    expect(out.experience[0].start_date).toBe("2020");
+    expect(out.experience[0].end_date).toBe("2022");
+    expect("is_current" in out.experience[0]).toBe(false);
+  });
+
+  it("leaves the date pair alone when the override touches no date field (#672)", () => {
+    // Normalisation answers a date EDIT. A role the parser produced is not
+    // something the user asked us to change, so re-titling it must not rewrite
+    // its dates.
+    const parsed = baseParsed();
+    parsed.experience[0] = { ...parsed.experience[0], is_current: true };
+    const { fields: out } = applyOverrides(
+      parsed,
+      "raw",
+      makeSections(),
+      {},
+      { 0: { title: "Staff Engineer" } },
+      {},
+      [],
+    );
+    expect(out.experience[0].start_date).toBe("2020");
+    expect(out.experience[0].end_date).toBe("2022");
+    expect(out.experience[0].is_current).toBe(true);
+  });
+
   it("applies an experience team override and clears it on empty string", () => {
     const parsed = baseParsed();
     parsed.experience[0].team = "Payments Platform";

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -40,6 +40,10 @@ import type { SectionedResume } from "../heuristics/sections.ts";
 import type { SectionName } from "../heuristics/regex.ts";
 import { normalizeBulletText } from "../score/group-bullets.ts";
 import {
+  applyNormalizedExperienceDates,
+  normalizeExperienceDates,
+} from "./experience-dates.ts";
+import {
   computeEditedSkills,
   isEmptySkillsOverride,
 } from "./skills-categories.ts";
@@ -288,8 +292,21 @@ function dedupeConfEdits(confEdits: readonly LegacyConfEdit[]): LegacyConfEdit[]
 
 // ── Experience / education header fields ────────────────────────────────────
 
-/** Fold `experience` header overrides (title/company/location/team/dates) into
- *  the cloned experience entries in place, keyed by array index. */
+/**
+ * Fold `experience` header overrides (title/company/location/team/dates) into the
+ * cloned experience entries in place, keyed by array index.
+ *
+ * NOT a plain field fold: the date pair is NORMALISED after it is written (#672).
+ * A date edit is the only way an experience entry can reach a shape the
+ * export/parse pair cannot represent — an end date with no start date, which
+ * Download-PDF silently returns as a START date. `normalizeExperienceDates` is the
+ * one rule for what the pair means; `useEditableParse` runs the same rule over the
+ * override MAP when the user commits a date cell, so the card reads back the pair
+ * this function is about to produce rather than the raw keystrokes.
+ *
+ * The normalisation is GATED on a date field actually appearing in the override —
+ * see the call site for why re-titling a role must not rewrite its dates.
+ */
 function applyExperienceHeaderOverrides(
   experience: HeuristicParsedResume["experience"],
   overrides: Record<number, ExperienceFieldOverrides>,
@@ -308,6 +325,22 @@ function applyExperienceHeaderOverrides(
     if (fields.team !== undefined) exp.team = fields.team || undefined;
     if (fields.start_date !== undefined) exp.start_date = fields.start_date;
     if (fields.end_date !== undefined) exp.end_date = fields.end_date;
+    if (fields.is_current !== undefined) {
+      if (fields.is_current) exp.is_current = true;
+      else delete exp.is_current;
+    }
+    // #672, the normalisation this function's docblock describes. Gated on a date
+    // field actually being in THIS override, not run for every touched entry: a
+    // role the parser produced with `is_current` and no start date is not
+    // something the user asked us to change, and re-titling it must not silently
+    // drop its flag.
+    if (
+      fields.start_date !== undefined ||
+      fields.end_date !== undefined ||
+      fields.is_current !== undefined
+    ) {
+      applyNormalizedExperienceDates(exp);
+    }
   }
 }
 
@@ -806,8 +839,16 @@ function pushAddedEntry(
       company: entry.subtitle ?? "",
       ...(entry.location ? { location: entry.location } : {}),
       ...(entry.team ? { team: entry.team } : {}),
-      start_date: entry.start_date,
-      end_date: entry.end_date,
+      // Through the same #672 rule the edit path uses: "+ Add role" with only an
+      // end date filled in reaches the identical unrepresentable shape, and a
+      // second convention here would mean an added role and an edited one export
+      // differently. Education is deliberately NOT normalised — a lone education
+      // date is a GRADUATION date and belongs in `end_date` (#97, pinned by
+      // #618).
+      ...normalizeExperienceDates({
+        start_date: entry.start_date,
+        end_date: entry.end_date,
+      }),
       description,
     });
   } else if (entry.section === "education") {

--- a/src/lib/edit/experience-dates.test.ts
+++ b/src/lib/edit/experience-dates.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The #672 date-anchor rule, asserted on values rather than on shape.
+ *
+ * What makes these worth reading: the SHAPES ARE INDISTINGUISHABLE downstream.
+ * `{end_date: "2022"}` and `{start_date: "2022"}` draw the identical bare "2022"
+ * into the exported header, and the parser reads that token as a start date on
+ * the way back — so the only place the difference can be resolved is here, before
+ * the value reaches the model.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  applyNormalizedDateOverrides,
+  applyNormalizedExperienceDates,
+  normalizeExperienceDates,
+  relocatedEndAnchor,
+} from "./experience-dates.ts";
+
+describe("normalizeExperienceDates", () => {
+  it("leaves a two-sided range alone — it is representable as drawn", () => {
+    expect(normalizeExperienceDates({ start_date: "2019", end_date: "2022" })).toEqual({
+      start_date: "2019",
+      end_date: "2022",
+    });
+  });
+
+  it("leaves a lone start date alone — the #358 case already round-trips", () => {
+    expect(normalizeExperienceDates({ start_date: "2022" })).toEqual({
+      start_date: "2022",
+    });
+  });
+
+  it("moves a lone end date into the anchor slot", () => {
+    // The defect verbatim: exported as a bare "2022", re-parsed as a start date.
+    // Doing it here makes the collapse the user's own edit, visible in the card,
+    // instead of a silent rewrite inside Download-PDF.
+    expect(normalizeExperienceDates({ end_date: "2022" })).toEqual({
+      start_date: "2022",
+    });
+  });
+
+  it("does not repeat the anchor as an end date", () => {
+    // Guarding a tempting "fill both slots" variant: it draws "2022 – 2022",
+    // which is a claim the résumé never made.
+    const out = normalizeExperienceDates({ end_date: "May 2022" });
+    expect(out.end_date).toBeUndefined();
+    expect(out.start_date).toBe("May 2022");
+  });
+
+  it("treats a cleared field as absent, not as a value", () => {
+    // The literal repro: the user clears the start date on a dated role. Before
+    // #672 this stored `start_date: ""` beside a live `end_date` — the exact
+    // unrepresentable pair, and unlike `location`/`team` two lines above it in
+    // `applyExperienceHeaderOverrides`, the empty string was stored verbatim.
+    expect(normalizeExperienceDates({ start_date: "", end_date: "2022" })).toEqual({
+      start_date: "2022",
+    });
+    expect(normalizeExperienceDates({ start_date: "   ", end_date: "" })).toEqual({});
+  });
+
+  it("keeps is_current when there is a start date to anchor it", () => {
+    expect(
+      normalizeExperienceDates({ start_date: "2019", is_current: true }),
+    ).toEqual({ start_date: "2019", is_current: true });
+  });
+
+  it("drops is_current when the anchor came from an end date", () => {
+    // The pair is self-contradictory — ended AND ongoing — and the end date is
+    // the half the user actually typed. Keeping the flag would read the role back
+    // as "joined 2022, still there", the rewrite this module exists to stop.
+    expect(
+      normalizeExperienceDates({ end_date: "2022", is_current: true }),
+    ).toEqual({ start_date: "2022" });
+  });
+
+  it("drops is_current when an end date sits beside the start date", () => {
+    // The same rule as the case above, with an anchor to keep. It matters on its
+    // own because this pair fails in the OPPOSITE direction: `experienceDateRange`
+    // and the `AtsEntryFields` builder both let `is_current` win, so leaving the
+    // flag on draws "2020 – Present" and silently discards the end date the user
+    // typed — the #672 rewrite, pointing the other way.
+    expect(
+      normalizeExperienceDates({
+        start_date: "2020",
+        end_date: "2022",
+        is_current: true,
+      }),
+    ).toEqual({ start_date: "2020", end_date: "2022" });
+  });
+
+  it("drops is_current when no date anchors it", () => {
+    // `experienceDateRange` would draw a bare "Present" into the header, which
+    // re-parses to no date field and no flag — the value is lost either way. It
+    // is lost here at edit time, where the card shows it, instead of at download.
+    expect(normalizeExperienceDates({ is_current: true })).toEqual({});
+    expect(normalizeExperienceDates({ start_date: "", is_current: true })).toEqual({});
+  });
+
+  it("does not mutate its input", () => {
+    const input = { start_date: "", end_date: "2022" };
+    normalizeExperienceDates(input);
+    expect(input).toEqual({ start_date: "", end_date: "2022" });
+  });
+});
+
+describe("applyNormalizedExperienceDates", () => {
+  it("deletes cleared keys rather than setting them to undefined", () => {
+    // `"end_date" in entry` is how the round-trip gates tell absent from empty,
+    // and `toJsonResume` serialises any own key it finds.
+    const entry: { start_date?: string; end_date?: string; is_current?: boolean } = {
+      start_date: "",
+      end_date: "2022",
+      is_current: true,
+    };
+    applyNormalizedExperienceDates(entry);
+    expect(entry.start_date).toBe("2022");
+    expect("end_date" in entry).toBe(false);
+    expect("is_current" in entry).toBe(false);
+  });
+
+  it("leaves an already-canonical pair byte-identical", () => {
+    const entry = { start_date: "2019", end_date: "2022" };
+    applyNormalizedExperienceDates(entry);
+    expect(entry).toEqual({ start_date: "2019", end_date: "2022" });
+  });
+});
+
+describe("applyNormalizedDateOverrides", () => {
+  // The two-step date sequence (#672), at the seam. Clearing the Start cell is
+  // the case the issue is about; typing an end date after it is the case
+  // render-only normalisation gets wrong.
+  //
+  // These cases hand a role with NO override yet, so the resolved entry and the
+  // parse coincide and `prior` is empty. The sequence where they diverge — a
+  // second edit, where the resolved entry already carries the first — cannot be
+  // written honestly here, because it needs the real reducer feeding the real
+  // `applyOverrides` output back in. That lives in
+  // `hooks/useEditableParse.date-slot-sequence.repro.test.tsx`.
+  const parsed = { start_date: "2019", end_date: "2022" };
+
+  it("writes the collapsed pair back, so a later edit resolves from what the card shows", () => {
+    // Clear the Start cell. The end date becomes the anchor, and that has to land
+    // in the MAP; storing the raw `{start_date: ""}` is what let the next commit
+    // discard the 2022 the user was looking at.
+    const entry: Record<string, unknown> = { start_date: "" };
+    applyNormalizedDateOverrides(entry, parsed);
+    expect(entry).toEqual({ start_date: "2022", end_date: "" });
+  });
+
+  it("deletes a key whose normalised value already equals the parse", () => {
+    // An override map is a delta. Storing a no-op edit keeps `hasEdits` true for
+    // the rest of the session over a value the user never changed.
+    const entry: Record<string, unknown> = { start_date: "2019" };
+    applyNormalizedDateOverrides(entry, parsed);
+    expect("start_date" in entry).toBe(false);
+    expect("end_date" in entry).toBe(false);
+  });
+
+  it("keeps a key that ALREADY carries an override, even when it equals the resolved value", () => {
+    // The delete-if-inert test is only valid where "resolved" is also "parsed",
+    // i.e. on a key with no override yet. Once a key has one, the resolved entry
+    // CONTAINS it — comparing against it would make the key delete itself and
+    // resurrect the value the previous edit replaced. `prior` is what draws that
+    // line.
+    const resolved = { start_date: "2022" }; // = parse + `{start_date:"2022"}`
+    const prior = { start_date: "2022", end_date: "" };
+    const entry: Record<string, unknown> = { ...prior, end_date: "2024" };
+    applyNormalizedDateOverrides(entry, resolved, prior);
+    expect(entry).toEqual({ start_date: "2022", end_date: "2024" });
+  });
+
+  it("clears an unanchored 'ongoing' claim through the map", () => {
+    // A bare "Present" with no start date draws into the header and re-parses to
+    // nothing. Dropping the flag at edit time makes the loss visible.
+    const current = { start_date: "2019", is_current: true };
+    const entry: Record<string, unknown> = { start_date: "" };
+    applyNormalizedDateOverrides(entry, current);
+    expect(entry).toEqual({ start_date: "", is_current: false });
+  });
+
+  it("does not mutate the entry it resolves against", () => {
+    const base = { start_date: "2019", end_date: "2022" };
+    applyNormalizedDateOverrides({ start_date: "" }, base);
+    expect(base).toEqual({ start_date: "2019", end_date: "2022" });
+  });
+});
+
+describe("relocatedEndAnchor", () => {
+  // The value the rule MOVES, which is the value a writer has to be able to hand
+  // back (#814). Every case here is a pair the rule is about to rewrite — the
+  // predicate reports what it takes out of the End cell, not what it leaves.
+  it("reports the end date when there is no start date to anchor the pair", () => {
+    expect(relocatedEndAnchor({ end_date: "2022" })).toBe("2022");
+    expect(relocatedEndAnchor({ start_date: "", end_date: "2022" })).toBe("2022");
+    expect(relocatedEndAnchor({ start_date: "  ", end_date: " 2022 " })).toBe("2022");
+  });
+
+  it("reports nothing when the pair has a start date of its own", () => {
+    // Nothing moves, so nothing is owed: a two-sided range is representable, and
+    // a lone start date is the shape the rule already leaves alone (#358).
+    expect(relocatedEndAnchor({ start_date: "2019", end_date: "2022" })).toBeUndefined();
+    expect(relocatedEndAnchor({ start_date: "2019" })).toBeUndefined();
+  });
+
+  it("reports nothing for a pair with no end date at all", () => {
+    expect(relocatedEndAnchor({})).toBeUndefined();
+    expect(relocatedEndAnchor({ end_date: "" })).toBeUndefined();
+    expect(relocatedEndAnchor({ is_current: true })).toBeUndefined();
+  });
+});

--- a/src/lib/edit/experience-dates.ts
+++ b/src/lib/edit/experience-dates.ts
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The one rule for what an experience entry's date pair MEANS after an edit
+ * (#672).
+ *
+ * THE CONSTRAINT: an experience entry has exactly ONE date anchor, and it is
+ * `start_date`. That is not a preference — it is what the export/parse pair can
+ * represent. `experienceDateRange` (`pdf/ats-resume-model.ts`) draws a two-sided
+ * range as "2019 – 2022" and a one-sided one as a bare "2022", side-blind; on the
+ * way back, every non-empty return path of `parseDateRange` writes `start_date`.
+ * So an entry holding ONLY an end date survives Download-PDF as a START date:
+ * "left Contoso in 2022" comes back as "joined Contoso in 2022", the `end_date`
+ * key gone entirely. Silent, and it moves the score — the date-completeness check
+ * in `computeAnonymousAtsScore` filters on `start_date`, so the corrupted role
+ * scores BETTER than the one the user typed.
+ *
+ * WHY THE FIX IS HERE AND NOT IN THE EXPORTER. Teaching the exporter to draw a
+ * directional token ("– 2022", "Until 2022") is the obvious fix and it is wrong:
+ * `DATE_RANGE_RE`'s bare-year anchor is `\d{4}`, so a leading-separator form makes
+ * any line containing "- 1234" a phantom entry anchor, and 56 of 57 corpus
+ * snapshots carry `experienceRegionHasDateRangeLines`. It would also fall back out
+ * of the flush-right slot #618 just gave lone dates. The representable set is
+ * fixed; what has to change is that we stop producing values outside it.
+ *
+ * THE RULE, in one line: **an end date with no start date becomes the start
+ * date.** Plus two corollaries — an empty string is not a value (it is a cleared
+ * field, exactly as `location`/`team` already treat it), and `is_current` is a
+ * claim that no end date exists, so it drops the moment one does. That covers two
+ * shapes, and they fail in opposite directions if only the first is handled:
+ *   • NO start date — a bare "Present" with nothing to anchor it draws into the
+ *     header and re-parses to nothing at all; dropping it loses the same flag,
+ *     visibly and at edit time, instead of silently at download.
+ *   • An END date beside `is_current` — `experienceDateRange` and the
+ *     `AtsEntryFields` builder both let the flag WIN, so the file draws
+ *     "2020 – Present" and the end date the user typed is dropped. Same silent
+ *     rewrite as #672, pointing the other way.
+ *
+ * WHERE IT RUNS, and why not at render. `applyOverrides` normalises the DATA with
+ * it, and `useEditableParse`'s `setExperienceField` normalises the override MAP
+ * with it on every date commit. The edit card's date cells read the map RAW —
+ * they do not re-run the rule — so the collapse shows up on screen (the Start
+ * cell fills in, the End cell empties) purely because the map already holds it.
+ * That direction is deliberate: a rule applied only where the card RENDERS would
+ * leave the map holding a pair the screen contradicts, and the next edit resolves
+ * from the map, not from the screen — see {@link applyNormalizedDateOverrides},
+ * which owns that hazard and the delta arithmetic it forces.
+ *
+ * WHAT THE RULE OWES BACK. Re-anchoring is not free: the End cell the user typed
+ * into is now empty and the value sits in Start, so the next thing they type into
+ * Start lands on top of it. Filling the pair End-first therefore destroyed the
+ * end date (#814) — an ordering that accumulated both dates before this rule
+ * existed, which makes it a regression rather than a gap. Both writers park the
+ * relocated value ({@link relocatedEndAnchor}) and hand it back to `end_date`
+ * when a real start date displaces it. The memory lives in `useEditableParse`,
+ * not here: which cell a value was typed into is a fact about the edit sequence
+ * and is not recoverable from the pair afterwards.
+ *
+ * `ReconstructedRole` does call {@link normalizeExperienceDates} once more, on the
+ * read-only `<h3>` composite it renders when the card is not editable. Two
+ * separate reasons that call changes nothing today, and both are worth knowing
+ * before deleting it. It is inert on anything the parser can produce — every
+ * non-empty return path of `parseDateRange` writes `start_date`, and `is_current`
+ * only ever arrives beside one, so `{end}` alone and `{start, end, is_current}`
+ * are both unreachable. And the branch itself does not render in the app at all:
+ * `editable` is `onFieldChange !== undefined`, the only `RoleEntry` call site that
+ * omits `onFieldChange` is the `experienceIndex={null}` "Other bullets" group, and
+ * there `group.experience` is null, so `RoleHeader` returns its own `<h3>` before
+ * reaching this branch. Tests are the only caller. It is kept rather than deleted
+ * because the EXPORTER reads the raw entry via `experienceDateRange`, where
+ * `is_current` still wins over an end date: if the composite ever did become
+ * reachable on such a shape, it and the exported file would disagree, and this
+ * call is the side that would be right.
+ *
+ * WHAT THIS MODULE DOES NOT OWN. "The one rule" above is the rule for the EDIT
+ * and EXPORT paths — the two that can corrupt a stored value. Two display-only
+ * formatters still hand-roll their own collapse and disagree with this one on the
+ * unanchored-`is_current` row: `buildDateRange` (`score/group-bullets.ts:328`,
+ * which feeds `formatExperienceHeader`) and `buildProjectDates`
+ * (`score/entry-dates.ts:16`) both draw a bare "Present" where
+ * {@link formatExperienceDateRange} draws "". They also use a tight "–" against
+ * this module's spaced " – ". Nothing is broken by that today: the shape is
+ * unreachable from the parser and, since #672, from the edit lane too, and
+ * neither formatter's output is ever re-parsed. Folding them in needs a separator
+ * parameter and a decision on that row, which is a change to display strings, not
+ * to #672's corruption — deliberately out of scope here. (`buildEducationDates`
+ * in the same file is NOT a candidate: it reads `end_date` first on purpose,
+ * because a lone education date is a graduation date, #97.)
+ *
+ * Pure and total: no throw, no mutation of the input, `undefined` in for every
+ * absent field rather than "".
+ */
+
+/** The date fields of an experience entry — the subset this rule reads. */
+export interface ExperienceDateFields {
+  start_date?: string;
+  end_date?: string;
+  is_current?: boolean;
+}
+
+/** `undefined` for a blank/whitespace-only value, the trimmed string otherwise.
+ *
+ *  The trim is deliberate and it is a behaviour change on the EXPORT path, not
+ *  only the edit one: `experienceDateRange` (`pdf/ats-resume-model.ts`) delegates
+ *  here, and its old body tested truthiness without trimming, so an entry holding
+ *  `start_date: "  "` used to draw two spaces into the header slot and now draws
+ *  nothing. That population is exactly the one this module is total over — raw
+ *  entries that never passed through `applyOverrides` — so the case is reachable,
+ *  even though no corpus snapshot moves. Whitespace is not a date. */
+function value(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Normalise one experience entry's dates onto the single representable shape.
+ *
+ * | In | Out |
+ * |---|---|
+ * | `{ start: "2019", end: "2022" }` | unchanged — a two-sided range is representable |
+ * | `{ start: "2022" }` | unchanged — the lone-start case (#358) already round-trips |
+ * | `{ end: "2022" }` | `{ start: "2022" }` — the anchor rule |
+ * | `{ start: "", end: "2022" }` | `{ start: "2022" }` — a cleared field is not a value |
+ * | `{ start: "2019", is_current: true }` | unchanged |
+ * | `{ is_current: true }` | `{}` — no anchor, so no ongoing claim |
+ * | `{ end: "2022", is_current: true }` | `{ start: "2022" }` — an end date says it ended |
+ * | `{ start: "2020", end: "2022", is_current: true }` | `{ start: "2020", end: "2022" }` — same rule, with an anchor to keep |
+ *
+ * Returns a NEW object; the caller decides whether to assign or render it.
+ */
+export function normalizeExperienceDates(
+  fields: ExperienceDateFields,
+): ExperienceDateFields {
+  const start = value(fields.start_date);
+  const end = value(fields.end_date);
+
+  const anchored = start ?? end;
+  if (!anchored) return {};
+
+  return {
+    start_date: anchored,
+    // Only when the anchor came from `start_date`; otherwise the end date IS the
+    // anchor and repeating it as an end would draw "2022 – 2022".
+    ...(start && end ? { end_date: end } : {}),
+    // `is_current` survives only on top of a real START date and with NO end
+    // date. A role whose only date is an END date has said it ended — keeping
+    // "ongoing" on it would turn "left in 2022" into "joined in 2022, still
+    // there", which is the very rewrite this module exists to stop. The `!end`
+    // half is the same rule pointing the other way: with both, the exporter lets
+    // the flag win and draws "2020 – Present", dropping the end date the user
+    // typed. An end date says it ended, whether or not a start date sits beside
+    // it.
+    ...(start && !end && fields.is_current ? { is_current: true } : {}),
+  };
+}
+
+/**
+ * The value {@link normalizeExperienceDates} MOVES out of the End cell and into
+ * the Start slot for this pair — `undefined` when nothing moves.
+ *
+ * The relocation is what makes the rule representable, and it is also the one
+ * thing about it a user cannot undo from the card: after it, the End cell is
+ * empty and the Start cell holds a value they typed as an END date. Typing the
+ * real start date over it destroyed the relocated one (#814) — an ordering that
+ * accumulated both dates before #672 — so the writers park this value and put it
+ * back when a real start date arrives. `useEditableParse` owns that memory,
+ * because provenance is a property of the EDIT SEQUENCE, not of the pair: a
+ * `{start: "2022"}` that was typed into the Start cell and one that was
+ * relocated out of the End cell are the same object, and only the second is owed
+ * a way back. Nothing in the map or the entry can tell them apart.
+ */
+export function relocatedEndAnchor(
+  fields: ExperienceDateFields,
+): string | undefined {
+  const end = value(fields.end_date);
+  return !value(fields.start_date) && end ? end : undefined;
+}
+
+/**
+ * Assign {@link normalizeExperienceDates} onto a mutable entry, DELETING the keys
+ * it clears rather than setting them to `undefined`.
+ *
+ * The distinction is load-bearing downstream: `"end_date" in role` is how the
+ * round-trip gates tell "the field is absent" from "the field is empty", and
+ * `toJsonResume` emits any own key it finds. Assigning `undefined` would leave a
+ * key that reads as present to the first and serialises as `null`-ish to the
+ * second.
+ */
+export function applyNormalizedExperienceDates<T extends ExperienceDateFields>(
+  entry: T,
+): void {
+  const next = normalizeExperienceDates(entry);
+  if (next.start_date === undefined) delete entry.start_date;
+  else entry.start_date = next.start_date;
+  if (next.end_date === undefined) delete entry.end_date;
+  else entry.end_date = next.end_date;
+  if (next.is_current === undefined) delete entry.is_current;
+  else entry.is_current = next.is_current;
+}
+
+/** Write one date key of a sparse override entry, DELETING it when the normalised
+ *  value already equals the resolved one AND this key carries no override yet —
+ *  the only case in which "resolved" is also "parsed". See
+ *  {@link applyNormalizedDateOverrides} for why both halves of that guard are
+ *  load-bearing. */
+function writeDateOverride(
+  entry: ExperienceDateFields,
+  key: "start_date" | "end_date",
+  next: string | undefined,
+  resolved: string | undefined,
+  alreadyOverridden: boolean,
+): void {
+  if (!alreadyOverridden && next === resolved) delete entry[key];
+  else entry[key] = next ?? "";
+}
+
+/**
+ * Normalise the DATE keys of a sparse override entry against the entry the map
+ * currently RESOLVES to — the override-map counterpart of
+ * {@link applyNormalizedExperienceDates}.
+ *
+ * The two differ because an override map is a DELTA, not a record: each field
+ * reads as "override if present, else the parsed value", so the rule has to run
+ * on the resolved pair but be written back sparsely. A key that clears is stored
+ * as `""`, the override map's existing spelling for a cleared field
+ * (`location`/`team` do the same), which is what distinguishes "the user emptied
+ * this" from "the user never touched it".
+ *
+ * WHY THE WRITE-BACK EXISTS AT ALL. Running the rule only where the card renders
+ * leaves the map holding a pair the card contradicts: clear the Start cell on a
+ * `{2019, 2022}` role and the card correctly reads "Start 2022", but the map
+ * still holds `{start_date: ""}` — so the next edit resolves from `{"", 2022}`
+ * and typing an end date of 2024 silently discards the 2022 the user was looking
+ * at. Normalising on COMMIT keeps the map and the card the same state (#672).
+ *
+ * WHY `alreadyOverridden` EXISTS, and why `resolvedEntry` is NOT the pristine
+ * parse. Callers hold the overrides-APPLIED entry (`display.parsed` is
+ * `applyOverrides` output; the pristine parse is not threaded this far), and that
+ * is the right input for the `??` resolution above — it already carries every
+ * earlier edit. It is the WRONG input for a delete-if-inert test, because on the
+ * second date edit the previous override is inside it, so a key compared against
+ * it looks unchanged and deletes ITSELF:
+ *
+ * ```
+ *                     override map                         resolves to
+ * step 1 clear Start  {start_date:"2022", end_date:""}     {s:"2022"}          ok
+ * step 2 End = 2024   {end_date:"2024"}                    {s:"2019",e:"2024"} BUG
+ * ```
+ *
+ * The cleared 2019 is back — #672's own corruption, one edit later. `prior` is
+ * the override entry as it stood BEFORE this commit, and a key present there is
+ * exactly a key for which `resolvedEntry` is not the parse. Those keys are always
+ * written; only a key the user has never overridden may be dropped, and for that
+ * key resolved === parsed by construction. The drop still matters: storing an
+ * inert edit keeps `hasEdits` true for the rest of the session over a value
+ * nobody changed.
+ *
+ * Mutates `entry` in place; `resolvedEntry` and `prior` are read-only.
+ */
+export function applyNormalizedDateOverrides(
+  entry: ExperienceDateFields,
+  resolvedEntry: ExperienceDateFields,
+  prior: ExperienceDateFields = {},
+): void {
+  const next = normalizeExperienceDates({
+    start_date: entry.start_date ?? resolvedEntry.start_date,
+    end_date: entry.end_date ?? resolvedEntry.end_date,
+    is_current: entry.is_current ?? resolvedEntry.is_current,
+  });
+
+  writeDateOverride(
+    entry,
+    "start_date",
+    next.start_date,
+    resolvedEntry.start_date,
+    prior.start_date !== undefined,
+  );
+  writeDateOverride(
+    entry,
+    "end_date",
+    next.end_date,
+    resolvedEntry.end_date,
+    prior.end_date !== undefined,
+  );
+
+  // `is_current` is absent-or-true out of the rule and boolean-or-absent in the
+  // map, so compare the two on their falsy floor rather than by identity.
+  const nextCurrent = next.is_current ?? false;
+  if (
+    prior.is_current === undefined &&
+    nextCurrent === (resolvedEntry.is_current ?? false)
+  ) {
+    delete entry.is_current;
+  } else {
+    entry.is_current = nextCurrent;
+  }
+}
+
+/**
+ * Format an experience date range into a user-facing string using an en-dash with spaces (e.g. "2019 – 2022").
+ *
+ * Total over the raw shape, NOT only the normalised one: `ats-resume-model.ts`
+ * formats entries that never passed through `applyOverrides`, so the lone-end and
+ * unanchored-`is_current` inputs still reach here and still need a string. Callers
+ * that have run the rule (the edit card) simply never produce those two.
+ */
+export function formatExperienceDateRange(fields: ExperienceDateFields): string {
+  const start = fields.start_date?.trim();
+  const end = fields.is_current ? "Present" : fields.end_date?.trim();
+  if (start && end) return `${start} – ${end}`;
+  if (start) return start;
+  if (end) return end;
+  return "";
+}
+

--- a/src/lib/heuristics/corpus-edit-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-edit-roundtrip.test.ts
@@ -68,6 +68,11 @@
  *      Claim 2 alone cannot be trusted without this: under a wrong-ROLE write the
  *      marker-carrying role IS the wrongly-edited one, which legitimately no
  *      longer holds the replaced value, so both other halves pass.
+ *   4. SLOT (#672) — the override clears `start_date` and writes `NEW_END_DATE`
+ *      into `end_date`, the one shape the export/parse pair cannot represent; the
+ *      value must come back in `start_date`, and `end_date` must be gone. Both
+ *      halves are needed: presence alone passes when the value is left in BOTH
+ *      slots, absence alone passes when the collapse dropped it entirely.
  *
  * What it still cannot see: a pure `title`↔`company` SWAP inside role 0. The
  * exporter renders the pair into one header line and the parser re-classifies it
@@ -124,6 +129,21 @@ const NEW_COMPANY = "Vantreon Systems";
 const NEW_BULLET =
   "Vantreon: cut p99 checkout latency 43% by resharding the session store.";
 const NEW_SKILL = "VantreonScript";
+// A DATE edit (#672), typed into the END cell of a role whose START the same
+// override clears — the exact unrepresentable shape, built corpus-wide. It is
+// deliberately a token no fixture carries, so the presence check cannot pass on a
+// value that was already there.
+//
+// Supplying the end date rather than reusing the fixture's own is what makes this
+// deterministic across 59 fixtures: a real end token can be "Present", "current",
+// or a form `parseDateRange` renormalises, and the gate would then be asserting
+// against whatever each fixture happened to hold. The collapse is the same either
+// way — an end date with no start date is the shape — and the value is ours.
+//
+// The edit-leg gate had never touched a date field, which is exactly why the
+// lone-end-date corruption could ship: `applyExperienceHeaderOverrides` wrote both
+// date keys verbatim, empty string included, and no gate could see it.
+const NEW_END_DATE = "Feb 1987";
 const ADDED_DEGREE = "B.S. in Vantreon Systems Engineering";
 const ADDED_INSTITUTION = "Vantreon Institute of Technology";
 
@@ -222,7 +242,13 @@ interface SyntheticEdits {
   exercised: Set<Exclude<EditCategory, "render">>;
   /** Original values the overrides replaced — for the "replaced value absent"
    *  assertion (read at runtime, never persisted). */
-  replaced: { email?: string; title?: string; company?: string; bullet?: string };
+  replaced: {
+    email?: string;
+    title?: string;
+    company?: string;
+    bullet?: string;
+    start_date?: string;
+  };
 }
 
 /**
@@ -248,7 +274,15 @@ function synthesizeOverrides(
     exercised.add("experience");
     replaced.title = fields.experience[0].title;
     replaced.company = fields.experience[0].company;
-    experience[0] = { title: NEW_TITLE, company: NEW_COMPANY };
+    replaced.start_date = fields.experience[0].start_date;
+    experience[0] = {
+      title: NEW_TITLE,
+      company: NEW_COMPANY,
+      // The #672 shape: START cleared, END supplied. `applyOverrides` must collapse
+      // it to `{start_date: NEW_END_DATE}` before the exporter ever sees it.
+      start_date: "",
+      end_date: NEW_END_DATE,
+    };
   }
 
   // bullets — only when a bullet observation exists.
@@ -344,7 +378,9 @@ function editedRoleText(experience: readonly unknown[], fallback: string): strin
 
 /** One string field off a re-parsed experience entry, or `undefined` when the
  *  key is absent or non-string. */
-function stringField(entry: unknown, key: "title" | "company"): string | undefined {
+type EditedRoleField = "title" | "company" | "start_date" | "end_date";
+
+function stringField(entry: unknown, key: EditedRoleField): string | undefined {
   const v = (entry as Record<string, unknown> | null)?.[key];
   return typeof v === "string" ? v : undefined;
 }
@@ -362,7 +398,7 @@ function stringField(entry: unknown, key: "title" | "company"): string | undefin
  */
 function experienceFieldCheck(
   experience: readonly unknown[],
-  key: "title" | "company",
+  key: EditedRoleField,
   present: string,
   replaced: string | undefined,
   absenceText: string,
@@ -418,6 +454,30 @@ function computeEditFailures(
       f3.experience, "company", NEW_COMPANY, edits.replaced.company, roleText,
       fails.experience,
     );
+    // The date half (#672), and it is the SLOT that is under test, not merely
+    // "a date field round-trips". The override cleared `start_date` and wrote
+    // `NEW_END_DATE` into `end_date`; asserting the value comes back in
+    // `start_date` is asserting that `applyOverrides` collapsed the pair to the one
+    // shape the export/parse round trip can represent.
+    //
+    // Measured against an injected regression, not argued — an earlier revision of
+    // this comment claimed date coverage the assertion did not have. With the
+    // `applyNormalizedExperienceDates` call removed from `applyOverrides`:
+    //   • this shape (START cleared, END supplied)  → 45 of 60 FAIL
+    //   • the earlier shape (a new `start_date`)    → 60/60 GREEN
+    // The presence of a date field was never the thing under test; the SLOT is.
+    experienceFieldCheck(
+      f3.experience, "start_date", NEW_END_DATE, edits.replaced.start_date,
+      roleText, fails.experience,
+    );
+    // …and it landed in ONE slot. Presence in `start_date` alone would still pass
+    // if the value were ALSO left in `end_date` (drawing "Feb 1987 – Feb 1987"),
+    // which is the other way a half-applied collapse can look.
+    const marked = f3.experience.find(
+      (e) => stringField(e, "title") === NEW_TITLE,
+    );
+    if (marked !== undefined && stringField(marked, "end_date") !== undefined)
+      fails.experience.push("end_date survived the lone-end-date collapse");
     // …and it landed where it was AIMED. Narrowing the absence half to the role
     // carrying the marker is correct, but on its own it makes a wrong-ROLE write
     // undetectable: that role legitimately no longer holds the replaced value,

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -48,6 +48,7 @@ import {
   buildProjectDates,
 } from "../score/entry-dates.ts";
 import { isLoneDateRange } from "../heuristics/line-primitives.ts";
+import { formatExperienceDateRange } from "../edit/experience-dates.ts";
 import { projectDisplay } from "../heuristics/projections.ts";
 import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
 import { buildContactFields, formatLinkDisplay } from "../contact.ts";
@@ -366,12 +367,7 @@ function experienceDateRange(exp: {
   end_date?: string;
   is_current?: boolean;
 }): string {
-  const start = exp.start_date || undefined;
-  const end = exp.is_current ? "Present" : exp.end_date || undefined;
-  if (start && end) return `${start} – ${end}`;
-  if (start) return start;
-  if (end) return end;
-  return "";
+  return formatExperienceDateRange(exp);
 }
 
 function joinHeader(parts: Array<string | undefined>, sep: string): string {

--- a/src/lib/pdf/render-roundtrip-lone-end-date.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-lone-end-date.repro.test.ts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Round-trip regression for #672 — an experience role carrying ONLY an end date
+ * came back from Download-PDF with that value in `start_date` and the `end_date`
+ * key gone. "Left Contoso in 2022" silently became "joined Contoso in 2022", and
+ * the corruption RAISED the score: `computeAnonymousAtsScore`'s date-completeness
+ * check filters on `start_date`, so the role read incomplete before the round trip
+ * and complete after it.
+ *
+ * Runs the FULL production leg, edit seam included:
+ *
+ *   parsed + overrides → applyOverrides → buildAtsResumeModel
+ *                      → renderAtsResumePdf → runCascade
+ *
+ * The seam is the point. `applyOverrides` is where the fix lives (the export can
+ * only draw one date anchor, and the parser reads a lone token as a start date —
+ * see `edit/experience-dates.ts` for why the exporter is the wrong place to fix
+ * it), so a test that built the end-only shape directly as a `CascadeResult` would
+ * be asserting against a state the app can no longer produce. These build it the
+ * way a user does: by clearing a start date, by typing an end date onto an ongoing
+ * role, and by adding a role with only an end date filled in.
+ *
+ * The whole variant matrix runs on ONE render — seven roles in `baseParsed`, one
+ * per date shape: bare year, month + year, ongoing with an end date typed in,
+ * ongoing with the start cleared, a re-anchor beside a location, and the two
+ * controls. The controls are the guarantees of
+ * `render-roundtrip-year-only.repro.test.ts` (#358, the lone-START case)
+ * re-asserted through this path — a fix that "solved" the end-only case by moving
+ * the lone-start or the two-sided case would pass the first test here and fail
+ * those.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import { applyOverrides } from "../edit/apply-overrides.ts";
+import type { ExperienceFieldOverrides } from "../../hooks/useEditableParse.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+const STUB_SCORE = { bullets: [] } as unknown as AnonymousAtsScore;
+
+function makeSections(): SectionedResume {
+  return {
+    byName: new Map() as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
+
+/** Seven roles (indices 0-6), one per date shape, so one render covers the whole
+ *  matrix. `beforeAll` indexes this array by hand — keep the numbering in the
+ *  comments and the override map below in step with it. */
+function baseParsed(): HeuristicParsedResume {
+  return {
+    full_name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    location: "Chicago, IL",
+    skills: ["TypeScript", "SQL"],
+    experience: [
+      // 0 — the repro: a dated role whose START the user clears.
+      { title: "Alpha Analyst", company: "Contoso", start_date: "2019", end_date: "2022", description: "Ran the alpha ledger." },
+      // 1 — same, month + year, to pin that the token shape is irrelevant.
+      { title: "Echo Editor", company: "Adventure Works", start_date: "Jan 2019", end_date: "May 2022", description: "Edited the house style guide." },
+      // 2 — control: lone START (#358).
+      { title: "Charlie Composer", company: "Northwind", start_date: "2022", description: "Scored the winter program." },
+      // 3 — control: two-sided range.
+      { title: "Delta Director", company: "Litware", start_date: "2019", end_date: "2022", description: "Directed the delta program." },
+      // 4 — the ONGOING shape #672 calls "a distinct and worse failure": a current
+      // role the user gives an end date to. `experienceDateRange` and the
+      // `AtsEntryFields` builder both let `is_current` win, so a surviving flag
+      // draws "2019 – Present" and the typed end date never reaches the file.
+      { title: "Golf Guide", company: "Fabrikam", start_date: "2019", is_current: true, description: "Guided the golf programme." },
+      // 5 — the re-anchor with a LOCATION beside it: the header carries
+      // "Company, City, ST" AND the collapsed date, so the two must not collide.
+      { title: "Hotel Host", company: "Wingtip Toys", location: "Austin, TX", start_date: "2019", end_date: "2021", description: "Hosted the hotel programme." },
+      // 6 — the issue's ongoing/no-start row: a current role whose START the user clears.
+      { title: "India Intern", company: "Proseware", start_date: "2019", is_current: true, description: "Interned on the india programme." },
+    ],
+    education: [],
+  };
+}
+
+/** What one role's dates look like on each side of the round trip. */
+interface DatePair {
+  start_date?: string;
+  end_date?: string;
+  is_current?: boolean;
+}
+
+function datesOf(entry: DatePair | undefined): DatePair {
+  return {
+    ...(entry?.start_date !== undefined ? { start_date: entry.start_date } : {}),
+    ...(entry?.end_date !== undefined ? { end_date: entry.end_date } : {}),
+    ...(entry?.is_current !== undefined ? { is_current: entry.is_current } : {}),
+  };
+}
+
+/** Render one `applyOverrides` result and read it back through the real cascade —
+ *  the leg both describes below share. */
+async function renderAndReparse(
+  applied: ReturnType<typeof applyOverrides>,
+): Promise<CascadeResult> {
+  const display = {
+    canonical: {
+      fields: applied.fields,
+      sections: makeSections(),
+      fieldConfidence: applied.fieldConfidence,
+    },
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+  const bytes = await renderAtsResumePdf(buildAtsResumeModel(display, STUB_SCORE));
+  return runCascade(bytes);
+}
+
+async function roundTrip(
+  overrides: Record<number, ExperienceFieldOverrides>,
+): Promise<{ applied: HeuristicParsedResume; reparsed: CascadeResult }> {
+  const applied = applyOverrides(
+    baseParsed(),
+    "raw",
+    makeSections(),
+    {},
+    overrides,
+    {},
+    [],
+  );
+  return { applied: applied.fields, reparsed: await renderAndReparse(applied) };
+}
+
+function roleNamed(result: CascadeResult, name: string) {
+  const roles = result.canonical.fields.experience ?? [];
+  return roles.find((e) => e.title === name || e.company === name);
+}
+
+function appliedRole(applied: HeuristicParsedResume, name: string) {
+  return applied.experience.find((e) => e.title === name);
+}
+
+describe("#672 — a role whose start date was cleared round-trips as one date, in one slot", () => {
+  let applied: HeuristicParsedResume;
+  let reparsed: CascadeResult;
+
+  beforeAll(async () => {
+    // Clear the start date on roles 0, 1, 5, and 6 — the plainest user intent there
+    // is, a correction — give the ongoing role 4 an end date instead, and leave
+    // the two controls untouched.
+    ({ applied, reparsed } = await roundTrip({
+      0: { start_date: "" },
+      1: { start_date: "" },
+      4: { end_date: "2022" },
+      5: { start_date: "" },
+      6: { start_date: "" },
+    }));
+    // Seven roles through buildAtsResumeModel → renderAtsResumePdf → runCascade
+    // in ONE hook: ~11s unloaded here against Vitest's 10s hook default, so the
+    // gate this PR turns on fails locally on a slower machine even though CI
+    // clears it. The budget is explicit rather than left to the default.
+  }, 60_000);
+
+  /**
+   * The load-bearing assertion, and the reason every case below compares the two
+   * SIDES rather than just naming the expected values: what comes out of the file
+   * is not by itself evidence of anything. Before #672, the end-only role
+   * re-parsed with `start_date: "2022"` too — the export drew a bare "2022" and
+   * `parseDateRange` read it as a start. Asserting the output alone would have
+   * PASSED on the broken build. What was broken is that the app HELD
+   * `{start: "", end: "2022"}` while the file said `{start: "2022"}`, so the
+   * defect is the disagreement, and the disagreement is what this checks.
+   */
+  function expectNoSlotDrift(name: string, expected: DatePair) {
+    const before = datesOf(appliedRole(applied, name));
+    const after = datesOf(roleNamed(reparsed, name));
+    expect(before).toEqual(expected);
+    expect(after).toEqual(expected);
+  }
+
+  it("keeps the surviving date, in the slot the export can actually represent", () => {
+    expectNoSlotDrift("Alpha Analyst", { start_date: "2022" });
+  });
+
+  it("does the same for a month + year token", () => {
+    expectNoSlotDrift("Echo Editor", { start_date: "May 2022" });
+  });
+
+  it("leaves the lone-start control (#358) untouched", () => {
+    expectNoSlotDrift("Charlie Composer", { start_date: "2022" });
+  });
+
+  it("leaves the two-sided-range control untouched", () => {
+    expectNoSlotDrift("Delta Director", { start_date: "2019", end_date: "2022" });
+  });
+
+  it("gives up 'ongoing' when the user supplies an end date", () => {
+    // `is_current` is a claim that no end date exists. Keeping it here is the same
+    // silent rewrite as #672 pointing the other way — the file would say
+    // "2019 – Present" while the user typed 2022.
+    expectNoSlotDrift("Golf Guide", { start_date: "2019", end_date: "2022" });
+  });
+
+  it("re-anchors beside a location without disturbing it", () => {
+    expectNoSlotDrift("Hotel Host", { start_date: "2021" });
+  });
+
+  it("drops an unanchored 'ongoing' claim rather than drawing a bare Present", () => {
+    expectNoSlotDrift("India Intern", {});
+  });
+
+  it("keeps the location on the re-anchored role", () => {
+    // The collapse rewrites the header's date slot; the header also carries
+    // "Company, City, ST". A fix that re-anchored by rebuilding the header line
+    // would drop or absorb the location, and the date assertion alone cannot see
+    // it.
+    expect(appliedRole(applied, "Hotel Host")?.location).toBe("Austin, TX");
+    expect(roleNamed(reparsed, "Hotel Host")?.location).toBe("Austin, TX");
+  });
+});
+
+describe("#672 — a role ADDED with only an end date round-trips the same way", () => {
+  it("routes the added role through the same rule as an edited one", async () => {
+    const applied = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      {},
+      {},
+      {},
+      [],
+      {},
+      { removed: [], added: [] },
+      [
+        {
+          id: "added:1",
+          section: "experience",
+          title: "Foxtrot Fellow",
+          subtitle: "Tailspin Toys",
+          end_date: "2021",
+        },
+      ],
+      { "added:1": ["Ran the fellowship programme."] },
+    );
+    const added = applied.fields.experience.find((e) => e.title === "Foxtrot Fellow");
+    expect(added).toBeDefined();
+    // Normalised at the seam, not at export: "+ Add role" with only an end date
+    // filled in is the second way a user reaches the unrepresentable shape.
+    expect(added!.start_date).toBe("2021");
+    expect("end_date" in added!).toBe(false);
+
+    const reparsed = await renderAndReparse(applied);
+    const foxtrot = roleNamed(reparsed, "Foxtrot Fellow");
+    expect(foxtrot).toBeDefined();
+    expect(foxtrot!.start_date).toBe("2021");
+    expect(foxtrot!.end_date).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #672.
Closes #814.

## The defect, reproduced first

Probed on `main` before touching anything — the role matrix from the issue, through `buildAtsResumeModel` → `renderAtsResumePdf` → `runCascade`:

```
OUT title="Alpha Analyst"  company="Contoso"         start="2022"     end=undefined hasEndKey=false
OUT title="Bravo Engineer" company="Fabrikam"        start=undefined  end=undefined current=undefined
OUT title="Echo Editor"    company="Adventure Works" start="May 2022" end=undefined hasEndKey=false
```

Confirmed, including post-#618: a lone bare year now draws in the flush-right slot, but the slot flip is unaffected by where it is drawn — `parseDateRange` writes `start_date` on every non-empty path.

## Fix: one date anchor, enforced where the value is produced

`edit/experience-dates.ts` is new and owns the whole rule:

| In | Out |
|---|---|
| `{ start: "2019", end: "2022" }` | unchanged |
| `{ start: "2022" }` | unchanged (#358) |
| `{ end: "2022" }` | `{ start: "2022" }` |
| `{ start: "", end: "2022" }` | `{ start: "2022" }` |
| `{ end: "2022", is_current: true }` | `{ start: "2022" }` — an end date says it ended |
| `{ start: "2020", end: "2022", is_current: true }` | `{ start: "2020", end: "2022" }` — same rule, with an anchor to keep |
| `{ is_current: true }` | `{}` — no anchor, no ongoing claim |

The rule runs where an override is **written**, never where the card renders. Four call sites:

1. `applyExperienceHeaderOverrides` — the DATA, when a date override is folded in.
2. `pushAddedEntry` — the same rule for the "+ Add role" path, so an added role and an edited one export identically.
3. `useEditableParse`'s `setExperienceField` — the override MAP, on every date-cell commit.
4. `useEditableParse`'s `setEntryField` — the same, for an added entry, which has no override map behind it. It is what empties the End cell and fills the Start cell on a freshly added role, and it is pinned in `useEditableParse.test.tsx` (1 of those 3 cases goes red without it; another is the education control, which must NOT normalise).

(3) is the mechanism that puts the collapse on screen for a parsed role. **The card's date cells read the override map raw; they do not re-run the rule at render.** That direction is deliberate: a rule applied only at render leaves the map holding a pair the screen contradicts, and the next edit resolves from the map, not from the screen. Undo and the edit snapshot therefore restore the **normalised** dates.

`ReconstructedRole` does call `normalizeExperienceDates` once, in its `!editable` branch — the read-only `<h3>` composite. Two independent reasons that call is a no-op today, both now recorded in the module docblock so nobody deletes it for the wrong reason. It is inert on anything the parser can produce (every non-empty `parseDateRange` path writes `start_date`, and `is_current` only ever arrives beside one), **and** the branch does not render in the app at all: `editable` is `onFieldChange !== undefined`, the only `RoleEntry` call site that omits `onFieldChange` is the `experienceIndex={null}` "Other bullets" group, and there `group.experience` is null, so `RoleHeader` returns its own `<h3>` first. Tests are its only caller. It is kept rather than deleted because the exporter reads the raw entry through `experienceDateRange`, where `is_current` still wins over an end date — if that composite ever did become reachable on such a shape, this call is the side that would be right.

**Not fixed in the exporter, per the issue's warning** — a directional token (`"– 2022"`) makes any line containing `- 1234` a phantom entry anchor against `DATE_RANGE_RE`'s bare-year branch, with 56 of 57 corpus snapshots carrying `experienceRegionHasDateRangeLines`, and it would fall back out of the flush-right slot #618 just added.

Normalisation of the DATA is **gated on a date field being in the override**, not run for every touched entry: a role the parser produced with `is_current` and no start date is not something the user asked us to change, so re-titling it must not drop its flag. Pinned by a test.

Education is untouched by construction — `pushAddedEntry`'s education branch does not call the helper, and a lone education date remains a graduation date in `end_date` (#97, pinned by #618). No education corpus snapshot moves.

**What the module does not own.** The rule covers the edit and export paths — the two that can corrupt a *stored* value. Two display-only formatters still hand-roll their own collapse and disagree with it on the unanchored-`is_current` row: `buildDateRange` (`score/group-bullets.ts:328`, feeding `formatExperienceHeader`) and `buildProjectDates` (`score/entry-dates.ts:16`) draw a bare `"Present"` where `formatExperienceDateRange` draws `""`, and use a tight `–` against this module's spaced ` – `. Nothing is broken by that: the shape is unreachable from the parser and, after this PR, from the edit lane too, and neither formatter's output is ever re-parsed. #672's Notes asked that any extracted helper reconcile the disagreement rather than silently pick a side — so it is named in the docblock and scoped out, because folding them in is a change to display strings, not to the corruption. (`buildEducationDates` is not a candidate: it reads `end_date` first on purpose, #97.)

## The second date edit on one role

The map normalisation was initially fed the wrong base. `ReconstructedResume` hands `setExperienceField` `display.parsed` — `applyOverrides` output — and the sparse write-back deleted any key whose normalised value equalled that base. On the second date edit the previous override is *inside* the base, so the key deleted itself:

```
                    override map                        applied
step 1 clear Start  {start_date:"2022", end_date:""}    {s:"2022"}           ok
step 2 End = 2024   {end_date:"2024"}                   {s:"2019", e:"2024"}  BUG
```

The 2019 the user cleared came back — #672's own corruption, one edit later.

The fix keeps the applied entry as the value the map **resolves** against (it has to: it already carries every earlier edit, which is what `??` resolution needs) and adds the pre-write override map as a third argument. A key that already carries an override is always written; only a key the user has never touched may be dropped, and for that key resolved *is* parsed. `applyNormalizedDateOverrides(entry, resolvedEntry, prior)`.

Threading the pristine parse instead was considered and rejected: it is four prop hops from `useAnalyzedResume` to `ReconstructedResume`, and it would not have helped `replay`, which must stay un-normalised (a snapshot's keys are already collapsed, and re-resolving them one at a time can produce `2022 – 2022`). `replay` passes no `resolvedEntry` and so opts out, which is now stated at the call site.

New regression: `hooks/useEditableParse.date-slot-sequence.repro.test.tsx` drives the **real hook** and the **real `applyOverrides`**, re-deriving the resolved entry between commits exactly as a re-render does, and asserts on the applied entry rather than the map. 4 of its 10 cases go red with the third argument removed.

## End typed before Start — the regression this rule introduced (#814)

Re-anchoring is not free, and the first version of this PR did not pay for it. Fill an experience role's dates **End-first** — "+ Add role", or a parsed role the parser found no dates on — and the rule moves the value out of the End cell, so the start date typed next lands on top of it:

```
after End=2022   : map {"start_date":"2022"}   -> applied {s:"2022"}
after Start=2019 : map {"start_date":"2019"}   -> applied {s:"2019"}   # the 2022 is gone
```

`main` accumulates both commits into `{2019, 2022}`, so this is a **regression this change introduced**, not a gap it exposed — user data loss in the edit lane, the same class as #672. Reported on the review; fixed here rather than deferred.

**Why `prior` alone cannot fix it.** The obvious patch — "on a Start commit against an entry whose only date sits in `start_date` because of a prior collapse, push it back into `end_date`" — needs to tell a *relocated* anchor from a *typed* start date, and the map cannot: `{start_date: "2022"}` typed into the Start cell and the same pair moved out of the End cell are the identical object. Every candidate signal aliases. `{start_date: "2022", end_date: ""}` is produced both by the collapse and by a user who typed a start date and then cleared the End cell — push-back there invents an end date the user deliberately deleted. Which cell a value was typed into is a fact about the edit **sequence**, and it has to be remembered while it is still known.

**What ships.** `relocatedEndAnchor(pair)` in the rule module reports the value a pair is about to lose, and `useEditableParse` parks it in `relocatedEndsRef` — keyed per parsed-role index and per added-entry id — handing it back to `end_date` when a real start date displaces it. `resolveDateCommit` decides restore-and-park for both writers, so `setExperienceField` and `setEntryField` cannot drift apart. Both call it **outside** their state updaters: an updater that reads and then clears the memory is not idempotent, and React double-invokes updaters under StrictMode.

| Ordering | before | after |
|---|---|---|
| End `2022`, then Start `2019` (parsed dateless role) | `{start: "2019"}` | `{start: "2019", end: "2022"}` |
| End `2022`, then Start `2019` ("+ Add role") | `{start: "2019", end: ""}` | `{start: "2019", end: "2022"}` |
| Clear Start on `{2019, 2022}`, then Start `2020` | `{start: "2020"}` | `{start: "2020", end: "2022"}` |
| Start `2022`, then Start `2019` (control — nothing was relocated) | `{start: "2019"}` | unchanged |
| Clear End on `{2019, 2022}`, then Start `2020` (control) | `{start: "2020"}` | unchanged |

**A restore is owed only where something was displaced.** `EditableField.commit` fires from `onBlur` with the untouched draft — there is no dirty check — so clicking into a date cell and clicking away re-commits the value it is already showing. Restoring on that writes the anchor into BOTH slots: one typed date becomes `2022 – 2022`, which the exporter draws and the parser reads back as a genuine two-sided range — a tenure nobody entered, and the exact shape `normalizeExperienceDates` exists to refuse. Consuming the parking on it is the opposite failure: one stray blur would disarm the restore and the next real Start commit would lose the end date just as it did before #814. So an unchanged commit returns the parking untouched and restores nothing. The guard is on the commit rather than on the Start field, because the End cell blurs the same way — and under a Start-only guard that blur cleared the parking.

The restore is also gated on the parked value still **being** the anchor on screen, so a write that bypasses the rule — `replay`, which passes no `resolvedEntry` — cannot push a stale value into a pair it never came from. Removing that guard turns exactly the one test that covers it red.

**The parking is not part of `ExperienceFieldOverrides`, deliberately.** It is session-local provenance, not a field value, and that type is persisted into `EditSnapshot`, which crosses to `/jobs/` through `jd-fit-handoff.ts`; #672 already widened it once with `is_current`. `resetAll` and `replay` clear the ref, so a replayed snapshot forgets the parking until that entry's next date commit re-parks — pre-#814 behaviour for one entry, nothing worse, and stated at both call sites.

## Judgement calls, stated

- **`is_current` on an end-anchored role is dropped**, whether or not a start date sits beside it. The pair is self-contradictory (ended *and* ongoing) and the end date is the half the user typed; keeping the flag would read the role back as "still there" — the exact rewrite this change exists to stop.
- **`is_current` with no date at all is dropped.** `experienceDateRange` draws a bare "Present" that re-parses to no date field and no flag, so the flag is lost either way; it is now lost at edit time, in the card, rather than inside the downloaded file.
- **`ExperienceFieldOverrides` gains `is_current?: boolean`.** That widens the `EditSnapshot` payload carried through `jd-fit-handoff.ts`. JSON-safe, so nothing breaks; `replay`'s cast was updated to say `string | boolean` rather than lying about it.
- **The widening is stated in the types, not guarded at runtime.** `RoleHeaderProps`/`RoleEntryProps.onFieldChange` are `Exclude<keyof ExperienceFieldOverrides, "is_current">`, which retires a runtime guard in `ReconstructedResume` and stops a future `onFieldChange("is_current", "false")` from type-checking its way into `applyExperienceHeaderOverrides`'s `if (fields.is_current)` test, where the string would read as **true**. `setExperienceField`'s value is now `ExperienceFieldOverrides[K]` rather than `any` — the widening had been absorbed by erasing the type, which let `setExperienceField(0, "title", 42)` compile. Those were the only two `: any` in non-test `src/`, and `eslint.config.js` registers no `no-explicit-any`, so CI would not have caught them.
- **`ADDED_ENTRY_FIELDS` order is now load-bearing** and says so. `setEntryField` normalises on every date write, so replaying an added role end-first would collapse `{2019, 2022}` to `{start: "2022"}` and then overwrite it. `start_date` stays ahead of `end_date` in the tuple. #814's parking does **not** rescue that ordering, and the docblock says why: `replay` writes every field of a fresh entry in one synchronous burst, so the entry mirror has not re-rendered and there is nothing to park against. Replay stays verbatim, for the same reason it passes no `resolvedEntry`.
- **The #814 memory is a ref, not a persisted override key.** See the section above: the alternative widens a payload that crosses to `/jobs/`, to carry a fact that is only meaningful for the length of one editing session.

## Tests, and why the obvious version of them is worthless

The round-trip repro runs the **full production leg including `applyOverrides`**, and asserts the applied state and the re-parsed state **agree**, rather than asserting the output values. That distinction is the test: on the broken build the end-only role also re-parsed to `start_date: "2022"` — the export drew a bare "2022" and the parser read it as a start — so an output-only assertion would have passed on the bug. What was broken is that the app *held* `{start: "", end: "2022"}` while the file said `{start: "2022"}`.

Measured non-vacuity, with both data wirings disabled: **6 of the repro file's 9 tests go red**, while the lone-start (#358) control, the two-sided control and the location assertion stay green. Restored after.

Also added:

- `experience-dates.test.ts` — the rule per row of the table above, including "does not mutate its input", the key-deletion behaviour (`"end_date" in entry` is how the round-trip gates tell absent from empty), and the `prior` guard.
- Seven cases in the hook repro for #814 — End-then-Start on a parsed dateless role, the same restore after a cleared start re-anchored the pair, the stale-parking guard, an untouched blur on each of the two cells, and the two controls that make the restore a rule rather than a guess (a start date corrected in the Start cell must not become an end date; an end date the user deliberately cleared must not come back) — plus Start-first asserted unchanged beside them. Three more in `useEditableParse.test.tsx` for the added-role path. Measured: with the restore disabled **5 go red and every control stays green**; with the unchanged-commit guard removed **3 go red**, of which **2 come back** if that guard drops the parking instead of keeping it; with the staleness guard removed, the guard case alone goes red. `relocatedEndAnchor` carries its own unit rows.
- Three `apply-overrides.test.ts` cases: the clear, the `is_current` drop, and the no-date-edit non-interference case.
- `corpus-edit-roundtrip.test.ts`'s `synthesizeOverrides` now writes the **#672 shape** on role 0 — `start_date: ""` **and** `end_date: NEW_END_DATE` — alongside the title/company edits. The slot is the whole point: measured, that shape fails **45 of 60** fixtures with the normalisation removed, whereas the earlier variant (a new non-empty `start_date`) passed **60/60 on the broken build** and would have closed nothing. **60/60 pass with the fix; no new `KNOWN_FAILURES` entries.**

## Known gaps, not fixed here

- **A restored draft forgets the parking** — filed as **#819**. `replay` clears the ref, and `replay` is the draft-restore path (`useAnalyzedResume.ts:368`), so End-then-leave-then-return-then-Start loses the end date: pre-#814 behaviour across that one boundary. Not a regression against `main` (before #672 there was nothing to remember) and fully fixed within a session. Filed rather than deferred silently, since `Closes #814` shuts the tracker for this class on merge.
- **`is_current` has no edit channel in either direction** — filed as **#686**. Clearing the "Present" End cell on an ongoing role is a no-op (the flag re-derives), and once dropped there is no affordance to bring it back. Neither `ExperienceFieldOverrides` nor `AddedEntry` carries an ongoing toggle, and the only writers in the tree are the parser and `webllm/merge-override.ts`. Out of #672's scope; it becomes *visible* here only because the End cell is now an honest field.

## Not covered, deliberately

There is no component-render test for `RoleHeader`. The genuinely untested seam was `useEditableParse` — that nothing asserted normalisation ran on commit, or against what — and that is what the new hook repro covers.

## Gates

Re-run on head `f2494d5`, one commit on `main` at `a50fca7`. `npm run verify` cannot run on this Windows checkout — the script's `(fallow audit … || echo …)` POSIX subshell is parsed by cmd.exe — so the steps were run individually.

| Gate | Result |
|---|---|
| `npx tsc -b --noEmit` | green |
| `npx eslint .` | green |
| `npx vitest run` | **5524 passed / 10 skipped**, 7 failed — all 7 pre-existing on `main`, see below |
| `corpus-edit-roundtrip` | 60/60, no snapshot or `KNOWN_FAILURES` movement |
| `corpus-roundtrip` + the edit / hook / render suites | green (`src/hooks` + `src/lib/edit`: 441 passed) |
| `npx vite build` | green (10.8s) |
| `npm run check:fixtures` | green — 58 PDFs, 15 sidecars, all personas synthetic (this diff adds no fixture) |
| `npm run check:baselines` | green; its 10 "unfiled" ground-truth warnings are pre-existing and untouched here |
| `npm run check:core` | **did not complete** — `spawnSync npm ENOENT` from its pack step on this Windows checkout, before any code is exercised. Environmental; CI is the authority |

**The 7 failures are not this diff.** Measured on `origin/main` at `a50fca7` in the same worktree with this branch not checked out: same 3 files, same 7 test names. Four are `Intl`-formatted salary strings (`jd-extract/schema-org.test.ts`, `schema-org-core.test.ts`); three are in `corpus.test.ts` — the `multi-degree-coursework.pdf` snapshot and both ground-truth-scoreboard coverage assertions, which print their fixture paths with `\` separators. Local Windows environment; CI is the authority.

`render-ats-pdf.test.ts` timed out at 5000ms on the first local run and passed on the second — the full-suite parallelism flake described before, which also reproduces on `main`.

fallow detail, since the diff touches these (CRAP estimated — run without `--coverage`): `RoleHeader` is still CRITICAL at 36 cyclomatic / 39 cognitive / 160 lines, `applyExperienceHeaderOverrides` 16 cyclomatic / 71.3 CRAP, `pushAddedEntry` 11 / 37.1, `replay` 11 / 37.1. `ReconstructedRole.tsx` is on `CLAUDE.md`'s known-debt list and this PR adds to it; report-only, not a merge gate, and not addressed here. The one duplication finding that *was* this PR's own — the repeated `CascadeResult` stub in the repro test — is gone, extracted into a single `renderAndReparse` helper; the new hook repro joins the existing 5-instance probe-harness clone group.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation | Claude Code (Opus 5) | — |
| Review revisions | Claude Opus 5 | high |




