### PR TITLE
fix(job-search,jd-match): read "and"-separated pay ranges, and split coverage on the corpus boundary (#699, #700)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -99,10 +99,22 @@
       "TierEngagedEvent", "ParseCompletedEvent", "TierId", "TierEngagementReason",
       "FinalSource", "FileSizeBucket", "ParseMetadata"
     ] },
+    //
+    // `computeCoverageFromCorpus` (#700) is the newest name on the jd-match
+    // barrel and the reason it is here is worth stating precisely, because it is
+    // NOT the `captureJob` case below. Its IMPLEMENTATION has an in-tree
+    // consumer — `computeCoverage` is a thin wrapper over it, and coverage.test.ts
+    // exercises both — so the function itself can never quietly go dead. What has
+    // no in-repo consumer is only the barrel RE-EXPORT, which exists because the
+    // corpus seam's whole point is to be callable by someone holding just the
+    // lowercased digest rather than a whole `HeuristicParsedResume`. That is the
+    // intended external surface this block already describes, not a suppression
+    // standing in for a missing caller.
     { "file": "src/lib/jd-match/index.ts", "exports": [
       "extractJdTerms", "stripBoilerplate",
       "ExtractedTerm", "ExtractJdTermsResult", "ExtractOptions",
-      "computeCoverage", "buildCorpus", "SKILL_WEIGHT", "NOUN_WEIGHT",
+      "computeCoverage", "computeCoverageFromCorpus",
+      "buildCorpus", "SKILL_WEIGHT", "NOUN_WEIGHT",
       "CoverageResult", "SKILLS", "getSkillIndex", "skillCount", "SkillEntry",
       "fetchJdFromUrl", "parseAtsUrl", "htmlToPlaintext", "AtsPlatform",
       "JdMatchResult"

--- a/src/lib/jd-match/coverage.test.ts
+++ b/src/lib/jd-match/coverage.test.ts
@@ -6,6 +6,7 @@ import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import { extractJdTerms } from "./extract-jd-terms.ts";
 import {
   computeCoverage,
+  computeCoverageFromCorpus,
   buildCorpus,
   buildResumeProjection,
   SKILL_WEIGHT,
@@ -141,5 +142,37 @@ Familiarity with Distributed Systems is a plus.
     expect(cov.score).toBe(0);
     expect(cov.covered).toHaveLength(0);
     expect(cov.missing).toHaveLength(0);
+  });
+});
+
+// The corpus seam (#700). `computeCoverage` is now a thin wrapper, so the two
+// entry points must stay one implementation — a caller holding only the
+// lowercased digest must score identically to one holding the whole résumé.
+describe("computeCoverageFromCorpus", () => {
+  const parsed = makeParsed({
+    summary: "Backend engineer who ships.",
+    skills: ["TypeScript", "Kubernetes"],
+    experience: [
+      { title: "Staff Engineer", company: "Acme", description: "Owned the Kafka pipeline." },
+    ],
+  });
+  const terms = extractJdTerms(
+    "We need a TypeScript engineer with Kubernetes experience and a Kafka pipeline background. Terraform is a plus.",
+  ).all;
+
+  it("is what computeCoverage delegates to — identical result for the same résumé", () => {
+    // Guard: an empty term list, or one nothing covers, would make this vacuous.
+    expect(terms.length).toBeGreaterThan(0);
+    const viaCorpus = computeCoverageFromCorpus(buildCorpus(parsed), terms);
+    expect(viaCorpus.covered.length).toBeGreaterThan(0);
+    expect(viaCorpus).toEqual(computeCoverage(parsed, terms));
+  });
+
+  it("scores from a corpus string alone, with no HeuristicParsedResume in hand", () => {
+    const cov = computeCoverageFromCorpus("typescript, kubernetes, kafka", terms);
+    expect(cov.covered.map((t) => t.id)).toEqual(
+      expect.arrayContaining(["typescript", "kubernetes"]),
+    );
+    expect(cov.score).toBeGreaterThan(0);
   });
 });

--- a/src/lib/jd-match/coverage.ts
+++ b/src/lib/jd-match/coverage.ts
@@ -51,17 +51,24 @@ export interface CoverageResult {
 }
 
 /**
- * Run the coverage check.
+ * Run the coverage check against an already-built corpus.
  *
- * `parsed` is the cascade's HeuristicParsedResume — `skills: string[]`,
- * `experience[].description`, `summary?`, `education[]`. We tolerate any
- * field being missing.
+ * The corpus — one lowercased string, as `buildCorpus` produces — is the only
+ * thing coverage matching ever reads. Splitting it out from `computeCoverage`
+ * (#700) makes "the résumé, reduced to what matching actually reads" a value a
+ * caller can hold, cache, or hand across a boundary WITHOUT holding a whole
+ * `HeuristicParsedResume`. A consumer that has only the digest can now score
+ * against it instead of forking a second coverage implementation, which is the
+ * fastest route to two scores that disagree.
+ *
+ * `corpus` MUST already be lowercased: the skill mention patterns and the
+ * phrase check below are matched case-insensitively against it on the
+ * assumption `buildCorpus` did that normalization.
  */
-export function computeCoverage(
-  parsed: HeuristicParsedResume,
+export function computeCoverageFromCorpus(
+  corpus: string,
   terms: readonly ExtractedTerm[],
 ): CoverageResult {
-  const corpus = buildCorpus(parsed);
   const covered: ExtractedTerm[] = [];
   const missing: ExtractedTerm[] = [];
 
@@ -90,6 +97,24 @@ export function computeCoverage(
     score,
     weights: { skill: SKILL_WEIGHT, noun: NOUN_WEIGHT },
   };
+}
+
+/**
+ * Run the coverage check against a parsed résumé.
+ *
+ * `parsed` is the cascade's HeuristicParsedResume — `skills: string[]`,
+ * `experience[].description`, `summary?`, `education[]`. We tolerate any
+ * field being missing.
+ *
+ * A thin wrapper over `computeCoverageFromCorpus`, kept at its original
+ * signature so every existing caller is untouched. This is the ONLY place the
+ * two are joined, so there is exactly one coverage implementation.
+ */
+export function computeCoverage(
+  parsed: HeuristicParsedResume,
+  terms: readonly ExtractedTerm[],
+): CoverageResult {
+  return computeCoverageFromCorpus(buildCorpus(parsed), terms);
 }
 
 /**

--- a/src/lib/jd-match/index.ts
+++ b/src/lib/jd-match/index.ts
@@ -10,6 +10,7 @@ export type {
 
 export {
   computeCoverage,
+  computeCoverageFromCorpus,
   buildCorpus,
   SKILL_WEIGHT,
   NOUN_WEIGHT,

--- a/src/lib/job-search/compensation.test.ts
+++ b/src/lib/job-search/compensation.test.ts
@@ -6,6 +6,7 @@ import {
   extractCompensation,
   isBelowFloor,
   formatCompensationRange,
+  annualizedTop,
 } from "./compensation.ts";
 
 describe("extractCompensation", () => {
@@ -224,6 +225,136 @@ describe("extractCompensation", () => {
     expect(comp).toBeDefined();
     expect(comp!.min).toBe(120000);
     expect(comp!.currency).toBe("USD");
+  });
+});
+
+// "between $X and $Y" is how US pay-transparency boilerplate (CA/NY/CO/WA)
+// states a range (issue 699). Before the "and" separator existed, RANGE_RE never
+// matched, extraction fell through to SINGLE_RE, and the FIRST figure came back
+// as both min and max — so a posting was rated at the floor of its own range.
+describe("extractCompensation — 'and'-separated ranges (issue 699)", () => {
+  it("extracts the full range from real pay-transparency boilerplate", () => {
+    const comp = extractCompensation(
+      "The base pay range for this role is between $183,700 and $319,800, and your base pay will depend on your skills.",
+    );
+    expect(comp).toBeDefined();
+    // The defect: max collapsed to 183700, the bottom of the range.
+    expect(comp!.min).toBe(183700);
+    expect(comp!.max).toBe(319800);
+    expect(comp!.currency).toBe("USD");
+    expect(comp!.period).toBe("year");
+  });
+
+  it("extracts a bare 'between $X and $Y' with no salary-context word anywhere", () => {
+    // Previously undefined: no context word meant SINGLE_RE's gate also failed.
+    const comp = extractCompensation("between $183,700 and $319,800");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(183700);
+    expect(comp!.max).toBe(319800);
+  });
+
+  it("extracts a K-suffixed 'between $Xk and $Yk'", () => {
+    const comp = extractCompensation("between $183k and $319k");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(183000);
+    expect(comp!.max).toBe(319000);
+  });
+
+  it("extracts an 'and' range introduced by 'from' or 'in the range of'", () => {
+    const from = extractCompensation("Compensation ranges from $95,000 and $145,000.");
+    expect(from!.min).toBe(95000);
+    expect(from!.max).toBe(145000);
+
+    const rangeOf = extractCompensation("Pay is in the range of $70,000 and $90,000 annually.");
+    expect(rangeOf!.min).toBe(70000);
+    expect(rangeOf!.max).toBe(90000);
+  });
+
+  it("keeps the currency-code and non-USD 'and' forms working", () => {
+    const usd = extractCompensation("The pay range is between USD 180000 and USD 240000.");
+    expect(usd!.min).toBe(180000);
+    expect(usd!.max).toBe(240000);
+    expect(usd!.currency).toBe("USD");
+
+    const gbp = extractCompensation("Base salary between £65,000 and £85,000 per annum.");
+    expect(gbp!.min).toBe(65000);
+    expect(gbp!.max).toBe(85000);
+    expect(gbp!.currency).toBe("GBP");
+  });
+
+  // The guard. "and" joins two UNRELATED figures far more often than two
+  // endpoints, and a false range actively mis-scores (a miss merely drops the
+  // axis and rateJobs renormalizes). Each of these fails WITHOUT the intro-word
+  // clause of isTrustedRange.
+  it("does NOT read an adjacent pair of unrelated figures as a range", () => {
+    expect(
+      extractCompensation("New hires receive a $500 and $2,000 relocation package."),
+    ).toBeUndefined();
+    expect(
+      extractCompensation("Grants of $50,000 and $75,000 were awarded to two teams."),
+    ).toBeUndefined();
+    expect(
+      extractCompensation("Equity worth $100,000 and $250,000 vests over four years."),
+    ).toBeUndefined();
+    expect(
+      extractCompensation("We raised $5,000,000 and $10,000,000 across two rounds."),
+    ).toBeUndefined();
+  });
+
+  it("does NOT join a salary figure to an adjacent bonus figure", () => {
+    // "Base pay" attaches to $120,000 as a SINGLE — which is correct — but the
+    // pair must never become a $20,000–$120,000 range.
+    const comp = extractCompensation("Base pay $120,000 and $20,000 target bonus.");
+    expect(comp).toBeDefined();
+    expect(comp!.min).toBe(120000);
+    expect(comp!.max).toBe(120000);
+  });
+
+  // Fails WITHOUT the ascending clause of isTrustedRange: the intro word is
+  // present, so only the ordering separates a range from a menu of options.
+  it("does NOT read a descending 'choose between A and B' enumeration as a range", () => {
+    expect(
+      extractCompensation(
+        "Relocation support: you may choose between $15,000 and $7,500 depending on distance.",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not join two figures separated by a sentence boundary", () => {
+    // The separator is whitespace-tight — `\s*(?:SEP)\s*` — so punctuation
+    // between the figures structurally prevents a match, and neither figure
+    // carries salary context of its own.
+    expect(
+      extractCompensation("Signing bonus is $20,000. And equity is worth $80,000."),
+    ).toBeUndefined();
+  });
+
+  it("returns the FIRST accepted 'and' range when a posting states two", () => {
+    // Matches the documented firstRange behaviour: multi-location postings list
+    // a range per locale.
+    const comp = extractCompensation(
+      "In California the range is between $183,700 and $319,800. In Texas it is between $160,000 and $280,000.",
+    );
+    expect(comp!.min).toBe(183700);
+    expect(comp!.max).toBe(319800);
+  });
+
+  it("skips a rejected 'and' pair and still finds a later genuine range", () => {
+    // A rejected match must not abort the scan.
+    const comp = extractCompensation(
+      "You get a $500 and $2,000 relocation package. Base salary $150,000 - $190,000.",
+    );
+    expect(comp!.min).toBe(150000);
+    expect(comp!.max).toBe(190000);
+  });
+
+  it("rates an 'and' range at its top, not its floor", () => {
+    // The whole reason this matters: annualizedTop feeds the 0.35-weighted comp
+    // axis, and isBelowFloor reads the same value.
+    const comp = extractCompensation("The base pay range is between $183,700 and $319,800.");
+    expect(annualizedTop(comp!)).toBe(319800);
+    // A $250K floor must NOT badge this posting "below your floor".
+    expect(isBelowFloor(comp, 250000)).toBe(false);
   });
 });
 

--- a/src/lib/job-search/compensation.ts
+++ b/src/lib/job-search/compensation.ts
@@ -65,6 +65,13 @@
  *      ("Base pay: $120,000") or it carries an explicit annual/hourly period.
  *      Ranges are exempt — a currency-anchored range that survives the suffix
  *      guard is a deliberate pay statement and wins before singles are scored.
+ *
+ * The one range shape NOT exempt from that last point is an "and"-separated
+ * pair (#699). "and" had to become a separator because "between $X and $Y" is
+ * how US pay-transparency boilerplate states a range, but it is also an
+ * ordinary conjunction between two unrelated figures — so it carries its own
+ * gate (`isTrustedRange`) rather than riding the ranges-are-deliberate
+ * exemption.
  */
 
 export type CompensationPeriod = "year" | "hour" | "month";
@@ -100,9 +107,14 @@ const CUR_CODE = String.raw`USD|EUR|GBP|CAD|AUD|NZD|CHF`;
  */
 const NUM = String.raw`\d+(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?`;
 
-/** Range separators: ASCII hyphen, en dash, em dash, "~", or the word "to"
- *  (word-bounded so it never matches inside "photo" etc.). */
-const SEP = String.raw`-|–|—|~|\bto\b`;
+/** Range separators: ASCII hyphen, en dash, em dash, "~", or the words "to"
+ *  and "and" (word-bounded so "to" never matches inside "photo" etc.). "and"
+ *  is here because "between $X and $Y" is the standard phrasing of US
+ *  pay-transparency boilerplate (CA/NY/CO/WA) and was previously unreadable
+ *  (#699) — but unlike the others it is a common conjunction, so a match on it
+ *  carries a guard the punctuation separators don't need. See
+ *  `isTrustedRange`. */
+const SEP = String.raw`-|–|—|~|\bto\b|\band\b`;
 
 /** Period tokens that require an explicit "/" or "per " prefix to count —
  *  "hour" alone is too generic to trust unprefixed. */
@@ -129,12 +141,14 @@ const PERIOD_TAIL = String.raw`(?:\s*(?:\/|per\s+)\s*(?<per1>${PERIOD_WORD})\b)?
 
 /** Range shape: currency + num [+K] + separator + [currency] + num [+K] +
  *  optional period. Tried before `SINGLE_RE` so a genuine range always wins
- *  over accidentally matching just its first number. */
+ *  over accidentally matching just its first number. The separator is captured
+ *  (`sep`) so `isTrustedRange` can tell an "and" match — which needs proof it is
+ *  a range at all — from the unambiguous punctuation separators. */
 const RANGE_RE = new RegExp(
   currencyGroup("sym1", "code1") +
     String.raw`\s*` +
     numWithK("num1", "k1") +
-    String.raw`\s*(?:${SEP})\s*` +
+    String.raw`\s*(?<sep>${SEP})\s*` +
     String.raw`(?:${currencyGroup("sym2", "code2")}\s*)?` +
     numWithK("num2", "k2") +
     PERIOD_TAIL,
@@ -339,11 +353,62 @@ function salaryAttachedIndices(text: string, figs: SingleFigure[]): Set<number> 
   return attached;
 }
 
+/**
+ * Words that may introduce an "and"-separated range, immediately before the
+ * figure. In English "and" joins two endpoints into a RANGE essentially only
+ * inside the "between … and …" construction; "from … and …" and "in the range
+ * of … and …" are the loose variants that show up in real posting boilerplate.
+ * End-anchored, and tested against the text PRECEDING the match, so the intro
+ * word must sit adjacent to the first figure rather than anywhere earlier in
+ * the sentence.
+ */
+const AND_RANGE_INTRO_RE = /\b(?:between|from|range\s+of)\s*$/i;
+
+/**
+ * Whether a `RANGE_RE` match may be trusted as a pay range (#699).
+ *
+ * The punctuation separators and "to" are unambiguous range markers, so they
+ * pass unconditionally — this gate exists only for "and", which is a far more
+ * common word and joins two UNRELATED figures far more often than two endpoints
+ * ("a $500 and $2,000 relocation", "we raised $10,000,000 and $5,000,000"). A
+ * false range is worse than a missed one: a miss drops the comp axis and
+ * `rateJobs` renormalizes the remaining weights, whereas a false range actively
+ * mis-scores. So an "and" pair must clear two independent tests:
+ *
+ *   1. AN INTRO WORD immediately precedes it (`AND_RANGE_INTRO_RE`). Without
+ *      this, every adjacent currency pair in a description reads as pay.
+ *   2. IT ASCENDS. A range runs low→high; the other common "between … and …"
+ *      construction is an ENUMERATION ("choose between $15,000 and $7,500
+ *      depending on distance"), and descending order is the tell. Note this is
+ *      deliberately scoped to "and" — `candidateFrom` normalizes with
+ *      Math.min/max, so a descending punctuation range keeps its existing
+ *      behaviour and no other separator changes.
+ *
+ * Measured against a labelled corpus of both shapes, each clause is
+ * load-bearing: dropping the intro test admits 8 false ranges, dropping the
+ * ascending test admits the enumeration above.
+ */
+function isTrustedRange(text: string, match: RegExpMatchArray): boolean {
+  const groups = match.groups;
+  if (!groups || match.index === undefined) return false;
+  if (groups.sep?.toLowerCase() !== "and") return true;
+
+  if (!AND_RANGE_INTRO_RE.test(text.slice(0, match.index))) return false;
+
+  if (typeof groups.num2 !== "string") return false;
+  const num1 = parseNum(groups.num1, groups.k1);
+  const num2 = parseNum(groups.num2, groups.k2);
+  return Number.isFinite(num1) && Number.isFinite(num2) && num2 > num1;
+}
+
 /** First accepted range across ALL matches of `RANGE_RE` — a currency-anchored
  *  range that survives the magnitude guard is a deliberate pay statement, so a
- *  leading non-salary figure is skipped and the first real range wins. */
+ *  leading non-salary figure is skipped and the first real range wins. An "and"
+ *  match that fails `isTrustedRange` is SKIPPED, not aborted on, so a later
+ *  genuine range in the same description still wins. */
 function firstRange(text: string): Compensation | undefined {
   for (const match of text.matchAll(RANGE_RE)) {
+    if (!isTrustedRange(text, match)) continue;
     const c = candidateFrom(text, match);
     if (c) return stripMeta(c);
   }


### PR DESCRIPTION
Two small, related changes in the search/match lanes.

Closes #699
Refs #700 (partial — the corpus seam only; the saved-library rating is **not** in this PR, see below)

---

## 1 — #699: `extractCompensation` dropped the top of an "and"-separated range

`SEP` (`compensation.ts`) listed `-`, `–`, `—`, `~` and `to`, but not `and`. So `RANGE_RE` never matched an "and"-separated pair, extraction fell through to `SINGLE_RE`, and that returns the **first** figure as both `min` and `max`.

"between $X and $Y" is the standard phrasing of US pay-transparency boilerplate (CA/NY/CO/WA), so this hits live feed postings. The value flows `extractCompensation` → `annualizedTop` → `RatingInput.compMax` → the **0.35-weighted** comp axis in `rateJobs`, and `isBelowFloor` reads the same figure — so an affected posting was rated at the **floor** of its own advertised range, and one whose top of range cleared the user's `compFloor` could still be badged "below your floor".

Every row of the issue's table is now covered by a test:

| Input | before | after |
|---|---|---|
| `The base pay range for this role is between $183,700 and $319,800, and your base pay will depend on…` | 183700 / **183700** | 183700 / 319800 |
| `between $183,700 and $319,800` (bare, no salary-context word) | `undefined` | 183700 / 319800 |
| `between $183k and $319k` | `undefined` | 183000 / 319000 |

The three separators that already worked (`-`, `–`, `to`) are unchanged.

### The guard is the actual work

Adding `\band\b` is one token. But "and" is an ordinary conjunction, so a currency-`and`-currency pair is much likelier to be two unrelated figures than a range. **A false range is worse than a missed one**: a miss drops the comp axis and `rateJobs` renormalizes the remaining weights, whereas a false range actively mis-scores.

Two facts narrowed the problem before picking a guard:

- `RANGE_RE`'s separator is **whitespace-tight** — `\s*(?:${SEP})\s*` — so `a $500 stipend and $2,000 relocation` can never match anyway (the word "stipend" sits between). The real exposure is **adjacent bare figures**: `a $500 and $2,000 relocation`, `we raised $10,000,000 and $5,000,000 in follow-on`.
- `candidateFrom` normalizes with `Math.min`/`Math.max`, so there was **no ascending-order check** anywhere — a descending pair silently became a range.

I measured candidate guards against a labelled corpus (8 true "and" ranges, 11 non-ranges):

| guard | missed a true range | produced a false range |
|---|---|---|
| none (just add `and`) | 0/8 | **11/11** |
| ascending only | 0/8 | 8/11 |
| salary-context word attached | 2/8 | 2/11 |
| intro word only | 0/8 | 1/11 |
| **intro word + ascending** | **0/8** | **0/11** |

So `isTrustedRange` gates **"and" matches only** — punctuation separators and "to" pass unconditionally — on two clauses:

1. **An intro word** (`between`, `from`, `range of`) immediately precedes the pair. In English "and" joins two endpoints into a *range* essentially only inside the "between … and …" construction.
2. **The pair ascends.** The other common "between … and …" construction is an *enumeration* — "choose between $15,000 and $7,500 depending on distance" — and descending order is the tell.

This is deliberately scoped to `and`, so `candidateFrom`'s `Math.min`/`Math.max` normalization and every other separator behave exactly as before. A rejected "and" match is **skipped, not aborted on**, so a later genuine range in the same description still wins (tested).

### Revert-proof

Each piece is load-bearing — verified by reverting one at a time against the new tests:

| reverted | tests that go red |
|---|---|
| `\band\b` removed from `SEP` (i.e. the fix itself) | **7** |
| intro-word clause removed from `isTrustedRange` | **2** |
| ascending clause removed from `isTrustedRange` | **1** |

## 2 — #700, the corpus seam only

`computeCoverage(parsed: HeuristicParsedResume, terms)` demanded a whole parsed résumé, but the only thing it did with it was `buildCorpus(parsed)` → one lowercased string. A consumer holding only that digest could not call it at all, and would have to fork a second coverage implementation — the fastest route to two scores that disagree.

Split on that boundary, keeping the existing signature as a thin wrapper so **zero callers change**:

```ts
export function computeCoverageFromCorpus(corpus: string, terms: readonly ExtractedTerm[]): CoverageResult
export function computeCoverage(parsed, terms) { return computeCoverageFromCorpus(buildCorpus(parsed), terms); }
```

Exported from the `src/lib/jd-match/index.ts` barrel alongside the existing `computeCoverage` / `buildCorpus`, and registered in `.fallowrc.jsonc`'s enumerated public surface for that barrel (see **fallow** below).

### ⚠️ #700's problem statement is half stale — verified

> **`ratingInputFor` is module-private in `rank.ts`**

**No longer true.** It is already exported at `src/lib/job-search/rank.ts:168`, and `src/lib/job-search/probe-jobs.test.ts:80` already imports it. `rg ratingInputFor` returns exactly one definition and no second `RatingInput` assembly site. **Nothing to do for that seam** — #700's step 2 is already satisfied.

`computeCoverageFromCorpus` genuinely did not exist; that was the real work, and it is what this PR does.

### Out of scope, deliberately

**#700 step 3 — rating the saved job library** (`JobTrackerEntry` / `StarRating` wiring) is **not** in this PR. It carries its own UI acceptance criteria (the "not rated" vs zero-stars distinction, one `rateJobs` call for the whole set so the set-relative stretch matches the search lane, no rating persisted to IndexedDB) and belongs in its own PR. This PR is the pure seam, so #700 stays open with exactly that remaining.

## Gates

- `npm run verify` green — 272 test files passed, 8 skipped; typecheck, lint, `check:fixtures`, `check:baselines`, coverage and build all clean. Exit 0.
- `rank.test.ts`, `rating.test.ts`, `probe-jobs.test.ts` and `search-plan.test.ts` pass **with no edits to their expectations** — change 2 is a pure refactor at the search lane, and change 1 moves no posting that contains no "and"-separated range.
- No fixtures added, so no PII surface. No component, token, or design-system change.

### fallow

The first push tripped fallow's dead-code check with one alert — **unused export `computeCoverageFromCorpus` (re-export)** at `src/lib/jd-match/index.ts:13`. That is now **fixed**, not waved through: the name is registered in `.fallowrc.jsonc`'s enumerated jd-match public surface, which is the convention this repo already uses for the heuristics, jd-match and storage barrels (`ignoreExports`, populated by #698 for exactly this class of finding). `fallow audit --base origin/main` is now **dead code 0**, exit 0.

Worth being precise about *why* it belongs there, because it is **not** the `captureJob` case documented lower in that file:

- The **implementation** has an in-tree consumer — `computeCoverage` is a thin wrapper over it and `coverage.test.ts` exercises both — so the function can never quietly go dead. fallow never flagged the source export in `coverage.ts`, only the barrel line.
- What has no in-repo consumer is the **barrel re-export**, which is the entire point of a seam: it exists to be callable by someone holding just the lowercased digest. That is the "intended external surface, not dead code" rationale the surrounding block already states.

Registered by name rather than `["*"]`, per the standing comment in that file, so a future accidentally-dead re-export from this barrel still trips the check.

One report-only finding remains and is **not** mine: **duplication, `compensation.test.ts:15-21` vs `38-43`** — pre-existing assertion blocks in the two oldest tests, surfaced only because the file is now in the changed set. `git diff origin/main` on that file shows **zero deleted lines**, so those blocks are untouched. fallow classifies it as an inherited finding and the gate excludes it.

## Provenance

Implemented with Claude Code (Opus 5). The guard was selected by measurement, not by inspection: candidate guards were scored against a hand-labelled corpus of "and"-separated shapes (the table above) before one was picked, and each surviving clause was then revert-proofed individually against the new tests. The stale `ratingInputFor` claim in #700 was verified by reading `rank.ts` and `rg`, not taken from the issue text.
