### PR TITLE
fix(resume-library): rebuild a record whose cached parse is missing

### DIFF
--- a/src/lib/resume-library.test.ts
+++ b/src/lib/resume-library.test.ts
@@ -47,6 +47,31 @@ const result = () =>
   }) as unknown as CascadeResult;
 const score = (overall: number) => ({ overall }) as AnonymousAtsScore;
 
+/** What the mocked cascade hands back on a re-parse, tagged "Reparsed Persona"
+ *  so a test can prove the loaded result came from the blob rather than from a
+ *  snapshot. Shared by every re-parse path — the stale-shape guard and the
+ *  no-cached-parse recovery both land on the same recovery code. */
+const reparsedResult = () =>
+  ({
+    canonical: toCanonicalResume(
+      { full_name: "Reparsed Persona", skills: [], experience: [], education: [] },
+      {
+        byName: new Map(),
+        accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
+        source: "regex",
+      },
+      {},
+    ),
+    confidence: 0,
+    triggers: [],
+    suggestedEscalation: "none",
+    tiers: ["t0_layout", "t1_openresume"],
+    rawText: "",
+    linkAnnotations: [],
+    diagnostics: { rawCharCount: 0, extractedCharCount: 0, pages: 1, elapsedMs: 0 },
+    timings: { t0_layout_ms: 0, t1_openresume_ms: 0 },
+  }) as unknown as CascadeResult;
+
 async function save(filename: string, overall = 72) {
   return saveResumeToLibrary({
     filename,
@@ -111,27 +136,7 @@ describe("resume-library: rename + delete", () => {
 
 describe("resume-library: cache-version mismatch (#445 / #321)", () => {
   it("re-parses from the stored blob instead of deserializing a stale-shape record", async () => {
-    // A re-parsed canonical result the mocked cascade returns, tagged so we can
-    // prove the loaded result came from the re-parse, not the stale snapshot.
-    const reparsed = {
-      canonical: toCanonicalResume(
-        { full_name: "Reparsed Persona", skills: [], experience: [], education: [] },
-        {
-          byName: new Map(),
-          accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
-          source: "regex",
-        },
-        {},
-      ),
-      confidence: 0,
-      triggers: [],
-      suggestedEscalation: "none",
-      tiers: ["t0_layout", "t1_openresume"],
-      rawText: "",
-      linkAnnotations: [],
-      diagnostics: { rawCharCount: 0, extractedCharCount: 0, pages: 1, elapsedMs: 0 },
-      timings: { t0_layout_ms: 0, t1_openresume_ms: 0 },
-    } as unknown as CascadeResult;
+    const reparsed = reparsedResult();
     vi.mocked(runCascade).mockResolvedValue(reparsed);
 
     // Write a pre-cutover record DIRECTLY through the storage layer: a stale
@@ -173,6 +178,62 @@ describe("resume-library: cache-version mismatch (#445 / #321)", () => {
         sourceKind: "docx",
       },
     });
+    expect(await loadResumeFromLibrary(rec.id)).toBeUndefined();
+    expect(runCascade).not.toHaveBeenCalled();
+  });
+});
+
+describe("resume-library: record with no cached parse (#693 producer write)", () => {
+  /** A record an outside producer writes through the backup-import door: the
+   *  PDF bytes and nothing else, because a producer cannot run the cascade. */
+  async function producerWritten(blob: Blob) {
+    return saveResume({ filename: "from-producer.pdf", blob });
+    // `parse` deliberately absent.
+  }
+
+  it("re-parses from the stored blob instead of refusing the record", async () => {
+    const reparsed = reparsedResult();
+    vi.mocked(runCascade).mockResolvedValue(reparsed);
+
+    const rec = await producerWritten(
+      new Blob([bytes().buffer], { type: "application/pdf" }),
+    );
+
+    const loaded = await loadResumeFromLibrary(rec.id);
+
+    // Before this fix the missing snapshot short-circuited to `undefined`, which
+    // is what left `/jobs/`'s #724 fallback rating nothing at all.
+    expect(runCascade).toHaveBeenCalledTimes(1);
+    expect(loaded).toBeDefined();
+    expect(loaded!.result).toBe(reparsed);
+    expect(loaded!.sourceKind).toBe("pdf");
+    expect(loaded!.score).toBeDefined();
+  });
+
+  it("re-stamps the record so the next load does not re-parse", async () => {
+    vi.mocked(runCascade).mockResolvedValue(reparsedResult());
+
+    const rec = await producerWritten(
+      new Blob([bytes().buffer], { type: "application/pdf" }),
+    );
+    await loadResumeFromLibrary(rec.id);
+    await loadResumeFromLibrary(rec.id);
+
+    expect(runCascade).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a parse-less record with no bytes to re-parse from", async () => {
+    const rec = await producerWritten(new Blob([], { type: "application/pdf" }));
+    expect(await loadResumeFromLibrary(rec.id)).toBeUndefined();
+    expect(runCascade).not.toHaveBeenCalled();
+  });
+
+  it("drops a parse-less record whose bytes are not a PDF", async () => {
+    const rec = await producerWritten(
+      new Blob([bytes().buffer], {
+        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      }),
+    );
     expect(await loadResumeFromLibrary(rec.id)).toBeUndefined();
     expect(runCascade).not.toHaveBeenCalled();
   });

--- a/src/lib/resume-library.ts
+++ b/src/lib/resume-library.ts
@@ -156,27 +156,56 @@ export async function listLibrary(): Promise<ResumeLibraryEntry[]> {
     .sort((a, b) => b.savedAt - a.savedAt);
 }
 
+/** The kind a record's stored bytes actually are, for a record whose snapshot
+ *  cannot say. Reverse of {@link MIME}; unknown/blank types read as `pdf`,
+ *  which is what every producer that writes bytes writes today. */
+function sourceKindOfBlob(blob: Blob): SourceKind {
+  for (const [kind, mime] of Object.entries(MIME) as [SourceKind, string][]) {
+    if (blob.type === mime) return kind;
+  }
+  return "pdf";
+}
+
 /** Load a saved resume for hydration into the results view. Returns `undefined`
- *  when the record is gone or its cached parse is unreadable. */
+ *  when the record is gone, or when its parse can neither be read nor rebuilt
+ *  from the stored bytes. */
 export async function loadResumeFromLibrary(
   id: string,
 ): Promise<LoadedResume | undefined> {
   const record = await getResume(id);
   if (record === undefined) return undefined;
   const snap = readSnapshot(record.parse);
-  if (snap === null) return undefined;
   const bytes =
     record.blob.size > 0 ? await record.blob.arrayBuffer() : undefined;
 
-  // Stale-shape guard (#445 / #321). A record written at a different parser-shape
-  // or score-algo version must NOT be deserialized as the current canonical
-  // shape (a pre-cutover record has a `parsed`/`sections` façade and no
-  // `canonical` member — reading it as canonical would crash downstream). Re-parse
-  // from the stored PDF blob instead. If there is no blob to re-parse from (e.g. a
-  // DOCX record, whose source bytes are not kept at rest), the record can't be
-  // safely restored — drop it rather than hand back a stale shape.
-  if (snap.shapeVersion !== CACHE_SHAPE_VERSION) {
+  // Rebuild from the stored bytes whenever the cached parse cannot be used as
+  // it stands. Two ways that happens, and they take the same recovery:
+  //
+  //  - **No cached parse at all** (`snap === null`). Reachable since #693 put a
+  //    public write door on this store: a producer outside this build imports a
+  //    `ResumeRecord` carrying the PDF and no `parse`, because it cannot run the
+  //    cascade. Such a record lists fine (`listLibrary` keeps it at score 0) and
+  //    used to load as `undefined`, which made `/jobs/`'s #724 fallback rate
+  //    NOTHING — no stars on any row, no console line, and `hasResume === false`
+  //    so the tracker showed the "open this from your resume" prompt against a
+  //    résumé that was sitting right there. The bytes are present; refusing them
+  //    was the bug.
+  //  - **Stale shape** (#445 / #321). A record written at a different
+  //    parser-shape or score-algo version must NOT be deserialized as the
+  //    current canonical shape (a pre-cutover record has a `parsed`/`sections`
+  //    façade and no `canonical` member — reading it as canonical would crash
+  //    downstream).
+  //
+  // Either way: no blob to rebuild from (a DOCX record, whose source bytes are
+  // not kept at rest) means the record can't be safely restored — drop it rather
+  // than hand back a stale or absent shape.
+  if (snap === null || snap.shapeVersion !== CACHE_SHAPE_VERSION) {
     if (bytes === undefined) return undefined;
+    const sourceKind = snap?.sourceKind ?? sourceKindOfBlob(record.blob);
+    // `runCascade` reads PDF bytes. A non-PDF record with no usable snapshot has
+    // nothing this module can rebuild from, so it degrades to "not loadable"
+    // rather than throwing inside the cascade.
+    if (sourceKind !== "pdf") return undefined;
     const result = await runCascade(bytes);
     const score = scoreForResult(result);
     // Re-stamp the record at the current shape version so this migration is a
@@ -187,7 +216,7 @@ export async function loadResumeFromLibrary(
     const migrated: SavedResumeSnapshot = {
       result,
       score,
-      sourceKind: snap.sourceKind,
+      sourceKind,
       shapeVersion: CACHE_SHAPE_VERSION,
     };
     try {
@@ -205,7 +234,7 @@ export async function loadResumeFromLibrary(
       filename: record.filename,
       fileSize: record.blob.size,
       bytes,
-      sourceKind: snap.sourceKind,
+      sourceKind,
       result,
       score,
     };


### PR DESCRIPTION
## Summary

`loadResumeFromLibrary` refused any `resumes` record with an empty `parse` slot — `if (snap === null) return undefined` — even when the source PDF was sitting in the record's blob. Since #693 made the store a public write door, that record is routine: a producer outside this build imports a `ResumeRecord` with the PDF and no parse, because it cannot run the cascade itself.

The damage showed up on `/jobs/`. `useFallbackResume` (#724) loads the newest library résumé so the Saved-jobs tab can rate against something on a direct visit. That load resolved `undefined`, so no fallback was set, `hasResume` stayed false, and **every** row lost its fitness block — including rows with a healthy `jdText`. And it was silent: the promise resolved rather than rejected, so the hook's `.catch` never fired, and the tracker rendered "Open this workbench from your resume" against a résumé already in the library.

Found live on a 541-record library whose only résumé record had a valid 25 KB PDF blob and no parse.

The fix is to stop treating "no cached parse" as a different problem from "stale cached parse". The stale-shape guard (#445 / #321) ten lines below already re-parses from the stored blob for the same underlying reason — the cached parse cannot be used as it stands — so both now take that path. Refusal is reserved for records that genuinely cannot be rebuilt: no bytes at rest (DOCX), or bytes the PDF cascade cannot read.

Closes #758.

## Review focus

- `src/lib/resume-library.ts:202` — the branch condition is now `snap === null || snap.shapeVersion !== CACHE_SHAPE_VERSION`. Does every read of `snap` *after* the branch still narrow to non-null, given the branch returns on all paths?
- `src/lib/resume-library.ts:174` — `sourceKindOfBlob` defaults an unknown or blank `blob.type` to `pdf`. Is that the right default for a producer-written record, or should a blank type refuse?
- `src/lib/resume-library.ts:208` — the new `sourceKind !== "pdf"` guard also applies to the *stale-shape* path, which previously called `runCascade` regardless of kind. A stale markdown record with bytes now returns `undefined` where it used to attempt a parse. Is that a behaviour change worth calling out, or was that path already dead?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` green — `src/lib/resume-library.test.ts` 12/12, stable across 3 runs
- [x] Fail-before proven: 3 tests fail with `resume-library.ts` reverted, pass with it
- [x] `npm run verify` green locally (typecheck, lint, fixture PII, baselines, coverage, build)
- [ ] Manually verified against a real parse-less record on a deployed build

No fixture binaries added or changed.

fallow reports one 11-line clone group, both instances in `resume-library.test.ts`: the assertion blocks of the two sibling recovery tests. Left duplicated on purpose — an extracted assertion helper would hide which outcome each scenario actually checks. The larger 77-line group from the first draft is gone; `reparsedResult()` is now shared by both paths.

## Provenance

Code implementation via: Claude Opus 5 (1M context) (high)
Verification: `npm run verify` — green locally and in CI
