### PR TITLE
feat(storage,jd-extract): six posting facts on the capture contract, and one bridge to it

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -196,11 +196,17 @@
       "LetterRecord", "LetterProvenance", "SkippedLetter"
     ] },
 
-    // The two contract constants that no in-tree caller reads at all — not even
-    // the deep-importing `capture.ts`. A barrel re-export whose barrel is itself
+    // A contract constant that no in-tree caller reads at all — not even the
+    // deep-importing `capture.ts`. A barrel re-export whose barrel is itself
     // ignored doesn't register as a consumer edge (same reason `ParseMetadata`
     // is listed above), so the source export must be marked here too.
-    { "file": "src/lib/storage/job-record-contract.ts", "exports": ["JOB_CAPTURE_CONTRACT_VERSION"] },
+    //
+    // `JOB_CAPTURE_CONTRACT_VERSION` was listed here for the same reason until
+    // #719, and is deliberately no longer: `src/lib/jd-extract/to-job-record.ts`
+    // stamps it onto every captured record, which is a real consumer edge. This
+    // is the "once something in-tree imports them, take them back OUT" rule in
+    // the block above, applied — the suppression list only stays honest if
+    // entries leave it as well as join it.
     { "file": "src/lib/storage/job-url.ts", "exports": ["JOB_URL_ID_PREFIX"] },
 
     // Same rule for the letter contract's own two: `LETTER_CONTRACT_VERSION` is

--- a/docs/job-capture-contract.md
+++ b/docs/job-capture-contract.md
@@ -1,12 +1,17 @@
-# Job capture contract (v1)
+# Job capture contract (v2)
 
 **Audience: anyone writing a job record into offlinecv from outside this repo** — a browser
 extension, a bookmarklet, a script that converts another tracker's export. You do not need to read
 the source to implement this. If a rule here and the code disagree, that is a bug; file it.
 
-**Status:** version 1, introduced in [#693](https://github.com/offlinecv/OfflineCV/issues/693).
+**Status:** version 2. Introduced in [#693](https://github.com/offlinecv/OfflineCV/issues/693);
+extended in [#719](https://github.com/offlinecv/OfflineCV/issues/719) with the six posting facts.
 Implemented by `src/lib/storage/job-record-contract.ts` (validation),
 `src/lib/storage/job-url.ts` (identity), and `src/lib/storage/capture.ts` (the write path).
+
+**Upgrading from v1 costs you nothing.** Every field v2 added is optional, so a producer written
+against v1 is already a valid v2 producer — send `"contract": 2` when you start sending the new
+fields, and not before.
 
 Records that violate this contract are **refused**, not repaired. offlinecv would rather tell you
 your record was wrong than store a mangled version of it and report success.
@@ -57,12 +62,32 @@ A record is a **plain JSON object**. Not an array, not `null`, not a class insta
 | `capture` | object | Provenance. See §7. |
 | `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. **`captureJob` ignores yours** and lets the store own them; a backup file carries them so a restore preserves `createdAt`. |
 
+### Optional — the posting facts (added in v2)
+
+Six more optional strings, all describing what the **posting itself says**. Send them when the posting states them and omit them when it does not — an absent field means "not stated", and an empty string means "stated as nothing", which is rarely what you mean.
+
+| Field | Type | Example | Meaning |
+|---|---|---|---|
+| `location` | string | `"Austin, TX"` | Where the posting says the job is. Free text — not geocoded, not split into city/region. |
+| `salaryRange` | string | `"$180k – $220k"` | Compensation as stated. Free text; **do not parse it into numbers.** |
+| `datePosted` | string | `"2026-07-28"` | ISO date the posting was published. See the warning below. |
+| `workModel` | string | `"remote"` | The posting's own declared arrangement. Take it from structured data — **do not infer it with a regex over the description.** |
+| `employmentType` | string | `"FULL_TIME"` | schema.org `employmentType`, passed through unvalidated. Any string is accepted; the vocabulary is the publisher's. |
+| `validThrough` | string | `"2026-09-01"` | ISO date the posting declares it expires, where it declares one. |
+
+**All six are passed through verbatim.** Nothing is parsed, normalised, or reconciled against the description. A lossy parse at this boundary is unrecoverable downstream, and offlinecv would rather hold the string you sent.
+
+**`datePosted` and `validThrough` should be absolute dates.** A value that does not start `YYYY-MM-DD` is still accepted, but it comes back as a **warning**, because a posting's age is a fact about the moment you captured it: `"3 days ago"` is not merely a lower-quality value — it becomes wrong the following day, and nothing downstream can tell. If the page only gives you a relative date, resolve it against your own clock before sending it.
+
+These six are **display-only record-keeping.** They are not ranking inputs, and offlinecv does not rank the saved library on them (`src/lib/job-search/rate-saved-jobs.ts` rates on fitness alone, because there is no query behind the library — no location preference, no comp floor).
+
 ### Unknown fields are PRESERVED
 
 Any key not listed above rides through onto the stored record untouched. This is deliberate: if a
-newer producer adds `salaryRange` and the user restores that backup on an older offlinecv, dropping
-the field would make an export → import → export cycle silently lossy. Older readers ignore what
-they cannot render.
+newer producer adds `employerRating` and the user restores that backup on an older offlinecv,
+dropping the field would make an export → import → export cycle silently lossy. Older readers
+ignore what they cannot render. (`salaryRange` was this section's example under v1, and is a real
+field as of v2 — which is exactly the path an unknown field is expected to take.)
 
 Their **values must be JSON-safe** (§6) — preserving a key whose value could not survive the next
 export would be preservation in name only, so a `Date` under an unknown key refuses the record just
@@ -205,7 +230,7 @@ value — a single click in the status picker fixes it.
 
 | Producer-owned — your value wins | User-owned — the stored value wins |
 |---|---|
-| `title`, `company`, `url`, `jdText`, `matchResult`, `capture` | `status`, `notes`, `resumeId` |
+| `title`, `company`, `url`, `jdText`, `matchResult`, `capture`, and the six posting facts | `status`, `notes`, `resumeId` |
 
 You are authoritative about the posting; the user is authoritative about their application. A
 re-capture that reset an `interviewing` job to `interested` would be worse than the duplicate it
@@ -263,12 +288,21 @@ Two version numbers exist and they are not the same thing.
 
 ```jsonc
 "capture": {
-  "contract": 1,                      // required within the object: which version you targeted
+  "contract": 2,                      // required within the object: which version you targeted
   "producer": "offlinecv-extension",  // optional, free text
   "producerVersion": "0.3.1",         // optional
   "capturedAt": 1753900000000         // optional epoch ms — when YOU captured it
 }
 ```
+
+### Version history
+
+| Version | Change | Migration |
+|---|---|---|
+| 1 | The contract as #693 introduced it. | — |
+| 2 | Added the six posting facts in §1: `location`, `salaryRange`, `datePosted`, `workModel`, `employmentType`, `validThrough`. | **None.** All six are optional, so a v1 record is already a valid v2 record that omits them. Existing stored records keep loading untouched. |
+
+**offlinecv never refuses a record for its version number.** The validator requires `capture.contract` to be a finite number and does not compare it against its own — so a record from a version this build has never heard of is accepted, and a v1 producer keeps working after a v2 build ships. Refusing a future version is precisely the forward-compatibility failure this section exists to avoid.
 
 `capture` is **optional**, and its absence means "written by offlinecv itself, contract 1". It
 exists now rather than later because a producer version cannot be retrofitted: once third-party
@@ -302,3 +336,8 @@ over `keyof Required<JobRecord>` and its guards are typed against each field's o
 the mechanism keeping the validator from quietly ceasing to cover a field. Update this document in
 the same change, and treat a change to §2's strip list as a contract version bump — every producer
 must apply exactly the same list or the id space forks.
+
+If the new field is something the extractor can read off a posting page, it also belongs in
+`src/lib/jd-extract/to-job-record.ts` — the single mapper from an extraction result to a capture
+payload. That file is deliberately the only crossing between the two, so the extraction result can
+change without touching this contract, and this contract cannot grow a field by accident.

--- a/src/lib/jd-extract/index.test.ts
+++ b/src/lib/jd-extract/index.test.ts
@@ -60,7 +60,7 @@ describe("the injected entry point", () => {
 });
 
 describe("the barrel's export surface", () => {
-  it.each(["extract", "extractApplyLink", "extractApplyLinkAsync"])(
+  it.each(["extract", "extractApplyLink", "extractApplyLinkAsync", "toJobRecord"])(
     "exports %s as a function",
     (name) => {
       expect(typeof (JD as unknown as Record<string, unknown>)[name]).toBe("function");
@@ -73,12 +73,14 @@ describe("the barrel's export surface", () => {
 
   // The surface is intentionally minimal — it is unchecked by any compiler for
   // the injected caller, so every extra name is unverified surface for no gain.
-  it("keeps the runtime surface to the documented four names", () => {
+  it("keeps the runtime surface to the documented names", () => {
     expect(Object.keys(JD).sort()).toEqual([
       "EXTRACTION_ALGORITHM_VERSION",
+      "POSTING_FACT_FIELDS",
       "extract",
       "extractApplyLink",
       "extractApplyLinkAsync",
+      "toJobRecord",
     ]);
   });
 

--- a/src/lib/jd-extract/index.ts
+++ b/src/lib/jd-extract/index.ts
@@ -51,5 +51,16 @@ export { extractPostingFromDocument as extract } from "./detect";
 export { extractApplyLink, extractApplyLinkAsync } from "./apply-link";
 export type { ApplyLinkResult } from "./apply-link";
 
+/**
+ * The bridge to the job capture contract. It belongs on the injected surface
+ * because the injected caller is exactly who needs it: the skill extracts inside
+ * the page and hands offlinecv a capture payload, so mapping in the page means
+ * one JSON object crosses the tool boundary instead of an extraction result plus
+ * a second mapping step the skill would have to describe in prose — which is the
+ * failure mode this whole lane exists to end.
+ */
+export { toJobRecord, POSTING_FACT_FIELDS } from "./to-job-record";
+export type { CaptureProducer, JobCaptureInput } from "./to-job-record";
+
 export { EXTRACTION_ALGORITHM_VERSION } from "./types";
 export type { ATSExtractor, ExtractedPosting, ExtractionTier } from "./types";

--- a/src/lib/jd-extract/to-job-record.test.ts
+++ b/src/lib/jd-extract/to-job-record.test.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The bridge from extraction to the capture contract (#719).
+ *
+ * Two things are worth pinning here and nothing else really is. The first is the
+ * `atsUrl` rule, because it decides record IDENTITY — get it wrong and the user
+ * gets three records for one job, or (far worse) one record for three jobs. The
+ * second is the boundary: extraction internals must not cross, and the way that
+ * fails is silently, by someone adding a field to `ExtractedPosting` and
+ * spreading the whole object.
+ *
+ * The payload is fed through `validateJobRecord` rather than only inspected,
+ * because "the mapper produces a contract-valid record" is the claim that
+ * matters and shape assertions cannot make it.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  JOB_CAPTURE_CONTRACT_VERSION,
+  validateJobRecord,
+} from "../storage/job-record-contract.ts";
+import { deriveJobId } from "../storage/job-url.ts";
+import { POSTING_FACT_FIELDS, toJobRecord } from "./to-job-record.ts";
+import type { ExtractedPosting } from "./types.ts";
+
+const PAGE_URL = "https://www.linkedin.com/jobs/view/4012345/";
+const ATS_URL = "https://boards.greenhouse.io/acme/jobs/4012345";
+
+function posting(overrides: Partial<ExtractedPosting> = {}): ExtractedPosting {
+  return {
+    title: "Staff Engineer",
+    company: "Acme",
+    body: "## About\n\n- 5 years TypeScript\n",
+    descriptionPreview: "About",
+    extractionTier: "schema_org",
+    ...overrides,
+  };
+}
+
+describe("toJobRecord: the posting facts that cross", () => {
+  it("carries all six, verbatim", () => {
+    const result = toJobRecord(
+      posting({
+        location: "Austin, TX",
+        salaryRange: "$180k – $220k",
+        datePosted: "2026-07-28",
+        workModel: "remote",
+        employmentType: "FULL_TIME",
+        validThrough: "2026-09-01",
+      }),
+      PAGE_URL,
+    );
+
+    expect(result).toMatchObject({
+      location: "Austin, TX",
+      salaryRange: "$180k – $220k",
+      datePosted: "2026-07-28",
+      workModel: "remote",
+      employmentType: "FULL_TIME",
+      validThrough: "2026-09-01",
+    });
+  });
+
+  it("copies the title, company and body", () => {
+    const result = toJobRecord(posting(), PAGE_URL);
+    expect(result.title).toBe("Staff Engineer");
+    expect(result.company).toBe("Acme");
+    expect(result.jdText).toBe("## About\n\n- 5 years TypeScript\n");
+  });
+
+  // Absent is not the same as empty: empty means the posting said nothing there,
+  // absent means we did not look. Only the second is true of a tier that never
+  // populates a field.
+  it.each(POSTING_FACT_FIELDS)("omits `%s` rather than writing an empty string", (field) => {
+    const result = toJobRecord(posting({ [field]: "" }), PAGE_URL);
+    expect(field in result).toBe(false);
+  });
+
+  it("omits jdText when the body is empty", () => {
+    expect("jdText" in toJobRecord(posting({ body: "" }), PAGE_URL)).toBe(false);
+  });
+
+  it("pins the crossing set, so adding one is a visible diff", () => {
+    expect([...POSTING_FACT_FIELDS]).toEqual([
+      "location",
+      "salaryRange",
+      "datePosted",
+      "workModel",
+      "employmentType",
+      "validThrough",
+    ]);
+  });
+});
+
+describe("toJobRecord: extraction internals stop at the boundary", () => {
+  // The failure this guards is someone spreading `...posting` into the payload.
+  // It would look fine — every assertion above would still pass — and it would
+  // put fields into a versioned public contract that no third-party producer
+  // could ever supply.
+  it("drops every internal, including ones a spread would carry", () => {
+    const result = toJobRecord(
+      posting({
+        jobId: "4012345",
+        atsDetected: "greenhouse",
+        applyUrl: "https://acme.com/apply",
+        structuredDataHash: "abc123",
+        schemaOrgRaw: { "@type": "JobPosting" },
+        algorithmVersion: 9,
+        requirements: ["TypeScript"],
+        qualifications: ["BSc"],
+        descriptionPreview: "About",
+      }),
+      PAGE_URL,
+    );
+
+    for (const internal of [
+      "extractionTier",
+      "jobId",
+      "atsDetected",
+      "applyUrl",
+      "structuredDataHash",
+      "schemaOrgRaw",
+      "algorithmVersion",
+      "requirements",
+      "qualifications",
+      "descriptionPreview",
+      "body",
+      "atsUrl",
+    ]) {
+      expect(internal in result, internal).toBe(false);
+    }
+  });
+});
+
+describe("toJobRecord: the atsUrl rule", () => {
+  // The point of the whole rule: one posting, three places it was found, one id.
+  it("prefers the ATS original over the page it was found on", () => {
+    const result = toJobRecord(posting({ atsUrl: ATS_URL }), PAGE_URL);
+    expect(result.url).toBe(ATS_URL);
+  });
+
+  it("collapses an aggregator capture and a direct capture onto one id", () => {
+    const viaLinkedIn = toJobRecord(posting({ atsUrl: ATS_URL }), PAGE_URL);
+    const viaIndeed = toJobRecord(
+      posting({ atsUrl: ATS_URL }),
+      "https://www.indeed.com/viewjob?jk=abc123",
+    );
+    const direct = toJobRecord(posting(), ATS_URL);
+
+    expect(deriveJobId(viaLinkedIn.url!)).toBe(deriveJobId(direct.url!));
+    expect(deriveJobId(viaIndeed.url!)).toBe(deriveJobId(direct.url!));
+  });
+
+  // The accepted cost, pinned so it is a decision rather than a surprise: a
+  // capture where apply-link missed forks from one where it hit. Under-merging
+  // is a duplicate the user can delete; over-merging destroys a record.
+  it("forks — does not merge — when apply-link missed on one of two captures", () => {
+    const found = toJobRecord(posting({ atsUrl: ATS_URL }), PAGE_URL);
+    const missed = toJobRecord(posting(), PAGE_URL);
+    expect(deriveJobId(found.url!)).not.toBe(deriveJobId(missed.url!));
+  });
+
+  it("falls back to the page URL when there is no ATS original", () => {
+    expect(toJobRecord(posting(), PAGE_URL).url).toBe(PAGE_URL);
+  });
+
+  // Falling back beats handing `captureJob` a record it refuses whole — and the
+  // tracker renders this value into an anchor's `href`.
+  it.each(["javascript:alert(1)", "data:text/html,x", "not a url"])(
+    "ignores an atsUrl of %s and uses the page URL",
+    (atsUrl) => {
+      expect(toJobRecord(posting({ atsUrl }), PAGE_URL).url).toBe(PAGE_URL);
+    },
+  );
+
+  it("omits url entirely when neither is capturable", () => {
+    const result = toJobRecord(posting(), "about:blank");
+    expect("url" in result).toBe(false);
+  });
+});
+
+describe("toJobRecord: provenance", () => {
+  it("stamps this build's contract version, not a caller's claim", () => {
+    const result = toJobRecord(posting(), PAGE_URL, { producer: "x", producerVersion: "1" });
+    expect(result.capture?.contract).toBe(JOB_CAPTURE_CONTRACT_VERSION);
+  });
+
+  it("carries the producer identity through", () => {
+    const result = toJobRecord(posting(), PAGE_URL, {
+      producer: "claude-code-job-hunt-skill",
+      producerVersion: "0.1.0",
+      capturedAt: 1_700_000_000_000,
+    });
+    expect(result.capture).toEqual({
+      contract: JOB_CAPTURE_CONTRACT_VERSION,
+      producer: "claude-code-job-hunt-skill",
+      producerVersion: "0.1.0",
+      capturedAt: 1_700_000_000_000,
+    });
+  });
+
+  it("stamps capture time when the caller does not", () => {
+    const before = Date.now();
+    const captured = toJobRecord(posting(), PAGE_URL).capture?.capturedAt ?? 0;
+    expect(captured).toBeGreaterThanOrEqual(before);
+  });
+
+  it("omits an unstated producer rather than inventing one", () => {
+    const capture = toJobRecord(posting(), PAGE_URL).capture!;
+    expect("producer" in capture).toBe(false);
+    expect("producerVersion" in capture).toBe(false);
+  });
+});
+
+describe("toJobRecord: the output satisfies the capture contract", () => {
+  // `captureJob` supplies the id; everything else must already be valid.
+  function validate(input: ReturnType<typeof toJobRecord>) {
+    return validateJobRecord({ ...input, id: "job-1" });
+  }
+
+  it("accepts a fully-populated posting with no warnings", () => {
+    const result = validate(
+      toJobRecord(
+        posting({
+          atsUrl: ATS_URL,
+          location: "Austin, TX",
+          salaryRange: "$180k – $220k",
+          datePosted: "2026-07-28",
+          workModel: "remote",
+          employmentType: "FULL_TIME",
+          validThrough: "2026-09-01",
+        }),
+        PAGE_URL,
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("accepts the minimum a tier can produce", () => {
+    expect(validate(toJobRecord(posting({ body: "" }), "about:blank")).ok).toBe(true);
+  });
+
+  // A JSON round trip is the real transport: the injected bundle returns a
+  // string, and an extension's message is structured-cloned.
+  it("survives a JSON round trip", () => {
+    const input = toJobRecord(posting({ location: "Austin, TX" }), PAGE_URL);
+    expect(JSON.parse(JSON.stringify(input))).toEqual(input);
+  });
+});

--- a/src/lib/jd-extract/to-job-record.ts
+++ b/src/lib/jd-extract/to-job-record.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The one bridge from an {@link ExtractedPosting} to the job capture contract
+ * (#719).
+ *
+ * The two types are deliberately not the same type, and this module is the
+ * reason that costs nothing. `ExtractedPosting` is an internal extraction result
+ * that changes whenever the extractors improve; `JobRecord` is a PUBLIC contract
+ * with a version number, a compile-enforced field-rule map and a prose spec a
+ * third party reimplements against. Routing every crossing through one function
+ * means an extractor change can never silently alter what a producer writes —
+ * to change the capture payload you have to edit this file, which sits next to
+ * the doc that says what the payload is.
+ *
+ * What crosses is exactly {@link POSTING_FACT_FIELDS} plus title, company, url
+ * and the body. Extraction internals — `extractionTier`, `structuredDataHash`,
+ * `schemaOrgRaw`, `algorithmVersion`, `jobId`, `atsDetected`, `applyUrl` — stop
+ * here. They describe how we read the page, not what the posting says, and a
+ * capture contract that carried them would oblige every third-party producer to
+ * either fabricate them or explain their absence.
+ *
+ * Output is a capture CANDIDATE, not a stored record: no `id`, no timestamps, no
+ * `status`. `captureJob` (`src/lib/storage/capture.ts`) owns all four, and the
+ * id it derives is the entire point of the `atsUrl` rule below.
+ */
+
+// Both imports reach past the storage barrel on purpose. This module ends up in
+// a bundle injected into a live page, and the barrel pulls the IndexedDB layer,
+// the backup path and the record validators — none of which a producer-side
+// mapper needs. `types.ts` has zero imports and `job-url.ts` is zero-dependency,
+// so what lands in the bundle is one integer and one URL predicate.
+import { isCapturableJobUrl } from "../storage/job-url.ts";
+import { JOB_CAPTURE_CONTRACT_VERSION, type JobRecord } from "../storage/types.ts";
+import type { ExtractedPosting } from "./types.ts";
+
+/**
+ * A capture payload: the fields a producer supplies, and nothing the store owns.
+ *
+ * Derived from `JobRecord` with `Pick` rather than declared independently — the
+ * whole argument of this module is that there is one definition of a job record,
+ * so a second hand-written field list here would reintroduce the drift the
+ * contract's mapped type exists to prevent.
+ */
+export type JobCaptureInput = Pick<
+  JobRecord,
+  | "title"
+  | "company"
+  | "url"
+  | "jdText"
+  | "capture"
+  | (typeof POSTING_FACT_FIELDS)[number]
+>;
+
+/**
+ * The posting facts that cross into a `JobRecord`, in one list so the bridge is
+ * readable at a glance and testable as a set.
+ *
+ * Both types declare all six as an optional `string`, so the copy below needs no
+ * per-field code and no cast. A field added to one type but not the other stops
+ * compiling here, which is the cheapest possible place to find out.
+ */
+export const POSTING_FACT_FIELDS = [
+  "location",
+  "salaryRange",
+  "datePosted",
+  "workModel",
+  "employmentType",
+  "validThrough",
+] as const;
+
+/** Who captured this, for `JobRecord.capture`. The contract version is not here:
+ *  it is this build's to state, not a caller's to claim. */
+export interface CaptureProducer {
+  /** Free-text producer id, e.g. `"claude-code-job-hunt-skill"`. */
+  producer?: string;
+  /** The producer's own release version. */
+  producerVersion?: string;
+  /** Epoch ms of capture. Defaults to now — the mapper runs at capture time, so
+   *  a caller only passes this when replaying an earlier extraction. */
+  capturedAt?: number;
+}
+
+/**
+ * The `atsUrl` rule.
+ *
+ * When apply-link discovery finds the ATS-hosted original behind an aggregator
+ * listing, THAT is the URL the record carries — so `deriveJobId` keys on it and
+ * the same posting found via LinkedIn, via Indeed, and on the company's own
+ * board collapses to one record instead of three.
+ *
+ * Two consequences, both accepted rather than overlooked:
+ *
+ *  - **Aggregator provenance is lost.** `JobCaptureProvenance` has no
+ *    source-URL field, so nothing records that this record was found on
+ *    LinkedIn. The user still has the ATS URL, which is where they apply.
+ *  - **Dedup becomes extraction-dependent.** Capture a posting once where
+ *    apply-link misses and again where it hits, and you get two records. That is
+ *    a fork, not a merge, and it lands on the safe side of the asymmetry
+ *    `job-url.ts` names: *under-merging is a duplicate the user can delete;
+ *    over-merging destroys a record.*
+ *
+ * A non-http(s) `atsUrl` is ignored rather than passed on: the tracker renders
+ * this straight into an anchor's `href`, and the contract would refuse it
+ * anyway — better to fall back to a URL that works than to hand `captureJob` a
+ * record it will reject whole.
+ */
+function captureUrl(posting: ExtractedPosting, pageUrl: string): string | undefined {
+  if (posting.atsUrl !== undefined && isCapturableJobUrl(posting.atsUrl)) return posting.atsUrl;
+  return isCapturableJobUrl(pageUrl) ? pageUrl : undefined;
+}
+
+/**
+ * Map an extraction result onto a capture payload.
+ *
+ * `pageUrl` is the page the posting was read from. It is a separate argument
+ * rather than a field on `ExtractedPosting` because the extractors take the URL
+ * as an input — a `Document` that was parsed rather than navigated to has no
+ * usable `location` — and the extraction result should not restate its own
+ * input.
+ *
+ * An absent value is OMITTED rather than written as `""`. The contract accepts
+ * an empty string, but the two mean different things to a reader: empty is "the
+ * posting says nothing here", absent is "we did not look". Only the second is
+ * true of a tier that never populates a field.
+ */
+export function toJobRecord(
+  posting: ExtractedPosting,
+  pageUrl: string,
+  producer: CaptureProducer = {},
+): JobCaptureInput {
+  const url = captureUrl(posting, pageUrl);
+
+  const facts: Partial<Record<(typeof POSTING_FACT_FIELDS)[number], string>> = {};
+  for (const field of POSTING_FACT_FIELDS) {
+    const value = posting[field];
+    if (value !== undefined && value !== "") facts[field] = value;
+  }
+
+  return {
+    title: posting.title,
+    company: posting.company,
+    ...(url !== undefined && { url }),
+    ...(posting.body !== "" && { jdText: posting.body }),
+    ...facts,
+    capture: {
+      contract: JOB_CAPTURE_CONTRACT_VERSION,
+      ...(producer.producer !== undefined && { producer: producer.producer }),
+      ...(producer.producerVersion !== undefined && {
+        producerVersion: producer.producerVersion,
+      }),
+      capturedAt: producer.capturedAt ?? Date.now(),
+    },
+  };
+}

--- a/src/lib/storage/job-record-contract.test.ts
+++ b/src/lib/storage/job-record-contract.test.ts
@@ -19,6 +19,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  JOB_CAPTURE_CONTRACT_VERSION,
   JOB_RECORD_RULES,
   isKnownStatus,
   validateJobRecord,
@@ -40,7 +41,15 @@ function validRecord(): Record<string, unknown> {
     status: "applied",
     resumeId: "resume-1",
     jdText: "We are hiring.",
+    location: "Austin, TX",
+    salaryRange: "$180k – $220k",
+    datePosted: "2026-07-28",
+    workModel: "remote",
+    employmentType: "FULL_TIME",
+    validThrough: "2026-09-01",
     matchResult: { coverage: 0.8, missing: ["kubernetes"] },
+    // Deliberately still `1`: a producer targeting the previous contract version
+    // must keep validating unchanged. See the version-2 block below.
     capture: { contract: 1, producer: "offlinecv-extension", producerVersion: "0.1.0" },
   };
 }
@@ -145,13 +154,16 @@ describe("validateJobRecord: out-of-union status is PRESERVED, not dropped or co
 describe("validateJobRecord: unknown extra keys are PRESERVED", () => {
   // Dropping them makes export → import → export lossy for a user who moves a
   // backup from a newer build to an older one and back.
+  //
+  // The key here used to be `salaryRange`, chosen when it was hypothetical. #719
+  // made it a real field, at which point this case silently stopped testing
+  // anything — it passed for the wrong reason, through the rule map rather than
+  // the extras pass. Pick a key no contract version will plausibly claim.
   it("carries an unrecognised field onto the stored record", () => {
-    const result = validateJobRecord({ ...validRecord(), salaryRange: "180-220k" });
+    const result = validateJobRecord({ ...validRecord(), employerRating: 4.5 });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect((result.record as unknown as Record<string, unknown>).salaryRange).toBe(
-      "180-220k",
-    );
+    expect((result.record as unknown as Record<string, unknown>).employerRating).toBe(4.5);
   });
 
   it("still requires an extra key's value to be JSON-safe", () => {
@@ -175,6 +187,84 @@ describe("validateJobRecord: a url that is not absolute is kept, with a warning"
     if (!result.ok) return;
     expect(result.record.url).toBe("acme.com/jobs/1");
     expect(result.warnings).toContainEqual(expect.stringContaining("not an absolute URL"));
+  });
+});
+
+describe("contract v2: the six posting facts (#719)", () => {
+  const FACTS = [
+    "location",
+    "salaryRange",
+    "datePosted",
+    "workModel",
+    "employmentType",
+    "validThrough",
+  ] as const;
+
+  it("declares version 2", () => {
+    expect(JOB_CAPTURE_CONTRACT_VERSION).toBe(2);
+  });
+
+  // The "no migration" claim, stated as a test rather than only in prose: every
+  // added field is optional, so a version-1 record IS a valid version-2 record
+  // that happens to omit them. If this ever fails, the bump needed a migration.
+  it("accepts a version-1 record carrying none of them", () => {
+    const v1 = { id: "job-1", title: "SWE", capture: { contract: 1 } };
+    const result = validateJobRecord(v1);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not refuse a record from a FUTURE contract version", () => {
+    const result = validateJobRecord({ id: "job-1", title: "SWE", capture: { contract: 99 } });
+    expect(result.ok).toBe(true);
+  });
+
+  it.each(FACTS)("refuses a non-string `%s`", (field) => {
+    expect(reasons({ ...validRecord(), [field]: 42 })).toContainEqual(
+      expect.stringContaining(`\`${field}\``),
+    );
+  });
+
+  // Passed through verbatim — no parsing, no enum coercion. A validator that
+  // "helpfully" normalised these would be the repair this contract refuses.
+  it.each([
+    ["salaryRange", "£90,000-£110,000 per annum, DOE"],
+    ["employmentType", "not-a-schema-org-enum"],
+    ["workModel", "hybrid (3 days on-site, Tuesdays fixed)"],
+    ["location", "Multiple locations"],
+  ])("keeps an unusual `%s` exactly as sent", (field, value) => {
+    const result = validateJobRecord({ ...validRecord(), [field]: value });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.record as unknown as Record<string, unknown>)[field]).toBe(value);
+  });
+});
+
+describe("contract v2: a non-ISO date is kept, with a warning", () => {
+  // The field exists because a posting's age is a fact about the capture moment.
+  // "3 days ago" is not merely lower quality — it becomes wrong the next day and
+  // nothing downstream can tell. Warned, not refused: the string is still more
+  // than nothing, and refusing costs the user the whole record.
+  it.each(["datePosted", "validThrough"] as const)("warns on a relative `%s`", (field) => {
+    const result = validateJobRecord({ ...validRecord(), [field]: "3 days ago" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.record as unknown as Record<string, unknown>)[field]).toBe("3 days ago");
+    expect(result.warnings).toContainEqual(expect.stringContaining(field));
+  });
+
+  it.each(["2026-07-28", "2026-07-28T00:00:00Z", "2026-07-28T09:30:00+02:00"])(
+    "accepts %s silently",
+    (value) => {
+      const result = validateJobRecord({ ...validRecord(), datePosted: value });
+      expect(result.ok && result.warnings).toEqual([]);
+    },
+  );
+
+  it("says nothing about an empty string — that is a gap, not a relative date", () => {
+    const result = validateJobRecord({ ...validRecord(), datePosted: "" });
+    expect(result.ok && result.warnings).toEqual([]);
   });
 });
 

--- a/src/lib/storage/job-record-contract.ts
+++ b/src/lib/storage/job-record-contract.ts
@@ -63,19 +63,20 @@ import {
 } from "./record-contract.ts";
 
 /**
- * Contract version a producer targets, carried on `JobRecord.capture.contract`.
- * Independent of `StorageExport.version` (the backup DOCUMENT format): a record
- * can outlive the file it arrived in, and the two evolve for different reasons.
- * Absent provenance means "written by this app against version 1".
+ * Re-exported so this module — the one `docs/job-capture-contract.md` names as
+ * the contract's runtime half — still presents the whole surface in one place.
+ * It LIVES in `types.ts` because the version number is vocabulary, not
+ * validation: it is the value of a field declared there, and the validator
+ * deliberately never reads it.
  *
- * Exported as part of the contract SURFACE, not awaiting a caller: §7 of
- * `docs/job-capture-contract.md` is normative for reimplementers, and this is
- * the number it tells them to send. Nothing in this build reads it, by design —
- * the validator requires `capture.contract` to be a finite number and does not
- * compare it against this constant, because refusing a record from a future
- * version is exactly the forward-compatibility failure §7 exists to avoid.
+ * The split is also load-bearing. `src/lib/jd-extract/to-job-record.ts` imports
+ * this constant into a bundle injected into a live page, and importing it from
+ * here would drag the rules map, `KNOWN_FIELDS`'s `new Set` (a top-level side
+ * effect no bundler may assume away) and all of `record-contract.ts` along with
+ * it — 2.9 KB of validator, measured, against a 25 KB budget, to carry one
+ * integer.
  */
-export const JOB_CAPTURE_CONTRACT_VERSION = 1;
+export { JOB_CAPTURE_CONTRACT_VERSION } from "./types.ts";
 
 /** A reason a record was refused, or a repair that was applied. One sentence,
  *  addressed to whoever has to fix the producer or the file. */
@@ -128,6 +129,14 @@ const isUrlLike = (value: unknown): value is string =>
 const isJsonSafe = (value: unknown): value is unknown =>
   findJsonSafetyProblem(value, "value") === null;
 
+/**
+ * A leading `YYYY-MM-DD`. Deliberately a prefix match, not a full-date parse: a
+ * publisher that sends `2026-07-28T00:00:00Z` has stated an absolute date and is
+ * doing nothing wrong, and this is a warning's threshold rather than a
+ * refusal's.
+ */
+const ISO_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}/;
+
 const isCaptureProvenance = (value: unknown): value is JobCaptureProvenance =>
   isProvenanceLike(value, "capturedAt", "capture");
 
@@ -157,6 +166,20 @@ export const JOB_RECORD_RULES: {
   status: { required: false, check: isStatusLike, expected: "a string" },
   resumeId: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
   jdText: { required: false, check: isString, expected: "a string" },
+
+  // The six posting facts (#719). Every one is `isString` on purpose. They are
+  // passed through verbatim — a validator that parsed `salaryRange` into numbers
+  // or coerced `employmentType` onto a closed enum would be the "repair" this
+  // contract refuses to do, and the vocabularies belong to the publisher. The
+  // two date fields are warned about rather than refused; see
+  // `collectAcceptedWarnings`.
+  location: { required: false, check: isString, expected: "a string" },
+  salaryRange: { required: false, check: isString, expected: "a string" },
+  datePosted: { required: false, check: isString, expected: "a string, ideally an ISO date" },
+  workModel: { required: false, check: isString, expected: "a string" },
+  employmentType: { required: false, check: isString, expected: "a string" },
+  validThrough: { required: false, check: isString, expected: "a string, ideally an ISO date" },
+
   matchResult: {
     required: false,
     check: isJsonSafe,
@@ -179,6 +202,14 @@ const KNOWN_FIELDS = new Set(Object.keys(JOB_RECORD_RULES));
  * Warnings, not refusals: these run only on values that already passed their
  * guard, so each names a record we ACCEPTED with something a caller should say
  * out loud. See the decision notes on `isStatusLike` and `isUrlLike`.
+ *
+ * `datePosted` and `validThrough` warn on anything not starting `YYYY-MM-DD`.
+ * The reason is the whole reason those fields exist: a posting's age is a fact
+ * about the moment it was captured, so `"3 days ago"` is not merely a
+ * lower-quality value — it silently becomes wrong the day after it is stored,
+ * and no reader can tell. Warned rather than refused because the string is still
+ * more than nothing, and the same asymmetry applies as everywhere else here:
+ * refusing costs the user the record, warning costs them one sentence.
  */
 function collectAcceptedWarnings(checked: Record<string, unknown>): JobRecordIssue[] {
   const warnings: JobRecordIssue[] = [];
@@ -189,6 +220,14 @@ function collectAcceptedWarnings(checked: Record<string, unknown>): JobRecordIss
   }
   if (typeof checked.url === "string" && !isAbsoluteUrl(checked.url)) {
     warnings.push(`URL "${checked.url}" is not an absolute URL; it was kept as-is.`);
+  }
+  for (const field of ["datePosted", "validThrough"] as const) {
+    const value = checked[field];
+    if (typeof value === "string" && value !== "" && !ISO_DATE_PREFIX.test(value)) {
+      warnings.push(
+        `\`${field}\` "${value}" is not an ISO date; it was kept as-is, but a relative date decays and cannot be rendered absolutely.`,
+      );
+    }
   }
   return warnings;
 }

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -59,9 +59,37 @@ export type JobStatus =
  * Deliberately NOT `StorageExport.version`: that numbers the backup DOCUMENT
  * format, and a record outlives the file it arrived in.
  */
+/**
+ * Contract version a producer targets, carried on
+ * {@link JobCaptureProvenance.contract}. Independent of `StorageExport.version`
+ * (the backup DOCUMENT format): a record can outlive the file it arrived in, and
+ * the two evolve for different reasons. Absent provenance means "written by this
+ * app against version 1".
+ *
+ * Exported as part of the contract SURFACE, not awaiting a caller: §7 of
+ * `docs/job-capture-contract.md` is normative for reimplementers, and this is
+ * the number it tells them to send. Nothing in this build reads it, by design —
+ * the validator requires `capture.contract` to be a finite number and does not
+ * compare it against this constant, because refusing a record from a future
+ * version is exactly the forward-compatibility failure §7 exists to avoid.
+ *
+ * It lives here, beside the field it fills, rather than in
+ * `job-record-contract.ts` (which re-exports it): a version number is vocabulary
+ * rather than validation, and this module is the vocabulary — zero imports and
+ * nothing but declarations, which is what lets a producer-side consumer take the
+ * number without taking the validator.
+ *
+ * `2` since #719 added the six posting-fact fields. **No migration**, and none
+ * could be needed: every added field is optional, so a version-1 record is a
+ * valid version-2 record that happens to omit them. The bump tells producers
+ * there is more they MAY send, not that they must resend anything — a version-1
+ * producer keeps working untouched.
+ */
+export const JOB_CAPTURE_CONTRACT_VERSION = 2;
+
 export interface JobCaptureProvenance {
   /** The capture-contract version this producer targeted
-   *  (`JOB_CAPTURE_CONTRACT_VERSION`). */
+   *  ({@link JOB_CAPTURE_CONTRACT_VERSION}). */
   contract: number;
   /** Free-text producer id, e.g. `"offlinecv-extension"`. */
   producer?: string;
@@ -104,6 +132,42 @@ export interface JobRecord extends StoredRecord {
   resumeId?: string;
   /** Optional pasted job description, when the job came from / ran a JD match. */
   jdText?: string;
+
+  // ─── Posting facts, as the posting states them (#719) ─────────────────────
+  //
+  // All optional, all `string`, so the whole group stays JSON-safe for the
+  // export/import round trip and needs no migration — an existing record simply
+  // lacks them. Values are passed through VERBATIM: nothing here is parsed into
+  // numbers, normalised to an enum, or reconciled against `jdText`. A lossy
+  // parse at the boundary is unrecoverable downstream, and interpreting these is
+  // a consumer's job.
+  //
+  // These are display-only record-keeping and are **not** ranking inputs.
+  // `src/lib/job-search/rate-saved-jobs.ts` rates the saved library on fitness
+  // alone because there is no query behind it — no location preference, no comp
+  // floor. The missing input is the *query's*, not the posting's, so carrying
+  // the posting's own values here does not give that module anything to rank on.
+
+  /** Where the posting says the job is, free text: `"Austin, TX"`, `"Remote
+   *  (US)"`. Not geocoded and not split into city/region. */
+  location?: string;
+  /** Compensation as the posting states it: `"$180k – $220k"`. Free text, never
+   *  parsed into numbers — currency, period and range syntax vary per posting,
+   *  and a wrong parse is worse than an unparsed string. */
+  salaryRange?: string;
+  /** ISO date the posting was published. A snapshot of the posting's age **at
+   *  capture**, which only decays — so a renderer must show it absolute
+   *  (`2026-07-28`), never as "3 days ago" against today's clock. */
+  datePosted?: string;
+  /** The posting's own declared arrangement (`"remote"`, `"hybrid"`), taken from
+   *  structured data — never inferred by a regex over `jdText`. */
+  workModel?: string;
+  /** schema.org `employmentType` (`"FULL_TIME"`, `"CONTRACTOR"`), passed through
+   *  unvalidated: the vocabulary is the publisher's, not ours. */
+  employmentType?: string;
+  /** ISO date the posting declares it expires, where it declares one. */
+  validThrough?: string;
+
   /** Optional JD-match result carried over from the JD-fit flow. Opaque +
    *  JSON-safe by contract so it survives export/import — enforced at the
    *  external boundary by `findJsonSafetyProblem` (#693). */


### PR DESCRIPTION
## Summary

PR 2 of #719. The extractor that landed in #721 reads location, salary, work model and three dates off a posting page, and had nowhere to put them — `JobRecord` carried `title`, `company`, `url` and `jdText`, so everything else fell into the preserve-unknown-keys pass: stored, exported, and invisible to every reader.

`JobRecord` gains `location`, `salaryRange`, `datePosted`, `workModel`, `employmentType`, `validThrough` — all optional, all `string`, so the group is JSON-safe for the export/import round trip. `JOB_CAPTURE_CONTRACT_VERSION` goes `1 → 2` with **no migration**, and none could be needed: every added field is optional, so a version-1 record is already a valid version-2 record that omits them. A test asserts that rather than leaving it as prose.

`src/lib/jd-extract/to-job-record.ts` is the one crossing from `ExtractedPosting` to the contract, and it implements the `atsUrl` rule.

Refs #719 — PR 3 (the `job-hunt` skill calling the module) is the last piece.

### Values are passed through verbatim

Nothing is parsed into numbers, coerced onto an enum, or reconciled against `jdText`. Currency, period and range syntax vary per posting; `employmentType`'s vocabulary belongs to the publisher; and a lossy parse at this boundary is unrecoverable downstream. A validator that "helpfully" normalised these would be the repair this contract exists to refuse.

They are **display-only record-keeping and not ranking inputs.** `src/lib/job-search/rate-saved-jobs.ts` rates the saved library on fitness alone because there is no query behind it — no location preference, no comp floor. The missing input is the *query's*, not the posting's, so carrying the posting's own values gives that module nothing new to rank on.

### Two dates warn, never refuse

`datePosted` and `validThrough` warn on any value not starting `YYYY-MM-DD`. That is the whole reason those fields exist: a posting's age is a fact about the moment of capture, so `"3 days ago"` is not merely a lower-quality value — it becomes wrong the next day and nothing downstream can tell. Warned rather than refused because the string still beats nothing, and the same asymmetry applies as everywhere else in this contract: refusing costs the user the record, warning costs one sentence.

### The constant moves to `types.ts`

`job-record-contract.ts` re-exports it, so the barrel and the doc's named surface are unchanged. Two reasons, and the second is load-bearing:

- A version number is **vocabulary, not validation** — it is the value of a field declared in `types.ts`, and the validator deliberately never reads it.
- Importing it from the validator dragged the rules map, `KNOWN_FIELDS`' top-level `new Set` (a side effect no bundler may assume away, and `/* @__PURE__ */` does not fix it because the nested `Object.keys` call is unannotatable) and all of `record-contract.ts` into the injected bundle. **2.9 KB of validator to carry one integer**, which pushed the bundle to 25,976 bytes — over #719's own 25 KB budget. It is **22,905** now.

### The `atsUrl` rule, and what it costs

When apply-link discovery finds the ATS original behind an aggregator listing, that is the URL the record carries — so `deriveJobId` keys on it and one posting found via LinkedIn, via Indeed, and on the company's own board collapses to **one** record. Two costs, both pinned by tests rather than left to be rediscovered:

- **Aggregator provenance is lost** — `JobCaptureProvenance` has no source-URL field, so nothing records that this was found on LinkedIn.
- **Dedup becomes extraction-dependent** — capture once where apply-link misses and again where it hits, and you get two records. That is a *fork, not a merge*, which lands on the safe side of the asymmetry `job-url.ts` names: *under-merging is a duplicate the user can delete; over-merging destroys a record.*

### Two pieces of drift found and fixed

- The contract test for "unknown extra keys are preserved" used **`salaryRange`** as its unknown key, chosen when it was hypothetical. It is a real field now, so that case had silently stopped testing the extras pass while still passing — it would have gone on passing for the wrong reason indefinitely. `docs/job-capture-contract.md` used it as the same example, in the same way.
- `.fallowrc.jsonc` suppressed `JOB_CAPTURE_CONTRACT_VERSION` as an export "no in-tree caller reads at all". One does now. The entry is removed — verified unnecessary by running `fallow audit` without it — per the rule the file itself states a few lines above: once something in-tree imports a suppressed name, take it back out. A suppression list stays honest only if entries leave it as well as join it.

## Review focus

- `src/lib/jd-extract/to-job-record.ts` — the boundary test asserts twelve extraction internals do *not* cross. Is anything on `ExtractedPosting` missing from that list, i.e. would a `...posting` spread today leak a field the test would not catch?
- `src/lib/storage/types.ts` — moving `JOB_CAPTURE_CONTRACT_VERSION` here makes `types.ts` a module producers import for a *value*, not just types. Is the re-export from `job-record-contract.ts` enough to keep the doc's "implemented by" pointer honest?
- `src/lib/storage/job-record-contract.ts` — the ISO-date warning is a prefix match, so `2026-13-45` passes it. Is a warning that accepts an impossible date worth having, or should it parse?
- The `atsUrl` fork case: is preferring `atsUrl` right when the page URL is *also* an ATS URL on a different host (a company board embedding a Greenhouse iframe)?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run verify` green locally — typecheck, eslint, `check:fixtures`, `check:baselines`, coverage, build
- [x] `npm run test` green: **4638 pass**, 10 skipped (pre-existing); 52 new tests
- [x] Bundle re-measured after the mapper joined the barrel: **22,905 bytes**, under the 25 KB criterion; `fetch(` → 0, node builtins → 0
- [x] Injected bundle smoke-tested end to end in jsdom on a real-shaped JSON-LD posting — extraction → `toJobRecord` → JSON round trip, all six facts populated
- [x] `src/lib/storage/` regression: 169 tests green, including `capture.test.ts` and `storage.test.ts`
- [x] No fixture binaries added or changed

`fallow audit`: 3 dead-code issues, all inherited unused deps in `extension/package.json`; 1 clone group (`job-record-contract.ts:267-284` ↔ `letter-contract.ts:139-155`) which is pre-existing untouched code, newly in scope only because the file changed — collapsing it would push the job-specific `status` default into the shared machinery. Report-only, as usual.

## Provenance

Code implementation via: Claude Opus 5
Verification: `npm run verify` — green locally, and in CI
