### PR TITLE
feat(job-hunt,jd-extract): the skill calls the extractor, and the extractor drops the people block

### DIFF
--- a/.claude/skills/job-hunt/SKILL.md
+++ b/.claude/skills/job-hunt/SKILL.md
@@ -60,6 +60,14 @@ Indeed and LinkedIn in a paired Chrome on the same day — URL parameters, selec
 every derived id in the table there are observed, not inferred. Where the obvious approach
 was tried and failed, that is called out — do not re-derive it.
 
+**One exception, stated so it is not mistaken for the rest.** Phase 2's extraction step
+(`jd-extract`, Appendix E) replaced hand-written page slicing in #719. The bundle, the call
+shape and the resulting record were verified against the real module in jsdom, and the
+module's own suite covers the adapters — but the inject-and-call round trip has **not** been
+run against live LinkedIn or Indeed. Treat the selectors it depends on as this repo's best
+current reading of those pages, not as observations from a paired run, and if something
+comes back empty on a real page, that is worth reporting rather than working around.
+
 ## The two doors
 
 | Direction | Mechanism | Why this one |
@@ -123,8 +131,10 @@ Load the Chrome tools in **one** `ToolSearch` call:
 select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__javascript_tool,mcp__claude-in-chrome__get_page_text,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__find,mcp__claude-in-chrome__file_upload,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__list_connected_browsers,mcp__claude-in-chrome__switch_browser
 ```
 
-`get_page_text` and `read_page` are for Phase 2's posting pages, not for offlinecv itself —
-everything this skill reads out of the app comes from IndexedDB via `javascript_tool`.
+`get_page_text` and `read_page` are for Phase 2's **search result** pages, not for offlinecv
+itself and not for posting bodies — everything this skill reads out of the app comes from
+IndexedDB via `javascript_tool`, and posting bodies come from the injected extractor
+(Appendix E). A posting body assembled from `get_page_text` is the failure #719 removed.
 
 `tabs_context_mcp{createIfEmpty:true}`, then navigate to `https://offlinecv.org/`.
 Reuse an existing offlinecv tab only if the user asks you to.
@@ -394,30 +404,74 @@ So, before Phase 3, rewrite every posting URL to its canonical form and store *t
 Do not capture a search URL, and do not capture a redirect shortlink. A tracker full of
 `rc/clk` links grows a new record every time the user re-runs the hunt.
 
-### Take the posting's own body, and only the posting's
+Hand that canonical URL to `JD.toJobRecord` as its second argument — **the extractor does
+not rewrite it for you.** What the mapper does do is prefer the posting's `atsUrl` over it:
+when the page links through to a Greenhouse or Lever original, that ATS URL becomes
+`JobRecord.url` instead, so the same job found on LinkedIn, on Indeed, and on the company's
+own board collapses to one record. The cost is that a posting captured once where that
+link is readable and once where it is not forks into two records — a duplicate the user can
+delete, which is the side of the trade `job-url.ts` deliberately lands on.
 
-Hydrating the body is also the liveness check — a closed posting cannot give you one, which
-is the same signal the old "fetch it and match the `h1`" pass was buying, for one fetch
-instead of two. If the body does not come back, the posting is gone; drop it and say so.
+### Take the posting's body with `jd-extract`, never by reading the page yourself
 
-Read the rendered page (`get_page_text` on the posting URL). **Do not call a site's internal
-JSON API** — LinkedIn's `/voyager/` endpoints answer, but reaching them means lifting the
-page's CSRF token out of `document.cookie`, and that is both a permission the skill does not
-have and an interface with no promise of stability. The rendered page is the supported read.
+**Do not slice the page text by hand.** `src/lib/jd-extract/` is this repo's job-posting
+extractor, and the app and the browser extension run the same code — that is the whole point
+of it existing (#719, the same argument `src/lib/storage/job-url.ts` makes for id
+derivation). This section used to describe extraction as English prose over string sentinels
+— "keep the text between `About the job` and `Set alert for similar jobs`" — and that is the
+implementation the module replaced. Do not re-derive it.
 
-Then cut it down, because the page is mostly not the posting:
+Build the injectable bundle once per session:
 
-- **Slice to the body.** On LinkedIn, keep the text between `About the job` and `Set alert
-  for similar jobs`. Everything after is "More jobs", the company blurb, the footer, and a
-  list of 37 language names — roughly 60% of the payload, all of it noise the matcher would
-  score.
-- **Strip the people block.** A LinkedIn posting page surfaces the user's 2nd-degree
-  connections under "People you can reach out to", by name, current title and school. That is
-  a *third party's* personal data, and this skill is about to write its input into the user's
-  IndexedDB. Cut it before it reaches `jdText`. The repo's fixture-PII rule is the same
-  instinct: a name that arrives incidentally is still a name you chose to persist.
-- **Expand truncation first.** Both sites collapse long descriptions behind a "see more"
-  control; the collapsed text ends mid-posting. Expand it, then read.
+```bash
+node_modules/.bin/esbuild src/lib/jd-extract/index.ts \
+  --bundle --format=iife --global-name=JD --minify \
+  --outfile="$SCRATCH/jd-extract.js" --log-level=error
+```
+
+~24 KB, network-free by construction: the barrel deliberately omits the `ats_api` tier
+because that one imports `fetch()`, so nothing you inject into the user's page can make a
+request. Read the file and pass its contents to `javascript_tool` on the posting tab,
+followed by the call — see Appendix E for the exact shape.
+
+Injection runs in the **page's own context**, so `window.JD` survives until the tab
+navigates. On LinkedIn that is worth using: the jobs search is an SPA, so you can inject
+once and then read posting after posting by changing `currentJobId` without paying the
+bundle again. Anywhere each posting is a real navigation, re-inject.
+
+What comes back is one ~1 KB JSON object, not the page. That direction matters: a LinkedIn
+job page is 1–2 MB of HTML, so shipping the page out to slice it here costs far more than
+shipping ~24 KB of extractor in.
+
+`JD.extract` returns `null` when the page is not a posting — a closed listing, a search
+results page, an interstitial. That **is** the liveness check, for one read instead of two.
+A `null` is not an error to retry; drop the posting and report the URL as unhydrated.
+
+**Do not call a site's internal JSON API** — LinkedIn's `/voyager/` endpoints answer, but
+reaching them means lifting the page's CSRF token out of `document.cookie`, which is both a
+permission this skill does not have and an interface with no promise of stability. The
+rendered page is the supported read.
+
+**Expand truncation before you extract.** Both sites collapse long descriptions behind a
+"see more" control, and the extractor reads the DOM it is given — a collapsed description
+extracts cleanly and stops mid-posting, which is the failure that looks most like success.
+Click it, then inject.
+
+### What the extractor already handles, so you do not
+
+- **The people block.** A LinkedIn posting page surfaces the user's 2nd-degree connections
+  under "People you can reach out to", by name, current title and school. That is a *third
+  party's* personal data, and `jdText` gets persisted to the user's IndexedDB.
+  `src/lib/jd-extract/prune.ts` drops that subtree, along with "More jobs for you" rails and
+  page chrome, before the body is built. Verified by test, not by inspection — but if you
+  ever see a person's name in a body you are about to write, stop and say so rather than
+  editing it out by hand, because a name reaching that far means the guard has rotted and
+  the extension is leaking it too.
+- **Line structure.** The body comes back as Markdown, with the list structure the
+  requirements live in. The old advice to convert `<br>`/`</p>`/`</li>` to newlines before
+  stripping tags is now the module's job.
+- **The canonical ATS URL.** Where a listing links through to a Greenhouse or Lever
+  original, `toJobRecord` puts *that* in `url` — see Phase 3.
 
 The app's own `/jobs/` Search tab is the remaining option, and it is the user's to drive: it
 egresses a keyword string built from their query, a deliberate and documented boundary
@@ -426,12 +480,8 @@ saying so.
 
 ### `jdText` is the requirements body, not a summary — this is the #1 quality lever
 
-**Do not write your own précis of the posting.** Capture the posting's own text, from the
-role/responsibilities heading through the qualifications, and keep the line breaks: the
-noun pass matches phrases within a line and cannot span a line break, so flattening the
-whitespace destroys the terms.
-
-Measured on a live posting, same résumé, same everything else:
+**Never hand-write, paraphrase, or top-and-tail the body.** Pass through exactly what
+`JD.extract` returned. Measured on a live posting, same résumé, same everything else:
 
 | `jdText` | terms extracted | rating |
 |---|---|---|
@@ -439,43 +489,58 @@ Measured on a live posting, same résumé, same everything else:
 | 8000 chars of the real JD body | 26 terms incl. real skills | **2.34★** |
 
 A hand-written blurb reads well and rates zero, because what survives paraphrase is the
-company name and the job title — `DEFCON AI`, `USA`, `Data Lead` — and no résumé on earth
-contains those. The fit rating is only as good as the text you save, and the user cannot
-tell a bad capture from a bad match: both render as "Weak fit".
+company name and the job title — and no résumé on earth contains those. The fit rating is
+only as good as the text you save, and the user cannot tell a bad capture from a bad match:
+both render as "Weak fit".
 
-Aim for **≥2000 characters** of real posting body. Take the whole thing when it is
-reasonable; do not trim to be tidy. Sanity-check before writing: if a capture yields under
-~1500 characters, or reads like prose you composed rather than text you copied, go back and
-take the real body.
+**Add nothing to it.** No synthesized provenance header — no `Posted: … ReqID: … Type: …`
+line, no fetch timestamp, no source URL. A capture that prepended one put the junk term
+`REQ` straight into the coverage denominator, where it cost real rating and no résumé could
+ever cover it. Provenance belongs in `capture`, a structured field the matcher never reads.
 
-When fetching HTML yourself, convert `<br>`, `</p>`, `</li>` to newlines **before**
-stripping tags. Flattening whitespace first cost a whole diagnostic round: the same JD
-yielded 0 terms flattened and 26 line-structured.
+**Check the extraction before you keep it.** Two fields on the result say how much to trust
+it, and both belong in the report:
 
-**Save the posting's text and nothing else.** No synthesized provenance header — no
-`Posted: … ReqID: … Type: …` line, no fetch timestamp, no source URL. A capture that
-prepended one put the junk term `REQ` straight into the coverage denominator, where it
-cost real rating and no résumé could ever cover it. Provenance belongs in `capture`,
-which is a structured field the matcher never reads. The posting *title* on its own first
-line is fine and expected — `extractJdTerms` is told the title separately
-(`ExtractOptions.postingTitle`) and drops it from the requirement terms.
+- `extractionTier` — `schema_org` is the publisher's own machine-readable declaration and is
+  the best case. `ats_extractor` is a host adapter. `dom_metadata` is the floor, and on a
+  LinkedIn posting it is also the *expected* value, because LinkedIn's adapter reports that
+  tier deliberately — it is an aggregator, not an ATS.
+- `body.length` — aim for **≥2000 characters**. Under ~1500 usually means the description
+  was still collapsed behind "see more", or the SPA had not rendered when you injected.
+  Expand, re-inject, re-read. If it stays short, keep it and say so in the report; do not
+  pad it and do not silently drop it.
 
 ---
 
 ## Phase 3 — Build the import document
 
+### The record is already built — `JD.toJobRecord` made it
+
+Phase 2's injected call returned a capture payload, not raw extraction output. It carries
+`title`, `company`, `url`, `jdText`, the six posting facts the contract added in v2
+(`location`, `salaryRange`, `datePosted`, `workModel`, `employmentType`, `validThrough`),
+and a filled `capture` block. **Pass those fields through unchanged.** Do not re-derive one,
+do not add one the mapper omitted, and do not fill a blank — an omitted field means "the
+posting did not say", and inventing a value there is the drift `to-job-record.ts` exists to
+prevent.
+
+What it deliberately does **not** give you is an `id` or a `status`. Those are next.
+
 ### Derive ids with the repo's own code, never by hand
 
 `deriveJobId` is normative (§2 of `docs/job-capture-contract.md`). A producer that strips
-one parameter differently forks the id space and creates silent duplicates. Bundle the
-real module and call it:
+one parameter differently forks the id space and creates silent duplicates. It is not on the
+injectable barrel — the page has no reason to derive an id — so bundle it separately and
+call it here:
 
 ```bash
 node_modules/.bin/esbuild src/lib/storage/job-url.ts \
   --bundle --format=esm --outfile="$SCRATCH/job-url.mjs" --log-level=error
 ```
 
-Then `import { deriveJobId } from "$SCRATCH/job-url.mjs"` in a node one-liner. Verified:
+Then `import { deriveJobId } from "$SCRATCH/job-url.mjs"` in a node one-liner, and feed it
+**the `url` the mapper returned**, not the URL you navigated to — they differ whenever the
+`atsUrl` rule fired, and that difference is the entire point of it. Verified:
 `https://boards.greenhouse.io/exampleco/jobs/4455661?gh_src=abc&utm_source=alerts`
 → `job:boards.greenhouse.io/exampleco/jobs/4455661`.
 
@@ -492,6 +557,9 @@ between a skill the user can re-run and one that quietly resets their pipeline.
 
 `StorageExport` v2. `resumes: []` always — this skill never writes résumés.
 
+Each job is the mapper's payload plus the two fields it does not own — the derived `id` and
+`status: "interested"`:
+
 ```json
 {
   "version": 2,
@@ -500,22 +568,34 @@ between a skill the user can re-run and one that quietly resets their pipeline.
   "jobs": [
     {
       "id": "job:<derived>",
+      "status": "interested",
+
       "title": "…",
       "company": "…",
       "url": "https://…",
-      "status": "interested",
       "jdText": "…",
+      "location": "Austin, TX",
+      "salaryRange": "$180k – $220k",
+      "datePosted": "2026-07-28",
+      "workModel": "remote",
+      "employmentType": "FULL_TIME",
+      "validThrough": "2026-09-01",
       "capture": {
-        "contract": 1,
+        "contract": 2,
         "producer": "claude-code-jobs-skill",
-        "producerVersion": "0.1.0",
-        "capturedAt": 0
+        "producerVersion": "0.2.0",
+        "capturedAt": 1754006400000
       }
     }
   ],
   "letters": []
 }
 ```
+
+The blank line marks the seam: everything below it came from `JD.toJobRecord` verbatim.
+The six posting facts are all optional — **emit only the ones the mapper returned.** They
+are display-only record-keeping; nothing ranks on them, so a missing one costs the user
+nothing and a guessed one is just wrong.
 
 Rules the validator enforces, so get them right up front:
 
@@ -527,6 +607,10 @@ Rules the validator enforces, so get them right up front:
 - **Write the job and its letters in the same document.** `importAll` writes
   resumes → jobs → letters, so a letter's `jobId` resolves. A letter whose `jobId` matches
   no job imports cleanly and is then reachable from nothing — nothing reconciles it.
+- `datePosted` and `validThrough` are accepted whatever they say, but a value that does not
+  start `YYYY-MM-DD` earns a warning. Never convert a relative date — `"3 days ago"` is
+  wrong tomorrow and nothing downstream can tell. Pass through what the mapper returned;
+  it is already the posting's own declared value.
 
 Write the file into the session scratchpad. `file_upload` accepts scratchpad paths.
 
@@ -573,6 +657,13 @@ Report:
 - **how old the postings are** — the oldest one captured, and anything over a week. Say the
   age; do not quietly drop stale rows and do not quietly keep them
 - jobs written / already-present-and-skipped / refused, each refusal with its reason
+- **how well each posting extracted** — its `extractionTier` and body length. A run where
+  everything landed on `dom_metadata` at 600 characters produced worse ratings than one on
+  `schema_org` at 8000, and the ratings alone do not distinguish a weak match from a weak
+  capture. Say which it was
+- **any posting whose `url` came from `atsUrl` rather than the page you captured it on** —
+  the record points at the ATS original, so the user clicking through will not land back on
+  the LinkedIn or Indeed listing they would expect
 - **links parked unhydrated** — anything found but not captured because its body would not
   load, with the URL so the user can open it themselves
 - letters written / refused, if any
@@ -662,3 +753,45 @@ for (const j of await read("jobs")) {
 
 Deleting a job through the **app** cascades to its letters. Deleting it through raw
 IndexedDB like this does **not** — sweep `letters` by `jobId` yourself, or prefer the UI.
+
+## Appendix E — extract a posting
+
+Build once per session (Phase 2), then per posting: read `$SCRATCH/jd-extract.js` and send
+its contents as the **first part** of one `javascript_tool` call, with this appended.
+`javascript_tool` has REPL semantics — top-level `await` works and the last expression is
+the return value, so there is no `return` here and there must not be one.
+
+```js
+// …contents of $SCRATCH/jd-extract.js above this line, defining `JD`…
+
+const canonical = "https://www.indeed.com/viewjob?jk=<jk>"; // Phase 2's normalised URL
+const posting = await JD.extract(document, new URL(location.href));
+
+JSON.stringify(
+  posting && {
+    tier: posting.extractionTier,
+    bodyChars: posting.body.length,
+    fromAtsUrl: Boolean(posting.atsUrl),
+    record: JD.toJobRecord(posting, canonical, {
+      producer: "claude-code-jobs-skill",
+      producerVersion: "0.2.0",
+    }),
+  },
+);
+```
+
+`document` and `location.href` are the *page's* — what it actually rendered, including
+whatever you expanded. `canonical` is a separate argument on purpose: the extractor reads
+the page it is on, and normalising away tracking parameters is Phase 2's job, not its.
+
+`null` back means the page is not a posting — a closed listing, a search page, an
+interstitial. Drop it and report the URL; do not retry.
+
+**Keep the `JSON.stringify`.** The record must cross the tool boundary as JSON, not as an
+object — an object built in the page's realm has that realm's `Object.prototype`, and
+`validateJobRecord` refuses it with `` `capture`: a Object is not a plain JSON object ``,
+which reads like a malformed record and is not one. Serialising is what re-homes it.
+
+The bundle runs in the page's own context, so `window.JD` persists until the tab navigates.
+Re-sending it is harmless — it just redefines `JD` — but on a page that still has it,
+sending only the call is free.

--- a/src/lib/jd-extract/adapters-extract.test.ts
+++ b/src/lib/jd-extract/adapters-extract.test.ts
@@ -23,6 +23,7 @@ import { workday } from "./adapters/workday";
 import { oracleHcm } from "./adapters/oracle-hcm";
 import { smartrecruiters } from "./adapters/smartrecruiters";
 import { generic } from "./adapters/generic";
+import { linkedin } from "./adapters/linkedin";
 
 function doc(html: string): Document {
   return new DOMParser().parseFromString(
@@ -349,5 +350,119 @@ describe("generic.extract", () => {
 
   it("returns null with no h1", () => {
     expect(generic.extract(doc(`<main>${LONG_BODY}</main>`), url)).toBeNull();
+  });
+
+  it("drops a related-jobs rail, whose titles would score as this posting's terms", () => {
+    const result = generic.extract(
+      doc(
+        `<h1>Platform Engineer</h1><main>${LONG_BODY}` +
+          "<section><h2>Related jobs</h2><ul><li>Principal Kubernetes Architect at OtherCo</li></ul></section>" +
+          "</main>",
+      ),
+      url,
+    );
+    expect(result!.body).not.toContain("Principal Kubernetes Architect");
+    expect(result!.body).toContain("distributed systems");
+  });
+});
+
+/**
+ * LinkedIn is the highest-volume source in the `job-hunt` lane and the one general
+ * tier that has nothing to fall back on — the logged-in job view ships neither
+ * JSON-LD nor `og:` tags, so if this adapter misses, the most commonly captured
+ * posting gets the worst extraction available.
+ */
+describe("linkedin.extract", () => {
+  const url = new URL("https://www.linkedin.com/jobs/view/4437835690/");
+
+  /** The logged-in job view's shape: description and page furniture share `<main>`. */
+  function linkedInDoc(extra = ""): Document {
+    const d = doc(
+      "<main>" +
+        "<h1>Staff Data Engineer</h1>" +
+        '<div class="job-details-jobs-unified-top-card__company-name"><a>ExampleCo</a></div>' +
+        '<div id="job-details"><h2>About the job</h2>' +
+        "<p>Own the streaming platform end to end, from ingestion through serving.</p>" +
+        "<h3>Qualifications</h3><ul><li>8+ years with Python and Spark</li></ul></div>" +
+        extra +
+        "</main>",
+    );
+    d.title = "Staff Data Engineer | ExampleCo | LinkedIn";
+    return d;
+  }
+
+  it("extracts title, company and body from the logged-in view", () => {
+    const result = linkedin.extract(linkedInDoc(), url);
+
+    expect(result!.title).toBe("Staff Data Engineer");
+    expect(result!.company).toBe("ExampleCo");
+    expect(result!.body).toContain("Python and Spark");
+    // LinkedIn is an aggregator, not an ATS — reporting one would misstate how the
+    // posting was obtained.
+    expect(result!.extractionTier).toBe("dom_metadata");
+    expect(result!.atsDetected).toBeUndefined();
+  });
+
+  it("falls back to the page title when the DOM carries no company", () => {
+    const d = doc(
+      '<main><h1>Staff Data Engineer</h1><div id="job-details">' +
+        `${LONG_BODY}</div></main>`,
+    );
+    d.title = "Staff Data Engineer | ExampleCo | LinkedIn";
+
+    expect(linkedin.extract(d, url)!.company).toBe("ExampleCo");
+  });
+
+  // Degrades rather than returning null: the body and URL still carry real value.
+  it("reports an unknown company rather than discarding the posting", () => {
+    const d = doc(`<main><h1>Staff Data Engineer</h1><div>${LONG_BODY}</div></main>`);
+    d.title = "";
+
+    expect(linkedin.extract(d, url)!.company).toBe("Unknown");
+  });
+
+  it("returns null when the SPA has not rendered the posting yet", () => {
+    const d = doc("<main><h1>Staff Data Engineer</h1><nav>Home Jobs Messaging</nav></main>");
+    expect(linkedin.extract(d, url)).toBeNull();
+  });
+
+  it("returns null with no title", () => {
+    expect(linkedin.extract(doc(`<main>${LONG_BODY}</main>`), url)).toBeNull();
+  });
+
+  /**
+   * The regression this adapter's pruning exists for. `body` becomes
+   * `JobRecord.jdText` and is persisted to the user's IndexedDB, so a connection's
+   * name reaching it is a privacy defect, not a quality one — asserted on the names
+   * themselves for that reason. Personas are synthetic.
+   */
+  it("keeps the 'People you can reach out to' block out of the body", () => {
+    const result = linkedin.extract(
+      linkedInDoc(
+        '<section class="people-who-can-help"><h2>People you can reach out to</h2>' +
+          "<ul><li><a>Dana Whitfield</a><span>Senior Recruiter at ExampleCo</span>" +
+          "<span>Purdue University</span></li></ul></section>",
+      ),
+      url,
+    );
+
+    expect(result!.body).not.toContain("Dana Whitfield");
+    expect(result!.body).not.toContain("Purdue University");
+    expect(result!.body).toContain("Python and Spark");
+  });
+
+  it("keeps other postings' titles out of the body", () => {
+    const result = linkedin.extract(
+      linkedInDoc(
+        "<section><h2>More jobs for you</h2>" +
+          "<ul><li>Principal Data Engineer at OtherCo</li></ul></section>" +
+          "<footer>Amharic Arabic Bangla Czech Danish</footer>",
+      ),
+      url,
+    );
+
+    expect(result!.body).not.toContain("Principal Data Engineer at OtherCo");
+    expect(result!.body).not.toContain("Amharic");
+    expect(result!.body).toContain("streaming platform");
   });
 });

--- a/src/lib/jd-extract/adapters/generic.ts
+++ b/src/lib/jd-extract/adapters/generic.ts
@@ -17,6 +17,7 @@
 // claiming one would misreport how the posting was obtained.
 
 import { htmlToMarkdown } from "../html-to-markdown";
+import { pruneNonPosting } from "../prune";
 import type { ATSExtractor, ExtractedPosting } from "../types";
 
 /** See `./linkedin.ts` — below this, the container held page chrome, not a JD. */
@@ -57,7 +58,13 @@ export const generic: ATSExtractor = {
       doc.querySelector("article") ||
       doc.querySelector("main") ||
       doc.querySelector('[role="main"]');
-    const body = mainEl ? htmlToMarkdown(mainEl) : doc.body?.textContent?.trim() || "";
+    // Pruned for the same reason the landmark is preferred over `doc.body`: a
+    // landmark is the smallest container the page offers, not a clean one. An
+    // unknown board's `<main>` still carries a "Related jobs" rail, and those are
+    // other postings' terms landing in this posting's coverage denominator.
+    const body = mainEl
+      ? htmlToMarkdown(pruneNonPosting(mainEl))
+      : doc.body?.textContent?.trim() || "";
 
     if (body.length < MIN_BODY_LENGTH) return null;
 

--- a/src/lib/jd-extract/adapters/linkedin.ts
+++ b/src/lib/jd-extract/adapters/linkedin.ts
@@ -16,6 +16,7 @@
 // posting was obtained.
 
 import { htmlToMarkdown } from "../html-to-markdown";
+import { pruneNonPosting } from "../prune";
 import type { ATSExtractor, ExtractedPosting } from "../types";
 import {
   extractLinkedInCompanyFromDOM,
@@ -52,9 +53,14 @@ export const linkedin: ATSExtractor = {
 
     if (!title) return null;
 
+    // `<main>` on the logged-in job view is not the posting: it also holds the
+    // "People you can reach out to" block — named 2nd-degree connections, their
+    // titles and their schools — and a list of other postings. Pruning is not a
+    // tidiness pass here; it is what keeps a third party's personal data out of
+    // `jdText`, which is persisted. See `../prune.ts`.
     const mainEl = doc.querySelector("main") || doc.querySelector('[role="main"]');
     const body = mainEl
-      ? htmlToMarkdown(mainEl)
+      ? htmlToMarkdown(pruneNonPosting(mainEl))
       : doc.body?.textContent?.trim() || "";
 
     if (body.length < MIN_BODY_LENGTH) return null;

--- a/src/lib/jd-extract/prune.test.ts
+++ b/src/lib/jd-extract/prune.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `pruneNonPosting` — the guard that keeps a third party's name out of `jdText`.
+ *
+ * The privacy cases below are the reason this module exists, so they assert on the
+ * absence of specific personal data rather than on a node count: the failure being
+ * prevented is "a connection's name was persisted to the user's library", and only
+ * an assertion phrased that way fails for the right reason.
+ *
+ * The personas are synthetic, per the repo's fixture-PII rule. That rule is written
+ * for binaries under `tests/fixtures/`, but a test whose subject IS name-handling
+ * would be a poor place to make an exception.
+ */
+
+import { pruneNonPosting } from "./prune";
+
+function root(html: string): Element {
+  const doc = new DOMParser().parseFromString(
+    `<!doctype html><html><body><main>${html}</main></body></html>`,
+    "text/html",
+  );
+  const main = doc.querySelector("main");
+  if (!main) throw new Error("fixture has no <main>");
+  return main;
+}
+
+const JD = `
+  <h2>About the job</h2>
+  <p>We are hiring a Staff Data Engineer to own the streaming platform.</p>
+  <h3>Qualifications</h3>
+  <ul><li>8+ years with Python and Spark</li></ul>
+`;
+
+describe("pruneNonPosting — third-party PII", () => {
+  it("drops the section a 'People you can reach out to' heading captions", () => {
+    const el = root(`
+      ${JD}
+      <section class="people-who-can-help">
+        <h2>People you can reach out to</h2>
+        <ul>
+          <li><a>Dana Whitfield</a><span>Senior Recruiter at ExampleCo</span><span>Purdue University</span></li>
+          <li><a>Marcus Ellery</a><span>Engineering Manager</span><span>Georgia Tech</span></li>
+        </ul>
+      </section>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Dana Whitfield");
+    expect(text).not.toContain("Marcus Ellery");
+    expect(text).not.toContain("Purdue University");
+    expect(text).toContain("Staff Data Engineer");
+  });
+
+  it("drops the block when it is a flat run of siblings with no wrapper", () => {
+    const el = root(`
+      ${JD}
+      <h2>People you can reach out to</h2>
+      <ul><li>Dana Whitfield — Senior Recruiter</li></ul>
+      <p>Purdue University</p>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Dana Whitfield");
+    expect(text).not.toContain("Purdue University");
+    expect(text).toContain("Python and Spark");
+  });
+
+  it("stops a flat run at the next heading, so real sections survive it", () => {
+    const el = root(`
+      <h2>More jobs for you</h2>
+      <ul><li>Principal Data Engineer at OtherCo</li></ul>
+      <h2>Benefits</h2>
+      <p>Health coverage and a learning stipend.</p>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Principal Data Engineer at OtherCo");
+    expect(text).toContain("Health coverage");
+  });
+
+  it("drops a 'Meet the hiring team' block, which is also named people", () => {
+    const el = root(`
+      ${JD}
+      <div><h3>Meet the hiring team</h3><p>Priya Raghunathan, Director of Data</p></div>
+    `);
+
+    expect(pruneNonPosting(el).textContent ?? "").not.toContain("Priya Raghunathan");
+  });
+});
+
+describe("pruneNonPosting — other postings' terms", () => {
+  it.each([
+    ["Similar jobs", "similar"],
+    ["Related Jobs", "related"],
+    ["Recommended jobs", "recommended"],
+    ["More jobs for you", "more"],
+    ["Jobs you may be interested in", "you may"],
+    ["People also viewed", "also viewed"],
+  ])("drops a %s rail", (heading) => {
+    const el = root(`
+      ${JD}
+      <section><h2>${heading}</h2><ul><li>Principal Kubernetes Architect at OtherCo</li></ul></section>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Principal Kubernetes Architect");
+    expect(text).toContain("Staff Data Engineer");
+  });
+
+  it("keeps a heading that merely mentions jobs without captioning a rail", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <p>This role reports to the Director of Data Platform.</p>
+      <h3>Why this job is different</h3>
+      <p>You will own Kafka end to end.</p>
+    `);
+
+    expect(pruneNonPosting(el).textContent ?? "").toContain("own Kafka end to end");
+  });
+});
+
+describe("pruneNonPosting — page chrome", () => {
+  it.each(["nav", "aside", "footer", "form"])("drops <%s>", (tag) => {
+    const el = root(`${JD}<${tag}>Amharic Arabic Bangla Czech Danish</${tag}>`);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Amharic");
+    expect(text).toContain("Staff Data Engineer");
+  });
+
+  it("drops <script> content, which would otherwise be a blob of page state", () => {
+    const el = root(`${JD}<script>window.__DATA__ = {"applicantCount": 412};</script>`);
+
+    expect(pruneNonPosting(el).textContent ?? "").not.toContain("applicantCount");
+  });
+});
+
+describe("pruneNonPosting — the input is never modified", () => {
+  it("leaves the live element intact, because this runs in the user's own tab", () => {
+    const el = root(`
+      ${JD}
+      <section><h2>People you can reach out to</h2><p>Dana Whitfield</p></section>
+    `);
+
+    const before = el.innerHTML;
+    pruneNonPosting(el);
+
+    expect(el.innerHTML).toBe(before);
+    expect(el.textContent).toContain("Dana Whitfield");
+  });
+
+  it("returns an equivalent copy when nothing matches", () => {
+    const el = root(JD);
+
+    const pruned = pruneNonPosting(el);
+
+    expect(pruned).not.toBe(el);
+    expect(pruned.innerHTML).toBe(el.innerHTML);
+  });
+
+  it("never removes the element it was asked to prune", () => {
+    // The heading captions the whole container, so the climb would reach the root
+    // if it were not bounded — and returning nothing at all would read downstream
+    // as an unreadable page rather than a pruned one.
+    const el = root(`<h2>Similar jobs</h2><p>Principal Data Engineer at OtherCo</p>`);
+
+    const pruned = pruneNonPosting(el);
+
+    expect(pruned.tagName.toLowerCase()).toBe("main");
+    expect(pruned.textContent ?? "").not.toContain("Principal Data Engineer");
+  });
+});

--- a/src/lib/jd-extract/prune.ts
+++ b/src/lib/jd-extract/prune.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Drop the parts of a posting page that are not the posting, before the body is
+// converted to Markdown.
+//
+// This exists because of one specific thing a LinkedIn job page does: it surfaces
+// the user's 2nd-degree connections under "People you can reach out to", by name,
+// current title and school — inside `<main>`, the same landmark the adapter reads
+// the description from. That is a THIRD PARTY's personal data, and the next thing
+// that happens to `body` is that it becomes `JobRecord.jdText` and gets persisted
+// to the user's IndexedDB. The repo's fixture-PII rule is the same instinct: a name
+// that arrives incidentally is still a name you chose to persist.
+//
+// It used to be a rule written as English prose in the `job-hunt` skill — "keep the
+// text between `About the job` and `Set alert for similar jobs`" — which is exactly
+// the fork #719 exists to end. A sentinel over flattened text cannot express "drop
+// this subtree", so the skill could only approximate it, the extension did not do it
+// at all, and the app had no answer either. Here it is one implementation, and every
+// consumer that calls `extract()` gets it.
+//
+// The second reason is rating quality, and it is not cosmetic. Everything this drops
+// is text the matcher would otherwise score: a "More jobs for you" block is a list of
+// OTHER postings' titles, which lands real-looking job terms in the coverage
+// denominator that no résumé could ever cover. `src/lib/job-search/rate-saved-jobs.ts`
+// treats a record with no extractable terms as *not rated* rather than rated zero, so
+// diluted text degrades quietly rather than visibly.
+//
+// Pruning is done on a CLONE, never on the passed element. This module runs inside
+// whatever page the user is looking at — `src/lib/jd-extract/index.ts` is bundled and
+// injected — so mutating the live DOM would visibly alter their page to read it.
+
+/**
+ * Tags that are page chrome wherever they appear.
+ *
+ * `form` is here because a form on a posting page is the application form, and its
+ * labels ("First name", "Attach resume") are the highest-confidence noise on the
+ * page. `script`/`style`/`noscript` are dropped by the Markdown walk too; they are
+ * repeated here so a caller that prunes without converting still gets them gone.
+ */
+const NON_POSTING_TAGS = [
+  "nav",
+  "aside",
+  "footer",
+  "form",
+  "script",
+  "style",
+  "noscript",
+] as const;
+
+/**
+ * Headings that caption a block belonging to something other than this posting.
+ *
+ * Matched against heading text rather than a class name on purpose: a class name is
+ * one vendor's markup and rots on their next redesign, while the heading is what the
+ * block says it is, in the copy a human reads. The patterns are deliberately narrow —
+ * a false positive here deletes real posting text, which is worse than the noise it
+ * was aiming at.
+ */
+const NON_POSTING_HEADINGS: readonly RegExp[] = [
+  // Third-party PII: names, titles and schools of the user's connections.
+  /people\s+you\s+can\s+reach\s+out\s+to/i,
+  /meet\s+the\s+(hiring\s+team|team\s+behind)/i,
+  // Other postings' titles, which the matcher would score as this posting's terms.
+  /\b(similar|related|recommended|suggested|more)\s+jobs\b/i,
+  /\bjobs\s+(you\s+may|that\s+may)\b/i,
+  /people\s+also\s+viewed/i,
+];
+
+const HEADING_SELECTOR = "h1, h2, h3, h4, h5, h6";
+
+/** The first heading in `el`'s subtree, or `null` if it holds none. */
+function firstHeading(el: Element): Element | null {
+  return el.querySelector(HEADING_SELECTOR);
+}
+
+/**
+ * The subtree a noise heading captions.
+ *
+ * Climbs from the heading while each parent's first heading is still this one — i.e.
+ * while the parent is a container this heading titles rather than a container it
+ * merely sits inside. Stops at `root`, so pruning can never remove the element the
+ * caller asked to convert.
+ *
+ * Returns the heading itself when it could not climb, which means the block is a flat
+ * run of siblings; {@link removeCaptionedRun} handles that shape instead.
+ */
+function captionedContainer(heading: Element, root: Element): Element {
+  let node = heading;
+  while (
+    node.parentElement &&
+    node.parentElement !== root &&
+    root.contains(node.parentElement) &&
+    firstHeading(node.parentElement) === heading
+  ) {
+    node = node.parentElement;
+  }
+  return node;
+}
+
+/**
+ * Remove a heading and the siblings that follow it, up to the next heading.
+ *
+ * The fallback for a flat document — `<main><h2>More jobs</h2><ul>…</ul><h2>…` — where
+ * there is no wrapper element to delete and the block is defined only by what comes
+ * between two headings. Stopping at the next heading is what keeps this from eating
+ * the rest of the page.
+ */
+function removeCaptionedRun(heading: Element): void {
+  let sibling = heading.nextElementSibling;
+  while (sibling && !sibling.matches(HEADING_SELECTOR)) {
+    const next = sibling.nextElementSibling;
+    sibling.remove();
+    sibling = next;
+  }
+  heading.remove();
+}
+
+/**
+ * Return a pruned copy of `element`, with non-posting subtrees removed.
+ *
+ * The input is never modified. When nothing matches, the result is an exact copy and
+ * the caller's behaviour is unchanged — so adding a pattern above can only ever remove
+ * text, never restructure what was already being read correctly.
+ */
+export function pruneNonPosting(element: Element): Element {
+  const clone = element.cloneNode(true) as Element;
+
+  for (const el of clone.querySelectorAll(NON_POSTING_TAGS.join(","))) {
+    el.remove();
+  }
+
+  // Collected before removing anything: removing a container can detach headings
+  // still in the list, and `contains` on a detached node is what would otherwise
+  // decide their fate arbitrarily.
+  const headings = Array.from(clone.querySelectorAll(HEADING_SELECTOR));
+  for (const heading of headings) {
+    if (!clone.contains(heading)) continue;
+    const text = heading.textContent?.trim() ?? "";
+    if (!NON_POSTING_HEADINGS.some((p) => p.test(text))) continue;
+
+    const container = captionedContainer(heading, clone);
+    if (container === heading) removeCaptionedRun(heading);
+    else container.remove();
+  }
+
+  return clone;
+}


### PR DESCRIPTION
## Summary

PR 3 of #719, and the one that makes the other two load-bearing. The `job-hunt` skill described JD extraction as English prose over string sentinels — *"keep the text between `About the job` and `Set alert for similar jobs`"* — which is the third implementation this issue exists to delete.

Phase 2 now builds `src/lib/jd-extract/` into an injectable IIFE, injects it into the posting page, and calls `JD.extract` + `JD.toJobRecord`. Phase 3 passes the mapper's payload through instead of assembling a record by hand, and still derives the id from `job-url.ts` — the page has no reason to derive an id, so that module is deliberately not on the injectable barrel.

Closes #719.

### This is not skill-only, and that was not optional

Deleting the prose is what surfaced the defect. **The LinkedIn adapter read all of `<main>`, and on the logged-in job view `<main>` also holds "People you can reach out to"** — the user's 2nd-degree connections, by name, current title and school. Switching the skill over as specified would have newly written a third party's personal data into `jdText`, which is persisted to the user's IndexedDB.

Measured on a LinkedIn-shaped page through the real injected bundle, before the fix:

```
tier: dom_metadata | body chars: 650
LEAKED  Dana Whitfield
LEAKED  Marcus Ellery
LEAKED  Purdue University
LEAKED  More jobs for you
LEAKED  Principal Data Engineer at OtherCo
LEAKED  Amharic
```

The only place that rule existed was the skill prose being removed. The extension never had it at all. So the fix belongs in the module, where all three consumers get it — which is the same argument #719 makes about extraction generally.

### `jd-extract/prune.ts`

Drops page chrome by tag (`nav`, `aside`, `footer`, `form`) and drops the subtree a non-posting heading captions: "People you can reach out to", "Meet the hiring team", similar/related/recommended/more-jobs rails, "People also viewed".

Matched on **heading text rather than a class name**, because a class name is one vendor's markup and rots on their next redesign, while the heading is what the block says it is in the copy a human reads. The patterns are deliberately narrow — a false positive here deletes real posting text, which is worse than the noise it aims at.

Two structural points that are easy to get wrong:

- **It prunes a clone, never the passed element.** This module is bundled and injected into whatever page the user is looking at, so mutating the live DOM to read it would visibly alter their page. A test asserts the input is untouched.
- **The climb is bounded.** It walks up from a noise heading only while each parent's first heading is still that heading, and stops at the root — so it removes the container a heading titles, never the element the caller asked to convert. For a flat document with no wrapper it falls back to removing the heading and its following siblings up to the next heading, which is what keeps it from eating the rest of the page.

The second motive is rating quality and it is not cosmetic: a "More jobs for you" rail is a list of *other* postings' titles, landing real-looking job terms in the coverage denominator that no résumé could ever cover.

`linkedin` and `generic` are the two adapters that read a whole landmark rather than a host-specific description container, so both prune.

### `linkedin.extract` had no test at all

Which is how this got here: the adapter covering the highest-volume source in the lane — and the one general tier with nothing to fall back on, since the logged-in view ships neither JSON-LD nor `og:` tags — was untested. It has seven tests now, two asserting the names do not reach `body`, phrased on the names themselves so they fail for the right reason. Personas are synthetic.

### Two honesty edits to the skill

It opens by claiming live end-to-end verification, so:

- The new extraction step is **called out as the exception**. The bundle, the call shape and the resulting record were verified against the real module in jsdom, and the module's own suite covers the adapters — but the inject-and-call round trip has **not** been run against live LinkedIn or Indeed. The skill now says so and tells the runner to report an empty result rather than work around it.
- Appendix E documents why the `JSON.stringify` is load-bearing: an object built in the page's realm carries that realm's `Object.prototype`, so `validateJobRecord` refuses it with ``` `capture`: a Object is not a plain JSON object ```, which reads like a malformed record and is not one. Found by writing the smoke test the wrong way first.

## Review focus

- `src/lib/jd-extract/prune.ts` — the heading patterns are the whole risk surface. Is there a real posting whose own section heading matches one of them, e.g. a role literally about recommending jobs?
- `src/lib/jd-extract/prune.ts` — `captionedContainer` climbs while `firstHeading(parent) === heading`. On a page where the description and the people block share a wrapper whose first heading is "About the job", the people heading cannot climb, so it takes the flat-run path. Does that path stop in the right place there?
- `.claude/skills/job-hunt/SKILL.md` Appendix E — the bundle is ~24 KB injected per posting. On a site where each posting is a real navigation, is that per-posting cost worth flagging more loudly, or is the ~1 KB return against a 1–2 MB page enough justification on its own?
- The skill still keeps `get_page_text`/`read_page` for **search result** pages only. Is that boundary stated clearly enough that a future run doesn't drift back to assembling a body from page text?

## Test plan

- [x] `npm run verify` green locally — typecheck, eslint, `check:fixtures`, `check:baselines`, coverage, build
- [x] `npm run test` green: **4665 pass**, 10 skipped (pre-existing); 27 new tests
- [x] `src/lib/jd-extract/`: 339 tests green across 12 files
- [x] Injected bundle smoke-tested end to end in jsdom on a LinkedIn-shaped page: `JD.extract` → `JD.toJobRecord` → JSON round trip → `deriveJobId` → `validateJobRecord` **accepted, no warnings**; id `job:linkedin.com/jobs/view/4437835690` matches the skill's own table
- [x] Same probe re-run after the fix: all six leak needles clean, body 650 → 310 chars (the JD itself)
- [x] Bundle re-measured: **23,821 bytes**, under #719's 25 KB criterion; built with the exact command the skill documents
- [x] No fixture binaries added or changed
- [ ] Not verified: inject-and-call against live LinkedIn / Indeed (stated as a limitation in the skill rather than glossed)

`fallow audit`: 3 dead-code issues, all inherited unused deps in `extension/package.json`. Two clone groups — one in `prune.test.ts` between two similar fixtures, and one between `generic.ts` and `linkedin.ts`. The second is real and mine: collapsing it into a shared helper was tried and **reverted**, because the two adapters differ in landmark order and in their `doc.body` fallback, so one helper would have changed both adapters' behaviour silently to remove a report-only finding. Per-adapter duplication is the house pattern `src/lib/job-search/CLAUDE.md` already names.

## Provenance

Code implementation via: Claude Opus 5
Verification: `npm run verify` — green locally, and in CI
