### PR TITLE
feat(storage): DB_VERSION 4 — tombstones, an updatedAt index, and a cursor store (#730)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -193,7 +193,33 @@
       // starts importing rather than letting the suppression rot.
       "saveLetter", "getLetter", "getAllLetters", "lettersForJob", "deleteLetter",
       "validateLetterRecord", "LETTER_CONTRACT_VERSION", "LetterRecordValidation",
-      "LetterRecord", "LetterProvenance", "SkippedLetter"
+      "LetterRecord", "LetterProvenance", "SkippedLetter",
+
+      // The replication surface (#730) — the schema half of cloud sync. Same
+      // "no consumer anywhere yet" exception `captureJob` above is, and for a
+      // stronger reason: the reader is the browser extension, which builds
+      // these modules from a PINNED commit of this repo and therefore cannot
+      // define an object store, an index, or a record shape of its own. The
+      // migration that creates the `updatedAt` index and the `sync` store lands
+      // here because it has to, so the query that reads the index and the
+      // accessor that reads the store belong here beside it — the alternative
+      // is that consumer re-deriving this repo's schema against a store it does
+      // not own, which is the second-definition failure the contract modules
+      // above exist to prevent.
+      //
+      // `isLive` is the one name here with a real in-tree consumer, and it is
+      // listed anyway only for its BARREL re-export: `crud.ts` exports it for
+      // `jobs.ts` / `letters.ts` / `backup.ts`, which deep-import it, so the
+      // barrel copy is the dead one. If the barrel copy is still unread when
+      // sync lands, take it back off the barrel rather than off this list.
+      //
+      // Time-bounded like `captureJob`'s entry: once something in-tree imports
+      // these, they come back OUT. If sync is abandoned, delete
+      // `sync-cursor.ts` and `listRecordsUpdatedSince` rather than leaving the
+      // suppression to rot — but note the SCHEMA cannot be rolled back the same
+      // way, since a shipped `DB_VERSION` is in users' browsers for good.
+      "isLive", "listRecordsUpdatedSince", "getSyncCursor", "setSyncCursor",
+      "SyncableStoreName", "SyncCursorRecord"
     ] },
 
     // A contract constant that no in-tree caller reads at all — not even the

--- a/docs/cover-letter-contract.md
+++ b/docs/cover-letter-contract.md
@@ -60,7 +60,8 @@ document as-is with no encoding step.
 | `label` | string | User-facing name, so two drafts for one job are tellable apart (`"Warm open"`, `"Short version"`). |
 | `resumeId` | non-empty string | The `ResumeRecord.id` this letter was written from. **User-owned.** Cleared, not orphaned, if that résumé is deleted — see §5. |
 | `producer` | object | Provenance. See §6. |
-| `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. The store owns them; a backup file carries them so a restore preserves `createdAt`. |
+| `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. The store owns them; a backup file carries them so a restore preserves both. |
+| `deletedAt` | finite number (epoch ms) | A **tombstone**: the letter is deleted, and its presence says so. See §5. |
 
 `body` is required but **may be empty**, while `jobId` may not. The asymmetry is deliberate: an
 empty draft is something the user can see and fix, whereas a letter with no job is reachable from
@@ -143,6 +144,26 @@ precisely so this rule has no exceptions.
 The cascade lives in the store (`deleteJob` → `deleteLettersForJob`), not in a UI layer, so no
 caller can forget it. The job record is deleted first: if the letter sweep then fails, the delete
 the user actually asked for still happened.
+
+### Deletion is a TOMBSTONE, not a removal
+
+Both sides of that cascade write a `deletedAt` and leave the row in place. A record that is simply
+gone is indistinguishable from one that never existed, so a second holder of the library — another
+device, a backup file the user restores — has no way to tell a deletion from a gap and re-adds it.
+
+Every read above this layer filters tombstones, so a deleted letter is gone from `getAllLetters`,
+from `lettersForJob`, and from `getLetter` by id. The row itself stays reachable only through the
+raw storage layer.
+
+The cascade tombstones **each letter individually** rather than leaning on the job's tombstone to
+hide them. A letter is a record in its own right: it can travel on its own, and a holder that
+received the letters but not the job's tombstone would have no reason to stop showing them.
+
+Both the deletion and the cascade are **idempotent** — a repeated delete finds nothing live and
+returns without re-stamping a newer `deletedAt`.
+
+Tombstones ride into the **backup document** and restore as deleted. The reasoning is the same one
+§5 of `job-capture-contract.md` sets out at length, and it applies unchanged here.
 
 ### Deleting the résumé CLEARS the link
 

--- a/docs/job-capture-contract.md
+++ b/docs/job-capture-contract.md
@@ -60,7 +60,8 @@ A record is a **plain JSON object**. Not an array, not `null`, not a class insta
 | `jdText` | string | The job description, verbatim. |
 | `matchResult` | JSON-safe value | An opaque match payload. See §6. |
 | `capture` | object | Provenance. See §7. |
-| `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. **`captureJob` ignores yours** and lets the store own them; a backup file carries them so a restore preserves `createdAt`. |
+| `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. **`captureJob` ignores yours** and lets the store own them; a backup file carries them so a restore preserves both. |
+| `deletedAt` | finite number (epoch ms) | A **tombstone**: the record is deleted, and its presence says so. **`captureJob` ignores yours** — see §5. A backup file carries it. |
 
 ### Optional — the posting facts (added in v2)
 
@@ -239,6 +240,54 @@ was meant to prevent.
 A re-capture does **not** stamp `updatedAt`, so it will not float the job to the top of a list
 sorted most-recently-updated-first. `created: false` in the result tells you the record was already
 there.
+
+### Deleted records, and why you cannot capture one
+
+A deleted job is **tombstoned**, not removed: the row stays with a `deletedAt` timestamp on it. It
+has to. A record that is simply gone is indistinguishable from one that was never there, so any
+second holder of the library — another device, a backup file, you — has no way to tell a deletion
+from a gap, and re-adds it.
+
+Two rules follow, and they point in opposite directions on purpose:
+
+- **`captureJob` strips a `deletedAt` you send.** You are authoritative about the posting; you are
+  not in a position to state that the user deleted their record of it. Deletion is not a fact about
+  the job market.
+- **Capturing a posting the user deleted brings the record back**, reported as `created: true`. The
+  tombstone exists to stop a *replica* resurrecting the record behind the user's back — not to stop
+  the user saving the posting again. `createdAt` survives from the tombstone, so the revived record
+  keeps the date it was first saved.
+
+If you are replicating rather than capturing — propagating a deletion made somewhere else — this is
+the wrong entry point. Use the store's own delete path.
+
+### Tombstones ARE in the backup document
+
+A backup carries deleted records, `deletedAt` and all, and restoring one restores them as deleted.
+If you read or write export files, expect them.
+
+The decision is not obvious, so here is the whole of it. Omitting tombstones looks tidier and is
+wrong in **merge** mode, which is the mode that exists to combine two copies of a library: device A
+deletes a job and exports, device B still has it live, and B merging A's file would hand the job
+straight back — because a record missing from a file is indistinguishable from one its author never
+had. The deletion silently undoes itself and the user cannot tell which device is right. In
+**replace** mode the visible result is identical either way, since the stores are wiped first. So
+the tie breaks toward carrying them: it costs a few bytes in the mode where it does not matter and
+buys convergence in the mode where it does.
+
+Two consequences worth knowing: the document is the state of the store rather than a list of what
+the user has, so `export → import → export` is stable rather than quietly shedding rows; and the
+counts a restore reports are **live** records, because "restored 40 jobs" has to mean forty the user
+can see.
+
+The document **version is not bumped** for this, and the older build's behaviour is the reason. An
+export written today still declares version 2, so a build that predates tombstones imports it,
+treats `deletedAt` as an unknown field, preserves it, and — having no filter — shows those jobs as
+live. That is not great, and every alternative is worse: bumping the version would make that build
+reject the whole file with "Unsupported storage export version", costing the user every record
+rather than resurrecting a few, and stripping tombstones on export would reintroduce the merge bug
+above for everyone. A few deleted jobs reappearing on an old build is exactly what that build did
+before deletions were recorded at all.
 
 ---
 

--- a/src/lib/storage/backup.ts
+++ b/src/lib/storage/backup.ts
@@ -12,12 +12,43 @@
  * `letters` key at all, must import forever — a backup on a user's disk does
  * not upgrade itself.
  *
+ * ## Tombstones ARE exported (#730)
+ *
+ * A deleted job or letter rides into the file carrying its `deletedAt`, and
+ * imports back as deleted. The decision is not obvious, so here is the whole
+ * of it.
+ *
+ * Omitting them looks tidier and is wrong in `merge` mode, which is the mode
+ * that exists precisely to combine two copies of a library. Device A deletes a
+ * job and exports; device B still has it live; B's file merged into A would
+ * hand the job straight back, because a record that is simply missing from a
+ * file is indistinguishable from one the file's author never had. The deletion
+ * silently undoes itself, and the user has no way to tell which of their two
+ * devices is right. Carrying the tombstone makes the file state a fact instead
+ * of an absence, so the merge converges.
+ *
+ * In `replace` mode the visible result is identical either way — the stores are
+ * wiped first, so an omitted record and a tombstoned one both end up
+ * unrendered. Exporting them costs a few bytes there and buys correctness in
+ * the other mode, which is why the tie breaks this way.
+ *
+ * It follows that the document is not a list of what the user has; it is the
+ * state of the store, deletions included. Two consequences worth stating: an
+ * export→import→export cycle is stable rather than quietly shedding rows, and
+ * {@link ImportCounts} therefore reports LIVE records, because "restored 40
+ * jobs" must mean forty the user can see.
+ *
+ * The `sync` store is the counter-example that shows where the line is: it is
+ * also part of the database and it is deliberately absent, because a cursor
+ * describes what one device has exchanged. Restoring it onto a second device
+ * would tell that device it had already pulled records it has never seen.
+ *
  * Base64 goes through `btoa`/`atob` over a binary string so it works the same in
  * the browser and the Node test env (no `Buffer` dependency). Blobs are read via
  * `arrayBuffer()`, so encode/import are async.
  */
 
-import { getAllRecords, putRecord, clearStore } from "./crud.ts";
+import { getAllRecords, putRecord, clearStore, isLive } from "./crud.ts";
 import { validateJobRecord } from "./job-record-contract.ts";
 import { validateLetterRecord } from "./letter-contract.ts";
 import type {
@@ -48,8 +79,16 @@ export interface SkippedLetter {
   reason: string;
 }
 
-/** What a restore did. `jobs` / `letters` count records actually WRITTEN, so
- *  each pairs with its `skipped…` list to account for every record in the file.
+/** What a restore did. `jobs` / `letters` count the records a user can now SEE:
+ *  written, and not tombstoned (#730). A file's tombstones are written too —
+ *  that is the point of exporting them — but counting them would tell the user
+ *  a restore brought back jobs that stay invisible, which reads as a bug in the
+ *  restore rather than as the deletions it faithfully reproduced.
+ *
+ *  So the three numbers no longer sum to the file's record count. The
+ *  `skipped…` lists still account for every record the contract REFUSED, which
+ *  is the thing a user can act on; a tombstone was accepted, it just isn't
+ *  something to celebrate having restored.
  *
  *  Nothing renders `skippedLetters` yet — #711 ships the store with no UI at
  *  all. It is reported from the first commit anyway because the alternative is
@@ -91,11 +130,17 @@ function base64ToBytes(base64: string): Uint8Array {
 /** Serialize every store to one JSON-ready document (blobs → base64). Always
  *  writes the current format; see {@link importAll} for what still reads. */
 export async function exportAll(): Promise<StorageExportV2> {
+  // `resumes` hard-deletes, so there is nothing tombstoned to ask for.
   const resumes = await getAllRecords<ResumeRecord>("resumes");
-  const jobs = await getAllRecords<JobRecord>("jobs");
+  // Jobs and letters carry their TOMBSTONES into the file (#730) — see the
+  // module docblock for why a backup records deletions rather than omitting
+  // them.
+  const jobs = await getAllRecords<JobRecord>("jobs", { includeDeleted: true });
   // Every `LetterRecord` field is JSON-safe by contract, so letters ride
   // through with no encode step — unlike resumes, which carry a `Blob`.
-  const letters = await getAllRecords<LetterRecord>("letters");
+  const letters = await getAllRecords<LetterRecord>("letters", {
+    includeDeleted: true,
+  });
 
   const exportedResumes: ExportedResume[] = await Promise.all(
     resumes.map(async ({ blob, ...rest }) => ({
@@ -177,22 +222,29 @@ export async function importAll(
     await clearStore("letters");
   }
 
+  // `touch: false` throughout (#730): a restored record keeps the `updatedAt`
+  // it had when the backup was taken. That timestamp describes the user's last
+  // edit, and a restore is not one — stamping `now` over it collapsed the whole
+  // library into a single instant, which silently reordered a tracker sorted
+  // most-recently-updated-first and, since v4, would tell a replicator that
+  // every record on the device had just changed. A record the file carries no
+  // timestamp for still gets `now` from `putRecord`.
   for (const { blobBase64, blobType, ...rest } of data.resumes) {
     const blob = new Blob([base64ToBytes(blobBase64)], { type: blobType });
-    await putRecord<ResumeRecord>("resumes", { ...rest, blob });
+    await putRecord<ResumeRecord>("resumes", { ...rest, blob }, { touch: false });
   }
   for (const job of jobs.accepted) {
-    await putRecord<JobRecord>("jobs", job);
+    await putRecord<JobRecord>("jobs", job, { touch: false });
   }
   for (const letter of letters.accepted) {
-    await putRecord<LetterRecord>("letters", letter);
+    await putRecord<LetterRecord>("letters", letter, { touch: false });
   }
 
   return {
     resumes: data.resumes.length,
-    jobs: jobs.accepted.length,
+    jobs: jobs.accepted.filter(isLive).length,
     skippedJobs: jobs.skipped,
-    letters: letters.accepted.length,
+    letters: letters.accepted.filter(isLive).length,
     skippedLetters: letters.skipped,
   };
 }

--- a/src/lib/storage/capture.ts
+++ b/src/lib/storage/capture.ts
@@ -78,6 +78,23 @@ function resolveCaptureId(input: Record<string, unknown>): string {
  * most-recently-updated-first, and a producer with a wrong clock would
  * otherwise bury or float its own captures. Hence `touch: false` — a brand-new
  * capture still gets `now` from `putRecord`, an update keeps what was there.
+ *
+ * `deletedAt` is dropped for a different reason (#730): a capture is a producer
+ * saying *this posting exists*, which is not a claim it can make about whether
+ * the user deleted their record of it. A producer that wants to replicate a
+ * deletion is doing replication, not capture, and goes through the store's own
+ * delete path.
+ *
+ * ## Capturing a posting the user deleted REVIVES it
+ *
+ * `getJob` reads a tombstoned job as absent, so the merge below sees no
+ * existing record, the write replaces the tombstone with a live record, and the
+ * result reports `created: true`. That is deliberate and it is also what this
+ * function already did when deletion was a hard delete — the user gets the same
+ * behaviour from the same action, and the tombstone's only job was to stop a
+ * *replica* from resurrecting the record behind their back, not to stop them
+ * saving the posting again. `createdAt` still survives from the tombstone, so a
+ * revived job keeps the date it was first saved.
  */
 export async function captureJob(input: unknown): Promise<JobCaptureResult> {
   if (input === null || typeof input !== "object" || Array.isArray(input)) {
@@ -87,6 +104,7 @@ export async function captureJob(input: unknown): Promise<JobCaptureResult> {
   const proposed: Record<string, unknown> = { ...candidate, id: resolveCaptureId(candidate) };
   delete proposed.createdAt;
   delete proposed.updatedAt;
+  delete proposed.deletedAt;
 
   const validation = validateJobRecord(proposed);
   if (!validation.ok) return validation;

--- a/src/lib/storage/crud.ts
+++ b/src/lib/storage/crud.ts
@@ -9,8 +9,8 @@
  */
 
 import type { IDBPDatabase } from "idb";
-import { getDB } from "./db.ts";
-import type { StoreName, StoredRecord } from "./types.ts";
+import { getDB, UPDATED_AT_INDEX } from "./db.ts";
+import type { StoreName, StoredRecord, SyncableStoreName } from "./types.ts";
 
 /**
  * The store-typed `getDB()` keys `get`/`put` to a specific store's value type,
@@ -29,11 +29,23 @@ async function looseDB(): Promise<IDBPDatabase> {
  *  therefore has `createdAt === updatedAt`. Domain helpers omit the timestamps and
  *  let this own them; import passes them through to preserve `createdAt`.
  *
- *  `touch: false` keeps the existing `updatedAt` — for a write the USER did not
- *  make. Clearing a job's dangling resume link when that resume is deleted (#323)
- *  is the motivating case: stamping it would reshuffle a tracker sorted
- *  most-recently-updated-first, so deleting one resume makes every job that
- *  merely referenced it jump to the top. Never use it for a user edit. */
+ *  `touch: false` means *the record's own `updatedAt` is the truth* — for a write
+ *  the USER did not make. Clearing a job's dangling resume link when that resume
+ *  is deleted (#323) is the motivating case: stamping it would reshuffle a
+ *  tracker sorted most-recently-updated-first, so deleting one resume makes every
+ *  job that merely referenced it jump to the top. Never use it for a user edit.
+ *
+ *  The record's own value is preferred over the stored one, and the order
+ *  matters (#730). Those housekeeping callers spread the existing record, so for
+ *  them the two are the same value and nothing changes. The caller that needs
+ *  this precedence is `importAll`: a restored record carries the `updatedAt` it
+ *  had when the backup was taken, and that timestamp is a fact about the user's
+ *  edit, not about the restore. Stamping `now` over it — which is what this did
+ *  before the option existed here — scrambled a whole library into one
+ *  indistinguishable instant, losing the tracker's ordering, and now also tells
+ *  a replicator that every record on the device changed at once. Only a record
+ *  with no timestamp at all falls through to `now`, which is the fresh-capture
+ *  case (`captureJob` strips both stamps deliberately). */
 export async function putRecord<T extends StoredRecord>(
   store: StoreName,
   record: Omit<T, "createdAt" | "updatedAt"> &
@@ -48,7 +60,7 @@ export async function putRecord<T extends StoredRecord>(
     createdAt: existing?.createdAt ?? record.createdAt ?? now,
     updatedAt:
       options.touch === false
-        ? (existing?.updatedAt ?? record.updatedAt ?? now)
+        ? (record.updatedAt ?? existing?.updatedAt ?? now)
         : now,
   } as T;
   await db.put(store, written);
@@ -63,13 +75,101 @@ export async function getRecord<T extends StoredRecord>(
   return (await db.get(store, id)) as T | undefined;
 }
 
+/**
+ * Every record in a store — **excluding tombstones by default** (#730).
+ *
+ * The default is the safe direction, and it is chosen rather than inherited: a
+ * caller that forgets the option shows the user live records, and a caller that
+ * wants deleted ones has to name that intent. The alternative default would
+ * make every existing list surface silently start rendering deleted rows,
+ * which is the failure `deletedAt` exists to prevent.
+ *
+ * `includeDeleted` has exactly two legitimate users, both of which need to see
+ * a deletion *as a fact* rather than as an absence: the export document (see
+ * `backup.ts`, which explains why a backup carries tombstones) and replication.
+ */
 export async function getAllRecords<T extends StoredRecord>(
   store: StoreName,
+  options: { includeDeleted?: boolean } = {},
 ): Promise<T[]> {
   const db = await looseDB();
-  return (await db.getAll(store)) as T[];
+  const all = (await db.getAll(store)) as T[];
+  return options.includeDeleted === true ? all : all.filter(isLive);
 }
 
+/** True for a record no delete has touched. One definition, so no caller
+ *  invents `deletedAt === 0` or a falsy check — `0` is a real epoch-ms value
+ *  and only ABSENCE means live. */
+export function isLive(record: StoredRecord): boolean {
+  return record.deletedAt === undefined;
+}
+
+/**
+ * Records whose `updatedAt` is strictly greater than `since`, read through the
+ * v4 index rather than by scanning the store (#730).
+ *
+ * **Tombstones are included**, and that is the whole point: a deletion this
+ * device has not replicated yet is a change, and the query that finds unpushed
+ * changes has to return it. It is the mirror image of {@link getAllRecords}'s
+ * default, for the mirror-image caller.
+ *
+ * Strictly greater, so passing back the last record's own `updatedAt` as the
+ * next cursor cannot loop on it forever. Ordered by the index key — oldest
+ * first — which is also the order a replicator must write in, so an interrupted
+ * pass can advance its cursor to the last record it actually wrote.
+ *
+ * Nothing in this build calls it; the browser extension does, across the pin.
+ * The same staging `capture.ts` documents, for the same reason: this repo owns
+ * the schema, so the query that reads the index belongs beside the migration
+ * that creates it rather than being re-derived against a store the caller does
+ * not own.
+ */
+export async function listRecordsUpdatedSince<T extends StoredRecord>(
+  store: SyncableStoreName,
+  since: number,
+): Promise<T[]> {
+  const db = await looseDB();
+  return (await db.getAllFromIndex(
+    store,
+    UPDATED_AT_INDEX,
+    IDBKeyRange.lowerBound(since, true),
+  )) as T[];
+}
+
+/**
+ * Tombstone a record: stamp `deletedAt` and leave the row in place. Returns
+ * false when there was nothing to delete or it was already deleted, so a repeat
+ * call is a no-op rather than a second deletion with a newer timestamp.
+ *
+ * **`updatedAt` moves too**, and it has to. A replicator finds unpushed work
+ * with {@link listRecordsUpdatedSince}; a tombstone that kept the record's old
+ * `updatedAt` would sit below every cursor that had already passed it and would
+ * never be pushed at all — the deletion would be invisible to every other
+ * holder of the library, which is exactly the state tombstones exist to avoid.
+ * This is also why it does not take `putRecord`'s `touch: false`: a deletion is
+ * a user action, and floating it to the top of a most-recently-updated-first
+ * list is correct — the row is about to stop being rendered anyway.
+ */
+export async function softDeleteRecord(
+  store: StoreName,
+  id: string,
+): Promise<boolean> {
+  const db = await looseDB();
+  const existing = (await db.get(store, id)) as StoredRecord | undefined;
+  if (existing === undefined || !isLive(existing)) return false;
+  const now = Date.now();
+  await db.put(store, { ...existing, deletedAt: now, updatedAt: now });
+  return true;
+}
+
+/**
+ * Remove a record outright, tombstone and all.
+ *
+ * Still the right delete for `resumes` and `boards` — see the per-store note on
+ * `StoredRecord.deletedAt`. For a replicating store this is a PURGE, not a
+ * delete: it destroys the evidence a second holder needs, so the next pull
+ * resurrects the record. Reach for {@link softDeleteRecord} there.
+ */
 export async function deleteRecord(
   store: StoreName,
   id: string,

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -4,8 +4,8 @@
 /**
  * IndexedDB handle for the local-first storage foundation (#321).
  *
- * One database, four object stores (`resumes`, `jobs`, `boards`, `letters`),
- * opened through the ~1KB
+ * One database, five object stores (`resumes`, `jobs`, `boards`, `letters` and
+ * the `sync` bookmarks that describe three of them), opened through the ~1KB
  * `idb` wrapper. Schema versioning lives here from day one: every future store
  * or index is a `DB_VERSION` bump with a matching branch in `upgrade()`, so an
  * existing user's data migrates forward instead of stranding. `upgrade()` runs
@@ -22,6 +22,7 @@ import type {
   JobRecord,
   BoardCacheRecord,
   LetterRecord,
+  SyncCursorRecord,
 } from "./types.ts";
 
 // Renamed from "resumelint" during the OfflineCV rename (#498). Safe to change
@@ -45,13 +46,18 @@ export const DB_NAME = "offlinecv";
  *  and gets a `VersionError`, breaking its captures. Bump the pin in lockstep
  *  and rebuild it; this repo's CI never compiles the extension, so nothing else
  *  will catch it. */
-const DB_VERSION = 3;
+const DB_VERSION = 4;
+
+/** Index name shared by every syncable store — one string so a range query and
+ *  the three `createIndex` calls cannot drift apart. */
+export const UPDATED_AT_INDEX = "updatedAt";
 
 interface OfflineCvDB extends DBSchema {
-  resumes: { key: string; value: ResumeRecord };
-  jobs: { key: string; value: JobRecord };
+  resumes: { key: string; value: ResumeRecord; indexes: { updatedAt: number } };
+  jobs: { key: string; value: JobRecord; indexes: { updatedAt: number } };
   boards: { key: string; value: BoardCacheRecord };
-  letters: { key: string; value: LetterRecord };
+  letters: { key: string; value: LetterRecord; indexes: { updatedAt: number } };
+  sync: { key: string; value: SyncCursorRecord };
 }
 
 let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
@@ -61,7 +67,7 @@ let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
 export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
   if (dbPromise === null) {
     dbPromise = openDB<OfflineCvDB>(DB_NAME, DB_VERSION, {
-      upgrade(db, oldVersion) {
+      upgrade(db, oldVersion, _newVersion, tx) {
         // v0 → v1: both stores keyed on `id`. Keep future migrations as
         // additional `if (oldVersion < N)` blocks below — never edit an
         // already-shipped block.
@@ -87,6 +93,37 @@ export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
         // reads letters at all would be pinning a schema on a guess.
         if (oldVersion < 3) {
           db.createObjectStore("letters", { keyPath: "id" });
+        }
+        // v3 → v4 (#730): the three things replication needs from the local
+        // schema. Additive like every block above it — no record is rewritten,
+        // no field is required, and a profile that never replicates is
+        // indistinguishable from a v3 one.
+        //
+        //  1. An `updatedAt` index on each syncable store. Without it, "what
+        //     changed since the last push" is a full scan of every record on
+        //     every pass. Survivable at a few hundred jobs and wrong as a
+        //     design — and unlike the `letters.jobId` index deferred at v3,
+        //     this one has a caller by construction, since a cursor that
+        //     cannot be queried efficiently is not a cursor.
+        //
+        //     Created here rather than at `createObjectStore` time so the three
+        //     stores get identical treatment in one place; a fresh database
+        //     runs blocks 1 and 3 first, so all three exist by now. The
+        //     versionchange transaction is the only place an index can be
+        //     added at all, which is why `upgrade` takes `tx`.
+        //
+        //  2. The `sync` store: one bookmark record per syncable store, keyed
+        //     on the store name. See `SyncCursorRecord` for why the pull and
+        //     push cursors are different types reading different clocks.
+        //
+        // The third thing — `StoredRecord.deletedAt` — needs no migration at
+        // all. It is optional, and an existing record without it is already
+        // correctly readable as "not deleted".
+        if (oldVersion < 4) {
+          for (const store of ["resumes", "jobs", "letters"] as const) {
+            tx.objectStore(store).createIndex(UPDATED_AT_INDEX, "updatedAt");
+          }
+          db.createObjectStore("sync", { keyPath: "id" });
         }
       },
     });

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -4,11 +4,12 @@
 /**
  * Local-first storage foundation (#321) — public surface.
  *
- * Typed CRUD over an IndexedDB database with four stores (`resumes`, `jobs`,
- * `boards`, `letters`), durability control, and a JSON export/import backup
- * path. Infrastructure only: the resume-library and job-tracker UIs build on
- * this. Product code imports from `../lib/storage` (the barrel), not the
- * internal files — tests may reach past it to exercise a layer directly.
+ * Typed CRUD over an IndexedDB database with four record stores (`resumes`,
+ * `jobs`, `boards`, `letters`) plus the `sync` bookmarks that describe three of
+ * them, durability control, and a JSON export/import backup path.
+ * Infrastructure only: the resume-library and job-tracker UIs build on this.
+ * Product code imports from `../lib/storage` (the barrel), not the internal
+ * files — tests may reach past it to exercise a layer directly.
  *
  * Two admission rules, and they are what keep that first sentence true:
  *
@@ -89,6 +90,20 @@ export {
   JOB_URL_TRACKING_PARAM_PREFIXES,
 } from "./job-url.ts";
 export { captureJob, type JobCaptureResult } from "./capture.ts";
+/**
+ * The replication surface (#730). No consumer inside this repo — the reader is
+ * the browser extension, which builds these modules from a pinned commit and
+ * therefore cannot define an object store, an index, or a record shape of its
+ * own. Every name here exists because the alternative is that consumer
+ * re-deriving this repo's schema against a store it does not own, which is the
+ * second-definition failure `job-record-contract.ts` documents at length.
+ *
+ * `softDeleteRecord` is deliberately NOT exported: deleting a job is
+ * {@link deleteJob}'s job, cascade and all, and a second door onto the same
+ * action is how a caller ends up tombstoning a job and orphaning its letters.
+ */
+export { isLive, listRecordsUpdatedSince } from "./crud.ts";
+export { getSyncCursor, setSyncCursor } from "./sync-cursor.ts";
 export { JOB_STATUS_ORDER } from "./types.ts";
 export type {
   JobRecord,
@@ -96,4 +111,6 @@ export type {
   JobCaptureProvenance,
   LetterRecord,
   LetterProvenance,
+  SyncableStoreName,
+  SyncCursorRecord,
 } from "./types.ts";

--- a/src/lib/storage/job-record-contract.ts
+++ b/src/lib/storage/job-record-contract.ts
@@ -155,6 +155,12 @@ export const JOB_RECORD_RULES: {
   id: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
   createdAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
   updatedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  // A tombstone (#730). Accepted from a FILE, because the export document
+  // carries deletions and a restore that dropped them would resurrect every
+  // job the user had deleted. Not accepted from a CAPTURE: `captureJob` strips
+  // it, since a producer telling us a posting exists is not in a position to
+  // tell us the user deleted it. See §5 of the contract doc.
+  deletedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
   title: { required: true, check: isString, expected: "a string" },
   company: { required: false, check: isString, expected: "a string" },
   url: {

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -11,7 +11,8 @@ import {
   putRecord,
   getRecord,
   getAllRecords,
-  deleteRecord,
+  isLive,
+  softDeleteRecord,
 } from "./crud.ts";
 import { deleteLettersForJob } from "./letters.ts";
 import type { JobRecord } from "./types.ts";
@@ -36,16 +37,29 @@ export async function saveJob(
     Partial<Pick<JobRecord, "createdAt" | "updatedAt">>, options);
 }
 
-export function getJob(id: string): Promise<JobRecord | undefined> {
-  return getRecord<JobRecord>("jobs", id);
+/**
+ * One job by id, or undefined — **including when the job is tombstoned**
+ * (#730).
+ *
+ * A deleted job reads as gone at this layer, so nothing built on it can leak
+ * one: `getJobById` cannot render it, and `updateJob` throws rather than
+ * quietly resurrecting it by writing a patch over the tombstone. The raw row is
+ * still reachable through `crud.ts`'s `getRecord`, which is what replication
+ * needs and what the tracker must never have.
+ */
+export async function getJob(id: string): Promise<JobRecord | undefined> {
+  const record = await getRecord<JobRecord>("jobs", id);
+  return record !== undefined && isLive(record) ? record : undefined;
 }
 
+/** Every live job. Tombstones are filtered by `getAllRecords`'s default. */
 export function getAllJobs(): Promise<JobRecord[]> {
   return getAllRecords<JobRecord>("jobs");
 }
 
 /**
- * Delete a job and CASCADE to its cover letters (#711).
+ * Delete a job and CASCADE to its cover letters (#711). Both sides are
+ * TOMBSTONED rather than removed (#730) — see `StoredRecord.deletedAt`.
  *
  * The cascade lives here, at the store, rather than a layer up in
  * `job-tracker.ts`: `LetterRecord.jobId` is a required parent link, so "no
@@ -59,8 +73,13 @@ export function getAllJobs(): Promise<JobRecord[]> {
  * intent — the job is gone — still happened; the reverse order would let a
  * failure delete the letters of a job that survives, which is data loss the
  * user did not ask for and cannot see coming.
+ *
+ * The cascade tombstones each letter individually rather than relying on the
+ * job's own tombstone to hide them. A letter is a record in its own right: it
+ * replicates on its own, and a second holder that received the letters but not
+ * the job's tombstone would have no reason to stop showing them.
  */
 export async function deleteJob(id: string): Promise<void> {
-  await deleteRecord("jobs", id);
+  await softDeleteRecord("jobs", id);
   await deleteLettersForJob(id);
 }

--- a/src/lib/storage/letter-contract.ts
+++ b/src/lib/storage/letter-contract.ts
@@ -99,6 +99,10 @@ export const LETTER_RECORD_RULES: {
   id: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
   createdAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
   updatedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  // A tombstone (#730) — the same rule the job contract carries, for the same
+  // reason: the export document holds deletions so a restore does not resurrect
+  // them. See §5 of the contract doc.
+  deletedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
   jobId: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
   resumeId: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
   body: { required: true, check: isString, expected: "a string" },

--- a/src/lib/storage/letters.test.ts
+++ b/src/lib/storage/letters.test.ts
@@ -195,13 +195,19 @@ describe("storage: letters schema migration v2 → v3 (#711)", () => {
     legacy.close();
   }
 
-  it("opens an existing v2 profile at v3 with resumes and jobs intact and letters empty", async () => {
+  it("opens an existing v2 profile with resumes and jobs intact and letters empty", async () => {
     await seedV2Profile();
 
     const db = await getDB();
     // Read the OPEN database's version, not the module constant — a test that
     // compared `DB_VERSION` to itself would pass even if `upgrade()` never ran.
-    expect(db.version).toBe(3);
+    //
+    // The literal moves with every schema bump (4 since #730) because a v2
+    // profile migrates ALL the way forward, not one step: `upgrade()` runs for
+    // the whole range `(oldVersion, DB_VERSION]`. What this case is actually
+    // about is the `letters` store below — that a profile written before it
+    // existed comes back with it present and its resumes and jobs untouched.
+    expect(db.version).toBe(4);
     expect(db.objectStoreNames.contains("letters")).toBe(true);
 
     expect((await getAllResumes()).map((r) => r.filename)).toEqual(["cv.pdf"]);
@@ -217,7 +223,9 @@ describe("storage: letters schema migration v2 → v3 (#711)", () => {
     expect((await getAllLetters()).map((l) => l.id)).toEqual([letter.id]);
   });
 
-  it("creates all four stores on a fresh v0 database", async () => {
+  // The four RECORD stores. `sync` (v4, #730) holds bookmarks rather than
+  // records and is covered by `sync-schema.test.ts`.
+  it("creates all four record stores on a fresh v0 database", async () => {
     const db = await getDB();
     for (const store of ["resumes", "jobs", "boards", "letters"] as const) {
       expect(db.objectStoreNames.contains(store)).toBe(true);

--- a/src/lib/storage/letters.ts
+++ b/src/lib/storage/letters.ts
@@ -23,7 +23,8 @@ import {
   putRecord,
   getRecord,
   getAllRecords,
-  deleteRecord,
+  isLive,
+  softDeleteRecord,
 } from "./crud.ts";
 import type { LetterRecord } from "./types.ts";
 
@@ -56,16 +57,22 @@ export async function saveLetter(
   );
 }
 
-export function getLetter(id: string): Promise<LetterRecord | undefined> {
-  return getRecord<LetterRecord>("letters", id);
+/** One live letter by id. Tombstoned letters read as gone here, exactly as
+ *  `getJob` treats a deleted job — see its note (#730). */
+export async function getLetter(id: string): Promise<LetterRecord | undefined> {
+  const record = await getRecord<LetterRecord>("letters", id);
+  return record !== undefined && isLive(record) ? record : undefined;
 }
 
+/** Every live letter. Tombstones are filtered by `getAllRecords`'s default. */
 export function getAllLetters(): Promise<LetterRecord[]> {
   return getAllRecords<LetterRecord>("letters");
 }
 
-export function deleteLetter(id: string): Promise<void> {
-  return deleteRecord("letters", id);
+/** Tombstone one letter (#730). Returns whether there was a live letter to
+ *  delete, so a double-click is a no-op rather than a second deletion. */
+export function deleteLetter(id: string): Promise<boolean> {
+  return softDeleteRecord("letters", id);
 }
 
 /** Every letter written for one job, most-recently-updated first — the order a
@@ -93,9 +100,12 @@ export async function lettersForJob(jobId: string): Promise<LetterRecord[]> {
  * `docs/cover-letter-contract.md`.
  */
 export async function deleteLettersForJob(jobId: string): Promise<number> {
+  // `lettersForJob` already filters tombstones, so a repeated cascade — a
+  // delete retried after a partial failure — finds nothing left to do and
+  // returns 0 rather than re-stamping letters with a newer `deletedAt`.
   const doomed = await lettersForJob(jobId);
   for (const letter of doomed) {
-    await deleteRecord("letters", letter.id);
+    await softDeleteRecord("letters", letter.id);
   }
   return doomed.length;
 }

--- a/src/lib/storage/sync-cursor.ts
+++ b/src/lib/storage/sync-cursor.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The `sync` store's accessor (#730) — one bookmark record per syncable store,
+ * read and written by whatever is replicating this library.
+ *
+ * Two functions rather than a slot in the generic CRUD, because a
+ * {@link SyncCursorRecord} is not a {@link StoredRecord}: it has no `createdAt`
+ * worth keeping and no `updatedAt` anything sorts on, and it must never be
+ * tombstoned. Routing it through `putRecord` would stamp a bookmark with
+ * timestamps that describe the bookmark rather than anything the user has, and
+ * would make it eligible for a soft delete that means nothing.
+ *
+ * **A cursor is a local fact, not a record.** It says what THIS device has
+ * already exchanged, so it never rides through the export document — restoring
+ * a backup onto a second device must not convince that device it has already
+ * pulled everything. `backup.ts` carries no `sync` key for the same reason it
+ * carries no `boards` key.
+ *
+ * Nothing in this build calls either function. Like `capture.ts` and
+ * `listRecordsUpdatedSince`, the reader is the browser extension, which builds
+ * these modules from a pinned commit of this repo and so cannot add an object
+ * store of its own — the schema is this repo's to own, and an accessor that
+ * lives anywhere else is a second definition of the record shape.
+ */
+
+import { getDB } from "./db.ts";
+import type { SyncableStoreName, SyncCursorRecord } from "./types.ts";
+
+/**
+ * The bookmarks for one store, or undefined when that store has never been
+ * replicated on this device.
+ *
+ * Undefined is deliberately not flattened into an empty record: "never pulled"
+ * and "pulled, found nothing" are different states, and only the first one
+ * licenses a full initial sync.
+ */
+export async function getSyncCursor(
+  store: SyncableStoreName,
+): Promise<SyncCursorRecord | undefined> {
+  const db = await getDB();
+  return db.get("sync", store);
+}
+
+/**
+ * Merge a partial cursor update over whatever is stored, and return the result.
+ *
+ * Merged rather than replaced because the two cursors advance on their own
+ * schedule — a pull that lands must not clear the push bookmark, and a push
+ * that lands must not clear the pull bookmark. A caller that spread the record
+ * itself would race the other direction on the read.
+ *
+ * The caller advances a cursor only AFTER the records it covers are written.
+ * The reverse order is the one unrecoverable ordering here: a cursor written
+ * first and then an interrupted write leaves a gap no later pass will look in
+ * again, and nothing reports it.
+ */
+export async function setSyncCursor(
+  store: SyncableStoreName,
+  patch: Omit<Partial<SyncCursorRecord>, "id">,
+): Promise<SyncCursorRecord> {
+  const db = await getDB();
+  const existing = await db.get("sync", store);
+  const written: SyncCursorRecord = { ...existing, ...patch, id: store };
+  await db.put("sync", written);
+  return written;
+}

--- a/src/lib/storage/sync-schema.test.ts
+++ b/src/lib/storage/sync-schema.test.ts
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The v4 schema and the behaviour it buys (#730) — tombstones, the `updatedAt`
+ * index, and the `sync` cursor store.
+ *
+ * Runs against `fake-indexeddb` like every other storage suite, so the real
+ * `idb` upgrade path is exercised rather than mocked. The migration case seeds a
+ * database by REPLAYING the shipped v3 upgrade blocks, not by calling `getDB()`
+ * — a test that built the old profile with the new code would be asserting
+ * against itself and would pass even if `upgrade()` never ran.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB, openDB } from "idb";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DB_NAME, getDB, closeDB } from "./db.ts";
+import {
+  getRecord,
+  getAllRecords,
+  isLive,
+  listRecordsUpdatedSince,
+} from "./crud.ts";
+import { getSyncCursor, setSyncCursor } from "./sync-cursor.ts";
+import { saveJob, getJob, getAllJobs, deleteJob } from "./jobs.ts";
+import {
+  saveLetter,
+  getLetter,
+  getAllLetters,
+  lettersForJob,
+  deleteLetter,
+} from "./letters.ts";
+import { getAllResumes } from "./resumes.ts";
+import { exportAll, importAll } from "./backup.ts";
+import { captureJob } from "./capture.ts";
+import { listJobs } from "../job-tracker.ts";
+import { tick } from "./__test-utils__/clock.ts";
+import type { JobRecord, LetterRecord } from "./types.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+const pdf = () => new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], {
+  type: "application/pdf",
+});
+
+const SEEDED_AT = 1_700_000_000_000;
+
+describe("storage: schema migration v3 → v4 (#730)", () => {
+  /** Recreate a database exactly as `DB_VERSION = 3` shipped it — the state a
+   *  returning user's browser is holding. Replays the shipped upgrade blocks
+   *  rather than asserting against them. */
+  async function seedV3Profile(): Promise<void> {
+    const legacy = await openDB(DB_NAME, 3, {
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          db.createObjectStore("resumes", { keyPath: "id" });
+          db.createObjectStore("jobs", { keyPath: "id" });
+        }
+        if (oldVersion < 2) db.createObjectStore("boards", { keyPath: "id" });
+        if (oldVersion < 3) db.createObjectStore("letters", { keyPath: "id" });
+      },
+    });
+    await legacy.put("resumes", {
+      id: "resume-1",
+      filename: "cv.pdf",
+      blob: pdf(),
+      createdAt: SEEDED_AT,
+      updatedAt: SEEDED_AT,
+    });
+    await legacy.put("jobs", {
+      id: "job-1",
+      title: "Staff Engineer",
+      company: "Northwind",
+      status: "applied",
+      createdAt: SEEDED_AT,
+      updatedAt: SEEDED_AT,
+    });
+    await legacy.put("letters", {
+      id: "letter-1",
+      jobId: "job-1",
+      body: "Dear Northwind,",
+      createdAt: SEEDED_AT,
+      updatedAt: SEEDED_AT,
+    });
+    legacy.close();
+  }
+
+  it("opens a v3 profile at v4 with resumes, jobs and letters intact", async () => {
+    await seedV3Profile();
+
+    const db = await getDB();
+    // The OPEN database's version, not the module constant — see the note in
+    // `db.ts` on why `DB_VERSION` is private.
+    expect(db.version).toBe(4);
+
+    expect((await getAllResumes()).map((r) => r.filename)).toEqual(["cv.pdf"]);
+    expect((await getAllJobs()).map((j) => j.title)).toEqual(["Staff Engineer"]);
+    expect((await getAllLetters()).map((l) => l.body)).toEqual([
+      "Dear Northwind,",
+    ]);
+  });
+
+  it("adds the sync store and an updatedAt index on each syncable store", async () => {
+    await seedV3Profile();
+
+    const db = await getDB();
+    expect(db.objectStoreNames.contains("sync")).toBe(true);
+    const tx = db.transaction(["resumes", "jobs", "letters"]);
+    for (const store of ["resumes", "jobs", "letters"] as const) {
+      expect(Array.from(tx.objectStore(store).indexNames)).toContain(
+        "updatedAt",
+      );
+    }
+    // `boards` is a cache and does not replicate — no index, and no cursor.
+    expect(Array.from(db.transaction("boards").objectStore("boards").indexNames))
+      .toEqual([]);
+  });
+
+  it("indexes records that were written BEFORE the index existed", async () => {
+    // The failure this guards: `createIndex` on a populated store backfills the
+    // existing rows. A migration that only indexed future writes would leave a
+    // returning user's whole library invisible to every range query, and every
+    // other assertion in this file would still pass.
+    await seedV3Profile();
+
+    const migrated = await listRecordsUpdatedSince<JobRecord>("jobs", 0);
+    expect(migrated.map((j) => j.id)).toEqual(["job-1"]);
+  });
+
+  it("upgrades a brand-new database straight to v4, indexes and all", async () => {
+    // oldVersion 0 runs every block in one transaction, so block 4 creates its
+    // indexes on stores blocks 1 and 3 made moments earlier.
+    const db = await getDB();
+    expect(db.version).toBe(4);
+    expect(db.objectStoreNames.contains("sync")).toBe(true);
+    expect(
+      Array.from(db.transaction("jobs").objectStore("jobs").indexNames),
+    ).toContain("updatedAt");
+  });
+});
+
+describe("storage: tombstones (#730)", () => {
+  async function seedJob(): Promise<JobRecord> {
+    return saveJob({ title: "Staff Engineer", company: "Northwind", status: "applied" });
+  }
+
+  it("deleting a job hides it from every list surface but keeps the row", async () => {
+    const job = await seedJob();
+    await deleteJob(job.id);
+
+    expect(await getAllJobs()).toEqual([]);
+    expect(await listJobs()).toEqual([]);
+    expect(await getJob(job.id)).toBeUndefined();
+
+    // Still readable at the raw storage layer, which is what replication needs
+    // and what nothing above `crud.ts` is given.
+    const raw = await getRecord<JobRecord>("jobs", job.id);
+    expect(raw?.id).toBe(job.id);
+    expect(raw?.title).toBe("Staff Engineer");
+    expect(typeof raw?.deletedAt).toBe("number");
+    expect(isLive(raw!)).toBe(false);
+  });
+
+  it("stamps updatedAt on the tombstone, so a replicator can still find it", async () => {
+    const job = await seedJob();
+    await tick();
+    await deleteJob(job.id);
+
+    const raw = await getRecord<JobRecord>("jobs", job.id);
+    // Without this the deletion sits below any cursor that already passed the
+    // live record and would never be pushed anywhere.
+    expect(raw!.updatedAt).toBeGreaterThan(job.updatedAt);
+    expect(
+      (await listRecordsUpdatedSince<JobRecord>("jobs", job.updatedAt)).map(
+        (j) => j.id,
+      ),
+    ).toEqual([job.id]);
+  });
+
+  it("cascades to letters as tombstones of their own", async () => {
+    const job = await seedJob();
+    const letter = await saveLetter({ jobId: job.id, body: "Dear Northwind," });
+
+    await deleteJob(job.id);
+
+    expect(await getAllLetters()).toEqual([]);
+    expect(await lettersForJob(job.id)).toEqual([]);
+    expect(await getLetter(letter.id)).toBeUndefined();
+    const raw = await getRecord<LetterRecord>("letters", letter.id);
+    expect(typeof raw?.deletedAt).toBe("number");
+  });
+
+  it("is idempotent — a second delete does not re-stamp a newer deletedAt", async () => {
+    const job = await seedJob();
+    await saveLetter({ jobId: job.id, body: "Dear Northwind," });
+    await deleteJob(job.id);
+    const first = await getRecord<JobRecord>("jobs", job.id);
+
+    await tick();
+    await deleteJob(job.id);
+
+    const second = await getRecord<JobRecord>("jobs", job.id);
+    expect(second!.deletedAt).toBe(first!.deletedAt);
+    expect(second!.updatedAt).toBe(first!.updatedAt);
+    expect(await deleteLetter("nonexistent")).toBe(false);
+  });
+
+  it("refuses to edit a deleted job rather than resurrecting it", async () => {
+    const { updateJob } = await import("../job-tracker.ts");
+    const job = await seedJob();
+    await deleteJob(job.id);
+
+    await expect(updateJob(job.id, { title: "Back again" })).rejects.toThrow(
+      /no job with id/,
+    );
+    expect(await getAllJobs()).toEqual([]);
+  });
+
+  it("but capturing the posting again revives it, as a hard delete always did", async () => {
+    const job = await saveJob({
+      title: "Staff Engineer",
+      company: "Northwind",
+      url: "https://boards.example.com/jobs/42",
+      status: "applied",
+    });
+    await deleteJob(job.id);
+
+    const result = await captureJob({
+      title: "Staff Engineer",
+      company: "Northwind",
+      url: "https://boards.example.com/jobs/42",
+    });
+
+    expect(result.ok).toBe(true);
+    expect((await getAllJobs()).map((j) => j.title)).toEqual(["Staff Engineer"]);
+  });
+
+  it("ignores a deletedAt a producer tried to send", async () => {
+    // A capture says a posting exists. It is in no position to say the user
+    // deleted their record of it, so the field is stripped before validation
+    // rather than written and then filtered.
+    const result = await captureJob({
+      title: "Staff Engineer",
+      url: "https://boards.example.com/jobs/43",
+      deletedAt: 1_700_000_000_000,
+    });
+
+    expect(result.ok).toBe(true);
+    const stored = await getRecord<JobRecord>(
+      "jobs",
+      result.ok ? result.record.id : "",
+    );
+    expect(stored?.deletedAt).toBeUndefined();
+    expect(await getAllJobs()).toHaveLength(1);
+  });
+});
+
+describe("storage: the updatedAt index (#730)", () => {
+  it("returns only records strictly newer than the cursor, oldest first", async () => {
+    const first = await saveJob({ title: "First", status: "interested" });
+    await tick();
+    await saveJob({ title: "Second", status: "interested" });
+    await tick();
+    const third = await saveJob({ title: "Third", status: "interested" });
+
+    expect(
+      (await listRecordsUpdatedSince<JobRecord>("jobs", 0)).map((j) => j.title),
+    ).toEqual(["First", "Second", "Third"]);
+
+    // Strictly greater: passing back the last record's own stamp as the next
+    // cursor must not return it a second time.
+    expect(
+      (await listRecordsUpdatedSince<JobRecord>("jobs", first.updatedAt)).map(
+        (j) => j.title,
+      ),
+    ).toEqual(["Second", "Third"]);
+    expect(
+      await listRecordsUpdatedSince<JobRecord>("jobs", third.updatedAt),
+    ).toEqual([]);
+  });
+
+  it("includes tombstones, unlike getAllRecords", async () => {
+    const job = await saveJob({ title: "Staff Engineer", status: "applied" });
+    await tick();
+    await deleteJob(job.id);
+
+    expect(await getAllRecords<JobRecord>("jobs")).toEqual([]);
+    expect(
+      (await listRecordsUpdatedSince<JobRecord>("jobs", 0)).map((j) => j.id),
+    ).toEqual([job.id]);
+    expect(
+      (await getAllRecords<JobRecord>("jobs", { includeDeleted: true })).map(
+        (j) => j.id,
+      ),
+    ).toEqual([job.id]);
+  });
+});
+
+describe("storage: sync cursors (#730)", () => {
+  it("is undefined until a store has been replicated", async () => {
+    expect(await getSyncCursor("jobs")).toBeUndefined();
+  });
+
+  it("merges the two cursors instead of clobbering the other direction", async () => {
+    await setSyncCursor("jobs", { lastPulledAt: "2026-08-02T10:00:00.123456Z" });
+    await setSyncCursor("jobs", { lastPushedAt: 1_700_000_000_000 });
+
+    expect(await getSyncCursor("jobs")).toEqual({
+      id: "jobs",
+      lastPulledAt: "2026-08-02T10:00:00.123456Z",
+      lastPushedAt: 1_700_000_000_000,
+    });
+  });
+
+  it("keeps the remote clock verbatim, sub-millisecond precision and all", async () => {
+    // Held as an opaque string on purpose: parsing it into epoch ms would round
+    // it, and a pull cursor that rounds UP skips every record written inside the
+    // truncated interval.
+    const remote = "2026-08-02T10:00:00.123456+05:30";
+    await setSyncCursor("letters", { lastPulledAt: remote });
+    expect((await getSyncCursor("letters"))?.lastPulledAt).toBe(remote);
+  });
+
+  it("keeps one cursor per store, and survives a reload", async () => {
+    await setSyncCursor("jobs", { lastPushedAt: 1 });
+    await setSyncCursor("letters", { lastPushedAt: 2 });
+
+    // Drop the cached connection the way a page reload would.
+    await closeDB();
+
+    expect((await getSyncCursor("jobs"))?.lastPushedAt).toBe(1);
+    expect((await getSyncCursor("letters"))?.lastPushedAt).toBe(2);
+    expect(await getSyncCursor("resumes")).toBeUndefined();
+  });
+
+  it("stays out of the export document, because it describes THIS device", async () => {
+    await setSyncCursor("jobs", { lastPushedAt: 1 });
+    expect(Object.keys(await exportAll())).not.toContain("sync");
+  });
+});
+
+describe("storage: tombstones through export / import (#730)", () => {
+  it("carries a deleted job into the file and back as deleted", async () => {
+    const kept = await saveJob({ title: "Kept", status: "applied" });
+    const dropped = await saveJob({ title: "Dropped", status: "interested" });
+    await deleteJob(dropped.id);
+
+    const doc = await exportAll();
+    expect(doc.jobs.map((j) => j.title).sort()).toEqual(["Dropped", "Kept"]);
+
+    await importAll(doc, "replace");
+
+    expect((await getAllJobs()).map((j) => j.title)).toEqual(["Kept"]);
+    expect(
+      (await getRecord<JobRecord>("jobs", dropped.id))?.deletedAt,
+    ).toBeDefined();
+    expect((await getAllJobs()).map((j) => j.id)).toEqual([kept.id]);
+  });
+
+  it("counts LIVE records, so a restore does not claim to bring back a deletion", async () => {
+    const job = await saveJob({ title: "Kept", status: "applied" });
+    await saveLetter({ jobId: job.id, body: "Dear Northwind," });
+    const dropped = await saveJob({ title: "Dropped", status: "interested" });
+    await deleteJob(dropped.id);
+
+    const counts = await importAll(await exportAll(), "replace");
+
+    expect(counts.jobs).toBe(1);
+    expect(counts.letters).toBe(1);
+    expect(counts.skippedJobs).toEqual([]);
+  });
+
+  it("a merge import propagates the deletion instead of resurrecting the job", async () => {
+    // The motivating case, stated as two devices. Device A deletes a job it
+    // shares with device B; B merges A's file. Before tombstones, the job was
+    // simply missing from A's file, B kept it live, and B's next export handed
+    // it back to A.
+    const shared = await saveJob({ title: "Shared", status: "applied" });
+    await deleteJob(shared.id);
+    const deviceAFile = await exportAll();
+
+    // Device B: same job id, still live, plus one of its own.
+    await closeDB();
+    await deleteDB(DB_NAME);
+    await saveJob({ id: shared.id, title: "Shared", status: "applied" });
+    await saveJob({ title: "B's own", status: "interested" });
+
+    const counts = await importAll(deviceAFile, "merge");
+
+    expect((await getAllJobs()).map((j) => j.title)).toEqual(["B's own"]);
+    expect(counts.jobs).toBe(0);
+  });
+
+  it("preserves each record's own updatedAt rather than collapsing them into one instant", async () => {
+    // Pre-#730 a restore stamped `now` on every record, so a library the user
+    // had built over months came back ordered by whatever sequence the import
+    // loop happened to write in — and, once `updatedAt` became a replication
+    // cursor, looked to a replicator like every record had just changed.
+    const older = await saveJob({ title: "Older", status: "applied" });
+    await tick();
+    const newer = await saveJob({ title: "Newer", status: "interested" });
+
+    const doc = await exportAll();
+    await tick();
+    await importAll(doc, "replace");
+
+    const restored = await listJobs();
+    expect(restored.map((j) => j.title)).toEqual(["Newer", "Older"]);
+    expect(restored.map((j) => j.updatedAt)).toEqual([
+      newer.updatedAt,
+      older.updatedAt,
+    ]);
+  });
+
+  it("round-trips a tombstone unchanged, so export → import → export is stable", async () => {
+    const job = await saveJob({ title: "Dropped", status: "interested" });
+    await deleteJob(job.id);
+
+    const first = await exportAll();
+    await importAll(first, "replace");
+    const second = await exportAll();
+
+    expect(second.jobs).toEqual(first.jobs);
+  });
+});

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -20,6 +20,78 @@ export interface StoredRecord {
   createdAt: number;
   /** Epoch ms of the most recent write. */
   updatedAt: number;
+  /**
+   * Epoch ms this record was deleted — a **tombstone** (#730). Absent on every
+   * live record, and absent is the only reading of "not deleted": a `0` would
+   * be a valid epoch-ms timestamp.
+   *
+   * A tombstone exists because a record that is simply *gone* replicates
+   * nothing. Any second holder of this library — another device, a backup file
+   * a user restores from, a producer that captured the same posting — cannot
+   * distinguish "deleted here" from "never existed here", so it re-adds the
+   * record and the deletion undoes itself. The row has to stay behind to say
+   * what happened.
+   *
+   * **It is declared on every record but only WRITTEN for `jobs` and
+   * `letters`.** Those two replicate; `resumes` and `boards` hard-delete
+   * through {@link deleteRecord} — a résumé's bytes are the bulk of the
+   * database and holding them after a delete is the opposite of what the user
+   * asked for, and `boards` is a pure cache whose miss path is already correct.
+   * Declaring it once anyway keeps the soft-delete machinery in `crud.ts`
+   * store-agnostic, which is where the rest of that layer already sits.
+   *
+   * Readers must filter. `getAllRecords` does it by default (opt out with
+   * `includeDeleted`) so a caller has to go out of its way to see one.
+   */
+  deletedAt?: number;
+}
+
+/**
+ * The stores that replicate, and therefore the ones that carry an `updatedAt`
+ * index and a sync cursor (#730).
+ *
+ * `boards` is excluded deliberately and is not an oversight: it is a cache of
+ * what a company's ATS board returned, re-fetched cheaply on a miss. Syncing it
+ * would replicate staleness between devices and resurrect boards the registry
+ * has since dropped — the same reason it is absent from the backup document.
+ */
+export type SyncableStoreName = "resumes" | "jobs" | "letters";
+
+/**
+ * Replication bookmarks for one object store — the `sync` store's record
+ * shape (#730), keyed on the store name it describes.
+ *
+ * Deliberately **not** a {@link StoredRecord}. It is a bookmark, not a record:
+ * it has no creation time worth keeping, nothing sorts it, it never
+ * replicates, and it must never be tombstoned. Giving it the record shape would
+ * mean `putRecord` stamping `updatedAt` on a cursor, which is a timestamp about
+ * the bookmark rather than about anything a user has.
+ *
+ * The two cursors read from **different clocks**, and conflating them is the
+ * bug this docblock exists to prevent:
+ *
+ *  - {@link lastPulledAt} is the REMOTE clock, held verbatim as whatever opaque
+ *    string the remote handed back. It is compared only against other values
+ *    from that same source. Parsing it into epoch ms would lose sub-millisecond
+ *    precision, and a cursor that rounds *up* silently skips every record
+ *    written inside the truncated interval.
+ *  - {@link lastPushedAt} is THIS device's `Date.now()`, compared against
+ *    `StoredRecord.updatedAt`, which is stamped from the same clock.
+ *
+ * Nothing in this build writes either one. The store lands here because the
+ * schema migration that creates it lands here (see `db.ts`) — the reader is the
+ * browser extension, which builds these modules from a pinned commit of this
+ * repo and cannot add an object store of its own.
+ */
+export interface SyncCursorRecord {
+  /** The object store these bookmarks describe — the keyPath. */
+  id: SyncableStoreName;
+  /** Opaque remote-clock bookmark: everything changed remotely at or before
+   *  this point has been written locally. Absent until the first pull. */
+  lastPulledAt?: string;
+  /** Local `Date.now()` bookmark: every local record with a strictly greater
+   *  `updatedAt` still needs pushing. Absent until the first push. */
+  lastPushedAt?: number;
 }
 
 /** A saved resume: raw PDF bytes as a `Blob` (no base64 inflation at rest) plus
@@ -261,7 +333,15 @@ export interface LetterRecord extends StoredRecord {
   producer?: LetterProvenance;
 }
 
-/** Object-store names. Adding a store is a schema-version bump (see db.ts). */
+/**
+ * Object-store names the generic CRUD in `crud.ts` operates over. Adding a
+ * store is a schema-version bump (see db.ts).
+ *
+ * `sync` is absent on purpose. Every name here holds a {@link StoredRecord} and
+ * `putRecord` stamps timestamps on the way in; {@link SyncCursorRecord} is
+ * neither, so it gets its own two-function accessor (`sync-cursor.ts`) rather
+ * than a cast that would let `putRecord` write a `createdAt` onto a bookmark.
+ */
 export type StoreName = "resumes" | "jobs" | "boards" | "letters";
 
 /** A resume as it appears in an export file: blob replaced by base64 + MIME so


### PR DESCRIPTION
Closes #730.

Three things the local schema did not provide, plus the reader audit that makes them safe and one
pre-existing bug they turned load-bearing.

## What landed

| | |
|---|---|
| **Tombstones** | `StoredRecord.deletedAt`. `jobs` / `letters` soft-delete; `resumes` / `boards` keep hard deletes (bytes, and a pure cache). |
| **`updatedAt` index** | On the three stores that can replicate. `createIndex` backfills, so a returning user's existing records are covered — asserted. |
| **`sync` store** | One bookmark per store. Not a `StoredRecord`, and the pull/push cursors are typed differently because they read different clocks. |

## The reader audit

Cheap, because the funnel was already there. `getAllRecords` filters tombstones **by default**
(`includeDeleted` opts out), so every list surface was correct without an edit; `getJob` /
`getLetter` filter by id so nothing above `crud.ts` can render or resurrect one.

Two behaviour calls worth review:

- `updateJob` now **throws** on a deleted job rather than reviving it by patch.
- `captureJob` still **revives**, reported as `created: true` — which is exactly what a hard delete
  always did. The tombstone exists to stop a *replica* bringing a record back behind the user's
  back, not to stop the user saving the posting again. A `deletedAt` a producer sends is stripped.

## Tombstones are exported

Omitting them is wrong in the mode that exists to combine two copies of a library: device A deletes
a job and exports, B still has it live, B merging A's file resurrects it. Replace mode looks
identical either way, so the tie breaks toward correctness in merge.

The document version is **not** bumped — an older build would reject a v3 file outright, costing the
user every record instead of resurfacing a few deleted ones. Full reasoning is in both contract docs.

## Pre-existing bug this surfaced

`importAll` stamped `updatedAt` on every restored record, collapsing a library built over months
into one instant and silently reordering a tracker sorted most-recently-updated-first. Once
`updatedAt` is a replication cursor it also claims every record on the device just changed. Import
now writes with `touch: false`; that option's precedence changed to prefer the record's own
timestamp over the stored one, which no current caller can observe (the housekeeping callers spread
the record they just read).

## ⚠️ This strands the browser extension

It builds these modules from a pinned commit (`extension/offlinecv-pin.json`) and carries whatever
version the pin had, so once a user's database is at v4 an extension at the old pin gets a
`VersionError` and every capture breaks. This repo's CI never compiles it, so nothing here catches
it. **The pin bump follows in the extension repo, referencing this commit.**

## Verification

`npm run verify` green — 4690 passed, 10 skipped; build clean. fallow: dead-code findings are the
extension's own `package.json` (inherited); the new staged exports are registered in `.fallowrc.jsonc`
beside `captureJob`, with the same time-bounded rationale.

New suite `src/lib/storage/sync-schema.test.ts` covers the v3→v4 migration (seeded by replaying the
shipped v3 upgrade blocks, not by calling `getDB()`), index backfill, tombstone visibility and
idempotence, the cascade, the range query, cursor persistence across a reload, and the
export/import round trip including the two-device merge case.

## Provenance

Written with Claude Code (Opus 5).
