### PR TITLE
feat: stamp environment and is_internal on every analytics event

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -10,3 +10,7 @@ BUCKET_NAME=your-bucket-name.example.com
 # (the posthog-js import is dead-code-eliminated when the key is unset).
 # VITE_POSTHOG_KEY=phc_xxx
 # VITE_POSTHOG_HOST=https://us.i.posthog.com
+# Optional. Overrides the inferred `environment` super-property (#739). The
+# GitHub Pages build sets it to `staging`; left unset here (or set empty), a
+# `vite build` falls back to `production`.
+# VITE_POSTHOG_ENV=production

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
           VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
+          VITE_POSTHOG_ENV: staging
       # v3 → v5 because v4 predates the Node 24 push; v5 (Apr 2026) is the first post-deprecation release.
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/README.md
+++ b/README.md
@@ -124,17 +124,38 @@ and error name — never PDF bytes, never extracted text, never names or URLs.
 Session recording and autocapture are disabled; the distinct ID is in-memory
 and reset on tab close.
 
+Every event also carries two PostHog super-properties, registered once at
+init. `environment` is build-level: `development` under `npm run dev`,
+`staging` from the `main` → GitHub Pages build at dev.offlinecv.org, and
+`production` as the fallback for any other keyed build that doesn't set
+`VITE_POSTHOG_ENV` — the Cloudflare release build, but equally a local
+`npm run build` + `npm run preview` with a key in `.env`. `is_internal` is
+not build-level: it is read per browser at runtime from the `ocv_internal`
+`localStorage` key below, and is present as a boolean on *every* event —
+`false` until that browser visits `?ocv_internal=1` once, `true` after.
+Those are the two dimensions to point PostHog's "Filter out internal and
+test users" project setting at (`is_internal is not true`, `environment =
+production`) so maintainer/staging/teammate traffic can be excluded from
+user-facing metrics; this app supplies the properties, the filter itself is
+configured in the PostHog project rather than here.
+
 The one exception is the optional feedback panel (`feedback_submitted`): it
 carries a 1–5 `rating` plus, **only when the user chooses to fill them**, a
 `category`, free-text `feedback_text`, and an `email`. That email is the single
 piece of user-supplied PII any event can carry — it is opt-in (the field is
 blank by default and is never sent as an empty string; see `buildFeedbackProps`),
-and the whole panel is hidden in builds where `VITE_POSTHOG_KEY` is unset.
+attached only as a property on that single event, and the whole panel is
+hidden in builds where `VITE_POSTHOG_KEY` is unset. It is never promoted to a
+PostHog person profile: this app never calls `identify()` or
+`setPersonProperties` anywhere. (`register()` is used, but only for the
+`environment`/`is_internal` super-properties above — PostHog
+super-properties ride on every *event*, not on a person profile.)
 
 `.env` and `.env.example` are gitignored, so the only documented surface
 for the env vars is this section. To enable telemetry in a local build,
 set `VITE_POSTHOG_KEY` (and optionally `VITE_POSTHOG_HOST`, defaulting to
-`https://us.i.posthog.com`) in the environment at build time.
+`https://us.i.posthog.com`, and `VITE_POSTHOG_ENV` to override the inferred
+`environment` super-property above) in the environment at build time.
 
 ### Browser storage
 
@@ -150,6 +171,7 @@ scoped to your browser:
 | `ocv_feedback_submitted` | set after a successful feedback submit so the panel never re-asks in that browser |
 | `ocv_star_cta_seen` | one-time flag so the post-feedback GitHub-star prompt shows only once per browser |
 | `ocv_gh_stars_cache` | caches the fetched star count (~1h TTL) to avoid re-hitting the GitHub API on every parse |
+| `ocv_internal` | marks this browser as internal so team traffic can be filtered out of analytics; set via `?ocv_internal=1`, cleared via `?ocv_internal=0` — only written in builds where `VITE_POSTHOG_KEY` is set |
 
 #### IndexedDB (local-first storage)
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   buildFeedbackProps,
   buildCascadeParseCompletedEvent,
   buildLlmParseRanEvent,
   buildLlmFallbackRanEvent,
+  resolveInternalFlag,
+  readInternalFlag,
 } from "./analytics.ts";
 import { CASCADE_VERSION } from "./heuristics/types.ts";
 import type { ParseEvent } from "./heuristics/types.ts";
@@ -150,5 +152,113 @@ describe("buildFeedbackProps — feedback_submitted payload shaping (#51)", () =
     expect(
       buildFeedbackProps({ rating: 4, wantsContact: true }).wants_contact,
     ).toBe(true);
+  });
+});
+
+describe("resolveInternalFlag — five acceptance-criteria cases (#739)", () => {
+  it("?ocv_internal=1 with nothing stored resolves true", () => {
+    expect(resolveInternalFlag("?ocv_internal=1", null)).toBe(true);
+  });
+
+  it("?ocv_internal=0 with '1' stored resolves false — param wins over storage", () => {
+    expect(resolveInternalFlag("?ocv_internal=0", "1")).toBe(false);
+  });
+
+  it("no param with '1' stored resolves true", () => {
+    expect(resolveInternalFlag("", "1")).toBe(true);
+  });
+
+  it("no param with nothing stored resolves false", () => {
+    expect(resolveInternalFlag("", null)).toBe(false);
+  });
+
+  it("no param with an unrecognized stored value resolves false", () => {
+    expect(resolveInternalFlag("", "yes")).toBe(false);
+  });
+});
+
+describe("readInternalFlag — never throws, even without a DOM (#739)", () => {
+  it("resolves false in the Node test env, where there is no `location`", () => {
+    // `location` is the sole throw source here: vitest runs against a Node
+    // environment (see vite.config.ts) that defines no `location` global.
+    // `localStorage` is NOT absent — `src/test-setup.ts` installs a working
+    // in-memory shim before every test (#398). The catch in `readInternalFlag`
+    // must swallow the `location` ReferenceError rather than propagate it.
+    expect(readInternalFlag()).toBe(false);
+  });
+
+  it("resolves false when localStorage is present but throws (e.g. private mode)", () => {
+    const originalLocation = (globalThis as { location?: unknown }).location;
+    const originalLocalStorage = (globalThis as { localStorage?: unknown })
+      .localStorage;
+    Object.defineProperty(globalThis, "location", {
+      value: { search: "?ocv_internal=1" },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem() {
+          throw new Error("SecurityError: storage disabled");
+        },
+        setItem() {
+          throw new Error("SecurityError: storage disabled");
+        },
+        removeItem() {
+          throw new Error("SecurityError: storage disabled");
+        },
+      },
+      configurable: true,
+    });
+    try {
+      expect(readInternalFlag()).toBe(false);
+    } finally {
+      if (originalLocation === undefined) {
+        delete (globalThis as { location?: unknown }).location;
+      } else {
+        Object.defineProperty(globalThis, "location", {
+          value: originalLocation,
+          configurable: true,
+        });
+      }
+      if (originalLocalStorage === undefined) {
+        delete (globalThis as { localStorage?: unknown }).localStorage;
+      } else {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: originalLocalStorage,
+          configurable: true,
+        });
+      }
+    }
+  });
+});
+
+describe("readInternalFlag — real localStorage round trip (#739)", () => {
+  // Only `location` is stubbed: `src/test-setup.ts` already gives every test a
+  // fresh in-memory `localStorage`, so this exercises the real write path and
+  // pins the literal key name — `resolveInternalFlag`'s cases take `stored` as
+  // a parameter and so can't see which key (or whether) anything was written.
+  const setSearch = (search: string): void => {
+    Object.defineProperty(globalThis, "location", {
+      value: { search },
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    delete (globalThis as { location?: unknown }).location;
+  });
+
+  it("persists on ?ocv_internal=1, survives a reload, and clears on =0", () => {
+    setSearch("?ocv_internal=1");
+    expect(readInternalFlag()).toBe(true);
+    expect(localStorage.getItem("ocv_internal")).toBe("1");
+
+    // Reload with no param: the stored marker alone must keep it true.
+    setSearch("");
+    expect(readInternalFlag()).toBe(true);
+
+    setSearch("?ocv_internal=0");
+    expect(readInternalFlag()).toBe(false);
+    expect(localStorage.getItem("ocv_internal")).toBeNull();
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -11,10 +11,86 @@ type PostHog = {
   capture: (event: string, props?: Record<string, unknown>) => void;
   isFeatureEnabled?: (key: string) => boolean | undefined;
   onFeatureFlags?: (cb: () => void) => void;
+  register: (props: Record<string, unknown>) => void;
 };
 
 const KEY = import.meta.env.VITE_POSTHOG_KEY ?? "";
 const HOST = import.meta.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+/**
+ * Which build produced this event: `development` under `npm run dev`,
+ * `staging` from the GitHub Pages deploy (dev.offlinecv.org), `production`
+ * as the fallback for every other build. Registered as a PostHog
+ * super-property (#739) so it lands on EVERY event — that's what makes it
+ * usable as a clause in PostHog's "Filter out internal and test users"
+ * project setting, which is configured in the PostHog project, not here. It
+ * describes the build, not the person: no person property is ever set (see
+ * the Telemetry section in README.md). `||`, not `??`: an unset CI variable
+ * expands to `""`, not `undefined`, and `""` would land on every event and
+ * silently match nothing in that filter.
+ */
+const ENVIRONMENT =
+  import.meta.env.VITE_POSTHOG_ENV ||
+  (import.meta.env.DEV ? "development" : "production");
+
+const INTERNAL_KEY = "ocv_internal";
+
+/**
+ * The precedence rule both readers below obey: an explicit `?ocv_internal=1`
+ * or `=0` overrides whatever is stored, and anything else — an unrecognised
+ * value, or no param at all — defers to storage. Split out so the rule is
+ * stated once rather than duplicated between the pure resolver and the
+ * wrapper that performs the write.
+ */
+function internalFlagWrite(search: string): "set" | "clear" | null {
+  const value = new URLSearchParams(search).get(INTERNAL_KEY);
+  if (value === "1") return "set";
+  if (value === "0") return "clear";
+  return null;
+}
+
+/**
+ * Pure resolution of the internal-traffic marker: query param wins when
+ * present, otherwise falls back to what's already stored. Exported and
+ * DOM-free (takes `search`/`stored` as plain strings) so every resolution
+ * case is testable without a browser. See
+ * `readInternalFlag` for the impure wrapper that supplies the real
+ * `location.search` / `localStorage` values and performs the write.
+ */
+export function resolveInternalFlag(
+  search: string,
+  stored: string | null,
+): boolean {
+  const write = internalFlagWrite(search);
+  if (write === "set") return true;
+  if (write === "clear") return false;
+  return stored === "1";
+}
+
+/**
+ * A teammate visits `?ocv_internal=1` once per browser; every later event
+ * from that browser carries `is_internal: true` so the project's test-account
+ * filter can drop it. A boolean UX flag persisted via `localStorage` — no id,
+ * no email, nothing identifying a person — matching the other first-party
+ * `ocv_*` keys in README.md's "Browser storage" table. `localStorage` (not
+ * PostHog's own `opt_out_capturing()`) is deliberate: PostHog's opt-out state
+ * is written through the configured `persistence`, which is `"memory"` here
+ * (see `initAnalytics`), so it would evaporate on tab close and each teammate
+ * would have to re-opt-out constantly. Must never throw: private mode (where
+ * `localStorage` access itself throws) and any environment without a
+ * `location` global both fall through to `false`.
+ */
+export function readInternalFlag(): boolean {
+  try {
+    const search = location.search;
+    const write = internalFlagWrite(search);
+    if (write === "set") localStorage.setItem(INTERNAL_KEY, "1");
+    else if (write === "clear") localStorage.removeItem(INTERNAL_KEY);
+    return resolveInternalFlag(search, localStorage.getItem(INTERNAL_KEY));
+  } catch {
+    return false;
+  }
+}
 
 /** True when analytics are enabled (VITE_POSTHOG_KEY is set at build time). */
 export const ANALYTICS_ENABLED = !!KEY;
@@ -54,6 +130,10 @@ export async function initAnalytics(): Promise<void> {
     capture_pageleave: false,
   });
   ph = mod.default as unknown as PostHog;
+  // Register the environment/internal super-properties BEFORE flushing the
+  // pre-init queue (#739), so events queued before `initAnalytics` resolved
+  // also carry them — not just events emitted after this point.
+  ph.register({ environment: ENVIRONMENT, is_internal: readInternalFlag() });
   for (const [evt, props] of queue) ph.capture(evt, props);
   queue.length = 0;
   // Fan PostHog's flag-refresh callback out to flag subscribers (see flags.ts).


### PR DESCRIPTION
## Summary

PostHog had no dimension to separate internal traffic from real users — dev servers, the staging deploy, and teammates clicking around production all emitted identically shaped events into one project. This registers two super-properties at init so they ride on every event: `environment` (`development` / `staging` / `production`, overridable via `VITE_POSTHOG_ENV`) and `is_internal` (a boolean set by visiting `?ocv_internal=1` once per browser, cleared via `?ocv_internal=0`).

No person profile is involved. `identify()` and `setPersonProperties` are still called nowhere in the tree, and the `feedback_submitted` email remains an opt-in property on that single event.

Closes #739

## What is NOT in this PR

The **PostHog project setting itself.** "Filter out internal and test users" is a hand-authored filter list in the PostHog UI, and as of today the project filters on `$host` (allowlisted to `offlinecv.org`, per the second comment on #739), not on these two properties. This PR supplies the properties; the `environment` / `is_internal` clauses still have to be added there:

- `is_internal` `is not` `true`
- `environment` `equals` `production`

The README wording was corrected during review specifically so it does not claim that configuration already exists.

### Deploy topology — verified against the live artifacts

The build environments were checked by fetching each deployed bundle and grepping it, rather than inferred from config. All three behave as this change assumes:

| Environment | URL | Ships posthog-js? | Stamps |
|---|---|---|---|
| Production — Cloudflare, from `release` | offlinecv.org | yes, real `phc_…` key | `production` (by fallback) |
| Staging — GitHub Pages, from `main` | dev.offlinecv.org | yes | `staging` (set in `deploy-pages.yml`) |
| PR preview — Cloudflare | `gh-<N>.offlinecv.pages.dev` | **no** — zero matches across every asset | emits nothing |

So `VITE_POSTHOG_KEY` is set on the Cloudflare **production** build but not on previews: `environment: "production"` does reach PostHog, and preview deploys cannot pollute production numbers. No `VITE_POSTHOG_ENV=preview` is needed.

## Review focus

- `src/lib/analytics.ts` — `readInternalFlag()` is called *inside* `initAnalytics`, after the `if (!KEY) return;` guard. Does anything reach the `localStorage` read or the query-string parse in a keyless build?
- `src/lib/analytics.ts` — `register()` runs before the pre-init queue is flushed. Do the queued events actually pick up the super-properties, or only events captured afterwards?
- `src/lib/analytics.ts` — `ENVIRONMENT` uses `||`, not `??`. Is that the right call for an unset CI variable that expands to `""`?
- `README.md` — the Telemetry paragraph makes several claims about which build produces which `environment` value. Do they each round-trip to code?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green (4769 tests)
- [x] `npm run verify` green (typecheck → lint → coverage → build → fallow)
- [x] Keyless build ships no posthog chunk: with `VITE_POSTHOG_KEY` unset, `npm run build` then `grep -rl "posthog\|ocv_internal\|is_internal" dist/` → no matches
- [x] `VITE_POSTHOG_ENV` regimes verified against the emitted bundle — unset → `production`, empty → `production`, `staging` → `staging`
- [x] No `identify()` / `setPersonProperties` anywhere in `src/` — `grep -rn "identify(\|setPersonProperties" src/` → zero hits
- [ ] Add the `environment` / `is_internal` clauses to the PostHog project's test-account filter (see above)

## Adversarial review

Two independent reviewers attacked the diff before this PR was opened — one on the runtime/correctness axis, one on the repo's own house gates (PII contract, copy-round-trip, style). **Neither found a blocking defect.** One round of fixes was applied and re-verified.

Constraints verified by execution, not inspection:

| Constraint | How it was checked |
|---|---|
| No person profile is created | Live posthog-js 1.376.2 under jsdom with the real `initAnalytics` config — captured event carried `$process_person_profile: false` and no `$set`. Statically: `register()` is a pass-through to persistence; person processing is gated on `__alias`/`$epp`, which `register` never writes |
| Keyless build stays inert | `dist/` after a keyless build contains no posthog chunk and no `ocv_internal` / `is_internal` strings — dead-code-eliminated, not merely guarded |
| `register()` before the queue flush works | Live capture immediately after `register` carried both properties; re-run with remote config enabled confirmed they survive the async round trip |
| Never throws on unavailable storage | Throwing stub, `setItem`-throws-`getItem`-works, and missing `location` all resolve to `false`; `URLSearchParams` probed on 14 malformed inputs |

Findings fixed in the review round:

- **`??` → `||` on `VITE_POSTHOG_ENV`.** Reproduced from the emitted bundle: `VITE_POSTHOG_ENV=` (set but empty) folded to `environment: ""` on every event, which would silently match nothing in the filter. An unset `${{ vars.X }}` expression expands to exactly that.
- **The `localStorage` half of the acceptance criteria was untested.** The original tests all passed `stored` as a parameter, so nothing pinned the key name or proved `setItem`/`removeItem` fire. Added a round-trip test against the repo's existing storage shim; mutation-proved it fails in both directions (renaming the key on either the write or the clear path now breaks it).
- **A test comment stated a falsehood** — it claimed the Node env lacks `localStorage`; `src/test-setup.ts` shims it for every test. `location` is what throws.
- **Four copy defects in the README**, all confirmed against code: the `ocv_internal` storage row was wrong for the default keyless build (the key is never written there), `is_internal` was described as absent rather than `false` on ordinary browsers (a reader configuring the filter as "is not set" would filter nothing), `production` was presented as one of three cases rather than the fallback, and the PostHog filter was described as already keyed on these properties.
- **Unexported `internalFlagWrite`** — its export was justified by a testability obstacle that `resolveInternalFlag` already removes.

One reviewer finding was **refuted** by the other and deliberately not acted on: a claimed landmine where the test's `Object.defineProperty` restore would leave `globalThis.localStorage` non-writable. Reproduced as false — `defineProperty` on an already-existing property retains its attributes.

Left unfixed by choice: `fallow` flags `initAnalytics` at 5 cyclomatic / 30 CRAP. It is pre-existing (this change adds one non-branching statement), and fallow is report-only inside `verify`.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation | Claude Sonnet (spawn alias `sonnet`; exact version not self-reported) | high |
| Adversarial review — correctness | Claude Opus (spawn alias `opus`; exact version not self-reported) | high |
| Adversarial review — house gates | Claude Opus (spawn alias `opus`; exact version not self-reported) | high |
| Review fixes | Claude Opus (spawn alias `opus`; exact version not self-reported) | high |
| Planning, orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green locally, and in CI on this branch | — |
