### PR TITLE
fix(jobs): make job capture and saved-job rating reliable (#729)

### DIFF
--- a/.claude/skills/job-hunt/SKILL.md
+++ b/.claude/skills/job-hunt/SKILL.md
@@ -88,15 +88,23 @@ different postings, waiting 25 s+ each:
 | `/jobs/view/<id>/` — the only URL `M.matches()` accepts | LinkedIn renders a **stub**. No `h1`, no JSON-LD, no description, `main` ≈ 1.4 KB. Body came back **812 chars** of page chrome |
 | `/jobs/search/?currentJobId=<id>` — where the description actually renders (6.3 KB, ~15 s to arrive) | Adapter does **not** match. Forcing it with a synthetic view URL makes it read all of `main`: **14.8 KB polluted** with the results list at the head and a "Trending employee content" rail at the tail, `company: "Unknown"` |
 
-Two component defects fall out of this, both worth fixing before the lane is usable:
+Three component defects fell out of this. **#725 fixed the first two; the third stands, so
+the lane is still search-only — do not capture from LinkedIn.**
 
-1. `v()` (the `document.title` fallback) splits on `-`, so
-   `"Head of Engineering ($225k-$325k + Equity)… | Jack & Jill | LinkedIn"` yields the title
-   **`"Head of Engineering ($225k"`**. It only runs when `h1` is missing — which on LinkedIn
-   is always.
-2. `prune.ts` does not drop the SERP results list: it is neither `nav`/`aside` nor under a
-   heading matching `ht`, so the "read the pane" workaround cannot be made safe by pruning
-   alone.
+1. ~~`parseLinkedInTitle` split the title on the first `-`, so
+   `"Head of Engineering ($225k - $275k) | Clera | LinkedIn"` yielded
+   **`"Head of Engineering ($225k"`**.~~ Fixed: a dash separates the team segment only when
+   it sits at bracket depth zero *and* has whitespace on both sides.
+2. ~~`prune.ts` did not drop the SERP results list — neither `nav`/`aside` nor under a
+   matching heading.~~ Fixed: a list whose every direct item links to a job permalink is
+   dropped, as is a `Trending employee content` rail.
+3. **The adapter still matches only `/jobs/view/<id>/`, which is the URL that renders a
+   stub.** Reading the detail pane on the search URL was considered and declined: the pane's
+   `h1` and the first `[aria-label^="Company,"]` on that page may belong to a *results card*
+   rather than the pane, which writes another posting's company into the record, and the
+   record URL would have to be rewritten to the `/jobs/view/` form by hand because
+   `deriveJobId` does not collapse the two shapes on its own. None of that is verifiable
+   from a fixture, and a capture that is right four times in five is worse than none.
 
 A 14.8 KB body of search chrome is exactly the input measured at 0.00★ further down. Report
 it; do not ship it.

--- a/src/components/features/JobTracker.test.tsx
+++ b/src/components/features/JobTracker.test.tsx
@@ -177,6 +177,54 @@ describe("JobTracker: fitness ratings (#700)", () => {
   });
 });
 
+describe("JobTracker: fallback résumé attribution (#724)", () => {
+  it("names the résumé when the ratings came from the fallback, not the handoff", () => {
+    const tracker = makeTracker([job({ id: "j1", jdText: "React" })]);
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          ratings={new Map()}
+          hasResume
+          fallbackResumeName="resume-v1.pdf"
+        />,
+      ),
+    );
+    expect(container.textContent).toContain("Fit vs.");
+    expect(container.textContent).toContain("resume-v1.pdf");
+  });
+
+  it("says nothing about a résumé source for a real handoff (no fallback name given)", () => {
+    const rating: JobRating = {
+      overall: 4.2,
+      fitness: 4.2,
+      compensation: null,
+      location: null,
+      seniority: null,
+    };
+    const tracker = makeTracker([job({ id: "j1", jdText: "React" })]);
+    act(() =>
+      root.render(
+        <JobTracker tracker={tracker} ratings={new Map([["j1", rating]])} hasResume />,
+      ),
+    );
+    expect(container.textContent).not.toContain("Fit vs.");
+  });
+
+  it("omits the attribution on an empty library, matching the other explanation lines", () => {
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={makeTracker([])}
+          hasResume
+          fallbackResumeName="resume-v1.pdf"
+        />,
+      ),
+    );
+    expect(container.textContent).not.toContain("Fit vs.");
+  });
+});
+
 describe("JobTracker: resume link picker", () => {
   const RESUMES = [
     { id: "r1", filename: "resume-v1.pdf" },

--- a/src/components/features/JobTracker.tsx
+++ b/src/components/features/JobTracker.tsx
@@ -13,8 +13,11 @@
  * Fitness ratings (#700) are computed on VIEW by `useSavedJobRatings` and never
  * stored on a record — a stored score would go stale the moment the résumé is
  * edited, with nothing to invalidate it. Rating needs a parsed résumé, which
- * this surface only has via the `/` handoff, so the library also stands alone
- * with none: `ratings === null` simply drops the fitness block from every row.
+ * this surface has either via the `/` handoff or, absent one, the #724 fallback
+ * (`JobsApp` → `useFallbackResume`, the most recently saved library résumé) —
+ * with neither, `ratings === null` simply drops the fitness block from every
+ * row. `fallbackResumeName` is set only in the fallback case, so a row's stars
+ * always name which résumé they were computed against.
  *
  * Letters (#715): `JobTrackerSection` owns `useJobLetters` the same way it
  * owns `useSavedJobRatings` — one read for the whole library, grouped by job
@@ -51,6 +54,14 @@ interface JobTrackerProps {
    *  "nothing to rate against" and "rated". Drives the one-line explanation, so
    *  an unrated library is never silently unexplained. */
   hasResume?: boolean;
+  /** Filename of the résumé backing `ratings`, set ONLY when it came from the
+   *  #724 fallback (the most recently saved library résumé) rather than the
+   *  `/` handoff. A star with an unstated referent is the failure mode
+   *  `rate-saved-jobs.ts` property 1 already guards against in the other
+   *  direction — this names it. Undefined for the handoff case (the user just
+   *  came from their résumé, so naming it would be redundant) and whenever
+   *  there is nothing to rate against. */
+  fallbackResumeName?: string;
   /** Resolve a linked resume id to its display name; returns undefined when the
    *  resume no longer exists, so the row degrades to "not linked". */
   resumeName?: (resumeId: string) => string | undefined;
@@ -94,6 +105,7 @@ export function JobTracker({
   tracker,
   ratings = null,
   hasResume = false,
+  fallbackResumeName,
   resumeName,
   resumeOptions,
   lettersById,
@@ -169,6 +181,17 @@ export function JobTracker({
       {!hasResume && jobs.length > 0 && (
         <p className="text-sm text-content-muted">
           Open this workbench from your resume to see how each saved job fits it.
+        </p>
+      )}
+
+      {/* #724: only set when `ratings` came from the fallback most-recently-
+          saved résumé rather than a real `/` handoff — names the referent so a
+          fit star is never shown against an unstated resume. */}
+      {hasResume && fallbackResumeName && jobs.length > 0 && (
+        <p className="text-sm text-content-muted">
+          Fit vs.{" "}
+          <span className="text-content-secondary">{fallbackResumeName}</span>{" "}
+          — your most recently saved resume.
         </p>
       )}
 

--- a/src/hooks/__test-utils__/memory-storage.test.ts
+++ b/src/hooks/__test-utils__/memory-storage.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Pins that `installMemoryLocalStorage` can overwrite a `localStorage` global
+ * left in a hostile descriptor state by a previously-run suite.
+ *
+ * This is a cross-file regression, so it cannot be reproduced by running the
+ * offending suites together — vitest's worker reuse decides whether the polluted
+ * global is ever observed, which is why the original defect presented as a rare
+ * flake in whichever unrelated file happened to run next. These tests recreate
+ * the two end states directly instead of trying to provoke the interleaving.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { installMemoryLocalStorage } from "./memory-storage.ts";
+
+// Every test here deliberately corrupts the global; hand the next test a clean
+// one rather than relying on the workload-wide `beforeEach` to survive it.
+afterEach(() => {
+  installMemoryLocalStorage();
+});
+
+describe("installMemoryLocalStorage — survives a polluted global (#398)", () => {
+  it("overwrites a non-writable data property", () => {
+    // The shape `Object.defineProperty(globalThis, "localStorage", { value })`
+    // leaves behind when the property did not already exist: omitting
+    // `writable` defaults it to false, so a plain assignment throws
+    // "Cannot assign to read only property".
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      value: { getItem: () => "poisoned" },
+      configurable: true,
+    });
+    expect(
+      Object.getOwnPropertyDescriptor(globalThis, "localStorage")?.writable,
+    ).toBe(false);
+
+    expect(() => installMemoryLocalStorage()).not.toThrow();
+
+    localStorage.setItem("k", "v");
+    expect(localStorage.getItem("k")).toBe("v");
+  });
+
+  it("overwrites a getter-only accessor", () => {
+    // The shape a suite faking a hostile/private-mode storage leaves behind.
+    // An accessor with no setter rejects assignment too, with a different
+    // message ("which has only a getter") — so a fix that handled only the
+    // read-only data property would still leave this path broken.
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      get: () => {
+        throw new Error("SecurityError: storage disabled");
+      },
+      configurable: true,
+    });
+
+    expect(() => installMemoryLocalStorage()).not.toThrow();
+
+    localStorage.setItem("k", "v");
+    expect(localStorage.getItem("k")).toBe("v");
+  });
+
+  it("hands each caller a storage that starts empty", () => {
+    localStorage.setItem("stale", "1");
+    installMemoryLocalStorage();
+    expect(localStorage.getItem("stale")).toBeNull();
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/src/hooks/__test-utils__/memory-storage.ts
+++ b/src/hooks/__test-utils__/memory-storage.ts
@@ -43,9 +43,25 @@ class MemoryStorage {
 /**
  * Replace the global `localStorage` with a fresh in-memory shim and return it.
  * Call in `beforeEach` so each test starts from clean persisted state.
+ *
+ * Defines the property rather than assigning it, because assignment is only
+ * valid when the *current* descriptor happens to permit it, and this runs after
+ * arbitrary other suites in the same worker. A test that swaps `localStorage`
+ * via `Object.defineProperty` — to fake private-mode throws, or a hostile
+ * getter — can leave behind either a non-writable data property or a
+ * getter-only accessor, and a plain assignment throws on both ("Cannot assign
+ * to read only property" / "which has only a getter"). That surfaces as a
+ * failure in the *next* file to run in that worker, which is why it presents as
+ * a rare flake in an unrelated suite. `defineProperty` with an explicit
+ * `writable`/`configurable` overwrites either shape unconditionally.
  */
 export function installMemoryLocalStorage(): Storage {
   const storage = new MemoryStorage() as unknown as Storage;
-  (globalThis as { localStorage?: Storage }).localStorage = storage;
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
   return storage;
 }

--- a/src/hooks/useFallbackResume.test.tsx
+++ b/src/hooks/useFallbackResume.test.tsx
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `useFallbackResume` (#724): picks the most recently saved library résumé to
+ * rate the Saved jobs tracker against when a direct visit to `/jobs/` never
+ * received the `/` handoff. What matters here is the wiring — `active` gating
+ * the handoff/fallback race, "most recent" selection, cancellation on unmount,
+ * and NOT re-triggering a reload for an entries refresh that leaves the newest
+ * id unchanged — not the library or parse internals, which are covered
+ * elsewhere.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useFallbackResume, type FallbackResumeLibrary } from "./useFallbackResume.ts";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { ResumeLibraryEntry, LoadedResume } from "../lib/resume-library.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function parsedFor(name: string): HeuristicParsedResume {
+  return { skills: [name], experience: [], education: [] };
+}
+
+function entry(id: string, savedAt: number): ResumeLibraryEntry {
+  return { id, filename: `${id}.pdf`, savedAt, scoreOverall: 80, sourceKind: "pdf" };
+}
+
+/** Just enough of `CascadeResult`/`LoadedResume` for the hook's one read
+ *  (`loaded.result.canonical.fields`). */
+function loadedFor(id: string): LoadedResume {
+  const result = {
+    canonical: { fields: parsedFor(id) },
+  } as unknown as CascadeResult;
+  return {
+    id,
+    filename: `${id}.pdf`,
+    fileSize: 0,
+    sourceKind: "pdf",
+    result,
+    score: { overall: 80 } as LoadedResume["score"],
+  };
+}
+
+function makeLibrary(
+  entries: ResumeLibraryEntry[],
+  opts: { ready?: boolean; loadDelayMs?: number } = {},
+): FallbackResumeLibrary & { load: ReturnType<typeof vi.fn> } {
+  const load = vi.fn(async (id: string) => {
+    if (opts.loadDelayMs) {
+      await new Promise((resolve) => setTimeout(resolve, opts.loadDelayMs));
+    }
+    return loadedFor(id);
+  });
+  return { ready: opts.ready ?? true, entries, load };
+}
+
+let container: HTMLElement;
+let root: Root;
+let latest: ReturnType<typeof useFallbackResume> = undefined;
+
+function Probe({
+  active,
+  library,
+}: {
+  active: boolean;
+  library: FallbackResumeLibrary;
+}) {
+  latest = useFallbackResume(active, library);
+  return null;
+}
+
+async function renderProbe(active: boolean, library: FallbackResumeLibrary) {
+  await act(async () => {
+    root.render(<Probe active={active} library={library} />);
+  });
+  for (let turn = 0; turn < 20; turn++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+beforeEach(() => {
+  latest = undefined;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useFallbackResume", () => {
+  it("resolves to undefined when inactive (a real handoff is present)", async () => {
+    const library = makeLibrary([entry("r1", 100)]);
+    await renderProbe(false, library);
+    expect(latest).toBeUndefined();
+    expect(library.load).not.toHaveBeenCalled();
+  });
+
+  it("resolves to undefined when the library has no saved résumés", async () => {
+    const library = makeLibrary([]);
+    await renderProbe(true, library);
+    expect(latest).toBeUndefined();
+    expect(library.load).not.toHaveBeenCalled();
+  });
+
+  it("waits for the library to become ready before loading", async () => {
+    const library = makeLibrary([entry("r1", 100)], { ready: false });
+    await renderProbe(true, library);
+    expect(latest).toBeUndefined();
+    expect(library.load).not.toHaveBeenCalled();
+  });
+
+  it("loads the MOST RECENTLY SAVED entry, not the first in the list", async () => {
+    const library = makeLibrary([entry("older", 100), entry("newer", 200)]);
+    await renderProbe(true, library);
+    expect(library.load).toHaveBeenCalledWith("newer");
+    expect(latest).toEqual({ resumeId: "newer", parsed: parsedFor("newer") });
+  });
+
+  it("does not set state after unmount (cancellable)", async () => {
+    const library = makeLibrary([entry("r1", 100)], { loadDelayMs: 20 });
+    await act(async () => {
+      root.render(<Probe active library={library} />);
+    });
+    // Unmount before the delayed `load()` resolves.
+    act(() => root.unmount());
+    // If the effect's cleanup did not cancel, the resolved `.then()` would call
+    // `setState` on an unmounted component tree — React would warn/throw in a
+    // dev build. Draining past the delay proves it either way.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 40));
+    });
+    // No assertion needed beyond "this didn't throw" — recreate the container
+    // so afterEach's unmount has something valid to act on.
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  it("does not re-load when entries refresh but the newest id is unchanged", async () => {
+    const library = makeLibrary([entry("r1", 100)]);
+    await renderProbe(true, library);
+    expect(library.load).toHaveBeenCalledTimes(1);
+
+    // A fresh array (as `useResumeLibrary`'s `setEntries` would hand down after
+    // an unrelated refresh), same newest id.
+    await renderProbe(true, { ...library, entries: [entry("r1", 100)] });
+    expect(library.load).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * `load` can reject for real — it is an IndexedDB read, it calls
+   * `blob.arrayBuffer()`, and on a stale-shape record it re-runs the cascade.
+   * Without a `.catch()` the rejection is unhandled AND silent: the tracker
+   * shows no ratings and nothing anywhere says why. Both halves are asserted,
+   * because either one alone would go green on a fix that only did the other.
+   */
+  it("logs a failed load and leaks no unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const boom = new Error("IndexedDB read failed");
+    const library: FallbackResumeLibrary = {
+      ready: true,
+      entries: [entry("r1", 100)],
+      load: vi.fn(() => Promise.reject(boom)),
+    };
+
+    try {
+      await renderProbe(true, library);
+      // Node surfaces an unhandled rejection only once the microtask queue has
+      // drained, so give it a macrotask turn before asserting there was none.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(consoleError).toHaveBeenCalledWith(
+        "[useFallbackResume] library load failed:",
+        boom,
+      );
+      expect(unhandled).toEqual([]);
+      // No fallback is the right end state: rating against nothing beats rating
+      // against a half-read résumé.
+      expect(latest).toBeUndefined();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      consoleError.mockRestore();
+    }
+  });
+
+  it("re-loads when a newer résumé is saved", async () => {
+    const library = makeLibrary([entry("r1", 100)]);
+    await renderProbe(true, library);
+    expect(latest?.resumeId).toBe("r1");
+
+    await renderProbe(true, { ...library, entries: [entry("r1", 100), entry("r2", 200)] });
+    expect(library.load).toHaveBeenCalledWith("r2");
+    expect(latest?.resumeId).toBe("r2");
+  });
+});

--- a/src/hooks/useFallbackResume.ts
+++ b/src/hooks/useFallbackResume.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useFallbackResume — the résumé `/jobs/`'s Saved jobs tab rates against when
+ * a direct visit (bookmark, pasted link, new tab, reload) never received the
+ * `/` → `/jobs/` handoff (#724). `JobsApp` reads `jobs-handoff.ts` once, on
+ * mount, in a `useState` lazy initializer that never changes for the life of
+ * the mount — so this hook's `active` flag is effectively fixed too, but it
+ * takes the flag as a parameter rather than reading the handoff itself so the
+ * "the fallback never overrides or races the handoff" rule is visible at the
+ * call site, not buried in this file.
+ *
+ * Loads the most recently saved library entry (max `savedAt`) and returns its
+ * EDITED `HeuristicParsedResume` alongside the id it came from — the same
+ * parse shape the handoff carries (`jobs-handoff.ts`), so `useSavedJobRatings`
+ * cannot tell the two apart. The id, not the filename, is the returned handle:
+ * a rename touches only `library.entries`, and re-deriving the display name
+ * from there on every render keeps the label current without re-triggering a
+ * reload of the (unchanged) parse.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { ResumeLibrary } from "./useResumeLibrary.ts";
+
+export interface FallbackResume {
+  resumeId: string;
+  parsed: HeuristicParsedResume;
+}
+
+/** The slice of `ResumeLibrary` this hook actually needs — narrowed so a
+ *  probe/test can hand it a stub instead of the whole hook's surface. */
+export type FallbackResumeLibrary = Pick<ResumeLibrary, "ready" | "entries" | "load">;
+
+export function useFallbackResume(
+  active: boolean,
+  library: FallbackResumeLibrary,
+): FallbackResume | undefined {
+  // Recomputed only from `entries` — NOT `library.ready`, which flips once and
+  // never again, so including it would be a no-op dep. Reduces to the entry
+  // with the largest `savedAt`; `listLibrary` already returns newest-first, but
+  // this does not lean on that ordering staying true.
+  const newestId = useMemo<string | undefined>(() => {
+    if (!active || library.entries.length === 0) return undefined;
+    return library.entries.reduce((newest, entry) =>
+      entry.savedAt > newest.savedAt ? entry : newest,
+    ).id;
+  }, [active, library.entries]);
+
+  const [fallback, setFallback] = useState<FallbackResume | undefined>(undefined);
+
+  useEffect(() => {
+    if (!active || !library.ready || newestId === undefined) {
+      // Covers both "nothing to fall back to" and the (theoretical) case
+      // `active` flips false after a fallback already resolved — the handoff
+      // must win outright, not race a stale fallback still in state.
+      setFallback(undefined);
+      return;
+    }
+    let cancelled = false;
+    void library
+      .load(newestId)
+      .then((loaded) => {
+        // Cancellable so a component unmount (or `newestId` moving on to a
+        // different entry before this resolves) never calls `setState` on a
+        // stale or unmounted result.
+        if (cancelled || loaded === undefined) return;
+        setFallback({ resumeId: newestId, parsed: loaded.result.canonical.fields });
+      })
+      .catch((err: unknown) => {
+        // `load` rejects for real: it is an IndexedDB read, it calls
+        // `blob.arrayBuffer()` on the stored bytes, and on a stale-shape record
+        // it re-runs the whole cascade (`resume-library.ts`). Leaving `fallback`
+        // undefined is the right end state — the tracker rates against nothing
+        // rather than against a half-read résumé — but without this the
+        // rejection is unhandled and the reason never reaches the console. Same
+        // shape and same reasoning as `useSavedJobRatings`.
+        console.error("[useFallbackResume] library load failed:", err);
+        if (!cancelled) {
+          setFallback(undefined);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Deps hand-audited both directions (`exhaustive-deps` is NOT enforced —
+    // CLAUDE.md): `active`, `library.ready` and `newestId` are the complete set
+    // of inputs that decide whether/what to load, and `library.load` is a
+    // `useCallback` with an empty dep array (stable). `library.entries` is
+    // deliberately omitted in favor of the `newestId` it feeds — the memo
+    // above already re-derives `newestId` when the entries that matter change,
+    // so listing the raw array too would re-fire this effect (and reload the
+    // same record) on every unrelated list refresh that leaves the newest
+    // entry's id unchanged.
+  }, [active, library.ready, newestId, library.load]);
+
+  return fallback;
+}

--- a/src/jobs/JobsApp.test.tsx
+++ b/src/jobs/JobsApp.test.tsx
@@ -22,11 +22,14 @@
 
 import "fake-indexeddb/auto";
 import { deleteDB } from "idb";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { DB_NAME, closeDB } from "../lib/storage/index.ts";
 import { createJob } from "../lib/job-tracker.ts";
+import { saveResumeToLibrary } from "../lib/resume-library.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+import type { AnonymousAtsScore } from "../lib/score/score.ts";
 import JobsApp from "./JobsApp.tsx";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -34,6 +37,13 @@ import JobsApp from "./JobsApp.tsx";
 
 let container: HTMLElement;
 let root: Root;
+
+beforeAll(async () => {
+  // Warm the module `useSavedJobRatings` dynamic-imports — see that hook's own
+  // test for why: cold, the first import pulls the whole rating graph and can
+  // outlast a fixed poll budget under a loaded runner.
+  await import("../lib/job-search/rate-saved-jobs.ts");
+});
 
 beforeEach(async () => {
   await closeDB();
@@ -198,5 +208,69 @@ describe("JobsApp: landing tab from the URL (#707)", () => {
     expect(
       container.querySelector<HTMLElement>("#jobs-panel-library")?.hidden,
     ).toBe(false);
+  });
+});
+
+describe("JobsApp: Saved jobs fit rating falls back to the library résumé (#724)", () => {
+  /** Minimal stand-in for `runCascade`'s output — `saveResumeToLibrary` stores
+   *  this opaquely and hands it back unchanged (its stamped shapeVersion
+   *  matches on read), so only the one field `useFallbackResume` actually
+   *  reads (`canonical.fields`) needs to be real. */
+  function fakeResult(skills: string[]): CascadeResult {
+    return {
+      canonical: { fields: { skills, experience: [], education: [] } },
+    } as unknown as CascadeResult;
+  }
+  const FAKE_SCORE = { overall: 80 } as unknown as AnonymousAtsScore;
+
+  const JD =
+    "We need a React and TypeScript engineer for our frontend web application.";
+
+  it("rates a saved job against the most recently saved résumé, and names it, with no handoff present", async () => {
+    // No `writeJobsHandoff` call — this is exactly the direct-visit case the
+    // issue describes: a bookmark, a pasted link, or a fresh tab.
+    await saveResumeToLibrary({
+      filename: "my-resume.pdf",
+      sourceKind: "pdf",
+      result: fakeResult(["React", "TypeScript"]),
+      score: FAKE_SCORE,
+    });
+    await createJob({ title: "Frontend Engineer", company: "Acme", jdText: JD });
+
+    await act(async () => {
+      root.render(<JobsApp />);
+    });
+    await flushIndexedDb(50);
+
+    clickTab("Saved jobs");
+    const libraryPanel = container.querySelector<HTMLElement>(
+      "#jobs-panel-library",
+    );
+    expect(libraryPanel?.textContent).toContain("Fit vs.");
+    expect(libraryPanel?.textContent).toContain("my-resume.pdf");
+    // The shared `RatingStars` widget, not just the attribution text — the
+    // row is actually rated, not merely labeled.
+    expect(libraryPanel?.querySelector('[role="img"]')).not.toBeNull();
+  });
+
+  it("shows neither stars nor an attribution with no saved résumé and no handoff", async () => {
+    await createJob({ title: "Frontend Engineer", company: "Acme", jdText: JD });
+
+    await act(async () => {
+      root.render(<JobsApp />);
+    });
+    await flushIndexedDb(20);
+
+    clickTab("Saved jobs");
+    const libraryPanel = container.querySelector<HTMLElement>(
+      "#jobs-panel-library",
+    );
+    expect(libraryPanel?.textContent).not.toContain("Fit vs.");
+    expect(libraryPanel?.querySelector('[role="img"]')).toBeNull();
+    // Unchanged empty-resume copy (#700) — the fallback must not paper over a
+    // genuinely resume-less library with a misleading message.
+    expect(libraryPanel?.textContent).toContain(
+      "Open this workbench from your resume",
+    );
   });
 });

--- a/src/jobs/JobsApp.tsx
+++ b/src/jobs/JobsApp.tsx
@@ -14,7 +14,11 @@
  * own — the job-search lane consumes a parsed résumé, and the parse pipeline
  * (with its cascade, score, and edit layer) is `/`'s job. Adding a second parse
  * entry point here would be the parallel surface CLAUDE.md's Reuse Gate exists
- * to prevent. With no handoff, this renders a pointer back to `/`.
+ * to prevent. With no handoff, the Search tab still renders a pointer back to
+ * `/` — but the Saved jobs tab is a passive view of records that already exist,
+ * so #724 gives it a fallback: the most recently saved library résumé
+ * (`useFallbackResume`), used ONLY to rate the tracker's rows, never fed to
+ * `FindJobsPanel` and never overriding a real handoff.
  *
  * Because the handoff is read but not consumed, a reload of `/jobs` keeps
  * working — see the handoff module for why that differs from `/jd-fit`.
@@ -42,6 +46,7 @@ import { returnToResumeRoot } from "../lib/nav-return.ts";
 import { resolveInitialJobsTab, type JobsTabId } from "../lib/jobs-landing.ts";
 import { useArrivedFromRoot } from "../hooks/useArrivedFromRoot.ts";
 import { useResumeLibrary } from "../hooks/useResumeLibrary.ts";
+import { useFallbackResume } from "../hooks/useFallbackResume.ts";
 
 // #706: goes to `/` directly, never via history.back() — the empty state only
 // shows when there is no in-progress parse to preserve, so this is a forward
@@ -96,6 +101,17 @@ export default function JobsApp() {
   const library = useResumeLibrary();
   const resumeName = (resumeId: string) =>
     library.entries.find((entry) => entry.id === resumeId)?.filename;
+
+  // #724: a direct visit to `/jobs/` (bookmark, pasted link, reload) never
+  // received the handoff, so the tracker would otherwise rate against nothing.
+  // `active` gates the whole hook on `handoff === null` — a real handoff always
+  // wins outright, the fallback never even loads. Scoped to the tracker only
+  // (see the docblock); `FindJobsPanel` below still reads `handoff` directly.
+  const fallback = useFallbackResume(handoff === null, library);
+  const fallbackResumeName = fallback
+    ? library.entries.find((entry) => entry.id === fallback.resumeId)?.filename
+    : undefined;
+  const trackerParsed = handoff?.parsed ?? fallback?.parsed;
 
   return (
     <PageShell
@@ -153,7 +169,8 @@ export default function JobsApp() {
           </TabPanel>
           <TabPanel id="library">
             <JobTrackerSection
-              parsed={handoff?.parsed}
+              parsed={trackerParsed}
+              fallbackResumeName={fallbackResumeName}
               resumeName={resumeName}
               resumeOptions={library.entries}
             />

--- a/src/lib/jd-extract/linkedin-parse.test.ts
+++ b/src/lib/jd-extract/linkedin-parse.test.ts
@@ -111,6 +111,83 @@ describe("parseLinkedInTitle", () => {
   });
 });
 
+/**
+ * The dashes that are NOT the team separator (#725).
+ *
+ * These are the shape LinkedIn actually serves, not the shape the parser expected:
+ * the first case is the live `<title>` observed on 2026-08-01, and the value it
+ * used to yield — `"Head of Engineering ($225k"` — was written into the user's
+ * tracker as the record of the job. A truncated title is worse than no capture,
+ * because it looks like a successful one.
+ */
+describe("parseLinkedInTitle — dashes inside the title", () => {
+  it("keeps a parenthesised salary range whole", () => {
+    expect(
+      parseLinkedInTitle("Head of Engineering ($225k - $275k) | Clera | LinkedIn"),
+    ).toEqual({
+      title: "Head of Engineering ($225k - $275k)",
+      company: "Clera",
+    });
+  });
+
+  it("keeps an en-dash comp band whole", () => {
+    expect(
+      parseLinkedInTitle("Staff Platform Engineer ($180k – $220k) | Acme | LinkedIn"),
+    ).toEqual({
+      title: "Staff Platform Engineer ($180k – $220k)",
+      company: "Acme",
+    });
+  });
+
+  it("keeps a square-bracketed qualifier whole", () => {
+    expect(
+      parseLinkedInTitle("Data Engineer [Contract - 12 months] | Acme | LinkedIn"),
+    ).toEqual({
+      title: "Data Engineer [Contract - 12 months]",
+      company: "Acme",
+    });
+  });
+
+  // A hyphen with no space around it is part of a token, not a separator.
+  it.each([
+    ["Full-Stack Engineer | Acme | LinkedIn", "Full-Stack Engineer", "Acme"],
+    [
+      "Head of Engineering $225k-$275k | Clera | LinkedIn",
+      "Head of Engineering $225k-$275k",
+      "Clera",
+    ],
+    ["E-commerce Analytics Lead | Acme | LinkedIn", "E-commerce Analytics Lead", "Acme"],
+  ])("keeps the hyphenated token in %s", (input, title, company) => {
+    expect(parseLinkedInTitle(input)).toEqual({ title, company });
+  });
+
+  // The team separator still separates once the brackets close.
+  it("splits at the first dash outside the brackets", () => {
+    expect(
+      parseLinkedInTitle(
+        "Head of Engineering ($225k - $275k) - Payments | Clera | LinkedIn",
+      ),
+    ).toEqual({ title: "Head of Engineering ($225k - $275k)", company: "Clera" });
+  });
+
+  // Unbalanced brackets mean the left side of every candidate dash is unbalanced
+  // too, so nothing splits and the segment survives whole — the safe direction.
+  it("declines to split a segment with an unbalanced bracket", () => {
+    expect(parseLinkedInTitle("Engineer (Platform - Core | Acme | LinkedIn")).toEqual({
+      title: "Engineer (Platform - Core",
+      company: "Acme",
+    });
+  });
+
+  // The two-part shape never dash-split, and must not start.
+  it("keeps a comp band whole in the two-part shape", () => {
+    expect(parseLinkedInTitle("Head of Engineering ($225k - $275k) | LinkedIn")).toEqual({
+      title: "Head of Engineering ($225k - $275k)",
+      company: "",
+    });
+  });
+});
+
 describe("isLinkedInJobUrl", () => {
   it("accepts a job view page", () => {
     expect(isLinkedInJobUrl("https://www.linkedin.com/jobs/view/4437835690/")).toBe(true);

--- a/src/lib/jd-extract/linkedin-parse.ts
+++ b/src/lib/jd-extract/linkedin-parse.ts
@@ -43,6 +43,80 @@ export function extractLinkedInCompanyFromDOM(doc: Document): string | null {
 }
 
 /**
+ * How each bracket character moves the nesting depth. All three families count
+ * toward one depth: the only question being asked is "is this dash inside
+ * something", and no page title mixes families in a way that telling them apart
+ * would resolve.
+ */
+const BRACKET_DEPTH: Readonly<Record<string, number>> = {
+  "(": 1,
+  "[": 1,
+  "{": 1,
+  ")": -1,
+  "]": -1,
+  "}": -1,
+};
+
+/** The dashes LinkedIn puts between a job title and its team/department. */
+const TEAM_DASHES = new Set(["-", "–"]);
+
+const WHITESPACE = /\s/;
+
+/**
+ * The part of a title segment that precedes its team/department dash.
+ *
+ * The naive split — first `-` or `–` wins — truncated real titles, because a dash
+ * appears inside a title far more often than the "Job Title - Department" shape
+ * suggests. Observed live: `"Head of Engineering ($225k - $275k)"` became
+ * `"Head of Engineering ($225k"`, and the truncated value was persisted as the
+ * user's record of the job.
+ *
+ * So a dash separates only when it is BOTH:
+ *
+ *  - **at bracket depth zero**, with no unbalanced closer before it — i.e. what it
+ *    leaves on the left is a bracket-balanced string. This is what rejects the
+ *    dash inside `($225k - $275k)`, `[Contract - 12 months]`, and every other
+ *    parenthesised comp band or qualifier; and
+ *  - **surrounded by whitespace on both sides**, which is how LinkedIn writes the
+ *    separator and is not how a hyphenated token is written. This is what rejects
+ *    `"Full-Stack Engineer"` and an unbracketed `"$225k-$275k"`.
+ *
+ * Both guards only ever *decline* a split the old code made, so the failure they
+ * can introduce is a title that keeps a department it should have dropped. That
+ * is the cheap direction: a title that says slightly too much is still the job,
+ * while `"Head of Engineering ($225k"` is not a title at all. A spaced dash
+ * outside brackets — `"Head of Engineering $225k - $275k"` — is genuinely
+ * ambiguous with the department shape and is left splitting, because nothing in
+ * the string distinguishes the two.
+ */
+function titleBeforeTeamSegment(segment: string): string {
+  let depth = 0;
+  let sawUnbalancedCloser = false;
+
+  for (let i = 0; i < segment.length; i += 1) {
+    const char = segment[i];
+
+    const delta = BRACKET_DEPTH[char];
+    if (delta !== undefined) {
+      depth += delta;
+      if (depth < 0) sawUnbalancedCloser = true;
+      continue;
+    }
+
+    if (!TEAM_DASHES.has(char)) continue;
+    if (depth !== 0 || sawUnbalancedCloser) continue;
+    // `segment[-1]` and the past-the-end read are both `undefined`, so a leading
+    // or trailing dash fails this and the whole segment is kept as the title.
+    if (!WHITESPACE.test(segment[i - 1] ?? "")) continue;
+    if (!WHITESPACE.test(segment[i + 1] ?? "")) continue;
+
+    return segment.slice(0, i);
+  }
+
+  return segment;
+}
+
+/**
  * Parse a LinkedIn page title into job title and company.
  *
  * LinkedIn's format is `"Job Title - Team/Department | Company | LinkedIn"`, so
@@ -55,6 +129,9 @@ export function extractLinkedInCompanyFromDOM(doc: Document): string | null {
  *     → pipes → ["Director, Engineering - Agentic Systems", "Visa", "LinkedIn"]
  *     → company = second-to-last = "Visa"
  *     → dash-split segment 0 → title = "Director, Engineering"
+ *
+ * Which dashes count as that separator is {@link titleBeforeTeamSegment}'s
+ * problem, and the answer is narrower than "the first one" — see its docblock.
  *
  * The trailing `"LinkedIn"` is required, not assumed: without it this is some
  * other page's title and guessing at it would invent a company name. Returns
@@ -72,8 +149,7 @@ export function parseLinkedInTitle(
   // Need at least 3 parts: [title-segment, company, "LinkedIn"]
   if (pipeParts.length >= 3 && pipeParts[pipeParts.length - 1] === "LinkedIn") {
     const company = pipeParts[pipeParts.length - 2]?.trim();
-    const dashParts = pipeParts[0].split(/\s*[-–]\s*/);
-    const title = dashParts[0]?.trim();
+    const title = titleBeforeTeamSegment(pipeParts[0]).trim();
 
     if (title && company) {
       return { title, company };

--- a/src/lib/jd-extract/prune.test.ts
+++ b/src/lib/jd-extract/prune.test.ts
@@ -127,6 +127,303 @@ describe("pruneNonPosting — other postings' terms", () => {
   });
 });
 
+/**
+ * The search-results list (#725).
+ *
+ * Observed live on 2026-08-01: LinkedIn renders the description only on
+ * `/jobs/search/?currentJobId=<id>`, where `main` is 14.8 KB and opens with the
+ * whole results list. That list is neither a pruned tag nor under any caption the
+ * heading patterns match, so it survived into `body`, became `jdText`, and every
+ * other posting's title was scored as this posting's requirements.
+ *
+ * The company names below are invented; the one real string is the role/company
+ * pair quoted in the issue, which is a public posting rather than a person.
+ */
+describe("pruneNonPosting — a list of other postings", () => {
+  const CARD = (id: string, title: string) =>
+    `<li><a href="/jobs/view/${id}/?trk=results">${title}</a>
+       <span>Nimbus Data · Remote</span></li>`;
+
+  it("drops an uncaptioned results list of job-permalink cards", () => {
+    const el = root(`
+      <ul>
+        ${CARD("4437835690", "Head of Engineering ($225k - $275k)")}
+        ${CARD("4437835691", "Principal Kubernetes Architect")}
+        ${CARD("4437835692", "Director of Platform Engineering")}
+      </ul>
+      ${JD}
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Principal Kubernetes Architect");
+    expect(text).not.toContain("Director of Platform Engineering");
+    expect(text).toContain("Staff Data Engineer");
+    expect(text).toContain("Python and Spark");
+  });
+
+  it("recognises an absolute permalink as well as a site-relative one", () => {
+    const el = root(`
+      ${JD}
+      <ul>
+        <li><a href="https://www.linkedin.com/jobs/view/4437835691/">Principal Kubernetes Architect</a></li>
+        <li><a href="https://www.linkedin.com/jobs/view/4437835692/">Director of Platform Engineering</a></li>
+      </ul>
+    `);
+
+    expect(pruneNonPosting(el).textContent ?? "").not.toContain(
+      "Principal Kubernetes Architect",
+    );
+  });
+
+  // The search SPA addresses a card by query parameter, not by path.
+  it("recognises the currentJobId form the search SPA links cards with", () => {
+    const el = root(`
+      ${JD}
+      <ul>
+        <li><a href="/jobs/search/?currentJobId=4437835691">Principal Kubernetes Architect</a></li>
+        <li><a href="/jobs/search/?currentJobId=4437835692">Director of Platform Engineering</a></li>
+      </ul>
+    `);
+
+    expect(pruneNonPosting(el).textContent ?? "").not.toContain(
+      "Principal Kubernetes Architect",
+    );
+  });
+
+  it("drops the uncaptioned 'Trending employee content' rail", () => {
+    const el = root(`
+      ${JD}
+      <section><h2>Trending employee content</h2>
+        <p>See what people at Nimbus Data are talking about.</p></section>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("are talking about");
+    expect(text).toContain("Staff Data Engineer");
+  });
+});
+
+/**
+ * The other half of the results-list rule, and the more important half.
+ *
+ * `prune.ts` states the asymmetry it works under — *a false positive here deletes
+ * real posting text, which is worse than the noise it was aiming at* — so these
+ * pin the shapes the rule must decline. Each one is a plausible description that
+ * a looser rule ("a list with links in it") would have eaten.
+ */
+describe("pruneNonPosting — lists that are posting body", () => {
+  it("keeps a list of ordinary links, which is not a rail", () => {
+    const el = root(`
+      ${JD}
+      <ul>
+        <li><a href="https://nimbus.example.com/handbook">Our engineering handbook</a></li>
+        <li><a href="https://nimbus.example.com/benefits">Benefits and leave policy</a></li>
+        <li><a href="https://nimbus.example.com/team">Meet the platform team</a></li>
+      </ul>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("engineering handbook");
+    expect(text).toContain("Benefits and leave policy");
+  });
+
+  it("keeps a requirements list where only one item links to another posting", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <ul>
+        <li>8+ years building streaming systems</li>
+        <li>Deep Kafka and Flink experience</li>
+        <li>Also hiring a <a href="/jobs/view/4437835691/">Principal Architect</a></li>
+      </ul>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("Kafka and Flink");
+    expect(text).toContain("8+ years building streaming systems");
+  });
+
+  it("keeps a single job link, which is a sentence rather than a rail", () => {
+    const el = root(`
+      ${JD}
+      <ul><li>Sister role: <a href="/jobs/view/4437835691/">Principal Architect</a></li></ul>
+    `);
+
+    expect(pruneNonPosting(el).textContent ?? "").toContain("Principal Architect");
+  });
+
+  it("keeps a plain bulleted list with no links at all", () => {
+    const el = root(`${JD}<ul><li>Kubernetes</li><li>Terraform</li></ul>`);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("Kubernetes");
+    expect(text).toContain("Terraform");
+  });
+
+  // A nested bullet must not vote on its grandparent: an item's vote comes only
+  // from anchors whose nearest enclosing `li` is that item, so an outer list with
+  // real prose survives whichever links sit inside it.
+  it("keeps an outer list whose own items are prose", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <ul>
+        <li>You will own the streaming platform, working with:
+          <ul>
+            <li><a href="/jobs/view/4437835691/">the Principal Architect we are hiring</a></li>
+            <li><a href="/jobs/view/4437835692/">the Director of Platform we are hiring</a></li>
+          </ul>
+        </li>
+      </ul>
+    `);
+
+    expect(pruneNonPosting(el).textContent ?? "").toContain(
+      "own the streaming platform",
+    );
+  });
+
+  /**
+   * The same shape with TWO prose items, which is the case the single-item test
+   * above could not distinguish.
+   *
+   * With one item the list fails `MIN_POSTING_LINK_LIST_ITEMS` and survives no
+   * matter how the items are judged, so the test passed without proving the
+   * nested-bullet rule worked. Duplicate the item and the `>= 2` gate opens: a
+   * "does this item CONTAIN a job link anywhere in its subtree" rule then calls
+   * both prose bullets cards and deletes the whole list, taking two sentences of
+   * real description with it.
+   */
+  it("keeps a two-item outer list whose own items are prose", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <ul>
+        <li>You will own the streaming platform, working with:
+          <ul>
+            <li><a href="/jobs/view/4437835691/">the Principal Architect we are hiring</a></li>
+            <li><a href="/jobs/view/4437835692/">the Director of Platform we are hiring</a></li>
+          </ul>
+        </li>
+        <li>You will also own the batch platform, working with:
+          <ul>
+            <li><a href="/jobs/view/4437835693/">the Staff Data Engineer we are hiring</a></li>
+            <li><a href="/jobs/view/4437835694/">the Analytics Lead we are hiring</a></li>
+          </ul>
+        </li>
+      </ul>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("own the streaming platform");
+    expect(text).toContain("own the batch platform");
+  });
+
+  // A link inside a sentence is a sentence, however many sentences there are.
+  // The anchor has non-whitespace text beside it; a card's link does not.
+  it("keeps bullets that are sentences with a job link inline in them", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <ul>
+        <li>You will pair with our <a href="/jobs/view/4437835691/">Staff Engineer</a> on the payments core.</li>
+        <li>You will also pair with our <a href="/jobs/view/4437835692/">Principal Architect</a> on the ledger rewrite.</li>
+      </ul>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("on the payments core");
+    expect(text).toContain("on the ledger rewrite");
+  });
+
+  it("keeps bullets that are sentences with a job link wrapped in inline formatting", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <ul>
+        <li>You will pair with our <strong><a href="/jobs/view/4437835691/">Staff Engineer</a></strong> on the payments core.</li>
+        <li>You will also pair with our <em><a href="/jobs/view/4437835692/">Principal Architect</a></em> on the ledger rewrite.</li>
+      </ul>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("on the payments core");
+    expect(text).toContain("on the ledger rewrite");
+  });
+
+  // Link-dominance, not link-presence: a standalone link is not a card when the
+  // item also carries a paragraph of real description.
+  it("keeps items where a standalone job link is outweighed by posting text", () => {
+    const el = root(`
+      <h2>About the job</h2>
+      <ul>
+        <li><a href="/jobs/view/4437835691/">Principal Architect</a>
+          <p>We are hiring this role alongside yours, and whoever takes it will
+             own the ledger rewrite end to end with you, sharing on-call, design
+             review and the migration plan for the payments core.</p></li>
+        <li><a href="/jobs/view/4437835692/">Director of Platform</a>
+          <p>We are hiring this role alongside yours too, and whoever takes it
+             will set the platform roadmap with you, sharing headcount planning
+             and the quarterly architecture review across both teams.</p></li>
+      </ul>
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).toContain("own the ledger rewrite end to end");
+    expect(text).toContain("set the platform roadmap");
+  });
+});
+
+/**
+ * Efficacy under the link-dominance rule (#725 review).
+ *
+ * The rule above must stay strict enough to remove the thing it was built for.
+ * LinkedIn does not render a card as `<li><a>`: the anchor sits under a wrapper
+ * `div` or two, and the card carries its own nested `ul` of metadata chips — so
+ * a fix that scoped the vote to an `li`'s DIRECT child anchors would have gone
+ * green on the synthetic fixtures above while silently letting the real search
+ * page back in. This pins the observed shape.
+ */
+describe("pruneNonPosting — the real search-results card shape", () => {
+  const REAL_CARD = (id: string, title: string) => `
+    <li>
+      <div class="job-card-container">
+        <div class="artdeco-entity-lockup__title">
+          <a class="job-card-list__title--link" href="/jobs/view/${id}/?alertAction=view&amp;refId=xyz">
+            <strong>${title}</strong>
+          </a>
+        </div>
+        <div class="artdeco-entity-lockup__subtitle"><span>Nimbus Data</span></div>
+        <ul class="job-card-container__metadata-wrapper">
+          <li>Remote (Hybrid)</li>
+          <li>Promoted</li>
+        </ul>
+      </div>
+    </li>`;
+
+  it("still drops a results list whose links are wrapped in card chrome", () => {
+    const el = root(`
+      <ul class="scaffold-layout__list-container">
+        ${REAL_CARD("4123456789", "Principal Kubernetes Architect")}
+        ${REAL_CARD("4123456790", "Director of Platform Engineering")}
+        ${REAL_CARD("4123456791", "Head of Data Engineering")}
+      </ul>
+      ${JD}
+    `);
+
+    const text = pruneNonPosting(el).textContent ?? "";
+
+    expect(text).not.toContain("Principal Kubernetes Architect");
+    expect(text).not.toContain("Director of Platform Engineering");
+    expect(text).not.toContain("Head of Data Engineering");
+    expect(text).toContain("Staff Data Engineer");
+    expect(text).toContain("Python and Spark");
+  });
+});
+
 describe("pruneNonPosting — page chrome", () => {
   it.each(["nav", "aside", "footer", "form"])("drops <%s>", (tag) => {
     const el = root(`${JD}<${tag}>Amharic Arabic Bangla Czech Danish</${tag}>`);

--- a/src/lib/jd-extract/prune.ts
+++ b/src/lib/jd-extract/prune.ts
@@ -65,7 +65,52 @@ const NON_POSTING_HEADINGS: readonly RegExp[] = [
   /\b(similar|related|recommended|suggested|more)\s+jobs\b/i,
   /\bjobs\s+(you\s+may|that\s+may)\b/i,
   /people\s+also\s+viewed/i,
+  // A feed rail LinkedIn hangs off the tail of a job page — other people's posts,
+  // matched on its literal caption because that is all it has in common with a
+  // posting. Observed live on 2026-08-01 at the end of a 14.8 KB `main`.
+  /trending\s+employee\s+content/i,
 ];
+
+/**
+ * Href shapes that are some job posting's own permalink.
+ *
+ * A permalink shape, not a class name and not a host: a board keeps its permalink
+ * stable across redesigns precisely because links to it are shared — that is the
+ * same property `src/lib/storage/job-url.ts` derives record ids from — while the
+ * markup wrapped around it rots on the next deploy. Both entries are narrow enough
+ * that no ordinary link in a posting body can match: a benefits page, a handbook,
+ * an engineering blog and a team page all fail them.
+ *
+ * The two shapes are the two ways LinkedIn addresses a posting, and the second is
+ * why the first is not enough — its search SPA links cards by query parameter.
+ */
+const JOB_PERMALINK_HREF: readonly RegExp[] = [
+  /\/jobs?\/view\/\d/i,
+  /[?&]currentJobId=\d/i,
+];
+
+/**
+ * Fewest items a list needs before it reads as a rail of other postings rather
+ * than a description bullet that happens to link somewhere.
+ *
+ * Two, not one: a single link to another opening inside a paragraph-shaped list is
+ * a sentence, and deleting it would take real posting text with it.
+ */
+const MIN_POSTING_LINK_LIST_ITEMS = 2;
+
+/**
+ * Longest run of non-link text an item may carry and still read as a job card.
+ *
+ * A card is a link plus label-shaped metadata — `Nimbus Data · Remote`,
+ * `Promoted`, `Actively hiring` — so what is left once its own links are
+ * subtracted is short. A paragraph hanging off a link is not. Generous on
+ * purpose, in the direction the asymmetry at the top of this file demands: it
+ * admits a verbose card rather than risking a terse piece of description.
+ */
+const MAX_NON_LINK_CHARS = 120;
+
+/** `Node.TEXT_NODE`, spelled out so this module needs no DOM global. */
+const TEXT_NODE = 3;
 
 const HEADING_SELECTOR = "h1, h2, h3, h4, h5, h6";
 
@@ -116,6 +161,127 @@ function removeCaptionedRun(heading: Element): void {
   heading.remove();
 }
 
+/** Length of `text` with whitespace runs collapsed, so indentation in the source
+ *  markup does not count against {@link MAX_NON_LINK_CHARS}. */
+function textLength(text: string | null): number {
+  return (text ?? "").replace(/\s+/g, " ").trim().length;
+}
+
+/**
+ * Is `anchor` sitting inside a run of prose rather than standing on its own?
+ *
+ * True when it has a non-whitespace text sibling — `You will pair with our
+ * <a>Staff Engineer</a> on the payments core` — which is a sentence that
+ * mentions another opening, not a card advertising one. A card's link has only
+ * elements and whitespace beside it.
+ */
+function isInlineInProse(anchor: Element): boolean {
+  const li = anchor.closest("li");
+  if (!li) return false;
+  let current: Element | null = anchor;
+  while (current && current !== li) {
+    const parentEl: Element | null = current.parentElement;
+    if (!parentEl) break;
+    for (const node of parentEl.childNodes) {
+      if (node === current) continue;
+      if (node.nodeType === TEXT_NODE && (node.textContent ?? "").trim() !== "") {
+        return true;
+      }
+    }
+    current = parentEl;
+  }
+  return false;
+}
+
+
+/**
+ * The anchors that are `item`'s OWN, in the sense that a card's link is its own.
+ *
+ * Two filters, each closing a way a link that is not a card's link would
+ * otherwise vote:
+ *   - the anchor's nearest enclosing `li` must be `item`, so a nested bullet
+ *     cannot vote on its grandparent. Deliberately not a direct-child test: a
+ *     real card wraps its link in a `div` or three, so requiring the anchor to
+ *     be `item`'s own child would stop matching the very shape this rule exists
+ *     for.
+ *   - the anchor must not be inline in prose ({@link isInlineInProse}).
+ */
+function ownCardAnchors(item: Element): Element[] {
+  return Array.from(item.querySelectorAll("a[href]")).filter(
+    (anchor) => anchor.closest("li") === item && !isInlineInProse(anchor),
+  );
+}
+
+/**
+ * Is `item` a job card — an item whose text is DOMINATED by a link to some
+ * posting's permalink, rather than one that merely contains such a link?
+ *
+ * Containment alone was not enough: a full sentence of description counted as a
+ * card because a permalink appeared somewhere inside it, and two such sentences
+ * deleted the entire list — the exact false positive this module's opening
+ * asymmetry forbids. Both halves are load-bearing. {@link ownCardAnchors}
+ * rejects the link that belongs to a nested bullet or sits mid-sentence, and the
+ * length test below rejects an item that pairs a standalone link with a
+ * paragraph of real posting text.
+ *
+ * Only the item's own links are subtracted from its length, never a nested
+ * bullet's, so a nested rail can only ever make its ancestor look MORE like
+ * prose — under-pruning, which is the safe direction.
+ */
+function isPostingCard(item: Element): boolean {
+  const anchors = ownCardAnchors(item);
+  const linksToPosting = anchors.some((anchor) =>
+    JOB_PERMALINK_HREF.some((pattern) =>
+      pattern.test(anchor.getAttribute("href") ?? ""),
+    ),
+  );
+  if (!linksToPosting) return false;
+
+  const linkChars = anchors.reduce(
+    (total, anchor) => total + textLength(anchor.textContent),
+    0,
+  );
+  return textLength(item.textContent) - linkChars <= MAX_NON_LINK_CHARS;
+}
+
+/**
+ * Is this list a rail of OTHER postings rather than part of this description?
+ *
+ * The structural half of the answer to a block the heading rules cannot reach: a
+ * search-results page carries its result list under no caption at all — it is a
+ * plain `ul` of job cards — so nothing above matches it, and on
+ * `/jobs/search/?currentJobId=` it lands at the head of `body` and every other
+ * posting's title is scored as this posting's requirements.
+ *
+ * The test is deliberately the strictest one that still catches it. EVERY direct
+ * `li` child must BE a job card by {@link isPostingCard} — link-DOMINATED, not
+ * merely link-containing — and every one, not a majority and not the first: a
+ * qualifications list with one item that happens to link to a related opening
+ * fails this and survives whole, which is the intended direction.
+ *
+ * Two things scope the vote, and both are checked in `isPostingCard` rather than
+ * asserted here. Only direct `li` children are items, and an item's vote comes
+ * only from anchors whose nearest enclosing `li` is that item — so neither a
+ * nested bullet nor an anchor buried in an ancestor's prose can decide a list's
+ * fate.
+ *
+ * What survives is a narrow false-positive class: a description whose own
+ * bulleted list is entirely bare links to other job postings, with no prose
+ * around them. Text of that shape is other postings' titles, which is the thing
+ * this module removes on purpose.
+ *
+ * The root itself is never reachable here: `querySelectorAll` excludes the node
+ * it is called on, so `pruneNonPosting` cannot delete what it was asked to prune.
+ */
+function isOtherPostingsList(list: Element): boolean {
+  const items = Array.from(list.children).filter(
+    (child) => child.tagName === "LI",
+  );
+  return (
+    items.length >= MIN_POSTING_LINK_LIST_ITEMS && items.every(isPostingCard)
+  );
+}
+
 /**
  * Return a pruned copy of `element`, with non-posting subtrees removed.
  *
@@ -142,6 +308,15 @@ export function pruneNonPosting(element: Element): Element {
     const container = captionedContainer(heading, clone);
     if (container === heading) removeCaptionedRun(heading);
     else container.remove();
+  }
+
+  // Last, and collected the same way for the same reason: an outer list is
+  // visited before the lists nested inside it, so removing one can detach others
+  // still in the array.
+  const lists = Array.from(clone.querySelectorAll("ul, ol"));
+  for (const list of lists) {
+    if (!clone.contains(list)) continue;
+    if (isOtherPostingsList(list)) list.remove();
   }
 
   return clone;

--- a/src/lib/jd-extract/types.ts
+++ b/src/lib/jd-extract/types.ts
@@ -44,8 +44,15 @@ export type ExtractionTier =
  *
  * Carried over from the upstream implementation at its then-current value, so
  * results already stamped by that code remain correctly comparable.
+ *
+ * `10` (#725): both halves of a result moved. `parseLinkedInTitle` stopped
+ * splitting a title at a dash inside brackets or inside a hyphenated token, so a
+ * title carrying a comp band extracts whole where it was previously truncated;
+ * and `pruneNonPosting` began dropping a list whose every item links to another
+ * posting, so `body` loses a search-results rail it used to carry. A version 9
+ * extraction of either page shape is not comparable to a version 10 one.
  */
-export const EXTRACTION_ALGORITHM_VERSION = 9;
+export const EXTRACTION_ALGORITHM_VERSION = 10;
 
 /**
  * What a job-posting page yields. Everything except `title` and `company` is

--- a/src/lib/jd-match/fetch-jd.test.ts
+++ b/src/lib/jd-match/fetch-jd.test.ts
@@ -82,6 +82,239 @@ describe("parseAtsUrl", () => {
   it("returns null for an empty string", () => {
     expect(parseAtsUrl("")).toBeNull();
   });
+
+  it("returns null for a non-URL string (malformed input, must not throw)", () => {
+    expect(parseAtsUrl("not a url")).toBeNull();
+  });
+
+  // #726 — host matching must be anchored to `URL.hostname`, not a substring
+  // scan of the raw string. Each platform gets a positive on its real host(s),
+  // a look-alike-host negative, and (Recruitee) a bare-apex-domain negative.
+
+  describe("Greenhouse — host anchoring (#726)", () => {
+    it("parses the modern `job-boards.greenhouse.io` host", () => {
+      expect(
+        parseAtsUrl("https://job-boards.greenhouse.io/acme/jobs/123"),
+      ).toEqual({ platform: "greenhouse", company: "acme", jobId: "123" });
+    });
+
+    it("still parses the legacy `boards.greenhouse.io` host", () => {
+      expect(
+        parseAtsUrl("https://boards.greenhouse.io/acme/jobs/123"),
+      ).toEqual({ platform: "greenhouse", company: "acme", jobId: "123" });
+    });
+
+    it("rejects a look-alike host that merely contains the string boards.greenhouse.io", () => {
+      expect(
+        parseAtsUrl(
+          "https://evil-boards.greenhouse.io.attacker.test/acme/jobs/123",
+        ),
+      ).toBeNull();
+    });
+
+    it("rejects a non-Greenhouse host with the target string in the path/query", () => {
+      expect(
+        parseAtsUrl(
+          "https://example.test/redirect?to=boards.greenhouse.io/acme/jobs/123",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("Lever — host anchoring (#726)", () => {
+    it("parses jobs.lever.co", () => {
+      expect(
+        parseAtsUrl(
+          "https://jobs.lever.co/acmecorp/abcd1234-ef56-7890-abcd-ef1234567890",
+        ),
+      ).toEqual({
+        platform: "lever",
+        company: "acmecorp",
+        jobId: "abcd1234-ef56-7890-abcd-ef1234567890",
+      });
+    });
+
+    it("rejects a look-alike host", () => {
+      expect(
+        parseAtsUrl(
+          "https://evil-jobs.lever.co.attacker.test/acmecorp/abcd1234-ef56-7890-abcd-ef1234567890",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("Workable — host anchoring (#726)", () => {
+    it("parses apply.workable.com", () => {
+      expect(
+        parseAtsUrl("https://apply.workable.com/acmecorp/j/AB12CD34EF"),
+      ).toEqual({ platform: "workable", company: "acmecorp", jobId: "AB12CD34EF" });
+    });
+
+    it("rejects a look-alike host", () => {
+      expect(
+        parseAtsUrl(
+          "https://apply.workable.com.attacker.test/acmecorp/j/AB12CD34EF",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("Recruitee — host anchoring (#726)", () => {
+    it("parses the company wildcard subdomain", () => {
+      expect(
+        parseAtsUrl("https://acmecorp.recruitee.com/o/senior-software-engineer"),
+      ).toEqual({
+        platform: "recruitee",
+        company: "acmecorp",
+        jobId: "senior-software-engineer",
+      });
+    });
+
+    it("rejects a look-alike host", () => {
+      expect(
+        parseAtsUrl(
+          "https://acmecorp.recruitee.com.attacker.test/o/senior-software-engineer",
+        ),
+      ).toBeNull();
+    });
+
+    it("rejects the bare apex domain with no company subdomain", () => {
+      expect(
+        parseAtsUrl("https://recruitee.com/o/senior-software-engineer"),
+      ).toBeNull();
+    });
+  });
+
+  describe("Ashby — host anchoring (#726)", () => {
+    it("parses jobs.ashbyhq.com", () => {
+      expect(
+        parseAtsUrl(
+          "https://jobs.ashbyhq.com/acmecorp/12345678-90ab-cdef-1234-567890abcdef",
+        ),
+      ).toEqual({
+        platform: "ashby",
+        company: "acmecorp",
+        jobId: "12345678-90ab-cdef-1234-567890abcdef",
+      });
+    });
+
+    it("rejects a look-alike host", () => {
+      expect(
+        parseAtsUrl(
+          "https://jobs.ashbyhq.com.attacker.test/acmecorp/12345678-90ab-cdef-1234-567890abcdef",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  /**
+   * Scheme-less input (#726 review).
+   *
+   * `JdInput` passes the raw trimmed string straight through, so a paste of
+   * `boards.greenhouse.io/acme/jobs/123` — the shape a board's own "copy link"
+   * and every job aggregator hands out — reaches `new URL` with no scheme.
+   * The pre-#726 substring matcher accepted these; anchoring on `URL.hostname`
+   * without a retry regressed them to "unsupported", telling the user Greenhouse
+   * URLs are supported about a Greenhouse URL.
+   */
+  describe("scheme-less input", () => {
+    it.each([
+      [
+        "boards.greenhouse.io/acme/jobs/123",
+        { platform: "greenhouse", company: "acme", jobId: "123" },
+      ],
+      [
+        "boards.greenhouse.io/acme/jobs/123?gh_src=https://linkedin.com",
+        { platform: "greenhouse", company: "acme", jobId: "123" },
+      ],
+      [
+        "job-boards.greenhouse.io/acme/jobs/123",
+        { platform: "greenhouse", company: "acme", jobId: "123" },
+      ],
+      [
+        "apply.workable.com/acme/j/AB12CD34EF",
+        { platform: "workable", company: "acme", jobId: "AB12CD34EF" },
+      ],
+      [
+        "acme.recruitee.com/o/senior-engineer",
+        { platform: "recruitee", company: "acme", jobId: "senior-engineer" },
+      ],
+      [
+        "jobs.lever.co/acme/abcd1234-ef56-7890-abcd-ef1234567890",
+        {
+          platform: "lever",
+          company: "acme",
+          jobId: "abcd1234-ef56-7890-abcd-ef1234567890",
+        },
+      ],
+      [
+        "jobs.ashbyhq.com/acme/12345678-90ab-cdef-1234-567890abcdef",
+        {
+          platform: "ashby",
+          company: "acme",
+          jobId: "12345678-90ab-cdef-1234-567890abcdef",
+        },
+      ],
+    ])("parses %s with no scheme", (url, expected) => {
+      expect(parseAtsUrl(url)).toEqual(expected);
+    });
+
+    /**
+     * The retry must not widen what the host checks accept.
+     *
+     * Every case below is #726's threat model re-run through the new code path:
+     * each one is a string an attacker would craft to make a hostile host read
+     * as an ATS host. They stay `null` because the checks read the PARSED
+     * `hostname`, which prefixing `https://` computes rather than assumes —
+     * `boards.greenhouse.io@evil.test/…` has hostname `evil.test`, and burying
+     * an ATS host in a path, query or fragment never moves it into the host.
+     */
+    it.each([
+      // The four #726 negatives, restated with their scheme (unchanged path)…
+      "https://evil-boards.greenhouse.io.attacker.test/acme/jobs/123",
+      "https://example.test/redirect?to=boards.greenhouse.io/acme/jobs/123",
+      "https://boards.greenhouse.io@evil.test/acme/jobs/123",
+      "not a url",
+      "",
+      // …and each one again with the scheme stripped, which is the new path.
+      "evil-boards.greenhouse.io.attacker.test/acme/jobs/123",
+      "example.test/redirect?to=boards.greenhouse.io/acme/jobs/123",
+      "boards.greenhouse.io@evil.test/acme/jobs/123",
+      // Userinfo smuggling on the other platforms too.
+      "acme.recruitee.com@evil.test/o/senior-engineer",
+      "jobs.lever.co@evil.test/acme/abcd1234-ef56-7890-abcd-ef1234567890",
+      // An ATS host as a path segment of a hostile host.
+      "evil.test/x/acme.recruitee.com/o/senior-engineer",
+      "evil.test/apply.workable.com/acme/j/AB12CD34EF",
+      // …and in the query and the fragment.
+      "evil.test/go?to=acme.recruitee.com/o/senior-engineer",
+      "evil.test#boards.greenhouse.io/acme/jobs/123",
+      // A protocol-relative reference to a hostile host.
+      "//evil.test/acme/jobs/123",
+      // A backslash ends the authority, so the ATS host survives as the host but
+      // the smuggled one lands in the path, where no path pattern matches it.
+      "boards.greenhouse.io\\@evil.test/acme/jobs/123",
+      // Non-http schemes: these parse on the FIRST attempt (so no retry runs)
+      // and carry no hostname or are otherwise rejected.
+      "javascript:alert(1)",
+      "javascript://boards.greenhouse.io/acme/jobs/123",
+      "data:text/html,boards.greenhouse.io/acme/jobs/123",
+      "file:///acme/jobs/123",
+    ])("returns null for %s", (url) => {
+      expect(parseAtsUrl(url)).toBeNull();
+    });
+
+    // A scheme-relative reference to a REAL board host is the board host — the
+    // retry resolves it to exactly the hostname written in it, so accepting it
+    // grants nothing a scheme'd paste of the same URL would not.
+    it("accepts a protocol-relative reference to a real board host", () => {
+      expect(parseAtsUrl("//boards.greenhouse.io/acme/jobs/123")).toEqual({
+        platform: "greenhouse",
+        company: "acme",
+        jobId: "123",
+      });
+    });
+  });
 });
 
 describe("classifyUnsupportedHost", () => {

--- a/src/lib/jd-match/fetch-jd.ts
+++ b/src/lib/jd-match/fetch-jd.ts
@@ -20,6 +20,54 @@ export interface ParsedAtsUrl {
 }
 
 // ─── URL parsers ──────────────────────────────────────────────────────────────
+//
+// Every parser below anchors on `URL.hostname`, never on a substring match of
+// the raw string. A substring match (the pre-#726 shape) accepts any host that
+// merely *contains* the target host as a substring — e.g.
+// `evil-boards.greenhouse.io.attacker.test` — and any path prefix, e.g.
+// `example.test/redirect?to=boards.greenhouse.io/...`. Both parse to a
+// same-shaped `ParsedAtsUrl` that `extractPostingFromAtsApi` (jd-extract/ats-api.ts)
+// turns into an outbound fetch built from attacker-influenced path segments.
+
+// A malformed/relative/non-URL string is "not an ATS URL", not a throw.
+//
+// The scheme-less retry is what keeps #726's move to `URL.hostname` from also
+// rejecting valid input. `JdInput` hands this the raw trimmed string the user
+// typed into a bare `<input type="url">` — nothing normalises it — and people
+// paste `boards.greenhouse.io/acme/jobs/123` without a scheme. `new URL` throws
+// on that, so without the retry the user is told Greenhouse URLs are supported
+// about a Greenhouse URL. The pre-#726 substring matcher accepted these.
+//
+// Prefixing cannot widen what the host checks accept, because those checks read
+// the PARSED `hostname` rather than the string: `boards.greenhouse.io@evil.test/…`
+// prefixes to a URL whose hostname is `evil.test`, and
+// `evil.test/x/acme.recruitee.com/o/slug` to one whose hostname is `evil.test` —
+// both still fail every host below. What the retry can do is turn "unparseable"
+// into "parseable but not ours", which is the same `null`.
+//
+// The `://` guard keeps the retry off a string that already declared a scheme,
+// so a scheme that merely failed to parse is never silently re-homed under
+// `https` — a malformed `http://…` stays malformed instead of becoming a host.
+function tryParseUrl(url: string): URL | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return parsed;
+    }
+    return null;
+  } catch {
+    // The scheme-less check prevents prepending a scheme to a string that already declared one.
+    // We check for a scheme at the start of the string (e.g. `https://` or `ftp://`) rather than
+    // a simple substring match (`url.includes("://")`), so a URL that contains `://` in its
+    // query or path (e.g. `boards.greenhouse.io/acme?dest=https://linkedin.com`) can still be retried.
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) return null;
+    try {
+      return new URL(`https://${url}`);
+    } catch {
+      return null;
+    }
+  }
+}
 
 export function parseAtsUrl(url: string): ParsedAtsUrl | null {
   return (
@@ -31,31 +79,57 @@ export function parseAtsUrl(url: string): ParsedAtsUrl | null {
   );
 }
 
+// `job-boards.greenhouse.io` is Greenhouse's current public board host;
+// `boards.greenhouse.io` is the legacy host, still live in old bookmarks and
+// in saved `JobRecord.url` values — dropping it would silently break existing
+// records.
+const GREENHOUSE_HOSTS = new Set([
+  "job-boards.greenhouse.io",
+  "boards.greenhouse.io",
+]);
+
 function parseGreenhouseUrl(url: string): ParsedAtsUrl | null {
-  const match = url.match(/boards\.greenhouse\.io\/(\w[\w-]*)\/jobs\/(\d+)/);
+  const parsed = tryParseUrl(url);
+  if (!parsed || !GREENHOUSE_HOSTS.has(parsed.hostname)) return null;
+  const match = parsed.pathname.match(/^\/(\w[\w-]*)\/jobs\/(\d+)/);
   return match
     ? { platform: "greenhouse", company: match[1], jobId: match[2] }
     : null;
 }
 
 function parseLeverUrl(url: string): ParsedAtsUrl | null {
-  const match = url.match(/jobs\.lever\.co\/([\w-]+)\/([\da-f-]+)/);
+  const parsed = tryParseUrl(url);
+  if (!parsed || parsed.hostname !== "jobs.lever.co") return null;
+  const match = parsed.pathname.match(/^\/([\w-]+)\/([\da-f-]+)/);
   return match
     ? { platform: "lever", company: match[1], jobId: match[2] }
     : null;
 }
 
 function parseWorkableUrl(url: string): ParsedAtsUrl | null {
-  const match = url.match(/apply\.workable\.com\/([\w-]+)\/j\/([A-Z0-9]+)/i);
+  const parsed = tryParseUrl(url);
+  if (!parsed || parsed.hostname !== "apply.workable.com") return null;
+  const match = parsed.pathname.match(/^\/([\w-]+)\/j\/([A-Z0-9]+)/i);
   return match
     ? { platform: "workable", company: match[1], jobId: match[2] }
     : null;
 }
 
+// Recruitee boards live on a wildcard subdomain (`{company}.recruitee.com`),
+// so this is a suffix match on the hostname rather than a fixed host —
+// but the suffix must be preceded by exactly one non-empty label, not a
+// substring anywhere in the string, and not the bare apex domain.
 function parseRecruiteeUrl(url: string): ParsedAtsUrl | null {
-  const match = url.match(/([\w-]+)\.recruitee\.com\/o\/([\w-]+)/);
+  const parsed = tryParseUrl(url);
+  if (!parsed) return null;
+  const suffix = ".recruitee.com";
+  const host = parsed.hostname;
+  if (!host.endsWith(suffix)) return null;
+  const company = host.slice(0, -suffix.length);
+  if (!company || company.includes(".")) return null;
+  const match = parsed.pathname.match(/^\/o\/([\w-]+)/);
   return match
-    ? { platform: "recruitee", company: match[1], jobId: match[2] }
+    ? { platform: "recruitee", company, jobId: match[1] }
     : null;
 }
 
@@ -64,8 +138,10 @@ function parseRecruiteeUrl(url: string): ParsedAtsUrl | null {
 // UUID-strict on the tail so a non-UUID path falls through to "unsupported"
 // instead of producing a 404 on the API.
 function parseAshbyUrl(url: string): ParsedAtsUrl | null {
-  const match = url.match(
-    /jobs\.ashbyhq\.com\/([\w-]+)\/([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})/i,
+  const parsed = tryParseUrl(url);
+  if (!parsed || parsed.hostname !== "jobs.ashbyhq.com") return null;
+  const match = parsed.pathname.match(
+    /^\/([\w-]+)\/([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})/i,
   );
   return match
     ? { platform: "ashby", company: match[1], jobId: match[2] }

--- a/src/lib/letter-egress-ack.test.ts
+++ b/src/lib/letter-egress-ack.test.ts
@@ -37,7 +37,13 @@ function useStorage(get: () => Storage | undefined) {
 }
 
 afterEach(() => {
+  // `real` is captured at module-eval time, before any `beforeEach` has run, so
+  // it is `undefined` whenever this file is the first in its worker to touch
+  // `localStorage`. Deleting rather than leaving the getter in place matters:
+  // the accessor `useStorage` installs has no setter, so anything that survives
+  // this hook breaks the next assignment to the global.
   if (real) Object.defineProperty(globalThis, "localStorage", real);
+  else delete (globalThis as { localStorage?: unknown }).localStorage;
   globalThis.localStorage?.clear();
 });
 


### PR DESCRIPTION
## Summary

Three defects in the job-capture lane, each of which wrote or displayed something wrong rather than failing loudly. Implemented as one batch on one branch, then hardened with a two-round adversarial review before this PR was opened.

- **#724** â€” Saved jobs rendered no fitness stars on any direct visit to `/jobs/` (bookmark, fresh tab, pasted `#saved` link), because the only rÃ©sumÃ© source was a `sessionStorage` handoff written on `/`. The rÃ©sumÃ© library was already loaded on the page; a new cancellable `useFallbackResume` hook offers the most-recently-saved entry to the rating hook, and the tracker names the file the stars were computed against. The rating stays derived â€” nothing persisted, no `JobRecord` field.
- **#725** â€” LinkedIn title parsing split on any dash, truncating `Head of Engineering ($225k - $275k)` to `Head of Engineering ($225k`. The split now declines inside a balanced bracket run and requires whitespace on both sides, so it only ever *refuses* a split it used to make. Separately, a search-results list survived pruning into the posting body, so one posting's `jdText` carried other postings' titles and scored against them.
- **#726** â€” ATS URL parsing matched hosts by substring, so `job-boards.greenhouse.io` worked only by accident and `evil-boards.greenhouse.io.attacker.test` worked too. All five `parse*Url` helpers now compare a parsed `URL.hostname` against an explicit allow-set.

Closes #729
Closes #724
Closes #725
Closes #726

## Decisions that need to be visible

**#725 defect 3 â€” LinkedIn stays a search-only source (Option B).** The adapter was *not* changed to read the detail pane off `/jobs/search/?currentJobId=`. Two reasons, the second verified empirically rather than reasoned:

1. On the search URL, `doc.querySelector("h1")` and the first `[aria-label^="Company,"]` may belong to a *results card* rather than the detail pane. That does not degrade â€” it writes another posting's company into the user's record.
2. `deriveJobId` does **not** collapse the two URL shapes: `/jobs/view/4437835690/` â†’ `job:linkedin.com/jobs/view/4437835690`, while `?currentJobId=4437835690` â†’ `job:linkedin.com/jobs/search?currentJobId=4437835690`, because `currentJobId` is on `job-url.ts`'s deliberate KEEP list. Option A therefore needs a hand-written rewrite to the canonical form, and the obvious carrier (`atsUrl`) is wrong twice â€” LinkedIn is not an ATS, and `withApplyLink` short-circuits when `atsUrl` is set, so it would *suppress* real ATS-original discovery and make dedup worse than today.

A live verification would need to show, across several postings and several sessions: that the detail pane's `h1` and company element are the ones `querySelector` reaches first; that `body` after pruning is the JD and not chrome; and that the pane renders *every* time, not four times in five. `.claude/skills/job-hunt/SKILL.md` keeps its refusal â€” the edit there is clarifying only, granting no capability.

**`EXTRACTION_ALGORITHM_VERSION` bumped 9 â†’ 10.** Extraction output changes for real inputs on both halves: a title carrying a comp band now extracts whole where it was truncated, and `body` no longer carries a results-list rail. A stored v9 extraction is not comparable to a fresh one, which is the staleness condition the constant exists to signal.

**Edited-vs-raw parse (#724 step 4).** `saveResumeToLibrary` stores the **edited** `CascadeResult` â€” `App.tsx:356` passes `displayResult`, built at `useAnalyzedResume.ts:292-305` by folding edited fields onto the canonical â€” so the fallback's parse is the same *kind* as the handoff's. One divergence, pre-existing and not introduced here: `loadResumeFromLibrary` (`resume-library.ts:178-211`) re-parses from the stored PDF bytes on a `CACHE_SHAPE_VERSION` mismatch, which drops edits. No edit-layer replay was added to `/jobs/`.

## Also in this PR â€” an unrelated flake fix

CI on this branch hit `TypeError: Cannot assign to read only property 'localStorage'` in `src/lib/analytics.test.ts`, a suite this batch does not touch. It is a pre-existing, order-dependent flake, not a regression from these changes â€” the full suite passes on this branch both before and after the fix, and the failure did not reproduce locally in a normal run.

Root cause: `installMemoryLocalStorage` (`src/hooks/__test-utils__/memory-storage.ts`), which `src/test-setup.ts` runs in a workload-wide `beforeEach`, installed the shim by **plain assignment**. Assignment is only valid if the *current* descriptor permits it, and this hook runs after arbitrary other suites in the same vitest worker. Two suites redefine `localStorage` through `Object.defineProperty` to fake private-mode behaviour, and `letter-egress-ack.test.ts` skipped its restore entirely when its module-eval-time descriptor capture was `undefined`. Either can leave the global as a non-writable data property or a getter-only accessor, and assignment throws on both â€” surfacing in whichever file ran next in that worker, which is why it presented as a rare flake somewhere unrelated.

Fix: define the property with an explicit `writable`/`configurable` instead of assigning, so the setup hook cannot fail on a polluted global; and delete rather than abandon the accessor in `letter-egress-ack.test.ts`'s `afterEach`.

Verified by reverting the fix against the new `memory-storage.test.ts`, which reproduces the reported error **byte-identically** (`Cannot assign to read only property 'localStorage' of object '#<Object>'`) and passes with it restored. The new tests recreate both hostile descriptor shapes directly, since a cross-file flake cannot be pinned by running the offending suites together.



## Post-Review Refinements

In response to the adversarial review findings, the following refinements have been applied to this branch:

- **Robust Inline Prose Checking in `prune.ts`**: Updated `isInlineInProse` to recursively walk up to the containing list item (`li`) rather than inspecting only the anchor's immediate parent. This ensures that inline styling wrappers (such as `<span>`, `<strong>`, or `<em>`) around a job link in a prose bullet do not prevent it from being correctly identified as prose.
- **Safer `useFallbackResume` Rejections**: Reset `fallback` state to `undefined` in `useFallbackResume.ts` when a library load fails (cancellable) to guarantee state consistency and ensure the tracker rates against nothing rather than stale/half-loaded data.
- **Regex-based Scheme-less Checking in `fetch-jd.ts`**: Replaced the substring `.includes("://")` check in `tryParseUrl` with a regex matching standard schemes at the beginning of the URL (`/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//`). This allows scheme-less Greenhouse/Lever URLs with query parameter URL schemes to pass the retry safely, while explicitly validating `parsed.protocol === "https:" || parsed.protocol === "http:"` to reject dangerous non-http protocols (like `javascript:`).

## Review focus

- `src/lib/jd-extract/prune.ts:178-187` â€” `isInlineInProse` inspects the anchor's own parent's text nodes. Does one level of inline wrapping (`<span>`, `<strong>`) around a job link in a prose bullet defeat it? See the surviving-nits note below.
- `src/lib/jd-extract/prune.ts:110` â€” is `MAX_NON_LINK_CHARS = 120` the right threshold, given real LinkedIn card metadata measured between 102 and 176 chars depending on whether an insight line is present?
- `src/lib/jd-match/fetch-jd.ts:56` â€” the scheme-less retry widens what parses on a security-relevant path. Does the `://` guard buy anything, and is the `//host/...` acceptance safe?
- `src/hooks/useFallbackResume.ts:53-93` â€” `exhaustive-deps` is not enforced in this repo. Does omitting `library.entries` from the load effect (relying on the `newestId` memo) hold under a rÃ©sumÃ© deletion?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Full suite green â€” 4845 passing, 10 skipped
- [x] `fallow audit --base origin/main` â€” report-only findings reviewed, no defect
- [ ] `npm run verify` â€” green in CI
- [ ] Manually verified in `npm run dev`: open `/jobs/#saved` in a fresh tab with â‰¥1 saved rÃ©sumÃ© and â‰¥1 saved job

No fixture binaries added or changed â€” all new fixtures are inline jsdom documents in test files, so the fixture-PII surface is untouched.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation â€” #726 | Claude Sonnet 5 | high |
| Implementation â€” #725 | Claude Opus 5 (1M context) | ultra |
| Implementation â€” #724 | Claude Sonnet 5 | high |
| Adversarial review â€” round 1 | Claude Opus 4.6 | high |
| Review fixes | Claude Opus 5 (1M context) | high |
| Adversarial review â€” round 2 | Claude Opus 5 (1M context) | high |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` â€” green in CI | â€” |

Every model string above is self-reported by the agent that ran that stage; the orchestrator requested aliases and does not know what they resolved to.

## Adversarial review

Two rounds, run pre-PR on the local diff. Round 2 returned `clean: true`.

### Round 1 â€” 3 blocking findings, all reproduced end-to-end and all fixed

1. **`prune.ts` deleted real posting body** â€” the module's one hard constraint ("a false positive here deletes real posting text, which is worse than the noise it was aiming at"). `linksToAPosting` scanned the whole `li` subtree, so a prose bullet counted as a job card merely by *containing* one job link, and a nested `li`'s anchor voted for its grandparent. Two such items deleted the list. The reviewer proved it by taking the repo's own negative test and duplicating its single prose `<li>` into two â€” both bullets vanished. That test passed only by the accident of having one item (failing the `>= 2` gate), not because the direct-children filter worked as its docblock claimed.
   **Fix:** link *dominance*, not link presence. An anchor votes only if `anchor.closest("li") === item` and it has no non-whitespace text-node sibling; plus a residue gate (`textLength(item) - own anchor text <= 120`). A direct-child-anchor test was deliberately rejected â€” real LinkedIn cards wrap the link several `div`s deep, so it would have gone green on synthetic fixtures while letting the real SERP back in. The falsified docblock was rewritten.
2. **`useFallbackResume.ts` unhandled promise rejection** â€” no `.catch()` on the load chain, though `loadResumeFromLibrary` can reject via IndexedDB `getResume`, `blob.arrayBuffer()`, or the stale-shape `runCascade` re-run. Reproduced with a real `unhandledRejection` listener.
   **Fix:** `.catch()` mirroring `useSavedJobRatings.ts:83-92`, the pattern #724 named as the model. The new test asserts *both* no-unhandled-rejection and the log, since either alone goes green on a half-fix.
3. **`fetch-jd.ts` regressed scheme-less URLs** â€” `JdInput.tsx:73` passes the raw trimmed user string through, and the field is a bare `<input type="url">` outside any `<form>`, so nothing normalises it. Pasting `boards.greenhouse.io/acme/jobs/123` without a scheme returned `null` and told the user Greenhouse URLs are unsupported.
   **Fix:** retry with an assumed `https://` when the first parse throws and the input has no `://`. Acceptance still reads the *parsed* hostname, so prefixing computes the host rather than assuming it.

Each fix carries a regression test verified to fail before it and pass after â€” the fixer reverted its own source change, observed the specific failures, and restored.

### Round 2 â€” `clean: true`, 6 surviving nits

Round 2 independently re-derived the fix-3 security argument rather than checking round 1's list: ~110 hostile inputs (scheme-guard dodges, authority reinterpretation, IDN/punycode homographs, control characters, IP literals, per-platform smuggles), with zero cases where a string denoting a non-ATS host parsed as an ATS host.

Surviving nits, for the reviewer's judgement:

- **`prune.ts:178-187`** â€” same defect *class* as round 1's blocker, much narrower: `isInlineInProse` only inspects the anchor's own parent, so one level of inline wrapping (`<span><a>â€¦</a></span>`) inside a prose bullet still gets the item counted as a card. Residual class is capped at â‰¤120 non-link chars per item and requires *every* direct `li` to carry a job-permalink href. Judged non-blocking; worth a follow-up.
- **`prune.ts:252-263`** â€” the rewritten docblock is still slightly false: prose around the links survives up to `MAX_NON_LINK_CHARS`, not "with no prose around them" (verified at the 118/119/120/121/122 boundary).
- **`prune.ts:110`** â€” `MAX_NON_LINK_CHARS = 120` sits inside the realistic spread of LinkedIn card metadata (measured 102â€“176 on constructed-but-plausible markup), and `items.every()` means one chatty card saves the whole rail. Under-pruning is the declared safe direction, so this is a risk note. Consider ~200 or a ratio.
- **`useFallbackResume.ts:53-93`** â€” on a *re-load* rejection the previous fallback stays in state; the docblock's "leaving `fallback` undefined is the right end state" is true only for the first load. Honest rather than wrong (the older filename is still named), so a nit.
- **`fetch-jd.ts:56`** â€” the `://` guard buys nothing security-relevant and costs a false negative: `boards.greenhouse.io/acme/jobs/123?gh_src=https://linkedin.com` returns `null` while the same URL with a scheme parses.
- **`fetch-jd.test.ts`** â€” a test comment over-generalises: `javascript://boards.greenhouse.io/acme/jobs/123` *does* carry a hostname and is accepted. Harmless (the parsed result only gates a hardcoded `https://<vendor>-apiâ€¦` fetch built from `\w`-restricted segments, and the input is never navigated to or rendered as an href), but the comment should say so or a scheme allowlist should be added.

Fallow (whole-tree, `--base origin/main`): 1 complexity finding (`titleBeforeTeamSegment`, 11 cyclomatic) and 13 clone groups, mostly test boilerplate. Report-only per `CLAUDE.md`; reviewed and judged not to indicate a defect.

