### PR TITLE
feat(jobs): collapse terminal status sections and page long ones (#740)

### DIFF
--- a/src/components/features/JobTracker.test.tsx
+++ b/src/components/features/JobTracker.test.tsx
@@ -15,6 +15,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { JobTracker } from "./JobTracker.tsx";
+import { SECTION_PAGE_SIZE } from "./JobTrackerStatusGroup.tsx";
 import type { JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import type { JobRecord, LetterRecord } from "../../lib/storage/index.ts";
 import type { JobRating } from "../../lib/job-search/rating.ts";
@@ -264,5 +265,253 @@ describe("JobTracker: letter indicator (#715)", () => {
     expect(
       container.querySelector('button[aria-label="View cover letter"]'),
     ).toBeNull();
+  });
+});
+
+describe("JobTracker: collapsible status sections (#740)", () => {
+  /** Every mounted row is a `JobTrackerEntry`, whose root is the only `<li>` in
+   *  the tree — so this counts ROWS, not a CSS-hidden class. */
+  function rows(): HTMLLIElement[] {
+    return [...container.querySelectorAll("li")];
+  }
+
+  /** The section disclosure for a status. Matched on the ` · ` the header count
+   *  puts there, which no row control has — a row's status picker renders a
+   *  button whose text is the bare label ("Rejected"). */
+  function toggleFor(label: string): HTMLButtonElement {
+    const button = [...container.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes(`${label} · `),
+    );
+    if (!button) throw new Error(`no section toggle for "${label}"`);
+    return button;
+  }
+
+  function click(button: Element | undefined) {
+    act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  }
+
+  function clickIn(scope: ParentNode, label: string) {
+    click([...scope.querySelectorAll("button")].find((b) => b.textContent === label));
+  }
+
+  function rowFor(title: string): HTMLLIElement {
+    const row = rows().find((li) => li.textContent?.includes(title));
+    if (!row) throw new Error(`no row for "${title}"`);
+    return row;
+  }
+
+  /** `n` jobs in the order the tracker actually hands down: `listJobs()` sorts
+   *  the whole library by `updatedAt` DESCENDING, so index 0 is the most
+   *  recently written. Fixtures that ignore this can't reproduce the reorder a
+   *  plain field edit causes. Sizes derive from `SECTION_PAGE_SIZE` so a
+   *  threshold change moves the tests with it rather than silently unpaging. */
+  function manyJobs(n: number): JobRecord[] {
+    return Array.from({ length: n }, (_, i) =>
+      job({ id: `j${i}`, title: `Job ${i}`, updatedAt: n - i }),
+    );
+  }
+
+  /** The bucket's page-N control, which `Pagination` labels. */
+  function pageButton(n: number): Element | undefined {
+    return [...container.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === `Page ${n}`,
+    );
+  }
+
+  const MIXED = [
+    job({ id: "live", title: "Live one", status: "interested" }),
+    job({ id: "dead", title: "Dead one", status: "rejected" }),
+    job({ id: "old", title: "Old one", status: "archived" }),
+  ];
+
+  it("opens rejected and archived collapsed, with the label and count still shown", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker(MIXED)} />));
+    const text = container.textContent ?? "";
+    // Nothing is hidden without declaring its size.
+    expect(text).toContain("Interested · 1");
+    expect(text).toContain("Rejected · 1");
+    expect(text).toContain("Archived · 1");
+    // Only the live bucket mounted its row — a real render saving.
+    expect(rows()).toHaveLength(1);
+    expect(text).toContain("Live one");
+    expect(text).not.toContain("Dead one");
+    expect(text).not.toContain("Old one");
+    expect(toggleFor("Rejected").getAttribute("aria-expanded")).toBe("false");
+    expect(toggleFor("Archived").getAttribute("aria-expanded")).toBe("false");
+    expect(toggleFor("Interested").getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("expands and re-collapses a section from its header, tracking aria-expanded", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker(MIXED)} />));
+
+    click(toggleFor("Rejected"));
+    expect(toggleFor("Rejected").getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Dead one");
+    expect(rows()).toHaveLength(2);
+    // Toggling one section leaves its neighbours alone.
+    expect(container.textContent).not.toContain("Old one");
+
+    click(toggleFor("Rejected"));
+    expect(toggleFor("Rejected").getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain("Dead one");
+    expect(rows()).toHaveLength(1);
+  });
+
+  it.each(["rejected", "archived"] as const)(
+    "expands %s when it is the only non-empty bucket",
+    (status) => {
+      const tracker = makeTracker([job({ title: "Only one", status })]);
+      act(() => root.render(<JobTracker tracker={tracker} />));
+      expect(rows()).toHaveLength(1);
+      expect(container.textContent).toContain("Only one");
+    },
+  );
+
+  it("expands both terminal buckets when the library is nothing else", () => {
+    // Neither is "the only" non-empty bucket, but between them they are the
+    // whole library — collapsing both would render a page of headers and no
+    // rows, which is the failure the rule exists to prevent.
+    const tracker = makeTracker([
+      job({ title: "Dead one", status: "rejected" }),
+      job({ title: "Old one", status: "archived" }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(rows()).toHaveLength(2);
+    expect(container.textContent).toContain("Dead one");
+    expect(container.textContent).toContain("Old one");
+  });
+
+  it("expands a bucket whose status it cannot explain", () => {
+    // A corrupt or future-version imported record. Unknown is NOT treated as
+    // terminal: a bucket the app can't explain is the one to surface.
+    const tracker = makeTracker([
+      job({ title: "Live one", status: "interested" }),
+      job({ title: "Dead one", status: "rejected" }),
+      job({ title: "Weird one", status: "ghosted" as JobRecord["status"] }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(container.textContent).toContain("Weird one");
+    expect(toggleFor("ghosted").getAttribute("aria-expanded")).toBe("true");
+    // …while the terminal bucket alongside it still opens closed.
+    expect(container.textContent).not.toContain("Dead one");
+  });
+
+  it("follows the default until the user touches the section, so a shrinking library still opens", () => {
+    // Rejected starts collapsed behind a live bucket. Delete the live job and
+    // rejected becomes the whole library — an open state frozen at mount would
+    // leave the user staring at a lone header.
+    act(() => root.render(<JobTracker tracker={makeTracker(MIXED.slice(0, 2))} />));
+    expect(container.textContent).not.toContain("Dead one");
+
+    act(() => root.render(<JobTracker tracker={makeTracker([MIXED[1]])} />));
+    expect(container.textContent).toContain("Dead one");
+    expect(toggleFor("Rejected").getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("does not slam a self-opened section shut when another bucket appears", () => {
+    // The default is derived from the WHOLE library, so it can flip back down
+    // under a user who did nothing. On /jobs/ that is reachable: Tabs keeps both
+    // panels mounted, so saving a job from Search grows the library while the
+    // user is reading an open Saved-jobs section. The latch is one-way.
+    act(() => root.render(<JobTracker tracker={makeTracker([MIXED[1]])} />));
+    expect(container.textContent).toContain("Dead one");
+
+    act(() => root.render(<JobTracker tracker={makeTracker(MIXED.slice(0, 2))} />));
+    expect(container.textContent).toContain("Dead one");
+    expect(toggleFor("Rejected").getAttribute("aria-expanded")).toBe("true");
+
+    // Still the user's to close, and it stays closed once they say so.
+    click(toggleFor("Rejected"));
+    expect(container.textContent).not.toContain("Dead one");
+  });
+
+  it("keeps a collapsed-then-expanded row fully actionable", () => {
+    const tracker = makeTracker(MIXED);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    click(toggleFor("Rejected"));
+
+    const row = rowFor("Dead one");
+    // The row's own status picker still moves the job out of the bucket…
+    clickIn(row, "Applied");
+    expect(tracker.setStatus).toHaveBeenCalledWith("dead", "applied");
+    // …and the two-click remove still removes it. A terminal bucket is not a
+    // read-only archive.
+    clickIn(rowFor("Dead one"), "Remove");
+    clickIn(rowFor("Dead one"), "Confirm");
+    expect(tracker.remove).toHaveBeenCalledWith("dead");
+  });
+
+  /** Rows past a full page, so the bucket splits into exactly two. */
+  const OVERFLOW = 5;
+  const LAST_TITLE = `Job ${SECTION_PAGE_SIZE + OVERFLOW - 1}`;
+
+  it("pages an expanded section past the row threshold, leaving every row reachable", () => {
+    const many = manyJobs(SECTION_PAGE_SIZE + OVERFLOW);
+    act(() => root.render(<JobTracker tracker={makeTracker(many)} />));
+
+    expect(rows()).toHaveLength(SECTION_PAGE_SIZE);
+    expect(container.textContent).toContain("Job 0");
+    expect(container.textContent).not.toContain(LAST_TITLE);
+    // The shared Pagination control, not a hand-rolled "Show more".
+    const nav = container.querySelector("nav[aria-label]");
+    expect(nav?.getAttribute("aria-label")).toContain("Interested jobs pagination");
+
+    click(pageButton(2));
+    expect(rows()).toHaveLength(OVERFLOW);
+    expect(container.textContent).toContain(LAST_TITLE);
+    expect(container.textContent).not.toContain("Job 0");
+  });
+
+  it("does not page a section at the threshold", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker(manyJobs(SECTION_PAGE_SIZE))} />));
+    expect(rows()).toHaveLength(SECTION_PAGE_SIZE);
+    expect(container.querySelector("nav[aria-label]")).toBeNull();
+  });
+
+  it("resets a section's page when its membership changes, not when a row is edited", () => {
+    const many = manyJobs(SECTION_PAGE_SIZE + OVERFLOW);
+    act(() => root.render(<JobTracker tracker={makeTracker(many)} />));
+    click(pageButton(2));
+    expect(container.textContent).toContain(LAST_TITLE);
+
+    // An inline edit does NOT hand down the same order. `updateJob()` bumps
+    // `updatedAt` and `listJobs()` re-sorts descending, so the edited job floats
+    // to the front of the bucket — modelled here by patching a job that is not
+    // already first and re-sorting exactly as the hook would. Page 2 must
+    // survive that reorder, or every note edit yanks the reader back to the top.
+    const edited = many
+      .map((j) =>
+        j.id === "j27"
+          ? { ...j, notes: "touched", updatedAt: many[0].updatedAt + 1 }
+          : { ...j },
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+    act(() => root.render(<JobTracker tracker={makeTracker(edited)} />));
+    // Still the last page: its tail row is on screen and page 1's head is not.
+    expect(container.textContent).toContain(LAST_TITLE);
+    expect(container.textContent).not.toContain("Job 0");
+
+    // Dropping a job changes what page 2 even means, so the page resets.
+    const shorter = many.slice(0, SECTION_PAGE_SIZE + 1);
+    act(() => root.render(<JobTracker tracker={makeTracker(shorter)} />));
+    expect(container.textContent).toContain("Job 0");
+    expect(container.textContent).not.toContain(`Job ${SECTION_PAGE_SIZE}`);
+  });
+
+  it("keeps the header total equal to the sum of every section count, open or not", () => {
+    const tracker = makeTracker([
+      ...MIXED,
+      job({ id: "dead2", title: "Dead two", status: "rejected" }),
+      job({ id: "weird", title: "Weird one", status: "ghosted" as JobRecord["status"] }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+
+    const sum = [...container.querySelectorAll("h3")]
+      .map((h) => Number((h.textContent ?? "").split("·").pop()))
+      .reduce((a, b) => a + b, 0);
+    expect(sum).toBe(5);
+    // Three of the five rows sit behind a collapsed header, and the total still
+    // matches — the counts are the bucket length, never the rendered slice.
+    expect(rows()).toHaveLength(2);
   });
 });

--- a/src/components/features/JobTracker.tsx
+++ b/src/components/features/JobTracker.tsx
@@ -20,16 +20,20 @@
  * owns `useSavedJobRatings` — one read for the whole library, grouped by job
  * id and handed down as `lettersById`. A job id absent from the map renders
  * no indicator (`JobTrackerEntry` → `JobLetterIndicator`).
+ *
+ * Collapse + paging (#740): this file keeps the grouping and the open-by-default
+ * POLICY; `JobTrackerStatusGroup` owns one bucket's open/closed and page state,
+ * which the parent cannot hold because the bucket count is data, not a fixed
+ * set of `useState`s.
  */
 
 import { useMemo } from "react";
 import { Card, Button, StatusBadge } from "@design-system";
 import { formatBytes } from "../../lib/format-bytes.ts";
-import { EVICTION_NOTICE } from "../../lib/storage/index.ts";
-import { JOB_STATUS_ORDER } from "../../lib/storage/index.ts";
+import { EVICTION_NOTICE, JOB_STATUS_ORDER } from "../../lib/storage/index.ts";
 import type { JobRecord, JobStatus, LetterRecord } from "../../lib/storage/index.ts";
-import { jobStatusLabel } from "./JobStatusPicker.tsx";
 import { JobTrackerEntry, type LinkableResume } from "./JobTrackerEntry.tsx";
+import { JobTrackerStatusGroup, isCollapsedByDefault } from "./JobTrackerStatusGroup.tsx";
 import { useJobTracker, type JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import { useSavedJobRatings } from "../../hooks/useSavedJobRatings.ts";
 import { useJobLetters } from "../../hooks/useJobLetters.ts";
@@ -119,6 +123,13 @@ export function JobTracker({
     }));
   }, [jobs]);
 
+  // Would ANY section open on mount? `groups` holds only non-empty buckets, so
+  // this is false just for a library that is nothing but rejected/archived —
+  // which would otherwise render as a page of headers over no rows, the very
+  // failure collapse-by-default exists to avoid. Then every section opens; the
+  // "only non-empty bucket is rejected" case is the single-bucket case of it.
+  const anyOpenByDefault = groups.some(({ status }) => !isCollapsedByDefault(status));
+
   if (!ready) return null;
 
   return (
@@ -168,33 +179,31 @@ export function JobTracker({
       ) : (
         <div className="flex flex-col gap-4">
           {groups.map(({ status, jobs: group }) => (
-              <section key={status} className="flex flex-col gap-2">
-                <h3 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
-                  {jobStatusLabel(status)} · {group.length}
-                </h3>
-                <ul className="flex flex-col gap-2">
-                  {group.map((job) => (
-                    <JobTrackerEntry
-                      key={job.id}
-                      job={job}
-                      linkedResumeName={
-                        job.resumeId !== undefined
-                          ? resumeName?.(job.resumeId)
-                          : undefined
-                      }
-                      resumeOptions={resumeOptions}
-                      rated={ratings !== null}
-                      rating={ratings?.get(job.id)}
-                      letters={lettersById?.get(job.id)}
-                      onUpdate={(id, patch) => void update(id, patch)}
-                      onStatusChange={(id, next) => void setStatus(id, next)}
-                      onLinkResume={(id, resumeId) => void link(id, resumeId)}
-                      onUnlinkResume={(id) => void unlink(id)}
-                      onRemove={(id) => void remove(id)}
-                    />
-                  ))}
-                </ul>
-              </section>
+            <JobTrackerStatusGroup
+              key={status}
+              status={status}
+              jobs={group}
+              defaultExpanded={!anyOpenByDefault || !isCollapsedByDefault(status)}
+              renderRow={(job) => (
+                <JobTrackerEntry
+                  job={job}
+                  linkedResumeName={
+                    job.resumeId !== undefined
+                      ? resumeName?.(job.resumeId)
+                      : undefined
+                  }
+                  resumeOptions={resumeOptions}
+                  rated={ratings !== null}
+                  rating={ratings?.get(job.id)}
+                  letters={lettersById?.get(job.id)}
+                  onUpdate={(id, patch) => void update(id, patch)}
+                  onStatusChange={(id, next) => void setStatus(id, next)}
+                  onLinkResume={(id, resumeId) => void link(id, resumeId)}
+                  onUnlinkResume={(id) => void unlink(id)}
+                  onRemove={(id) => void remove(id)}
+                />
+              )}
+            />
           ))}
         </div>
       )}

--- a/src/components/features/JobTrackerStatusGroup.tsx
+++ b/src/components/features/JobTrackerStatusGroup.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobTrackerStatusGroup — one status bucket of the job tracker (#740): a
+ * disclosure header that always states the bucket's size, and the paged slice
+ * of rows beneath it.
+ *
+ * Split off `JobTracker.tsx` because the per-section state (open/closed, page)
+ * cannot live in the parent without one `useState` per bucket in a component
+ * that does not know how many buckets there are — and because `JobTracker` was
+ * already at the ~200 LOC gate. The name `JobTrackerSection` was taken by the
+ * hook-owning wrapper in that file.
+ *
+ * Collapse is a REAL render saving, not a CSS hide: `{expanded && …}` means a
+ * closed bucket mounts none of its `JobTrackerEntry` rows. At 444 saved jobs
+ * that is the whole point. The header still prints `{label} · {count}`, so
+ * nothing is hidden without saying how much — and the count is the bucket's
+ * FULL length, never the paged slice, so the sum across sections still equals
+ * the header total whatever is open.
+ *
+ * A collapsed bucket stays fully actionable once opened: the rows are the same
+ * `JobTrackerEntry`s with the same status picker and remove affordance. This is
+ * not an archive you can only look at.
+ *
+ * No `Disclosure` primitive: this follows the house idiom of a `<Button>` with
+ * `aria-expanded` over local state (`WeakMatchesSection.tsx`,
+ * `CompanyTargets.tsx`). Promoting that idiom to `@design-system` would be an
+ * explicit review decision, not a side effect of this change.
+ *
+ * Open/closed is EPHEMERAL — no storage write on a UI toggle, in a surface
+ * whose whole claim is that it writes only what the user asked it to.
+ */
+
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Button, Pagination } from "@design-system";
+import { jobStatusLabel } from "./JobStatusPicker.tsx";
+import type { JobRecord } from "../../lib/storage/index.ts";
+
+/**
+ * Rows an expanded bucket renders at once, and therefore the size above which
+ * it pages. **25 is a guess, not a measurement** — it is roughly a screenful
+ * and a half, chosen so the common bucket never pages at all. Nothing depends
+ * on the exact value; raising it costs render time, lowering it costs clicks.
+ */
+export const SECTION_PAGE_SIZE = 25;
+
+/**
+ * Buckets that open closed. `rejected` and `archived` are where a job goes to
+ * stop being work: the largest buckets in a mature library and the least
+ * useful open. `offer` is deliberately NOT here — `JOB_STATUS_ORDER`'s docblock
+ * calls it terminal, but it is terminal in the way a user wants to look at.
+ *
+ * Every other status opens expanded, INCLUDING one this build does not know
+ * (a corrupt or future-version imported record): a bucket the app cannot
+ * explain is the one the user most needs to see.
+ */
+const COLLAPSED_BY_DEFAULT: readonly string[] = ["rejected", "archived"];
+
+/** Whether this status's bucket opens closed. Takes the raw status string, not
+ *  `JobStatus`, because the tracker groups on whatever the record carries. */
+export function isCollapsedByDefault(status: string): boolean {
+  return COLLAPSED_BY_DEFAULT.includes(status);
+}
+
+export function JobTrackerStatusGroup({
+  status,
+  jobs,
+  defaultExpanded,
+  renderRow,
+}: {
+  /** The raw status string this bucket holds — may be outside `JobStatus`. */
+  status: string;
+  /** Every job in the bucket, in the parent's order. Not sliced by the caller:
+   *  the header count and the page arithmetic both need the full length. */
+  jobs: readonly JobRecord[];
+  /** Whether this bucket should open on its own. Followed in the OPENING
+   *  direction for as long as the user has not toggled the section (see
+   *  `override` below), so a bucket that becomes the only non-empty one after a
+   *  delete still opens instead of stranding the user on a page of headers over
+   *  no rows. Never followed back down — see `everOpenedItself`. */
+  defaultExpanded: boolean;
+  /** Renders one row. A callback rather than nine pass-through props: this
+   *  component's concern is collapsing and paging a list, and it has no
+   *  business knowing about ratings, letters or linked résumés. */
+  renderRow: (job: JobRecord) => ReactNode;
+}) {
+  // `null` = the user has not touched this section, so the default below still
+  // governs and keeps governing as the library changes under it. Storing a
+  // plain `useState(defaultExpanded)` would freeze the mount-time value, so a
+  // bucket that only becomes the last one standing after a delete would open
+  // closed. The default governs only until the user first expresses an intent:
+  // once they toggle, `override` is theirs and it sticks, so a section the user
+  // explicitly collapsed stays collapsed — the labelled toggle is right there.
+  const [override, setOverride] = useState<boolean | null>(null);
+  const [page, setPage] = useState(1);
+
+  // A one-way latch, because `defaultExpanded` is derived from the WHOLE
+  // library: a terminal bucket that opened itself as the last one standing
+  // would otherwise slam shut the moment a job lands in another bucket —
+  // unmounting rows the user is reading, with no action of theirs. On `/jobs/`
+  // that is reachable, not theoretical: `Tabs` keeps both panels mounted, so
+  // saving a job from Search mutates the library under an open Saved-jobs
+  // section. Latching also keeps this closer to the precedent it follows
+  // (`WeakMatchesSection`'s `useState(defaultOpen)`), which simply never
+  // re-reads the default. Writing a ref during render is safe here: the write
+  // is idempotent, so a StrictMode double-invoke lands on the same value.
+  const everOpenedItself = useRef(false);
+  if (defaultExpanded) everOpenedItself.current = true;
+  const expanded = override ?? everOpenedItself.current;
+
+  // Page resets when this section's MEMBERSHIP changes — an add, a remove or a
+  // status move, the three things that make a page index point at different
+  // jobs. The key is a SET of ids, not an ordered list, precisely BECAUSE the
+  // order is not stable: `listJobs()` re-sorts the whole library by `updatedAt`
+  // descending on every read, and `updateJob()` bumps `updatedAt`
+  // (`src/lib/job-tracker.ts`), so editing one note floats that job to the front
+  // of its bucket. An order-sensitive key — or `jobs` identity, which the parent
+  // rebuilds on any tracker write — would therefore yank the reader back to page
+  // 1 mid-read on a mere inline edit. Ids join on a NUL no realistic id carries.
+  // (An id here is whatever a backup carried, not necessarily a UUID, so the
+  // separator is worth picking.) Memoised because the sort now runs over the
+  // whole bucket — 444 ids in the motivating case. `.map()` already returns a
+  // fresh array, so the `.sort()` never touches the readonly `jobs`.
+  const membership = useMemo(
+    () =>
+      jobs
+        .map((job) => job.id)
+        .sort()
+        .join("\u0000"),
+    [jobs],
+  );
+  useEffect(() => {
+    setPage(1);
+  }, [membership]);
+
+  // An empty bucket is a header apologising for itself. The parent never builds
+  // one, but the guard keeps the page arithmetic below total.
+  if (jobs.length === 0) return null;
+
+  const pageCount = Math.ceil(jobs.length / SECTION_PAGE_SIZE);
+  // Clamp rather than trust `page`: the reset effect runs AFTER the render in
+  // which the bucket shrank, so for one commit `page` can point past the end.
+  const current = Math.min(page, pageCount);
+  const start = (current - 1) * SECTION_PAGE_SIZE;
+  const shown = jobs.slice(start, start + SECTION_PAGE_SIZE);
+  const label = jobStatusLabel(status);
+
+  return (
+    <section className="flex flex-col gap-2">
+      {/* Restoring the pre-#740 heading look through the Button takes two
+          different mechanisms, because two different things are in the way.
+          `uppercase`/`tracking-wider` INHERIT, so they sit on the `h3`.
+          `font-semibold` does not inherit, but nothing at the same specificity
+          emits after it, so it beats BASE's `font-medium` from `className`.
+          Colour is the one that cannot be won that way: the repo has no
+          `tailwind-merge`, `Button` just joins the strings, and Tailwind
+          resolves same-layer/same-specificity conflicts by STYLESHEET order —
+          where `text-content-secondary` (the ghost variant's) is emitted after
+          `text-content-muted`, following the `@theme inline` declaration order
+          in `styles/theme.css`. Class-attribute order is irrelevant. So the
+          colour goes on an inner span, where the variant does not compete and
+          no `!` is needed. The span re-declares the flex row because it is now
+          the Button's single child, and BASE's `gap-1` would otherwise have
+          nothing left to separate. */}
+      <h3 className="uppercase tracking-wider">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-expanded={expanded}
+          // Cancels ghost's `px-2` so the label lines up with the rows.
+          className="-ml-2 font-semibold"
+          onClick={() => setOverride(!expanded)}
+        >
+          <span className="inline-flex items-center gap-1 text-content-muted">
+            <span aria-hidden="true">{expanded ? "▾" : "▸"}</span>
+            {label} · {jobs.length}
+          </span>
+        </Button>
+      </h3>
+
+      {expanded && (
+        <>
+          <ul className="flex flex-col gap-2">
+            {shown.map((job) => (
+              <Fragment key={job.id}>{renderRow(job)}</Fragment>
+            ))}
+          </ul>
+          {/* One guard over both, the shape `JobSearchResults` uses: the count
+              line and the control are the same affordance, so an unpaged bucket
+              renders neither rather than leaning on Pagination's internal null. */}
+          {pageCount > 1 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-sm text-content-muted">
+                Showing {start + 1}–{start + shown.length} of {jobs.length}.
+              </p>
+              <Pagination
+                page={current}
+                pageCount={pageCount}
+                onPageChange={setPage}
+                label={`${label} jobs`}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Saved jobs rendered every status group fully expanded — at 444 saved jobs that is 444 mounted rows on one card, with the sections a user acts on buried under hundreds they never wanted open. Terminal buckets (`rejected`, `archived`) now open closed and mount none of their rows, and any expanded section past 25 rows pages through the shared `Pagination` control.

Closes #740

## What shipped

- **Collapse by default, for terminal buckets only.** `rejected` and `archived` open closed; `{expanded && …}` means a closed bucket mounts none of its `JobTrackerEntry` rows — a real render saving, not a CSS hide. Headers still print `{label} · {count}`, so nothing is hidden without declaring its size, and the count is always the bucket's full length, never the paged slice — the `Tracked jobs · N` invariant holds whatever is open.
- **Escape hatches.** A status this build cannot explain (a corrupt or future-version imported record) opens expanded — a bucket the app can't explain is the one to surface. A library that is *nothing but* terminal buckets opens them, rather than rendering a page of headers over no rows.
- **Paging.** `SECTION_PAGE_SIZE = 25` (named and commented as a guess, not a measurement), via the existing `@design-system` `Pagination` — no hand-rolled "Show more".
- **New `JobTrackerStatusGroup`** owns one bucket's open/closed and page state. The parent can't hold it: the bucket count is data, not a fixed set of `useState`s.
- **No new `@design-system` component.** Follows the house disclosure idiom (`Button` + `aria-expanded` + local state) from `WeakMatchesSection` / `CompanyTargets`; promoting it to the barrel stays an explicit decision, per the issue.
- Collapse state is **ephemeral** — no storage write on a UI toggle, on a surface whose whole claim is that it writes only what the user asked it to.

## Review focus

- `src/components/features/JobTrackerStatusGroup.tsx:132` — the page-reset key is the id **set** (sorted before joining), not their order. Does a set still catch every case that changes what a page index *means*? Round-2 review probed add / remove / status-move / same-count-swap; the deliberate non-reset is a pure reorder.
- `src/components/features/JobTrackerStatusGroup.tsx:115` — `defaultExpanded` is derived from the **whole** library, so it can flip back down under a user who did nothing. A one-way `useRef` latch is what stops a self-opened section slamming shut. Is a ref written during render the right shape here, or should this be state?
- `src/components/features/JobTrackerStatusGroup.tsx:157` — the heading colour rides an inner `<span>`, not the `Button`'s `className`. Worth checking the reasoning: there's no `tailwind-merge` in the repo, and `text-content-secondary` is emitted *after* `text-content-muted` in the built CSS, so a `className` override loses on stylesheet order regardless of string order.
- `src/components/features/JobTracker.tsx:186` — `anyOpenByDefault` is the policy that decides which buckets may open themselves. Does it read correctly for a library with only unknown statuses?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — 4703 passed / 10 skipped, incl. 12 new `JobTracker` cases
- [x] `npm run verify` exit 0 (typecheck · lint · fixtures · baselines · coverage · build · fallow)
- [x] `fallow audit --base origin/main` — dead code 0, complexity 0; 5 duplication groups, all pre-existing test scaffold in untouched files
- [ ] Manually verified in `npm run dev` at `/jobs/` → Saved jobs

No fixtures added or changed (`npm run check:fixtures` green: 58 PDFs + 15 sidecars, all personas synthetic).

## Known gaps

- `JobTracker.tsx` is 212 LOC and `JobTrackerStatusGroup.tsx` 216, both over the ~200 guide. The split was raised by the issue's open question 3 to get under it and did not — the JSX shrank; docblocks account for the remainder.
- No `aria-controls` linking each toggle to its disclosed region. Both cited precedents omit it, so this is house-consistent rather than a regression, but the disclosed content here is a whole section.
- The issue's noted adjacent cost is untouched by design: `useSavedJobRatings` still rates the whole library on view regardless of what is rendered. Collapsing sections does not reduce that work.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #740 | unreported (requested: `opus`) | ultra |
| Adversarial review — round 1 | Claude Opus 5 | ultra |
| Review fixes | Claude Opus 4.5 | ultra |
| Adversarial review — round 2 | Claude Opus 5 (1M context) | ultra |
| Orchestration, final fixes + PR | Claude Opus 5 (1M context) | ultra |
| Verification | `npm run verify` — exit 0 locally, green in CI | — |

The implementing subagent never returned its self-report, so its row states the requested alias rather than a guessed model name.

## Adversarial review

Two rounds, pre-PR, on the local diff. Round 1 found 3 blocking; round 2 confirmed two of the three fixes independently and found the third only half-applied. Every blocking finding below was reproduced end-to-end before being accepted, and each fix was proven red-before-green.

### Round 1 — 3 blocking

**B1 — the page-reset key was order-sensitive, but the list re-sorts on every write.** `jobs.map(id).join(…)` as the reset key, with a docblock claiming it deliberately avoided firing on a note edit. False against the data path: `listJobs()` (`src/lib/job-tracker.ts:52-55`) sorts by `updatedAt` descending, `updateJob()` bumps `updatedAt`, and `useJobTracker.update()` calls `refresh()` — so editing a note floated that job to the front of its bucket, changed the key, and snapped the section back to page 1 mid-read. `link`/`unlink`/`setStatus` all route the same way. **Fixed:** the key is now the sorted id *set*; the docblock states the real reason.

**B2 — the test certifying B1 was false-green.** Its fixture used `.map()`, which preserves position, handing down an order `useJobTracker` cannot produce — and patched `j0`, already at index 0, the one id where the mock coincided with reality. **Fixed:** the fixture now models `listJobs()` (descending `updatedAt`, patch `j27`, bump it, re-sort). Proven RED on the old key (1 failed / 25 passed, `expected … to contain 'Job 29'`, DOM showing the snap-back to `Showing 1–25 of 30`) and GREEN restored.

**B3 — the section heading's weight and colour regressed silently**, while the docblock asserted the look was preserved. Only case and tracking inherit from the `h3`; `Button`'s `font-medium` and ghost's `text-content-secondary` won over the removed `font-semibold` / `text-content-muted`.

### Round 2 — B1/B2 confirmed, B3 found half-fixed (blocking)

Round 2 independently re-probed B1 across add / remove / status-move / same-count-swap / reorder and re-ran the B2 red/green itself, confirming both. It then showed **B3's fix worked for weight but not colour**: the repo has no `tailwind-merge` — `Button` just joins the strings — and Tailwind resolves same-layer, same-specificity conflicts by *stylesheet* order, where `text-content-secondary` is emitted after `text-content-muted` (following the `@theme inline` declaration order in `styles/theme.css`). Class-attribute order is irrelevant, so `text-content-muted` in `className` could never win, and the comment claiming it did was a false statement committed to the tree. **Fixed:** the colour now rides an inner `<span>`, where the variant does not compete and no `!` is needed; the comment explains why the two utilities need two different mechanisms.

Round 2 also raised a **medium** finding, accepted and fixed: `expanded = override ?? defaultExpanded` followed the default live in **both** directions, so a terminal bucket that had opened itself as the last one standing slammed shut — unmounting rows mid-read, with no user action — the moment a job landed in another bucket. Reachable on `/jobs/`, where `Tabs` keeps both panels mounted and saving from Search mutates the library under an open Saved-jobs section. Fixed with a one-way `useRef` latch, matching the `WeakMatchesSection` precedent; covered by a new test proven to fail without it.

### Surviving nits — for the human reviewer

- **Both files sit over the ~200 LOC guide** (`JobTracker.tsx` 212, `JobTrackerStatusGroup.tsx` 216). The split was raised by the issue's open question 3 specifically to get under it, and did not; the JSX shrank and docblocks account for the rest. Trimmed once already — worth a call on whether that is acceptable.
- **No `aria-controls`** on the toggles. Deliberately left alone: both precedents the change follows omit it, so adding it here alone would diverge. But the disclosed content is a whole region, so it is the strongest a11y argument against the house idiom yet — a reasonable moment to revisit it repo-wide.
- **`jobStatusLabel` falls through to the raw string**, so an imported record carrying a cased variant (`"Rejected"`) would render a second, expanded header beside the canonical collapsed one. Exotic; noted, not fixed.
- **5 fallow duplication groups remain**, all pre-existing test scaffold (`beforeEach` / `job()` / `makeTracker`) shared with eight untouched files. The one clone group this change introduced was removed.

### Gates

`npm run verify` exit 0 — typecheck, `eslint .`, fixture PII (58 PDFs + 15 sidecars, all synthetic), baselines, 4703 tests, build, fallow. Design-system reuse, token, and SPDX gates all pass: barrel imports only, no raw `<button>`, no hex or raw palette class, no manual `dark:` variant, `src/design-system/index.ts` untouched.
