### PR TITLE
feat(storage): a letters store, and a résumé list an outside producer can afford (#711, #712)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -169,7 +169,31 @@
       "canonicalJobUrl", "deriveJobId", "isAbsoluteUrl", "isCapturableJobUrl",
       "JOB_URL_ID_PREFIX", "JOB_URL_TRACKING_PARAMS",
       "JOB_URL_TRACKING_PARAM_PREFIXES",
-      "captureJob", "JobCaptureResult", "JobCaptureProvenance"
+      "captureJob", "JobCaptureResult", "JobCaptureProvenance",
+      "listResumeChoices", "ResumeChoice",
+
+      // The cover-letter contract (#711). Same shape as the job capture
+      // contract above and then some: `letters` is the first store whose
+      // records this build never writes at all — #711 defines the artifact and
+      // deliberately leaves generation out, so EVERY writer is a producer
+      // outside this repo (a Claude Code skill driving the page, the extension
+      // later, an in-app generator whenever on-device prose quality justifies
+      // one). `docs/cover-letter-contract.md` is what they implement against
+      // and these are the names it points at. No PRODUCTION code in-tree
+      // consumes any of it — `backup.ts` and `jobs.ts` reach the two functions
+      // they need by deep import — so every barrel re-export here reads as
+      // dead.
+      //
+      // `clearLetterResumeLink` is deliberately NOT in this list: it has a real
+      // consumer (`useResumeLibrary`'s delete path), and listing it would hide
+      // the day that wiring is dropped. Same for `LETTER_RECORD_RULES`, which
+      // is not on the barrel at all — the drift-guard test deep-imports it.
+      //
+      // When a letters UI or the extension lands, take back out whatever it
+      // starts importing rather than letting the suppression rot.
+      "saveLetter", "getLetter", "getAllLetters", "lettersForJob", "deleteLetter",
+      "validateLetterRecord", "LETTER_CONTRACT_VERSION", "LetterRecordValidation",
+      "LetterRecord", "LetterProvenance", "SkippedLetter"
     ] },
 
     // The two contract constants that no in-tree caller reads at all — not even
@@ -177,6 +201,27 @@
     // ignored doesn't register as a consumer edge (same reason `ParseMetadata`
     // is listed above), so the source export must be marked here too.
     { "file": "src/lib/storage/job-record-contract.ts", "exports": ["JOB_CAPTURE_CONTRACT_VERSION"] },
-    { "file": "src/lib/storage/job-url.ts", "exports": ["JOB_URL_ID_PREFIX"] }
+    { "file": "src/lib/storage/job-url.ts", "exports": ["JOB_URL_ID_PREFIX"] },
+
+    // Same rule for the letter contract's own two: `LETTER_CONTRACT_VERSION` is
+    // a number the prose doc tells producers to send and nothing in-tree reads,
+    // and `LetterRecordValidation` names `validateLetterRecord`'s result for a
+    // caller that does not exist here yet. `SkippedLetter` is the third of the
+    // same kind — `ImportCounts` reports skipped letters from the first commit
+    // (a restore that drops one silently is the failure `backup.ts` exists to
+    // prevent) but nothing renders them until there is a letters surface.
+    { "file": "src/lib/storage/letter-contract.ts", "exports": [
+      "LETTER_CONTRACT_VERSION", "LetterRecordValidation"
+    ] },
+    { "file": "src/lib/storage/backup.ts", "exports": ["SkippedLetter"] },
+
+    // `listResumeChoices` / `ResumeChoice` (#712) are the same shape as
+    // `captureJob` above: no consumer anywhere yet, because the picker that
+    // calls this lives in the browser extension repo, not here. And per the
+    // `ParseMetadata` / job-capture-contract note, the barrel's ignored
+    // re-export above doesn't register as a consumer edge for the source
+    // file, so `resumes.ts` needs its own entry too. Once the extension (or an
+    // in-tree caller) imports it, take this back out.
+    { "file": "src/lib/storage/resumes.ts", "exports": ["listResumeChoices", "ResumeChoice"] }
   ]
 }

--- a/docs/cover-letter-contract.md
+++ b/docs/cover-letter-contract.md
@@ -1,0 +1,270 @@
+# Cover letter contract (v1)
+
+**Audience: anyone writing a cover letter into offlinecv from outside this repo** — a Claude Code
+skill driving `offlinecv.org` through browser automation, the browser extension, a script that
+converts drafts out of another tool. You do not need to read the source to implement this. If a rule
+here and the code disagree, that is a bug; file it.
+
+**Status:** version 1, introduced in [#711](https://github.com/offlinecv/OfflineCV/issues/711).
+Implemented by `src/lib/storage/letter-contract.ts` (validation), `src/lib/storage/letters.ts` (the
+store and its integrity rules), and `src/lib/storage/backup.ts` (export/import).
+
+Records that violate this contract are **refused**, not repaired. offlinecv would rather tell you
+your record was wrong than store a mangled version of it and report success.
+
+Sibling of `docs/job-capture-contract.md`, and deliberately so: where the two say the same thing —
+JSON safety, unknown-key preservation, `__proto__`, the two-version rule — they say it identically,
+and this document points at that one rather than paraphrasing it.
+
+---
+
+## 0. Why this store exists before any generator does
+
+offlinecv stores letters and does **not** write them. That is the decision #711 encodes, not an
+accident of sequencing:
+
+- On-device long-form prose quality is unproven here, and pinning the schema to one engine would be
+  backwards.
+- Most of what a letter needs is already persisted — `JobRecord.jdText` holds the job description,
+  `JobRecord.resumeId` links the résumé, and `ResumeRecord.parse` caches the structured parse — so
+  a producer never has to re-run the parser to write one.
+
+The consequence for you: **you are the first real writer of this record type.** There is no in-app
+path that produces a letter, so the validator is the only thing standing between your output and
+the object store, and provenance (§6) is the only thing that will ever distinguish your drafts from
+offlinecv's own.
+
+The **PDF export of a letter is out of scope** in v1. `render-ats-pdf.ts` is résumé-shaped
+(sections / roles / bullets); a letter is a different document model and needs a different renderer.
+
+---
+
+## 1. Fields
+
+A record is a **plain JSON object**. Not an array, not `null`, not a class instance. Every field is
+JSON-safe (§4) — there is no `Blob` anywhere in a letter, so the whole record survives the backup
+document as-is with no encoding step.
+
+### Required
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | non-empty string | Primary key. See §2. |
+| `jobId` | non-empty string | The `JobRecord.id` this letter is for. See §5 — this link is what makes the letter reachable. |
+| `body` | string | The letter itself, **markdown**. May be empty (an empty draft is a real state), but the key must be present. |
+
+### Optional
+
+| Field | Type | Meaning |
+|---|---|---|
+| `label` | string | User-facing name, so two drafts for one job are tellable apart (`"Warm open"`, `"Short version"`). |
+| `resumeId` | non-empty string | The `ResumeRecord.id` this letter was written from. **User-owned.** Cleared, not orphaned, if that résumé is deleted — see §5. |
+| `producer` | object | Provenance. See §6. |
+| `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. The store owns them; a backup file carries them so a restore preserves `createdAt`. |
+
+`body` is required but **may be empty**, while `jobId` may not. The asymmetry is deliberate: an
+empty draft is something the user can see and fix, whereas a letter with no job is reachable from
+nothing and survives no cascade.
+
+### Unknown fields are PRESERVED
+
+Exactly as in the job contract — any key not listed above rides through onto the stored record
+untouched, its value must be JSON-safe (§4), and an own key literally named **`__proto__`** refuses
+the whole record wherever it appears. See §1 of `docs/job-capture-contract.md` for the full
+reasoning; it applies here unchanged.
+
+---
+
+## 2. Identity
+
+**There is no derivation. Supply a `crypto.randomUUID()` (or your own unique string) and own
+uniqueness yourself.**
+
+This is the one place the letter contract deliberately differs from the job contract, which derives
+`id` from the posting URL so two captures of one posting converge. A letter has no such natural key,
+and convergence would be the *wrong* behaviour if it did: several drafts per job, and versions of
+one draft, are the normal case. Two writes that mean two drafts must produce two records.
+
+The corollary: **re-writing a draft means reusing its `id`.** The store upserts, so writing the same
+`id` again replaces the body and preserves `createdAt`. Writing a fresh `id` adds a draft.
+
+---
+
+## 3. Where records enter, and what checks them
+
+| Door | Entry point | Who uses it |
+|---|---|---|
+| A backup file the user picks | `importFromJson` → `importAll` | "Import backup" in the résumé library |
+| A direct write into the store | `saveLetter` | A producer running in the page's own origin |
+
+`validateLetterRecord(value: unknown)` returns either `{ ok: true, record }` or
+`{ ok: false, reasons: string[] }`. **Call it yourself before `saveLetter`** — unlike jobs, which
+have `captureJob` as a validating front door, `saveLetter` is the raw store wrapper and does not
+validate. The validator is exported from `src/lib/storage`.
+
+There is no `warnings` channel. A job has two fields that are accepted-but-suspect (a `status`
+outside a closed vocabulary; a `url` about to be rendered into an `href`); a letter has neither, so
+every result here is a clean accept or a named refusal.
+
+---
+
+## 4. JSON safety
+
+Identical to §6 of `docs/job-capture-contract.md`, enforced by the same function
+(`findJsonSafetyProblem`, now in `src/lib/storage/record-contract.ts` and shared by both contracts).
+
+In short: `null` · booleans · strings · **finite** numbers · arrays · plain objects, with no cycles
+and no own `__proto__`. A `Date`, a `Map`, `NaN`, a function or an `undefined` object property
+refuses the record with the failing path named. It refuses rather than normalising because
+`JSON.parse(JSON.stringify(x))` silently *rewrites* most of those, and a producer who sent a `Date`
+meant a `Date`.
+
+This matters more here than it looks: a producer driving the page through browser automation is
+handing values across a structured-clone boundary, which carries `Date`s and `Map`s happily right up
+until IndexedDB's own clone throws.
+
+---
+
+## 5. Lifecycle — what happens when the job or the résumé goes away
+
+This is the part of the contract with no analogue in the job document, and the two links behave
+differently on purpose.
+
+### Deleting the job CASCADES
+
+**Deleting a job deletes every letter written for it.** Not orphan-and-keep.
+
+A letter reaches every surface through its job — a letters list is a list *within* a job. So a
+letter whose job is gone is unreachable: nothing can list it, open it, edit it, or delete it.
+Keeping it would not preserve anything the user could ever get back; it would only grow the store
+invisibly, against a browser quota they do not see until it is exceeded. `jobId` is required
+precisely so this rule has no exceptions.
+
+The cascade lives in the store (`deleteJob` → `deleteLettersForJob`), not in a UI layer, so no
+caller can forget it. The job record is deleted first: if the letter sweep then fails, the delete
+the user actually asked for still happened.
+
+### Deleting the résumé CLEARS the link
+
+**Deleting a résumé clears `resumeId` on every letter that pointed at it, and keeps the letters.**
+
+The opposite call, because `resumeId` is decoration rather than reachability: the letter still opens
+from its job, with the résumé line reading "not linked". The prose the user wrote is not the
+résumé's to take with it. This is the same graceful degrade `JobRecord.resumeId` gets.
+
+The repair is written with `touch: false`, so `updatedAt` is **not** stamped. A write the user did
+not make must not reshuffle a list sorted most-recently-updated-first — otherwise deleting one
+résumé floats every letter that merely referenced it to the top.
+
+### Known gap in v1: neither link is reconciled on import
+
+**Merge-mode import can strand either link.** A partial or stale backup from another device can
+graft in a letter whose `jobId` matches no job here — that letter is stored but *unreachable*, since
+§5 says a letter is only ever reached through its job — and equally a letter whose `resumeId` matches
+no résumé here, which is the milder degrade (the letter still opens; its résumé line just reads "not
+linked" forever). Nothing sweeps either one today.
+
+Jobs are only half-covered by the existing sweep, and not for the same link: `reconcileResumeLinks`
+clears a dangling **`resumeId` on a job**, so it is the analogue of the *second* case above, not the
+first. Nothing reconciles a dangling `jobId` on anything. Letters will get the same treatment when
+there is a surface that lists them.
+
+Replace-mode import is unaffected: it rebuilds both stores from one document produced by `exportAll`,
+whose records are read from a single store snapshot and so cannot reference each other's absences.
+
+If you produce letters, **write the job first**, and write the résumé before the letter that cites it.
+
+---
+
+## 6. Versioning and provenance
+
+Three version numbers exist and they are not the same thing.
+
+- **`StorageExport.version`** numbers the **backup document format** — the file with `resumes`,
+  `jobs` and `letters` arrays. It went from `1` to `2` when this store landed. A v1 document has no
+  `letters` key at all and **still imports, forever**: a backup on a user's disk never learns about
+  a format bump.
+- **`LetterRecord.producer.contract`** numbers **this document**. A record outlives the file it
+  arrived in, so it carries its own version.
+- **`JobRecord.capture.contract`** numbers the job contract. Unrelated to this one; the two move for
+  different reasons.
+
+```jsonc
+"producer": {
+  "contract": 1,                          // required within the object: which version you targeted
+  "producer": "claude-code-letter-skill", // optional, free text
+  "producerVersion": "0.1.0",             // optional
+  "generatedAt": 1753900000000            // optional epoch ms — when YOU generated the draft
+}
+```
+
+The field is `producer` and the timestamp is `generatedAt`, where a job carries `capture` and
+`capturedAt`. That is the distinction, not an inconsistency: a job is *captured* from a page that
+already existed; a letter is *generated*.
+
+`producer` is **optional**, and its absence means "written by offlinecv itself, contract 1". It
+exists in v1 rather than later because a producer version cannot be retrofitted: once third-party
+producers are writing records, a record with no version is indistinguishable from one written before
+the field existed, and the ambiguity is permanent. Since offlinecv currently writes **no** letters at
+all, in practice every letter in a user's store should carry it.
+
+**Producers should always send it.**
+
+---
+
+## 7. Failure handling
+
+`validateLetterRecord` returns `{ ok: false, reasons: string[] }`. Each reason names the field and
+what it should have been. Nothing is written — the validator does not touch storage.
+
+On the **import** path a refused letter is **skipped, not fatal**: the rest of the file still
+imports, and the skipped letters come back on `ImportCounts.skippedLetters` with a reason each. One
+malformed letter must not cost the user their résumés, their jobs, or the file's other letters —
+and since `replace` mode has already wiped the stores by the time records are written, it must never
+abort the restore partway. Validation therefore runs before any store is touched.
+
+`replace` mode wipes the `letters` store **even when the document is v1** and contributes no
+letters. Replace means "make storage match this file"; skipping the wipe would leave letters
+stranded on jobs the restore just deleted, which is exactly the orphan §5's cascade exists to make
+impossible.
+
+Nothing renders `skippedLetters` yet — v1 ships the store with no UI at all. It is reported from the
+first commit anyway, because a counter added later cannot recover the records already dropped in
+silence.
+
+---
+
+## 8. Changing this contract
+
+Adding a field to `LetterRecord` (`src/lib/storage/types.ts`) will not compile until you add a
+matching rule to `LETTER_RECORD_RULES` (`src/lib/storage/letter-contract.ts`), because that map is
+typed over `keyof Required<LetterRecord>` and its guards are typed against each field's own type.
+That is the mechanism keeping the validator from quietly ceasing to cover a field. Update this
+document in the same change.
+
+Changing §5's cascade rule, or §2's "no derivation", is a **contract version bump** — both are
+things a producer builds assumptions on top of.
+
+---
+
+## Appendix — a complete example
+
+Every value below is synthetic.
+
+```json
+{
+  "id": "6f0a3b2c-1d4e-4a77-9b21-0c5e8f7a1234",
+  "jobId": "job:boards.example.com/northwind/jobs/4012345",
+  "resumeId": "b1c2d3e4-5f60-4718-9a2b-3c4d5e6f7081",
+  "label": "Short version",
+  "body": "Dear hiring team,\n\nI am applying for the Staff Engineer role at Northwind. I have spent the last six years on browser-side document tooling, most recently leading the parser rewrite that cut our extraction failures by half.\n\nI would welcome the chance to talk.\n\nJordan Vance\njordan.vance@example.com",
+  "producer": {
+    "contract": 1,
+    "producer": "claude-code-letter-skill",
+    "producerVersion": "0.1.0",
+    "generatedAt": 1753900000000
+  },
+  "createdAt": 1753900000000,
+  "updatedAt": 1753900000000
+}
+```

--- a/src/hooks/useResumeLibrary.test.tsx
+++ b/src/hooks/useResumeLibrary.test.tsx
@@ -7,12 +7,13 @@
  * useResumeLibrary — the one behaviour that lives in the hook rather than the
  * domain layer: deleting a resume must also clear it from any tracked job that
  * pointed at it (#323 AC, "deleting that resume degrades gracefully — link
- * cleared, job kept").
+ * cleared, job kept"), and since #711 from any cover letter too.
  *
- * The lib-level `clearResumeLink` is covered in `job-tracker.test.ts`; what is
- * asserted here is the *wiring* — that the resume-delete path actually calls
- * it. Exercised through a probe component against `fake-indexeddb`, since the
- * project has no @testing-library/react (same pattern as the other hook tests).
+ * The lib-level `clearResumeLink` / `clearLetterResumeLink` are covered in
+ * `job-tracker.test.ts` and `storage/letters.test.ts`; what is asserted here is
+ * the *wiring* — that the resume-delete path actually calls them. Exercised
+ * through a probe component against `fake-indexeddb`, since the project has no
+ * @testing-library/react (same pattern as the other hook tests).
  */
 
 import "fake-indexeddb/auto";
@@ -20,7 +21,13 @@ import { deleteDB } from "idb";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { DB_NAME, closeDB, saveResume } from "../lib/storage/index.ts";
+import {
+  DB_NAME,
+  closeDB,
+  saveResume,
+  saveLetter,
+  getLetter,
+} from "../lib/storage/index.ts";
 import { createJob, listJobs } from "../lib/job-tracker.ts";
 import { useResumeLibrary, type ResumeLibrary } from "./useResumeLibrary.ts";
 
@@ -97,6 +104,35 @@ describe("useResumeLibrary: delete clears tracked-job links", () => {
     expect(jobs.find((j) => j.id === untouched.id)?.resumeId).toBe(
       "other-resume",
     );
+  });
+
+  it("keeps a cover letter that pointed at the deleted resume, minus the link (#711)", async () => {
+    const resume = await saveResume({
+      filename: "resume-v1.pdf",
+      blob: new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+    });
+    const linked = await saveLetter({
+      jobId: "job-1",
+      body: "Dear hiring team,",
+      resumeId: resume.id,
+    });
+    const untouched = await saveLetter({
+      jobId: "job-2",
+      body: "Another draft",
+      resumeId: "other-resume",
+    });
+
+    const library = await mountLibrary();
+    await act(async () => {
+      await library().remove(resume.id);
+    });
+
+    // Same degrade jobs get: the prose survives, only the dangling link goes.
+    // `clearLetterResumeLink` itself is covered in `storage/letters.test.ts`;
+    // what this asserts is that the delete path actually calls it.
+    expect((await getLetter(linked.id))?.body).toBe("Dear hiring team,");
+    expect((await getLetter(linked.id))?.resumeId).toBeUndefined();
+    expect((await getLetter(untouched.id))?.resumeId).toBe("other-resume");
   });
 
   it("deletes a resume with no tracked jobs at all without throwing", async () => {

--- a/src/hooks/useResumeLibrary.ts
+++ b/src/hooks/useResumeLibrary.ts
@@ -25,6 +25,7 @@ import {
   isStoragePersisted,
   downloadStorageBackup,
   importFromJson,
+  clearLetterResumeLink,
   type ImportCounts,
 } from "../lib/storage/index.ts";
 import { clearResumeLink, reconcileResumeLinks } from "../lib/job-tracker.ts";
@@ -111,18 +112,21 @@ export function useResumeLibrary(): ResumeLibrary {
   const remove = useCallback(
     async (id: string) => {
       await removeLibraryResume(id);
-      try {
-        // Graceful degrade (#323 AC): a tracked job that pointed at this resume
-        // keeps its record and loses only the dangling link. Runs after the
-        // delete so a failure here can never leave the resume undeleted — and
-        // is caught so it can't skip the refresh below either, which would
-        // leave the just-deleted resume on screen until something re-lists.
-        // `reconcileResumeLinks` is the backstop for a link missed here.
-        await clearResumeLink(id);
-      } catch {
-        // Swallowed deliberately: the resume IS gone, and a stale link is a
-        // cosmetic "Not linked" degrade, not a failure worth blocking the UI.
-      }
+      // Graceful degrade (#323 AC, #711): a tracked job and a cover letter both
+      // carry the same optional résumé link, and both keep their record and lose
+      // only the dangling link — the prose the user wrote is not the résumé's to
+      // take with it. Runs after the delete so a failure here can never leave the
+      // resume undeleted.
+      //
+      // `allSettled` does two jobs, which is why there is no `try`/`catch` here.
+      // It stops either repair starving the other — the asymmetry is what makes
+      // that matter, since jobs have `reconcileResumeLinks` (called on
+      // merge-import below) as a backstop for a link missed here while letters
+      // have no equivalent sweep, so a skipped letter link stays dangling until
+      // the letter is rewritten. And because it never rejects, it is also the
+      // swallow: the resume IS gone, and a stale link is a cosmetic "Not linked"
+      // degrade, not a failure worth blocking the UI or skipping the refresh for.
+      await Promise.allSettled([clearResumeLink(id), clearLetterResumeLink(id)]);
       await refresh();
     },
     [refresh],

--- a/src/lib/storage/__test-utils__/clock.ts
+++ b/src/lib/storage/__test-utils__/clock.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Wall-clock helper shared by the `src/lib/storage/*.test.ts` suites.
+ *
+ * The stores stamp `updatedAt` from `Date.now()` and several suites assert a
+ * newest-first order, so two writes inside the same millisecond leave the sort
+ * breaking a tie arbitrarily — the assertion then passes or fails on how fast
+ * the machine is. Every storage suite needs the same nudge, so it lives here
+ * once rather than being re-derived per file.
+ */
+
+/**
+ * Resolve once the wall clock has advanced past the current millisecond, so the
+ * next write gets a strictly greater `updatedAt` than the previous one.
+ *
+ * Real timers on purpose: it busy-waits on `Date.now()`, which fake timers
+ * would freeze into an infinite loop. A suite that installs them must not use
+ * this.
+ */
+export async function tick(): Promise<void> {
+  const started = Date.now();
+  while (Date.now() === started) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}

--- a/src/lib/storage/backup.ts
+++ b/src/lib/storage/backup.ts
@@ -4,8 +4,13 @@
 /**
  * Export / import (#321) — the user's own backup path and the mitigation for
  * browser eviction. Everything round-trips through a single JSON document:
- * resume blobs are base64-encoded (the only place bytes inflate), job records
- * pass through as-is. Import restores byte-identical blobs.
+ * resume blobs are base64-encoded (the only place bytes inflate), job and
+ * letter records pass through as-is. Import restores byte-identical blobs.
+ *
+ * The document is versioned separately from the IndexedDB schema. It is at
+ * **2** since the letters store landed (#711); a **1** document, which has no
+ * `letters` key at all, must import forever — a backup on a user's disk does
+ * not upgrade itself.
  *
  * Base64 goes through `btoa`/`atob` over a binary string so it works the same in
  * the browser and the Node test env (no `Buffer` dependency). Blobs are read via
@@ -14,11 +19,14 @@
 
 import { getAllRecords, putRecord, clearStore } from "./crud.ts";
 import { validateJobRecord } from "./job-record-contract.ts";
+import { validateLetterRecord } from "./letter-contract.ts";
 import type {
   ResumeRecord,
   JobRecord,
+  LetterRecord,
   ExportedResume,
   StorageExport,
+  StorageExportV2,
 } from "./types.ts";
 
 /** One job a restore refused, named well enough for the user to find it in the
@@ -31,21 +39,36 @@ export interface SkippedJob {
   reason: string;
 }
 
-/** What a restore did. `jobs` counts records actually WRITTEN, so it and
- *  `skippedJobs.length` together account for every job in the file. */
+/** One letter a restore refused. Sibling of {@link SkippedJob}; `label` rather
+ *  than `title` because that is the letter's own user-facing name. */
+export interface SkippedLetter {
+  id?: string;
+  label?: string;
+  /** Every reason the record failed, joined into one sentence. */
+  reason: string;
+}
+
+/** What a restore did. `jobs` / `letters` count records actually WRITTEN, so
+ *  each pairs with its `skipped…` list to account for every record in the file.
+ *
+ *  Nothing renders `skippedLetters` yet — #711 ships the store with no UI at
+ *  all. It is reported from the first commit anyway because the alternative is
+ *  a restore that drops a letter and says nothing, and a counter added later
+ *  cannot recover the ones already dropped. */
 export interface ImportCounts {
   resumes: number;
   jobs: number;
   skippedJobs: SkippedJob[];
+  letters: number;
+  skippedLetters: SkippedLetter[];
 }
 
-function describeCandidate(value: unknown): Pick<SkippedJob, "id" | "title"> {
-  if (value === null || typeof value !== "object") return {};
-  const record = value as Record<string, unknown>;
-  return {
-    id: typeof record.id === "string" ? record.id : undefined,
-    title: typeof record.title === "string" ? record.title : undefined,
-  };
+/** Read one string field off a candidate that failed validation — so `id` /
+ *  `title` / `label` can be reported without trusting the record's shape. */
+function readStringField(value: unknown, key: string): string | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "string" ? field : undefined;
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -65,10 +88,14 @@ function base64ToBytes(base64: string): Uint8Array {
   return bytes;
 }
 
-/** Serialize every store to one JSON-ready document (blobs → base64). */
-export async function exportAll(): Promise<StorageExport> {
+/** Serialize every store to one JSON-ready document (blobs → base64). Always
+ *  writes the current format; see {@link importAll} for what still reads. */
+export async function exportAll(): Promise<StorageExportV2> {
   const resumes = await getAllRecords<ResumeRecord>("resumes");
   const jobs = await getAllRecords<JobRecord>("jobs");
+  // Every `LetterRecord` field is JSON-safe by contract, so letters ride
+  // through with no encode step — unlike resumes, which carry a `Blob`.
+  const letters = await getAllRecords<LetterRecord>("letters");
 
   const exportedResumes: ExportedResume[] = await Promise.all(
     resumes.map(async ({ blob, ...rest }) => ({
@@ -79,10 +106,11 @@ export async function exportAll(): Promise<StorageExport> {
   );
 
   return {
-    version: 1,
+    version: 2,
     exportedAt: Date.now(),
     resumes: exportedResumes,
     jobs,
+    letters,
   };
 }
 
@@ -96,8 +124,13 @@ export async function exportToJson(): Promise<string> {
  * store is wiped first; otherwise records are merged (upsert by id). Resume
  * blobs are rebuilt byte-identically from base64.
  *
- * Every job is put through the capture contract (#693) BEFORE any store is
- * touched — the file is the boundary at which `JobRecord` stops being a type
+ * Both a v1 and a v2 document import: a v1 file simply has no letters. That
+ * back-compat is not a courtesy — an exported backup lives on the user's disk
+ * and never learns about a format bump.
+ *
+ * Every job is put through the capture contract (#693), and every letter
+ * through the letter contract (#711), BEFORE any store is touched — the file is
+ * the boundary at which `JobRecord` / `LetterRecord` stop being types
  * TypeScript can vouch for. Three things follow from where that check sits:
  *
  *  - **Skip the record, not the document.** One malformed job must not cost the
@@ -108,43 +141,105 @@ export async function exportToJson(): Promise<string> {
  *    unreachable.
  *  - **Report it.** A silently-dropped record is the real failure mode here, so
  *    the skips ride back on {@link ImportCounts} and `ResumeLibrary` announces
- *    them in its `aria-live` region.
+ *    them in its `aria-live` region. Skipped LETTERS ride back too but are not
+ *    announced yet — there is no letters surface to announce them next to. The
+ *    counter still lands now, because one added later cannot recover the
+ *    records already dropped in silence.
  */
 export async function importAll(
   data: StorageExport,
   mode: "replace" | "merge" = "replace",
 ): Promise<ImportCounts> {
-  if (data.version !== 1) {
-    throw new Error(`Unsupported storage export version: ${data.version}`);
+  // Widened to `number` so the guard survives the union narrowing: with
+  // `data.version` typed `1 | 2`, TypeScript would narrow the failing branch to
+  // `never` and the message could not read the value it is reporting. The check
+  // has to run at runtime regardless — the caller may be a JSON file.
+  const version: number = data.version;
+  if (version !== 1 && version !== 2) {
+    throw new Error(`Unsupported storage export version: ${version}`);
   }
 
-  const accepted: JobRecord[] = [];
-  const skippedJobs: SkippedJob[] = [];
-  for (const job of data.jobs) {
-    const validation = validateJobRecord(job);
-    if (validation.ok) accepted.push(validation.record);
-    else {
-      skippedJobs.push({
-        ...describeCandidate(job),
-        reason: validation.reasons.join(" "),
-      });
-    }
-  }
+  // A v1 document predates the letters store (#711) and carries no `letters`
+  // key at all. An empty list — not a refusal, and not an error — is what makes
+  // every backup a user already has on disk still restorable.
+  const incomingLetters: unknown[] = data.version === 2 ? data.letters : [];
+
+  const jobs = partitionJobs(data.jobs);
+  const letters = partitionLetters(incomingLetters);
 
   if (mode === "replace") {
     await clearStore("resumes");
     await clearStore("jobs");
+    // Cleared even when the document is v1 and therefore contributes no
+    // letters. Replace means "make storage match this file", and skipping the
+    // wipe would leave letters whose jobs were just deleted — orphans the
+    // `deleteJob` cascade exists to make impossible.
+    await clearStore("letters");
   }
 
   for (const { blobBase64, blobType, ...rest } of data.resumes) {
     const blob = new Blob([base64ToBytes(blobBase64)], { type: blobType });
     await putRecord<ResumeRecord>("resumes", { ...rest, blob });
   }
-  for (const job of accepted) {
+  for (const job of jobs.accepted) {
     await putRecord<JobRecord>("jobs", job);
   }
+  for (const letter of letters.accepted) {
+    await putRecord<LetterRecord>("letters", letter);
+  }
 
-  return { resumes: data.resumes.length, jobs: accepted.length, skippedJobs };
+  return {
+    resumes: data.resumes.length,
+    jobs: jobs.accepted.length,
+    skippedJobs: jobs.skipped,
+    letters: letters.accepted.length,
+    skippedLetters: letters.skipped,
+  };
+}
+
+/** Split a file's jobs into the ones the capture contract accepts and the ones
+ *  it refused, with a reason each. Runs before any store is touched — see
+ *  {@link importAll}. */
+function partitionJobs(candidates: unknown[]): {
+  accepted: JobRecord[];
+  skipped: SkippedJob[];
+} {
+  const accepted: JobRecord[] = [];
+  const skipped: SkippedJob[] = [];
+  for (const candidate of candidates) {
+    const validation = validateJobRecord(candidate);
+    if (validation.ok) accepted.push(validation.record);
+    else {
+      skipped.push({
+        id: readStringField(candidate, "id"),
+        title: readStringField(candidate, "title"),
+        reason: validation.reasons.join(" "),
+      });
+    }
+  }
+  return { accepted, skipped };
+}
+
+/** The letters half of {@link partitionJobs}. Same skip-don't-throw rule: one
+ *  malformed letter must not cost the user the file's other records. */
+function partitionLetters(candidates: unknown[]): {
+  accepted: LetterRecord[];
+  skipped: SkippedLetter[];
+} {
+  const accepted: LetterRecord[] = [];
+  const skipped: SkippedLetter[] = [];
+  for (const candidate of candidates) {
+    const validation = validateLetterRecord(candidate);
+    if (validation.ok) accepted.push(validation.record);
+    else {
+      skipped.push({
+        id: readStringField(candidate, "id"),
+        label: readStringField(candidate, "label"),
+        reason: validation.reasons.join(" "),
+      });
+    }
+  }
+  return { accepted, skipped };
 }
 
 /** Narrows `value` to `StorageExport`, or throws a readable message — never a
@@ -158,12 +253,22 @@ function assertStorageExport(value: unknown): asserts value is StorageExport {
   if (value === null || typeof value !== "object") {
     throw new Error("Not an offlinecv backup file.");
   }
-  const v = value as Partial<StorageExport>;
+  // Read through a loose shape rather than `Partial<StorageExport>`: the union
+  // types `version` as `1 | 2`, and comparing that against an arbitrary parsed
+  // value is exactly the comparison TypeScript would call unintentional. The
+  // point of this function is that nothing here is typed yet.
+  const v = value as Record<string, unknown>;
   if (!Array.isArray(v.resumes) || !Array.isArray(v.jobs)) {
     throw new Error("Not an offlinecv backup file.");
   }
-  if (v.version !== 1) {
+  if (v.version !== 1 && v.version !== 2) {
     throw new Error(`Unsupported storage export version: ${String(v.version)}`);
+  }
+  // A v2 document without a `letters` array is malformed, not a v1 document:
+  // the version number is the file's own claim about its shape, and a file that
+  // fails its own claim is the "wrong file picked" case, not a back-compat one.
+  if (v.version === 2 && !Array.isArray(v.letters)) {
+    throw new Error("Not an offlinecv backup file.");
   }
 }
 

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -4,7 +4,8 @@
 /**
  * IndexedDB handle for the local-first storage foundation (#321).
  *
- * One database, two object stores (`resumes`, `jobs`), opened through the ~1KB
+ * One database, four object stores (`resumes`, `jobs`, `boards`, `letters`),
+ * opened through the ~1KB
  * `idb` wrapper. Schema versioning lives here from day one: every future store
  * or index is a `DB_VERSION` bump with a matching branch in `upgrade()`, so an
  * existing user's data migrates forward instead of stranding. `upgrade()` runs
@@ -16,7 +17,12 @@
  */
 
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
-import type { ResumeRecord, JobRecord, BoardCacheRecord } from "./types.ts";
+import type {
+  ResumeRecord,
+  JobRecord,
+  BoardCacheRecord,
+  LetterRecord,
+} from "./types.ts";
 
 // Renamed from "resumelint" during the OfflineCV rename (#498). Safe to change
 // outright: the store had no external users at cutover, so there was no data to
@@ -25,13 +31,27 @@ import type { ResumeRecord, JobRecord, BoardCacheRecord } from "./types.ts";
 // `DB_VERSION` migration.
 export const DB_NAME = "offlinecv";
 /** Bump when adding/altering a store or index; add a matching `oldVersion < N`
- *  branch in `upgrade()`. Internal — only `getDB()` below reads it. */
-const DB_VERSION = 2;
+ *  branch in `upgrade()`. Internal — only `getDB()` below reads it. Kept
+ *  private deliberately: the migration tests assert against the OPEN database's
+ *  own `db.version`, which is the thing a user's browser actually sees. A test
+ *  that read this constant would compare the code to itself and pass even if
+ *  `upgrade()` never ran.
+ *
+ *  ⚠️ A bump is a BREAKING change for the browser extension, which builds this
+ *  module from a pinned commit of this repo (`extension/offlinecv-pin.json`)
+ *  and reaches `getDB()` from a content script in the app's own origin — so it
+ *  carries whatever version the pin had. Once the app has upgraded a user's
+ *  database, an extension built at the older pin opens it at the lower version
+ *  and gets a `VersionError`, breaking its captures. Bump the pin in lockstep
+ *  and rebuild it; this repo's CI never compiles the extension, so nothing else
+ *  will catch it. */
+const DB_VERSION = 3;
 
 interface OfflineCvDB extends DBSchema {
   resumes: { key: string; value: ResumeRecord };
   jobs: { key: string; value: JobRecord };
   boards: { key: string; value: BoardCacheRecord };
+  letters: { key: string; value: LetterRecord };
 }
 
 let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
@@ -54,6 +74,19 @@ export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
         // starts empty (a cache miss, which the caller already handles).
         if (oldVersion < 2) {
           db.createObjectStore("boards", { keyPath: "id" });
+        }
+        // v2 → v3 (#711): cover letters, one record per draft. Additive in the
+        // same way `boards` was — an existing profile's resumes and jobs are
+        // untouched and the new store simply starts empty, which is also the
+        // correct reading of an older profile (it has no letters because the
+        // build that wrote it could not make one).
+        //
+        // No index on `jobId`: `lettersForJob` filters in memory. An index is a
+        // further schema migration, and the store holds a handful of records
+        // per tracked job — buying an index before there is a surface that
+        // reads letters at all would be pinning a schema on a guess.
+        if (oldVersion < 3) {
+          db.createObjectStore("letters", { keyPath: "id" });
         }
       },
     });

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -4,22 +4,24 @@
 /**
  * Local-first storage foundation (#321) — public surface.
  *
- * Typed CRUD over an IndexedDB database with three stores (`resumes`, `jobs`,
- * `boards`), durability control, and a JSON export/import backup path.
- * Infrastructure only: the resume-library and job-tracker UIs build on this.
- * Product code imports from `../lib/storage` (the barrel), not the internal
- * files — tests may reach past it to exercise a layer directly.
+ * Typed CRUD over an IndexedDB database with four stores (`resumes`, `jobs`,
+ * `boards`, `letters`), durability control, and a JSON export/import backup
+ * path. Infrastructure only: the resume-library and job-tracker UIs build on
+ * this. Product code imports from `../lib/storage` (the barrel), not the
+ * internal files — tests may reach past it to exercise a layer directly.
  *
  * Two admission rules, and they are what keep that first sentence true:
  *
  *  - A name earns a slot by having a consumer outside this directory, or by
  *    being registered in `.fallowrc.jsonc` as intended external API (the job
- *    capture contract below, normative for third-party producers per
- *    `docs/job-capture-contract.md`). The vocabulary the module only talks to
+ *    capture contract and the cover-letter contract below, both normative for
+ *    third-party producers per `docs/job-capture-contract.md` and
+ *    `docs/cover-letter-contract.md`). The vocabulary the module only talks to
  *    itself in — `StoredRecord`, `StoreName`, `ResumeRecord`, `SaveResumeInput`,
- *    `ExportedResume`, `StorageExport`, and the `exportAll`/`exportToJson`/
- *    `importAll` primitives under {@link downloadStorageBackup} and
- *    {@link importFromJson} — is deliberately absent.
+ *    `ExportedResume`, `StorageExport`, `LETTER_RECORD_RULES`, and the
+ *    `exportAll`/`exportToJson`/`importAll` primitives under
+ *    {@link downloadStorageBackup} and {@link importFromJson} — is deliberately
+ *    absent.
  *  - Conversely, a name a consumer needs belongs here. Withholding one is what
  *    produced the deep imports of `./types.ts` this barrel exists to prevent:
  *    `JobStatus` and `JOB_STATUS_ORDER` were reachable no other way.
@@ -36,8 +38,18 @@ export {
   getResume,
   getAllResumes,
   deleteResume,
+  listResumeChoices,
+  type ResumeChoice,
 } from "./resumes.ts";
 export { saveJob, getJob, getAllJobs, deleteJob } from "./jobs.ts";
+export {
+  saveLetter,
+  getLetter,
+  getAllLetters,
+  lettersForJob,
+  deleteLetter,
+  clearLetterResumeLink,
+} from "./letters.ts";
 export {
   requestStoragePersistence,
   isStoragePersisted,
@@ -48,17 +60,25 @@ export {
   downloadStorageBackup,
   type ImportCounts,
   type SkippedJob,
+  type SkippedLetter,
 } from "./backup.ts";
 export {
-  validateJobRecord,
   findJsonSafetyProblem,
+  type JsonSafetyProblem,
+} from "./record-contract.ts";
+export {
+  validateJobRecord,
   isKnownStatus,
   JOB_CAPTURE_CONTRACT_VERSION,
   JOB_RECORD_RULES,
   type JobRecordValidation,
   type JobRecordIssue,
-  type JsonSafetyProblem,
 } from "./job-record-contract.ts";
+export {
+  validateLetterRecord,
+  LETTER_CONTRACT_VERSION,
+  type LetterRecordValidation,
+} from "./letter-contract.ts";
 export {
   canonicalJobUrl,
   deriveJobId,
@@ -74,4 +94,6 @@ export type {
   JobRecord,
   JobStatus,
   JobCaptureProvenance,
+  LetterRecord,
+  LetterProvenance,
 } from "./types.ts";

--- a/src/lib/storage/job-record-contract.test.ts
+++ b/src/lib/storage/job-record-contract.test.ts
@@ -20,10 +20,12 @@
 import { describe, expect, it } from "vitest";
 import {
   JOB_RECORD_RULES,
-  findJsonSafetyProblem,
   isKnownStatus,
   validateJobRecord,
 } from "./job-record-contract.ts";
+// Moved to `record-contract.ts` with the rest of the machinery the job and
+// letter contracts share (#711); the behaviour asserted below is unchanged.
+import { findJsonSafetyProblem } from "./record-contract.ts";
 
 /** A record every rule accepts — the baseline each case perturbs one field of. */
 function validRecord(): Record<string, unknown> {

--- a/src/lib/storage/job-record-contract.ts
+++ b/src/lib/storage/job-record-contract.ts
@@ -18,6 +18,11 @@
  * The prose half is `docs/job-capture-contract.md`. It is normative for
  * producers; this module must never disagree with it.
  *
+ * The generic machinery — the rule shape, the JSON-safety walk, the
+ * preserve-unknown-keys pass — lives in `record-contract.ts` and is shared with
+ * the cover-letter contract (#711). What stays here is everything a JOB record
+ * specifically means.
+ *
  * ## The drift guard
  *
  * The danger the issue names is this file becoming a SECOND definition of
@@ -36,18 +41,32 @@
  * `job-record-contract.test.ts` then loops over the map, so a newly-added field
  * is exercised without anyone remembering to write a case for it. The one field
  * the type system cannot help with is `matchResult`, whose declared type is
- * `unknown`; its real check is {@link findJsonSafetyProblem}, wired explicitly.
+ * `unknown`; its real check is `findJsonSafetyProblem`, wired explicitly.
  */
 
 import type { JobRecord, JobStatus, JobCaptureProvenance } from "./types.ts";
 import { JOB_STATUS_ORDER } from "./types.ts";
 import { isAbsoluteUrl, isCapturableJobUrl } from "./job-url.ts";
+import {
+  checkDeclaredFields,
+  collectJsonSafeExtras,
+  explainJsonSafety,
+  findJsonSafetyProblem,
+  hasOwn,
+  isFiniteNumber,
+  isNonEmptyString,
+  isPlainObject,
+  isProvenanceLike,
+  isString,
+  FORBIDDEN_KEY,
+  type FieldRule,
+} from "./record-contract.ts";
 
 /**
  * Contract version a producer targets, carried on `JobRecord.capture.contract`.
- * Independent of `StorageExport.version` (the backup DOCUMENT format, still 1):
- * a record can outlive the file it arrived in, and the two evolve for different
- * reasons. Absent provenance means "written by this app against version 1".
+ * Independent of `StorageExport.version` (the backup DOCUMENT format): a record
+ * can outlive the file it arrived in, and the two evolve for different reasons.
+ * Absent provenance means "written by this app against version 1".
  *
  * Exported as part of the contract SURFACE, not awaiting a caller: §7 of
  * `docs/job-capture-contract.md` is normative for reimplementers, and this is
@@ -73,31 +92,6 @@ export type JobRecordIssue = string;
 export type JobRecordValidation =
   | { ok: true; record: JobRecord; warnings: JobRecordIssue[] }
   | { ok: false; reasons: JobRecordIssue[] };
-
-/** A type predicate over `unknown`, narrowing to one field's declared type. */
-type Guard<T> = (value: unknown) => value is T;
-
-interface FieldRule<T> {
-  /** False ⇒ the key may be absent. Absent is never the same as present-and-
-   *  wrong: an absent optional field is silent, a wrong one is a reason. */
-  required: boolean;
-  check: Guard<T>;
-  /** Phrased as the producer's obligation, because that is who reads it. */
-  expected: string;
-  /** A sharper reason for a value that failed `check`, when the rule can point
-   *  at WHERE inside a nested value it went wrong. `expected` alone is useless
-   *  for a 200-key `matchResult` — "not JSON-safe" doesn't tell a producer
-   *  which key to fix. Returns undefined to fall back to `expected`. */
-  explain?: (value: unknown) => string | undefined;
-}
-
-const isString = (value: unknown): value is string => typeof value === "string";
-
-const isNonEmptyString = (value: unknown): value is string =>
-  typeof value === "string" && value.length > 0;
-
-const isFiniteNumber = (value: unknown): value is number =>
-  typeof value === "number" && Number.isFinite(value);
 
 /**
  * `status` accepts ANY string, including one outside {@link JOB_STATUS_ORDER},
@@ -134,15 +128,8 @@ const isUrlLike = (value: unknown): value is string =>
 const isJsonSafe = (value: unknown): value is unknown =>
   findJsonSafetyProblem(value, "value") === null;
 
-const isCaptureProvenance = (value: unknown): value is JobCaptureProvenance => {
-  if (!isPlainObject(value)) return false;
-  if (!isFiniteNumber(value.contract)) return false;
-  for (const key of ["producer", "producerVersion"] as const) {
-    if (value[key] !== undefined && !isString(value[key])) return false;
-  }
-  if (value.capturedAt !== undefined && !isFiniteNumber(value.capturedAt)) return false;
-  return findJsonSafetyProblem(value, "capture") === null;
-};
+const isCaptureProvenance = (value: unknown): value is JobCaptureProvenance =>
+  isProvenanceLike(value, "capturedAt", "capture");
 
 /**
  * One rule per `JobRecord` field. See the drift-guard note in the module
@@ -184,185 +171,9 @@ export const JOB_RECORD_RULES: {
   },
 };
 
-function explainJsonSafety(value: unknown, path: string): string | undefined {
-  const problem = findJsonSafetyProblem(value, path);
-  return problem ? `\`${problem.path}\`: ${problem.reason}.` : undefined;
-}
-
 /** Field names the rules cover — everything else on an incoming record is an
  *  unknown extra key. */
 const KNOWN_FIELDS = new Set(Object.keys(JOB_RECORD_RULES));
-
-/** Own-key name refused wherever it appears. `JSON.parse` turns `"__proto__"`
- *  into a real own property, and a later `Object.assign`-style merge would then
- *  reach the prototype setter. No legitimate producer emits it. `constructor`
- *  is deliberately allowed: shadowing it on a plain data object is inert here
- *  (nothing reads `record.constructor`), and refusing a plausible field name
- *  costs a producer more than it buys. */
-const FORBIDDEN_KEY = "__proto__";
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const proto = Object.getPrototypeOf(value) as object | null;
-  return proto === Object.prototype || proto === null;
-}
-
-function hasOwn(value: object, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(value, key);
-}
-
-/** Where a value stopped being JSON-safe, and why. */
-export interface JsonSafetyProblem {
-  /** Dotted/bracketed path from the value's root, e.g. `matchResult.rows[2].score`. */
-  path: string;
-  reason: string;
-}
-
-/**
- * The definition of "JSON-safe" this contract enforces: a value built only from
- * `null`, booleans, strings, **finite** numbers, arrays, and plain objects (own
- * prototype `Object.prototype` or `null`), with no cycles and no own
- * `__proto__` key. Returns the first problem found, or null.
- *
- * It **refuses** rather than normalizes, and that is the point. The obvious
- * alternative — `JSON.parse(JSON.stringify(x))` — does not reject these values,
- * it silently rewrites them: `undefined` object properties vanish, `NaN` and
- * `Infinity` become `null`, a `Date` becomes a string, a `Map` becomes `{}`.
- * Only cycles and `BigInt` actually throw. A producer that sent a `Date` meant
- * a `Date`; handing it back a string and reporting success is the exact failure
- * this contract exists to prevent, so the producer is told instead.
- *
- * Why it matters even though a backup arrives via `JSON.parse` (and so is
- * JSON-safe almost by construction): the capture path does not. A record that
- * crosses `postMessage` or `chrome.runtime` is structured-cloned, which happily
- * carries `Date`s, `Map`s and cycles — and a function or symbol among them
- * makes IndexedDB's own clone throw `DataCloneError` mid-write.
- */
-export function findJsonSafetyProblem(
-  value: unknown,
-  path: string,
-  stack: Set<object> = new Set(),
-): JsonSafetyProblem | null {
-  if (value === null || typeof value !== "object") return findScalarJsonProblem(value, path);
-
-  // A path-stack, not a visited-set: an object reached twice down DIFFERENT
-  // branches is a DAG and perfectly serialisable, so it is removed on the way
-  // back up. Only an object that contains itself is a cycle.
-  if (stack.has(value)) return { path, reason: "a circular reference has no JSON representation" };
-  stack.add(value);
-  try {
-    return findContainerJsonProblem(value, path, stack);
-  } finally {
-    stack.delete(value);
-  }
-}
-
-/**
- * The terminal half of {@link findJsonSafetyProblem}'s dispatch — every value
- * that is `null` or a non-`object` `typeof`. Split out so neither half carries
- * the other's branch count; there is nothing here to recurse into, so each case
- * returns a verdict directly.
- */
-function findScalarJsonProblem(value: unknown, path: string): JsonSafetyProblem | null {
-  if (value === null) return null;
-  switch (typeof value) {
-    case "boolean":
-    case "string":
-      return null;
-    case "number":
-      return Number.isFinite(value)
-        ? null
-        : { path, reason: `${String(value)} has no JSON representation` };
-    case "bigint":
-      return { path, reason: "a BigInt has no JSON representation" };
-    case "function":
-      return { path, reason: "a function has no JSON representation" };
-    case "symbol":
-      return { path, reason: "a symbol has no JSON representation" };
-    default:
-      // `undefined` — `object` is excluded by the only caller's guard.
-      return { path, reason: "undefined has no JSON representation" };
-  }
-}
-
-/**
- * The recursive half — arrays and plain objects, walked element by element.
- * Called only with the cycle stack already holding `object`, so it recurses
- * through {@link findJsonSafetyProblem} rather than itself and the push/pop
- * stays in one place.
- */
-function findContainerJsonProblem(
-  object: object,
-  path: string,
-  stack: Set<object>,
-): JsonSafetyProblem | null {
-  if (Array.isArray(object)) {
-    for (let i = 0; i < object.length; i++) {
-      const problem = findJsonSafetyProblem(object[i], `${path}[${i}]`, stack);
-      if (problem) return problem;
-    }
-    return null;
-  }
-  if (!isPlainObject(object)) {
-    // `Object.prototype.toString` rather than `.constructor` — no property
-    // read on a value we have already decided we do not trust.
-    const tag = Object.prototype.toString.call(object).slice(8, -1);
-    return { path, reason: `a ${tag} is not a plain JSON object` };
-  }
-  for (const key of Object.keys(object)) {
-    if (key === FORBIDDEN_KEY) {
-      return { path: `${path}.${FORBIDDEN_KEY}`, reason: "a `__proto__` key is not accepted" };
-    }
-    const problem = findJsonSafetyProblem(object[key], `${path}.${key}`, stack);
-    if (problem) return problem;
-  }
-  return null;
-}
-
-/**
- * Run every {@link JOB_RECORD_RULES} entry against `value`, returning the
- * refusal reasons and the subset of fields that passed their guard.
- *
- * Split out of {@link validateJobRecord} so the rule loop's branch count sits
- * on its own: an absent-but-required field, a present-but-wrong field and a
- * field with a bespoke `explain` are three shapes, and reading them beside the
- * warning and extras passes was what pushed the caller over the complexity bar.
- */
-function checkDeclaredFields(value: Record<string, unknown>): {
-  reasons: JobRecordIssue[];
-  checked: Record<string, unknown>;
-} {
-  const reasons: JobRecordIssue[] = [];
-  const checked: Record<string, unknown> = {};
-
-  for (const field of Object.keys(JOB_RECORD_RULES)) {
-    // The map's value type is a union of `FieldRule<T>` for every field's own
-    // `T`, which is exactly what makes the drift guard bite at compile time.
-    // A store-agnostic loop can't hold that union, so it reads each rule
-    // through the erased boolean-returning shape — the narrowing is the
-    // declaration's job, not this loop's.
-    const rule = JOB_RECORD_RULES[field as keyof JobRecord] as {
-      required: boolean;
-      check: (value: unknown) => boolean;
-      expected: string;
-      explain?: (value: unknown) => string | undefined;
-    };
-    const present = hasOwn(value, field) && value[field] !== undefined;
-    if (!present) {
-      if (rule.required) reasons.push(`\`${field}\` is required and must be ${rule.expected}.`);
-      continue;
-    }
-    if (!rule.check(value[field])) {
-      reasons.push(
-        rule.explain?.(value[field]) ?? `\`${field}\` must be ${rule.expected}.`,
-      );
-      continue;
-    }
-    checked[field] = value[field];
-  }
-
-  return { reasons, checked };
-}
 
 /**
  * Warnings, not refusals: these run only on values that already passed their
@@ -397,7 +208,7 @@ function collectAcceptedWarnings(checked: Record<string, unknown>): JobRecordIss
  * does not render.
  *
  * The bounded exception is an own `__proto__` key, which is refused outright
- * (see {@link FORBIDDEN_KEY}) — it is never a forward-compatible field.
+ * (see `FORBIDDEN_KEY`) — it is never a forward-compatible field.
  *
  * ## What is repaired rather than refused
  *
@@ -413,7 +224,7 @@ export function validateJobRecord(value: unknown): JobRecordValidation {
     return { ok: false, reasons: ["A job record must not carry a `__proto__` key."] };
   }
 
-  const { reasons, checked } = checkDeclaredFields(value);
+  const { reasons, checked } = checkDeclaredFields(value, JOB_RECORD_RULES);
   const warnings = collectAcceptedWarnings(checked);
 
   if (reasons.length > 0) return { ok: false, reasons };
@@ -422,13 +233,9 @@ export function validateJobRecord(value: unknown): JobRecordValidation {
   // record has nothing to preserve. They are held to the same JSON-safety bar
   // as `matchResult`: a preserved key that can't survive the next export would
   // be preservation in name only.
-  const extras: Record<string, unknown> = {};
-  for (const key of Object.keys(value)) {
-    if (!KNOWN_FIELDS.has(key)) extras[key] = value[key];
-  }
-  const extraProblem = findJsonSafetyProblem(extras, "record");
-  if (extraProblem) {
-    return { ok: false, reasons: [`\`${extraProblem.path}\`: ${extraProblem.reason}.`] };
+  const { extras, problem } = collectJsonSafeExtras(value, KNOWN_FIELDS);
+  if (problem) {
+    return { ok: false, reasons: [`\`${problem.path}\`: ${problem.reason}.`] };
   }
 
   return {

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -13,6 +13,7 @@ import {
   getAllRecords,
   deleteRecord,
 } from "./crud.ts";
+import { deleteLettersForJob } from "./letters.ts";
 import type { JobRecord } from "./types.ts";
 
 /** Save a job record. Generates a UUID when `id` is absent; timestamps managed
@@ -43,6 +44,23 @@ export function getAllJobs(): Promise<JobRecord[]> {
   return getAllRecords<JobRecord>("jobs");
 }
 
-export function deleteJob(id: string): Promise<void> {
-  return deleteRecord("jobs", id);
+/**
+ * Delete a job and CASCADE to its cover letters (#711).
+ *
+ * The cascade lives here, at the store, rather than a layer up in
+ * `job-tracker.ts`: `LetterRecord.jobId` is a required parent link, so "no
+ * letter outlives its job" is referential integrity, not tracker policy, and
+ * putting it behind the one door means no future caller of `deleteJob` can
+ * forget it. (Contrast `clearResumeLink`, which is called from the resume-delete
+ * path a layer up — that one is cross-aggregate policy about a link, not about
+ * a child record's existence.)
+ *
+ * The job goes first. If the letter sweep then fails, the user's actual
+ * intent — the job is gone — still happened; the reverse order would let a
+ * failure delete the letters of a job that survives, which is data loss the
+ * user did not ask for and cannot see coming.
+ */
+export async function deleteJob(id: string): Promise<void> {
+  await deleteRecord("jobs", id);
+  await deleteLettersForJob(id);
 }

--- a/src/lib/storage/letter-contract.ts
+++ b/src/lib/storage/letter-contract.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The runtime half of the cover-letter contract (#711) — the gate an
+ * externally-authored {@link LetterRecord} passes through on its way into
+ * IndexedDB.
+ *
+ * `letters` is the first store whose records this build never writes: #711
+ * defines the artifact and refuses to pin it to a generator. Every real writer
+ * is therefore outside the typechecker's reach — a Claude Code skill running JS
+ * in the page's own origin, the browser extension later, a hosted tier if that
+ * path is ever taken — which is exactly the situation `job-record-contract.ts`
+ * was retrofitted into. Letters get the validator on day one instead.
+ *
+ * The prose half is `docs/cover-letter-contract.md`. It is normative for
+ * producers; this module must never disagree with it. The shared machinery is
+ * `record-contract.ts`, and the drift guard is the same one the job contract
+ * documents at length: {@link LETTER_RECORD_RULES} is a mapped type over
+ * `keyof Required<LetterRecord>`, so adding a field to `LetterRecord` without a
+ * rule for it fails `tsc`, and giving a field the wrong guard fails `tsc` too.
+ *
+ * ## Why there is no `warnings` channel
+ *
+ * `JobRecordValidation` carries one because a job has two fields that are
+ * accepted-but-suspect: a `status` outside a closed vocabulary, and a `url`
+ * that is not absolute but is about to be rendered into an `href`. A letter has
+ * neither — no closed vocabulary, nothing rendered as a link, no field whose
+ * value is preserved verbatim against this build's judgement. An always-empty
+ * warnings array would be dead surface pretending to be symmetry, so the
+ * success branch is just the record.
+ */
+
+import type { LetterRecord, LetterProvenance } from "./types.ts";
+import {
+  checkDeclaredFields,
+  collectJsonSafeExtras,
+  explainJsonSafety,
+  hasOwn,
+  isFiniteNumber,
+  isNonEmptyString,
+  isPlainObject,
+  isProvenanceLike,
+  isString,
+  FORBIDDEN_KEY,
+  type FieldRule,
+} from "./record-contract.ts";
+
+/**
+ * Contract version a producer targets, carried on `LetterRecord.producer.contract`.
+ *
+ * Independent of `StorageExport.version` (the backup DOCUMENT format) and of
+ * `JOB_CAPTURE_CONTRACT_VERSION` (a different record): a letter outlives the
+ * file it arrived in, and the letter contract will move for reasons the job
+ * contract does not share. Absent provenance means "written by this app against
+ * version 1".
+ *
+ * Exported as part of the contract SURFACE, not awaiting a caller: §6 of
+ * `docs/cover-letter-contract.md` is normative for reimplementers and this is
+ * the number it tells them to send. Nothing in this build reads it, by design —
+ * the validator requires `producer.contract` to be a finite number and does not
+ * compare it against this constant, because refusing a record from a future
+ * version is the forward-compatibility failure §6 exists to avoid.
+ */
+export const LETTER_CONTRACT_VERSION = 1;
+
+/** A reason a letter was refused. One sentence, addressed to whoever has to fix
+ *  the producer or the file. */
+export type LetterRecordIssue = string;
+
+/** Outcome of validating one candidate letter. See the module docblock for why
+ *  the success branch has no `warnings`. */
+export type LetterRecordValidation =
+  | { ok: true; record: LetterRecord }
+  | { ok: false; reasons: LetterRecordIssue[] };
+
+const isLetterProvenance = (value: unknown): value is LetterProvenance =>
+  isProvenanceLike(value, "generatedAt", "producer");
+
+/**
+ * One rule per `LetterRecord` field. The mapped type, not this list, is what
+ * keeps it complete — see the module docblock.
+ *
+ * `body` is `required` but checked with `isString`, not `isNonEmptyString`: an
+ * empty draft is a legitimate state (a producer that created the record before
+ * filling it, a user who cleared the text), and refusing it would make the
+ * store unable to hold something the user can plainly see. `jobId` is the
+ * opposite — a letter with an empty `jobId` is reachable from nothing and would
+ * survive no cascade, so emptiness there is a refusal.
+ *
+ * `createdAt` / `updatedAt` are optional because `putRecord` owns them: a
+ * backup carries them (so `createdAt` survives a restore) and a fresh write
+ * omits them. Present-but-not-a-number is still a refusal — a drafts list sorts
+ * on `updatedAt`.
+ */
+export const LETTER_RECORD_RULES: {
+  [K in keyof Required<LetterRecord>]: FieldRule<Required<LetterRecord>[K]>;
+} = {
+  id: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
+  createdAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  updatedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  jobId: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
+  resumeId: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
+  body: { required: true, check: isString, expected: "a string" },
+  label: { required: false, check: isString, expected: "a string" },
+  producer: {
+    required: false,
+    check: isLetterProvenance,
+    expected: "an object with a finite `contract` number",
+    explain: (value) => explainJsonSafety(value, "producer"),
+  },
+};
+
+/** Field names the rules cover — everything else on an incoming record is an
+ *  unknown extra key. */
+const KNOWN_FIELDS = new Set(Object.keys(LETTER_RECORD_RULES));
+
+/**
+ * Validate one candidate letter and return it in the shape the store accepts.
+ *
+ * Unknown extra keys are **preserved**, and an own `__proto__` key refuses the
+ * record outright — the same two rules `validateJobRecord` documents at length,
+ * for the same reasons (dropping unknown keys makes export → import → export
+ * silently lossy across versions; `JSON.parse` turns `__proto__` into a real
+ * own property and no legitimate producer emits it).
+ *
+ * Nothing is repaired. The job contract defaults an absent `status` because it
+ * has a lifecycle a producer can reasonably have no opinion about; a letter has
+ * no such field, so every refusal here is a genuine "this record is not one".
+ */
+export function validateLetterRecord(value: unknown): LetterRecordValidation {
+  if (!isPlainObject(value)) {
+    return { ok: false, reasons: ["A letter record must be a plain JSON object."] };
+  }
+  if (hasOwn(value, FORBIDDEN_KEY)) {
+    return { ok: false, reasons: ["A letter record must not carry a `__proto__` key."] };
+  }
+
+  const { reasons, checked } = checkDeclaredFields(value, LETTER_RECORD_RULES);
+  if (reasons.length > 0) return { ok: false, reasons };
+
+  // Only once the record is otherwise accepted — a refused record has nothing
+  // to preserve, and a preserved key that can't survive the next export would
+  // be preservation in name only.
+  const { extras, problem } = collectJsonSafeExtras(value, KNOWN_FIELDS);
+  if (problem) {
+    return { ok: false, reasons: [`\`${problem.path}\`: ${problem.reason}.`] };
+  }
+
+  // `id`, `jobId` and `body` were just proved to be strings, and the store owns
+  // `createdAt` / `updatedAt` (see `putRecord`) — but `checked` is an erased
+  // `Record<string, unknown>`, so that proof lives in the rules map rather than
+  // in a type the compiler can follow from here. Asserted through `unknown`
+  // because an index-signature type structurally overlaps nothing.
+  return { ok: true, record: { ...extras, ...checked } as unknown as LetterRecord };
+}

--- a/src/lib/storage/letters.test.ts
+++ b/src/lib/storage/letters.test.ts
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Letters store, contract, and migration (#711).
+ *
+ * Kept out of `storage.test.ts` for one reason that is not tidiness: the
+ * migration cases below open the database at version 2 BY HAND — the shape a
+ * user's browser is already holding — and then let `getDB()` upgrade it. That
+ * needs the shipped `upgrade()` blocks to be replayed exactly, so the file
+ * carries its own fixtures and its own delete-first `beforeEach` rather than
+ * sharing state with the CRUD suites.
+ *
+ * Everything here is synthetic: `@example.com`, no real person, and a letter
+ * body that names a company that does not exist.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB, openDB } from "idb";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DB_NAME, getDB, closeDB } from "./db.ts";
+import {
+  saveLetter,
+  getLetter,
+  getAllLetters,
+  lettersForJob,
+  deleteLetter,
+  deleteLettersForJob,
+  clearLetterResumeLink,
+} from "./letters.ts";
+import { saveJob, getAllJobs, deleteJob } from "./jobs.ts";
+import { saveResume, getAllResumes } from "./resumes.ts";
+import { validateLetterRecord, LETTER_RECORD_RULES } from "./letter-contract.ts";
+import { exportAll, exportToJson, importAll, importFromJson } from "./backup.ts";
+import { tick } from "./__test-utils__/clock.ts";
+import type { LetterRecord, StorageExport } from "./types.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+const pdf = () => new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: "application/pdf" });
+
+const BODY = "Dear hiring team,\n\nI am applying for the Staff Engineer role at Northwind.";
+
+describe("storage: letters CRUD (#711)", () => {
+  it("round-trips a letter through save + get, with a generated id and matched timestamps", async () => {
+    const saved = await saveLetter({ jobId: "job-1", body: BODY, label: "First draft" });
+    expect(saved.id).toBeTruthy();
+    expect(saved.createdAt).toBe(saved.updatedAt);
+
+    const loaded = await getLetter(saved.id);
+    expect(loaded).toEqual(saved);
+    expect(loaded!.body).toBe(BODY);
+    expect(loaded!.label).toBe("First draft");
+  });
+
+  it("preserves createdAt but advances updatedAt on an edit", async () => {
+    const a = await saveLetter({ jobId: "job-1", body: "v1" });
+    const b = await saveLetter({ id: a.id, jobId: "job-1", body: "v2" });
+    expect(b.id).toBe(a.id);
+    expect(b.createdAt).toBe(a.createdAt);
+    expect(b.updatedAt).toBeGreaterThanOrEqual(a.updatedAt);
+    expect(await getAllLetters()).toHaveLength(1); // update, not insert
+  });
+
+  it("holds several drafts for one job — the reason letters are a store, not a field", async () => {
+    const warm = await saveLetter({ jobId: "job-1", body: "draft one", label: "Warm" });
+    await tick();
+    const direct = await saveLetter({ jobId: "job-1", body: "draft two", label: "Direct" });
+    await saveLetter({ jobId: "job-2", body: "other job" });
+
+    const forJob = await lettersForJob("job-1");
+    expect(forJob).toHaveLength(2);
+    expect(direct.updatedAt).toBeGreaterThan(warm.updatedAt);
+    expect(forJob.map((l) => l.id)).toEqual([direct.id, warm.id]); // newest first
+    expect(await lettersForJob("job-3")).toEqual([]);
+  });
+
+  it("deletes one letter without touching its siblings", async () => {
+    const a = await saveLetter({ jobId: "job-1", body: "keep" });
+    const b = await saveLetter({ jobId: "job-1", body: "drop" });
+    await deleteLetter(b.id);
+    expect(await getLetter(b.id)).toBeUndefined();
+    expect((await lettersForJob("job-1")).map((l) => l.id)).toEqual([a.id]);
+  });
+});
+
+describe("storage: letters follow their job and their résumé (#711)", () => {
+  it("CASCADES: deleting a job deletes its letters, and only its letters", async () => {
+    const job = await saveJob({ title: "Staff Engineer" });
+    const other = await saveJob({ title: "Principal Engineer" });
+    await saveLetter({ jobId: job.id, body: "draft one" });
+    await saveLetter({ jobId: job.id, body: "draft two" });
+    const survivor = await saveLetter({ jobId: other.id, body: "different job" });
+
+    await deleteJob(job.id);
+
+    // The decision documented in `docs/cover-letter-contract.md` §5: a letter
+    // whose job is gone is unreachable from every surface, so orphaning it
+    // would only grow the store invisibly.
+    expect(await lettersForJob(job.id)).toEqual([]);
+    expect((await getAllLetters()).map((l) => l.id)).toEqual([survivor.id]);
+    expect((await getAllJobs()).map((j) => j.id)).toEqual([other.id]);
+  });
+
+  it("cascade is a no-op for a job that never had a letter", async () => {
+    const job = await saveJob({ title: "Staff Engineer" });
+    await saveLetter({ jobId: "some-other-job", body: "unrelated" });
+    expect(await deleteLettersForJob(job.id)).toBe(0);
+    expect(await getAllLetters()).toHaveLength(1);
+  });
+
+  it("CLEARS, not cascades, on résumé delete — and leaves updatedAt untouched", async () => {
+    const resume = await saveResume({ filename: "cv.pdf", blob: pdf() });
+    const linked = await saveLetter({ jobId: "job-1", body: BODY, resumeId: resume.id });
+    const unlinked = await saveLetter({ jobId: "job-1", body: "no résumé" });
+
+    // Past the millisecond, so a spurious `updatedAt` stamp would be visible.
+    await tick();
+    expect(await clearLetterResumeLink(resume.id)).toBe(1);
+
+    const after = await getLetter(linked.id);
+    expect(after!.resumeId).toBeUndefined();
+    expect(after!.body).toBe(BODY); // the prose is not the résumé's to take
+    // The `touch: false` requirement: a write the USER did not make must not
+    // reshuffle a most-recently-updated-first list.
+    expect(after!.updatedAt).toBe(linked.updatedAt);
+    expect(after!.createdAt).toBe(linked.createdAt);
+
+    expect((await getLetter(unlinked.id))!.updatedAt).toBe(unlinked.updatedAt);
+  });
+
+  it("clearing a résumé link is idempotent and a no-op when nothing linked it", async () => {
+    await saveLetter({ jobId: "job-1", body: BODY, resumeId: "resume-1" });
+    expect(await clearLetterResumeLink("resume-1")).toBe(1);
+    expect(await clearLetterResumeLink("resume-1")).toBe(0);
+    expect(await clearLetterResumeLink("resume-never-existed")).toBe(0);
+  });
+
+  it("keeps unknown extra keys through a résumé-link clear", async () => {
+    // The link clear spreads the stored record back through `saveLetter`. A
+    // strict input shape would silently drop whatever the contract preserved on
+    // import — data loss caused by a housekeeping write.
+    await importAll(
+      backupWith([
+        {
+          id: "letter-1",
+          jobId: "job-1",
+          body: BODY,
+          resumeId: "resume-1",
+          tone: "warm",
+        },
+      ]),
+    );
+    await clearLetterResumeLink("resume-1");
+    const [stored] = await getAllLetters();
+    expect(stored.resumeId).toBeUndefined();
+    expect((stored as unknown as Record<string, unknown>).tone).toBe("warm");
+  });
+});
+
+describe("storage: letters schema migration v2 → v3 (#711)", () => {
+  /** Recreate a database exactly as `DB_VERSION = 2` shipped it — the state a
+   *  returning user's browser is holding. Replays the shipped upgrade blocks
+   *  rather than asserting against them. */
+  async function seedV2Profile(): Promise<void> {
+    const legacy = await openDB(DB_NAME, 2, {
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          db.createObjectStore("resumes", { keyPath: "id" });
+          db.createObjectStore("jobs", { keyPath: "id" });
+        }
+        if (oldVersion < 2) {
+          db.createObjectStore("boards", { keyPath: "id" });
+        }
+      },
+    });
+    await legacy.put("resumes", {
+      id: "resume-1",
+      filename: "cv.pdf",
+      blob: pdf(),
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    await legacy.put("jobs", {
+      id: "job-1",
+      title: "Staff Engineer",
+      company: "Northwind",
+      status: "applied",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    legacy.close();
+  }
+
+  it("opens an existing v2 profile at v3 with resumes and jobs intact and letters empty", async () => {
+    await seedV2Profile();
+
+    const db = await getDB();
+    // Read the OPEN database's version, not the module constant — a test that
+    // compared `DB_VERSION` to itself would pass even if `upgrade()` never ran.
+    expect(db.version).toBe(3);
+    expect(db.objectStoreNames.contains("letters")).toBe(true);
+
+    expect((await getAllResumes()).map((r) => r.filename)).toEqual(["cv.pdf"]);
+    expect((await getAllJobs()).map((j) => j.title)).toEqual(["Staff Engineer"]);
+    expect(await getAllLetters()).toEqual([]);
+    // `boards` survived the additive migration too.
+    expect(db.objectStoreNames.contains("boards")).toBe(true);
+  });
+
+  it("the migrated store is writable, so an upgraded profile is not read-only", async () => {
+    await seedV2Profile();
+    const letter = await saveLetter({ jobId: "job-1", body: BODY });
+    expect((await getAllLetters()).map((l) => l.id)).toEqual([letter.id]);
+  });
+
+  it("creates all four stores on a fresh v0 database", async () => {
+    const db = await getDB();
+    for (const store of ["resumes", "jobs", "boards", "letters"] as const) {
+      expect(db.objectStoreNames.contains(store)).toBe(true);
+    }
+  });
+});
+
+/** A valid candidate letter — the baseline each contract case perturbs one
+ *  field of. */
+function validLetter(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "letter-1",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_001_000,
+    jobId: "job-1",
+    resumeId: "resume-1",
+    body: BODY,
+    label: "First draft",
+    producer: {
+      contract: 1,
+      producer: "claude-code-letter-skill",
+      producerVersion: "0.1.0",
+      generatedAt: 1_700_000_000_500,
+    },
+    ...overrides,
+  };
+}
+
+describe("storage: letter contract (#711)", () => {
+  it("accepts the fully-populated baseline unchanged", () => {
+    const result = validateLetterRecord(validLetter());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record).toEqual(validLetter());
+  });
+
+  it("names a missing jobId, a non-string body, and a non-JSON-safe field", () => {
+    const missingJob = validateLetterRecord(validLetter({ jobId: undefined }));
+    expect(missingJob.ok).toBe(false);
+    if (missingJob.ok) return;
+    expect(missingJob.reasons.join(" ")).toContain("`jobId` is required");
+
+    const badBody = validateLetterRecord(validLetter({ body: 42 }));
+    expect(badBody.ok).toBe(false);
+    if (badBody.ok) return;
+    expect(badBody.reasons.join(" ")).toContain("`body` must be a string");
+
+    // The JSON-safety bar applies to unknown extras too: a `Date` under a key
+    // this build has never heard of would silently become a string on the next
+    // export, so it refuses the record and names the path.
+    const notJsonSafe = validateLetterRecord(validLetter({ draftedOn: new Date() }));
+    expect(notJsonSafe.ok).toBe(false);
+    if (notJsonSafe.ok) return;
+    expect(notJsonSafe.reasons.join(" ")).toContain("record.draftedOn");
+    expect(notJsonSafe.reasons.join(" ")).toContain("Date");
+  });
+
+  it("refuses an empty jobId but accepts an empty body", () => {
+    // A letter with no job is reachable from nothing; an empty draft is a state
+    // the user can plainly see and fix.
+    expect(validateLetterRecord(validLetter({ jobId: "" })).ok).toBe(false);
+    expect(validateLetterRecord(validLetter({ body: "" })).ok).toBe(true);
+  });
+
+  it("refuses a non-object, and a record carrying a __proto__ key", () => {
+    for (const candidate of [null, 42, "letter", [validLetter()]]) {
+      expect(validateLetterRecord(candidate).ok).toBe(false);
+    }
+    const polluted = JSON.parse(
+      '{"id":"l1","jobId":"j1","body":"x","__proto__":{"admin":true}}',
+    ) as unknown;
+    const result = validateLetterRecord(polluted);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasons.join(" ")).toContain("__proto__");
+  });
+
+  it("refuses provenance with no contract number, and accepts provenance with only one", () => {
+    expect(validateLetterRecord(validLetter({ producer: { producer: "x" } })).ok).toBe(false);
+    expect(validateLetterRecord(validLetter({ producer: { contract: 1 } })).ok).toBe(true);
+    expect(
+      validateLetterRecord(validLetter({ producer: { contract: 1, generatedAt: "yesterday" } })).ok,
+    ).toBe(false);
+  });
+
+  it("preserves unknown extra keys rather than stripping them", () => {
+    const result = validateLetterRecord(validLetter({ tone: "warm", revision: 3 }));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const record = result.record as unknown as Record<string, unknown>;
+    expect(record.tone).toBe("warm");
+    expect(record.revision).toBe(3);
+  });
+
+  it.each(Object.keys(LETTER_RECORD_RULES))(
+    "the rule for `%s` actually rejects something",
+    (field) => {
+      // The runtime half of the drift guard: a rule added only to satisfy the
+      // mapped type, whose `check` accepts everything, fails here. `{}` is not
+      // a string, not a number, and not valid provenance.
+      const rule = LETTER_RECORD_RULES[field as keyof LetterRecord];
+      expect(rule.check({})).toBe(false);
+      expect(rule.expected.length).toBeGreaterThan(0);
+    },
+  );
+});
+
+/** A backup document carrying exactly the letters given, and nothing else. */
+function backupWith(letters: unknown[]): StorageExport {
+  return {
+    version: 2,
+    exportedAt: Date.now(),
+    resumes: [],
+    jobs: [],
+    letters: letters as LetterRecord[],
+  };
+}
+
+describe("storage: letters through export / import (#711)", () => {
+  it("round-trips a letter unchanged, at document version 2", async () => {
+    const job = await saveJob({ title: "Staff Engineer" });
+    const saved = await saveLetter({
+      jobId: job.id,
+      body: BODY,
+      label: "First draft",
+      resumeId: "resume-1",
+    });
+
+    const dump = await exportAll();
+    expect(dump.version).toBe(2);
+    expect(dump.letters).toEqual([saved]);
+
+    await closeDB();
+    await deleteDB(DB_NAME);
+
+    const counts = await importAll(dump);
+    expect(counts.letters).toBe(1);
+    expect(counts.skippedLetters).toEqual([]);
+
+    // Every field survives except `updatedAt`, which `putRecord` restamps on
+    // any write that doesn't opt out — the pre-existing rule for resumes and
+    // jobs too, not something letters are singled out for. `createdAt` is what
+    // a restore preserves, and it is asserted exactly.
+    const [restored] = await getAllLetters();
+    expect(restored).toEqual({ ...saved, updatedAt: expect.any(Number) });
+    expect(restored.createdAt).toBe(saved.createdAt);
+  });
+
+  it("survives the JSON string round-trip, not just the in-memory object", async () => {
+    const saved = await saveLetter({ jobId: "job-1", body: BODY, label: "First draft" });
+    const json = await exportToJson();
+
+    await closeDB();
+    await deleteDB(DB_NAME);
+
+    const counts = await importFromJson(json, "replace");
+    expect(counts.letters).toBe(1);
+    const [restored] = await getAllLetters();
+    expect(restored.id).toBe(saved.id);
+    expect(restored.body).toBe(BODY);
+    expect(restored.label).toBe("First draft");
+    expect(restored.createdAt).toBe(saved.createdAt);
+  });
+
+  it("imports a v1 document, which has no `letters` key at all", async () => {
+    // The back-compat requirement, stated as the file a user already has on
+    // disk: an exported backup never learns about a format bump.
+    const v1 = JSON.stringify({
+      version: 1,
+      exportedAt: 1_700_000_000_000,
+      resumes: [],
+      jobs: [
+        {
+          id: "job-1",
+          title: "Staff Engineer",
+          company: "Northwind",
+          status: "applied",
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_000,
+        },
+      ],
+    });
+
+    const counts = await importFromJson(v1, "replace");
+    expect(counts.jobs).toBe(1);
+    expect(counts.letters).toBe(0);
+    expect(counts.skippedLetters).toEqual([]);
+    expect(await getAllLetters()).toEqual([]);
+  });
+
+  it("replace mode wipes letters even from a v1 document, so no letter outlives its job", async () => {
+    const job = await saveJob({ title: "Staff Engineer" });
+    await saveLetter({ jobId: job.id, body: BODY });
+
+    // A v1 backup restores jobs from scratch; leaving the letters behind would
+    // strand them on a jobId the restore just deleted — exactly the orphan the
+    // `deleteJob` cascade exists to make impossible.
+    const v1 = JSON.stringify({ version: 1, exportedAt: 0, resumes: [], jobs: [] });
+    await importFromJson(v1, "replace");
+    expect(await getAllLetters()).toEqual([]);
+  });
+
+  it("skips a malformed letter, imports the rest, and names what it skipped", async () => {
+    const counts = await importAll(
+      backupWith([
+        validLetter(),
+        validLetter({ id: "letter-2", label: "Second", jobId: undefined }),
+        validLetter({ id: "letter-3", body: null }),
+      ]),
+    );
+
+    expect(counts.letters).toBe(1);
+    expect(counts.skippedLetters).toHaveLength(2);
+    expect(counts.skippedLetters.map((s) => s.id)).toEqual(["letter-2", "letter-3"]);
+    expect(counts.skippedLetters[0].label).toBe("Second");
+    expect(counts.skippedLetters[0].reason).toContain("`jobId`");
+    expect((await getAllLetters()).map((l) => l.id)).toEqual(["letter-1"]);
+  });
+
+  it("one malformed letter costs the user nothing else in the file", async () => {
+    await saveResume({ filename: "cv.pdf", blob: pdf() });
+    await saveJob({ title: "Staff Engineer" });
+    const dump = await exportAll();
+
+    const counts = await importAll(
+      { ...dump, letters: [validLetter({ jobId: 7 })] as unknown as LetterRecord[] },
+      "replace",
+    );
+    expect(counts.resumes).toBe(1);
+    expect(counts.jobs).toBe(1);
+    expect(counts.letters).toBe(0);
+    expect(counts.skippedLetters).toHaveLength(1);
+    expect(await getAllResumes()).toHaveLength(1);
+  });
+
+  it("rejects a v2 document whose `letters` key is missing, as a wrong-file pick", async () => {
+    // Not a v1 document: the version number is the file's own claim about its
+    // shape, and a file that fails its own claim is malformed.
+    const doc = JSON.stringify({ version: 2, exportedAt: 0, resumes: [], jobs: [] });
+    await expect(importFromJson(doc, "replace")).rejects.toThrow(
+      /Not an offlinecv backup file/,
+    );
+  });
+});

--- a/src/lib/storage/letters.ts
+++ b/src/lib/storage/letters.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Letter store — domain wrappers over the generic CRUD (#711), the sibling of
+ * `jobs.ts` and `resumes.ts`.
+ *
+ * #711 stores cover letters without GENERATING them, deliberately: pinning the
+ * schema to one engine would be backwards while on-device long-form prose is
+ * unproven. So this module is written for a producer it cannot see — a Claude
+ * Code skill driving the page, the browser extension, an in-app generator
+ * later — and `letter-contract.ts` + `docs/cover-letter-contract.md` are what
+ * such a producer validates against. Nothing in this build writes a letter yet.
+ *
+ * The two housekeeping functions at the bottom are the referential-integrity
+ * half of that, and they are the reason a letter can never quietly become
+ * unreachable: {@link deleteLettersForJob} cascades from `deleteJob`, and
+ * {@link clearLetterResumeLink} degrades a deleted résumé's link the way
+ * `clearResumeLink` already does for jobs.
+ */
+
+import {
+  putRecord,
+  getRecord,
+  getAllRecords,
+  deleteRecord,
+} from "./crud.ts";
+import type { LetterRecord } from "./types.ts";
+
+/**
+ * Save a letter. Generates a UUID when `id` is absent; timestamps are managed
+ * by `putRecord`.
+ *
+ * The input is a `Partial<LetterRecord>` narrowed to require `jobId` and
+ * `body` — the two fields without which the record means nothing — rather than
+ * the fully-specified shape `saveResume` takes. That is the same permissive
+ * write `saveJob` makes, for the same reason: a stored letter may carry unknown
+ * extra keys the contract PRESERVED on import, and a housekeeping write that
+ * spreads a record back through here must not silently drop them.
+ *
+ * `touch: false` preserves `updatedAt` for a write the user did not make — see
+ * `putRecord`.
+ */
+export async function saveLetter(
+  input: Partial<LetterRecord> & Pick<LetterRecord, "jobId" | "body">,
+  options: { touch?: boolean } = {},
+): Promise<LetterRecord> {
+  return putRecord<LetterRecord>(
+    "letters",
+    {
+      ...input,
+      id: input.id ?? crypto.randomUUID(),
+    } as Omit<LetterRecord, "createdAt" | "updatedAt"> &
+      Partial<Pick<LetterRecord, "createdAt" | "updatedAt">>,
+    options,
+  );
+}
+
+export function getLetter(id: string): Promise<LetterRecord | undefined> {
+  return getRecord<LetterRecord>("letters", id);
+}
+
+export function getAllLetters(): Promise<LetterRecord[]> {
+  return getAllRecords<LetterRecord>("letters");
+}
+
+export function deleteLetter(id: string): Promise<void> {
+  return deleteRecord("letters", id);
+}
+
+/** Every letter written for one job, most-recently-updated first — the order a
+ *  drafts list wants, and the same one `listJobs` uses. Filters in memory
+ *  rather than over an index; see the `oldVersion < 3` note in `db.ts`. */
+export async function lettersForJob(jobId: string): Promise<LetterRecord[]> {
+  const letters = await getAllLetters();
+  return letters
+    .filter((letter) => letter.jobId === jobId)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * Cascade: delete every letter written for `jobId`. Returns how many were
+ * deleted; a no-op when the job had none.
+ *
+ * **Cascade, not orphan** — the decision #711 asks to be written down. A letter
+ * reaches every surface through its job, so a letter whose job is gone is
+ * unreachable: nothing can list it, open it, or delete it. Orphaning would only
+ * grow the store invisibly, and IndexedDB has no quota the user sees until it
+ * is exceeded. `jobId` is required precisely so this rule has no exceptions.
+ *
+ * Called from `deleteJob` rather than a layer up, so the invariant belongs to
+ * the store and no future caller can forget it. See §5 of
+ * `docs/cover-letter-contract.md`.
+ */
+export async function deleteLettersForJob(jobId: string): Promise<number> {
+  const doomed = await lettersForJob(jobId);
+  for (const letter of doomed) {
+    await deleteRecord("letters", letter.id);
+  }
+  return doomed.length;
+}
+
+/**
+ * Graceful degrade for a deleted résumé: clear `resumeId` on every letter that
+ * pointed at it, keeping the letters. Idempotent and cheap — a no-op when
+ * nothing linked it. Returns the number of letters repaired.
+ *
+ * The exact rule `clearResumeLink` applies to jobs (#323), and it is a CLEAR
+ * rather than a cascade for the reason the cascade above is a cascade: the link
+ * is decoration, not reachability. A letter still opens from its job with the
+ * résumé line reading "not linked"; the prose the user wrote is not the
+ * résumé's to take with it.
+ */
+export async function clearLetterResumeLink(resumeId: string): Promise<number> {
+  const letters = await getAllLetters();
+  const linked = letters.filter((letter) => letter.resumeId === resumeId);
+  for (const letter of linked) {
+    // `touch: false` — the user deleted a RÉSUMÉ, not these letters. Stamping
+    // `updatedAt` would float every letter that merely referenced it to the top
+    // of a list sorted most-recently-updated-first.
+    await saveLetter({ ...letter, resumeId: undefined }, { touch: false });
+  }
+  return linked.length;
+}

--- a/src/lib/storage/record-contract.ts
+++ b/src/lib/storage/record-contract.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The machinery both record contracts are built from — the job capture contract
+ * (#693, `job-record-contract.ts`) and the cover-letter contract (#711,
+ * `letter-contract.ts`).
+ *
+ * It exists because those two files answer the same question about different
+ * records: *is this externally-authored object safe to put in an object store?*
+ * The answer has one shape — a rules map typed over the record's own fields, a
+ * JSON-safety walk, and a preserve-unknown-keys pass — and duplicating it would
+ * produce the exact failure the drift-guard note in `job-record-contract.ts`
+ * warns about, twice over: a second copy that quietly stops matching the first.
+ *
+ * Nothing here knows what a job or a letter is. Everything record-specific —
+ * which fields exist, which are required, what is repaired, what is merely
+ * warned about — stays in the contract module that owns that record, next to
+ * the prose doc that is normative for its producers.
+ */
+
+/** A type predicate over `unknown`, narrowing to one field's declared type. */
+export type Guard<T> = (value: unknown) => value is T;
+
+export interface FieldRule<T> {
+  /** False ⇒ the key may be absent. Absent is never the same as present-and-
+   *  wrong: an absent optional field is silent, a wrong one is a reason. */
+  required: boolean;
+  check: Guard<T>;
+  /** Phrased as the producer's obligation, because that is who reads it. */
+  expected: string;
+  /** A sharper reason for a value that failed `check`, when the rule can point
+   *  at WHERE inside a nested value it went wrong. `expected` alone is useless
+   *  for a 200-key `matchResult` — "not JSON-safe" doesn't tell a producer
+   *  which key to fix. Returns undefined to fall back to `expected`. */
+  explain?: (value: unknown) => string | undefined;
+}
+
+/**
+ * A {@link FieldRule} with its type parameter erased — what a store-agnostic
+ * loop can hold.
+ *
+ * A rules map's declared value type is a UNION of `FieldRule<T>` for every
+ * field's own `T`, and that union is exactly what makes the drift guard bite at
+ * compile time. {@link checkDeclaredFields} cannot hold it, so it reads each
+ * rule through this shape instead: the narrowing is the map declaration's job,
+ * not the loop's. A `Guard<T>` is assignable to `(value: unknown) => boolean`,
+ * so passing a well-typed rules map here needs no cast.
+ */
+export interface ErasedFieldRule {
+  required: boolean;
+  check: (value: unknown) => boolean;
+  expected: string;
+  explain?: (value: unknown) => string | undefined;
+}
+
+export const isString = (value: unknown): value is string => typeof value === "string";
+
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;
+
+export const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+/**
+ * Own-key name refused wherever it appears. `JSON.parse` turns `"__proto__"`
+ * into a real own property, and a later `Object.assign`-style merge would then
+ * reach the prototype setter. No legitimate producer emits it. `constructor` is
+ * deliberately allowed: shadowing it on a plain data object is inert here
+ * (nothing reads `record.constructor`), and refusing a plausible field name
+ * costs a producer more than it buys.
+ */
+export const FORBIDDEN_KEY = "__proto__";
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value) as object | null;
+  return proto === Object.prototype || proto === null;
+}
+
+export function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+/** Where a value stopped being JSON-safe, and why. */
+export interface JsonSafetyProblem {
+  /** Dotted/bracketed path from the value's root, e.g. `matchResult.rows[2].score`. */
+  path: string;
+  reason: string;
+}
+
+/**
+ * The definition of "JSON-safe" these contracts enforce: a value built only from
+ * `null`, booleans, strings, **finite** numbers, arrays, and plain objects (own
+ * prototype `Object.prototype` or `null`), with no cycles and no own
+ * `__proto__` key. Returns the first problem found, or null.
+ *
+ * It **refuses** rather than normalizes, and that is the point. The obvious
+ * alternative — `JSON.parse(JSON.stringify(x))` — does not reject these values,
+ * it silently rewrites them: `undefined` object properties vanish, `NaN` and
+ * `Infinity` become `null`, a `Date` becomes a string, a `Map` becomes `{}`.
+ * Only cycles and `BigInt` actually throw. A producer that sent a `Date` meant
+ * a `Date`; handing it back a string and reporting success is the exact failure
+ * this contract exists to prevent, so the producer is told instead.
+ *
+ * Why it matters even though a backup arrives via `JSON.parse` (and so is
+ * JSON-safe almost by construction): the capture path does not. A record that
+ * crosses `postMessage` or `chrome.runtime` is structured-cloned, which happily
+ * carries `Date`s, `Map`s and cycles — and a function or symbol among them
+ * makes IndexedDB's own clone throw `DataCloneError` mid-write.
+ */
+export function findJsonSafetyProblem(
+  value: unknown,
+  path: string,
+  stack: Set<object> = new Set(),
+): JsonSafetyProblem | null {
+  if (value === null || typeof value !== "object") return findScalarJsonProblem(value, path);
+
+  // A path-stack, not a visited-set: an object reached twice down DIFFERENT
+  // branches is a DAG and perfectly serialisable, so it is removed on the way
+  // back up. Only an object that contains itself is a cycle.
+  if (stack.has(value)) return { path, reason: "a circular reference has no JSON representation" };
+  stack.add(value);
+  try {
+    return findContainerJsonProblem(value, path, stack);
+  } finally {
+    stack.delete(value);
+  }
+}
+
+/**
+ * The terminal half of {@link findJsonSafetyProblem}'s dispatch — every value
+ * that is `null` or a non-`object` `typeof`. Split out so neither half carries
+ * the other's branch count; there is nothing here to recurse into, so each case
+ * returns a verdict directly.
+ */
+function findScalarJsonProblem(value: unknown, path: string): JsonSafetyProblem | null {
+  if (value === null) return null;
+  switch (typeof value) {
+    case "boolean":
+    case "string":
+      return null;
+    case "number":
+      return Number.isFinite(value)
+        ? null
+        : { path, reason: `${String(value)} has no JSON representation` };
+    case "bigint":
+      return { path, reason: "a BigInt has no JSON representation" };
+    case "function":
+      return { path, reason: "a function has no JSON representation" };
+    case "symbol":
+      return { path, reason: "a symbol has no JSON representation" };
+    default:
+      // `undefined` — `object` is excluded by the only caller's guard.
+      return { path, reason: "undefined has no JSON representation" };
+  }
+}
+
+/**
+ * The recursive half — arrays and plain objects, walked element by element.
+ * Called only with the cycle stack already holding `object`, so it recurses
+ * through {@link findJsonSafetyProblem} rather than itself and the push/pop
+ * stays in one place.
+ */
+function findContainerJsonProblem(
+  object: object,
+  path: string,
+  stack: Set<object>,
+): JsonSafetyProblem | null {
+  if (Array.isArray(object)) {
+    for (let i = 0; i < object.length; i++) {
+      const problem = findJsonSafetyProblem(object[i], `${path}[${i}]`, stack);
+      if (problem) return problem;
+    }
+    return null;
+  }
+  if (!isPlainObject(object)) {
+    // `Object.prototype.toString` rather than `.constructor` — no property
+    // read on a value we have already decided we do not trust.
+    const tag = Object.prototype.toString.call(object).slice(8, -1);
+    return { path, reason: `a ${tag} is not a plain JSON object` };
+  }
+  for (const key of Object.keys(object)) {
+    if (key === FORBIDDEN_KEY) {
+      return { path: `${path}.${FORBIDDEN_KEY}`, reason: "a `__proto__` key is not accepted" };
+    }
+    const problem = findJsonSafetyProblem(object[key], `${path}.${key}`, stack);
+    if (problem) return problem;
+  }
+  return null;
+}
+
+/** A {@link FieldRule.explain} body for any field whose real check is JSON
+ *  safety — names the failing path instead of repeating `expected`. */
+export function explainJsonSafety(value: unknown, path: string): string | undefined {
+  const problem = findJsonSafetyProblem(value, path);
+  return problem ? `\`${problem.path}\`: ${problem.reason}.` : undefined;
+}
+
+/**
+ * Both record contracts carry a provenance object with the same three
+ * producer-identifying fields (`contract`, `producer`, `producerVersion`) and
+ * one contract-specific timestamp — `capturedAt` on a job, `generatedAt` on a
+ * letter. Only `contract` is required, and only its absence or a wrong type is
+ * a refusal; unknown extra keys inside the object ride through, held to the
+ * same JSON-safety bar as everything else.
+ *
+ * Returns a plain boolean rather than a predicate: the concrete provenance type
+ * differs per contract, so each caller wraps this in its own one-line `value is
+ * T` guard.
+ */
+export function isProvenanceLike(
+  value: unknown,
+  timestampKey: string,
+  path: string,
+): boolean {
+  if (!isPlainObject(value)) return false;
+  if (!isFiniteNumber(value.contract)) return false;
+  for (const key of ["producer", "producerVersion"]) {
+    if (value[key] !== undefined && !isString(value[key])) return false;
+  }
+  if (value[timestampKey] !== undefined && !isFiniteNumber(value[timestampKey])) return false;
+  return findJsonSafetyProblem(value, path) === null;
+}
+
+/**
+ * Run every rule in `rules` against `value`, returning the refusal reasons and
+ * the subset of fields that passed their guard.
+ *
+ * Split out of the per-contract `validate…` functions so the rule loop's branch
+ * count sits on its own: an absent-but-required field, a present-but-wrong field
+ * and a field with a bespoke `explain` are three shapes, and reading them beside
+ * the warning and extras passes was what pushed the caller over the complexity
+ * bar.
+ */
+export function checkDeclaredFields(
+  value: Record<string, unknown>,
+  rules: Record<string, ErasedFieldRule>,
+): { reasons: string[]; checked: Record<string, unknown> } {
+  const reasons: string[] = [];
+  const checked: Record<string, unknown> = {};
+
+  for (const [field, rule] of Object.entries(rules)) {
+    const present = hasOwn(value, field) && value[field] !== undefined;
+    if (!present) {
+      if (rule.required) reasons.push(`\`${field}\` is required and must be ${rule.expected}.`);
+      continue;
+    }
+    if (!rule.check(value[field])) {
+      reasons.push(rule.explain?.(value[field]) ?? `\`${field}\` must be ${rule.expected}.`);
+      continue;
+    }
+    checked[field] = value[field];
+  }
+
+  return { reasons, checked };
+}
+
+/**
+ * Gather the keys no rule covers, and check they could survive the next export.
+ *
+ * Unknown keys are PRESERVED by both contracts — dropping them would make an
+ * export → import → export cycle silently lossy for a user who moves a backup
+ * between two offlinecv versions. But a preserved key whose value can't be
+ * serialised would be preservation in name only, so the extras are held to the
+ * same JSON-safety bar as any opaque declared field.
+ *
+ * Call this only once a record is otherwise accepted: a refused record has
+ * nothing to preserve.
+ */
+export function collectJsonSafeExtras(
+  value: Record<string, unknown>,
+  knownFields: ReadonlySet<string>,
+): { extras: Record<string, unknown>; problem: JsonSafetyProblem | null } {
+  const extras: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    if (!knownFields.has(key)) extras[key] = value[key];
+  }
+  return { extras, problem: findJsonSafetyProblem(extras, "record") };
+}

--- a/src/lib/storage/resumes.ts
+++ b/src/lib/storage/resumes.ts
@@ -46,3 +46,25 @@ export function getAllResumes(): Promise<ResumeRecord[]> {
 export function deleteResume(id: string): Promise<void> {
   return deleteRecord("resumes", id);
 }
+
+/** One saved resume, stripped to what a picker needs. No `blob`, no cached
+ *  `parse` — see {@link listResumeChoices}. */
+export interface ResumeChoice {
+  id: string;
+  filename: string;
+  /** Epoch ms of the last save (record `updatedAt`). */
+  updatedAt: number;
+}
+
+/** List saved resumes as picker choices, newest first (#712). `getAllResumes`
+ *  returns whole `ResumeRecord`s, each carrying the raw PDF `blob` — fine for
+ *  this app's own UI, but wasteful to structured-clone across a `postMessage`
+ *  bridge (e.g. to the browser extension) just to ask "which resume?". This is
+ *  the narrow, cross-origin-safe answer: id, filename, and a timestamp, and
+ *  nothing that touches the resume corpus. */
+export async function listResumeChoices(): Promise<ResumeChoice[]> {
+  const records = await getAllResumes();
+  return records
+    .map((r) => ({ id: r.id, filename: r.filename, updatedAt: r.updatedAt }))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}

--- a/src/lib/storage/storage.test.ts
+++ b/src/lib/storage/storage.test.ts
@@ -12,11 +12,18 @@ import "fake-indexeddb/auto";
 import { deleteDB } from "idb";
 import { beforeEach, describe, expect, it } from "vitest";
 import { DB_NAME, getDB, closeDB } from "./db.ts";
-import { saveResume, getResume, getAllResumes, deleteResume } from "./resumes.ts";
+import {
+  saveResume,
+  getResume,
+  getAllResumes,
+  deleteResume,
+  listResumeChoices,
+} from "./resumes.ts";
 import { saveJob, getAllJobs } from "./jobs.ts";
 import { exportAll, exportToJson, importAll, importFromJson } from "./backup.ts";
 import { captureJob } from "./capture.ts";
 import { requestStoragePersistence, isStoragePersisted } from "./persist.ts";
+import { tick } from "./__test-utils__/clock.ts";
 import type { JobRecord, StorageExport } from "./types.ts";
 
 beforeEach(async () => {
@@ -30,6 +37,7 @@ const pdf = () => new Blob([bytes()], { type: "application/pdf" });
 async function blobBytes(blob: Blob): Promise<number[]> {
   return Array.from(new Uint8Array(await blob.arrayBuffer()));
 }
+
 
 describe("storage: schema", () => {
   it("upgrades an empty/v0 database to both stores", async () => {
@@ -74,6 +82,40 @@ describe("storage: resumes CRUD", () => {
   });
 });
 
+describe("storage: listResumeChoices (#712)", () => {
+  it("lists id/filename/updatedAt newest first, with no blob or parse", async () => {
+    const a = await saveResume({ filename: "a.pdf", blob: pdf(), parse: { score: 1 } });
+    // Past the millisecond before the second save: two writes inside one
+    // `Date.now()` tick give equal sort keys, and "newest first" then decides
+    // nothing — the assertion would pass or fail on how loaded the machine is.
+    await tick();
+    const b = await saveResume({ filename: "b.pdf", blob: pdf(), parse: { score: 2 } });
+    expect(b.updatedAt).toBeGreaterThan(a.updatedAt);
+
+    const choices = await listResumeChoices();
+    expect(choices).toEqual([
+      { id: b.id, filename: "b.pdf", updatedAt: b.updatedAt },
+      { id: a.id, filename: "a.pdf", updatedAt: a.updatedAt },
+    ]);
+  });
+
+  it("carries no Blob and is structured-cloneable — the property the bridge depends on", async () => {
+    await saveResume({ filename: "cv.pdf", blob: pdf(), parse: { score: 72 } });
+    const choices = await listResumeChoices();
+    expect(choices).toHaveLength(1);
+    for (const choice of choices) {
+      for (const value of Object.values(choice)) {
+        expect(value).not.toBeInstanceOf(Blob);
+      }
+    }
+    expect(structuredClone(choices)).toEqual(choices);
+  });
+
+  it("returns an empty list when nothing is saved", async () => {
+    expect(await listResumeChoices()).toEqual([]);
+  });
+});
+
 describe("storage: jobs CRUD", () => {
   it("saves a job with a generated id and open fields", async () => {
     const job = await saveJob({ title: "SWE", url: "https://example.com/j/1" });
@@ -97,7 +139,13 @@ describe("storage: export / import", () => {
     await closeDB();
     await deleteDB(DB_NAME);
     const counts = await importAll(dump);
-    expect(counts).toEqual({ resumes: 1, jobs: 1, skippedJobs: [] });
+    expect(counts).toEqual({
+      resumes: 1,
+      jobs: 1,
+      skippedJobs: [],
+      letters: 0,
+      skippedLetters: [],
+    });
 
     const [restored] = await getAllResumes();
     expect(restored.filename).toBe("cv.pdf");
@@ -122,7 +170,13 @@ describe("storage: export / import", () => {
     const b = await saveResume({ filename: "b.pdf", blob: pdf() });
 
     const counts = await importAll(dump, "merge");
-    expect(counts).toEqual({ resumes: 1, jobs: 0, skippedJobs: [] });
+    expect(counts).toEqual({
+      resumes: 1,
+      jobs: 0,
+      skippedJobs: [],
+      letters: 0,
+      skippedLetters: [],
+    });
 
     const all = await getAllResumes();
     expect(all.map((r) => r.id).sort()).toEqual([a.id, b.id].sort());
@@ -147,14 +201,15 @@ describe("storage: export / import", () => {
 
     it("rejects a version mismatch by name, without touching storage even in replace mode", async () => {
       await saveResume({ filename: "cv.pdf", blob: pdf() });
+      // 3, not 2: 2 became a real format when the letters store landed (#711).
       const doc = JSON.stringify({
-        version: 2,
+        version: 3,
         exportedAt: 0,
         resumes: [],
         jobs: [],
       });
       await expect(importFromJson(doc, "replace")).rejects.toThrow(
-        /Unsupported storage export version: 2/,
+        /Unsupported storage export version: 3/,
       );
       expect(await getAllResumes()).toHaveLength(1);
     });
@@ -168,7 +223,13 @@ describe("storage: export / import", () => {
       await deleteDB(DB_NAME);
 
       const counts = await importFromJson(json, "merge");
-      expect(counts).toEqual({ resumes: 1, jobs: 1, skippedJobs: [] });
+      expect(counts).toEqual({
+        resumes: 1,
+        jobs: 1,
+        skippedJobs: [],
+        letters: 0,
+        skippedLetters: [],
+      });
       expect(await getAllResumes()).toHaveLength(1);
     });
   });
@@ -263,7 +324,13 @@ describe("storage: import routes every job through the capture contract (#693)",
     await deleteDB(DB_NAME);
 
     const counts = await importFromJson(json, "replace");
-    expect(counts).toEqual({ resumes: 0, jobs: 2, skippedJobs: [] });
+    expect(counts).toEqual({
+      resumes: 0,
+      jobs: 2,
+      skippedJobs: [],
+      letters: 0,
+      skippedLetters: [],
+    });
     expect((await getAllJobs()).every((j) => j.status === "interested")).toBe(true);
   });
 });

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -135,8 +135,70 @@ export interface BoardCacheRecord extends StoredRecord {
   postings: unknown[];
 }
 
+/**
+ * Where a letter came from, when it came from outside this build (#711).
+ *
+ * The same shape as {@link JobCaptureProvenance} and there for the same
+ * reason — a producer version cannot be retrofitted — but it is a SEPARATE
+ * type because the two number different contracts (`LETTER_CONTRACT_VERSION`
+ * vs `JOB_CAPTURE_CONTRACT_VERSION`) and carry different timestamps: a job is
+ * *captured* from a page that already existed, a letter is *generated*.
+ *
+ * Absent on everything this build writes. That absence is the whole point:
+ * #711 stores letters without generating them, so the first real writers are
+ * outside producers — a Claude Code skill driving the page, the browser
+ * extension — and a letter with no provenance must be readable as "offlinecv
+ * itself wrote this", not as "some producer that predates the field".
+ */
+export interface LetterProvenance {
+  /** The letter-contract version this producer targeted
+   *  (`LETTER_CONTRACT_VERSION`). */
+  contract: number;
+  /** Free-text producer id, e.g. `"claude-code-letter-skill"`. */
+  producer?: string;
+  /** The producer's own release version. */
+  producerVersion?: string;
+  /** Epoch ms the producer generated the draft, which is not necessarily when
+   *  the record was written here. */
+  generatedAt?: number;
+}
+
+/**
+ * A cover letter for one tracked job (#711).
+ *
+ * A separate store rather than a field on {@link JobRecord} because letters are
+ * ITERATED — several drafts per job, and versions of one draft, are the normal
+ * case, and a field gives you exactly one forever.
+ *
+ * Every field is JSON-safe (no `Blob`, unlike `ResumeRecord`), so the whole
+ * record rides through the export document as-is with no base64 step.
+ *
+ * Like `JobRecord`, this is a PUBLIC contract, not an internal type: #711
+ * stores letters without generating them, so every writer that matters is
+ * outside this build. Adding a field here obliges you to add a rule for it in
+ * `letter-contract.ts` (the mapped type there will not compile otherwise) and
+ * to describe it in `docs/cover-letter-contract.md`.
+ */
+export interface LetterRecord extends StoredRecord {
+  /** The job this letter is for (`JobRecord.id`). Required — a letter with no
+   *  job is unreachable from every surface. Deleting the job CASCADES to its
+   *  letters; see `deleteLettersForJob` and §5 of the contract doc. */
+  jobId: string;
+  /** Optional link to the saved resume this letter was written from
+   *  (`ResumeRecord.id`). Cleared (not orphaned) if that resume is later
+   *  deleted — the same rule `JobRecord.resumeId` follows. */
+  resumeId?: string;
+  /** The letter itself, markdown. */
+  body: string;
+  /** User-facing name, so two drafts for one job are tellable apart. */
+  label?: string;
+  /** Provenance for a record written by a producer outside this build. Absent
+   *  for every record this app creates. */
+  producer?: LetterProvenance;
+}
+
 /** Object-store names. Adding a store is a schema-version bump (see db.ts). */
-export type StoreName = "resumes" | "jobs" | "boards";
+export type StoreName = "resumes" | "jobs" | "boards" | "letters";
 
 /** A resume as it appears in an export file: blob replaced by base64 + MIME so
  *  the whole backup is a single JSON document. */
@@ -145,11 +207,35 @@ export interface ExportedResume extends Omit<ResumeRecord, "blob"> {
   blobType: string;
 }
 
-/** The full export document (see backup.ts). `version` tracks the export
- *  format, independent of the IndexedDB schema version. */
-export interface StorageExport {
+/**
+ * The export document as version 1 shipped it (see backup.ts). Kept as a named
+ * type, not folded into an optional `letters?` key, because the distinction is
+ * load-bearing: a v1 file has no `letters` key AT ALL, and saying so in the
+ * type is what stops a reader treating "no letters" and "an empty letters
+ * array" as the same evidence. Nothing writes one any more; import still reads
+ * one, forever.
+ */
+export interface StorageExportV1 {
   version: 1;
   exportedAt: number;
   resumes: ExportedResume[];
   jobs: JobRecord[];
 }
+
+/** The current export document — v1 plus the letters store (#711). */
+export interface StorageExportV2 extends Omit<StorageExportV1, "version"> {
+  version: 2;
+  letters: LetterRecord[];
+}
+
+/**
+ * The full export document. `version` tracks the export FORMAT, independent of
+ * the IndexedDB schema version (`DB_VERSION` in db.ts) and of the per-record
+ * contract versions — the three number different things and move for different
+ * reasons.
+ *
+ * A union rather than a single widening interface: `exportAll` only ever writes
+ * {@link StorageExportV2}, and `importAll` accepts BOTH, which is the whole
+ * back-compat requirement stated as a type.
+ */
+export type StorageExport = StorageExportV1 | StorageExportV2;


### PR DESCRIPTION
## Summary

Two seams an outside producer — the browser extension, or a Claude Code skill driving the app — needs before it can do anything per-résumé or per-job: a cheap way to ask "which résumé?", and somewhere to put a cover letter. No generator and no UI ships here; both issues are deliberately storage-only.

**#712 — `listResumeChoices()`.** Returns `{ id, filename, updatedAt }[]`, newest first. `getAllResumes()` carries `blob` (the raw source bytes), so structured-cloning a library across a `postMessage` bridge just to render a picker was never affordable. `listLibrary()` was close but lives in the resume-library module and reads the cached parse snapshot to produce a score a picker does not want.

**#711 — a `letters` store.** `LetterRecord` as a first-class record any producer can write, with `LetterProvenance` mirroring `JobCaptureProvenance` so a Claude-written draft stays distinguishable from an in-app one. A separate store rather than a field on `JobRecord`: drafts are iterated, `JobRecord` is a validated contract the extension writes against, and an additive migration is the established pattern (`boards` arrived at v1→v2 exactly this way). `letter-contract.ts` (`validateLetterRecord`, `LETTER_CONTRACT_VERSION`) mirrors `job-record-contract.ts`, and `docs/cover-letter-contract.md` is normative for outside producers.

Two lifecycle decisions, both documented in the contract doc:

- **Deleting a job cascade-deletes its letters** (scope item 7, decided in favour of cascade). A letter whose job is gone is unreachable from every surface, so orphaning it just grows the store invisibly. The job is deleted first, so a failed sweep strands letters rather than deleting the letters of a surviving job.
- **Deleting a résumé clears `resumeId` with `touch: false`.** A write the user did not make must not reshuffle a most-recently-updated sort.

**Also in the diff:** `src/lib/storage/record-contract.ts`, extracted from the shipped `job-record-contract.ts` so `letter-contract.ts` reuses the JSON-safety and guard machinery instead of duplicating ~100 lines of exactly what that module's own docblock warns against copying. It is a pure move — the existing 45-test contract suite is unchanged and green, and the review below diffed it function by function for behaviour drift and found none.

Closes #711
Closes #712

## Downstream breaking change — the extension pin must move in lockstep

`DB_VERSION` 2→3 breaks the pinned browser extension, and not obviously: its content script opens this database **transitively**, so grepping the bridge for `openDB` finds nothing. The real chain is `content/offlinecv-bridge.ts` → `createDrainer` → `capture/drain.ts` → `captureJob` → `src/lib/storage/crud.ts` → `getDB()`.

The extension compiles `src/lib/storage/` from a pinned commit of this repo, so it carries whatever `DB_VERSION` that commit had. Once this app upgrades a user's database to 3, an extension built at a pre-#711 pin calls `openDB(DB_NAME, 2)` against a v3 database and gets a `VersionError` — its captures stop working. The remedy is bumping `offlinecv-pin.json` to this PR's merge SHA; a companion PR in the extension repo does exactly that. The `DB_VERSION` docblock in `db.ts` now carries this warning so the next bump doesn't have to rediscover it.

## Review focus

- `src/lib/storage/backup.ts` — both version guards moved to accept `{1, 2}`. Does a **v1** document (no `letters` key) still import, and does a v2 document with a malformed `letters` array skip per-record rather than throwing the whole import away?
- `src/lib/storage/db.ts` — the `oldVersion < 3` block is additive, but does a **v1** user (not just v0 and v2) land on v3 with `resumes`/`jobs` intact? That path had no in-tree test before this PR's review probed it.
- `src/lib/storage/record-contract.ts` — this is shipped contract code that moved. Is it genuinely a pure move, or did a guard quietly change strictness on the way out?
- `src/lib/storage/jobs.ts` — the cascade has no cross-store transaction. Is "job first, letters second" the safe failure direction?
- `src/hooks/useResumeLibrary.ts` — the two link repairs run under one `Promise.allSettled`. `exhaustive-deps` is not enforced in this repo, so the dep array is hand-audited: is `[refresh]` still right?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 4201 passed / 10 skipped / 0 failed
- [x] `npm run check:fixtures` clean — 58 PDFs and 15 sidecars, all personas synthetic. **No fixture binary is added or changed by this PR** (the diff is `.ts` / `.tsx` / `.md` / `.jsonc` only).
- [x] `fallow audit --base origin/main` — zero dead code in `src/`. The 3 unused-dependency findings are the nested private `extension/package.json` and are pre-existing noise.
- [x] `npm run verify` — green in CI

## Adversarial review

One round, pre-PR, against the accumulated working tree. **Zero blocking findings** — the reviewer ran the gates, wrote 11 throwaway probe tests against the real modules, and reported `clean: true`. What it verified rather than assumed:

- **The untested migration path.** v0→v3 and v2→v3 had in-tree tests; **v1→v3 did not**. The reviewer seeded a real v1 database, opened it through `getDB()`, and confirmed `db.version === 3` with all four stores present and the seeded résumé and job intact.
- **Malformed import input.** `letters: [null, 42, [], {valid}]` → `letters: 1`, `skippedLetters: 3`, each with a reason. Skips per record; never throws the import away.
- **`touch: false` is really threaded** — `letters.ts` → `saveLetter` → `putRecord` in `crud.ts`, which resolves `existing?.updatedAt` first. Probed the post-clear record through both `exportAll`/`importAll` and the JSON path.
- **The extraction is a pure move** — diffed function by function. `FORBIDDEN_KEY`, `isPlainObject`, `hasOwn`, the JSON-safety path-stack semantics, and `validateJobRecord`'s status repair and `warnings` channel all unchanged.
- **`deleteJob` has no bypass** — it is the only job-delete path; `clearStore("jobs")` happens only in `importAll` replace, which clears `letters` too.
- **Privacy** — no `fetch(`, `XMLHttpRequest`, or `sendBeacon` anywhere in the diff or the five new files.

Five nits were returned. Four were fixed in a follow-up pass; the fifth was judged and dismissed:

| Nit | Disposition |
|---|---|
| `letter-contract.ts` cited `§7` of the contract doc for the version constant; that section is `§6` | **Fixed** — section numbers re-verified against the doc before editing |
| `useResumeLibrary.ts` ran the two link repairs as sequential `await`s in one `try`, so a throw from the first skipped the second — and letters have no `reconcileResumeLinks` backstop, so a skipped letter link stays dangling forever | **Fixed** — now one `Promise.allSettled`. Because it never rejects, the outer `catch` became unreachable and was collapsed |
| `tick()` copy-pasted between two storage suites (fallow `dup:68fe1036`) | **Fixed** — extracted to `src/lib/storage/__test-utils__/clock.ts` |
| The contract doc's "Known gap in v1" named only a dangling `jobId`, and mis-described `reconcileResumeLinks` | **Fixed** — now covers both links and states what that function actually reconciles |
| `saveLetter`'s `input.id ?? crypto.randomUUID()` lets `id: ""` through | **Dismissed** — `jobs.ts` and `resumes.ts` have the identical `??`. Pre-existing family; fix all three or none, and `saveLetter` is consistent with its neighbours |

The reviewer also reported, as a bonus check, that the extension does **not** open this database — which would have made the `DB_VERSION` bump harmless downstream. That was **wrong**, and the section above is the corrected finding: the check grepped `offlinecv-bridge.ts` for a literal `openDB` and missed the transitive chain through `captureJob`. It was re-verified twice before the warning was written.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #712 | Claude Sonnet 5 | medium |
| Implementation — #711 | Claude Opus 5 (1M context) | ultra |
| Adversarial review | Claude Opus 5 (1M context) | high |
| Review fixes | Claude Opus 5 (1M context) | high |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |
