### PR TITLE
chore: ignore nested private checkouts in git and eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,11 @@ __pycache__/
 # Local-only internal working directory — never ship in the OSS repo
 internal/
 
+# Private sibling repo cloned into this checkout so the extension can import the
+# shared, dependency-free fitness chain (src/lib/jd-match, src/lib/job-search)
+# by relative path. Same pattern as internal/ above. Never ship in the OSS repo.
+extension/
+
 # Maintainer-only skill whose source of truth lives in the private
 # offlinecv-internal repo (internal/.claude/skills/oss-translate). It is
 # surfaced here as a symlink so Claude Code discovers it as /oss-translate,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -113,6 +113,13 @@ export default [
       "scripts/**",
       "coverage/**",
       ".claude/**",
+      // Private repos cloned into this checkout (see .gitignore). `npm run lint`
+      // is `eslint .`, and flat config does NOT read .gitignore — so without
+      // these, lint walks into a nested checkout that has its own toolchain and
+      // its own rules. vitest, coverage and tsconfig.app need no equivalent:
+      // all three are allowlisted to `src/**` already.
+      "internal/**",
+      "extension/**",
     ],
   },
 


### PR DESCRIPTION
## Summary

`internal/` is a private repo cloned into this checkout; a second one now sits at `extension/`. Both are gitignored — but `npm run lint` is `eslint .`, and ESLint v9 flat config does **not** read `.gitignore`, so eslint walked into them.

Adds `extension/` to `.gitignore` and both `internal/**` and `extension/**` to eslint's global ignores.

## Why it matters

A single unparseable `.js` anywhere in a nested checkout — a build config, a manifest helper — fails `npm run lint`, which fails `verify`, which fails CI on a PR that has nothing to do with it.

Verified by measurement rather than inspection, with a stray `extension/Broken.js` present:

| | `eslint .` exit | Finding |
|---|---|---|
| without the ignore | **1** | `extension/Broken.js` → `Parsing error: Unexpected token is` |
| with the ignore | **0** | — |

A first probe using a `.tsx` file was inconclusive and is worth recording: every rule block in `eslint.config.js` is globbed to `src/**`, and those globs are root-relative, so a `.tsx` under `extension/src/components/` matches nothing and is silently skipped. The exposure is specifically plain `.js`, which eslint's default handling picks up.

## Scope

`vitest`, coverage and `tsconfig.app` need no equivalent entry — checked all three, they are already allowlisted to `src/**` and never see a sibling directory. This is the only scanner that needed changing.

## Test plan

- [x] `npm run lint` exits 0
- [x] `tsc -b --noEmit` clean
- [x] Ignore verified against a deliberately broken file, with a before/after exit code
- [x] CI `verify` green

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — via CI