### PR TITLE
fix(analytics): give the two WebLLM passes their own event names

### DIFF
--- a/src/hooks/useResumeAnalysisLlm.ts
+++ b/src/hooks/useResumeAnalysisLlm.ts
@@ -16,11 +16,12 @@
  * The escape hatch (#243) stays a separate, degenerate-case pass (different
  * trigger + provenance) — see `useLlmEscapeHatch`.
  *
- * Telemetry is preserved: the controller still emits the existing
- * `cascade_parse_completed{llm_ran:true}`, `disagreements_found`, and
- * `llm_critique_ran` events so the funnel reads the same as before. The
- * three events still fire in a single user action because they describe
- * distinct facts (LLM ran, gaps detected, critique completed).
+ * Telemetry: the controller emits `llm_parse_ran`, `disagreements_found`, and
+ * `llm_critique_ran`. The three still fire in a single user action because they
+ * describe distinct facts (LLM ran, gaps detected, critique completed). The
+ * first was once a `cascade_parse_completed` re-emit; it now has its own name so
+ * counting completed parses does not also count LLM passes — see the docblock on
+ * `trackLlmParseRan` in `lib/analytics.ts`.
  *
  * Pure React/engine glue. The combined LLM logic lives in
  * `lib/webllm/analyze-resume.ts`; the diff lives in

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -2,7 +2,99 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect } from "vitest";
-import { buildFeedbackProps } from "./analytics.ts";
+import {
+  buildFeedbackProps,
+  buildCascadeParseCompletedEvent,
+  buildLlmParseRanEvent,
+  buildLlmFallbackRanEvent,
+} from "./analytics.ts";
+import { CASCADE_VERSION } from "./heuristics/types.ts";
+import type { ParseEvent } from "./heuristics/types.ts";
+
+const completedEvent: Extract<ParseEvent, { type: "parse_completed" }> = {
+  type: "parse_completed",
+  cascade_version: CASCADE_VERSION,
+  user_type: "anon",
+  final_source: "tier_1_alone",
+  total_duration_ms: 412,
+  confidence: 0.82,
+  triggers: [],
+  tier_mask: 0b11,
+  llm_ran: false,
+};
+
+describe("parse-event names — one emit per parse (#734)", () => {
+  it("gives the cascade completion and the two LLM passes distinct names", () => {
+    const names = [
+      buildCascadeParseCompletedEvent(completedEvent).event,
+      buildLlmParseRanEvent({ model: "Llama-3.2-3B" }).event,
+      buildLlmFallbackRanEvent({ model: "Llama-3.2-3B" }).event,
+    ];
+    expect(new Set(names).size).toBe(3);
+    expect(names).toEqual([
+      "cascade_parse_completed",
+      "llm_parse_ran",
+      "llm_fallback_ran",
+    ]);
+  });
+
+  it("emits cascade_parse_completed from the cascade path only", () => {
+    // The regression: both LLM passes used to re-emit this name, so counting it
+    // counted LLM passes too and parse success rate read above 100%.
+    expect(buildLlmParseRanEvent({ model: "m" }).event).not.toBe(
+      "cascade_parse_completed",
+    );
+    expect(buildLlmFallbackRanEvent({ model: "m" }).event).not.toBe(
+      "cascade_parse_completed",
+    );
+  });
+
+  it("carries total_duration_ms on the cascade emit and on neither LLM emit", () => {
+    // Saved insights filter on `total_duration_ms is set` to exclude the
+    // historical re-emits. That filter stays correct only while this holds.
+    expect(buildCascadeParseCompletedEvent(completedEvent).props).toHaveProperty(
+      "total_duration_ms",
+      412,
+    );
+    expect(buildLlmParseRanEvent({ model: "m" }).props).not.toHaveProperty(
+      "total_duration_ms",
+    );
+    expect(buildLlmFallbackRanEvent({ model: "m" }).props).not.toHaveProperty(
+      "total_duration_ms",
+    );
+  });
+
+  it("keeps llm_ran true on both LLM events and the fallback's final_source", () => {
+    expect(buildLlmParseRanEvent({ model: "m" }).props.llm_ran).toBe(true);
+    expect(buildLlmFallbackRanEvent({ model: "m" }).props).toMatchObject({
+      llm_ran: true,
+      final_source: "llm_fallback",
+      model: "m",
+    });
+  });
+
+  it("carries no field values or PII on any of the three", () => {
+    const all = [
+      buildCascadeParseCompletedEvent(completedEvent).props,
+      buildLlmParseRanEvent({ model: "m" }).props,
+      buildLlmFallbackRanEvent({ model: "m" }).props,
+    ];
+    const allowed = new Set([
+      "cascade_version",
+      "user_type",
+      "final_source",
+      "total_duration_ms",
+      "confidence",
+      "triggers",
+      "tier_mask",
+      "llm_ran",
+      "model",
+    ]);
+    for (const props of all) {
+      for (const key of Object.keys(props)) expect(allowed.has(key)).toBe(true);
+    }
+  });
+});
 
 describe("buildFeedbackProps — feedback_submitted payload shaping (#51)", () => {
   it("always includes the rating", () => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -213,54 +213,112 @@ export function trackCascadeEvent(event: ParseEvent): void {
         elapsed_ms_since_start: event.elapsed_ms_since_start,
       });
       break;
-    case "parse_completed":
-      // Named "cascade_parse_completed" (not "parse_completed") to avoid
-      // collision with the manual trackParseCompleted event that adds
-      // score-dimension data unavailable inside the cascade.
-      track("cascade_parse_completed", {
-        cascade_version: event.cascade_version,
-        user_type: event.user_type,
-        final_source: event.final_source,
-        total_duration_ms: event.total_duration_ms,
-        confidence: event.confidence,
-        triggers: [...event.triggers],
-        tier_mask: event.tier_mask,
-        llm_ran: event.llm_ran,
-      });
+    case "parse_completed": {
+      const { event: name, props } = buildCascadeParseCompletedEvent(event);
+      track(name, props);
       break;
+    }
   }
 }
 
+/** An event name paired with its payload, before `track()` stamps the surface. */
+export type TrackedEvent = {
+  event: string;
+  props: Record<string, unknown>;
+};
+
 /**
- * The opt-in WebLLM parse pass ran (#242). The cascade's
- * `cascade_parse_completed` event always carries `llm_ran: false` because the
- * LLM pass runs AFTER the cascade returns — by the time the user opts in, that
- * event has already fired. So re-emit the completion signal with `llm_ran: true`
- * (same event name, so PostHog correlates the two on the same person/session)
- * to satisfy the "set `llm_ran: true` on parse_completed when the LLM pass runs"
- * contract. Carries only the model id + the flag — no field values, no PII.
+ * Payload for `cascade_parse_completed` — one emit per finished cascade.
+ *
+ * Named "cascade_parse_completed" (not "parse_completed") to avoid collision
+ * with the manual `trackParseCompleted` event that adds score-dimension data
+ * unavailable inside the cascade.
+ *
+ * `total_duration_ms` is load-bearing beyond its own value: it is the only
+ * property that separates this emit from the LLM events, which carry a model id
+ * instead. The saved parse-volume insights filter on it being set, so dropping
+ * it here silently zeroes those charts rather than failing loudly.
+ *
+ * Pure and exported so the name and shape are testable without a PostHog key —
+ * `track()` short-circuits when `VITE_POSTHOG_KEY` is unset, which is every test
+ * run. Same pattern as `buildFeedbackProps`.
  */
-export function trackLlmParseRan(args: { model: string }): void {
-  track("cascade_parse_completed", {
-    cascade_version: CASCADE_VERSION,
-    llm_ran: true,
-    model: args.model,
-  });
+export function buildCascadeParseCompletedEvent(
+  event: Extract<ParseEvent, { type: "parse_completed" }>,
+): TrackedEvent {
+  return {
+    event: "cascade_parse_completed",
+    props: {
+      cascade_version: event.cascade_version,
+      user_type: event.user_type,
+      final_source: event.final_source,
+      total_duration_ms: event.total_duration_ms,
+      confidence: event.confidence,
+      triggers: [...event.triggers],
+      tier_mask: event.tier_mask,
+      llm_ran: event.llm_ran,
+    },
+  };
+}
+
+/** Payload for `llm_parse_ran` (#242). See `trackLlmParseRan`. */
+export function buildLlmParseRanEvent(args: { model: string }): TrackedEvent {
+  return {
+    event: "llm_parse_ran",
+    props: {
+      cascade_version: CASCADE_VERSION,
+      llm_ran: true,
+      model: args.model,
+    },
+  };
+}
+
+/** Payload for `llm_fallback_ran` (#243). See `trackLlmFallbackRan`. */
+export function buildLlmFallbackRanEvent(args: { model: string }): TrackedEvent {
+  return {
+    event: "llm_fallback_ran",
+    props: {
+      cascade_version: CASCADE_VERSION,
+      llm_ran: true,
+      final_source: "llm_fallback",
+      model: args.model,
+    },
+  };
 }
 
 /**
- * The degenerate-case LLM escape hatch ran (#243). Re-emits `cascade_parse_completed`
- * with `llm_ran: true` AND `final_source: "llm_fallback"` to distinguish the
- * recovery-pass from the comparison-pass (#242, which uses `trackLlmParseRan`).
- * Carries only the model id — no field values, no PII.
+ * The opt-in WebLLM parse pass ran (#242). The LLM pass runs AFTER the cascade
+ * returns, so by the time the user opts in, `cascade_parse_completed` has
+ * already fired carrying `llm_ran: false`.
+ *
+ * This used to re-emit `cascade_parse_completed` to restate the flag. That made
+ * the event name mean two different things — "a parse finished" and "the LLM
+ * pass ran on a parse that already finished" — so every count of it read high:
+ * parse success rate (completions / files accepted) sat above 100%, and the
+ * `triggers` / `final_source` breakdowns gained a null bucket, because a
+ * re-emit carries none of the cascade's measurements. The stated reason for
+ * sharing the name was to let PostHog "correlate the two on the same
+ * person/session", which a distinct name does not prevent — correlation is by
+ * `distinct_id` / `$session_id`, never by event name.
+ *
+ * So this is its own event. Anything that wants both reads them as two series.
+ * Carries only the model id + the flag — no field values, no PII.
+ */
+export function trackLlmParseRan(args: { model: string }): void {
+  const { event, props } = buildLlmParseRanEvent(args);
+  track(event, props);
+}
+
+/**
+ * The degenerate-case LLM escape hatch ran (#243). Distinct from the
+ * comparison-pass (#242, `trackLlmParseRan`) because this one is a recovery:
+ * the cascade produced too little to use and the LLM re-parsed from scratch.
+ * Same reasoning as above for why it is not a `cascade_parse_completed`
+ * re-emit. Carries only the model id — no field values, no PII.
  */
 export function trackLlmFallbackRan(args: { model: string }): void {
-  track("cascade_parse_completed", {
-    cascade_version: CASCADE_VERSION,
-    llm_ran: true,
-    final_source: "llm_fallback",
-    model: args.model,
-  });
+  const { event, props } = buildLlmFallbackRanEvent(args);
+  track(event, props);
 }
 
 export function trackRenderError(args: { errorName: string }): void {


### PR DESCRIPTION
## Summary

`trackLlmParseRan` and `trackLlmFallbackRan` re-emitted `cascade_parse_completed` to restate `llm_ran: true`, so one event name meant two different things — "a parse finished" and "the LLM pass ran on a parse that already finished". Every count of it read high. On `offlinecv.org` over all ingested history: 67 `file_accepted`, 73 `cascade_parse_completed`, of which **67 are real cascade emits and 6 are LLM re-emits** — so parse success rate rendered 109%.

The two passes now emit `llm_parse_ran` and `llm_fallback_ran`. Each payload moves into a pure builder next to the existing `buildFeedbackProps`, because `track()` short-circuits when `VITE_POSTHOG_KEY` is unset — which is every test run — leaving the emitted name otherwise unreachable from a test.

Refs #734 (filed and closed as `not planned`; this fixes the metric half of it, so no reopen).

## Action required after this deploys

**`WebLLM opt-in rate (90d)` (insight `hLBcsOXY`) will go stale for new data.** It counts `cascade_parse_completed` filtered to `llm_ran = true` — after this lands, no new event carries that combination. It needs repointing at `llm_parse_ran`, and it has to keep reading the old event to retain the 90-day history, so it can't be a straight rename. I deliberately left it untouched here: editing it before the deploy would break it *now*.

Nothing else needs touching. Seven saved insights were already filtered to `total_duration_ms is set` to exclude the historical re-emits, and that filter stays correct after this change — the cascade emit still carries `total_duration_ms` and neither LLM event does. `Parse funnel: accept → start → complete` was never affected (funnels count a person once per step).

## Review focus

- `src/lib/analytics.ts` — the old docblock said the shared name let PostHog "correlate the two on the same person/session". I read that as wrong (correlation is by `distinct_id` / `$session_id`, not event name) and dropped the constraint. Is there a correlation path I'm missing that did depend on the shared name?
- `src/lib/analytics.test.ts:16` — the fixture pins `final_source: "tier_1_alone"`. Does any assertion here accidentally depend on that specific value rather than on the shape?
- Extracting three exported builders to make the event name testable is more surface than the rename needs. Reasonable trade for a metric that was silently wrong for two months, or too much?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 195 tests, 24 files
- [x] `npm run verify` green (pre-push hook)
- [x] New tests verified to **fail** against the old event names, not just pass against the new — reverting both builders to `cascade_parse_completed` fails exactly the two name assertions, then passes on restore
- [x] fallow: 1 complexity finding on `initAnalytics`, pre-existing and untouched by this diff; report-only per `CLAUDE.md`
- [ ] Post-deploy: confirm `llm_parse_ran` appears in the event taxonomy, then repoint insight `hLBcsOXY`

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Diagnosis (PostHog queries) + implementation | Claude Opus 5 (1M context) | — |
| Verification | `npm run verify` — green via pre-push | — |
