### PR TITLE
fix(parser): strip inline markdown images from rawText, not just the PdfLine reading (#613)

### DIFF
--- a/src/lib/heuristics/markdown-lines.ts
+++ b/src/lib/heuristics/markdown-lines.ts
@@ -13,9 +13,9 @@
  * while keeping the adapter small enough to audit.
  *
  * Pre-cleaning pass (real-world DOCX artifacts):
- *   - Strip base64 data URIs in `![...](data:...)` — mammoth+turndown emits
- *     embedded images this way and they can bloat markdown 3× with zero
- *     signal for parsing.
+ *   - Strip inline images `![alt](url)`, including the base64 data URIs
+ *     mammoth+turndown emits for embedded images — they can bloat markdown 3×
+ *     with zero signal for parsing. Shared with `mdToPlainText` since #613.
  *   - Flatten inline links `[label](url)` and autolinks `<url>` to `label url`
  *     (#610). Without this the bracket-paren syntax reaches every extractor
  *     verbatim, so a `.md` renders literal markdown in the exported PDF and
@@ -52,6 +52,7 @@ import {
   extractLinkDefinitions,
   flattenAutolinks,
   resolveReferenceLinks,
+  stripInlineImages,
   stripReferenceImages,
 } from "../markdown-link-refs.ts";
 import type { PdfLine, PdfSection } from "./line-model.ts";
@@ -88,17 +89,15 @@ const INLINE_BOLD_RE = /\*\*(.+?)\*\*/g;
 const INLINE_ITALIC_UNDERSCORE_RE = /(^|[^\w\\])_([^\s_][^_]*?[^\s_]|[^\s_])_(?=[^\w]|$)/g;
 const INLINE_ITALIC_STAR_RE = /(^|[^\w\\*])\*([^\s*][^*]*?[^\s*]|[^\s*])\*(?=[^\w*]|$)/g;
 
-// Base64 data-URI images in markdown: ![alt](data:image/...;base64,....)
-// Multi-line friendly because turndown occasionally wraps.
-const DATA_URI_IMAGE_RE = /!\[[^\]]*\]\(data:[^)]*\)/g;
-
-// Non-data markdown images: `![alt](https://...)` and `![](path.png)`. Alt
-// text alone isn't useful for resume parsing — drop the whole image ref so
-// it doesn't pollute the line text.
-const ANY_IMAGE_RE = /!\[[^\]]*\]\([^)]*\)/g;
+// Inline images — `![alt](https://…)`, `![](path.png)` and the base64
+// data-URI form — are stripped by the shared `stripInlineImages` in
+// `../markdown-link-refs.ts` (see the import above). The rule lives there so
+// `mdToPlainText` applies the identical one to `rawText`: before #613 it had no
+// image rule at all, and the image's `[alt](url)` tail matched its generic LINK
+// rule and flattened to `!alt url` in the text the Evidence panel prints.
 
 // Reference-style images (`![alt][ref]`, `![alt][]`, `![alt]`) cannot be
-// stripped here: unlike the two shapes above they are not self-identifying —
+// stripped there: unlike the inline shapes above they are not self-identifying —
 // whether `![great]` is an image or literal prose depends on the document's
 // `[ref]: url` definition table, which does not exist yet at this point in the
 // pipeline. They are handled inside `flattenLinks` via the shared
@@ -123,13 +122,6 @@ const INLINE_LINK_RE = /\[([^\]\n]*)\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
 // escapes that appear in contact data / prose. We keep `\n` as-is.
 const BACKSLASH_ESCAPE_RE = /\\([_*[\]()!`#>.+-])/g;
 
-/** Strip base64 image blobs and non-data image refs from markdown. */
-function stripImages(markdown: string): string {
-  return markdown
-    .replace(DATA_URI_IMAGE_RE, "")
-    .replace(ANY_IMAGE_RE, "");
-}
-
 /**
  * Flatten every markdown link shape to its plain-text reading — inline links
  * and autolinks (#610), then reference-style links (#611).
@@ -138,14 +130,13 @@ function stripImages(markdown: string): string {
  * first point that has the definition table `stripReferenceImages` needs to
  * tell an image (`![badge][ci]`, with `[ci]` defined) from prose that merely
  * puts a `!` beside a bracket (`Grew revenue 40%![details][cat]`, with nothing
- * defining `[cat]`). Deciding it a step earlier, in `stripImages`, is not
- * possible without the table and deleted the prose.
+ * defining `[cat]`). Deciding it a step earlier, alongside the INLINE strip in
+ * `stripInlineImages`, is not possible without the table and deleted the prose.
  *
  * An image that the table does NOT resolve therefore survives into
- * `resolveReferenceLinks` — as does every image on `mdToPlainText`'s path,
- * which has no strip pass at all. Both are safe: the image alternative in that
- * scan consumes the whole usage and returns it untouched, so no image can
- * start flattening to `alt url` on either path.
+ * `resolveReferenceLinks`, on both readings' paths. That is safe: the image
+ * alternative in that scan consumes the whole usage and returns it untouched,
+ * so no image can start flattening to `alt url` on either path.
  *
  * `label url` (not bare `label`) is deliberate: it mirrors the `$1 $2` rewrite
  * `mdToPlainText` (`src/lib/ingest/markdown.ts`) already applies to the
@@ -241,7 +232,7 @@ function normalizeSplitLetterHeaders(markdown: string): string {
  */
 function preprocessMarkdown(markdown: string): string {
   let out = markdown;
-  out = stripImages(out);
+  out = stripInlineImages(out);
   out = flattenLinks(out);
   out = unescapeBackslashes(out);
   out = normalizeSplitLetterHeaders(out);

--- a/src/lib/ingest/markdown.ts
+++ b/src/lib/ingest/markdown.ts
@@ -17,6 +17,7 @@ import {
   extractLinkDefinitions,
   flattenAutolinks,
   resolveReferenceLinks,
+  stripInlineImages,
 } from "../markdown-link-refs.ts";
 
 export interface MarkdownParseResult {
@@ -54,10 +55,22 @@ export interface MarkdownParseResult {
  *     `INLINE_LINK_RE`. Without that, `[writeup](url "Pricing rebuild")`
  *     swallowed the CommonMark title into the target and printed
  *     `writeup url "Pricing rebuild"`.
+ *   - Inline IMAGES are stripped through the shared `stripInlineImages` (#613).
+ *     There was no image rule here at all, so an image's `[alt](url)` tail
+ *     matched the link rule above and the leading `!` was simply left behind:
+ *     `![Company logo](https://…/logo.png)` became `!Company logo https://…`,
+ *     an image URL printed to the user as if it were résumé prose. The data-URI
+ *     form was the damaging half — a base64 blob flattened into `rawText` and
+ *     scored as text.
+ *
+ * The image strip runs over the WHOLE document, before the per-line map, for
+ * two reasons: a wrapped data URI spans a line break, and `markdown-lines.ts`
+ * strips at document level too, so anything else would put the two readings
+ * back out of step on exactly the shape this is fixing.
  */
 export function mdToPlainText(text: string): string {
   const { definitions, body } = extractLinkDefinitions(text);
-  return body
+  return stripInlineImages(body)
     .split("\n")
     .map((line) =>
       // Reference resolution runs with the link rules, before emphasis: it

--- a/src/lib/markdown-link-refs.ts
+++ b/src/lib/markdown-link-refs.ts
@@ -93,6 +93,27 @@ const AUTOLINK_URI_RE = /<([A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\s]*)>/g;
 const AUTOLINK_EMAIL_RE = /<([^<>\s@]+@[^<>\s@]+\.[^<>\s@]+)>/g;
 
 /**
+ * INLINE images — `![alt](https://…/logo.png)`, `![](path.png)` — and the
+ * base64 data-URI form mammoth+turndown emits for an embedded image.
+ *
+ * Two regexes rather than one because the data-URI target routinely contains
+ * characters the general target class would have to admit anyway; keeping it
+ * first and explicit is also what makes the intent readable at the call site
+ * (that payload is the damaging half — a base64 blob can bloat the document
+ * several-fold and is scored as text).
+ *
+ * Neither class excludes newlines, deliberately: turndown occasionally wraps a
+ * long data URI, so the strip has to be able to span a line break. That is why
+ * both consumers apply this to the WHOLE document before splitting into lines
+ * rather than per line (#613).
+ *
+ * Alt text alone carries no résumé signal — there is no `label url` reading to
+ * preserve the way there is for a link — so the whole usage goes.
+ */
+const DATA_URI_IMAGE_RE = /!\[[^\]]*\]\(data:[^)]*\)/g;
+const ANY_IMAGE_RE = /!\[[^\]]*\]\([^)]*\)/g;
+
+/**
  * A reference-style IMAGE usage: `![alt][ref]`, `![alt][]`, `![alt]`.
  *
  * The alt class admits ONE level of nested brackets — `[^[\]\n]` for ordinary
@@ -191,6 +212,38 @@ export function resolveReferenceLinks(
       return label.trim() ? `${label} ${url}` : url;
     },
   );
+}
+
+/**
+ * Drop INLINE markdown images — the self-identifying shape, `![alt](target)`,
+ * in both its ordinary and base64 data-URI forms (#613).
+ *
+ * Shared for the same reason `flattenAutolinks` is: it used to live inside
+ * `markdown-lines.ts` as a private `stripImages`, so only ONE of the two
+ * readings of a dropped `.md` applied it. The other reading —
+ * `mdToPlainText` — had no image rule at all, so the image's `[alt](url)` tail
+ * matched its generic LINK rule and flattened to `!alt url`: a stray `!`, the
+ * alt text, and an image URL, printed back to the user verbatim by
+ * `EvidencePanel` and scanned by the scorer. `PdfLine` reading: image gone.
+ * `rawText` reading: image URL in the résumé. One definition, both readings.
+ *
+ * NO DEFINITION TABLE, unlike {@link stripReferenceImages}. That asymmetry is
+ * the whole reason these are two functions: `![alt](url)` carries its own
+ * target, so it is an image on sight and can be stripped anywhere in the
+ * pipeline. `![great]` is an image only if something defines `[great]` — strip
+ * it unconditionally and ordinary prose that puts a `!` beside a bracket
+ * ("Wow![great] news") silently loses characters.
+ *
+ * The `!` must be immediately before the `[`, so a LINK whose label merely ends
+ * in one — `[Ship it!](https://…)` — is untouched and still flattens to
+ * `label url`. Text that runs into an image (`Fast![label](url)`) is read as
+ * text plus an image, which is CommonMark's own reading, and the text survives.
+ *
+ * Apply to the whole document BEFORE splitting into lines: a wrapped data URI
+ * spans a line break (see the regexes' docblock).
+ */
+export function stripInlineImages(text: string): string {
+  return text.replace(DATA_URI_IMAGE_RE, "").replace(ANY_IMAGE_RE, "");
 }
 
 /**

--- a/src/lib/markdown-readings-agree.test.ts
+++ b/src/lib/markdown-readings-agree.test.ts
@@ -19,6 +19,14 @@
  * `rawText`. This compares the two readings against each other, line for line,
  * over both markdown fixtures.
  *
+ * #613 closed the last shape the two readings disagreed on: an INLINE image.
+ * `markdown-lines.ts` stripped it; `mdToPlainText` had no image rule at all, so
+ * the image's `[alt](url)` tail matched its generic LINK rule and flattened to
+ * `!alt url` — an image URL (or a base64 payload) printed to the user by
+ * `EvidencePanel` and scanned by the scorer. Neither fixture contained an image
+ * at the time, which is why the line-for-line comparison above saw nothing;
+ * `inline-links.md` now carries both forms.
+ *
  * THE ONE DELIBERATE DIFFERENCE. `markdown-lines.ts` keeps a bullet's leading
  * `- ` so the shared `isBulletLine` extractor matches; `mdToPlainText` strips it
  * because the scorer wants prose. Normalizing that marker away is therefore
@@ -76,6 +84,102 @@ describe.each(["inline-links", "reference-links"])(
     });
   },
 );
+
+describe("inline-links.md — an inline image contributes nothing to either reading", () => {
+  // #613. The fixture carries both shapes: a base64 data-URI headshot in the
+  // profile band (mammoth+turndown's output for an embedded image) and an
+  // https badge sitting immediately after a real link in Projects.
+  //
+  // The badge's placement is the load-bearing part. `mdToPlainText` had no
+  // image rule, so the image's `[alt](url)` tail matched its generic LINK rule
+  // and flattened to `!alt url` — putting an image URL in the text
+  // `EvidencePanel` prints back. Next to a genuine link, a fix that
+  // over-claims would take the link with it.
+  let markdown: string;
+
+  beforeAll(async () => {
+    markdown = await fsp.readFile(join(FIXTURE_DIR, "inline-links.md"), "utf8");
+  });
+
+  it("leaks neither image URL, nor its alt text, nor a stray `!`", () => {
+    const { mdLines, rawText } = readings(markdown);
+    for (const line of [...mdLines, ...rawText]) {
+      expect(line).not.toContain("data:image/png;base64");
+      expect(line).not.toContain("badges/ledger-toolkit.svg");
+      expect(line).not.toContain("build status");
+      expect(line).not.toContain("Headshot");
+      expect(line).not.toMatch(/!\[|!\w/); // `![alt](…)` residue, and `!alt url`
+    }
+  });
+
+  it("still flattens the link the badge sits next to", () => {
+    const { mdLines, rawText } = readings(markdown);
+    for (const lines of [mdLines, rawText]) {
+      expect(lines.join("\n")).toContain(
+        "ledger-toolkit https://example.org/ledger-toolkit",
+      );
+    }
+  });
+});
+
+describe("an INLINE image is inert in both readings", () => {
+  // #613. `markdown-lines.ts` had stripped these since #552; `mdToPlainText`
+  // never had the rule, so one file read two ways disagreed about images —
+  // the last shape left over after #610/#611 aligned every LINK shape.
+  //
+  // Both readings are asserted for every case: the defect was invisible on the
+  // `PdfLine` side, so a one-sided test would have passed against the bug.
+  it.each([
+    ["https image", "Shipped ![Company logo](https://example.org/logo.png) fast."],
+    ["data-URI image", "Shipped ![logo](data:image/png;base64,iVBORw0KGgo=) fast."],
+    ["empty alt text", "Shipped ![](https://example.org/logo.png) fast."],
+    ["title-bearing image", 'Shipped ![logo](https://example.org/l.png "Logo") fast.'],
+  ])("%s leaves only the surrounding prose", (_label, markdown) => {
+    for (const reading of [
+      mdToPlainText(markdown),
+      sectionizeMarkdown(markdown).lines.map((l) => l.text).join("\n"),
+    ]) {
+      expect(reading).not.toContain("example.org");
+      expect(reading).not.toContain("data:image");
+      expect(reading).not.toContain("!");
+      expect(reading).toContain("Shipped");
+      expect(reading).toContain("fast.");
+    }
+  });
+
+  it("strips a data URI that turndown wrapped across a line break", () => {
+    // The reason both readings apply the strip to the WHOLE document rather
+    // than per line. A per-line strip leaves the two halves of the payload
+    // behind, and `rawText` is the reading where that lands in front of a user.
+    const markdown =
+      "Badge ![b](data:image/png;base64,\niVBORw0KGgo=) here.";
+    expect(mdToPlainText(markdown)).not.toContain("base64");
+    expect(
+      sectionizeMarkdown(markdown).lines.map((l) => l.text).join("\n"),
+    ).not.toContain("base64");
+  });
+
+  it("does not claim a LINK whose label merely ends in `!`", () => {
+    // The `!` has to be immediately before the `[`. `[Ship it!](url)` is a
+    // link; over-claiming here would delete résumé content outright.
+    const markdown = "[Ship it!](https://example.org/ship)";
+    expect(mdToPlainText(markdown)).toBe("Ship it! https://example.org/ship");
+    expect(sectionizeMarkdown(markdown).lines.map((l) => l.text)).toEqual([
+      "Ship it! https://example.org/ship",
+    ]);
+  });
+
+  it("keeps the text an image runs straight into", () => {
+    // CommonMark reads `Fast![label](url)` as the text "Fast" followed by an
+    // image, so the text survives and the image goes — where the pre-#613
+    // `rawText` reading emitted `Fast!label https://…`.
+    const markdown = "Fast![label](https://example.org/x.png)";
+    expect(mdToPlainText(markdown)).toBe("Fast");
+    expect(sectionizeMarkdown(markdown).lines.map((l) => l.text)).toEqual([
+      "Fast",
+    ]);
+  });
+});
 
 describe("a DEFINED reference-style image never leaks its URL in EITHER reading", () => {
   // #610's criterion "images still strip entirely" holds for the inline shape

--- a/tests/fixtures/markdown/README.md
+++ b/tests/fixtures/markdown/README.md
@@ -18,5 +18,5 @@ manual — read the fixture before you add or change one.
 
 | Fixture | Guards |
 |---|---|
-| `inline-links.md` | `#610` — inline `[label](url)` / autolink flattening, and that a body-section URL never reaches the contact card |
+| `inline-links.md` | `#610` — inline `[label](url)` / autolink flattening, and that a body-section URL never reaches the contact card. `#613` — inline images (`![alt](url)` and the base64 data-URI form) contribute nothing to *either* reading; the badge sits beside a real link so the link must still flatten next to it |
 | `reference-links.md` | `#611` — reference-style `[label][ref]` / `[label][]` / `[label]` resolution, that `[ref]: url` definition lines never become content (including from the profile band, where they otherwise become `website_url`), and that an *undefined* reference stays literal |

--- a/tests/fixtures/markdown/inline-links.md
+++ b/tests/fixtures/markdown/inline-links.md
@@ -1,5 +1,7 @@
 # Riley Nakamura
 
+![Headshot](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==)
+
 riley.nakamura@example.com · (312) 555-0123 · Chicago, IL
 
 <https://linkedin.com/in/rileynakamura> · github.com/rileynakamura
@@ -21,7 +23,7 @@ Platform engineer who ships checkout and catalog systems. Earlier, sold sidebiz.
 
 ## Projects
 
-**Ledger Toolkit** — [ledger-toolkit](https://example.org/ledger-toolkit)
+**Ledger Toolkit** — [ledger-toolkit](https://example.org/ledger-toolkit) ![build status](https://example.org/badges/ledger-toolkit.svg)
 
 - Double-entry bookkeeping library used by three internal teams.
 


### PR DESCRIPTION
## Summary

`mdToPlainText` had no image-stripping rule, so a markdown inline image — `![alt](url)` — was flattened by the generic link rule into `!alt url`. That string landed in `rawText`, which `EvidencePanel` prints back to the user verbatim and the scorer scans. The `PdfLine` reading of the same file stripped the image outright, so the two readings of one dropped `.md` disagreed on images — the last shape left over after #610/#611 aligned every *link* shape.

Fixed by moving `stripImages` out of `markdown-lines.ts` into the shared `markdown-link-refs.ts` as `stripInlineImages`, and calling it from both readings. One definition, two consumers — the invariant #610/#611 established — rather than a second, differently-worded rule.

Closes #613

## Before / after

```
## Summary

Shipped ![Company logo](https://example.org/logo.png) fast.
```

| | before | after |
|---|---|---|
| `rawText` | `Summary\n\nShipped !Company logo https://example.org/logo.png fast.\n` | `Summary\n\nShipped  fast.\n` |
| `mdLines` | `["Summary", "Shipped  fast."]` | unchanged |

The data-URI form was the damaging half — `Badge !b data:image/png;base64,… here.` — a base64 payload flattened into `rawText` and scored as text.

## Two implementation notes

**The strip runs over the whole document, before the per-line map.** `mdToPlainText` otherwise works line-by-line, but turndown occasionally wraps a long data URI across a line break, and neither image regex excludes newlines for exactly that reason. `markdown-lines.ts` already strips at document level, so per-line stripping here would have put the two readings back out of step on the shape this fixes. A test pins the wrapped-data-URI case.

**Inline and reference images stay two functions.** `![alt](url)` carries its own target, so it is an image on sight and can be stripped anywhere in the pipeline. `![great]` is an image only if something defines `[great]` — which is why `stripReferenceImages` takes the definition table and #611's behaviour is untouched here: a defined reference-style image still leaks no URL, an undefined one is still literal text.

## The fixture

`inline-links.md` gains both forms: a base64 headshot in the profile band (mammoth+turndown's output for an embedded image) and an https badge sitting **immediately after a real link** in Projects. The badge's placement is the load-bearing part — a fix that over-claims the `!` would take the adjacent link with it, and a separate assertion holds that `ledger-toolkit https://example.org/ledger-toolkit` still flattens.

Persona unchanged and synthetic (Riley Nakamura, `@example.com`, `(312) 555-0123`). The added image URLs are `example.org`; the data URI is a 1×1 transparent PNG. Per `tests/fixtures/markdown/README.md`, `npm run check:fixtures` does not cover this directory — the judgement is manual and was made.

## The assertions were proven to fail first

`mdToPlainText` was reverted to its pre-fix form with the new tests and fixture in place. All **eight** new assertions failed, including the pre-existing line-for-line agreement test — which had been passing only because neither fixture contained an image:

```
× produces identical lines from both readings
  → expected [ 'Riley Nakamura', …(20) ] to deeply equal [ 'Riley Nakamura', …(19) ]
× leaks neither image URL, nor its alt text, nor a stray `!`
  → expected '!Headshot data:image/png;base64,iVBOR…' not to contain 'data:image/png;base64'
× https image leaves only the surrounding prose
  → expected 'Shipped !Company logo https://example…' not to contain 'example.org'
× keeps the text an image runs straight into
  → expected 'Fast!label https://example.org/x.png' to be 'Fast'
```

Every case asserts **both** readings, not just `rawText`: the defect was invisible on the `PdfLine` side, so a one-sided test would have passed against the bug.

## Acceptance criteria

- [x] `![alt](https://…)` contributes nothing to `rawText` — no `!`, no alt text, no URL
- [x] The data-URI form is stripped from `rawText` too
- [x] `sectionizeMarkdown` and `mdToPlainText` agree on a document containing an inline image, asserted in `markdown-readings-agree.test.ts`
- [x] `[Ship it!](https://…)` still flattens to `label url`; `Fast![label](url)` keeps the text and drops the image
- [x] Reference-style images behave as #611 left them — the existing describes are untouched and green
- [x] An image added to `tests/fixtures/markdown/inline-links.md`, in both forms
- [x] No corpus snapshot re-bake — `git status` after `npm run verify` shows no `.expected.json` touched

## Review focus

- `src/lib/markdown-link-refs.ts:132` — `ANY_IMAGE_RE`'s target class is `[^)]*`, so a `)`-bearing image URL truncates. That is the pre-existing behaviour moved verbatim, and it matches `INLINE_LINK_RE`'s own limits — but is a percent-encoded `%29` worth admitting now that this rule is shared?
- `src/lib/ingest/markdown.ts:71` — the strip runs *after* `extractLinkDefinitions`. Can an image's data URI ever contain something the definition-line regex claims first?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 4699 passed, 8 files skipped
- [x] `npm run verify` green
- [x] New assertions confirmed failing before the fix (above)
- [ ] Manually verified by dropping a `.md` with an image in `npm run dev`

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — green locally, and in CI