### PR TITLE
feat(job-tracker): group by lifecycle bucket, record origin, and merge duplicate postings (#744, #745, #746)

### DIFF
--- a/docs/job-capture-contract.md
+++ b/docs/job-capture-contract.md
@@ -5,7 +5,10 @@ extension, a bookmarklet, a script that converts another tracker's export. You d
 the source to implement this. If a rule here and the code disagree, that is a bug; file it.
 
 **Status:** version 2. Introduced in [#693](https://github.com/offlinecv/OfflineCV/issues/693);
-extended in [#719](https://github.com/offlinecv/OfflineCV/issues/719) with the six posting facts.
+extended in [#719](https://github.com/offlinecv/OfflineCV/issues/719) with the six posting facts,
+and in [#745](https://github.com/offlinecv/OfflineCV/issues/745) with `origin` and
+[#746](https://github.com/offlinecv/OfflineCV/issues/746) with `aliasUrls` — no version bump for
+either; see §8 and §9.
 Implemented by `src/lib/storage/job-record-contract.ts` (validation),
 `src/lib/storage/job-url.ts` (identity), and `src/lib/storage/capture.ts` (the write path).
 
@@ -60,6 +63,8 @@ A record is a **plain JSON object**. Not an array, not `null`, not a class insta
 | `jdText` | string | The job description, verbatim. |
 | `matchResult` | JSON-safe value | An opaque match payload. See §6. |
 | `capture` | object | Provenance. See §7. |
+| `origin` | string (closed vocabulary) | Where this record came from, **display only**. See §8. |
+| `aliasUrls` | array of strings | Other URLs the same posting is reachable at. **Never affects `id`.** See §9. |
 | `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. **`captureJob` ignores yours** and lets the store own them; a backup file carries them so a restore preserves both. |
 | `deletedAt` | finite number (epoch ms) | A **tombstone**: the record is deleted, and its presence says so. **`captureJob` ignores yours** — see §5. A backup file carries it. |
 
@@ -180,6 +185,13 @@ keeping:
 - **Path case.** Most servers are case-sensitive; `/Jobs/AB` and `/jobs/ab` may be different pages.
 - **A non-default port.** That is a genuinely different origin.
 
+### An alias is not an identity
+
+`aliasUrls` (§9) records that a posting is *also* reachable at some other URL. It does **not**
+take part in the derivation above: `id` comes from `url` and only from `url`. Two records that
+list each other's URLs as aliases still have two different ids, and that is correct — merging
+them is a decision the user makes, not one a producer or a URL rule may make for them.
+
 ### If you have no URL
 
 Then you have no identity, and `captureJob` gives the record a fresh `crypto.randomUUID()`. Two
@@ -231,11 +243,18 @@ value — a single click in the status picker fixes it.
 
 | Producer-owned — your value wins | User-owned — the stored value wins |
 |---|---|
-| `title`, `company`, `url`, `jdText`, `matchResult`, `capture`, and the six posting facts | `status`, `notes`, `resumeId` |
+| `title`, `company`, `url`, `jdText`, `matchResult`, `capture`, `origin`, and the six posting facts | `status`, `notes`, `resumeId` |
 
 You are authoritative about the posting; the user is authoritative about their application. A
 re-capture that reset an `interviewing` job to `interested` would be worse than the duplicate it
 was meant to prevent.
+
+`aliasUrls` (§9) is in **neither** column: it is **unioned**, and it is the only field that is. An
+alias is additive by definition, so the two sides cannot conflict — and the direction that matters
+is what producer-wins would do instead. The aliases on a stored record are usually the ones the
+*user* put there by merging two rows, and a re-capture that simply omitted the field would undo
+that merge silently, which is the same loss as resetting an `interviewing` job to `interested`.
+Two spellings of one URL collapse (§2 canonical form), so re-capturing does not grow the list.
 
 A re-capture does **not** stamp `updatedAt`, so it will not float the job to the top of a list
 sorted most-recently-updated-first. `created: false` in the result tells you the record was already
@@ -351,6 +370,11 @@ Two version numbers exist and they are not the same thing.
 | 1 | The contract as #693 introduced it. | — |
 | 2 | Added the six posting facts in §1: `location`, `salaryRange`, `datePosted`, `workModel`, `employmentType`, `validThrough`. | **None.** All six are optional, so a v1 record is already a valid v2 record that omits them. Existing stored records keep loading untouched. |
 
+`origin` (§8, #745) and `aliasUrls` (§9, #746) are **not** in this table: both are additive and
+optional like the six posting facts, but neither was judged to need a version bump even as a
+courtesy entry — a build that predates them treats them as unknown extra keys (§1) and preserves
+them, with no migration to write down.
+
 **offlinecv never refuses a record for its version number.** The validator requires `capture.contract` to be a finite number and does not compare it against its own — so a record from a version this build has never heard of is accepted, and a v1 producer keeps working after a v2 build ships. Refusing a future version is precisely the forward-compatibility failure this section exists to avoid.
 
 `capture` is **optional**, and its absence means "written by offlinecv itself, contract 1". It
@@ -363,7 +387,85 @@ apart from its own and apply a migration to just yours.
 
 ---
 
-## 8. Failure handling
+## 8. `origin`
+
+Where the record says it came from — **display only**. It is never a lifecycle, and it never
+feeds merge, dedupe, or sync ordering; the only thing it changes is a short phrase on the tracker
+row. The closed vocabulary:
+
+```
+capture · alert · shared · import · manual
+```
+
+- **Omit it** when you have no better answer than "the user made it here". Every record this
+  build's own UI writes omits it, and most producers with no opinion about provenance should too.
+- **Send one of the five** and it is stored as-is. The tracker renders a short phrase for it
+  ("shared with you", "from a job alert") next to the status badge — never a second badge, and
+  never a sentence.
+- **Send anything else that is a string** — a term from another system's vocabulary, a value a
+  future offlinecv defines — and it is **dropped, with a warning**. This is the opposite choice
+  from `status` (§4): an unrecognised status is preserved because the tracker renders it under its
+  literal string, giving the user a surface to see and fix it. Nothing renders an unrecognised
+  origin, so there is no surface for keeping it to serve, and dropping it costs the user one
+  warning line rather than a value that would otherwise sit on the record unexplained forever.
+- **Send a non-string** and the record is refused, the same as any other field whose type is
+  wrong.
+
+**No `JOB_CAPTURE_CONTRACT_VERSION` bump for this field.** It is additive and optional, so a
+producer that sends nothing keeps validating unchanged, and one that sends it needs no version
+bump to be understood by a build that predates this field: that build has never heard of `origin`
+and preserves it as an unknown extra key (§1), which is exactly the forward-compatibility path
+`salaryRange` took under v1 before it became a real field.
+
+---
+
+## 9. `aliasUrls`
+
+Other URLs the same posting is reachable at: the employer's own ATS link found on an aggregator
+page, or the `url` of a record the user merged into this one.
+
+```jsonc
+"url": "https://boards.greenhouse.io/acme/jobs/4012345",
+"aliasUrls": ["https://jobs.example.com/listing/4012345"]
+```
+
+The problem it exists for: one posting, reached two ways, becomes two records. A user saves a job
+from an aggregator, follows "Apply" to the employer's Workday/Greenhouse/Lever page, and saves it
+again. Those two URLs share no host, no path and no parameter, so no canonicalisation rule in §2
+can ever relate them, and none should try — the rule that governs §2 is that over-merging destroys
+a record. An alias is the missing thing: a link between two URLs, recorded by somebody with more
+context than a URL parser.
+
+- **`url` stays canonical, and `id` never moves.** No value of `aliasUrls` may change a record's
+  identity; see §2, "An alias is not an identity". Sending an alias to *make* two records converge
+  does not work and is not what the field is for — supply the same `id`, or let the user merge.
+- **Each entry must be an absolute `http` or `https` URL** — the same bar `url` clears in §3.
+- **An entry that is not is DROPPED, with a warning. The record is never refused for it.** Losing
+  one alias costs the user a duplicate they can still merge by hand; losing the record costs them
+  the application. This is stricter than `url`, which keeps a non-absolute string (§3): `url` has a
+  corpus of half-typed values in existing backups to protect and is what the row renders, whereas
+  an alias is machine-recorded, is never rendered as the row's link, and — not being
+  canonicalisable — could never match anything anyway.
+- **An `aliasUrls` that is left empty by that, or that you send empty, is removed.** "No aliases"
+  has one representation: an absent key.
+- **Send anything that is not an array** — a bare string, an object — **and the record is
+  refused**, like any other field whose declared type is wrong.
+- **Order and spelling are yours.** Entries are stored verbatim. offlinecv compares them by their
+  §2 canonical form when it looks for duplicates, so `www.` and a `utm_` parameter do not make two
+  entries out of one, but it does not rewrite what you sent.
+
+The field is additive: recording an alias never rewrites the record it points at. That is also why
+it is the one field a re-capture **unions** rather than overwriting — see §5. What offlinecv
+does with it locally — surface a "looks like the same posting" prompt, and merge only when the
+user clicks — is this build's business, not the contract's. A producer's obligation ends at
+sending true URLs.
+
+**No `JOB_CAPTURE_CONTRACT_VERSION` bump for this field**, for the reason given in §8: it is
+additive and optional, and a build that predates it preserves it as an unknown extra key (§1).
+
+---
+
+## 10. Failure handling
 
 `captureJob` returns `{ ok: false, reasons: string[] }`. Each reason names the field and what it
 should have been. Nothing is written.
@@ -377,7 +479,7 @@ written — must never abort the restore partway.
 
 ---
 
-## 9. Changing this contract
+## 11. Changing this contract
 
 Adding a field to `JobRecord` (`src/lib/storage/types.ts`) will not compile until you add a matching
 rule to `JOB_RECORD_RULES` (`src/lib/storage/job-record-contract.ts`), because that map is typed

--- a/src/components/features/JobDuplicateNotice.tsx
+++ b/src/components/features/JobDuplicateNotice.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobDuplicateNotice — the inline "looks like the same posting" affordance on a
+ * job tracker row (#746), with **Merge** and **Not the same**.
+ *
+ * The one product rule this component exists to hold: **nothing merges without
+ * an explicit click.** Under-merging leaves a duplicate the user deletes in one
+ * click; over-merging destroys a record — so this surface only ever *offers*.
+ * The offer itself is gated on `probable` or better (`useJobDuplicates`), and
+ * the click is a two-step confirm, the same shape the row's own Remove uses so
+ * a stray click cannot collapse two applications into one.
+ *
+ * Merging is directional and the direction is the user's: the affordance shows
+ * on BOTH rows of a pairing, and "Merge into this one" makes the row you are
+ * reading the survivor. That is how the user picks which record's status,
+ * notes-first-paragraph and canonical URL stay — see `job-merge.ts`, which
+ * keeps the survivor's fields and fills only what it lacks.
+ *
+ * Split from `JobTrackerEntry` rather than grown into it, the way
+ * `JobLetterIndicator` was: that file already sits past the ~200 LOC feature
+ * guideline, and this is a self-contained offer → confirm → act state machine
+ * rather than a couple of lines of row markup.
+ *
+ * Reuse analysis: `Button` from `@design-system`, no raw `<button>`, no
+ * hand-rolled banner — the muted-panel look is `border-border-light` +
+ * `bg-surface-subtle`, the same semantic tokens the row itself uses. No
+ * `Dialog`: a modal for a suggestion the user is entitled to ignore would
+ * interrupt a list they are scanning, which is what the inline confirm avoids.
+ */
+
+import { useState } from "react";
+import { Button } from "@design-system";
+import type { JobDuplicateSuggestion } from "../../hooks/useJobDuplicates.ts";
+
+/** How the notice opens, per confidence. `certain` states the evidence because
+ *  it HAS evidence — somebody recorded these two URLs as one posting — while
+ *  `probable` is an inference and says so. A `possible` match never reaches
+ *  this component; see `isActionableDuplicate`. */
+const LEAD_IN: Record<JobDuplicateSuggestion["confidence"], string> = {
+  certain: "Same posting as another saved job — they share a URL:",
+  probable: "Looks like the same posting as another saved job:",
+  possible: "May be the same posting as another saved job:",
+};
+
+interface JobDuplicateNoticeProps {
+  /** The row this notice sits on. Becomes the SURVIVOR of any merge started
+   *  here. */
+  jobId: string;
+  /** Actionable, undismissed matches for this row. Empty or omitted renders
+   *  nothing — an untouched library carries no notice. */
+  duplicates?: readonly JobDuplicateSuggestion[];
+  /** `(survivorId, absorbedId)` — this row survives. */
+  onMerge: (survivorId: string, absorbedId: string) => void;
+  /** "Not the same": suppress this pairing durably, in both directions. */
+  onDismiss: (a: string, b: string) => void;
+}
+
+export function JobDuplicateNotice({
+  jobId,
+  duplicates = [],
+  onMerge,
+  onDismiss,
+}: JobDuplicateNoticeProps) {
+  // The id of the match whose merge is awaiting confirmation, or null. A single
+  // value rather than a set: confirming one suggestion while another is already
+  // half-confirmed is a state with no user meaning.
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  if (duplicates.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {duplicates.map(({ job: other, confidence }) => (
+        <div
+          key={other.id}
+          className="flex flex-col gap-1 rounded-md border border-border-light bg-surface-subtle p-2"
+        >
+          <p className="text-sm text-content-secondary">
+            {LEAD_IN[confidence]}{" "}
+            <span className="text-content-primary">{other.title || "Untitled job"}</span>
+          </p>
+          {other.url && (
+            <span className="truncate text-xs text-content-muted">{other.url}</span>
+          )}
+          {confirming === other.id ? (
+            <div className="flex flex-wrap items-center gap-1 text-sm text-content-secondary">
+              <span>Keep this row and fold the other one into it?</span>
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => {
+                  setConfirming(null);
+                  onMerge(jobId, other.id);
+                }}
+              >
+                Confirm merge
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-1">
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(other.id)}>
+                Merge into this one
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => onDismiss(jobId, other.id)}>
+                Not the same
+              </Button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/JobStatusPicker.tsx
+++ b/src/components/features/JobStatusPicker.tsx
@@ -7,11 +7,19 @@
  * current status is the primary button, the rest are ghost buttons that switch
  * to that status on click. Also exports the shared status → label / badge-tone
  * maps so the row badge and the picker never disagree.
+ *
+ * Selection is by BUCKET, not by string identity (#744). A row stored as
+ * `shared` used to match none of the six and render with no selection at all —
+ * six ghost buttons and no indication of where the job was. It now shows
+ * Interested selected, and clicking Interested is a genuine no-op rather than a
+ * write of `interested` over `shared`. Moving to a DIFFERENT bucket writes that
+ * bucket's canonical status, which is the ordinary transition.
  */
 
 import { Button, type StatusBadgeTone } from "@design-system";
 import { JOB_STATUS_ORDER } from "../../lib/storage/index.ts";
 import type { JobStatus } from "../../lib/storage/index.ts";
+import { jobStatusBucket } from "../../lib/job-status-bucket.ts";
 
 const STATUS_LABEL: Record<JobStatus, string> = {
   interested: "Interested",
@@ -49,28 +57,45 @@ export function jobStatusTone(status: string): StatusBadgeTone {
 }
 
 interface JobStatusPickerProps {
-  value: JobStatus;
+  /** The row's STORED status, which may sit outside `JobStatus` — a synced or
+   *  imported record carries whatever its producer wrote, and the record
+   *  contract preserves it verbatim. Typed `string` so that is stated rather
+   *  than assumed away by the `JobStatus` on `JobRecord`. */
+  value: string;
+  /** Fired only for a bucket the row is not already in, and always with a
+   *  canonical `JobStatus` — the picker never echoes a foreign status back. */
   onChange: (status: JobStatus) => void;
 }
 
 export function JobStatusPicker({ value, onChange }: JobStatusPickerProps) {
+  const current = jobStatusBucket(value);
   return (
     <div
       className="flex flex-wrap items-center gap-1"
       role="group"
       aria-label="Application status"
     >
-      {JOB_STATUS_ORDER.map((status) => (
-        <Button
-          key={status}
-          variant={status === value ? "primary" : "ghost"}
-          size="sm"
-          aria-pressed={status === value}
-          onClick={() => onChange(status)}
-        >
-          {STATUS_LABEL[status]}
-        </Button>
-      ))}
+      {JOB_STATUS_ORDER.map((status) => {
+        const selected = status === current;
+        return (
+          <Button
+            key={status}
+            variant={selected ? "primary" : "ghost"}
+            size="sm"
+            aria-pressed={selected}
+            // No handler at all on the selected bucket, rather than an
+            // idempotent-looking `onChange(status)`. For a row stored as
+            // `shared` that call would write `interested` — not a no-op but a
+            // silent normalisation, destroying the meaning its producer
+            // attached and bumping `updatedAt` for nothing. Left focusable and
+            // enabled: `disabled` would drop the button out of the tab order,
+            // and "you are already here" is not an unavailable action.
+            onClick={selected ? undefined : () => onChange(status)}
+          >
+            {STATUS_LABEL[status]}
+          </Button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/features/JobTracker.test.tsx
+++ b/src/components/features/JobTracker.test.tsx
@@ -19,6 +19,7 @@ import { SECTION_PAGE_SIZE } from "./JobTrackerStatusGroup.tsx";
 import type { JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import type { JobRecord, LetterRecord } from "../../lib/storage/index.ts";
 import type { JobRating } from "../../lib/job-search/rating.ts";
+import type { JobDuplicateSuggestion } from "../../hooks/useJobDuplicates.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -61,6 +62,7 @@ function makeTracker(jobs: JobRecord[]): Tracker {
     link: vi.fn(async () => {}),
     unlink: vi.fn(async () => {}),
     remove: vi.fn(async () => {}),
+    merge: vi.fn(async () => {}),
     saveFromMatch: vi.fn(async () => "new-id"),
     exportBackup: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),
@@ -265,6 +267,40 @@ describe("JobTracker: letter indicator (#715)", () => {
     expect(
       container.querySelector('button[aria-label="View cover letter"]'),
     ).toBeNull();
+  });
+});
+
+describe("JobTracker: origin phrase on the tracker row (#745)", () => {
+  it("shows a short phrase for a recognised origin", () => {
+    const tracker = makeTracker([job({ id: "j1", title: "Shared job", origin: "shared" })]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(container.textContent).toContain("shared with you");
+  });
+
+  it("renders nothing when origin is absent — the common case", () => {
+    const tracker = makeTracker([job({ id: "j1", title: "Plain job" })]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    for (const phrase of [
+      "captured from a posting",
+      "from a job alert",
+      "shared with you",
+      "imported from a backup",
+      "added manually",
+    ]) {
+      expect(container.textContent).not.toContain(phrase);
+    }
+  });
+
+  it("never repeats the status badge's own text as the origin phrase", () => {
+    // The row's badge already prints the literal status via jobStatusLabel;
+    // the origin phrase exists to answer a different question ("how did this
+    // get here"), not to echo it as a second chip.
+    const tracker = makeTracker([
+      job({ id: "j1", title: "Applied via alert", status: "applied", origin: "alert" }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(container.textContent).toContain("Applied");
+    expect(container.textContent).toContain("from a job alert");
   });
 });
 
@@ -513,5 +549,288 @@ describe("JobTracker: collapsible status sections (#740)", () => {
     // Three of the five rows sit behind a collapsed header, and the total still
     // matches — the counts are the bucket length, never the rendered slice.
     expect(rows()).toHaveLength(2);
+  });
+});
+
+describe("JobTracker: lifecycle buckets over raw statuses (#744)", () => {
+  /** A record carrying a status outside this build's lifecycle, the way a synced
+   *  one does. The cast is the same deliberate lie `JobRecord.status` makes: the
+   *  record contract accepts and preserves any string. FROZEN, so a view-time
+   *  normalisation would throw here rather than pass quietly. */
+  function synced(
+    over: Omit<Partial<JobRecord>, "status"> & { status: string },
+  ): JobRecord {
+    return Object.freeze(
+      job({ ...over, status: over.status as JobRecord["status"] }),
+    );
+  }
+
+  function sectionHeadings(): string[] {
+    return [...container.querySelectorAll("h3")].map((h) => h.textContent ?? "");
+  }
+
+  function rowFor(title: string): HTMLLIElement {
+    const row = [...container.querySelectorAll("li")].find((li) =>
+      li.textContent?.includes(title),
+    );
+    if (!row) throw new Error(`no row for "${title}"`);
+    return row;
+  }
+
+  /** That row's status picker specifically — scoped by the group's own label so
+   *  the assertions can't be satisfied by some other pressed control. */
+  function pickerFor(title: string): HTMLElement {
+    const picker = rowFor(title).querySelector<HTMLElement>(
+      '[role="group"][aria-label="Application status"]',
+    );
+    if (!picker) throw new Error(`no status picker in the row for "${title}"`);
+    return picker;
+  }
+
+  function buttonIn(scope: ParentNode, label: string): HTMLButtonElement {
+    const button = [...scope.querySelectorAll("button")].find(
+      (b) => b.textContent === label,
+    );
+    if (!button) throw new Error(`no "${label}" button in scope`);
+    return button;
+  }
+
+  function click(button: Element) {
+    act(() => button.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  }
+
+  /** The four pre-application statuses a Recruidea sync produces — one stage of
+   *  a job search, spelled four ways. */
+  const PRE_APPLICATION = [
+    synced({ id: "a", title: "Ours", status: "interested" }),
+    synced({ id: "b", title: "Manually saved", status: "saved" }),
+    synced({ id: "c", title: "From an alert", status: "scouted" }),
+    synced({ id: "d", title: "Sponsor share", status: "shared" }),
+  ];
+
+  it("renders one Interested section holding every pre-application status", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker(PRE_APPLICATION)} />));
+
+    expect(sectionHeadings()).toHaveLength(1);
+    expect(sectionHeadings()[0]).toContain("Interested · 4");
+    // No parallel Saved / Scouted / Shared sections beside it.
+    const headings = sectionHeadings().join(" ");
+    for (const gone of ["Saved ·", "Scouted ·", "Shared ·"]) {
+      expect(headings).not.toContain(gone);
+    }
+    // And the section is open, so all four rows are actually on screen.
+    expect(container.querySelectorAll("li")).toHaveLength(4);
+    for (const { title } of PRE_APPLICATION) {
+      expect(container.textContent).toContain(title);
+    }
+  });
+
+  it("leaves the stored status byte-identical through a render", () => {
+    // Asserted on the RECORD, not the DOM: grouping is a view concern and must
+    // not normalise what a producer wrote. The fixtures are frozen, so a write
+    // would throw here rather than pass quietly.
+    const jobs = PRE_APPLICATION;
+    act(() => root.render(<JobTracker tracker={makeTracker(jobs)} />));
+    expect(jobs.map((j) => j.status)).toEqual([
+      "interested",
+      "saved",
+      "scouted",
+      "shared",
+    ]);
+  });
+
+  it("shows Interested as the selected button on a shared row", () => {
+    act(() => root.render(<JobTracker tracker={makeTracker(PRE_APPLICATION)} />));
+    const picker = pickerFor("Sponsor share");
+    expect(buttonIn(picker, "Interested").getAttribute("aria-pressed")).toBe("true");
+    // …and exactly one button is selected, not zero (the pre-#744 bug) and not
+    // several.
+    expect(picker.querySelectorAll('button[aria-pressed="true"]')).toHaveLength(1);
+  });
+
+  it("writes nothing when the user clicks the bucket a shared row is already in", () => {
+    const tracker = makeTracker([...PRE_APPLICATION]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+
+    click(buttonIn(pickerFor("Sponsor share"), "Interested"));
+
+    expect(tracker.setStatus).not.toHaveBeenCalled();
+    // The record still says what its producer said — no idempotent-looking
+    // write of `interested` over `shared`.
+    expect(tracker.jobs.find((j) => j.id === "d")?.status).toBe("shared");
+  });
+
+  it("writes the canonical status when a shared row moves to a different bucket", () => {
+    const tracker = makeTracker([...PRE_APPLICATION]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+
+    click(buttonIn(pickerFor("Sponsor share"), "Applied"));
+
+    // The ordinary transition, and it writes the lifecycle's own vocabulary —
+    // never an echo of the foreign status.
+    expect(tracker.setStatus).toHaveBeenCalledWith("d", "applied");
+  });
+
+  it("folds withdrawn into the rejected bucket", () => {
+    const tracker = makeTracker([
+      synced({ id: "w", title: "Pulled out", status: "withdrawn" }),
+      synced({ id: "r", title: "Turned down", status: "rejected" }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(sectionHeadings()).toHaveLength(1);
+    expect(sectionHeadings()[0]).toContain("Rejected · 2");
+  });
+
+  it("still gives a status outside both vocabularies its own expanded section", () => {
+    // The escape hatch #744 narrows but does not remove. `ghosted` maps to
+    // nothing, so it heads its own section under its literal string, expanded.
+    const tracker = makeTracker([
+      synced({ id: "s", title: "Sponsor share", status: "shared" }),
+      synced({ id: "g", title: "Weird one", status: "ghosted" }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+
+    const headings = sectionHeadings();
+    expect(headings).toHaveLength(2);
+    expect(headings.join(" ")).toContain("ghosted · 1");
+    expect(container.textContent).toContain("Weird one");
+    // No selection on a row the picker genuinely cannot place — the honest
+    // state, and the one a click can repair.
+    expect(
+      pickerFor("Weird one").querySelectorAll('button[aria-pressed="true"]'),
+    ).toHaveLength(0);
+  });
+
+  it("keeps the header total equal to the sum of section counts across buckets", () => {
+    const tracker = makeTracker([
+      ...PRE_APPLICATION,
+      synced({ id: "w", title: "Pulled out", status: "withdrawn" }),
+      synced({ id: "g", title: "Weird one", status: "ghosted" }),
+    ]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+
+    const sum = sectionHeadings()
+      .map((text) => Number(text.split("·").pop()))
+      .reduce((a, b) => a + b, 0);
+    expect(sum).toBe(6);
+    expect(container.textContent).toContain("Tracked jobs");
+    expect(container.querySelector("header")?.textContent).toContain("6");
+  });
+});
+
+describe("JobTracker: the duplicate affordance never merges on its own (#746)", () => {
+  const ATS = "https://boards.greenhouse.io/acme/jobs/1";
+  const AGGREGATOR = "https://jobs.example.com/listing/1";
+
+  function click(label: string) {
+    const button = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === label,
+    );
+    expect(button, `no button labelled "${label}"`).toBeDefined();
+    act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  }
+
+  function pairedTracker() {
+    const a = job({ id: "a", title: "Senior Frontend Engineer", url: ATS });
+    const b = job({ id: "b", title: "Senior Frontend Engineer", url: AGGREGATOR });
+    const suggestion = (other: JobRecord): JobDuplicateSuggestion[] => [
+      { job: other, confidence: "probable" },
+    ];
+    return {
+      tracker: makeTracker([a, b]),
+      duplicatesByJobId: new Map<string, readonly JobDuplicateSuggestion[]>([
+        ["a", suggestion(b)],
+        ["b", suggestion(a)],
+      ]),
+    };
+  }
+
+  it("shows the affordance for a probable match, and merges nothing by rendering it", () => {
+    const { tracker, duplicatesByJobId } = pairedTracker();
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          duplicatesByJobId={duplicatesByJobId}
+          onDismissDuplicate={vi.fn()}
+        />,
+      ),
+    );
+    expect(container.textContent).toContain("Looks like the same posting");
+    expect(container.textContent).toContain(AGGREGATOR);
+    expect(tracker.merge).not.toHaveBeenCalled();
+  });
+
+  it("does not merge on the first click — the offer only opens a confirm", () => {
+    const { tracker, duplicatesByJobId } = pairedTracker();
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          duplicatesByJobId={duplicatesByJobId}
+          onDismissDuplicate={vi.fn()}
+        />,
+      ),
+    );
+    click("Merge into this one");
+    expect(tracker.merge).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("fold the other one into it");
+  });
+
+  it("merges only on the explicit confirm, with the clicked row as the survivor", () => {
+    const { tracker, duplicatesByJobId } = pairedTracker();
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          duplicatesByJobId={duplicatesByJobId}
+          onDismissDuplicate={vi.fn()}
+        />,
+      ),
+    );
+    click("Merge into this one");
+    click("Confirm merge");
+    // The FIRST row's offer was clicked, so the first row survives.
+    expect(tracker.merge).toHaveBeenCalledWith("a", "b");
+  });
+
+  it("cancels back to the offer without merging", () => {
+    const { tracker, duplicatesByJobId } = pairedTracker();
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          duplicatesByJobId={duplicatesByJobId}
+          onDismissDuplicate={vi.fn()}
+        />,
+      ),
+    );
+    click("Merge into this one");
+    click("Cancel");
+    expect(tracker.merge).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Looks like the same posting");
+  });
+
+  it("'Not the same' suppresses the pairing and merges nothing", () => {
+    const { tracker, duplicatesByJobId } = pairedTracker();
+    const onDismissDuplicate = vi.fn();
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          duplicatesByJobId={duplicatesByJobId}
+          onDismissDuplicate={onDismissDuplicate}
+        />,
+      ),
+    );
+    click("Not the same");
+    expect(onDismissDuplicate).toHaveBeenCalledWith("a", "b");
+    expect(tracker.merge).not.toHaveBeenCalled();
+  });
+
+  it("renders no notice at all for a caller that supplied no matches", () => {
+    const { tracker } = pairedTracker();
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    expect(container.textContent).not.toContain("Looks like the same posting");
   });
 });

--- a/src/components/features/JobTracker.tsx
+++ b/src/components/features/JobTracker.tsx
@@ -25,18 +25,36 @@
  * POLICY; `JobTrackerStatusGroup` owns one bucket's open/closed and page state,
  * which the parent cannot hold because the bucket count is data, not a fixed
  * set of `useState`s.
+ *
+ * Duplicates (#746): `JobTrackerSection` owns `useJobDuplicates` the same way it
+ * owns the two hooks above — one sweep for the whole library, grouped by job id
+ * and handed down. Computed on VIEW and never stored, for the reason ratings
+ * are: a stored "these two are the same posting" verdict goes stale the moment
+ * a title is edited. Nothing here merges anything; the row's notice offers, and
+ * `tracker.merge` only ever runs from a click on it.
+ *
+ * Buckets, not raw statuses (#744): sections key on `jobStatusBucket(status)`,
+ * so a synced record's `saved` / `scouted` / `shared` share the one Interested
+ * section instead of splitting one pipeline stage into four. That mapping is
+ * strictly a VIEW concern — this surface never writes a normalised status back
+ * over what a producer stored.
  */
 
 import { useMemo } from "react";
 import { Card, Button, StatusBadge } from "@design-system";
 import { formatBytes } from "../../lib/format-bytes.ts";
-import { EVICTION_NOTICE, JOB_STATUS_ORDER } from "../../lib/storage/index.ts";
-import type { JobRecord, JobStatus, LetterRecord } from "../../lib/storage/index.ts";
+import { EVICTION_NOTICE, JOB_STATUS_ORDER, isKnownStatus } from "../../lib/storage/index.ts";
+import type { JobRecord, LetterRecord } from "../../lib/storage/index.ts";
+import { jobStatusBucket } from "../../lib/job-status-bucket.ts";
 import { JobTrackerEntry, type LinkableResume } from "./JobTrackerEntry.tsx";
 import { JobTrackerStatusGroup, isCollapsedByDefault } from "./JobTrackerStatusGroup.tsx";
 import { useJobTracker, type JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import { useSavedJobRatings } from "../../hooks/useSavedJobRatings.ts";
 import { useJobLetters } from "../../hooks/useJobLetters.ts";
+import {
+  useJobDuplicates,
+  type JobDuplicateSuggestion,
+} from "../../hooks/useJobDuplicates.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import type { JobRating } from "../../lib/job-search/rating.ts";
 
@@ -60,6 +78,14 @@ interface JobTrackerProps {
   /** Every letter, grouped by job id (#715) — `useJobLetters`' shape. A job id
    *  absent from the map has no letters, so its row renders no indicator. */
   lettersById?: ReadonlyMap<string, readonly LetterRecord[]>;
+  /** Other saved jobs that look like the same posting, per job id (#746) —
+   *  `useJobDuplicates`' shape, already filtered to `probable`-or-better and to
+   *  pairings the user has not dismissed. Omitted renders no notice anywhere,
+   *  which is what a caller that has not run the sweep should get. */
+  duplicatesByJobId?: ReadonlyMap<string, readonly JobDuplicateSuggestion[]>;
+  /** "Not the same" — suppress one pairing durably. Required alongside
+   *  `duplicatesByJobId` for either to reach a row. */
+  onDismissDuplicate?: (a: string, b: string) => void;
 }
 
 /**
@@ -71,7 +97,15 @@ interface JobTrackerProps {
 export function JobTrackerSection({
   parsed,
   ...props
-}: Omit<JobTrackerProps, "tracker" | "ratings" | "hasResume" | "lettersById"> & {
+}: Omit<
+  JobTrackerProps,
+  | "tracker"
+  | "ratings"
+  | "hasResume"
+  | "lettersById"
+  | "duplicatesByJobId"
+  | "onDismissDuplicate"
+> & {
   /** The résumé saved jobs are rated against — the `/` handoff `JobsApp` holds.
    *  Must be referentially stable; `useSavedJobRatings` deps on it directly. */
   parsed?: HeuristicParsedResume;
@@ -79,12 +113,15 @@ export function JobTrackerSection({
   const tracker = useJobTracker();
   const ratings = useSavedJobRatings(tracker.jobs, parsed);
   const letters = useJobLetters();
+  const duplicates = useJobDuplicates(tracker.jobs);
   return (
     <JobTracker
       tracker={tracker}
       ratings={ratings}
       hasResume={parsed !== undefined}
       lettersById={letters.byJobId}
+      duplicatesByJobId={duplicates.byJobId}
+      onDismissDuplicate={duplicates.dismiss}
       {...props}
     />
   );
@@ -97,29 +134,36 @@ export function JobTracker({
   resumeName,
   resumeOptions,
   lettersById,
+  duplicatesByJobId,
+  onDismissDuplicate,
 }: JobTrackerProps) {
-  const { jobs, ready, persisted, usageBytes, update, setStatus, link, unlink, remove, create, exportBackup } =
+  const { jobs, ready, persisted, usageBytes, update, setStatus, link, unlink, remove, merge, create, exportBackup } =
     tracker;
 
-  // One pass, bucketed by each job's ACTUAL status string — canonical lifecycle
-  // statuses in order first, then any status not in JOB_STATUS_ORDER (a corrupt
-  // or future-version imported record). Keying the render on JOB_STATUS_ORDER
-  // alone would silently drop such a job: it'd still count toward the header
-  // total but appear in no section, so the count would exceed the visible rows.
+  // One pass, bucketed by each job's DISPLAY bucket rather than its literal
+  // status string (#744): a synced record's `saved` / `scouted` / `shared` are
+  // one stage of a job search, not three, and this surface renders stages. The
+  // record itself is untouched — `jobStatusBucket` maps at VIEW time only, and
+  // the row badge still prints the stored status verbatim.
+  //
+  // Canonical lifecycle buckets in order first, then any bucket `jobStatusBucket`
+  // could not map (a corrupt or future-version imported record), sorted. Keying
+  // the render on JOB_STATUS_ORDER alone would silently drop such a job: it'd
+  // still count toward the header total but appear in no section, so the count
+  // would exceed the visible rows.
   const groups = useMemo(() => {
     const buckets = new Map<string, JobRecord[]>();
     for (const job of jobs) {
-      const bucket = buckets.get(job.status);
+      const key = jobStatusBucket(job.status);
+      const bucket = buckets.get(key);
       if (bucket) bucket.push(job);
-      else buckets.set(job.status, [job]);
+      else buckets.set(key, [job]);
     }
     const known = JOB_STATUS_ORDER.filter((status) => buckets.has(status));
-    const unknown = [...buckets.keys()]
-      .filter((status) => !JOB_STATUS_ORDER.includes(status as JobStatus))
-      .sort();
-    return [...known, ...unknown].map((status) => ({
-      status,
-      jobs: buckets.get(status) ?? [],
+    const unknown = [...buckets.keys()].filter((key) => !isKnownStatus(key)).sort();
+    return [...known, ...unknown].map((bucket) => ({
+      bucket,
+      jobs: buckets.get(bucket) ?? [],
     }));
   }, [jobs]);
 
@@ -128,7 +172,7 @@ export function JobTracker({
   // which would otherwise render as a page of headers over no rows, the very
   // failure collapse-by-default exists to avoid. Then every section opens; the
   // "only non-empty bucket is rejected" case is the single-bucket case of it.
-  const anyOpenByDefault = groups.some(({ status }) => !isCollapsedByDefault(status));
+  const anyOpenByDefault = groups.some(({ bucket }) => !isCollapsedByDefault(bucket));
 
   if (!ready) return null;
 
@@ -178,12 +222,12 @@ export function JobTracker({
         </p>
       ) : (
         <div className="flex flex-col gap-4">
-          {groups.map(({ status, jobs: group }) => (
+          {groups.map(({ bucket, jobs: group }) => (
             <JobTrackerStatusGroup
-              key={status}
-              status={status}
+              key={bucket}
+              bucket={bucket}
               jobs={group}
-              defaultExpanded={!anyOpenByDefault || !isCollapsedByDefault(status)}
+              defaultExpanded={!anyOpenByDefault || !isCollapsedByDefault(bucket)}
               renderRow={(job) => (
                 <JobTrackerEntry
                   job={job}
@@ -196,6 +240,11 @@ export function JobTracker({
                   rated={ratings !== null}
                   rating={ratings?.get(job.id)}
                   letters={lettersById?.get(job.id)}
+                  duplicates={duplicatesByJobId?.get(job.id)}
+                  onMerge={(survivorId, absorbedId) =>
+                    void merge(survivorId, absorbedId)
+                  }
+                  onDismissDuplicate={onDismissDuplicate}
                   onUpdate={(id, patch) => void update(id, patch)}
                   onStatusChange={(id, next) => void setStatus(id, next)}
                   onLinkResume={(id, resumeId) => void link(id, resumeId)}

--- a/src/components/features/JobTrackerEntry.tsx
+++ b/src/components/features/JobTrackerEntry.tsx
@@ -24,15 +24,44 @@
  * owns the click/acknowledge/reveal state machine and renders nothing when
  * the array is empty. Kept as a whole sibling component rather than inlined
  * here, both to reuse the "letters" concern and to avoid growing this file.
+ *
+ * Duplicate notice (#746): `duplicates` is other saved jobs that look like the
+ * same posting, handed straight to `JobDuplicateNotice`, which owns the
+ * offer → confirm → merge state machine and renders nothing when the list is
+ * empty. Kept as a whole sibling component for the reason `JobLetterIndicator`
+ * is: this file is already past the size guideline, and a merge is the one
+ * action here that destroys a record, so it gets its own place to say so.
+ *
+ * Origin phrase (#745): `job.origin` is display-only provenance — "how did
+ * this row get here" — and this is the one place in the app allowed to read
+ * it (see `JobRecord.origin`'s docblock and the structural test that
+ * enforces it). Deliberately a plain muted caption, not a second
+ * `StatusBadge`: the badge above already answers "what stage is this at" via
+ * `jobStatusLabel`, and a second chip repeating that would be noise. Renders
+ * nothing when the field is absent, which is the common case — every job
+ * this build's own UI creates has no origin.
  */
 
 import { useState } from "react";
 import { Button, EditableField, RatingStars, StatusBadge } from "@design-system";
 import { JobStatusPicker, jobStatusTone, jobStatusLabel } from "./JobStatusPicker.tsx";
 import { JobLetterIndicator } from "./JobLetterIndicator.tsx";
-import type { JobRecord, JobStatus, LetterRecord } from "../../lib/storage/index.ts";
+import { JobDuplicateNotice } from "./JobDuplicateNotice.tsx";
+import type { JobDuplicateSuggestion } from "../../hooks/useJobDuplicates.ts";
+import type { JobOrigin, JobRecord, JobStatus, LetterRecord } from "../../lib/storage/index.ts";
 import type { JobPatch } from "../../lib/job-tracker.ts";
 import { describeRating, type JobRating } from "../../lib/job-search/rating.ts";
+
+/** One short phrase per {@link JobOrigin}, never a sentence — see the
+ *  docblock above. A `Record`, not a lookup function, so a `JobOrigin` added
+ *  without a phrase here is a compile error rather than a blank caption. */
+const ORIGIN_PHRASE: Record<JobOrigin, string> = {
+  capture: "captured from a posting",
+  alert: "from a job alert",
+  shared: "shared with you",
+  import: "imported from a backup",
+  manual: "added manually",
+};
 
 /** A saved resume the user can link this job to — the light shape the picker
  *  renders, structurally satisfied by `ResumeLibraryEntry`. */
@@ -58,6 +87,14 @@ interface JobTrackerEntryProps {
   /** This job's letters, most-recently-updated first (#715). Empty/omitted
    *  renders no indicator — see `JobLetterIndicator`. */
   letters?: readonly LetterRecord[];
+  /** Other saved jobs that look like the same posting (#746). Rendered by the
+   *  sibling `JobDuplicateNotice`, and only when both handlers below come with
+   *  it — a merge offer with nowhere to send the click would be a button that
+   *  lies. Omitted by any caller that has not run the sweep. */
+  duplicates?: readonly JobDuplicateSuggestion[];
+  /** `(survivorId, absorbedId)`, with THIS row as the survivor. */
+  onMerge?: (survivorId: string, absorbedId: string) => void;
+  onDismissDuplicate?: (a: string, b: string) => void;
   onUpdate: (id: string, patch: JobPatch) => void;
   onStatusChange: (id: string, status: JobStatus) => void;
   onLinkResume: (id: string, resumeId: string) => void;
@@ -80,6 +117,9 @@ export function JobTrackerEntry({
   rated = false,
   rating,
   letters,
+  duplicates,
+  onMerge,
+  onDismissDuplicate,
   onUpdate,
   onStatusChange,
   onLinkResume,
@@ -113,6 +153,9 @@ export function JobTrackerEntry({
             </StatusBadge>
             <JobLetterIndicator letters={letters} />
           </div>
+          {job.origin && (
+            <span className="text-xs text-content-muted">{ORIGIN_PHRASE[job.origin]}</span>
+          )}
           {rated && !rating && (
             <span className="text-xs text-content-muted">
               Not rated · no job description saved
@@ -135,6 +178,15 @@ export function JobTrackerEntry({
           )}
         </div>
       </div>
+
+      {duplicates && onMerge && onDismissDuplicate && (
+        <JobDuplicateNotice
+          jobId={job.id}
+          duplicates={duplicates}
+          onMerge={onMerge}
+          onDismiss={onDismissDuplicate}
+        />
+      )}
 
       <JobStatusPicker
         value={job.status}

--- a/src/components/features/JobTrackerStatusGroup.tsx
+++ b/src/components/features/JobTrackerStatusGroup.tsx
@@ -58,26 +58,32 @@ export const SECTION_PAGE_SIZE = 25;
  * useful open. `offer` is deliberately NOT here — `JOB_STATUS_ORDER`'s docblock
  * calls it terminal, but it is terminal in the way a user wants to look at.
  *
- * Every other status opens expanded, INCLUDING one this build does not know
- * (a corrupt or future-version imported record): a bucket the app cannot
- * explain is the one the user most needs to see.
+ * Every other bucket opens expanded, INCLUDING one this build does not know
+ * (a corrupt or future-version imported record `jobStatusBucket` could not
+ * map): a bucket the app cannot explain is the one the user most needs to see.
  */
 const COLLAPSED_BY_DEFAULT: readonly string[] = ["rejected", "archived"];
 
-/** Whether this status's bucket opens closed. Takes the raw status string, not
- *  `JobStatus`, because the tracker groups on whatever the record carries. */
-export function isCollapsedByDefault(status: string): boolean {
-  return COLLAPSED_BY_DEFAULT.includes(status);
+/** Whether this bucket opens closed. Takes the DISPLAY bucket key, not a stored
+ *  status, so a status that maps into a terminal bucket (`withdrawn` →
+ *  `rejected`, #744) collapses with it rather than opening on its own. Typed
+ *  `string` rather than `JobStatus` because an unmapped status buckets as
+ *  itself. */
+export function isCollapsedByDefault(bucket: string): boolean {
+  return COLLAPSED_BY_DEFAULT.includes(bucket);
 }
 
 export function JobTrackerStatusGroup({
-  status,
+  bucket,
   jobs,
   defaultExpanded,
   renderRow,
 }: {
-  /** The raw status string this bucket holds — may be outside `JobStatus`. */
-  status: string;
+  /** The DISPLAY bucket this section holds (#744) — a `JobStatus` for anything
+   *  `jobStatusBucket` could map, otherwise the literal stored status. Never a
+   *  value to write back: the rows inside may each carry a different stored
+   *  status, and the header speaks for the bucket, not for any one of them. */
+  bucket: string;
   /** Every job in the bucket, in the parent's order. Not sliced by the caller:
    *  the header count and the page arithmetic both need the full length. */
   jobs: readonly JobRecord[];
@@ -151,7 +157,9 @@ export function JobTrackerStatusGroup({
   const current = Math.min(page, pageCount);
   const start = (current - 1) * SECTION_PAGE_SIZE;
   const shown = jobs.slice(start, start + SECTION_PAGE_SIZE);
-  const label = jobStatusLabel(status);
+  // `jobStatusLabel` still takes the raw string and falls back to it, so an
+  // unmapped bucket heads its section with its literal status.
+  const label = jobStatusLabel(bucket);
 
   return (
     <section className="flex flex-col gap-2">

--- a/src/components/features/SaveJobFromMatch.test.tsx
+++ b/src/components/features/SaveJobFromMatch.test.tsx
@@ -58,6 +58,7 @@ function makeTracker(): Tracker {
     link: vi.fn(async () => {}),
     unlink: vi.fn(async () => {}),
     remove: vi.fn(async () => {}),
+    merge: vi.fn(async () => {}),
     saveFromMatch: vi.fn(async () => "new-id"),
     exportBackup: vi.fn(async () => {}),
     refresh: vi.fn(async () => {}),

--- a/src/hooks/useJobDuplicates.ts
+++ b/src/hooks/useJobDuplicates.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useJobDuplicates — the tracker's view of "which saved jobs look like the same
+ * posting" (#746). A thin subscription wrapper, in the shape
+ * `useSectionRewriteLock` establishes: every rule that decides anything lives in
+ * `src/lib/job-duplicates.ts` (pure, testable at module scope) and
+ * `src/lib/job-duplicate-dismissals.ts` (the durable "Not the same"), and this
+ * hook only holds the memo and the one piece of state.
+ *
+ * ## Computed on VIEW, never stored
+ *
+ * The same rule `useSavedJobRatings` follows: a stored "these two are
+ * duplicates" verdict would go stale the moment the user edits a title, with
+ * nothing to invalidate it. So the sweep runs over the current list.
+ * `findDuplicatePairs` is indexed rather than quadratic for exactly this reason.
+ *
+ * ## Only actionable matches come out
+ *
+ * `possible` matches are dropped here rather than in the lib: the pure module's
+ * job is to report every tier it can distinguish, and the decision that a
+ * merge affordance needs `probable` or better is a product one
+ * ({@link isActionableDuplicate} states it once, and this is its only caller).
+ * A pairing the user dismissed is filtered on the same pass — reading the
+ * dismissals fresh into state at mount, so a reload does not re-offer a merge
+ * the user already declined.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  findDuplicatePairs,
+  isActionableDuplicate,
+  jobPairKey,
+  type JobDuplicateConfidence,
+} from "../lib/job-duplicates.ts";
+import {
+  dismissJobPair,
+  readDismissedJobPairs,
+} from "../lib/job-duplicate-dismissals.ts";
+import type { JobRecord } from "../lib/storage/index.ts";
+
+/** One "this row may be the same posting as that one" suggestion, resolved to
+ *  the other record so a row can name it. */
+export interface JobDuplicateSuggestion {
+  /** The OTHER job — the one this row would absorb on a merge. */
+  job: JobRecord;
+  confidence: JobDuplicateConfidence;
+}
+
+export interface JobDuplicates {
+  /** Actionable, undismissed suggestions per job id. A job id absent from the
+   *  map has none, so its row renders nothing. */
+  byJobId: ReadonlyMap<string, readonly JobDuplicateSuggestion[]>;
+  /** "Not the same" — suppress this pairing durably, in both directions. */
+  dismiss: (a: string, b: string) => void;
+}
+
+export function useJobDuplicates(jobs: readonly JobRecord[]): JobDuplicates {
+  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(() =>
+    readDismissedJobPairs(),
+  );
+
+  const byJobId = useMemo(() => {
+    const byId = new Map(jobs.map((job) => [job.id, job]));
+    const suggestions = new Map<string, JobDuplicateSuggestion[]>();
+    for (const pair of findDuplicatePairs(jobs)) {
+      if (!isActionableDuplicate(pair.confidence)) continue;
+      if (dismissed.has(jobPairKey(pair.a, pair.b))) continue;
+      const a = byId.get(pair.a);
+      const b = byId.get(pair.b);
+      if (a === undefined || b === undefined) continue;
+      // Both directions: whichever row the user is looking at should be able to
+      // be the survivor, which is how they choose which record's status stays.
+      push(suggestions, a.id, { job: b, confidence: pair.confidence });
+      push(suggestions, b.id, { job: a, confidence: pair.confidence });
+    }
+    return suggestions;
+  }, [jobs, dismissed]);
+
+  const dismiss = useCallback((a: string, b: string) => {
+    dismissJobPair(a, b);
+    // Re-read rather than adding to the in-memory set, so the state can never
+    // claim a suppression that localStorage refused to store (a full quota, a
+    // locked-down browser). The prompt returning is the honest outcome there.
+    setDismissed(readDismissedJobPairs());
+  }, []);
+
+  return { byJobId, dismiss };
+}
+
+function push(
+  index: Map<string, JobDuplicateSuggestion[]>,
+  key: string,
+  value: JobDuplicateSuggestion,
+): void {
+  const bucket = index.get(key);
+  if (bucket) bucket.push(value);
+  else index.set(key, [value]);
+}

--- a/src/hooks/useJobTracker.ts
+++ b/src/hooks/useJobTracker.ts
@@ -20,6 +20,7 @@ import {
   linkResume,
   unlinkResume,
   removeJob,
+  mergeJobs,
   createTrackedJobFromMatch,
   type NewJobInput,
   type JobPatch,
@@ -47,6 +48,11 @@ export interface JobTracker {
   link: (id: string, resumeId: string) => Promise<void>;
   unlink: (id: string) => Promise<void>;
   remove: (id: string) => Promise<void>;
+  /** Fold `absorbedId` into `survivorId` (#746): the survivor keeps its own
+   *  fields and gains the other's, including its URL as an alias, and the
+   *  absorbed record is tombstoned. Never called except from an explicit user
+   *  click — see `mergeJobs`. */
+  merge: (survivorId: string, absorbedId: string) => Promise<void>;
   /** "Save this job" from the JD-match flow — carries JD text + match result. */
   saveFromMatch: (
     input: Parameters<typeof createTrackedJobFromMatch>[0],
@@ -134,6 +140,14 @@ export function useJobTracker(): JobTracker {
     [refresh],
   );
 
+  const merge = useCallback(
+    async (survivorId: string, absorbedId: string) => {
+      await mergeJobs(survivorId, absorbedId);
+      await refresh();
+    },
+    [refresh],
+  );
+
   const saveFromMatch = useCallback(
     async (input: Parameters<typeof createTrackedJobFromMatch>[0]) => {
       await ensurePersistence();
@@ -157,6 +171,7 @@ export function useJobTracker(): JobTracker {
     link,
     unlink,
     remove,
+    merge,
     saveFromMatch,
     exportBackup,
     refresh,

--- a/src/lib/job-duplicate-dismissals.test.ts
+++ b/src/lib/job-duplicate-dismissals.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * "Not the same", remembered (#746). The property that matters is durability
+ * across a reload, which here is a fresh read of `localStorage` — the module
+ * caches nothing, so a second read IS what the next session sees. The other
+ * half is the failure direction: an unusable or corrupt store must read as
+ * "nothing dismissed" (ask again), never as "everything dismissed" (silently
+ * suppress a merge the user never declined).
+ *
+ * The `localStorage` shim is installed globally before every test by
+ * `src/test-setup.ts`.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  dismissJobPair,
+  readDismissedJobPairs,
+} from "./job-duplicate-dismissals.ts";
+import { jobPairKey } from "./job-duplicates.ts";
+
+describe("job-duplicate-dismissals", () => {
+  it("starts empty", () => {
+    expect(readDismissedJobPairs().size).toBe(0);
+  });
+
+  it("remembers a dismissed pairing across a fresh read — the reload case", () => {
+    dismissJobPair("a", "b");
+    expect(readDismissedJobPairs().has(jobPairKey("a", "b"))).toBe(true);
+  });
+
+  it("suppresses the pairing in both directions", () => {
+    dismissJobPair("b", "a");
+    expect(readDismissedJobPairs().has(jobPairKey("a", "b"))).toBe(true);
+  });
+
+  it("does not suppress an unrelated pairing", () => {
+    dismissJobPair("a", "b");
+    expect(readDismissedJobPairs().has(jobPairKey("a", "c"))).toBe(false);
+  });
+
+  it("is idempotent — dismissing twice stores one entry", () => {
+    dismissJobPair("a", "b");
+    dismissJobPair("a", "b");
+    expect(readDismissedJobPairs().size).toBe(1);
+  });
+
+  it("accumulates rather than replacing", () => {
+    dismissJobPair("a", "b");
+    dismissJobPair("c", "d");
+    expect(readDismissedJobPairs().size).toBe(2);
+  });
+
+  it("reads a corrupt value as nothing dismissed, so it re-asks rather than suppressing", () => {
+    globalThis.localStorage.setItem("offlinecv:jobs:not-duplicates", "{not json");
+    expect(readDismissedJobPairs().size).toBe(0);
+  });
+
+  it("ignores non-string entries in an otherwise readable list", () => {
+    globalThis.localStorage.setItem(
+      "offlinecv:jobs:not-duplicates",
+      JSON.stringify([jobPairKey("a", "b"), 42, null]),
+    );
+    expect([...readDismissedJobPairs()]).toEqual([jobPairKey("a", "b")]);
+  });
+
+  it("fails silent when the store refuses a write, and does not claim the suppression", () => {
+    const setItem = vi
+      .spyOn(globalThis.localStorage, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("QuotaExceededError");
+      });
+    expect(() => dismissJobPair("a", "b")).not.toThrow();
+    setItem.mockRestore();
+    expect(readDismissedJobPairs().size).toBe(0);
+  });
+});

--- a/src/lib/job-duplicate-dismissals.ts
+++ b/src/lib/job-duplicate-dismissals.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-duplicate-dismissals — the "Not the same" half of the duplicate
+ * affordance (#746): which pairings of tracked jobs the user has already told
+ * us are two different postings, remembered across reloads.
+ *
+ * ## Why this is not a field on `JobRecord`
+ *
+ * A dismissal is symmetric — it is about a PAIR, not about either record — so
+ * storing it on a record means writing to two of them. That write is the
+ * problem, and it is a product problem rather than a plumbing one: `saveJob`
+ * stamps `updatedAt` on a user action, the tracker sorts most-recently-updated
+ * first, and dismissing a prompt would therefore jump both jobs to the top of
+ * the list. A UI dismissal must not reorder the user's library.
+ *
+ * It also has no business on the capture contract. That contract is normative
+ * for third-party producers (`docs/job-capture-contract.md`), and a producer is
+ * in no position to assert that the USER decided two of their records are
+ * different postings — the same reason `captureJob` strips a `deletedAt`.
+ *
+ * ## Why localStorage rather than a store of its own
+ *
+ * An IndexedDB store would cost a schema-version bump and a place in the backup
+ * document, for a preference. localStorage is where this app already keeps
+ * durable UI decisions (`letter-egress-ack.ts`, `usePersistentFlag.ts`,
+ * `useModelSelection.ts`), and the failure direction is the safe one: if the
+ * value is lost — private browsing, a cleared origin, a full quota — the user
+ * is asked once more about a pairing they already judged. That costs a prompt,
+ * never a record, which is the same asymmetry the whole feature is built on.
+ * Fail-silent throughout, for the same reason.
+ *
+ * Entries are never pruned. A dismissal naming a job that has since been
+ * deleted (or merged away) is inert — nothing pairs against an id that is no
+ * longer in the library — and pruning against the live ids would forget the
+ * judgement for a job that a re-capture legitimately revives under the same id
+ * (see `capture.ts`). Two ids per entry is a cost worth not managing.
+ */
+
+import { jobPairKey } from "./job-duplicates.ts";
+
+const KEY = "offlinecv:jobs:not-duplicates";
+
+/** Every dismissed pairing. An unreadable, absent or malformed value reads as
+ *  "nothing dismissed", which re-asks rather than silently suppressing. */
+export function readDismissedJobPairs(): ReadonlySet<string> {
+  try {
+    const raw = globalThis.localStorage?.getItem(KEY);
+    if (raw === null || raw === undefined) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((entry): entry is string => typeof entry === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+/** Record that the user said two jobs are different postings. Idempotent. */
+export function dismissJobPair(a: string, b: string): void {
+  const pairs = new Set(readDismissedJobPairs());
+  pairs.add(jobPairKey(a, b));
+  try {
+    globalThis.localStorage?.setItem(KEY, JSON.stringify([...pairs]));
+  } catch {
+    // Fail silent — quota / private mode / security error. The prompt returns
+    // next session, which is the safe direction to fail in: the alternative is
+    // suppressing a suggestion we did not manage to remember.
+  }
+}

--- a/src/lib/job-duplicates.test.ts
+++ b/src/lib/job-duplicates.test.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Duplicate detection (#746). The four cases the issue names are the spine —
+ * an alias hit, same company + title, same company + DIFFERENT title (must not
+ * match), different company + same title (must not match) — because the last
+ * two are what stop the tracker offering a merge that destroys a record.
+ *
+ * Minimal typed stubs over full fixtures, the shape `contact.test.ts` uses:
+ * every field this module reads is named in the stub, and nothing else matters
+ * to it.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  findDuplicatePairs,
+  isActionableDuplicate,
+  jobDuplicateConfidence,
+  jobPairKey,
+} from "./job-duplicates.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+function job(over: Partial<JobRecord>): JobRecord {
+  return {
+    id: over.id ?? "job-x",
+    createdAt: 1,
+    updatedAt: 1,
+    title: "Senior Frontend Engineer",
+    company: "Acme",
+    status: "interested",
+    ...over,
+  };
+}
+
+const AGGREGATOR = "https://jobs.example.com/listing/4012345";
+const ATS = "https://boards.greenhouse.io/acme/jobs/4012345";
+
+describe("jobDuplicateConfidence: the four cases the issue names", () => {
+  it("alias hit — one record's url is in the other's aliasUrls — is `certain`", () => {
+    const a = job({ id: "a", url: AGGREGATOR });
+    const b = job({ id: "b", url: ATS, aliasUrls: [AGGREGATOR], company: "Acme Corp" });
+    // Both directions, and across a company disagreement the URL evidence
+    // outranks: an aggregator and an ATS routinely spell the company apart.
+    expect(jobDuplicateConfidence(a, b)).toBe("certain");
+    expect(jobDuplicateConfidence(b, a)).toBe("certain");
+  });
+
+  it("alias-alias intersection — both records share a common alias URL — is `certain`", () => {
+    const a = job({ id: "a", url: "https://first-canonical.com/1", aliasUrls: [AGGREGATOR] });
+    const b = job({ id: "b", url: "https://second-canonical.com/2", aliasUrls: [AGGREGATOR], company: "Acme Corp" });
+    expect(jobDuplicateConfidence(a, b)).toBe("certain");
+    expect(jobDuplicateConfidence(b, a)).toBe("certain");
+  });
+
+  it("same company + same title is `probable`", () => {
+    const a = job({ id: "a", url: AGGREGATOR });
+    const b = job({ id: "b", url: ATS });
+    expect(jobDuplicateConfidence(a, b)).toBe("probable");
+  });
+
+  it("same company + DIFFERENT title does NOT match", () => {
+    const a = job({ id: "a", title: "Senior Frontend Engineer" });
+    const b = job({ id: "b", title: "Director of Finance" });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("different company + same title does NOT match", () => {
+    const a = job({ id: "a", company: "Acme" });
+    const b = job({ id: "b", company: "Globex" });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+});
+
+describe("jobDuplicateConfidence: what must never pair", () => {
+  // The single most reachable over-match: `company` is documented as "may be
+  // empty when the user hasn't filled it in yet", so a library of half-filled
+  // rows would otherwise be one giant duplicate cluster.
+  it("two blank companies are not a match, whatever the titles say", () => {
+    const a = job({ id: "a", company: "", title: "Engineer" });
+    const b = job({ id: "b", company: "", title: "Engineer" });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("two blank titles at one company are not a match", () => {
+    const a = job({ id: "a", title: "" });
+    const b = job({ id: "b", title: "" });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("an alias that is not an absolute http(s) URL matches nothing", () => {
+    const a = job({ id: "a", url: AGGREGATOR, company: "Acme" });
+    const b = job({ id: "b", company: "Globex", aliasUrls: ["jobs.example.com/listing/4012345"] });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("survives a record whose fields are not the types they claim", () => {
+    // Reachable: `saveJob` writes whatever a caller supplies and a restored
+    // backup predates every field here. A throw would take the whole tracker
+    // render down.
+    const hostile = { id: "b", createdAt: 1, updatedAt: 1, status: "interested" } as unknown as JobRecord;
+    Object.assign(hostile, { title: 42, company: null, aliasUrls: "not-an-array", url: 7 });
+    expect(jobDuplicateConfidence(job({ id: "a" }), hostile)).toBeNull();
+  });
+});
+
+describe("jobDuplicateConfidence: normalisation", () => {
+  it("ignores case, punctuation and a trailing legal form on the company", () => {
+    const a = job({ id: "a", company: "Acme, Inc." });
+    const b = job({ id: "b", company: "acme" });
+    expect(jobDuplicateConfidence(a, b)).toBe("probable");
+  });
+
+  it("keeps a company whose whole name is a legal form, so it cannot normalise to blank", () => {
+    const a = job({ id: "a", company: "Limited" });
+    const b = job({ id: "b", company: "" });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("ignores case and punctuation in the title", () => {
+    const a = job({ id: "a", title: "Senior Frontend Engineer" });
+    const b = job({ id: "b", title: "  senior  frontend/engineer " });
+    expect(jobDuplicateConfidence(a, b)).toBe("probable");
+  });
+
+  it("matches an alias across a `www.` prefix and a tracking parameter", () => {
+    // Canonicalisation is READ from `job-url.ts`, never reimplemented — the same
+    // rules that decide identity decide whether two spellings are one alias.
+    const a = job({ id: "a", url: "https://www.jobs.example.com/listing/4012345?utm_source=li" });
+    const b = job({ id: "b", company: "Globex", aliasUrls: [AGGREGATOR] });
+    expect(jobDuplicateConfidence(a, b)).toBe("certain");
+  });
+
+  it("treats two records holding the same posting URL as `certain`", () => {
+    // The duplicate a user can make entirely inside this app: "Add a job" mints
+    // a UUID rather than deriving an id, so pasting one URL twice makes two rows.
+    const a = job({ id: "a", url: ATS, company: "Acme" });
+    const b = job({ id: "b", url: `${ATS}#apply`, company: "Globex", title: "Something else" });
+    expect(jobDuplicateConfidence(a, b)).toBe("certain");
+  });
+});
+
+describe("jobDuplicateConfidence: the `possible` tier", () => {
+  const JD_A =
+    "Build and ship the customer dashboard in React and TypeScript. Own accessibility, performance budgets and the design system.";
+  const JD_B =
+    "Own accessibility, performance budgets and the design system. Build and ship the customer dashboard in React and TypeScript, with a focus on testing.";
+
+  it("same company + similar title + overlapping description is `possible`", () => {
+    const a = job({ id: "a", title: "Senior Frontend Engineer", jdText: JD_A });
+    const b = job({ id: "b", title: "Frontend Engineer II", jdText: JD_B });
+    expect(jobDuplicateConfidence(a, b)).toBe("possible");
+  });
+
+  it("a similar title with NO overlapping description does not match", () => {
+    const a = job({ id: "a", title: "Senior Frontend Engineer", jdText: JD_A });
+    const b = job({
+      id: "b",
+      title: "Frontend Engineer II",
+      jdText: "Maintain the payroll batch pipeline in COBOL for our banking clients.",
+    });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("a similar title with no descriptions at all does not match", () => {
+    const a = job({ id: "a", title: "Senior Frontend Engineer" });
+    const b = job({ id: "b", title: "Frontend Engineer II" });
+    expect(jobDuplicateConfidence(a, b)).toBeNull();
+  });
+
+  it("is below the bar for offering a merge", () => {
+    expect(isActionableDuplicate("possible")).toBe(false);
+    expect(isActionableDuplicate("probable")).toBe(true);
+    expect(isActionableDuplicate("certain")).toBe(true);
+  });
+});
+
+describe("jobPairKey", () => {
+  it("is the same key whichever side asks", () => {
+    expect(jobPairKey("a", "b")).toBe(jobPairKey("b", "a"));
+  });
+
+  it("cannot collide two different pairings that share a concatenation", () => {
+    expect(jobPairKey("a b", "c")).not.toBe(jobPairKey("a", "b c"));
+  });
+});
+
+describe("findDuplicatePairs", () => {
+  it("reports one pairing once, with `a` < `b`", () => {
+    const pairs = findDuplicatePairs([
+      job({ id: "b", url: ATS }),
+      job({ id: "a", url: AGGREGATOR }),
+    ]);
+    expect(pairs).toEqual([{ a: "a", b: "b", confidence: "probable" }]);
+  });
+
+  it("finds an alias hit across a company disagreement, which no company bucket could", () => {
+    const pairs = findDuplicatePairs([
+      job({ id: "a", url: AGGREGATOR, company: "Acme via ExampleJobs", title: "Frontend dev" }),
+      job({ id: "b", url: ATS, company: "Acme", aliasUrls: [AGGREGATOR] }),
+    ]);
+    expect(pairs).toEqual([{ a: "a", b: "b", confidence: "certain" }]);
+  });
+
+  it("keeps the STRONGEST confidence when both passes find one pairing", () => {
+    // Same company + title (probable) AND an alias hit (certain). The alias is
+    // the evidence somebody actually recorded, so it must win.
+    const pairs = findDuplicatePairs([
+      job({ id: "a", url: AGGREGATOR }),
+      job({ id: "b", url: ATS, aliasUrls: [AGGREGATOR] }),
+    ]);
+    expect(pairs).toEqual([{ a: "a", b: "b", confidence: "certain" }]);
+  });
+
+  it("never pairs a record with itself", () => {
+    const self = job({ id: "a", url: AGGREGATOR, aliasUrls: [AGGREGATOR] });
+    expect(findDuplicatePairs([self])).toEqual([]);
+  });
+
+  it("reports nothing for a library of unrelated jobs", () => {
+    expect(
+      findDuplicatePairs([
+        job({ id: "a", company: "Acme", title: "Frontend Engineer" }),
+        job({ id: "b", company: "Globex", title: "Backend Engineer" }),
+        job({ id: "c", company: "Initech", title: "" }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("finds a pair by alias-alias intersection when neither has it as canonical url", () => {
+    const a = job({ id: "a", url: "https://first-canonical.com/1", aliasUrls: [AGGREGATOR] });
+    const b = job({ id: "b", url: "https://second-canonical.com/2", aliasUrls: [AGGREGATOR], company: "Acme Corp" });
+    expect(findDuplicatePairs([a, b])).toEqual([{ a: "a", b: "b", confidence: "certain" }]);
+  });
+});

--- a/src/lib/job-duplicates.ts
+++ b/src/lib/job-duplicates.ts
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-duplicates — "do these two tracked records look like the same posting?"
+ * (#746). Pure, zero-storage, zero-UI: it reads two {@link JobRecord}s and
+ * returns a confidence, and every caller decides for itself what to do with the
+ * answer. Sibling of `job-status-bucket.ts`, and testable at module scope for
+ * the same reason.
+ *
+ * ## Why this exists at all
+ *
+ * `deriveJobId` (`storage/job-url.ts`) is a pure function of the canonicalised
+ * URL, and it refuses to guess beyond what cannot plausibly distinguish two
+ * postings, because **under-merging is a duplicate the user can delete;
+ * over-merging destroys a record.** An aggregator listing and the employer's own
+ * ATS page for one job share no host, no path and no parameter, so no URL rule
+ * can ever relate them and none should try. The missing piece was never a better
+ * URL rule — it was any representation of "these two URLs are the same posting".
+ * `JobRecord.aliasUrls` is that representation, and this module is what reads it.
+ *
+ * ## This module NEVER decides anything
+ *
+ * It reports evidence; it does not merge, write, or rank. The asymmetry above
+ * forbids an automatic merge outright — this build has no evidence source strong
+ * enough to overrule it — so the strongest thing a caller may do with a
+ * {@link JobDuplicateConfidence} is *offer* a merge that a user then clicks.
+ * Nothing here reads or writes `id`: an alias is display/dedupe evidence and
+ * must never fork the id space.
+ *
+ * ## Totality
+ *
+ * Every field is read through {@link text} / an `Array.isArray` guard rather
+ * than trusted from the type. Records reach the `jobs` store through a
+ * deliberately permissive write (`saveJob`) and from a backup file that may
+ * predate any field here, so a record whose `title` is not a string is
+ * reachable — and this function runs on every tracker render. It degrades to
+ * "no evidence", never to a throw.
+ */
+
+import { canonicalJobUrl } from "./storage/index.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+/**
+ * How strongly two records look like one posting.
+ *
+ * - `certain` — their URL sets intersect: one record's `url` is the other's, or
+ *   appears in the other's `aliasUrls`. Somebody with more context than a URL
+ *   parser (a user who merged, a producer that followed an "Apply" link) said
+ *   these are the same page.
+ * - `probable` — same normalised company AND same normalised title. Strong, but
+ *   inference: a company really can post two identically-titled roles.
+ * - `possible` — same company, similar title, overlapping description. Weak by
+ *   construction, and deliberately below the bar {@link isActionableDuplicate}
+ *   sets, so no merge affordance is ever offered on it.
+ */
+export type JobDuplicateConfidence = "certain" | "probable" | "possible";
+
+const CONFIDENCE_RANK: Record<JobDuplicateConfidence, number> = {
+  possible: 1,
+  probable: 2,
+  certain: 3,
+};
+
+/**
+ * Whether a confidence is strong enough to put a *merge* in front of the user.
+ * `probable` and up. A `possible` match is computed, and is worth having as a
+ * distinct answer, but offering a destructive action on "same company, similar
+ * title" would invert the asymmetry this whole module is written around.
+ */
+export function isActionableDuplicate(confidence: JobDuplicateConfidence): boolean {
+  return CONFIDENCE_RANK[confidence] >= CONFIDENCE_RANK.probable;
+}
+
+/**
+ * Fraction of the SMALLER token set the two share. Containment rather than
+ * Jaccard: "Senior Frontend Engineer" against a 900-word job description is a
+ * containment of 1 and a Jaccard of ~0.003, and it is containment that says
+ * what we mean — does the shorter text appear inside the longer one.
+ */
+function containment(a: ReadonlySet<string>, b: ReadonlySet<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  let shared = 0;
+  for (const token of small) if (large.has(token)) shared += 1;
+  return shared / small.size;
+}
+
+/** Title-token containment at or above which two titles count as "similar".
+ *  A guess, not a measurement — it only ever gates the `possible` tier, which
+ *  no affordance acts on, so the cost of it being wrong is bounded to a value
+ *  nothing renders. */
+const SIMILAR_TITLE = 0.6;
+
+/** Description-token containment at or above which two job descriptions count
+ *  as overlapping. Same bounded blast radius as {@link SIMILAR_TITLE}. */
+const OVERLAPPING_DESCRIPTION = 0.5;
+
+/** Description tokens shorter than this are dropped before comparing: "a",
+ *  "of", "to" appear in every posting ever written and would float the
+ *  containment of two unrelated descriptions. Titles are NOT filtered this way —
+ *  "QA" and "ML" are the whole signal in a title. */
+const DESCRIPTION_TOKEN_MIN_LENGTH = 3;
+
+/** Anything that is not a letter or a number, in any script. `\p{L}\p{N}` and
+ *  not `a-z0-9`, so "Nestlé" and "楽天" normalise to themselves rather than to
+ *  a stump. */
+const NON_WORD = /[^\p{L}\p{N}]+/gu;
+
+/** A field's value if it is really a string, otherwise the empty string — see
+ *  the totality note in the module docblock. */
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** Lowercased, punctuation-flattened, whitespace-collapsed. The one place
+ *  "normalised" is defined for this module. */
+function normalise(value: unknown): string {
+  return text(value).toLowerCase().replace(NON_WORD, " ").trim();
+}
+
+function tokenSet(value: unknown, minLength: number): Set<string> {
+  const tokens = new Set<string>();
+  for (const token of normalise(value).split(" ")) {
+    if (token.length >= minLength) tokens.add(token);
+  }
+  return tokens;
+}
+
+/**
+ * Trailing legal-form words dropped from a company name, so the ATS's
+ * "Acme, Inc." and the aggregator's "Acme" are one company. Only ever stripped
+ * from the END, where a legal form actually sits — a leading or interior match
+ * ("Co-operative Bank") is a real word.
+ *
+ * Stripping widens what counts as the same company, which widens what can be
+ * offered as a merge, so the list stays short and boring: only forms that are
+ * legal suffixes and nothing else in ordinary company-name usage.
+ */
+const LEGAL_SUFFIXES = new Set([
+  "inc",
+  "incorporated",
+  "llc",
+  "ltd",
+  "limited",
+  "corp",
+  "corporation",
+  "company",
+  "gmbh",
+  "plc",
+  "ag",
+  "bv",
+  "nv",
+  "pty",
+  "pvt",
+  "pte",
+  "oy",
+  "ab",
+]);
+
+function normaliseCompany(value: unknown): string {
+  const words = normalise(value).split(" ").filter((word) => word.length > 0);
+  // `> 1`, so a company whose whole name is a legal form ("Limited") keeps it
+  // rather than normalising to the empty string, which would then match every
+  // other blank-company record.
+  while (words.length > 1 && LEGAL_SUFFIXES.has(words[words.length - 1])) words.pop();
+  return words.join(" ");
+}
+
+/**
+ * One record reduced to what a comparison needs. Built once per record per
+ * sweep so {@link findDuplicatePairs} normalises N records instead of N²
+ * pairs — at a few hundred saved jobs the difference is the whole cost.
+ */
+interface Fingerprint {
+  id: string;
+  /** Canonical form of `url`, or undefined when there is none to canonicalise. */
+  canonicalUrl?: string;
+  /** Canonical forms of `aliasUrls`. Entries that do not canonicalise are
+   *  dropped: they can never match anything, and the capture contract refuses
+   *  them at the boundary anyway (§9). */
+  aliases: Set<string>;
+  company: string;
+  title: string;
+  titleTokens: Set<string>;
+  jdText: string;
+  /** Filled by {@link jdTokensOf} on first use. Tokenising a job description is
+   *  the one expensive step here and only the `possible` tier ever needs it, so
+   *  a library where no pair has a similar title never pays for it. */
+  jdTokens?: Set<string>;
+}
+
+function jdTokensOf(print: Fingerprint): Set<string> {
+  print.jdTokens ??= tokenSet(print.jdText, DESCRIPTION_TOKEN_MIN_LENGTH);
+  return print.jdTokens;
+}
+
+function fingerprint(job: JobRecord): Fingerprint {
+  const aliases = new Set<string>();
+  // `Array.isArray`, not `?? []`: a stored record's `aliasUrls` is only as
+  // typed as whatever wrote it, and `for…of` over a non-iterable throws.
+  if (Array.isArray(job.aliasUrls)) {
+    for (const alias of job.aliasUrls) {
+      const canonical = canonicalJobUrl(text(alias));
+      if (canonical !== undefined) aliases.add(canonical);
+    }
+  }
+  return {
+    id: job.id,
+    canonicalUrl: canonicalJobUrl(text(job.url)),
+    aliases,
+    company: normaliseCompany(job.company),
+    title: normalise(job.title),
+    titleTokens: tokenSet(job.title, 1),
+    jdText: text(job.jdText),
+  };
+}
+
+/**
+ * Do the two records' URL sets intersect?
+ *
+ * Both directions of the alias check, plus the degenerate case where the two
+ * records simply hold the same posting URL. That last one is not a new identity
+ * rule and changes nothing about `deriveJobId`: it is the *existing* rule read
+ * as evidence. Two records with one canonical URL are the same posting by the
+ * capture contract's own definition (§2) — they only exist as two rows because
+ * the tracker's own "Add a job" mints a UUID rather than deriving an id, so the
+ * one duplicate a user can produce entirely inside this app would otherwise be
+ * the one duplicate this module could not see.
+ */
+function sharesAUrl(a: Fingerprint, b: Fingerprint): boolean {
+  if (a.canonicalUrl !== undefined && a.canonicalUrl === b.canonicalUrl) return true;
+  if (a.canonicalUrl !== undefined && b.aliases.has(a.canonicalUrl)) return true;
+  if (b.canonicalUrl !== undefined && a.aliases.has(b.canonicalUrl)) return true;
+
+  // Intersecting alias sets (#746) — both records are aliases of a common third URL,
+  // indicating they are views of the same underlying posting.
+  for (const alias of a.aliases) {
+    if (b.aliases.has(alias)) return true;
+  }
+  return false;
+}
+
+function compare(a: Fingerprint, b: Fingerprint): JobDuplicateConfidence | null {
+  if (sharesAUrl(a, b)) return "certain";
+  // An empty company is the common case for a half-filled record, not a match:
+  // without this, every blank-company job would pair with every other one.
+  if (a.company === "" || a.company !== b.company) return null;
+  if (a.title !== "" && a.title === b.title) return "probable";
+  if (containment(a.titleTokens, b.titleTokens) < SIMILAR_TITLE) return null;
+  if (containment(jdTokensOf(a), jdTokensOf(b)) < OVERLAPPING_DESCRIPTION) return null;
+  return "possible";
+}
+
+/**
+ * How strongly `a` and `b` look like the same posting, or null for no evidence.
+ *
+ * Symmetric, and deliberately does NOT check that the two ids differ: "are
+ * these the same posting" has an honest answer for a record compared with
+ * itself, and it is the caller's business not to ask. {@link findDuplicatePairs}
+ * never does.
+ */
+export function jobDuplicateConfidence(
+  a: JobRecord,
+  b: JobRecord,
+): JobDuplicateConfidence | null {
+  return compare(fingerprint(a), fingerprint(b));
+}
+
+/** One unordered pairing, with `a` < `b` so a pair has exactly one
+ *  representation whichever side found it. */
+export interface JobDuplicatePair {
+  a: string;
+  b: string;
+  confidence: JobDuplicateConfidence;
+}
+
+function pushInto<K, V>(index: Map<K, V[]>, key: K, value: V): void {
+  const bucket = index.get(key);
+  if (bucket) bucket.push(value);
+  else index.set(key, [value]);
+}
+
+/**
+ * The one identity of an unordered pairing of two records: sorted, so a pair
+ * has the same key whichever side found it, and NUL-joined — the separator
+ * `JobTrackerStatusGroup` already picked, because an id here is whatever a
+ * backup carried rather than necessarily a UUID, and a printable separator
+ * would let `("a b", "c")` and `("a", "b c")` collide on one key.
+ *
+ * Exported because `job-duplicate-dismissals.ts` keys the user's "Not the
+ * same" decisions on exactly this pairing, and two definitions of "the same
+ * pair" would silently stop suppressing what the user dismissed.
+ */
+export function jobPairKey(a: string, b: string): string {
+  return (a < b ? [a, b] : [b, a]).join("\u0000");
+}
+
+/** Record a pairing, keeping the strongest confidence when two passes find the
+ *  same pair. */
+function keepStrongest(
+  found: Map<string, JobDuplicatePair>,
+  x: Fingerprint,
+  y: Fingerprint,
+  confidence: JobDuplicateConfidence,
+): void {
+  const [a, b] = x.id < y.id ? [x.id, y.id] : [y.id, x.id];
+  const key = jobPairKey(a, b);
+  const existing = found.get(key);
+  if (existing && CONFIDENCE_RANK[existing.confidence] >= CONFIDENCE_RANK[confidence]) return;
+  found.set(key, { a, b, confidence });
+}
+
+function indexByUrl(prints: readonly Fingerprint[]): Map<string, Fingerprint[]> {
+  const byUrl = new Map<string, Fingerprint[]>();
+  for (const print of prints) {
+    if (print.canonicalUrl !== undefined) pushInto(byUrl, print.canonicalUrl, print);
+  }
+  return byUrl;
+}
+
+function findUrlPairs(
+  prints: readonly Fingerprint[],
+  byUrl: Map<string, Fingerprint[]>,
+  found: Map<string, JobDuplicatePair>
+): void {
+  // Direct canonicalUrl matches
+  for (const sharing of byUrl.values()) {
+    for (let i = 0; i < sharing.length; i++) {
+      for (let j = i + 1; j < sharing.length; j++) {
+        keepStrongest(found, sharing[i], sharing[j], "certain");
+      }
+    }
+  }
+
+  // Canonical-alias intersections
+  for (const print of prints) {
+    for (const alias of print.aliases) {
+      for (const other of byUrl.get(alias) ?? []) {
+        if (other.id !== print.id) keepStrongest(found, print, other, "certain");
+      }
+    }
+  }
+
+  // Alias-alias intersections
+  const byAlias = new Map<string, Fingerprint[]>();
+  for (const print of prints) {
+    for (const alias of print.aliases) {
+      pushInto(byAlias, alias, print);
+    }
+  }
+  for (const sharing of byAlias.values()) {
+    for (let i = 0; i < sharing.length; i++) {
+      for (let j = i + 1; j < sharing.length; j++) {
+        if (sharing[i].id !== sharing[j].id) {
+          keepStrongest(found, sharing[i], sharing[j], "certain");
+        }
+      }
+    }
+  }
+}
+
+function findCompanyPairs(
+  prints: readonly Fingerprint[],
+  found: Map<string, JobDuplicatePair>
+): void {
+  const byCompany = new Map<string, Fingerprint[]>();
+  for (const print of prints) {
+    if (print.company !== "") pushInto(byCompany, print.company, print);
+  }
+  for (const bucket of byCompany.values()) {
+    for (let i = 0; i < bucket.length; i++) {
+      for (let j = i + 1; j < bucket.length; j++) {
+        const confidence = compare(bucket[i], bucket[j]);
+        if (confidence !== null) keepStrongest(found, bucket[i], bucket[j], confidence);
+      }
+    }
+  }
+}
+
+/**
+ * Every pairing in one library that looks like a duplicate, at any confidence.
+ *
+ * Indexed rather than quadratic, because the caller is a tracker render over a
+ * library that reaches into the hundreds. Two passes, because the two kinds of
+ * evidence have different reach:
+ *
+ *  - a shared URL relates records that may disagree about the company entirely
+ *    (an aggregator's "Acme Corp" against the ATS's "Acme"), so it is found
+ *    through a URL index over the whole library;
+ *  - company+title evidence requires the companies to match by definition, so
+ *    it only ever compares within one normalised-company bucket.
+ *
+ * A record whose company normalises empty is in no bucket and can still be
+ * found by the URL pass, which is right: a blank company is missing evidence,
+ * not evidence of difference.
+ */
+export function findDuplicatePairs(jobs: readonly JobRecord[]): JobDuplicatePair[] {
+  const prints = jobs.map(fingerprint);
+  const found = new Map<string, JobDuplicatePair>();
+
+  const byUrl = indexByUrl(prints);
+  findUrlPairs(prints, byUrl, found);
+  findCompanyPairs(prints, found);
+
+  return [...found.values()];
+}

--- a/src/lib/job-merge.test.ts
+++ b/src/lib/job-merge.test.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * What a merge keeps (#746). A merge is the one tracker action that destroys a
+ * record, so these assert the direction of every rule: notes are added to and
+ * never overwritten, the survivor's own values are never replaced, and the
+ * absorbed record's URL becomes an alias rather than disappearing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mergeJobRecords } from "./job-merge.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+const AGGREGATOR = "https://jobs.example.com/listing/4012345";
+const ATS = "https://boards.greenhouse.io/acme/jobs/4012345";
+
+function job(over: Partial<JobRecord>): JobRecord {
+  return {
+    id: over.id ?? "job-x",
+    createdAt: 1,
+    updatedAt: 2,
+    title: "Senior Frontend Engineer",
+    company: "Acme",
+    status: "interested",
+    ...over,
+  };
+}
+
+describe("mergeJobRecords: the surviving record", () => {
+  it("carries both URLs — its own as `url`, the other's as an alias", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", url: ATS }),
+      job({ id: "b", url: AGGREGATOR }),
+    );
+    expect(merged.url).toBe(ATS);
+    expect(merged.aliasUrls).toEqual([AGGREGATOR]);
+  });
+
+  it("keeps the survivor's id, so identity cannot move", () => {
+    const merged = mergeJobRecords(job({ id: "a", url: ATS }), job({ id: "b", url: AGGREGATOR }));
+    expect(merged.id).toBe("a");
+  });
+
+  it("unions both records' existing aliases, deduplicated by canonical form", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", url: ATS, aliasUrls: [AGGREGATOR] }),
+      job({
+        id: "b",
+        url: `${AGGREGATOR}?utm_source=li`,
+        aliasUrls: ["https://www.jobs.example.com/listing/4012345", "https://acme.com/careers/7"],
+      }),
+    );
+    // The three spellings of the aggregator listing collapse to the one the
+    // survivor already held; the genuinely different URL is added.
+    expect(merged.aliasUrls).toEqual([AGGREGATOR, "https://acme.com/careers/7"]);
+  });
+
+  it("never lists its own url as an alias of itself", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", url: ATS }),
+      job({ id: "b", url: AGGREGATOR, aliasUrls: [`${ATS}#apply`] }),
+    );
+    expect(merged.aliasUrls).toEqual([AGGREGATOR]);
+  });
+
+  it("drops a stale alias list rather than leaving one the merge emptied", () => {
+    // The survivor had no url and one alias; it adopts that alias as its `url`,
+    // at which point nothing is an alias any more.
+    const merged = mergeJobRecords(
+      job({ id: "a", url: undefined, aliasUrls: [ATS] }),
+      job({ id: "b", url: ATS }),
+    );
+    expect(merged.url).toBe(ATS);
+    expect("aliasUrls" in merged).toBe(false);
+  });
+
+  it("drops an alias candidate that is not an absolute http(s) URL", () => {
+    // §9 of the capture contract would refuse it on the next import, so writing
+    // it would mean storing a record this build's own validator rejects.
+    const merged = mergeJobRecords(
+      job({ id: "a", url: ATS }),
+      job({ id: "b", url: "acme.com/jobs/1" }),
+    );
+    expect(merged.aliasUrls).toBeUndefined();
+  });
+});
+
+describe("mergeJobRecords: notes are concatenated, never overwritten", () => {
+  it("keeps both, survivor first", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", notes: "Referred by Dana." }),
+      job({ id: "b", notes: "Recruiter called 12 Aug." }),
+    );
+    expect(merged.notes).toBe("Referred by Dana.\n\nRecruiter called 12 Aug.");
+  });
+
+  it("takes the other's notes when the survivor has none", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a" }),
+      job({ id: "b", notes: "Recruiter called." }),
+    );
+    expect(merged.notes).toBe("Recruiter called.");
+  });
+
+  it("does not duplicate identical notes", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", notes: "Referred by Dana." }),
+      job({ id: "b", notes: " Referred by Dana. " }),
+    );
+    expect(merged.notes).toBe("Referred by Dana.");
+  });
+
+  it("invents no `notes` key when neither record had one", () => {
+    expect("notes" in mergeJobRecords(job({ id: "a" }), job({ id: "b" }))).toBe(false);
+  });
+});
+
+describe("mergeJobRecords: fills gaps, keeps what the survivor has", () => {
+  it("fills an absent field from the other record", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a" }),
+      job({ id: "b", salaryRange: "$180k – $220k", jdText: "We are hiring.", resumeId: "cv-1" }),
+    );
+    expect(merged.salaryRange).toBe("$180k – $220k");
+    expect(merged.jdText).toBe("We are hiring.");
+    expect(merged.resumeId).toBe("cv-1");
+  });
+
+  it("treats an empty string as a gap, not a statement", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", company: "", title: "" }),
+      job({ id: "b", company: "Acme", title: "Senior Frontend Engineer" }),
+    );
+    expect(merged.company).toBe("Acme");
+    expect(merged.title).toBe("Senior Frontend Engineer");
+  });
+
+  it("keeps the survivor's own value over the other's", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", company: "Acme", status: "interviewing", resumeId: "cv-1" }),
+      job({ id: "b", company: "Acme Corp", status: "rejected", resumeId: "cv-2" }),
+    );
+    expect(merged.company).toBe("Acme");
+    // The survivor's status wins even when the other's is further along — the
+    // user chooses by choosing which row survives. See the module docblock.
+    expect(merged.status).toBe("interviewing");
+    expect(merged.resumeId).toBe("cv-1");
+  });
+
+  it("carries an unknown extra key over from the absorbed record", () => {
+    // The capture contract preserves keys this build has never heard of; a
+    // merge that dropped one would be the same silent loss, one step later.
+    const absorbed = job({ id: "b" }) as unknown as Record<string, unknown>;
+    absorbed.employerRating = 4.5;
+    const merged = mergeJobRecords(job({ id: "a" }), absorbed as unknown as JobRecord);
+    expect((merged as unknown as Record<string, unknown>).employerRating).toBe(4.5);
+  });
+
+  it("leaves the store's own fields alone", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", createdAt: 10, updatedAt: 20 }),
+      job({ id: "b", createdAt: 1, updatedAt: 2 }),
+    );
+    expect(merged.createdAt).toBe(10);
+    expect(merged.updatedAt).toBe(20);
+  });
+
+  it("does not inherit the absorbed record's provenance", () => {
+    // `capture` and `origin` describe how a RECORD came to exist, so the
+    // survivor cannot acquire them: a hand-typed row that absorbs an extension
+    // capture would otherwise claim a producer that never wrote it, and render
+    // "from a job alert" for a row the user typed. See `NOT_FILLED`.
+    const merged = mergeJobRecords(
+      job({ id: "a" }),
+      job({
+        id: "b",
+        origin: "alert",
+        capture: { contract: 2, producer: "offlinecv-extension", producerVersion: "1.2" },
+      }),
+    );
+    expect("capture" in merged).toBe(false);
+    expect("origin" in merged).toBe(false);
+  });
+
+  it("keeps its own provenance when it has some", () => {
+    const merged = mergeJobRecords(
+      job({ id: "a", origin: "manual", capture: { contract: 1, producer: "mine" } }),
+      job({
+        id: "b",
+        origin: "alert",
+        capture: { contract: 2, producer: "offlinecv-extension" },
+      }),
+    );
+    expect(merged.origin).toBe("manual");
+    expect(merged.capture).toEqual({ contract: 1, producer: "mine" });
+  });
+
+  it("mutates neither argument", () => {
+    const survivor = job({ id: "a", url: ATS, notes: "Mine." });
+    const absorbed = job({ id: "b", url: AGGREGATOR, notes: "Theirs." });
+    const survivorBefore = JSON.stringify(survivor);
+    const absorbedBefore = JSON.stringify(absorbed);
+    mergeJobRecords(survivor, absorbed);
+    expect(JSON.stringify(survivor)).toBe(survivorBefore);
+    expect(JSON.stringify(absorbed)).toBe(absorbedBefore);
+  });
+
+  it("refuses to let a `__proto__` key on the absorbed record reach a prototype", () => {
+    const absorbed = JSON.parse(
+      '{"id":"b","createdAt":1,"updatedAt":2,"title":"SWE","company":"Acme","status":"interested","__proto__":{"polluted":true}}',
+    ) as JobRecord;
+    const merged = mergeJobRecords(job({ id: "a" }), absorbed);
+    expect((merged as unknown as { polluted?: boolean }).polluted).toBeUndefined();
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});

--- a/src/lib/job-merge.ts
+++ b/src/lib/job-merge.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-merge — what one tracked job looks like after another is folded into it
+ * (#746). Pure and storage-free: it takes two records and returns the record
+ * that should survive. `job-tracker.ts`'s `mergeJobs` is what writes it, and
+ * what tombstones the other one.
+ *
+ * ## Lossy in exactly one direction
+ *
+ * A merge is the one action in the tracker that destroys a record, so every
+ * rule here resolves toward keeping text the user wrote:
+ *
+ *  - **Notes are concatenated, never overwritten.** Two paragraphs about one
+ *    application are both about that application.
+ *  - **A field the survivor lacks is filled from the other; a field it has is
+ *    kept.** "Lacks" means absent OR empty, because a `company: ""` on a
+ *    half-filled record is a gap and not a statement.
+ *  - **The survivor's `url` stays canonical** and the other's becomes an
+ *    `aliasUrls` entry, which is the whole point of the field: the record now
+ *    answers to both ways the user reached the posting, and `id` — derived from
+ *    `url` and only from `url` — does not move.
+ *
+ * The rule that is NOT symmetric is `status`: the survivor's wins, so merging
+ * an `interviewing` record into an `interested` one loses the lifecycle
+ * position. That is deliberate rather than overlooked. Picking the "further
+ * along" status would need an ordering `JOB_STATUS_ORDER`'s own docblock
+ * refuses to claim (`offer`, `rejected` and `archived` are terminal branches,
+ * not later stages), and the affordance instead lets the user merge from
+ * EITHER row — choosing the survivor is how they choose which status stays.
+ *
+ * `createdAt` is not decided here at all: `putRecord` takes the existing row's
+ * value over anything a caller passes, so the survivor keeps the date it was
+ * first saved no matter what this function returns.
+ */
+
+import { dedupeCanonicalUrls } from "./storage/index.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+/**
+ * Keys the field-by-field fill never touches.
+ *
+ * The three timestamps and `id` belong to the store. `notes` and `aliasUrls`
+ * have their own rules below — a fill would overwrite one and truncate the
+ * other. `__proto__` can only arrive on a record that predates the contract
+ * check (`FORBIDDEN_KEY` in `storage/record-contract.ts` refuses it at every
+ * boundary), and assigning it by computed key would reach the prototype setter
+ * rather than write a property.
+ *
+ * `capture` and `origin` are excluded for a different reason, and it is the one
+ * worth stating: the fill exists for facts about the POSTING — a salary range,
+ * a JD, a work model — which are equally true of whichever record survives,
+ * because both records describe the same job. These two are claims about how a
+ * RECORD came to exist, which is true of one record and cannot be inherited by
+ * another. A user's hand-typed row that absorbs an extension capture would
+ * otherwise start carrying `capture: {producer: "offlinecv-extension", …}` — a
+ * compatibility claim about a record that no longer exists, made on behalf of a
+ * producer that never wrote this one (`JobRecord.capture` says "absent for
+ * every record this app creates", and §7 of `docs/job-capture-contract.md`
+ * exists so a future reader can decide whether to trust the fields) — and start
+ * rendering "from a job alert" for a row the user typed themselves.
+ */
+const NOT_FILLED = new Set([
+  "id",
+  "createdAt",
+  "updatedAt",
+  "deletedAt",
+  "notes",
+  "aliasUrls",
+  "capture",
+  "origin",
+  "__proto__",
+]);
+
+/** Absent, blank, or an empty list — the three shapes of "the user has not put
+ *  anything here", which is what makes a field eligible to be filled from the
+ *  record being absorbed. `null` is NOT missing: it is a value some producer
+ *  chose, under a key this build may not even know. */
+function isMissing(value: unknown): boolean {
+  if (value === undefined || value === "") return true;
+  return Array.isArray(value) && value.length === 0;
+}
+
+/**
+ * The two records' notes, in survivor-then-absorbed order.
+ *
+ * Returns the survivor's own value — possibly `undefined` — when there is
+ * nothing to add, so a merge cannot invent a `notes` key on a record that never
+ * had one. Text is compared trimmed but written verbatim: whitespace is not
+ * evidence of a difference, and it is also not ours to tidy.
+ */
+function joinNotes(survivor?: string, absorbed?: string): string | undefined {
+  const kept = typeof survivor === "string" ? survivor : "";
+  const added = typeof absorbed === "string" ? absorbed : "";
+  if (added.trim() === "") return survivor;
+  if (kept.trim() === "") return absorbed;
+  if (kept.trim() === added.trim()) return survivor;
+  return `${kept}\n\n${added}`;
+}
+
+/** A record's `aliasUrls` as strings, defensively: the store's write path is
+ *  permissive and a restored backup may carry anything the validator has since
+ *  learnt to drop. */
+function aliasEntries(job: JobRecord): string[] {
+  const entries = Array.isArray(job.aliasUrls) ? job.aliasUrls : [];
+  return entries.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Every other URL the merged record is reachable at: the survivor's existing
+ * aliases, then the absorbed record's `url`, then its aliases.
+ *
+ * Deduplicated by CANONICAL form while storing the spelling as it was first
+ * seen — two aliases that differ only by `www.` or a `utm_` parameter are one
+ * alias, and there is no reason to prefer a rewritten spelling of a URL the
+ * user may recognise. The final `url` is excluded for the same reason: a record
+ * listing its own address as an alias of itself says nothing.
+ *
+ * An entry that is not an absolute http(s) URL is dropped. It could never match
+ * anything (`canonicalJobUrl` is what a comparison runs through), and §9 of the
+ * capture contract would drop it on the next import anyway — writing one here
+ * would mean this build storing a record its own validator refuses. The one
+ * value that can cost: an absorbed record whose `url` the user typed by hand
+ * (`acme.com/jobs/1`) is lost when the survivor already has a `url` of its own.
+ */
+function mergeAliasUrls(
+  url: string | undefined,
+  survivor: JobRecord,
+  absorbed: JobRecord,
+): string[] {
+  return dedupeCanonicalUrls(
+    [
+      ...aliasEntries(survivor),
+      ...(typeof absorbed.url === "string" ? [absorbed.url] : []),
+      ...aliasEntries(absorbed),
+    ],
+    typeof url === "string" ? [url] : [],
+  );
+}
+
+/**
+ * `survivor` with `absorbed` folded into it. Neither argument is mutated.
+ *
+ * Unknown extra keys take part in the fill, deliberately: the capture contract
+ * preserves a key this build has never heard of precisely so a newer producer's
+ * field survives a round trip through an older build, and a merge that dropped
+ * the absorbed record's copy of one would be the same silent loss one step
+ * later.
+ */
+export function mergeJobRecords(survivor: JobRecord, absorbed: JobRecord): JobRecord {
+  const merged: JobRecord = { ...survivor };
+  const fillable = merged as unknown as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(absorbed)) {
+    if (NOT_FILLED.has(key)) continue;
+    if (!isMissing(fillable[key]) || isMissing(value)) continue;
+    fillable[key] = value;
+  }
+
+  const notes = joinNotes(survivor.notes, absorbed.notes);
+  if (notes !== undefined) merged.notes = notes;
+
+  // Read `merged.url`, not `survivor.url`: the fill above may just have given
+  // the survivor the absorbed record's URL, and that URL is now the canonical
+  // one rather than an alias of itself.
+  const aliasUrls = mergeAliasUrls(merged.url, survivor, absorbed);
+  // Assigned in BOTH directions. The spread above copied the survivor's own
+  // `aliasUrls`, so leaving an empty result alone would keep a stale list — the
+  // reachable case being a survivor whose only alias is the URL it just adopted
+  // from the absorbed record, which is no longer an alias of anything.
+  if (aliasUrls.length > 0) merged.aliasUrls = aliasUrls;
+  else delete merged.aliasUrls;
+
+  return merged;
+}

--- a/src/lib/job-origin-reach.test.ts
+++ b/src/lib/job-origin-reach.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Structural guard for `JobRecord.origin` (#745): the field is display-only by
+ * contract (see its docblock in `storage/types.ts` and §8 of
+ * `docs/job-capture-contract.md`), and the issue that added it asks for that
+ * restriction to be a real check, not a comment nobody re-reads. Every other
+ * "nothing else may reach this" invariant in this repo — the egress helper in
+ * `job-search/providers/keywords.ts`, the PII fixture rules — is enforced by a
+ * script or a test, never prose alone; this is the test for `origin`.
+ *
+ * The check is a source-text scan, not a type-system one, because the whole
+ * point is to catch a plain property READ (`job.origin`) anywhere it has no
+ * business being. It walks every non-test `.ts`/`.tsx` file under `src/` and
+ * refuses if any file OTHER than the validator (which must read it to decide
+ * whether to keep or drop it) and the tracker row (the one place it renders)
+ * contains a `.origin` property access.
+ *
+ * `\.origin\b` deliberately requires a leading `.`: an object literal that
+ * CONSTRUCTS a record (`origin: "capture"`, a fixture, a producer payload) has
+ * no dot before the key and never matches, so this only ever flags a READ.
+ * Test files are excluded — they legitimately assert on `.origin` to prove the
+ * validator and the row behave, and that assertion is not a production module
+ * reaching the field.
+ *
+ * ## The two halves match different text, on purpose
+ *
+ * The offender scan runs against raw source, comments included: a guard that
+ * over-flags sends a human to look, and one that under-flags is the bug it
+ * exists to prevent. The drift half — which asserts the allowlisted files still
+ * read the field, so the scan above cannot pass by having nothing left to find —
+ * strips comments first, because the file that RENDERS the phrase is also the
+ * file that DOCUMENTS it. `JobTrackerEntry.tsx`'s docblock contains the words
+ * "`job.origin` is display-only", which satisfies a raw-text match all by
+ * itself; stub the render out and prose alone would hold this green.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(HERE, "..");
+
+/** The only two production modules allowed to read `job.origin` (paths
+ *  relative to `src/`) — see the module docblock. */
+const ALLOWED = new Set([
+  "lib/storage/job-record-contract.ts",
+  "components/features/JobTrackerEntry.tsx",
+]);
+
+/**
+ * Simple regex property access check. Known evasion: cannot detect destructured
+ * reads like `const { origin } = job`. Added to document this limitation and
+ * advise against using destructuring to bypass this safety guard.
+ */
+const ORIGIN_READ = /\.origin\b/;
+
+/** Named on the offender assertion, because `\.origin\b` matches a property
+ *  called `origin` on ANY object and the tree is only clean of the others by
+ *  luck of what has been written so far. */
+const FALSE_POSITIVE_HINT =
+  "A `new URL(u).origin`, `location.origin` or `event.origin` (the standard " +
+  "postMessage sender check) is NOT a `JobRecord.origin` read and NOT a #745 " +
+  "violation — narrow this regex to exclude it rather than adding the file to " +
+  "ALLOWED, which would let a real read in through the same door.";
+
+/** Source with comments removed, for the drift assertion only — see the "two
+ *  halves" section of the module docblock. Crude on purpose: a `//` inside a
+ *  string literal takes the rest of that line with it, which can only drop a
+ *  read this check wanted to see and fail loudly, never invent one. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+/** Directories that hold test scaffolding rather than production code — the
+ *  same reason `*.test.ts` files are excluded below: a helper here may
+ *  legitimately read or describe an unrelated `.origin` (e.g. the parser
+ *  corpus's `.origin.json` breadcrumb convention), and none of it ships. */
+const TEST_DIRS = new Set(["node_modules", "__test-utils__"]);
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (TEST_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSourceFiles(full, out);
+      continue;
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue;
+    if (/\.test\.(ts|tsx)$/.test(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+describe("JobRecord.origin: read only by the validator and the tracker row (#745)", () => {
+  it("is not read anywhere else in src/", () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles(SRC_ROOT)) {
+      const relPath = relative(SRC_ROOT, file).split("\\").join("/");
+      if (ALLOWED.has(relPath)) continue;
+      if (ORIGIN_READ.test(readFileSync(file, "utf8"))) offenders.push(relPath);
+    }
+    expect(offenders, FALSE_POSITIVE_HINT).toEqual([]);
+  });
+
+  it("the allowlisted files still read `origin` in CODE, so this test can't pass by drift", () => {
+    // Guards against the allowlist going stale silently: if `JobTrackerEntry.tsx`
+    // stopped rendering the phrase, or the validator stopped checking the field,
+    // the test above would pass for the wrong reason — every file it scans would
+    // simply have nothing left to flag. Comments are stripped so the docblock
+    // that DESCRIBES the read cannot stand in for the read.
+    for (const relPath of ALLOWED) {
+      const code = stripComments(readFileSync(join(SRC_ROOT, relPath), "utf8"));
+      expect(ORIGIN_READ.test(code), `${relPath} no longer reads \`origin\` in code`).toBe(true);
+    }
+  });
+});

--- a/src/lib/job-status-bucket.test.ts
+++ b/src/lib/job-status-bucket.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-status-bucket (#744). The properties the tracker's grouping leans on: the
+ * canonical lifecycle is its own fixed point, the foreign aliases collapse onto
+ * the stage they mean, and anything else passes through untouched so it still
+ * gets its own fail-loud section.
+ */
+
+import { describe, it, expect } from "vitest";
+import { jobStatusBucket } from "./job-status-bucket.ts";
+import { JOB_STATUS_ORDER } from "./storage/index.ts";
+
+describe("jobStatusBucket", () => {
+  it.each(JOB_STATUS_ORDER)("leaves the canonical status %s as its own bucket", (status) => {
+    expect(jobStatusBucket(status)).toBe(status);
+  });
+
+  it("is idempotent — a bucket key re-bucketed is itself", () => {
+    // The tracker keys sections on the RESULT, and `JobStatusPicker` compares a
+    // bucket against `JOB_STATUS_ORDER`. Both break if mapping twice moves.
+    for (const status of ["shared", "saved", "scouted", "withdrawn", "ghosted", ""]) {
+      expect(jobStatusBucket(jobStatusBucket(status))).toBe(jobStatusBucket(status));
+    }
+  });
+
+  it.each(["saved", "scouted", "shared"])(
+    "buckets the pre-application status %s as interested",
+    (status) => {
+      // The three differ by how the job ARRIVED, not by pipeline stage — one
+      // section, not four (the motivating Recruidea sync).
+      expect(jobStatusBucket(status)).toBe("interested");
+    },
+  );
+
+  it("buckets withdrawn as rejected — a closed application either way", () => {
+    expect(jobStatusBucket("withdrawn")).toBe("rejected");
+  });
+
+  it("passes an unmapped status through as its own bucket", () => {
+    // The escape hatch this change narrows but does not remove: a status outside
+    // both vocabularies still gets a section labelled with its literal string.
+    expect(jobStatusBucket("ghosted")).toBe("ghosted");
+    expect(jobStatusBucket("")).toBe("");
+  });
+
+  it("matches exactly, so a differently-cased status is not folded in", () => {
+    // Deliberate: folding case would guess about a producer nobody has seen.
+    expect(jobStatusBucket("Shared")).toBe("Shared");
+    expect(jobStatusBucket("INTERESTED")).toBe("INTERESTED");
+  });
+
+  it("returns the literal string for a status that names an Object.prototype key", () => {
+    // `status` is untrusted imported data. An object-literal alias table would
+    // answer these with a function, and the tracker would key a section on a
+    // non-string — hence the `Map`.
+    for (const key of ["toString", "constructor", "hasOwnProperty", "__proto__"]) {
+      expect(jobStatusBucket(key)).toBe(key);
+    }
+  });
+});

--- a/src/lib/job-status-bucket.ts
+++ b/src/lib/job-status-bucket.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-status-bucket — the job tracker's DISPLAY vocabulary (#744). Zero-dep
+ * beyond the stored vocabulary itself, sibling of `job-tracker.ts`, and testable
+ * at module scope.
+ *
+ * The stored vocabulary is open by contract: `job-record-contract.ts`'s
+ * `isStatusLike` accepts any string and preserves it verbatim, precisely so a
+ * record written by another producer keeps whatever that producer meant. The
+ * tracker then grouped on that literal string, so a synced library rendered
+ * `Saved`, `Scouted`, `Shared` and `Interested` as four top-level sections —
+ * which a user reads as four different things when they are one stage of a job
+ * search. Those three differ by how the job ARRIVED (a manual save, a job
+ * alert, a sponsor share), not by where it sits in the pipeline, and the tracker
+ * renders pipeline stages.
+ *
+ * So the mapping happens at VIEW time and never at write time. That distinction
+ * is the whole point of the module: rewriting a stored `shared` to `interested`
+ * is not a display change, it is a write that destroys the meaning the producing
+ * system attached to the row and that a sync would carry back. **Nothing here
+ * returns a value anyone should persist.** {@link jobStatusBucket} answers only
+ * "which section does this row render under"; the row's badge still prints the
+ * literal status through `jobStatusLabel`.
+ *
+ * A status this module cannot map still buckets as ITSELF, which keeps the
+ * fail-loud escape hatch `JobTracker` and `JobTrackerStatusGroup` each document.
+ * This narrows what counts as unrecognised; it does not remove the hatch.
+ */
+
+import { isKnownStatus } from "./storage/index.ts";
+import type { JobStatus } from "./storage/index.ts";
+
+/**
+ * Statuses outside this build's lifecycle that name the same STAGE as one
+ * inside it.
+ *
+ * These are Recruidea's (`saved_jobs.status`), whose vocabulary is a superset of
+ * ours: `saved` / `scouted` / `shared` all say a job is on the list and not
+ * applied to yet, and `withdrawn` closes an application the same way `rejected`
+ * does — just from the other side.
+ *
+ * A `Map`, not an object literal, because the key is untrusted imported data: an
+ * object literal answers `"toString"` with a function off `Object.prototype`,
+ * which would hand the tracker a bucket key that is not even a string.
+ *
+ * Adding a row here is a decision about MEANING, not spelling. Two statuses
+ * belong in one bucket only when the user's next action on both is the same —
+ * an alias that merely *looks* similar hides a distinction instead of a
+ * duplicate.
+ */
+const BUCKET_OF_ALIAS = new Map<string, JobStatus>([
+  ["saved", "interested"],
+  ["scouted", "interested"],
+  ["shared", "interested"],
+  ["withdrawn", "rejected"],
+]);
+
+/**
+ * The section a stored status renders under.
+ *
+ * A status this build's lifecycle knows is its own bucket; a known alias maps to
+ * the lifecycle status it means; anything else buckets as itself, so a status
+ * outside both vocabularies still gets a section labelled with its literal
+ * string.
+ *
+ * {@link isKnownStatus} is consulted FIRST so the canonical vocabulary can never
+ * be shadowed by an alias: were a future `JobStatus` to adopt `saved`, the stale
+ * row here would stop mattering rather than silently redirect it.
+ *
+ * Matching is exact — `"Shared"` is not `"shared"`. Case-folding would be a
+ * guess about a producer nobody has seen, and the cost of guessing wrong is an
+ * unrelated status quietly folded into a bucket it does not belong in; the cost
+ * of not guessing is one extra section, which is exactly the fail-loud state.
+ *
+ * Never store the return value — see this module's docblock.
+ */
+export function jobStatusBucket(status: string): string {
+  if (isKnownStatus(status)) return status;
+  return BUCKET_OF_ALIAS.get(status) ?? status;
+}

--- a/src/lib/job-tracker.test.ts
+++ b/src/lib/job-tracker.test.ts
@@ -27,7 +27,11 @@ import {
   reconcileResumeLinks,
   createTrackedJobFromMatch,
   deriveJobTitleFromJd,
+  mergeJobs,
 } from "./job-tracker.ts";
+import { getRecord } from "./storage/crud.ts";
+import { saveLetter, lettersForJob } from "./storage/letters.ts";
+import type { JobRecord } from "./storage/types.ts";
 
 beforeEach(async () => {
   await closeDB();
@@ -190,5 +194,89 @@ describe("job-tracker: link cleanup is housekeeping, not a user edit", () => {
     await new Promise((r) => setTimeout(r, 2));
     const edited = await updateJob(job.id, { notes: "referred by Dana" });
     expect(edited.updatedAt).toBeGreaterThan(before);
+  });
+});
+
+describe("job-tracker: merge is a user action, lossy in one direction only (#746)", () => {
+  const AGGREGATOR = "https://jobs.example.com/listing/4012345";
+  const ATS = "https://boards.greenhouse.io/acme/jobs/4012345";
+
+  async function twoRowsForOnePosting() {
+    const survivor = await createJob({
+      title: "Senior Frontend Engineer",
+      company: "Acme",
+      url: ATS,
+      notes: "Referred by Dana.",
+      status: "applied",
+    });
+    const absorbed = await createJob({
+      title: "Senior Frontend Engineer",
+      company: "Acme",
+      url: AGGREGATOR,
+      notes: "Recruiter called 12 Aug.",
+      jdText: "We are hiring.",
+    });
+    return { survivor, absorbed };
+  }
+
+  it("leaves one record carrying both URLs, with no note text lost", async () => {
+    const { survivor, absorbed } = await twoRowsForOnePosting();
+
+    const merged = await mergeJobs(survivor.id, absorbed.id);
+
+    expect(await listJobs()).toHaveLength(1);
+    expect(merged.id).toBe(survivor.id);
+    expect(merged.url).toBe(ATS);
+    expect(merged.aliasUrls).toEqual([AGGREGATOR]);
+    expect(merged.notes).toContain("Referred by Dana.");
+    expect(merged.notes).toContain("Recruiter called 12 Aug.");
+    // A gap on the survivor is filled; a value it already had is kept.
+    expect(merged.jdText).toBe("We are hiring.");
+    expect(merged.status).toBe("applied");
+  });
+
+  it("TOMBSTONES the absorbed record rather than removing the row", async () => {
+    // A hard delete is indistinguishable from "never existed" to any second
+    // holder of this library, which would hand the duplicate straight back.
+    const { survivor, absorbed } = await twoRowsForOnePosting();
+    await mergeJobs(survivor.id, absorbed.id);
+
+    expect(await getJobById(absorbed.id)).toBeUndefined();
+    const row = await getRecord<JobRecord>("jobs", absorbed.id);
+    expect(row?.deletedAt).toBeGreaterThan(0);
+  });
+
+  it("does not change the surviving record's id", async () => {
+    const { survivor, absorbed } = await twoRowsForOnePosting();
+    await mergeJobs(survivor.id, absorbed.id);
+    expect((await getJobById(survivor.id))?.id).toBe(survivor.id);
+  });
+
+  it("reparents the absorbed job's cover letters instead of cascading them away", async () => {
+    // `deleteJob` cascades to letters (#711). A merge that destroyed the letter
+    // the user wrote for this posting would be the over-merge this feature
+    // exists to avoid.
+    const { survivor, absorbed } = await twoRowsForOnePosting();
+    await saveLetter({ jobId: absorbed.id, body: "Dear hiring team," });
+
+    await mergeJobs(survivor.id, absorbed.id);
+
+    expect(await lettersForJob(absorbed.id)).toHaveLength(0);
+    const kept = await lettersForJob(survivor.id);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].body).toBe("Dear hiring team,");
+  });
+
+  it("refuses to merge a job into itself", async () => {
+    const job = await createJob({ title: "SWE" });
+    await expect(mergeJobs(job.id, job.id)).rejects.toThrow(/into itself/);
+  });
+
+  it("throws rather than half-merging when either record is gone", async () => {
+    const job = await createJob({ title: "SWE" });
+    await expect(mergeJobs(job.id, "missing")).rejects.toThrow(/no job with id missing/);
+    await expect(mergeJobs("missing", job.id)).rejects.toThrow(/no job with id missing/);
+    // The survivor was not written in either failed attempt.
+    expect(await listJobs()).toHaveLength(1);
   });
 });

--- a/src/lib/job-tracker.ts
+++ b/src/lib/job-tracker.ts
@@ -14,7 +14,15 @@
  * `src/lib/storage`, and neither imports the parser graph.
  */
 
-import { saveJob, getJob, getAllJobs, deleteJob } from "./storage/index.ts";
+import {
+  saveJob,
+  getJob,
+  getAllJobs,
+  deleteJob,
+  lettersForJob,
+  saveLetter,
+} from "./storage/index.ts";
+import { mergeJobRecords } from "./job-merge.ts";
 import type { JobRecord, JobStatus } from "./storage/index.ts";
 
 /** Fields a caller supplies when creating a tracked job. `status` defaults to
@@ -102,6 +110,60 @@ export function unlinkResume(id: string): Promise<JobRecord> {
 
 export function removeJob(id: string): Promise<void> {
   return deleteJob(id);
+}
+
+/**
+ * Fold one tracked job into another (#746) — the write half of the merge whose
+ * field rules live in `job-merge.ts`. Returns the surviving record.
+ *
+ * **Only ever called from an explicit user click.** Nothing infers a merge:
+ * `job-duplicates.ts` reports evidence and stops there, because under-merging
+ * leaves a duplicate the user can delete while over-merging destroys a record,
+ * and this build has no evidence source strong enough to overrule that.
+ *
+ * ## The order of the three writes is the recovery story
+ *
+ * 1. **The survivor is written first**, so the merged fields and both URLs are
+ *    durable before anything is destroyed. Every failure after this point
+ *    leaves an under-merge — two records, one of which already carries
+ *    everything — which the user can see and redo. The reverse order can lose
+ *    the absorbed record's fields outright.
+ * 2. **Its letters are reparented next**, before the delete rather than after,
+ *    because `deleteJob` CASCADES to a job's cover letters (`storage/jobs.ts`)
+ *    and a merge that silently destroyed the letters the user wrote for this
+ *    posting would be exactly the over-merge this feature is built to avoid.
+ *    `touch: false`: the user merged two jobs, they did not edit a letter, and
+ *    stamping `updatedAt` would reorder a drafts list sorted by it.
+ * 3. **The absorbed record is deleted through the normal path**, so it
+ *    TOMBSTONES (#730). A hard delete would be indistinguishable from "never
+ *    existed" to any second holder of this library, which would hand the
+ *    duplicate straight back on the next restore or sync.
+ */
+export async function mergeJobs(
+  survivorId: string,
+  absorbedId: string,
+): Promise<JobRecord> {
+  if (survivorId === absorbedId) {
+    throw new Error(`job-tracker: cannot merge job ${survivorId} into itself`);
+  }
+  const [survivor, absorbed] = await Promise.all([
+    getJob(survivorId),
+    getJob(absorbedId),
+  ]);
+  if (!survivor) throw new Error(`job-tracker: no job with id ${survivorId}`);
+  if (!absorbed) throw new Error(`job-tracker: no job with id ${absorbedId}`);
+
+  const merged = await saveJob({
+    ...mergeJobRecords(survivor, absorbed),
+    id: survivorId,
+  });
+
+  for (const letter of await lettersForJob(absorbedId)) {
+    await saveLetter({ ...letter, jobId: survivorId }, { touch: false });
+  }
+  await removeJob(absorbedId);
+
+  return merged;
 }
 
 /**

--- a/src/lib/storage/capture.test.ts
+++ b/src/lib/storage/capture.test.ts
@@ -25,7 +25,7 @@ import "fake-indexeddb/auto";
 import { deleteDB } from "idb";
 import { beforeEach, describe, expect, it } from "vitest";
 import { DB_NAME, closeDB } from "./db.ts";
-import { getAllJobs, getJob } from "./jobs.ts";
+import { getAllJobs, getJob, saveJob } from "./jobs.ts";
 import { captureJob } from "./capture.ts";
 import { setJobStatus, updateJob } from "../job-tracker.ts";
 
@@ -206,6 +206,54 @@ describe("captureJob: refusals write nothing", () => {
     const stored = await getJob(first.record.id);
     expect(stored?.title).toBe("Staff Engineer");
     expect(stored?.status).toBe("applied");
+    expect(await getAllJobs()).toHaveLength(1);
+  });
+});
+
+describe("captureJob: `aliasUrls` is UNIONED, not overwritten (#746)", () => {
+  const ATS = "https://boards.greenhouse.io/acme/jobs/4012345";
+  const AGGREGATOR = "https://jobs.example.com/listing/4012345";
+
+  it("keeps an alias the user's merge put there when the producer sends none", async () => {
+    // The loss this guards: the stored aliases are usually a merge the USER
+    // performed, and a plain producer-wins would silently undo it.
+    await captureJob({ title: "SWE", url: ATS });
+    const [saved] = await getAllJobs();
+    await saveJob({ ...saved, aliasUrls: [AGGREGATOR] });
+
+    const result = await captureJob({ title: "SWE", url: ATS });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.aliasUrls).toEqual([AGGREGATOR]);
+  });
+
+  it("adds an alias the producer discovered, keeping the one already there", async () => {
+    await captureJob({ title: "SWE", url: ATS, aliasUrls: [AGGREGATOR] });
+    const result = await captureJob({
+      title: "SWE",
+      url: ATS,
+      aliasUrls: ["https://acme.com/careers/7"],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.aliasUrls).toEqual([AGGREGATOR, "https://acme.com/careers/7"]);
+  });
+
+  it("does not accumulate two spellings of one alias across re-captures", async () => {
+    await captureJob({ title: "SWE", url: ATS, aliasUrls: [AGGREGATOR] });
+    const result = await captureJob({
+      title: "SWE",
+      url: ATS,
+      aliasUrls: [`${AGGREGATOR}?utm_source=li`],
+    });
+    expect(result.ok && result.record.aliasUrls).toEqual([AGGREGATOR]);
+  });
+
+  it("never lets an alias change the derived id", async () => {
+    const first = await captureJob({ title: "SWE", url: ATS });
+    const second = await captureJob({ title: "SWE", url: ATS, aliasUrls: [AGGREGATOR] });
+    expect(first.ok && second.ok && first.record.id).toBe(second.ok ? second.record.id : "");
+    expect(second.ok && second.created).toBe(false);
     expect(await getAllJobs()).toHaveLength(1);
   });
 });

--- a/src/lib/storage/capture.ts
+++ b/src/lib/storage/capture.ts
@@ -17,6 +17,8 @@
  *    `resumeId` are the user's; `title`, `company`, `url`, `jdText`,
  *    `matchResult` and `capture` are the producer's. A re-capture that reset an
  *    "applied" job to "interested" would be worse than the duplicate it fixed.
+ *    `aliasUrls` is neither: it is unioned, because an alias is additive and
+ *    the stored ones are usually a merge the user performed (#746).
  *
  * Lib-only and browser-agnostic: no `fetch`, no extension API, no UI. The
  * transport that carries a record here (an extension message port, a paste, a
@@ -37,7 +39,7 @@
 
 import { getJob, saveJob } from "./jobs.ts";
 import { validateJobRecord, type JobRecordIssue } from "./job-record-contract.ts";
-import { deriveJobId } from "./job-url.ts";
+import { dedupeCanonicalUrls, deriveJobId } from "./job-url.ts";
 import type { JobRecord } from "./types.ts";
 
 export type JobCaptureResult =
@@ -50,6 +52,12 @@ export type JobCaptureResult =
       warnings: JobRecordIssue[];
     }
   | { ok: false; reasons: JobRecordIssue[] };
+
+/** One record's `aliasUrls` as strings, defensively — see the call site. */
+function aliasList(job: JobRecord): string[] {
+  const entries = Array.isArray(job.aliasUrls) ? job.aliasUrls : [];
+  return entries.filter((entry): entry is string => typeof entry === "string");
+}
 
 /**
  * Resolve the id for a candidate capture.
@@ -118,6 +126,24 @@ export async function captureJob(input: unknown): Promise<JobCaptureResult> {
     merged.status = existing.status;
     merged.notes = existing.notes ?? merged.notes;
     merged.resumeId = existing.resumeId ?? merged.resumeId;
+
+    // `aliasUrls` is neither producer-owned nor user-owned: it is UNIONED, and
+    // it is the only field here that is (#746). An alias is additive by
+    // definition — recording one never rewrites anything — so the two sides
+    // cannot conflict. The direction that matters is what a plain
+    // producer-wins would do: the aliases on the stored record are usually the
+    // ones the USER put there by merging two rows, and a re-capture that
+    // omitted the field would silently undo that merge, which is the same
+    // family of loss as resetting an `interviewing` job to `interested`.
+    // `Array.isArray`, not `?? []`: the store's write path is permissive, so
+    // the stored value is only as typed as whatever wrote it, and spreading a
+    // non-iterable throws.
+    const aliasUrls = dedupeCanonicalUrls(
+      [...aliasList(existing), ...aliasList(merged)],
+      merged.url === undefined ? [] : [merged.url],
+    );
+    if (aliasUrls.length > 0) merged.aliasUrls = aliasUrls;
+    else delete merged.aliasUrls;
   }
 
   const record = await saveJob(merged, { touch: false });

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -82,6 +82,7 @@ export {
 } from "./letter-contract.ts";
 export {
   canonicalJobUrl,
+  dedupeCanonicalUrls,
   deriveJobId,
   isAbsoluteUrl,
   isCapturableJobUrl,
@@ -108,6 +109,7 @@ export { JOB_STATUS_ORDER } from "./types.ts";
 export type {
   JobRecord,
   JobStatus,
+  JobOrigin,
   JobCaptureProvenance,
   LetterRecord,
   LetterProvenance,

--- a/src/lib/storage/job-record-contract.test.ts
+++ b/src/lib/storage/job-record-contract.test.ts
@@ -24,6 +24,7 @@ import {
   isKnownStatus,
   validateJobRecord,
 } from "./job-record-contract.ts";
+import { JOB_ORIGINS } from "./types.ts";
 // Moved to `record-contract.ts` with the rest of the machinery the job and
 // letter contracts share (#711); the behaviour asserted below is unchanged.
 import { findJsonSafetyProblem } from "./record-contract.ts";
@@ -51,6 +52,8 @@ function validRecord(): Record<string, unknown> {
     // Deliberately still `1`: a producer targeting the previous contract version
     // must keep validating unchanged. See the version-2 block below.
     capture: { contract: 1, producer: "offlinecv-extension", producerVersion: "0.1.0" },
+    origin: "shared",
+    aliasUrls: ["https://boards.greenhouse.io/acme/jobs/1"],
   };
 }
 
@@ -148,6 +151,133 @@ describe("validateJobRecord: out-of-union status is PRESERVED, not dropped or co
   it("isKnownStatus reads the one lifecycle vocabulary", () => {
     expect(isKnownStatus("interviewing")).toBe(true);
     expect(isKnownStatus("screening")).toBe(false);
+  });
+});
+
+describe("validateJobRecord: an out-of-vocabulary `origin` is DROPPED, not refused (#745)", () => {
+  // The opposite choice from `status` above, and deliberately so: nothing
+  // renders an unrecognised origin (there is no picker, no bucket, no badge
+  // for it), so keeping it would carry a value nothing ever surfaces.
+  it.each(JOB_ORIGINS)("keeps a recognised origin %s as-is, with no warning", (origin) => {
+    const result = validateJobRecord({ ...validRecord(), origin });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.origin).toBe(origin);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("drops an unrecognised origin and warns, but still accepts the record", () => {
+    const result = validateJobRecord({ ...validRecord(), origin: "linkedin" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.origin).toBeUndefined();
+    expect(result.warnings).toContainEqual(expect.stringContaining("linkedin"));
+  });
+
+  it("defaults an ABSENT origin to nothing, silently", () => {
+    const result = validateJobRecord({ id: "job-1", title: "SWE" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.origin).toBeUndefined();
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("refuses an origin that is not a string at all", () => {
+    expect(reasons({ ...validRecord(), origin: 3 })).toContainEqual(
+      expect.stringContaining("`origin`"),
+    );
+  });
+});
+
+describe("validateJobRecord: `aliasUrls` drops bad ENTRIES, never the record (#746)", () => {
+  // The asymmetry, again: an alias is an extra way to reach a posting, so
+  // losing one costs the user a duplicate they can still merge by hand —
+  // losing the record costs them the application.
+  it("keeps a list of absolute http(s) URLs as sent, with no warning", () => {
+    const aliasUrls = ["https://acme.com/careers/7", "http://jobs.example.com/listing/1"];
+    const result = validateJobRecord({ ...validRecord(), aliasUrls });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.aliasUrls).toEqual(aliasUrls);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it.each([
+    ["a non-absolute URL", "acme.com/jobs/1"],
+    ["a javascript: URL", "javascript:alert(1)"],
+    ["an empty string", ""],
+    ["a number", 42],
+    ["an object", { url: "https://acme.com" }],
+  ])("drops %s and warns, keeping the good entries and the record", (_label, bad) => {
+    const good = "https://acme.com/careers/7";
+    const result = validateJobRecord({ ...validRecord(), aliasUrls: [good, bad] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.aliasUrls).toEqual([good]);
+    expect(result.warnings).toContainEqual(expect.stringContaining("aliasUrls"));
+  });
+
+  it("never puts an untrusted value into the warning text", () => {
+    const result = validateJobRecord({ ...validRecord(), aliasUrls: [{ huge: "x".repeat(50) }] });
+    expect(result.ok && result.warnings.join(" ")).toContain("a value of type object");
+  });
+
+  it("removes an `aliasUrls` every entry of which was dropped", () => {
+    const result = validateJobRecord({ ...validRecord(), aliasUrls: ["acme.com"] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect("aliasUrls" in result.record).toBe(false);
+  });
+
+  it("normalises an empty list to an absent field, silently", () => {
+    const result = validateJobRecord({ ...validRecord(), aliasUrls: [] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect("aliasUrls" in result.record).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("deduplicates aliasUrls silently", () => {
+    const result = validateJobRecord({
+      ...validRecord(),
+      aliasUrls: ["https://acme.com/jobs/2", "https://acme.com/jobs/2"],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.aliasUrls).toEqual(["https://acme.com/jobs/2"]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("removes an aliasUrl that matches the canonical url, silently", () => {
+    const result = validateJobRecord({
+      ...validRecord(),
+      url: "https://acme.com/jobs/1",
+      aliasUrls: ["https://acme.com/jobs/1", "https://acme.com/jobs/2"],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.aliasUrls).toEqual(["https://acme.com/jobs/2"]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("REFUSES a value that is not a list at all — that is a broken producer", () => {
+    // The opposite of the per-entry rule, deliberately: `aliasUrls` given a
+    // bare string is a field whose declared type is wrong end to end, which
+    // every other field here refuses too.
+    expect(reasons({ ...validRecord(), aliasUrls: "https://acme.com" })).toContainEqual(
+      expect.stringContaining("`aliasUrls`"),
+    );
+  });
+
+  it("does not let an alias change the record's id", () => {
+    const withAliases = validateJobRecord({
+      ...validRecord(),
+      aliasUrls: ["https://jobs.example.com/listing/999"],
+    });
+    const without = validateJobRecord({ ...validRecord(), aliasUrls: undefined });
+    expect(withAliases.ok && without.ok && withAliases.record.id).toBe(
+      without.ok ? without.record.id : "",
+    );
   });
 });
 

--- a/src/lib/storage/job-record-contract.ts
+++ b/src/lib/storage/job-record-contract.ts
@@ -44,9 +44,9 @@
  * `unknown`; its real check is `findJsonSafetyProblem`, wired explicitly.
  */
 
-import type { JobRecord, JobStatus, JobCaptureProvenance } from "./types.ts";
-import { JOB_STATUS_ORDER } from "./types.ts";
-import { isAbsoluteUrl, isCapturableJobUrl } from "./job-url.ts";
+import type { JobRecord, JobStatus, JobOrigin, JobCaptureProvenance } from "./types.ts";
+import { JOB_STATUS_ORDER, JOB_ORIGINS } from "./types.ts";
+import { isAbsoluteUrl, isCapturableJobUrl, dedupeCanonicalUrls } from "./job-url.ts";
 import {
   checkDeclaredFields,
   collectJsonSafeExtras,
@@ -119,6 +119,49 @@ export type JobRecordValidation =
  */
 const isStatusLike = (value: unknown): value is JobStatus => typeof value === "string";
 
+/**
+ * Widens like `isStatusLike` above, for the same reason: a malformed `origin`
+ * must never refuse the whole record. It diverges from `isStatusLike` after
+ * that — `collectAcceptedWarnings` and `validateJobRecord` below strip an
+ * out-of-vocabulary value rather than keeping it, because `origin` is
+ * display-only glossary text and a value this build doesn't recognise cannot
+ * be phrased. See §8 of `docs/job-capture-contract.md`.
+ */
+const isOriginLike = (value: unknown): value is JobOrigin => typeof value === "string";
+
+/**
+ * Widens to `string[]` from nothing more than "it is an array" (#746), so the
+ * per-ENTRY verdict can be a drop rather than a refusal: `collectAcceptedWarnings`
+ * warns about each entry that is not an absolute http(s) URL and
+ * `validateJobRecord` filters them out before the record is stored. See §9 of
+ * `docs/job-capture-contract.md`.
+ *
+ * The array-ness itself IS a refusal, and that is not a contradiction of the
+ * "never refuses" rule the issue states: that rule is about entries. A field
+ * whose declared type is wrong end-to-end — `aliasUrls: "https://…"`, a single
+ * string where a list belongs — is a broken producer, and every other field
+ * here refuses one (`status: 3`, `origin: 3`). Telling them beats storing a
+ * value no reader can iterate.
+ */
+const isAliasUrlsLike = (value: unknown): value is string[] => Array.isArray(value);
+
+/** One rejected `aliasUrls` entry, phrased for a warning without ever
+ *  stringifying an untrusted value: a non-string entry is described by its
+ *  type, so a function or a 10 MB object cannot become the warning text. */
+function describeAliasEntry(value: unknown): string {
+  return typeof value === "string" ? `"${value}"` : `a value of type ${typeof value}`;
+}
+
+/** The entries of an already-guarded `aliasUrls` that clear the `href` bar —
+ *  the value actually stored. Absolute http(s) only: unlike `url`, there is no
+ *  legacy corpus of half-typed values to protect here and nothing renders an
+ *  alias as the row's link, so an entry that cannot be canonicalised is an
+ *  entry that can never match anything. */
+function keptAliasUrls(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => isString(entry) && isCapturableJobUrl(entry));
+}
+
 /** `url` refuses only what an `href` must never receive. An absolute URL whose
  *  scheme is not http(s) — `javascript:`, `data:`, `file:` — is refused;
  *  a string that is not absolute at all (`acme.com`) is accepted and warned,
@@ -168,6 +211,11 @@ export const JOB_RECORD_RULES: {
     check: isUrlLike,
     expected: "an http or https URL (an absolute URL with any other scheme is refused)",
   },
+  aliasUrls: {
+    required: false,
+    check: isAliasUrlsLike,
+    expected: "an array of absolute http or https URLs",
+  },
   notes: { required: false, check: isString, expected: "a string" },
   status: { required: false, check: isStatusLike, expected: "a string" },
   resumeId: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
@@ -198,6 +246,7 @@ export const JOB_RECORD_RULES: {
     expected: "an object with a finite `contract` number",
     explain: (value) => explainJsonSafety(value, "capture"),
   },
+  origin: { required: false, check: isOriginLike, expected: "a string" },
 };
 
 /** Field names the rules cover — everything else on an incoming record is an
@@ -235,7 +284,30 @@ function collectAcceptedWarnings(checked: Record<string, unknown>): JobRecordIss
       );
     }
   }
+  // Unlike `status`, an out-of-vocabulary `origin` is DROPPED — see
+  // `isOriginLike`'s docblock — so this warns about a removal, not a keep.
+  if (typeof checked.origin === "string" && !isKnownOrigin(checked.origin)) {
+    warnings.push(`Origin "${checked.origin}" is not one this build recognises; it was dropped.`);
+  }
+  warnings.push(...collectAliasUrlWarnings(checked.aliasUrls));
   return warnings;
+}
+
+/**
+ * One warning per dropped `aliasUrls` entry (#746) — per ENTRY, never a
+ * refusal, because an alias is an extra way to reach a posting and losing one
+ * costs the user a duplicate they can still merge by hand. Losing the whole
+ * record over it would cost them the application.
+ */
+function collectAliasUrlWarnings(value: unknown): JobRecordIssue[] {
+  if (!Array.isArray(value)) return [];
+  const kept = new Set(keptAliasUrls(value));
+  return value
+    .filter((entry) => !(isString(entry) && kept.has(entry)))
+    .map(
+      (entry) =>
+        `\`aliasUrls\` entry ${describeAliasEntry(entry)} is not an absolute http or https URL; it was dropped.`,
+    );
 }
 
 /**
@@ -259,7 +331,10 @@ function collectAcceptedWarnings(checked: Record<string, unknown>): JobRecordIss
  *
  * An absent `status` becomes `"interested"`, matching `createJob`'s documented
  * default, so a producer that omits a lifecycle it has no opinion about is not
- * punished for it. Nothing else is rewritten.
+ * punished for it. An out-of-vocabulary `origin` is dropped — see
+ * `isOriginLike`'s docblock. An `aliasUrls` entry that is not an absolute
+ * http(s) URL is dropped one entry at a time, and an `aliasUrls` left empty by
+ * that is removed entirely. Nothing else is rewritten.
  */
 export function validateJobRecord(value: unknown): JobRecordValidation {
   if (!isPlainObject(value)) {
@@ -273,6 +348,24 @@ export function validateJobRecord(value: unknown): JobRecordValidation {
   const warnings = collectAcceptedWarnings(checked);
 
   if (reasons.length > 0) return { ok: false, reasons };
+
+  // Strip a dropped origin AFTER warning about it above, and before the
+  // `...checked` spread below — otherwise the unrecognised value would ride
+  // straight through onto the stored record.
+  if (typeof checked.origin === "string" && !isKnownOrigin(checked.origin)) {
+    delete checked.origin;
+  }
+
+  // Same shape, per entry (#746): warned about above, removed here. An
+  // `aliasUrls` left with nothing in it is deleted rather than stored as `[]` —
+  // "no aliases" has one representation, and an empty array on the record would
+  // say nothing a missing key does not.
+  if (checked.aliasUrls !== undefined) {
+    const aliases = keptAliasUrls(checked.aliasUrls);
+    const deduped = dedupeCanonicalUrls(aliases, typeof checked.url === "string" ? [checked.url] : []);
+    if (deduped.length > 0) checked.aliasUrls = deduped;
+    else delete checked.aliasUrls;
+  }
 
   // Extras are gathered only after the record is otherwise accepted — a refused
   // record has nothing to preserve. They are held to the same JSON-safety bar
@@ -298,4 +391,13 @@ export function validateJobRecord(value: unknown): JobRecordValidation {
  *  `JOB_STATUS_ORDER` so the vocabulary has exactly one definition. */
 export function isKnownStatus(status: string): status is JobStatus {
   return (JOB_STATUS_ORDER as readonly string[]).includes(status);
+}
+
+/** True when `origin` is one of {@link JOB_ORIGINS}. Reads that constant so
+ *  the vocabulary has exactly one definition, the same reason
+ *  {@link isKnownStatus} reads `JOB_STATUS_ORDER`. Module-private: nothing
+ *  outside this file needs to ask, since an unrecognised value never survives
+ *  {@link validateJobRecord}. */
+function isKnownOrigin(origin: string): origin is JobOrigin {
+  return (JOB_ORIGINS as readonly string[]).includes(origin);
 }

--- a/src/lib/storage/job-url.test.ts
+++ b/src/lib/storage/job-url.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  dedupeCanonicalUrls,
   canonicalJobUrl,
   deriveJobId,
   isAbsoluteUrl,
@@ -219,5 +220,35 @@ describe("url shape predicates", () => {
 
     expect(isAbsoluteUrl("https://acme.com/j")).toBe(true);
     expect(isCapturableJobUrl("https://acme.com/j")).toBe(true);
+  });
+});
+
+describe("dedupeCanonicalUrls (#746)", () => {
+  it("collapses two spellings of one posting to the first seen, verbatim", () => {
+    expect(
+      dedupeCanonicalUrls([
+        "https://www.jobs.example.com/listing/1?utm_source=li",
+        "https://jobs.example.com/listing/1",
+      ]),
+    ).toEqual(["https://www.jobs.example.com/listing/1?utm_source=li"]);
+  });
+
+  it("drops anything that is not an absolute http(s) URL", () => {
+    expect(
+      dedupeCanonicalUrls(["acme.com/jobs/1", "javascript:alert(1)", "", "https://acme.com/j/1"]),
+    ).toEqual(["https://acme.com/j/1"]);
+  });
+
+  it("excludes a URL the caller already holds, whatever its spelling", () => {
+    expect(
+      dedupeCanonicalUrls(["https://www.acme.com/j/1", "https://other.example/j/2"], [
+        "https://acme.com/j/1",
+      ]),
+    ).toEqual(["https://other.example/j/2"]);
+  });
+
+  it("keeps two genuinely different postings apart", () => {
+    const urls = ["https://acme.com/j/1", "https://acme.com/j/2"];
+    expect(dedupeCanonicalUrls(urls)).toEqual(urls);
   });
 });

--- a/src/lib/storage/job-url.ts
+++ b/src/lib/storage/job-url.ts
@@ -179,6 +179,41 @@ export function canonicalJobUrl(raw: string): string | undefined {
   return `${url.protocol}//${host}${port}${path}${query === "" ? "" : `?${query}`}`;
 }
 
+/**
+ * `urls` with everything that is not an absolute http(s) URL removed, and with
+ * two spellings of one posting collapsed to the first seen — the operation
+ * `JobRecord.aliasUrls` needs wherever two lists of aliases meet (a merge, a
+ * re-capture over a record that already has some).
+ *
+ * Compares by {@link canonicalJobUrl} and stores the ORIGINAL spelling: a
+ * `www.` prefix or a `utm_` parameter must not make two aliases out of one, and
+ * there is equally no reason to hand the user back a rewritten form of a URL
+ * they may recognise. `exclude` seeds the comparison — a caller passes the
+ * record's own `url` so it never appears as an alias of itself.
+ *
+ * It lives here, beside the canonicalisation it is defined in terms of, because
+ * both callers would otherwise reimplement "the same posting" — the second
+ * definition this module exists to prevent.
+ */
+export function dedupeCanonicalUrls(
+  urls: readonly string[],
+  exclude: readonly string[] = [],
+): string[] {
+  const seen = new Set<string>();
+  for (const url of exclude) {
+    const canonical = canonicalJobUrl(url);
+    if (canonical !== undefined) seen.add(canonical);
+  }
+  const kept: string[] = [];
+  for (const url of urls) {
+    const canonical = canonicalJobUrl(url);
+    if (canonical === undefined || seen.has(canonical)) continue;
+    seen.add(canonical);
+    kept.push(url);
+  }
+  return kept;
+}
+
 /** Prefix marking an id as URL-derived rather than a `crypto.randomUUID()`.
  *  Both shapes coexist in the `jobs` store; the prefix is what tells a reader
  *  which rule produced a given id. Exported as part of the contract surface —

--- a/src/lib/storage/storage.test.ts
+++ b/src/lib/storage/storage.test.ts
@@ -154,6 +154,33 @@ describe("storage: export / import", () => {
     expect(await blobBytes(restored.blob)).toEqual([...bytes()]);
   });
 
+  it("carries `origin` through an export → import round-trip (#745)", async () => {
+    await saveJob({ title: "Referred", origin: "shared" });
+    const dump = await exportAll();
+    expect(dump.jobs[0].origin).toBe("shared");
+
+    await closeDB();
+    await deleteDB(DB_NAME);
+    await importAll(dump);
+
+    const [restored] = await getAllJobs();
+    expect(restored.origin).toBe("shared");
+  });
+
+  it("carries `aliasUrls` through an export → import round-trip (#746)", async () => {
+    const aliasUrls = ["https://jobs.example.com/listing/4012345"];
+    await saveJob({ title: "Frontend Engineer", url: "https://boards.greenhouse.io/acme/jobs/1", aliasUrls });
+    const dump = await exportAll();
+    expect(dump.jobs[0].aliasUrls).toEqual(aliasUrls);
+
+    await closeDB();
+    await deleteDB(DB_NAME);
+    await importAll(dump);
+
+    const [restored] = await getAllJobs();
+    expect(restored.aliasUrls).toEqual(aliasUrls);
+  });
+
   it("rejects an unknown export version", async () => {
     await expect(
       // @ts-expect-error — deliberately wrong version for the guard

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -120,6 +120,14 @@ export type JobStatus =
   | "archived";
 
 /**
+ * Where a job RECORD says it arrived from — display only (#745). A closed
+ * vocabulary, unlike `JobStatus`: nothing renders an out-of-vocabulary origin
+ * (see `JobRecord`'s own `origin` field below), so there is no case for
+ * preserving one the way an unrecognised status is preserved.
+ */
+export type JobOrigin = "capture" | "alert" | "shared" | "import" | "manual";
+
+/**
  * Where a job record came from, when it came from outside this app (#693).
  *
  * Absent on every record this app writes itself — an absent value means
@@ -195,6 +203,28 @@ export interface JobRecord extends StoredRecord {
    *  to id derivation, so two captures of one posting converge — see
    *  `job-url.ts`. */
   url?: string;
+  /**
+   * Other URLs the same posting is reachable at (#746) — an employer ATS link
+   * found on an aggregator page, or the `url` of a record the user merged into
+   * this one.
+   *
+   * **Additive, and display/dedupe-only.** `url` stays the canonical one and
+   * `id` is derived from `url` and ONLY from `url`: no value here may change a
+   * record's identity, because that would fork the id space, which is the exact
+   * failure `job-url.ts` exists to prevent. Nothing in `deriveJobId` or
+   * `canonicalJobUrl` reads this field, and nothing may start.
+   *
+   * An alias is a link between two URLs discovered by something with more
+   * context than a URL parser — a user clicking Merge, a producer that followed
+   * an "Apply" link. It is never inferred from the URLs themselves: an
+   * aggregator URL and an employer ATS URL share no host, path or parameter, so
+   * no canonicalisation rule can ever relate them, and none should try.
+   *
+   * Every entry is an absolute http(s) URL, the same bar `url` clears for an
+   * `href` — but unlike `url`, a non-absolute entry is DROPPED rather than kept
+   * (see §9 of `docs/job-capture-contract.md`).
+   */
+  aliasUrls?: string[];
   /** Free-text notes. */
   notes?: string;
   /** Where this job sits in the application lifecycle. */
@@ -247,6 +277,19 @@ export interface JobRecord extends StoredRecord {
   /** Provenance for a record written by a producer outside this build (#693).
    *  Absent for every record this app creates. */
   capture?: JobCaptureProvenance;
+
+  /** Where this record says it came from, for DISPLAY ONLY (#745) — the
+   *  tracker row renders a short phrase for it and nothing else may read it
+   *  (see `job-origin-reach.test.ts`'s structural guard and
+   *  `docs/job-capture-contract.md` §8). Never an input to merge, dedupe, or
+   *  sync ordering.
+   *
+   *  Absent on any record with no better answer than "the user made it
+   *  here" — every record this build's own UI writes, and a producer that
+   *  simply has no opinion. An out-of-vocabulary value is dropped rather
+   *  than kept, unlike `status`: there is no row that renders it, so keeping
+   *  it would carry a value nothing ever surfaces. */
+  origin?: JobOrigin;
 }
 
 /** The lifecycle order for display grouping and the "advance status" affordance
@@ -259,6 +302,18 @@ export const JOB_STATUS_ORDER: readonly JobStatus[] = [
   "offer",
   "rejected",
   "archived",
+];
+
+/** The closed vocabulary {@link JobOrigin} draws from — exported so
+ *  `job-record-contract.ts`'s `isKnownOrigin` and this module share exactly
+ *  one definition, the same reason {@link JOB_STATUS_ORDER} exists. No
+ *  "order" to it; `origin` has no lifecycle. */
+export const JOB_ORIGINS: readonly JobOrigin[] = [
+  "capture",
+  "alert",
+  "shared",
+  "import",
+  "manual",
 ];
 
 /** A cached company ATS board: the light-index postings one board returned,


### PR DESCRIPTION
## Summary

Three issues about **record identity** in the job tracker, built on one branch because they share a contract file and read as one story.

- **#744** â€” a synced library split one stage of a job search across four top-level sections (`Saved`, `Scouted`, `Shared`, `Interested`). Sections now key on a *display bucket* computed at view time. The stored status is never rewritten: `job-record-contract.ts` accepts any status string on purpose so a producer's vocabulary round-trips, and normalising `shared` â†’ `interested` would destroy that and sync it back. Clicking the bucket a row already sits in writes nothing â€” the selected button has no handler at all, rather than an idempotent-looking `onChange`.
- **#745** â€” new optional `JobRecord.origin` (`capture` | `alert` | `shared` | `import` | `manual`), rendered as a short muted phrase on the row. It answers "how did this row get here" now that the merged sections no longer imply it. Display-only, enforced by a structural test.
- **#746** â€” new optional `JobRecord.aliasUrls`, a pure duplicate-detection module, and a user-driven merge. An aggregator URL and an employer-ATS URL share no host, path or parameter, so no canonicalisation rule can ever merge them and none should try; what was missing was any representation of "these two URLs are the same posting."

`id` stays derived from `url` and only from `url` â€” `deriveJobId` and `canonicalJobUrl` are byte-identical on this branch.

Closes #744
Closes #745
Closes #746

## Review focus

- `src/lib/job-merge.ts:51` â€” `NOT_FILLED` now excludes `capture` and `origin`. Is that the right cut? The claim is that they describe *how a record came to exist* and so cannot be inherited, unlike the posting facts the fill exists for.
- `src/lib/job-merge.ts` â€” the survivor's `status` wins, so merging `interviewing` into `interested` loses the lifecycle position. This follows #744's "fields it has are kept" verbatim; if you disagree, this is the decision to relitigate.
- `src/lib/job-duplicates.ts:242` â€” `probable` is company + title and ignores `location`. Should Google "Software Engineer" in NYC and in Mountain View really be offered a destructive merge? `LEGAL_SUFFIXES` widens the company side at the same time.
- `src/lib/job-duplicates.ts` â€” `SIMILAR_TITLE = 0.6` / `OVERLAPPING_DESCRIPTION = 0.5` are unmeasured guesses. They gate only the `possible` tier, which no affordance acts on.
- `src/lib/job-tracker.ts` â€” a merge reparents the absorbed job's cover letters *before* deleting it, because `deleteJob` cascades to letters (#711). Does the ordering hold if a reparent fails midway?
- `src/components/features/JobDuplicateNotice.tsx:16` â€” #746 proposes defaulting the survivor to the employer's own URL; this offers symmetrically on both rows instead, because the repo has no aggregator-vs-ATS host classifier and guessing wrong picks the wrong survivor for a destructive action.

## Deliberate deviations from the issue text

- **#744's "part C" literal-status chip was dropped.** The issue leaves it explicitly undecided ("decide in review"). The row badge already prints the literal status via `jobStatusLabel`, and #745's origin phrase is the better answer to the question the merge raises. The decision is made here rather than deferred, which is why this PR closes #744 outright.
- **No `JOB_CAPTURE_CONTRACT_VERSION` bump.** Both new fields are additive and optional; `types.ts:158`'s precedent ("a producer keeps working untouched") says a producer that ignores them stays valid. #745 asks for this call to be explicit rather than by omission â€” this is it.
- **`aliasUrls` is unioned on re-capture**, not producer-owned, so a producer re-capturing a posting cannot erase aliases the user's merge created.
- **`sharesAUrl` also treats two records with the same canonical `url` as `certain`**, not only an alias hit â€” "Add a job" mints a UUID rather than deriving an id, so the one duplicate a user can create entirely inside this app would otherwise be invisible.
- **Merge is a two-click confirm**, mirroring the row's existing Remove, rather than the single click the issue's wording implies.

**One factual correction to #745's body:** it justifies drop-with-warning by citing "the same asymmetry consumers already apply to a malformed `capture` block." That premise does not hold â€” `capture: 3`, `capture: null`, `capture: {}` and `capture: {contract: "2"}` all *refuse* the record today. The implementation matches actual house behaviour (a bad *value* is dropped and warned; a bad *type* refuses), and `docs/job-capture-contract.md` Â§8 now states the choice out loud.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green â€” 4881 passed, 10 skipped, 0 failed
- [x] `npm run lint` clean
- [x] `fallow audit --base origin/main` â€” no new dead code; the only new finding is `findDuplicatePairs` HIGH complexity (report-only per `CLAUDE.md`)
- [ ] Manually verified in `npm run dev`

No fixture binaries are added or changed by this PR, so the Step 3.5 fixture-PII preflight has nothing to clear.

**Unrelated flake seen once under load:** `src/lib/resume-library.test.ts > lists saved resumes newest-first` failed a single run while several agents ran concurrently, then passed 5/5 in isolation. `resume-library.ts:156` sorts by `b.savedAt - a.savedAt` where `savedAt` is a `Date.now()` millisecond; two back-to-back saves landing in the same ms make the comparator return `0`, and a stable sort then preserves insertion order â€” exactly the observed inversion. Pre-existing, untouched by this branch, worth its own issue.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation â€” #744 | unreported (requested: opus) | ultra |
| Implementation â€” #745 | Claude Sonnet 4.6 | high |
| Implementation â€” #746 | Claude Opus 5 (1M context) | ultra |
| Adversarial review â€” round 1 | Claude Opus 5 (1M context) | high |
| Review fixes | Claude Opus 5 (1M context) | high |
| Adversarial review â€” round 2 | Claude Opus 5 (1M context) | high |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` â€” green in CI | â€” |
| Review revisions | Gemini 3.5 Flash | medium |

The #744 row is `unreported` on purpose: that subagent went idle without answering the model self-report, and inferring a version string from the `model: opus` alias that was *requested* would be a fabrication. Its work was verified independently regardless.

## Adversarial review

Two bounded rounds ran on the local diff before this PR existed, so the reviewed base is what you are reading.

**Round 1 â€” 1 blocking finding, reproduced:**

`src/lib/job-merge.ts` â€” **a merge wrote false provenance onto the surviving record.** `NOT_FILLED` omitted `capture`, so the generic fill loop copied the absorbed record's block onto the survivor whenever the survivor lacked one. Scenario: the user hand-adds a job (no `capture`), the extension separately captured the same posting, the user merges keeping their own row â€” the survivor then claims `producer: "offlinecv-extension"`, a compatibility assertion about a record that no longer exists, attached to a record that producer never wrote. This contradicts `types.ts:277` ("Absent for every record this app creates") and Â§7's stated purpose of informing "a future reader deciding whether it can trust the fields" â€” precisely the reader it misleads, and precisely what a `capture.contract`-keyed migration would key on.

The same loop copied `origin`, which made it a second-order defect: the merge path genuinely propagated `origin`, but through a generic copy that never spells `.origin`, so #745's structural guard never fired. Worse, that guard's anti-drift half turned out satisfiable by a **comment** â€” `JobTrackerEntry.tsx`'s docblock contains "`job.origin` is display-only", which matched the bare `/\.origin\b/`; stubbing the render out left it green.

**Fix:** `capture` and `origin` added to `NOT_FILLED` with a docblock naming the distinction; the guard's drift half now strips comments before matching, and the offender assertion carries a hint explaining that a `URL.origin` / `event.origin` read is a false positive to be narrowed out rather than allowlisted around.

**Round 2 â€” clean, zero new blocking findings.** The fix was verified by fail-before revert (removing the two keys fails the new regression test), by enumerating every other path an absorbed record's `capture`/`origin` could take to the survivor (fill loop, explicit rules, `putRecord`'s wholesale replace, letters reparenting, re-capture union, backup import â€” no second door), and by re-stubbing both allowlisted files to confirm the hardened guard is non-vacuous on each.

**Invariants attacked and held:** no path rewrites a stored status; `deriveJobId`/`canonicalJobUrl` byte-identical; nothing merges without an explicit click; notes concatenated and the absorbed record tombstoned rather than hard-deleted; cover letters on both jobs survive; all four `useMemo`/`useCallback` dep arrays exact â€” which is load-bearing here because `eslint.config.js` registers no `react-hooks` plugin, so a stale closure lints green.

**Surviving nits, not fixed** (the loop had converged; unreviewed edits after convergence defeat the point):

- `types.ts:281` â€” the `origin` docblock points at `job-record-contract.ts`'s "drift guard", but that section is the `JOB_RECORD_RULES` mapped type, a different check. The reach guard is `src/lib/job-origin-reach.test.ts`.
- `job-origin-reach.test.ts:54` â€” `/\.origin\b/` cannot see a destructured read (`const { origin } = job`). Worth a docblock sentence naming the known evasion; not worth widening the regex.
- `job-duplicates.ts:231` â€” `sharesAUrl` misses `a.aliases âˆ© b.aliases`, the exact aggregator/ATS shape. Under-merge is the safe direction, so a gap rather than a defect.
- `job-record-contract.ts:337` â€” `keptAliasUrls` neither dedupes nor excludes the record's own `url`; `dedupeCanonicalUrls` already exists and would make all three write paths agree.
- `capture.ts:107` â€” `captureJob` never consults `aliasUrls` when resolving identity, so re-capturing a merged-away URL recreates the row and re-offers the same merge forever. Not blocking: `captureJob` has no production caller in this build, and #746 scopes sync-side alias resolution out.
- `job-merge.ts:140` â€” `jdText` and `matchResult` fill independently, so a survivor can hold its own JD beside a match result computed against a different one. No consumer reads `matchResult` today.
- `JobTrackerEntry.tsx` (283 LOC) and `JobTracker.tsx` (261) exceed the ~200 guideline. Both were already over before this branch; the new concerns went into siblings (`JobDuplicateNotice`, `useJobDuplicates`).