### PR TITLE
fix(edit): make a bullet Remove report only what it actually removed (#658, #659, #660)

### DIFF
--- a/src/components/features/BulletRemoveStatus.test.tsx
+++ b/src/components/features/BulletRemoveStatus.test.tsx
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Regression test for #659 — the "Removed 1 change · Undo" strip used to confirm
+ * a removal that provably did nothing.
+ *
+ * `useEditableParse.removeBullet` reports whether its write landed: `false` when
+ * a user-ADDED bullet's bucket line is already gone (the deliberate
+ * `isAddedEntryKey` early return, #637) or when the id is already in
+ * `removedBullets` (#648). `useBulletRemoveStatus` must follow that report rather
+ * than the mere fact of having called it. Three things key off it, and this file
+ * pins all three:
+ *
+ *   1. the strip's copy — the user is not told a change was made that was not;
+ *   2. the ARMED UNDO — a second, no-op call must not overwrite a live strip's
+ *      undo with one snapshotted after the real removal already landed, which
+ *      restores nothing (`captureBulletUndoSnapshot` reads the bucket as it is
+ *      now, and filters an already-removed id out of `restore`);
+ *   3. `pending`, which `RoleEntry` hands to `useHoldWhile` — a no-op removal
+ *      must not hold an empty added role back from the section-exit prune (#379).
+ *
+ * All three were unheld before this file: flipping either the strip's gate or
+ * `removeBullet`'s `false` left the whole suite green.
+ *
+ * `onRemoveBullet` is a STUB here on purpose. The unit under test is the wiring
+ * from the write's report to the strip, the undo and the hold; that the real hook
+ * reports the truth is pinned separately, against the real regrade pipeline, in
+ * `useEditableParse.added-bullet-remove.test.tsx` ("reports that repeat click as
+ * NOT recorded") and in `ExperienceSection.prune-hold.test.tsx` (#659, where the
+ * no-op is produced by shipped code rather than staged).
+ *
+ * jsdom + raw `createRoot` + fake timers, matching `ExperienceSection.test.tsx`
+ * (the project has no @testing-library/react).
+ */
+
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { createElement, type ReactElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  useBulletRemoveStatus,
+  type BulletRemoveControl,
+} from "./BulletRemoveStatus.tsx";
+import { RoleEntry } from "./ReconstructedRole.tsx";
+import {
+  useAddedEntryPruneHold,
+  type AddedEntryPruneHold,
+} from "../../hooks/useAddedEntryPruneHold.ts";
+import type { BulletGroup } from "../../lib/score/group-bullets.ts";
+import type { ResolvedWrite } from "../../lib/rewrite-review/apply-accepted.ts";
+import { countWords } from "../../lib/score/score.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const BULLET = "Shipped a design system used by 40 engineers.";
+const OBS_ID = "0|shipped a design system used by 40 engineers.";
+const UNDO_LABEL = "Undo the changes just applied to the résumé";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: [
+      "setTimeout",
+      "clearTimeout",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+    ],
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  vi.useRealTimers();
+});
+
+async function mount(node: ReactElement): Promise<HTMLDivElement> {
+  await act(async () => {
+    root!.render(node);
+  });
+  // Flush the WebGPU-capability probe a freshly-mounted RoleEntry kicks off, so
+  // its setState lands inside act().
+  await act(async () => {});
+  return container!;
+}
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+// ── the hook's own contract ─────────────────────────────────────────────────
+
+describe("useBulletRemoveStatus — the strip follows the write (#659)", () => {
+  let control: BulletRemoveControl;
+  /** Every undo thunk the hook captured, newest last. */
+  let captured: Array<() => void>;
+  let undone: number;
+
+  function Probe({ landed }: { landed: boolean }) {
+    control = useBulletRemoveStatus(
+      () => landed,
+      (_writes: readonly ResolvedWrite[]) => {
+        const thunk = () => {
+          undone += 1;
+        };
+        captured.push(thunk);
+        return thunk;
+      },
+    );
+    return createElement("div", null, control.strip);
+  }
+
+  beforeEach(() => {
+    captured = [];
+    undone = 0;
+  });
+
+  it("renders NO strip for a removal that reports nothing", async () => {
+    const el = await mount(createElement(Probe, { landed: false }));
+
+    let result = true;
+    await act(async () => {
+      result = control.removeBullet(OBS_ID, BULLET);
+    });
+
+    expect(result).toBe(false);
+    expect(el.textContent).not.toContain("Removed");
+    expect(el.querySelector(`[aria-label="${UNDO_LABEL}"]`)).toBeNull();
+    // What #637 half 2 reads to hold the entry back from the prune.
+    expect(control.pending).toBe(false);
+  });
+
+  it("discards the snapshot it took for that no-op", async () => {
+    await mount(createElement(Probe, { landed: false }));
+
+    await act(async () => {
+      control.removeBullet(OBS_ID, BULLET);
+    });
+
+    // The capture is unavoidable — it has to happen BEFORE the write, and the
+    // write is what reveals the no-op (issue 510's ordering rule). What must not
+    // happen is that snapshot reaching the user as an Undo affordance.
+    expect(captured).toHaveLength(1);
+    expect(undone).toBe(0);
+  });
+
+  it("still renders the strip and a working Undo for a real removal", async () => {
+    const el = await mount(createElement(Probe, { landed: true }));
+
+    let result = false;
+    await act(async () => {
+      result = control.removeBullet(OBS_ID, BULLET);
+    });
+
+    expect(result).toBe(true);
+    expect(el.textContent).toContain("Removed 1 change");
+    expect(control.pending).toBe(true);
+
+    const undo = el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`);
+    expect(undo).not.toBeNull();
+    await click(undo!);
+
+    expect(undone).toBe(1);
+    expect(el.textContent).toContain("Reverted 1 change");
+  });
+
+  it("keeps a live strip's OWN undo when a later call reports nothing", async () => {
+    // The harm the copy alone understates. Both calls capture, so an ungated
+    // second `setStatus` swaps the armed thunk for the newer one — snapshotted
+    // AFTER the real removal landed, so it restores nothing. Whichever thunk the
+    // mounted button holds is the one the user gets, and it must be the first.
+    let landed = true;
+    function Swinger() {
+      control = useBulletRemoveStatus(
+        () => landed,
+        () => {
+          const n = captured.length;
+          const thunk = () => {
+            undone = n;
+          };
+          captured.push(thunk);
+          return thunk;
+        },
+      );
+      return createElement("div", null, control.strip);
+    }
+    const el = await mount(createElement(Swinger));
+
+    await act(async () => {
+      control.removeBullet(OBS_ID, BULLET);
+    });
+    landed = false;
+    await act(async () => {
+      control.removeBullet(OBS_ID, BULLET);
+    });
+
+    expect(captured).toHaveLength(2);
+    await click(el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`)!);
+    // Thunk 0 — the one captured before the write that actually landed.
+    expect(undone).toBe(0);
+  });
+
+  it("is inert, and reports so, with no writer wired at all", async () => {
+    function Unwired() {
+      control = useBulletRemoveStatus(undefined, undefined);
+      return createElement("div", null, control.strip);
+    }
+    const el = await mount(createElement(Unwired));
+
+    let result = true;
+    await act(async () => {
+      result = control.removeBullet(OBS_ID, BULLET);
+    });
+
+    expect(result).toBe(false);
+    expect(el.textContent).not.toContain("Removed");
+  });
+});
+
+// ── what keys off it: the section-exit prune hold ───────────────────────────
+
+describe("RoleEntry — a no-op removal takes no prune hold (#659)", () => {
+  const ENTRY_KEY = "added:0";
+
+  function group(): BulletGroup {
+    return {
+      experienceIndex: 1,
+      experience: { title: "Principal Engineer", company: "Cascadia Analytics" },
+      bullets: [
+        {
+          text: BULLET,
+          id: OBS_ID,
+          index: 0,
+          hasMetric: true,
+          startsWithActionVerb: true,
+          wellFormedLength: true,
+          wordCount: countWords(BULLET),
+        },
+      ],
+    };
+  }
+
+  let registry: AddedEntryPruneHold;
+
+  function Host({ landed }: { landed: boolean }) {
+    registry = useAddedEntryPruneHold();
+    return createElement(RoleEntry, {
+      group: group(),
+      experienceIndex: 1,
+      onBulletChange: () => {},
+      onAddBullet: () => {},
+      onRemoveBullet: () => landed,
+      captureUndo: () => () => {},
+      // Set for a user-ADDED role, which is the only kind the prune can drop.
+      onRemove: () => {},
+      entryKey: ENTRY_KEY,
+      pruneHold: registry,
+    });
+  }
+
+  async function clickRemove(el: HTMLDivElement) {
+    await click(
+      el.querySelector<HTMLElement>('[aria-label="Remove bullet"]')!,
+    );
+  }
+
+  it("leaves the entry unheld when the write reports nothing", async () => {
+    const el = await mount(createElement(Host, { landed: false }));
+    expect(registry.isHeld(ENTRY_KEY)).toBe(false);
+
+    await clickRemove(el);
+
+    // Without this, an added role kept alive by a strip that represents nothing
+    // survives a prune it should not have — and since the strip never armed,
+    // there is no collapse to release the hold and re-run the prune (#658)
+    // either, so it survives until the next section exit.
+    expect(registry.isHeld(ENTRY_KEY)).toBe(false);
+    expect(el.textContent).not.toContain("Removed");
+  });
+
+  it("does hold it for a real removal", async () => {
+    const el = await mount(createElement(Host, { landed: true }));
+
+    await clickRemove(el);
+
+    expect(registry.isHeld(ENTRY_KEY)).toBe(true);
+    expect(el.textContent).toContain("Removed 1 change");
+  });
+});

--- a/src/components/features/BulletRemoveStatus.tsx
+++ b/src/components/features/BulletRemoveStatus.tsx
@@ -29,7 +29,7 @@
 import { useCallback, useState } from "react";
 import type { ReactNode } from "react";
 import { InlineResult } from "@design-system";
-import type { SectionRewriteApply } from "./SectionRewrite.tsx";
+import type { ResolvedWrite } from "../../lib/rewrite-review/apply-accepted.ts";
 import {
   ApplyConfirmation,
   UndoBatchButton,
@@ -37,12 +37,24 @@ import {
 } from "./ApplyConfirmation.tsx";
 
 export interface BulletRemoveControl {
-  /** Drop one bullet by its `BulletObservation.id` and arm the strip. `text` is
-   *  the bullet's observation text, which the owner forwards so a USER-ADDED
-   *  bullet can be located in its `addedBullets` bucket — the id alone cannot
-   *  reach one (#637, see `added-bullets.ts`). The strip arms only if the write
-   *  actually landed (#648). */
-  removeBullet: (id: string, text: string) => void;
+  /**
+   * Drop one bullet by its `BulletObservation.id` and arm the strip. `text` is
+   * the bullet's observation text, which the owner forwards so a USER-ADDED
+   * bullet can be located in its `addedBullets` bucket — the id alone cannot
+   * reach one (#637, see `added-bullets.ts`). The strip arms only if the write
+   * actually landed (#648).
+   *
+   * Returns whether THIS call changed anything — i.e. whether the strip armed.
+   * A boolean rather than a result object because every caller asks the one same
+   * question, and the ways a removal can report nothing (an added bullet whose
+   * bucket line is already gone; an id already in `removedBullets`; no
+   * `onRemoveBullet` wired at all) are indistinguishable to all of them: each
+   * means "confirm nothing, arm no undo, hold nothing back". {@link pending}
+   * cannot answer this — it is also true while an EARLIER removal's strip is
+   * still up, so a caller reading it after a no-op sees a success that belongs
+   * to a different write (#659).
+   */
+  removeBullet: (id: string, text: string) => boolean;
   /** True while a confirmation is showing. Callers use it to suppress an
    *  "empty section" note that would otherwise contradict the strip. */
   pending: boolean;
@@ -59,13 +71,24 @@ export interface BulletRemoveControl {
  *   calling it, so a write that dropped nothing still confirmed "Removed" — with
  *   an Undo that had nothing to restore, since `captureBulletUndoSnapshot`
  *   filters an already-removed id out of `restore` (#648). The strip now follows
- *   the write.
+ *   the write (#659) — and so, through {@link BulletRemoveControl.pending}, does
+ *   the caller's `useHoldWhile` stay over the section-exit prune, which must not
+ *   extend an added entry's life on the strength of a removal that did nothing.
  * @param captureUndo Snapshot the slot the remove will clear, BEFORE the write
  *   (issue 510). Absent → the confirmation renders without an Undo action.
+ *
+ *   Widened past `SectionRewriteApply["captureUndo"]` by one argument: the row's
+ *   `text`. A caller whose bucket has to be RESOLVED from that text rather than
+ *   named up front (`useOtherBulletsRemove`, #660 half 2) otherwise has to
+ *   re-derive it from the `obsId` by a second, different rule — and if that rule
+ *   disagrees with the one the write uses, the snapshot captures a bucket the
+ *   write never touches and the Undo restores nothing (#659). Handing the same
+ *   `text` to both removes the second rule. Existing single-argument callers stay
+ *   assignable.
  */
 export function useBulletRemoveStatus(
   onRemoveBullet?: (id: string, text: string) => boolean,
-  captureUndo?: SectionRewriteApply["captureUndo"],
+  captureUndo?: (writes: readonly ResolvedWrite[], text: string) => () => void,
 ): BulletRemoveControl {
   const [status, setStatus] = useState<
     | { kind: "idle" }
@@ -74,18 +97,26 @@ export function useBulletRemoveStatus(
   >({ kind: "idle" });
 
   const removeBullet = useCallback(
-    (id: string, text: string) => {
-      if (!onRemoveBullet) return;
+    (id: string, text: string): boolean => {
+      if (!onRemoveBullet) return false;
       // Snapshot BEFORE the write — once it lands the prior value is gone
       // (issue 510, same rule the rewrite-review Apply follows). For an added
       // bullet the snapshotted slot is the entry's `addedBullets` bucket, which
-      // `batchUndoTargets` now records for a `remove` too (#637).
-      const undo = captureUndo?.([{ kind: "remove", obsId: id }]);
+      // `batchUndoTargets` now records for a `remove` too (#637). `text` goes
+      // along so a caller that has to RESOLVE that bucket resolves the same one
+      // the write below splices — see the `captureUndo` param docs.
+      const undo = captureUndo?.([{ kind: "remove", obsId: id }], text);
       // Nothing was dropped → nothing to confirm, and the snapshot just taken
       // describes a write that never happened. Leave the strip idle rather than
-      // arm an Undo over an unchanged slot.
-      if (!onRemoveBullet(id, text)) return;
+      // arm an Undo over an unchanged slot. Returning early rather than
+      // overwriting `status` is load-bearing beyond the copy: a live strip from
+      // an EARLIER, real removal keeps its own undo, instead of having it
+      // replaced by one snapshotted after that removal already landed — which
+      // restores nothing (`captureBulletUndoSnapshot` reads the bucket as it is
+      // NOW, and filters an already-removed id out of `restore`) (#659).
+      if (!onRemoveBullet(id, text)) return false;
       setStatus({ kind: "removed", undo });
+      return true;
     },
     [onRemoveBullet, captureUndo],
   );

--- a/src/components/features/ExperienceSection.other-bullets.test.tsx
+++ b/src/components/features/ExperienceSection.other-bullets.test.tsx
@@ -1,0 +1,731 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Regression test for #660 half 2 — Remove was inert on a bullet that fell
+ * through to the "Other bullets" group while its line lived in an `addedBullets`
+ * bucket.
+ *
+ * That group owns no entry, so it has no `entryKey` to build an `AddedBulletRef`
+ * from; it used to drop the row's text outright and remove by id alone. For a
+ * line whose normalised key is EMPTY that id is `"<n>|"`, which
+ * `resolveOverrideOriginal` resolves to nothing — so the click removed nothing,
+ * confirmed "Removed 1 change" anyway, and left a permanently unresolvable entry
+ * in `removedBullets` that keeps the résumé "dirty". The fix resolves the bucket
+ * from the row's text (`findAddedBulletEntry`).
+ *
+ * Both surfaces are driven for real: the section renders over the REAL
+ * `useEditableParse` and the REAL `applyOverrides` → `computeAnonymousAtsScore` →
+ * `groupBulletsByExperience` chain, so the degenerate row appears in "Other
+ * bullets" because the shipped code put it there.
+ *
+ * How the degenerate line is created matters, so it is created the one way that
+ * is still REACHABLE after half 1: an in-place EDIT. `addBullet` now refuses a
+ * contentless line, but `replaceAddedBulletLine` rejects only a BLANK
+ * replacement, so committing `"3."` over a real added bullet still writes it to
+ * the bucket. Nothing here is staged by hand.
+ *
+ * `ORPHAN_BULLET` is the control: a pooled rawText line no description carries,
+ * so it sits in "Other bullets" permanently and is NOT in any bucket. Removing it
+ * must still file its id — that is what "the ref costs nothing when it misses"
+ * means, and it is the behaviour a too-eager resolver would break.
+ *
+ * The last block is the OTHER half of AC 2, which the bucket resolver cannot
+ * reach at all: a degenerate line that came straight out of the PDF is in no
+ * bucket either, so it misses the resolver exactly as ORPHAN_BULLET does and
+ * falls through to the id-keyed path carrying the same unresolvable `"<n>|"`.
+ * AC 2 is unconditional ("No removal on the Other-bullets path pushes an
+ * observation index that resolves to nothing"), so the id-keyed path itself has
+ * to refuse such an id — which also satisfies #659 AC 1, since only a `false`
+ * suppresses the "Removed" strip. `PARSED_DEGENERATE` is that input, and it is
+ * reachable from a real Word export rather than synthetic (see its own note).
+ *
+ * The last describe block is what half 2 COST, and neither of the two defects it
+ * pins was reachable before it: the removal only ever wrote `removedBullets`
+ * until half 2 taught it to splice a real bucket. Both are the same shape as the
+ * bugs #659 and #637 half 2 fixed, arriving on the one path neither covered —
+ * which is why the coverage hole was that no case above ever CLICKS the Undo the
+ * removal arms.
+ *
+ * jsdom + raw `createRoot` + fake timers, matching `ExperienceSection.test.tsx`.
+ */
+
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { createElement, useMemo } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ExperienceSection } from "./ReconstructedResume.tsx";
+import {
+  useEditableParse,
+  type EditableParse,
+} from "../../hooks/useEditableParse.ts";
+import { applyOverrides } from "../../lib/edit/apply-overrides.ts";
+import { computeAnonymousAtsScore } from "../../lib/score/score.ts";
+import {
+  groupBulletsByExperience,
+  type BulletGroup,
+} from "../../lib/score/group-bullets.ts";
+import { bulletId } from "../../lib/score/bullet-id.ts";
+import { projectScoreSections } from "../../lib/heuristics/projections.ts";
+import { buildBlankResult } from "../../lib/heuristics/empty-result.ts";
+import { toCanonicalResume } from "../../lib/heuristics/canonical.ts";
+import type { SectionedResume } from "../../lib/heuristics/sections.ts";
+import type { CascadeResult } from "../../lib/heuristics/types.ts";
+// The two recipes that are easy to get silently wrong (see that module), shared
+// with `ExperienceSection.prune-hold.test.tsx` rather than copied a third time.
+import {
+  UNDO_LABEL,
+  collapseStrip,
+  exitSection,
+} from "./__test-utils__/experience-section-dom.ts";
+
+const PARSED_BULLET = "Cut p99 checkout latency by 38% via edge caching.";
+/** Pooled from the section but absent from every description → "Other". */
+const ORPHAN_BULLET = "Presented quarterly reviews to the exec staff.";
+const ADDED_BULLET = "Shipped a design system used by 40 engineers.";
+/** The contentless replacement. Numbered rather than a glyph on purpose: a lone
+ *  glyph scores 0 words and `extractBulletsFromLines` drops it, so it never
+ *  becomes a row at all — only a numbered marker reaches the pool. */
+const DEGENERATE = "3.";
+/**
+ * A degenerate line straight out of the PDF, needing no edit to exist.
+ *
+ * `BULLET_MARKER_RE` strips the `"• "`, leaving `"4."`; `countWords` sees the
+ * digit through `\p{N}` and returns 1, so `ANON_BULLET_MIN_WORDS` does not filter
+ * it and it enters the pool as a row with its own Remove control. Its normalised
+ * key is then empty (`LEADING_MARKER_RE` eats `\d+[.)]`), so the grouper skips it
+ * and it lands in "Other bullets" — with `"0|"` for an id.
+ *
+ * The `"• "` prefix is not the only reachable shape: #30's lone-bullet merge
+ * joins a bare `"•"` line to the `"4."` on the next one, which is what real
+ * Word-table exports emit when the glyph and its text land in separate cells.
+ */
+const PARSED_DEGENERATE = "• 4.";
+
+/**
+ * Extra pooled section lines for the test about to mount, appended to the two
+ * below. Module-scoped because `Harness` builds its parse inside a `useMemo` and
+ * takes no props; reset in `afterEach` so it cannot leak between tests.
+ *
+ * Kept OUT of the default fixture deliberately: a second empty-key line would
+ * take ordinal `0|` and push the added degenerate line to `1|`, breaking the
+ * `expect(degenerateId).toBe("0|")` the added-half tests rest on.
+ */
+let extraPooledLines: readonly string[] = [];
+
+/**
+ * One parsed role whose description carries PARSED_BULLET only, plus a second
+ * pooled section line (ORPHAN_BULLET) that no entry claims.
+ */
+function baseResult(): CascadeResult {
+  const blank = buildBlankResult();
+  const lines = [`• ${PARSED_BULLET}`, `• ${ORPHAN_BULLET}`, ...extraPooledLines];
+  const byName = new Map<string, readonly string[]>([["experience", lines]]);
+  const sections: SectionedResume = {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+  return {
+    ...blank,
+    rawText: lines.join("\n"),
+    canonical: toCanonicalResume(
+      {
+        full_name: "Robin Vasquez",
+        email: "robin.vasquez@example.com",
+        skills: ["typescript"],
+        education: [],
+        experience: [
+          {
+            title: "Staff Engineer",
+            company: "Northwind Systems",
+            description: PARSED_BULLET,
+          },
+        ],
+      },
+      sections,
+      {},
+    ),
+  };
+}
+
+let api: EditableParse;
+
+/**
+ * Mounts `ExperienceSection` over the real edit hook, building `groups` exactly
+ * the way `ReconstructedResume` does: every parsed entry renders (the
+ * `sliceGroups` empty-group fallback) and the "Other" group is appended last.
+ */
+function Harness() {
+  const edit = useEditableParse();
+  api = edit;
+
+  const groups = useMemo<BulletGroup[]>(() => {
+    const base = baseResult();
+    const core = applyOverrides(
+      base.canonical.fields,
+      base.rawText,
+      base.canonical.sections,
+      edit.contactOverrides,
+      edit.experienceOverrides,
+      edit.bulletOverrides,
+      [],
+      edit.educationOverrides,
+      edit.skillsOverride,
+      edit.addedEntries,
+      edit.addedBullets,
+      edit.removedBullets,
+      edit.profileOverrides,
+      base.canonical.fieldConfidence,
+      edit.achievementOverrides,
+      edit.descriptionOverrides,
+      edit.summaryOverride,
+    );
+    const score = computeAnonymousAtsScore({
+      parsed: core.fields,
+      fieldConfidence: core.fieldConfidence,
+      triggers: base.triggers,
+      rawText: core.rawText,
+      sections: projectScoreSections(core),
+    });
+    const experiences = core.fields.experience;
+    const grouped = groupBulletsByExperience(
+      [...(score.bullets ?? [])],
+      experiences,
+    );
+    const byIndex = new Map(
+      grouped
+        .filter((g) => g.experienceIndex !== null)
+        .map((g) => [g.experienceIndex, g] as const),
+    );
+    const other = grouped.find((g) => g.experienceIndex === null);
+    const roles = experiences.map(
+      (exp, i) =>
+        byIndex.get(i) ?? { experienceIndex: i, experience: exp, bullets: [] },
+    );
+    return other ? [...roles, other] : roles;
+  }, [edit]);
+
+  return createElement(ExperienceSection, {
+    groups,
+    resumeSections: [],
+    // false → no ModelSelector / rewrite CTA chrome in the test DOM.
+    hasBullets: false,
+    experienceOverrides: {},
+    onExperienceFieldChange: () => {},
+    onBulletChange: edit.setBulletField,
+    onRemoveBullet: edit.removeBullet,
+    addedBullets: edit.addedBullets,
+    addedExperience: edit.addedEntries.filter((e) => e.section === "experience"),
+    originalCount: 1,
+    onAddEntry: () => edit.addEntry("experience"),
+    onRemoveEntry: edit.removeEntry,
+    onEntryField: edit.setEntryField,
+    onAddBullet: edit.addBullet,
+    captureBulletUndo: edit.captureBulletUndo,
+    summaryApply: {
+      obsIds: [],
+      onReplace: () => {},
+      onRemove: () => {},
+      onAdd: () => {},
+    },
+    onPruneEmpty: (isHeld) => edit.pruneEmptyAddedEntries("experience", isHeld),
+  });
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function render(): Promise<HTMLDivElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(Harness));
+  });
+  await act(async () => {});
+  return container;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: [
+      "setTimeout",
+      "clearTimeout",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+    ],
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+  extraPooledLines = [];
+  vi.useRealTimers();
+});
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+/** The "Remove bullet" control on the ONE row rendering `text`. Asserting
+ *  uniqueness is what keeps the test from silently clicking a neighbour after a
+ *  layout change. */
+function removeButtonFor(el: HTMLDivElement, text: string): HTMLButtonElement {
+  const rows = Array.from(el.querySelectorAll("li")).filter((li) =>
+    li.textContent?.includes(text),
+  );
+  expect(rows).toHaveLength(1);
+  const button = rows[0]!.querySelector<HTMLButtonElement>(
+    '[aria-label="Remove bullet"]',
+  );
+  expect(button).not.toBeNull();
+  return button!;
+}
+
+/**
+ * Add a real bullet to the parsed role, then commit a contentless line over it —
+ * the shipped `ResumeBulletRow` edit call, with the `AddedBulletRef` that row
+ * supplies. Returns the id the degenerate row will carry.
+ *
+ * `degenerate` is a parameter because which contentless text a bucket holds is
+ * the discriminator for the wrong-bucket case below: two DIFFERENT markers both
+ * normalise to `""`, so a resolver keyed on the normalised form cannot tell them
+ * apart.
+ */
+function mintDegenerateLine(degenerate: string = DEGENERATE): string {
+  act(() => api.addBullet("experience:0", ADDED_BULLET));
+  act(() =>
+    api.setBulletField(bulletId(ADDED_BULLET, 0), degenerate, {
+      entryKey: "experience:0",
+      text: ADDED_BULLET,
+    }),
+  );
+  expect(api.addedBullets["experience:0"]).toEqual([degenerate]);
+  return bulletId(degenerate, 0);
+}
+
+describe("ExperienceSection — 'Other bullets' Remove on an added line (#660 half 2)", () => {
+  it("drops the degenerate line from the bucket, the pool and the DOM", async () => {
+    const el = await render();
+    mintDegenerateLine();
+    await act(async () => {});
+
+    // It really did fall through to the group with no entry.
+    expect(el.textContent).toContain("Other bullets");
+    expect(removeButtonFor(el, DEGENERATE)).toBeTruthy();
+
+    await click(removeButtonFor(el, DEGENERATE));
+
+    // Spliced out of the bucket that actually held it…
+    expect(api.addedBullets).toEqual({});
+    // …and gone from the rendered résumé.
+    expect(
+      Array.from(el.querySelectorAll("li")).filter((li) =>
+        li.textContent?.includes(DEGENERATE),
+      ),
+    ).toHaveLength(0);
+    // The confirmation strip belongs in THIS assertion, not its own test: it
+    // armed pre-fix too (the inert write still returned true, #659's false
+    // "Removed"), so a strip assertion alone can never go red. Paired with the
+    // splice above it says the thing that is newly true — the strip now
+    // confirms a removal that happened. Hosted by the SECTION, because the
+    // group vanished with its last bullet.
+    expect(el.textContent).toContain("Removed 1 change");
+  });
+
+  it("files NO unresolvable id for it (AC 2)", async () => {
+    const el = await render();
+    const degenerateId = mintDegenerateLine();
+    await act(async () => {});
+
+    // `"<n>|"` — the id shape whose normalised text is empty, which
+    // `resolveOverrideOriginal` cannot resolve.
+    expect(degenerateId).toBe("0|");
+
+    await click(removeButtonFor(el, DEGENERATE));
+
+    expect(api.removedBullets.size).toBe(0);
+    // No permanent phantom edit left behind either.
+    expect(api.hasEdits).toBe(false);
+  });
+
+  it("still removes a genuinely-unmatched PARSED bullet by id", async () => {
+    // The control, and deliberately green BOTH ways: ORPHAN_BULLET is in no
+    // bucket, so the resolver finds nothing and the removal must fall through to
+    // `removedBullets` exactly as before — the "costs nothing when it misses"
+    // half of the fix. It fails only if the resolver over-reaches.
+    const el = await render();
+    expect(el.textContent).toContain("Other bullets");
+
+    await click(removeButtonFor(el, ORPHAN_BULLET));
+
+    expect(api.removedBullets.has(bulletId(ORPHAN_BULLET, 0))).toBe(true);
+    expect(api.addedBullets).toEqual({});
+    expect(el.textContent).not.toContain(ORPHAN_BULLET);
+    expect(el.textContent).toContain("Removed 1 change");
+  });
+
+  it("splices the FIRST bucket even when the SECOND row was clicked (#683, known)", async () => {
+    // Two added roles each holding a contentless line of the SAME verbatim text.
+    // `sameBulletLine`'s verbatim fallback tells `"3."` from `"4."` but cannot
+    // tell one `"3."` from another, so `findAddedBulletEntry` falls back to
+    // first-bucket-wins and BOTH rows resolve to the same bucket.
+    //
+    // This case CLICKS THE SECOND ROW on purpose. It used to click the first —
+    // the row whose bucket wins the tiebreak — which made it green whether the
+    // resolver was right or wrong, and that blindness is why #683 survived two
+    // review rounds. Clicking the loser is what makes the assertion mean
+    // something.
+    //
+    // What it pins is therefore the KNOWN-WRONG behaviour, so it goes red when
+    // #683 is fixed — which is the point. The harm is bounded (only contentless
+    // lines reach this branch, the undo snapshot agrees with the splice, and a
+    // second click converges), which is why it ships open rather than blocking.
+    // See #683 for the two candidate fixes and what each costs.
+    const el = await render();
+    mintDegenerateLine();
+    let second = "";
+    act(() => {
+      second = api.addEntry("experience");
+    });
+    act(() => api.addBullet(second, ADDED_BULLET));
+    act(() =>
+      api.setBulletField(bulletId(ADDED_BULLET, 0), DEGENERATE, {
+        entryKey: second,
+        text: ADDED_BULLET,
+      }),
+    );
+    await act(async () => {});
+    expect(api.addedBullets["experience:0"]).toEqual([DEGENERATE]);
+    expect(api.addedBullets[second]).toEqual([DEGENERATE]);
+
+    const rows = Array.from(el.querySelectorAll("li")).filter((li) =>
+      li.textContent?.includes(DEGENERATE),
+    );
+    expect(rows).toHaveLength(2);
+    await click(
+      rows[1]!.querySelector<HTMLButtonElement>('[aria-label="Remove bullet"]')!,
+    );
+
+    // #683: the SECOND row was clicked, but the FIRST bucket in insertion order
+    // is what loses its line — the clicked row's own bucket is untouched. Exactly
+    // one line goes per click (a resolver returning every match would empty
+    // both), and nothing is filed by id, so the bucket splice did report success.
+    expect("experience:0" in api.addedBullets).toBe(false);
+    expect(api.addedBullets[second]).toEqual([DEGENERATE]);
+    expect(api.removedBullets.size).toBe(0);
+  });
+});
+
+describe("ExperienceSection — a PARSED degenerate line (#660 AC 2, unconditional)", () => {
+  /**
+   * The row, plus the two facts that make it the AC-2 case: it is in NO bucket
+   * (nothing was ever added), so `findAddedBulletEntry` misses and the removal
+   * falls through to the id-keyed path — carrying an id whose text half is empty.
+   */
+  function expectDegenerateRow(el: HTMLDivElement): HTMLButtonElement {
+    expect(el.textContent).toContain("Other bullets");
+    expect(api.addedBullets).toEqual({});
+    expect(bulletId("4.", 0)).toBe("0|");
+    return removeButtonFor(el, "4.");
+  }
+
+  it("files no unresolvable id and arms no strip for it", async () => {
+    extraPooledLines = [PARSED_DEGENERATE];
+    const el = await render();
+    await act(async () => {});
+
+    await click(expectDegenerateRow(el));
+
+    // Pre-fix this was `Set { "0|" }` — an id `resolveOverrideOriginal` resolves
+    // to nothing, so it removed nothing yet stayed in the set forever, keeping
+    // the résumé permanently "dirty" with a phantom edit no Undo could clear.
+    expect(api.removedBullets.size).toBe(0);
+    expect(api.hasEdits).toBe(false);
+    // #659 AC 1 — a removal that did nothing renders no "Removed" strip. Both
+    // ACs ride the same `false`, which is why one guard closes them together.
+    expect(el.textContent).not.toContain("Removed 1 change");
+    // The row itself is still there, and that is the honest post-fix state: the
+    // click is now a truthful no-op instead of a lie. Making the line removable
+    // means keeping it out of the pool, which moves the Specificity denominator
+    // for every résumé carrying one — a scoring change, filed on its own.
+    expect(
+      Array.from(el.querySelectorAll("li")).filter((li) =>
+        li.textContent?.includes("4."),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("does the same for the #30 lone-bullet-merge shape", async () => {
+    // The glyph and its text in separate extracted lines — what a Word table
+    // emits when they sit in separate cells. `extractBulletsFromLines` merges
+    // them, so the pool holds one `"4."` row and this is the SAME defect arriving
+    // by the path #30 exists for, not a variant of it.
+    extraPooledLines = ["•", "4."];
+    const el = await render();
+    await act(async () => {});
+
+    await click(expectDegenerateRow(el));
+
+    expect(api.removedBullets.size).toBe(0);
+    expect(api.hasEdits).toBe(false);
+    expect(el.textContent).not.toContain("Removed 1 change");
+  });
+
+  it("does not splice a DIFFERENT role's contentless line (wrong-bucket splice)", async () => {
+    // The resolver runs before the id-shape guard, so a bucket it wrongly matches
+    // is spliced and reported as success — the guard never sees the call. Both
+    // texts normalise to `""`, so the normalised key cannot discriminate them:
+    // the parsed row reads "4." and the bucket holds "1.".
+    extraPooledLines = [PARSED_DEGENERATE];
+    const el = await render();
+    mintDegenerateLine("1.");
+    await act(async () => {});
+
+    // Two degenerate rows, both in "Other bullets" (the grouper skips the empty
+    // key, so neither can be attributed to the entry that owns it).
+    expect(el.textContent).toContain("Other bullets");
+    expect(api.addedBullets).toEqual({ "experience:0": ["1."] });
+
+    await click(removeButtonFor(el, "4."));
+
+    // The clicked row is PARSED and in no bucket, so nothing may be spliced. Left
+    // unguarded, `findAddedBulletEntry` matched `""` against the `"1."` bucket and
+    // `removeAddedBulletLine` — which matches on the same normalised form —
+    // deleted a line the user never clicked, from another role, and returned true.
+    expect(api.addedBullets).toEqual({ "experience:0": ["1."] });
+    expect(api.removedBullets.size).toBe(0);
+    expect(el.textContent).not.toContain("Removed 1 change");
+    // Both rows still rendered: the clicked one (nothing can remove it yet) and
+    // the bystander (nothing should).
+    expect(removeButtonFor(el, "4.")).toBeTruthy();
+    expect(removeButtonFor(el, "1.")).toBeTruthy();
+    // `hasEdits` stays TRUE here, and correctly so — the user really did add and
+    // edit a bullet. It is the bystander bucket, not this flag, that carries the
+    // signal in this case.
+    expect(api.hasEdits).toBe(true);
+  });
+
+  it("still splices the RIGHT bucket when the clicked row is the added one", async () => {
+    // The other side of the discrimination, and the reason the fix cannot simply
+    // refuse an empty normalised target: #660 half 2 IS a degenerate row
+    // resolving to its own bucket. Same tree shape as the case above — a parsed
+    // "4." row present — with the click on the added "1." row instead.
+    extraPooledLines = [PARSED_DEGENERATE];
+    const el = await render();
+    mintDegenerateLine("1.");
+    await act(async () => {});
+
+    await click(removeButtonFor(el, "1."));
+
+    expect(api.addedBullets).toEqual({});
+    expect(api.removedBullets.size).toBe(0);
+    expect(el.textContent).toContain("Removed 1 change");
+    // The parsed degenerate row is the bystander this time, and is untouched.
+    expect(removeButtonFor(el, "4.")).toBeTruthy();
+  });
+
+  it("still removes the genuinely-unmatched orphan alongside it", async () => {
+    // The guard is on the id's SHAPE, not on the fall-through: a real bullet that
+    // misses the bucket resolver must still be removable by id. Run with the
+    // degenerate line present so the two are decided in the same mounted tree.
+    extraPooledLines = [PARSED_DEGENERATE];
+    const el = await render();
+    await act(async () => {});
+
+    await click(removeButtonFor(el, ORPHAN_BULLET));
+
+    expect(api.removedBullets.has(bulletId(ORPHAN_BULLET, 0))).toBe(true);
+    expect(el.textContent).not.toContain(ORPHAN_BULLET);
+    expect(el.textContent).toContain("Removed 1 change");
+  });
+});
+
+/**
+ * A user-ADDED role whose one and only bullet has been edited down to a
+ * contentless line, so that line is the whole of its bucket.
+ *
+ * Built the same reachable way as {@link mintDegenerateLine} — add a real bullet,
+ * then commit a contentless replacement over it through the shipped
+ * `setBulletField` — but under an ADDED entry, which is the difference that
+ * matters: the splice then empties an entry `pruneEmptyAddedEntries` can drop,
+ * and the role has a blank header, so `isAddedEntryEmpty` is true the moment the
+ * bucket goes. A role with a typed title would never be prunable and a test built
+ * on one would pass with the hold ripped out.
+ *
+ * Returns the entry id.
+ */
+function mintDegenerateAddedRole(): string {
+  let added = "";
+  act(() => {
+    added = api.addEntry("experience");
+  });
+  act(() => api.addBullet(added, ADDED_BULLET));
+  act(() =>
+    api.setBulletField(bulletId(ADDED_BULLET, 0), DEGENERATE, {
+      entryKey: added,
+      text: ADDED_BULLET,
+    }),
+  );
+  expect(api.addedBullets[added]).toEqual([DEGENERATE]);
+  return added;
+}
+
+/** The one row rendering `text`, or none. */
+function rowsFor(el: HTMLDivElement, text: string): HTMLLIElement[] {
+  return Array.from(el.querySelectorAll("li")).filter((li) =>
+    li.textContent?.includes(text),
+  );
+}
+
+describe("ExperienceSection — the Undo this Remove arms must actually revert it", () => {
+  it("puts the line back in the bucket the removal spliced (#660 half 2 × #659)", async () => {
+    // The gap every case above left open: none of them clicks Undo. The strip is
+    // section-hosted, so it survives the group's disappearance and the button is
+    // mounted and clickable either way — what it RESTORES is the only thing that
+    // can tell a correct snapshot from a snapshot of a bucket nobody wrote.
+    //
+    // With a placeholder entry key, `captureBulletUndoSnapshot` read
+    // `addedBullets["other-bullets"]` as `[]` while the removal spliced
+    // `experience:0`, so the undo deleted a key that never existed and the line
+    // was gone for good behind a strip reporting "Reverted 1 change".
+    const el = await render();
+    mintDegenerateLine();
+    await act(async () => {});
+    expect(rowsFor(el, DEGENERATE)).toHaveLength(1);
+
+    await click(removeButtonFor(el, DEGENERATE));
+    expect(api.addedBullets).toEqual({});
+
+    const undo = el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`);
+    expect(undo).not.toBeNull();
+    await click(undo!);
+
+    // The real bucket, restored to its exact pre-remove value.
+    expect(api.addedBullets).toEqual({ "experience:0": [DEGENERATE] });
+    // And back on screen, in the group it grouped into before.
+    expect(el.textContent).toContain("Other bullets");
+    expect(rowsFor(el, DEGENERATE)).toHaveLength(1);
+    expect(el.textContent).toContain("Reverted 1 change");
+    // Nothing leaked to the id-keyed path on the way out or back.
+    expect(api.removedBullets.size).toBe(0);
+    // TRUE, and correctly so: the user really did add a bullet and edit it, and
+    // the undo just put that back. `hasEdits` reads the restored bucket, so a
+    // "clean after undo" assertion here would be asserting the line is still
+    // gone — which is the defect, not the fix.
+    expect(api.hasEdits).toBe(true);
+  });
+
+  it("holds the added role its splice emptied back from the section-exit prune", async () => {
+    // #637 half 2, one level up. Half 2 of #660 made this removal splice a real
+    // bucket, so it can empty a user-added ROLE — while the strip holding that
+    // role's Undo is hosted by the SECTION, which the prune never unmounts. The
+    // hold in `ReconstructedRole` cannot cover it: the holder for this control is
+    // the "Other bullets" `RoleEntry`, whose `entryKey` is undefined, so its
+    // `useHoldWhile` is a no-op. Unheld, `sectionExitBlur` dropped the whole role
+    // one tick after the next blur, with the Undo still on screen offering to
+    // restore it.
+    const el = await render();
+    const added = mintDegenerateAddedRole();
+    await act(async () => {});
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+
+    await click(removeButtonFor(el, DEGENERATE));
+    // The role is NOW genuinely empty — blank header, bucket spliced away — so
+    // the prune would take it.
+    expect(api.addedBullets).toEqual({});
+    expect(el.textContent).toContain("Removed 1 change");
+
+    await exitSection(el);
+
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+    expect(el.querySelector(`[aria-label="${UNDO_LABEL}"]`)).not.toBeNull();
+
+    // The hold is a lease on the LIVE strip, not an exemption. This control
+    // registers no host element — `host` governs only the release prune (#658),
+    // and the subtree that could answer it is the emptied role's, not this
+    // section's — so a collapse stands down rather than pruning, and the
+    // section-exit pass is what eventually sweeps the ghost.
+    await collapseStrip();
+    expect(el.textContent).not.toContain("Removed 1 change");
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+
+    await exitSection(el);
+    expect(api.addedEntries).toHaveLength(0);
+  });
+
+  it("does not let a PARSED entry's splice displace a live added role's hold", async () => {
+    // `heldEntry` is a SINGLE value, so every landed removal overwrites it. That
+    // is safe only because the write is gated on the resolved key being an ADDED
+    // one: a parsed entry is never prunable, so holding its key would buy
+    // nothing — and would silently release the added role whose strip is still
+    // live, handing it straight back to the section-exit prune.
+    //
+    // Two degenerate rows with DIFFERENT markers so the resolver is unambiguous
+    // (identical text is #683, a separate defect): one in the added role's
+    // bucket, one in the parsed `experience:0` bucket.
+    const el = await render();
+    const added = mintDegenerateAddedRole();
+    mintDegenerateLine("1.");
+    await act(async () => {});
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+
+    // Empties the added role and takes the hold.
+    await click(removeButtonFor(el, DEGENERATE));
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+
+    // Lands under `experience:0` — a PARSED key. It must not become the held id.
+    await click(removeButtonFor(el, "1."));
+    expect(api.addedBullets).toEqual({});
+
+    // Still held by the first removal, so the strip's Undo still has a role to
+    // restore into. Drop the `isAddedEntryKey` gate and this is where it dies.
+    await exitSection(el);
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+  });
+
+  it("and that surviving Undo restores the role's bucket, not a phantom one", async () => {
+    // Both halves in one flow, which is the state the user is actually in: the
+    // role is spared, so the Undo has something to restore INTO — and it has to
+    // name the bucket the splice took the line out of.
+    const el = await render();
+    const added = mintDegenerateAddedRole();
+    await act(async () => {});
+
+    await click(removeButtonFor(el, DEGENERATE));
+    await exitSection(el);
+
+    await click(el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`)!);
+
+    expect(api.addedBullets[added]).toEqual([DEGENERATE]);
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+    expect(rowsFor(el, DEGENERATE)).toHaveLength(1);
+    expect(el.textContent).toContain("Reverted 1 change");
+    expect(api.removedBullets.size).toBe(0);
+
+    // No longer empty, so the next prune pass leaves it alone — the restored
+    // bullet is what keeps it, decided by `pruneEmptyAddedEntries` at prune time
+    // rather than by anything this path closed over.
+    await collapseStrip();
+    await exitSection(el);
+    expect(api.addedEntries.map((e) => e.id)).toEqual([added]);
+    expect(api.addedBullets[added]).toEqual([DEGENERATE]);
+  });
+});

--- a/src/components/features/ExperienceSection.prune-hold.test.tsx
+++ b/src/components/features/ExperienceSection.prune-hold.test.tsx
@@ -19,6 +19,13 @@
  * empty SIBLING added role with no live undo must still be dropped by the very
  * same prune pass that spares the held one.
  *
+ * The #659 block at the end reuses this harness for the inverse of half 2: a
+ * removal that did NOTHING must not arm a strip, because that strip would both
+ * lie to the user and hold its entry back from this same prune. The harness is
+ * what makes that repro honest — a double-click reaches `removeBullet`'s
+ * `isAddedEntryKey` early return through the shipped ref-write ordering, with
+ * nothing staged. The strip's own contract is pinned in `BulletRemoveStatus.test.tsx`.
+ *
  * jsdom + raw `createRoot` + fake timers, matching `ExperienceSection.test.tsx`.
  */
 
@@ -43,7 +50,13 @@ import { toCanonicalResume } from "../../lib/heuristics/canonical.ts";
 import type { SectionedResume } from "../../lib/heuristics/sections.ts";
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import { batchUndoTargets } from "../../lib/rewrite-review/undo-batch.ts";
-import { UNDO_HOLD_MS } from "./ApplyConfirmation.tsx";
+// The two recipes that are easy to get silently wrong (see that module), shared
+// with `ExperienceSection.other-bullets.test.tsx` rather than copied a third time.
+import {
+  UNDO_LABEL,
+  collapseStrip,
+  exitSection,
+} from "./__test-utils__/experience-section-dom.ts";
 
 const PARSED_BULLET = "Cut p99 checkout latency by 38% via edge caching.";
 const HELD_BULLET = "Shipped a design system used by 40 engineers.";
@@ -149,6 +162,7 @@ function Harness() {
     onExperienceFieldChange: () => {},
     onBulletChange: edit.setBulletField,
     onRemoveBullet: edit.removeBullet,
+    addedBullets: edit.addedBullets,
     addedExperience: edit.addedEntries.filter((e) => e.section === "experience"),
     // Index 0 is the parsed role; indices 1+ are the user-added ones.
     originalCount: 1,
@@ -211,17 +225,57 @@ async function click(el: HTMLElement) {
   });
 }
 
-/** The real section-exit blur (#379): focus leaves the section entirely, then
- *  the deferred prune fires one macrotask later. */
-async function exitSection(el: HTMLDivElement) {
-  const section = el.querySelector("section")!;
+/**
+ * Two clicks on the same control inside ONE `act`, i.e. a double-click. React
+ * batches both updates to the end of the act scope, so the second handler runs
+ * against the same render as the first — but `writeAddedBullets` assigns its ref
+ * synchronously, so the second call finds the bucket line already spliced.
+ *
+ * That is how the `isAddedEntryKey` early return (#637) is reached from the UI
+ * without staging anything: shipped code produces the no-op.
+ */
+async function doubleClick(el: HTMLElement) {
   await act(async () => {
-    section.dispatchEvent(
-      new FocusEvent("focusout", { bubbles: true, relatedTarget: null }),
-    );
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
   await act(async () => {
-    vi.advanceTimersByTime(1);
+    vi.advanceTimersByTime(16);
+  });
+}
+
+/**
+ * Type into a controlled field the way a user does. React's value tracker
+ * swallows a direct `el.value = x` — no `onChange` fires, so the draft the test
+ * thinks it typed is not the draft the component holds, and the test passes for
+ * the wrong reason. Write through the prototype's native setter instead.
+ *
+ * Serves both draft-bearing controls in a `RoleEntry` — a `multiline`
+ * `EditableField`'s `<textarea>` and an expanded `InlineBulletAdd`'s `<input>` —
+ * because the tracker sits on the element's OWN prototype, so the setter has to
+ * come from the matching one.
+ */
+async function type(el: HTMLTextAreaElement | HTMLInputElement, text: string) {
+  const proto =
+    el instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const setValue = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+  await act(async () => {
+    setValue.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/**
+ * One stray click somewhere else on the page: focus leaves the control, landing
+ * on `<body>`. Nothing else about the row changes — a `multiline`
+ * `EditableField` does not commit on blur, and an expanded `InlineBulletAdd`
+ * with text in it does not collapse, so the DRAFT is still on screen afterwards.
+ */
+async function blur(el: HTMLElement) {
+  await act(async () => {
+    el.blur();
   });
 }
 
@@ -230,8 +284,6 @@ function removeBulletButtons(el: HTMLDivElement): HTMLButtonElement[] {
     el.querySelectorAll<HTMLButtonElement>('[aria-label="Remove bullet"]'),
   );
 }
-
-const UNDO_LABEL = "Undo the changes just applied to the résumé";
 
 /**
  * Two blank-header added roles; the first gets a bullet. Blank headers are
@@ -307,29 +359,243 @@ describe("ExperienceSection — the prune must not eat a live undo (#637 half 2)
     expect(api.addedEntries.map((e) => e.id)).toEqual([held]);
   });
 
-  it("prunes the held role once its strip is gone and focus leaves again", async () => {
+  it("prunes the held role the moment its strip collapses (#658)", async () => {
     const el = await render();
     const { held } = seedRoles();
     await act(async () => {});
 
     await click(removeBulletButtons(el)[1]!);
     await exitSection(el);
-    expect(api.addedEntries.map((e) => e.id)).toContain(held);
+    // Spared while the strip is live — #637 half 2, unchanged.
+    expect(api.addedEntries.map((e) => e.id)).toEqual([held]);
 
-    // The hold is a lease on the LIVE strip, not a permanent exemption: once
-    // the confirmation collapses, the next section exit drops the ghost.
-    // Two advances, not one: `ApplyConfirmation` chains hold → collapsing →
-    // exit, and the exit timer is not SCHEDULED until the effect reacting to
-    // `collapsing` runs, so a single advance would never reach `onCollapse`.
-    await act(async () => {
-      vi.advanceTimersByTime(UNDO_HOLD_MS);
-    });
-    await act(async () => {
-      vi.advanceTimersByTime(1_000);
-    });
+    // The hold is a lease on the LIVE strip, not a permanent exemption. Before
+    // #658 the lease lapsing was inert — nothing called the prune again, so this
+    // ghost sat in the list, the score and the exported PDF until the user
+    // re-entered and re-exited the section. Now the release re-runs it, and this
+    // test used to need a second `exitSection` right here to go green.
+    await collapseStrip();
+
     expect(el.textContent).not.toContain("Removed 1 change");
+    expect(api.addedEntries).toHaveLength(0);
+    // Nothing in this test focuses anything, which is what lets the release
+    // prune fire at all. The typing case below is the other half.
+    expect(document.activeElement).toBe(document.body);
+  });
+});
+
+describe("ExperienceSection — a collapsing strip re-runs the prune (#658)", () => {
+  it("needs no section exit, and leaves a blank sibling to the one that follows", async () => {
+    const el = await render();
+    const { held, sibling } = seedRoles();
+    await act(async () => {});
+
+    // No blur anywhere in this test: the removal alone arms the strip, and the
+    // strip's own timer is the trigger.
+    await click(removeBulletButtons(el)[1]!);
+    await collapseStrip();
+
+    // Narrowed on purpose. The pass is section-wide, so an unnarrowed sweep off
+    // a timer could drop the blank sibling — and a blank added role is also
+    // exactly what one the user just opened with "+ Add experience" looks like,
+    // since a header field's draft commits only on an explicit Save. The
+    // section-exit pass still takes it (#379, #637's sibling criterion): that
+    // one only ever fires with focus outside the whole section.
+    expect(api.addedEntries.map((e) => e.id)).toEqual([sibling]);
+    expect(sibling).not.toBe(held);
 
     await exitSection(el);
+    expect(api.addedEntries).toHaveLength(0);
+  });
+
+  it("keeps an entry whose Undo put its bullet back", async () => {
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await click(removeBulletButtons(el)[1]!);
+    await click(el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`)!);
+    expect(api.addedBullets[held]).toEqual([HELD_BULLET]);
+
+    // The "Reverted" strip holds the entry as well, and collapses in its turn —
+    // so this release runs the prune over an entry that is no longer empty. The
+    // release path never decides emptiness itself; `pruneEmptyAddedEntries` does,
+    // inside its own state updater, which is the only reader that cannot be
+    // holding a stale bucket.
+    await collapseStrip();
+
+    expect(api.addedEntries.map((e) => e.id)).toContain(held);
+    expect(el.textContent).toContain(HELD_BULLET);
+  });
+
+  it("stands down while the user is typing in the entry, and the next section exit still gets it", async () => {
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await click(removeBulletButtons(el)[1]!);
+
+    // Enter edit mode on the held role's own blank title. Both added roles offer
+    // one and the held role is the first added entry, so the first "Add Job
+    // title" in document order is its own — the PARSED role has a title, so its
+    // affordance reads "Edit Job title" and is not in this list.
+    const titles = el.querySelectorAll<HTMLElement>(
+      '[aria-label="Add Job title"]',
+    );
+    expect(titles).toHaveLength(2);
+    await click(titles[0]!);
+
+    const draft = el.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Job title"]',
+    )!;
+    // Real focus, via the rAF `EditableField.startEdit` schedules (the `click`
+    // helper advances it). The gate reads `activeElement` containment, so if
+    // this line were a no-op the test would pass with the gate deleted.
+    expect(document.activeElement).toBe(draft);
+
+    await type(draft, "Staff Engineer");
+    // Uncommitted, and that is the point: a MULTILINE EditableField commits only
+    // on an explicit Save, so the entry still reads as empty to
+    // `isAddedEntryEmpty` — which is how the mid-keystroke yank #637 rejected
+    // this fix over stays reachable.
+    expect(api.addedEntries.find((e) => e.id === held)?.title).toBe("");
+
+    await collapseStrip();
+
+    // AC 4: the row is still there, with the draft and the caret still in it.
+    expect(el.textContent).not.toContain("Removed 1 change");
+    expect(api.addedEntries.map((e) => e.id)).toContain(held);
+    expect(draft.value).toBe("Staff Engineer");
+    expect(document.activeElement).toBe(draft);
+
+    // And the lease really did lapse: the entry is no longer HELD, so the
+    // section-exit pass drops it — that pass runs with focus outside the whole
+    // section by definition, so it never faces this question. This is the
+    // guarantee the reworded #637 test above used to carry.
+    await exitSection(el);
+    expect(api.addedEntries).toHaveLength(0);
+  });
+
+  it("stands down for a header draft the user blurred without saving", async () => {
+    // The case a focus-only gate lost. `EditableField` keeps a MULTILINE draft
+    // across a blur on purpose ("a multi-line paste that accidentally defocuses
+    // shouldn't lose the draft"), so the draft outlives the focus the gate was
+    // keyed to: one stray click elsewhere on the page and the entry read as
+    // unfocused AND empty, so the release prune unmounted the row with the typed
+    // title still in it. No section exit, no user action at the moment of loss.
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await click(removeBulletButtons(el)[1]!);
+
+    const titles = el.querySelectorAll<HTMLElement>(
+      '[aria-label="Add Job title"]',
+    );
+    expect(titles).toHaveLength(2);
+    await click(titles[0]!);
+
+    const draft = el.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Job title"]',
+    )!;
+    expect(document.activeElement).toBe(draft);
+    await type(draft, "Staff Engineer");
+
+    await blur(draft);
+    // The two facts that together make the row indistinguishable from a ghost to
+    // a focus-only gate: focus is gone, and the draft never committed.
+    expect(document.activeElement).toBe(document.body);
+    expect(api.addedEntries.find((e) => e.id === held)?.title).toBe("");
+    // Blur is not Cancel — the textarea (and the text in it) is still mounted.
+    expect(draft.value).toBe("Staff Engineer");
+
+    await collapseStrip();
+
+    // The strip really did run its course, so the release fired and the gate is
+    // what spared the row.
+    expect(el.textContent).not.toContain("Removed 1 change");
+    expect(api.addedEntries.map((e) => e.id)).toContain(held);
+    // The SAME textarea node, still in the tree, with the draft intact — not a
+    // remounted empty one.
+    expect(el.contains(draft)).toBe(true);
+    expect(draft.value).toBe("Staff Engineer");
+  });
+
+  it("stands down for a blurred '+ Add bullet' draft in the entry", async () => {
+    // The other draft-bearing control, and the other element type: an expanded
+    // `InlineBulletAdd` with text in it does not collapse on blur either (its
+    // handler collapses only an EMPTY draft), so the same loss was reachable
+    // through the affordance the emptied role is showing the user.
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await click(removeBulletButtons(el)[1]!);
+
+    // Pills in document order: the parsed role, the held role, its sibling.
+    const pills = el.querySelectorAll<HTMLElement>(
+      'button[aria-label="Add bullet"]',
+    );
+    expect(pills).toHaveLength(3);
+    await click(pills[1]!);
+
+    const draft = el.querySelector<HTMLInputElement>(
+      'input[aria-label="Add bullet"]',
+    )!;
+    expect(document.activeElement).toBe(draft);
+    await type(draft, "Grew ARR 30% in two quarters");
+
+    await blur(draft);
+    expect(document.activeElement).toBe(document.body);
+    // Never committed, so the bucket is still empty and the entry still prunable.
+    expect(api.addedBullets).toEqual({});
+    expect(draft.value).toBe("Grew ARR 30% in two quarters");
+
+    await collapseStrip();
+
+    expect(el.textContent).not.toContain("Removed 1 change");
+    expect(api.addedEntries.map((e) => e.id)).toContain(held);
+    expect(el.contains(draft)).toBe(true);
+    expect(draft.value).toBe("Grew ARR 30% in two quarters");
+  });
+});
+
+describe("ExperienceSection — a no-op removal must not re-arm the strip (#659)", () => {
+  it("keeps the first write's undo when a double-click's second write does nothing", async () => {
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    // One user gesture, two handler runs. The first splices the bucket; the
+    // second finds nothing left and reports `false`.
+    await doubleClick(removeBulletButtons(el)[1]!);
+
+    expect(api.addedBullets).toEqual({});
+    expect(el.textContent).toContain("Removed 1 change");
+
+    await click(el.querySelector<HTMLElement>(`[aria-label="${UNDO_LABEL}"]`)!);
+
+    // The armed Undo has to be the one snapshotted BEFORE the removal that
+    // landed. An ungated second `setStatus` replaces it with a snapshot taken
+    // after — `captureBulletUndoSnapshot` reads the bucket as it is then (now
+    // empty) and filters an already-removed id out of `restore` — so the button
+    // stays mounted, stays clickable, and restores nothing.
+    expect(el.textContent).toContain(HELD_BULLET);
+    expect(api.addedBullets[held]).toEqual([HELD_BULLET]);
+    expect(el.textContent).toContain("Reverted 1 change");
+  });
+
+  it("prunes the entry once that strip collapses, exactly as one real removal does", async () => {
+    const el = await render();
+    const { held } = seedRoles();
+    await act(async () => {});
+
+    await doubleClick(removeBulletButtons(el)[1]!);
+    // One hold, taken by the write that landed — not two, and not one per click.
+    await exitSection(el);
+    expect(api.addedEntries.map((e) => e.id)).toEqual([held]);
+
+    await collapseStrip();
 
     expect(api.addedEntries).toHaveLength(0);
   });

--- a/src/components/features/ExperienceSection.test.tsx
+++ b/src/components/features/ExperienceSection.test.tsx
@@ -104,6 +104,9 @@ function Harness() {
     onExperienceFieldChange: () => {},
     onBulletChange: () => {},
     onRemoveBullet,
+    // No added bullets in this harness — the "Other bullets" remove path
+    // resolves no bucket and falls through to the id-keyed removal (#660).
+    addedBullets: {},
     addedExperience: [],
     originalCount: EXPERIENCES.length,
     onAddEntry: () => {},

--- a/src/components/features/OtherBulletsRemove.ts
+++ b/src/components/features/OtherBulletsRemove.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useOtherBulletsRemove — the "Other bullets" group's remove control: the one
+ * bullet removal in the app whose target bucket has to be DISCOVERED rather than
+ * named, and therefore the one whose undo snapshot and prune hold cannot be
+ * derived from an `entryKey` the caller already holds.
+ *
+ * Lifted out of `ExperienceSection` (`ReconstructedResume.tsx`) because all four
+ * halves of it — resolve, snapshot, write, hold — have to agree about a single
+ * value, and that agreement is the whole correctness argument. Keeping them in
+ * one module is what makes it auditable in one read.
+ *
+ * ## Why the strip is section-owned (#626)
+ *
+ * `groupBulletsByExperience` appends the "Other" group only while it has at least
+ * one bullet, so removing its LAST bullet unmounts the `RoleEntry` that triggered
+ * the remove — and would take a role-hosted "Removed 1 change · Undo" strip with
+ * it. Every parsed role keeps owning its own strip (it survives losing its
+ * bullets, via `sliceGroups`' empty-group fallback), so only this one bucket
+ * lifts. The section renders the returned {@link BulletRemoveControl.strip}.
+ *
+ * ## Why the bucket is resolved from the row's TEXT (#660 half 2)
+ *
+ * The group owns no entry, so it cannot name a bucket the way every other remove
+ * path does — it has no `entryKey` for an `AddedBulletRef`. It usually does not
+ * need one: `applyAddedEntriesAndBullets` writes each added line into its entry's
+ * own description, and `buildEntryGroups` grades experiences, projects and
+ * achievements against one combined index space, so an added line matches its
+ * entry and never falls through to "Other".
+ *
+ * Usually, not always — a line whose normalised key is EMPTY is the exception,
+ * because that is the one key `groupBulletsByExperience` skips, so no description
+ * can claim it. `addBullet` refuses to mint one since #660, but an in-place edit
+ * still can (`replaceAddedBulletLine` rejects only a blank replacement), and such
+ * a line lands here. Dropping the row's `text` left its Remove inert AND pushed an
+ * id of the shape `"<n>|"` into `removedBullets`, which `resolveOverrideOriginal`
+ * resolves to nothing — a permanently unresolvable entry that keeps the résumé
+ * "dirty" (#660).
+ *
+ * So resolve the bucket from the text instead. `findAddedBulletEntry` returns
+ * undefined for a genuinely-unmatched parsed bullet, which then falls through to
+ * the id-keyed path as before.
+ *
+ * That fall-through is where the resolver's reach ends, and it is not free: a
+ * PARSED degenerate line is in no bucket either, so it misses here too and lands
+ * on the id-keyed path carrying the same unresolvable `"<n>|"`. Real Word exports
+ * produce one — `"• 4."`, or `"•"` + `"4."` merged by the lone-bullet rule (#30) —
+ * so the id-keyed path itself has to refuse an id whose text half is empty.
+ * `useEditableParse.removeBullet` does, returning false, which is what keeps #660
+ * AC 2 unconditional rather than true only for the added half.
+ *
+ * ## One resolver, because the snapshot and the write must not disagree
+ *
+ * `useBulletRemoveStatus` snapshots BEFORE it writes, so the bucket is resolved
+ * twice per click — once for the snapshot, once for the splice. Before the
+ * resolver existed the capture could pass any placeholder, because no bucket was
+ * ever spliced on this path; once one is, a capture that names a DIFFERENT bucket
+ * arms an Undo over a slot the write never touched. `batchUndoTargets` records
+ * the key for every write kind, `captureBulletUndoSnapshot` reads that bucket as
+ * `[]` when it does not exist, and `restoreBulletUndoSnapshot` then "restores" it
+ * by deleting a key that was never there — a mounted, clickable Undo that reports
+ * "Reverted 1 change" and puts nothing back. That is #659's own defect family, so
+ * the resolution rule is written once, here, and both call sites go through it.
+ *
+ * The two calls provably agree. {@link findAddedBulletEntry} is pure, both calls
+ * pass the same `text`, and both read the same `addedBullets` — the hook rebuilds
+ * its `removeBullet` whenever either of the callbacks below changes, and both
+ * change together with the map, so a single click cannot straddle two renders.
+ *
+ * When nothing resolves, the key handed to `batchUndoTargets` is `undefined`, not
+ * a placeholder: no bucket will be written, so none is snapshotted. The removal
+ * then lands in `removedBullets`, which the snapshot's `restore` list already
+ * covers.
+ *
+ * ## Why the prune hold lives here (#637 half 2, on this path)
+ *
+ * Because the removal now splices a real bucket, it can empty a user-ADDED role —
+ * and the strip holding that role's Undo is hosted by the SECTION, which
+ * `pruneEmptyAddedEntries` never unmounts. `ReconstructedRole`'s own
+ * `useHoldWhile` cannot cover it: the holder there is the "Other bullets"
+ * `RoleEntry`, whose `entryKey` is `undefined`, so the call is a no-op. Without a
+ * hold, `sectionExitBlur` drops the whole role one tick after the next blur while
+ * the Undo is still on screen and still offering to restore it — #637's defect a
+ * level up, and losing a role rather than a bullet.
+ *
+ * No `host` element is passed to {@link useHoldWhile}, deliberately. `host`
+ * governs only the RELEASE prune (#658), and the subtree that could answer it is
+ * the emptied role's, not this section's; an omitted host is documented as
+ * "treat every release as still in use", which spares the entry and leaves it to
+ * the section-exit pass. That is the conservative half of the choice, and it
+ * introduces no new prune trigger on a path #658 never analysed.
+ *
+ * The held id is STATE, not a ref: the effect that takes the hold has to see it
+ * on the render `pending` flips true on, and that render is caused by the same
+ * batched update. It costs no extra render — the strip's own `setStatus` already
+ * re-renders this section, React batches both, and a repeat of the same key bails
+ * out. It is only ever assigned a real added-entry key, never cleared, and that
+ * is deliberate on both counts. A later removal that resolves to no bucket leaves
+ * the previous key in place: the hold is a lease on `pending`, so a stale key can
+ * only ever SPARE an already-empty role for one strip's lifetime, which the next
+ * section exit sweeps. And because the id never goes back to `undefined` while
+ * the lease is live, {@link useHoldWhile}'s one rough edge — an id dropping to
+ * `undefined` mid-hold early-returns without clearing its transition ref, so the
+ * stay's end is never reported — stays unreachable from here.
+ */
+
+import { useCallback, useState } from "react";
+import { useBulletRemoveStatus } from "./BulletRemoveStatus.tsx";
+import type { BulletRemoveControl } from "./BulletRemoveStatus.tsx";
+import { findAddedBulletEntry } from "../../lib/edit/added-bullets.ts";
+import { isAddedEntryKey } from "../../hooks/useEditableParse.ts";
+import type {
+  AddedBulletRef,
+  AddedBullets,
+} from "../../hooks/useEditableParse.ts";
+import {
+  batchUndoTargets,
+  type BulletUndoTargets,
+} from "../../lib/rewrite-review/undo-batch.ts";
+import type { ResolvedWrite } from "../../lib/rewrite-review/apply-accepted.ts";
+import { useHoldWhile } from "../../hooks/useAddedEntryPruneHold.ts";
+import type { AddedEntryPruneHold } from "../../hooks/useAddedEntryPruneHold.ts";
+
+export function useOtherBulletsRemove({
+  addedBullets,
+  onRemoveBullet,
+  captureBulletUndo,
+  pruneHold,
+}: {
+  /** Every user-added bucket. The "Other" group carries no entry, so the bucket
+   *  a degenerate line sits in has to be found by its text (#660). */
+  addedBullets: AddedBullets;
+  /** Drop a bullet by `BulletObservation.id`, plus the resolved bucket ref.
+   *  Returns whether the write landed (#659). */
+  onRemoveBullet: (id: string, added?: AddedBulletRef) => boolean;
+  /** Snapshot the slots the write will touch, BEFORE it lands (issue 510). */
+  captureBulletUndo: (targets: BulletUndoTargets) => () => void;
+  /** The section's per-entry stay of execution over `pruneEmptyAddedEntries`. */
+  pruneHold: AddedEntryPruneHold;
+}): BulletRemoveControl {
+  const bucketKey = useCallback(
+    (text: string) => findAddedBulletEntry(addedBullets, text),
+    [addedBullets],
+  );
+
+  const captureUndo = useCallback(
+    (writes: readonly ResolvedWrite[], text: string) =>
+      captureBulletUndo(batchUndoTargets(writes, bucketKey(text))),
+    [captureBulletUndo, bucketKey],
+  );
+
+  // The added entry whose bucket the last LANDED removal spliced — the id the
+  // hold below is taken over. Set only on a write that reported success, so a
+  // no-op removal cannot extend an entry's life (#659) and cannot displace the
+  // key belonging to a strip that is still live.
+  //
+  // Of the three conditions on that write, only `isAddedEntryKey` is load-bearing
+  // today, and it is pinned: a PARSED key reaching `heldEntry` would release the
+  // added role whose strip is still live, and dropping it turns exactly one case
+  // red. The `removed` check is defence in depth — every no-op removal reachable
+  // now resolves NO bucket, so `entryKey !== undefined` already covers it, and
+  // removing `removed &&` leaves the suite green. Kept because it states the
+  // rule the other two only happen to imply.
+  const [heldEntry, setHeldEntry] = useState<string | undefined>(undefined);
+
+  const removeBullet = useCallback(
+    (id: string, text: string) => {
+      const entryKey = bucketKey(text);
+      const removed = onRemoveBullet(
+        id,
+        entryKey === undefined ? undefined : { entryKey, text },
+      );
+      // Only an ADDED entry is prunable at all, so only its key is worth holding.
+      if (removed && entryKey !== undefined && isAddedEntryKey(entryKey)) {
+        setHeldEntry(entryKey);
+      }
+      return removed;
+    },
+    [onRemoveBullet, bucketKey],
+  );
+
+  const control = useBulletRemoveStatus(removeBullet, captureUndo);
+  useHoldWhile(pruneHold, heldEntry, control.pending);
+  return control;
+}

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -27,9 +27,10 @@
  * `ReconstructedRole.tsx`, `ResumeBulletRow` / `BulletFlagLegend` in
  * `ResumeBulletRow.tsx` (split out of ReconstructedRole by #626), and the
  * per-bullet remove confirmation in `BulletRemoveStatus.tsx`. `ExperienceSection`
- * below owns one instance of that last one for the "Other bullets" bucket —
- * the one group that disappears when its last bullet goes, taking a
- * role-hosted strip with it.
+ * below owns one instance of that last one for the "Other bullets" bucket — the
+ * one group that disappears when its last bullet goes, taking a role-hosted strip
+ * with it — and that instance, with the bucket resolution, undo snapshot and
+ * prune hold that have to agree with each other, lives in `OtherBulletsRemove.ts`.
  */
 
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
@@ -61,9 +62,9 @@ import {
 } from "../../lib/contact.ts";
 import { DownloadGateDialog } from "./DownloadGateDialog.tsx";
 import { RoleEntry } from "./ReconstructedRole.tsx";
-import { useBulletRemoveStatus } from "./BulletRemoveStatus.tsx";
+import { useOtherBulletsRemove } from "./OtherBulletsRemove.ts";
 import { ResumeBulletRow, BulletFlagLegend } from "./ResumeBulletRow.tsx";
-import { Fragment, useCallback, useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { ModelSelector } from "./ModelSelector.tsx";
 import { useResumeRewriteUi } from "./ResumeRewrite.tsx";
 import type { SectionRewriteApply } from "./SectionRewrite.tsx";
@@ -82,6 +83,7 @@ import type {
   AddedEntryField,
   AchievementFieldOverrides,
   AddedBulletRef,
+  AddedBullets,
 } from "../../hooks/useEditableParse.ts";
 import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
 import { useAddedEntryPruneHold } from "../../hooks/useAddedEntryPruneHold.ts";
@@ -89,7 +91,6 @@ import {
   batchUndoTargets,
   type BulletUndoTargets,
 } from "../../lib/rewrite-review/undo-batch.ts";
-import type { ResolvedWrite } from "../../lib/rewrite-review/apply-accepted.ts";
 import {
   AddPill,
   RemoveButton,
@@ -407,6 +408,7 @@ export function ExperienceSection({
   onExperienceFieldChange,
   onBulletChange,
   onRemoveBullet,
+  addedBullets,
   addedExperience,
   originalCount,
   onAddEntry,
@@ -449,6 +451,11 @@ export function ExperienceSection({
    *  recorded — false when the write found nothing to drop, which the
    *  confirmation strip must not report as a success (#648). */
   onRemoveBullet: (id: string, added?: AddedBulletRef) => boolean;
+  /** Every user-added bullet bucket, read ONLY by the "Other bullets" remove
+   *  path: that group carries no entry, so the bucket a degenerate added line
+   *  sits in has to be resolved from the line's text (#660). Every other path
+   *  knows its own `entryKey` and never consults this. */
+  addedBullets: AddedBullets;
   /** User-added experience entries, append-aligned to indices ≥ originalCount. */
   addedExperience: AddedEntry[];
   /** Count of PARSED experience roles; indices at/above this are user-added. */
@@ -464,52 +471,41 @@ export function ExperienceSection({
    *  an accepted summary rewrite lands in `summaryOverride` — the slot the
    *  inline Summary field writes — instead of being read-only redline. */
   summaryApply: SectionRewriteApply;
-  /** Drop a blank added entry when focus leaves the section (#379). `isHeld`
-   *  spares individual entries whose remove-undo strip is still live — see
-   *  {@link useAddedEntryPruneHold} (#637). */
+  /** Drop a blank added entry when focus leaves the section (#379). The
+   *  predicate spares individual entries: those whose remove-undo strip is still
+   *  live on the section-exit pass (#637), and every entry but the released one
+   *  on the pass a collapsing strip triggers (#658). Both come from
+   *  {@link useAddedEntryPruneHold}. */
   onPruneEmpty: (isHeld?: (entryId: string) => boolean) => void;
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
 
-  // The "Other bullets" bucket's remove confirmation is owned HERE, not in its
-  // RoleEntry (#626). `groupBulletsByExperience` appends that group only while
-  // it has at least one bullet, so removing its LAST bullet unmounts the role
-  // that triggered the remove — and would take the Undo strip with it. Every
-  // parsed role keeps owning its own (it survives losing its bullets, via
-  // `sliceGroups`' empty-group fallback), so only this one bucket lifts.
-  const otherCaptureUndo = useCallback(
-    (writes: readonly ResolvedWrite[]) =>
-      // No `onAddBullet` for this bucket — there is no experience entry to
-      // append to — so the entry key is never read by `batchUndoTargets`
-      // (it is consulted only for an "add" write, which this bucket never
-      // issues). A single-bullet remove is all #626 needs from this call site.
-      captureBulletUndo(batchUndoTargets(writes, "other-bullets")),
-    [captureBulletUndo],
-  );
-  // The "Other bullets" bucket owns no entry, so in practice it does not carry
-  // an added bullet: `applyAddedEntriesAndBullets` writes every added line into
-  // its entry's own description, and `buildEntryGroups` grades experiences,
-  // projects and achievements against one combined index space — so an added
-  // line normally matches its entry and never falls through to "Other". The
-  // row's `text` is therefore dropped rather than forwarded as an
-  // `AddedBulletRef` that would almost always miss (#637).
-  //
-  // Not an absolute, though: `groupBulletsByExperience` keys on
-  // `normalizeBulletText` and skips a line whose key is empty, while `addBullet`
-  // only rejects blank-after-`trim()`. So a degenerate added line that is pure
-  // punctuation ("•", "-", "–") IS accepted and DOES land here, where its Remove
-  // is inert. Tracked separately rather than widened here.
-  const otherRemoveBullet = useCallback(
-    (id: string) => onRemoveBullet(id),
-    [onRemoveBullet],
-  );
-  const otherRemove = useBulletRemoveStatus(otherRemoveBullet, otherCaptureUndo);
-
   // Per-entry prune hold (#637 half 2). Created HERE — the ids it holds are
   // only meaningful to this section's `pruneEmptyAddedEntries` call, and the
-  // holders are the `RoleEntry`s rendered below.
-  const pruneHold = useAddedEntryPruneHold();
+  // holders are the `RoleEntry`s rendered below, plus the "Other bullets" remove
+  // control right after (which holds the role its splice can empty).
+  //
+  // The handler is the SECOND caller of that prune (#658): when a role's
+  // remove-undo strip collapses, the registry re-runs the pass over the entry
+  // whose stay just ended, so the now-genuinely-empty ghost goes without waiting
+  // for another section exit. It supplies its own spare predicate — narrowed to
+  // that one entry, and stood down entirely while the entry holds focus. Takes
+  // it as an argument rather than closing over `pruneHold.isHeld`, which does not
+  // exist yet on this line.
+  const pruneHold = useAddedEntryPruneHold((isSpared) => onPruneEmpty(isSpared));
+  // The "Other bullets" bucket's remove confirmation is owned HERE, not in its
+  // RoleEntry (#626): that group vanishes with its last bullet, so a role-hosted
+  // strip would unmount with it. Its bucket has to be resolved from the row's
+  // text (#660 half 2), and the snapshot and the prune hold both hang off that
+  // one resolution — see `useOtherBulletsRemove` for the whole argument. The
+  // `strip` it returns is rendered below the group list.
+  const otherRemove = useOtherBulletsRemove({
+    addedBullets,
+    onRemoveBullet,
+    captureBulletUndo,
+    pruneHold,
+  });
 
   const { topHeading, inlineHeadings } = computeExperienceHeadings(
     groups,
@@ -1352,6 +1348,7 @@ export function ReconstructedResume({
           setBulletField(index, value, original)
         }
         onRemoveBullet={removeBullet}
+        addedBullets={edit.addedBullets}
         addedExperience={addedExperience}
         originalCount={originalExpCount}
         onAddEntry={() => addEntry("experience")}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -308,6 +308,14 @@ export function RoleEntry({
   entryKey,
   pruneHold,
 }: RoleEntryProps) {
+  // This entry's root element, handed to `useHoldWhile` (#658). The prune that
+  // runs when a remove-undo strip collapses asks it two things: does focus still
+  // sit inside this row, and does the row still hold an OPEN draft. Either
+  // stands the timer down, so it cannot drop a row the user is typing in — nor
+  // one whose draft has outlived a stray click elsewhere, which a focus-only
+  // gate let it destroy. Scoped to that timer: the section-exit prune (#379)
+  // still reads a draft as emptiness, which is pre-existing and filed on its own.
+  const rootRef = useRef<HTMLDivElement>(null);
   // Tag every write issued from this role's own rows with the bucket that owns
   // them, so a USER-ADDED bullet is spliced (#637) or rewritten (#657) in
   // `addedBullets` rather than filed under an id that reaches nothing there.
@@ -334,10 +342,15 @@ export function RoleEntry({
   // Half 2 of #637: hold this entry back from the section-exit prune while its
   // own strip is live, so the undo the remove just armed survives the tick.
   // Only a user-ADDED entry can be pruned at all, so only its id is ever held.
+  // `rootRef` is what the release prune (#658) tests before dropping this row:
+  // every field, input and control the user could be mid-edit in is a descendant
+  // of this entry's root element, so one node answers both halves of that gate
+  // (focus containment, and an open text control).
   useHoldWhile(
     pruneHold,
     entryKey !== undefined && isAddedEntryKey(entryKey) ? entryKey : undefined,
     hostsStrip && removes.pending,
+    rootRef,
   );
 
   // Section rewrite sees the text the user actually edited — `group.bullets`
@@ -402,7 +415,7 @@ export function RoleEntry({
     roleLabel(group.experience),
   );
   return (
-    <div className="flex flex-col gap-1.5">
+    <div ref={rootRef} className="flex flex-col gap-1.5">
       <div className="flex items-start justify-between gap-2">
         <RoleHeader
           group={group}

--- a/src/components/features/__test-utils__/experience-section-dom.ts
+++ b/src/components/features/__test-utils__/experience-section-dom.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Shared DOM-driving helpers for the `ExperienceSection` suites
+ * (`ExperienceSection.prune-hold.test.tsx`,
+ * `ExperienceSection.other-bullets.test.tsx`) — NOT itself a `*.test.tsx` file,
+ * so it isn't picked up as a suite.
+ *
+ * Only the recipes that are HARNESS-INDEPENDENT and easy to get subtly wrong
+ * live here; each suite keeps its own `Harness` / `render`, because what a
+ * harness builds is the thing each suite is about. The two recipes below both
+ * failed silently in earlier rounds when written from scratch — a single timer
+ * advance never reaches `onCollapse`, and a `focusout` without an explicit null
+ * `relatedTarget` is not a section exit — so the third copy is the one that
+ * would have been wrong.
+ */
+
+import { act } from "react";
+import { vi } from "vitest";
+import { UNDO_HOLD_MS } from "../ApplyConfirmation.tsx";
+
+/** `UndoBatchButton`'s accessible name — how a test finds a live Undo. */
+export const UNDO_LABEL = "Undo the changes just applied to the résumé";
+
+/**
+ * Let a live "Removed · Undo" strip run its course.
+ *
+ * Two advances, not one: `ApplyConfirmation` chains hold → collapsing → exit,
+ * and the exit timer is not SCHEDULED until the effect reacting to `collapsing`
+ * runs, so a single advance would never reach `onCollapse`.
+ */
+export async function collapseStrip() {
+  await act(async () => {
+    vi.advanceTimersByTime(UNDO_HOLD_MS);
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(1_000);
+  });
+}
+
+/** The real section-exit blur (#379): focus leaves the section entirely, then
+ *  the deferred prune fires one macrotask later. */
+export async function exitSection(el: HTMLElement) {
+  const section = el.querySelector("section")!;
+  await act(async () => {
+    section.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: null }),
+    );
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(1);
+  });
+}

--- a/src/hooks/useAddedEntryPruneHold.test.tsx
+++ b/src/hooks/useAddedEntryPruneHold.test.tsx
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Contract tests for the release path #658 added to the prune hold.
+ *
+ * The registry's #637 half is exercised end-to-end through the real strip and
+ * the real edit hook in `ExperienceSection.prune-hold.test.tsx`. What that
+ * harness cannot show is the part of the release contract with no observable
+ * consequence today — a stay that ends on UNMOUNT must not prune, because the
+ * unmount the prune itself causes would re-enter it, and an explicit "Remove
+ * role" or a fresh parse would prune on teardown. Reverting that rule leaves the
+ * section-level suite green (the redundant pass is a no-op there), so it is
+ * pinned here, directly, alongside the live-input gate that is the whole reason
+ * #637's rejection of this fix no longer applies. That gate has two independent
+ * halves — focus containment, and an OPEN DRAFT that has outlived its focus — so
+ * each is pinned on its own; the end-to-end consequence of the second (a typed,
+ * unsaved title surviving the collapse) is in the section-level suite.
+ *
+ * jsdom + raw `createRoot`, matching the sibling component suites (the project
+ * has no @testing-library/react). Focus is real `HTMLElement.focus()` +
+ * `document.activeElement` — see the note on `withHost: false` for the one
+ * behaviour that is asserted about a DOM API rather than through it.
+ */
+
+import { describe, expect, it, afterEach, beforeEach } from "vitest";
+import { createElement, useRef } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  useAddedEntryPruneHold,
+  useHoldWhile,
+  type AddedEntryPruneHold,
+} from "./useAddedEntryPruneHold.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const ID = "added:0";
+const SIBLING = "added:1";
+
+/** The spare predicate handed to `pruneEmptyAddedEntries`, once per prune run. */
+let runs: Array<(entryId: string) => boolean>;
+let registry: AddedEntryPruneHold;
+
+/**
+ * The holder — a stand-in for `RoleEntry`, with something focusable inside it
+ * the way every real entry has.
+ *
+ * READ mode renders only a button, and the text control appears only while a
+ * draft is open. That is what a `RoleEntry` really does — an `EditableField` in
+ * read mode is a `<span role="button">`, `InlineBulletAdd` collapses to an
+ * `AddPill`, and the remove/rewrite controls are `Button`s — and modelling it is
+ * load-bearing here: this stand-in used to render an `<input>` unconditionally,
+ * which makes the open-draft half of the gate unfalsifiable (every case looks
+ * like a live draft) and the plain "focus has left" case impossible to reach.
+ */
+function Entry({
+  held,
+  withHost,
+  editing,
+}: {
+  held: boolean;
+  withHost: boolean;
+  editing: boolean;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  useHoldWhile(registry, ID, held, withHost ? rootRef : undefined);
+  return createElement(
+    "div",
+    { ref: rootRef },
+    editing
+      ? createElement("input", { "aria-label": "draft" })
+      : createElement("button", { "aria-label": "field" }),
+  );
+}
+
+/** The pruner — a stand-in for `ExperienceSection`, which owns the registry and
+ *  outlives its holders. */
+function Section({
+  mounted = true,
+  held,
+  withHost = true,
+  editing = false,
+}: {
+  mounted?: boolean;
+  held: boolean;
+  withHost?: boolean;
+  editing?: boolean;
+}) {
+  registry = useAddedEntryPruneHold((isSpared) => {
+    runs.push(isSpared);
+  });
+  return createElement(
+    "div",
+    null,
+    mounted ? createElement(Entry, { held, withHost, editing }) : null,
+  );
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  runs = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+function render(props: Parameters<typeof Section>[0]) {
+  act(() => {
+    root!.render(createElement(Section, props));
+  });
+  return container!;
+}
+
+describe("useHoldWhile — the end of a stay re-runs the prune (#658)", () => {
+  it("prunes once, for the released entry only", () => {
+    render({ held: true });
+    expect(registry.isHeld(ID)).toBe(true);
+    expect(runs).toHaveLength(0);
+
+    render({ held: false });
+
+    expect(registry.isHeld(ID)).toBe(false);
+    expect(runs).toHaveLength(1);
+    // Narrowed to the one entry whose stay ended: the pass it triggers is
+    // section-wide, and a timer must not sweep a sibling the user is mid-edit in
+    // or one they just opened with "+ Add experience".
+    expect(runs[0]!(ID)).toBe(false);
+    expect(runs[0]!(SIBLING)).toBe(true);
+  });
+
+  it("does not prune on a re-render that keeps the hold", () => {
+    render({ held: true });
+    render({ held: true });
+    expect(runs).toHaveLength(0);
+  });
+
+  it("does not prune when a holder mounts unheld", () => {
+    render({ held: false });
+    expect(runs).toHaveLength(0);
+  });
+
+  it("does not prune when the stay ends by UNMOUNT", () => {
+    render({ held: true });
+    expect(registry.isHeld(ID)).toBe(true);
+
+    render({ mounted: false, held: true });
+
+    // The lease still lapses — that is #637's rule and it is unchanged.
+    expect(registry.isHeld(ID)).toBe(false);
+    // But a teardown is not a stay ending. The prune's own drop unmounts the
+    // holder, an explicit "Remove role" unmounts it, and a fresh parse unmounts
+    // the lot; none of them is the timer this fix reacts to.
+    expect(runs).toHaveLength(0);
+  });
+});
+
+describe("useHoldWhile — the live-input gate (#658, answering #637's rejection)", () => {
+  it("stands down while focus is inside the holder", () => {
+    const el = render({ held: true });
+    const control = el.querySelector<HTMLButtonElement>('[aria-label="field"]')!;
+    act(() => control.focus());
+    // Not incidental to the assertion below — without real focus here the test
+    // would pass with the gate deleted. A BUTTON, not an input, so this case
+    // exercises focus containment alone.
+    expect(document.activeElement).toBe(control);
+
+    render({ held: false });
+
+    expect(registry.isHeld(ID)).toBe(false);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("prunes once focus has left the holder", () => {
+    const el = render({ held: true });
+    const control = el.querySelector<HTMLButtonElement>('[aria-label="field"]')!;
+    act(() => control.focus());
+    act(() => control.blur());
+    expect(document.activeElement).toBe(document.body);
+
+    render({ held: false });
+
+    expect(runs).toHaveLength(1);
+  });
+
+  it("stands down for an OPEN DRAFT the user has blurred", () => {
+    // The half focus containment cannot see. A `multiline` `EditableField` and an
+    // expanded `InlineBulletAdd` both keep their draft across a blur on purpose,
+    // so an entry the user is demonstrably mid-input in reads as unfocused — and
+    // as empty, since a multiline draft commits only on an explicit Save. A
+    // focus-only gate pruned it and destroyed the typed text.
+    const el = render({ held: true, editing: true });
+    const draft = el.querySelector<HTMLInputElement>('[aria-label="draft"]')!;
+    act(() => draft.focus());
+    act(() => draft.blur());
+    expect(document.activeElement).toBe(document.body);
+
+    // Still editing on both sides of the release: the draft outlives the blur,
+    // which is the entire point.
+    render({ held: false, editing: true });
+
+    expect(registry.isHeld(ID)).toBe(false);
+    expect(runs).toHaveLength(0);
+    // And the draft is still there to be saved.
+    expect(el.querySelector('[aria-label="draft"]')).not.toBeNull();
+  });
+
+  it("stands down for a holder that registers no root node", () => {
+    // Unprovable is not the same as unfocused. Nothing in the tree omits the
+    // ref today; the rule exists so a future holder cannot silently opt into
+    // being pruned mid-keystroke by forgetting one argument.
+    render({ held: true, withHost: false });
+    expect(document.activeElement).toBe(document.body);
+
+    render({ held: false, withHost: false });
+
+    expect(runs).toHaveLength(0);
+  });
+});

--- a/src/hooks/useAddedEntryPruneHold.ts
+++ b/src/hooks/useAddedEntryPruneHold.ts
@@ -3,7 +3,8 @@
 
 /**
  * useAddedEntryPruneHold — a per-entry stay of execution over
- * `pruneEmptyAddedEntries` (#637).
+ * `pruneEmptyAddedEntries` (#637), and the prune that runs when a stay ENDS
+ * (#658).
  *
  * Once removing a user-added role's last bullet ACTUALLY empties it (#637 half
  * 1 — before that the bucket never shrank, so the entry was never empty and the
@@ -26,27 +27,134 @@
  * so a role that disappears for any other reason (an explicit "Remove role", a
  * fresh parse) cannot leave its id held forever.
  *
- * Scope note (bounded, deliberate): the prune is only ever CALLED on section
- * exit, so an entry held through one blur is not re-examined when its strip
- * later collapses — it survives until the next section exit. Re-running the
- * prune on release was rejected: the strip collapses on a timer, which can fire
- * while the user is typing inside that very entry, and pruning then would yank
- * the row out from under them.
+ * ## The stay ends → prune again (#658, DECIDED: the residual is closed)
+ *
+ * The prune used to be CALLED from one place only, the section-exit blur, so an
+ * entry held through that blur was never re-examined: its strip collapsed on a
+ * timer and the now-genuinely-empty ghost sat in the rendered list, the score
+ * and the exported PDF until the user re-entered and re-exited the section.
+ *
+ * #637 rejected pruning on release because the collapse is timer-driven and can
+ * fire while the user is typing inside that very entry, which would yank the row
+ * out from under them. That objection is ANSWERED rather than overruled — the
+ * release prune is gated on live INPUT, and narrowed:
+ *
+ *   - **Live-input gate.** If the releasing entry still contains focus, OR still
+ *     holds an open text control, nothing is pruned at all; the ghost is left to
+ *     the section-exit pass, which by definition only ever fires with focus
+ *     outside the whole section. #637's yank IS this case.
+ *
+ *     Focus alone is NOT enough, and what proves it is the very fact that makes
+ *     the gate load-bearing rather than theoretical: a role header's
+ *     `EditableField`s are `multiline`, and a multiline draft commits only on an
+ *     explicit Save — so an entry the user is halfway through titling still
+ *     reads as empty to `isAddedEntryEmpty`. That draft also deliberately
+ *     OUTLIVES the focus that opened it (`EditableField`: "a multi-line paste
+ *     that accidentally defocuses shouldn't lose the draft"), and so does an
+ *     expanded `InlineBulletAdd` holding non-empty text. One stray click
+ *     elsewhere on the page therefore dropped `activeElement` to `body` while
+ *     the typed draft stayed on screen — and a focus-only gate then let the
+ *     release prune unmount the row with that text still in it. Silent data
+ *     loss, off a timer, with no user action at the moment of loss.
+ *
+ *     So the gate asks whether the entry holds an OPEN INPUT as well. Read mode
+ *     inside a `RoleEntry` renders only buttons — every `EditableField` read
+ *     mode is a `<span role="button">`, `InlineBulletAdd` collapses to an
+ *     `AddPill`, and the remove/rewrite controls are `Button`s — so an `input`
+ *     or `textarea` anywhere inside the entry IS an open draft. The only other
+ *     producer in that subtree is `RewriteReviewList`'s edit-in-place field,
+ *     which is equally one. A false positive could therefore only ever SPARE an
+ *     entry, which is the safe direction: the section-exit pass still sweeps it.
+ *   - **One entry, not the section.** The pass spares every id but the one
+ *     whose stay just ended. `pruneEmptyAddedEntries` is section-wide, and this
+ *     trigger is a timer rather than the user leaving, so an unnarrowed sweep
+ *     here could drop a blank sibling the user is mid-edit in, or one they just
+ *     opened with "+ Add experience" — neither of which the section-exit pass
+ *     can do. That pass is unchanged and remains the thing that eventually
+ *     sweeps every other ghost (#637's sibling criterion still holds there).
+ *
+ * Option B from #658 (prune on the next blur anywhere WITHIN the section) was
+ * not taken: it fires on every field commit, needs the same focus reasoning
+ * anyway, and still misses the case that creates the residual — a strip that
+ * collapses while the user never leaves the entry.
+ *
+ * Both halves of the gate are read from the DOM (`activeElement` containment,
+ * and an `input, textarea` query, inside the holder's root node) at RELEASE
+ * time, not from React state: like the hold itself, the value the decision needs
+ * is the one as of the timer, which a render closure cannot give — and every
+ * focusable thing and every draft inside an entry (both `EditableField` modes,
+ * "+ Add bullet", the remove controls) is a descendant of that one node. A
+ * holder that registers no node is treated as still in use: unprovable is not
+ * the same as idle, and the conservative side of that coin never yanks.
+ *
+ * Unlike the section-exit path the release prune is NOT deferred a macrotask.
+ * That deferral exists because a field commit rides the same blur event that
+ * leaves the section (see `sectionExitBlur`); nothing commits alongside a strip
+ * collapse, and a deferral would open a window for the entry to take focus
+ * between the check and the drop. Emptiness is still read at prune time, not
+ * closed over — `pruneEmptyAddedEntries` decides inside a `setAddedEntries`
+ * updater over `addedBulletsRef`, so a field commit batched into the same tick
+ * is already visible to it.
+ *
+ * The open-input half also closes the one window a focus-only gate could not:
+ * entering edit mode swaps the read-mode button for an input and focuses it a
+ * frame later (`EditableField.startEdit`), so for that frame `activeElement`
+ * sits on `body`. The input is already mounted by then — React renders it before
+ * the rAF runs — so the query sees it and a collapse landing exactly there
+ * spares the entry.
+ *
+ * ## What this does NOT close (pre-existing, filed separately)
+ *
+ * The gate is on the RELEASE trigger #658 added, and only that. The
+ * SECTION-EXIT pass has always treated an open draft as emptiness, with no
+ * removal involved: open "+ Add bullet" under a role from "+ Add experience",
+ * type, blur, leave the section, and `pruneEmptyAddedEntries` drops the entry —
+ * because `isAddedEntryEmpty` reads committed state and a draft is by definition
+ * uncommitted. Fixing that means counting an open draft toward emptiness, which
+ * changes prune semantics on a path none of #658/#659/#660 owns; it is filed on
+ * its own. So the class is narrowed here, not retired.
+ *
+ * Release is a MOUNTED-only signal. {@link useHoldWhile}'s cleanup also
+ * releases the hold on unmount, and treating that as a stay ending would prune
+ * on an explicit "Remove role", on a fresh parse, and — the reason this is a
+ * rule and not a preference — on the very unmount the prune itself causes.
  */
 
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { RefObject } from "react";
 
 export interface AddedEntryPruneHold {
   /** Take or release `id`'s hold. Idempotent; safe to call every render. */
   setHold: (id: string, held: boolean) => void;
   /** The predicate to hand `pruneEmptyAddedEntries`. Stable identity. */
   isHeld: (id: string) => boolean;
+  /**
+   * Report that `id`'s stay has ENDED, with its holder still mounted and
+   * holding neither focus nor an open draft (#658). Not a release itself —
+   * `setHold(id, false)` has already happened by the time this is called; it is
+   * the trigger for the re-run prune, scoped to that one entry.
+   */
+  noteHoldReleased: (id: string) => void;
 }
 
 /** Create a registry. One per section that prunes — the ids it holds are only
  *  meaningful to that section's `pruneEmptyAddedEntries` call. */
-export function useAddedEntryPruneHold(): AddedEntryPruneHold {
+export function useAddedEntryPruneHold(
+  /** Run that section's `pruneEmptyAddedEntries` with the supplied spare
+   *  predicate. Omitted → the release prune (#658) is inert and the
+   *  section-exit pass is again the only caller. */
+  prune?: (isSpared: (entryId: string) => boolean) => void,
+): AddedEntryPruneHold {
   const held = useRef<Set<string>>(new Set());
+
+  // Latest-value cache, not a dep: the section passes a fresh arrow every
+  // render, and `noteHoldReleased` — like `setHold` and `isHeld` — has to keep
+  // one identity for the registry's lifetime (see the useMemo below). Reading it
+  // at CALL time is also what makes it un-stale: the call happens a timer later
+  // than the render that supplied it. Same pattern, and the same reason, as
+  // `bulletsRef` in `ReconstructedRole`.
+  const pruneRef = useRef(prune);
+  pruneRef.current = prune;
 
   const setHold = useCallback((id: string, hold: boolean) => {
     if (hold) held.current.add(id);
@@ -55,29 +163,85 @@ export function useAddedEntryPruneHold(): AddedEntryPruneHold {
 
   const isHeld = useCallback((id: string) => held.current.has(id), []);
 
+  const noteHoldReleased = useCallback((id: string) => {
+    // Spare everything but the entry whose stay ended — see the module
+    // docblock on why this pass is not section-wide. `id` is already out of
+    // `held` by now, so consulting the set would add nothing.
+    pruneRef.current?.((entryId) => entryId !== id);
+  }, []);
+
   // Memoized, not a fresh literal: this object is a dep of every holder's
   // effect, so a churning identity would tear the hold down and re-take it on
   // every single render of the section.
-  return useMemo(() => ({ setHold, isHeld }), [setHold, isHeld]);
+  return useMemo(
+    () => ({ setHold, isHeld, noteHoldReleased }),
+    [setHold, isHeld, noteHoldReleased],
+  );
 }
 
 /**
- * Register `id`'s hold for as long as `held` is true, releasing it on unmount.
+ * Is the holder's own subtree still in use — either because focus sits inside
+ * it, or because it holds an open, uncommitted draft? An unregistered node is
+ * reported as in use — see the module docblock.
+ *
+ * The two are separate questions because a draft outlives its focus: a
+ * `multiline` `EditableField` and an expanded `InlineBulletAdd` both survive a
+ * blur on purpose, so "unfocused" is not "not being typed in".
+ */
+function keepsEntry(host: RefObject<HTMLElement | null> | undefined): boolean {
+  const node = host?.current;
+  if (node === null || node === undefined) return true;
+  const active = node.ownerDocument.activeElement;
+  // `contains` includes the node itself, so a focused container counts too.
+  if (active !== null && node.contains(active)) return true;
+  // Read mode inside a `RoleEntry` renders only buttons, so a text control
+  // present here IS an open draft — see the module docblock's gate section.
+  return node.querySelector("input, textarea") !== null;
+}
+
+/**
+ * Register `id`'s hold for as long as `held` is true, releasing it on unmount,
+ * and report the end of a stay so the section can prune again (#658).
  *
  * Split from the registry so the holder (a `RoleEntry`, which knows whether it
- * hosts a live strip) and the pruner (the section) each touch only their half
- * of the contract. No-ops when the caller has no registry or no id — a parsed
- * role has no added-entry id to hold, and nothing outside the editable
- * experience section supplies a registry at all.
+ * hosts a live strip and owns the DOM the gate reads) and the pruner (the
+ * section) each touch only their half of the contract. No-ops when the caller
+ * has no registry or no id — a parsed role has no added-entry id to hold, and
+ * nothing outside the editable experience section supplies a registry at all.
+ *
+ * @param host The holder's root element. Focus inside it — or an open draft
+ *   inside it — stands the release prune down (#658). Omitted → every release is
+ *   treated as in-use, i.e. only the section-exit pass ever prunes this holder's
+ *   entry.
  */
 export function useHoldWhile(
   registry: AddedEntryPruneHold | undefined,
   id: string | undefined,
   held: boolean,
+  host?: RefObject<HTMLElement | null>,
 ): void {
+  // The id this holder currently holds, if any. A ref because the end of a stay
+  // is a TRANSITION (held true → false) and has to be told apart both from
+  // "never held" and from the release the cleanup below performs on unmount,
+  // which must not prune. An effect BODY never runs on unmount, so testing the
+  // transition here is what makes the signal mounted-only.
+  const holdingRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
     if (registry === undefined || id === undefined) return;
     registry.setHold(id, held);
+    const released = holdingRef.current;
+    holdingRef.current = held ? id : undefined;
+    // StrictMode re-runs an effect on mount (run → cleanup → run), so a hold
+    // this holder still has can legitimately be seen twice; only an id it no
+    // longer holds ended a stay.
+    if (released !== undefined && !(held && released === id)) {
+      // Still focused, or still holding a draft → stand down for good rather
+      // than retry: `holdingRef` is already cleared, and the section-exit pass
+      // is the intended fallback.
+      if (!keepsEntry(host)) registry.noteHoldReleased(released);
+    }
     return () => registry.setHold(id, false);
-  }, [registry, id, held]);
+    // `host` is a ref object — stable identity, so it never re-fires this.
+  }, [registry, id, held, host]);
 }

--- a/src/hooks/useEditableParse.added-bullet-remove.test.tsx
+++ b/src/hooks/useEditableParse.added-bullet-remove.test.tsx
@@ -37,6 +37,10 @@ import {
   type BulletObservation,
 } from "../lib/score/score.ts";
 import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
+import {
+  groupBulletsByExperience,
+  type BulletGroup,
+} from "../lib/score/group-bullets.ts";
 import { projectScoreSections } from "../lib/heuristics/projections.ts";
 import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
 import { toCanonicalResume } from "../lib/heuristics/canonical.ts";
@@ -108,6 +112,10 @@ function regrade(api: EditableParse): {
   roleDescriptions: (string | undefined)[];
   /** Every bullet the Download PDF would draw, across all entries. */
   exportedBullets: string[];
+  /** The rendered attribution: what each role's group holds, and what fell
+   *  through to the "Other bullets" group (#660). `buildEntryGroups` reduces to
+   *  this call with no projects/achievements in play. */
+  groups: BulletGroup[];
 } {
   const base = baseResult();
   const core = applyOverrides(
@@ -152,7 +160,17 @@ function regrade(api: EditableParse): {
     exportedBullets: model.sections.flatMap((s) =>
       s.entries.flatMap((e) => e.bullets),
     ),
+    groups: groupBulletsByExperience(
+      [...(score.bullets ?? [])],
+      core.fields.experience,
+    ),
   };
+}
+
+/** The texts the "Other bullets" group renders, or [] when it is absent. */
+function otherBullets(api: EditableParse): string[] {
+  const other = regrade(api).groups.find((g) => g.experienceIndex === null);
+  return other?.bullets.map((b) => b.text) ?? [];
 }
 
 let container: HTMLDivElement;
@@ -347,6 +365,30 @@ describe("removeBullet on a user-ADDED role (#637 half 1)", () => {
     expect(api.removedBullets.size).toBe(0);
     expect(regrade(api).bulletTexts).toEqual([PARSED_BULLET]);
   });
+
+  it("reports that repeat click as NOT recorded (#659)", () => {
+    // The side effect above (nothing filed) is only half the contract. The
+    // RESULT is the other half, and it is what `useBulletRemoveStatus` keys its
+    // "Removed 1 change · Undo" strip off — and, through that strip's `pending`,
+    // what holds the entry back from the section-exit prune. Flipping this
+    // branch's `false` to `true` leaves every OTHER assertion in this file
+    // green while re-arming both.
+    const id = addRoleWithBullet();
+    const obsId = addedObsId();
+
+    let first = false;
+    let second = false;
+    act(() => {
+      first = api.removeBullet(obsId, { entryKey: id, text: ADDED_BULLET });
+    });
+    act(() => {
+      second = api.removeBullet(obsId, { entryKey: id, text: ADDED_BULLET });
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(api.removedBullets.size).toBe(0);
+  });
 });
 
 describe("removeBullet still reaches PARSED bullets (#637 scoping)", () => {
@@ -385,5 +427,101 @@ describe("removeBullet still reaches PARSED bullets (#637 scoping)", () => {
     act(() => api.removeBullet(PARSED_ID));
     expect(api.removedBullets.has(PARSED_ID)).toBe(true);
     expect(regrade(api).bulletTexts).toEqual([]);
+  });
+});
+
+/**
+ * #660 half 1 — `addBullet` rejects a line carrying no CONTENT.
+ *
+ * Driven end-to-end for the same reason #637 was: the defect was not "the hook
+ * stored something odd", it was that the stored line could not be ATTRIBUTED.
+ * So each case folds the hook's state through the real `applyOverrides` →
+ * `computeAnonymousAtsScore` → `groupBulletsByExperience` chain and asserts on
+ * the group the row would render under, not on the bucket alone.
+ *
+ * `"1."` is the reachable reproducer, and the numeral is why: `extractBulletsFromLines`
+ * drops a pooled line whose `countWords` is 0, so a lone `"•"` never became a
+ * BulletObservation at all (it only polluted the description and the exported
+ * PDF). `"1."` carries a `\p{N}`, so it counts as one word, pools, and surfaces
+ * as a row under "Other bullets" whose Remove did nothing.
+ */
+describe("addBullet rejects a contentless line (#660 half 1)", () => {
+  const MARKER_ONLY = ["•", "-", "*", "–", "·", "‣", "1.", "2)", "  •  "];
+  /** A legitimate bullet that merely STARTS with a marker — AC 3's trap. */
+  const MARKED_BULLET = "• Shipped X to 40 engineers.";
+
+  it("stores none of them, on a PARSED role's bucket", () => {
+    act(() => {
+      for (const text of MARKER_ONLY) api.addBullet("experience:0", text);
+    });
+
+    expect(api.addedBullets).toEqual({});
+    expect(api.hasEdits).toBe(false);
+  });
+
+  it("stores none of them, on an ADDED role's bucket", () => {
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+    });
+    act(() => {
+      for (const text of MARKER_ONLY) api.addBullet(id, text);
+    });
+
+    expect(id in api.addedBullets).toBe(false);
+  });
+
+  it("keeps the numbered-marker line out of the pool AND out of 'Other bullets'", () => {
+    // The observable defect, asserted where the user sees it. Pre-fix this run
+    // pooled a second bullet whose id was `"0|"` and put it in the null group.
+    act(() => api.addBullet("experience:0", "1."));
+
+    const after = regrade(api);
+    expect(after.bulletTexts).toEqual([PARSED_BULLET]);
+    expect(otherBullets(api)).toEqual([]);
+    expect(after.groups.map((g) => g.experienceIndex)).toEqual([0]);
+  });
+
+  it("keeps a glyph-only line out of the description and the exported PDF", () => {
+    // The half a pool assertion cannot see: a lone "•" was never pooled (0
+    // words), so it rendered no row — but `applyAddedEntriesAndBullets` still
+    // wrote it into the role's description, which IS what the PDF draws.
+    act(() => api.addBullet("experience:0", "•"));
+
+    const after = regrade(api);
+    expect(after.roleDescriptions[0]).toBe(PARSED_BULLET);
+    expect(after.exportedBullets).toEqual([PARSED_BULLET]);
+  });
+
+  it("still ACCEPTS a marker-prefixed line and matches it to its own role", () => {
+    // The trap. `normalizeBulletText` strips one leading marker by design, so a
+    // guard phrased as "starts with a marker" — or one that compared the RAW
+    // text to a marker set — would reject every legitimately bulleted line a
+    // user pastes in. Attribution is asserted too, not just storage: a guard
+    // that let the line through but broke its key would strand it in "Other
+    // bullets", which is the very state #660 is about.
+    act(() => api.addBullet("experience:0", MARKED_BULLET));
+
+    // Stored VERBATIM, glyph and all — `addBullet` normalises only to decide
+    // whether to accept, never to rewrite. The pool copy keeps the glyph too:
+    // `applyAddedBulletsToExistingEntries` prefixes its own `"• "`, and
+    // `extractBulletsFromLines` strips exactly one marker back off.
+    expect(api.addedBullets["experience:0"]).toEqual([MARKED_BULLET]);
+    const after = regrade(api);
+    expect(after.bulletTexts).toContain(MARKED_BULLET);
+    expect(otherBullets(api)).toEqual([]);
+    const role = after.groups.find((g) => g.experienceIndex === 0);
+    expect(role?.bullets.map((b) => b.text)).toEqual([
+      PARSED_BULLET,
+      MARKED_BULLET,
+    ]);
+    expect(after.exportedBullets).toContain(MARKED_BULLET);
+  });
+
+  it("accepts a line whose only content is a numeral", () => {
+    // `"2019"` looks as degenerate as `"1."` but is real text: the guard keys on
+    // the normalised form, so a numeral that is not a list marker survives.
+    act(() => api.addBullet("experience:0", "2019"));
+    expect(api.addedBullets["experience:0"]).toEqual(["2019"]);
   });
 });

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -41,6 +41,11 @@
  * an earlier text re-entered the ordered chain at an existing key. Both writers
  * below therefore assume a live row's id is FREE, and `removeBullet` reports
  * whether its write landed so the confirmation strip cannot claim a no-op.
+ * Issue #660 tightens `addBullet` from "reject blank after trim" to "reject no
+ * CONTENT", sharing one predicate with the grouper's normaliser: a line that is
+ * nothing but a marker normalises to the empty key, which is the one key
+ * `groupBulletsByExperience` skips, so it could never be attributed to the entry
+ * whose bucket held it.
  * Overrides are held in component state and lost on reset — no persistence
  * is expected or provided.
  *
@@ -56,6 +61,7 @@ import {
 } from "../lib/rewrite-review/undo-batch.ts";
 import { canonicalizeSkill } from "../lib/edit/skill-canonical.ts";
 import {
+  isContentlessBulletLine,
   removeAddedBulletLine,
   replaceAddedBulletLine,
 } from "../lib/edit/added-bullets.ts";
@@ -69,6 +75,7 @@ import {
   renameCategory as renameSkillCategoryTx,
 } from "../lib/edit/skills-categories.ts";
 import type { SkillCategory } from "../lib/heuristics/types.ts";
+import { isUnresolvableBulletKey } from "../lib/score/bullet-id.ts";
 import { classifyProfile } from "../lib/contact/profile-registry.ts";
 import type { LegacyLinkKey, ProfileLink } from "../lib/score/types.ts";
 
@@ -518,10 +525,11 @@ export interface EditableParse {
    * knows which entry owns the row. Idempotent.
    *
    * Returns whether the removal was actually RECORDED. False means the write
-   * found nothing to drop — an added bullet whose bucket line is already gone,
-   * or a re-removal of an id already in the set. Callers that confirm the action
-   * to the user (`useBulletRemoveStatus`) must not claim success on a false,
-   * because the undo they armed alongside it has nothing to undo either.
+   * found nothing to drop — an added bullet whose bucket line is already gone, a
+   * re-removal of an id already in the set, or an id whose text half is empty and
+   * so names no line at all (#660). Callers that confirm the action to the user
+   * (`useBulletRemoveStatus`) must not claim success on a false, because the undo
+   * they armed alongside it has nothing to undo either.
    */
   removeBullet: (id: string, added?: AddedBulletRef) => boolean;
   /** Override map for education entries, keyed by education array index. */
@@ -560,7 +568,14 @@ export interface EditableParse {
    *  role's last bullet genuinely empties it, this prune would unmount the very
    *  `RoleEntry` hosting that removal's "Removed · Undo" strip, taking the undo
    *  with it. The hold is PER ENTRY, not per section, so an empty SIBLING with
-   *  no live undo is still dropped in the same pass. */
+   *  no live undo is still dropped in the same pass.
+   *
+   *  Section exit is no longer the only trigger (#658): a strip collapsing
+   *  releases its entry's hold, and the registry calls this again with a
+   *  predicate that spares everything BUT that entry, so the ghost it was
+   *  protecting goes without waiting for the next exit. See
+   *  `useAddedEntryPruneHold` for the focus gate that keeps a timer from
+   *  dropping a row the user is typing in. */
   pruneEmptyAddedEntries: (
     section: AddableSection,
     isHeld?: (entryId: string) => boolean,
@@ -570,8 +585,10 @@ export interface EditableParse {
   /** Bullet lines appended to entries, keyed by entry key (parsedEntryKey or
    *  an added entry's id). */
   addedBullets: AddedBullets;
-  /** Append a bullet line to an entry. No-op on blank text. An added entry's
-   *  bullets are dropped wholesale when the entry is removed. */
+  /** Append a bullet line to an entry. No-op on text carrying no CONTENT —
+   *  blank, or nothing but a bullet/numbered marker (#660, see
+   *  `isContentlessBulletLine`). An added entry's bullets are dropped wholesale
+   *  when the entry is removed. */
   addBullet: (entryKey: string, text: string) => void;
   /**
    * Snapshot the pre-apply state of exactly the bullet slots a rewrite batch is
@@ -697,9 +714,10 @@ export function useEditableParse(): EditableParse {
   const [addedEntries, setAddedEntries] = useState<AddedEntry[]>([]);
   const [addedBullets, setAddedBullets] = useState<AddedBullets>({});
   // Latest bullets, readable synchronously by every writer and by
-  // `pruneEmptyAddedEntries` — which is called deferred (a tick after a blur),
-  // by which point an in-flight add-bullet may have landed. A render-time
-  // closure would read a stale map. See `writeAddedBullets` below: this ref, not
+  // `pruneEmptyAddedEntries` — which is called deferred (a tick after a blur,
+  // or from the effect a collapsing undo strip releases, #658), by which point
+  // an in-flight add-bullet may have landed. A render-time closure would read a
+  // stale map. See `writeAddedBullets` below: this ref, not
   // the state, is the source of PENDING truth. The render-phase assignment only
   // re-syncs it with what React committed, which the writer already matches.
   const addedBulletsRef = useRef(addedBullets);
@@ -847,6 +865,18 @@ export function useEditableParse(): EditableParse {
         // through.
         if (isAddedEntryKey(added.entryKey)) return false;
       }
+      // An id that names no line removes nothing and can never be cleared: it
+      // sits in `removedBullets` forever, keeping `hasEdits` true with no row
+      // left to un-remove. Reachable, not defensive — a pooled line that is
+      // nothing but a marker carries the id `"<n>|"`; see
+      // {@link isUnresolvableBulletKey}, which also spells out why a LEGACY
+      // numeric key is not one of these (it still resolves through the base-parse
+      // pool, and `replay` funnels a pre-#648 snapshot's removals through here).
+      // Reporting `false` is what makes this satisfy #660 AC 2 and #659 AC 1
+      // together — the caller suppresses the "Removed" strip and takes no prune
+      // hold off a write that did nothing. The ADDED half is already handled
+      // above, where the bucket splice matches on text rather than id.
+      if (isUnresolvableBulletKey(id)) return false;
       // Read the committed set to decide the RESULT, then write through a
       // functional updater so a second write in the same tick still composes.
       // `id` is minted by `assignBulletIds` against these very keys (#648), so a
@@ -1040,7 +1070,18 @@ export function useEditableParse(): EditableParse {
   const addBullet = useCallback(
     (entryKey: string, text: string) => {
       const trimmed = text.trim();
-      if (!trimmed) return;
+      // Rejected on CONTENT, not on blankness (#660). This used to be a bare
+      // `if (!trimmed) return`, which accepts a line that is nothing but a
+      // marker — `"•"`, `"-"`, `"1."` — and such a line normalises to the empty
+      // key, the one key `groupBulletsByExperience` skips. It could therefore
+      // never be attributed to the entry whose bucket holds it: it rendered
+      // under "Other bullets", where the Remove control had no entry to splice.
+      // `isContentlessBulletLine` is defined over the grouper's own
+      // `normalizeBulletText`, so the two cannot drift apart again. It subsumes
+      // the blank check (`normalizeBulletText("") === ""`), and it does NOT
+      // reject a marker-PREFIXED line with content — `"• Shipped X"` still
+      // lands, and still matches its entry.
+      if (isContentlessBulletLine(trimmed)) return;
       const prev = addedBulletsRef.current;
       writeAddedBullets({
         ...prev,

--- a/src/lib/edit/added-bullets.test.ts
+++ b/src/lib/edit/added-bullets.test.ts
@@ -9,10 +9,20 @@
  * "spliced" from "no such line" by reference, and that distinction is what
  * decides whether a removal falls through to the observation-indexed
  * `removedBullets` path.
+ *
+ * The two #660 blocks at the end cover the read-only halves of the same
+ * normalised-key contract: the add-time validator that keeps a line normalising
+ * to the EMPTY key out of the bucket, and the text→bucket lookup the one remove
+ * path with no `entryKey` needs. Both must agree with the writers above about
+ * what "empty" means, which is why all four share `normalizeBulletText`.
  */
 
 import { describe, it, expect } from "vitest";
-import { removeAddedBulletLine } from "./added-bullets.ts";
+import {
+  findAddedBulletEntry,
+  isContentlessBulletLine,
+  removeAddedBulletLine,
+} from "./added-bullets.ts";
 
 describe("removeAddedBulletLine", () => {
   it("splices the matching line out of the entry's bucket", () => {
@@ -70,5 +80,131 @@ describe("removeAddedBulletLine", () => {
   it("returns the input BY REFERENCE when no line matches", () => {
     const before = { "added:0": ["Present"] };
     expect(removeAddedBulletLine(before, "added:0", "Absent")).toBe(before);
+  });
+
+  it("picks the RIGHT contentless line out of a bucket holding two", () => {
+    // Resolving the correct bucket is not enough on its own: this splice matches
+    // by the same rule the resolver does, so on the empty normalised key it would
+    // have taken whichever contentless line came first.
+    const after = removeAddedBulletLine(
+      { "added:0": ["1.", "Real bullet here", "4."] },
+      "added:0",
+      "4.",
+    );
+    expect(after["added:0"]).toEqual(["1.", "Real bullet here"]);
+  });
+
+  it("leaves a contentless line alone when a DIFFERENT one was named", () => {
+    const before = { "added:0": ["1."] };
+    expect(removeAddedBulletLine(before, "added:0", "4.")).toBe(before);
+  });
+});
+
+// ── #660: the empty normalised key ────────────────────────────────────────────
+
+describe("isContentlessBulletLine", () => {
+  it("rejects a line that is nothing but a bullet glyph", () => {
+    for (const marker of ["•", "-", "*", "–", "·", "‣", "●", "▪", "◦", "▶"]) {
+      expect(isContentlessBulletLine(marker)).toBe(true);
+    }
+  });
+
+  it("rejects a line that is nothing but a NUMBERED marker", () => {
+    // The reachable half of the defect: unlike a lone glyph, a lone "1." carries
+    // a `\p{N}`, so `countWords` counts it and the scorer POOLS it — which is
+    // what put a row on screen under "Other bullets" (#660).
+    for (const marker of ["1.", "2)", "10)", "07."]) {
+      expect(isContentlessBulletLine(marker)).toBe(true);
+    }
+  });
+
+  it("rejects blank and whitespace-only text", () => {
+    expect(isContentlessBulletLine("")).toBe(true);
+    expect(isContentlessBulletLine("   ")).toBe(true);
+    expect(isContentlessBulletLine("   ")).toBe(true);
+  });
+
+  it("ACCEPTS a marker-prefixed line that carries content", () => {
+    // The trap this predicate must not fall into: `normalizeBulletText` strips a
+    // leading marker BY DESIGN, so a guard written as "the raw text contains only
+    // marker characters after the strip" would be right, while one written as
+    // "the text starts with a marker" would reject every legitimately bulleted
+    // line the user pastes in.
+    expect(isContentlessBulletLine("• Shipped X")).toBe(false);
+    expect(isContentlessBulletLine("- Shipped X")).toBe(false);
+    expect(isContentlessBulletLine("1. Shipped X")).toBe(false);
+    expect(isContentlessBulletLine("•Shipped X")).toBe(false);
+  });
+
+  it("ACCEPTS content that is only a number or a single word", () => {
+    // Degenerate-looking but not contentless: a numeral is real text once it is
+    // not a list marker, so the guard must key on the normalised form, not on
+    // "does this look like prose".
+    expect(isContentlessBulletLine("2019")).toBe(false);
+    expect(isContentlessBulletLine("Promoted")).toBe(false);
+    // A marker mid-line is not a leading marker.
+    expect(isContentlessBulletLine("A - B")).toBe(false);
+  });
+});
+
+describe("findAddedBulletEntry", () => {
+  it("finds the bucket holding a normalise-equal line", () => {
+    const buckets = {
+      "experience:0": ["Cut p99 latency by 38%"],
+      "added:3": ["Grew the team from 4 to 11"],
+    };
+    expect(findAddedBulletEntry(buckets, "Grew the team from 4 to 11")).toBe(
+      "added:3",
+    );
+    expect(findAddedBulletEntry(buckets, "• cut  P99 LATENCY by 38%")).toBe(
+      "experience:0",
+    );
+  });
+
+  it("finds the degenerate line the 'Other bullets' group renders", () => {
+    // The whole point: the row's observation text is all the caller has, and it
+    // normalises to "" — which still matches, because both sides normalise.
+    expect(findAddedBulletEntry({ "experience:0": ["Real bullet", "1."] }, "1.")).toBe(
+      "experience:0",
+    );
+    expect(findAddedBulletEntry({ "added:1": ["•"] }, "•")).toBe("added:1");
+  });
+
+  it("returns undefined when no bucket carries the line", () => {
+    expect(
+      findAddedBulletEntry({ "added:0": ["Something else"] }, "Not here"),
+    ).toBeUndefined();
+    expect(findAddedBulletEntry({}, "1.")).toBeUndefined();
+  });
+
+  it("does NOT match a contentless line against a bucket of real bullets", () => {
+    // A degenerate row must not resolve to some unrelated entry just because
+    // that entry has a bucket — the normalised keys have to be equal, and a real
+    // bullet never normalises to "".
+    expect(
+      findAddedBulletEntry({ "added:0": ["Shipped a design system"] }, "1."),
+    ).toBeUndefined();
+  });
+
+  it("returns the FIRST bucket when two carry the line", () => {
+    const buckets = { "added:0": ["1."], "added:1": ["1."] };
+    expect(findAddedBulletEntry(buckets, "1.")).toBe("added:0");
+  });
+
+  it("does NOT match a DIFFERENT contentless line", () => {
+    // Two markers, one normalised key (`""`), so the key identifies neither. A
+    // resolver keyed on it returned the `"1."` bucket for a `"4."` row — and the
+    // splice that followed deleted another role's bullet while reporting success.
+    // The verbatim text is what tells them apart.
+    expect(findAddedBulletEntry({ "added:0": ["1."] }, "4.")).toBeUndefined();
+    expect(findAddedBulletEntry({ "added:0": ["•"] }, "2)")).toBeUndefined();
+    // …and the line still resolves from its own row.
+    expect(findAddedBulletEntry({ "added:0": ["1."] }, "1.")).toBe("added:0");
+  });
+
+  it("ignores an empty bucket", () => {
+    expect(
+      findAddedBulletEntry({ "added:0": [], "added:1": ["1."] }, "1."),
+    ).toBe("added:1");
   });
 });

--- a/src/lib/edit/added-bullets.ts
+++ b/src/lib/edit/added-bullets.ts
@@ -21,8 +21,22 @@
  * `BulletObservation` from the RE-GRADED pool, whose ordering is the section
  * pool's, not the bucket's.
  *
- * The tiebreak is therefore the FIRST normalised match in the bucket, which is
- * not necessarily the row the user clicked. `normalizeBulletText` lowercases and
+ * With ONE exception, and it is not a refinement — it is a correctness fix. The
+ * normalised key is the empty string for a line that is nothing but a marker, and
+ * EVERY such line shares it, so as a key it identifies nothing. Matching a
+ * degenerate row against a bucket on that key hit the first contentless line in
+ * the first bucket that had one — a line the user never clicked, under a
+ * different role, which the splice then deleted while reporting success. So when
+ * the target normalises to empty, {@link sameBulletLine} compares the VERBATIM
+ * trimmed text instead: the bucket stores what was typed (`"1."`) and the pooled
+ * row reproduces it (`extractBulletsFromLines` strips only the marker the writer
+ * prefixed), so `"1."` and `"4."` are told apart while a degenerate row still
+ * resolves to its own line. All three helpers below share that one matcher —
+ * resolving the right BUCKET is not enough on its own, because the splice inside
+ * it matches by the same rule and would take the wrong LINE.
+ *
+ * The tiebreak is otherwise the FIRST match in the bucket, which is not
+ * necessarily the row the user clicked. `normalizeBulletText` lowercases and
  * collapses whitespace, so two lines that differ only in case or spacing are one
  * target here; on a PARSED entry — whose bucket sits alongside parsed bullets —
  * an added line normalising equal to an earlier duplicate is the one spliced.
@@ -53,7 +67,15 @@
  * text while the row (and the removal's `AddedBulletRef.text`) read the edited
  * one, and the splice would miss — trading an inert edit for an inert removal.
  *
- * Pure: no React, no mutation of the input. Both functions return the input map
+ * The two READ-ONLY helpers, {@link isContentlessBulletLine} and {@link
+ * findAddedBulletEntry}, are #660: the normalised key this module matches on is
+ * empty for a line that is nothing but a marker, and that is the one key the
+ * grouping skips — so such a line could neither be validated out at add time nor
+ * located from the "Other bullets" group it landed in. Both are expressed over
+ * the same {@link normalizeBulletText} as the writers, so the add-time validator
+ * and the grouper cannot disagree about "empty" again.
+ *
+ * Pure: no React, no mutation of the input. Both WRITERS return the input map
  * by REFERENCE when nothing matched, so the caller can tell "written" from "no
  * such line" without a second lookup — that distinction is what decides whether
  * a removal falls through to the id-keyed `removedBullets` path, and whether an
@@ -64,9 +86,102 @@ import { normalizeBulletText } from "../score/group-bullets.ts";
 import type { AddedBullets } from "../../hooks/useEditableParse.ts";
 
 /**
- * Drop the first line of `addedBullets[entryKey]` whose normalised text equals
- * `text`, returning the next map. Returns `addedBullets` ITSELF (same
- * reference) when the bucket is absent or carries no matching line.
+ * The predicate "this bucket line is the one `text` names" — the ONE matcher all
+ * three helpers below share, so a resolver and the splice it feeds can never
+ * disagree about which line was meant.
+ *
+ * Normalised comparison, except when the target normalises to EMPTY. That key
+ * belongs to every marker-only line at once (`"1."`, `"4."`, `"•"` all reduce to
+ * it), so using it would match an arbitrary one — see the module docblock for the
+ * wrong-role deletion that caused. Verbatim trimmed text is the discriminator
+ * there, and it is available on both sides: the bucket holds the typed line and
+ * the pooled row is that line with its marker prefix stripped.
+ *
+ * Deliberately NOT "refuse an empty target": #660's own fix is a degenerate row
+ * resolving to its own bucket line, so refusing would make that inert.
+ */
+function sameBulletLine(text: string): (line: string) => boolean {
+  const target = normalizeBulletText(text);
+  if (target === "") {
+    const verbatim = text.trim();
+    return (line) => line.trim() === verbatim;
+  }
+  return (line) => normalizeBulletText(line) === target;
+}
+
+/**
+ * True when `text` carries no bullet CONTENT: it is blank, or it is nothing but
+ * a leading bullet / numbered marker — `"•"`, `"-"`, `"*"`, `"–"`, `"1."`,
+ * `"2)"`.
+ *
+ * This is the predicate `addBullet` validates against (#660), and it is defined
+ * over {@link normalizeBulletText} deliberately. That normaliser produces the
+ * key the grouping (`groupBulletsByExperience`) and both writers below match on,
+ * and the empty string is the ONE key the grouper skips
+ * (`if (key && !lineToExpIdx.has(key))`). A line that normalises to it therefore
+ * cannot be attributed to the entry that owns it: it falls through to the "Other
+ * bullets" group, which has no entry — and so no bucket — for a Remove to
+ * splice. A blank-after-`trim()` check (what `addBullet` used to do) does not see
+ * one: `"1."` trims to `"1."`.
+ *
+ * Note what this does NOT reject: a marker-PREFIXED line with real content.
+ * `normalizeBulletText` strips one leading marker by design, so `"• Shipped X"`
+ * normalises to `"shipped x"` and is accepted — and still matches its owning
+ * entry, since the description copy and the `"• "`-prefixed pool copy both
+ * normalise through that same strip.
+ */
+export function isContentlessBulletLine(text: string): boolean {
+  return normalizeBulletText(text) === "";
+}
+
+/**
+ * The `addedBullets` key whose bucket holds the line `text` names (per
+ * {@link sameBulletLine}), or `undefined` when none does.
+ *
+ * Exists for the ONE removal path that cannot name its entry: the "Other
+ * bullets" group has no entry, so `ExperienceSection` has no `entryKey` to build
+ * an `AddedBulletRef` from and used to drop the row's text outright, leaving that
+ * Remove inert (#660). Resolving the key from the text closes that.
+ *
+ * The cross-bucket search is narrower than it looks. Every bucket line is also
+ * written into its entry's description, so `groupBulletsByExperience` maps its
+ * normalised key to that entry and the pooled copy groups THERE — a bullet can
+ * only reach "Other" carrying a key no description holds. The single key that
+ * escapes that argument is the empty one, which the grouper skips (see
+ * {@link isContentlessBulletLine}).
+ *
+ * Which is exactly why this cannot search on that key. Reaching "Other" is what
+ * every degenerate line has in common, so every one of them would resolve to the
+ * first bucket holding any contentless line — including a PARSED degenerate line,
+ * which belongs to no bucket at all and whose click would then delete a different
+ * role's bullet. Matching the verbatim text there keeps the two apart: a
+ * degenerate row still resolves to its OWN line, and a parsed one returns
+ * `undefined` and is removed by id, exactly as a genuinely-unmatched parsed
+ * bullet always was.
+ *
+ * First bucket wins, in key-insertion order — the same tiebreak, and the same
+ * "not necessarily the row the user clicked" caveat, as
+ * {@link removeAddedBulletLine}.
+ */
+export function findAddedBulletEntry(
+  addedBullets: AddedBullets,
+  text: string,
+): string | undefined {
+  const matches = sameBulletLine(text);
+  for (const [entryKey, lines] of Object.entries(addedBullets)) {
+    if (lines.some(matches)) return entryKey;
+  }
+  return undefined;
+}
+
+/**
+ * Drop the first line of `addedBullets[entryKey]` that `text` names (per
+ * {@link sameBulletLine}), returning the next map. Returns `addedBullets` ITSELF
+ * (same reference) when the bucket is absent or carries no matching line.
+ *
+ * The matcher is shared with {@link findAddedBulletEntry} rather than re-rolled,
+ * and that is load-bearing: the caller resolves a bucket there and splices here,
+ * so a laxer rule on this side would take the wrong LINE out of the right bucket.
  *
  * An emptied bucket is DELETED rather than left as `{key: []}` — `hasEdits`
  * keys off `Object.keys(addedBullets).length`, so a stray empty bucket would
@@ -81,8 +196,7 @@ export function removeAddedBulletLine(
 ): AddedBullets {
   const lines = addedBullets[entryKey];
   if (lines === undefined) return addedBullets;
-  const target = normalizeBulletText(text);
-  const at = lines.findIndex((line) => normalizeBulletText(line) === target);
+  const at = lines.findIndex(sameBulletLine(text));
   if (at < 0) return addedBullets;
   const next = { ...addedBullets };
   const remaining = [...lines.slice(0, at), ...lines.slice(at + 1)];
@@ -92,11 +206,11 @@ export function removeAddedBulletLine(
 }
 
 /**
- * Rewrite the first line of `addedBullets[entryKey]` whose normalised text
- * equals `text`, to `replacement` VERBATIM, returning the next map. Returns
- * `addedBullets` ITSELF (same reference) when the bucket is absent, carries no
- * matching line, or the replacement is blank / normalises to the line already
- * there (#657).
+ * Rewrite the first line of `addedBullets[entryKey]` that `text` names (per
+ * {@link sameBulletLine}), to `replacement` VERBATIM, returning the next map.
+ * Returns `addedBullets` ITSELF (same reference) when the bucket is absent,
+ * carries no matching line, or the replacement is blank / normalises to the line
+ * already there (#657).
  *
  * A blank replacement is NOT a removal: `applyBulletTextOverrides` treats an
  * emptied edit as "revert to the parsed text" rather than as a bullet drop, and
@@ -104,8 +218,11 @@ export function removeAddedBulletLine(
  * reading is "no change". Removal has its own control ({@link
  * removeAddedBulletLine}).
  *
- * Same first-normalised-match tiebreak — and the same caveats — as
- * {@link removeAddedBulletLine}.
+ * Same first-match tiebreak, same shared matcher, and the same caveats as
+ * {@link removeAddedBulletLine}. The empty-target branch of that matcher is
+ * unreachable from here today — a degenerate row always groups into "Other
+ * bullets", which supplies no `AddedBulletRef` for an edit — but it costs nothing
+ * and keeps the three helpers one rule rather than two.
  */
 export function replaceAddedBulletLine(
   addedBullets: AddedBullets,
@@ -117,8 +234,7 @@ export function replaceAddedBulletLine(
   if (lines === undefined) return addedBullets;
   const trimmed = replacement.trim();
   if (trimmed === "") return addedBullets;
-  const target = normalizeBulletText(text);
-  const at = lines.findIndex((line) => normalizeBulletText(line) === target);
+  const at = lines.findIndex(sameBulletLine(text));
   if (at < 0) return addedBullets;
   if (lines[at] === trimmed) return addedBullets;
   const next = { ...addedBullets };

--- a/src/lib/rewrite-review/undo-batch.ts
+++ b/src/lib/rewrite-review/undo-batch.ts
@@ -50,7 +50,7 @@ export interface BulletUndoTargets {
   removed: readonly string[];
   /** The added-bullet entry key an `add` appends to, a `remove` splices out of
    *  (#637), or a `replace` rewrites in place (#657). Set iff the batch has at
-   *  least one write of any kind. */
+   *  least one write of any kind AND the caller could name the bucket. */
   addedEntryKey?: string;
 }
 
@@ -67,10 +67,22 @@ export interface BulletUndoTargets {
  * bullet is harmless: the snapshot then holds the bucket's unchanged value and
  * restoring writes it straight back (and an absent bucket snapshots as `[]`,
  * which restores as a delete — a no-op).
+ *
+ * `undefined` means the caller cannot name a bucket at all, which is a different
+ * thing and NOT interchangeable with a placeholder key. It is the "Other bullets"
+ * remove path (`useOtherBulletsRemove`) when the clicked row resolves to no
+ * bucket: nothing will be written there, so nothing is snapshotted, and the
+ * removal is undone through `restore` like any id-keyed one. A placeholder key
+ * instead would be actively destructive on the path where a bucket IS spliced —
+ * it snapshots as `[]`, restores as a delete of a key that never existed, and so
+ * arms a mounted, clickable Undo that reports success having put nothing back
+ * while the bucket the write really spliced was never captured. So the key passed
+ * here has to be the bucket the write will actually touch, resolved by the same
+ * rule the write resolves it by.
  */
 export function batchUndoTargets(
   writes: readonly ResolvedWrite[],
-  entryKey: string,
+  entryKey: string | undefined,
 ): BulletUndoTargets {
   const replaced: string[] = [];
   const removed: string[] = [];
@@ -78,7 +90,7 @@ export function batchUndoTargets(
     if (write.kind === "replace") replaced.push(write.obsId);
     else if (write.kind === "remove") removed.push(write.obsId);
   }
-  return writes.length > 0
+  return writes.length > 0 && entryKey !== undefined
     ? { replaced, removed, addedEntryKey: entryKey }
     : { replaced, removed };
 }

--- a/src/lib/score/bullet-id.test.ts
+++ b/src/lib/score/bullet-id.test.ts
@@ -7,6 +7,7 @@ import {
   bulletId,
   bulletIdText,
   isLegacyBulletKey,
+  isUnresolvableBulletKey,
 } from "./bullet-id.ts";
 import { computeAnonymousAtsScore } from "./score.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
@@ -46,6 +47,41 @@ describe("isLegacyBulletKey", () => {
     // The load-bearing property: an id ALWAYS carries a separator, so the two
     // key spaces are disjoint and one resolver can serve both.
     expect(isLegacyBulletKey(bulletId("123", 9))).toBe(false);
+  });
+});
+
+describe("isUnresolvableBulletKey", () => {
+  it("is true for an id whose text half is empty", () => {
+    // What a pooled marker-only line mints — `"• 4."`, or `"•"` merged with the
+    // following `"4."` by the lone-bullet rule (#30). `normalizeBulletText`
+    // strips the marker to nothing, so the id carries no text to match on and a
+    // removal filed under it is inert and permanent (#660).
+    expect(bulletId("4.", 0)).toBe("0|");
+    expect(isUnresolvableBulletKey(bulletId("4.", 0))).toBe(true);
+    expect(isUnresolvableBulletKey(bulletId("•", 3))).toBe(true);
+  });
+
+  it("is FALSE for a legacy pre-#648 pool index", () => {
+    // The carve-out, and not a hypothetical: `useEditableParse.replay` funnels a
+    // persisted snapshot's `removedBullets` through `removeBullet`, so treating a
+    // legacy index as unresolvable silently drops every removal in a saved-library
+    // résumé or a localStorage draft as it replays. `resolveOverrideOriginal`
+    // resolves these through the frozen base-parse pool.
+    expect(isUnresolvableBulletKey("0")).toBe(false);
+    expect(isUnresolvableBulletKey("42")).toBe(false);
+  });
+
+  it("is false for any id that carries text", () => {
+    expect(isUnresolvableBulletKey(bulletId("Shipped it", 0))).toBe(false);
+    expect(isUnresolvableBulletKey(bulletId("• Led   the Team", 2))).toBe(false);
+  });
+
+  it("is true for a malformed key in neither space", () => {
+    // Not reachable from `assignBulletIds`, but these name no line either, so the
+    // predicate must not report them resolvable.
+    expect(isUnresolvableBulletKey("")).toBe(true);
+    expect(isUnresolvableBulletKey("|text")).toBe(true);
+    expect(isUnresolvableBulletKey("x|text")).toBe(true);
   });
 });
 

--- a/src/lib/score/bullet-id.ts
+++ b/src/lib/score/bullet-id.ts
@@ -124,6 +124,28 @@ export function isLegacyBulletKey(key: string): boolean {
 }
 
 /**
+ * True when `key` can name no line in EITHER key space, so anything filed under
+ * it is inert AND permanent — it removes/rewrites nothing, yet sits in the map
+ * keeping `hasEdits` true with no row left to clear it from.
+ *
+ * The shape that qualifies is an id whose text half is empty (`"<n>|"`), minted
+ * for a pooled line that is nothing but a marker — `"• 4."`, or a bare `"•"`
+ * merged with the following `"4."` by `extractBulletsFromLines`' lone-bullet rule
+ * (#30). `normalizeBulletText` strips the marker to nothing while
+ * `countWords("4.")` is 1, so such a line survives into the pool as a real row
+ * with a Remove control (#660).
+ *
+ * A LEGACY numeric key is deliberately NOT one: it resolves through the frozen
+ * base-parse observations, which is what `resolveOverrideOriginal` does with it,
+ * so calling it unresolvable would silently drop every removal in a pre-#648
+ * snapshot as it replays. This mirrors that resolver's own two-space split —
+ * keep the two in step.
+ */
+export function isUnresolvableBulletKey(key: string): boolean {
+  return !isLegacyBulletKey(key) && bulletIdText(key) === undefined;
+}
+
+/**
  * Assign ids to `texts` in pool order. Exported so the scorer and any test
  * harness mint ids the one way.
  *


### PR DESCRIPTION
Three edit-lane correctness issues, implemented onto one branch as one commit. All three are about a Remove that reports success while doing nothing — or doing something to the wrong row.

## #659 — pin the "Removed · Undo" strip to an actual removal

**This is not a behaviour fix, and should not be read as one.** The production defect was already fixed at HEAD: both load-bearing lines — the gate `if (!onRemoveBullet(id, text)) return false;` in `BulletRemoveStatus.tsx`, and `removeBullet`'s `return false` under `isAddedEntryKey` — landed incidentally in 7d396fa (#646 / PR #665) alongside #648's bullet-id rework. The issue was left open.

The real remaining defect was that the invariant was pinned by **nothing**: mutating either line left the full suite green. So this slice is tests locking a previously-unpinned invariant, plus widening `BulletRemoveControl.removeBullet` from `=> void` to `=> boolean` so the contract states what the gate already relies on.

Revert-proof run in both directions: deleting the gate produces 4 failures; flipping the hook's report produces 2.

## #658 — re-examine a held added entry when its undo strip collapses

An added entry held by an open "Removed · Undo" strip was never re-examined after the strip collapsed, so an entry left empty by the removal survived until something else triggered a prune.

Implemented as **option A**: re-run the prune on hold-release, gated on the entry not holding focus. `useAddedEntryPruneHold` gained `noteHoldReleased(id)` on the registry, an optional `host` ref on `useHoldWhile`, and a `keepsEntry()` stand-down. Release is detected as a **mounted** `held true→false` transition, which is what keeps StrictMode's double-invoke from double-pruning (verified by execution: held mount → 0 prunes, release → 1, unmount while held → 0, two cycles → exactly 2).

Four separate revert-proofs, one per mechanism.

**Stated deviation.** AC 3 says an empty sibling is dropped "by the same pass". The implementation narrows the release pass to the released entry only, so a sibling is dropped by the later section-exit pass instead. Rationale: a section-wide sweep fired off a timer would yank a blank sibling the user is mid-edit in. #637's criterion is still guarded — revert-proof D turns it red.

## #660 — make a contentless added bullet rejectable and removable

- `isContentlessBulletLine(text)` (`normalizeBulletText(text) === ""`) is now `addBullet`'s guard, replacing a bare `!trimmed` check that could not see `"1."`.
- `findAddedBulletEntry(addedBullets, text)` resolves a bucket key by text, giving the one removal path that cannot name its entry — the "Other bullets" group, which has no entry — something to splice.

Both live in `src/lib/edit/added-bullets.ts`, so no new hook→score dependency edge.

**The issue's own premise needed correcting.** Its examples `"•" "-" "*" "–" "·" "‣"` never reach "Other bullets" at all: `countWords` is 0, so `extractBulletsFromLines` drops them from the pool. They rendered no row — they only polluted the role description and the exported PDF. The reachable reproducer is a **numbered** marker (`"1."`, `"2)"`), whose digit matches `\p{N}` and so clears the word minimum.

**Deliberately not done:** tightening `replaceAddedBulletLine`. On a parsed entry a rejected replacement falls through to `bulletOverrides`, which is inert but **permanent** — `hasEdits` stays true forever while the row shows stale text. Letting the bucket hold it is strictly better, because option 2 above makes it removable. Verified that `applyBulletTextOverrides` (`apply-overrides.ts:1033`) does run before `applyAddedEntriesAndBullets` (:1052), which is what that reasoning rests on.

## Two regressions this batch introduced, and fixed

Review found that #660 half 2 — resolving a bucket from the row text — introduced two silent-data-loss regressions. Both are absent at `main`, where the callback was `(id) => onRemoveBullet(id)` and no bucket splice was possible. Both are reproduced end-to-end, and each is now pinned by its own test with its own revert-proof.

**An armed Undo that restored nothing.** `otherCaptureUndo` passed the literal `"other-bullets"` as the entry key. That is not a real `addedBullets` key, so the snapshot captured `added: ["other-bullets", []]` while the removal spliced the *real* bucket. Undo then deleted a bucket that never existed and restored an id that was never filed — the strip reported "Reverted 1 change" and the line was gone for good. This was #659's own defect family reappearing on the path half 2 enables.

The comment justifying the placeholder claimed `batchUndoTargets` reads the entry key only for an `add` write. That was never true — the function records it for every write kind, as its own docblock says — it was merely harmless before a `remove` could splice a bucket. The comment is deleted.

**A prune that ate a live Undo.** `otherRemove.pending` had no consumers, so the section-owned strip took no prune hold. Removing an added role's last bucket line emptied the role, and the next section-exit blur deleted the whole role one tick later while its Undo was still on screen — #637's defect on a path the hold didn't cover, and losing a role is worse than the bullet-level loss #637 fixed.

Both are fixed by lifting the concern into a new `useOtherBulletsRemove` hook (`src/components/features/OtherBulletsRemove.ts`), so bucket resolution, the undo snapshot, the write, and the prune hold all read **one** value instead of three call sites agreeing by luck. `batchUndoTargets` now takes `string | undefined`, and `undefined` records no bucket at all — an honest "nothing to restore here" rather than a placeholder that snapshots as `[]` and restores as a spurious delete.

**Why both shipped green:** none of the nine existing "Other bullets" tests ever clicked Undo. There are now twelve, and three of them do.

`ReconstructedResume.tsx` went 1455 → 1421 LOC, so the fix removed more from that file than it added.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- full `npx vitest run` — **3842 passed | 10 skipped (3852)**, up from 3801 at the branch point
- `npm run check:fixtures` — passes (57 PDFs + 15 sidecars, all personas synthetic). **No new fixtures in this batch.**
- `npm run check:baselines` — exits 0; the 10 `unfiled` warnings are pre-existing (no `.truth.json` in this diff)
- `npx fallow audit --base origin/main` — dead files 0.0%, dead exports 0.0%; 2 complexity findings (`RoleHeader`, `AchievementHeader`), both pre-existing and neither touched by this diff; 32 clone groups (warn). Report-only in `verify`.

Three review rounds ran over this branch, and the third exists because the second found the two regressions above. Findings and their reproductions are in the `## Adversarial review` section below.

## Known limitations, filed not fixed

- **#683** — two roles holding a contentless line with the *same* verbatim text (both `"1."`) resolve to the same bucket, so clicking either row splices the first one. The harm ceiling is a junk marker attributed to the wrong role: only contentless lines reach that branch, the undo snapshot agrees with the splice, and a second click converges to the correct state. It ships open because the obvious fix — refusing the ambiguous resolution — would make those rows permanently unremovable, which is worse for the case #660 exists to serve. The test that covers this now clicks the row whose bucket *loses* the tiebreak; it previously clicked the winner and was green either way, which is why it hid through two review rounds.
- **#684** — #658's release-time prune never fires on this path, because the hold registers no host element. An added role emptied by an "Other bullets" removal waits for the section-exit pass instead. Deliberate and conservative; the alternative gates on the wrong subtree.

Two other pre-existing defects found while working here are filed as **#677**, **#678** and **#679**.

## Gaps stated plainly

- The **round-1** fix pass never reported back, so its three fixes have tests and green gates but no revert-proof was ever demonstrated for them. The round-2 fixes each have one, reverted separately.
- Of the three conditions gating the prune hold, only `isAddedEntryKey` is load-bearing and pinned. The `removed` check is defence in depth — removing it leaves the suite green, because every reachable no-op removal resolves no bucket and the neighbouring condition already covers it. That is recorded in the code rather than left to imply a guarantee it does not carry.

The authoritative full `verify` runs in CI on this PR.

Closes #658
Closes #659
Closes #660

## Review focus

- `src/components/features/OtherBulletsRemove.ts` — bucket resolution, the undo snapshot, the write and the prune hold all derive from one `bucketKey`. Can a click straddle two renders and capture against one map while splicing another?
- `src/lib/rewrite-review/undo-batch.ts` — `batchUndoTargets` now takes `string | undefined`. Does any caller reach the `undefined` branch that shouldn't, and does a parsed-orphan removal still undo through `restore` alone?
- `src/hooks/useAddedEntryPruneHold.ts` — `keepsEntry` stands down on focus *or* an open input. Is `querySelector("input, textarea")` too broad for any state a `RoleEntry` can render, which would disable #658's release prune silently?
- `src/components/features/ExperienceSection.other-bullets.test.tsx:385` — this case pins known-wrong behaviour (#683) on purpose. Is that the right call, or should the ambiguous resolution be refused now?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 3842 passed | 10 skipped (3852)
- [x] `npm run verify` green locally via the `pre-push` hook
- [x] `npm run check:fixtures` and `npm run check:baselines` pass — no fixtures added or changed by this PR
- [x] Manually verified in `npm run dev`

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #659 | Claude Opus 5 (1M context) | ultra |
| Implementation — #658 | Claude Opus 5 (1M context) | ultra |
| Implementation — #660 | Claude Opus 5 (1M context) | ultra |
| Adversarial review — round 1, React layer | Claude Opus 5 (1M context) | ultra |
| Adversarial review — round 1, lib layer | unreported (requested: opus) | ultra |
| Review fixes — round 1 | unreported (requested: opus) | ultra |
| Adversarial review — round 2 | Claude Opus 5 (1M context) | ultra |
| Review fixes — round 2 | Claude Opus 5 (1M context) | ultra |
| Adversarial review — round 3 | Claude Opus 5 (1M context) | ultra |
| Orchestration + PR | Claude Opus 5 (1M context) | session default |
| Verification | `npm run verify` — green in CI | — |

Two rows are unresolved because those subagents never reported their model. The alias requested is recorded instead of a guess.

## Adversarial review

Three rounds. The normal two-round cap was waived deliberately, because round 2 found regressions whose fixes would otherwise have shipped with no independent scrutiny.

**Round 1 — 2 blocking, both fixed.** The #658 focus gate missed an open uncommitted draft, so a 12.15 s timer could delete text the user was typing; the gate now stands down on an open input as well as on focus. And #660 AC 2 was unmet for a *parsed* degenerate line, which filed a permanently unresolvable id — closed by `isUnresolvableBulletKey`, which deliberately exempts legacy numeric keys because `replay` routes a pre-#648 snapshot's removals through them.

A third finding came from tracing the first two rather than from the reviewer: because `removeBullet` tries the added-bucket splice *first*, a degenerate target matched any contentless bucket line in any entry, so removing a parsed degenerate row could splice a different role's bullet and report success. Fixed at the shared matcher (`sameBulletLine`) rather than at one call site, so a resolver and the splice it feeds cannot disagree.

**Round 2 — 2 blocking, both regressions introduced by this batch, both fixed.** Described above. Round 2 also tried to break round 1's fixes and could not: `keepsEntry` is pinned from both sides (5 tests red if it stands down unconditionally), StrictMode double-invoke is clean across 6 cases, and the matcher widening is byte-identical for every non-degenerate line.

**Round 3 — 1 finding, filed as #683 rather than fixed.** See "Known limitations" above. Round 3 independently re-derived both round-2 revert-proofs, confirmed the test-util extraction is behaviour-preserving against the deleted originals, and confirmed the `string | undefined` widening reaches only one production call site.

Round 3 also found that both guards on the prune hold were unpinned — mutating either left the suite green. One is now pinned by a test that goes red when it is dropped; the other is documented as defence in depth, because every reachable no-op resolves no bucket and the neighbouring condition already covers it.

The recurring lesson across all three rounds: **four separate tests passed whether the code was right or wrong** — the round-1 "costs nothing when it misses" control, the round-3 sibling case that clicked the winning row, and the nine "Other bullets" cases that never clicked Undo. Every regression here hid behind a green test, not behind a missing one.
