### PR TITLE
chore(parser): use synthetic personas in the experience test data

### DIFF
--- a/src/lib/heuristics/cascade-markdown.test.ts
+++ b/src/lib/heuristics/cascade-markdown.test.ts
@@ -409,7 +409,7 @@ describe("runCascadeFromMarkdown — escalation path", () => {
  */
 describe("runCascadeFromMarkdown — below-anchor role scope (#615 issue variants)", () => {
   const HEADER =
-    "### Sr. Engineering Manager · Google, Hyderabad, India · Enterprise Platforms";
+    "### Sr. Engineering Manager · Globex, Toronto, Canada · Enterprise Platforms";
   const DATE = "*01/2024 – 12/2024*";
   const BULLETS = [
     "- Built an 18-engineer org in under 6 months.",

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -47,10 +47,10 @@ const LEGAL_SUFFIX_RE =
  *
  *  Silicon-Valley/Peninsula additions (#616): "Mountain View", "Palo Alto",
  *  "Menlo Park" are the multi-word tech-hub cities that show up co-located
- *  with Google/Meta/Stanford in a `Title · Company, City · Team` middot header
+ *  with Globex/Meta/Stanford in a `Title · Company, City · Team` middot header
  *  with NO trailing state suffix. Without the vocab entry, Pass F of
  *  `stripLocationSuffix` (bare-city tail check) failed to full-match them and
- *  the middle segment stayed whole ("Google, Mountain View" → company). Same
+ *  the middle segment stayed whole ("Globex, Mountain View" → company). Same
  *  closed-vocab discipline as the pre-existing entries: a real company that
  *  merely contains one of these tokens ("Mountain View Software") still fails
  *  the `^…$`-anchored full-string match.
@@ -143,8 +143,8 @@ function cityStartsWithCompanyText(city: string): boolean {
  *  "Springs", "Heights", "Town", …) is never a standalone city — it is the
  *  truncated tail of a multi-word place ("Mexico City", "Long Beach", "Cape
  *  Town") whose earlier words the single-token space-fold regex left glued to the
- *  company. Peeling it would mis-split "Google Mexico City, Mexico" into company
- *  "Google Mexico" + location "City, Mexico" — both wrong (#286 review). Defer:
+ *  company. Peeling it would mis-split "Globex Mexico City, Mexico" into company
+ *  "Globex Mexico" + location "City, Mexico" — both wrong (#286 review). Defer:
  *  leave the whole string as company rather than fragment a real multi-word city.
  *  (A proper-noun compound like "Buenos Aires" has no generic tell and stays a
  *  known limitation — distinguishing it from a real company+city fold needs a
@@ -322,7 +322,7 @@ function stripLocationSuffix(s: string): {
     //   - single-token city (space boundary). A multi-word space-fold city whose
     //     last token is a locality generic ("…City", "…Beach") would otherwise be
     //     truncated to that generic tail and mis-split, so LOCALITY_SUFFIX_RE
-    //     defers it ("Google Mexico City, Mexico" stays company, not fragmented),
+    //     defers it ("Globex Mexico City, Mexico" stays company, not fragmented),
     //     and
     //   - a closed-vocabulary country (COUNTRY_GAZETTEER), not any capitalized
     //     word — so it fires on a real "City, Country" fold, not on a company
@@ -483,7 +483,7 @@ function anchorCarriesOrgSignal(text: string): boolean {
  * WHOLE string (not merely a trailing suffix). The full-length check on the
  * US/intl matches distinguishes a self-contained location ("Pomona, CA",
  * "Mountain View, CA") from a company that merely carries a trailing city
- * ("Globex, Hyderabad, India", where INTL_LOCATION_RE matches only a substring).
+ * ("Globex, Toronto, Canada", where INTL_LOCATION_RE matches only a substring).
  *
  * Shape is NOT sufficient — the comma-tail must resolve against a REAL location
  * signal, not merely a "CapWords, CapWords" shape. `US_LOCATION_RE` /
@@ -996,7 +996,7 @@ function mapWithoutCompanyMatch(
     // Symmetric to `mapTitleFirst`'s handling of the reverse ordering.
     //
     // Additional guard on `!isBareLocationString(s2)` (#639 review): a segment
-    // that is entirely a bare location ("New York, NY", "Hyderabad, India")
+    // that is entirely a bare location ("New York, NY", "Toronto, Canada")
     // fails `looksLikeTitle` too — but it is the LOCATION, not the company.
     // Promoting it here would shred it: `recoverLocation`'s `stripLocationSuffix`
     // then peels its own tail as location, so `New York, NY` → company="New" /
@@ -1047,8 +1047,8 @@ function mapWithoutCompanyMatch(
  * (3a) Try stripping a trailing location suffix from team — handles the case
  *      where `looksLikeCompany` mis-routed a "Group"/"Systems"/"Labs" segment
  *      as company (e.g. "Platform Group" in
- *      "Title · Globex, Hyderabad, India · Platform Group"), pushing
- *      "Globex, Hyderabad, India" into the team slot. If strip succeeds and
+ *      "Title · Globex, Toronto, Canada · Platform Group"), pushing
+ *      "Globex, Toronto, Canada" into the team slot. If strip succeeds and
  *      the team isn't itself a bare whole-string location (which the step-3b
  *      check below handles), rotate: remainder → company, old company → team.
  *
@@ -1057,8 +1057,8 @@ function mapWithoutCompanyMatch(
  *      but it IS already a bare location (US_LOCATION_RE covers the whole
  *      string). Exclude these by checking whether any location regex matches
  *      the FULL string (not just a substring), so "Mountain View, CA"
- *      (full match) vs. "Globex, Hyderabad, India" (INTL_LOCATION_RE only
- *      matches "Globex, Hyderabad", not the full "…India" tail) are
+ *      (full match) vs. "Globex, Toronto, Canada" (INTL_LOCATION_RE only
+ *      matches "Globex, Toronto", not the full "…Canada" tail) are
  *      distinguished correctly.
  *
  * (3b) Whole-string bare location check. Uses the SAME shared

--- a/src/lib/heuristics/extract/experience.date-subline-extra-tokens.test.ts
+++ b/src/lib/heuristics/extract/experience.date-subline-extra-tokens.test.ts
@@ -48,7 +48,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Toronto",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024", fontSize: 11 },
@@ -58,7 +58,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const role = roles[0];
 
     expect(role.company).toBe("Globex");
-    expect(role.location).toBe("Hyderabad");
+    expect(role.location).toBe("Toronto");
     expect(role.team).toBe("Site Lead, Payments Platform");
   });
 
@@ -66,7 +66,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Toronto",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
@@ -76,7 +76,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const role = roles[0];
 
     expect(role.company).toBe("Globex");
-    expect(role.location).toBe("Hyderabad");
+    expect(role.location).toBe("Toronto");
     expect(role.team).toBe("Site Lead, Payments Platform");
     // The date-line data token must not appear in any parsed field.
     expect(role.company).not.toBe("M4");
@@ -87,7 +87,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad, India",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Toronto, Canada",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
@@ -97,7 +97,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const role = roles[0];
 
     expect(role.company).toBe("Globex");
-    expect(role.location).toBe("Hyderabad, India");
+    expect(role.location).toBe("Toronto, Canada");
     expect(role.team).toBe("Site Lead, Payments Platform");
   });
 
@@ -105,7 +105,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Globex, Hyderabad, India · Site Lead, Payments Platform",
+        text: "Sr. Engineering Manager · Globex, Toronto, Canada · Site Lead, Payments Platform",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024 · M4 · 22 engineers, 3 squads", fontSize: 11 },
@@ -115,7 +115,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const role = roles[0];
 
     expect(role.company).toBe("Globex");
-    expect(role.location).toBe("Hyderabad, India");
+    expect(role.location).toBe("Toronto, Canada");
     expect(role.team).toBe("Site Lead, Payments Platform");
   });
 
@@ -190,7 +190,7 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Hyderabad, India",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Toronto, Canada",
         fontSize: 11,
       },
       { text: "01/2024 – 12/2024", fontSize: 11 },
@@ -199,8 +199,8 @@ describe("date sub-line extra tokens don't hijack company (#614)", () => {
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.location).toBe("Hyderabad, India");
-    expect(role.company).not.toBe("Hyderabad");
-    expect(role.company).not.toBe("Hyderabad, India");
+    expect(role.location).toBe("Toronto, Canada");
+    expect(role.company).not.toBe("Toronto");
+    expect(role.company).not.toBe("Toronto, Canada");
   });
 });

--- a/src/lib/heuristics/extract/experience.leading-body-prose.test.ts
+++ b/src/lib/heuristics/extract/experience.leading-body-prose.test.ts
@@ -47,7 +47,7 @@ function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
 // Baseline: the shared header for every variant. Every field lands on line 1
 // via the middot split, so any surviving below-anchor line is pure body.
 const HEADER_LINE = {
-  text: "Sr. Engineering Manager · Google, Hyderabad, India · Enterprise Platforms",
+  text: "Sr. Engineering Manager · Globex, Toronto, Canada · Enterprise Platforms",
   fontSize: 11,
 };
 const DATE_LINE = { text: "01/2024 – 12/2024", fontSize: 11 };
@@ -67,9 +67,9 @@ function assertHeaderFieldsIntact(role: {
   // AC #3 — header fields (title/company/team/location/dates) unchanged by
   // the presence of the leading-body-prose line.
   expect(role.title).toBe("Sr. Engineering Manager");
-  expect(role.company).toBe("Google");
+  expect(role.company).toBe("Globex");
   expect(role.team).toBe("Enterprise Platforms");
-  expect(role.location).toBe("Hyderabad, India");
+  expect(role.location).toBe("Toronto, Canada");
   expect(role.start_date).toBe("01/2024");
   expect(role.end_date).toBe("12/2024");
 }
@@ -132,7 +132,7 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       // NOTE: no `· Enterprise Platforms` segment — this is the whole point.
-      { text: "Sr. Engineering Manager · Google, Hyderabad, India", fontSize: 11 },
+      { text: "Sr. Engineering Manager · Globex, Toronto, Canada", fontSize: 11 },
       DATE_LINE,
       { text: "Founding site leader; owned charter and headcount.", fontSize: 11 },
       ...BULLETS,
@@ -143,8 +143,8 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
     expect(role.team).toBeUndefined();
     // The other header fields still come off line 1 unchanged.
     expect(role.title).toBe("Sr. Engineering Manager");
-    expect(role.company).toBe("Google");
-    expect(role.location).toBe("Hyderabad, India");
+    expect(role.company).toBe("Globex");
+    expect(role.location).toBe("Toronto, Canada");
     expect(role.start_date).toBe("01/2024");
     expect(role.end_date).toBe("12/2024");
     // And the sentence surfaces on description, not team.
@@ -172,7 +172,7 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
       const roles = roleFromSection([
         { text: "EXPERIENCE", fontSize: 13 },
         // NOTE: no team segment — this is the case the preempt exists to protect.
-        { text: "Sr. Engineering Manager · Google, Hyderabad, India", fontSize: 11 },
+        { text: "Sr. Engineering Manager · Globex, Toronto, Canada", fontSize: 11 },
         DATE_LINE,
         { text: scope, fontSize: 11 },
         ...BULLETS,
@@ -181,8 +181,8 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
       const role = roles[0];
       expect(role.team).toBeUndefined();
       expect(role.title).toBe("Sr. Engineering Manager");
-      expect(role.company).toBe("Google");
-      expect(role.location).toBe("Hyderabad, India");
+      expect(role.company).toBe("Globex");
+      expect(role.location).toBe("Toronto, Canada");
       const lines = role.description!.split("\n");
       expect(lines[0]).toBe(scope);
     }
@@ -198,7 +198,7 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
     // the scope line is present, which the exported org header renders.
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
-      { text: "Sr. Engineering Manager · Google, Hyderabad, India", fontSize: 11 },
+      { text: "Sr. Engineering Manager · Globex, Toronto, Canada", fontSize: 11 },
       DATE_LINE,
       { text: "L7 · 18 engineers, 2 TLMs reporting", fontSize: 11 },
       ...BULLETS,
@@ -208,8 +208,8 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
     // AC #3 — `team` stays undefined (was "L7" without the preempt).
     expect(role.team).toBeUndefined();
     expect(role.title).toBe("Sr. Engineering Manager");
-    expect(role.company).toBe("Google");
-    expect(role.location).toBe("Hyderabad, India");
+    expect(role.company).toBe("Globex");
+    expect(role.location).toBe("Toronto, Canada");
     // Scope line lands on `description` and is not double-recorded.
     const lines = role.description!.split("\n");
     expect(lines[0]).toBe("L7 · 18 engineers, 2 TLMs reporting");
@@ -235,14 +235,14 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
       { text: "EXPERIENCE", fontSize: 13 },
       DATE_LINE,
       { text: "Founding site leader; owned charter and headcount.", fontSize: 11 },
-      { text: "• Sr. Engineering Manager, Google", fontSize: 11 },
+      { text: "• Sr. Engineering Manager, Globex", fontSize: 11 },
       ...BULLETS,
     ]);
     expect(roles).toHaveLength(1);
     const role = roles[0];
     // Promotion recovers title + company from the first bullet.
     expect(role.title).toBe("Sr. Engineering Manager");
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     // The scope line MUST NOT be silently dropped just because the
     // promotion path fired.
     expect(role.description).toBeDefined();
@@ -318,13 +318,13 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
     // The line reads as a bare location string (no `;`, no terminal `.!?`), so
     // `looksLikeBelowAnchorProse` returns false and it reaches disambiguation
     // as a header candidate. The token-coverage sweep is what protects it:
-    // every token in "Hyderabad, India" appears in the resolved `location`
+    // every token in "Toronto, Canada" appears in the resolved `location`
     // field, so the line is skipped rather than prepended.
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
-      { text: "Sr. Engineering Manager · Google, Hyderabad, India", fontSize: 11 },
+      { text: "Sr. Engineering Manager · Globex, Toronto, Canada", fontSize: 11 },
       DATE_LINE,
-      { text: "Hyderabad, India", fontSize: 11 },
+      { text: "Toronto, Canada", fontSize: 11 },
       ...BULLETS,
     ]);
     expect(roles).toHaveLength(1);
@@ -332,7 +332,7 @@ describe("leading body prose between date sub-line and bullets (#615)", () => {
     // The description must NOT lead with the redundant location line.
     expect(role.description).toBeDefined();
     const lines = role.description!.split("\n");
-    expect(lines[0]).not.toBe("Hyderabad, India");
-    expect(lines).not.toContain("Hyderabad, India");
+    expect(lines[0]).not.toBe("Toronto, Canada");
+    expect(lines).not.toContain("Toronto, Canada");
   });
 });

--- a/src/lib/heuristics/extract/experience.location.test.ts
+++ b/src/lib/heuristics/extract/experience.location.test.ts
@@ -153,16 +153,16 @@ describe("role location extraction (#218)", () => {
   describe("multi-word city in comma-delimited 'Company, City, ST' tail", () => {
     it("keeps a two-word city intact (Mountain View, not just View)", () => {
       // Regression: single-token city rule truncated "Mountain View" to "View"
-      // and glued "Mountain" onto company ("Google, Mountain" / "View, CA").
+      // and glued "Mountain" onto company ("Globex, Mountain" / "View, CA").
       const roles = roleFromSection([
         { text: "EXPERIENCE", fontSize: 13 },
-        { text: "Engineering Lead · Google, Mountain View, CA", fontSize: 11 },
+        { text: "Engineering Lead · Globex, Mountain View, CA", fontSize: 11 },
         { text: "01/2018 - 12/2020", fontSize: 11 },
         { text: "• Led the GFiber platform team.", fontSize: 11 },
       ]);
       expect(roles.length).toBeGreaterThanOrEqual(1);
       const role = roles[0];
-      expect(role.company).toBe("Google");
+      expect(role.company).toBe("Globex");
       expect(role.company).not.toContain("Mountain");
       expect(role.location).toBe("Mountain View, CA");
     });
@@ -217,12 +217,12 @@ describe("role location extraction (#218)", () => {
   });
 
   describe("international City, Country extraction (Pass C, #229)", () => {
-    it("extracts 'Hyderabad, India' from mid-dot header (primary AC)", () => {
-      // "Regional Engineering Lead · Globex, Hyderabad, India · Platform Group"
+    it("extracts 'Toronto, Canada' from mid-dot header (primary AC)", () => {
+      // "Regional Engineering Lead · Globex, Toronto, Canada · Platform Group"
       const roles = roleFromSection([
         { text: "EXPERIENCE", fontSize: 13 },
         {
-          text: "Regional Engineering Lead · Globex, Hyderabad, India · Platform Group",
+          text: "Regional Engineering Lead · Globex, Toronto, Canada · Platform Group",
           fontSize: 11,
         },
         { text: "03/2021 - 12/2023", fontSize: 11 },
@@ -233,9 +233,9 @@ describe("role location extraction (#218)", () => {
 
       expect(role.title?.toLowerCase()).toContain("engineering lead");
       expect(role.company).toBe("Globex");
-      expect(role.company).not.toContain("Hyderabad");
+      expect(role.company).not.toContain("Toronto");
       expect(role.team).toBe("Platform Group");
-      expect(role.location).toBe("Hyderabad, India");
+      expect(role.location).toBe("Toronto, Canada");
     });
 
     it("extracts 'London, United Kingdom' (multi-word country) from mid-dot header", () => {
@@ -282,24 +282,24 @@ describe("role location extraction (#218)", () => {
       // Regression: Pass A must fire before Pass C for US locations.
       const roles = roleFromSection([
         { text: "EXPERIENCE", fontSize: 13 },
-        { text: "Engineering Lead · Google, Mountain View, CA", fontSize: 11 },
+        { text: "Engineering Lead · Globex, Mountain View, CA", fontSize: 11 },
         { text: "01/2018 - 12/2020", fontSize: 11 },
         { text: "• Led the GFiber platform team.", fontSize: 11 },
       ]);
       expect(roles.length).toBeGreaterThanOrEqual(1);
       const role = roles[0];
-      expect(role.company).toBe("Google");
+      expect(role.company).toBe("Globex");
       expect(role.location).toBe("Mountain View, CA");
     });
 
     it("non-empty-remainder guard: does not consume entire string into location", () => {
-      // If company = "Hyderabad, India" (no company name before city), the guard
+      // If company = "Toronto, Canada" (no company name before city), the guard
       // must block stripping and leave the string intact rather than setting
-      // company = "" and location = "Hyderabad, India".
+      // company = "" and location = "Toronto, Canada".
       const roles = roleFromSection([
         { text: "EXPERIENCE", fontSize: 13 },
         {
-          text: "Software Engineer · Hyderabad, India",
+          text: "Software Engineer · Toronto, Canada",
           fontSize: 11,
         },
         { text: "05/2022 - Present", fontSize: 11 },
@@ -308,7 +308,7 @@ describe("role location extraction (#218)", () => {
       expect(roles.length).toBeGreaterThanOrEqual(1);
       const role = roles[0];
       // Either the location is extracted with a non-empty company, or the
-      // entire "Hyderabad, India" remains as company — either way company must
+      // entire "Toronto, Canada" remains as company — either way company must
       // be non-empty and we must not have eaten all text into location.
       expect(role.company).toBeTruthy();
     });
@@ -373,10 +373,10 @@ describe("role location extraction (#218)", () => {
 
     it("defers a multi-word city with a locality-generic tail ('Mexico City') (#286 review)", () => {
       // Single-token Pass D would grab "City" as the city and mis-split into
-      // company "Google Mexico" + location "City, Mexico". "City" is a locality
+      // company "Globex Mexico" + location "City, Mexico". "City" is a locality
       // generic (never a standalone city), so LOCALITY_SUFFIX_RE defers: the
       // whole string stays with the company rather than fragmenting the city.
-      const role = roleFromTwoLine("Google Mexico City, Mexico");
+      const role = roleFromTwoLine("Globex Mexico City, Mexico");
       expect(role.company).toContain("Mexico City");
       expect(role.location).not.toBe("City, Mexico");
     });

--- a/src/lib/heuristics/extract/experience.multiword-city.test.ts
+++ b/src/lib/heuristics/extract/experience.multiword-city.test.ts
@@ -113,7 +113,7 @@ describe("multi-word city on space-folded header (#368)", () => {
 // `Company City, ST` shape. #616 is the same "multi-word bare city" weakness on
 // the single-line MIDDOT header path: `Title · Company, City · Team` where the
 // city carries NO state/country suffix — the closed BARE_LOCATION_RE vocab (Pass
-// F of stripLocationSuffix) knows single-word "Hyderabad" but not multi-word
+// F of stripLocationSuffix) knows single-word "Toronto" but not multi-word
 // "Mountain View", so the middle segment stayed whole and `company` swallowed
 // the city. Fixed by adding Mountain View (a canonical tech-hub example) to the
 // single-source MULTIWORD_US_CITY_ALT vocab so BARE_LOCATION_RE full-matches it.
@@ -126,7 +126,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
   // entry, dropping an entry from the alternation string fails a test instead
   // of passing silently.
   it.each([
-    ["Google", "Mountain View", "GFiber"],
+    ["Globex", "Mountain View", "GFiber"],
     ["Meta", "Menlo Park", "Ads"],
     ["Stanford", "Palo Alto", "SLAC"],
     ["Nvidia", "Santa Clara", "Compute"],
@@ -160,7 +160,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Engineering Lead · Google, Mountain View, CA · GFiber",
+        text: "Engineering Lead · Globex, Mountain View, CA · GFiber",
         fontSize: 11,
       },
       { text: "04/2021 – 12/2023", fontSize: 11 },
@@ -169,7 +169,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     expect(roles.length).toBeGreaterThanOrEqual(1);
     const role = roles[0];
 
-    expect(role.company).toBe("Google");
+    expect(role.company).toBe("Globex");
     expect(role.location).toBe("Mountain View, CA");
     expect(role.team).toBe("GFiber");
   });
@@ -178,7 +178,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Globex, Hyderabad · Payments Platform",
+        text: "Sr. Engineering Manager · Globex, Toronto · Payments Platform",
         fontSize: 11,
       },
       { text: "04/2021 – 12/2023", fontSize: 11 },
@@ -188,7 +188,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const role = roles[0];
 
     expect(role.company).toBe("Globex");
-    expect(role.location).toBe("Hyderabad");
+    expect(role.location).toBe("Toronto");
     expect(role.team).toBe("Payments Platform");
   });
 
@@ -196,7 +196,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const roles = roleFromSection([
       { text: "EXPERIENCE", fontSize: 13 },
       {
-        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Hyderabad",
+        text: "Sr. Engineering Manager · Site Lead, Payments Platform · Globex, Toronto",
         fontSize: 11,
       },
       { text: "04/2021 – 12/2023", fontSize: 11 },
@@ -206,7 +206,7 @@ describe("multi-word city without state/country suffix on middot header (#616)",
     const role = roles[0];
 
     expect(role.company).toBe("Globex");
-    expect(role.location).toBe("Hyderabad");
+    expect(role.location).toBe("Toronto");
   });
 
   it("position-independence — trailing `Company, MultiWordCity` splits the same way as middle", () => {


### PR DESCRIPTION
## Summary

Six files under `src/lib/heuristics/` carried a real employer name and a real
city in their experience-header test data, and in the docblocks that quote that
data. The repo is public and `CLAUDE.md`'s fixture rule wants synthetic personas
throughout, so both are replaced — with the synthetic company name already used
elsewhere in the suite, and with a city taken from the parser's own recognised-
city vocabulary.

Mechanical rename only. No assertion, input shape, or expected value changes
beyond the substituted tokens.

Product references to Google Docs *exports* are deliberately untouched: those
name a real exporter whose output the parser handles, not a persona.

## Review focus

- `experience-disambiguate.ts` is the only non-test file in the diff, and the
  only interesting part of the change. `BARE_LOCATION_RE` matches a
  `Company, City` tail against a **closed** single-token city vocabulary, so the
  replacement city is not free: a first pass with a city outside that list left
  `company` as the whole `Company, City` string and turned four tests red
  (#614 rows a/b, #616 rows c/d). The city that shipped is one already in
  `BARE_LOCATION_RE`, paired with a country already in `country-registry.ts`,
  which is what keeps the split — and the intl-vs-US assertions around it —
  behaviourally identical. Worth a second pair of eyes on whether any other
  assertion in these files keys on a token I substituted.
- The docblock edits in `experience-disambiguate.ts` are comments only; the
  regex vocabularies themselves are unchanged.

## Test plan

- [x] `npm run verify` green locally — 4101 passed / 10 skipped, `fallow` dead
  code 0.
- [x] `npx vitest run src/lib/heuristics` — 1271 passed, including every test
  whose input strings were rewritten.
- [x] Corpus snapshots untouched (no fixture binary or `.expected.json` in the
  diff).

## Provenance

Code implementation: Claude Opus 5 (1M context, high)
Verification: `npm run verify` — green locally; CI to confirm
