### PR TITLE
feat(webllm,design-system): offer the rewrite prompt as a copyable artifact (#609)

### DIFF
--- a/src/components/features/LetterRevealDialog.tsx
+++ b/src/components/features/LetterRevealDialog.tsx
@@ -22,10 +22,12 @@
  * demos — and `writeText` rejects outright when the permission is denied. A
  * caught-and-dropped failure leaves the button reading "Copy to clipboard"
  * with nothing on the clipboard, so the user pastes whatever was there before
- * and never learns why. `WebGpuUnavailableNotice`'s `CopyablePath` is this
- * repo's precedent for the same degrade; the difference here is that the body
- * is a selectable text region, so the fallback ("select it yourself") is a real
- * instruction rather than a shrug.
+ * and never learns why. That branch is no longer this file's to get right — it
+ * moved into `useCopyToClipboard` (#609), which every clipboard call site in
+ * the tree now shares. What stays here is the shape of the telling: the body is
+ * a selectable text region, so the fallback ("select it yourself") is a real
+ * instruction rather than a shrug, and it needs its own line beside the button
+ * rather than a truncated label inside it.
  *
  * Reuse analysis: `Dialog` + `Button` from `@design-system`, no hand-rolled
  * modal. No `Card` — the dialog is already the surface. The copy-failure line
@@ -36,7 +38,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { Button, Dialog } from "@design-system";
+import { Button, Dialog, useCopyToClipboard } from "@design-system";
 import type { LetterRecord } from "../../lib/storage/index.ts";
 
 interface LetterRevealDialogProps {
@@ -47,11 +49,6 @@ interface LetterRevealDialogProps {
    *  the caller (`JobLetterIndicator`) renders nothing when there are none. */
   letters: readonly LetterRecord[];
 }
-
-/** Idle, or the outcome of the last copy attempt. A boolean cannot hold
- *  "tried and failed" apart from "not tried", which is what made the failure
- *  invisible — the button simply kept offering to copy. */
-type CopyState = "idle" | "copied" | "failed";
 
 function formatDate(ms: number): string {
   return new Date(ms).toLocaleDateString(undefined, {
@@ -69,7 +66,12 @@ export function LetterRevealDialog({
   const [selectedId, setSelectedId] = useState<string | undefined>(
     letters[0]?.id,
   );
-  const [copyState, setCopyState] = useState<CopyState>("idle");
+  // The clipboard write itself comes from the shared `useCopyToClipboard`
+  // (#609) — this file was the precedent for the absent-`navigator.clipboard`
+  // branch that hook now enforces for every caller. The MARKUP stays here: the
+  // failure is a full instruction sentence sitting beside the button, not a
+  // label swap inside it, so `CopyButton` is the wrong half of the pair.
+  const { state: copyState, copy, reset: resetCopy } = useCopyToClipboard();
 
   // Re-pick the most-recent draft and clear any stale copy result every time
   // the dialog opens — without this, reopening after picking an older draft
@@ -82,30 +84,11 @@ export function LetterRevealDialog({
   useEffect(() => {
     if (open) {
       setSelectedId(letters[0]?.id);
-      setCopyState("idle");
+      resetCopy();
     }
-  }, [open, letters]);
+  }, [open, letters, resetCopy]);
 
   const selected = letters.find((letter) => letter.id === selectedId) ?? letters[0];
-
-  async function onCopy() {
-    if (!selected) return;
-    // Read the API off `navigator` explicitly rather than optional-chaining the
-    // call: `navigator.clipboard?.writeText(…)` yields `undefined` on an
-    // insecure origin, which awaits cleanly and would report a copy that never
-    // happened. The absence has to be its own branch.
-    const clipboard = navigator.clipboard;
-    if (!clipboard) {
-      setCopyState("failed");
-      return;
-    }
-    try {
-      await clipboard.writeText(selected.body);
-      setCopyState("copied");
-    } catch {
-      setCopyState("failed");
-    }
-  }
 
   if (!selected) return null;
 
@@ -130,7 +113,7 @@ export function LetterRevealDialog({
                 size="sm"
                 onClick={() => {
                   setSelectedId(letter.id);
-                  setCopyState("idle");
+                  resetCopy();
                 }}
               >
                 {letter.label || "Untitled draft"}
@@ -166,7 +149,11 @@ export function LetterRevealDialog({
               Couldn&rsquo;t copy — select the text above and copy it yourself.
             </span>
           )}
-          <Button variant="primary" size="sm" onClick={() => void onCopy()}>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => copy(selected.body)}
+          >
             {copyState === "copied" ? "Copied" : "Copy to clipboard"}
           </Button>
         </div>

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -8,7 +8,9 @@
  *   - The single primary CTA (mounted next to the model picker at the
  *     top of the Experience section), which opens a steering dialog
  *   - The steering dialog (#210 page-length chips + instructions), shown
- *     before the run; "Run rewrite" starts it and closes the dialog
+ *     before the run; "Run rewrite" starts it and closes the dialog. Its
+ *     collapsed "copy the prompt instead" disclosure (#609) lives in the
+ *     sibling `RewritePromptDisclosure.tsx`
  *   - The status-to-UI routing (loading → running → proposed → error)
  *   - The in-flight `StepIndicator` + `CompletedList`
  *
@@ -50,6 +52,7 @@ import {
   ProposedPanel,
   type ResumeRewriteApply,
 } from "./ResumeRewriteProposed.tsx";
+import { RewritePromptDisclosure } from "./RewritePromptDisclosure.tsx";
 
 export interface ResumeRewriteParts {
   /** The CTA button; opens the steering dialog (#210 steering box now lives
@@ -158,6 +161,12 @@ function RewriteLauncher({
               Run rewrite
             </Button>
           </div>
+          {/* #609 — the secondary path, BELOW the primary CTA and collapsed.
+              The on-device pass stays the one-click answer; this only reveals
+              the prompt behind it for a user who would rather run it somewhere
+              stronger. It reads the same `controller`, so what it shows is the
+              steering this dialog is currently expressing. */}
+          <RewritePromptDisclosure controller={controller} />
         </div>
       </Dialog>
     </>

--- a/src/components/features/RewritePromptDisclosure.test.tsx
+++ b/src/components/features/RewritePromptDisclosure.test.tsx
@@ -183,6 +183,83 @@ describe("RewritePromptDisclosure — the prompt tracks live steering", () => {
   });
 });
 
+describe("the controller absorbs parent render churn (#732 review)", () => {
+  // `ReconstructedResume` calls `buildResumeSections(…)` in its render body —
+  // a plain call, not a memo — so `sections` arrives as a NEW array on every
+  // render. That churn used to reach `rewriteableSections` and `steering`,
+  // which made the disclosure's prompt `useMemo` inert: deps that change every
+  // render memoize nothing.
+  //
+  // Asserted on the controller rather than on the rendered prompt, because the
+  // prompt is derived — it comes out identical either way, which is exactly why
+  // the churn was invisible until someone looked at the dep list.
+  const ROLE = "Staff Engineer · Northwind Logistics";
+
+  function freshSections(label: string, second: string): SectionInput[] {
+    return [
+      { kind: "summary", id: "s", label: "Summary", text: SUMMARY },
+      { kind: "experience", id: "e1", label, bullets: [BULLET_A, second] },
+    ];
+  }
+
+  let churn: ResumeRewriteController;
+
+  function ChurnProbe({ label, second }: { label: string; second: string }) {
+    churn = useResumeRewrite(freshSections(label, second));
+    return null;
+  }
+
+  async function render(label = ROLE, second = BULLET_B) {
+    await act(async () => {
+      root.render(<ChurnProbe label={label} second={second} />);
+      await Promise.resolve();
+    });
+  }
+
+  it("holds section and steering identity across a content-identical re-render", async () => {
+    await render();
+    // A page target makes `steering` a real object — with no steering at all it
+    // is `undefined`, and `undefined === undefined` would pass vacuously.
+    act(() => churn.setPageTarget(1));
+
+    const sections = churn.rewriteableSections;
+    const steering = churn.steering;
+    expect(steering).toBeDefined();
+
+    await render();
+
+    expect(churn.rewriteableSections).toBe(sections);
+    expect(churn.steering).toBe(steering);
+  });
+
+  it("still adopts a new array when a display LABEL changes", async () => {
+    // The stabilizer is stricter than `sectionsEqual`, which ignores `label`.
+    // These objects are what the progress line and the proposal panel's
+    // headings read, so holding a stale one would show the old employer.
+    await render();
+    const sections = churn.rewriteableSections;
+
+    await render("Staff Engineer · Contoso Freight");
+
+    expect(churn.rewriteableSections).not.toBe(sections);
+    expect(churn.rewriteableSections.map((s) => s.label)).toContain(
+      "Staff Engineer · Contoso Freight",
+    );
+  });
+
+  it("still adopts a new array when a BULLET changes", async () => {
+    await render();
+    const sections = churn.rewriteableSections;
+
+    await render(ROLE, "Rebuilt the pricing service end to end.");
+
+    expect(churn.rewriteableSections).not.toBe(sections);
+    expect(JSON.stringify(churn.rewriteableSections)).toContain(
+      "Rebuilt the pricing service end to end.",
+    );
+  });
+});
+
 describe("RewritePromptDisclosure — copying", () => {
   it("puts the shown prompt on the clipboard and confirms in place", async () => {
     const writeText = vi.fn(() => Promise.resolve());

--- a/src/components/features/RewritePromptDisclosure.test.tsx
+++ b/src/components/features/RewritePromptDisclosure.test.tsx
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * End-to-end coverage for the copyable-prompt disclosure (#609), driven
+ * through the REAL `useResumeRewrite` controller rather than a stubbed
+ * `steering` object.
+ *
+ * That choice is the point of the file. The likely bug in this feature is a
+ * prompt built once and never rebuilt — and it passes any test that stubs the
+ * steering, because the stub only ever holds one value. Driving the real
+ * controller's `setPageTarget` / `setUserInstructions` exercises the whole
+ * chain the user does: state → assembled steering → prompt → the text in the
+ * box → the bytes on the clipboard.
+ *
+ * Only the engine layer is mocked (capability probe + `web-llm`), matching
+ * `hooks/webllm-controllers.test.tsx`; nothing about steering or prompt
+ * assembly is.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+vi.mock("../../lib/webllm/capability.ts", () => ({
+  detectWebGpu: () => Promise.resolve("available"),
+}));
+
+vi.mock("../../lib/webllm/web-llm.ts", () => ({
+  loadEngine: () => Promise.resolve({ chat: {} }),
+  acquireInference: vi.fn(),
+  releaseInference: vi.fn(),
+}));
+
+import { RewritePromptDisclosure } from "./RewritePromptDisclosure.tsx";
+import {
+  useResumeRewrite,
+  type ResumeRewriteController,
+} from "../../hooks/useResumeRewrite.ts";
+import {
+  NO_FABRICATION_RULE,
+  PRESERVE_NUMBERS_RULE,
+} from "../../lib/webllm/rewrite-guardrails.ts";
+import type { SectionInput } from "../../lib/webllm/rewrite-resume.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+// Synthetic persona, per CLAUDE.md's fixture rule — a résumé-shaped literal in
+// a test is the thing that gets lifted into a fixture later.
+const SUMMARY = "Platform engineer with 9 years in payments at Northwind Logistics.";
+const BULLET_A = "Cut checkout latency 42% by resharding the ledger service.";
+const BULLET_B = "Led 5 engineers through a zero-downtime Oracle migration.";
+const RESUME_VALUES = [
+  SUMMARY,
+  BULLET_A,
+  BULLET_B,
+  "Staff Engineer · Northwind Logistics",
+  "Northwind",
+  "Oracle",
+  "42%",
+];
+
+const SECTIONS: SectionInput[] = [
+  { kind: "summary", id: "s", label: "Summary", text: SUMMARY },
+  {
+    kind: "experience",
+    id: "e1",
+    label: "Staff Engineer · Northwind Logistics",
+    bullets: [BULLET_A, BULLET_B],
+  },
+];
+
+let container: HTMLElement;
+let root: Root;
+let controller: ResumeRewriteController;
+
+function Probe() {
+  const c = useResumeRewrite(SECTIONS);
+  controller = c;
+  return <RewritePromptDisclosure controller={c} />;
+}
+
+beforeEach(async () => {
+  // `useResumeRewrite` persists steering to localStorage, so a target set in
+  // one case would otherwise be the starting state of the next.
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // Flush the mocked `detectWebGpu()` inside `act` — its resolution sets
+  // capability state, and letting it land mid-test is what produces the
+  // "update not wrapped in act" noise (and, worse, a re-render between an
+  // assertion and the thing it is asserting about).
+  await act(async () => {
+    root.render(<Probe />);
+    await Promise.resolve();
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stubClipboard(undefined);
+});
+
+function stubClipboard(value: unknown) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function toggle() {
+  const button = container.querySelector("button[aria-expanded]");
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+function clickButton(text: string) {
+  const button = [...container.querySelectorAll("button")].find(
+    (b) => b.textContent === text,
+  );
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+function shownPrompt(): string {
+  return container.querySelector("textarea")?.value ?? "";
+}
+
+describe("RewritePromptDisclosure — disclosure", () => {
+  it("hides the prompt until a deliberate action reveals it", () => {
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.textContent).not.toContain(PRESERVE_NUMBERS_RULE);
+    expect(container.querySelector("button[aria-expanded]")?.getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+  });
+
+  it("reveals a prompt carrying the shared guardrails", () => {
+    toggle();
+    expect(shownPrompt()).toContain(PRESERVE_NUMBERS_RULE);
+    expect(shownPrompt()).toContain(NO_FABRICATION_RULE);
+  });
+
+  it("shows the prompt read-only, not disabled, so it stays selectable", () => {
+    toggle();
+    const textarea = container.querySelector("textarea")!;
+    expect(textarea.readOnly).toBe(true);
+    expect(textarea.disabled).toBe(false);
+  });
+});
+
+describe("RewritePromptDisclosure — the prompt tracks live steering", () => {
+  it("updates when the page target changes", () => {
+    toggle();
+    expect(shownPrompt()).not.toContain("Target a one-page résumé");
+
+    act(() => controller.setPageTarget(1));
+    expect(shownPrompt()).toContain("Target a one-page résumé");
+
+    act(() => controller.setPageTarget(3));
+    expect(shownPrompt()).toContain("Target a three-page résumé");
+    expect(shownPrompt()).not.toContain("Target a one-page résumé");
+  });
+
+  it("updates when the freeform instructions change", () => {
+    toggle();
+    act(() => controller.setUserInstructions("drop the internships"));
+    expect(shownPrompt()).toContain(
+      "The user has these additional instructions: drop the internships",
+    );
+  });
+
+  it("is complete with no steering set at all", () => {
+    toggle();
+    const prompt = shownPrompt();
+    expect(prompt).toContain(PRESERVE_NUMBERS_RULE);
+    expect(prompt).not.toContain("The user has these additional instructions:");
+    expect(prompt).not.toMatch(/\n{3}/);
+  });
+});
+
+describe("RewritePromptDisclosure — copying", () => {
+  it("puts the shown prompt on the clipboard and confirms in place", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    stubClipboard({ writeText });
+    toggle();
+    act(() => controller.setPageTarget(2));
+
+    await act(async () => {
+      clickButton("Copy prompt");
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledWith(shownPrompt());
+    expect(container.textContent).toContain("Copied the prompt");
+    expect(container.querySelector('[aria-live="polite"]')?.textContent).toBe(
+      "Copied the prompt",
+    );
+  });
+
+  it("copies no résumé content", async () => {
+    const writeText = vi.fn((_text: string) => Promise.resolve());
+    stubClipboard({ writeText });
+    toggle();
+    act(() => controller.setUserInstructions("emphasise the payments work"));
+
+    await act(async () => {
+      clickButton("Copy prompt");
+      await Promise.resolve();
+    });
+
+    const copied = writeText.mock.calls[0]![0];
+    for (const value of RESUME_VALUES) {
+      expect(copied).not.toContain(value);
+    }
+  });
+
+  it("degrades without throwing when there is no Clipboard API, leaving the text on screen", async () => {
+    stubClipboard(undefined);
+    toggle();
+
+    await act(async () => {
+      clickButton("Copy prompt");
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Couldn’t copy — select the text above");
+    expect(shownPrompt()).toContain(PRESERVE_NUMBERS_RULE);
+    expect(container.querySelector("textarea")?.disabled).toBe(false);
+  });
+});

--- a/src/components/features/RewritePromptDisclosure.tsx
+++ b/src/components/features/RewritePromptDisclosure.tsx
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * RewritePromptDisclosure — "or take our prompt to a model you already use"
+ * (#609).
+ *
+ * A collapsed secondary affordance inside the existing rewrite steering dialog.
+ * The on-device pass stays the primary, one-click path and is unchanged: a user
+ * who never opens this sees and does what they did before, unchanged. This is a
+ * DISCLOSURE, not a fork in the road — which is why it is a link under the
+ * dialog's own CTA row rather than a second button competing with "Run
+ * rewrite".
+ *
+ * Why it exists: the on-device model is the only rewriter that keeps the résumé
+ * text on the device, and it is also the weakest one most users can reach.
+ * Someone with a frontier model in the next tab could do better, and the only
+ * thing standing between them and that is our prompt — which was locked inside
+ * the bundle. Handing it over costs this project nothing in privacy posture: a
+ * clipboard write is local, the copied text carries no résumé content
+ * (`export-prompt.ts` property 1), and where the user takes it afterwards is
+ * their own deliberate choice rather than our default. No reassurance copy
+ * about that here — this surface states what it does and lets the user decide.
+ *
+ * A sibling file rather than more lines in `ResumeRewrite.tsx` (CLAUDE.md's
+ * ~200 LOC rule; that file is already at 200+ and owns the dialog).
+ *
+ * Reuse (CLAUDE.md 3-tier rule): `Button`, `TextAreaField` and `CopyButton`
+ * from `@design-system` — no raw `<button>`, `<textarea>`, or a fourth
+ * hand-rolled clipboard write. The prompt itself is built by the pure
+ * `buildExportableRewritePrompt`; this file only renders.
+ */
+
+import { useMemo, useState } from "react";
+import { Button, CopyButton, TextAreaField } from "@design-system";
+import type { ResumeRewriteController } from "../../hooks/useResumeRewrite.ts";
+import { buildExportableRewritePrompt } from "../../lib/webllm/export-prompt.ts";
+
+export function RewritePromptDisclosure({
+  controller,
+}: {
+  controller: ResumeRewriteController;
+}) {
+  const [open, setOpen] = useState(false);
+  const { rewriteableSections, steering } = controller;
+
+  // Derived on every render from the controller's LIVE steering, so editing the
+  // instructions box or switching a length chip with this open rewrites the
+  // shown text. Building it once on mount is the obvious bug here and would
+  // pass any "the prompt renders" test — `RewritePromptDisclosure.test.tsx`
+  // asserts the update for both inputs.
+  const prompt = useMemo(
+    () => buildExportableRewritePrompt(rewriteableSections, steering),
+    [rewriteableSections, steering],
+  );
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border-light pt-3">
+      <div>
+        <Button
+          variant="link"
+          size="sm"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          className="text-2xs text-content-secondary"
+        >
+          {open ? "Hide the prompt" : "Prefer another model? Copy the prompt ↓"}
+        </Button>
+      </div>
+
+      {open && (
+        <div className="flex flex-col gap-2">
+          <p className="text-2xs text-content-muted">
+            The same rules the on-device rewrite runs on, with your settings
+            above folded in. Take it to any model, bring your own résumé, and
+            edit the result back in below. This text holds no résumé content.
+          </p>
+          {/* Read-only, not disabled: a disabled textarea's text cannot be
+              selected with the mouse in Chromium, and manual selection is the
+              whole fallback when the clipboard is unavailable (dev:http, a
+              denied permission). `autoGrow={false}` keeps a long prompt from
+              pushing the dialog's own controls off-screen. */}
+          <TextAreaField
+            label="Rewrite prompt to copy"
+            value={prompt}
+            onChange={() => {}}
+            readOnly
+            autoGrow={false}
+            rows={8}
+            className="max-h-56 font-mono text-2xs"
+          />
+          <div className="flex items-center justify-end">
+            <CopyButton
+              value={prompt}
+              variant="ghost"
+              size="sm"
+              className="rounded-md border border-border-light bg-surface-card px-2.5 py-1 text-2xs text-content-primary hover:border-border hover:bg-surface-hover"
+              copiedLabel="Copied the prompt"
+              failedLabel="Couldn’t copy — select the text above"
+              resetAfterMs={3000}
+            >
+              Copy prompt
+            </CopyButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/SectionRewrite.test.ts
+++ b/src/components/features/SectionRewrite.test.ts
@@ -119,16 +119,11 @@ describe("NumberPreservationWarning", () => {
 // ── ProposedSection ─────────────────────────────────────────────────────────
 
 describe("ProposedSection", () => {
-  function render(
-    result: SectionRewriteResult,
-    extras: { copied?: boolean } = {},
-  ): string {
+  function render(result: SectionRewriteResult): string {
     return renderToStaticMarkup(
       createElement(ProposedSection, {
         original: ["Original bullet 1.", "Original bullet 2."],
         result,
-        copied: extras.copied ?? false,
-        onCopyAll: () => {},
         onReject: () => {},
       }),
     );
@@ -179,16 +174,19 @@ describe("ProposedSection", () => {
     expect(html).toContain("two");
   });
 
-  it("flips the copy button label after a successful copy-all", () => {
-    const result: SectionRewriteResult = {
+  // The label swap after a successful copy moved into the shared `CopyButton`
+  // with #609 — it is covered against a real stubbed clipboard in
+  // `design-system/primitives/CopyButton.test.tsx`, which this static-markup
+  // suite cannot do (no click, no promise). What stays this file's job is that
+  // the panel still OFFERS the copy in its idle state.
+  it("offers the copy-all affordance in its idle state", () => {
+    const html = render({
       bullets: ["one"],
       numbersPreserved: true,
       droppedNumbers: [],
       addedNumbers: [],
-    };
-    expect(render(result, { copied: false })).toContain(
-      "Use this — copy all bullets",
-    );
-    expect(render(result, { copied: true })).toContain("Copied");
+    });
+    expect(html).toContain("Use this — copy all bullets");
+    expect(html).not.toContain("Copied");
   });
 });

--- a/src/components/features/SectionRewrite.tsx
+++ b/src/components/features/SectionRewrite.tsx
@@ -48,7 +48,13 @@ import type {
 import type { SectionRewriteResult } from "../../lib/webllm/rewrite-section.ts";
 import { useSectionRewriteLock } from "../../hooks/useSectionRewriteLock.ts";
 import { useModelSelection } from "../../hooks/useModelSelection.ts";
-import { Button, ModelLoadProgress, InlineResult, InlineDiff } from "@design-system";
+import {
+  Button,
+  CopyButton,
+  ModelLoadProgress,
+  InlineResult,
+  InlineDiff,
+} from "@design-system";
 import { computeTextDiff } from "../../lib/diff/text-diff.ts";
 import {
   alignBullets,
@@ -207,7 +213,6 @@ export function useSectionRewrite(
 ): SectionRewriteParts {
   const [capability, setCapability] = useState<WebGpuCapability | null>(null);
   const [status, setStatus] = useState<Status>({ kind: "idle" });
-  const [copied, setCopied] = useState(false);
   const { isLocked, acquire } = useSectionRewriteLock();
   const { selectedModelId } = useModelSelection();
 
@@ -266,12 +271,10 @@ export function useSectionRewrite(
     if (status.kind !== "proposed") return;
     if (!bulletsEqual(status.snapshot, trimmedBullets)) {
       setStatus({ kind: "idle" });
-      setCopied(false);
     }
   }, [trimmedBullets, status]);
 
   const onClick = useCallback(async () => {
-    setCopied(false);
     // Atomic acquire — null means another instance already holds the lock and
     // we must bail. This is the real "no concurrent generate()" guard; the
     // disabled flag on the button is only the UI surface of the same check
@@ -322,7 +325,6 @@ export function useSectionRewrite(
 
   const onReject = useCallback(() => {
     setStatus({ kind: "idle" });
-    setCopied(false);
   }, []);
 
   // `ApplyConfirmation` re-arms its EXIT_MS collapse timer whenever `onCollapse`
@@ -352,7 +354,6 @@ export function useSectionRewrite(
     // path's zero-write dismiss.
     if (writes.length === 0) {
       setStatus({ kind: "idle" });
-      setCopied(false);
       return;
     }
     // Snapshot BEFORE the loop — once a write lands the prior value is gone
@@ -370,7 +371,6 @@ export function useSectionRewrite(
       sections: [sectionLabel],
       undo,
     });
-    setCopied(false);
   }, [
     apply,
     pairs,
@@ -379,16 +379,6 @@ export function useSectionRewrite(
     keptObsIds,
     sectionLabel,
   ]);
-
-  const onCopyAll = useCallback(async () => {
-    if (status.kind !== "proposed") return;
-    try {
-      await navigator.clipboard.writeText(status.result.bullets.join("\n"));
-      setCopied(true);
-    } catch {
-      setCopied(false);
-    }
-  }, [status]);
 
   if (capability !== "available" || trimmedBullets.length === 0) {
     return { trigger: null, panel: null };
@@ -453,8 +443,6 @@ export function useSectionRewrite(
             <ProposedSection
               original={trimmedBullets}
               result={status.result}
-              copied={copied}
-              onCopyAll={onCopyAll}
               onReject={onReject}
             />
           ))}
@@ -529,17 +517,23 @@ export function labelFor(status: Status, lockedByOther: boolean): string {
   }
 }
 
+/**
+ * The no-edit-model fallback panel: a before/after diff whose only exit is
+ * "copy the bullets and paste them yourself".
+ *
+ * Copy state used to live in `useSectionRewrite` as a `copied` boolean that
+ * five separate transitions had to remember to clear. It now belongs to the
+ * shared `CopyButton` (#609), which is mounted only while this panel is — every
+ * one of those transitions unmounts it, so the reset is structural rather than
+ * five call sites agreeing.
+ */
 export function ProposedSection({
   original,
   result,
-  copied,
-  onCopyAll,
   onReject,
 }: {
   original: readonly string[];
   result: SectionRewriteResult;
-  copied: boolean;
-  onCopyAll: () => void;
   onReject: () => void;
 }) {
   return (
@@ -562,14 +556,15 @@ export function ProposedSection({
       />
 
       <div className="flex flex-wrap items-center gap-3">
-        <Button
+        <CopyButton
+          value={result.bullets.join("\n")}
           variant="ghost"
           size="sm"
-          onClick={onCopyAll}
           className="rounded-md border border-border-light bg-surface-card px-2.5 py-1 text-2xs text-content-primary hover:border-border hover:bg-surface-hover"
+          failedLabel="Couldn’t copy — select the bullets above"
         >
-          {copied ? "Copied" : "Use this — copy all bullets"}
-        </Button>
+          Use this — copy all bullets
+        </CopyButton>
         <Button
           variant="link"
           size="sm"

--- a/src/components/features/WebGpuUnavailableNotice.tsx
+++ b/src/components/features/WebGpuUnavailableNotice.tsx
@@ -18,13 +18,14 @@
  * browsers block web navigation to those schemes.
  *
  * Reuse (CLAUDE.md 3-tier rule): `InlineResult` (warning) for the compact strip
- * and `Dialog` for the how-to; `Button` for every control. External help is a
- * raw `<a>` (a link, not an interactive-button primitive concern). No new
- * banner/modal chrome is introduced.
+ * and `Dialog` for the how-to; `Button` for every control, and `CopyButton` for
+ * the copy-path rows (#609). External help is a raw `<a>` (a link, not an
+ * interactive-button primitive concern). No new banner/modal chrome is
+ * introduced.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Dialog, InlineResult } from "@design-system";
+import { useEffect, useMemo, useState } from "react";
+import { Button, CopyButton, Dialog, InlineResult } from "@design-system";
 import type { WebGpuCapability } from "../../lib/webllm/types.ts";
 import {
   detectBrowserPlatform,
@@ -168,28 +169,14 @@ export function WebGpuUnavailableNotice({ capability }: Props) {
 /**
  * A copy-to-clipboard row for an internal URL the user must paste into their
  * own address bar (browsers block web navigation to `chrome://` / `about:`).
- * Shows a transient "Copied" confirmation; degrades to a no-op label if the
- * Clipboard API is unavailable or denied.
+ *
+ * Migrated onto the shared `CopyButton` (#609) — this file was one of the three
+ * hand-rolled clipboard implementations that primitive replaced. One behaviour
+ * change came with it, deliberately: a denied or unavailable clipboard now says
+ * so instead of leaving the button reading "Copy". The path stays on screen and
+ * selectable either way, which is why the failure label points back at it.
  */
 function CopyablePath({ path }: { path: CopyPath }) {
-  const [copied, setCopied] = useState(false);
-
-  const onCopy = useCallback(() => {
-    void navigator.clipboard
-      ?.writeText(path.value)
-      .then(() => setCopied(true))
-      .catch(() => {
-        // Clipboard denied — leave the value visible for manual selection.
-      });
-  }, [path.value]);
-
-  // Clear the confirmation after a moment so a second copy re-confirms.
-  useEffect(() => {
-    if (!copied) return;
-    const id = setTimeout(() => setCopied(false), 1500);
-    return () => clearTimeout(id);
-  }, [copied]);
-
   return (
     <div className="flex flex-col gap-0.5">
       <span className="text-2xs text-content-tertiary">{path.label}</span>
@@ -197,15 +184,18 @@ function CopyablePath({ path }: { path: CopyPath }) {
         <code className="flex-1 overflow-x-auto text-2xs text-content-primary">
           {path.value}
         </code>
-        <Button
+        <CopyButton
+          value={path.value}
           variant="link"
           size="sm"
-          onClick={onCopy}
           aria-label={`Copy ${path.value}`}
           className="shrink-0 text-2xs text-accent-primary"
+          copiedLabel="Copied ✓"
+          failedLabel="Select it above"
+          resetAfterMs={1500}
         >
-          {copied ? "Copied ✓" : "Copy"}
-        </Button>
+          Copy
+        </CopyButton>
       </div>
     </div>
   );

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -18,6 +18,8 @@ export * from "./icons/TrustIcons.tsx";
 export * from "./primitives/Button.tsx";
 export * from "./primitives/Checkbox.tsx";
 export * from "./primitives/Chip.tsx";
+export * from "./primitives/CopyButton.tsx";
+export * from "./primitives/useCopyToClipboard.ts";
 export * from "./primitives/Dialog.tsx";
 export * from "./primitives/EditableField.tsx";
 export * from "./primitives/StarRating.tsx";

--- a/src/design-system/primitives/CopyButton.test.tsx
+++ b/src/design-system/primitives/CopyButton.test.tsx
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Behavioural tests for the shared copy affordance (#609).
+ *
+ * These are the cases that were previously untested at all three hand-rolled
+ * call sites, and that the extraction exists to make true everywhere at once:
+ * a success confirms IN PLACE, a failure says so rather than leaving a button
+ * still offering to copy, and both are announced through a live region rather
+ * than only to a sighted user.
+ *
+ * Mounts through raw `createRoot` (no RTL in this repo — see
+ * `ResumeLibrary.test.tsx`). The harness is inlined rather than imported from
+ * `components/features/__test-utils__/`: design-system code must not reach
+ * back across the `@design-system` seam, not even in a test, or a downstream
+ * cloner who repoints the alias inherits a broken suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CopyButton } from "./CopyButton.tsx";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stubClipboard(undefined);
+  vi.useRealTimers();
+});
+
+/** jsdom ships no `navigator.clipboard`; every case installs the one it wants. */
+function stubClipboard(value: unknown) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function click() {
+  const button = container.querySelector("button");
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+function liveRegionText(): string {
+  return container.querySelector('[aria-live="polite"]')?.textContent ?? "";
+}
+
+describe("CopyButton", () => {
+  it("writes the value and confirms in place", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    stubClipboard({ writeText });
+    act(() => root.render(<CopyButton value="the prompt">Copy prompt</CopyButton>));
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledWith("the prompt");
+    expect(container.querySelector("button")?.textContent).toBe("Copied");
+  });
+
+  it("announces the confirmation through a live region, not colour or shape", async () => {
+    stubClipboard({ writeText: vi.fn(() => Promise.resolve()) });
+    act(() => root.render(<CopyButton value="x">Copy</CopyButton>));
+
+    // The region has to exist BEFORE the change or there is nothing for
+    // assistive tech to observe — assert it is mounted and empty while idle.
+    expect(container.querySelector('[aria-live="polite"]')).not.toBeNull();
+    expect(liveRegionText()).toBe("");
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+
+    expect(liveRegionText()).toBe("Copied");
+  });
+
+  it("says the copy failed when there is no Clipboard API at all", async () => {
+    // The `npm run dev:http` case: an insecure origin exposes no
+    // `navigator.clipboard`. Optional-chaining the call yields `undefined`,
+    // which awaits cleanly — this is the branch that would silently report a
+    // copy that never happened.
+    stubClipboard(undefined);
+    act(() => root.render(<CopyButton value="x">Copy</CopyButton>));
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("button")?.textContent).toBe("Couldn’t copy");
+    expect(liveRegionText()).toBe("Couldn’t copy");
+  });
+
+  it("says the copy failed when writeText rejects", async () => {
+    stubClipboard({ writeText: vi.fn(() => Promise.reject(new Error("denied"))) });
+    act(() => root.render(<CopyButton value="x">Copy</CopyButton>));
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("button")?.textContent).toBe("Couldn’t copy");
+  });
+
+  it("uses the caller's labels when given them", async () => {
+    stubClipboard(undefined);
+    act(() =>
+      root.render(
+        <CopyButton value="x" failedLabel="Select it above">
+          Copy
+        </CopyButton>,
+      ),
+    );
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("button")?.textContent).toBe("Select it above");
+  });
+
+  it("expires a confirmation on resetAfterMs so a second copy re-confirms", async () => {
+    vi.useFakeTimers();
+    stubClipboard({ writeText: vi.fn(() => Promise.resolve()) });
+    act(() =>
+      root.render(
+        <CopyButton value="x" resetAfterMs={1500}>
+          Copy
+        </CopyButton>,
+      ),
+    );
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector("button")?.textContent).toBe("Copied");
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(container.querySelector("button")?.textContent).toBe("Copy");
+  });
+
+  it("holds a FAILURE past resetAfterMs — a message nobody read is not a message", async () => {
+    vi.useFakeTimers();
+    stubClipboard(undefined);
+    act(() =>
+      root.render(
+        <CopyButton value="x" resetAfterMs={1500}>
+          Copy
+        </CopyButton>,
+      ),
+    );
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(container.querySelector("button")?.textContent).toBe("Couldn’t copy");
+  });
+
+  it("reads the value at click time, so a caller may recompute it every render", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    stubClipboard({ writeText });
+    act(() => root.render(<CopyButton value="first">Copy</CopyButton>));
+    act(() => root.render(<CopyButton value="second">Copy</CopyButton>));
+
+    await act(async () => {
+      click();
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledWith("second");
+  });
+});

--- a/src/design-system/primitives/CopyButton.tsx
+++ b/src/design-system/primitives/CopyButton.tsx
@@ -13,6 +13,28 @@
  * `SkillTermGuidance`) — the label change alone reaches a sighted user and
  * nobody else — and meaning is carried by the WORD, never by colour.
  *
+ * ── The live region duplicates the label, knowingly (#732 review) ──
+ *
+ * When the button carries no `aria-label`, its visible text IS its accessible
+ * name, so a screen reader focused on it may announce the change itself — and
+ * then again from the live region. That redundancy is the deliberate choice
+ * over both alternatives:
+ *
+ *   - **Drop the region.** Accessible-name-change announcement is inconsistent
+ *     across screen readers, so this trades a possible double-announcement for
+ *     a possible SILENT one — worse for an action whose whole feedback is the
+ *     confirmation. It also breaks the one call site that is not redundant at
+ *     all: `WebGpuUnavailableNotice`'s `CopyablePath` passes a fixed
+ *     `aria-label` ("Copy chrome://flags"), so its name never changes and the
+ *     region is the ONLY channel it has.
+ *   - **Keep the name fixed and swap only the visible text.** Then the visible
+ *     label reads "Copied" while the accessible name still says "Copy prompt",
+ *     which is what WCAG 2.5.3 Label in Name exists to prevent — a speech-input
+ *     user saying "click Copied" would hit nothing.
+ *
+ * Announcing twice is the least-bad of the three. If this is ever revisited, it
+ * needs profiling against real screen readers, not a re-reading of the spec.
+ *
  * Renders a fragment, not a wrapper: every call site puts this inside a flex
  * row it already sizes, and the live region is `sr-only` (absolutely
  * positioned), so it contributes no box. Layout stays with the caller, matching

--- a/src/design-system/primitives/CopyButton.tsx
+++ b/src/design-system/primitives/CopyButton.tsx
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * CopyButton — a {@link Button} that writes `value` to the clipboard and
+ * reports the outcome in its own label (#609).
+ *
+ * The house confirmation pattern, applied to the one action that had been
+ * hand-rolled three times: this design system ships no toast
+ * (design-system/CLAUDE.md), so a completed action confirms by swapping the
+ * content of the control the user just pressed. The swap is announced through
+ * an `sr-only` `aria-live="polite"` region (precedent: `ReconstructedSkills`,
+ * `SkillTermGuidance`) — the label change alone reaches a sighted user and
+ * nobody else — and meaning is carried by the WORD, never by colour.
+ *
+ * Renders a fragment, not a wrapper: every call site puts this inside a flex
+ * row it already sizes, and the live region is `sr-only` (absolutely
+ * positioned), so it contributes no box. Layout stays with the caller, matching
+ * `Button` / `TextAreaField`.
+ *
+ * A caller that needs the failure to render somewhere other than the label —
+ * `LetterRevealDialog` puts a full "select the text above and copy it
+ * yourself" sentence beside its button — should use {@link useCopyToClipboard}
+ * directly and keep its own markup. Both halves come from the same module pair,
+ * so there is still exactly one clipboard implementation in the tree.
+ */
+
+import type { ReactNode } from "react";
+import { Button, type ButtonSize, type ButtonVariant } from "./Button.tsx";
+import { useCopyToClipboard } from "./useCopyToClipboard.ts";
+
+interface CopyButtonProps {
+  /**
+   * The text to copy. Read at click time, so a caller may recompute it on
+   * every render (the exported rewrite prompt does — it tracks live steering).
+   */
+  value: string;
+  /** Idle label — what the button offers to do. */
+  children: ReactNode;
+  /** Label held after a successful copy. */
+  copiedLabel?: ReactNode;
+  /**
+   * Label held after a failed copy. The default states the outcome only;
+   * a caller whose text stays selectable on screen should say so here, since
+   * "select it yourself" is a real instruction rather than a shrug.
+   */
+  failedLabel?: ReactNode;
+  /** Clear the confirmation after this many ms. See `useCopyToClipboard`. */
+  resetAfterMs?: number;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+  disabled?: boolean;
+  /** Accessible name. Defaults to the button's own label text. */
+  "aria-label"?: string;
+}
+
+export function CopyButton({
+  value,
+  children,
+  copiedLabel = "Copied",
+  failedLabel = "Couldn’t copy",
+  resetAfterMs,
+  variant = "ghost",
+  size = "sm",
+  className,
+  disabled,
+  "aria-label": ariaLabel,
+}: CopyButtonProps) {
+  const { state, copy } = useCopyToClipboard(resetAfterMs);
+
+  const label =
+    state === "copied" ? copiedLabel : state === "failed" ? failedLabel : children;
+
+  return (
+    <>
+      <Button
+        variant={variant}
+        size={size}
+        className={className}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onClick={() => copy(value)}
+      >
+        {label}
+      </Button>
+      {/* Rendered unconditionally (empty while idle): a live region has to be
+          in the DOM BEFORE its content changes, or assistive tech has nothing
+          to observe and the first copy announces nothing. */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {state === "idle" ? "" : label}
+      </span>
+    </>
+  );
+}

--- a/src/design-system/primitives/TextAreaField.tsx
+++ b/src/design-system/primitives/TextAreaField.tsx
@@ -14,7 +14,9 @@
  * Owns the raw <textarea> so feature code never hand-rolls one (the textarea is
  * a UI primitive concern; CLAUDE.md's 3-tier rule keeps it here, not in
  * src/components/). Auto-grows to fit content like EditableField's multiline
- * variant.
+ * variant — opt out with `autoGrow={false}` when the value is generated rather
+ * than typed and can be arbitrarily long (#609's exported prompt), where
+ * growing to fit would push the surrounding dialog's own controls off-screen.
  *
  * Design rules (CLAUDE.md): semantic tokens only; no hardcoded hex or raw
  * palette classes.
@@ -33,8 +35,21 @@ interface TextAreaFieldProps {
   placeholder?: string;
   /** Minimum visible rows before auto-grow kicks in. Defaults to 2. */
   rows?: number;
-  /** When true, the textarea is read-only and dimmed. */
+  /** When true, the textarea is non-interactive and dimmed. */
   disabled?: boolean;
+  /**
+   * When true, the value cannot be edited but stays focusable, scrollable and
+   * SELECTABLE. Distinct from `disabled`, which dims the field and takes it out
+   * of the tab order — a disabled textarea's text cannot be selected with the
+   * mouse in Chromium, which makes it useless as a manual-copy fallback for a
+   * generated artifact the user is meant to take elsewhere (#609).
+   */
+  readOnly?: boolean;
+  /**
+   * Sync the height to the content on every change. Defaults to true. False
+   * pins the box at `rows` and scrolls the overflow instead.
+   */
+  autoGrow?: boolean;
   /** Extra classes on the root wrapper (layout stays with the caller). */
   className?: string;
 }
@@ -46,6 +61,8 @@ export function TextAreaField({
   placeholder,
   rows = 2,
   disabled = false,
+  readOnly = false,
+  autoGrow = true,
   className,
 }: TextAreaFieldProps) {
   const ref = useRef<HTMLTextAreaElement>(null);
@@ -55,11 +72,12 @@ export function TextAreaField({
   // inside a closed <dialog> — so it doesn't collapse to 0px; the natural
   // `rows` height then shows once the field becomes visible.
   useEffect(() => {
+    if (!autoGrow) return;
     const ta = ref.current;
     if (!ta) return;
     ta.style.height = "auto";
     if (ta.scrollHeight > 0) ta.style.height = `${ta.scrollHeight}px`;
-  }, [value]);
+  }, [value, autoGrow]);
 
   return (
     <textarea
@@ -69,9 +87,11 @@ export function TextAreaField({
       rows={rows}
       placeholder={placeholder}
       disabled={disabled}
+      readOnly={readOnly}
       onChange={(e) => onChange(e.target.value)}
       className={[
-        "w-full resize-none overflow-hidden rounded border border-border",
+        "w-full resize-none rounded border border-border",
+        autoGrow ? "overflow-hidden" : "overflow-y-auto",
         "bg-surface-card px-2 py-1.5 text-sm leading-snug",
         "text-content-primary placeholder:text-content-muted",
         "outline-hidden focus:ring-1 focus:ring-accent-primary",

--- a/src/design-system/primitives/useCopyToClipboard.ts
+++ b/src/design-system/primitives/useCopyToClipboard.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useCopyToClipboard — the ONE definition of "put this text on the clipboard
+ * and say what happened" (#609).
+ *
+ * Before this hook the same twelve lines were hand-rolled in three feature
+ * components (`WebGpuUnavailableNotice`'s `CopyablePath`, `SectionRewrite`'s
+ * `ProposedSection`, `LetterRevealDialog`), and they had already drifted:
+ * two swallowed a failure into `idle` — leaving a button that still reads
+ * "Copy" while the clipboard holds whatever was there before — and only the
+ * third told the user. #609 would have been the fourth, which is where
+ * CLAUDE.md's Golden Rule says it stops.
+ *
+ * Lives in `design-system/` next to {@link CopyButton} rather than in
+ * `src/hooks/`: it carries no domain state, it is the logic half of a
+ * primitive, and a downstream cloner repointing the `@design-system` alias has
+ * to be able to swap both halves together.
+ *
+ * ── The two things this hook exists to get right ──
+ *
+ * 1. **Absence is its own branch.** `navigator.clipboard` is `undefined` on an
+ *    insecure origin — `npm run dev:http`, a workflow this repo documents for
+ *    LAN demos. `navigator.clipboard?.writeText(t)` evaluates to `undefined`,
+ *    which `await`s cleanly and reports a copy that never happened. So the
+ *    API is read off `navigator` explicitly and its absence sets `failed`
+ *    (`LetterRevealDialog`'s lesson, now enforced for every caller).
+ *
+ * 2. **A failure persists; a confirmation expires.** `resetAfterMs` clears
+ *    `copied` only. A transient "Copied ✓" that lingers would claim a copy the
+ *    user made a minute ago, but a failure notice that vanishes on a timer is
+ *    a message the user may never read — and the fallback it points at
+ *    ("select the text yourself") stays true until they act on it.
+ *
+ * There is no toast in this design system (design-system/CLAUDE.md): callers
+ * confirm by swapping content in the surface already mounted.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Idle, or the outcome of the last attempt. A boolean cannot hold "tried and
+ * failed" apart from "not tried" — which is exactly what made the failure
+ * invisible at two of the three pre-#609 call sites.
+ */
+export type CopyState = "idle" | "copied" | "failed";
+
+export interface CopyToClipboard {
+  /** Outcome of the most recent {@link copy}. */
+  state: CopyState;
+  /** Attempt a clipboard write. Never throws and never rejects. */
+  copy: (text: string) => void;
+  /**
+   * Drop back to `idle`. For callers whose surface outlives the copy (a dialog
+   * that stays open while the user switches to a different draft) — without it
+   * a stale "Copied" would describe the previous selection.
+   */
+  reset: () => void;
+}
+
+export function useCopyToClipboard(
+  /**
+   * Clear a `copied` confirmation after this many ms, so a second copy of the
+   * same value re-confirms visibly. Omitted → the confirmation holds until the
+   * caller resets or unmounts. Never applies to `failed` (see the docblock).
+   */
+  resetAfterMs?: number,
+): CopyToClipboard {
+  const [state, setState] = useState<CopyState>("idle");
+
+  const copy = useCallback((text: string) => {
+    const clipboard = navigator.clipboard;
+    if (!clipboard) {
+      setState("failed");
+      return;
+    }
+    // `.then(onOk, onErr)` rather than `.then().catch()`: a `catch` chained
+    // after the success handler would also swallow a throw FROM it, turning a
+    // render-time bug into a silent "Couldn't copy".
+    void clipboard.writeText(text).then(
+      () => setState("copied"),
+      () => setState("failed"),
+    );
+  }, []);
+
+  const reset = useCallback(() => setState("idle"), []);
+
+  useEffect(() => {
+    if (resetAfterMs === undefined || state !== "copied") return;
+    const id = setTimeout(() => setState("idle"), resetAfterMs);
+    return () => clearTimeout(id);
+  }, [state, resetAfterMs]);
+
+  return { state, copy, reset };
+}

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -151,6 +151,19 @@ export interface ResumeRewriteController {
   useFindings: boolean;
   /** Toggle the findings channel (persists to localStorage). */
   setUseFindings: (value: boolean) => void;
+  /**
+   * The steering `start()` would run with, right now — the SAME object, not a
+   * reconstruction (#609).
+   *
+   * The copyable-prompt disclosure has to show a prompt carrying the user's
+   * current intent, and the intent is not simply `{userInstructions,
+   * pageTarget}`: `/jd-fit` folds a JD context in front of the user's own text,
+   * and the findings channel rides the same object. Exposing the assembled
+   * value means the copied prompt cannot disagree with the button beside it —
+   * a second assembly in the UI layer would drift the first time either input
+   * changed. `undefined` when nothing is set, exactly as `start()` sees it.
+   */
+  steering: RewriteSteering | undefined;
 }
 
 export function labelForResumeRewrite(
@@ -273,6 +286,34 @@ export function useResumeRewrite(
     );
   }, [findings, rewriteableSections]);
 
+  // The one assembly of "what this rewrite is being asked to do" (#609). Built
+  // here rather than inside `start` so the copyable-prompt disclosure can show
+  // the very object the run would use — see `ResumeRewriteController.steering`.
+  const steering = useMemo<RewriteSteering | undefined>(() => {
+    // Combine the user's freeform instructions with the optional JD-driven
+    // steering (#226) into ONE userInstructions string. The JD context leads
+    // (it sets the tailoring intent); the user's own text follows so it stays
+    // the most-salient, last instruction. Both empty → no userInstructions.
+    const jd = jdContext?.trim();
+    const userText = userInstructions.trim();
+    const combinedInstructions = [jd, userText]
+      .filter((s): s is string => !!s)
+      .join("\n\n");
+    // The app's own findings (#608) ride the SAME steering channel rather than
+    // a fourth parameter on `rewriteResumeWithLlm` — one intent channel, per
+    // #608's reuse analysis. Gated on the user's toggle, so opting out restores
+    // the pre-#608 prompt exactly.
+    const activeFindings = useFindings ? findings : undefined;
+    if (!combinedInstructions && pageTarget === null && !activeFindings) {
+      return undefined;
+    }
+    return {
+      ...(combinedInstructions ? { userInstructions: combinedInstructions } : {}),
+      ...(pageTarget !== null ? { pageTarget } : {}),
+      ...(activeFindings ? { findings: activeFindings } : {}),
+    };
+  }, [jdContext, userInstructions, pageTarget, useFindings, findings]);
+
   useEffect(() => {
     let cancelled = false;
     void detectWebGpu().then((c) => {
@@ -312,30 +353,6 @@ export function useResumeRewrite(
       const engine = await loadEngine(modelId, (progress) => {
         setStatus({ kind: "loading", progress });
       });
-      // Combine the user's freeform instructions with the optional JD-driven
-      // steering (#226) into ONE userInstructions string. The JD context leads
-      // (it sets the tailoring intent); the user's own text follows so it stays
-      // the most-salient, last instruction. Both empty → no userInstructions.
-      const jd = jdContext?.trim();
-      const userText = userInstructions.trim();
-      const combinedInstructions = [jd, userText]
-        .filter((s): s is string => !!s)
-        .join("\n\n");
-      // The app's own findings (#608) ride the SAME steering channel rather
-      // than a fourth parameter on `rewriteResumeWithLlm` — one intent channel,
-      // per the issue's reuse analysis. Gated on the user's toggle, so opting
-      // out restores the pre-#608 prompt exactly.
-      const activeFindings = useFindings ? findings : undefined;
-      const steering: RewriteSteering | undefined =
-        combinedInstructions || pageTarget !== null || activeFindings
-          ? {
-              ...(combinedInstructions
-                ? { userInstructions: combinedInstructions }
-                : {}),
-              ...(pageTarget !== null ? { pageTarget } : {}),
-              ...(activeFindings ? { findings: activeFindings } : {}),
-            }
-          : undefined;
       const result = await rewriteResumeWithLlm(
         rewriteableSections,
         engine,
@@ -367,22 +384,13 @@ export function useResumeRewrite(
       releaseInference(modelId);
       release();
     }
-    // `findings` + `useFindings` are read inside, so both are deps — the lint
-    // plugin is not registered in this repo (CLAUDE.md → Data & hooks), so a
-    // stale closure here would lint green and silently ignore the toggle until
-    // some unrelated dep changed. `findings` is a `useMemo` over
-    // `[critique, rewriteableSections]`, both already stable across renders
-    // that don't change them, so this adds no re-creation of its own.
-  }, [
-    acquire,
-    rewriteableSections,
-    selectedModelId,
-    userInstructions,
-    pageTarget,
-    jdContext,
-    findings,
-    useFindings,
-  ]);
+    // `steering` replaces the five inputs this callback used to assemble
+    // inline (#609). The lint plugin is not registered in this repo (CLAUDE.md
+    // → Data & hooks), so a stale closure here would lint green and silently
+    // run with last render's intent — reading ONE memoized value instead of
+    // five raw ones is one dep to get wrong instead of five, and it is the same
+    // value the disclosure shows the user.
+  }, [acquire, rewriteableSections, selectedModelId, steering]);
 
   const dismiss = useCallback(() => {
     setStatus({ kind: "idle" });
@@ -434,6 +442,7 @@ export function useResumeRewrite(
     hasFindings,
     useFindings,
     setUseFindings,
+    steering,
   };
 }
 

--- a/src/hooks/useResumeRewrite.ts
+++ b/src/hooks/useResumeRewrite.ts
@@ -258,9 +258,8 @@ export function useResumeRewrite(
     [setPageTargetRaw],
   );
 
-  const rewriteableSections = useMemo(
-    () => sections.filter(isNonEmptyForUi),
-    [sections],
+  const rewriteableSections = useStableSections(
+    useMemo(() => sections.filter(isNonEmptyForUi), [sections]),
   );
 
   // The critique's findings, keyed by the line they describe (#608). Built off
@@ -444,6 +443,55 @@ export function useResumeRewrite(
     setUseFindings,
     steering,
   };
+}
+
+/**
+ * Hold the previous section array whenever the new one says the same thing.
+ *
+ * `ReconstructedResume` calls `buildResumeSections(…)` in its render body — a
+ * plain call, not a `useMemo` — so `sections` is a fresh array on EVERY render,
+ * and filtering it produced a fresh `rewriteableSections` on every render too.
+ * That identity churn propagated to `findings`, `steering`, `start` and (since
+ * #609) the copyable prompt's `useMemo`, which therefore memoized nothing: it
+ * rebuilt the prompt string on every render of the disclosure. Nothing broke —
+ * every consumer is derived, so recomputing yields the same value, and `start`
+ * is called on click rather than watched — but a `useMemo` whose deps change
+ * every render is a claim the code does not keep, and the next consumer to
+ * watch `steering` in an effect would get a re-fire per render (#732 review).
+ *
+ * STRICTER THAN `sectionsEqual`, DELIBERATELY. That comparator ignores `label`,
+ * which is right where it is used: the stale-proposal guard should not throw
+ * away a live proposal because the user retyped an employer name. Here the
+ * identity being gated feeds what the user SEES — the progress line ("Rewriting
+ * 2 of 5: Engineer — Acme") and every heading in the proposal panel read
+ * `label` off these very objects — so holding an array whose labels went stale
+ * would show the old employer against the new bullets.
+ *
+ * Adjusts state during render rather than writing a ref, which is React's
+ * documented shape for "a value derived from props that has to stay stable":
+ * the `setHeld` call makes React discard this render pass and immediately redo
+ * it with the new array, so no effect ever observes the stale value. It costs
+ * one extra pass on a real edit and nothing at all on the churn it exists to
+ * absorb.
+ */
+function useStableSections(
+  sections: readonly SectionInput[],
+): readonly SectionInput[] {
+  const [held, setHeld] = useState(sections);
+  if (held !== sections && !sameSectionsForDisplay(held, sections)) {
+    setHeld(sections);
+    return sections;
+  }
+  return held;
+}
+
+/** `sectionsEqual` plus the display labels — see {@link useStableSections}. */
+function sameSectionsForDisplay(
+  a: readonly SectionInput[],
+  b: readonly SectionInput[],
+): boolean {
+  // `sectionsEqual` checks length first, so the index into `b` is in range.
+  return sectionsEqual(a, b) && a.every((s, i) => s.label === b[i]!.label);
 }
 
 function isNonEmptyForUi(section: SectionInput): boolean {

--- a/src/lib/webllm/export-prompt.test.ts
+++ b/src/lib/webllm/export-prompt.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit tests for the copyable rewrite prompt (#609).
+ *
+ * The load-bearing one is "carries no résumé content": this is the only string
+ * in the app built to be put on the clipboard and taken to a third party, and
+ * the feature's whole claim is that what leaves is INSTRUCTIONS. A regression
+ * there is silent — the prompt still looks right, still copies, and quietly
+ * carries a bullet with it. So the assertion is made against a full synthetic
+ * résumé, field by field, rather than by eyeballing the template.
+ *
+ * The persona is synthetic per CLAUDE.md's fixture rule (fake name,
+ * `@example.com`, real area code + 555 exchange), even though nothing here
+ * touches `tests/fixtures/pdfs/` — a résumé-shaped literal in a test file is
+ * exactly the thing that gets copied into a fixture later.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildExportableRewritePrompt,
+  describeShape,
+} from "./export-prompt.ts";
+import {
+  NO_FABRICATION_RULE,
+  PRESERVE_NUMBERS_RULE,
+} from "./rewrite-guardrails.ts";
+import { findingsKey, type RewriteSteering } from "./steering.ts";
+import type { SectionInput } from "./rewrite-resume.ts";
+
+const SUMMARY_TEXT =
+  "Platform engineer with 9 years building payment infrastructure at Northwind Logistics.";
+
+const BULLETS_ONE = [
+  "Cut checkout latency 42% by resharding the ledger service across 6 regions.",
+  "Led a team of 5 through a zero-downtime migration off Oracle.",
+];
+
+const BULLETS_TWO = [
+  "Shipped the fraud-scoring pipeline handling 2.1M events per day.",
+];
+
+function resume(): SectionInput[] {
+  return [
+    { kind: "summary", id: "s", label: "Summary", text: SUMMARY_TEXT },
+    {
+      kind: "experience",
+      id: "e1",
+      label: "Staff Engineer · Northwind Logistics",
+      bullets: BULLETS_ONE,
+    },
+    {
+      kind: "experience",
+      id: "e2",
+      label: "Senior Engineer · Contoso Freight",
+      bullets: BULLETS_TWO,
+    },
+  ];
+}
+
+/** Every value in the fixture that came off the résumé. None may appear. */
+const RESUME_VALUES = [
+  SUMMARY_TEXT,
+  ...BULLETS_ONE,
+  ...BULLETS_TWO,
+  // Section labels are résumé content too — they are the parsed title and
+  // employer. They reach the prompt builder (they are on `SectionInput`) and
+  // are the easiest thing to leak by accident while writing a "shape" line.
+  "Staff Engineer · Northwind Logistics",
+  "Senior Engineer · Contoso Freight",
+  "Northwind",
+  "Contoso",
+  "Oracle",
+  "42%",
+  "2.1M",
+];
+
+describe("buildExportableRewritePrompt — guardrails", () => {
+  it("carries the number-preservation and no-fabrication rules from the shared constants", () => {
+    const prompt = buildExportableRewritePrompt(resume());
+    // Matched against the exported constants, never against a copy of the
+    // sentence written here — a test holding its own copy is a second
+    // definition of the rule, which is the drift this module exists to stop.
+    expect(prompt).toContain(PRESERVE_NUMBERS_RULE);
+    expect(prompt).toContain(NO_FABRICATION_RULE);
+  });
+
+  it("does not inherit the small-model line-per-bullet output contract", () => {
+    const prompt = buildExportableRewritePrompt(resume());
+    expect(prompt).not.toContain("No bullet markers. No quotes. No preamble.");
+  });
+});
+
+describe("buildExportableRewritePrompt — no résumé content", () => {
+  it("contains no field value from the résumé it was built for", () => {
+    const prompt = buildExportableRewritePrompt(resume(), {
+      pageTarget: 1,
+      userInstructions: "lead with impact",
+    });
+    for (const value of RESUME_VALUES) {
+      expect(prompt).not.toContain(value);
+    }
+  });
+
+  it("drops the per-line findings channel rather than quoting the lines it names", () => {
+    // #608 keys findings BY BULLET TEXT. Rendering them means naming the line,
+    // and naming the line means putting it on the clipboard — so the channel is
+    // omitted here by construction (no `units` reach `buildSteeringSuffix`).
+    // This asserts it stays omitted: `RewriteSteering` is passed through whole,
+    // so a future caller threading `units` in would leak every flagged bullet.
+    const findings = new Map<string, readonly string[]>([
+      [findingsKey(BULLETS_ONE[0]!), ["add a concrete metric or outcome"]],
+    ]);
+    const steering: RewriteSteering = { findings };
+    const prompt = buildExportableRewritePrompt(resume(), steering);
+    expect(prompt).not.toContain(BULLETS_ONE[0]!);
+    expect(prompt).not.toContain("add a concrete metric or outcome");
+  });
+});
+
+describe("buildExportableRewritePrompt — steering", () => {
+  it("reflects the page target through the shared budget text", () => {
+    const one = buildExportableRewritePrompt(resume(), { pageTarget: 1 });
+    const three = buildExportableRewritePrompt(resume(), { pageTarget: 3 });
+    expect(one).toContain("Target a one-page résumé");
+    expect(three).toContain("Target a three-page résumé");
+    expect(one).not.toBe(three);
+  });
+
+  it("carries the user's freeform instructions verbatim", () => {
+    const prompt = buildExportableRewritePrompt(resume(), {
+      userInstructions: "emphasise the payments work, drop the internships",
+    });
+    expect(prompt).toContain(
+      "The user has these additional instructions: emphasise the payments work, drop the internships",
+    );
+  });
+
+  it("is complete and free of dangling steering scaffolding with no steering set", () => {
+    const prompt = buildExportableRewritePrompt(resume());
+    expect(prompt).toContain(PRESERVE_NUMBERS_RULE);
+    expect(prompt).not.toContain("The user has these additional instructions:");
+    expect(prompt).not.toContain("Target a");
+    // No triple newline: an omitted block must not leave its blank-line seam.
+    expect(prompt).not.toMatch(/\n{3}/);
+    expect(prompt.trimEnd()).toBe(prompt);
+    expect(prompt).toContain("Paste your résumé below");
+  });
+
+  it("treats blank instructions as no instructions", () => {
+    const blank = buildExportableRewritePrompt(resume(), {
+      userInstructions: "   ",
+    });
+    expect(blank).toBe(buildExportableRewritePrompt(resume()));
+  });
+});
+
+describe("describeShape", () => {
+  it("counts roles and bullets without naming either", () => {
+    expect(describeShape(resume())).toContain(
+      "a summary paragraph and 2 roles carrying 3 bullets between them",
+    );
+  });
+
+  it("singularises a one-role, one-bullet résumé", () => {
+    expect(
+      describeShape([
+        { kind: "experience", id: "e", label: "L", bullets: ["Did a thing."] },
+      ]),
+    ).toContain("1 role carrying 1 bullet between them");
+  });
+
+  it("omits a summary that is present but empty", () => {
+    const shape = describeShape([
+      { kind: "summary", id: "s", label: "Summary", text: "   " },
+      { kind: "experience", id: "e", label: "L", bullets: ["Did a thing."] },
+    ]);
+    expect(shape).not.toContain("summary paragraph");
+  });
+
+  it("returns null when there is nothing to describe, and the prompt omits the line", () => {
+    expect(describeShape([])).toBeNull();
+    const prompt = buildExportableRewritePrompt([]);
+    expect(prompt).not.toContain("For scale");
+    expect(prompt).not.toMatch(/\n{3}/);
+    expect(prompt).toContain(PRESERVE_NUMBERS_RULE);
+  });
+});

--- a/src/lib/webllm/export-prompt.ts
+++ b/src/lib/webllm/export-prompt.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * export-prompt.ts — the rewrite prompt the user takes ELSEWHERE (#609).
+ *
+ * The on-device pass is the right default: it is the only rewrite that keeps
+ * the résumé text on the device, and it is what makes this project's custody
+ * claim true. It is also, straightforwardly, a 1–3B instruct model, which is
+ * the weakest rewriter most users have access to — someone with a frontier
+ * model open in the next tab has a far better one and, before this module, no
+ * way to use it without improvising a prompt from scratch and losing every
+ * guardrail this repo has tuned.
+ *
+ * So: hand them the prompt. A clipboard write is local — nothing here fetches,
+ * and where the user takes the text afterwards is their own deliberate choice
+ * rather than our default.
+ *
+ * ── Three properties this string has to hold ──
+ *
+ * 1. **No résumé content.** The user brings their own document to the external
+ *    model; this is INSTRUCTIONS ONLY. Nothing derived from a bullet, a name,
+ *    an employer or a date may appear here — `export-prompt.test.ts` asserts
+ *    the absence against a full fixture résumé. The one résumé-derived thing
+ *    that does appear is a COUNT (see {@link describeShape}), which names no
+ *    field value. Copying the reconstructed résumé text is a genuinely useful
+ *    follow-up and a deliberately separate one: it needs its own control and
+ *    its own label, never this one.
+ *
+ * 2. **The same guardrails as the shipped prompts.** Every rule comes from
+ *    `rewrite-guardrails.ts`, so `Preserve every concrete number …` has exactly
+ *    one definition in the tree and cannot drift between the path we run and
+ *    the path we hand out. What differs is the I/O contract: the shipped
+ *    prompts are tuned for a small model rewriting ONE section, and their rigid
+ *    line-per-bullet rule would hobble a capable model handed a whole document.
+ *
+ * 3. **The user's live steering.** `buildSteeringSuffix` is called — not
+ *    restated — so a user who picked "1 page" and typed instructions gets a
+ *    prompt carrying exactly what the on-device run would have carried. Passing
+ *    no `units` also means the per-line findings channel (#608) contributes
+ *    nothing, which is deliberate: a finding names a specific line, and naming
+ *    the line means quoting it, which would put résumé text on the clipboard
+ *    and break property 1. Findings become possible in the follow-up that
+ *    copies the résumé text alongside.
+ *
+ * Pure: no I/O, no clock, no React. `src/lib/score/score.ts` is the exemplar.
+ */
+
+import type { SectionInput } from "./rewrite-resume.ts";
+import {
+  composeRulesPrompt,
+  DROP_FILLER_RULE,
+  keepIfAlreadyStrongRule,
+  MERGE_AND_PRUNE_RULE,
+  NO_FABRICATION_RULE,
+  PRESERVE_NUMBERS_RULE,
+  rewriteTaskLine,
+  STRONG_VERB_RULE,
+  SUMMARY_LEAD_RULE,
+  VARY_VERBS_RULE,
+} from "./rewrite-guardrails.ts";
+import { buildSteeringSuffix, type RewriteSteering } from "./steering.ts";
+
+/**
+ * The whole-document contract, and the only rule here with no counterpart in
+ * the shipped prompts — because the shipped prompts never see a whole document.
+ * A section rewrite cannot drop a section it was never given; a frontier model
+ * handed the entire résumé can, and "make this stronger" is exactly the
+ * instruction under which one quietly disappears.
+ */
+const WHOLE_DOCUMENT_CONTRACT =
+  "Rewrite the entire résumé and return it in full, keeping the original section order and headings. Do not add sections that are not in the input, and do not drop one.";
+
+/**
+ * The output shape. Deliberately a preference, not the shipped prompts' rigid
+ * "no markers, no preamble" contract — that contract exists because a 1.5B
+ * model breaks each clause of it, and imposing it on a capable model buys
+ * nothing. What it does buy is the trip home: the user has to move this output
+ * back into offlinecv's inline editor field by field, and plain text with one
+ * bullet per line is what makes that mechanical rather than a re-typing job.
+ */
+const PLAIN_TEXT_PREFERENCE =
+  "Return plain text — no markdown, no tables — with one bullet per line, so each line can be pasted straight back into a résumé editor.";
+
+/** Closing instruction. Last, because it is the one thing the USER must do. */
+const ATTACH_NOTE =
+  "Paste your résumé below, or attach it, and reply with the rewritten version.";
+
+interface ResumeShape {
+  hasSummary: boolean;
+  roleCount: number;
+  bulletCount: number;
+}
+
+function shapeOf(sections: readonly SectionInput[]): ResumeShape {
+  let hasSummary = false;
+  let roleCount = 0;
+  let bulletCount = 0;
+  for (const section of sections) {
+    if (section.kind === "summary") {
+      if (section.text.trim().length > 0) hasSummary = true;
+      continue;
+    }
+    const bullets = section.bullets.filter((b) => b.trim().length > 0);
+    if (bullets.length === 0) continue;
+    roleCount += 1;
+    bulletCount += bullets.length;
+  }
+  return { hasSummary, roleCount, bulletCount };
+}
+
+function plural(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * One sentence of résumé-derived context — counts only, never a field value
+ * (see property 1 in the module docblock). This is what makes the copied text
+ * *this résumé's* prompt rather than a template out of the docs: a model told
+ * to expect three roles behaves differently from one told to expect eleven,
+ * and a user who reads "1 role" here learns something real about our parse
+ * before they trust the rest of the app's output.
+ *
+ * Returns `null` when there is nothing to describe, so the caller omits the
+ * line rather than emitting "read this résumé as nothing".
+ */
+export function describeShape(sections: readonly SectionInput[]): string | null {
+  const { hasSummary, roleCount, bulletCount } = shapeOf(sections);
+  const parts: string[] = [];
+  if (hasSummary) parts.push("a summary paragraph");
+  if (roleCount > 0) {
+    parts.push(
+      `${plural(roleCount, "role")} carrying ${plural(bulletCount, "bullet")} between them`,
+    );
+  }
+  if (parts.length === 0) return null;
+  return `For scale: offlinecv read this résumé as ${parts.join(" and ")}. That is what our text extractor saw, which is not always what the document holds — work from the document itself.`;
+}
+
+/**
+ * Build the prompt a user copies out to an external model.
+ *
+ * `sections` supplies SHAPE ONLY (counts — see {@link describeShape}).
+ * `steering` is the very object the on-device run would have used, so the
+ * copied prompt and the button beside it carry the same intent; its `findings`
+ * are ignored by construction (no `units` passed — see the module docblock).
+ */
+export function buildExportableRewritePrompt(
+  sections: readonly SectionInput[],
+  steering?: RewriteSteering,
+): string {
+  const rules = composeRulesPrompt(rewriteTaskLine("a résumé"), [
+    WHOLE_DOCUMENT_CONTRACT,
+    PRESERVE_NUMBERS_RULE,
+    NO_FABRICATION_RULE,
+    STRONG_VERB_RULE,
+    VARY_VERBS_RULE,
+    MERGE_AND_PRUNE_RULE,
+    `Summary paragraph — ${SUMMARY_LEAD_RULE}`,
+    DROP_FILLER_RULE,
+    keepIfAlreadyStrongRule("a line"),
+    PLAIN_TEXT_PREFERENCE,
+  ]);
+
+  // The shape line goes BEFORE the steering, not after: `buildSteeringSuffix`
+  // puts the user's own words last on purpose (steering.ts — most salient
+  // position, and the only part they typed seconds ago with a specific intent),
+  // and sliding a sentence about our parser in after them would undo that. Its
+  // return value is "" or a "\n\n"-prefixed block, so the blank-line seam is its
+  // contract, not ours to re-derive.
+  const shape = describeShape(sections);
+  const context = shape === null ? rules : `${rules}\n\n${shape}`;
+  return `${context}${buildSteeringSuffix(steering)}\n\n${ATTACH_NOTE}`;
+}

--- a/src/lib/webllm/rewrite-guardrails.test.ts
+++ b/src/lib/webllm/rewrite-guardrails.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The refactor gate for #609's guardrail extraction.
+ *
+ * `SECTION_REWRITE_SYSTEM_PROMPT` and `SUMMARY_REWRITE_SYSTEM_PROMPT` stopped
+ * being string literals and became compositions of `rewrite-guardrails.ts`.
+ * Both are model INPUT on the shipped on-device path, so a single changed
+ * character is a behaviour change for every user who clicks Rewrite — the kind
+ * that produces no error, no failing test elsewhere, and no way to notice
+ * except by reading eval output weeks later.
+ *
+ * The two literals below were captured from `git show` of the pre-extraction
+ * files (`rewrite-section.ts:28`, `rewrite-summary.ts:39` at 0571a82) and are
+ * deliberately written out in full rather than derived from the constants they
+ * are meant to check. A test that rebuilt the expected string from the same
+ * exports it is testing would pass for any wording whatsoever — it would only
+ * prove that `composeRulesPrompt` is deterministic, which is not the claim.
+ *
+ * If you are here because this test failed after you edited a rule: that is the
+ * test working. Deciding to change a shipped prompt is fine; doing it as a side
+ * effect of touching something else is what this blocks. Update the literal in
+ * the same commit that changes the rule, and say so in the PR.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildSectionSystemPrompt,
+  SECTION_REWRITE_SYSTEM_PROMPT,
+} from "./rewrite-section.ts";
+import {
+  buildSummarySystemPrompt,
+  SUMMARY_REWRITE_SYSTEM_PROMPT,
+} from "./rewrite-summary.ts";
+import {
+  NO_FABRICATION_RULE,
+  PRESERVE_NUMBERS_RULE,
+  composeRulesPrompt,
+  keepIfAlreadyStrongRule,
+  rewriteTaskLine,
+} from "./rewrite-guardrails.ts";
+
+/** Verbatim `SECTION_REWRITE_SYSTEM_PROMPT` as it shipped before #609. */
+const SECTION_PROMPT_BEFORE_609 = `You are rewriting a list of resume bullets to be more specific and outcome-oriented.
+Rules:
+- Output one bullet per line. No numbering. No bullet markers. No quotes. No preamble.
+- Lead every bullet with a strong action verb.
+- Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.
+- You may merge two weak bullets into one strong bullet, drop pure filler, or reorder for emphasis.
+- Vary the action verbs across bullets — don't start every line the same way.
+- If a bullet is already strong, keep it unchanged.`;
+
+/** Verbatim `SUMMARY_REWRITE_SYSTEM_PROMPT` as it shipped before #609. */
+const SUMMARY_PROMPT_BEFORE_609 = `You are rewriting a resume summary to be more specific and outcome-oriented.
+Rules:
+- Output a single paragraph of 2–3 sentences. No bullet points. No numbering. No quotes. No preamble.
+- Lead with the strongest concrete claim (years of experience, primary domain, or signature outcome).
+- Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.
+- Drop generic filler ("hard-working", "team player", "passionate"). Keep specifics.
+- If the summary is already strong, keep it unchanged.`;
+
+describe("shipped on-device prompts survive the guardrail extraction", () => {
+  it("SECTION_REWRITE_SYSTEM_PROMPT is byte-identical to its pre-#609 value", () => {
+    expect(SECTION_REWRITE_SYSTEM_PROMPT).toBe(SECTION_PROMPT_BEFORE_609);
+  });
+
+  it("SUMMARY_REWRITE_SYSTEM_PROMPT is byte-identical to its pre-#609 value", () => {
+    expect(SUMMARY_REWRITE_SYSTEM_PROMPT).toBe(SUMMARY_PROMPT_BEFORE_609);
+  });
+
+  // The constants are what the prompts are BUILT from, but the on-device path
+  // calls the builders, not the constants — so the extraction is only provably
+  // invisible if what actually reaches the engine is unchanged too. With no
+  // context and no steering both builders are the bare prompt.
+  it("the section builder's no-context, no-steering output is unchanged", () => {
+    expect(buildSectionSystemPrompt()).toBe(SECTION_PROMPT_BEFORE_609);
+  });
+
+  it("the summary builder's no-context, no-steering output is unchanged", () => {
+    expect(buildSummarySystemPrompt()).toBe(SUMMARY_PROMPT_BEFORE_609);
+  });
+
+  // The steering suffix is appended AFTER the base prompt; #609 must not have
+  // moved that seam. A page target is the shortest steering that produces one.
+  it("a steered section prompt is still the base prompt plus a suffix", () => {
+    const steered = buildSectionSystemPrompt(undefined, { pageTarget: 1 });
+    expect(steered.startsWith(`${SECTION_PROMPT_BEFORE_609}\n\n`)).toBe(true);
+  });
+});
+
+describe("the guardrail constants", () => {
+  it("state the number-preservation rule exactly once, and both prompts carry it", () => {
+    expect(SECTION_REWRITE_SYSTEM_PROMPT).toContain(PRESERVE_NUMBERS_RULE);
+    expect(SUMMARY_REWRITE_SYSTEM_PROMPT).toContain(PRESERVE_NUMBERS_RULE);
+  });
+
+  // The whole-document rule is for the EXPORTED prompt only. Leaking it into a
+  // shipped prompt would be a silent behaviour change on the on-device path —
+  // which is exactly what the byte-identity tests above would catch, so this
+  // asserts the intent directly rather than leaving it to a diff.
+  it("keeps the whole-document no-fabrication rule out of the on-device prompts", () => {
+    expect(SECTION_REWRITE_SYSTEM_PROMPT).not.toContain(NO_FABRICATION_RULE);
+    expect(SUMMARY_REWRITE_SYSTEM_PROMPT).not.toContain(NO_FABRICATION_RULE);
+  });
+
+  it("renders rules as a dash list under a Rules: header", () => {
+    expect(composeRulesPrompt("Task line.", ["first rule", "second rule"])).toBe(
+      "Task line.\nRules:\n- first rule\n- second rule",
+    );
+  });
+
+  it("carries the subject's own article into the already-strong rule", () => {
+    expect(keepIfAlreadyStrongRule("a bullet")).toBe(
+      "If a bullet is already strong, keep it unchanged.",
+    );
+    expect(keepIfAlreadyStrongRule("the summary")).toBe(
+      "If the summary is already strong, keep it unchanged.",
+    );
+  });
+
+  it("builds the task line from its object", () => {
+    expect(rewriteTaskLine("a resume summary")).toBe(
+      "You are rewriting a resume summary to be more specific and outcome-oriented.",
+    );
+  });
+});

--- a/src/lib/webllm/rewrite-guardrails.ts
+++ b/src/lib/webllm/rewrite-guardrails.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * rewrite-guardrails.ts — the rewrite rules, written once (#609).
+ *
+ * offlinecv now builds THREE rewrite prompts from the same set of rules:
+ *
+ *   1. `SECTION_REWRITE_SYSTEM_PROMPT` — on-device, one section of bullets.
+ *   2. `SUMMARY_REWRITE_SYSTEM_PROMPT` — on-device, the summary paragraph.
+ *   3. `buildExportableRewritePrompt` — the prompt the user copies out to
+ *      whatever model they already pay for, applied to the whole résumé.
+ *
+ * What differs between them is the **I/O contract**: (1) and (2) are tuned for
+ * a 1–3B instruct model and carry a rigid line-per-bullet / single-paragraph
+ * output rule, and (3) hands a capable model an entire document. What must NOT
+ * differ is the guardrails — number preservation and no fabrication are the
+ * reason a user can trust any of the three, and a rule stated in three places
+ * disagrees within a release. This module is the one place each rule is
+ * written; the three prompts compose it and add only their own contract.
+ *
+ * These strings are model input, so they are frozen artifacts, not copy: an
+ * edit here changes the behaviour of every shipped rewrite path at once. That
+ * is the point — but it means `rewrite-guardrails.test.ts` pins the two
+ * on-device prompts against literals captured BEFORE the extraction, so a
+ * wording change can never ride along with an unrelated refactor.
+ *
+ * Pure: no imports, no I/O, no clock. Follows `src/lib/score/score.ts` as the
+ * zero-dep lib-module exemplar.
+ */
+
+/**
+ * The single most important rule in the tree, and the one #609 required to
+ * have exactly one definition.
+ *
+ * The deterministic `checkNumbersPreserved` multiset diff is what actually
+ * catches a violation after the fact; this sentence is what stops the model
+ * producing one. Both halves are needed — the check can only warn, it cannot
+ * repair — so neither is redundant with the other.
+ */
+export const PRESERVE_NUMBERS_RULE =
+  "Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.";
+
+/**
+ * The whole-document generalisation of {@link PRESERVE_NUMBERS_RULE}'s second
+ * clause, for the exported prompt only.
+ *
+ * The on-device prompts do not carry it and must not start: they see one
+ * section at a time, and a section rewrite has no opportunity to invent an
+ * employer or a degree because it is never handed the fields that hold them. A
+ * frontier model handed the ENTIRE résumé does have that opportunity, and
+ * "make my résumé stronger" is exactly the instruction under which a model
+ * embellishes a title.
+ */
+export const NO_FABRICATION_RULE =
+  "Do not invent employers, job titles, dates, degrees, or credentials. Every fact in your output must already appear in the input.";
+
+/** Section + exported prompt. Not the summary — a paragraph has no bullets. */
+export const STRONG_VERB_RULE =
+  "Lead every bullet with a strong action verb.";
+
+/** Section + exported prompt. Guards against a wall of "Led …, Led …, Led …". */
+export const VARY_VERBS_RULE =
+  "Vary the action verbs across bullets — don't start every line the same way.";
+
+/** Section + exported prompt. The licence to restructure, not just reword. */
+export const MERGE_AND_PRUNE_RULE =
+  "You may merge two weak bullets into one strong bullet, drop pure filler, or reorder for emphasis.";
+
+/** Summary + exported prompt. */
+export const SUMMARY_LEAD_RULE =
+  "Lead with the strongest concrete claim (years of experience, primary domain, or signature outcome).";
+
+/** Summary + exported prompt. */
+export const DROP_FILLER_RULE =
+  'Drop generic filler ("hard-working", "team player", "passionate"). Keep specifics.';
+
+/**
+ * "Leave it alone if it's already good" — stated for whatever unit the prompt
+ * is about. Parameterised rather than triplicated because the rule is one rule;
+ * only the noun changes, and a divergence between the three wordings would be
+ * an accident every time.
+ *
+ * `subject` carries its own article ("a bullet", "the summary") — English does
+ * not let the caller supply a bare noun and get both "a bullet" and "the
+ * summary" out of one template.
+ */
+export function keepIfAlreadyStrongRule(subject: string): string {
+  return `If ${subject} is already strong, keep it unchanged.`;
+}
+
+/** The opening task line shared by the two on-device prompts. */
+export function rewriteTaskLine(object: string): string {
+  return `You are rewriting ${object} to be more specific and outcome-oriented.`;
+}
+
+/**
+ * Assemble a task line + a `Rules:` block. The `- ` markers live here so a rule
+ * constant is a plain sentence — the exported prompt renders the same sentences
+ * into its own list without stripping anything back off.
+ */
+export function composeRulesPrompt(
+  taskLine: string,
+  rules: readonly string[],
+): string {
+  return `${taskLine}\nRules:\n${rules.map((rule) => `- ${rule}`).join("\n")}`;
+}

--- a/src/lib/webllm/rewrite-section.ts
+++ b/src/lib/webllm/rewrite-section.ts
@@ -8,6 +8,15 @@ import {
 } from "../analytics.ts";
 import { cleanRewriteLine } from "./post-process.ts";
 import { checkNumbersPreserved } from "./preserve-numbers.ts";
+import {
+  composeRulesPrompt,
+  keepIfAlreadyStrongRule,
+  MERGE_AND_PRUNE_RULE,
+  PRESERVE_NUMBERS_RULE,
+  rewriteTaskLine,
+  STRONG_VERB_RULE,
+  VARY_VERBS_RULE,
+} from "./rewrite-guardrails.ts";
 import { buildSteeringSuffix, type RewriteSteering } from "./steering.ts";
 import type { WebLlmEngine } from "./types.ts";
 import { acquireInference, releaseInference } from "./web-llm.ts";
@@ -24,15 +33,34 @@ import { acquireInference, releaseInference } from "./web-llm.ts";
  * Tuned for Qwen2.5-1.5B-Instruct: small models need the rules stated
  * emphatically. "One bullet per line, no preamble, no numbering, no quotes"
  * has to be repeated because each rule is broken often enough on its own.
+ *
+ * Composed from `rewrite-guardrails.ts` since #609, which added a third prompt
+ * (the one the user copies out to an external model) stating the same rules.
+ * Only `SECTION_OUTPUT_CONTRACT` is this file's own — it is the small-model I/O
+ * contract, which is precisely what the exported prompt must NOT inherit.
+ * `rewrite-guardrails.test.ts` pins the assembled string byte-for-byte against
+ * its pre-extraction value.
  */
-export const SECTION_REWRITE_SYSTEM_PROMPT = `You are rewriting a list of resume bullets to be more specific and outcome-oriented.
-Rules:
-- Output one bullet per line. No numbering. No bullet markers. No quotes. No preamble.
-- Lead every bullet with a strong action verb.
-- Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.
-- You may merge two weak bullets into one strong bullet, drop pure filler, or reorder for emphasis.
-- Vary the action verbs across bullets — don't start every line the same way.
-- If a bullet is already strong, keep it unchanged.`;
+
+/**
+ * The line-per-bullet output contract. Local, not shared: a frontier model
+ * handed a whole résumé is hobbled by it, and every clause here exists because
+ * a 1.5B model broke it in evaluation.
+ */
+const SECTION_OUTPUT_CONTRACT =
+  "Output one bullet per line. No numbering. No bullet markers. No quotes. No preamble.";
+
+export const SECTION_REWRITE_SYSTEM_PROMPT = composeRulesPrompt(
+  rewriteTaskLine("a list of resume bullets"),
+  [
+    SECTION_OUTPUT_CONTRACT,
+    STRONG_VERB_RULE,
+    PRESERVE_NUMBERS_RULE,
+    MERGE_AND_PRUNE_RULE,
+    VARY_VERBS_RULE,
+    keepIfAlreadyStrongRule("a bullet"),
+  ],
+);
 
 const SECTION_MAX_TOKENS_PER_BULLET = 60;
 const SECTION_MAX_TOKENS_CEILING = 768;

--- a/src/lib/webllm/rewrite-summary.ts
+++ b/src/lib/webllm/rewrite-summary.ts
@@ -3,6 +3,14 @@
 
 import { cleanRewriteLine } from "./post-process.ts";
 import { checkNumbersPreserved } from "./preserve-numbers.ts";
+import {
+  composeRulesPrompt,
+  DROP_FILLER_RULE,
+  keepIfAlreadyStrongRule,
+  PRESERVE_NUMBERS_RULE,
+  rewriteTaskLine,
+  SUMMARY_LEAD_RULE,
+} from "./rewrite-guardrails.ts";
 import { buildSteeringSuffix, type RewriteSteering } from "./steering.ts";
 import type { WebLlmEngine } from "./types.ts";
 import { acquireInference, releaseInference } from "./web-llm.ts";
@@ -36,13 +44,24 @@ import { acquireInference, releaseInference } from "./web-llm.ts";
  * one-shot flag (`webllm_first_resume_rewrite`). The per-section /
  * per-bullet one-shots stay distinct so the funnels don't cross-pollute.
  */
-export const SUMMARY_REWRITE_SYSTEM_PROMPT = `You are rewriting a resume summary to be more specific and outcome-oriented.
-Rules:
-- Output a single paragraph of 2–3 sentences. No bullet points. No numbering. No quotes. No preamble.
-- Lead with the strongest concrete claim (years of experience, primary domain, or signature outcome).
-- Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.
-- Drop generic filler ("hard-working", "team player", "passionate"). Keep specifics.
-- If the summary is already strong, keep it unchanged.`;
+/**
+ * The single-paragraph output contract. Local for the same reason
+ * `SECTION_OUTPUT_CONTRACT` is (#609): the shape of the output is what the two
+ * on-device prompts do NOT share with each other or with the exported prompt.
+ */
+const SUMMARY_OUTPUT_CONTRACT =
+  "Output a single paragraph of 2–3 sentences. No bullet points. No numbering. No quotes. No preamble.";
+
+export const SUMMARY_REWRITE_SYSTEM_PROMPT = composeRulesPrompt(
+  rewriteTaskLine("a resume summary"),
+  [
+    SUMMARY_OUTPUT_CONTRACT,
+    SUMMARY_LEAD_RULE,
+    PRESERVE_NUMBERS_RULE,
+    DROP_FILLER_RULE,
+    keepIfAlreadyStrongRule("the summary"),
+  ],
+);
 
 const SUMMARY_MAX_TOKENS = 256;
 


### PR DESCRIPTION
## Summary

The rewrite lane offered exactly one rewriter: the on-device 1–3B pass. It is the right default — it is the only one that keeps the résumé text on the device — and it is also the weakest model most users can reach. Anyone with a frontier model in the next tab could do better, and the only thing standing in the way was our prompt, locked inside the bundle.

This adds a **collapsed disclosure under the steering dialog's CTA** that reveals and copies a whole-résumé rewrite prompt, built from the current résumé's shape and the user's live steering. The on-device path is untouched: a user who never opens the disclosure sees and does what they did before.

Closes #609

## The three design decisions the issue asked to settle explicitly

### 1. One prompt, or the shipped per-section prompts? → **A separate artifact, composed from shared guardrails.**

New `src/lib/webllm/rewrite-guardrails.ts` holds each rule as a named export. `SECTION_REWRITE_SYSTEM_PROMPT` and `SUMMARY_REWRITE_SYSTEM_PROMPT` now compose them and keep only their own I/O contract (`SECTION_OUTPUT_CONTRACT` / `SUMMARY_OUTPUT_CONTRACT`), which is precisely the part a frontier model must not inherit. `Preserve every concrete number from the input EXACTLY. Do not invent new numbers or metrics.` now has exactly one definition in the tree, and all three prompts carry it.

**Proof the shipped prompts did not move:** `rewrite-guardrails.test.ts` pins both against literals captured from `git show 0571a82` *before* the extraction, written out in full rather than derived from the constants under test — a test that rebuilt the expected string from the same exports would only prove `composeRulesPrompt` is deterministic. It also asserts the two *builders* (`buildSectionSystemPrompt` / `buildSummarySystemPrompt`) are unchanged, since those are what actually reach the engine, and that the steering suffix still appends at the same seam.

One rule is **new and export-only**: `NO_FABRICATION_RULE` (no invented employers, titles, dates, degrees). The on-device prompts deliberately do not carry it — they see one section at a time and are never handed the fields that hold those facts. A test asserts it stays out of both.

`buildSteeringSuffix` is **called, not restated**, so the page budget and the user's instructions reach the copied prompt through the same code path the on-device run uses.

### 2. Does the copied text include the résumé? → **No. Prompt only, as recommended.**

The copied text is instructions. `export-prompt.test.ts` asserts the absence field by field against a full synthetic résumé — summary, every bullet, both section labels (the parsed title + employer, the easiest thing to leak while writing a "shape" line), and distinctive tokens. `RewritePromptDisclosure.test.tsx` repeats the assertion against the bytes actually handed to `writeText`.

The one résumé-derived thing that does appear is a **count**: *"For scale: offlinecv read this résumé as a summary paragraph and 2 roles carrying 3 bullets between them. That is what our text extractor saw, which is not always what the document holds — work from the document itself."* No field value. This is what makes it *this résumé's* prompt rather than a template out of the docs.

Copying the reconstructed résumé text is a genuinely useful follow-up and is deliberately **not** here — it needs its own control and its own label.

### 3. Where the disclosure lives → **Inside the existing steering dialog, below the CTA row, collapsed.**

A `Button variant="link"` reading "Prefer another model? Copy the prompt ↓" under a `border-t` separator. Not visible by default; no second prominent button competing with "Run rewrite". `ResumeRewrite.tsx` grew by 8 lines (424 → 432); the surface itself is a new 109-LOC sibling, `RewritePromptDisclosure.tsx`.

## Two deviations from the issue, stated rather than done silently

**The #608 findings are NOT carried into the copied prompt**, even though #608 has landed. The findings channel is keyed **per line** (`findingsKey(bullet)`), and naming the line means quoting it — which puts résumé text on the clipboard and breaks decision 2. Reduced to category notes only ("add a concrete metric"), it degrades to generic advice a capable model already follows. So `buildExportableRewritePrompt` passes no `units` to `buildSteeringSuffix`, which drops the channel by construction, and a test pins that it stays dropped — `RewriteSteering` is threaded through whole, so a future caller adding `units` would leak every flagged bullet. Findings become possible in the same follow-up that copies the résumé text.

**A third hand-rolled clipboard call site existed** that the issue did not name: `LetterRevealDialog.tsx:97` (#715, landed after the issue was written). All three are migrated, not two.

## The clipboard extraction

`useCopyToClipboard` (logic) + `CopyButton` (the label-swap primitive) in `src/design-system/primitives/`, both exported through the barrel. Two behaviours the three call sites had already drifted on are now uniform:

- **Absence is its own branch.** `navigator.clipboard?.writeText(t)` yields `undefined` on an insecure origin (`npm run dev:http`, a workflow this repo documents), which awaits cleanly and reports a copy that never happened. Two of the three sites had that bug; `LetterRevealDialog` did not, and its fix is now everyone's.
- **A failure persists; a confirmation expires.** `resetAfterMs` clears `copied` only.

`LetterRevealDialog` migrates onto the **hook**, not the button — its failure is a full "select the text above and copy it yourself" sentence beside the button, not a label swap inside it. Both halves ship from the same module pair, so there is still one clipboard implementation in the tree.

`TextAreaField` gains `readOnly` and `autoGrow` — a `disabled` textarea's text cannot be selected with the mouse in Chromium, which makes it useless as the manual-copy fallback, and auto-growing a ~1.5KB prompt would push the dialog's own controls off-screen.

`useResumeRewrite` now assembles its steering once (`useMemo`) and exposes it, so the copied prompt cannot disagree with the button beside it; `start()`'s dep list drops from five raw inputs to that one value.

## Review focus

- `src/lib/webllm/export-prompt.ts:160` — the shape line goes *before* the steering suffix so the user's own words stay last (steering.ts's ordering rationale). Does anything downstream depend on the suffix being terminal?
- `src/lib/webllm/rewrite-guardrails.ts:88` — `keepIfAlreadyStrongRule(subject)` takes the article with the noun. Is parameterising this rule worth it versus three literals, given a future fourth caller?
- `src/design-system/primitives/CopyButton.tsx:75` — the live region renders the same node as the button label. Does a screen reader double-announce when the button also has focus?
- `src/hooks/useResumeRewrite.ts:294` — `steering` is now a `useMemo` dep of `start()`. `findings` derives from `rewriteableSections`, so identity churn in the caller's `sections` array propagates further than it did. Worth checking against `ReconstructedResume`'s render.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 4729 passed, 8 files skipped
- [x] `npm run verify` green (fallow report-only; its two findings are the pre-existing `useSectionRewrite` / `sectionsEqual` entries)
- [x] `npm run build` green
- [ ] Manually verified in `npm run dev` — dialog → disclosure → copy → paste

New coverage: `rewrite-guardrails.test.ts` (10), `export-prompt.test.ts` (12), `CopyButton.test.tsx` (8, jsdom + stubbed clipboard), `RewritePromptDisclosure.test.tsx` (9, driven through the real controller rather than a stubbed `steering` — a prompt built once on mount passes any stubbed test and is the likely bug here).

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — green locally, and in CI