### PR TITLE
feat(jd-extract): one JD extractor for the app, the skill and the extension

### DIFF
--- a/src/lib/jd-extract/adapters-extract.test.ts
+++ b/src/lib/jd-extract/adapters-extract.test.ts
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The `extract()` half of each host adapter, against realistic page markup.
+ *
+ * These are the most brittle functions in the lane by construction — every one is
+ * a set of CSS selectors aimed at someone else's markup, and they rot when that
+ * markup changes. Which is the argument for covering them rather than only their
+ * `matches()` counterparts (`./adapters.test.ts`): when a selector does rot, the
+ * adapter does not throw, it silently returns a worse result or `null`, and a page
+ * that used to extract quietly falls through to the catch-all tier.
+ *
+ * Each case therefore asserts the *specific* selector path an adapter was written
+ * for, not merely that something came back.
+ */
+
+import { greenhouse } from "./adapters/greenhouse";
+import { lever } from "./adapters/lever";
+import { workday } from "./adapters/workday";
+import { oracleHcm } from "./adapters/oracle-hcm";
+import { smartrecruiters } from "./adapters/smartrecruiters";
+import { generic } from "./adapters/generic";
+
+function doc(html: string): Document {
+  return new DOMParser().parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    "text/html",
+  );
+}
+
+/** Long enough to clear the adapters' 100-character body floor. */
+const LONG_BODY =
+  "<p>We are looking for an experienced engineer to join the platform team and " +
+  "help us build reliable distributed systems at scale.</p>";
+
+describe("greenhouse.extract — direct board page", () => {
+  const url = new URL("https://boards.greenhouse.io/acme/jobs/4012345");
+
+  it("extracts from the board's own markup", () => {
+    const result = greenhouse.extract(
+      doc(
+        '<h1 class="app-title">Backend Engineer</h1>' +
+          '<span class="company-name">Acme Inc</span>' +
+          '<div class="location">Austin, TX</div>' +
+          `<div id="content">${LONG_BODY}<ul><li>Go</li><li>Postgres</li></ul></div>`,
+      ),
+      url,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Backend Engineer");
+    expect(result!.company).toBe("Acme Inc");
+    expect(result!.location).toBe("Austin, TX");
+    expect(result!.extractionTier).toBe("ats_extractor");
+    expect(result!.atsDetected).toBe("greenhouse");
+    expect(result!.body).toContain("- Go");
+  });
+
+  // Board URLs are `/<company>/jobs/<id>`, so the path carries the company when
+  // the page does not name it.
+  it("falls back to the company slug in the URL path", () => {
+    const result = greenhouse.extract(
+      doc(`<h1>Backend Engineer</h1><div id="content">${LONG_BODY}</div>`),
+      url,
+    );
+    expect(result!.company).toBe("acme");
+  });
+
+  it("returns null with no title", () => {
+    expect(greenhouse.extract(doc(`<div id="content">${LONG_BODY}</div>`), url)).toBeNull();
+  });
+});
+
+describe("greenhouse.extract — embedded widget", () => {
+  // The embedded case is the one that matters for dedup: the visible URL is the
+  // company's own domain, so without recovering the board URL the same posting
+  // saved here and on the board itself forks into two records.
+  const url = new URL("https://acme.com/careers?gh_jid=4012345");
+
+  it("recovers the canonical board URL from the widget iframe", () => {
+    const result = greenhouse.extract(
+      doc(
+        '<iframe id="grnhse_iframe" src="https://boards.greenhouse.io/acmecorp/jobs/4012345"></iframe>',
+      ),
+      url,
+    );
+    expect(result!.atsUrl).toBe("https://boards.greenhouse.io/acmecorp/jobs/4012345");
+    expect(result!.jobId).toBe("4012345");
+  });
+
+  it("recovers the board slug from the embed script when no iframe has rendered", () => {
+    const result = greenhouse.extract(
+      doc(
+        '<script src="https://boards.greenhouse.io/embed/job_board/js?for=acmecorp"></script>',
+      ),
+      url,
+    );
+    expect(result!.atsUrl).toBe("https://boards.greenhouse.io/acmecorp/jobs/4012345");
+  });
+
+  it("takes the job id from gh_jid when the iframe omits it", () => {
+    const result = greenhouse.extract(doc("<h1>Engineer</h1>"), url);
+    expect(result!.jobId).toBe("4012345");
+    // No board slug anywhere, so no canonical URL can be built.
+    expect(result!.atsUrl).toBeUndefined();
+  });
+
+  // atsUrl is the entire point of this path — without an id there is nothing to
+  // contribute that the general tiers could not.
+  it("returns null when there is no job id at all", () => {
+    expect(
+      greenhouse.extract(doc('<iframe id="grnhse_iframe"></iframe>'), new URL("https://acme.com/careers")),
+    ).toBeNull();
+  });
+
+  // The description lives inside a cross-origin iframe and is not readable here.
+  it("returns an empty body rather than scraping the host page", () => {
+    const result = greenhouse.extract(
+      doc(
+        `<iframe id="grnhse_iframe" src="https://boards.greenhouse.io/acmecorp/jobs/4012345"></iframe>${LONG_BODY}`,
+      ),
+      url,
+    );
+    expect(result!.body).toBe("");
+  });
+});
+
+describe("lever.extract", () => {
+  const url = new URL("https://jobs.lever.co/acme/0d5c1d1e-1b1e-4b1e-8b1e-1b1e4b1e8b1e");
+
+  // Lever splits the body across several .section-wrapper elements — taking only
+  // the first would drop most of the JD.
+  it("concatenates every section wrapper into one body", () => {
+    const result = lever.extract(
+      doc(
+        '<div class="posting-headline"><h2>Staff Engineer</h2></div>' +
+          '<div class="posting-page">' +
+          `<div class="section-wrapper"><p>About the role.</p></div>` +
+          `<div class="section-wrapper"><ul><li>Rust</li></ul></div>` +
+          `<div class="section-wrapper"><p>Benefits.</p></div>` +
+          "</div>",
+      ),
+      url,
+    );
+
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.body).toContain("About the role.");
+    expect(result!.body).toContain("- Rust");
+    expect(result!.body).toContain("Benefits.");
+  });
+
+  it("reads location and work model from Lever's own category fields", () => {
+    const result = lever.extract(
+      doc(
+        '<div class="posting-headline"><h2>Staff Engineer</h2></div>' +
+          '<div class="posting-categories"><span class="location">Remote - US</span>' +
+          '<span class="workplaceType">Remote</span></div>' +
+          `<div class="posting-page"><div class="section-wrapper">${LONG_BODY}</div></div>`,
+      ),
+      url,
+    );
+    expect(result!.location).toBe("Remote - US");
+    expect(result!.workModel).toBe("Remote");
+  });
+
+  it("falls back to .content when no section wrappers exist", () => {
+    const result = lever.extract(
+      doc(`<h1>Staff Engineer</h1><div class="content">${LONG_BODY}</div>`),
+      url,
+    );
+    expect(result!.body).toContain("experienced engineer");
+  });
+
+  it("falls back to the company slug in the URL path", () => {
+    const result = lever.extract(
+      doc(`<h1>Staff Engineer</h1><div class="content">${LONG_BODY}</div>`),
+      url,
+    );
+    expect(result!.company).toBe("acme");
+  });
+
+  it("returns null with no title", () => {
+    expect(lever.extract(doc(`<div class="content">${LONG_BODY}</div>`), url)).toBeNull();
+  });
+});
+
+describe("workday.extract", () => {
+  const url = new URL("https://acme.wd5.myworkdayjobs.com/en-US/External/job/Austin/Eng_R123");
+
+  // Selectors key on data-automation-id, Workday's own stable test-hook attribute,
+  // rather than its generated CSS class names.
+  it("extracts via data-automation-id attributes", () => {
+    const result = workday.extract(
+      doc(
+        '<h1 data-automation-id="jobPostingHeader">Senior Engineer</h1>' +
+          '<div data-automation-id="jobPostingCompanyName">Acme</div>' +
+          '<div data-automation-id="locations">Austin, TX</div>' +
+          `<div data-automation-id="jobPostingDescription">${LONG_BODY}<ul><li>Java</li></ul></div>`,
+      ),
+      url,
+    );
+
+    expect(result!.title).toBe("Senior Engineer");
+    expect(result!.company).toBe("Acme");
+    expect(result!.location).toBe("Austin, TX");
+    expect(result!.atsDetected).toBe("workday");
+    expect(result!.body).toContain("- Java");
+  });
+
+  it("falls back to the jobPostingTitle automation id", () => {
+    const result = workday.extract(
+      doc(
+        '<h2 data-automation-id="jobPostingTitle">Senior Engineer</h2>' +
+          `<div class="jobDescription">${LONG_BODY}</div>`,
+      ),
+      url,
+    );
+    expect(result!.title).toBe("Senior Engineer");
+  });
+
+  it("returns null with no title", () => {
+    expect(workday.extract(doc(`<div class="jobDescription">${LONG_BODY}</div>`), url)).toBeNull();
+  });
+});
+
+describe("oracleHcm.extract", () => {
+  const url = new URL("https://acme.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/job/123");
+
+  it("extracts from Oracle's job-detail classes", () => {
+    const result = oracleHcm.extract(
+      doc(
+        '<div class="job-title">Data Engineer</div>' +
+          '<div class="job-company">Acme</div>' +
+          '<div class="job-location">Hyderabad, India</div>' +
+          `<div class="job-description">${LONG_BODY}<ul><li>Python</li></ul></div>`,
+      ),
+      url,
+    );
+
+    expect(result!.title).toBe("Data Engineer");
+    expect(result!.company).toBe("Acme");
+    expect(result!.location).toBe("Hyderabad, India");
+    expect(result!.atsDetected).toBe("oracle-hcm");
+    expect(result!.body).toContain("- Python");
+  });
+
+  it("falls back to a partial-class description container", () => {
+    const result = oracleHcm.extract(
+      doc(`<h1>Data Engineer</h1><div class="jobDescriptionBody">${LONG_BODY}</div>`),
+      url,
+    );
+    expect(result!.body).toContain("experienced engineer");
+  });
+
+  it("returns null with no title", () => {
+    expect(oracleHcm.extract(doc(LONG_BODY), url)).toBeNull();
+  });
+});
+
+describe("smartrecruiters.extract", () => {
+  const url = new URL("https://jobs.smartrecruiters.com/Acme/744000112520307-staff-engineer");
+
+  // SmartRecruiters serves an IE11 sunset notice whose <h1> precedes the real
+  // title in document order — a generic h1 read would capture that banner, which
+  // is why this adapter never falls back to h1.
+  it("prefers .summary-title over an earlier unrelated h1", () => {
+    const result = smartrecruiters.extract(
+      doc(
+        "<h1>Your browser is no longer supported</h1>" +
+          '<h2 class="summary-title">Staff Engineer</h2>' +
+          `<div class="jobad-container">${LONG_BODY}</div>`,
+      ),
+      url,
+    );
+    expect(result!.title).toBe("Staff Engineer");
+  });
+
+  it("extracts the requisition id from the URL path", () => {
+    const result = smartrecruiters.extract(
+      doc(`<h2 class="summary-title">Staff Engineer</h2><div class="jobad-container">${LONG_BODY}</div>`),
+      url,
+    );
+    expect(result!.jobId).toBe("744000112520307");
+    expect(result!.company).toBe("Acme");
+  });
+
+  it("returns null when the body is too short to be a posting", () => {
+    expect(
+      smartrecruiters.extract(
+        doc('<h2 class="summary-title">Staff Engineer</h2><div class="jobad-container">Tiny</div>'),
+        url,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null with no title", () => {
+    expect(smartrecruiters.extract(doc(`<div class="jobad-container">${LONG_BODY}</div>`), url)).toBeNull();
+  });
+});
+
+describe("generic.extract", () => {
+  const url = new URL("https://careers.acme.com/jobs/9");
+
+  it("reads company from og:site_name when present", () => {
+    const d = doc(`<h1>Platform Engineer</h1><main>${LONG_BODY}</main>`);
+    const meta = d.createElement("meta");
+    meta.setAttribute("property", "og:site_name");
+    meta.setAttribute("content", "Acme");
+    d.head.appendChild(meta);
+
+    const result = generic.extract(d, url);
+    expect(result!.company).toBe("Acme");
+    expect(result!.extractionTier).toBe("dom_metadata");
+  });
+
+  it("falls back to the trailing segment of the page title", () => {
+    const d = doc(`<h1>Platform Engineer</h1><main>${LONG_BODY}</main>`);
+    d.title = "Platform Engineer | Acme Careers";
+    expect(generic.extract(d, url)!.company).toBe("Acme Careers");
+  });
+
+  // The domain is always available, which is what lets this adapter — the ladder's
+  // floor — return a usable result rather than null for want of a company.
+  it("falls back to the bare domain", () => {
+    const result = generic.extract(doc(`<h1>Platform Engineer</h1><main>${LONG_BODY}</main>`), url);
+    expect(result!.company).toBe("careers");
+  });
+
+  // Landmark elements only — body would sweep in header, nav and footer.
+  it("reads only landmark elements, not the whole body", () => {
+    const result = generic.extract(
+      doc(
+        "<header>Site navigation menu goes here</header>" +
+          `<h1>Platform Engineer</h1><main>${LONG_BODY}</main>` +
+          "<footer>Copyright notice</footer>",
+      ),
+      url,
+    );
+    expect(result!.body).not.toContain("Site navigation");
+    expect(result!.body).not.toContain("Copyright notice");
+  });
+
+  it("returns null when the landmark holds page chrome rather than a posting", () => {
+    expect(generic.extract(doc("<h1>Engineer</h1><main>Home About Contact</main>"), url)).toBeNull();
+  });
+
+  it("returns null with no h1", () => {
+    expect(generic.extract(doc(`<main>${LONG_BODY}</main>`), url)).toBeNull();
+  });
+});

--- a/src/lib/jd-extract/adapters.test.ts
+++ b/src/lib/jd-extract/adapters.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// `matches()` is pure URL/fingerprint dispatch, so these run in the node
+// environment against minimal stubs — no jsdom, no fixture pages. The extraction
+// half of each adapter needs a real DOM and is covered in `./detect.test.ts`.
+//
+// The exclusivity matrix at the bottom is the load-bearing part. Dispatch is
+// first-match-wins over an ordered list, so an adapter that over-matches does not
+// merely add a wrong result — it *silently steals* pages from the adapter written
+// for them, and the symptom (a slightly worse extraction) looks nothing like the
+// cause.
+
+import { greenhouse } from "./adapters/greenhouse";
+import { lever } from "./adapters/lever";
+import { linkedin } from "./adapters/linkedin";
+import { workday } from "./adapters/workday";
+import { oracleHcm } from "./adapters/oracle-hcm";
+import { smartrecruiters } from "./adapters/smartrecruiters";
+import { generic } from "./adapters/generic";
+import type { ATSExtractor } from "./types";
+
+const emptyDoc = {
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  getElementById: () => null,
+} as unknown as Document;
+
+/** A stub whose only readable feature is one `<meta>` tag — Oracle's last resort. */
+function docWithGenerator(content: string): Document {
+  return {
+    querySelector: (selector: string) =>
+      selector === 'meta[name="generator"]'
+        ? { getAttribute: () => content }
+        : null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+  } as unknown as Document;
+}
+
+describe("greenhouse.matches", () => {
+  it.each([
+    ["https://boards.greenhouse.io/acme/jobs/123", true],
+    ["https://acme.greenhouse.io/jobs/123", true],
+    ["https://jobs.lever.co/acme/123", false],
+    ["https://acme.wd5.myworkdayjobs.com/job/123", false],
+    ["https://careers.google.com/jobs/123", false],
+  ])("%s → %s", (url, expected) => {
+    expect(greenhouse.matches(new URL(url), emptyDoc)).toBe(expected);
+  });
+
+  // The embedded case is why Greenhouse has fingerprints beyond its hostname: the
+  // visible URL is the company's own domain and says nothing about Greenhouse.
+  it("matches an embedded board via the gh_jid parameter", () => {
+    expect(
+      greenhouse.matches(new URL("https://acme.com/careers?gh_jid=456"), emptyDoc),
+    ).toBe(true);
+  });
+
+  it("matches an embedded board via the widget iframe", () => {
+    const doc = {
+      querySelector: () => null,
+      getElementById: (id: string) => (id === "grnhse_iframe" ? {} : null),
+    } as unknown as Document;
+    expect(greenhouse.matches(new URL("https://acme.com/careers"), doc)).toBe(true);
+  });
+
+  it("matches an embedded board via the embed script", () => {
+    const doc = {
+      querySelector: (s: string) =>
+        s === 'script[src*="boards.greenhouse.io/embed"]' ? {} : null,
+      getElementById: () => null,
+    } as unknown as Document;
+    expect(greenhouse.matches(new URL("https://acme.com/careers"), doc)).toBe(true);
+  });
+});
+
+describe("lever.matches", () => {
+  it.each([
+    ["https://jobs.lever.co/acme/abc-123", true],
+    ["https://boards.greenhouse.io/acme/jobs/123", false],
+    // Exact-host match: `lever.co` marketing pages are not postings...
+    ["https://lever.co/about", false],
+    // ...and a hostname merely *containing* the string is a different company.
+    ["https://notlever.co/jobs/123", false],
+  ])("%s → %s", (url, expected) => {
+    expect(lever.matches(new URL(url), emptyDoc)).toBe(expected);
+  });
+});
+
+describe("workday.matches", () => {
+  it.each([
+    ["https://acme.myworkdayjobs.com/en-US/External/job/NYC/Eng_R123", true],
+    ["https://acme.wd5.myworkdayjobs.com/job/123", true],
+    ["https://acme.wd1.myworkdayjobs.com/job/123", true],
+    ["https://boards.greenhouse.io/acme/jobs/123", false],
+    ["https://careers.acme.com/jobs/123", false],
+  ])("%s → %s", (url, expected) => {
+    expect(workday.matches(new URL(url), emptyDoc)).toBe(expected);
+  });
+});
+
+describe("oracleHcm.matches", () => {
+  it.each([
+    ["https://acme.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/job/123", true],
+    // Tenant-owned domains keep Oracle's UI path segments even when the host
+    // reveals nothing.
+    ["https://careers.acme.com/hcmUI/CandidateExperience/job/123", true],
+    ["https://careers.acme.com/fscmUI/jobs/123", true],
+    ["https://boards.greenhouse.io/acme/jobs/123", false],
+  ])("%s → %s", (url, expected) => {
+    expect(oracleHcm.matches(new URL(url), emptyDoc)).toBe(expected);
+  });
+
+  it("matches on the Oracle generator meta tag as a last resort", () => {
+    expect(
+      oracleHcm.matches(
+        new URL("https://careers.acme.com/jobs/123"),
+        docWithGenerator("Oracle HCM Cloud"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a non-Oracle page with an empty generator", () => {
+    expect(
+      oracleHcm.matches(
+        new URL("https://careers.acme.com/jobs/123"),
+        docWithGenerator(""),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("smartrecruiters.matches", () => {
+  it.each([
+    ["https://jobs.smartrecruiters.com/Acme/744000112520307-engineer", true],
+    ["https://careers.smartrecruiters.com/Acme/123", true],
+    ["https://boards.greenhouse.io/acme/jobs/123", false],
+  ])("%s → %s", (url, expected) => {
+    expect(smartrecruiters.matches(new URL(url), emptyDoc)).toBe(expected);
+  });
+});
+
+describe("linkedin.matches", () => {
+  it("matches a job view page", () => {
+    expect(
+      linkedin.matches(new URL("https://www.linkedin.com/jobs/view/4437835690/"), emptyDoc),
+    ).toBe(true);
+  });
+
+  // Narrower than "is this LinkedIn" on purpose — search, company and feed pages
+  // live on the same host and are not postings.
+  it.each([
+    "https://www.linkedin.com/jobs/search/?keywords=engineer",
+    "https://www.linkedin.com/company/acme/",
+    "https://www.linkedin.com/feed/",
+  ])("does not match %s", (url) => {
+    expect(linkedin.matches(new URL(url), emptyDoc)).toBe(false);
+  });
+});
+
+describe("generic.matches", () => {
+  it("always matches, which is why it must be registered last", () => {
+    expect(generic.matches(new URL("https://anything.example/whatever"), emptyDoc)).toBe(
+      true,
+    );
+  });
+});
+
+describe("cross-adapter exclusivity", () => {
+  const owners: ReadonlyArray<[string, string]> = [
+    ["greenhouse", "https://boards.greenhouse.io/acme/jobs/123"],
+    ["lever", "https://jobs.lever.co/acme/abc-123"],
+    ["workday", "https://acme.wd5.myworkdayjobs.com/job/123"],
+    ["oracle-hcm", "https://acme.fa.us2.oraclecloud.com/hcmUI/job/123"],
+    ["smartrecruiters", "https://jobs.smartrecruiters.com/Acme/744000112520307"],
+    ["linkedin", "https://www.linkedin.com/jobs/view/4437835690/"],
+  ];
+
+  const adapters: ReadonlyArray<ATSExtractor> = [
+    greenhouse,
+    lever,
+    workday,
+    oracleHcm,
+    smartrecruiters,
+    linkedin,
+  ];
+
+  for (const [owner, url] of owners) {
+    for (const adapter of adapters) {
+      if (adapter.name === owner) continue;
+      it(`${adapter.name} does not claim the ${owner} URL`, () => {
+        expect(adapter.matches(new URL(url), emptyDoc)).toBe(false);
+      });
+    }
+  }
+
+  it("every owner claims its own URL", () => {
+    for (const [owner, url] of owners) {
+      const adapter = adapters.find((a) => a.name === owner);
+      expect(adapter?.matches(new URL(url), emptyDoc)).toBe(true);
+    }
+  });
+});

--- a/src/lib/jd-extract/adapters/generic.ts
+++ b/src/lib/jd-extract/adapters/generic.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The catch-all adapter: no host knowledge, only conventions every content page
+// shares — an `<h1>`, an `<article>`/`<main>` landmark, an `og:site_name`.
+//
+// `matches()` always returns true, so this MUST be registered last. It is the
+// dispatcher's floor, and the only reason the ladder can be described as "first hit
+// wins" without a special case for the miss.
+//
+// Because it knows nothing, its guards do the work. `MIN_BODY_LENGTH` is what
+// separates a real posting from a page whose `<main>` is a nav bar, and returning
+// `null` there is what lets a genuinely unreadable page report as unreadable
+// instead of producing a plausible-looking record of navigation labels.
+//
+// Reports `dom_metadata` rather than `ats_extractor`: no ATS was identified, and
+// claiming one would misreport how the posting was obtained.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+
+/** See `./linkedin.ts` — below this, the container held page chrome, not a JD. */
+const MIN_BODY_LENGTH = 100;
+
+export const generic: ATSExtractor = {
+  name: "generic",
+
+  matches(): boolean {
+    return true;
+  },
+
+  extract(doc: Document, url: URL): ExtractedPosting | null {
+    const title = doc.querySelector("h1")?.textContent?.trim();
+    if (!title) return null;
+
+    // Company, in descending order of reliability: the page's declared site name,
+    // then the trailing segment of `<title>` (the "… | Acme" branding convention),
+    // then the bare domain. The last is always available, so `company` is never
+    // empty here — which is what lets this adapter return a usable result at all.
+    const ogSiteName = doc
+      .querySelector('meta[property="og:site_name"]')
+      ?.getAttribute("content");
+    const titleParts = (doc.title || "").split(/\s*[-|]\s*/);
+    const company =
+      ogSiteName ||
+      (titleParts.length > 1 ? titleParts[titleParts.length - 1].trim() : "") ||
+      url.hostname.replace(/^www\./, "").split(".")[0];
+
+    const locationEl = doc.querySelector(
+      '[class*="location"], [data-testid*="location"], .job-location',
+    );
+    const location = locationEl?.textContent?.trim() || undefined;
+
+    // Landmark elements only — never `doc.body`, which on an unknown page would
+    // sweep in the header, nav, and footer along with the posting.
+    const mainEl =
+      doc.querySelector("article") ||
+      doc.querySelector("main") ||
+      doc.querySelector('[role="main"]');
+    const body = mainEl ? htmlToMarkdown(mainEl) : doc.body?.textContent?.trim() || "";
+
+    if (body.length < MIN_BODY_LENGTH) return null;
+
+    return {
+      title,
+      company,
+      location,
+      body,
+      descriptionPreview: body.slice(0, 200),
+      atsDetected: undefined,
+      extractionTier: "dom_metadata",
+    };
+  },
+};

--- a/src/lib/jd-extract/adapters/greenhouse.ts
+++ b/src/lib/jd-extract/adapters/greenhouse.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Greenhouse adapter — the only one that handles two genuinely different page
+// shapes, which is why it is the largest.
+//
+// A posting can be served directly on `boards.greenhouse.io`, or embedded into a
+// company's own careers page through an iframe or a job-board script. The embedded
+// case matters disproportionately: the visible URL is the company's domain, so
+// nothing about it says "Greenhouse", and without recovering the underlying board
+// URL the same posting saved from the company site and from the board itself forks
+// into two records.
+//
+// Per-host adapters are the last tier for the reason given in `../types.ts`. This
+// file only runs for pages the JSON-LD and metadata tiers could not read.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+
+function isDirectGreenhouseHost(url: URL): boolean {
+  return (
+    url.hostname === "boards.greenhouse.io" ||
+    url.hostname.endsWith(".greenhouse.io")
+  );
+}
+
+export const greenhouse: ATSExtractor = {
+  name: "greenhouse",
+
+  matches(url: URL, doc: Document): boolean {
+    if (isDirectGreenhouseHost(url)) return true;
+
+    // Embedded fingerprints, in decreasing order of how conclusive they are.
+    // `gh_jid` is Greenhouse's own job-id parameter and appears on the company's
+    // URL; the element ids and the embed script are what the widget injects.
+    if (url.searchParams.has("gh_jid")) return true;
+    if (doc.getElementById("grnhse_iframe")) return true;
+    if (doc.querySelector("#grnhse_app")) return true;
+    if (doc.querySelector('script[src*="boards.greenhouse.io/embed"]')) return true;
+
+    return false;
+  },
+
+  extract(doc: Document, url: URL): ExtractedPosting | null {
+    return isDirectGreenhouseHost(url)
+      ? extractDirectGreenhousePage(doc, url)
+      : extractEmbeddedGreenhousePage(doc, url);
+  },
+};
+
+function extractDirectGreenhousePage(
+  doc: Document,
+  url: URL,
+): ExtractedPosting | null {
+  const title =
+    doc.querySelector("h1.app-title")?.textContent?.trim() ||
+    doc.querySelector("h1")?.textContent?.trim();
+  if (!title) return null;
+
+  // Board URLs are `boards.greenhouse.io/<company>/jobs/<id>`, so the first path
+  // segment is the company slug when the page itself doesn't name the company.
+  const company =
+    doc.querySelector(".company-name")?.textContent?.trim() ||
+    url.pathname.split("/")[1] ||
+    "";
+
+  const location = doc.querySelector(".location")?.textContent?.trim() || undefined;
+
+  const contentEl = doc.querySelector("#content") || doc.querySelector(".content");
+  const body = contentEl
+    ? htmlToMarkdown(contentEl)
+    : doc.body?.textContent?.trim() || "";
+
+  return {
+    title,
+    company,
+    location,
+    body,
+    descriptionPreview: body.slice(0, 200),
+    atsDetected: "greenhouse",
+    extractionTier: "ats_extractor",
+  };
+}
+
+/**
+ * Recover the canonical board URL from an embedded widget.
+ *
+ * The description text lives inside the iframe and is cross-origin, so it is not
+ * readable from here — this path deliberately returns an empty `body` and leans on
+ * `atsUrl` instead. That is the useful half: with the canonical URL in hand, the
+ * capture collapses onto the same record as the board page, and the body can be
+ * fetched from Greenhouse's public API by the `ats_api` tier.
+ *
+ * Returns `null` without a job id, since `atsUrl` is the entire point of this path.
+ */
+function extractEmbeddedGreenhousePage(
+  doc: Document,
+  url: URL,
+): ExtractedPosting | null {
+  let jobId = url.searchParams.get("gh_jid") || undefined;
+  let companySlug: string | undefined;
+
+  const iframe = doc.getElementById("grnhse_iframe") as HTMLIFrameElement | null;
+  if (iframe?.src) {
+    const iframeMatch = iframe.src.match(
+      /boards\.greenhouse\.io\/(\w[\w-]*)\/jobs\/(\d+)/,
+    );
+    if (iframeMatch) {
+      companySlug = iframeMatch[1];
+      jobId = jobId || iframeMatch[2];
+    }
+  }
+
+  // The embed script names the board via `?for=<company>` even when no iframe
+  // has rendered yet.
+  if (!companySlug) {
+    const embedScript = doc.querySelector(
+      'script[src*="boards.greenhouse.io/embed"]',
+    ) as HTMLScriptElement | null;
+    if (embedScript?.src) {
+      const forMatch = embedScript.src.match(/[?&]for=(\w[\w-]*)/);
+      if (forMatch) companySlug = forMatch[1];
+    }
+  }
+
+  if (!jobId) return null;
+
+  const atsUrl = companySlug
+    ? `https://boards.greenhouse.io/${companySlug}/jobs/${jobId}`
+    : undefined;
+
+  const title =
+    doc.querySelector('meta[property="og:title"]')?.getAttribute("content")?.trim() ||
+    doc.querySelector("h1")?.textContent?.trim() ||
+    "";
+
+  const company =
+    doc
+      .querySelector('meta[property="og:site_name"]')
+      ?.getAttribute("content")
+      ?.trim() ||
+    url.hostname.replace(/^www\./, "").split(".")[0] ||
+    "";
+
+  return {
+    title,
+    company,
+    location: undefined,
+    body: "",
+    descriptionPreview: "",
+    atsDetected: "greenhouse",
+    extractionTier: "ats_extractor",
+    jobId,
+    atsUrl,
+  };
+}

--- a/src/lib/jd-extract/adapters/lever.ts
+++ b/src/lib/jd-extract/adapters/lever.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Lever adapter.
+//
+// Lever splits a posting body across several `.section-wrapper` elements rather
+// than nesting them under one container, so the body is assembled by concatenating
+// them in document order — taking only the first would drop most of the JD.
+//
+// Per-host adapters are the last tier for the reason given in `../types.ts`.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+
+export const lever: ATSExtractor = {
+  name: "lever",
+
+  // Exact host match: Lever serves postings only from this hostname, and a
+  // suffix match would also claim unrelated `*.lever.co` marketing pages.
+  matches(url: URL): boolean {
+    return url.hostname === "jobs.lever.co";
+  },
+
+  extract(doc: Document, url: URL): ExtractedPosting | null {
+    const title =
+      doc.querySelector(".posting-headline h2")?.textContent?.trim() ||
+      doc.querySelector("h1")?.textContent?.trim();
+    if (!title) return null;
+
+    // Lever URLs are `jobs.lever.co/<company>/<id>`, so the first path segment is
+    // the company slug when the page doesn't name it.
+    const company =
+      doc.querySelector(".posting-headline .company-name")?.textContent?.trim() ||
+      url.pathname.split("/")[1] ||
+      "";
+
+    const location =
+      doc.querySelector(".posting-categories .location")?.textContent?.trim() ||
+      doc
+        .querySelector(".sort-by-time .posting-category:first-child")
+        ?.textContent?.trim() ||
+      undefined;
+
+    // Lever is one of the few boards that publishes work model as its own field
+    // rather than leaving it to prose.
+    const workModel =
+      doc.querySelector(".posting-categories .workplaceType")?.textContent?.trim() ||
+      undefined;
+
+    const contentSections = doc.querySelectorAll(".posting-page .section-wrapper");
+    let body = "";
+    contentSections.forEach((section) => {
+      body += htmlToMarkdown(section) + "\n\n";
+    });
+
+    if (!body.trim()) {
+      const contentEl = doc.querySelector(".content");
+      body = contentEl
+        ? htmlToMarkdown(contentEl)
+        : doc.body?.textContent?.trim() || "";
+    }
+
+    body = body.trim();
+
+    return {
+      title,
+      company,
+      location,
+      workModel,
+      body,
+      descriptionPreview: body.slice(0, 200),
+      atsDetected: "lever",
+      extractionTier: "ats_extractor",
+    };
+  },
+};

--- a/src/lib/jd-extract/adapters/linkedin.ts
+++ b/src/lib/jd-extract/adapters/linkedin.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// LinkedIn adapter — the most load-bearing file in this directory.
+//
+// LinkedIn's logged-in job view ships no JSON-LD and no `og:` meta tags, so every
+// general tier misses it. It is also the highest-volume source in the `job-hunt`
+// lane, which means without this adapter the single most common posting the user
+// captures gets the worst extraction available.
+//
+// The parsing itself lives in `../linkedin-parse.ts` because it is needed in two
+// contexts, only one of which has a `Document` — see that module's docblock.
+//
+// Reports `dom_metadata` rather than `ats_extractor`: LinkedIn is an aggregator,
+// not an applicant tracking system, and labelling it as one would misreport how the
+// posting was obtained.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+import {
+  extractLinkedInCompanyFromDOM,
+  isLinkedInJobUrl,
+  parseLinkedInTitle,
+} from "../linkedin-parse";
+
+/**
+ * Below this many characters, `<main>` held navigation chrome rather than a
+ * posting — the SPA had not rendered the job yet. Returning null lets the caller
+ * fall through instead of persisting a body of menu labels, which would score as a
+ * successful capture and produce no extractable skill terms.
+ */
+const MIN_BODY_LENGTH = 100;
+
+export const linkedin: ATSExtractor = {
+  name: "linkedin",
+
+  matches(url: URL): boolean {
+    return isLinkedInJobUrl(url);
+  },
+
+  extract(doc: Document): ExtractedPosting | null {
+    // The DOM's `aria-label` is more reliable than the title string, so it wins;
+    // title parsing fills whichever half it left empty.
+    let company = extractLinkedInCompanyFromDOM(doc) || undefined;
+    let title = doc.querySelector("h1")?.textContent?.trim();
+
+    const parsed = parseLinkedInTitle(doc.title || "");
+    if (parsed) {
+      if (!title) title = parsed.title;
+      if (!company) company = parsed.company;
+    }
+
+    if (!title) return null;
+
+    const mainEl = doc.querySelector("main") || doc.querySelector('[role="main"]');
+    const body = mainEl
+      ? htmlToMarkdown(mainEl)
+      : doc.body?.textContent?.trim() || "";
+
+    if (body.length < MIN_BODY_LENGTH) return null;
+
+    return {
+      title,
+      // A posting with no readable company is still worth capturing — the body
+      // and URL carry real value — so this degrades rather than returning null.
+      company: company || "Unknown",
+      body,
+      descriptionPreview: body.slice(0, 200),
+      atsDetected: undefined,
+      extractionTier: "dom_metadata",
+    };
+  },
+};

--- a/src/lib/jd-extract/adapters/oracle-hcm.ts
+++ b/src/lib/jd-extract/adapters/oracle-hcm.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Oracle HCM Cloud adapter.
+//
+// Oracle is self-hosted per tenant, so there is no single hostname to key on. The
+// three fingerprints below are ordered from cheapest to most specific: the shared
+// `oraclecloud.com` domain, then Oracle's distinctive UI path segments (`/hcmUI/`,
+// `/fscmUI/`) which appear on tenant-owned domains, then the `generator` meta tag
+// as a last resort for a tenant that rewrote both.
+//
+// Per-host adapters are the last tier for the reason given in `../types.ts`.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+
+export const oracleHcm: ATSExtractor = {
+  name: "oracle-hcm",
+
+  matches(url: URL, doc: Document): boolean {
+    if (url.hostname.includes(".oraclecloud.com")) return true;
+    if (url.pathname.includes("/hcmUI/") || url.pathname.includes("/fscmUI/")) {
+      return true;
+    }
+    const generator =
+      doc.querySelector('meta[name="generator"]')?.getAttribute("content") || "";
+    return generator.toLowerCase().includes("oracle");
+  },
+
+  extract(doc: Document): ExtractedPosting | null {
+    const title =
+      doc.querySelector(".job-title")?.textContent?.trim() ||
+      doc.querySelector("h1.app-heading")?.textContent?.trim() ||
+      doc.querySelector("h1")?.textContent?.trim();
+    if (!title) return null;
+
+    const company =
+      doc.querySelector(".job-company")?.textContent?.trim() ||
+      doc.querySelector(".company-name")?.textContent?.trim() ||
+      "";
+
+    const location =
+      doc.querySelector(".job-location")?.textContent?.trim() || undefined;
+
+    const descEl =
+      doc.querySelector(".job-description") ||
+      doc.querySelector('[class*="jobDescription"]');
+    const body = descEl
+      ? htmlToMarkdown(descEl)
+      : doc.body?.textContent?.trim() || "";
+
+    return {
+      title,
+      company,
+      location,
+      body,
+      descriptionPreview: body.slice(0, 200),
+      atsDetected: "oracle-hcm",
+      extractionTier: "ats_extractor",
+    };
+  },
+};

--- a/src/lib/jd-extract/adapters/smartrecruiters.ts
+++ b/src/lib/jd-extract/adapters/smartrecruiters.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// SmartRecruiters adapter.
+//
+// The title selectors are ordered deliberately and the order is the whole point:
+// SmartRecruiters serves an IE11 sunset notice whose `<h1>` appears BEFORE the real
+// job title in document order. A generic `h1` read — which every other adapter uses
+// as its fallback — captures that banner instead of the posting. So the
+// SmartRecruiters-specific classes are tried first and `h1` is not a fallback here
+// at all; `og:title` is used instead.
+//
+// Per-host adapters are the last tier for the reason given in `../types.ts`.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+
+/** See `../adapters/linkedin.ts` — below this, the container held page chrome. */
+const MIN_BODY_LENGTH = 100;
+
+export const smartrecruiters: ATSExtractor = {
+  name: "smartrecruiters",
+
+  matches(url: URL): boolean {
+    return (
+      url.hostname === "jobs.smartrecruiters.com" ||
+      url.hostname.endsWith(".smartrecruiters.com")
+    );
+  },
+
+  extract(doc: Document, url: URL): ExtractedPosting | null {
+    const title =
+      doc.querySelector(".summary-title")?.textContent?.trim() ||
+      doc.querySelector(".job-title")?.textContent?.trim() ||
+      doc.querySelector('meta[property="og:title"]')?.getAttribute("content")?.trim();
+    if (!title) return null;
+
+    // URLs are `jobs.smartrecruiters.com/<Company>/<id>-<slug>`.
+    const pathCompany = url.pathname.split("/")[1];
+    const ogSiteName = doc
+      .querySelector('meta[property="og:site_name"]')
+      ?.getAttribute("content");
+    const company = ogSiteName || pathCompany || "";
+
+    const locationEl =
+      doc.querySelector(".job-details .location") ||
+      doc.querySelector('[class*="location"]');
+    const location = locationEl?.textContent?.trim() || undefined;
+
+    const contentEl =
+      doc.querySelector(".jobad-container") ||
+      doc.querySelector('[role="main"]') ||
+      doc.querySelector("main");
+    const body = contentEl
+      ? htmlToMarkdown(contentEl)
+      : doc.body?.textContent?.trim() || "";
+
+    if (body.length < MIN_BODY_LENGTH) return null;
+
+    // Requisition ids are long numeric runs; the 10-digit floor keeps a short
+    // number elsewhere in the path from being mistaken for one.
+    const idMatch = url.pathname.match(/\/(\d{10,})/);
+    const jobId = idMatch?.[1] || undefined;
+
+    return {
+      title,
+      company,
+      location,
+      jobId,
+      body,
+      descriptionPreview: body.slice(0, 200),
+      atsDetected: "smartrecruiters",
+      extractionTier: "ats_extractor",
+    };
+  },
+};

--- a/src/lib/jd-extract/adapters/workday.ts
+++ b/src/lib/jd-extract/adapters/workday.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Workday adapter.
+//
+// Workday matters here for a reason specific to this repo: `fetch-jd.ts` lists it
+// as an unsupported host because its JSON endpoint sends no permissive CORS header,
+// so the browser blocks the response. That closes the network path but not the DOM
+// path — reading a Workday page the user already has open is exactly the case this
+// lane exists to cover.
+//
+// Selectors key on `data-automation-id`, Workday's own stable test-hook attribute,
+// rather than its generated CSS classes. The one `.css-…` selector below is a
+// last-resort fallback and will rot; that is acceptable because it is reached only
+// after the automation ids miss.
+//
+// Per-host adapters are the last tier for the reason given in `../types.ts`.
+
+import { htmlToMarkdown } from "../html-to-markdown";
+import type { ATSExtractor, ExtractedPosting } from "../types";
+
+export const workday: ATSExtractor = {
+  name: "workday",
+
+  matches(url: URL): boolean {
+    // The `wd1`/`wd5` hosts are data-center shards; each tenant is on exactly one,
+    // and the bare suffix does not match them because they carry an extra label.
+    return (
+      url.hostname.endsWith(".myworkdayjobs.com") ||
+      url.hostname.endsWith(".wd5.myworkdayjobs.com") ||
+      url.hostname.endsWith(".wd1.myworkdayjobs.com")
+    );
+  },
+
+  extract(doc: Document): ExtractedPosting | null {
+    const title =
+      doc
+        .querySelector('[data-automation-id="jobPostingHeader"]')
+        ?.textContent?.trim() ||
+      doc
+        .querySelector('h2[data-automation-id="jobPostingTitle"]')
+        ?.textContent?.trim() ||
+      doc.querySelector("h1")?.textContent?.trim();
+    if (!title) return null;
+
+    const company =
+      doc
+        .querySelector('[data-automation-id="jobPostingCompanyName"]')
+        ?.textContent?.trim() ||
+      doc.querySelector(".css-1q2dra3")?.textContent?.trim() ||
+      "";
+
+    const location =
+      doc.querySelector('[data-automation-id="locations"]')?.textContent?.trim() ||
+      doc
+        .querySelector('[data-automation-id="jobPostingLocation"]')
+        ?.textContent?.trim() ||
+      undefined;
+
+    const descEl =
+      doc.querySelector('[data-automation-id="jobPostingDescription"]') ||
+      doc.querySelector(".jobDescription");
+    const body = descEl
+      ? htmlToMarkdown(descEl)
+      : doc.body?.textContent?.trim() || "";
+
+    return {
+      title,
+      company,
+      location,
+      body,
+      descriptionPreview: body.slice(0, 200),
+      atsDetected: "workday",
+      extractionTier: "ats_extractor",
+    };
+  },
+};

--- a/src/lib/jd-extract/apply-link.test.ts
+++ b/src/lib/jd-extract/apply-link.test.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Canonical ATS-URL discovery from an aggregator's apply button.
+ *
+ * This is dedup machinery, not application machinery: the same posting on
+ * LinkedIn, on Indeed, and on the company's board must collapse to one record,
+ * and `deriveJobId` keys on the URL. Nothing here clicks or submits anything.
+ *
+ * The three-way distinction in the result is what most of these cases pin down —
+ * "found it", "the aggregator hosts the application so there is nothing to find",
+ * and "there is an external apply but its URL is not in the DOM" call for different
+ * handling, and the last one is invisible unless it is asserted.
+ */
+
+import { extractApplyLink, extractApplyLinkAsync } from "./apply-link";
+
+function page(html: string, url: string) {
+  return {
+    doc: new DOMParser().parseFromString(
+      `<!doctype html><html><body>${html}</body></html>`,
+      "text/html",
+    ),
+    url: new URL(url),
+  };
+}
+
+function run(html: string, url: string) {
+  const { doc, url: parsed } = page(html, url);
+  return extractApplyLink(doc, parsed);
+}
+
+const LINKEDIN_URL = "https://www.linkedin.com/jobs/view/123/";
+const INDEED_URL = "https://www.indeed.com/viewjob?jk=abc123";
+const GLASSDOOR_URL = "https://www.glassdoor.com/job-listing/eng-acme-JV_123.htm";
+
+describe("LinkedIn", () => {
+  it("finds an external apply link by aria-label", () => {
+    const result = run(
+      '<a aria-label="Apply to Engineer on company website" href="https://boards.greenhouse.io/acme/jobs/9">Apply</a>',
+      LINKEDIN_URL,
+    );
+    expect(result.sourceUrl).toBe("https://boards.greenhouse.io/acme/jobs/9");
+    expect(result.sourceDomain).toBe("boards.greenhouse.io");
+    expect(result.isEasyApply).toBe(false);
+  });
+
+  // Left wrapped, the "canonical" URL would be a linkedin.com URL carrying a
+  // per-impression tracking hash — which defeats the dedup this exists for.
+  it("unwraps a /redir/redirect wrapper", () => {
+    const target = "https://boards.greenhouse.io/acme/jobs/9";
+    const result = run(
+      `<a aria-label="Apply" href="https://www.linkedin.com/redir/redirect?url=${encodeURIComponent(target)}&urlhash=abcd">Apply</a>`,
+      LINKEDIN_URL,
+    );
+    expect(result.sourceUrl).toBe(target);
+  });
+
+  it("unwraps a /safety/go wrapper found without a matching aria-label", () => {
+    const target = "https://jobs.lever.co/acme/uuid";
+    const result = run(
+      `<a href="https://www.linkedin.com/safety/go?url=${encodeURIComponent(target)}">Continue</a>`,
+      LINKEDIN_URL,
+    );
+    expect(result.sourceUrl).toBe(target);
+  });
+
+  it("reports Easy Apply, which has no external URL to find", () => {
+    const result = run('<button aria-label="Easy Apply to Engineer">Easy Apply</button>', LINKEDIN_URL);
+    expect(result.isEasyApply).toBe(true);
+    expect(result.sourceUrl).toBeNull();
+    expect(result.externalDetected).toBe(false);
+  });
+
+  it("ignores an apply link that stays on linkedin.com", () => {
+    const result = run(
+      '<a aria-label="Apply" href="https://www.linkedin.com/jobs/view/456/">Apply</a>',
+      LINKEDIN_URL,
+    );
+    expect(result.sourceUrl).toBeNull();
+  });
+});
+
+describe("Indeed", () => {
+  it("finds an external link inside the apply container", () => {
+    const result = run(
+      '<div id="applyButtonLinkContainer"><a href="https://acme.wd5.myworkdayjobs.com/job/1">Apply on company site</a></div>',
+      INDEED_URL,
+    );
+    expect(result.sourceUrl).toBe("https://acme.wd5.myworkdayjobs.com/job/1");
+    expect(result.sourceDomain).toBe("acme.wd5.myworkdayjobs.com");
+  });
+
+  it("falls back to link text when no container matches", () => {
+    const result = run(
+      '<a href="https://boards.greenhouse.io/acme/jobs/9">Apply on company site</a>',
+      INDEED_URL,
+    );
+    expect(result.sourceUrl).toBe("https://boards.greenhouse.io/acme/jobs/9");
+  });
+
+  it("reads a URL from a data attribute on a button", () => {
+    const result = run(
+      '<div id="applyButtonLinkContainer"><button data-apply-url="https://jobs.lever.co/acme/uuid">Apply</button></div>',
+      INDEED_URL,
+    );
+    expect(result.sourceUrl).toBe("https://jobs.lever.co/acme/uuid");
+  });
+
+  it("reports Indeed-hosted apply as Easy Apply", () => {
+    const result = run('<div class="indeed-apply-button">Apply now</div>', INDEED_URL);
+    expect(result.isEasyApply).toBe(true);
+  });
+});
+
+describe("Glassdoor", () => {
+  // The one aggregator whose external apply URL is genuinely unreadable — the
+  // button carries no href and resolves the destination through an API call.
+  // This flag is the whole reason the result type is three-way rather than two.
+  it("reports an external apply it cannot read, distinctly from finding nothing", () => {
+    const result = run(
+      '<button data-test="applyButton">Apply on employer site</button>',
+      GLASSDOOR_URL,
+    );
+    expect(result.sourceUrl).toBeNull();
+    expect(result.isEasyApply).toBe(false);
+    expect(result.externalDetected).toBe(true);
+  });
+
+  it("distinguishes that case from a page with no apply route at all", () => {
+    const result = run("<p>Nothing here</p>", GLASSDOOR_URL);
+    expect(result.externalDetected).toBe(false);
+    expect(result.isEasyApply).toBe(false);
+    expect(result.sourceUrl).toBeNull();
+  });
+
+  it("reports Easy Apply", () => {
+    const result = run('<div data-test="easyApply">Easy Apply</div>', GLASSDOOR_URL);
+    expect(result.isEasyApply).toBe(true);
+  });
+});
+
+describe("generic aggregator fallback", () => {
+  it("finds an off-site apply link on an unrecognised host", () => {
+    const result = run(
+      '<a href="https://boards.greenhouse.io/acme/jobs/9">Apply for this job</a>',
+      "https://jobs.example.com/listing/1",
+    );
+    expect(result.sourceUrl).toBe("https://boards.greenhouse.io/acme/jobs/9");
+  });
+
+  it("ignores a same-host apply link", () => {
+    const result = run(
+      '<a href="https://jobs.example.com/apply/1">Apply</a>',
+      "https://jobs.example.com/listing/1",
+    );
+    expect(result.sourceUrl).toBeNull();
+  });
+
+  // A mailto: apply route is real on some postings but is not an ATS URL.
+  it("ignores a non-http apply link", () => {
+    const result = run(
+      '<a href="mailto:jobs@example.com">Apply by email</a>',
+      "https://jobs.example.com/listing/1",
+    );
+    expect(result.sourceUrl).toBeNull();
+  });
+});
+
+describe("resilience", () => {
+  it("never throws on a page with no links", () => {
+    expect(() => run("<p>Empty</p>", LINKEDIN_URL)).not.toThrow();
+  });
+
+  // Data attributes are read raw via getAttribute, so an unparseable value here
+  // reaches `new URL()` directly — unlike an `href`, which the DOM resolves
+  // against the document base before we ever see it.
+  it("skips a malformed data-attribute URL rather than throwing", () => {
+    const result = run(
+      '<div id="applyButtonLinkContainer"><button data-apply-url="ht!tp://[malformed">Apply</button></div>',
+      INDEED_URL,
+    );
+    expect(result.sourceUrl).toBeNull();
+  });
+
+  it("skips a relative data-attribute URL, which points back at the aggregator", () => {
+    const result = run(
+      '<div id="applyButtonLinkContainer"><button data-apply-url="/apply/123">Apply</button></div>',
+      INDEED_URL,
+    );
+    expect(result.sourceUrl).toBeNull();
+  });
+});
+
+describe("extractApplyLinkAsync", () => {
+  it("resolves immediately when the link is already present", async () => {
+    const { doc, url } = page(
+      '<a aria-label="Apply" href="https://boards.greenhouse.io/acme/jobs/9">Apply</a>',
+      LINKEDIN_URL,
+    );
+    const result = await extractApplyLinkAsync(doc, url);
+    expect(result.sourceUrl).toBe("https://boards.greenhouse.io/acme/jobs/9");
+  });
+
+  it("resolves when the apply button is rendered late", async () => {
+    const { doc, url } = page("<div id=\"root\"></div>", LINKEDIN_URL);
+    const pending = extractApplyLinkAsync(doc, url, 2_000);
+
+    const link = doc.createElement("a");
+    link.setAttribute("aria-label", "Apply");
+    link.setAttribute("href", "https://jobs.lever.co/acme/uuid");
+    doc.getElementById("root")!.appendChild(link);
+
+    expect((await pending).sourceUrl).toBe("https://jobs.lever.co/acme/uuid");
+  });
+
+  // A caller waiting on a canonical URL must not have to handle a rejection for
+  // the ordinary case of "this page has no apply button".
+  it("resolves rather than rejecting when nothing ever appears", async () => {
+    const { doc, url } = page("<p>Nothing</p>", LINKEDIN_URL);
+    const result = await extractApplyLinkAsync(doc, url, 50);
+    expect(result.sourceUrl).toBeNull();
+  });
+});

--- a/src/lib/jd-extract/apply-link.ts
+++ b/src/lib/jd-extract/apply-link.ts
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Find the ATS-hosted original behind an aggregator listing, by reading where the
+// page's "Apply" button points.
+//
+// This is a *dedup* mechanism, not an application mechanism. The same posting
+// appears on LinkedIn, on Indeed, and on the company's own board, and
+// `deriveJobId` (`src/lib/storage/job-url.ts`) keys on the URL — so without a
+// canonical URL the user's saved library accumulates three records for one job.
+// Discovering where an apply button points is not applying to anything; nothing
+// here clicks, submits, or navigates.
+//
+// The selectors below are per-aggregator and WILL break when those sites
+// redesign. That is expected and is why every extractor degrades to "no result"
+// rather than throwing: a stale selector must cost the canonical URL, never the
+// extraction. The `job-url.ts` asymmetry applies directly — a missed canonical URL
+// forks a duplicate record the user can delete, which is the safe failure.
+//
+// Note this reads the page's own rendered DOM only. No request is made to the
+// discovered URL, so nothing here fetches, follows, or verifies an external link.
+
+/**
+ * What an aggregator page says about how to apply.
+ *
+ * `sourceUrl === null` has three distinct causes, and they are worth telling
+ * apart because they call for different handling:
+ *   - Easy Apply — the aggregator hosts the application itself, so no external
+ *     URL exists to find. `isEasyApply` is true.
+ *   - External but unreadable — an external apply exists but its URL is not in the
+ *     DOM (Glassdoor resolves it through an API call on click). `externalDetected`
+ *     is true, and the caller should fall back to canonicalizing the page URL
+ *     rather than concluding there is no ATS original.
+ *   - Nothing found — neither signal present. Both flags false.
+ */
+export interface ApplyLinkResult {
+  sourceUrl: string | null;
+  isEasyApply: boolean;
+  /**
+   * An external apply route was detected but its URL could not be read.
+   *
+   * The upstream implementation drew this distinction in a comment but returned a
+   * value byte-identical to "nothing found", so no caller could act on it. This
+   * flag is what makes the distinction real.
+   */
+  externalDetected: boolean;
+  sourceDomain: string | null;
+}
+
+const NO_RESULT: ApplyLinkResult = {
+  sourceUrl: null,
+  isEasyApply: false,
+  externalDetected: false,
+  sourceDomain: null,
+};
+
+const EASY_APPLY: ApplyLinkResult = {
+  sourceUrl: null,
+  isEasyApply: true,
+  externalDetected: false,
+  sourceDomain: null,
+};
+
+const EXTERNAL_NOT_EXTRACTABLE: ApplyLinkResult = {
+  sourceUrl: null,
+  isEasyApply: false,
+  externalDetected: true,
+  sourceDomain: null,
+};
+
+function found(url: string, hostname: string): ApplyLinkResult {
+  return {
+    sourceUrl: url,
+    isEasyApply: false,
+    externalDetected: true,
+    sourceDomain: hostname,
+  };
+}
+
+/** Read a valid absolute URL out of the data attributes aggregators use. */
+function getUrlFromDataAttrs(el: Element): string | null {
+  for (const attr of [
+    "data-url",
+    "data-href",
+    "data-job-url",
+    "data-apply-url",
+    "data-redirect-url",
+    "data-outbound-url",
+  ]) {
+    const val = el.getAttribute(attr);
+    if (val) {
+      try {
+        new URL(val);
+        return val;
+      } catch {
+        // Not an absolute URL — a relative path here points back at the
+        // aggregator, which is never what we're looking for.
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the first link in `containerSelectors` that leaves `aggregatorDomain`.
+ *
+ * "Leaves the aggregator" is the whole test. Within an apply container, any
+ * off-site link is the external apply target — there is nothing else it could be —
+ * and this holds without knowing which ATS the company runs.
+ *
+ * Containers are tried in order and treated as a preference list: the earlier
+ * selectors are the tightest apply-area matches, so a hit there is more certain
+ * than one from a broader container later in the list.
+ */
+function findExternalLink(
+  doc: Document,
+  containerSelectors: string[],
+  aggregatorDomain: string,
+): ApplyLinkResult {
+  for (const selector of containerSelectors) {
+    const container = doc.querySelector(selector);
+    if (!container) continue;
+
+    const links = container.querySelectorAll<HTMLAnchorElement>("a[href]");
+    for (const link of links) {
+      try {
+        const url = new URL(link.href);
+        // Protocol check keeps `mailto:` / `tel:` apply links out — they are real
+        // on some postings but are not an ATS URL.
+        if (
+          url.protocol.startsWith("http") &&
+          !url.hostname.includes(aggregatorDomain)
+        ) {
+          return found(link.href, url.hostname);
+        }
+      } catch {
+        // Unparseable href — skip.
+      }
+    }
+
+    const allElements = container.querySelectorAll(
+      "button, [data-url], [data-href], [data-job-url], [data-apply-url]",
+    );
+    for (const el of allElements) {
+      const dataUrl = getUrlFromDataAttrs(el);
+      if (dataUrl) {
+        try {
+          const url = new URL(dataUrl);
+          if (!url.hostname.includes(aggregatorDomain)) {
+            return found(dataUrl, url.hostname);
+          }
+        } catch {
+          // Skip.
+        }
+      }
+    }
+  }
+  return NO_RESULT;
+}
+
+// ─── Per-aggregator extractors ───────────────────────────────────────────────
+// Selectors reflect these sites' markup as observed during development. They are
+// the most brittle code in this lane by design — see the module docblock.
+
+/**
+ * Unwrap LinkedIn's outbound redirect wrappers to the real destination.
+ *
+ * LinkedIn routes external links through `/redir/redirect?url=…` and
+ * `/safety/go?url=…`. Left wrapped, the "canonical" URL would be a linkedin.com
+ * URL carrying a tracking hash — which would defeat the dedup this module exists
+ * for, since it varies per impression. Returns the input unchanged when it is not
+ * a redirect.
+ */
+function unwrapLinkedInRedirect(href: string): string {
+  try {
+    const parsed = new URL(href);
+    if (
+      parsed.hostname.includes("linkedin.com") &&
+      (parsed.pathname.includes("/redir/redirect") ||
+        parsed.pathname.includes("/safety/go"))
+    ) {
+      const destination = parsed.searchParams.get("url");
+      if (destination) return destination;
+    }
+  } catch {
+    // Not a valid URL.
+  }
+  return href;
+}
+
+/**
+ * LinkedIn: match on `aria-label`, not class names.
+ *
+ * LinkedIn's class names are hashed and rotate between deploys; `aria-label` is
+ * user-facing text and stays stable. The second pass catches apply links whose
+ * label differs by locale, by looking for the redirect path shape instead.
+ */
+function extractLinkedIn(doc: Document): ApplyLinkResult {
+  const applyLinks = doc.querySelectorAll<HTMLAnchorElement>(
+    'a[aria-label*="Apply"][href], a[aria-label*="apply"][href]',
+  );
+
+  for (const link of applyLinks) {
+    const actualUrl = unwrapLinkedInRedirect(link.href);
+    try {
+      const url = new URL(actualUrl);
+      if (
+        url.protocol.startsWith("http") &&
+        !url.hostname.includes("linkedin.com")
+      ) {
+        return found(actualUrl, url.hostname);
+      }
+    } catch {
+      // Skip.
+    }
+  }
+
+  const redirectLinks = doc.querySelectorAll<HTMLAnchorElement>(
+    'a[href*="/redir/redirect"], a[href*="/safety/go"]',
+  );
+  for (const link of redirectLinks) {
+    const actualUrl = unwrapLinkedInRedirect(link.href);
+    try {
+      const url = new URL(actualUrl);
+      if (!url.hostname.includes("linkedin.com")) {
+        return found(actualUrl, url.hostname);
+      }
+    } catch {
+      // Skip.
+    }
+  }
+
+  const easyApplyBtn = doc.querySelector(
+    'button[aria-label*="Easy Apply"], button[aria-label*="easy apply"]',
+  );
+  if (easyApplyBtn) return EASY_APPLY;
+
+  return NO_RESULT;
+}
+
+/** Indeed: "Apply on company site" is a real external link in the apply area. */
+function extractIndeed(doc: Document): ApplyLinkResult {
+  const result = findExternalLink(
+    doc,
+    [
+      "#applyButtonLinkContainer",
+      ".jobsearch-IndeedApplyButton-contentWrapper",
+      ".jobsearch-ViewJobButtons-container",
+      "#viewJobButtonLinkContainer",
+    ],
+    "indeed.com",
+  );
+  if (result.sourceUrl) return result;
+
+  // Fallback: scan every link for apply-on-company wording. Broader than the
+  // containers above, so it runs only after they miss.
+  const allLinks = doc.querySelectorAll<HTMLAnchorElement>("a[href]");
+  for (const link of allLinks) {
+    const text = link.textContent?.trim() || "";
+    if (
+      /apply\s+on\s+company/i.test(text) ||
+      /apply\s+on\s+employer/i.test(text)
+    ) {
+      try {
+        const url = new URL(link.href);
+        if (!url.hostname.includes("indeed.com")) {
+          return found(link.href, url.hostname);
+        }
+      } catch {
+        // Skip.
+      }
+    }
+  }
+
+  const indeedApply = doc.querySelector(
+    '.indeed-apply-button, [id*="indeedApply"]',
+  );
+  if (indeedApply) return EASY_APPLY;
+
+  return NO_RESULT;
+}
+
+/**
+ * Glassdoor: the only aggregator here whose external apply URL is genuinely
+ * unreadable — the button carries no href and resolves the destination through an
+ * API call on click. That case returns `externalDetected` so the caller knows an
+ * ATS original exists even though this module cannot name it.
+ */
+function extractGlassdoor(doc: Document): ApplyLinkResult {
+  const result = findExternalLink(
+    doc,
+    [
+      '[class*="applyButtonContainer"]',
+      '[data-test="applyButton"]',
+      '[class*="applySaveButtonPosition"]',
+    ],
+    "glassdoor.com",
+  );
+  if (result.sourceUrl) return result;
+
+  const applyButton = doc.querySelector('button[data-test="applyButton"]');
+  if (applyButton) {
+    const text = applyButton.textContent?.trim() || "";
+
+    if (
+      /apply\s+on\s+employer/i.test(text) ||
+      /apply\s+on\s+company/i.test(text)
+    ) {
+      return EXTERNAL_NOT_EXTRACTABLE;
+    }
+
+    if (/easy\s*apply/i.test(text)) return EASY_APPLY;
+  }
+
+  const easyApply = doc.querySelector('[data-test="easyApply"]');
+  if (easyApply) return EASY_APPLY;
+
+  return NO_RESULT;
+}
+
+function extractZipRecruiter(doc: Document): ApplyLinkResult {
+  return findExternalLink(
+    doc,
+    [".apply_button_container", ".job_details_apply", ".apply-section"],
+    "ziprecruiter.com",
+  );
+}
+
+/**
+ * Last resort for an aggregator with no dedicated extractor: any link whose text
+ * mentions "apply" and whose host is not the aggregator's.
+ *
+ * Looser than the per-site extractors and more likely to pick up a false positive
+ * (a footer "apply to other roles" link), which is why it runs only when no
+ * hostname matched.
+ */
+function extractGenericAggregator(doc: Document, domain: string): ApplyLinkResult {
+  const allLinks = doc.querySelectorAll<HTMLAnchorElement>("a[href]");
+  for (const link of allLinks) {
+    const text = link.textContent?.trim() || "";
+    if (/apply/i.test(text)) {
+      try {
+        const url = new URL(link.href);
+        if (url.protocol.startsWith("http") && !url.hostname.includes(domain)) {
+          return found(link.href, url.hostname);
+        }
+      } catch {
+        // Skip.
+      }
+    }
+  }
+  return NO_RESULT;
+}
+
+/**
+ * Aggregator hostname fragment → its extractor.
+ *
+ * Keyed on the domain rather than on an opaque pattern name, so the aggregator is
+ * identified from the page's own URL and this module needs no external
+ * configuration to know where it is running.
+ */
+const EXTRACTORS: ReadonlyArray<
+  readonly [string, (doc: Document) => ApplyLinkResult]
+> = [
+  ["linkedin.com", extractLinkedIn],
+  ["indeed.com", extractIndeed],
+  ["glassdoor.com", extractGlassdoor],
+  ["ziprecruiter.com", extractZipRecruiter],
+];
+
+/**
+ * Find the canonical ATS URL behind an aggregator listing.
+ *
+ * Picks the per-site extractor by hostname and falls back to the generic scan for
+ * an unrecognised aggregator. Never throws — every failure path returns a result
+ * with a null `sourceUrl`.
+ */
+export function extractApplyLink(doc: Document, url: URL): ApplyLinkResult {
+  const hostname = url.hostname.toLowerCase();
+  for (const [domain, extractor] of EXTRACTORS) {
+    if (hostname.includes(domain)) return extractor(doc);
+  }
+  return extractGenericAggregator(doc, hostname);
+}
+
+/**
+ * `extractApplyLink`, but waits for a lazily-rendered apply button.
+ *
+ * LinkedIn and Glassdoor render the apply area after the initial paint, so a
+ * synchronous read on a freshly-loaded page finds nothing. Tries synchronously
+ * first and returns immediately on a hit — the observer is only paid for when the
+ * button genuinely is not there yet.
+ *
+ * Always resolves, never rejects: on timeout it makes one last attempt and
+ * resolves with whatever that yields. A caller waiting on a canonical URL must not
+ * have to handle a rejection for the ordinary case of "this page has no apply
+ * button".
+ */
+export function extractApplyLinkAsync(
+  doc: Document,
+  url: URL,
+  timeoutMs = 10_000,
+): Promise<ApplyLinkResult> {
+  const immediate = extractApplyLink(doc, url);
+  if (immediate.sourceUrl || immediate.isEasyApply) {
+    return Promise.resolve(immediate);
+  }
+
+  return new Promise<ApplyLinkResult>((resolve) => {
+    // No `document.body` to observe (a detached document) — nothing can change,
+    // so the synchronous answer is final.
+    if (!doc.body || typeof MutationObserver === "undefined") {
+      resolve(immediate);
+      return;
+    }
+
+    let settled = false;
+
+    const cleanup = () => {
+      if (!settled) {
+        settled = true;
+        observer.disconnect();
+        clearTimeout(timer);
+      }
+    };
+
+    const observer = new MutationObserver(() => {
+      if (settled) return;
+      const result = extractApplyLink(doc, url);
+      if (result.sourceUrl || result.isEasyApply) {
+        cleanup();
+        resolve(result);
+      }
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      const last = extractApplyLink(doc, url);
+      cleanup();
+      resolve(last);
+    }, timeoutMs);
+
+    // `attributeFilter` keeps the observer from firing on every unrelated class
+    // toggle an SPA makes — only the attributes that could reveal an apply URL.
+    observer.observe(doc.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["href", "aria-label", "data-url", "data-href"],
+    });
+  });
+}

--- a/src/lib/jd-extract/ats-api.test.ts
+++ b/src/lib/jd-extract/ats-api.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The `ats_api` tier, and the full ladder that interleaves it.
+ *
+ * The tier itself takes a URL rather than a `Document` — which is exactly why it
+ * lives outside `./detect.ts` and outside the injectable bundle. jsdom is here only
+ * for the ladder cases at the bottom, which need a real document to fall through to.
+ *
+ * `fetch` is stubbed rather than the module mocked, so the real `parseAtsUrl` and
+ * the real platform clients run. Mocking `fetch-jd.ts` would defeat the point —
+ * the thing worth asserting is that this tier delegates to that module instead of
+ * carrying a second ATS-URL parser.
+ */
+
+import { extractPosting, extractPostingFromAtsApi, isAtsApiUrl } from "./ats-api";
+import { EXTRACTION_ALGORITHM_VERSION } from "./types";
+
+const GREENHOUSE_URL = "https://boards.greenhouse.io/acme/jobs/4012345";
+
+function stubFetch(body: unknown, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  } as unknown as Response);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("isAtsApiUrl", () => {
+  it.each([
+    ["https://boards.greenhouse.io/acme/jobs/123", true],
+    ["https://jobs.lever.co/acme/0d5c1d1e-1b1e-4b1e-8b1e-1b1e4b1e8b1e", true],
+    ["https://apply.workable.com/acme/j/ABC123", true],
+    ["https://acme.recruitee.com/o/engineer", true],
+    // Not fetchable — no public JSON API, so the DOM tiers handle these.
+    ["https://www.linkedin.com/jobs/view/123/", false],
+    ["https://www.indeed.com/viewjob?jk=abc", false],
+    ["https://acme.wd5.myworkdayjobs.com/job/1", false],
+  ])("%s → %s", (url, expected) => {
+    expect(isAtsApiUrl(url)).toBe(expected);
+  });
+});
+
+describe("extractPostingFromAtsApi", () => {
+  it("returns null for a URL no supported platform claims, with no network call", async () => {
+    const fetchStub = stubFetch({});
+    vi.stubGlobal("fetch", fetchStub);
+
+    expect(
+      await extractPostingFromAtsApi("https://www.linkedin.com/jobs/view/123/"),
+    ).toBeNull();
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it("extracts a Greenhouse posting", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubFetch({
+        title: "Staff Engineer",
+        company: { name: "Acme" },
+        content: "<p>Build things.</p><ul><li>5 years TypeScript</li></ul>",
+      }),
+    );
+
+    const result = await extractPostingFromAtsApi(GREENHOUSE_URL);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.company).toBe("Acme");
+    expect(result!.extractionTier).toBe("ats_api");
+    expect(result!.atsDetected).toBe("greenhouse");
+    expect(result!.algorithmVersion).toBe(EXTRACTION_ALGORITHM_VERSION);
+  });
+
+  // The whole reason `fetchJdFromUrl` now passes `descriptionHtml` through: the
+  // plaintext it also returns has already lost the list structure that the fit
+  // rating's term extraction depends on.
+  it("converts the platform's HTML to Markdown rather than taking its plaintext", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubFetch({
+        title: "Staff Engineer",
+        company: { name: "Acme" },
+        content: "<p>Build things.</p><ul><li>5 years TypeScript</li><li>Go</li></ul>",
+      }),
+    );
+
+    const result = await extractPostingFromAtsApi(GREENHOUSE_URL);
+    expect(result!.body).toContain("- 5 years TypeScript");
+    expect(result!.body).toContain("- Go");
+  });
+
+  it("sets a preview capped at 200 characters", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubFetch({
+        title: "Staff Engineer",
+        company: { name: "Acme" },
+        content: `<p>${"x".repeat(500)}</p>`,
+      }),
+    );
+
+    const result = await extractPostingFromAtsApi(GREENHOUSE_URL);
+    expect(result!.descriptionPreview).toHaveLength(200);
+  });
+
+  // An ATS API being down is a reason to read the page instead, not a reason for
+  // the whole extraction to fail.
+  it("returns null on an API error rather than throwing", async () => {
+    vi.stubGlobal("fetch", stubFetch({}, false));
+    await expect(extractPostingFromAtsApi(GREENHOUSE_URL)).resolves.toBeNull();
+  });
+
+  it("returns null on a network failure rather than throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    await expect(extractPostingFromAtsApi(GREENHOUSE_URL)).resolves.toBeNull();
+  });
+
+  // Same rule as every other tier — a partial result is worse than none.
+  it("returns null when the platform gives no title", async () => {
+    vi.stubGlobal("fetch", stubFetch({ company: { name: "Acme" }, content: "<p>x</p>" }));
+    expect(await extractPostingFromAtsApi(GREENHOUSE_URL)).toBeNull();
+  });
+});
+
+describe("extractPosting — the full ladder", () => {
+  function docFrom(html: string): Document {
+    return new DOMParser().parseFromString(html, "text/html");
+  }
+
+  const JSON_LD_PAGE = `<html><head><script type="application/ld+json">${JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "JobPosting",
+    title: "From JSON-LD",
+    hiringOrganization: { "@type": "Organization", name: "Acme" },
+  })}</script></head><body></body></html>`;
+
+  // Tier 1 outranks the API tier, so a page that declares itself needs no
+  // network round-trip at all.
+  it("prefers schema_org over the API tier, and makes no network call", async () => {
+    const fetchStub = stubFetch({});
+    vi.stubGlobal("fetch", fetchStub);
+
+    const result = await extractPosting(
+      docFrom(JSON_LD_PAGE),
+      new URL(GREENHOUSE_URL),
+    );
+
+    expect(result!.extractionTier).toBe("schema_org");
+    expect(result!.title).toBe("From JSON-LD");
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it("uses the API tier when the page ships no JSON-LD", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stubFetch({ title: "From API", company: { name: "Acme" }, content: "<p>Body.</p>" }),
+    );
+
+    const result = await extractPosting(
+      docFrom("<html><body><h1>Ignored</h1></body></html>"),
+      new URL(GREENHOUSE_URL),
+    );
+
+    expect(result!.extractionTier).toBe("ats_api");
+    expect(result!.title).toBe("From API");
+  });
+
+  // A non-fetchable host must cost no round-trip on its way to the DOM tiers.
+  it("skips the API tier entirely for a host with no public API", async () => {
+    const fetchStub = stubFetch({});
+    vi.stubGlobal("fetch", fetchStub);
+
+    await extractPosting(
+      docFrom(
+        "<html><body><h1>Engineer</h1><main><p>Job description. Responsibilities and requirements. Equal opportunity employer.</p></main></body></html>",
+      ),
+      new URL("https://www.linkedin.com/jobs/view/123/"),
+    );
+
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the DOM tiers when the API tier fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    const result = await extractPosting(
+      docFrom(
+        `<html><body><h1 class="app-title">From DOM</h1><div id="content"><p>Job description. Responsibilities and requirements. Equal opportunity employer. Build systems at scale.</p></div></body></html>`,
+      ),
+      new URL(GREENHOUSE_URL),
+    );
+
+    expect(result!.extractionTier).toBe("ats_extractor");
+    expect(result!.title).toBe("From DOM");
+  });
+});

--- a/src/lib/jd-extract/ats-api.ts
+++ b/src/lib/jd-extract/ats-api.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The `ats_api` tier — read a posting from its ATS platform's public JSON API
+// instead of from a rendered page.
+//
+// Second in the ladder, below the publisher's own JSON-LD and above every
+// DOM-reading tier, because an ATS's own API is authoritative about its own
+// postings: no markup to guess at, no SPA to wait for, no selector to rot.
+//
+// This module is a thin adapter over `src/lib/jd-match/fetch-jd.ts`, which already
+// owns every ATS URL parser and API client in this repo. It deliberately adds no
+// second parser — two implementations of "is this a Greenhouse URL, and which job"
+// is exactly the fork `src/lib/jd-extract/` exists to end, and the same argument
+// `src/lib/storage/job-url.ts` makes for id derivation.
+//
+// **Kept out of `./detect.ts` and out of the injectable bundle on purpose.**
+// `fetch-jd.ts` owns live `fetch()` calls, so anything importing it pulls a network
+// primitive into its import graph — the boundary #704 established when it split
+// `html-to-plaintext.ts` out for exactly this reason. `./index.ts` (the page-injected
+// entry point) must never reach this file: injected code runs in the page's origin,
+// where a cross-origin ATS request would be blocked by CORS anyway.
+
+import { fetchJdFromUrl, parseAtsUrl } from "../jd-match/fetch-jd";
+import { extractFromDomTiers, finalize } from "./detect";
+import { extractSchemaOrgJobPosting } from "./schema-org";
+import { stripHtml } from "./schema-org-core";
+import { EXTRACTION_ALGORITHM_VERSION, type ExtractedPosting } from "./types";
+
+/**
+ * Can this URL be read through a public ATS API?
+ *
+ * Delegates to `parseAtsUrl` rather than testing hostnames here, so the set of
+ * fetchable platforms has exactly one definition. Note this is a narrower question
+ * than "which ATS is this", which `matchAtsDomain` in `./schema-org-core.ts`
+ * answers for a much longer list of platforms that have no fetchable API.
+ */
+export function isAtsApiUrl(url: string): boolean {
+  return parseAtsUrl(url) !== null;
+}
+
+/**
+ * Extract a posting through its ATS platform's public API.
+ *
+ * Returns `null` for a URL no supported platform claims — the caller falls through
+ * to the DOM tiers. Network failures also return `null` rather than throwing: an
+ * ATS API being down is a reason to read the page instead, not a reason for the
+ * whole extraction to fail. (`fetchJdFromUrl` distinguishes these two cases by
+ * returning `null` vs throwing; that distinction matters to `JdInput`, which routes
+ * them to different user-facing copy, but not here, where both mean "try the DOM".)
+ *
+ * Prefers the platform's raw HTML over its plaintext so the body keeps its list
+ * structure — see `ExtractedPosting.body`. Falls back to the plaintext `text` when
+ * a platform returns no HTML (Workable's widget has no description body at all).
+ */
+export async function extractPostingFromAtsApi(
+  url: string,
+): Promise<ExtractedPosting | null> {
+  if (!parseAtsUrl(url)) return null;
+
+  let result: Awaited<ReturnType<typeof fetchJdFromUrl>>;
+  try {
+    result = await fetchJdFromUrl(url);
+  } catch {
+    return null;
+  }
+  if (!result) return null;
+
+  const body = result.descriptionHtml
+    ? stripHtml(result.descriptionHtml)
+    : result.text;
+
+  // Same rule as every other tier: without a title and a company there is nothing
+  // to display or deduplicate on, so report nothing rather than something partial.
+  if (!result.title || !result.company) return null;
+
+  return {
+    title: result.title,
+    company: result.company,
+    body,
+    descriptionPreview: body.slice(0, 200),
+    atsDetected: result.source,
+    extractionTier: "ats_api",
+    algorithmVersion: EXTRACTION_ALGORITHM_VERSION,
+  };
+}
+
+/**
+ * The full tier ladder, including the network-bound `ats_api` tier:
+ *
+ *   `schema_org` → `ats_api` → `dom_metadata` / `ats_extractor`
+ *
+ * First hit wins. Use this from app code that can make network requests; use
+ * `extractPostingFromDocument` in `./detect.ts` where the extraction must stay
+ * offline — including anything that gets injected into a page.
+ *
+ * The API tier is skipped without a cheap URL test first, so a page on a
+ * non-fetchable host costs no network round-trip on its way to the DOM tiers.
+ */
+export async function extractPosting(
+  doc: Document,
+  url: URL,
+): Promise<ExtractedPosting | null> {
+  const schemaOrgPosting = await extractSchemaOrgJobPosting(doc);
+  if (schemaOrgPosting) return finalize(schemaOrgPosting, doc, url);
+
+  if (isAtsApiUrl(url.href)) {
+    const fromApi = await extractPostingFromAtsApi(url.href);
+    if (fromApi) return fromApi;
+  }
+
+  return extractFromDomTiers(doc, url);
+}

--- a/src/lib/jd-extract/detect.test.ts
+++ b/src/lib/jd-extract/detect.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The dispatcher — tier ordering and fall-through.
+ *
+ * The ordering assertions here are the ones worth keeping. Dispatch is
+ * first-hit-wins, `generic.matches()` returns `true` unconditionally, and the
+ * failure mode of a wrong order is silent: the page still extracts, just by a worse
+ * tier than the one written for it. Nothing else in the suite would catch that.
+ */
+
+import { DOM_EXTRACTORS, extractPostingFromDocument } from "./detect";
+import { EXTRACTION_ALGORITHM_VERSION } from "./types";
+
+function pageFrom(html: string, url: string) {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return { doc, url: new URL(url) };
+}
+
+function extract(html: string, url = "https://careers.example.com/jobs/1") {
+  const { doc, url: parsed } = pageFrom(html, url);
+  return extractPostingFromDocument(doc, parsed);
+}
+
+/** Enough job-page vocabulary to clear the signal gate. */
+const JOB_SIGNALS_TEXT =
+  "<p>Job description. Responsibilities and requirements. Equal opportunity employer.</p>";
+
+const JSON_LD = `<script type="application/ld+json">${JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "JobPosting",
+  title: "Staff Engineer",
+  hiringOrganization: { "@type": "Organization", name: "Acme" },
+  description: "<p>Build things.</p><ul><li>5 years TypeScript</li></ul>",
+})}</script>`;
+
+describe("DOM_EXTRACTORS ordering", () => {
+  // `generic` accepts every page, so anything after it would be unreachable.
+  it("registers generic last", () => {
+    expect(DOM_EXTRACTORS[DOM_EXTRACTORS.length - 1].name).toBe("generic");
+  });
+
+  it("is the exact expected order", () => {
+    expect(DOM_EXTRACTORS.map((e) => e.name)).toEqual([
+      "greenhouse",
+      "lever",
+      "linkedin",
+      "workday",
+      "oracle-hcm",
+      "smartrecruiters",
+      "generic",
+    ]);
+  });
+
+  it("registers linkedin before generic, or LinkedIn gets the catch-all", () => {
+    const names = DOM_EXTRACTORS.map((e) => e.name);
+    expect(names.indexOf("linkedin")).toBeLessThan(names.indexOf("generic"));
+  });
+
+  it("has exactly one adapter that matches unconditionally", () => {
+    const alwaysMatch = DOM_EXTRACTORS.filter((e) =>
+      e.matches(new URL("https://unrelated.example/x"), new DOMParser().parseFromString("<html></html>", "text/html")),
+    );
+    expect(alwaysMatch.map((e) => e.name)).toEqual(["generic"]);
+  });
+});
+
+describe("tier 1 wins outright", () => {
+  it("extracts a JSON-LD page via schema_org", async () => {
+    const result = await extract(`<html><head>${JSON_LD}</head><body></body></html>`);
+    expect(result!.extractionTier).toBe("schema_org");
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.company).toBe("Acme");
+  });
+
+  // Tier 1 runs before the job-signal gate: a valid JobPosting block is itself
+  // conclusive, so a page carrying one must never be rejected by a keyword
+  // heuristic. This page has an <h1> and no job vocabulary whatsoever.
+  it("extracts JSON-LD even on a page that would fail the signal gate", async () => {
+    const result = await extract(
+      `<html><head>${JSON_LD}</head><body><h1>x</h1></body></html>`,
+      "https://example.com/",
+    );
+    expect(result!.extractionTier).toBe("schema_org");
+  });
+
+  // The acceptance criterion: a JSON-LD page must be read with no host-specific
+  // code executing. Proved by putting the page on a Workday host and asserting
+  // none of Workday's fields (which the markup does not carry) appear.
+  it("runs no host adapter when JSON-LD is present", async () => {
+    const result = await extract(
+      `<html><head>${JSON_LD}</head><body><h1>Workday Heading</h1></body></html>`,
+      "https://acme.wd5.myworkdayjobs.com/job/123",
+    );
+    expect(result!.extractionTier).toBe("schema_org");
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.atsDetected).toBe("Workday"); // named, but not extracted by
+  });
+});
+
+describe("fall-through when there is no JSON-LD", () => {
+  it("falls through to a host adapter", async () => {
+    const result = await extract(
+      `<html><body><h1 class="app-title">Backend Engineer</h1>` +
+        `<div id="content">${JOB_SIGNALS_TEXT}<ul><li>Go</li><li>Postgres</li></ul></div>` +
+        `</body></html>`,
+      "https://boards.greenhouse.io/acme/jobs/123",
+    );
+    expect(result!.extractionTier).toBe("ats_extractor");
+    expect(result!.atsDetected).toBe("greenhouse");
+    expect(result!.title).toBe("Backend Engineer");
+    expect(result!.body).toContain("- Go");
+  });
+
+  it("falls through to the generic adapter on an unknown host", async () => {
+    const result = await extract(
+      `<html><head><meta property="og:site_name" content="Acme"></head><body>` +
+        `<h1>Platform Engineer</h1><main>${JOB_SIGNALS_TEXT}` +
+        `<ul><li>Kubernetes</li><li>Terraform</li></ul></main></body></html>`,
+      "https://careers.acme.com/jobs/9",
+    );
+    expect(result!.extractionTier).toBe("dom_metadata");
+    expect(result!.title).toBe("Platform Engineer");
+    expect(result!.body).toContain("- Kubernetes");
+  });
+
+  it("does not throw on a page with no JSON-LD and nothing a host claims", async () => {
+    await expect(
+      extract(`<html><body>${JOB_SIGNALS_TEXT}</body></html>`),
+    ).resolves.not.toThrow();
+  });
+});
+
+describe("returns null rather than a partial result", () => {
+  // A half-filled result looks like a successful extraction to every caller
+  // downstream, which is worse than reporting nothing.
+  it("returns null for a page with no job signals at all", async () => {
+    expect(
+      await extract(
+        "<html><body><h1>About us</h1><p>We make software.</p></body></html>",
+        "https://example.com/about",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when a page has signals but no title", async () => {
+    expect(await extract(`<html><body>${JOB_SIGNALS_TEXT}</body></html>`)).toBeNull();
+  });
+
+  it("returns null when the body is too short to be a posting", async () => {
+    expect(
+      await extract(
+        `<html><body><h1>Engineer</h1>${JOB_SIGNALS_TEXT}<main>Tiny</main></body></html>`,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("the LinkedIn path", () => {
+  // LinkedIn ships no JSON-LD and no og: tags on the logged-in job view, so this
+  // is the case where every general tier misses and only the adapter works.
+  const LINKEDIN_PAGE =
+    `<html><head><title>Director, Engineering - Agentic Systems | Visa | LinkedIn</title></head>` +
+    `<body><div aria-label="Company, Visa.">v</div><h1>Director, Engineering</h1>` +
+    `<main>${JOB_SIGNALS_TEXT}<ul><li>Distributed systems</li><li>Team leadership</li></ul>` +
+    `<p>You will lead a team building agentic systems at scale.</p></main></body></html>`;
+
+  it("extracts a logged-in job view via the LinkedIn adapter", async () => {
+    const result = await extract(
+      LINKEDIN_PAGE,
+      "https://www.linkedin.com/jobs/view/4437835690/",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Director, Engineering");
+    expect(result!.company).toBe("Visa");
+    expect(result!.body).toContain("- Distributed systems");
+  });
+
+  it("recovers the company from the page title when the aria-label is absent", async () => {
+    const result = await extract(
+      LINKEDIN_PAGE.replace('<div aria-label="Company, Visa.">v</div>', ""),
+      "https://www.linkedin.com/jobs/view/4437835690/",
+    );
+    expect(result!.company).toBe("Visa");
+  });
+});
+
+describe("every result is stamped", () => {
+  it("carries the algorithm version", async () => {
+    const result = await extract(`<html><head>${JSON_LD}</head><body></body></html>`);
+    expect(result!.algorithmVersion).toBe(EXTRACTION_ALGORITHM_VERSION);
+  });
+
+  // A bump must be a visible diff, not an incidental one.
+  it("EXTRACTION_ALGORITHM_VERSION is a positive integer", () => {
+    expect(Number.isInteger(EXTRACTION_ALGORITHM_VERSION)).toBe(true);
+    expect(EXTRACTION_ALGORITHM_VERSION).toBeGreaterThan(0);
+  });
+});
+
+describe("dom-metadata enrichment", () => {
+  it("fills a job id the winning tier missed, without touching its other fields", async () => {
+    const result = await extract(
+      `<html><head>${JSON_LD}<meta name="requisitionId" content="R-9182"></head>` +
+        `<body></body></html>`,
+    );
+    expect(result!.jobId).toBe("R-9182");
+    // The tier that won still owns the fields it extracted.
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.company).toBe("Acme");
+  });
+});

--- a/src/lib/jd-extract/detect.ts
+++ b/src/lib/jd-extract/detect.ts
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The dispatcher: run the extraction tiers against a document in trust order and
+// return the first result.
+//
+// Deliberately network-free. Every tier below reads the document it was handed and
+// nothing else, which is what lets this module be bundled and injected into a live
+// page — see `./index.ts`. The `ats_api` tier is real but lives in `./ats-api.ts`,
+// because it needs `fetch()` and the boundary #704 established is that a consumer
+// auditing its own import graph for network primitives must be able to take the
+// DOM half without one appearing.
+//
+// The upstream implementation of this logic was a browser-extension content-script
+// entry point: it read `window` globals, called `chrome.runtime.sendMessage`, and
+// could not be called as a function or tested. Only the tier ordering and the
+// job-page signal heuristic carried over; the surrounding plumbing is new.
+
+import { greenhouse } from "./adapters/greenhouse";
+import { lever } from "./adapters/lever";
+import { linkedin } from "./adapters/linkedin";
+import { workday } from "./adapters/workday";
+import { oracleHcm } from "./adapters/oracle-hcm";
+import { smartrecruiters } from "./adapters/smartrecruiters";
+import { generic } from "./adapters/generic";
+import { extractSchemaOrgJobPosting } from "./schema-org";
+import { enrichWithDomMetadata, extractFromDomMetadata } from "./dom-metadata";
+import { extractApplyLink } from "./apply-link";
+import {
+  EXTRACTION_ALGORITHM_VERSION,
+  type ATSExtractor,
+  type ExtractedPosting,
+} from "./types";
+
+/**
+ * Host adapters in dispatch order — most specific first, `generic` always last.
+ *
+ * Exported so a test can pin the ordering. The order is behaviour, not
+ * configuration: `generic.matches()` returns `true` unconditionally, so anything
+ * placed after it is unreachable, and `linkedin` must precede it or LinkedIn
+ * postings get the catch-all's extraction instead of the one written for them.
+ */
+export const DOM_EXTRACTORS: readonly ATSExtractor[] = [
+  greenhouse,
+  lever,
+  linkedin,
+  workday,
+  oracleHcm,
+  smartrecruiters,
+  generic,
+];
+
+/**
+ * Weighted evidence that a page is a job posting at all.
+ *
+ * Needed because `generic.matches()` accepts everything: without a gate, every
+ * page with an `<h1>` and a `<main>` would extract as a posting. Weighted rather
+ * than a keyword list because no single phrase is conclusive — "responsibilities"
+ * appears on an about-us page, "salary" on a blog post — while a combination is.
+ *
+ * Weight 3 signals are near-exclusive to job listings; weight 2 are standard
+ * job-page section headings; weight 1 are supportive but common elsewhere.
+ */
+const JOB_SIGNALS: ReadonlyArray<{ pattern: RegExp; weight: number }> = [
+  { pattern: /apply\s*(now|for\s*this)/i, weight: 3 },
+  { pattern: /job\s*(description|summary|details|overview)/i, weight: 3 },
+  { pattern: /equal\s*opportunity\s*employer/i, weight: 3 },
+  { pattern: /job\s*(id|number|code|ref(erence)?)\b/i, weight: 3 },
+
+  { pattern: /responsibilities/i, weight: 2 },
+  { pattern: /qualifications/i, weight: 2 },
+  { pattern: /requirements?\b/i, weight: 2 },
+  { pattern: /certifications?\s*(required)?/i, weight: 2 },
+  { pattern: /about\s*the\s*(role|position|job)/i, weight: 2 },
+  { pattern: /what\s*you('ll| will)\s*(do|bring)/i, weight: 2 },
+  { pattern: /who\s*you\s*are/i, weight: 2 },
+  // A careers path is URL-borne evidence — the safety net for an ATS embedded
+  // into a company site, where the page markup reveals nothing.
+  { pattern: /\/careers?\//i, weight: 2 },
+
+  { pattern: /date\s*published|posted\s*(on|date)?/i, weight: 1 },
+  { pattern: /work\s*model|remote|hybrid|on.?site/i, weight: 1 },
+  { pattern: /job\s*category|employment\s*type/i, weight: 1 },
+  { pattern: /full.?time|part.?time|contract/i, weight: 1 },
+  { pattern: /years?\s*(of\s*)?experience/i, weight: 1 },
+  { pattern: /salary|compensation|pay\s*range/i, weight: 1 },
+  { pattern: /benefits|perks/i, weight: 1 },
+  { pattern: /how\s*to\s*apply/i, weight: 1 },
+  { pattern: /join\s*our\s*(team|talent)/i, weight: 1 },
+];
+
+/**
+ * Score needed to treat a page as a posting: one strong signal plus one standard,
+ * or two medium. Low enough that a terse posting still passes, high enough that a
+ * single incidental keyword does not.
+ */
+const SIGNAL_THRESHOLD = 4;
+
+/** Does a non-`generic` adapter claim this URL outright? */
+function isKnownAtsUrl(doc: Document, url: URL): boolean {
+  return DOM_EXTRACTORS.some(
+    (e) => e.name !== "generic" && e.matches(url, doc),
+  );
+}
+
+/** Accumulate signal weight over the page text and URL; stop as soon as it passes. */
+function hasJobSignals(doc: Document, url: URL): boolean {
+  const bodyText = doc.body?.textContent || "";
+  const searchText = bodyText + "\n" + url.href;
+  let score = 0;
+  for (const { pattern, weight } of JOB_SIGNALS) {
+    if (pattern.test(searchText)) {
+      score += weight;
+      if (score >= SIGNAL_THRESHOLD) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Attach the canonical ATS URL behind an aggregator listing, when one is readable.
+ *
+ * Only ever fills a gap: an adapter that already recovered an `atsUrl` (Greenhouse's
+ * embedded path does) knows more than an apply-button scan does. Failures are
+ * swallowed — a missing canonical URL forks a duplicate record the user can delete,
+ * whereas a throw here would cost the whole extraction.
+ */
+function withApplyLink(
+  posting: ExtractedPosting,
+  doc: Document,
+  url: URL,
+): ExtractedPosting {
+  if (posting.atsUrl) return posting;
+  try {
+    const result = extractApplyLink(doc, url);
+    if (result.sourceUrl) {
+      return { ...posting, applyUrl: result.sourceUrl, atsUrl: result.sourceUrl };
+    }
+  } catch {
+    // Selector rot or a hostile DOM — not worth failing the extraction over.
+  }
+  return posting;
+}
+
+/**
+ * Extract a job posting from a document, or `null` if the page is not one.
+ *
+ * Tier order, first hit wins:
+ *   1. `schema_org`     — the publisher's own JSON-LD declaration.
+ *   2. `ats_extractor`  — a host adapter, for boards that ship no JSON-LD.
+ *   3. `dom_metadata`   — `og:`/`<meta>` tags, the floor.
+ *
+ * (The `ats_api` tier sits between 1 and 2 conceptually but is network-bound and
+ * lives in `./ats-api.ts`; `extractPosting` there composes the two.)
+ *
+ * Tier 1 runs before the job-page gate on purpose: a valid `JobPosting` block is
+ * itself conclusive evidence, so a page carrying one should never be rejected for
+ * failing a keyword heuristic. The gate exists only to protect the guess-based
+ * tiers below it.
+ *
+ * Every result is stamped with `algorithmVersion` so a stored extraction can be
+ * recognised as stale rather than silently compared against fresher output.
+ */
+export async function extractPostingFromDocument(
+  doc: Document,
+  url: URL,
+): Promise<ExtractedPosting | null> {
+  // ─── Tier 1: schema.org JSON-LD ────────────────────────────────────────────
+  const schemaOrgPosting = await extractSchemaOrgJobPosting(doc, url);
+  if (schemaOrgPosting) return finalize(schemaOrgPosting, doc, url);
+
+  return extractFromDomTiers(doc, url);
+}
+
+/**
+ * The tiers below `schema_org`: the job-page gate, the host adapters, then the
+ * metadata floor.
+ *
+ * Split out so the network-bound `ats_api` tier can be interleaved at its declared
+ * position without re-running tier 1. `extractPosting` in `./ats-api.ts` is the only
+ * other caller; it runs tier 1, then the API tier, then this.
+ */
+export async function extractFromDomTiers(
+  doc: Document,
+  url: URL,
+): Promise<ExtractedPosting | null> {
+  // ─── Gate ──────────────────────────────────────────────────────────────────
+  if (!isKnownAtsUrl(doc, url) && !hasJobSignals(doc, url)) return null;
+
+  // ─── Tier 2/3: host adapters, then the metadata floor ──────────────────────
+  for (const extractor of DOM_EXTRACTORS) {
+    if (!extractor.matches(url, doc)) continue;
+    const posting = extractor.extract(doc, url);
+    if (posting) return finalize(posting, doc, url);
+  }
+
+  // `generic` declined — usually too little body text. Metadata alone may still
+  // carry a title and company, which is a thin but honest result.
+  const fromMeta = extractFromDomMetadata(
+    doc,
+    doc.body?.textContent?.trim() || "",
+    undefined,
+    url,
+  );
+  return fromMeta ? finalize(fromMeta, doc, url) : null;
+}
+
+/**
+ * The common tail every DOM tier's result passes through: fill metadata gaps,
+ * attach a canonical ATS URL if one is readable, stamp the algorithm version.
+ */
+export function finalize(
+  posting: ExtractedPosting,
+  doc: Document,
+  url: URL,
+): ExtractedPosting {
+  return {
+    ...withApplyLink(enrichWithDomMetadata(posting, doc, url), doc, url),
+    algorithmVersion: EXTRACTION_ALGORITHM_VERSION,
+  };
+}

--- a/src/lib/jd-extract/dom-metadata.ts
+++ b/src/lib/jd-extract/dom-metadata.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The `og:` / `<meta>` / data-attribute tier, and the enrichment pass that runs
+// after every other tier.
+//
+// Two jobs, deliberately in one module because they read the same metadata:
+//
+//   - `extractFromDomMetadata` — a standalone tier for pages with no JSON-LD that
+//     no host adapter claims. Social-preview tags are the lowest-common-denominator
+//     structured data on the web: nearly every page has them, they are meant to be
+//     machine-read, and unlike a host adapter they are not a guess about one
+//     vendor's markup.
+//   - `enrichWithDomMetadata` — a gap-filler applied to whatever an earlier tier
+//     produced. It only ever fills fields that are missing and never overwrites,
+//     because the tier that produced the result was more trusted than this one;
+//     letting a page-level `og:` tag overwrite a JSON-LD field would invert the
+//     ladder's whole ordering.
+
+import type { ExtractedPosting, ExtractionTier } from "./types";
+import { matchAtsDomain } from "./schema-org-core";
+
+interface DomMetadata {
+  title?: string;
+  company?: string;
+  location?: string;
+  description?: string;
+  jobId?: string;
+  atsPlatform?: string;
+}
+
+function getMetaContent(doc: Document, selector: string): string | undefined {
+  const el = doc.querySelector(selector);
+  const content = el?.getAttribute("content")?.trim();
+  return content || undefined;
+}
+
+/**
+ * Read what the page says about itself through metadata rather than content.
+ *
+ * `og:site_name` is used as the company, which is right on a company's own careers
+ * page and wrong on an aggregator — where it yields the aggregator's name. That is
+ * acceptable precisely because this tier runs last among the general tiers: an
+ * aggregator page that a host adapter claims never reaches here, and one that
+ * reaches here has no better answer available.
+ *
+ * The job-id meta names are alternatives, not a hierarchy of quality — different
+ * ATS vendors simply chose different spellings for the same thing.
+ *
+ * `url` is passed in rather than read off `doc.location` for the reason given in
+ * `./schema-org.ts`: a `Document` only has a meaningful location when it came from
+ * navigation.
+ */
+function extractDomMetadata(doc: Document, url?: URL): DomMetadata {
+  const meta: DomMetadata = {};
+
+  const ogTitle = getMetaContent(doc, 'meta[property="og:title"]');
+  const ogSiteName = getMetaContent(doc, 'meta[property="og:site_name"]');
+  const ogDescription = getMetaContent(doc, 'meta[property="og:description"]');
+
+  if (ogTitle) meta.title = ogTitle;
+  if (ogSiteName) meta.company = ogSiteName;
+  if (ogDescription) meta.description = ogDescription;
+
+  const jobIdMeta =
+    getMetaContent(doc, 'meta[name="JobIdentifier"]') ||
+    getMetaContent(doc, 'meta[name="job-id"]') ||
+    getMetaContent(doc, 'meta[name="jobId"]') ||
+    getMetaContent(doc, 'meta[name="requisitionId"]') ||
+    getMetaContent(doc, 'meta[name="job_id"]');
+  if (jobIdMeta) meta.jobId = jobIdMeta;
+
+  // Data attributes on a job-detail container. Only read when the container is
+  // found — these attribute names are generic enough that querying for them
+  // individually across the whole document would collect unrelated widgets.
+  const jobContainer = doc.querySelector(
+    '[data-jobtitle], [data-job-title], [data-id][class*="job"]',
+  );
+  if (jobContainer) {
+    const dataTitle =
+      jobContainer.getAttribute("data-jobtitle") ||
+      jobContainer.getAttribute("data-job-title");
+    if (dataTitle && !meta.title) meta.title = dataTitle;
+
+    const dataId = jobContainer.getAttribute("data-id");
+    if (dataId && !meta.jobId) meta.jobId = dataId;
+
+    const dataLocation =
+      jobContainer.getAttribute("data-location") ||
+      jobContainer.getAttribute("data-job-location");
+    if (dataLocation) meta.location = dataLocation;
+  }
+
+  // ATS platform from apply-button targets, then from the page's own URL — the
+  // same two-step and the same shared domain table the schema.org tier uses, so
+  // platform naming stays one rule rather than drifting per tier.
+  const applyLinks = doc.querySelectorAll(
+    'a[href*="apply"], a[class*="apply"], [data-apply-url]',
+  );
+  for (const link of applyLinks) {
+    const href =
+      link.getAttribute("href") || link.getAttribute("data-apply-url") || "";
+    const platform = matchAtsDomain(href);
+    if (platform) {
+      meta.atsPlatform = platform;
+      break;
+    }
+  }
+
+  if (!meta.atsPlatform) {
+    meta.atsPlatform = matchAtsDomain(url?.href || doc.location?.href || "");
+  }
+
+  return meta;
+}
+
+/**
+ * Fill gaps in a posting an earlier tier produced.
+ *
+ * Only `location`, `jobId`, and `atsDetected` are enriched. The rest are left
+ * alone on purpose: `title`, `company`, and `body` are the fields the earlier tier
+ * was chosen for, and metadata versions of them are systematically worse —
+ * `og:title` carries site branding, `og:description` is a truncated blurb.
+ */
+export function enrichWithDomMetadata(
+  posting: ExtractedPosting,
+  doc: Document,
+  url?: URL,
+): ExtractedPosting {
+  const meta = extractDomMetadata(doc, url);
+
+  return {
+    ...posting,
+    location: posting.location || meta.location,
+    jobId: posting.jobId || meta.jobId,
+    atsDetected: posting.atsDetected || meta.atsPlatform,
+  };
+}
+
+/**
+ * Build a posting from metadata alone.
+ *
+ * `body` is supplied by the caller rather than read here, because this tier has no
+ * view of which element holds the description — the dispatcher does. The `og:`
+ * description, when present, is used only for the short preview.
+ *
+ * Returns `null` without both a title and a company, for the reason given on
+ * `ATSExtractor.extract`: a partially-populated result is indistinguishable from a
+ * successful one to every caller downstream.
+ *
+ * `existingTier` lets a host adapter reuse this builder while keeping its own,
+ * more specific tier label on the result.
+ */
+export function extractFromDomMetadata(
+  doc: Document,
+  body: string,
+  existingTier?: ExtractionTier,
+  url?: URL,
+): ExtractedPosting | null {
+  const meta = extractDomMetadata(doc, url);
+
+  const title = meta.title || doc.querySelector("h1")?.textContent?.trim();
+  const company = meta.company;
+
+  if (!title || !company) return null;
+
+  return {
+    title,
+    company,
+    location: meta.location,
+    body,
+    descriptionPreview: (meta.description || body).slice(0, 200),
+    atsDetected: meta.atsPlatform,
+    extractionTier: existingTier || "dom_metadata",
+    jobId: meta.jobId,
+  };
+}

--- a/src/lib/jd-extract/html-to-markdown.test.ts
+++ b/src/lib/jd-extract/html-to-markdown.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The DOM-walking HTML → Markdown converter.
+ *
+ * List structure is the thing under test. Everything else here is presentation,
+ * but bullets are what the fit rating's term extraction reads — a converter that
+ * flattens `<li>` into a paragraph costs extracted terms and, below the threshold,
+ * costs the rating entirely.
+ */
+
+import { compressBlankLines, htmlToMarkdown, htmlStringToMarkdown } from "./html-to-markdown";
+
+function md(html: string): string {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return htmlToMarkdown(el);
+}
+
+describe("htmlToMarkdown — structure", () => {
+  it("converts an unordered list to bullets", () => {
+    expect(md("<ul><li>One</li><li>Two</li></ul>")).toBe("- One\n- Two");
+  });
+
+  it("numbers an ordered list", () => {
+    expect(md("<ol><li>First</li><li>Second</li></ol>")).toBe("1. First\n2. Second");
+  });
+
+  // Numbering indexes among element children, so interleaved text or comment
+  // nodes cannot shift it.
+  it("numbers correctly despite interleaved whitespace text nodes", () => {
+    expect(md("<ol>\n  <li>A</li>\n  <li>B</li>\n  <li>C</li>\n</ol>")).toBe(
+      "1. A\n2. B\n3. C",
+    );
+  });
+
+  it.each([
+    ["h1", "#"],
+    ["h2", "##"],
+    ["h3", "###"],
+    ["h4", "####"],
+    ["h5", "#####"],
+    ["h6", "######"],
+  ])("converts <%s> to a %s heading", (tag, hashes) => {
+    expect(md(`<${tag}>Title</${tag}>`)).toBe(`${hashes} Title`);
+  });
+
+  it("separates paragraphs with a blank line", () => {
+    expect(md("<p>One</p><p>Two</p>")).toBe("One\n\nTwo");
+  });
+
+  it("converts <br> to a single newline", () => {
+    expect(md("<p>One<br>Two</p>")).toBe("One\nTwo");
+  });
+});
+
+describe("htmlToMarkdown — emphasis and links", () => {
+  it("converts bold and italic", () => {
+    expect(md("<strong>bold</strong> and <em>italic</em>")).toBe(
+      "**bold** and *italic*",
+    );
+    expect(md("<b>bold</b> and <i>italic</i>")).toBe("**bold** and *italic*");
+  });
+
+  // An empty wrapper would otherwise emit `****`, which renders as literal asterisks.
+  it("drops an empty emphasis wrapper rather than emitting stray markers", () => {
+    expect(md("<p>A<strong></strong>B</p>")).toBe("AB");
+  });
+
+  it("converts an external link", () => {
+    expect(md('<a href="https://example.com">Site</a>')).toBe(
+      "[Site](https://example.com)",
+    );
+  });
+
+  // In-page anchors carry no information for a reader of extracted text, and a
+  // `javascript:` href must never survive into text that gets persisted.
+  it.each(["#section", "javascript:void(0)"])(
+    "degrades a %s link to its label",
+    (href) => {
+      expect(md(`<a href="${href}">Label</a>`)).toBe("Label");
+    },
+  );
+
+  it("degrades a link with no href to its label", () => {
+    expect(md("<a>Label</a>")).toBe("Label");
+  });
+});
+
+describe("htmlToMarkdown — noise removal", () => {
+  // On a job page these usually hold a large blob of JSON app state, which would
+  // otherwise swamp the description.
+  it.each(["script", "style", "noscript"])("drops <%s> content entirely", (tag) => {
+    expect(md(`<p>Real</p><${tag}>NOISE</${tag}>`)).toBe("Real");
+  });
+
+  it("collapses runs of spaces and tabs inside text", () => {
+    expect(md("<p>a    b\tc</p>")).toBe("a b c");
+  });
+
+  it("compresses runs of blank lines", () => {
+    expect(md("<p>A</p><p></p><p></p><p>B</p>")).toBe("A\n\nB");
+  });
+
+  it("returns an empty string for an empty element", () => {
+    expect(md("")).toBe("");
+  });
+
+  // The default must be lossless — job pages wrap description text in arbitrary
+  // framework-generated markup and custom elements.
+  it("passes unknown and inline tags through losslessly", () => {
+    expect(md("<span>a</span><custom-el>b</custom-el><code>c</code>")).toBe("abc");
+  });
+});
+
+describe("htmlToMarkdown — a realistic job description", () => {
+  it("preserves the requirement bullets a fit rating depends on", () => {
+    const result = md(
+      "<div><h2>About the role</h2><p>Build things.</p>" +
+        "<h3>Requirements</h3><ul><li>5 years TypeScript</li><li>Distributed systems</li></ul>" +
+        "<script>window.__STATE__={}</script></div>",
+    );
+    expect(result).toBe(
+      "## About the role\n\nBuild things.\n\n### Requirements\n\n- 5 years TypeScript\n- Distributed systems",
+    );
+  });
+});
+
+describe("htmlStringToMarkdown", () => {
+  it("parses a string and converts it", () => {
+    expect(htmlStringToMarkdown("<ul><li>One</li></ul>")).toBe("- One");
+  });
+});
+
+describe("compressBlankLines", () => {
+  it("reduces 3+ newlines to exactly 2", () => {
+    expect(compressBlankLines("a\n\n\n\n\nb")).toBe("a\n\nb");
+  });
+
+  it("leaves a single blank line alone", () => {
+    expect(compressBlankLines("a\n\nb")).toBe("a\n\nb");
+  });
+});

--- a/src/lib/jd-extract/html-to-markdown.ts
+++ b/src/lib/jd-extract/html-to-markdown.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// DOM-walking HTML → Markdown converter, used by every host adapter to turn a
+// job-description element into `ExtractedPosting.body`.
+//
+// Why not `turndown`, which this repo already depends on: this converter is
+// ~120 lines and adds nothing to the injected bundle, while turndown adds 11.4 KB
+// minified — measured, not estimated. The `jd-extract` entry point is injected
+// into a live page through a browser tool, so bundle size is a per-call cost paid
+// on every posting, and 11.4 KB would push the bundle past its 25 KB budget for
+// output this converter already produces. `turndown` remains the right tool for
+// the app-side lanes that import it (`markdown-lines.ts`, `openresume.ts`,
+// `ingest/docx.ts`) and are not size-constrained.
+//
+// Why not `htmlToPlaintext` from `src/lib/jd-match/html-to-plaintext.ts`: that
+// module flattens to plaintext, and flattening is precisely what costs extracted
+// terms here — see the note on `ExtractedPosting.body`. It stays the right choice
+// wherever plaintext is genuinely what is wanted.
+//
+// Why a DOM walk rather than regex over `outerHTML`: `<li>` numbering needs the
+// parent's tag and the child's index, and `<script>` / `<style>` subtrees must be
+// dropped whole. Both are structural questions a regex answers badly. The
+// string-input counterpart (`stripHtml` in `./schema-org-core.ts`) exists only for
+// HTML that arrives inside a JSON-LD string value, where no `Document` is available.
+
+/** Compress 3+ consecutive newlines down to 2, i.e. at most one blank line. */
+export function compressBlankLines(text: string): string {
+  return text.replace(/\n{3,}/g, "\n\n");
+}
+
+/**
+ * Convert a DOM element's content to Markdown.
+ *
+ * Emits generous whitespace during the walk and normalizes once at the end, so
+ * no individual case has to reason about what its neighbours already emitted.
+ */
+export function htmlToMarkdown(element: Element): string {
+  const md = walkNode(element);
+  return compressBlankLines(md).trim();
+}
+
+/**
+ * Convert an HTML string to Markdown by parsing it into a detached element first.
+ *
+ * Requires a live `document`, so it is only usable in a DOM context. The
+ * container is never attached, so nothing in the HTML can affect the real page —
+ * but note that `innerHTML` still triggers resource-loading side effects for some
+ * elements, which is why this is reserved for markup already fetched from the page
+ * being read rather than used as a general-purpose sanitiser.
+ */
+export function htmlStringToMarkdown(html: string): string {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  return htmlToMarkdown(container);
+}
+
+function walkNode(node: Node): string {
+  // `Node.TEXT_NODE` / `Node.ELEMENT_NODE` are referenced as numeric literals
+  // rather than through the `Node` global: this module is bundled for injection
+  // into a page, and reading a global at module scope would break if the bundle
+  // were ever evaluated somewhere `Node` is not defined.
+  if (node.nodeType === 3) {
+    // Collapse runs of spaces/tabs but keep single spaces — the block-level cases
+    // below own line breaks, and letting text nodes emit them would double up.
+    return (node.textContent || "").replace(/[ \t]+/g, " ");
+  }
+
+  if (node.nodeType !== 1) return "";
+
+  const el = node as Element;
+  const tag = el.tagName.toLowerCase();
+
+  // Drop non-visible subtrees entirely. Their text content is real text as far as
+  // `textContent` is concerned, and on a job page it is usually a large blob of
+  // JSON state that would swamp the description.
+  if (tag === "script" || tag === "style" || tag === "noscript") return "";
+
+  const children = Array.from(el.childNodes).map(walkNode).join("");
+  const trimmed = children.trim();
+
+  switch (tag) {
+    case "h1":
+      return `\n\n# ${trimmed}\n\n`;
+    case "h2":
+      return `\n\n## ${trimmed}\n\n`;
+    case "h3":
+      return `\n\n### ${trimmed}\n\n`;
+    case "h4":
+      return `\n\n#### ${trimmed}\n\n`;
+    case "h5":
+      return `\n\n##### ${trimmed}\n\n`;
+    case "h6":
+      return `\n\n###### ${trimmed}\n\n`;
+
+    case "p":
+      return trimmed ? `\n\n${trimmed}\n\n` : "";
+
+    case "br":
+      return "\n";
+
+    // Emphasis wrappers collapse to nothing when empty, rather than emitting
+    // stray `****` that would render as literal asterisks.
+    case "strong":
+    case "b":
+      return trimmed ? `**${trimmed}**` : "";
+
+    case "em":
+    case "i":
+      return trimmed ? `*${trimmed}*` : "";
+
+    // Only element children contribute. The whitespace between `<li>` tags in
+    // pretty-printed HTML is formatting, not content — walked as text it injects a
+    // blank line and a leading space into every bullet, which turns a tight list
+    // into a loose, indented one. Server-rendered job pages are almost always
+    // pretty-printed, so this is the common case rather than an edge case.
+    case "ul":
+    case "ol":
+      return `\n\n${Array.from(el.children).map(walkNode).join("")}\n`;
+
+    case "li": {
+      const parent = el.parentElement;
+      if (parent?.tagName.toLowerCase() === "ol") {
+        // Index among element children, so interleaved text nodes don't shift
+        // the numbering.
+        const index = Array.from(parent.children).indexOf(el) + 1;
+        return `${index}. ${trimmed}\n`;
+      }
+      return `- ${trimmed}\n`;
+    }
+
+    case "a": {
+      const href = el.getAttribute("href");
+      // In-page anchors and `javascript:` hrefs carry no information for a reader
+      // of the extracted text, so they degrade to their label rather than
+      // becoming a link. Dropping `javascript:` also keeps executable strings out
+      // of text that gets persisted and re-rendered downstream.
+      if (
+        href &&
+        !href.startsWith("#") &&
+        !href.startsWith("javascript:") &&
+        trimmed
+      ) {
+        return `[${trimmed}](${href})`;
+      }
+      return children;
+    }
+
+    case "div":
+    case "section":
+    case "article":
+    case "main":
+    case "header":
+    case "footer":
+    case "blockquote":
+      return `\n${children}\n`;
+
+    // Unknown and inline tags (`span`, `code`, custom elements) pass their
+    // children through untouched — the default must be lossless, since job pages
+    // wrap description text in arbitrary framework-generated markup.
+    default:
+      return children;
+  }
+}

--- a/src/lib/jd-extract/index.test.ts
+++ b/src/lib/jd-extract/index.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * The barrel's public surface.
+ *
+ * This file is the entry point esbuild bundles for injection into a live page, so
+ * its exports are a contract with code that is *not* type-checked against it: the
+ * `job-hunt` skill calls `JD.extract(...)` from a string injected through a browser
+ * tool. Renaming or dropping an export here breaks that caller silently, and no
+ * compiler anywhere would notice — hence asserting the surface directly.
+ *
+ * It also pins the boundary that keeps the bundle injectable: nothing reachable
+ * from here may pull in `fetch()`. That is why `./ats-api.ts` is deliberately
+ * absent from the barrel.
+ */
+
+import * as JD from "./index";
+import { EXTRACTION_ALGORITHM_VERSION } from "./types";
+
+describe("the injected entry point", () => {
+  it("exposes extract() as the primary call", () => {
+    expect(typeof JD.extract).toBe("function");
+  });
+
+  it("extracts a posting through the barrel, the way the skill calls it", async () => {
+    const html =
+      `<html><head><script type="application/ld+json">${JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "JobPosting",
+        title: "Staff Engineer",
+        hiringOrganization: { "@type": "Organization", name: "Acme" },
+        description: "<p>Build things.</p><ul><li>5 years TypeScript</li></ul>",
+      })}</script></head><body></body></html>`;
+
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const result = await JD.extract(doc, new URL("https://careers.acme.com/jobs/1"));
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Staff Engineer");
+    expect(result!.body).toContain("- 5 years TypeScript");
+    expect(result!.algorithmVersion).toBe(EXTRACTION_ALGORITHM_VERSION);
+  });
+
+  // The result crosses a tool boundary as JSON, so it must survive a round trip —
+  // no functions, no cycles, no undefined-only payload.
+  it("returns a JSON-serializable result", async () => {
+    const doc = new DOMParser().parseFromString(
+      `<html><body><h1>Platform Engineer</h1><main><p>Job description. Responsibilities and requirements. Equal opportunity employer. Build reliable systems at scale.</p><ul><li>Kubernetes</li></ul></main></body></html>`,
+      "text/html",
+    );
+    const result = await JD.extract(doc, new URL("https://careers.acme.com/jobs/9"));
+
+    const roundTripped = JSON.parse(JSON.stringify(result));
+    expect(roundTripped.title).toBe("Platform Engineer");
+    expect(roundTripped.body).toContain("- Kubernetes");
+  });
+});
+
+describe("the barrel's export surface", () => {
+  it.each(["extract", "extractApplyLink", "extractApplyLinkAsync"])(
+    "exports %s as a function",
+    (name) => {
+      expect(typeof (JD as unknown as Record<string, unknown>)[name]).toBe("function");
+    },
+  );
+
+  it("exports the algorithm version", () => {
+    expect(JD.EXTRACTION_ALGORITHM_VERSION).toBe(EXTRACTION_ALGORITHM_VERSION);
+  });
+
+  // The surface is intentionally minimal — it is unchecked by any compiler for
+  // the injected caller, so every extra name is unverified surface for no gain.
+  it("keeps the runtime surface to the documented four names", () => {
+    expect(Object.keys(JD).sort()).toEqual([
+      "EXTRACTION_ALGORITHM_VERSION",
+      "extract",
+      "extractApplyLink",
+      "extractApplyLinkAsync",
+    ]);
+  });
+
+  // `ats-api.ts` imports `fetch-jd.ts`, which owns live fetch() calls. Re-exporting
+  // it here would pull a network primitive into the injected payload and break the
+  // boundary #704 established.
+  it("does not re-export the network-bound ats_api tier", () => {
+    const surface = JD as unknown as Record<string, unknown>;
+    expect(surface.extractPosting).toBeUndefined();
+    expect(surface.extractPostingFromAtsApi).toBeUndefined();
+    expect(surface.isAtsApiUrl).toBeUndefined();
+  });
+});

--- a/src/lib/jd-extract/index.ts
+++ b/src/lib/jd-extract/index.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The public surface of the JD-extraction lane, and the entry point that gets
+// bundled for injection into a live page.
+//
+// **This barrel is deliberately partial: it does not re-export `./ats-api.ts`.**
+// That module imports `src/lib/jd-match/fetch-jd.ts`, which owns live `fetch()`
+// calls — and this file is bundled and injected into whatever page the user is
+// looking at. Re-exporting it would pull a network primitive into the injected
+// payload, breaking the boundary #704 established and adding weight to a bundle
+// that crosses a tool boundary on every single posting. App code that wants the
+// full ladder imports `./ats-api` directly and gets a compile-time-obvious
+// dependency on the network for doing so.
+//
+// The skill and the extension inject this bundle and call `extract()`, so both run
+// the same code the app runs — one implementation, three consumers, which is the
+// whole reason this lane exists (`src/lib/storage/job-url.ts` makes the same
+// argument for id derivation).
+//
+// Build it with:
+//
+//   node_modules/.bin/esbuild src/lib/jd-extract/index.ts \
+//     --bundle --format=iife --global-name=JD --minify \
+//     --outfile="$SCRATCH/jd-extract.js" --log-level=error
+//
+// then, in the page:
+//
+//   <bundle>;
+//   JSON.stringify(await JD.extract(document, new URL(location.href)))
+//
+// Injecting rather than shipping the page's HTML back out is a deliberate cost
+// decision: a LinkedIn job page is 1–2 MB of HTML, and moving that across a tool
+// boundary per posting dwarfs the ~21 KB bundle. The injected form returns ~1 KB.
+
+// The surface below is kept deliberately small. It is a contract with a caller
+// that is NOT type-checked against it — the skill injects this bundle as a string
+// and calls `JD.extract(...)`, so every name here is one a compiler will never
+// verify for anyone. Re-exporting the lane's internals would multiply that
+// unchecked surface for no gain: app code in this repo imports lib modules by
+// path (`../jd-extract/html-to-markdown`), and only the injected caller needs a
+// barrel at all.
+
+/** The primary call: a document and its URL in, a posting or `null` out. */
+export { extractPostingFromDocument as extract } from "./detect";
+
+/**
+ * Canonical-URL discovery on its own, for a caller that wants to collapse an
+ * aggregator listing onto its ATS original without paying for a full extraction.
+ */
+export { extractApplyLink, extractApplyLinkAsync } from "./apply-link";
+export type { ApplyLinkResult } from "./apply-link";
+
+export { EXTRACTION_ALGORITHM_VERSION } from "./types";
+export type { ATSExtractor, ExtractedPosting, ExtractionTier } from "./types";

--- a/src/lib/jd-extract/linkedin-parse.test.ts
+++ b/src/lib/jd-extract/linkedin-parse.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * LinkedIn title/company parsing.
+ *
+ * LinkedIn is the highest-volume source in the `job-hunt` lane and the one host
+ * that ships neither JSON-LD nor `og:` tags on its logged-in job view, so these
+ * two strategies are the only thing standing between it and the weakest tier.
+ *
+ * The two-stage split order is the subtle part: pipes are LinkedIn's own branding
+ * separator, dashes appear inside company names, so splitting on dashes globally
+ * would shred a company like "Acme - EMEA".
+ */
+
+import {
+  extractLinkedInCompanyFromDOM,
+  isLinkedInJobUrl,
+  parseLinkedInTitle,
+} from "./linkedin-parse";
+
+function docWith(html: string): Document {
+  return new DOMParser().parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    "text/html",
+  );
+}
+
+describe("extractLinkedInCompanyFromDOM", () => {
+  // The accessibility layer is the stable surface — LinkedIn's class names are
+  // hashed and rotate between deploys.
+  it("reads the company from the aria-label", () => {
+    expect(
+      extractLinkedInCompanyFromDOM(docWith('<div aria-label="Company, Visa.">x</div>')),
+    ).toBe("Visa");
+  });
+
+  it("strips the trailing period and surrounding whitespace", () => {
+    expect(
+      extractLinkedInCompanyFromDOM(
+        docWith('<div aria-label="Company,   Acme Corp.  ">x</div>'),
+      ),
+    ).toBe("Acme Corp");
+  });
+
+  it("returns null when the element is absent", () => {
+    expect(extractLinkedInCompanyFromDOM(docWith("<div>nothing</div>"))).toBeNull();
+  });
+
+  it("returns null rather than an empty string when the label has no name", () => {
+    expect(
+      extractLinkedInCompanyFromDOM(docWith('<div aria-label="Company,">x</div>')),
+    ).toBeNull();
+  });
+});
+
+describe("parseLinkedInTitle", () => {
+  it("splits title, team and company", () => {
+    expect(
+      parseLinkedInTitle(
+        "Director, Engineering - Agentic Systems | Visa | LinkedIn",
+      ),
+    ).toEqual({ title: "Director, Engineering", company: "Visa" });
+  });
+
+  it("handles a title with no team segment", () => {
+    expect(parseLinkedInTitle("Software Engineer | Google | LinkedIn")).toEqual({
+      title: "Software Engineer",
+      company: "Google",
+    });
+  });
+
+  it("keeps a comma inside the job title", () => {
+    expect(parseLinkedInTitle("Director, Engineering | Acme | LinkedIn")).toEqual({
+      title: "Director, Engineering",
+      company: "Acme",
+    });
+  });
+
+  it("splits on an en dash as well as a hyphen", () => {
+    expect(parseLinkedInTitle("Engineer – Platform | Acme | LinkedIn")).toEqual({
+      title: "Engineer",
+      company: "Acme",
+    });
+  });
+
+  it("handles the fullwidth pipe some locales emit", () => {
+    expect(parseLinkedInTitle("Engineer ｜ Acme ｜ LinkedIn")).toEqual({
+      title: "Engineer",
+      company: "Acme",
+    });
+  });
+
+  it("returns an empty company for the two-part shape that carries none", () => {
+    expect(parseLinkedInTitle("Software Engineer | LinkedIn")).toEqual({
+      title: "Software Engineer",
+      company: "",
+    });
+  });
+
+  // Without the trailing "LinkedIn" this is some other page's title, and guessing
+  // would invent a company name.
+  it.each([
+    ["Some Blog Post | Medium", "a non-LinkedIn title"],
+    ["", "an empty string"],
+    ["No separators at all", "a title with no pipes"],
+  ])("returns null for %s (%s)", (input) => {
+    expect(parseLinkedInTitle(input)).toBeNull();
+  });
+});
+
+describe("isLinkedInJobUrl", () => {
+  it("accepts a job view page", () => {
+    expect(isLinkedInJobUrl("https://www.linkedin.com/jobs/view/4437835690/")).toBe(true);
+  });
+
+  it("accepts a URL object", () => {
+    expect(isLinkedInJobUrl(new URL("https://linkedin.com/jobs/view/123"))).toBe(true);
+  });
+
+  // Deliberately narrower than "is this LinkedIn" — these are not postings.
+  it.each([
+    "https://www.linkedin.com/jobs/search/?keywords=eng",
+    "https://www.linkedin.com/company/acme/",
+    "https://www.linkedin.com/feed/",
+    "https://example.com/jobs/view/123",
+  ])("rejects %s", (url) => {
+    expect(isLinkedInJobUrl(url)).toBe(false);
+  });
+
+  // A malformed href off a page must not throw inside a matches() call.
+  it("returns false for a malformed URL rather than throwing", () => {
+    expect(isLinkedInJobUrl("not a url at all")).toBe(false);
+  });
+});

--- a/src/lib/jd-extract/linkedin-parse.ts
+++ b/src/lib/jd-extract/linkedin-parse.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// LinkedIn job title / company parsing, kept separate from the LinkedIn adapter
+// because LinkedIn is the one host that forces two independent strategies.
+//
+// LinkedIn's logged-in job view ships no JSON-LD and no `og:` meta tags — it is
+// SPA-rendered, so the tiers that work everywhere else all miss it. That matters
+// more than it sounds: LinkedIn is the highest-volume source in the `job-hunt`
+// lane, and without host-specific parsing it falls through to the weakest tier.
+//
+// So there are two entry points, for two different contexts:
+//   - `extractLinkedInCompanyFromDOM` — a real `Document` is in hand.
+//   - `parseLinkedInTitle` — only the `<title>` string is available.
+// The title parser is pure, which is also why it can be unit-tested without jsdom.
+
+export interface LinkedInParseResult {
+  title: string;
+  company: string;
+}
+
+/**
+ * Read the company name from LinkedIn's `aria-label` on the company element.
+ *
+ * The accessibility layer is the most reliable surface here: LinkedIn's visible
+ * class names are hashed and rotate between deploys, while the `aria-label` text
+ * is user-facing and stable. Expected shape: `<div aria-label="Company, Visa.">`.
+ *
+ * Returns `null` rather than an empty string when the element is missing or the
+ * label is empty, so callers can use `||` to fall through to title parsing.
+ */
+export function extractLinkedInCompanyFromDOM(doc: Document): string | null {
+  const companyEl = doc.querySelector('[aria-label^="Company,"]');
+  if (!companyEl) return null;
+  const raw = companyEl.getAttribute("aria-label");
+  if (!raw) return null;
+  return (
+    raw
+      .replace(/^Company,\s*/, "")
+      .replace(/\.\s*$/, "")
+      .trim() || null
+  );
+}
+
+/**
+ * Parse a LinkedIn page title into job title and company.
+ *
+ * LinkedIn's format is `"Job Title - Team/Department | Company | LinkedIn"`, so
+ * the split is two-stage and the order matters. Pipes first, because they are
+ * LinkedIn's own branding structure and are not used inside job titles; dashes
+ * second and only within the first segment, because dashes appear inside company
+ * names ("Acme - EMEA") and splitting on them globally would shred those.
+ *
+ *   "Director, Engineering - Agentic Systems | Visa | LinkedIn"
+ *     → pipes → ["Director, Engineering - Agentic Systems", "Visa", "LinkedIn"]
+ *     → company = second-to-last = "Visa"
+ *     → dash-split segment 0 → title = "Director, Engineering"
+ *
+ * The trailing `"LinkedIn"` is required, not assumed: without it this is some
+ * other page's title and guessing at it would invent a company name. Returns
+ * `null` in that case, and returns an empty `company` for the two-part shape
+ * where the title genuinely carries none.
+ */
+export function parseLinkedInTitle(
+  rawTitle: string,
+): LinkedInParseResult | null {
+  if (!rawTitle) return null;
+
+  // Includes the fullwidth pipe (U+FF5C) — LinkedIn emits it on some locales.
+  const pipeParts = rawTitle.split(/\s*[|｜]\s*/);
+
+  // Need at least 3 parts: [title-segment, company, "LinkedIn"]
+  if (pipeParts.length >= 3 && pipeParts[pipeParts.length - 1] === "LinkedIn") {
+    const company = pipeParts[pipeParts.length - 2]?.trim();
+    const dashParts = pipeParts[0].split(/\s*[-–]\s*/);
+    const title = dashParts[0]?.trim();
+
+    if (title && company) {
+      return { title, company };
+    }
+  }
+
+  // Two-part shape — "Job Title | LinkedIn" — carries no company at all.
+  if (pipeParts.length === 2 && pipeParts[pipeParts.length - 1] === "LinkedIn") {
+    const title = pipeParts[0]?.trim();
+    if (title) {
+      return { title, company: "" };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Is this a LinkedIn job *view* page?
+ *
+ * Deliberately narrower than "is this LinkedIn": a search results page, a company
+ * page, and a feed post all live on the same host, and the adapter must decline
+ * them. Accepts a string or a `URL` and swallows parse failures, so a malformed
+ * href from the page cannot throw inside a `matches()` call.
+ */
+export function isLinkedInJobUrl(url: string | URL): boolean {
+  try {
+    const u = typeof url === "string" ? new URL(url) : url;
+    return (
+      u.hostname.endsWith("linkedin.com") && u.pathname.includes("/jobs/view/")
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/jd-extract/schema-org-core.test.ts
+++ b/src/lib/jd-extract/schema-org-core.test.ts
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The pure core's tests run in the default node environment — no jsdom pragma,
+// no fixture HTML, no document. That is the point of the core/shell split: these
+// functions take plain objects, so the cases below are the actual malformed
+// JSON-LD shapes publishers emit rather than pages that happen to contain them.
+
+import {
+  ATS_DOMAIN_MAP,
+  computeStructuredDataHash,
+  extractJobId,
+  extractLocation,
+  extractSalary,
+  extractWorkModel,
+  findJobPosting,
+  hasSchemaOrgContext,
+  matchAtsDomain,
+  parseHtmlSections,
+  stripHtml,
+} from "./schema-org-core";
+
+describe("findJobPosting", () => {
+  it("finds a JobPosting at the root", () => {
+    const posting = { "@type": "JobPosting", title: "Engineer" };
+    expect(findJobPosting(posting)).toBe(posting);
+  });
+
+  it("finds a JobPosting inside @graph", () => {
+    const job = { "@type": "JobPosting", title: "PM" };
+    expect(findJobPosting({ "@graph": [{ "@type": "WebPage" }, job] })).toBe(job);
+  });
+
+  it("finds a JobPosting inside a bare top-level array", () => {
+    const job = { "@type": "JobPosting", title: "Designer" };
+    expect(findJobPosting([{ "@type": "Organization" }, job])).toBe(job);
+  });
+
+  it("returns null when no JobPosting is present", () => {
+    expect(findJobPosting({ "@type": "WebPage" })).toBeNull();
+  });
+
+  it.each([[null], [undefined], ["a string"], [42]])(
+    "returns null for non-object input %p",
+    (input) => {
+      expect(findJobPosting(input)).toBeNull();
+    },
+  );
+});
+
+describe("hasSchemaOrgContext", () => {
+  it("accepts a string context", () => {
+    expect(hasSchemaOrgContext({ "@context": "https://schema.org" })).toBe(true);
+  });
+
+  it("accepts an array context containing schema.org", () => {
+    expect(
+      hasSchemaOrgContext({ "@context": ["https://example.com", "https://schema.org"] }),
+    ).toBe(true);
+  });
+
+  it("rejects a non-schema.org context", () => {
+    expect(hasSchemaOrgContext({ "@context": "https://example.com" })).toBe(false);
+  });
+
+  it("rejects a missing context", () => {
+    expect(hasSchemaOrgContext({})).toBe(false);
+  });
+});
+
+describe("extractLocation", () => {
+  it("composes city, region and country from a nested address", () => {
+    expect(
+      extractLocation({
+        jobLocation: {
+          address: {
+            addressLocality: "Hyderabad",
+            addressRegion: "Telangana",
+            addressCountry: "India",
+          },
+        },
+      }),
+    ).toBe("Hyderabad, Telangana, India");
+  });
+
+  // A posting open in three cities is materially different from one open in one,
+  // so multiple locations are preserved rather than collapsed to the first.
+  it("joins multiple locations with a pipe", () => {
+    expect(
+      extractLocation({
+        jobLocation: [
+          { address: { addressLocality: "Austin", addressRegion: "TX" } },
+          { address: { addressLocality: "Denver", addressRegion: "CO" } },
+        ],
+      }),
+    ).toBe("Austin, TX | Denver, CO");
+  });
+
+  it("falls back to Place.name when there is no address object", () => {
+    expect(extractLocation({ jobLocation: { name: "Remote - US" } })).toBe(
+      "Remote - US",
+    );
+  });
+
+  it("omits absent address components rather than emitting empty segments", () => {
+    expect(
+      extractLocation({ jobLocation: { address: { addressCountry: "India" } } }),
+    ).toBe("India");
+  });
+
+  it("returns undefined when jobLocation is missing", () => {
+    expect(extractLocation({})).toBeUndefined();
+  });
+
+  it("returns undefined when no location entry yields anything usable", () => {
+    expect(extractLocation({ jobLocation: [{ address: {} }] })).toBeUndefined();
+  });
+});
+
+describe("extractWorkModel", () => {
+  it("reads TELECOMMUTE as remote", () => {
+    expect(extractWorkModel({ jobLocationType: "TELECOMMUTE" })).toBe("remote");
+  });
+
+  it("reads TELECOMMUTE inside an array", () => {
+    expect(extractWorkModel({ jobLocationType: ["TELECOMMUTE"] })).toBe("remote");
+  });
+
+  it("treats applicant location requirements with no job location as remote", () => {
+    expect(
+      extractWorkModel({ applicantLocationRequirements: { name: "USA" } }),
+    ).toBe("remote");
+  });
+
+  it("does not infer remote when a physical job location is also present", () => {
+    expect(
+      extractWorkModel({
+        applicantLocationRequirements: { name: "USA" },
+        jobLocation: { name: "Austin" },
+      }),
+    ).toBeUndefined();
+  });
+
+  // schema.org has exactly one machine-readable signal here, so "hybrid" and
+  // "onsite" are left absent rather than guessed at from prose.
+  it("returns undefined rather than guessing a non-remote model", () => {
+    expect(extractWorkModel({ jobLocation: { name: "Austin" } })).toBeUndefined();
+  });
+});
+
+describe("extractSalary", () => {
+  it("formats a min/max range with its period", () => {
+    expect(
+      extractSalary({
+        baseSalary: {
+          currency: "USD",
+          value: { minValue: 150000, maxValue: 200000, unitText: "YEAR" },
+        },
+      }),
+    ).toBe("USD 150,000 - 200,000 per year");
+  });
+
+  it("formats an open-ended minimum", () => {
+    expect(
+      extractSalary({ baseSalary: { currency: "USD", value: { minValue: 150000 } } }),
+    ).toBe("USD 150,000+");
+  });
+
+  it("formats a maximum-only range", () => {
+    expect(
+      extractSalary({ baseSalary: { currency: "USD", value: { maxValue: 200000 } } }),
+    ).toBe("Up to USD 200,000");
+  });
+
+  it("formats a scalar value", () => {
+    expect(extractSalary({ baseSalary: { currency: "EUR", value: 90000 } })).toBe(
+      "EUR 90,000",
+    );
+  });
+
+  it("omits a missing currency without leaving stray whitespace", () => {
+    expect(extractSalary({ baseSalary: { value: { minValue: 100 } } })).toBe("100+");
+  });
+
+  it("returns undefined when baseSalary is absent or unusable", () => {
+    expect(extractSalary({})).toBeUndefined();
+    expect(extractSalary({ baseSalary: { currency: "USD", value: {} } })).toBeUndefined();
+  });
+});
+
+describe("extractJobId", () => {
+  it("reads a string identifier", () => {
+    expect(extractJobId({ identifier: "JR333705" })).toBe("JR333705");
+  });
+
+  it("reads identifier.value", () => {
+    expect(extractJobId({ identifier: { value: "R-123" } })).toBe("R-123");
+  });
+
+  it("falls back to identifier.name", () => {
+    expect(extractJobId({ identifier: { name: "REQ-9" } })).toBe("REQ-9");
+  });
+
+  it("returns undefined when there is no identifier", () => {
+    expect(extractJobId({})).toBeUndefined();
+  });
+});
+
+describe("computeStructuredDataHash", () => {
+  it("is stable for identical content", async () => {
+    const posting = { title: "Engineer", description: "Build things" };
+    expect(await computeStructuredDataHash(posting)).toBe(
+      await computeStructuredDataHash({ ...posting }),
+    );
+  });
+
+  it("differs when a hashed field changes", async () => {
+    expect(await computeStructuredDataHash({ title: "A" })).not.toBe(
+      await computeStructuredDataHash({ title: "B" }),
+    );
+  });
+
+  // Publishers mutate unrelated keys (view counts, tracking ids) on every render.
+  // Hashing those would report a change on every visit, which is the whole thing
+  // this hash exists to avoid.
+  it("ignores fields outside the hashed subset", async () => {
+    expect(await computeStructuredDataHash({ title: "A", viewCount: 1 })).toBe(
+      await computeStructuredDataHash({ title: "A", viewCount: 9999 }),
+    );
+  });
+});
+
+describe("parseHtmlSections", () => {
+  const html =
+    "<p><strong>Requirements</strong></p><ul><li>Strong CS background</li><li>Proficiency in Java</li></ul>" +
+    "<p><strong>Preferred</strong></p><ul><li>Experience with Data Cloud</li></ul>";
+
+  it("splits requirements from qualifications", () => {
+    const sections = parseHtmlSections(html);
+    expect(sections.requirements).toEqual([
+      "Strong CS background",
+      "Proficiency in Java",
+    ]);
+    expect(sections.qualifications).toEqual(["Experience with Data Cloud"]);
+  });
+
+  it("returns empty arrays when the posting writes its requirements as prose", () => {
+    const sections = parseHtmlSections("<p>We want someone great.</p>");
+    expect(sections.requirements).toEqual([]);
+    expect(sections.qualifications).toEqual([]);
+    expect(sections.description).toBe("We want someone great.");
+  });
+
+  it("recognises heading synonyms", () => {
+    expect(
+      parseHtmlSections("<h3>Responsibilities</h3><ul><li>Ship code</li></ul>")
+        .requirements,
+    ).toEqual(["Ship code"]);
+    expect(
+      parseHtmlSections("<h3>Nice to have</h3><ul><li>Go</li></ul>").qualifications,
+    ).toEqual(["Go"]);
+  });
+});
+
+describe("stripHtml", () => {
+  // Markdown rather than plaintext because list structure carries the
+  // requirements — flattening it measurably costs extracted terms downstream.
+  it("preserves list structure as Markdown bullets", () => {
+    expect(stripHtml("<ul><li>One</li><li>Two</li></ul>")).toBe("- One\n- Two");
+  });
+
+  it("converts headings to Markdown", () => {
+    expect(stripHtml("<h2>About</h2>")).toBe("## About");
+    expect(stripHtml("<h4>Team</h4>")).toBe("#### Team");
+  });
+
+  it("converts emphasis", () => {
+    expect(stripHtml("<strong>bold</strong> and <em>italic</em>")).toBe(
+      "**bold** and *italic*",
+    );
+  });
+
+  it("decodes the common named entities", () => {
+    expect(stripHtml("<p>R&amp;D &lt;team&gt; &quot;x&quot; &#39;y&#39;&nbsp;z</p>")).toBe(
+      "R&D <team> \"x\" 'y' z",
+    );
+  });
+
+  it("compresses runs of blank lines", () => {
+    expect(stripHtml("<p>A</p><p></p><p></p><p>B</p>")).toBe("A\n\nB");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(stripHtml("")).toBe("");
+  });
+});
+
+describe("matchAtsDomain", () => {
+  it.each([
+    ["https://boards.greenhouse.io/acme/jobs/1", "Greenhouse"],
+    ["jobs.lever.co", "Lever"],
+    ["https://acme.wd5.myworkdayjobs.com/job/1", "Workday"],
+    ["https://acme.fa.us2.oraclecloud.com/hcmUI/x", "Oracle HCM"],
+    ["https://jobs.ashbyhq.com/acme/uuid", "Ashby"],
+  ])("names the platform behind %s", (href, platform) => {
+    expect(matchAtsDomain(href)).toBe(platform);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchAtsDomain("HTTPS://BOARDS.GREENHOUSE.IO/x")).toBe("Greenhouse");
+  });
+
+  it("returns undefined for an unknown host", () => {
+    expect(matchAtsDomain("https://careers.example.com/jobs/1")).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(matchAtsDomain("")).toBeUndefined();
+  });
+
+  // This table names platforms; it must not become a second answer to "can I
+  // fetch this", which `parseAtsUrl` in src/lib/jd-match/fetch-jd.ts owns.
+  it("covers more platforms than the fetchable set, by design", () => {
+    expect(Object.keys(ATS_DOMAIN_MAP).length).toBeGreaterThan(5);
+  });
+});

--- a/src/lib/jd-extract/schema-org-core.ts
+++ b/src/lib/jd-extract/schema-org-core.ts
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The DOM-free half of schema.org `JobPosting` extraction: given already-parsed
+// JSON-LD, pull out the fields a posting declares about itself.
+//
+// Split from the DOM shell (`schema-org.ts`) on purpose, and the split is load-
+// bearing rather than tidy-minded. Nothing here touches `Document`, so it is
+// unit-testable in the default `environment: "node"` (`vite.config.ts`) with no
+// jsdom pragma and no fixture HTML — the tests can hand these functions plain
+// objects. It also means this half runs anywhere JSON-LD can be obtained,
+// including contexts that have no DOM at all.
+//
+// Every extractor here is defensive to the point of paranoia about types. JSON-LD
+// is publisher-authored and routinely violates its own schema: `jobLocation` is a
+// single object on one board and an array on the next, `identifier` is a bare
+// string here and a `{ value }` object there, `employmentType` is sometimes an
+// array. So each helper narrows from `unknown` and returns `undefined` rather
+// than throwing — one malformed field must never cost the whole extraction.
+
+/**
+ * Domain fragment → human-readable ATS platform name.
+ *
+ * This table only *names* the platform behind a page. It deliberately does not
+ * decide whether that platform can be fetched: `parseAtsUrl` in
+ * `src/lib/jd-match/fetch-jd.ts` remains the single owner of "does this URL
+ * resolve to a public JSON API I can call", and this map must not grow into a
+ * second one. The two answer different questions — most domains below have no
+ * fetchable API at all, and putting them in the fetch parser would produce a
+ * platform id with no client behind it.
+ *
+ * Matched by substring against a hostname or href, so `boards.greenhouse.io`
+ * and a bare `greenhouse.io` both resolve; the longer keys exist to document the
+ * shapes seen in the wild, not because matching requires them.
+ */
+export const ATS_DOMAIN_MAP: Record<string, string> = {
+  "greenhouse.io": "Greenhouse",
+  "boards.greenhouse.io": "Greenhouse",
+  "lever.co": "Lever",
+  "jobs.lever.co": "Lever",
+  "taleo.net": "Taleo",
+  "myworkdayjobs.com": "Workday",
+  "wd5.myworkdayjobs.com": "Workday",
+  "icims.com": "iCIMS",
+  "smartrecruiters.com": "SmartRecruiters",
+  "jobvite.com": "Jobvite",
+  "applytojob.com": "JazzHR",
+  "breezy.hr": "Breezy HR",
+  "ashbyhq.com": "Ashby",
+  "bamboohr.com": "BambooHR",
+  "recruitee.com": "Recruitee",
+  "successfactors.com": "SAP SuccessFactors",
+  "phenom.com": "Phenom",
+  "oraclecloud.com": "Oracle HCM",
+  "workable.com": "Workable",
+};
+
+/**
+ * Name the ATS platform behind a hostname or href, or `undefined` if none match.
+ *
+ * The sole reader of `ATS_DOMAIN_MAP`, so the substring-matching rule lives in
+ * one place rather than being re-implemented by each caller.
+ */
+export function matchAtsDomain(hrefOrHost: string): string | undefined {
+  if (!hrefOrHost) return undefined;
+  const haystack = hrefOrHost.toLowerCase();
+  for (const [domain, platform] of Object.entries(ATS_DOMAIN_MAP)) {
+    if (haystack.includes(domain)) return platform;
+  }
+  return undefined;
+}
+
+// ─── JSON-LD helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Find a `JobPosting` node in parsed JSON-LD.
+ *
+ * Recursive because publishers nest it three different ways: as the root object,
+ * inside a `@graph` array alongside `Organization` / `BreadcrumbList` nodes, or
+ * inside a bare top-level array of unrelated blocks. Returns the first match —
+ * a page advertising two distinct postings in one block is not a shape worth
+ * guessing about, and taking the first is at least deterministic.
+ */
+export function findJobPosting(data: unknown): Record<string, unknown> | null {
+  if (!data || typeof data !== "object") return null;
+  const obj = data as Record<string, unknown>;
+
+  if (obj["@type"] === "JobPosting") return obj;
+
+  if (Array.isArray(obj["@graph"])) {
+    for (const item of obj["@graph"]) {
+      if (
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>)["@type"] === "JobPosting"
+      ) {
+        return item as Record<string, unknown>;
+      }
+    }
+  }
+
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      const found = findJobPosting(item);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check that a JSON-LD block declares a schema.org context.
+ *
+ * Guards against reading a `@type: "JobPosting"` that belongs to some other
+ * vocabulary entirely. `@context` is a string on most pages and an array on
+ * pages that mix vocabularies, so both are accepted.
+ */
+export function hasSchemaOrgContext(data: Record<string, unknown>): boolean {
+  const context = data["@context"];
+  if (typeof context === "string") return context.includes("schema.org");
+  if (Array.isArray(context)) {
+    return context.some((c) => typeof c === "string" && c.includes("schema.org"));
+  }
+  return false;
+}
+
+// ─── Field extraction ────────────────────────────────────────────────────────
+
+/**
+ * Compose a location string from `jobLocation`.
+ *
+ * Multiple locations are joined with `" | "` rather than collapsed to the first:
+ * a posting open in three cities is materially different from one open in one,
+ * and the consumer displays this verbatim. Falls back to a `Place.name` when a
+ * publisher skips the nested `address` object.
+ */
+export function extractLocation(
+  posting: Record<string, unknown>,
+): string | undefined {
+  const jobLocation = posting.jobLocation;
+  if (!jobLocation) return undefined;
+
+  const locations = Array.isArray(jobLocation) ? jobLocation : [jobLocation];
+  const parts: string[] = [];
+
+  for (const loc of locations) {
+    if (!loc || typeof loc !== "object") continue;
+    const place = loc as Record<string, unknown>;
+    const address = place.address as Record<string, unknown> | undefined;
+
+    if (address && typeof address === "object") {
+      const city = address.addressLocality as string | undefined;
+      const region = address.addressRegion as string | undefined;
+      const country = address.addressCountry as string | undefined;
+      const components = [city, region, country].filter(Boolean);
+      if (components.length > 0) parts.push(components.join(", "));
+    } else if (typeof place.name === "string") {
+      parts.push(place.name);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(" | ") : undefined;
+}
+
+/**
+ * Read the posting's own declared work model.
+ *
+ * Returns only `"remote"` or `undefined` — never a guess. schema.org has exactly
+ * one machine-readable signal here (`TELECOMMUTE`), so "hybrid" and "onsite" are
+ * not derivable and are left absent rather than inferred from prose. A regex over
+ * the description would be a guess wearing a declared field's clothes.
+ *
+ * The third branch is the shape where a publisher states *who may apply from
+ * where* (`applicantLocationRequirements`) but names no physical `jobLocation` —
+ * in practice that is a remote role.
+ */
+export function extractWorkModel(
+  posting: Record<string, unknown>,
+): string | undefined {
+  if (posting.jobLocationType === "TELECOMMUTE") return "remote";
+  if (
+    Array.isArray(posting.jobLocationType) &&
+    posting.jobLocationType.includes("TELECOMMUTE")
+  ) {
+    return "remote";
+  }
+  if (posting.applicantLocationRequirements && !posting.jobLocation) {
+    return "remote";
+  }
+  return undefined;
+}
+
+/**
+ * Format `baseSalary` into display text.
+ *
+ * Deliberately produces a string, not numbers. Currency, period, and open-ended
+ * ranges ("$180k+", "up to $220k") all carry meaning that a `{min, max}` pair
+ * loses, and no consumer in this repo does arithmetic on pay.
+ */
+export function extractSalary(
+  posting: Record<string, unknown>,
+): string | undefined {
+  const salary = posting.baseSalary;
+  if (!salary || typeof salary !== "object") return undefined;
+
+  const salaryObj = salary as Record<string, unknown>;
+  const currency = (salaryObj.currency as string) || "";
+  const value = salaryObj.value;
+
+  if (!value || typeof value !== "object") {
+    if (typeof value === "number") {
+      return `${currency} ${value.toLocaleString()}`.trim();
+    }
+    return undefined;
+  }
+
+  const valueObj = value as Record<string, unknown>;
+  const min = valueObj.minValue as number | undefined;
+  const max = valueObj.maxValue as number | undefined;
+  const unitText = (valueObj.unitText as string) || "";
+
+  if (min && max) {
+    const suffix = unitText ? ` per ${unitText.toLowerCase()}` : "";
+    return `${currency} ${min.toLocaleString()} - ${max.toLocaleString()}${suffix}`.trim();
+  }
+  if (min) return `${currency} ${min.toLocaleString()}+`.trim();
+  if (max) return `Up to ${currency} ${max.toLocaleString()}`.trim();
+
+  return undefined;
+}
+
+/**
+ * Read the publisher's own job identifier.
+ *
+ * Note this is the *publisher's* id, not this repo's. `deriveJobId` in
+ * `src/lib/storage/job-url.ts` remains the only thing that decides whether two
+ * captures are the same posting; this value is a hint carried alongside, never a
+ * substitute for that rule.
+ */
+export function extractJobId(
+  posting: Record<string, unknown>,
+): string | undefined {
+  if (typeof posting.identifier === "string") return posting.identifier;
+  if (posting.identifier && typeof posting.identifier === "object") {
+    const idObj = posting.identifier as Record<string, unknown>;
+    if (typeof idObj.value === "string") return idObj.value;
+    if (typeof idObj.name === "string") return idObj.name;
+  }
+  return undefined;
+}
+
+/**
+ * Hash the JSON-LD fields that decide whether a posting has materially changed,
+ * so a re-capture can tell "the publisher edited this" from "the page re-rendered".
+ *
+ * Hashes a fixed field subset rather than the whole node, because publishers mutate
+ * unrelated keys (view counts, tracking ids) on every render and hashing those
+ * would report a change on every visit.
+ *
+ * Returns `undefined` rather than throwing when Web Crypto is unavailable — the
+ * hash is an optimisation for change detection, and losing it must never cost the
+ * extraction itself.
+ */
+export async function computeStructuredDataHash(
+  posting: Record<string, unknown>,
+): Promise<string | undefined> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) return undefined;
+
+  const hashContent = JSON.stringify({
+    title: posting.title,
+    description: posting.description,
+    identifier: posting.identifier,
+    jobLocation: posting.jobLocation,
+    baseSalary: posting.baseSalary,
+    datePosted: posting.datePosted,
+    validThrough: posting.validThrough,
+  });
+
+  try {
+    const encoder = new TextEncoder();
+    const hashBuffer = await subtle.digest("SHA-256", encoder.encode(hashContent));
+    return Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── HTML section parser ─────────────────────────────────────────────────────
+
+export interface ParsedSections {
+  requirements: string[];
+  qualifications: string[];
+  description: string;
+}
+
+/**
+ * Split a posting's HTML description into requirements, qualifications, and the
+ * full body.
+ *
+ * Regex over an HTML *string* rather than a DOM walk, because this runs on the
+ * `description` field of a JSON-LD node — HTML embedded inside a JSON string,
+ * with no `Document` in sight. That is also why this file stays DOM-free.
+ *
+ * The two heading patterns encode the vocabulary boards actually use for the
+ * must-have / nice-to-have split. Matching only a heading immediately followed by
+ * a list keeps prose paragraphs out of the bullet arrays; a posting that writes
+ * its requirements as prose yields empty arrays and a full `description`, which
+ * is the honest answer rather than a mangled one.
+ */
+export function parseHtmlSections(html: string): ParsedSections {
+  const requirements: string[] = [];
+  const qualifications: string[] = [];
+
+  const reqPatterns =
+    /(?:<(?:strong|b|h[1-6])[^>]*>)\s*(?:requirements?|responsibilities|key\s+skills?|must[\s-]+have|what\s+you(?:'ll|\s+will)\s+(?:do|bring|need)|certifications?\s+required|essential\s+(?:skills|qualifications))\s*(?:<\/(?:strong|b|h[1-6])>)/gi;
+
+  const qualPatterns =
+    /(?:<(?:strong|b|h[1-6])[^>]*>)\s*(?:qualifications?|preferred|nice[\s-]+to[\s-]+have|desired|bonus|additional\s+(?:skills|qualifications)|who\s+you\s+are)\s*(?:<\/(?:strong|b|h[1-6])>)/gi;
+
+  extractListItems(html, reqPatterns, requirements);
+  extractListItems(html, qualPatterns, qualifications);
+
+  const description = stripHtml(html);
+
+  return { requirements, qualifications, description };
+}
+
+/**
+ * Collect `<li>` text from the first list following each match of
+ * `headingPattern`, appending into `target`.
+ *
+ * `headingPattern` must carry the `g` flag — the loop relies on `lastIndex`
+ * advancing, and a non-global regex would spin forever on the first match.
+ *
+ * Module-private: `parseHtmlSections` is the only caller, and the heading
+ * vocabulary it pairs this with is what makes the output meaningful.
+ */
+function extractListItems(
+  html: string,
+  headingPattern: RegExp,
+  target: string[],
+): void {
+  let match: RegExpExecArray | null;
+  while ((match = headingPattern.exec(html)) !== null) {
+    const afterHeading = html.slice(match.index + match[0].length);
+    const listMatch = afterHeading.match(/^[\s\S]*?<[uo]l[^>]*>([\s\S]*?)<\/[uo]l>/i);
+    if (listMatch) {
+      const itemPattern = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+      let itemMatch: RegExpExecArray | null;
+      while ((itemMatch = itemPattern.exec(listMatch[1])) !== null) {
+        const text = stripHtml(itemMatch[1]).trim();
+        if (text.length > 0) target.push(text);
+      }
+    }
+  }
+}
+
+/**
+ * Convert an HTML string to Markdown.
+ *
+ * The string-level counterpart to `htmlToMarkdown` in `./html-to-markdown.ts`,
+ * which walks a real DOM. Both exist because the two inputs genuinely differ:
+ * the DOM walker is more accurate and is used wherever an element is in hand,
+ * while this one handles HTML that arrives as a JSON string value with no
+ * `Document` available to parse it into.
+ *
+ * Markdown rather than plaintext for the reason given on `ExtractedPosting.body`:
+ * list structure carries the requirements, and flattening it costs extracted terms.
+ */
+export function stripHtml(html: string): string {
+  return (
+    html
+      // Headers → Markdown
+      .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, (_, c) => `\n\n# ${stripTags(c).trim()}\n\n`)
+      .replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, (_, c) => `\n\n## ${stripTags(c).trim()}\n\n`)
+      .replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, (_, c) => `\n\n### ${stripTags(c).trim()}\n\n`)
+      .replace(/<h4[^>]*>([\s\S]*?)<\/h4>/gi, (_, c) => `\n\n#### ${stripTags(c).trim()}\n\n`)
+      .replace(/<h5[^>]*>([\s\S]*?)<\/h5>/gi, (_, c) => `\n\n##### ${stripTags(c).trim()}\n\n`)
+      .replace(/<h6[^>]*>([\s\S]*?)<\/h6>/gi, (_, c) => `\n\n###### ${stripTags(c).trim()}\n\n`)
+      // Bold / italic
+      .replace(/<(?:strong|b)[^>]*>([\s\S]*?)<\/(?:strong|b)>/gi, "**$1**")
+      .replace(/<(?:em|i)[^>]*>([\s\S]*?)<\/(?:em|i)>/gi, "*$1*")
+      // List items → Markdown bullets
+      .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_, c) => `- ${stripTags(c).trim()}\n`)
+      // Strip list wrapper tags
+      .replace(/<\/?(ul|ol)[^>]*>/gi, "\n")
+      // Block elements → line breaks
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>/gi, "\n\n")
+      .replace(/<\/div>/gi, "\n")
+      // Strip remaining tags
+      .replace(/<[^>]+>/g, "")
+      // Decode entities
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&nbsp;/g, " ")
+      // Compress blank lines
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]+>/g, "");
+}

--- a/src/lib/jd-extract/schema-org.test.ts
+++ b/src/lib/jd-extract/schema-org.test.ts
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Tier 1 — the schema.org JSON-LD extractor.
+ *
+ * Real jsdom rather than a `querySelector` stub: this tier's job is finding and
+ * reading `<script type="application/ld+json">` blocks among whatever else a page
+ * ships, and a stub that returns a canned list of scripts would assert nothing
+ * about the selector actually being right.
+ *
+ * The negative cases carry most of the weight. A page ships several JSON-LD blocks
+ * in arbitrary order, one of them routinely malformed by some vendor widget, and
+ * this tier has to skip past all of that to the posting — so "skips a broken block
+ * and finds the next" matters more than any single happy path.
+ */
+
+import { extractSchemaOrgJobPosting } from "./schema-org";
+
+interface PageOptions {
+  jsonLd?: string[];
+  bodyHtml?: string;
+  url?: string;
+}
+
+const DEFAULT_URL = "https://careers.example.com/jobs/1";
+
+/**
+ * Build a page and run tier 1 against it.
+ *
+ * The URL is passed to the extractor rather than stamped onto `doc.location`,
+ * because a `DOMParser` document's location is `about:blank` and non-configurable
+ * — which is exactly why the extractor takes the URL as a parameter instead of
+ * reading it off the document.
+ */
+function extract(opts: PageOptions = {}) {
+  const { jsonLd = [], bodyHtml = "", url = DEFAULT_URL } = opts;
+  const scripts = jsonLd
+    .map((raw) => `<script type="application/ld+json">${raw}</script>`)
+    .join("");
+  const doc = new DOMParser().parseFromString(
+    `<!doctype html><html><head>${scripts}</head><body>${bodyHtml}</body></html>`,
+    "text/html",
+  );
+  return extractSchemaOrgJobPosting(doc, new URL(url));
+}
+
+/** A JSON-LD block wrapping `posting` in a valid schema.org envelope. */
+function jobPosting(posting: Record<string, unknown>): string {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "JobPosting",
+    ...posting,
+  });
+}
+
+const FULL_POSTING = jobPosting({
+  title: "Success Engineer",
+  description:
+    "<p><strong>Requirements</strong></p><ul><li>Strong CS background</li><li>Proficiency in Java</li></ul>" +
+    "<p><strong>Preferred</strong></p><ul><li>Experience with Data Cloud</li></ul>",
+  identifier: "JR333705",
+  datePosted: "2026-03-13",
+  validThrough: "2026-06-13",
+  employmentType: "FULL_TIME",
+  hiringOrganization: { "@type": "Organization", name: "Salesforce, Inc." },
+  jobLocation: [
+    {
+      "@type": "Place",
+      address: {
+        addressLocality: "Hyderabad",
+        addressRegion: "Telangana",
+        addressCountry: "India",
+      },
+    },
+    {
+      "@type": "Place",
+      address: {
+        addressLocality: "Bangalore",
+        addressRegion: "Karnataka",
+        addressCountry: "India",
+      },
+    },
+  ],
+});
+
+const MINIMAL = jobPosting({
+  title: "Software Engineer",
+  hiringOrganization: { "@type": "Organization", name: "Acme Corp" },
+});
+
+describe("extractSchemaOrgJobPosting — happy paths", () => {
+  it("extracts a complete posting", async () => {
+    const result = await extract({ jsonLd: [FULL_POSTING] });
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Success Engineer");
+    expect(result!.company).toBe("Salesforce, Inc.");
+    expect(result!.extractionTier).toBe("schema_org");
+    expect(result!.jobId).toBe("JR333705");
+    expect(result!.datePosted).toBe("2026-03-13");
+    expect(result!.validThrough).toBe("2026-06-13");
+    expect(result!.employmentType).toBe("FULL_TIME");
+    expect(result!.location).toBe(
+      "Hyderabad, Telangana, India | Bangalore, Karnataka, India",
+    );
+  });
+
+  it("splits the description into requirements and qualifications", async () => {
+    const result = await extract({ jsonLd: [FULL_POSTING] });
+    expect(result!.requirements).toEqual([
+      "Strong CS background",
+      "Proficiency in Java",
+    ]);
+    expect(result!.qualifications).toEqual(["Experience with Data Cloud"]);
+  });
+
+  // The body is what the fit rating consumes, and its list structure is what
+  // yields extractable skill terms — see the note on ExtractedPosting.body.
+  it("produces a Markdown body that keeps list structure", async () => {
+    const result = await extract({ jsonLd: [FULL_POSTING] });
+    expect(result!.body).toContain("- Strong CS background");
+    expect(result!.body).toContain("**Requirements**");
+    expect(result!.descriptionPreview).toBe(result!.body.slice(0, 200));
+  });
+
+  it("extracts a minimal posting carrying only a title and company", async () => {
+    const result = await extract({ jsonLd: [MINIMAL] });
+    expect(result!.title).toBe("Software Engineer");
+    expect(result!.company).toBe("Acme Corp");
+    expect(result!.body).toBe("");
+  });
+
+  it("finds a posting nested in a @graph array", async () => {
+    const result = await extract({
+      jsonLd: [
+        JSON.stringify({
+          "@context": "https://schema.org",
+          "@graph": [
+            { "@type": "WebPage", name: "Careers" },
+            {
+              "@type": "JobPosting",
+              title: "Product Manager",
+              hiringOrganization: { "@type": "Organization", name: "GraphCo" },
+            },
+          ],
+        }),
+      ],
+    });
+    expect(result!.title).toBe("Product Manager");
+    expect(result!.company).toBe("GraphCo");
+  });
+
+  it("extracts salary and remote work model", async () => {
+    const result = await extract({
+      jsonLd: [
+        jobPosting({
+          title: "Senior Engineer",
+          hiringOrganization: { "@type": "Organization", name: "PayCo" },
+          baseSalary: {
+            currency: "USD",
+            value: { minValue: 150000, maxValue: 200000, unitText: "YEAR" },
+          },
+          jobLocationType: "TELECOMMUTE",
+        }),
+      ],
+    });
+    expect(result!.salaryRange).toBe("USD 150,000 - 200,000 per year");
+    expect(result!.workModel).toBe("remote");
+  });
+
+  it("joins an array employmentType", async () => {
+    const result = await extract({
+      jsonLd: [
+        jobPosting({
+          title: "Contractor",
+          hiringOrganization: { "@type": "Organization", name: "FlexCo" },
+          employmentType: ["PART_TIME", "CONTRACTOR"],
+        }),
+      ],
+    });
+    expect(result!.employmentType).toBe("PART_TIME, CONTRACTOR");
+  });
+
+  it("passes the original JSON-LD node through untouched", async () => {
+    const result = await extract({ jsonLd: [MINIMAL] });
+    expect(result!.schemaOrgRaw).toMatchObject({
+      "@type": "JobPosting",
+      title: "Software Engineer",
+    });
+  });
+
+  it("normalizes empty section arrays to undefined", async () => {
+    // A posting whose requirements are prose should read as "none extracted",
+    // not as "zero requirements".
+    const result = await extract({
+      jsonLd: [
+        jobPosting({
+          title: "Engineer",
+          hiringOrganization: { "@type": "Organization", name: "Acme" },
+          description: "<p>We want someone great.</p>",
+        }),
+      ],
+    });
+    expect(result!.requirements).toBeUndefined();
+    expect(result!.qualifications).toBeUndefined();
+  });
+});
+
+describe("extractSchemaOrgJobPosting — resilience", () => {
+  it("returns null when the page ships no JSON-LD at all", async () => {
+    expect(await extract()).toBeNull();
+  });
+
+  it("returns null when the JSON-LD is not a JobPosting", async () => {
+    const result = await extract({
+      jsonLd: [JSON.stringify({ "@context": "https://schema.org", "@type": "WebPage" })],
+    });
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    ["title", { hiringOrganization: { "@type": "Organization", name: "Acme" } }],
+    ["hiringOrganization", { title: "Engineer" }],
+  ])("returns null when %s is missing", async (_field, partial) => {
+    expect(await extract({ jsonLd: [jobPosting(partial)] })).toBeNull();
+  });
+
+  it("returns null on invalid JSON rather than throwing", async () => {
+    expect(await extract({ jsonLd: ["{ this is not json"] })).toBeNull();
+  });
+
+  it("returns null when the context is not schema.org", async () => {
+    const result = await extract({
+      jsonLd: [
+        JSON.stringify({
+          "@context": "https://example.com",
+          "@type": "JobPosting",
+          title: "Engineer",
+          hiringOrganization: { "@type": "Organization", name: "Acme" },
+        }),
+      ],
+    });
+    expect(result).toBeNull();
+  });
+
+  // Pages ship several blocks in arbitrary order — the posting is rarely first.
+  it("skips non-JobPosting blocks and finds the posting in a later one", async () => {
+    const result = await extract({
+      jsonLd: [
+        JSON.stringify({ "@context": "https://schema.org", "@type": "Organization" }),
+        JSON.stringify({ "@context": "https://schema.org", "@type": "BreadcrumbList" }),
+        MINIMAL,
+      ],
+    });
+    expect(result!.title).toBe("Software Engineer");
+  });
+
+  it("skips a malformed block and extracts from a valid later one", async () => {
+    const result = await extract({ jsonLd: ["{ broken", MINIMAL] });
+    expect(result!.title).toBe("Software Engineer");
+  });
+
+  it("handles CDATA-wrapped JSON-LD", async () => {
+    const result = await extract({ jsonLd: [`<![CDATA[${MINIMAL}]]>`] });
+    expect(result!.company).toBe("Acme Corp");
+  });
+
+  it("skips an empty block", async () => {
+    const result = await extract({ jsonLd: ["", "   ", MINIMAL] });
+    expect(result!.company).toBe("Acme Corp");
+  });
+});
+
+describe("extractSchemaOrgJobPosting — ATS naming", () => {
+  // The selector keys on "apply" appearing in the href or the class — a company's
+  // careers page on its own domain reveals its ATS only through where this points.
+  it("names the platform from an apply link's class", async () => {
+    const result = await extract({
+      jsonLd: [MINIMAL],
+      bodyHtml:
+        '<a class="apply-button" href="https://boards.greenhouse.io/acme/jobs/9">Apply</a>',
+    });
+    expect(result!.atsDetected).toBe("Greenhouse");
+  });
+
+  it("names the platform from an apply link's href", async () => {
+    const result = await extract({
+      jsonLd: [MINIMAL],
+      bodyHtml: '<a href="https://jobs.lever.co/acme/abc/apply">Apply now</a>',
+    });
+    expect(result!.atsDetected).toBe("Lever");
+  });
+
+  // An off-site link that is not an apply link must not name a platform.
+  it("ignores a non-apply link to an ATS domain", async () => {
+    const result = await extract({
+      jsonLd: [MINIMAL],
+      bodyHtml: '<a href="https://boards.greenhouse.io/acme">Our other roles</a>',
+    });
+    expect(result!.atsDetected).toBeUndefined();
+  });
+
+  it("falls back to the page's own hostname", async () => {
+    const result = await extract({
+      jsonLd: [MINIMAL],
+      url: "https://jobs.lever.co/acme/abc-123",
+    });
+    expect(result!.atsDetected).toBe("Lever");
+  });
+
+  it("leaves the platform undefined when nothing identifies one", async () => {
+    expect((await extract({ jsonLd: [MINIMAL] }))!.atsDetected).toBeUndefined();
+  });
+});
+
+describe("structuredDataHash", () => {
+  it("is stable across two extractions of identical content", async () => {
+    const a = await extract({ jsonLd: [FULL_POSTING] });
+    const b = await extract({ jsonLd: [FULL_POSTING] });
+    expect(a!.structuredDataHash).toBeDefined();
+    expect(a!.structuredDataHash).toBe(b!.structuredDataHash);
+  });
+
+  it("differs when the posting content changes", async () => {
+    const a = await extract({ jsonLd: [FULL_POSTING] });
+    const b = await extract({ jsonLd: [MINIMAL] });
+    expect(a!.structuredDataHash).not.toBe(b!.structuredDataHash);
+  });
+});

--- a/src/lib/jd-extract/schema-org.ts
+++ b/src/lib/jd-extract/schema-org.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Tier 1 — read the publisher's own JSON-LD `JobPosting` declaration.
+//
+// This tier is first in the ladder because it is the only one that is not a guess
+// about someone else's markup. A `JobPosting` block is what the publisher chose to
+// tell machines about the role, so it is site-agnostic, survives redesigns, and
+// costs nothing to read. Most modern boards ship one, which means most pages are
+// extracted here with no host-specific code executing at all — the per-host
+// adapters exist for the remainder, not the common case.
+//
+// The DOM half of the tier only: finding and parsing `<script type="ld+json">`
+// blocks. Everything that operates on the parsed object lives in
+// `./schema-org-core.ts`, which is DOM-free and testable without jsdom.
+
+import type { ExtractedPosting } from "./types";
+import {
+  computeStructuredDataHash,
+  extractJobId,
+  extractLocation,
+  extractSalary,
+  extractWorkModel,
+  findJobPosting,
+  hasSchemaOrgContext,
+  matchAtsDomain,
+  parseHtmlSections,
+} from "./schema-org-core";
+
+/**
+ * Name the ATS platform behind a page, from its apply links and then its own host.
+ *
+ * Apply links first because they are the more informative signal: a company's
+ * careers page on its own domain reveals which ATS it runs only through where its
+ * "Apply" button points. The page's own hostname is the fallback for postings
+ * hosted directly on the ATS.
+ *
+ * `url` is passed in rather than read off `doc.location` because a `Document` only
+ * has a meaningful location when it came from navigation — one built by
+ * `DOMParser`, or detached, reports `about:blank`. `doc.location` remains the
+ * fallback for callers that have no URL in hand.
+ */
+function detectAtsPlatform(doc: Document, url?: URL): string | undefined {
+  const applyLinks = doc.querySelectorAll(
+    'a[href*="apply"], a[class*="apply"], button[data-href]',
+  );
+
+  for (const link of applyLinks) {
+    const href =
+      link.getAttribute("href") || link.getAttribute("data-href") || "";
+    const platform = matchAtsDomain(href);
+    if (platform) return platform;
+  }
+
+  return matchAtsDomain(url?.hostname || doc.location?.hostname || "");
+}
+
+/**
+ * Extract a posting from a document's JSON-LD blocks, or `null` if none carries a
+ * usable `JobPosting`.
+ *
+ * Iterates every `ld+json` block rather than stopping at the first, because pages
+ * routinely ship several (an `Organization` block, a `BreadcrumbList`, then the
+ * posting) and their order is arbitrary. A block that fails to parse, fails the
+ * schema.org context check, or lacks both a title and a company is skipped and the
+ * next is tried — a malformed block from one vendor widget must not cost the whole
+ * extraction.
+ *
+ * `title` and `company` are both required. Without them there is nothing a
+ * consumer can display or deduplicate on, and returning a body with no identity
+ * attached would look like a successful extraction to every caller downstream.
+ *
+ * Async solely because the change-detection hash uses Web Crypto.
+ */
+export async function extractSchemaOrgJobPosting(
+  doc: Document,
+  url?: URL,
+): Promise<ExtractedPosting | null> {
+  const scripts = doc.querySelectorAll('script[type="application/ld+json"]');
+  if (scripts.length === 0) return null;
+
+  for (const script of scripts) {
+    try {
+      // Some publishers wrap JSON-LD in CDATA markers, which are not valid JSON.
+      const text = (script.textContent || "")
+        .replace(/^\s*<!\[CDATA\[/, "")
+        .replace(/\]\]>\s*$/, "")
+        .trim();
+
+      if (!text) continue;
+
+      const data = JSON.parse(text);
+
+      // Only object roots can declare a context; a bare array root is checked by
+      // `findJobPosting` reaching into its items instead.
+      const root = typeof data === "object" && !Array.isArray(data) ? data : null;
+      if (root && !hasSchemaOrgContext(root)) continue;
+
+      const posting = findJobPosting(data);
+      if (!posting) continue;
+
+      const title = posting.title as string | undefined;
+      const org = posting.hiringOrganization as
+        | Record<string, unknown>
+        | undefined;
+      const company =
+        (org && typeof org === "object" ? (org.name as string) : null) ||
+        undefined;
+
+      if (!title || !company) continue;
+
+      // `description` is HTML inside a JSON string, so it is parsed by the
+      // string-input converter rather than a DOM walk. This is the JD body: the
+      // publisher's own description field IS the job description, which is why
+      // this lane needs no heuristic guess at which part of the page is the article.
+      const htmlDescription = (posting.description as string) || "";
+      const sections = htmlDescription
+        ? parseHtmlSections(htmlDescription)
+        : { requirements: [], qualifications: [], description: "" };
+
+      // `employmentType` is a string on most boards and an array on some.
+      let employmentType: string | undefined;
+      if (typeof posting.employmentType === "string") {
+        employmentType = posting.employmentType;
+      } else if (Array.isArray(posting.employmentType)) {
+        employmentType = posting.employmentType.join(", ");
+      }
+
+      return {
+        title,
+        company,
+        location: extractLocation(posting),
+        workModel: extractWorkModel(posting),
+        body: sections.description,
+        descriptionPreview: sections.description.slice(0, 200),
+        atsDetected: detectAtsPlatform(doc, url),
+        extractionTier: "schema_org",
+        jobId: extractJobId(posting),
+        datePosted: (posting.datePosted as string) || undefined,
+        validThrough: (posting.validThrough as string) || undefined,
+        employmentType,
+        salaryRange: extractSalary(posting),
+        // Empty arrays are normalized away: a posting that writes its
+        // requirements as prose should read as "none extracted", not "zero
+        // requirements", and `undefined` is the honest encoding of that.
+        requirements:
+          sections.requirements.length > 0 ? sections.requirements : undefined,
+        qualifications:
+          sections.qualifications.length > 0
+            ? sections.qualifications
+            : undefined,
+        structuredDataHash: await computeStructuredDataHash(posting),
+        schemaOrgRaw: posting,
+      };
+    } catch {
+      // Invalid JSON or an unexpected structure — try the next block.
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/jd-extract/types.ts
+++ b/src/lib/jd-extract/types.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// The vocabulary for job-posting extraction: what a posting page yields, and
+// what an extractor must implement to yield it.
+//
+// This lane exists because JD extraction was forked across three consumers —
+// this app, the `job-hunt` skill (which described extraction as English prose
+// over string sentinels), and the browser extension. `src/lib/storage/job-url.ts`
+// already established the pattern this follows: one implementation of a rule
+// that several producers must agree on, so they converge instead of drifting.
+//
+// `ExtractedPosting` is deliberately NOT `JobRecord`. `JobRecord` is a public
+// capture contract with a version number and a compile-enforced field-rule map;
+// this type is an internal extraction result that changes whenever the
+// extractors improve. A single `toJobRecord()` mapper is the only bridge, so an
+// extractor change can never silently bump a public contract.
+
+/**
+ * Which strategy produced a posting, in the order they are attempted.
+ *
+ * The ladder is ordered by trust, not convenience. `schema_org` is a publisher's
+ * own machine-readable declaration and is site-agnostic; a per-host adapter is a
+ * guess about someone else's markup that breaks when they redesign. So a host
+ * adapter is the LAST resort, never the first — most modern boards ship a JSON-LD
+ * `JobPosting` and need no host-specific code at all.
+ *
+ * The upstream implementation carried a fifth `llm` tier. It is deliberately
+ * omitted: this repo has an on-device WebLLM lane, but wiring it in is scope
+ * creep, and a non-deterministic tier under a deterministic one would make
+ * extraction results irreproducible across runs.
+ */
+export type ExtractionTier =
+  | "schema_org"
+  | "ats_api"
+  | "dom_metadata"
+  | "ats_extractor";
+
+/**
+ * Bumped whenever extraction changes materially enough that a stored result is
+ * no longer comparable to a fresh one. Same idea as `ATS_SCORE_ALGO_VERSION` in
+ * `src/lib/score/score.ts`: a cached extraction stamped with an older version is
+ * treated as stale and re-extracted rather than trusted.
+ *
+ * Carried over from the upstream implementation at its then-current value, so
+ * results already stamped by that code remain correctly comparable.
+ */
+export const EXTRACTION_ALGORITHM_VERSION = 9;
+
+/**
+ * What a job-posting page yields. Everything except `title` and `company` is
+ * optional, because every field below is absent from some real posting — a
+ * partially-populated result is the normal case, not a degraded one.
+ *
+ * Field values are passed through as the posting states them. Nothing here is
+ * parsed into numbers, normalized to an enum, or reconciled against another
+ * source: `salaryRange` stays `"$180k – $220k"` and `employmentType` stays
+ * whatever schema.org string the publisher wrote. Interpreting those is a
+ * consumer's job, and a lossy parse here would be unrecoverable downstream.
+ */
+export interface ExtractedPosting {
+  title: string;
+  company: string;
+  location?: string;
+  workModel?: string;
+
+  /**
+   * The job description as Markdown.
+   *
+   * Markdown rather than plaintext because list structure carries the
+   * requirements, and flattening it measurably costs extracted terms: on a real
+   * posting, a 489-character flattened summary yielded 0 extractable skill terms
+   * and no fit rating at all, while the same job's 8000-character structured
+   * body yielded 26 terms. `src/lib/job-search/rate-saved-jobs.ts` treats a
+   * record with no extractable terms as *not rated* rather than rated zero, so a
+   * weak body makes a saved job silently vanish from the rated set.
+   *
+   * Named `body` rather than the upstream `rawText` because it is neither raw
+   * nor incidental — it is the field the fit rating actually consumes.
+   */
+  body: string;
+
+  /** First ~200 characters of `body`, for list rows that must not render it all. */
+  descriptionPreview: string;
+
+  /** The ATS platform this posting appears to be hosted on, when detectable. */
+  atsDetected?: string;
+
+  // ─── Extraction metadata — internal, never crosses into `JobRecord` ───────
+
+  extractionTier: ExtractionTier;
+  jobId?: string;
+  /** ISO date. A snapshot of the posting's age at capture; it only decays. */
+  datePosted?: string;
+  /** ISO date — the posting's own declared expiry, where it declares one. */
+  validThrough?: string;
+  /** schema.org enum string (`FULL_TIME`, …), passed through unvalidated. */
+  employmentType?: string;
+  salaryRange?: string;
+  requirements?: string[];
+  qualifications?: string[];
+  /** SHA-256 over the JSON-LD fields that matter, for change detection. */
+  structuredDataHash?: string;
+  /** The original JSON-LD node, passed through untouched. */
+  schemaOrgRaw?: Record<string, unknown>;
+  /** `EXTRACTION_ALGORITHM_VERSION` at the time this result was produced. */
+  algorithmVersion?: number;
+  /** An external apply link discovered on an aggregator page. */
+  applyUrl?: string;
+  /**
+   * The canonical ATS-hosted URL behind an aggregator listing, e.g.
+   * `boards.greenhouse.io/acme/jobs/123` found from a LinkedIn page.
+   *
+   * This is what lets the same posting found via LinkedIn, via Indeed, and on
+   * the company's own board collapse to one record instead of three. Discovering
+   * a canonical URL is not applying to anything.
+   */
+  atsUrl?: string;
+}
+
+/**
+ * A per-host extraction strategy.
+ *
+ * `matches` is separate from `extract` so the dispatcher can ask "is this yours?"
+ * without paying for extraction, and so a host adapter can decline a page that
+ * merely lives on its domain (a board's search results page, say).
+ *
+ * Both take a `Document` rather than a string: the whole point of this lane is
+ * that structure is the signal. A sentinel over flattened text cannot express
+ * "drop this subtree", which is the operation that actually matters — dropping a
+ * block of third-party names off a posting page, for instance.
+ *
+ * `extract` returns `null`, never a partially-populated object, when the page is
+ * not one it can read. A half-filled result is worse than none: it looks like a
+ * successful extraction to every caller downstream.
+ */
+export interface ATSExtractor {
+  name: string;
+  matches(url: URL, doc: Document): boolean;
+  extract(doc: Document, url: URL): ExtractedPosting | null;
+}

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -13,7 +13,7 @@ export type AtsPlatform =
   | "recruitee"
   | "ashby";
 
-interface ParsedAtsUrl {
+export interface ParsedAtsUrl {
   platform: AtsPlatform;
   company: string;
   jobId: string;
@@ -300,10 +300,23 @@ export function classifyUnsupportedHost(url: string): UnsupportedHost | null {
  *
  * Analytics are wired in the caller (see `JdInput`), not here, so this
  * module stays pure (#75).
+ *
+ * `descriptionHtml` is passed through unconverted alongside `text` when the
+ * platform returned HTML. `text` is unchanged and remains what every existing
+ * caller reads; the raw HTML exists for `src/lib/jd-extract/`, which converts to
+ * Markdown rather than plaintext because list structure carries the requirements
+ * (see the note on `ExtractedPosting.body`). Without this, that lane would have to
+ * either re-fetch or accept an already-flattened body.
  */
 export async function fetchJdFromUrl(
   url: string,
-): Promise<{ text: string; title?: string; company?: string; source: AtsPlatform } | null> {
+): Promise<{
+  text: string;
+  title?: string;
+  company?: string;
+  descriptionHtml?: string;
+  source: AtsPlatform;
+} | null> {
   const parsed = parseAtsUrl(url);
   if (!parsed) return null;
 
@@ -318,6 +331,7 @@ export async function fetchJdFromUrl(
     text,
     title: result.title,
     company: result.company,
+    descriptionHtml: result.descriptionHtml,
     source: parsed.platform,
   };
 }


### PR DESCRIPTION
## Summary

Adds `src/lib/jd-extract/` — one JD extractor for the app, the `job-hunt` skill and the extension. HTML in, a typed `ExtractedPosting` out, no network and no UI. Tier order, first hit wins: `schema_org` → `ats_api` → the DOM tiers, with a per-host adapter as the last resort rather than the first. The upstream `llm` tier is deliberately dropped — a non-deterministic tier under deterministic ones makes results irreproducible across runs.

Quality here is not cosmetic. `jdText` drives the fit rating, and `job-search/rate-saved-jobs.ts` treats a record with no extractable terms as *not rated* rather than rated zero, so a weak extraction makes a saved job silently vanish from the rated set. Measured on a real posting during design: a 489-character flattened summary yielded 0 skill terms and no rating, while the same job's 8000-character structured body yielded 26. That is why the body is Markdown rather than plaintext, and why the DOM tiers take a `Document` rather than text — a sentinel over flattened text cannot drop a subtree.

Refs #719 — this is **PR 1 of 3** (`src/lib/jd-extract/` plus tests, no contract changes, no skill changes). The `JobRecord` field additions + `toJobRecord()` mapper, and the skill change that deletes the Phase 2 prose heuristics, land separately.

No new dependency. No storage changes. No `jd-match` behaviour change.

### Divergences from the issue body

Four of #719's instructions turned out to be wrong once the source files were actually measured. Flagging them so the issue is treated as superseded on these points:

- **`turndown` is not used, and using it would have broken the issue's own size budget.** The adapters already depend on a zero-dep DOM `htmlToMarkdown` (~120 LOC) that the file survey missed, and it was already inside the measured 21 KB. turndown is 11.4 KB minified → a ~33 KB bundle, to duplicate output the port already produces. The criterion's intent (no Readability, no new dep) holds.
- **Two entry points, not one.** `ats-api.ts` needs `fetch()`; `index.ts` gets injected into a live page. So the barrel is DOM-only and deliberately omits it — the boundary #704 established when it split out `html-to-plaintext.ts`.
- **`ATS_DOMAIN_MAP` stays separate from `parseAtsUrl`.** They answer different questions: what platform is this (19 domains, most with no public API) versus can I fetch this (5 platforms with clients). Merging would produce platform ids with no client behind them. The criterion's actual protection — no second ATS-URL parser — holds: the `ats_api` tier calls `parseAtsUrl`.
- **`job-detector.ts` could not be ported.** It was a content-script entry point reading `window` globals and calling `chrome.runtime.sendMessage` — neither callable nor testable. Only the tier ordering and the weighted job-page signal heuristic carried over; `detect.ts` is new.
- **`extraction-upgrade.test.ts` (561 LOC) was not ported.** Nearly all of it exercises an enrichment module outside this scope, plus the dropped `llm` tier. 285 tests were written against the acceptance criteria and real behaviour instead.

`fetch-jd.ts` gains two additive changes: `ParsedAtsUrl` is exported, and `fetchJdFromUrl` passes `descriptionHtml` through alongside the unchanged `text`, so this lane can convert to Markdown instead of inheriting an already-flattened body. No existing caller changes behaviour.

### Three defects fixed rather than carried over

- `htmlToMarkdown` walked the whitespace text nodes between `<li>` elements as content, injecting a blank line and a leading space into **every bullet**. Server-rendered job pages are almost always pretty-printed, so this was the common case, not an edge case.
- `apply-link.ts`'s `EXTERNAL_NOT_EXTRACTABLE` result was byte-identical to "nothing found", so the distinction its own comment claimed did not exist for any caller. An `externalDetected` flag makes it real — Glassdoor resolves the apply URL through an API call on click, so the caller needs to know an ATS original exists even though the URL cannot be read.
- The DOM tiers read `doc.location`, which is `about:blank` for any document not created by navigation (i.e. every `DOMParser` document). The URL is now a parameter, with `doc.location` kept only as fallback.

## Review focus

- `src/lib/jd-extract/index.ts` — the barrel omits `ats-api.ts` on purpose. Is `index.test.ts`'s export-surface assertion the right guard, or should something stop a future `export *` from silently pulling `fetch()` into the injected bundle?
- `src/lib/jd-extract/detect.ts:1` — tier 1 runs *before* the weighted `JOB_SIGNALS` gate. Does a page with a valid JSON-LD `JobPosting` but few page signals extract when it should?
- `src/lib/jd-match/fetch-jd.ts` — `descriptionHtml` is additive, but does any existing caller destructure the result in a way that changes?
- `src/lib/jd-extract/apply-link.ts` — `EXTRACTORS` is keyed by hostname fragment now instead of the upstream's opaque pattern name. Does the matching stay correct for a host that appears as a substring of another?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 285 new tests in `src/lib/jd-extract/`; `src/lib/jd-match/` unchanged at 120 green
- [x] `npm run verify` green locally (pre-push hook)
- [x] Bundle measured: `esbuild --bundle --format=iife --global-name=JD --minify` → **21,934 bytes**, under the 25 KB criterion
- [x] Bundle contains zero `fetch(` and no node builtins (grep)
- [x] IIFE smoke-tested end to end in jsdom — full field extraction, list structure preserved in the Markdown body

`fallow audit` on this branch: 5 complexity findings (tag switches and metadata sweeps — inherent to the shape), 2 clone groups (one the deliberate per-adapter house pattern, one pre-existing in `fetch-jd.ts`), and 3 dead-code issues that are all inherited unused deps in `extension/package.json`. Report-only, as usual.

## Provenance

Code implementation via: Claude Opus 5
Verification: `npm run verify` — green locally, and in CI
