### PR TITLE
feat(jobs,nav): rate the saved job library, and make "back to your resume" a real back

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import { useAnalyzedResume } from "./hooks/useAnalyzedResume.ts";
 import { useResumeLibrary } from "./hooks/useResumeLibrary.ts";
 import { useReplaceResumeOnDrop } from "./hooks/useReplaceResumeOnDrop.ts";
 import { writeJdFitHandoff } from "./lib/jd-fit-handoff.ts";
+import { departToJobs } from "./lib/jobs-departure.ts";
+import { markDeparture } from "./lib/nav-return.ts";
 import { isScoreRevealed } from "./lib/contact.ts";
 import { useFlag } from "./lib/flags.ts";
 
@@ -83,7 +85,21 @@ export default function App() {
         edit: edit.snapshot,
       });
     }
+    // #706: mark the departure so /jd-fit/'s "Parser audit" back control can
+    // use a real history.back() instead of pushing a fresh, blank `/`.
+    markDeparture();
     window.location.href = `${import.meta.env.BASE_URL}jd-fit/`;
+  };
+
+  // The header's "Saved jobs" link (#707) is the second route from `/` into
+  // `/jobs/`, and only this surface knows there is a parse to hand over — so
+  // `PageShell` asks and `/` answers, with exactly what `FindJobsLauncher`'s
+  // button does (`departToJobs`). Without the handoff the library would rate
+  // nothing (#700) and tell a user who had just parsed a résumé to "open this
+  // workbench from your resume". `PageShell` fires this only on an unmodified
+  // primary click, so the marker always accompanies a real navigation.
+  const goToSavedJobs = () => {
+    departToJobs(displayResult?.canonical.fields);
   };
 
   // #313 — an unresolved draft prompt (from-scratch authoring, reload with a
@@ -109,7 +125,7 @@ export default function App() {
     // alone on the header-right instead of sharing it. `/jd-fit` and `/jobs`
     // still pass one: they open straight into a form with no headline of their
     // own, so there the header line is the only orientation.
-    <PageShell badge="alpha">
+    <PageShell badge="alpha" onSavedJobsNavigate={goToSavedJobs}>
       {(state.phase === "idle" ||
         state.phase === "parsing" ||
         state.phase === "error") && (

--- a/src/components/features/FindJobsLauncher.test.tsx
+++ b/src/components/features/FindJobsLauncher.test.tsx
@@ -22,6 +22,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { FindJobsLauncher } from "./FindJobsLauncher.tsx";
 import { readJobsHandoff } from "../../lib/jobs-handoff.ts";
+import { readDepartureMarker } from "../../lib/nav-return.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -79,7 +80,7 @@ describe("FindJobsLauncher", () => {
     expect(el.querySelectorAll("input").length).toBe(0);
   });
 
-  it("stashes the parse before navigating", () => {
+  it("stashes the parse AND marks the departure before navigating", () => {
     const el = render({ parsed });
     act(() => launchButton(el).click());
 
@@ -87,6 +88,11 @@ describe("FindJobsLauncher", () => {
     expect(handoff).not.toBeNull();
     expect(handoff?.parsed.full_name).toBe("Dana Fixture");
     expect(handoff?.parsed.skills).toContain("GraphQL");
+    // #706: without the marker, `/jobs/`'s "Back to your resume" pushes a fresh
+    // `/` and this parse — plus every inline edit — is gone. Nothing else in
+    // the suite watches this wiring, so removing `departToJobs` from `go()`
+    // would otherwise stay green.
+    expect(readDepartureMarker()).toBe(true);
   });
 
   it("still offers the jump when no query could be derived", () => {

--- a/src/components/features/FindJobsLauncher.tsx
+++ b/src/components/features/FindJobsLauncher.tsx
@@ -16,6 +16,12 @@
  * under both the custom-domain "/" base and the "/OfflineCV/" Pages-fallback
  * base (same pattern as `App.tsx`'s /jd-fit cross-link).
  *
+ * The stash + the departure marker (#706, so `/jobs/`'s "Back to your resume"
+ * control knows this trip actually started at `/` and can use a real
+ * `history.back()` instead of pushing a fresh, blank `/`) both come from
+ * `departToJobs` — the same helper the header's parse-independent "Saved jobs"
+ * link (#707) calls, so the two routes off `/` cannot drift apart.
+ *
  * Nothing here fetches, and the navigation is same-origin, so no résumé data
  * leaves the browser at this step.
  */
@@ -24,7 +30,7 @@ import { useMemo } from "react";
 import { Button, Chip } from "@design-system";
 import { buildJobQuery } from "../../lib/job-search/query-builder.ts";
 import { roleFilterForResume, seedExcludeTermsForFamilies } from "../../lib/job-search/role-keywords.ts";
-import { writeJobsHandoff } from "../../lib/jobs-handoff.ts";
+import { departToJobs } from "../../lib/jobs-departure.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import { JobQuerySummary } from "./JobQuerySummary.tsx";
 
@@ -43,7 +49,7 @@ export function FindJobsLauncher({ parsed }: { parsed: HeuristicParsedResume }) 
   const isDegenerate = query.titles.length === 0 && query.skills.length === 0;
 
   const go = () => {
-    writeJobsHandoff({ parsed });
+    departToJobs(parsed);
     window.location.href = `${import.meta.env.BASE_URL}jobs/`;
   };
 

--- a/src/components/features/JobTracker.test.tsx
+++ b/src/components/features/JobTracker.test.tsx
@@ -17,6 +17,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { JobTracker } from "./JobTracker.tsx";
 import type { JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import type { JobRecord } from "../../lib/storage/index.ts";
+import type { JobRating } from "../../lib/job-search/rating.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -119,6 +120,59 @@ describe("JobTracker", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("Not linked to a resume");
     expect(text).not.toContain("deleted-resume");
+  });
+});
+
+describe("JobTracker: fitness ratings (#700)", () => {
+  /** Fitness-only, as every saved-job rating is — the library carries no query,
+   *  so the comp/location/seniority axes are absent. */
+  const RATING: JobRating = {
+    overall: 4.2,
+    fitness: 4.2,
+    compensation: null,
+    location: null,
+    seniority: null,
+  };
+
+  it("shows the shared star widget and reason words for a rated job", () => {
+    const tracker = makeTracker([job({ id: "j1", jdText: "React" })]);
+    act(() =>
+      root.render(
+        <JobTracker tracker={tracker} ratings={new Map([["j1", RATING]])} hasResume />,
+      ),
+    );
+    // `RatingStars` — the shared read-only widget, not a hand-rolled star row.
+    const stars = container.querySelector('[role="img"]');
+    expect(stars?.getAttribute("aria-label")).toBe("Resume fit: 4.2 out of 5 stars");
+    // The same reason band the search cards print, off `describeRating`.
+    expect(container.textContent).toContain("Top fit here");
+    expect(container.textContent).not.toContain("Not rated");
+  });
+
+  it("renders 'not rated' — never zero stars — for a record with no job description", () => {
+    // The library HAS been rated (non-null map); this record simply has no JD to
+    // match against, so it is absent from the map. A 0-star row would read as
+    // "terrible fit", which is a different and false claim.
+    const tracker = makeTracker([job({ id: "j1" })]);
+    act(() =>
+      root.render(<JobTracker tracker={tracker} ratings={new Map()} hasResume />),
+    );
+    expect(container.textContent).toContain("Not rated");
+    expect(container.querySelector('[role="img"]')).toBeNull();
+  });
+
+  it("shows no fitness block, and says why, when no résumé reached this tab", () => {
+    const tracker = makeTracker([job({ id: "j1", jdText: "React" })]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(container.querySelector('[role="img"]')).toBeNull();
+    // "Not rated" would be wrong here: the record has a JD, we have no résumé.
+    expect(container.textContent).not.toContain("Not rated");
+    expect(container.textContent).toContain("Open this workbench from your resume");
+  });
+
+  it("keeps the explanation off an empty library, where it would be noise", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker([])} />));
+    expect(container.textContent).not.toContain("Open this workbench from your resume");
   });
 });
 

--- a/src/components/features/JobTracker.tsx
+++ b/src/components/features/JobTracker.tsx
@@ -9,6 +9,12 @@
  * sync. Row rendering + status transitions live in JobTrackerEntry; storage
  * access is the `useJobTracker` hook. Renders an empty-state prompt until the
  * first job is added.
+ *
+ * Fitness ratings (#700) are computed on VIEW by `useSavedJobRatings` and never
+ * stored on a record — a stored score would go stale the moment the résumé is
+ * edited, with nothing to invalidate it. Rating needs a parsed résumé, which
+ * this surface only has via the `/` handoff, so the library also stands alone
+ * with none: `ratings === null` simply drops the fitness block from every row.
  */
 
 import { useMemo } from "react";
@@ -20,9 +26,21 @@ import type { JobRecord, JobStatus } from "../../lib/storage/index.ts";
 import { jobStatusLabel } from "./JobStatusPicker.tsx";
 import { JobTrackerEntry, type LinkableResume } from "./JobTrackerEntry.tsx";
 import { useJobTracker, type JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
+import { useSavedJobRatings } from "../../hooks/useSavedJobRatings.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+import type { JobRating } from "../../lib/job-search/rating.ts";
 
 interface JobTrackerProps {
   tracker: Tracker;
+  /** Fitness rating per job id, or null when the library has not been rated —
+   *  no résumé in this tab, or the pass is still resolving. A job id ABSENT from
+   *  a non-null map has no saved job description; its row says "not rated"
+   *  rather than showing a zero (see `rate-saved-jobs.ts`). */
+  ratings?: ReadonlyMap<string, JobRating> | null;
+  /** Whether a parsed résumé reached this tab at all — the difference between
+   *  "nothing to rate against" and "rated". Drives the one-line explanation, so
+   *  an unrated library is never silently unexplained. */
+  hasResume?: boolean;
   /** Resolve a linked resume id to its display name; returns undefined when the
    *  resume no longer exists, so the row degrades to "not linked". */
   resumeName?: (resumeId: string) => string | undefined;
@@ -37,12 +55,33 @@ interface JobTrackerProps {
  * surface that imports this module. {@link JobTracker} stays tracker-injected
  * so tests drive it with a fake.
  */
-export function JobTrackerSection(props: Omit<JobTrackerProps, "tracker">) {
+export function JobTrackerSection({
+  parsed,
+  ...props
+}: Omit<JobTrackerProps, "tracker" | "ratings" | "hasResume"> & {
+  /** The résumé saved jobs are rated against — the `/` handoff `JobsApp` holds.
+   *  Must be referentially stable; `useSavedJobRatings` deps on it directly. */
+  parsed?: HeuristicParsedResume;
+}) {
   const tracker = useJobTracker();
-  return <JobTracker tracker={tracker} {...props} />;
+  const ratings = useSavedJobRatings(tracker.jobs, parsed);
+  return (
+    <JobTracker
+      tracker={tracker}
+      ratings={ratings}
+      hasResume={parsed !== undefined}
+      {...props}
+    />
+  );
 }
 
-export function JobTracker({ tracker, resumeName, resumeOptions }: JobTrackerProps) {
+export function JobTracker({
+  tracker,
+  ratings = null,
+  hasResume = false,
+  resumeName,
+  resumeOptions,
+}: JobTrackerProps) {
   const { jobs, ready, persisted, usageBytes, update, setStatus, link, unlink, remove, create, exportBackup } =
     tracker;
 
@@ -104,6 +143,12 @@ export function JobTracker({ tracker, resumeName, resumeOptions }: JobTrackerPro
         {!persisted && EVICTION_NOTICE}
       </p>
 
+      {!hasResume && jobs.length > 0 && (
+        <p className="text-sm text-content-muted">
+          Open this workbench from your resume to see how each saved job fits it.
+        </p>
+      )}
+
       {jobs.length === 0 ? (
         <p className="text-sm text-content-muted">
           No tracked jobs yet. Add a job, or save one from a JD match.
@@ -126,6 +171,8 @@ export function JobTracker({ tracker, resumeName, resumeOptions }: JobTrackerPro
                           : undefined
                       }
                       resumeOptions={resumeOptions}
+                      rated={ratings !== null}
+                      rating={ratings?.get(job.id)}
                       onUpdate={(id, patch) => void update(id, patch)}
                       onStatusChange={(id, next) => void setStatus(id, next)}
                       onLinkResume={(id, resumeId) => void link(id, resumeId)}

--- a/src/components/features/JobTrackerEntry.tsx
+++ b/src/components/features/JobTrackerEntry.tsx
@@ -11,13 +11,21 @@
  * vocabulary. Remove is a two-click inline confirm so a stray click can't drop
  * a tracked application. All state access is the caller's `useJobTracker`
  * handlers — this component is presentational.
+ *
+ * Fitness rating (#700): the row reuses `RatingStars` and `describeRating`
+ * verbatim, so a saved job and a searched one can never disagree about the same
+ * posting. The caller computes it on view and never stores it on the record. A
+ * record with no saved job description renders an explicit "not rated", NOT
+ * zero stars — a 0 reads as "terrible fit" when the truth is that there is
+ * nothing to match against.
  */
 
 import { useState } from "react";
-import { Button, EditableField, StatusBadge } from "@design-system";
+import { Button, EditableField, RatingStars, StatusBadge } from "@design-system";
 import { JobStatusPicker, jobStatusTone, jobStatusLabel } from "./JobStatusPicker.tsx";
 import type { JobRecord, JobStatus } from "../../lib/storage/index.ts";
 import type { JobPatch } from "../../lib/job-tracker.ts";
+import { describeRating, type JobRating } from "../../lib/job-search/rating.ts";
 
 /** A saved resume the user can link this job to — the light shape the picker
  *  renders, structurally satisfied by `ResumeLibraryEntry`. */
@@ -34,6 +42,12 @@ interface JobTrackerEntryProps {
   /** Saved resumes offered by the link picker. Empty (or omitted) hides it —
    *  a user with no saved resumes has nothing to link. */
   resumeOptions?: readonly LinkableResume[];
+  /** True once the library has been rated. False (the default) = nothing to rate
+   *  against yet, so the row shows no fitness block rather than a placeholder. */
+  rated?: boolean;
+  /** This row's rating. Undefined WHILE `rated` means the record carries no job
+   *  description → "Not rated", which is not the same state as 0 stars. */
+  rating?: JobRating;
   onUpdate: (id: string, patch: JobPatch) => void;
   onStatusChange: (id: string, status: JobStatus) => void;
   onLinkResume: (id: string, resumeId: string) => void;
@@ -53,6 +67,8 @@ export function JobTrackerEntry({
   job,
   linkedResumeName,
   resumeOptions = [],
+  rated = false,
+  rating,
   onUpdate,
   onStatusChange,
   onLinkResume,
@@ -79,9 +95,31 @@ export function JobTrackerEntry({
             onCommit={(v) => onUpdate(job.id, { company: v })}
           />
         </div>
-        <StatusBadge tone={jobStatusTone(job.status)}>
-          {jobStatusLabel(job.status)}
-        </StatusBadge>
+        <div className="flex flex-col items-end gap-1">
+          <StatusBadge tone={jobStatusTone(job.status)}>
+            {jobStatusLabel(job.status)}
+          </StatusBadge>
+          {rated && !rating && (
+            <span className="text-xs text-content-muted">
+              Not rated · no job description saved
+            </span>
+          )}
+          {rated && rating && (
+            <>
+              {/* No comp floor: the library carries no query, so `describeRating`
+                  yields the fitness phrase alone (see `rate-saved-jobs.ts`). */}
+              <RatingStars
+                value={rating.overall}
+                size="sm"
+                showValue
+                ariaLabel={`Resume fit: ${Math.round(rating.overall * 10) / 10} out of 5 stars`}
+              />
+              <span className="text-xs text-content-tertiary">
+                {describeRating(rating, { hasCompFloor: false }).join(" · ")}
+              </span>
+            </>
+          )}
+        </div>
       </div>
 
       <JobStatusPicker

--- a/src/components/features/PageShell.test.tsx
+++ b/src/components/features/PageShell.test.tsx
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The "Saved jobs" header link (#707) and what it is allowed to do on the way
+ * out (#706).
+ *
+ * `PageShell` is chrome shared by all three surfaces, so it cannot know which
+ * one it is rendering on — and the departure marker means "this trip started at
+ * the app root". When the shell marked the departure itself, `/jd-fit/` got a
+ * link that wrote a root marker it had no right to write, which sent `/jobs/`'s
+ * "Back to your resume" control to `/jd-fit/` and consumed the marker `/` had
+ * written, re-arming the lost-parse bug #706 exists to fix. The shell now asks
+ * (`onSavedJobsNavigate`) and the surface answers, so these tests pin BOTH
+ * directions: the surface that passes nothing writes nothing, and the surface
+ * that passes the real `/` callback writes the handoff `/jobs/` needs.
+ *
+ * The modified-click case is the second half of the same invariant: a
+ * ⌘/ctrl/shift/alt-click on an `<a>` fires an ordinary `click` (unlike
+ * middle-click's `auxclick`) while the browser opens a NEW tab and this
+ * document stays put, so a callback that ran there would leave a marker
+ * attached to no navigation at all.
+ *
+ * jsdom implements no navigation, so following the link logs a "Not
+ * implemented: navigation" notice from the virtual console. Expected noise; the
+ * assertions are on sessionStorage.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createElement, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { PageShell, type PageShellProps } from "./PageShell.tsx";
+import { departToJobs } from "../../lib/jobs-departure.ts";
+import { readJobsHandoff } from "../../lib/jobs-handoff.ts";
+import { readDepartureMarker } from "../../lib/nav-return.ts";
+import { savedJobsHref } from "../../lib/jobs-landing.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  skills: ["React"],
+  experience: [],
+  education: [],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(props: Partial<PageShellProps> = {}) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(PageShell, { badge: "alpha", children: null, ...props }),
+    );
+  });
+  return container;
+}
+
+function savedJobsLink(el: HTMLElement): HTMLAnchorElement | undefined {
+  return [...el.querySelectorAll("a")].find(
+    (a) => a.textContent === "Saved jobs",
+  );
+}
+
+function click(
+  link: HTMLAnchorElement,
+  init: MouseEventInit = {},
+): MouseEvent {
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...init,
+  });
+  act(() => {
+    link.dispatchEvent(event);
+  });
+  return event;
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  // useGitHubStars / useUpdateChecker both fetch on mount and both swallow a
+  // failure — stubbed so this suite never touches the network.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.reject(new Error("no network in tests"))),
+  );
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("PageShell — the Saved jobs link", () => {
+  it("points at /jobs/ landing on the library tab", () => {
+    const link = savedJobsLink(render());
+    expect(link?.getAttribute("href")).toBe(savedJobsHref());
+  });
+
+  it("is suppressed on /jobs/ itself", () => {
+    expect(savedJobsLink(render({ hideSavedJobsLink: true }))).toBeUndefined();
+  });
+
+  it("writes NO departure marker when the surface supplies no callback", () => {
+    // This is the /jd-fit/ case, and the whole reason the shell no longer marks
+    // departures itself. A marker from here would make /jobs/'s "Back to your
+    // resume" control land on /jd-fit/ — and swallow the marker `/` wrote.
+    const link = savedJobsLink(render());
+    click(link!);
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+    expect(readDepartureMarker()).toBe(false);
+  });
+
+  it("hands the parse over when `/` supplies its callback", () => {
+    // Exactly what App.tsx passes: without the handoff the library rates
+    // nothing (#700) and tells a user who just parsed a résumé to open the
+    // workbench from their résumé.
+    const link = savedJobsLink(
+      render({ onSavedJobsNavigate: () => departToJobs(parsed) }),
+    );
+    click(link!);
+    expect(readJobsHandoff()?.parsed.full_name).toBe("Dana Fixture");
+    expect(readDepartureMarker()).toBe(true);
+  });
+
+  it.each([
+    ["metaKey", { metaKey: true }],
+    ["ctrlKey", { ctrlKey: true }],
+    ["shiftKey", { shiftKey: true }],
+    ["altKey", { altKey: true }],
+    ["a non-primary button", { button: 1 }],
+  ])("does not run the callback on a %s click", (_label, init) => {
+    const onSavedJobsNavigate = vi.fn();
+    const link = savedJobsLink(render({ onSavedJobsNavigate }));
+    const event = click(link!, init);
+    // The browser handled this one somewhere else (new tab / window /
+    // download); this document did not move, so nothing may be recorded as if
+    // it had.
+    expect(onSavedJobsNavigate).not.toHaveBeenCalled();
+    // …and the link must still be followable — never preventDefault.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("runs the callback on a plain primary click, without preventing it", () => {
+    const onSavedJobsNavigate = vi.fn();
+    const link = savedJobsLink(render({ onSavedJobsNavigate }));
+    const event = click(link!);
+    expect(onSavedJobsNavigate).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -2,23 +2,40 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * PageShell — the chrome both root surfaces share (issue #226).
+ * PageShell — the chrome all three root surfaces share (issue #226, #707).
  *
- * `/` (parser audit, App.tsx) and `/jd-fit` (JdFitApp.tsx) are two products
- * under one brand, so the header (logo + GitHub-star CTA + update banner) and
- * the footer (privacy line + links) are identical between them. This shell owns
- * that chrome once; each surface passes its own `subtitle`, `badge`, optional
- * `chips`, and an optional `headerExtra` slot (e.g. the cross-link CTA), then
- * renders its body as `children`.
+ * `/` (parser audit, App.tsx), `/jd-fit` (JdFitApp.tsx), and `/jobs`
+ * (JobsApp.tsx) are three products under one brand, so the header (logo +
+ * "Saved jobs" link + GitHub-star CTA + update banner) and the footer
+ * (privacy line + links) are identical between them. This shell owns that
+ * chrome once; each surface passes its own `subtitle`, `badge`, optional
+ * `chips`, and an optional `headerExtra` slot (e.g. a "back" cross-link CTA),
+ * then renders its body as `children`.
+ *
+ * The "Saved jobs" link (#707) is the one entry point into `/jobs/` that
+ * doesn't depend on a parse — `FindJobsLauncher` only renders once a résumé
+ * is parsed. It's a plain `<a href>`, not a `Button`, matching the wordmark
+ * link and the footer links above/below it: this is real navigation (right-
+ * click / open-in-new-tab should work), not an imperative action. `JobsApp`
+ * passes `hideSavedJobsLink`: a link to `/jobs/` rendered on `/jobs/` itself
+ * would point at the page already open.
+ *
+ * What the link must do BEFORE it navigates differs per surface — `/` has a
+ * parse to hand over and a departure to mark (#706), `/jd-fit/` has neither —
+ * and this shell cannot know which surface it is rendering on. So it owns none
+ * of that: it invokes an optional `onSavedJobsNavigate` and the surface decides.
+ * Calling `markDeparture()` from here instead was a real bug — the marker means
+ * "this trip started at the app root", and shared chrome renders everywhere.
  *
  * Reuse: consumes only `@design-system` primitives/shared components + the
  * useGitHubStars / useUpdateChecker hooks. No raw <button> / hardcoded palette.
  */
 
-import { useState, type ReactNode } from "react";
+import { useState, type MouseEvent, type ReactNode } from "react";
 import { UpdateBanner, GitHubStarCta } from "@design-system";
 import { useGitHubStars } from "../../hooks/useGitHubStars.ts";
 import { useUpdateChecker } from "../../hooks/useUpdateChecker.ts";
+import { savedJobsHref } from "../../lib/jobs-landing.ts";
 
 export interface PageShellProps {
   /**
@@ -38,6 +55,19 @@ export interface PageShellProps {
   chips?: ReactNode;
   /** Optional header-right slot rendered before the GitHub CTA. */
   headerExtra?: ReactNode;
+  /**
+   * Suppress the "Saved jobs" link (#707). Only `JobsApp` sets this — a link
+   * to `/jobs/` on `/jobs/` itself would point at the page already open.
+   */
+  hideSavedJobsLink?: boolean;
+  /**
+   * Ran just before the browser follows the "Saved jobs" link, for whatever
+   * this surface must do on its way out (`/` writes the jobs handoff and marks
+   * the departure — see `jobs-departure.ts`; `/jd-fit/` passes nothing). Fires
+   * only on an unmodified primary click, i.e. only when THIS document is the
+   * one navigating.
+   */
+  onSavedJobsNavigate?: () => void;
   children: ReactNode;
 }
 
@@ -46,6 +76,8 @@ export function PageShell({
   badge,
   chips,
   headerExtra,
+  hideSavedJobsLink,
+  onSavedJobsNavigate,
   children,
 }: PageShellProps) {
   const { count: starCount } = useGitHubStars();
@@ -81,6 +113,34 @@ export function PageShell({
             </span>
           </div>
           <div className="flex items-center gap-4">
+            {!hideSavedJobsLink && (
+              <a
+                href={savedJobsHref()}
+                onClick={(e: MouseEvent<HTMLAnchorElement>) => {
+                  // A ⌘/ctrl/shift/alt-click, or a non-primary button, opens
+                  // the link somewhere else (new tab, new window, download)
+                  // and leaves THIS document exactly where it is — but it
+                  // still dispatches an ordinary `click`, unlike middle-click's
+                  // `auxclick`. Running the callback then would decouple its
+                  // side effects (a departure marker, a handoff write) from any
+                  // navigation at all. Never `preventDefault` — the browser
+                  // must still follow the link in every case.
+                  if (
+                    e.button !== 0 ||
+                    e.metaKey ||
+                    e.ctrlKey ||
+                    e.shiftKey ||
+                    e.altKey
+                  ) {
+                    return;
+                  }
+                  onSavedJobsNavigate?.();
+                }}
+                className="text-sm text-content-secondary transition-colors hover:text-content-primary"
+              >
+                Saved jobs
+              </a>
+            )}
             {headerExtra}
             {subtitle && (
               <p className="hidden text-sm text-content-muted sm:block">

--- a/src/hooks/useArrivedFromRoot.test.tsx
+++ b/src/hooks/useArrivedFromRoot.test.tsx
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `useArrivedFromRoot` — the marker's lifetime is ONE visit, not one click.
+ *
+ * The defect (#706 follow-up): the marker records only WHERE a trip started,
+ * so consuming it at click time lets `/`'s marker outlive the `/` → `/jd-fit/`
+ * leg it was written for and answer whichever back control the user reaches
+ * next. These tests pin both halves of the fix at the hook boundary —
+ * consumption happens at MOUNT even when no control is ever clicked, and the
+ * answer is captured for the visit — and the StrictMode assertion is the one
+ * that would go red if the read and the clear were ever folded back into a
+ * single lazy initializer.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createElement, StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useArrivedFromRoot } from "./useArrivedFromRoot.ts";
+import { markDeparture } from "../lib/nav-return.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** Mount a probe that renders the hook's answer, optionally under StrictMode. */
+function mount(strict = false): () => string | null {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const Probe = () => String(useArrivedFromRoot());
+  act(() => {
+    root.render(
+      strict
+        ? createElement(StrictMode, null, createElement(Probe))
+        : createElement(Probe),
+    );
+  });
+  return () => container.textContent;
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+});
+
+describe("useArrivedFromRoot", () => {
+  it("reports the root marker and retires it at mount, with no click involved", () => {
+    markDeparture();
+    const answer = mount();
+    expect(answer()).toBe("true");
+    // The half that fixes the two-hop bug: the next surface must find nothing.
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+  });
+
+  it("reports false for a visit that was never marked", () => {
+    expect(mount()()).toBe("false");
+  });
+
+  it("retires a NON-root marker too, without claiming it", () => {
+    markDeparture({ pathname: "/jd-fit/" });
+    const answer = mount();
+    expect(answer()).toBe("false");
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+  });
+
+  it("still answers true under StrictMode's double-invoked render", () => {
+    // React double-invokes a component's render on mount in dev and keeps the
+    // SECOND pass's hook state. A lazy initializer that cleared storage would
+    // answer `true` then `false`, and the `false` would win — the feature would
+    // be dead under `npm run dev` while every non-Strict test stayed green.
+    // Splitting the pure read (initializer) from the idempotent clear (effect)
+    // is what makes both passes agree.
+    markDeparture();
+    const answer = mount(true);
+    expect(answer()).toBe("true");
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+  });
+});

--- a/src/hooks/useArrivedFromRoot.ts
+++ b/src/hooks/useArrivedFromRoot.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useArrivedFromRoot — bind the `/`-departure marker's lifetime to ONE visit.
+ *
+ * `nav-return.ts` writes a marker on the way out of `/`; a back control on
+ * `/jobs/` or `/jd-fit/` needs to know whether this document's arrival is the
+ * far end of that trip. The marker records only WHERE the trip started, never
+ * where it was headed, so the surface that ANSWERS must also be the surface
+ * that retires it: consumed at click time instead, `/`'s marker survives the
+ * whole `/jd-fit/` session and answers the next back control the user happens
+ * to reach — `/jobs/`'s, whose "Back to your resume" then lands on `/jd-fit/`
+ * and swallows the marker `/jd-fit/`'s own control needed.
+ *
+ * So each non-root surface calls this once, at mount: the answer is captured
+ * for the visit and the marker is gone, whether or not the back control is
+ * ever clicked. A later hop finds nothing and correctly falls back to a fresh
+ * `/`, which is the safe failure mode (a lost parse, never a foreign page).
+ *
+ * StrictMode: the read is in a lazy `useState` initializer and the clear is in
+ * a mount effect, deliberately not folded together. React double-invokes a
+ * component's render on mount in dev and KEEPS the second pass's hook state, so
+ * a clearing initializer would answer `true` then `false` and the `false` would
+ * win — the feature would be dead under `npm run dev`. `readDepartureMarker`
+ * is pure, so both passes agree; `clearDepartureMarker` is idempotent, so
+ * StrictMode's setup→cleanup→setup effect replay is a no-op. No ref guard is
+ * needed here (unlike `useJdFitResume`, whose consume is destructive and whose
+ * payload cannot be re-read).
+ */
+
+import { useEffect, useState } from "react";
+import {
+  readDepartureMarker,
+  clearDepartureMarker,
+} from "../lib/nav-return.ts";
+
+export function useArrivedFromRoot(): boolean {
+  const [arrivedFromRoot] = useState(() => readDepartureMarker());
+  useEffect(() => {
+    clearDepartureMarker();
+  }, []);
+  return arrivedFromRoot;
+}

--- a/src/hooks/useSavedJobRatings.chunk-failure.test.tsx
+++ b/src/hooks/useSavedJobRatings.chunk-failure.test.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * What `useSavedJobRatings` does when its dynamic import FAILS — a real case,
+ * not a hypothetical: a tab left open across a deploy asks for a chunk hash
+ * that no longer exists.
+ *
+ * Its own file because the failure has to be injected by mocking the imported
+ * module, which is file-scoped: the sibling `useSavedJobRatings.test.tsx` needs
+ * the real one.
+ *
+ * The losing behaviour is silent, which is why it needs a test at all. The hook
+ * keeps returning null, and because a résumé IS present the tracker suppresses
+ * the line that would explain why no ratings are shown — so the library renders
+ * an unexplained blank forever while the only trace, an unhandled promise
+ * rejection, goes nowhere.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useSavedJobRatings } from "./useSavedJobRatings.ts";
+import type { JobRating } from "../lib/job-search/rating.ts";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+
+vi.mock("../lib/job-search/rate-saved-jobs.ts", () => {
+  throw new Error("Failed to fetch dynamically imported module (simulated)");
+});
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React"],
+  experience: [],
+  education: [],
+};
+
+let container: HTMLElement;
+let root: Root;
+let latest: ReadonlyMap<string, JobRating> | null = null;
+
+function Probe() {
+  latest = useSavedJobRatings([{ id: "j1", title: "SWE", jdText: "React" }], parsed);
+  return null;
+}
+
+beforeEach(() => {
+  latest = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useSavedJobRatings when the rating chunk fails to load", () => {
+  it("reports the failure and stays null instead of rejecting unhandled", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    // Let the rejected import settle.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Null, not an empty map — "we could not rate" must never be readable as
+    // "rated, and none of them matched".
+    expect(latest).toBeNull();
+    // Unhandled, this rejection is invisible to everyone: the console line is
+    // the only evidence a user's blank library has a cause.
+    expect(logged).toHaveBeenCalled();
+    expect(String(logged.mock.calls[0][0])).toContain("useSavedJobRatings");
+  });
+});

--- a/src/hooks/useSavedJobRatings.test.tsx
+++ b/src/hooks/useSavedJobRatings.test.tsx
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `useSavedJobRatings` (#700). The rating MATH is covered in
+ * `rate-saved-jobs.test.ts`; what only this layer can get wrong is the wiring —
+ * the three states it reports (nothing to rate / not settled / settled), and the
+ * effect key, which decides when the library is re-rated. That key is the piece
+ * `exhaustive-deps` cannot check for us (no `react-hooks` plugin — CLAUDE.md),
+ * so it is pinned here in both directions: an edit to a field the rating does
+ * not read must NOT re-rate, and an edit to one it does read MUST.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useSavedJobRatings } from "./useSavedJobRatings.ts";
+import type { JobRating } from "../lib/job-search/rating.ts";
+import type { RatableSavedJob } from "../lib/job-search/rate-saved-jobs.ts";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [
+    { title: "Frontend Engineer", company: "Acme", description: "Built React apps" },
+  ],
+  education: [],
+};
+
+const JD = "We need a React and TypeScript engineer for our frontend web application.";
+
+let container: HTMLElement;
+let root: Root;
+let latest: ReadonlyMap<string, JobRating> | null = null;
+
+function Probe({
+  jobs,
+  resume,
+}: {
+  jobs: readonly RatableSavedJob[];
+  resume?: HeuristicParsedResume;
+}) {
+  latest = useSavedJobRatings(jobs, resume);
+  return null;
+}
+
+/**
+ * Render, then settle the hook's dynamic import and the state update it feeds.
+ *
+ * Waits on the CONDITION, not a tick count: the first `import()` of
+ * `rate-saved-jobs.ts` is a cold module load and the later ones resolve warm, so
+ * any fixed number of turns would be tuned to whichever it saw first. The bound
+ * is only a runaway guard.
+ */
+async function renderProbe(jobs: readonly RatableSavedJob[], resume?: HeuristicParsedResume) {
+  await act(async () => {
+    root.render(<Probe jobs={jobs} resume={resume} />);
+  });
+  for (let turn = 0; turn < 100 && latest === null; turn++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    // With no résumé nothing will ever resolve — one turn is enough to show the
+    // hook stays null rather than settling into an empty map.
+    if (resume === undefined) break;
+  }
+}
+
+beforeAll(async () => {
+  // Warm the module the hook dynamic-imports. Cold, it pulls the whole rating
+  // graph (rank + coverage + the skill dictionary), and under a loaded runner
+  // that transform can outlast any settle budget below — the wait would then be
+  // measuring the module loader, not the hook. Warmed here, it waits on React.
+  await import("../lib/job-search/rate-saved-jobs.ts");
+});
+
+beforeEach(() => {
+  latest = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useSavedJobRatings", () => {
+  it("reports null when no résumé reached this tab", async () => {
+    await renderProbe([{ id: "j1", title: "SWE", jdText: JD }], undefined);
+    // Null, not an empty map: "we cannot rate" must not be readable as "rated,
+    // and none of them scored".
+    expect(latest).toBeNull();
+  });
+
+  it("resolves to a map covering only the records with a job description", async () => {
+    await renderProbe(
+      [
+        { id: "with", title: "SWE", jdText: JD },
+        { id: "without", title: "SWE" },
+      ],
+      parsed,
+    );
+    expect(latest).not.toBeNull();
+    expect(latest!.has("with")).toBe(true);
+    expect(latest!.has("without")).toBe(false);
+  });
+
+  it("does not re-rate when a field the rating never reads changes", async () => {
+    // `useJobTracker` hands back a FRESH array after every mutation, so keying
+    // the effect on array identity would re-rate the whole library on a notes
+    // edit or a status change. Same id/title/jdText ⇒ same result object.
+    await renderProbe([{ id: "j1", title: "SWE", jdText: JD }], parsed);
+    const first = latest;
+    expect(first).not.toBeNull();
+
+    await renderProbe([{ id: "j1", title: "SWE", jdText: JD }], parsed);
+    expect(latest).toBe(first);
+  });
+
+  it("re-rates when the job description changes", async () => {
+    await renderProbe([{ id: "j1", title: "SWE", jdText: JD }], parsed);
+    const before = latest!.get("j1")!.fitness;
+
+    await renderProbe(
+      [{ id: "j1", title: "SWE", jdText: "We need Rust and Kubernetes and Terraform." }],
+      parsed,
+    );
+    // A stale closure over the old `jobs` would leave this unchanged.
+    expect(latest!.get("j1")!.fitness).not.toBeCloseTo(before, 10);
+  });
+
+  it("re-rates when a record joins the library, because the scale is set-relative", async () => {
+    await renderProbe([{ id: "j1", title: "SWE", jdText: JD }], parsed);
+    const alone = latest!.get("j1")!.fitness;
+
+    await renderProbe(
+      [
+        { id: "j1", title: "SWE", jdText: JD },
+        { id: "j2", title: "SWE", jdText: "Rust, Kubernetes and Terraform, plus React." },
+      ],
+      parsed,
+    );
+    expect(latest!.size).toBe(2);
+    expect(latest!.get("j1")!.fitness).not.toBeCloseTo(alone, 10);
+  });
+});

--- a/src/hooks/useSavedJobRatings.ts
+++ b/src/hooks/useSavedJobRatings.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useSavedJobRatings — the saved job library's fitness ratings, recomputed on
+ * view (#700).
+ *
+ * Two constraints shape this hook, and neither is visible in the call site:
+ *
+ * **It must not drag the rating chain into the `/jobs/` entry chunk.** The
+ * tracker renders eagerly on `/jobs/`, and `refine.ts` deliberately holds
+ * `rank.ts` behind `await import("./rank.ts")` so a search pays for that graph
+ * and a page load does not. A static import here would undo it for every
+ * visitor who never opens the library. Measured, not assumed: `skills.ts` is
+ * ALREADY eager on this entry (`FindJobsPanel` → `query-builder.ts` imports
+ * `getSkillIndex`), so what the dynamic import actually keeps out is `rank.ts`,
+ * `coverage.ts` and `extract-jd-terms.ts` (~20 KB) — real, but not the whole
+ * dictionary. So `rate-saved-jobs.ts` is dynamic-imported, every other import in
+ * this file is `import type`, and the result is state rather than a `useMemo`.
+ *
+ * **Nothing is cached against a record.** The rating is a function of the
+ * résumé, so any value written to a `JobRecord` would go stale the moment the
+ * user edits their résumé on `/` with nothing to invalidate it. Recomputing is
+ * cheap, so the ratings live here for the life of the mount and nowhere else.
+ *
+ * Returns `null` while there is no rating to show — no résumé in this tab, or a
+ * pass in flight for the current inputs — so the caller renders no fitness block
+ * rather than a stale or zeroed one. A returned map is complete for the current
+ * inputs; a job id ABSENT from it carries no job description and must render as
+ * "not rated", never as zero stars.
+ *
+ * `parsed` must be referentially stable across renders — `JobsApp` holds it in
+ * `useState`, which is the contract. It is a direct effect dependency (a new
+ * résumé must re-rate), so a caller that rebuilt the object every render would
+ * re-fire the effect every render.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { JobRating } from "../lib/job-search/rating.ts";
+import type { RatableSavedJob } from "../lib/job-search/rate-saved-jobs.ts";
+
+/** Field separator / record separator for the input signature. Control
+ *  characters, so no title or JD body can forge a boundary. */
+const FIELD_SEP = "\u001f";
+const RECORD_SEP = "\u001e";
+
+export function useSavedJobRatings(
+  jobs: readonly RatableSavedJob[],
+  parsed: HeuristicParsedResume | undefined,
+): ReadonlyMap<string, JobRating> | null {
+  // Every field `rateSavedJobs` reads, in order. `useJobTracker` hands back a
+  // fresh array after EVERY mutation, so keying the effect on `jobs` identity
+  // would re-rate the whole library on a notes keystroke commit or a status
+  // change. Keying on the content that actually feeds a rating means an edit to
+  // any other field is free — and, because the signature covers every field
+  // read, the `jobs` array closed over below can never be stale in a way that
+  // changes the result.
+  const signature = useMemo(
+    () =>
+      jobs
+        .map((job) => `${job.id}${FIELD_SEP}${job.title}${FIELD_SEP}${job.jdText ?? ""}`)
+        .join(RECORD_SEP),
+    [jobs],
+  );
+
+  const [computed, setComputed] = useState<{
+    signature: string;
+    parsed: HeuristicParsedResume;
+    byId: ReadonlyMap<string, JobRating>;
+  } | null>(null);
+
+  useEffect(() => {
+    if (parsed === undefined) return;
+    let cancelled = false;
+    void import("../lib/job-search/rate-saved-jobs.ts")
+      .then(({ rateSavedJobs }) => {
+        // A superseded pass (or an unmount) must not overwrite a newer result:
+        // the import resolves out of band, so ordering is not guaranteed.
+        if (cancelled) return;
+        setComputed({ signature, parsed, byId: rateSavedJobs(jobs, parsed) });
+      })
+      .catch((err: unknown) => {
+        // The chunk can fail to load for real — a stale index after a deploy is
+        // the common one. Without this the rejection is unhandled AND invisible:
+        // `computed` stays null, and because `parsed` is defined the tracker
+        // also suppresses the line explaining why no ratings are shown, so the
+        // library silently renders nothing forever. Leaving `computed` null is
+        // the right end state (no rating is better than a wrong one); the point
+        // is that the reason reaches the console.
+        console.error("[useSavedJobRatings] rating pass failed:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Deps hand-audited (`exhaustive-deps` is not enforced here — CLAUDE.md):
+    // `signature` and `parsed` are the complete set of inputs the result depends
+    // on. `jobs` is read but deliberately omitted — see the signature comment;
+    // adding it would re-fire on every unrelated tracker mutation. `setComputed`
+    // is stable.
+  }, [signature, parsed]);
+
+  if (parsed === undefined) return null;
+  // Only surface a result computed from exactly the inputs we hold now. During
+  // a recompute the previous map describes a different library, so it is
+  // withheld rather than shown against the wrong rows.
+  return computed !== null && computed.signature === signature && computed.parsed === parsed
+    ? computed.byId
+    : null;
+}

--- a/src/jd-fit/JdFitApp.tsx
+++ b/src/jd-fit/JdFitApp.tsx
@@ -26,9 +26,16 @@ import { useAnalyzedResume } from "../hooks/useAnalyzedResume.ts";
 import { useJdFitResume } from "./useJdFitResume.ts";
 import { extractJdTerms, computeCoverage, type JdMatchResult } from "../lib/jd-match";
 import { buildJdRewriteContext } from "../lib/jd-match/rewrite-context.ts";
+import { returnToResumeRoot } from "../lib/nav-return.ts";
+import { useArrivedFromRoot } from "../hooks/useArrivedFromRoot.ts";
 
 export default function JdFitApp() {
   const [jdText, setJdText] = useState("");
+  // #706: answered ONCE, at mount. Consuming the marker here — even though this
+  // surface's back control may never be clicked — is what stops `/`'s marker
+  // from following the user on to `/jobs/` via the header link and answering
+  // THAT surface's back control. See `useArrivedFromRoot`.
+  const arrivedFromRoot = useArrivedFromRoot();
   const analyzed = useAnalyzedResume();
   // Resolve the résumé source: a one-shot handoff from `/` (rehydrated parsed
   // JSON) takes precedence; otherwise this surface's own DropZone parse. Both
@@ -67,13 +74,21 @@ export default function JdFitApp() {
     <PageShell
       subtitle="Tailor your resume to a job description"
       badge="JD Fit"
+      // No `onSavedJobsNavigate`: this surface is not the app root, so it has
+      // no jobs handoff to write and must NOT mark a departure — a marker from
+      // here would travel with the user to `/jobs/` and send its "Back to your
+      // resume" control to `/jd-fit/`, a real page but not the one the label
+      // names. (The marker `/` wrote for the leg INTO this page is already
+      // gone: `useArrivedFromRoot` retired it at mount.) See `nav-return.ts`.
       headerExtra={
+        // #706: a real back navigation when this tab arrived from `/` (a
+        // trip `App.tsx`'s `goToJdFit` marks via `markDeparture`), so the
+        // in-progress parse there survives via bfcache. Falls back to a
+        // fresh `/` for a deep link, a new tab, or a reload of /jd-fit/.
         <Button
           variant="link"
           size="sm"
-          onClick={() => {
-            window.location.href = import.meta.env.BASE_URL;
-          }}
+          onClick={() => returnToResumeRoot(arrivedFromRoot)}
         >
           ← Parser audit
         </Button>

--- a/src/jobs/JobsApp.test.tsx
+++ b/src/jobs/JobsApp.test.tsx
@@ -47,6 +47,7 @@ beforeEach(async () => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  window.history.pushState({}, "", "/");
 });
 
 function clickTab(label: string) {
@@ -56,6 +57,20 @@ function clickTab(label: string) {
   act(() => {
     tab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
+}
+
+/** Drain `useJobTracker`'s and `useResumeLibrary`'s initial fake-indexeddb
+ *  reads — both resolve over several macrotask ticks (open → upgrade →
+ *  transaction), not one, so a single flush is flaky. Same shape as
+ *  `useSavedJobRatings.test.tsx`'s polling loop, just unconditional: nothing
+ *  here depends on a specific value settling, only on the requests draining
+ *  before the test ends and the next test's `beforeEach` tears the db down. */
+async function flushIndexedDb(turns = 10) {
+  for (let i = 0; i < turns; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
 }
 
 describe("JobsApp: Search / Saved jobs tabs", () => {
@@ -104,5 +119,39 @@ describe("JobsApp: Search / Saved jobs tabs", () => {
     // The library's data survives the round trip — it was never unmounted,
     // so there is nothing to re-fetch.
     expect(libraryPanel?.textContent).toContain("Staff Frontend Engineer");
+  });
+});
+
+describe("JobsApp: landing tab from the URL (#707)", () => {
+  it("lands on Search for a plain /jobs/ visit — the losing case for the new param", async () => {
+    // No pushState here: default jsdom URL carries no `tab` param, matching a
+    // bookmark or a link minted before #707 existed.
+    await act(async () => {
+      root.render(<JobsApp />);
+    });
+    await flushIndexedDb();
+
+    expect(
+      container.querySelector<HTMLElement>("#jobs-panel-search")?.hidden,
+    ).toBe(false);
+    expect(
+      container.querySelector<HTMLElement>("#jobs-panel-library")?.hidden,
+    ).toBe(true);
+  });
+
+  it("lands on Saved jobs when arriving via ?tab=library", async () => {
+    window.history.pushState({}, "", "/jobs/?tab=library");
+
+    await act(async () => {
+      root.render(<JobsApp />);
+    });
+    await flushIndexedDb();
+
+    expect(
+      container.querySelector<HTMLElement>("#jobs-panel-search")?.hidden,
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLElement>("#jobs-panel-library")?.hidden,
+    ).toBe(false);
   });
 });

--- a/src/jobs/JobsApp.tsx
+++ b/src/jobs/JobsApp.tsx
@@ -38,11 +38,15 @@ import { PageShell } from "../components/features/PageShell.tsx";
 import { FindJobsPanel } from "../components/features/FindJobsPanel.tsx";
 import { JobTrackerSection } from "../components/features/JobTracker.tsx";
 import { readJobsHandoff } from "../lib/jobs-handoff.ts";
+import { returnToResumeRoot } from "../lib/nav-return.ts";
+import { resolveInitialJobsTab, type JobsTabId } from "../lib/jobs-landing.ts";
+import { useArrivedFromRoot } from "../hooks/useArrivedFromRoot.ts";
 import { useResumeLibrary } from "../hooks/useResumeLibrary.ts";
 
-type JobsTabId = "search" | "library";
-
-function backToResume() {
+// #706: goes to `/` directly, never via history.back() — the empty state only
+// shows when there is no in-progress parse to preserve, so this is a forward
+// action (like the DropZone CTA it replaces), not an undo of the trip here.
+function goToResume() {
   window.location.href = import.meta.env.BASE_URL;
 }
 
@@ -51,7 +55,19 @@ export default function JobsApp() {
   // the read is non-destructive, so there is no StrictMode double-invoke hazard
   // of the kind `useJdFitResume` needs a ref for.
   const [handoff] = useState(() => readJobsHandoff());
-  const [tab, setTab] = useState<JobsTabId>("search");
+  // #707: `PageShell`'s "Saved jobs" link arrives with `?tab=library` so this
+  // surface lands there directly instead of the Search tab a plain `/jobs/`
+  // visit defaults to. Lazy initializer (not an effect) — same read-once-on-
+  // mount shape as the handoff above; `window.location.search` is inert at
+  // mount and never needs to be re-read.
+  const [tab, setTab] = useState<JobsTabId>(() =>
+    resolveInitialJobsTab(window.location.search),
+  );
+
+  // #706: answered ONCE, at mount, not per click — the marker belongs to the
+  // leg that landed here, and a marker still live at click time is one that
+  // was written for some earlier hop. See `useArrivedFromRoot`.
+  const arrivedFromRoot = useArrivedFromRoot();
 
   // The library the resume-link picker offers on tracked-job rows. Independent
   // of the handoff — a saved resume can exist here even when this tab has no
@@ -64,8 +80,24 @@ export default function JobsApp() {
     <PageShell
       subtitle="Find jobs that fit your resume"
       badge="Jobs"
+      // #707: PageShell's "Saved jobs" link exists to get a user here from one
+      // of the other two surfaces — rendered on `/jobs/` itself it would point
+      // at the page already open, which is confusing rather than useful.
+      hideSavedJobsLink
       headerExtra={
-        <Button variant="link" size="sm" onClick={backToResume}>
+        // #706: a real back navigation when this tab arrived from `/` (either
+        // route off it marks the departure — see `jobs-departure.ts`), so the
+        // in-progress parse and its inline edits there survive via bfcache.
+        // Falls back to a fresh `/` for a deep link, a new tab, a reload of
+        // /jobs/, or an arrival from `/jd-fit/` — whose "Saved jobs" link marks
+        // nothing, and whose own mount already absorbed any marker `/` wrote
+        // for the earlier leg, so this control never lands on a page the label
+        // doesn't name.
+        <Button
+          variant="link"
+          size="sm"
+          onClick={() => returnToResumeRoot(arrivedFromRoot)}
+        >
           <span aria-hidden="true">‹</span> Back to your resume
         </Button>
       }
@@ -90,7 +122,7 @@ export default function JobsApp() {
                   your PDF there, then open the job workbench from the Find
                   jobs tab.
                 </ErrorState>
-                <Button variant="primary" size="md" onClick={backToResume}>
+                <Button variant="primary" size="md" onClick={goToResume}>
                   Go to your resume
                 </Button>
               </div>
@@ -100,6 +132,7 @@ export default function JobsApp() {
           </TabPanel>
           <TabPanel id="library">
             <JobTrackerSection
+              parsed={handoff?.parsed}
               resumeName={resumeName}
               resumeOptions={library.entries}
             />

--- a/src/lib/jd-match/fetch-jd.test.ts
+++ b/src/lib/jd-match/fetch-jd.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   parseAtsUrl,
-  htmlToPlaintext,
   classifyUnsupportedHost,
   fetchJdFromUrl,
 } from "./fetch-jd.ts";
@@ -82,100 +81,6 @@ describe("parseAtsUrl", () => {
 
   it("returns null for an empty string", () => {
     expect(parseAtsUrl("")).toBeNull();
-  });
-});
-
-describe("htmlToPlaintext", () => {
-  it("strips tags and decodes entities", () => {
-    const html = "<p>Hello&amp;</p><ul><li>A</li><li>B</li></ul>";
-    const text = htmlToPlaintext(html);
-    expect(text).toContain("Hello&");
-    expect(text).toContain("A");
-    expect(text).toContain("B");
-    expect(text).not.toMatch(/<[^>]+>/);
-  });
-
-  it("removes <style> and <script> blocks", () => {
-    const html =
-      "<style>body{color:red}</style><p>Content</p><script>alert(1)</script>";
-    const text = htmlToPlaintext(html);
-    expect(text).toContain("Content");
-    expect(text).not.toContain("color:red");
-    expect(text).not.toContain("alert");
-  });
-
-  it("converts <br> and block-end tags to newlines", () => {
-    const html = "<p>First</p><p>Second</p><br/><p>Third</p>";
-    const text = htmlToPlaintext(html);
-    expect(text).toContain("First");
-    expect(text).toContain("Second");
-    expect(text).toContain("Third");
-    // No consecutive runs of 3+ newlines
-    expect(text).not.toMatch(/\n{3,}/);
-  });
-
-  it("decodes &lt; &gt; &quot; &#39; &nbsp;", () => {
-    const html = "<p>&lt;tag&gt; &quot;quoted&quot; it&#39;s&nbsp;fine</p>";
-    const text = htmlToPlaintext(html);
-    expect(text).toContain("<tag>");
-    expect(text).toContain('"quoted"');
-    expect(text).toContain("it's");
-    expect(text).toContain("fine");
-  });
-
-  it("trims and collapses excess newlines", () => {
-    const html = "<p>A</p>\n\n\n\n<p>B</p>";
-    const text = htmlToPlaintext(html);
-    expect(text.startsWith("A")).toBe(true);
-    expect(text).not.toMatch(/\n{3,}/);
-  });
-
-  it("decodes decimal numeric entities (&#160;)", () => {
-    // &#160; is the decimal nbsp; should become a space, not leak as `&#160;`.
-    const text = htmlToPlaintext("<p>Use&nbsp;Kubernetes&#160;daily.</p>");
-    expect(text).toBe("Use Kubernetes daily.");
-    expect(text).not.toContain("&#");
-  });
-
-  it("decodes hex numeric entities (&#x2013;)", () => {
-    // &#x2013; is an en-dash (–), common in Lever-generated typographic ranges.
-    const text = htmlToPlaintext("<p>2020&#x2013;2024</p>");
-    expect(text).toContain("2020–2024");
-    expect(text).not.toContain("&#");
-  });
-
-  it("decodes a decimal curly apostrophe (&#8217;) so skills regex sees the word", () => {
-    const text = htmlToPlaintext("<p>you&#8217;ll ship</p>");
-    expect(text).toContain("you’ll ship");
-    expect(text).not.toContain("&#");
-  });
-
-  it("leaves a malformed numeric reference (&#x;) unchanged", () => {
-    const text = htmlToPlaintext("<p>price &#x; range</p>");
-    expect(text).toContain("&#x;");
-  });
-
-  it("leaves an out-of-range numeric reference unchanged", () => {
-    // 0x110000 is one past the highest Unicode scalar — must not throw.
-    const text = htmlToPlaintext("<p>bad &#1114112; ref</p>");
-    expect(text).toContain("&#1114112;");
-  });
-
-  it("drops non-whitespace control-character references (&#0;, &#7;)", () => {
-    // Null and BEL would inject invisible bytes into the matched plaintext;
-    // they are stripped, not decoded and not left as raw `&#…;`.
-    const text = htmlToPlaintext("<p>a&#0;b&#7;c</p>");
-    expect(text).toBe("abc");
-    expect(text).not.toContain("&#");
-  });
-
-  it("decodes whitespace control references (&#13;/&#10;) without leaking", () => {
-    // CR/LF are legitimate whitespace — decoded then normalized by the
-    // line-collapse pass, never left as a raw `&#13;` fragment.
-    const text = htmlToPlaintext("<p>line1&#13;&#10;line2</p>");
-    expect(text).not.toContain("&#");
-    expect(text).toContain("line1");
-    expect(text).toContain("line2");
   });
 });
 

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -4,6 +4,8 @@
 // ATS public JSON API clients — fetch a job description as plaintext.
 // These APIs are free, unauthenticated, and legally safe.
 
+import { htmlToPlaintext } from "./html-to-plaintext.ts";
+
 export type AtsPlatform =
   | "greenhouse"
   | "lever"
@@ -205,84 +207,11 @@ async function fetchAshbyJob(
 
 // ─── HTML → plaintext ─────────────────────────────────────────────────────────
 
-/**
- * Resolve a numeric character reference's code point to its character, leaving
- * the original `&#…;` text untouched when the value isn't a valid Unicode
- * scalar (out of the 0–0x10FFFF range, or a lone surrogate). This keeps a
- * malformed/overflowing reference visible rather than throwing or emitting U+FFFD.
- *
- * Code point 0xA0 (non-breaking space) is folded to a regular space so numeric
- * `&#160;` / `&#xA0;` references match the named `&nbsp;` decode path.
- *
- * Non-whitespace C0 control characters and DEL (e.g. `&#0;`, `&#7;`, `&#8;`) are
- * dropped — decoding them would inject invisible control bytes into the matched
- * plaintext. Tab / LF / CR are kept as legitimate whitespace (the line-collapse
- * pass downstream normalizes them).
- */
-function decodeCodePoint(original: string, codePoint: number): string {
-  if (
-    !Number.isInteger(codePoint) ||
-    codePoint < 0 ||
-    codePoint > 0x10ffff ||
-    (codePoint >= 0xd800 && codePoint <= 0xdfff)
-  ) {
-    return original;
-  }
-  if (codePoint === 0xa0) return " ";
-  if (
-    (codePoint < 0x20 &&
-      codePoint !== 0x09 &&
-      codePoint !== 0x0a &&
-      codePoint !== 0x0d) ||
-    codePoint === 0x7f
-  ) {
-    return "";
-  }
-  return String.fromCodePoint(codePoint);
-}
-
-export function htmlToPlaintext(html: string): string {
-  // Strip <style> and <script> blocks
-  let text = html
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
-
-  // Convert block-end tags to newlines
-  text = text.replace(/<\/(p|li|div|tr)>/gi, "\n");
-  text = text.replace(/<br\s*\/?>/gi, "\n");
-
-  // Strip remaining tags
-  text = text.replace(/<[^>]+>/g, "");
-
-  // Decode common named HTML entities
-  text = text
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
-
-  // Decode numeric character references (decimal &#160; and hex &#x2013;).
-  // Generators such as Lever lean on these for typographic punctuation; left
-  // raw they leak `&#…;` fragments into the JD-match passes. Malformed refs
-  // like `&#x;` never match (the digit group requires 1+); out-of-range or
-  // surrogate code points are preserved by decodeCodePoint.
-  text = text
-    .replace(/&#(\d+);/g, (m, n: string) => decodeCodePoint(m, parseInt(n, 10)))
-    .replace(/&#x([0-9a-f]+);/gi, (m, h: string) =>
-      decodeCodePoint(m, parseInt(h, 16)),
-    );
-
-  // Collapse trailing spaces on each line, then collapse 3+ newlines to 2
-  text = text
-    .split("\n")
-    .map((line) => line.trimEnd())
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n");
-
-  return text.trim();
-}
+// Moved to ./html-to-plaintext.ts (#704) — a zero-dependency module a
+// network-primitive-auditing consumer can import without pulling in this
+// file's fetch() calls. Re-exported here so existing callers of
+// `htmlToPlaintext` from this module keep working unchanged.
+export { htmlToPlaintext };
 
 // ─── Fetcher dispatch table ───────────────────────────────────────────────────
 

--- a/src/lib/jd-match/html-to-plaintext.test.ts
+++ b/src/lib/jd-match/html-to-plaintext.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import { htmlToPlaintext } from "./html-to-plaintext.ts";
+
+describe("htmlToPlaintext", () => {
+  it("strips tags and decodes entities", () => {
+    const html = "<p>Hello&amp;</p><ul><li>A</li><li>B</li></ul>";
+    const text = htmlToPlaintext(html);
+    expect(text).toContain("Hello&");
+    expect(text).toContain("A");
+    expect(text).toContain("B");
+    expect(text).not.toMatch(/<[^>]+>/);
+  });
+
+  it("removes <style> and <script> blocks", () => {
+    const html =
+      "<style>body{color:red}</style><p>Content</p><script>alert(1)</script>";
+    const text = htmlToPlaintext(html);
+    expect(text).toContain("Content");
+    expect(text).not.toContain("color:red");
+    expect(text).not.toContain("alert");
+  });
+
+  it("converts <br> and block-end tags to newlines", () => {
+    const html = "<p>First</p><p>Second</p><br/><p>Third</p>";
+    const text = htmlToPlaintext(html);
+    expect(text).toContain("First");
+    expect(text).toContain("Second");
+    expect(text).toContain("Third");
+    // No consecutive runs of 3+ newlines
+    expect(text).not.toMatch(/\n{3,}/);
+  });
+
+  it("decodes &lt; &gt; &quot; &#39; &nbsp;", () => {
+    const html = "<p>&lt;tag&gt; &quot;quoted&quot; it&#39;s&nbsp;fine</p>";
+    const text = htmlToPlaintext(html);
+    expect(text).toContain("<tag>");
+    expect(text).toContain('"quoted"');
+    expect(text).toContain("it's");
+    expect(text).toContain("fine");
+  });
+
+  it("trims and collapses excess newlines", () => {
+    const html = "<p>A</p>\n\n\n\n<p>B</p>";
+    const text = htmlToPlaintext(html);
+    expect(text.startsWith("A")).toBe(true);
+    expect(text).not.toMatch(/\n{3,}/);
+  });
+
+  it("decodes decimal numeric entities (&#160;)", () => {
+    // &#160; is the decimal nbsp; should become a space, not leak as `&#160;`.
+    const text = htmlToPlaintext("<p>Use&nbsp;Kubernetes&#160;daily.</p>");
+    expect(text).toBe("Use Kubernetes daily.");
+    expect(text).not.toContain("&#");
+  });
+
+  it("decodes hex numeric entities (&#x2013;)", () => {
+    // &#x2013; is an en-dash (–), common in Lever-generated typographic ranges.
+    const text = htmlToPlaintext("<p>2020&#x2013;2024</p>");
+    expect(text).toContain("2020–2024");
+    expect(text).not.toContain("&#");
+  });
+
+  it("decodes a decimal curly apostrophe (&#8217;) so skills regex sees the word", () => {
+    const text = htmlToPlaintext("<p>you&#8217;ll ship</p>");
+    expect(text).toContain("you’ll ship");
+    expect(text).not.toContain("&#");
+  });
+
+  it("leaves a malformed numeric reference (&#x;) unchanged", () => {
+    const text = htmlToPlaintext("<p>price &#x; range</p>");
+    expect(text).toContain("&#x;");
+  });
+
+  it("leaves an out-of-range numeric reference unchanged", () => {
+    // 0x110000 is one past the highest Unicode scalar — must not throw.
+    const text = htmlToPlaintext("<p>bad &#1114112; ref</p>");
+    expect(text).toContain("&#1114112;");
+  });
+
+  it("drops non-whitespace control-character references (&#0;, &#7;)", () => {
+    // Null and BEL would inject invisible bytes into the matched plaintext;
+    // they are stripped, not decoded and not left as raw `&#…;`.
+    const text = htmlToPlaintext("<p>a&#0;b&#7;c</p>");
+    expect(text).toBe("abc");
+    expect(text).not.toContain("&#");
+  });
+
+  it("decodes whitespace control references (&#13;/&#10;) without leaking", () => {
+    // CR/LF are legitimate whitespace — decoded then normalized by the
+    // line-collapse pass, never left as a raw `&#13;` fragment.
+    const text = htmlToPlaintext("<p>line1&#13;&#10;line2</p>");
+    expect(text).not.toContain("&#");
+    expect(text).toContain("line1");
+    expect(text).toContain("line2");
+  });
+});

--- a/src/lib/jd-match/html-to-plaintext.ts
+++ b/src/lib/jd-match/html-to-plaintext.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Pure HTML-to-plaintext normalizer, deliberately split out of `fetch-jd.ts`
+// (#704). `fetch-jd.ts` also owns live `fetch()` calls to the ATS platforms,
+// so anything that imports from it pulls a network primitive into its import
+// graph. This module has zero dependencies and makes no network calls, so a
+// consumer that audits its own import graph for network primitives (or wants
+// this repo's HTML normalizer without forking it) can import it directly
+// without that audit ever seeing a `fetch(` literal.
+
+/**
+ * Resolve a numeric character reference's code point to its character, leaving
+ * the original `&#…;` text untouched when the value isn't a valid Unicode
+ * scalar (out of the 0–0x10FFFF range, or a lone surrogate). This keeps a
+ * malformed/overflowing reference visible rather than throwing or emitting U+FFFD.
+ *
+ * Code point 0xA0 (non-breaking space) is folded to a regular space so numeric
+ * `&#160;` / `&#xA0;` references match the named `&nbsp;` decode path.
+ *
+ * Non-whitespace C0 control characters and DEL (e.g. `&#0;`, `&#7;`, `&#8;`) are
+ * dropped — decoding them would inject invisible control bytes into the matched
+ * plaintext. Tab / LF / CR are kept as legitimate whitespace (the line-collapse
+ * pass downstream normalizes them).
+ */
+function decodeCodePoint(original: string, codePoint: number): string {
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint < 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
+    return original;
+  }
+  if (codePoint === 0xa0) return " ";
+  if (
+    (codePoint < 0x20 &&
+      codePoint !== 0x09 &&
+      codePoint !== 0x0a &&
+      codePoint !== 0x0d) ||
+    codePoint === 0x7f
+  ) {
+    return "";
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+export function htmlToPlaintext(html: string): string {
+  // Strip <style> and <script> blocks
+  let text = html
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+
+  // Convert block-end tags to newlines
+  text = text.replace(/<\/(p|li|div|tr)>/gi, "\n");
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+
+  // Strip remaining tags
+  text = text.replace(/<[^>]+>/g, "");
+
+  // Decode common named HTML entities
+  text = text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+
+  // Decode numeric character references (decimal &#160; and hex &#x2013;).
+  // Generators such as Lever lean on these for typographic punctuation; left
+  // raw they leak `&#…;` fragments into the JD-match passes. Malformed refs
+  // like `&#x;` never match (the digit group requires 1+); out-of-range or
+  // surrogate code points are preserved by decodeCodePoint.
+  text = text
+    .replace(/&#(\d+);/g, (m, n: string) => decodeCodePoint(m, parseInt(n, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (m, h: string) =>
+      decodeCodePoint(m, parseInt(h, 16)),
+    );
+
+  // Collapse trailing spaces on each line, then collapse 3+ newlines to 2
+  text = text
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+
+  return text.trim();
+}

--- a/src/lib/jd-match/index.ts
+++ b/src/lib/jd-match/index.ts
@@ -20,7 +20,9 @@ export type { CoverageResult } from "./coverage.ts";
 export { SKILLS, getSkillIndex, skillCount } from "./skills.ts";
 export type { SkillEntry } from "./skills.ts";
 
-export { fetchJdFromUrl, parseAtsUrl, htmlToPlaintext } from "./fetch-jd.ts";
+export { fetchJdFromUrl, parseAtsUrl } from "./fetch-jd.ts";
 export type { AtsPlatform } from "./fetch-jd.ts";
+
+export { htmlToPlaintext } from "./html-to-plaintext.ts";
 
 export type { JdMatchResult } from "./types.ts";

--- a/src/lib/job-search/rank.ts
+++ b/src/lib/job-search/rank.ts
@@ -55,7 +55,7 @@
 
 import type { HeuristicParsedResume } from "../heuristics/types.ts";
 import type { JdMatchResult } from "../jd-match/types.ts";
-import { extractJdTerms } from "../jd-match/extract-jd-terms.ts";
+import { extractJdTerms, type ExtractedTerm } from "../jd-match/extract-jd-terms.ts";
 import { computeCoverage } from "../jd-match/coverage.ts";
 import type { JobPosting } from "./types.ts";
 import type { JobQuery } from "./query-builder.ts";
@@ -160,13 +160,38 @@ function seniorityDistance(
 }
 
 /**
+ * The signals `ratingInputFor` actually reads off a job — a structural subset
+ * that `RankedJob` already satisfies, so widening to it changes no call site.
+ *
+ * Why it exists (#700): `rateJobs` calls itself "the SINGLE rating computation
+ * the whole lane reads", and that guarantee is only as strong as its INPUT.
+ * Pinning the assembler's parameter to `RankedJob` meant any consumer holding
+ * something else — the saved job library holds a `JobRecord` plus a JD text,
+ * never a `RankedJob` — had to fork a second `RatingInput` mapping, which is the
+ * fastest route to two ratings that disagree. Narrowing the parameter to the
+ * fields the body reads lets those consumers feed the same assembler instead.
+ */
+export interface RatingSignalSource {
+  /** The three posting fields the axes read. `title` feeds the seniority ladder
+   *  and `location` the location match — both inert when the caller passes no
+   *  query seniority / location, which is the case off the search lane. */
+  posting: Pick<JobPosting, "title" | "location" | "compensation">;
+  /** Raw coverage 0..100, before the specificity discount below. */
+  score: number;
+  /** Only the term COUNT is read — it is the specificity denominator. */
+  jdMatch: { terms: readonly ExtractedTerm[] };
+}
+
+/**
  * Build the raw `RatingInput` for one already-coverage-scored posting — the
  * bridge between rank.ts's signal extraction and `rateJobs`. Exported so the
  * `probe-jobs` diagnostic can reconstruct exactly what fed a rating without
- * re-deriving the constants (the single source of truth for the rating inputs).
+ * re-deriving the constants, and so off-lane consumers (`rate-saved-jobs.ts`)
+ * assemble their inputs HERE rather than duplicating the mapping. This is the
+ * single `RatingInput` assembly site in the tree — keep it that way.
  */
 export function ratingInputFor(
-  job: RankedJob,
+  job: RatingSignalSource,
   queryLocation: string | undefined,
   querySeniorityRung: number | undefined,
   compFloor: number | undefined,

--- a/src/lib/job-search/rate-saved-jobs.test.ts
+++ b/src/lib/job-search/rate-saved-jobs.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `rateSavedJobs` (#700). The three properties the saved library's rating has to
+ * hold — not-rated is distinct from zero, nothing is written back to the record,
+ * and the whole library is rated as ONE set so its scale matches the search
+ * lane's — plus parity with `rankPostings` on the shared fitness base.
+ */
+
+import { describe, it, expect } from "vitest";
+import { rateSavedJobs, type RatableSavedJob } from "./rate-saved-jobs.ts";
+import { rankPostings } from "./rank.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { JobPosting } from "./types.ts";
+
+const parsed: HeuristicParsedResume = {
+  skills: ["React", "TypeScript"],
+  experience: [
+    { title: "Frontend Engineer", company: "Acme", description: "Built React apps" },
+  ],
+  education: [],
+};
+
+const STRONG_JD =
+  "We need a React and TypeScript engineer to build our frontend web application.";
+/** Deliberately PARTIALLY covered, not uncovered: an all-missing JD scores 0,
+ *  whose absolute fitness is 0 both in a set and alone, so it would pass the
+ *  set-relative test for the wrong reason. One skill hits, five miss. */
+const WEAK_JD =
+  "We need Rust, Kubernetes, Terraform, Go and Postgres experts, with some React exposure, for our infrastructure platform team.";
+
+function saved(over: Partial<RatableSavedJob> & { id: string }): RatableSavedJob {
+  return { title: "Engineer", ...over };
+}
+
+function posting(id: string, description: string): JobPosting {
+  return {
+    id,
+    title: "Engineer",
+    company: "Co",
+    location: "",
+    url: `https://x/${id}`,
+    description,
+    source: "Test",
+  };
+}
+
+describe("rateSavedJobs", () => {
+  it("omits a record with no jdText — 'not rated' is absence, never a zero", () => {
+    const ratings = rateSavedJobs(
+      [saved({ id: "with", jdText: STRONG_JD }), saved({ id: "without" })],
+      parsed,
+    );
+    expect(ratings.has("with")).toBe(true);
+    // The row renderer reads absence as "not rated". A 0-star entry here would
+    // read as "terrible fit" when the truth is "no description to match".
+    expect(ratings.has("without")).toBe(false);
+    expect(ratings.get("without")).toBeUndefined();
+  });
+
+  it("treats a blank/whitespace jdText as no description at all", () => {
+    const ratings = rateSavedJobs(
+      [saved({ id: "blank", jdText: "   \n\t " }), saved({ id: "empty", jdText: "" })],
+      parsed,
+    );
+    expect(ratings.size).toBe(0);
+  });
+
+  it("omits a record whose jdText carries no extractable terms", () => {
+    // The losing input is prose, not blankness: a capture that saved only a
+    // pointer to the posting passes any `jdText.trim() !== ""` gate, extracts
+    // zero terms, and coverage scores an empty requirement set 0 — which would
+    // paint an EMPTY 5-star widget labelled "Weak fit" on a job we simply have
+    // no description for. Text is not a description.
+    const noTerms = [
+      "Apply on our website.",
+      "See job posting.",
+      "Full job description available at the link below.",
+      "-",
+    ];
+    const ratings = rateSavedJobs(
+      [
+        saved({ id: "real", jdText: STRONG_JD }),
+        ...noTerms.map((jdText, i) => saved({ id: `bare${i}`, jdText })),
+      ],
+      parsed,
+    );
+    expect(ratings.has("real")).toBe(true);
+    for (let i = 0; i < noTerms.length; i++) {
+      expect(ratings.has(`bare${i}`)).toBe(false);
+    }
+    expect(ratings.size).toBe(1);
+  });
+
+  it("does not rate a library whose every record is term-less", () => {
+    // The whole-set path, where a 0 would also have been the set's max and so
+    // could not be spotted by comparing rows against each other.
+    const ratings = rateSavedJobs(
+      [
+        saved({ id: "a", jdText: "Apply on our website." }),
+        saved({ id: "b", jdText: "See job posting." }),
+      ],
+      parsed,
+    );
+    expect(ratings.size).toBe(0);
+  });
+
+  it("rates the whole library in ONE set, not one record at a time", () => {
+    // The fitness axis is hybrid absolute + SET-relative (see rating.ts): rated
+    // as a set, the weakest member sits at the bottom of the stretch; rated
+    // alone, `spread === 0` collapses it to the pure absolute curve. So a
+    // per-record `rateJobs([one])` implementation is detectable — the weak job's
+    // fitness must be STRICTLY lower in the set than it is on its own.
+    const asSet = rateSavedJobs(
+      [saved({ id: "strong", jdText: STRONG_JD }), saved({ id: "weak", jdText: WEAK_JD })],
+      parsed,
+    );
+    const alone = rateSavedJobs([saved({ id: "weak", jdText: WEAK_JD })], parsed);
+
+    const weakInSet = asSet.get("weak");
+    const weakAlone = alone.get("weak");
+    expect(weakInSet).toBeDefined();
+    expect(weakAlone).toBeDefined();
+    expect(weakInSet!.fitness).toBeLessThan(weakAlone!.fitness);
+
+    // And the set still orders correctly.
+    expect(asSet.get("strong")!.overall).toBeGreaterThan(weakInSet!.overall);
+  });
+
+  it("never writes a rating back onto the record it rated", () => {
+    const record = saved({ id: "j1", jdText: STRONG_JD });
+    const before = JSON.stringify(record);
+    rateSavedJobs([record], parsed);
+    // Recomputed on view: a stored score would go stale the moment the résumé is
+    // edited, and JobRecord's shape is a public capture contract.
+    expect(JSON.stringify(record)).toBe(before);
+    expect(Object.keys(record).sort()).toEqual(["id", "jdText", "title"]);
+  });
+
+  it("returns an empty map for an empty library", () => {
+    expect(rateSavedJobs([], parsed).size).toBe(0);
+  });
+
+  it("only the fitness axis is present — the library carries no query", () => {
+    const rating = rateSavedJobs([saved({ id: "j1", jdText: STRONG_JD })], parsed).get("j1")!;
+    expect(rating.compensation).toBeNull();
+    expect(rating.location).toBeNull();
+    expect(rating.seniority).toBeNull();
+    // With every other axis absent, the blend is fitness alone.
+    expect(rating.overall).toBeCloseTo(rating.fitness, 10);
+  });
+
+  it("agrees with the search lane on the same JD text and résumé", () => {
+    // Same chain, same constants: a posting rated through `rankPostings` with no
+    // query and the same description must land on the identical fitness. This is
+    // the property that would break if a second RatingInput mapping existed.
+    const [ranked] = rankPostings(parsed, [posting("p1", STRONG_JD)]);
+    const rating = rateSavedJobs([saved({ id: "p1", jdText: STRONG_JD })], parsed).get("p1")!;
+    expect(rating.fitness).toBeCloseTo(ranked.rating.fitness, 10);
+    expect(rating.overall).toBeCloseTo(ranked.rating.overall, 10);
+  });
+});

--- a/src/lib/job-search/rate-saved-jobs.ts
+++ b/src/lib/job-search/rate-saved-jobs.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Rate the SAVED job library against the parsed résumé (#700).
+ *
+ * The search lane has always had a fitness rating; the library — the jobs the
+ * user cared enough to keep — showed none, because the whole chain could only
+ * be driven from inside `rankPostings`. Nothing about the algorithm blocked it:
+ * `extractJdTerms` → `computeCoverageFromCorpus` → `ratingInputFor` → `rateJobs`
+ * is pure, dependency-free and cheap. Only two seams did, and both have moved
+ * (`computeCoverageFromCorpus` in #699/#703, `RatingSignalSource` here), so this
+ * module is the wiring and nothing else — no second coverage implementation, no
+ * second `RatingInput` mapping, no second star scale.
+ *
+ * Three properties this module exists to hold:
+ *
+ *  1. **A record with nothing to match against is NOT rated — it is not rated
+ *     ZERO.** A 0 reads as "terrible fit"; the truth is "no description to
+ *     match against", and the two must not render the same. Such records are
+ *     simply absent from the returned map, so a caller cannot accidentally
+ *     paint them 0 stars. "Nothing to match against" is decided AFTER term
+ *     extraction, not from the presence of text: a capture that saved only
+ *     "Apply on our website." (or any prose `extractJdTerms` finds no terms in
+ *     — a non-English posting, a "-" placeholder) yields zero terms, and
+ *     `computeCoverageFromCorpus` correctly returns score 0 for an empty
+ *     requirement set, which would paint an empty 5-star widget labelled
+ *     "Weak fit". Text is not a description.
+ *  2. **Nothing is persisted.** The rating is derived from the résumé, which the
+ *     user edits on `/`, and no write to a `JobRecord` would ever be invalidated
+ *     by that edit. So the rating is recomputed on view and `JobRecord`'s shape
+ *     is untouched — which also keeps the public capture contract
+ *     (`job-record-contract.ts`, `docs/job-capture-contract.md`) out of it.
+ *  3. **The library is rated as a SET, in one `rateJobs` call.** `rateJobs`'s
+ *     fitness axis is hybrid absolute + set-relative: with a single input the
+ *     spread is 0 and the stretch collapses to the pure absolute curve (see
+ *     `rating.ts`). Rating records one at a time would therefore put the library
+ *     on a different scale from the search lane, for the same posting. So the
+ *     whole rateable set goes in at once, exactly as `rankPostings` pass 2 does.
+ *
+ * Which axes are present: fitness only. There is no query behind the library —
+ * no location, no seniority, no comp floor — so those three axes are absent,
+ * drop out of the blend, and their weight redistributes onto fitness (the
+ * "silence is neutral" rule in `rating.ts`). `describeRating` therefore yields
+ * exactly one reason phrase per saved job, which is the honest amount to say.
+ */
+
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import {
+  extractJdTerms,
+  type ExtractedTerm,
+} from "../jd-match/extract-jd-terms.ts";
+import { buildCorpus, computeCoverageFromCorpus } from "../jd-match/coverage.ts";
+import { ratingInputFor } from "./rank.ts";
+import { rateJobs, type JobRating } from "./rating.ts";
+
+/**
+ * The slice of a `JobRecord` a fitness rating is derived from. Structural, so a
+ * real `JobRecord` satisfies it and a test can pass a three-field literal —
+ * this module has no reason to reach into the storage layer's types.
+ */
+export interface RatableSavedJob {
+  id: string;
+  title: string;
+  /** The saved posting text. Absent, blank, or carrying no extractable terms
+   *  all mean there is nothing to match against, and the record is left OUT of
+   *  the returned map — see property 1. */
+  jdText?: string;
+}
+
+/**
+ * Rate every saved job that carries a job description, against `parsed`.
+ *
+ * Returns one entry per RATEABLE record, keyed by `JobRecord.id`. A record
+ * whose `jdText` yields no requirement terms has no entry: absence is the "not
+ * rated" signal, and the caller must render it as such rather than as a zero.
+ */
+export function rateSavedJobs(
+  jobs: readonly RatableSavedJob[],
+  parsed: HeuristicParsedResume,
+): Map<string, JobRating> {
+  // Extraction decides rateability, so it happens FIRST and exactly once per
+  // record — the terms it produces are carried forward rather than recomputed.
+  const rateable: { id: string; title: string; terms: ExtractedTerm[] }[] = [];
+  for (const job of jobs) {
+    const jdText = (job.jdText ?? "").trim();
+    if (jdText === "") continue;
+    const terms = extractJdTerms(jdText).all;
+    // Zero terms is an empty requirement set, which coverage scores 0 — the
+    // "terrible fit" reading property 1 forbids. Not rateable.
+    if (terms.length === 0) continue;
+    rateable.push({ id: job.id, title: job.title, terms });
+  }
+  if (rateable.length === 0) return new Map();
+
+  // The résumé reduced to what matching actually reads — built once for the
+  // whole library, not once per record.
+  const corpus = buildCorpus(parsed);
+
+  const inputs = rateable.map(({ title, terms }) => {
+    const coverage = computeCoverageFromCorpus(corpus, terms);
+    // `location` is a placeholder, never read: `ratingInputFor` only consults it
+    // when a query location is passed, and the library has no query. Same for
+    // `title` and the seniority rung. Assembling the input HERE rather than
+    // hand-rolling a `RatingInput` is the point — see `ratingInputFor`.
+    return ratingInputFor(
+      {
+        posting: { title, location: "" },
+        score: coverage.score,
+        jdMatch: { terms },
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  // ONE call over the whole set — property 3.
+  const ratings = rateJobs(inputs);
+  return new Map(rateable.map(({ id }, i) => [id, ratings[i]]));
+}

--- a/src/lib/jobs-departure.test.ts
+++ b/src/lib/jobs-departure.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `departToJobs` — the single definition of "leave `/` for `/jobs/`".
+ *
+ * The defect this guards is a route that navigates but hands nothing over: the
+ * saved library on `/jobs/` reads its résumé from the handoff, so a missing
+ * write costs every fitness rating (#700) AND shows a "open this workbench from
+ * your resume" hint to someone who did exactly that. Both writes, or the route
+ * is broken — so both are asserted here rather than at the two call sites.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { departToJobs } from "./jobs-departure.ts";
+import { readJobsHandoff, writeJobsHandoff } from "./jobs-handoff.ts";
+import { readDepartureMarker } from "./nav-return.ts";
+import type { HeuristicParsedResume } from "./heuristics/types.ts";
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  skills: ["React"],
+  experience: [],
+  education: [],
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("departToJobs", () => {
+  it("writes the handoff AND marks the departure", () => {
+    departToJobs(parsed);
+    expect(readJobsHandoff()?.parsed.full_name).toBe("Dana Fixture");
+    expect(readDepartureMarker()).toBe(true);
+  });
+
+  it("still marks the departure when there is no parse to hand over", () => {
+    // The header link renders before any parse — that is its point — and the
+    // trip still started at the root, so the back control is right to go there.
+    departToJobs(undefined);
+    expect(readJobsHandoff()).toBeNull();
+    expect(readDepartureMarker()).toBe(true);
+  });
+
+  it("CLEARS a previous launch's résumé when departing with no parse", () => {
+    // The handoff key is deliberately not one-shot, so skipping the write is
+    // not the same as handing over nothing: parse on `/`, visit `/jobs/`, come
+    // back, reset the parse, then take the header link — and `/jobs/` ranks the
+    // library against the résumé the user just discarded, with its "open this
+    // workbench from your resume" hint suppressed because a handoff exists.
+    writeJobsHandoff({ parsed });
+    departToJobs(undefined);
+    expect(readJobsHandoff()).toBeNull();
+  });
+});

--- a/src/lib/jobs-departure.ts
+++ b/src/lib/jobs-departure.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The one definition of "leave `/` for `/jobs/`".
+ *
+ * There are two routes off the parser-audit surface into the job workbench:
+ * `FindJobsLauncher`'s button (rendered only once a résumé is parsed) and the
+ * "Saved jobs" link `PageShell` puts in the header on every surface (#707).
+ * Both must do exactly the same two things before the browser navigates, and
+ * when they diverged the second one shipped a route that defeated the first:
+ * the library on `/jobs/` reads its résumé from the sessionStorage handoff, so
+ * a user who parsed on `/` and arrived via the header link got no fitness
+ * ratings at all, plus a "open this workbench from your resume" hint — shown to
+ * someone who had just done that. Composing the two writes here means a third
+ * route cannot re-introduce that split by forgetting one of them.
+ *
+ * It is deliberately NOT the navigation itself: the launcher assigns
+ * `location.href` while the header link is a real `<a href>` the browser
+ * follows (so open-in-new-tab works), and folding the navigation in would
+ * force one of them to fake the other.
+ *
+ * `parsed` is optional because the header link exists on `/` before any parse —
+ * that is the whole point of it — and there is simply nothing to hand over
+ * then. The departure marker is written either way: the trip really did start
+ * at the root, and `/jobs/`'s back control is right to return there. "Nothing
+ * to hand over" is itself a write, though: the handoff key is deliberately not
+ * one-shot (see `jobs-handoff.ts`), so skipping it silently would leave a
+ * PREVIOUS launch's résumé in place — the user parses, visits `/jobs/`, comes
+ * back, resets, and the header link then ranks the library against the résumé
+ * they just discarded, with the "open this workbench from your resume" hint
+ * suppressed because a handoff exists. Departing with no parse clears.
+ */
+
+import type { HeuristicParsedResume } from "./heuristics/types.ts";
+import { writeJobsHandoff, clearJobsHandoff } from "./jobs-handoff.ts";
+import { markDeparture } from "./nav-return.ts";
+
+/**
+ * Hand the current parse to `/jobs/` — or explicitly hand over nothing — and
+ * record that this trip started at the app root. Call immediately before
+ * navigating; safe to call from `/` only — `markDeparture` reads the current
+ * path, and only a marker written at the root reads back as one.
+ */
+export function departToJobs(parsed?: HeuristicParsedResume): void {
+  if (parsed !== undefined) writeJobsHandoff({ parsed });
+  else clearJobsHandoff();
+  markDeparture();
+}

--- a/src/lib/jobs-handoff.ts
+++ b/src/lib/jobs-handoff.ts
@@ -50,6 +50,26 @@ export function writeJobsHandoff(payload: JobsHandoff): void {
 }
 
 /**
+ * Drop the handoff payload.
+ *
+ * The counterpart to the "not one-shot" rule above: because a read never
+ * clears, a payload from an earlier launch survives until something overwrites
+ * it — and a route that leaves `/` with NO parse (the header link before a
+ * parse, or after the user reset one) would otherwise hand `/jobs/` a résumé
+ * the user has already discarded, silently ranking against it and suppressing
+ * the "open this workbench from your resume" hint that is the correct empty
+ * state. Departing with nothing must therefore say so, not stay silent.
+ */
+export function clearJobsHandoff(): void {
+  try {
+    sessionStorage.removeItem(JOBS_HANDOFF_KEY);
+  } catch {
+    // Inaccessible storage — nothing was readable either, so `/jobs/` already
+    // renders its empty state.
+  }
+}
+
+/**
  * Read the handoff payload. Returns null when absent or malformed so `/jobs/`
  * falls back to its empty state instead of rendering a broken query.
  *

--- a/src/lib/jobs-landing.test.ts
+++ b/src/lib/jobs-landing.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * #707: the losing case matters as much as the winning one — a plain
+ * `/jobs/` visit (no param) must still land on Search, or every existing
+ * deep link and the FindJobsLauncher navigation would silently start
+ * defaulting to the wrong tab.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveInitialJobsTab, savedJobsHref } from "./jobs-landing.ts";
+
+describe("resolveInitialJobsTab", () => {
+  it("lands on search when the param is absent", () => {
+    expect(resolveInitialJobsTab("")).toBe("search");
+  });
+
+  it("lands on search for an unrelated query string", () => {
+    expect(resolveInitialJobsTab("?foo=bar")).toBe("search");
+  });
+
+  it("lands on search for an unrecognized tab value", () => {
+    expect(resolveInitialJobsTab("?tab=bogus")).toBe("search");
+  });
+
+  it("lands on library when tab=library", () => {
+    expect(resolveInitialJobsTab("?tab=library")).toBe("library");
+  });
+
+  it("lands on library alongside other params", () => {
+    expect(resolveInitialJobsTab("?foo=bar&tab=library")).toBe("library");
+  });
+});
+
+describe("savedJobsHref", () => {
+  it("builds a base-aware URL landing on Saved jobs", () => {
+    expect(savedJobsHref()).toBe(`${import.meta.env.BASE_URL}jobs/?tab=library`);
+  });
+});

--- a/src/lib/jobs-landing.ts
+++ b/src/lib/jobs-landing.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Landing-tab routing for `/jobs/` (#707): `PageShell`'s "Saved jobs" link
+ * needs `JobsApp` to land on the Saved jobs tab instead of the Search tab its
+ * `tab` state defaults to (`JobsApp.tsx`). A query param is the right carrier
+ * — this is a plain `<a href>` full-document navigation, not client-side
+ * routing, so there is no router state to thread through, and unlike
+ * `nav-return.ts`'s sessionStorage marker (consumed on read, so a reload or a
+ * pasted URL loses it) a param survives both a direct paste of the URL and a
+ * reload, which the issue's Done-when explicitly requires.
+ *
+ * The decision (which tab a given URL lands on) is factored out from the
+ * `window.location` IO so it is unit-testable with a plain string — same
+ * shape as `nav-return.ts`'s `shouldReturnViaHistory`.
+ */
+
+export type JobsTabId = "search" | "library";
+
+const TAB_PARAM = "tab";
+const LIBRARY_VALUE = "library";
+
+/** Decide which `JobsApp` tab a `/jobs/` URL should land on, from its query
+ *  string. Absent or any other value falls back to "search" — the same
+ *  default a plain `/jobs/` visit gets today, so an old bookmark or a link
+ *  from before this param existed is unaffected. */
+export function resolveInitialJobsTab(search: string): JobsTabId {
+  return new URLSearchParams(search).get(TAB_PARAM) === LIBRARY_VALUE
+    ? "library"
+    : "search";
+}
+
+/** Base-aware URL to `/jobs/`, landing directly on Saved jobs — same
+ *  `import.meta.env.BASE_URL` pattern as `FindJobsLauncher`'s navigation, so
+ *  it resolves correctly under both the custom-domain `/` base and the
+ *  `/OfflineCV/` Pages-fallback base. */
+export function savedJobsHref(): string {
+  return `${import.meta.env.BASE_URL}jobs/?${TAB_PARAM}=${LIBRARY_VALUE}`;
+}

--- a/src/lib/nav-return.surfaces.test.tsx
+++ b/src/lib/nav-return.surfaces.test.tsx
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The departure marker's lifetime, exercised through the REAL surfaces that
+ * write and answer it — `App` (`/`), `JdFitApp` (`/jd-fit/`), `JobsApp`
+ * (`/jobs/`).
+ *
+ * `nav-return.test.ts` covers the module in isolation and
+ * `PageShell.test.tsx` covers the shell's contract with a hand-written
+ * callback, but neither is evidence about the WIRING: reverting
+ * `onSavedJobsNavigate={goToSavedJobs}` out of `App.tsx`, or adding a marking
+ * callback to `JdFitApp`, left the whole suite green. So the two invariants the
+ * fix exists for — only `/` marks a departure, and every non-root surface
+ * retires the marker at mount — are pinned here, at the surfaces themselves.
+ *
+ * The headline case is the two-hop sequence a marker consumed at CLICK time
+ * gets wrong: `/` → `/jd-fit/` → (header "Saved jobs") → `/jobs/` → Back. Each
+ * step below is a real mount and a real click on visible chrome.
+ *
+ * jsdom implements no navigation, so the fallback branch assigning
+ * `location.href` logs a "Not implemented: navigation" notice from the virtual
+ * console. Expected noise; the assertions are on the `history.back` spy.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createElement, act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import App from "../App.tsx";
+import JdFitApp from "../jd-fit/JdFitApp.tsx";
+import JobsApp from "../jobs/JobsApp.tsx";
+import { DB_NAME, closeDB } from "./storage/index.ts";
+import { markDeparture, readDepartureMarker } from "./nav-return.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root | undefined;
+let back: ReturnType<typeof vi.fn>;
+
+/** Drain `useResumeLibrary`'s (and the tracker's) initial fake-indexeddb reads
+ *  — they resolve over several macrotask ticks (open → upgrade → transaction),
+ *  not one, so an unmount or a `deleteDB` before they settle rejects mid-flight.
+ *  Same shape as `JobsApp.test.tsx`'s loop. */
+async function flushIndexedDb(turns = 10) {
+  for (let i = 0; i < turns; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+async function mount(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root!.render(element));
+  await flushIndexedDb();
+}
+
+function unmount() {
+  act(() => root?.unmount());
+  root = undefined;
+  container.remove();
+}
+
+/** Click the visible chrome by its label — a `Button` renders a `<button>`,
+ *  the "Saved jobs" entry point is an `<a href>`. */
+function clickChrome(label: string) {
+  const el = [...container.querySelectorAll("button, a")].find((node) =>
+    node.textContent?.includes(label),
+  );
+  expect(el, `no chrome labelled "${label}"`).toBeDefined();
+  act(() => {
+    el!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+    );
+  });
+}
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+  sessionStorage.clear();
+  // useGitHubStars / useUpdateChecker both fetch on mount and both swallow a
+  // failure — stubbed so this suite never touches the network.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.reject(new Error("no network in tests"))),
+  );
+  back = vi.fn();
+  vi.spyOn(window.history, "back").mockImplementation(back);
+});
+
+afterEach(async () => {
+  await flushIndexedDb();
+  if (root) unmount();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("the marker belongs to ONE visit, not to the next click", () => {
+  it("/ → /jd-fit/ → Saved jobs → /jobs/: the Back control falls back, it does not land on /jd-fit/", async () => {
+    // 1. On `/`, "Check fit against a job" marks the departure (App.tsx).
+    markDeparture();
+
+    // 2. `/jd-fit/` loads and absorbs the marker at mount — even though its own
+    //    back control is never clicked here.
+    await mount(createElement(JdFitApp));
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+
+    // 2b. Its header "Saved jobs" link writes nothing: this surface is not the
+    //     app root, so it supplies no `onSavedJobsNavigate`.
+    clickChrome("Saved jobs");
+    expect(readDepartureMarker()).toBe(false);
+    unmount();
+
+    // 3. `/jobs/` loads with no marker of its own, so "Back to your resume"
+    //    must NOT fire history.back() — that would land on `/jd-fit/`, a real
+    //    page but not the one the label names.
+    await mount(createElement(JobsApp));
+    clickChrome("Back to your resume");
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("…and /jd-fit/'s own Back control still gets its real history.back()", async () => {
+    // The other half of the same defect: with the marker swallowed by `/jobs/`,
+    // this control fell back and pushed a fresh blank `/`, losing the parse and
+    // every inline edit — the very bug #706 exists to fix.
+    markDeparture();
+    await mount(createElement(JdFitApp));
+    clickChrome("← Parser audit");
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("a legitimate / → /jobs/ trip still goes back through history", async () => {
+    // The feature itself: fixing the two-hop bug must not cost the one-hop one.
+    markDeparture();
+    await mount(createElement(JobsApp));
+    clickChrome("Back to your resume");
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("a direct /jobs/ visit falls back rather than firing into a foreign history stack", async () => {
+    await mount(createElement(JobsApp));
+    clickChrome("Back to your resume");
+    expect(back).not.toHaveBeenCalled();
+  });
+});
+
+describe("only `/` marks a departure", () => {
+  it("`/` supplies the Saved jobs callback, so its header link marks the trip", async () => {
+    // Pins `onSavedJobsNavigate={goToSavedJobs}` in App.tsx: removing it left
+    // the entire suite green (1170 passed) before this test existed.
+    await mount(createElement(App));
+    clickChrome("Saved jobs");
+    expect(readDepartureMarker()).toBe(true);
+  });
+
+  it("`/jd-fit/` supplies none, so its identical-looking link marks nothing", async () => {
+    // Same click, same shared chrome, opposite obligation — and re-introducing
+    // a marking callback on JdFitApp also stayed green (633 passed) before.
+    await mount(createElement(JdFitApp));
+    clickChrome("Saved jobs");
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+  });
+
+  it("`/jobs/` does not render the link at all", async () => {
+    await mount(createElement(JobsApp));
+    const link = [...container.querySelectorAll("a")].find(
+      (a) => a.textContent === "Saved jobs",
+    );
+    expect(link).toBeUndefined();
+  });
+});

--- a/src/lib/nav-return.test.ts
+++ b/src/lib/nav-return.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the #706 back-navigation decision: `/jobs/` and `/jd-fit/`'s
+ * "back to resume" controls should use a real `history.back()` only when this
+ * tab actually arrived via a `markDeparture()`-marked launch from `/` — never
+ * on ambient inference. The case that must lose is the direct visit (no
+ * marker): it has to take the fallback, not fire `history.back()` into
+ * whatever history stack happens to exist.
+ *
+ * Since the marker carries the path it was written from, the OTHER losing case
+ * is a marker written somewhere that is not the app root — the shared
+ * `PageShell` header puts a `/jobs/` link on every surface, so a caller can be
+ * on `/jd-fit/` when it marks. That must read as "no marker".
+ *
+ * The read is non-destructive and the clear is separate on purpose; the pairing
+ * (once per VISIT, at mount) lives in `useArrivedFromRoot` and is tested there
+ * and in the two surfaces' own suites.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  isAppRoot,
+  markDeparture,
+  readDepartureMarker,
+  clearDepartureMarker,
+  shouldReturnViaHistory,
+  returnToResumeRoot,
+} from "./nav-return.ts";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("shouldReturnViaHistory (pure decision)", () => {
+  it("goes back when the marker is present", () => {
+    expect(shouldReturnViaHistory(true)).toBe(true);
+  });
+
+  it("LOSES the round trip and falls back when the marker is absent", () => {
+    expect(shouldReturnViaHistory(false)).toBe(false);
+  });
+});
+
+describe("markDeparture / readDepartureMarker / clearDepartureMarker", () => {
+  it("round-trips: a marked departure reads back as present", () => {
+    markDeparture();
+    expect(readDepartureMarker()).toBe(true);
+    // …and stays readable until something clears it. The read is deliberately
+    // pure: it runs inside a `useState` lazy initializer, which StrictMode
+    // double-invokes.
+    expect(readDepartureMarker()).toBe(true);
+    clearDepartureMarker();
+    expect(readDepartureMarker()).toBe(false);
+  });
+
+  it("reads absent when nothing marked a departure", () => {
+    expect(readDepartureMarker()).toBe(false);
+  });
+
+  it("a marker written from a NON-root surface does not satisfy the read", () => {
+    // The losing case the bare-boolean marker got wrong: the shared PageShell
+    // header renders a "Saved jobs" link on /jd-fit/ too, so a marker can be
+    // written from somewhere that is not the app root. Honouring it would send
+    // /jobs/'s "Back to your resume" control back to /jd-fit/ — a real page,
+    // but not the one the label names.
+    markDeparture({ pathname: "/jd-fit/" });
+    expect(readDepartureMarker()).toBe(false);
+  });
+
+  it("clears a non-root marker anyway, so it cannot answer a later visit", () => {
+    markDeparture({ pathname: "/jd-fit/" });
+    clearDepartureMarker();
+    // A marker left behind would still be sitting there when the NEXT leg —
+    // this time a real one from `/` — asked its question.
+    expect(sessionStorage.getItem("ocv_nav_from_root")).toBeNull();
+  });
+
+  it("clearing is idempotent, so StrictMode's effect replay costs nothing", () => {
+    markDeparture();
+    clearDepartureMarker();
+    expect(() => clearDepartureMarker()).not.toThrow();
+    expect(readDepartureMarker()).toBe(false);
+  });
+
+  it("recognises the index.html spelling of the root", () => {
+    markDeparture({ pathname: `${import.meta.env.BASE_URL}index.html` });
+    expect(readDepartureMarker()).toBe(true);
+  });
+
+  it("defaults to the current document's path", () => {
+    // jsdom's default location is the app root, so the no-argument call — what
+    // every production caller makes — must read back as a root departure.
+    expect(isAppRoot(window.location.pathname)).toBe(true);
+    markDeparture();
+    expect(readDepartureMarker()).toBe(true);
+  });
+});
+
+describe("returnToResumeRoot", () => {
+  it("calls history.back() when this visit's mount found a root marker", () => {
+    const back = vi.fn();
+    const win = { history: { back }, location: { href: "" } };
+    returnToResumeRoot(true, win);
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(win.location.href).toBe("");
+  });
+
+  it("a direct visit (no departure marker) falls back to a fresh navigation, not history.back()", () => {
+    const back = vi.fn();
+    const win = { history: { back }, location: { href: "" } };
+    returnToResumeRoot(false, win);
+    expect(back).not.toHaveBeenCalled();
+    expect(win.location.href).not.toBe("");
+  });
+
+  it("reads NO storage of its own, so a marker written after mount cannot arm it", () => {
+    // The two-hop defect in miniature: a marker that is live at click time is
+    // one written for some OTHER leg. This control answers from what its own
+    // visit saw at mount, so a marker appearing later is irrelevant to it.
+    markDeparture();
+    const back = vi.fn();
+    const win = { history: { back }, location: { href: "" } };
+    returnToResumeRoot(false, win);
+    expect(back).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("ocv_nav_from_root")).not.toBeNull();
+  });
+});

--- a/src/lib/nav-return.ts
+++ b/src/lib/nav-return.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * "Back to your resume" / "Parser audit" controls on `/jobs/` and `/jd-fit/`
+ * (#706): make a real back navigation when one is available, so a completed
+ * parse and its inline edits — which live only in React state, restored by
+ * bfcache on a genuine back navigation (measured on #706) — survive the trip.
+ * A plain `window.location.href = BASE_URL` always PUSHES a fresh `/`, which
+ * boots to its idle state and loses both.
+ *
+ * There is no API to read the previous history entry's URL from JavaScript,
+ * by design, so "is the previous entry the app root?" cannot be answered by
+ * inspecting `history` itself. Candidates considered: `document.referrer`
+ * (ambient, and clobbered by whichever page loaded most recently — not
+ * necessarily via one of these controls) and `history.length` (also ambient,
+ * and wrong the moment a user has other same-tab navigations queued up). Both
+ * infer the trip happened; neither proves it.
+ *
+ * Instead the OUTBOUND leg leaves a marker: `App.tsx` (the `/` → `/jd-fit/`
+ * link) and `jobs-departure.ts` (both `/` → `/jobs/` routes) call
+ * `markDeparture()` right before they navigate. A back control here then
+ * knows a round trip through an instrumented launch point actually happened,
+ * rather than guessing from ambient state. The known gap: it only covers
+ * navigations that went through those call sites. A bookmarked `/jobs/`
+ * URL, a link opened in a new tab, or a manual reload of `/jobs/` never sets
+ * the marker — and correctly falls back to a fresh `/` rather than firing
+ * `history.back()` into someone else's history stack.
+ *
+ * The marker stores the path it was written FROM, not a bare `"1"`, and
+ * `readDepartureMarker()` answers true only for the app root. That is what
+ * makes the fallback the safe failure mode rather than merely the usual one:
+ * a marker written from `/jd-fit/` (the shared `PageShell` header renders a
+ * "Saved jobs" link on every surface) would otherwise send `/jobs/`'s "Back to
+ * your resume" control back to `/jd-fit/` — a real page, but not the one the
+ * label names — and would consume the marker `/`'s own leg wrote, re-arming
+ * the very lost-parse bug this module exists to fix. Encoding the origin makes
+ * "only `/` marks a departure" an invariant this module enforces instead of a
+ * convention every future caller has to remember. With it, the failure mode is
+ * one-directional again: a marker that fails to read as root costs a lost
+ * parse (today's status quo), never a dead end or a foreign page.
+ *
+ * The other half of that guarantee lives at the call sites: a marker must only
+ * be written when THIS document is actually leaving. `PageShell`'s link is an
+ * `<a href>`, and a ⌘/ctrl/shift-click on one dispatches an ordinary `click`
+ * (unlike middle-click's `auxclick`) while the browser opens a new tab and this
+ * document stays put — so the callback that marks is guarded on the modifier
+ * keys there, and this module never gets a marker decoupled from a navigation.
+ *
+ * sessionStorage, per the repo's `ocv_*` convention: per-tab, dies with the
+ * tab, and (unlike `jobs-handoff.ts`) single-use — a marker answers only the
+ * NEXT visit's question, so leaving it live would tell a later, unrelated
+ * visit in the same tab (e.g. a reload after the back control already fired)
+ * that it, too, arrived from `/`.
+ *
+ * "Visit", specifically — not "click". This module deliberately does NOT
+ * export a combined read-and-clear that a click handler can call, because a
+ * marker consumed at click time outlives the leg it was written for: `/` →
+ * `/jd-fit/` writes a root marker, and if `/jd-fit/` never touches it, the
+ * user's next hop (the shared header's "Saved jobs" link) lands on `/jobs/`
+ * with `/`'s marker still live — so `/jobs/`'s "Back to your resume" fires
+ * `history.back()` into `/jd-fit/`, a real page but not the one the label
+ * names, AND swallows the marker, so `/jd-fit/`'s own back control then
+ * pushes a fresh blank `/` and loses the parse. Both halves of the bug above,
+ * through two clicks on visible chrome. So the read and the clear are
+ * separate exports and the pairing lives in `useArrivedFromRoot`, which each
+ * non-root surface calls once at mount: whichever surface the marker's leg
+ * actually landed on absorbs it, and every later surface correctly finds
+ * nothing.
+ */
+
+const NAV_RETURN_KEY = "ocv_nav_from_root";
+
+/**
+ * Is `path` the app root — the one origin a departure marker may claim?
+ *
+ * Base-aware (`import.meta.env.BASE_URL` is `/` on the custom domain and
+ * `/OfflineCV/` on the Pages fallback), and accepts the explicit
+ * `index.html` spelling of the same page, which a direct file-ish link or a
+ * static host can produce. `/jobs/` and `/jd-fit/` are neither.
+ */
+export function isAppRoot(path: string): boolean {
+  const base = import.meta.env.BASE_URL;
+  return path === base || path === `${base}index.html`;
+}
+
+/**
+ * Call immediately before navigating away from `/` toward `/jobs/` or
+ * `/jd-fit/` — records WHERE the trip started, so a back control can tell a
+ * genuine round trip from `/` apart from one that started somewhere else.
+ *
+ * The origin is read off an injected `Location`, defaulting to this document's,
+ * rather than taken as a bare `string`: a string parameter is an escape hatch a
+ * future production caller can use to forge `markDeparture("/")` from a
+ * non-root surface, which silently defeats `isAppRoot` and re-arms exactly the
+ * defect the encoded origin exists to prevent. A test still writes the losing
+ * case by passing `{ pathname: "/jd-fit/" }`, the same injection shape
+ * `returnToResumeRoot` takes for `history`/`location`.
+ */
+export function markDeparture(
+  from: Pick<Location, "pathname"> = window.location,
+): void {
+  try {
+    sessionStorage.setItem(NAV_RETURN_KEY, from.pathname);
+  } catch {
+    // Quota / private-mode / disabled storage — the back control falls back
+    // to a fresh navigation, which is always correct, just not a true back.
+  }
+}
+
+/**
+ * Does a departure marker say this visit's trip started at the app root?
+ *
+ * Non-destructive on purpose — see the module docblock: the clear belongs to
+ * the visit (`useArrivedFromRoot`, at mount), not to whoever asks. Keeping the
+ * read pure is also what makes it safe inside a `useState` lazy initializer,
+ * which React StrictMode double-invokes; a clearing initializer would return
+ * `true` on the first pass and `false` on the second, and the second is the one
+ * React keeps.
+ *
+ * Non-throwing: absent or inaccessible storage both read as "no marker", which
+ * resolves to the safe fallback.
+ */
+export function readDepartureMarker(): boolean {
+  try {
+    const from = sessionStorage.getItem(NAV_RETURN_KEY);
+    return from !== null && isAppRoot(from);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Retire the marker for this visit. Clears unconditionally — a marker from a
+ * NON-root path is single-use too, and leaving it behind would let it answer a
+ * later, unrelated visit's question. Idempotent, so StrictMode's
+ * setup→cleanup→setup effect replay costs nothing.
+ */
+export function clearDepartureMarker(): void {
+  try {
+    sessionStorage.removeItem(NAV_RETURN_KEY);
+  } catch {
+    // Inaccessible storage — nothing was readable either, so there is no
+    // marker left to mislead a later visit.
+  }
+}
+
+/**
+ * The decision itself, factored out from the sessionStorage IO above so it is
+ * unit-testable with a plain boolean — no jsdom, no storage — and so the
+ * "no marker" branch (a direct `/jobs/` visit) is exercised as easily as the
+ * round-trip one.
+ */
+export function shouldReturnViaHistory(markerPresent: boolean): boolean {
+  return markerPresent;
+}
+
+/** Minimal shape `returnToResumeRoot` needs from `window`, so a test can pass
+ *  a stub instead of relying on jsdom's unimplemented `location.href`
+ *  navigation. */
+export interface ReturnNavigable {
+  history: Pick<History, "back">;
+  location: Pick<Location, "href">;
+}
+
+/**
+ * The composed control: `history.back()` when this visit's departure marker
+ * said the tab actually came from `/`, else a fresh navigation to the app
+ * root. Used by both `/jobs/`'s and `/jd-fit/`'s "back to resume" controls —
+ * the target root is the same for both.
+ *
+ * `arrivedFromRoot` is a parameter rather than a storage read here because the
+ * marker is consumed once at mount (`useArrivedFromRoot`), not per click — see
+ * the module docblock for the two-hop bug that made click-time consumption
+ * wrong.
+ */
+export function returnToResumeRoot(
+  arrivedFromRoot: boolean,
+  win: ReturnNavigable = window,
+): void {
+  if (shouldReturnViaHistory(arrivedFromRoot)) {
+    win.history.back();
+  } else {
+    win.location.href = import.meta.env.BASE_URL;
+  }
+}


### PR DESCRIPTION
## Summary

Four issues, one branch: the saved job library now shows a fitness rating, `Back to your resume` is a real back navigation instead of a forward push to a blank page, `/jobs/` is reachable without parsing first, and `htmlToPlaintext` moves out of the module that owns the network calls.

They ship together because they interact. #707's new route to `/jobs/` would have driven more traffic onto the round trip #706 fixes, and #700's ratings only appear on a route that hands the parse over — which the new link initially did not.

Closes #700
Closes #704
Closes #706
Closes #707

## What each one does

- **#704** — `htmlToPlaintext` moves to its own zero-dependency module. `fetch-jd.ts` re-exports it so every existing caller is unchanged; the barrel now sources it directly, so a barrel consumer's import graph never touches the file holding a live `fetch(`. Byte-identical move, verified with `diff` against `main`.
- **#700** — saved rows rate through the same chain the search lane uses. Recomputed on view, never persisted (a stored score would go stale the moment the résumé is edited, and nothing would invalidate it). One `rateJobs` call for the whole library, so the set-relative stretch matches the search lane's scale. A record with no usable description is **absent from the result map** and renders "not rated" — absence is the signal, so a caller cannot paint it 0 stars.
- **#706** — `history.back()` when this tab arrived from the app root, `location.href` fallback otherwise. Applies to `/jd-fit/`'s control too. `/jobs/`'s empty-state CTA stays a forward push deliberately — it only appears when there is no parse to preserve.
- **#707** — a parse-independent "Saved jobs" link in the shared `PageShell` header, landing on `/jobs/?tab=library`. Shown on `/` and `/jd-fit/`, suppressed on `/jobs/` itself.

## bfcache: measured, not assumed

#706 rests on `/` being restored from the back/forward cache — otherwise `history.back()` returns to a page that reloads from scratch and the fix delivers nothing. The issue flagged this as a source-read inference with a re-scope trigger. It was measured before any code was written, against the deployed site in Chrome:

```
pageshow                          → { persisted: true }
window.__bf2                      → "ALIVE-2"     (in-memory JS state survived)
PerformanceNavigationTiming.type  → "navigate"    (original entry retained, not a fresh load)
```

Two notes, because each cost a false negative first:

- **Playwright's Chromium has BackForwardCache disabled.** The probe failed there — and so did a two-file static control page, which is the only reason that wasn't reported as "not eligible".
- **Chrome refused `http://localhost`** for the local preview build, so the measurement moved to production. That is the better environment for the claim anyway: real headers, the URL users actually hit.

## Review focus

- `src/lib/nav-return.ts` — the departure marker is retired **once per visit, at mount**, not on whichever back control clicks first. Does any sequence still let a marker outlive the leg that wrote it?
- `src/hooks/useArrivedFromRoot.ts` — pure read in the lazy initializer, idempotent clear in an effect. Under React 19 StrictMode the second initializer's value is the one that commits; does this shape still hold if the clear ever moves back into render?
- `src/components/features/PageShell.tsx` — shared chrome renders on every surface, so it takes an `onSavedJobsNavigate` callback rather than deciding a departure happened. Is there a surface that should supply one and doesn't?
- `src/lib/job-search/rate-saved-jobs.ts:88` — rateability is decided *after* extraction. Does any input reach `rateJobs` with an empty term set?
- `src/App.tsx:102` vs `ResultDetailTabs.tsx:193` — see the known gap below.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 285 files, 4153 tests, 0 failures
- [x] `npm run lint` clean
- [x] `npm run check:fixtures` — 58 PDFs + 15 sidecars, all personas synthetic; no fixture binary added or changed by this PR
- [x] `npm run check:baselines` — pass (the 10 `unfiled` warnings pre-exist on `main`)
- [x] `fallow audit --base origin/main` — no new findings
- [x] bfcache restoration confirmed in a real browser (above)
- [x] `npm run verify` — green in CI

## Known gap, not fixed here

`App.tsx:102` hands the header link `displayResult?.canonical.fields`, while `FindJobsLauncher` (`ResultDetailTabs.tsx:193`) hands over `activeResult.canonical.fields` — the LLM-recovered merge when `llmOverride` is set, which is component-local state `App` cannot see. So after an LLM parse recovery the two routes off `/` ship **different résumés**, which undercuts `jobs-departure.ts`'s claim that both routes do exactly the same two things.

Left alone deliberately: deciding which of the two is canonical is a product call, not a patch to pick mid-batch.

Also deferred, all recorded during review: `JobTrackerEntry.tsx` is 217 LOC (over the ~200 guideline — the new fitness block extracts cleanly); `JobTrackerEntry.tsx:115` re-implements `JobResultCard`'s module-private `star1` rounding; `useSavedJobRatings`'s signature memo rebuilds a string containing every saved job's full `jdText` on each tracker mutation; `?tab=library` persists in the address bar, so switching to Search and reloading bounces back to the library (a recorded trade-off — the param is what makes a pasted URL work).

Two things remain **unguarded by any test**: `App`'s handoff *payload* on the header route (the idle mount only exercises `departToJobs(undefined)`; the payload is covered on the button route only), and `goToJdFit`'s `markDeparture()` call, since that cross-link is flag-gated off by default. Both need a real PDF parse in a test.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #704 | Claude Sonnet 5 | medium |
| Implementation — #700 | unreported (requested: opus) | ultra |
| Implementation — #706 | Claude Sonnet 4.6 | high |
| Implementation — #707 | Claude Sonnet 5 | high |
| Adversarial review — round 1 | Claude Opus 5 (1M context) | high |
| Review fixes — round 1 | Claude Opus 5 (1M context) | high |
| Adversarial review — round 2 | Claude Opus 5 (1M context) | high |
| Review fixes — round 2 | Claude Opus 5 (1M context) | high |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |

The #700 row is `unreported` because that subagent went idle without returning its model name, and a `model:` alias does not establish what it resolved to. Its work was verified independently against the tree rather than accepted on report.

## Adversarial review

Two review rounds plus a third fix pass ran against this diff **before** the PR opened, so it starts from a reviewed base rather than a first draft. Every finding below was reproduced end-to-end by the reviewer, not reasoned about — scratch repros were run outside the repo.

### Round 1 — 4 blocking, all fixed

| # | Finding | Resolution |
|---|---|---|
| B1 | `PageShell` wrote the "came from root" marker from shared chrome, so `/jd-fit/` claimed a trip had started at `/`. Because the marker was single-use, that write **consumed the one `App.tsx` made** — re-arming the exact #706 defect on a path #706 claims to fix. | `PageShell` no longer imports `nav-return.ts`; it takes a callback and only `/` supplies one. Marker became path-valued, so a non-root write can never satisfy the root question. |
| B2 | `markDeparture()` fired on a ⌘/Ctrl-click, which dispatches an ordinary `click` (unlike middle-click's `auxclick`) while *this* tab stays put — decoupling the marker from any navigation and inverting the module's stated one-directional failure mode. | Early return on `button !== 0 \|\| meta \|\| ctrl \|\| shift \|\| alt`, never `preventDefault`. |
| B3 | A saved job whose `jdText` yields **zero extractable terms** rendered 0 stars + "Weak fit" — the precise display #700 exists to prevent. Reproduced with `"Apply on our website."`, `"See job posting."`, `"-"`. The guard tested for *text*, not for *a description to match against*. | Rateability decided after extraction, single pass; zero-term records take the same absence as blank ones. |
| B4 | The new header link never wrote the jobs handoff, so reaching the library through it showed no ratings **plus** "Open this workbench from your resume to see how each saved job fits it" — to someone who had just done that. | New `jobs-departure.ts` composes handoff + marker; both `/` → `/jobs/` routes go through it so a third route cannot re-split them. |

### Round 2 — 1 blocking, fixed

The path-valued marker fixed *who may write* one, but not *how long it lives*. Nothing consumed a marker except an explicit back-control click, so the `/`-marker written on the way to `/jd-fit/` sat live for that whole session and answered whichever back control asked next:

```
/ → "Check fit against a job"      marker = "/"        history [/, /jd-fit/]
/jd-fit/ → header "Saved jobs"     marker still "/"    history [/, /jd-fit/, /jobs/]
/jobs/ → "‹ Back to your resume"   isAppRoot("/") ✓ → history.back()  →  lands on /jd-fit/
/jd-fit/ → "← Parser audit"        marker consumed → location.href → fresh blank /
```

Both halves of B1, back through two clicks on visible chrome. Fixed by making the marker **per-visit**: each non-root surface retires it once at mount (`useArrivedFromRoot`), and the back control reads the captured boolean.

That fix corrected a suggestion made during orchestration. A lazy `useState` initializer that *clears* storage is broken under React 19 StrictMode — the fiber's hook list is reset and re-run, so the **second** initializer's value commits: `true` on pass 1, `false` on pass 2, and `false` wins. The feature would have been dead under `npm run dev` while every non-Strict test stayed green. The shipped shape is a pure read in the initializer plus an idempotent clear in an effect — no side effect in render at all — pinned by a test that mounts inside a real `<StrictMode>`.

### What the reviewer tried to break and could not

`rateJobs` ordering (index alignment in `rate-saved-jobs.ts` is sound — verified empirically with a deliberately mis-ordered set); `ratingInputFor`'s widened parameter (both placeholder fields traced and genuinely inert with all query args `undefined`); `isAppRoot` prefix confusion (it is `===` against two literals — 15 adversarial inputs under both the `/` and `/OfflineCV/` bases, including `/OfflineCV/jobs/`, `/OfflineCVevil/`, `..` traversal and case variants, all reject); `useSavedJobRatings`'s omitted `jobs` dep (the signature covers exactly the fields `rateSavedJobs` reads, structurally pinned by `RatableSavedJob`); NaN poisoning of the set via a zero-term record; #704's move (byte-identical); and the `.catch` leaving a permanent spinner (it renders no fitness block, not a placeholder).

### A revert-proof claim that did not hold

The round-1 fix pass reported "reverting all four fixes fails exactly 7 new tests". Round 2 disproved half of it: reverting B4's actual wiring — `onSavedJobsNavigate={goToSavedJobs}` in `App.tsx` — left **1170 tests passing, zero failures**, and re-adding a marking callback to `JdFitApp` also stayed green. `PageShell.test.tsx` pinned the shell's contract against a hand-written callback, which is no evidence that `/` supplies one.

`nav-return.surfaces.test.tsx` now closes that hole by mounting the real `App`, `JdFitApp` and `JobsApp` and clicking real chrome. Both reverts now fail, and the D2 revert fails *two* tests — the forged marker travels forward to `/jobs/` and arms its back control, the same defect through a different door.

One limit worth stating plainly: jsdom implements no navigation, so these proofs run against a `history.back` spy. They establish that the wrong **branch** is taken, not the wrong **destination**. The destination claim rests on the production bfcache measurement in the PR body, not on the test suite.
