### PR TITLE
chore(storage): drop citations to a deleted issue from the capture docblocks

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -139,13 +139,13 @@
     //
     // `captureJob` / `JobCaptureResult` are the honest exception in this list.
     // They are not merely unconsumed in-tree — they have NO consumer anywhere
-    // yet, because the MV3 extension that calls them is #694, deferred out of
-    // the batch that shipped the contract (see the "staged for #694" note in
-    // `capture.ts`). Listing them here means fallow will not be the thing that
-    // tells us if #694 never lands. That is a deliberate, time-bounded trade:
-    // when #694 merges, its import makes these live and the two names should
-    // come back OUT of this list. If #694 is abandoned instead, delete
-    // `capture.ts` rather than leaving the suppression to rot.
+    // yet, because the browser extension that calls them is tracked outside
+    // this repo (see the "staged for the extension" note in `capture.ts`).
+    // Listing them here means fallow will not be the thing that tells us if
+    // that extension never lands. That is a deliberate, time-bounded trade:
+    // once something in-tree imports them, these two names should come back OUT
+    // of this list. If the extension is abandoned instead, delete `capture.ts`
+    // rather than leaving the suppression to rot.
     //
     // Enumerated, not `["*"]`, for the reason the barrel comment above gives:
     // `*` would silence the whole file and let a future accidentally-dead

--- a/src/lib/storage/capture.test.ts
+++ b/src/lib/storage/capture.test.ts
@@ -2,7 +2,8 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * `captureJob` (#693) — the producer-facing write path, staged for #694.
+ * `captureJob` (#693) — the producer-facing write path, staged for the browser
+ * extension (tracked outside this repo).
  *
  * Boundary with `storage.test.ts`: that file owns the store-level proof (two
  * captures of one posting leave exactly one row in `jobs`). This file owns the

--- a/src/lib/storage/capture.ts
+++ b/src/lib/storage/capture.ts
@@ -23,12 +23,13 @@
  * file) is the caller's problem — this module's contract is `unknown` in, a
  * validated record or a list of reasons out.
  *
- * NOTE: staged for #694 — no production caller yet. Nothing in this build
- * captures a job from outside its own UI: the tracker and the JD-match "save
- * this job" button are typechecked against `JobRecord` and write through
+ * NOTE: staged for the extension — no production caller yet. Nothing in this
+ * build captures a job from outside its own UI: the tracker and the JD-match
+ * "save this job" button are typechecked against `JobRecord` and write through
  * `job-tracker.ts`, and the backup import path has its own entry point
- * (`backup.ts`). The MV3 capture extension that calls this is #694, deferred
- * out of the batch that shipped `docs/job-capture-contract.md`. Until it lands
+ * (`backup.ts`). The MV3 capture extension that calls this is tracked outside
+ * this repo, deferred out of the batch that shipped
+ * `docs/job-capture-contract.md`. Until it lands
  * this module is exercised only by `capture.test.ts` and `storage.test.ts`; it
  * ships now, and is exported from the storage barrel, so the extension imports
  * the ownership merge below rather than reimplementing it against the store.


### PR DESCRIPTION
## Summary

The MV3 capture extension's issues were removed from this repo when that work moved to a private tracker. Four places still cited one of them by number, so each now points at a 404.

- `src/lib/storage/capture.ts` — the "staged for" note
- `src/lib/storage/capture.test.ts` — the docblock header
- `.fallowrc.jsonc` — the `ignoreExports` rationale for `captureJob` / `JobCaptureResult`

A dangling citation is worse than no citation: it reads as a live pointer, and the reasoning wrapped around it is load-bearing. The fallow entry exists *precisely because* `captureJob` has no consumer yet, and a reader has to be able to establish that from the comment alone — including the exit conditions (import it → the names come out of the list; abandon it → delete `capture.ts`).

Reasoning kept verbatim. Only the dead issue reference changes, to "tracked outside this repo". The private repo is deliberately not named.

## Test plan

- [x] `rg '#69[45]\b'` over the tree returns nothing
- [x] `tsc -b --noEmit` clean
- [x] `npm run lint` clean
- [x] `vitest run src/lib/storage/capture.test.ts` green
- [x] CI `verify` green

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — via CI