### PR TITLE
fix(seo): make the site indexable (#751)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,6 +30,12 @@ jobs:
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
           VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
           VITE_POSTHOG_ENV: staging
+          # dev.offlinecv.org serves a byte-identical copy of production from a
+          # subdomain of the same registrable domain. Left indexable, the two
+          # compete and a search engine drops one of them. This marks the build
+          # non-canonical: noindex on every HTML entry, no sitemap. See
+          # SEO_NOINDEX in vite.config.ts for why robots.txt still allows crawling.
+          OFFLINECV_SEO_NOINDEX: "1"
       # v3 → v5 because v4 predates the Node 24 push; v5 (Apr 2026) is the first post-deprecation release.
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/index.html
+++ b/index.html
@@ -9,6 +9,19 @@
       content="Drop a resume PDF and see what a generic parser pulls out of it. Free, private, open-source — your PDF never leaves your browser."
     />
     <meta name="color-scheme" content="light dark" />
+    <!-- Absolute, not base-relative: the staging build at dev.offlinecv.org
+         serves this same HTML, and this tag is what folds that copy onto
+         production instead of letting the two compete. -->
+    <link rel="canonical" href="https://offlinecv.org/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/" />
+    <meta property="og:title" content="OfflineCV — see what a resume parser reads from your PDF" />
+    <meta
+      property="og:description"
+      content="Drop a resume PDF and see what a generic parser pulls out of it. Free, private, open-source — your PDF never leaves your browser."
+    />
+    <meta name="twitter:card" content="summary" />
   </head>
   <body>
     <div id="root"></div>

--- a/jd-fit/index.html
+++ b/jd-fit/index.html
@@ -9,6 +9,17 @@
       content="Paste a job description; see which of its skills and key phrases your resume covers, and rewrite toward the role."
     />
     <meta name="color-scheme" content="light dark" />
+    <!-- Absolute — see the note in the root index.html. -->
+    <link rel="canonical" href="https://offlinecv.org/jd-fit/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/jd-fit/" />
+    <meta property="og:title" content="OfflineCV — JD Fit" />
+    <meta
+      property="og:description"
+      content="Paste a job description; see which of its skills and key phrases your resume covers, and rewrite toward the role."
+    />
+    <meta name="twitter:card" content="summary" />
   </head>
   <body>
     <div id="root"></div>

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -9,6 +9,17 @@
       content="Search job boards from the search we built out of your resume, and page through every match ranked by fit."
     />
     <meta name="color-scheme" content="light dark" />
+    <!-- Absolute — see the note in the root index.html. -->
+    <link rel="canonical" href="https://offlinecv.org/jobs/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/jobs/" />
+    <meta property="og:title" content="OfflineCV — Find Jobs" />
+    <meta
+      property="og:description"
+      content="Search job boards from the search we built out of your resume, and page through every match ranked by fit."
+    />
+    <meta name="twitter:card" content="summary" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 The offlinecv Authors
+
+  Served for any unknown path by both deploy targets: Cloudflare Workers via
+  `"not_found_handling": "404-page"` (wrangler.jsonc) and GitHub Pages, which
+  picks up /404.html natively. Before that config change, an unknown path
+  answered 200 with the root parser page — an unbounded set of URLs all serving
+  identical content.
+
+  Deliberately self-contained: no /content.css link, no bundle. This page is
+  served AT the URL that was not found, so a relative asset path would resolve
+  against an arbitrary directory depth, and a root-absolute one is one more
+  request to fail on a page whose whole job is to fail gracefully.
+
+  The same reason makes the links below root-absolute (`/jd-fit/`) where the
+  content pages under public/ use relative ones (`../jd-fit/`) — the difference
+  is deliberate, not an oversight, so do not "fix" it to match. The trade taken
+  knowingly: root-absolute breaks under a non-`/` base, which is the case the
+  content pages' relative links survive. Both deploy targets serve from the root
+  today, and Vite never base-rewrites public/ in any case.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page not found — OfflineCV</title>
+    <meta name="robots" content="noindex" />
+    <meta name="color-scheme" content="light dark" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f8fafc;
+        --fg: #0f172a;
+        --muted: #475569;
+        --accent: #1a56db;
+        --accent-hover: #1d4ed8;
+        --on-accent: #ffffff;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0f172a;
+          --fg: #f1f5f9;
+          --muted: #a8b6c8;
+          --accent: #7bb0fa;
+          --accent-hover: #93c5fd;
+          --on-accent: #0f172a;
+        }
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem 1.25rem;
+        background: var(--bg);
+        color: var(--muted);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+          sans-serif;
+        line-height: 1.65;
+      }
+      main {
+        max-width: 30rem;
+        text-align: center;
+      }
+      h1 {
+        color: var(--fg);
+        font-size: clamp(1.5rem, 1.2rem + 1.5vw, 2rem);
+        line-height: 1.25;
+        margin: 0 0 0.75rem;
+      }
+      p {
+        margin: 0 0 1.5rem;
+      }
+      a.cta {
+        display: inline-block;
+        background: var(--accent);
+        color: var(--on-accent);
+        font-weight: 600;
+        text-decoration: none;
+        border-radius: 0.5rem;
+        padding: 0.7rem 1.4rem;
+      }
+      a.cta:hover,
+      a.cta:focus-visible {
+        background: var(--accent-hover);
+      }
+      ul {
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1.25rem;
+        justify-content: center;
+        padding: 0;
+        margin: 1.75rem 0 0;
+        font-size: 0.9375rem;
+      }
+      a {
+        color: var(--accent);
+        text-underline-offset: 0.15em;
+      }
+      a:hover,
+      a:focus-visible {
+        color: var(--accent-hover);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>That page isn&rsquo;t here</h1>
+      <p>The link may be old, or the address may have a typo in it.</p>
+      <a class="cta" href="/">Go to the resume parser</a>
+      <ul>
+        <li><a href="/jd-fit/">Match a job description</a></li>
+        <li><a href="/jobs/">Find jobs</a></li>
+        <li><a href="/how-it-works/">How it works</a></li>
+        <li><a href="/faq/">FAQ</a></li>
+        <li><a href="/privacy/">Privacy &amp; data</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/public/content.css
+++ b/public/content.css
@@ -1,0 +1,248 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 The offlinecv Authors
+ *
+ * Styling for the static content pages under public/ (/how-it-works/, /faq/,
+ * /privacy/, /open-source/).
+ *
+ * These pages are deliberately plain HTML, outside the React app and outside
+ * the Tailwind build: they exist to be readable with no JavaScript executed,
+ * because the three app entries render into an empty `<div id="root">` and give
+ * a crawler nothing but a <title> until it runs the bundle. That constraint is
+ * also why this file cannot import `@design-tokens` — it is copied verbatim out
+ * of public/, never processed by Vite.
+ *
+ * The custom properties below therefore MIRROR the light/dark values in
+ * src/design-system/styles/tokens.css rather than deriving from them. That
+ * duplication is the cost of the no-JS requirement; if the palette there moves,
+ * these move by hand. Only the handful of tokens these pages actually use are
+ * copied — not the whole file.
+ */
+
+:root {
+  color-scheme: light dark;
+
+  --color-bg-base: #f8fafc;
+  --color-bg-card: #ffffff;
+  --color-bg-subtle: #f1f5f9;
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #334155;
+  --color-text-tertiary: #475569;
+  --color-border-light: #e2e8f0;
+  --color-border-default: #cbd5e1;
+  --color-accent-primary: #1a56db;
+  --color-accent-primary-hover: #1d4ed8;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg-base: #0f172a;
+    --color-bg-card: #1e293b;
+    --color-bg-subtle: #334155;
+    --color-text-primary: #f1f5f9;
+    --color-text-secondary: #cbd5e1;
+    --color-text-tertiary: #a8b6c8;
+    --color-border-light: #334155;
+    --color-border-default: #475569;
+    --color-accent-primary: #7bb0fa;
+    --color-accent-primary-hover: #93c5fd;
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2.5rem 1.25rem 4rem;
+  background: var(--color-bg-base);
+  color: var(--color-text-secondary);
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.wrap {
+  max-width: 44rem;
+  margin: 0 auto;
+}
+
+/* Skip link — visible only on keyboard focus. */
+.skip {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip:focus {
+  position: static;
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
+h1,
+h2,
+h3 {
+  color: var(--color-text-primary);
+  line-height: 1.25;
+  margin: 2.25rem 0 0.75rem;
+  text-wrap: balance;
+}
+
+h1 {
+  font-size: clamp(1.75rem, 1.2rem + 2vw, 2.5rem);
+  margin-top: 0;
+}
+
+h2 {
+  font-size: 1.35rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border-light);
+}
+
+h3 {
+  font-size: 1.075rem;
+}
+
+p,
+ul,
+ol,
+table {
+  margin: 0 0 1rem;
+}
+
+ul,
+ol {
+  padding-left: 1.25rem;
+}
+
+li {
+  margin-bottom: 0.4rem;
+}
+
+a {
+  color: var(--color-accent-primary);
+  text-underline-offset: 0.15em;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--color-accent-primary-hover);
+}
+
+strong {
+  color: var(--color-text-primary);
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.875em;
+  background: var(--color-bg-subtle);
+  border-radius: 0.25rem;
+  padding: 0.1em 0.35em;
+  overflow-wrap: anywhere;
+}
+
+.lede {
+  font-size: 1.125rem;
+  color: var(--color-text-tertiary);
+  margin-bottom: 2rem;
+}
+
+/* Nav rows: the site header and footer on every content page. Content pages are
+ * the only internally-linked surface a crawler can follow without running JS,
+ * so every one of them links to every other one and back into the app. */
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  font-size: 0.9375rem;
+}
+
+.nav--top {
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.nav--bottom {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border-light);
+  color: var(--color-text-tertiary);
+}
+
+.nav strong {
+  font-weight: 600;
+}
+
+.card {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border-light);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  margin: 0 0 1.5rem;
+}
+
+/* A card supplies its own padding and rule, so the first and last children drop
+ * the margins (and, for an h2, the section rule) they carry in flowing text. */
+.card > :first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.card > :last-child {
+  margin-bottom: 0;
+}
+
+.cta {
+  display: inline-block;
+  background: var(--color-accent-primary);
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  padding: 0.7rem 1.4rem;
+  margin: 0.5rem 0 1.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .cta {
+    color: #0f172a;
+  }
+}
+
+.cta:hover,
+.cta:focus-visible {
+  background: var(--color-accent-primary-hover);
+}
+
+/* Tables scroll inside their own box rather than widening the page. */
+.table-scroll {
+  overflow-x: auto;
+  margin-bottom: 1.25rem;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.9375rem;
+}
+
+th,
+td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+th {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  border-bottom-color: var(--color-border-default);
+  white-space: nowrap;
+}

--- a/public/faq/index.html
+++ b/public/faq/index.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 The offlinecv Authors
+
+  Static content page — plain HTML, no bundle, readable with JavaScript off.
+
+  Carries FAQPage structured data. The JSON-LD at the bottom MUST stay a
+  faithful copy of the visible questions and answers above it — structured data
+  that does not match the rendered page is a spam signal, not an optimisation.
+  Edit both halves together or neither.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FAQ — OfflineCV resume parser</title>
+    <meta
+      name="description"
+      content="Common questions about OfflineCV: whether it is really free, whether your resume is uploaded, why a field came back empty, what the score means, and whether it predicts a specific applicant tracking system."
+    />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="canonical" href="https://offlinecv.org/faq/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/faq/" />
+    <meta property="og:title" content="FAQ — OfflineCV resume parser" />
+    <meta
+      property="og:description"
+      content="Whether it is really free, whether your resume is uploaded, why a field came back empty, and what the score does and does not mean."
+    />
+    <meta name="twitter:card" content="summary" />
+    <link rel="stylesheet" href="../content.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <a class="skip" href="#main">Skip to content</a>
+
+      <nav class="nav nav--top" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../how-it-works/">How it works</a>
+        <strong aria-current="page">FAQ</strong>
+        <a href="../privacy/">Privacy &amp; data</a>
+        <a href="../open-source/">Open source</a>
+      </nav>
+
+      <main id="main">
+        <h1>Frequently asked questions</h1>
+
+        <p class="lede">
+          Short answers, with links to the longer ones. If something here contradicts what the app
+          actually does, the app is right and this page is a bug.
+        </p>
+
+        <h2>Is it free? Do I need an account?</h2>
+        <p>
+          Free, and there is no account. There is no sign-up, no login, no email wall and no paid
+          tier gating the parse, the score, the editor or the PDF export. The project is open source
+          under the Apache 2.0 licence.
+        </p>
+
+        <h2>Is my resume uploaded anywhere?</h2>
+        <p>
+          No. The PDF is read by JavaScript in your browser tab; there is no upload step and no
+          application server behind the site. Neither the PDF bytes nor the text extracted from them
+          are carried by any request the app makes. Some other things do go over the network &mdash;
+          job-search keywords, a GitHub star count, analytics on this hosted build &mdash; and they
+          are itemised on the <a href="../privacy/">privacy page</a> rather than glossed over.
+        </p>
+
+        <h2>Does this tell me what an applicant tracking system will see?</h2>
+        <p>
+          It does not, and any tool claiming otherwise is guessing. Applicant tracking systems are
+          closed, they differ from each other, and their parsers change. What OfflineCV shows you is
+          one generic text extractor&rsquo;s reading of your file. That is genuinely useful &mdash;
+          if a generic parser cannot find your job titles, that is a fragility worth fixing &mdash;
+          but it is a signal, not a prediction about a named employer&rsquo;s software.
+        </p>
+
+        <h2>Why is a field empty or wrong?</h2>
+        <p>
+          Usually the layout. Text in a two-column grid, inside a header or footer, drawn within a
+          graphic, or set in a font with no usable character mapping can all come out reordered or
+          missing. A resume exported as a scanned image contains no text at all, so nothing can be
+          extracted from it. Compare the extracted text against your PDF: where they diverge is
+          where a real parser is likely to diverge too.
+        </p>
+
+        <h2>What does the score actually measure?</h2>
+        <p>
+          Three things, weighted: how specific your bullets are (0.4), how well-structured the
+          entries and bullets are (0.3), and how much of the expected content the parser recovered
+          (0.3). That total is then multiplied down where the layout probes fired &mdash; to 0.85
+          for one trigger, 0.7 for two or more, and to zero for a scanned file. It is deterministic
+          and anonymous: the same text always yields the same number.
+          <a href="../how-it-works/">The full breakdown is here.</a>
+        </p>
+
+        <h2>Is a low score bad news?</h2>
+        <p>
+          It is information about the file, not a judgement of your career. A strong candidate with
+          a heavily designed template can score poorly because the design defeats extraction. That
+          is exactly the case the tool is built to surface, and it is usually fixable by exporting a
+          plainer version for applications while keeping the designed one for humans.
+        </p>
+
+        <h2>Can I fix the resume here, or only see the problems?</h2>
+        <p>
+          You can fix it. Every extracted field is editable in place, and your edits are stored as
+          overrides on top of the parse rather than overwriting it, so the original reading stays
+          visible. You can then download a plain single-column PDF built from the corrected fields.
+          That export is tested to re-parse to the same fields it was built from.
+        </p>
+
+        <h2>What is the AI part, and does it send my resume to a model provider?</h2>
+        <p>
+          The AI features run a small language model inside your browser using WebGPU, and they are
+          optional. The model weights are downloaded once from a public CDN and cached; the prompts
+          built from your resume are evaluated locally rather than sent to a provider. If your
+          browser or device does not support WebGPU, those features are unavailable and everything
+          else still works.
+        </p>
+
+        <h2>What can it do besides parse a PDF?</h2>
+        <p>
+          Two more lanes. <a href="../jd-fit/">JD fit</a> takes a job description &mdash; pasted, or
+          fetched from a Greenhouse, Lever, Workable, Recruitee or Ashby posting URL, which contacts
+          that job board &mdash; and shows which of its requirements your resume gives evidence for,
+          then helps rewrite toward the gaps. <a href="../jobs/">Find jobs</a> searches public job
+          feeds using a query built from your resume &mdash; editable before you search &mdash;
+          ranks results by fit, and keeps the ones you care about in a local tracker.
+        </p>
+
+        <h2>Are the job results every job that exists?</h2>
+        <p>
+          No, and the app labels them as a sample. They come from a few free, public, keyless feeds
+          that skew remote and technical. They are a starting point, not a complete view of the
+          market.
+        </p>
+
+        <h2>Where is my data if I close the tab?</h2>
+        <p>
+          Saved resumes and tracked jobs live in your browser&rsquo;s IndexedDB storage on your own
+          disk. Browsers can clear that &mdash; Safari does so after seven days without a visit, and
+          any browser may evict under disk pressure &mdash; so the resume library includes a JSON
+          export for taking your own backup. Clearing site data removes everything.
+        </p>
+
+        <h2>Can I run or modify it myself?</h2>
+        <p>
+          Yes. The source is public under Apache 2.0 and the app is static files, so a local build
+          serves the whole thing from your own machine, without the analytics this hosted site
+          carries. See the <a href="../open-source/">open source page</a>.
+        </p>
+
+        <a class="cta" href="../">Try it on your own resume</a>
+      </main>
+
+      <nav class="nav nav--bottom" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../how-it-works/">How it works</a>
+        <a href="../privacy/">Privacy &amp; data</a>
+        <a href="../open-source/">Open source</a>
+        <a href="https://github.com/offlinecv/OfflineCV" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is it free? Do I need an account?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Free, and there is no account. There is no sign-up, no login, no email wall and no paid tier gating the parse, the score, the editor or the PDF export. The project is open source under the Apache 2.0 licence."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is my resume uploaded anywhere?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. The PDF is read by JavaScript in your browser tab; there is no upload step and no application server behind the site. Neither the PDF bytes nor the text extracted from them are carried by any request the app makes. Some other things do go over the network — job-search keywords, a GitHub star count, analytics on this hosted build — and they are itemised on the privacy page rather than glossed over."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does this tell me what an applicant tracking system will see?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "It does not, and any tool claiming otherwise is guessing. Applicant tracking systems are closed, they differ from each other, and their parsers change. What OfflineCV shows you is one generic text extractor's reading of your file. That is genuinely useful — if a generic parser cannot find your job titles, that is a fragility worth fixing — but it is a signal, not a prediction about a named employer's software."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why is a field empty or wrong?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Usually the layout. Text in a two-column grid, inside a header or footer, drawn within a graphic, or set in a font with no usable character mapping can all come out reordered or missing. A resume exported as a scanned image contains no text at all, so nothing can be extracted from it. Compare the extracted text against your PDF: where they diverge is where a real parser is likely to diverge too."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What does the score actually measure?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Three things, weighted: how specific your bullets are (0.4), how well-structured the entries and bullets are (0.3), and how much of the expected content the parser recovered (0.3). That total is then multiplied down where the layout probes fired — to 0.85 for one trigger, 0.7 for two or more, and to zero for a scanned file. It is deterministic and anonymous: the same text always yields the same number."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is a low score bad news?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "It is information about the file, not a judgement of your career. A strong candidate with a heavily designed template can score poorly because the design defeats extraction. That is exactly the case the tool is built to surface, and it is usually fixable by exporting a plainer version for applications while keeping the designed one for humans."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I fix the resume here, or only see the problems?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You can fix it. Every extracted field is editable in place, and your edits are stored as overrides on top of the parse rather than overwriting it, so the original reading stays visible. You can then download a plain single-column PDF built from the corrected fields. That export is tested to re-parse to the same fields it was built from."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the AI part, and does it send my resume to a model provider?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The AI features run a small language model inside your browser using WebGPU, and they are optional. The model weights are downloaded once from a public CDN and cached; the prompts built from your resume are evaluated locally rather than sent to a provider. If your browser or device does not support WebGPU, those features are unavailable and everything else still works."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What can it do besides parse a PDF?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Two more lanes. JD fit takes a job description — pasted, or fetched from a Greenhouse, Lever, Workable, Recruitee or Ashby posting URL, which contacts that job board — and shows which of its requirements your resume gives evidence for, then helps rewrite toward the gaps. Find jobs searches public job feeds using a query built from your resume — editable before you search — ranks results by fit, and keeps the ones you care about in a local tracker."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Are the job results every job that exists?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No, and the app labels them as a sample. They come from a few free, public, keyless feeds that skew remote and technical. They are a starting point, not a complete view of the market."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where is my data if I close the tab?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Saved resumes and tracked jobs live in your browser's IndexedDB storage on your own disk. Browsers can clear that — Safari does so after seven days without a visit, and any browser may evict under disk pressure — so the resume library includes a JSON export for taking your own backup. Clearing site data removes everything."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I run or modify it myself?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. The source is public under Apache 2.0 and the app is static files, so a local build serves the whole thing from your own machine, without the analytics this hosted site carries."
+            }
+          }
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/public/how-it-works/index.html
+++ b/public/how-it-works/index.html
@@ -1,0 +1,269 @@
+<!doctype html>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 The offlinecv Authors
+
+  Static content page — plain HTML, no bundle, readable with JavaScript off.
+  See public/content.css for why these exist outside the React app.
+
+  Every number on this page is quoted from code and must move when the code
+  does: the dimension weights and the layout multipliers from
+  src/lib/score/score.ts (WEIGHTS, and the `multiplier` ladder near the end of
+  computeAnonymousAtsScore), the verdict bands from getScoreTier/getScoreLabel
+  in the same file, and the tier names from src/lib/heuristics/cascade.ts.
+  Links are relative so the page resolves under any base path.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>How OfflineCV reads your resume — parse cascade and scoring</title>
+    <meta
+      name="description"
+      content="What happens to a resume PDF inside OfflineCV: the four-tier text extraction cascade, the three scored dimensions and their weights, and the layout penalty that a two-column or scanned PDF earns."
+    />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="canonical" href="https://offlinecv.org/how-it-works/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/how-it-works/" />
+    <meta property="og:title" content="How OfflineCV reads your resume" />
+    <meta
+      property="og:description"
+      content="The four-tier text extraction cascade, the three scored dimensions and their weights, and the layout penalty a two-column or scanned PDF earns."
+    />
+    <meta name="twitter:card" content="summary" />
+    <link rel="stylesheet" href="../content.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <a class="skip" href="#main">Skip to content</a>
+
+      <nav class="nav nav--top" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <strong aria-current="page">How it works</strong>
+        <a href="../faq/">FAQ</a>
+        <a href="../privacy/">Privacy &amp; data</a>
+        <a href="../open-source/">Open source</a>
+      </nav>
+
+      <main id="main">
+        <h1>How OfflineCV reads your resume</h1>
+
+        <p class="lede">
+          You drop in a PDF and get back two things: the text a generic extractor pulled out of it,
+          and a score built from that text. This page describes what happens in between, including
+          where it goes wrong.
+        </p>
+
+        <h2>The point is the gap, not the score</h2>
+
+        <p>
+          A resume PDF looks like a document to you. To a parser it is a bag of positioned glyphs
+          with no reliable notion of &ldquo;this line is a job title&rdquo; or &ldquo;these bullets
+          belong to that role&rdquo;. Section headers, two-column layouts, text drawn inside a
+          graphic, and dates rendered as an image all have to be inferred, and the inference is
+          sometimes wrong.
+        </p>
+
+        <p>
+          What OfflineCV shows you is one generic parser&rsquo;s reading of your file. It is
+          <strong>not</strong> a simulation of any particular applicant tracking system &mdash; those
+          are closed, they differ from one another, and we have not measured them. Treat a field
+          that comes back empty or garbled as a signal that the information is fragile in this file,
+          not as a verdict from a specific employer&rsquo;s software.
+        </p>
+
+        <h2>Step 1 &mdash; the extraction cascade</h2>
+
+        <p>
+          Text extraction runs as a cascade of tiers. Each tier only handles what the one before it
+          left behind, so a clean single-column PDF is finished early and a difficult one keeps
+          falling through.
+        </p>
+
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Tier</th>
+                <th scope="col">What it does</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Tier&nbsp;0</th>
+                <td>
+                  Pull raw text items and page geometry out of the PDF with pdf.js, plus the
+                  link annotations &mdash; a <code>mailto:</code> or <code>tel:</code> href often
+                  survives when the drawn text of the same email or phone number does not. Layout
+                  probes run here too and flag a scanned or two-column file.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Tier&nbsp;1</th>
+                <td>
+                  A heuristic parser turns those items into lines, finds section headers, and
+                  segments the experience and education regions into entries with titles, employers,
+                  dates and bullets.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Tier&nbsp;1.5</th>
+                <td>
+                  A regex pass fills in individual fields the heuristic parser missed &mdash; most
+                  often contact details that sit outside any recognised section.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">On&nbsp;device&nbsp;AI</th>
+                <td>
+                  Optional, and only where your browser supports WebGPU. A small language model runs
+                  locally to critique the result and propose rewrites. Where its reading disagrees
+                  with the heuristic parser, the disagreement is shown rather than silently resolved.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          The cascade reports a per-field confidence alongside the values, so a field it guessed at
+          is distinguishable from one it read cleanly.
+        </p>
+
+        <h2>Step 2 &mdash; the score</h2>
+
+        <p>
+          The score is deterministic and anonymous: the same text always produces the same number,
+          and nothing about it is personalised or sent anywhere. It combines three dimensions.
+        </p>
+
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Dimension</th>
+                <th scope="col">Weight</th>
+                <th scope="col">What it looks for</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Specificity</th>
+                <td>0.4</td>
+                <td>
+                  Bullets carrying a concrete quantity &mdash; a number, a percentage, a currency
+                  amount, a duration &mdash; rather than a description of responsibilities.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Structure</th>
+                <td>0.3</td>
+                <td>
+                  Bullets that are actually bullet-shaped and in a workable length band, under
+                  entries that have a title, an employer and a date range.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Completeness</th>
+                <td>0.3</td>
+                <td>
+                  Whether the fields a reader expects came through at all: name, contact details, a
+                  summary, a skills list, education, experience.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          Note what the weights imply. Completeness is scored on what the
+          <em>parser recovered</em>, so a resume that contains everything but hides it in a layout
+          the parser cannot follow loses points it would keep in a plainer file. That is the
+          intended behaviour, and it is the whole reason to look at the extracted text next to the
+          number.
+        </p>
+
+        <h2>Step 3 &mdash; the layout penalty</h2>
+
+        <p>
+          Layout is applied as a multiplier over the combined dimensions rather than as a fourth
+          additive dimension, because a layout problem degrades every other signal at once instead
+          of costing a fixed slice.
+        </p>
+
+        <ul>
+          <li><strong>No layout triggers</strong> &mdash; multiplier 1.0, no penalty.</li>
+          <li><strong>One trigger</strong> &mdash; multiplier 0.85.</li>
+          <li><strong>Two or more triggers</strong> &mdash; multiplier 0.7.</li>
+          <li>
+            <strong>Scanned</strong> &mdash; multiplier 0. A page of images carries no extractable
+            text, so there is nothing underneath the score to defend.
+          </li>
+        </ul>
+
+        <p>The rounded result lands in one of three bands:</p>
+
+        <ul>
+          <li><strong>80 and above</strong> &mdash; Strong</li>
+          <li><strong>60 to 79</strong> &mdash; Getting There</li>
+          <li><strong>Below 60</strong> &mdash; Needs Work</li>
+        </ul>
+
+        <p>
+          The scoring algorithm is versioned, so a score you recorded under an earlier version is
+          not silently comparable to a new one.
+        </p>
+
+        <h2>Step 4 &mdash; fix it and export</h2>
+
+        <p>
+          Every extracted field is editable in place. Your edits are stored as overrides on top of
+          the parse rather than written back over it, so the original reading stays visible. From
+          there you can download a plain, single-column PDF built from the corrected fields.
+        </p>
+
+        <p>
+          That export is tested against the parser that produced it: the exported PDF has to
+          re-parse to the same fields it was built from. It is the one round trip we can actually
+          verify, and we verify it in CI.
+        </p>
+
+        <h2>Two more lanes</h2>
+
+        <ul>
+          <li>
+            <a href="../jd-fit/">JD fit</a> &mdash; paste a job description and see which of its
+            requirements your resume gives evidence for, then rewrite sections toward the ones it
+            does not.
+          </li>
+          <li>
+            <a href="../jobs/">Find jobs</a> &mdash; search open job feeds using a query built from
+            your resume (which you can edit before searching), rank the results by fit, and keep the
+            ones worth applying to in a local tracker.
+          </li>
+        </ul>
+
+        <p>
+          Both work from the parsed resume, never from the PDF bytes. What leaves your browser, and
+          when, is itemised on the <a href="../privacy/">privacy page</a>.
+        </p>
+
+        <a class="cta" href="../">Try it on your own resume</a>
+      </main>
+
+      <nav class="nav nav--bottom" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../faq/">FAQ</a>
+        <a href="../privacy/">Privacy &amp; data</a>
+        <a href="../open-source/">Open source</a>
+        <a href="https://github.com/offlinecv/OfflineCV" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </body>
+</html>

--- a/public/open-source/index.html
+++ b/public/open-source/index.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 The offlinecv Authors
+
+  Static content page — plain HTML, no bundle, readable with JavaScript off.
+
+  The commands quoted here are the real ones from package.json. If a script is
+  renamed there, rename it here too — a build page whose commands do not run is
+  worse than no build page.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Open source — run your own OfflineCV | Apache 2.0</title>
+    <meta
+      name="description"
+      content="OfflineCV is Apache 2.0 licensed and its source is public. How to run it locally, why a local build carries no analytics, and where to file a parser bug."
+    />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="canonical" href="https://offlinecv.org/open-source/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/open-source/" />
+    <meta property="og:title" content="Open source — run your own OfflineCV" />
+    <meta
+      property="og:description"
+      content="Apache 2.0, public source. How to run it locally, and why a local build carries no analytics."
+    />
+    <meta name="twitter:card" content="summary" />
+    <link rel="stylesheet" href="../content.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <a class="skip" href="#main">Skip to content</a>
+
+      <nav class="nav nav--top" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../how-it-works/">How it works</a>
+        <a href="../faq/">FAQ</a>
+        <a href="../privacy/">Privacy &amp; data</a>
+        <strong aria-current="page">Open source</strong>
+      </nav>
+
+      <main id="main">
+        <h1>Open source</h1>
+
+        <p class="lede">
+          OfflineCV is licensed under Apache 2.0 and developed in the open at
+          <a href="https://github.com/offlinecv/OfflineCV" rel="noopener"
+            >github.com/offlinecv/OfflineCV</a
+          >. You can read it, run it, fork it, and reskin it.
+        </p>
+
+        <h2>Why that matters here specifically</h2>
+
+        <p>
+          This is a tool you hand your resume to. Every privacy claim on the
+          <a href="../privacy/">privacy page</a> is the kind of claim you should not have to take on
+          trust, and public source is what makes it checkable: open the network tab, then open the
+          code, and confirm the two agree. A closed tool making the same claim is asking for
+          something quite different from you.
+        </p>
+
+        <h2>Run it yourself</h2>
+
+        <p>
+          The app is static files &mdash; no server, no database, no environment to provision. A
+          local build runs the whole product from your own machine.
+        </p>
+
+        <div class="card">
+          <p><strong>Requirements:</strong> Node.js and npm.</p>
+          <ul>
+            <li><code>git clone https://github.com/offlinecv/OfflineCV.git</code></li>
+            <li><code>cd OfflineCV &amp;&amp; npm install</code></li>
+            <li><code>npm run dev</code> &mdash; development server</li>
+            <li><code>npm run build</code> &mdash; production build into <code>dist/</code></li>
+          </ul>
+          <p>
+            The dev server runs over HTTPS with a self-signed certificate. That is deliberate: WebGPU
+            is gated behind a secure context, so the on-device AI features need it. Accept the
+            browser warning once.
+          </p>
+        </div>
+
+        <p>
+          A build made without a PostHog key contains no analytics at all &mdash; the dependency is
+          dynamically imported and is eliminated from the bundle entirely, so it is absent rather
+          than merely disabled. The hosted site at offlinecv.org is built <em>with</em> a key; that
+          difference is described on the <a href="../privacy/">privacy page</a>.
+        </p>
+
+        <h2>Reskin it without forking</h2>
+
+        <p>
+          Colours are plain CSS custom properties in two layers: a stable semantic vocabulary
+          (<code>--color-surface-card</code>, <code>--color-content-primary</code>, and so on) and a
+          swappable file of raw values behind it. The default palette is a generic accessible one,
+          not a brand. You can override the values from your own stylesheet in the cascade, or point
+          the build&rsquo;s token alias at your own file. The component layer has an equivalent
+          swap seam. The README covers both.
+        </p>
+
+        <h2>Contributing</h2>
+
+        <p>
+          Bug reports about parsing are the most valuable contribution, and the most useful ones
+          name a specific PDF shape rather than a general complaint &mdash; a two-column template
+          whose dates vanish, a header whose email survives only as a link annotation, an employer
+          line that merges into the title above it.
+        </p>
+
+        <p>
+          Please do not attach your real resume to an issue. The repository ships a local
+          command-line probe that reads a PDF path you give it and prints only to your terminal
+          &mdash; it writes nothing and hardcodes no path &mdash; so you can characterise a bug
+          against your own private file and then report the <em>shape</em> of it. Run it with
+          <code>npm run fidelity path/to/resume.pdf</code>. Regression tests use synthetic, PII-free
+          fixtures, and a CI gate enforces that.
+        </p>
+
+        <ul>
+          <li>
+            <a href="https://github.com/offlinecv/OfflineCV/issues" rel="noopener">Issues</a>
+          </li>
+          <li>
+            <a href="https://github.com/offlinecv/OfflineCV/blob/main/README.md" rel="noopener"
+              >README</a
+            >
+            &mdash; architecture, telemetry, theming
+          </li>
+          <li>
+            <a href="https://github.com/offlinecv/OfflineCV/blob/main/LICENSE" rel="noopener"
+              >Apache 2.0 licence</a
+            >
+          </li>
+        </ul>
+
+        <a class="cta" href="https://github.com/offlinecv/OfflineCV" rel="noopener"
+          >View the source on GitHub</a
+        >
+      </main>
+
+      <nav class="nav nav--bottom" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../how-it-works/">How it works</a>
+        <a href="../faq/">FAQ</a>
+        <a href="../privacy/">Privacy &amp; data</a>
+        <a href="https://github.com/offlinecv/OfflineCV" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </body>
+</html>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 The offlinecv Authors
+
+  Static content page — plain HTML, no bundle, readable with JavaScript off.
+
+  This page makes falsifiable claims about network egress, so every one of them
+  has to point at code: src/lib/analytics.ts (PostHog, env-gated),
+  src/lib/job-search/providers/keywords.ts (the ONLY resume-derived egress
+  helper) and its sibling adapters, src/hooks/useGitHubStars.ts, and
+  src/lib/storage/ for what is written locally. The README's "Telemetry"
+  section is the long form; this page is the short form and must not exceed it.
+
+  Do not add a claim here without grepping the actual fetch() calls first. In
+  particular there is no BYOK / hosted LLM provider in the tree — do not imply
+  one either way.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy &amp; data — what leaves your browser | OfflineCV</title>
+    <meta
+      name="description"
+      content="An itemised list of every network request OfflineCV makes, what each one carries, and what is stored in your browser. Your resume PDF and its text are not among them."
+    />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="canonical" href="https://offlinecv.org/privacy/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="OfflineCV" />
+    <meta property="og:url" content="https://offlinecv.org/privacy/" />
+    <meta property="og:title" content="Privacy &amp; data — what leaves your browser" />
+    <meta
+      property="og:description"
+      content="An itemised list of every network request OfflineCV makes, what each one carries, and what is stored in your browser."
+    />
+    <meta name="twitter:card" content="summary" />
+    <link rel="stylesheet" href="../content.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <a class="skip" href="#main">Skip to content</a>
+
+      <nav class="nav nav--top" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../how-it-works/">How it works</a>
+        <a href="../faq/">FAQ</a>
+        <strong aria-current="page">Privacy &amp; data</strong>
+        <a href="../open-source/">Open source</a>
+      </nav>
+
+      <main id="main">
+        <h1>Privacy &amp; data</h1>
+
+        <p class="lede">
+          The claim worth making is about custody, not about runtime: your resume PDF and the text
+          extracted from it stay in your browser. Some other things do go over the network, and this
+          page lists them.
+        </p>
+
+        <div class="card">
+          <h2>The short version</h2>
+          <p>
+            There is no account, no login, and no upload step. The PDF is read by JavaScript in the
+            tab you dropped it into; parsing, scoring, editing and PDF export all happen there. No
+            request this app makes carries the PDF bytes or the extracted resume text.
+          </p>
+          <p>
+            What does go out: the page and its assets, a job-search keyword string when you press
+            search, a public company name when you check a company&rsquo;s own board, a job posting
+            URL when you ask the app to fetch one for you, a GitHub star count, optional AI model
+            weights, and &mdash; on this hosted site &mdash; anonymous product analytics.
+          </p>
+        </div>
+
+        <h2>What never leaves</h2>
+
+        <ul>
+          <li>The PDF file itself, in whole or in part.</li>
+          <li>
+            The text extracted from it &mdash; your name, contact details, employers, titles, dates,
+            bullets, skills, education.
+          </li>
+          <li>Any edit you make to those fields, and the PDF you export from them.</li>
+          <li>
+            The job description you <strong>paste</strong> into JD fit. Asking the app to
+            <em>fetch</em> one from a posting URL is an outbound request, and it is itemised below.
+          </li>
+        </ul>
+
+        <p>
+          One helper &mdash; <code>src/lib/job-search/providers/keywords.ts</code> &mdash; is the
+          single place in the codebase where anything derived from your resume is turned into
+          outbound data, and it is deliberately kept to one file so it can be audited in one place.
+          Its output is described below.
+        </p>
+
+        <h2>Every request, itemised</h2>
+
+        <h3>1. Loading the site</h3>
+        <p>
+          Serving you the page means our host sees your IP address and user agent, the same as any
+          website. The app is static files; there is no application server to send anything to.
+        </p>
+
+        <h3>2. Job search feeds</h3>
+        <p>
+          The <a href="../jobs/">Find jobs</a> tab can query free, keyless, public job feeds. These
+          requests fire <strong>only when you click &ldquo;Search jobs&rdquo;</strong> &mdash; not
+          when you drop a resume, not when you open the tab, not while you edit the query. What is
+          sent is the short keyword string built from the query&rsquo;s title and skills fields,
+          which are shown to you and editable before you search. The feeds shipped today are
+          Remotive, Arbeitnow and Jobicy. Each is contacted directly from your browser, so
+          <strong>each sees your IP address</strong>.
+        </p>
+        <p>
+          Within Find jobs, where you ask about a specific company&rsquo;s own job board
+          (Greenhouse, Lever, Ashby), the request carries that company&rsquo;s public board name and
+          nothing else. Fetching one specific posting by its URL is a different request, described
+          next.
+        </p>
+
+        <h3>3. Fetching a job posting from its URL</h3>
+        <p>
+          Where the app offers to fetch a posting for you rather than have you paste it &mdash; the
+          URL field on <a href="../jd-fit/">JD fit</a> today &mdash; pressing
+          <strong>Fetch</strong> calls that applicant tracking system&rsquo;s own public API
+          directly from your browser. Five are supported: Greenhouse, Lever, Workable, Recruitee and
+          Ashby. The request fires <strong>only on that click</strong>, and nothing derived from
+          your resume is part of it.
+        </p>
+        <p>
+          What it carries is the company&rsquo;s public board name &mdash; which for Recruitee is
+          the hostname itself &mdash; and, for Greenhouse and Lever, the identifier of the one
+          posting you asked for. The other three return the whole board and the match happens in
+          your browser. Because the call comes from your browser,
+          <strong>that ATS sees your IP address</strong>, and for Greenhouse and Lever it also sees
+          which specific posting you are reading. That is a sharper disclosure than anything else on
+          this page, which is why it is worth pasting the description instead if you would rather
+          the ATS not see you.
+        </p>
+
+        <h3>4. GitHub star count</h3>
+        <p>
+          The footer shows the repository&rsquo;s star count via an unauthenticated call to the
+          GitHub API, cached for about an hour. It carries no data about you beyond the request
+          itself, and it fails silently. Because it originates in your browser,
+          <strong>GitHub sees your IP address</strong>.
+        </p>
+
+        <h3>5. On-device AI model weights</h3>
+        <p>
+          The optional AI features run a language model inside your browser via WebGPU. Running it
+          locally still means <em>downloading</em> it first: the weights are fetched from the public
+          CDN that the <code>@mlc-ai/web-llm</code> library points at, on the first use of an AI
+          feature, and cached by your browser afterwards. Your resume is not part of that download,
+          and once the model is loaded the prompts built from your resume are evaluated locally.
+        </p>
+
+        <h3>6. Analytics on this hosted site</h3>
+        <p>
+          This site is built with a PostHog key set, so it emits anonymous product analytics &mdash;
+          events like a file being accepted, a parse completing, or a parse failing. The payloads
+          carry file size, page count, parse duration, the score breakdown, layout triggers and
+          error names. They do not carry PDF bytes, extracted text, names or URLs. Session recording
+          and autocapture are off, and the identifier is held in memory and reset when the tab
+          closes.
+        </p>
+        <p>
+          This is a property of <em>this deployment</em>, not of the software. A build made without
+          that key removes the analytics code entirely &mdash; the dependency is dynamically
+          imported and is eliminated from the bundle. If you would rather not be counted, you can
+          <a href="../open-source/">run your own build</a>, or block the request.
+        </p>
+
+        <h3>7. Feedback, if you send it</h3>
+        <p>
+          The optional feedback panel sends a 1&ndash;5 rating, plus a category, free text and an
+          email address <strong>only where you choose to fill them in</strong>. The email field is
+          blank by default. It is attached as a property on that one event and is never turned into
+          a stored profile.
+        </p>
+
+        <h2>What is stored in your browser</h2>
+
+        <p>
+          The app writes to your browser&rsquo;s own storage so that state survives a reload. This
+          is first-party and local; none of it is transmitted, and it introduces no network requests
+          of its own. HTTP cookies are not used at all.
+        </p>
+
+        <ul>
+          <li>
+            <strong>A handful of small flags</strong> &mdash; whether the feedback prompt has been
+            shown, whether the star prompt has been dismissed, a cached star count. Booleans and
+            counters, no identifiers.
+          </li>
+          <li>
+            <strong>An IndexedDB database</strong> for the resume library and the job tracker: saved
+            resume PDFs with their cached parse, and the job records you track. This is the only
+            place your PDF is persisted, and it is on your disk.
+          </li>
+        </ul>
+
+        <p>
+          Browsers can clear this. Safari in particular clears script-writable storage after seven
+          days without a visit, and any browser may evict under disk pressure. The app asks for
+          persistent storage on first write, but that grant is best-effort, so there is a JSON
+          export in the resume library for taking your own backup. Clearing site data removes
+          everything above.
+        </p>
+
+        <h2>How to verify any of this</h2>
+
+        <p>
+          Do not take the claim on the strength of the sentence. Open your browser&rsquo;s developer
+          tools, switch to the Network tab, and use the app &mdash; drop a resume, edit it, export
+          it. The requests you see are the requests there are. The
+          <a href="https://github.com/offlinecv/OfflineCV" rel="noopener">source is public</a>, and
+          the README&rsquo;s telemetry section documents the same ground in more detail than this
+          page does.
+        </p>
+
+        <p>
+          If you find an egress path this page does not name, that is a bug in the page or the code,
+          and it is worth
+          <a href="https://github.com/offlinecv/OfflineCV/issues" rel="noopener">filing an issue</a>.
+        </p>
+
+        <a class="cta" href="../">Open the resume parser</a>
+      </main>
+
+      <nav class="nav nav--bottom" aria-label="Site">
+        <a href="../">Resume parser</a>
+        <a href="../jd-fit/">JD fit</a>
+        <a href="../jobs/">Find jobs</a>
+        <a href="../how-it-works/">How it works</a>
+        <a href="../faq/">FAQ</a>
+        <a href="../open-source/">Open source</a>
+        <a href="https://github.com/offlinecv/OfflineCV" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </body>
+</html>

--- a/scripts/seo-artifacts.test.mjs
+++ b/scripts/seo-artifacts.test.mjs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// Both directions matter here. The flag's failure mode is silent either way: a
+// production build that inverts it ships `noindex` everywhere and no sitemap and
+// still succeeds, and a staging build that loses its `noindex` re-creates the
+// duplicate-site defect. Neither shows up in the app, so asserting only the
+// happy direction would leave the expensive half uncovered.
+
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRobotsTxt,
+  buildSitemapXml,
+  HTML_ENTRIES,
+  NOINDEX_META,
+  seoHeadTags,
+  SITE_ORIGIN,
+  SITEMAP_PATHS,
+  STATIC_PAGE_PATHS,
+  withNoindexMeta,
+} from "./seo-artifacts.ts";
+
+describe("buildRobotsTxt", () => {
+  it("advertises the sitemap on a production build", () => {
+    expect(buildRobotsTxt(false)).toContain(`Sitemap: ${SITE_ORIGIN}/sitemap.xml`);
+  });
+
+  it("advertises no sitemap on a noindex build", () => {
+    expect(buildRobotsTxt(true)).not.toContain("Sitemap:");
+  });
+
+  it("allows crawling in both builds", () => {
+    // Deliberate: a `Disallow: /` staging copy could never be dropped from the
+    // index, because the crawler would not be permitted to read the directive
+    // that drops it.
+    for (const robots of [buildRobotsTxt(false), buildRobotsTxt(true)]) {
+      expect(robots).toContain("User-agent: *");
+      expect(robots).toContain("Allow: /");
+      expect(robots).not.toContain("Disallow:");
+    }
+  });
+});
+
+describe("buildSitemapXml", () => {
+  it("emits one absolute <loc> per path", () => {
+    const xml = buildSitemapXml(["/", "/faq/"]);
+    expect(xml).toContain(`<loc>${SITE_ORIGIN}/</loc>`);
+    expect(xml).toContain(`<loc>${SITE_ORIGIN}/faq/</loc>`);
+    expect(xml.match(/<loc>/g)).toHaveLength(2);
+  });
+
+  it("declares the sitemap namespace and closes the urlset", () => {
+    const xml = buildSitemapXml(SITEMAP_PATHS);
+    expect(xml.startsWith(`<?xml version="1.0" encoding="UTF-8"?>`)).toBe(true);
+    expect(xml).toContain(`xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"`);
+    expect(xml.trimEnd().endsWith("</urlset>")).toBe(true);
+  });
+
+  it("carries no <lastmod>", () => {
+    // Only honoured when consistently accurate; the build timestamp changes on
+    // every redeploy whether or not the page did.
+    expect(buildSitemapXml(SITEMAP_PATHS)).not.toContain("<lastmod>");
+  });
+});
+
+describe("seoHeadTags", () => {
+  it("injects nothing on a production build", () => {
+    expect(seoHeadTags(false)).toEqual([]);
+  });
+
+  it("injects noindex, nofollow on a noindex build", () => {
+    expect(seoHeadTags(true)).toEqual([
+      {
+        tag: "meta",
+        attrs: { name: "robots", content: "noindex, nofollow" },
+        injectTo: "head-prepend",
+      },
+    ]);
+  });
+});
+
+describe("withNoindexMeta", () => {
+  it("injects the directive into a static page's head", () => {
+    const out = withNoindexMeta("<html><head><title>x</title></head><body></body></html>");
+    expect(out).toContain(NOINDEX_META);
+    expect(out.indexOf(NOINDEX_META)).toBeLessThan(out.indexOf("<title>"));
+  });
+
+  it("skips a page that already declares a robots directive", () => {
+    // 404.html ships its own `noindex`; the bundled entries get theirs from
+    // transformIndexHtml before this pass runs. Neither should be double-tagged.
+    expect(
+      withNoindexMeta(`<html><head><meta name="robots" content="noindex" /></head></html>`),
+    ).toBeNull();
+  });
+
+  it("skips a robots directive whose name is not the first attribute", () => {
+    // Attribute order carries no meaning in HTML, so the skip must not depend on
+    // it — a hand-edit to `content` first would otherwise ship two robots metas.
+    expect(
+      withNoindexMeta(`<html><head><meta content="noindex" name="robots" /></head></html>`),
+    ).toBeNull();
+  });
+
+  it("skips a file with no head to inject into", () => {
+    expect(withNoindexMeta("<p>fragment</p>")).toBeNull();
+  });
+});
+
+describe("SITEMAP_PATHS", () => {
+  it("advertises every HTML entry the build ships", () => {
+    for (const { url } of Object.values(HTML_ENTRIES)) {
+      expect(SITEMAP_PATHS).toContain(url);
+    }
+  });
+
+  it("advertises every static page directory under public/", () => {
+    // The one list that is hand-kept — public/ pages are copied through, not
+    // declared to the bundler, so nothing else can derive them. A page added
+    // here and forgotten is not blocked from indexing, just never advertised,
+    // so it silently stays unindexed.
+    // The `index.html` predicate is what keeps this honest: without it the first
+    // asset directory (`public/images/` for an og:image) fails the test with a
+    // message that reads "you forgot to list /images/", and the obvious way to
+    // green it advertises a directory with no page in sitemap.xml. A test whose
+    // failure points at the wrong fix is worse than one that doesn't fire.
+    const publicDir = fileURLToPath(new URL("../public", import.meta.url));
+    const onDisk = readdirSync(publicDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && existsSync(join(publicDir, entry.name, "index.html")))
+      .map((entry) => `/${entry.name}/`);
+    expect([...STATIC_PAGE_PATHS].sort()).toEqual(onDisk.sort());
+  });
+
+  it("lists no path twice", () => {
+    expect(new Set(SITEMAP_PATHS).size).toBe(SITEMAP_PATHS.length);
+  });
+
+  it("uses canonical trailing-slash form throughout", () => {
+    for (const path of SITEMAP_PATHS) {
+      expect(path.startsWith("/")).toBe(true);
+      expect(path.endsWith("/")).toBe(true);
+    }
+  });
+});

--- a/scripts/seo-artifacts.ts
+++ b/scripts/seo-artifacts.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Search-engine artifacts — the decisions behind robots.txt, sitemap.xml and
+ * the staging `noindex` meta, lifted out of `vite.config.ts` so they can be
+ * unit-tested.
+ *
+ * They live here rather than inline in the config because their failure mode is
+ * silent in both directions: a build that inverts the flag ships `noindex` on
+ * every page and no sitemap, and the build still succeeds and the site still
+ * works — you find out from Search Console weeks later. The reverse (staging
+ * losing its `noindex`) is equally quiet and re-creates the duplicate-site
+ * defect the flag exists to prevent. Nothing in the app surfaces either, so the
+ * only thing that can catch an inversion is an assertion on the strings
+ * themselves.
+ *
+ * Everything exported here is pure — string in, string out, no fs, no Vite —
+ * except that `HTML_ENTRIES` is also the single source of the build's
+ * `rollupOptions.input`, so an entry cannot be added to the build without
+ * appearing in the sitemap. See `scripts/seo-artifacts.test.mjs`.
+ */
+
+/**
+ * Canonical origin. Every indexable URL is advertised under this host — both in
+ * the sitemap and in the hardcoded `<link rel="canonical">` each HTML entry
+ * carries. Hardcoded rather than base-derived on purpose: the point of a
+ * canonical is to name ONE address for a page, and the staging build serves
+ * byte-identical HTML from a different host.
+ */
+export const SITE_ORIGIN = "https://offlinecv.org";
+
+/**
+ * The app's HTML entries, keyed by rollup input name. `file` is repo-relative;
+ * `url` is the canonical trailing-slash path it is served at.
+ *
+ * `vite.config.ts` derives `build.rollupOptions.input` from this map and
+ * `SITEMAP_PATHS` below derives from it too, so the two can no longer drift: a
+ * fourth entry added to the build is advertised in the sitemap by construction,
+ * rather than by someone remembering a second list. That omission is the kind
+ * nobody notices — the URL is not blocked from indexing, just never advertised,
+ * so it simply stays unindexed.
+ */
+export const HTML_ENTRIES = {
+  main: { file: "index.html", url: "/" },
+  jdFit: { file: "jd-fit/index.html", url: "/jd-fit/" },
+  jobs: { file: "jobs/index.html", url: "/jobs/" },
+} as const;
+
+/**
+ * The static content pages under `public/`. These are copied through verbatim
+ * rather than bundled, so they are not derivable from the build config the way
+ * `HTML_ENTRIES` is — this list is hand-kept, and the test asserts it against
+ * the directories actually present under `public/`.
+ */
+export const STATIC_PAGE_PATHS = [
+  "/how-it-works/",
+  "/faq/",
+  "/privacy/",
+  "/open-source/",
+] as const;
+
+/** The indexable URL set, in canonical trailing-slash form. */
+export const SITEMAP_PATHS: readonly string[] = [
+  ...Object.values(HTML_ENTRIES).map((entry) => entry.url),
+  ...STATIC_PAGE_PATHS,
+];
+
+/**
+ * robots.txt. Crawling stays ALLOWED even on the noindex build, deliberately:
+ * `Disallow: /` stops the crawler fetching the page at all, and a URL that is
+ * *already* in the index can only be dropped by a directive the crawler is
+ * permitted to read — a blocked staging copy would linger indefinitely. Crawl
+ * budget on a host nothing links to is not worth trading that for. What the
+ * flag removes is the `Sitemap:` line, so staging advertises nothing.
+ */
+export function buildRobotsTxt(noindex: boolean): string {
+  const lines = ["User-agent: *", "Allow: /", ""];
+  if (!noindex) lines.push(`Sitemap: ${SITE_ORIGIN}/sitemap.xml`, "");
+  return lines.join("\n");
+}
+
+/**
+ * sitemap.xml. No `<lastmod>`: it is only honoured when consistently accurate,
+ * and the only value available at build time is the build timestamp, which
+ * changes on every redeploy whether or not the page did.
+ */
+export function buildSitemapXml(paths: readonly string[]): string {
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
+    ...paths.map((path) => `  <url><loc>${SITE_ORIGIN}${path}</loc></url>`),
+    `</urlset>`,
+    "",
+  ].join("\n");
+}
+
+/** The staging robots directive, as the literal tag injected into static HTML. */
+export const NOINDEX_META = `<meta name="robots" content="noindex, nofollow" />`;
+
+/**
+ * Head tags for the bundled HTML entries. Empty on a production build — the
+ * absence of a robots meta is what "index me" looks like.
+ */
+export function seoHeadTags(noindex: boolean): {
+  tag: string;
+  attrs: Record<string, string>;
+  injectTo: "head-prepend";
+}[] {
+  if (!noindex) return [];
+  return [
+    {
+      tag: "meta",
+      attrs: { name: "robots", content: "noindex, nofollow" },
+      injectTo: "head-prepend",
+    },
+  ];
+}
+
+/**
+ * Inject the staging robots directive into a static page's HTML.
+ *
+ * The bundled entries get theirs through `transformIndexHtml`, which never sees
+ * the pages under `public/` — Vite copies those through verbatim. Without this
+ * the flag would mean two different things on one deploy: a hard directive on
+ * the three entries that have nothing to index anyway (empty `#root`), and a
+ * canonical — a hint a search engine may decline — on the four content pages
+ * that carry the actual crawlable prose. Those are the staging URLs most able to
+ * rank against production, which is the whole defect.
+ *
+ * Returns `null` when the file already carries a robots meta (404.html ships its
+ * own `noindex`) or has no `<head>` to inject into, so the caller can skip the
+ * write rather than double-tagging.
+ */
+export function withNoindexMeta(html: string): string | null {
+  // `<meta\b[^>]*\bname=` and not `<meta\s+name=`: HTML attribute order carries no
+  // meaning, so a hand-written `<meta content="…" name="robots">` is the same
+  // directive. Anchoring on position would let that page through and double-tag it.
+  if (/<meta\b[^>]*\bname=["']robots["']/i.test(html)) return null;
+  const head = html.match(/<head[^>]*>/i);
+  if (!head) return null;
+  const at = html.indexOf(head[0]) + head[0].length;
+  return `${html.slice(0, at)}\n    ${NOINDEX_META}${html.slice(at)}`;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -245,79 +245,35 @@ export default function App() {
           )}
 
           {(state.phase === "idle" || state.phase === "error") && (
-            // What this is, plainly — plus the three claims displaced from the
-            // old trust-chip row (#517: speed, no-signup, determinism) and the
-            // citation. Quiet block below the drop zone: context, never
+            // The one guarantee a visitor needs before dropping a file, and
+            // nothing else. Quiet block below the drop zone: reassurance, never
             // competing with the primary action.
             //
-            // Rewritten Jul 2026 (user testing: "too long and not clear of its
-            // value"). The old copy opened on the *trend* — "recruiters are
-            // starting to run AI agents over resumes" — so the first thing a
-            // visitor read was someone else's behaviour, and what they
-            // personally get arrived in clause four, as a metaphor ("the
-            // candidate-side mirror"). It now opens on the three things the
-            // product does, in the order a user does them: parse, edit,
-            // download. 85 words → 27.
+            // Cut to a single line Aug 2026. Two paragraphs went with it and
+            // neither should come back here:
             //
-            // The recruiter-trend sentence was cut outright, not demoted, on a
-            // second pass: an unhedged "recruiters increasingly screen with AI"
-            // is a claim about an industry we would have to defend, and the
-            // Greenhouse report below measures AI *trust* among hiring
-            // managers, not screening prevalence — it never sourced that
-            // sentence as tightly as the old comment here asserted. The
-            // citation now stands on its own weaker, supportable claim
-            // ("a hiring process job seekers say they can't see into").
+            //   1. A product pitch ("OfflineCV parses your resume, shows you
+            //      what a machine read back, …"). Accurate, but this is an open
+            //      source project — it does not need to sell itself on its own
+            //      landing page, and a visitor who wants the description can
+            //      read /how-it-works/ (public/how-it-works/index.html), which
+            //      is where that sentence now lives in longer form.
+            //   2. The Greenhouse "2025 AI in Hiring Report" citation. It
+            //      sourced a claim about the hiring industry that this app
+            //      never needed to make in order to be useful. People can look
+            //      up the state of AI in hiring themselves.
             //
-            // ⚠️ Cut with it: "the score rates how readable your file is, not
-            // how good you are." That framing is now nowhere in the app — the
-            // header subtitle that used to carry it ("not a judge") is deleted
-            // in this PR too, and `AtsScoreReadout` never stated it. If it
-            // comes back, it belongs next to the score, not on the landing.
-            //
-            // Both export formats are real, so the remaining claim round-trips:
-            // PDF via `useDownloadPdf.ts` → `render-ats-pdf.ts`, Markdown via
-            // `useDownloadMarkdown.ts` (#552). If either is removed, this
-            // sentence moves in the same PR. "A machine", never "the ATS" — we
-            // run one generic text extractor (pdfjs), so a definite article
-            // would claim a fidelity we have not measured. Determinism stays
-            // scoped to the score, not to the parse.
+            // What survives is the part that is a *guarantee* rather than a
+            // pitch: there is no signup wall, and the score is deterministic.
+            // Both round-trip to code — no auth exists anywhere in the tree,
+            // and `computeAnonymousAtsScore` in `src/lib/score/score.ts` is a
+            // pure function of the extracted text. Determinism stays scoped to
+            // the score, never claimed for the parse.
             <div className="rounded-lg border border-border-light bg-surface-subtle px-4 py-3">
-              {/* One shared `mx-auto max-w-3xl` wrapper, not three. Applied
-                  per-paragraph, `mx-auto` centres each block independently, so
-                  a paragraph long enough to wrap reads as left-aligned while a
-                  short one visibly centres itself — the three lines rendered
-                  with three different left edges. Centring the group once
-                  gives them one. */}
-              <div className="mx-auto flex max-w-3xl flex-col gap-2">
-                <p className="text-pretty text-sm font-medium text-content-primary">
-                  OfflineCV parses your resume, shows you what a machine read
-                  back, and lets you edit it and download a cleanly formatted
-                  PDF or Markdown file.
-                </p>
-                {/* The three claims displaced from the trust-chip row (#517).
-                    Muted and on their own line: they are reassurance a visitor
-                    scans for, not part of the argument above. */}
-                <p className="text-sm text-content-secondary">
-                  No account, no email, results in seconds — and the same file
-                  always gets the same score.
-                </p>
-                {/* The trust stat, relocated from the hero. It sources the
-                    "recruiters increasingly screen with AI" claim above it,
-                    which is what it was always evidence for — in the hero it
-                    was a third competing message ahead of the primary action. */}
-                <p className="text-sm text-content-muted">
-                  Built in response to a hiring process job seekers say they
-                  can&apos;t see into — source:{" "}
-                  <a
-                    href="https://www.greenhouse.com/newsroom/an-ai-trust-crisis-70-of-hiring-managers-trust-ai-to-make-faster-and-better-hiring-decisions-only-8-of-job-seekers-call-it-fair"
-                    target="_blank"
-                    rel="nofollow noopener noreferrer"
-                    className="hover:underline"
-                  >
-                    Greenhouse, 2025 AI in Hiring Report (4,100+ job seekers and hiring managers)
-                  </a>
-                </p>
-              </div>
+              <p className="mx-auto max-w-3xl text-pretty text-sm text-content-secondary">
+                No account, no email, results in seconds — and the same file
+                always gets the same score.
+              </p>
             </div>
           )}
         </section>

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -156,8 +156,32 @@ export function PageShell({
       {children}
 
       <footer className="mt-auto flex flex-col items-center gap-2 border-t border-border-light pt-6 text-center text-sm text-content-tertiary">
-        <p>Your PDF stays in this browser tab by default and is never used to train AI. AI analysis is optional.</p>
+        {/* No prose line here. The privacy sentence that used to sit above
+            these links ("Your PDF stays in this browser tab by default…") was
+            a claim compressed to the point where it could not carry its own
+            caveats — the honest version needs the itemised egress list, so it
+            lives on /privacy/, one link away, instead of being asserted in
+            passing on every screen. */}
         <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+          {/* Same-tab, base-aware links to the static content pages under
+              public/. They are the only pages on this site a crawler can read
+              without executing the bundle (every app entry renders into an
+              empty #root), so this footer is also what keeps them from being
+              orphaned — a page nothing links to is a page nothing finds.
+              "Privacy & data" now lands on /privacy/, which summarises the
+              README's telemetry section and links onward to it. */}
+          <a href={`${import.meta.env.BASE_URL}how-it-works/`} className="hover:underline">
+            How it works
+          </a>
+          <a href={`${import.meta.env.BASE_URL}faq/`} className="hover:underline">
+            FAQ
+          </a>
+          <a href={`${import.meta.env.BASE_URL}privacy/`} className="hover:underline">
+            Privacy &amp; data
+          </a>
+          <a href={`${import.meta.env.BASE_URL}open-source/`} className="hover:underline">
+            Open source
+          </a>
           <a
             href="https://github.com/offlinecv/OfflineCV/blob/main/LICENSE"
             target="_blank"
@@ -165,22 +189,6 @@ export function PageShell({
             className="hover:underline"
           >
             License
-          </a>
-          <a
-            href="https://www.hbs.edu/managing-the-future-of-work/research/Pages/hidden-workers-untapped-talent.aspx"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="hover:underline"
-          >
-            Further reading: HBS Hidden Workers
-          </a>
-          <a
-            href="https://github.com/offlinecv/OfflineCV/blob/main/README.md#telemetry"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="hover:underline"
-          >
-            Privacy &amp; data
           </a>
         </div>
       </footer>

--- a/src/design-system/shared/CapabilityStrip.tsx
+++ b/src/design-system/shared/CapabilityStrip.tsx
@@ -45,8 +45,11 @@
  * reads all three at once. "Device" also understates the guarantee — another
  * app on the same device cannot read the resume either. If you change the
  * noun here, change it in `App.tsx`'s hero in the same commit. `PageShell`'s
- * footer states a narrower, hedged claim about a different object ("your PDF
- * stays in this browser tab by default") — same noun, not the same sentence.
+ * footer used to restate a narrower, hedged version of this ("your PDF stays
+ * in this browser tab by default"); that sentence is gone — the footer now
+ * links to `/privacy/`, which itemises the egress instead of compressing it
+ * into a clause. This rail is therefore the only place the claim is *made*
+ * rather than linked to, so it is the one that has to stay defensible.
  */
 
 import { Chip } from "../primitives/Chip.tsx";

--- a/src/lib/jobs-landing.ts
+++ b/src/lib/jobs-landing.ts
@@ -18,12 +18,14 @@
  * `jobs/index.html`, and this app deliberately does not have that: Vite's
  * `appType: "mpa"` (see `vite.config.ts`) 404s an unmatched path honestly
  * instead of falling back to the wrong page, and the production Workers-
- * assets deploy's `single-page-application` `not_found_handling` serves the
- * ROOT `/index.html` for any unmatched request — the parser-audit page, not
- * this one (verified against Cloudflare's docs, which describe serving "the
- * `/index.html` file", not the nearest ancestor one). A hash is never sent to
- * the server, so `/jobs/#saved` resolves identically in dev, GitHub Pages,
- * and Workers assets with no routing change anywhere.
+ * assets deploy's `not_found_handling` now serves `404.html` with a real 404
+ * status for any unmatched request. (It previously said
+ * `single-page-application`, which served the ROOT `/index.html` — the
+ * parser-audit page, not this one. Either way the unmatched path does not
+ * reach this surface; the newer setting just fails honestly instead of
+ * silently rendering the wrong page.) A hash is never sent to the server, so
+ * `/jobs/#saved` resolves identically in dev, GitHub Pages, and Workers
+ * assets with no routing change anywhere.
  *
  * The decision (which tab a given URL lands on) is factored out from the
  * `window.location` IO so it is unit-testable with plain strings — same

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,22 @@
 
 /// <reference types="vitest" />
 import { execSync } from "node:child_process";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, type Plugin } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import basicSsl from "@vitejs/plugin-basic-ssl";
+
+import {
+  buildRobotsTxt,
+  buildSitemapXml,
+  HTML_ENTRIES,
+  seoHeadTags,
+  SITEMAP_PATHS,
+  withNoindexMeta,
+} from "./scripts/seo-artifacts.ts";
 
 // Dev-server TLS opt-out. `basicSsl()` below makes `npm run dev` serve HTTPS,
 // which is what a LAN client needs for WebGPU (see the plugin's comment) — but
@@ -73,6 +84,80 @@ const APP_VERSION = resolveAppVersion();
 // VITE_BASE_PATH to override. Default "/" is the custom-domain production
 // target and local dev.
 const BASE_PATH = process.env.VITE_BASE_PATH ?? "/";
+
+// Non-canonical build marker. The `main` → GitHub Pages deploy at
+// dev.offlinecv.org (.github/workflows/deploy-pages.yml) is a byte-identical
+// copy of production on a subdomain of the same registrable domain, so a search
+// engine sees two complete sites and picks one — which is how production ends
+// up dropped. That workflow sets OFFLINECV_SEO_NOINDEX=1; this build then adds
+// `<meta name="robots" content="noindex, nofollow">` to every page — bundled
+// entries and static pages alike — and ships no sitemap.
+//
+// Its robots.txt still ALLOWS crawling, deliberately — see buildRobotsTxt in
+// scripts/seo-artifacts.ts for why a blocked staging copy is the worse trade.
+const SEO_NOINDEX = process.env.OFFLINECV_SEO_NOINDEX === "1";
+
+// Recursively list every .html file under a directory.
+function htmlFilesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return htmlFilesUnder(path);
+    return entry.name.endsWith(".html") ? [path] : [];
+  });
+}
+
+// Search-engine directives, generated at build time so the two deploy targets
+// differ without a second copy of the URL list checked into public/. Emitting
+// rather than shipping public/robots.txt is what makes SEO_NOINDEX possible at
+// all: a file in public/ is copied identically into both builds.
+//
+// Note that `sitemap.xml` and `robots.txt` MUST exist as real assets. The
+// Cloudflare Workers assets config used to serve unknown paths as the root
+// SPA page, so both URLs answered 200 with HTML — a sitemap that cannot parse
+// and a robots.txt with no valid directives in it.
+//
+// The decisions all three hooks below make live in scripts/seo-artifacts.ts as
+// pure functions, because a plugin hook is not reachable from a unit test and
+// an inverted flag is silent in both directions.
+function emitSeoFiles(): Plugin {
+  let outDir = "dist";
+  return {
+    name: "offlinecv:seo",
+    apply: "build",
+    configResolved(config) {
+      outDir = config.build.outDir;
+    },
+    transformIndexHtml() {
+      return seoHeadTags(SEO_NOINDEX);
+    },
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "robots.txt",
+        source: buildRobotsTxt(SEO_NOINDEX),
+      });
+      if (SEO_NOINDEX) return;
+      this.emitFile({
+        type: "asset",
+        fileName: "sitemap.xml",
+        source: buildSitemapXml(SITEMAP_PATHS),
+      });
+    },
+    // `transformIndexHtml` only ever sees the bundled entries, so the static
+    // pages under public/ would otherwise ship a canonical and nothing else —
+    // a hint a crawler may decline, on exactly the staging URLs that carry
+    // crawlable prose and can therefore rank against production. By closeBundle
+    // the public dir has been copied and outDir is on disk, so one pass over
+    // it makes the flag mean one thing across every page.
+    closeBundle() {
+      if (!SEO_NOINDEX) return;
+      for (const file of htmlFilesUnder(outDir)) {
+        const tagged = withNoindexMeta(readFileSync(file, "utf8"));
+        if (tagged !== null) writeFileSync(file, tagged);
+      }
+    },
+  };
+}
 
 // Emit dist/version.json at build time only. Unhashed + at the site root so the
 // proactive update checker can poll a stable URL. GitHub Pages forces its own
@@ -162,6 +247,7 @@ export default defineConfig({
     tailwindcss(),
     react(),
     emitVersionJson(APP_VERSION),
+    emitSeoFiles(),
     jdFitTrailingSlash(),
   ],
   build: {
@@ -175,12 +261,17 @@ export default defineConfig({
     // pages — the dev-only `jd-spike.html` / `eval-rewrite.html`
     // harnesses (which Vite's default auto-discovery would otherwise bundle) are
     // no longer emitted into dist/, which is the intended production surface.
+    //
+    // Derived from HTML_ENTRIES rather than spelled out here so the entry set
+    // and the sitemap cannot drift: a fourth entry is advertised for indexing
+    // by construction instead of by someone remembering a second list.
     rollupOptions: {
-      input: {
-        main: fileURLToPath(new URL("./index.html", import.meta.url)),
-        jdFit: fileURLToPath(new URL("./jd-fit/index.html", import.meta.url)),
-        jobs: fileURLToPath(new URL("./jobs/index.html", import.meta.url)),
-      },
+      input: Object.fromEntries(
+        Object.entries(HTML_ENTRIES).map(([name, { file }]) => [
+          name,
+          fileURLToPath(new URL(`./${file}`, import.meta.url)),
+        ]),
+      ),
     },
   },
   resolve: {
@@ -233,6 +324,7 @@ export default defineConfig({
         "src/**/*.{ts,tsx}",
         "scripts/check-fixture-pii.mjs",
         "scripts/check-known-failures.mjs",
+        "scripts/seo-artifacts.ts",
       ],
       exclude: [
         "src/**/*.test.ts",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,13 +2,22 @@
 // builds (build: `npm run build`, deploy: `npx wrangler deploy`). Assets-only:
 // no worker script, no build-time Cloudflare dependency — the OSS build stays
 // host-agnostic (vite build → dist/), matching the repo's client-side-only
-// constraint. SPA not-found handling mirrors the old Pages behavior.
+// constraint.
+//
+// `404-page`, not `single-page-application`. This is a multi-page app with no
+// client-side router (see `appType: "mpa"` in vite.config.ts, which already
+// makes dev and preview 404 honestly); the SPA setting was the odd one out and
+// it answered EVERY unknown path with 200 + the root parser page. That produced
+// an unbounded set of distinct URLs all serving identical content — soft 404s —
+// and it swallowed /robots.txt and /sitemap.xml, which have to resolve to real
+// files. `404-page` serves dist/404.html with a real 404 status instead.
+// GitHub Pages picks up the same /404.html natively, so both targets agree.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "offlinecv",
   "compatibility_date": "2026-07-20",
   "assets": {
     "directory": "./dist",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "404-page"
   }
 }


### PR DESCRIPTION
## Summary

`offlinecv.org` is verified in Search Console but none of its pages are indexed. The cause was five defects in what the site actually serves — not a Search Console setting. This fixes all five: `robots.txt` / `sitemap.xml` now exist as real generated assets, unknown paths 404 instead of returning the homepage with a 200, the staging duplicate at `dev.offlinecv.org` is marked `noindex`, the three entries carry absolute canonical + OG tags, and four plain-HTML content pages give the crawler something to read that does not require executing the bundle.

Also trims the landing block to its one guarantee and removes the footer's compressed privacy sentence — separately motivated, but it touches the same two files, so it lands here rather than in a second PR fighting for the same lines.

Closes #751

## Review focus

- `vite.config.ts` — `SEO_NOINDEX` inverted would deindex **production**, silently and for weeks. **Answered in review:** the decisions now live in `scripts/seo-artifacts.ts` as pure functions with unit tests asserting both branches, and `rollupOptions.input` derives from the same `HTML_ENTRIES` map the sitemap does, so an entry cannot go unadvertised.
- `public/privacy/index.html` — does the itemised egress list match the actual `fetch(` callsites, or did I miss a path? It claims to be exhaustive, which is a claim worth attacking. **One was missed and is now fixed in review:** JD fit's URL field calls five ATS APIs directly from the browser. It is itemised as §3, the "never leaves" line is narrowed to a *pasted* JD, and the FAQ answer + its JSON-LD copy say so too.
- `public/how-it-works/index.html` — every number (weights `0.4`/`0.3`/`0.3`, multipliers `1.0`/`0.85`/`0.7`/`0`, bands `80`/`60`) is quoted from `src/lib/score/score.ts`. Worth checking one against source rather than trusting the prose.
- `src/lib/jobs-landing.ts` — the `#saved`-hash docblock justified itself partly by what the old `single-page-application` handling did. I kept the conclusion and rewrote the mechanism; does the argument still hold under `404-page`?
- `public/content.css` duplicates token values from `src/design-system/styles/tokens.css` rather than importing them. Is the no-JS constraint (files in `public/` are copied verbatim, never processed by Vite) a good enough reason, or is there a seam I missed?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green — 5000 passed / 10 skipped, no regressions
- [x] `npm run verify` green (fallow report-only: flags `public/content.css` as unreachable, which is expected — it is referenced from static HTML fallow does not parse; the `App.tsx` complexity finding is pre-existing and this PR reduces that function's line count)
- [x] Default build emits `dist/robots.txt` with a `Sitemap:` line and `dist/sitemap.xml` with all 7 URLs (byte-identical to before the review changes); **no** `noindex` in any page except `404.html`
- [x] `OFFLINECV_SEO_NOINDEX=1 npm run build` emits a `Sitemap:`-free `robots.txt`, **no** `sitemap.xml`, and exactly one `noindex` meta in **all eight** built pages — the three entries via `transformIndexHtml`, the four content pages via the `closeBundle` pass, and `404.html` left with the one it already shipped (not double-tagged)
- [x] FAQ `FAQPage` JSON-LD parses, and all 12 questions match the visible `<h2>`s one for one (checked programmatically)
- [x] All four content pages, `content.css` and `404.html` present in `dist/` after a build

## Not in this PR

- **`og:image`** — no image asset exists in the repo, and referencing a missing file is worse than omitting the tag.
- **Prerendering the three app entries.** The static content pages are the cheap fix for "nothing to index"; server-rendering the React surfaces is the thorough one and is a much larger change.
- **Inbound links.** A new domain with zero backlinks has no crawl reason. Linking `offlinecv.org` from the repo's About field is a settings action, not a code change.

## Provenance

Code implementation via: Claude Opus 5 (1M context). Reasoning effort is not surfaced to the session, so it is omitted rather than guessed.
Verification: `npm run verify` — green locally via the pre-push hook, and in CI.

