### PR TITLE
fix(jd-match): stop rating a posting against its own name, and add the cover-letter skill

### DIFF
--- a/.claude/skills/cover-letter/SKILL.md
+++ b/.claude/skills/cover-letter/SKILL.md
@@ -1,0 +1,469 @@
+---
+name: cover-letter
+description: Write, revise and store cover letters for jobs in the user's own offlinecv.org library. Takes posting URLs (saving them to the job tracker first) or picks from already-tracked jobs, reads each JD, names where the résumé does not match it, and interviews the user for what a résumé structurally cannot carry — then drafts, revises with them, and writes the letters into the letters store through the app's backup-import door so every record passes the cover-letter contract. Use when the user says "/cover-letter", "write a cover letter", "draft a letter for this job", "revise my cover letter", or asks for letters for jobs they have tracked.
+---
+
+# cover-letter — write letters into offlinecv's letters store
+
+`docs/cover-letter-contract.md` is **normative**; this skill is one implementation of it.
+Read it when anything below is ambiguous — it wins.
+
+This skill is the sibling of **`job-hunt`**, and deliberately thin where they overlap.
+Chrome pairing, the two doors, the import mechanics and the store read all live in
+`.claude/skills/job-hunt/SKILL.md` — **read that file's Phase 0, Phase 4 and Appendices A
+and B before driving the browser.** Do not re-derive them here.
+
+What is different about letters, and why this is a separate skill:
+
+- A job is **captured**; a letter is **generated**. The quality bar is prose, not plumbing.
+- Letters have **no natural key** — no `deriveJobId`, no convergence. Ids are yours to own.
+- Letters are **write-only in the shipped build**. Nothing renders them (verified: zero
+  matches for `letter` under `src/components` and `src/design-system`). A letters UI is
+  tracked separately; until it ships, this skill must hand the user a readable file too.
+
+## Say this once, at the start
+
+> Writing the letter sends your saved résumé parse and the job description to the
+> Anthropic API — that is what a Claude Code skill is. The app's "never leaves your
+> browser" claim is about the app; this step is outside it, by your choice. The letter is
+> stored back in your own library, on your machine.
+
+Once, plainly, then move on. Do not re-hedge it in every phase.
+
+## Hard rules
+
+1. **Emit a letters-only document — `jobs: []`, `resumes: []`.** Never re-include a job
+   that is already tracked, not even the one the letter is for. Merge import calls
+   `putRecord`, a wholesale replace, so re-writing a tracked job **resets the user's
+   `status`, `notes` and `resumeId`**. A letter needs the job to *exist*, not to be rewritten.
+2. **Never write a letter whose `jobId` is not already in the `jobs` store.** §5 of the
+   contract: a letter is only ever reached through its job, and nothing reconciles a
+   dangling `jobId`. It would import cleanly and be unreachable forever. If the job is not
+   there, save it first (Phase 1).
+3. **Never state a fact neither the résumé nor the user gave you.** Every claim traces to
+   a field in `ResumeRecord.parse` — an employer, a title, a date range, a bullet, a
+   number — **or to an answer the user gave in Phase 3.5**, which is first-hand evidence
+   about their own career and is exactly what a letter is for. What is forbidden is
+   invention: a year of experience, a technology, a scale, an outcome that came from
+   neither source. That is the one failure the user cannot catch by reading fast, and it
+   is the failure that costs them the job.
+4. **Name the mismatch out loud.** If the posting's named requirements are largely
+   unevidenced, say so to the user — before drafting (Phase 3.5) and again in the report
+   (Phase 7). A letter that reads as a strong match for a job the résumé does not support
+   is a disservice dressed as helpfulness. Whether to apply anyway is their call, not yours.
+5. **Show the draft before writing it.** The user reads and approves prose, then it is
+   stored. Never import a letter they have not seen.
+6. **Never select `replace` mode**, and **verify every write by re-reading the store** —
+   `job-hunt` hard rules 1 and 3, unchanged.
+7. **Revise = reuse the `id`.** The store upserts, so the same id replaces the body and
+   keeps `createdAt`. A fresh id adds a second draft. Never both by accident — read the
+   existing letters for that job before writing.
+8. **Never delete or edit a letter this skill did not write.** Its marker is
+   `producer.producer === "claude-code-letter-skill"`.
+
+---
+
+## Phase 0 — Pair, and read the store
+
+Run `job-hunt` Phase 0 verbatim: one `ToolSearch` call, `switch_browser` broadcast (never
+`select_browser` — the unit is the **Chrome profile**), then Appendix A's store read.
+
+One extra check letters need:
+
+- **No `letters` object store → stop.** The tab is on a build older than `DB_VERSION 3`.
+  Unlike jobs, there is no reduced mode to fall back to; a v2 document into a v1 build
+  throws `Unsupported storage export version: 2` and writes nothing. Tell them what is
+  missing and let them decide to reload. Do not reload for them.
+
+Read, and keep: the `jobs` records (id, title, company, `status`, `resumeId`, `jdText`
+length), the existing `letters` (id, `jobId`, `label`, `updatedAt`, body length — **not**
+the bodies), and the `resumes` summaries.
+
+---
+
+## Phase 1 — Which jobs, and are they tracked yet?
+
+Ask first, before anything else — and **before pairing Chrome**, since this question does
+not need a browser and pairing costs a two-minute broadcast. `AskUserQuestion`:
+
+> **Do you have the postings, or are these jobs already in your library?**
+> - **I have URLs** — paste them; I'll save them to your tracker first, then write
+> - **Already tracked** — pick from your saved jobs
+> - **Both**
+
+### I have URLs
+
+Collect them, then **run `job-hunt` Phases 2, 3 and 4** to capture and import them —
+including its `jdText` rule, which matters twice as much here (Phase 3 below). The jobs
+land in the tracker as a side effect, which is what the user wants: a letter is for a job
+they are pursuing, and a job they are pursuing belongs in the library.
+
+Do not hand-roll a job record in this skill. `deriveJobId` is normative and forking the id
+space is silent.
+
+If a URL is already tracked, `job-hunt`'s dedupe drops it — that is correct, and it just
+means the job moves to the "already tracked" list below. Say so; do not re-import it.
+
+### Already tracked
+
+`AskUserQuestion` with one option per job, most-recently-updated first. Label
+`<Title> — <Company>`; description carries `status` and whether a letter already exists.
+**Multi-select** — several letters in one sitting is the normal case.
+
+If a chosen job **already has a letter**, ask which they mean: revise that draft (reuse
+its id), or add a second draft (new id, and give both a `label` so they are tellable
+apart). This is hard rule 7 and it is invisible if you get it wrong — an accidental
+overwrite looks exactly like a successful write.
+
+### Batching
+
+**Work in batches of up to four, and run each phase across the whole batch before moving
+on.** Read every JD (Phase 3), interview once (Phase 3.5), draft all, show all, then
+import all in **one** document — one dialog, one `Restore`, one verification read.
+
+Four is the ceiling because the interview is what makes a letter specific, and an
+interview stretched across more than four postings collapses into generic questions.
+Past four, say so and do a second batch rather than diluting it.
+
+Batching does **not** mean one letter reused. Each letter answers its own posting's named
+requirements, in that posting's own words.
+
+---
+
+## Phase 2 — Resolve the résumé
+
+A letter needs `ResumeRecord.parse`, not just a filename.
+
+1. **If `JobRecord.resumeId` is set**, that is the user's own answer — use it, and name it
+   in the report. It is user-owned; do not second-guess it.
+2. **Otherwise** follow `job-hunt` Phase 1's rules: zero saved résumés → stop and tell them
+   to drop a PDF and click **Save to library**; exactly one → use it silently; more than
+   one → `AskUserQuestion`, most-recent first, filename as label, saved date + score in the
+   description.
+
+Read the parse out narrowly. **Never dump a whole `ResumeRecord`; each carries the PDF
+`blob`.** The paths, verified against a live record (`DB_VERSION 3`, `shapeVersion` on the
+parse envelope):
+
+| What | Path |
+|---|---|
+| Structured fields | `parse.result.canonical.fields` |
+| Sections + per-field confidence | `parse.result.canonical.sections` / `.fieldConfidence` |
+| The whole résumé as text | `parse.result.markdown`, else `parse.result.rawText` |
+| Score | `parse.score.overall` |
+
+It is **`canonical`, not `parsed`** — `parsed` is the cascade's internal heuristic shape and
+never reaches storage (`cascade.ts` builds `canonical` via `toCanonicalResume` and that is
+what `CascadeResult` carries). A read for `parse.result.parsed` returns `undefined`, which
+looks exactly like an uncached résumé. `docs/canonical-resume-model.md` is the model.
+
+From `canonical.fields` you need: `full_name`, `email`, `phone`, `location`, `linkedin_url`
+(use them verbatim — never invent a signature), `summary`, `experience[]` with `title`,
+`company`, dates and `description`, `skills`, `education`.
+
+**`parse.result.markdown` is usually the better read for drafting.** The canonical fields
+are the ground truth for names and dates, but the markdown carries every bullet in the
+order the user wrote them, in one read instead of a walk.
+
+`javascript_tool` truncates its output near 1 kB, so a 6 kB résumé needs slicing —
+`(md).slice(0, 900)`, `.slice(900, 1800)`, … Issue the slices as parallel calls; they are
+independent reads.
+
+If `parse` is genuinely absent, the résumé was saved by a build that did not cache it. Stop
+and ask the user to load it on `/` once; that repopulates the cache.
+
+---
+
+## Phase 3 — Get the real requirements text
+
+**`JobRecord.jdText` is the raw material, and a thin one produces a generic letter.** The
+same lever that drives fit ratings drives letter quality: a 400-character blurb contains
+the company name and the job title and nothing a letter can answer.
+
+Check the length. Under ~800 characters, **re-fetch the posting** (`WebFetch`, or a Chrome
+tab if the board needs JS) and use the fresh body for the letter.
+
+**Do not write the re-fetched text back into the `JobRecord`** as a side effect of asking
+for a letter — that is hard rule 1. If the stored `jdText` is thin, say so at the end and
+offer `job-hunt` as a separate step.
+
+When converting HTML to text, turn `<br>`, `</p>` and `</li>` into newlines **before**
+stripping tags. Flattening line breaks destroys the structure that separates
+responsibilities from qualifications.
+
+From each JD, extract explicitly before drafting:
+
+- the **named requirements** — the 3–5 the posting leads with, in its own words
+- the **team's problem** — what the role exists to solve, if the posting says
+- **must-haves with no evidence in the résumé** — the gap list. Phase 3.5 turns these into
+  questions and Phase 5 reports whatever survives.
+
+Do the whole batch here, then move on once. Do not read one JD, draft, and come back.
+
+---
+
+## Phase 3.5 — Interview the user
+
+**This is the phase that makes the letter worth sending.** A résumé is already in the
+application; a letter that only restates it adds nothing. What a letter can carry, and a
+résumé structurally cannot, is the person: why this role, what they are actually good at
+that no bullet captured, what a number leaves out.
+
+Skipping this and drafting from the parse alone produces a competent, forgettable letter.
+Do not skip it.
+
+### First, show them the gap
+
+Before asking anything, state plainly where the résumé does **not** meet the posting:
+
+> This JD leads with <requirement>. Your résumé shows <adjacent thing> but nothing direct
+> on that. Is there something not on the résumé?
+
+Two reasons this comes first. It is honest — the user should know what a reader will
+notice, from you, before they send it. And it is the highest-yield question in the
+interview: the answer is either real experience that never made the résumé, or a genuine
+gap the letter should stop trying to paper over.
+
+If the résumé is a **weak match overall** — most of the named requirements unevidenced —
+say that as a judgement, not a hedge, and ask whether they want to proceed. That is their
+call. Do not quietly write an enthusiastic letter for a job the résumé does not support.
+
+### Then ask
+
+Three to five questions. Not a form — pick the ones this posting and this résumé actually
+raise, and ask them in one message so the user can answer in one pass. Draw from:
+
+- **Why this company, specifically?** Anything real — a product they use, someone they
+  know there, a problem they have watched this team get wrong or right. Generic admiration
+  is what the ban list exists to kill; this question is how you get past it.
+- **The story behind the strongest bullet.** What the résumé line compresses — what was
+  actually hard, what they decided, what it cost. One paragraph of this beats three
+  bullets restated.
+- **The gap question(s)** from above.
+- **A move the résumé makes look odd** — a short stint, a pivot, a gap in dates, a title
+  that reads down. Only if the posting's reader would plausibly stop on it. Ask what
+  happened; a sentence of context in the letter closes it, and silence lets them guess.
+- **What they want next** — the part of this role they actually want, versus the part they
+  can already do. A letter that knows the difference reads like a person.
+- **Anything they want in and anything they want out.** Cheapest question, frequently the
+  most useful.
+
+`AskUserQuestion` when the answers are genuinely a choice among options. Otherwise ask in
+prose — these are open questions and a four-option chip does not fit them.
+
+### Batch shape
+
+Ask the **shared** questions once for the whole batch (why this kind of role, the strongest
+story, the odd move). Ask **per-job** only what differs — usually the gap question and
+"why this company". Do not re-ask the same thing per posting.
+
+### Then use the answers
+
+Everything the user says here is admissible. That is the point: rule 3 forbids facts the
+**résumé** does not support *and* the user has not supplied — a thing they tell you about
+their own career is evidence, and a letter is exactly where it belongs.
+
+Do not soften it back into résumé language. If they say the migration took eleven months
+and two of those were spent convincing people, that sentence is better than any paraphrase.
+
+---
+
+## Phase 4 — Write it
+
+### Format: plain prose
+
+`LetterRecord.body` is typed as markdown, and the user's preference is **plain text** —
+these agree, because plain prose *is* valid markdown. So:
+
+- **No markdown syntax.** No `#`, no `**`, no `-` bullets, no tables. An employer pasting
+  this into a form or an email must not see asterisks.
+- Paragraphs separated by a blank line. `\n\n`, not `<br>`.
+- No header block, no date line, no company address — the letter opens with the salutation.
+  Modern applications are a textarea or an email body, not a printed page.
+- Sign with the real name from `parse.contact`, then email, then phone if present, one per
+  line. Nothing else.
+
+**The parsed contact IS the contact. Do not ask the user to confirm it.** The résumé is
+the document the employer will hold next to this letter; an address that disagrees with it
+is the bug, not an address that matches it. The user chose what to put on their résumé, and
+they chose it for employers — a different address they happen to use elsewhere (a work
+account, the one they are chatting from) is not more current, it is less relevant. If
+`parse.contact` is empty or the parse is low-confidence on a contact field, that is a
+**parse** problem: say which field is missing and let them fill it. That is the only
+question about contact this skill ever asks.
+
+### Shape: four paragraphs, under 350 words
+
+1. **The specific role, and one concrete reason for this company** — drawn from the
+   posting and from the interview, not from adjectives. "You are rebuilding the ingestion
+   path for X" beats "I have long admired your work."
+2. **One achievement, with its real number**, mapped to a requirement the posting named —
+   and told with the Phase 3.5 detail the bullet compressed. The number is the claim; the
+   story is why they should believe it.
+3. **A second achievement**, mapped to a different requirement. Different in kind from the
+   first — do not restate one accomplishment twice.
+4. **Close**: what they would be getting, and the contact line.
+
+**Never state availability.** Not "available immediately", not a start date, not a notice
+period. Volunteering it weakens the letter and it weakens a senior one most: a leader who
+announces they can start tomorrow is answering a question nobody asked, and the reading is
+that nothing is currently holding them. Availability is a scheduling detail that belongs in
+the first conversation, where it costs nothing. If the posting explicitly asks for a start
+date, answer it — in the field that asks, not in the letter.
+
+**At least one paragraph must carry something that is not in the résumé.** If every
+sentence could be reconstructed from the parse alone, the interview was wasted and the
+letter is redundant with the document sitting next to it.
+
+### Register
+
+The house rules for offlinecv copy apply to a letter as much as to product prose:
+
+- **Defensible, not merely confident.** Every claim points at something real. Do not name
+  a system, a scale, or an outcome the résumé does not carry.
+- **No false precision.** "Roughly a third" when the bullet says roughly a third.
+- **No self-serving negation.** Do not tell them what you are not. Say what you are.
+- **Ban list**: "I am excited to apply", "passionate about", "perfect fit", "proven track
+  record", "leverage", "synergy", "wear many hats", "hit the ground running", "as you can
+  see from my résumé", "available immediately". Any sentence that survives deleting the
+  company name is a sentence about nobody.
+
+### Gaps
+
+Phase 3.5 already asked about these. For each one that survived the interview, choose one
+and say which you chose in the report:
+
+- **The interview answer** — if the user supplied real experience the résumé omitted, that
+  is now evidence. Use it. This is the best outcome and the reason the phase exists.
+- **Adjacent and true** — the nearest real experience, named as what it is.
+- **Silence** — the letter is not obliged to enumerate every requirement.
+- **Never** — a claim neither source supports. Rule 3.
+
+---
+
+## Phase 5 — Show it, revise it
+
+Print the full draft in the conversation — every letter in the batch, in one message.
+Under each, say what it claims and where each claim comes from: one line per paragraph,
+citing the résumé field or the interview answer. Then ask.
+
+Revising one letter in a batch does not reopen the others. Track which are approved.
+
+Revise in the conversation, not in storage. Only import once the user says it is right.
+This costs one round trip and saves the far worse loop of revising a record that already
+has an id and a `createdAt`.
+
+---
+
+## Phase 6 — Write it into the library
+
+`StorageExport` v2, letters only:
+
+```json
+{
+  "version": 2,
+  "exportedAt": 0,
+  "resumes": [],
+  "jobs": [],
+  "letters": [
+    {
+      "id": "<crypto.randomUUID(), or the existing id when revising>",
+      "jobId": "job:<the id already in the jobs store>",
+      "resumeId": "<the ResumeRecord id from Phase 2>",
+      "label": "Draft 1",
+      "body": "Dear hiring team,\n\n…",
+      "producer": {
+        "contract": 1,
+        "producer": "claude-code-letter-skill",
+        "producerVersion": "0.1.0",
+        "generatedAt": 0
+      }
+    }
+  ]
+}
+```
+
+What the validator enforces, so get it right up front:
+
+- `id`, `jobId`, `body` required. `body` may be empty; `jobId` may not.
+- `producer.contract` must be a **finite number**. The rest of the object is optional but
+  send it — provenance cannot be retrofitted, and offlinecv writes no letters itself, so
+  every letter in the store should carry it.
+- Every value JSON-safe: no `Date`, no `undefined`, no `NaN`, no functions. An own
+  `__proto__` key refuses the whole record.
+- **A v2 document must carry all three arrays.** `jobs: []` and `resumes: []` are written,
+  not omitted.
+- Unknown keys are preserved, not dropped — so do not stash scratch state on the record.
+
+Then import exactly as `job-hunt` Phase 4 does: `find` the file input on `/` (it is only on
+`/`), `file_upload`, assert the open `<dialog>` shows your filename with **merge** checked,
+click `Restore` programmatically from inside the dialog, wait, **re-read the store**.
+
+Submitted-minus-accepted is the refusal count. Refusals are per-record and silent at the
+storage layer — derive them from the diff and report each with its record.
+
+---
+
+## Phase 7 — Hand it back, twice
+
+**Store it, and also give them a file.** Nothing in the app renders letters yet, so a
+letter that exists only in IndexedDB is a letter the user cannot use today. Write
+`cover-letter-<company>-<role>.txt` into the session scratchpad and surface it with
+`SendUserFile`. Plain `.txt`, the exact body that went into the store.
+
+Report:
+
+- per letter: the job (title, company) and the résumé used, and whether that résumé came
+  from `JobRecord.resumeId` or from a pick
+- letter id, and whether it **revised an existing draft** or **added a new one**
+- letters written / refused, each refusal with its reason
+- jobs newly saved to the tracker on the way through, and any URL dropped as already tracked
+- which JD requirements each letter answers, and which named must-haves it deliberately did
+  not claim
+- **the honest match verdict** (rule 4) — for each posting, whether the résumé plus what
+  the user told you actually supports it, said as a judgement. This is the line the user
+  needs and the one it is most tempting to soften.
+- what came from the interview rather than the résumé — so they can see what the letter
+  adds over the document they are already sending
+- if `jdText` was thin and you re-fetched: say so, say the stored record is unchanged, and
+  offer `job-hunt` to re-capture it
+- where the `.txt` landed
+- that the letter is not visible in the app yet, and that this is tracked
+
+---
+
+## Appendix — read letters for a job
+
+```js
+const db = await new Promise((res, rej) => {
+  const r = indexedDB.open("offlinecv");
+  r.onsuccess = () => res(r.result); r.onerror = () => rej(r.error);
+});
+const read = (n) => new Promise((res) => {
+  const q = db.transaction(n, "readonly").objectStore(n).getAll();
+  q.onsuccess = () => res(q.result);
+});
+JSON.stringify((await read("letters")).map(l => ({
+  id: l.id, jobId: l.jobId, label: l.label ?? null,
+  resumeId: l.resumeId ?? null, updatedAt: l.updatedAt,
+  bodyChars: l.body.length, producer: l.producer?.producer ?? null,
+})));
+```
+
+Summaries, not bodies — a bodies dump is the user's own prose scrolling past for no reason.
+Read one body only when revising it.
+
+## Appendix — cleanup
+
+Only letters carrying this skill's marker:
+
+```js
+const tx = db.transaction("letters", "readwrite"), s = tx.objectStore("letters");
+for (const l of await read("letters")) {
+  if (l.producer?.producer === "claude-code-letter-skill") s.delete(l.id);
+}
+```
+
+Deleting the **job** through the app cascades to its letters (`deleteJob` →
+`deleteLettersForJob`). Deleting a job through raw IndexedDB does **not** — sweep by
+`jobId` yourself, or prefer the UI.

--- a/.claude/skills/job-hunt/SKILL.md
+++ b/.claude/skills/job-hunt/SKILL.md
@@ -1,0 +1,456 @@
+---
+name: job-hunt
+description: Run a job hunt end to end against the user's own offlinecv.org library — find real postings, capture their requirements text, and write them in through the app's own backup-import door so every record passes the capture contract. Picks the résumé to work against and loads it so /jobs/ ranks postings against it; never overwrites a job the user has already moved through their pipeline. Use when the user says "/job-hunt", "find me some jobs", "drop these jobs into offlinecv", "save these postings to my library", or "put this in my job tracker".
+---
+
+# job-hunt — Claude Code as an outside producer for offlinecv
+
+offlinecv's storage layer was designed for a producer exactly like this skill.
+`docs/job-capture-contract.md` and `docs/cover-letter-contract.md` are **normative**;
+this skill is one implementation of them. Read them when anything below is ambiguous —
+they win.
+
+Everything in this file was verified end-to-end against live `offlinecv.org`
+(release `283a7bd`, `DB_VERSION 3`) on 2026-08-01. Where the obvious approach was
+tried and failed, that is called out — do not re-derive it.
+
+## The two doors
+
+| Direction | Mechanism | Why this one |
+|---|---|---|
+| **Read** | `javascript_tool` → `indexedDB.open("offlinecv")` on an app-origin tab | IndexedDB is origin-scoped, not world-scoped, so this works regardless of which world the tool's JS lands in |
+| **Write** | `file_upload` a JSON backup document → the app's import dialog, **merge** mode | Reuses `validateJobRecord` / `validateLetterRecord`; the app refuses malformed records instead of this skill guessing |
+
+**The export download is NOT a read door.** `downloadStorageBackup` builds a blob and
+clicks a synthetic `a.download`; in an automated tab the file never lands — not in
+`~/Downloads`, not anywhere. Never wait on it. Read IndexedDB.
+
+There is no automation seam: `window.offlinecv` is `undefined`, by design.
+
+## Hard rules
+
+1. **Never select `replace` mode.** It wipes every store. Merge is the default and the
+   only mode this skill uses — assert the `merge` radio is `checked` immediately before
+   confirming, every time.
+2. **Never write a job id that already exists** without the user asking for it
+   explicitly. Merge import does *not* apply `captureJob`'s ownership merge — it calls
+   `putRecord`, a wholesale replace — so re-importing a tracked job **resets the user's
+   `status`, `notes` and `resumeId`**. Diffing against a live read is the whole guard.
+3. **Verify every write by re-reading the store.** A click on `Restore` can silently
+   no-op: no error, dialog gone, nothing written. Never report success from a click.
+4. **Do not click a "new version available — reload" banner.** Reloading mid-flow has
+   effects the user did not ask for. Detect a stale build (below), tell them, let them
+   decide.
+5. **Never delete or edit a record this skill did not write.** Records it wrote carry
+   `capture.producer === "claude-code-jobs-skill"` (jobs) or
+   `producer.producer === "claude-code-letter-skill"` (letters). That marker is the only
+   thing that makes cleanup safe.
+6. **Never invent an id.** Job ids come from the repo's real `deriveJobId` — see Phase 3.
+
+---
+
+## Phase 0 — Open and take stock
+
+Load the Chrome tools in **one** `ToolSearch` call:
+
+```
+select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__javascript_tool,mcp__claude-in-chrome__find,mcp__claude-in-chrome__file_upload,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__list_connected_browsers,mcp__claude-in-chrome__switch_browser
+```
+
+`tabs_context_mcp{createIfEmpty:true}`, then navigate to `https://offlinecv.org/`.
+Reuse an existing offlinecv tab only if the user asks you to.
+
+### Always let the user pick the profile
+
+**Pair with `switch_browser`. Never `select_browser`, and never offer a browser list.**
+
+The unit that matters is the **Chrome profile**, not the machine. A `deviceId` names an
+extension connection, Chrome runs one per profile, and two ids can be the same physical
+box — so a list labelled by machine ("macOS" / "Windows") does not let the user express
+the only choice that matters, and picking one yourself is a guess. IndexedDB is
+partitioned per profile: the wrong attachment reads a real, empty store with no error,
+and the `tabId` can match across profiles, so it looks like the same tab.
+
+`switch_browser` broadcasts a Connect prompt to every profile at once. Ask the user to
+click it **in the window they mean**. That interstitial is the selection mechanism —
+it is the user choosing, in Chrome, with the window in front of them.
+
+It waits ~2 minutes and then fails with *"No browser responded within the timeout"*. Do
+not fall back to `select_browser` because of it. There are two causes, and the second is
+the one worth spelling out:
+
+1. **They didn't see it.** Say where to look — the Claude extension, in every open Chrome
+   profile — and call `switch_browser` again.
+2. **The profile they want has no extension.** Extensions install **per profile**, so a
+   profile without it is silently absent from the broadcast: no prompt, no entry in
+   `list_connected_browsers`, nothing to select. It cannot be distinguished from cause 1
+   by any tool call — so **say both** while you wait, rather than letting them re-look at
+   a window that will never show a prompt.
+
+**You cannot open an install link in the profile that needs it.** Every tool here rides
+the extension, so an extension-less profile is unreachable — no tab, no navigation, no
+link. The only thing that crosses the gap is text the user pastes themselves. Give it to
+them in the waiting message:
+
+> If the profile you want isn't showing a Connect prompt, it may not have the extension —
+> it installs per Chrome profile. Switch to that profile and install from
+> `https://claude.ai/chrome`, or go straight to the listing:
+> `https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn`
+> Then tell me and I'll broadcast again.
+
+Both URLs verified live on 2026-08-01 (`claude.ai/chrome` redirects to
+`claude.com/claude-for-chrome`). Note the extension is **beta**, and the store page says
+so — don't present installing it as routine.
+
+If they'd rather not install anything, the alternative is to work in a profile that
+already has it and accept that its offlinecv library is a **separate** store — a résumé
+saved in one profile is not visible in another.
+
+If a read later comes back empty while the user can see the data on screen, re-pair
+**before** theorising about anything else. Two reads of "the same tab" disagreeing on
+`navigator.storage.estimate().usage` is the tell.
+
+Then read the store (see Appendix A). Check three things:
+
+- **`db.version < 3` or no `letters` store** → the tab is running a stale build. Say so,
+  name what is missing, and ask whether to proceed jobs-only or have them reload. Do not
+  reload for them. A v2 document imported into a v1 build throws
+  `Unsupported storage export version: 2` and writes nothing.
+- **`jobs`** → this is the dedupe set for Phase 3.
+- **`resumes`** → drives Phase 1.
+
+---
+
+## Phase 1 — Pick a résumé, and load it
+
+The résumé is not decoration: `/jobs/` ranks postings against a parse handed over in
+`sessionStorage`, and a cover letter needs `ResumeRecord.parse`. Resolve it first.
+
+### Zero saved résumés → stop and wait
+
+Do not proceed, and do not work around it. Tell the user:
+
+> No résumé saved in your offlinecv library. Drop your PDF on offlinecv.org in **this**
+> window — the one you just connected — and click **Save to library** after it parses,
+> so it's there next time instead of dying with the tab. Tell me when it's in and I'll
+> pick up from there.
+
+That second sentence matters: a parse that is never saved leaves nothing for this skill
+to read on the next run. And "this window" matters because the drop has to land in the
+profile you are paired to — a résumé saved in a different profile is invisible here, no
+matter what the user can see on their screen.
+
+**Then wait for them.** Do not poll, do not re-read on a timer, do not guess that they
+are done. When they say it is in, re-read the store and continue step by step from
+there — one phase at a time, reporting what each one actually did.
+
+### Exactly one → use it, silently
+
+No question. Name it in the final report, not before.
+
+### More than one → ask
+
+`AskUserQuestion`, one option per résumé, most-recently-saved first. Label with the
+filename; put the saved date and the score in the description. Read them from the
+records (`filename`, `updatedAt`, `parse.score.overall`) — the same fields
+`listResumeChoices` exposes, plus the score, which is what makes two similar filenames
+tellable apart.
+
+### Skip the load if that résumé is already active
+
+If the tab is already showing a parsed result (`[aria-label="Parsed result views"]` and a
+score), the **Saved resumes** card is not rendered at all — it only exists in the
+pre-parse landing state. Do not go looking for it and do not conclude the library is
+empty. Confirm the active parse is the résumé you want (match the filename in
+`Try another file` / the score against the record), then jump straight to step 3.
+
+### Then load it into the tab
+
+The app must own this handoff — it applies the user's edit layer and writes the
+departure marker that makes `/jobs/`'s "Back to your resume" work. Drive its UI:
+
+1. On `/`, in the **Saved resumes** card, find the `<li>` whose text contains the chosen
+   filename and click its **Load** button.
+2. Wait, then confirm the parse landed: `[aria-label="Parsed result views"]` exists.
+3. Click the tab labelled **Find jobs**.
+4. Click the button **Open job workbench ▸**. This calls `departToJobs`, which writes
+   `sessionStorage["ocv_jobs_handoff"]` and navigates to `/jobs/`.
+5. Verify: `sessionStorage.getItem("ocv_jobs_handoff")` is non-null on `/jobs/`.
+
+If a dialog opens at step 1 (e.g. "Analyze a different resume?"), **read it and ask the
+user** — do not guess at a confirm.
+
+If the UI path fails twice, fall back to writing the handoff directly (Appendix C) and
+**say in the report that you did**, because that path skips whatever the app would have
+applied on load.
+
+---
+
+## Phase 2 — Find the postings
+
+Skip this phase when the user brought their own URLs; go straight to the capture rules
+below, which apply either way.
+
+### Search against the résumé you loaded, not against a guess
+
+Phase 1 left the parse in hand — `current_title`, `experience[].title`, `skills`. Build
+queries from those, and say which terms you searched so the user can correct them. Ask
+before widening into a domain they have not worked in: a plausible-looking senior title in
+an unrelated industry is exactly the result that wastes their review time.
+
+Two sources, in this order:
+
+1. **Company board indexes** — `job-boards.greenhouse.io/<co>`, `jobs.lever.co/<co>`,
+   `jobs.ashbyhq.com/<co>`. Read the anchors. Live by construction, and the cheapest
+   source of URLs that actually resolve.
+2. **Web search**, restricted to those hosts via `allowed_domains`. Faster for breadth,
+   but see below — its results decay.
+
+The app's own `/jobs/` Search tab is the other option, and it is the user's to drive: it
+egresses a keyword string built from their query, which is a deliberate, documented
+boundary (`src/lib/job-search/providers/keywords.ts`). Do not automate it on their behalf
+without saying so.
+
+### Verify the posting is live before you capture it
+
+Search indexes go stale fast — postings close within days. Observed on 2026-08-01: of
+four URLs taken from search results, **three were dead**. Greenhouse silently redirects a
+closed job id to the company's board index (so a fetch "succeeds" and returns the wrong
+listings); Lever returns an honest 404. Capturing either writes a dead link into the
+user's tracker with a plausible title.
+
+Fetch each posting and confirm the page is the posting itself — an `h1`/headline matching
+the title you are about to write. A cheaper source of live URLs: load the company's board
+index and read the anchors, which are live by construction.
+
+### `jdText` is the requirements body, not a summary — this is the #1 quality lever
+
+**Do not write your own précis of the posting.** Capture the posting's own text, from the
+role/responsibilities heading through the qualifications, and keep the line breaks: the
+noun pass matches phrases within a line and cannot span a line break, so flattening the
+whitespace destroys the terms.
+
+Measured on a live posting, same résumé, same everything else:
+
+| `jdText` | terms extracted | rating |
+|---|---|---|
+| 489-char summary written by the producer | 5 nouns, **0 skills** | **0.00★ "Weak fit"** |
+| 8000 chars of the real JD body | 26 terms incl. real skills | **2.34★** |
+
+A hand-written blurb reads well and rates zero, because what survives paraphrase is the
+company name and the job title — `DEFCON AI`, `USA`, `Data Lead` — and no résumé on earth
+contains those. The fit rating is only as good as the text you save, and the user cannot
+tell a bad capture from a bad match: both render as "Weak fit".
+
+Aim for **≥2000 characters** of real posting body. Take the whole thing when it is
+reasonable; do not trim to be tidy. Sanity-check before writing: if a capture yields under
+~1500 characters, or reads like prose you composed rather than text you copied, go back and
+take the real body.
+
+When fetching HTML yourself, convert `<br>`, `</p>`, `</li>` to newlines **before**
+stripping tags. Flattening whitespace first cost a whole diagnostic round: the same JD
+yielded 0 terms flattened and 26 line-structured.
+
+**Save the posting's text and nothing else.** No synthesized provenance header — no
+`Posted: … ReqID: … Type: …` line, no fetch timestamp, no source URL. A capture that
+prepended one put the junk term `REQ` straight into the coverage denominator, where it
+cost real rating and no résumé could ever cover it. Provenance belongs in `capture`,
+which is a structured field the matcher never reads. The posting *title* on its own first
+line is fine and expected — `extractJdTerms` is told the title separately
+(`ExtractOptions.postingTitle`) and drops it from the requirement terms.
+
+---
+
+## Phase 3 — Build the import document
+
+### Derive ids with the repo's own code, never by hand
+
+`deriveJobId` is normative (§2 of `docs/job-capture-contract.md`). A producer that strips
+one parameter differently forks the id space and creates silent duplicates. Bundle the
+real module and call it:
+
+```bash
+node_modules/.bin/esbuild src/lib/storage/job-url.ts \
+  --bundle --format=esm --outfile="$SCRATCH/job-url.mjs" --log-level=error
+```
+
+Then `import { deriveJobId } from "$SCRATCH/job-url.mjs"` in a node one-liner. Verified:
+`https://boards.greenhouse.io/exampleco/jobs/4455661?gh_src=abc&utm_source=alerts`
+→ `job:boards.greenhouse.io/exampleco/jobs/4455661`.
+
+A posting with no URL gets `crypto.randomUUID()` and simply does not converge. Say so in
+the report rather than deduping on title.
+
+### Drop everything already tracked
+
+Intersect derived ids with the `jobs` ids from Phase 0. Report the dropped ones as
+"already in your library — left untouched". This is rule 2, and it is the difference
+between a skill the user can re-run and one that quietly resets their pipeline.
+
+### Emit the document
+
+`StorageExport` v2. `resumes: []` always — this skill never writes résumés.
+
+```json
+{
+  "version": 2,
+  "exportedAt": 0,
+  "resumes": [],
+  "jobs": [
+    {
+      "id": "job:<derived>",
+      "title": "…",
+      "company": "…",
+      "url": "https://…",
+      "status": "interested",
+      "jdText": "…",
+      "capture": {
+        "contract": 1,
+        "producer": "claude-code-jobs-skill",
+        "producerVersion": "0.1.0",
+        "capturedAt": 0
+      }
+    }
+  ],
+  "letters": []
+}
+```
+
+Rules the validator enforces, so get them right up front:
+
+- `title` required; `status` must be one of `interested | applied | interviewing | offer |
+  rejected | archived`; `url` must be absolute `http(s)` (it is rendered into an `href`).
+- **A v2 document without a `letters` array is malformed** — emit `[]`, never omit it.
+- Every value must survive `structuredClone` and a JSON round-trip. No `Date`, no
+  `undefined`, no functions. An own `__proto__` key refuses the whole record.
+- **Write the job and its letters in the same document.** `importAll` writes
+  resumes → jobs → letters, so a letter's `jobId` resolves. A letter whose `jobId` matches
+  no job imports cleanly and is then reachable from nothing — nothing reconciles it.
+
+Write the file into the session scratchpad. `file_upload` accepts scratchpad paths.
+
+---
+
+## Phase 4 — Import it
+
+1. `find` the file input (`input[accept="application/json,.json"]`, `sr-only`) on `/`.
+   It is **only** on `/` — `/jobs/` offers Export but no Import.
+2. `file_upload` the document to that ref. The dialog opens on file-chosen; no click needed.
+3. Confirm state *before* confirming: the dialog is a native **`<dialog open>`**, not
+   `[role=dialog]` — query `[...document.querySelectorAll('dialog')].find(d => d.open)`.
+   Assert the file name shown is yours and the `merge` radio is `checked`.
+4. Click `Restore` **programmatically, from inside that dialog element**. A click through
+   an element ref has been observed to silently no-op.
+5. Wait ~1.5s, then **re-read the store** and compare against the counts from Phase 0.
+
+Accepted-minus-submitted is the refusal count. Refusals are per-record and silent at the
+storage layer — the app announces them in an `aria-live` region that is easy to miss — so
+derive them from the diff and report each one with the record it belongs to.
+
+---
+
+## Phase 5 — Verify and report
+
+Navigate `/jobs/`, click the **Saved jobs** tab (`role="tab"`, text starts with
+"Saved jobs"), confirm the new jobs render.
+
+**Verify in a tab that mounted *after* the import.** The tracker snapshots the store at
+mount and does not observe cross-tab IndexedDB writes, so a `/jobs/` tab that was already
+open when you imported keeps showing the old count — observed reading `Tracked jobs 0`
+while a raw read **in that same tab** returned 3. Navigate the tab you imported from, or
+reload. Do not read the stale count as a failed import, and do not reload the user's own
+tabs to fix their view — tell them theirs needs a refresh. Note: the tracker's `Remove` is a two-step
+inline confirm (`Cancel` / `Confirm`), not a modal — relevant only if the user asks you
+to undo.
+
+Report:
+
+- résumé used (and whether it was chosen or the only one)
+- jobs written / already-present-and-skipped / refused, each refusal with its reason
+- letters written / refused, if any
+- anything that landed with a UUID id because it had no URL
+- whether the handoff was written by the app or by the fallback
+
+## Cover letters — hand off to `cover-letter`
+
+Letters are a different job: a posting is *captured*, a letter is *generated*, and the
+quality bar is prose rather than plumbing. `.claude/skills/cover-letter/SKILL.md` owns
+that lane — grounding the draft in the résumé parse, the revise loop, and the letters-only
+import document. Invoke it rather than writing a `LetterRecord` from here.
+
+The one rule that binds **this** skill: a letter is only ever reachable through its job
+(§5 of the contract), and nothing reconciles a dangling `jobId`. So when a letter is
+coming, **the job must be imported first** — which is the order Phases 3 and 4 already
+produce.
+
+---
+
+## Appendix A — read the store
+
+```js
+const db = await new Promise((res, rej) => {
+  const r = indexedDB.open("offlinecv");
+  r.onsuccess = () => res(r.result); r.onerror = () => rej(r.error);
+});
+const read = (n) => new Promise((res) => {
+  const q = db.transaction(n, "readonly").objectStore(n).getAll();
+  q.onsuccess = () => res(q.result);
+});
+const has = (n) => [...db.objectStoreNames].includes(n);
+JSON.stringify({
+  version: db.version,
+  stores: [...db.objectStoreNames],
+  resumes: (await read("resumes")).map(r => ({
+    id: r.id, filename: r.filename, updatedAt: r.updatedAt,
+    score: r.parse?.score?.overall ?? null,
+  })),
+  jobIds: (await read("jobs")).map(j => j.id),
+  letters: has("letters") ? (await read("letters")).length : null,
+});
+```
+
+Do **not** dump whole résumé records — each carries the PDF `blob`.
+
+## Appendix B — confirm the import
+
+```js
+const dlg = [...document.querySelectorAll('dialog')].find(d => d.open);
+const merge = [...dlg.querySelectorAll('input[type=radio]')]
+  .find(r => r.value === 'merge');
+if (!merge?.checked) throw new Error('refusing: merge is not selected');
+[...dlg.querySelectorAll('button')].find(b => b.textContent.trim() === 'Restore').click();
+```
+
+Then re-read the store. Always.
+
+## Appendix C — handoff fallback (only if the UI path fails twice)
+
+```js
+const rec = /* the chosen ResumeRecord, read from IndexedDB */;
+const parsed = rec.parse?.result?.canonical;
+if (!parsed) throw new Error('no cached parse on this résumé record');
+sessionStorage.setItem('ocv_jobs_handoff', JSON.stringify({ parsed }));
+```
+
+**It is `parse.result.canonical`, not `.parsed`** — verified against a live record.
+`parsed` is the cascade's internal heuristic shape; `cascade.ts` converts it with
+`toCanonicalResume` and only `canonical` reaches storage. Reading `.parsed` returns
+`undefined`, which is indistinguishable from an uncached résumé.
+
+Same tab, then navigate to `/jobs/` — `sessionStorage` is per-tab and survives a
+same-tab navigation. This skips the departure marker, so `/jobs/`'s "Back to your resume"
+will push a fresh `/` instead of going back. Acceptable, but say you used it.
+
+## Appendix D — cleanup
+
+Only records carrying this skill's producer marker:
+
+```js
+const tx = db.transaction("jobs", "readwrite"), s = tx.objectStore("jobs");
+for (const j of await read("jobs")) {
+  if (j.capture?.producer === "claude-code-jobs-skill") s.delete(j.id);
+}
+```
+
+Deleting a job through the **app** cascades to its letters. Deleting it through raw
+IndexedDB like this does **not** — sweep `letters` by `jobId` yourself, or prefer the UI.

--- a/src/lib/jd-match/coverage.test.ts
+++ b/src/lib/jd-match/coverage.test.ts
@@ -34,6 +34,27 @@ describe("buildResumeProjection", () => {
     expect(projection).toContain("Staff Engineer");
     expect(buildCorpus(parsed)).toBe(projection.toLowerCase());
   });
+
+  it("projects an education entry's field of study, not just the credential", () => {
+    // The extractor splits a degree line into a bare credential + its subject
+    // (`extract/education.ts`), so `degree` alone carries no subject at all.
+    // Measured on a real résumé: a posting requiring "Computer Science" scored
+    // it MISSING against a CS graduate because only `degree` was projected.
+    const parsed = makeParsed({
+      education: [
+        {
+          degree: "Bachelor of Technology",
+          field: "Computer Science & Engineering",
+          institution: "JNTU College of Engineering",
+        },
+      ],
+    });
+    const coverage = computeCoverage(
+      parsed,
+      extractJdTerms("BS or MS in Computer Science required.").all,
+    );
+    expect(coverage.covered.map((t) => t.display)).toContain("Computer Science");
+  });
 });
 
 describe("buildCorpus", () => {

--- a/src/lib/jd-match/coverage.ts
+++ b/src/lib/jd-match/coverage.ts
@@ -137,7 +137,14 @@ export function buildResumeProjection(parsed: HeuristicParsedResume): string {
     pushPresent(parts, exp.title, exp.company, exp.description);
   }
   for (const edu of parsed.education ?? []) {
-    pushPresent(parts, edu.degree, edu.institution, edu.description);
+    // `field` is the SUBJECT of study, and `degree` deliberately excludes it —
+    // the extractor splits "Bachelor of Technology, Computer Science &
+    // Engineering" into credential + field (`extract/education.ts`
+    // `parseDegreeAndField`). Projecting only `degree` therefore drops the one
+    // part of an education entry a JD ever asks for: measured on a real résumé,
+    // a posting requiring "Computer Science" scored it MISSING against a CS
+    // graduate purely because the field never reached the corpus.
+    pushPresent(parts, edu.degree, edu.field, edu.institution, edu.description);
   }
   return parts.join("\n");
 }

--- a/src/lib/jd-match/extract-jd-terms.test.ts
+++ b/src/lib/jd-match/extract-jd-terms.test.ts
@@ -98,6 +98,26 @@ We also do a lot of Kotlin here.
     expect(reactHits).toHaveLength(1);
   });
 
+  it("does not read a clearance acronym as a two-letter language alias", () => {
+    // Observed on a live defense JD: "Active TS/SCI Clearance" was the ONLY
+    // skill hit in an 8000-character posting, and TypeScript appears nowhere
+    // in it. A false positive here credits a résumé for a skill the posting
+    // never asked for, so it must not survive.
+    const { skills } = extractJdTerms(
+      "Active TS/SCI Clearance required for work at IL-6 and above.",
+    );
+    expect(skills.find((s) => s.id === "typescript")).toBeUndefined();
+  });
+
+  it("keeps a two-letter alias when the other side of the slash is also a skill", () => {
+    // The discriminator is the neighbour, not the slash — "JS/TS" is how a
+    // résumé writes two real skills and must keep working.
+    const { skills } = extractJdTerms("Strong JS/TS fundamentals expected.");
+    const ids = skills.map((s) => s.id);
+    expect(ids).toContain("typescript");
+    expect(ids).toContain("javascript");
+  });
+
   it("includes a noun-phrase pass and drops any noun that also matched a skill", () => {
     const jd = `
 We work on Distributed Systems and Event Sourcing patterns.
@@ -147,6 +167,20 @@ Kubernetes is a core piece of the platform.
     const out = extractJdTerms(lines.join("\n"));
     expect(out.nouns.length).toBeLessThanOrEqual(25);
     expect(out.nounsDropped).toBeGreaterThan(0);
+  });
+
+  it("drops the outcomes-framing heading family from the noun pass (#156)", () => {
+    // Observed leaking from a live JD, where "What Success Looks Like" was
+    // surfaced as a requirement term the résumé was then marked as missing.
+    const jd = `
+What Success Looks Like:
+Authoritative data sources are onboarded with Data Modeling in place.
+`;
+    const { nouns } = extractJdTerms(jd);
+    const displays = nouns.map((n) => n.display);
+    expect(displays).not.toContain("What Success Looks Like");
+    // The real competency in the same block still comes through.
+    expect(displays).toEqual(expect.arrayContaining(["Data Modeling"]));
   });
 
   it("drops JD structural section headings from the noun pass (#156)", () => {
@@ -241,6 +275,81 @@ You'll work on Distributed Systems daily.
     expect(displays).not.toContain("The Summer Music Intern");
     // A genuine phrase in the same JD is unaffected.
     expect(displays).toContain("Distributed Systems");
+  });
+
+  it("drops prepositional sentence openers, not just articles", () => {
+    // Both observed on a live Apple posting: the phrase regex needs a leading
+    // capital, so these only ever fire at the head of a sentence — where the
+    // capture is a fragment, never a competency. The 4-word cap even truncates
+    // the second one mid-phrase.
+    const jd = `
+At Apple, new ideas have a way of becoming phenomenal products.
+As Senior Software Engineering Manager, you will lead a talented group.
+You'll work on Distributed Systems daily.
+`;
+    const displays = extractJdTerms(jd).nouns.map((n) => n.display);
+    expect(displays).not.toContain("At Apple");
+    expect(displays).not.toContain("As Senior Software Engineering");
+    expect(displays).toContain("Distributed Systems");
+  });
+
+  it("drops degree abbreviations but keeps the field of study", () => {
+    const jd = "BS or MS in Computer Science or equivalent experience.";
+    const displays = extractJdTerms(jd).nouns.map((n) => n.display);
+    expect(displays).not.toContain("BS");
+    expect(displays).not.toContain("MS");
+    // The matchable half of the requirement survives.
+    expect(displays).toContain("Computer Science");
+  });
+
+  it("does not read a gerund verb phrase as a competency", () => {
+    // "team" is the tail of "engineering team"; "building" opens a verb phrase.
+    // The `team building` alias straddles the two and would report a competency
+    // the posting never asked for.
+    const verbUsage = extractJdTerms(
+      "Ready to lead a high-performing engineering team building some of our most beloved apps?",
+    );
+    expect(verbUsage.all.map((t) => t.display)).not.toContain("Team Building");
+    // The competency reading is untouched — nothing here opens a direct object.
+    const realUsage = extractJdTerms(
+      "Strong team building and mentorship skills required.",
+    );
+    expect(realUsage.all.map((t) => t.display)).toContain("Team Building");
+  });
+
+  it("keeps the posting's own title and team out of its requirement terms", () => {
+    const jd = `
+Senior Engineering Manager, Info Apps
+The Info Apps team ships News, Stocks and Weather.
+You will work on Distributed Systems daily.
+`;
+    const displays = extractJdTerms(jd, {
+      postingTitle: "Senior Engineering Manager, Info Apps",
+    }).nouns.map((n) => n.display);
+    expect(displays).not.toContain("Senior Engineering Manager");
+    expect(displays).not.toContain("Info Apps");
+    // Everything the posting actually asks for is untouched.
+    expect(displays).toContain("Distributed Systems");
+  });
+
+  it("keeps title phrases when no postingTitle is supplied", () => {
+    // The JD-fit lane pastes bare JD text with no separate title field, so the
+    // guard must be opt-in rather than inferred from the first line.
+    const jd = `
+Senior Engineering Manager, Info Apps
+The Info Apps team ships News, Stocks and Weather.
+`;
+    const displays = extractJdTerms(jd).nouns.map((n) => n.display);
+    expect(displays).toContain("Info Apps");
+  });
+
+  it("does not drop a title-borne skill, which the skill pass owns", () => {
+    // Scoping the title guard to the NOUN pass is what makes it safe: a title
+    // naming a real technology still yields that technology as a term.
+    const out = extractJdTerms("Senior Rust Engineer\nYou will write Rust.", {
+      postingTitle: "Senior Rust Engineer",
+    });
+    expect(out.skills.map((t) => t.id)).toContain("rust");
   });
 
   it("does not over-strip skill phrases that share a heading tail word (#156)", () => {

--- a/src/lib/jd-match/extract-jd-terms.ts
+++ b/src/lib/jd-match/extract-jd-terms.ts
@@ -241,6 +241,12 @@ const SECTION_HEADING_STOP_PHRASES = new Set<string>([
   "who we are",
   "what we do",
   "what to expect",
+  // The outcomes-framing heading family. Observed leaking from a live JD as
+  // the term "What Success Looks Like" — a heading over the requirements it
+  // introduces, so it is exactly the #156 case, and no résumé will ever
+  // "cover" it.
+  "what success looks like",
+  "what success means",
   "why join us",
   "why work here",
   "about the role",
@@ -299,6 +305,58 @@ function isSectionHeading(keyLower: string): boolean {
   return SECTION_HEADING_TAIL_WORDS.has(lastWord);
 }
 
+/**
+ * Words that, as the FIRST word of a captured noun phrase, mark it a sentence
+ * or title opener rather than a competency: articles, prepositions,
+ * conjunctions and pronouns. The phrase regex requires every word to be
+ * capitalized, so these only fire sentence-initially or in a title — exactly
+ * where the capture is a fragment.
+ *
+ * Observed on a live Apple posting: *"**At Apple**, new ideas…"* and *"**As
+ * Senior Software Engineering** Manager, you will…"* both became requirement
+ * terms, the second truncated mid-phrase by the 4-word cap. No résumé covers
+ * either, so each one is pure denominator.
+ *
+ * Note this is NOT the same guard as {@link ACRONYM_STOPLIST}, which contains
+ * several of the same words: that set governs the all-caps ACRONYM regex only.
+ * The two regexes are independent, so the stoplist did nothing for "At Apple".
+ */
+const LEADING_FUNCTION_WORDS = new Set<string>([
+  "the",
+  "an",
+  "as",
+  "at",
+  "in",
+  "on",
+  "of",
+  "for",
+  "to",
+  "by",
+  "with",
+  "from",
+  "and",
+  "or",
+  "but",
+  "if",
+  "this",
+  "these",
+  "those",
+  "we",
+  "you",
+  "your",
+  "our",
+  "it",
+  "is",
+  "are",
+]);
+
+/** True when a captured noun phrase leads with a function word — see
+ *  {@link LEADING_FUNCTION_WORDS}. */
+function hasLeadingFunctionWord(keyLower: string): boolean {
+  const first = keyLower.slice(0, keyLower.indexOf(" "));
+  return LEADING_FUNCTION_WORDS.has(first);
+}
+
 /** Single-token acronyms we never want as a noun-pass term. Matches things
  *  the regex would otherwise sweep up from JD copy. */
 const ACRONYM_STOPLIST = new Set<string>([
@@ -320,11 +378,40 @@ const ACRONYM_STOPLIST = new Set<string>([
   "US",
   "YOU",
   "YOUR",
+  // Degree abbreviations. "BS or MS in Computer Science" is a real requirement,
+  // but the CREDENTIAL half of it carries no matchable signal — the field of
+  // study does, and it is captured separately as its own phrase. Left as terms
+  // they are two more entries no résumé projection will ever contain (the
+  // parser stores "Bachelor of Technology", never "BS"), so they are pure
+  // denominator. MBA is deliberately absent: it is a specific, matchable
+  // credential rather than a generic level marker.
+  "BS",
+  "BA",
+  "MS",
+  "MA",
+  "BSC",
+  "MSC",
 ]);
 
 export interface ExtractOptions {
   /** Override the snippet length. Default 80. */
   snippetChars?: number;
+  /**
+   * The posting's own title, when the caller knows it. A posting cannot be
+   * evidence for itself: noun-pass phrases contained in the title are the job's
+   * IDENTITY, not its requirements, so they are dropped from the term list.
+   *
+   * Observed on a live Apple posting titled "Senior Engineering Manager, Info
+   * Apps": both `Senior Engineering Manager` and `Info Apps` (the team name)
+   * entered the coverage denominator, which no résumé can ever cover — the
+   * candidate is penalized for the posting having a name.
+   *
+   * Scoped to the NOUN pass on purpose. A title naming a real technology
+   * ("Senior Rust Engineer") is caught by the skill pass, which this never
+   * touches, and the noun pass already drops any hit the skill dictionary
+   * knows — so a genuine title skill survives while the job-identity phrases go.
+   */
+  postingTitle?: string;
 }
 
 /**
@@ -342,6 +429,7 @@ export function extractJdTerms(
 ): ExtractJdTermsResult {
   const snippetChars = options.snippetChars ?? 80;
   const body = stripBoilerplate(rawJd);
+  const titleLower = (options.postingTitle ?? "").toLowerCase();
 
   const skills = extractSkillPass(body, snippetChars);
   const skilledAliases = new Set(skills.map((t) => t.id));
@@ -353,6 +441,9 @@ export function extractJdTerms(
     // Drop noun hits that the skill pass already saw under a different alias.
     const index = getSkillIndex();
     if (index.aliasToId.has(lower)) return false;
+    // Drop the posting's own title/team words — see `ExtractOptions.postingTitle`.
+    // Word-boundary anchored so "Eng" inside "Engineering" is not a title hit.
+    if (titleLower && countOccurrences(titleLower, lower) > 0) return false;
     return true;
   });
 
@@ -408,6 +499,116 @@ export function stripBoilerplate(raw: string): string {
   return kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
 }
 
+/**
+ * Longest alias length that is short enough to collide with an unrelated
+ * acronym. Only `js`, `ts`, `c#` and `d3` are this short today, and only they
+ * are subject to the slash-compound guard below — a longer alias ("java",
+ * "rust") carries enough signal that a compound hit is almost certainly real.
+ */
+const SHORT_ALIAS_MAX_LEN = 2;
+
+/** Token characters an alias can be built from — the set `escapeRegex`'d into
+ *  the alias pattern, so a compound neighbour is read with the same alphabet
+ *  the dictionary uses (`c++`, `.net`, `react.js`). */
+const ALIAS_TOKEN_RE = /[A-Za-z0-9#+.]+/;
+
+/**
+ * Is a SHORT alias hit inside a slash compound whose other side is not itself
+ * a known skill?
+ *
+ * `/` is a word boundary in `ALIAS_BOUNDARY_PREFIX`/`SUFFIX`, and it has to be:
+ * "JS/TS" is how résumés write two real skills, and dropping slash boundaries
+ * would lose it. But the same boundary makes a security clearance read as a
+ * language — **"Active TS/SCI Clearance" matched the `ts` alias and reported
+ * TypeScript**, observed on a live defense JD where TypeScript appears nowhere.
+ * That is a false POSITIVE in the user's favour, which is worse than a miss: it
+ * credits a résumé for a skill the posting never asked for.
+ *
+ * The discriminator is the other side of the slash. In "JS/TS" it is itself an
+ * alias; in "TS/SCI" it is not. So a short alias in a compound is kept only
+ * when its neighbour is also in the dictionary — which preserves every
+ * legitimate compound without enumerating clearance jargon we would never
+ * finish listing (TS/SCI, NOFORN, JADC2 …).
+ *
+ * Scope, deliberately: this covers the COMPOUND only. A bare "TS clearance"
+ * still reads as TypeScript, because the only thing distinguishing it from a
+ * résumé's bare "TS" is domain knowledge this module does not have. Narrowing
+ * that would need either a clearance-phrase list (unbounded) or dropping the
+ * two-letter aliases outright (loses real résumé hits) — neither is worth it
+ * for a case the compound guard already covers in its common form.
+ */
+function isForeignSlashCompound(
+  body: string,
+  aliasStart: number,
+  aliasLen: number,
+  aliasToId: ReadonlyMap<string, string>,
+): boolean {
+  const before = body.slice(0, aliasStart);
+  const after = body.slice(aliasStart + aliasLen);
+
+  const neighbour = before.endsWith("/")
+    ? ALIAS_TOKEN_RE.exec(
+        before.slice(0, -1).split(/[^A-Za-z0-9#+.]/).pop() ?? "",
+      )?.[0]
+    : after.startsWith("/")
+      ? ALIAS_TOKEN_RE.exec(after.slice(1))?.[0]
+      : undefined;
+
+  return neighbour !== undefined && !aliasToId.has(neighbour.toLowerCase());
+}
+
+/**
+ * Words that can open a direct object, and so mark the word before them as a
+ * transitive VERB rather than the tail of a noun phrase.
+ */
+const DIRECT_OBJECT_OPENERS = new Set<string>([
+  "a",
+  "an",
+  "the",
+  "some",
+  "our",
+  "its",
+  "their",
+  "his",
+  "her",
+  "this",
+  "these",
+  "those",
+  "several",
+  "many",
+  "multiple",
+]);
+
+/**
+ * Is a multi-word alias ending in a GERUND actually a verb phrase here?
+ *
+ * Observed: the `team-building` alias `"team building"` matched *"lead a
+ * high-performing engineering **team building** some of Apple's most beloved
+ * apps"* — where "team" is the tail of "engineering team" and "building" opens
+ * a verb phrase. The alias straddles two constituents and reports a competency
+ * the posting never asked for. Same family as the TS/SCI false positive above,
+ * and judged the same way: a bogus requirement is worse than a missed one,
+ * because it enters the coverage denominator no résumé can cover.
+ *
+ * The discriminator is what FOLLOWS. A gerund used as a verb takes a direct
+ * object, which opens with a determiner or quantifier ("building **some** of
+ * Apple's apps"); the competency reading does not ("team building and
+ * mentorship", "strong team building skills", end of clause). So the guard
+ * fires only on a directly-following determiner, which leaves every ordinary
+ * usage of the alias intact.
+ */
+function isGerundVerbUsage(
+  body: string,
+  matchedAlias: string,
+  aliasStart: number,
+  aliasLen: number,
+): boolean {
+  const lastWord = matchedAlias.slice(matchedAlias.lastIndexOf(" ") + 1);
+  if (lastWord === matchedAlias || !lastWord.endsWith("ing")) return false;
+  const next = /^\s+([A-Za-z']+)/.exec(body.slice(aliasStart + aliasLen));
+  return next !== null && DIRECT_OBJECT_OPENERS.has(next[1].toLowerCase());
+}
+
 function extractSkillPass(body: string, snippetChars: number): ExtractedTerm[] {
   const index = getSkillIndex();
   const pattern = new RegExp(index.pattern.source, index.pattern.flags);
@@ -419,6 +620,13 @@ function extractSkillPass(body: string, snippetChars: number): ExtractedTerm[] {
     if (!id) continue;
     if (seen.has(id)) continue;
     const aliasStart = m.index + (m[0].length - m[1].length);
+    if (
+      matchedAlias.length <= SHORT_ALIAS_MAX_LEN &&
+      isForeignSlashCompound(body, aliasStart, m[1].length, index.aliasToId)
+    ) {
+      continue;
+    }
+    if (isGerundVerbUsage(body, matchedAlias, aliasStart, m[1].length)) continue;
     seen.set(id, {
       id,
       display: index.idToLabel.get(id) ?? id,
@@ -459,11 +667,11 @@ function extractNounPass(body: string, snippetChars: number): ExtractedTerm[] {
     // Drop JD structural section headings ("Minimum Qualifications",
     // "Physical Demands", …) — document structure, not a competency (#156).
     if (isSectionHeading(key)) continue;
-    // Drop "The …" sentence/title openers ("The Summer Music Intern", "The
-    // Ideal Candidate") — the capitalized run after a leading "The" is almost
-    // always a title or sentence subject, not a skill (#156). Real skill
-    // phrases don't lead with an article.
-    if (key.startsWith("the ")) continue;
+    // Drop sentence/title openers ("The Summer Music Intern", "At Apple", "As
+    // Senior Software Engineering") — the capitalized run after a leading
+    // function word is almost always a title or sentence subject, not a skill
+    // (#156). Real skill phrases don't lead with an article or preposition.
+    if (hasLeadingFunctionWord(key)) continue;
     if (seen.has(key)) continue;
     seen.set(key, {
       id: key,

--- a/src/lib/job-search/rank.ts
+++ b/src/lib/job-search/rank.ts
@@ -226,7 +226,13 @@ export function rankPostings(
 
   // Pass 1 — coverage + comp per posting (rating still unset; filled in pass 2).
   const ranked = postings.map((posting): RankedJob => {
-    const extracted = extractJdTerms(posting.description);
+    // `postingTitle` keeps the posting's own name and team out of its
+    // requirement set — a posting cannot be evidence for itself (see
+    // `ExtractOptions`). Same call shape as `rateSavedJobs`, so the search lane
+    // and the saved library extract identically for the same text.
+    const extracted = extractJdTerms(posting.description, {
+      postingTitle: posting.title,
+    });
     const coverage = computeCoverage(parsed, extracted.all);
     const jdMatch: KeywordJdMatch = {
       path: "keyword",

--- a/src/lib/job-search/rate-saved-jobs.ts
+++ b/src/lib/job-search/rate-saved-jobs.ts
@@ -85,7 +85,9 @@ export function rateSavedJobs(
   for (const job of jobs) {
     const jdText = (job.jdText ?? "").trim();
     if (jdText === "") continue;
-    const terms = extractJdTerms(jdText).all;
+    // `postingTitle` keeps the job's own name and team out of its requirement
+    // set — a posting cannot be evidence for itself (see `ExtractOptions`).
+    const terms = extractJdTerms(jdText, { postingTitle: job.title }).all;
     // Zero terms is an empty requirement set, which coverage scores 0 — the
     // "terrible fit" reading property 1 forbids. Not rateable.
     if (terms.length === 0) continue;


### PR DESCRIPTION
## Summary

Running the job-hunt and cover-letter skills end to end against two live Apple postings
surfaced a 0.82★ "Weak fit" on a résumé the postings partly fit. **9 of the 13 extracted
"requirements" on one posting were not requirements** — the posting's own title, its team
name, two sentence fragments (`At Apple`, `As Senior Software Engineering`), two degree
abbreviations, a verb phrase read as a competency (`Team Building`, from *"engineering
team building some of Apple's most beloved apps"*), and a header line the skill itself had
synthesized. All of them sit in the coverage denominator, where no résumé can cover them.

Six fixes, each with a test. Measured on the same posting and résumé:

| | before | after |
|---|---|---|
| terms extracted | 13 | **5**, all genuine |
| rated in the saved pair | 0.82★ | **1.10★** |
| rated alone (pure absolute curve) | 2.04★ | **2.75★** |

The remaining gap between those last two rows is the set-relative fitness axis, filed
separately as #716 (fitness should be absolute) — deliberately not touched here, because
it changes scoring semantics across three lanes and its calibration has to sit on top of
the clean extraction this PR produces.

Also lands the two skills that drove the investigation, including a real bug in both: they
read the cached parse at `parse.result.parsed`, which is `undefined` — the canonical shape
is at `parse.result.canonical` (`cascade.ts:195` converts via `toCanonicalResume` before
storage). The wrong path would have read as an uncached résumé rather than as a bug.

Refs #716

## Review focus

- `src/lib/jd-match/extract-jd-terms.ts` `isGerundVerbUsage` — is a following determiner
  enough? Which real JD phrasings put a determiner right after a gerund-final alias?
- `src/lib/jd-match/extract-jd-terms.ts` `postingTitle` filter — the guard is scoped to the
  noun pass on the argument that a title-borne *skill* is caught by the skill pass. Does
  that hold for a multi-word skill phrase the dictionary doesn't have?
- `src/lib/jd-match/coverage.ts` `buildResumeProjection` — adding `edu.field` widens the
  corpus every consumer reads, including the WebLLM evidence judge. Anything else keyed to
  the old projection?
- `LEADING_FUNCTION_WORDS` — does any real competency phrase start with one of these?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 4211 passed, 10 skipped
- [x] `npm run verify` green (fallow's 3 unused-dependency findings are pre-existing, in
      `extension/package.json`, and untouched by this change)
- [x] Measured against the two live Apple postings and the real parsed résumé, not only
      against synthetic fixtures

## Provenance

Code implementation via: Claude Opus 5 (1M context)
Verification: `npm run verify` — green locally, and in CI
