### PR TITLE
feat(storage,jobs): observable, validated, bulk-safe local library

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,16 @@ export default function App() {
   const library = useResumeLibrary();
   const onLoadSavedResume = async (id: string) => {
     const loaded = await library.load(id);
-    if (loaded === undefined) return;
+    if (loaded === undefined) {
+      // The one case this reaches: no cached parse AND no stored bytes to
+      // rebuild it from (or bytes the PDF cascade can't read) — see
+      // `loadResumeFromLibrary`. Say so; the Saved-resumes card otherwise
+      // looks like a dead Load button.
+      library.setLoadError(
+        "Couldn't restore this resume — its saved parse is missing and there's no usable file kept to rebuild it from. Drop the file in again to load it fresh.",
+      );
+      return;
+    }
     loadSavedResume({
       fileName: loaded.filename,
       fileSize: loaded.fileSize,

--- a/src/components/features/JobArchiveSweepDialog.test.tsx
+++ b/src/components/features/JobArchiveSweepDialog.test.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * JobArchiveSweepDialog (#759). Covers the acceptance criteria the issue
+ * names for the dialog itself: the count and the write agree because they
+ * are the SAME predicate, and a cutoff matching zero rows disables Confirm
+ * rather than running a no-op. The predicate itself
+ * (`isSweepable`/`jobsToArchive`) is unit-tested at module scope in
+ * `job-archive-sweep.test.ts`; the domain-layer write is covered in
+ * `job-tracker.test.ts`. This file only exercises the UI wiring between them.
+ *
+ * jsdom has no `HTMLDialogElement.showModal`/`close` — the polyfill, the
+ * per-test root, and the "scope assertions to the OPEN dialog" recipe all
+ * come from `__test-utils__/dialog-dom.ts`; see `JobLetterIndicator.test.tsx`
+ * for the same shape.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { JobArchiveSweepDialog } from "./JobArchiveSweepDialog.tsx";
+import { installDialogPolyfill, setupDomRoot } from "./__test-utils__/dialog-dom.ts";
+import type { JobRecord } from "../../lib/storage/index.ts";
+
+installDialogPolyfill();
+const dom = setupDomRoot();
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.now();
+
+function job(over: Partial<JobRecord>): JobRecord {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    createdAt: NOW - 60 * DAY_MS,
+    updatedAt: NOW - 60 * DAY_MS,
+    title: "SWE",
+    company: "Acme",
+    status: "interested",
+    ...over,
+  };
+}
+
+function clickButton(scope: ParentNode, label: string) {
+  const button = [...scope.querySelectorAll("button")].find(
+    (b) => b.textContent === label,
+  );
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  return button;
+}
+
+function openDialogEl(): HTMLElement {
+  return dom.container.querySelector("dialog[open]") as HTMLElement;
+}
+
+function setCutoff(value: number) {
+  const input = openDialogEl().querySelector(
+    "input[type='number']",
+  ) as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  act(() => {
+    setter.call(input, String(value));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("JobArchiveSweepDialog", () => {
+  it("previews the count jobsToArchive would compute for the default cutoff", () => {
+    const jobs = [
+      job({ title: "Old", createdAt: NOW - 60 * DAY_MS }),
+      job({ title: "Fresh", createdAt: NOW - 1 * DAY_MS }),
+      job({ title: "Pipeline", status: "applied", createdAt: NOW - 400 * DAY_MS }),
+    ];
+    dom.render(<JobArchiveSweepDialog jobs={jobs} archiveOlderThan={vi.fn()} />);
+    clickButton(dom.container, "Archive old jobs");
+    // Default cutoff (30 days): only "Old" qualifies — "Fresh" is too recent
+    // and "Pipeline" is outside the Interested bucket however old.
+    expect(openDialogEl().textContent).toContain("1 job");
+  });
+
+  it("disables Confirm when the cutoff matches zero rows, rather than running a no-op", () => {
+    const jobs = [job({ title: "Fresh", createdAt: NOW - 1 * DAY_MS })];
+    dom.render(<JobArchiveSweepDialog jobs={jobs} archiveOlderThan={vi.fn()} />);
+    clickButton(dom.container, "Archive old jobs");
+    const confirm = [...openDialogEl().querySelectorAll("button")].find(
+      (b) => b.textContent === "Archive",
+    ) as HTMLButtonElement | undefined;
+    expect(confirm?.disabled).toBe(true);
+  });
+
+  it("enables Confirm once the cutoff matches at least one row, and calls archiveOlderThan with it", async () => {
+    const jobs = [job({ title: "Old", createdAt: NOW - 60 * DAY_MS })];
+    const archiveOlderThan = vi.fn(async () => 1);
+    dom.render(<JobArchiveSweepDialog jobs={jobs} archiveOlderThan={archiveOlderThan} />);
+    clickButton(dom.container, "Archive old jobs");
+    const confirm = [...openDialogEl().querySelectorAll("button")].find(
+      (b) => b.textContent === "Archive",
+    ) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(false);
+
+    await act(async () => {
+      confirm.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(archiveOlderThan).toHaveBeenCalledWith(30);
+    // Confirm swaps to a done state in place — no toast primitive in this repo.
+    expect(openDialogEl().textContent).toContain("Archived 1 job.");
+  });
+
+  it("recomputes the preview count and re-disables Confirm as the cutoff changes", () => {
+    const jobs = [job({ title: "Old", createdAt: NOW - 60 * DAY_MS })];
+    dom.render(<JobArchiveSweepDialog jobs={jobs} archiveOlderThan={vi.fn()} />);
+    clickButton(dom.container, "Archive old jobs");
+    const confirmFor = () =>
+      [...openDialogEl().querySelectorAll("button")].find(
+        (b) => b.textContent === "Archive",
+      ) as HTMLButtonElement;
+    expect(confirmFor().disabled).toBe(false);
+
+    // Raise the cutoff past the one row's age — nothing qualifies anymore.
+    setCutoff(90);
+    expect(confirmFor().disabled).toBe(true);
+    expect(openDialogEl().textContent).toContain("0 jobs");
+  });
+});

--- a/src/components/features/JobArchiveSweepDialog.tsx
+++ b/src/components/features/JobArchiveSweepDialog.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobArchiveSweepDialog — bulk-archive control for the Saved-jobs surface
+ * (#759). Sibling of `ResumeLibraryImportDialog`: owns its own trigger
+ * `Button` + `Dialog`, split into its own file so `JobTracker.tsx` (already
+ * past the ~200 LOC guideline) doesn't grow further for this feature
+ * (CLAUDE.md).
+ *
+ * The preview count and the write share ONE predicate — `jobsToArchive`
+ * (`lib/job-archive-sweep.ts`) — computed here for the live count and handed
+ * to `archiveOlderThan` unchanged: that function runs the identical
+ * predicate over the identical `jobs` array this dialog was given. That
+ * equality is the #759 acceptance criterion — the sweep can never select a
+ * row on a policy the preview did not apply — and it is why `jobs` is a prop
+ * rather than a fresh read inside this component.
+ *
+ * The number this dialog PRINTS on completion is the count `archiveOlderThan`
+ * returns, never `toArchive.length`, and the distinction is deliberate. A row
+ * that stopped being Interested while the sweep ran — another tab, the
+ * extension, a sync — is skipped at the write rather than overwritten, so the
+ * two can legitimately differ downward. Printing the returned count keeps
+ * "Archived N jobs." a statement about writes that happened; printing the
+ * preview would make it a statement about intent, which is the one place this
+ * surface could quietly tell the user something untrue.
+ *
+ * The confirm step states the three things #759 names as decisions worth
+ * getting wrong silently: the cutoff reads `createdAt` (when the job entered
+ * this library) and never posting age; the sweep reaches only the Interested
+ * bucket, never a row with hand-built pipeline state; and archiving
+ * overwrites whatever vocabulary (`saved` / `scouted`) a synced row arrived
+ * with — one-way, unlike the `archived` status itself.
+ *
+ * No toast on completion — this repo ships none (`@design-system`'s
+ * CLAUDE.md). The dialog swaps its own content to a done state instead of
+ * closing, the same "confirm in place" rule `ResumeLibraryImportDialog`'s
+ * parent follows with `InlineResult`; kept inside this dialog rather than a
+ * region in `JobTracker.tsx` because there's nowhere else on the page for a
+ * "archived N jobs" result to attach to.
+ */
+
+import { useId, useState } from "react";
+import { Button, Dialog, InlineResult } from "@design-system";
+import { jobsToArchive } from "../../lib/job-archive-sweep.ts";
+import type { JobRecord } from "../../lib/storage/index.ts";
+
+/** Shown when the dialog opens. Long enough that a library synced within the
+ *  last month doesn't greet the user with a same-day surprise count. */
+const DEFAULT_CUTOFF_DAYS = 30;
+
+interface JobArchiveSweepDialogProps {
+  /** The tracker's current job list — the exact array `archiveOlderThan`
+   *  reads, so the preview count computed here can't drift from the write. */
+  jobs: readonly JobRecord[];
+  /** `useJobTracker`'s bulk-archive sweep. */
+  archiveOlderThan: (cutoffDays: number) => Promise<number>;
+}
+
+export function JobArchiveSweepDialog({
+  jobs,
+  archiveOlderThan,
+}: JobArchiveSweepDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [cutoffDays, setCutoffDays] = useState(DEFAULT_CUTOFF_DAYS);
+  const [archiving, setArchiving] = useState(false);
+  const [archivedCount, setArchivedCount] = useState<number | null>(null);
+  const inputId = useId();
+
+  // NaN (an emptied or non-numeric input) and a non-positive value both mean
+  // "no valid cutoff yet" — `jobsToArchive` would otherwise read a NaN cutoff
+  // as "never matches" anyway, but checking here keeps the preview count and
+  // the disabled Confirm in agreement without relying on that coincidence.
+  const validCutoff = Number.isFinite(cutoffDays) && cutoffDays > 0;
+  const toArchive = validCutoff ? jobsToArchive(jobs, cutoffDays) : [];
+
+  function reset() {
+    setOpen(false);
+    setCutoffDays(DEFAULT_CUTOFF_DAYS);
+    setArchivedCount(null);
+  }
+
+  async function handleConfirm() {
+    setArchiving(true);
+    try {
+      setArchivedCount(await archiveOlderThan(cutoffDays));
+    } finally {
+      setArchiving(false);
+    }
+  }
+
+  return (
+    <>
+      <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+        Archive old jobs
+      </Button>
+
+      <Dialog
+        open={open}
+        onClose={reset}
+        title="Archive old jobs"
+        className="max-w-sm"
+      >
+        {archivedCount !== null ? (
+          <div className="flex flex-col gap-4">
+            <InlineResult tone="success">
+              Archived {archivedCount} {archivedCount === 1 ? "job" : "jobs"}.
+            </InlineResult>
+            <div className="flex justify-end">
+              <Button variant="primary" onClick={reset}>
+                Done
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-content-secondary">
+              Moves jobs from your{" "}
+              <span className="font-medium text-content-primary">
+                Interested
+              </span>{" "}
+              list to Archived when they were added to your library more than
+              this many days ago. Applied, Interviewing, Offer, and Rejected
+              jobs are never touched.
+            </p>
+
+            <label
+              htmlFor={inputId}
+              className="flex items-center gap-2 text-sm text-content-secondary"
+            >
+              Added more than
+              <input
+                id={inputId}
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                value={Number.isFinite(cutoffDays) ? cutoffDays : ""}
+                disabled={archiving}
+                onChange={(e) => setCutoffDays(e.target.valueAsNumber)}
+                className="w-20 rounded border border-border bg-surface-card px-2 py-1 text-sm text-content-primary outline-hidden focus:ring-1 focus:ring-accent-primary"
+              />
+              days ago
+            </label>
+
+            <p className="text-sm text-content-secondary">
+              <span className="font-medium text-content-primary">
+                {toArchive.length} {toArchive.length === 1 ? "job" : "jobs"}
+              </span>{" "}
+              will be archived.
+            </p>
+
+            <p className="text-sm text-content-tertiary">
+              Every archived row&apos;s status becomes the literal{" "}
+              <span className="font-medium">archived</span> — including a job
+              that arrived as Saved or Scouted from a synced source, whose
+              original label is gone once this runs. It also updates each
+              row&apos;s last-modified time, which a syncing job board may
+              push again on its next pass.
+            </p>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" onClick={reset} disabled={archiving}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => void handleConfirm()}
+                disabled={archiving || toArchive.length === 0}
+              >
+                {archiving ? "Archiving…" : "Archive"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/features/JobDuplicateNotice.tsx
+++ b/src/components/features/JobDuplicateNotice.tsx
@@ -36,12 +36,16 @@ import type { JobDuplicateSuggestion } from "../../hooks/useJobDuplicates.ts";
 
 /** How the notice opens, per confidence. `certain` states the evidence because
  *  it HAS evidence — somebody recorded these two URLs as one posting — while
- *  `probable` is an inference and says so. A `possible` match never reaches
- *  this component; see `isActionableDuplicate`. */
+ *  `probable` is an inference and says so. Neither `possible` nor `title-only`
+ *  reaches this component; see `isActionableDuplicate`. They are spelled out
+ *  anyway because the `Record` is exhaustive, which is the point: a tier added
+ *  to `JobDuplicateConfidence` fails the build here rather than rendering a
+ *  blank lead-in above a merge button. */
 const LEAD_IN: Record<JobDuplicateSuggestion["confidence"], string> = {
   certain: "Same posting as another saved job — they share a URL:",
   probable: "Looks like the same posting as another saved job:",
   possible: "May be the same posting as another saved job:",
+  "title-only": "Shares a title with another saved job, and nothing else:",
 };
 
 interface JobDuplicateNoticeProps {

--- a/src/components/features/JobRepostClusterList.test.tsx
+++ b/src/components/features/JobRepostClusterList.test.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `JobRepostClusterList` (#754) — the statement the tracker makes instead of
+ * offering a merge.
+ *
+ * Reached indirectly through `JobTracker.test.tsx` already, which is why this
+ * file stays narrow: it covers the two things that are properties of THIS
+ * component rather than of the tracker wiring, and that a tracker-level test
+ * would only exercise by accident.
+ *
+ *  - **The optional-span branch.** `firstSeen`/`lastSeen`/`spanDays` are absent
+ *    together when no member of a cluster carries a readable capture time, and
+ *    the row must then drop the date line rather than print `NaN days`. The
+ *    tracker's own fixtures all have timestamps, so nothing above this reaches
+ *    that branch.
+ *  - **The absence of an affordance.** #754's whole decision was to replace 30
+ *    destructive **Merge into this one** buttons with one sentence, so "there
+ *    is no button here" is the requirement, not an implementation detail. A
+ *    later change that helpfully re-adds one should fail a test.
+ */
+
+import { describe, it, expect } from "vitest";
+import { setupDomRoot } from "./__test-utils__/dialog-dom.ts";
+import { JobRepostClusterList } from "./JobRepostClusterList.tsx";
+import type { JobRepostCluster } from "../../lib/job-repost-clusters.ts";
+
+const dom = setupDomRoot();
+
+const JAN_1 = Date.parse("2026-01-01T00:00:00Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function cluster(over: Partial<JobRepostCluster> = {}): JobRepostCluster {
+  return {
+    key: "acme::staff engineer",
+    company: "Acme",
+    title: "Staff Engineer",
+    ids: ["a", "b", "c"],
+    count: 3,
+    firstSeen: JAN_1,
+    lastSeen: JAN_1 + 49 * DAY_MS,
+    spanDays: 49,
+    ...over,
+  };
+}
+
+describe("JobRepostClusterList", () => {
+  it("renders nothing at all when no role has been re-listed", () => {
+    dom.render(<JobRepostClusterList clusters={[]} />);
+    expect(dom.container.textContent).toBe("");
+    // Not merely empty text — the whole section is absent, so it cannot leave
+    // a stray heading or spacing above the pipeline.
+    expect(dom.container.querySelector("section")).toBeNull();
+  });
+
+  it("states the count, the role and the span once per cluster", () => {
+    dom.render(<JobRepostClusterList clusters={[cluster()]} />);
+
+    const text = dom.container.textContent ?? "";
+    expect(text).toContain("Reposted 3×");
+    expect(text).toContain("Staff Engineer");
+    expect(text).toContain("Acme");
+    expect(text).toContain("49 days apart");
+    // One line for the cluster, not one per member — the point of the surface.
+    expect(dom.container.querySelectorAll("li")).toHaveLength(1);
+  });
+
+  it("drops the date line, keeping the count, when the cluster has no readable span", () => {
+    dom.render(
+      <JobRepostClusterList
+        clusters={[
+          cluster({ firstSeen: undefined, lastSeen: undefined, spanDays: undefined }),
+        ]}
+      />,
+    );
+
+    const text = dom.container.textContent ?? "";
+    // The count is still true and still stated…
+    expect(text).toContain("Reposted 3×");
+    expect(text).toContain("Staff Engineer");
+    // …but nothing pretends to know a span. `NaN`/`Invalid Date` reaching the
+    // user is the specific failure this branch exists to prevent.
+    expect(text).not.toContain("days apart");
+    expect(text).not.toContain("NaN");
+    expect(text).not.toContain("Invalid Date");
+  });
+
+  it("offers no action — no button, and the copy says why", () => {
+    dom.render(<JobRepostClusterList clusters={[cluster(), cluster({ key: "b" })]} />);
+
+    // #754 replaced a grid of destructive merge buttons with a statement.
+    // Nothing here is for the user to accept, decline, or dismiss.
+    expect(dom.container.querySelectorAll("button")).toHaveLength(0);
+    expect(dom.container.textContent).toContain("no merge is offered");
+  });
+
+  it("counts the clusters in its heading, not the records inside them", () => {
+    dom.render(
+      <JobRepostClusterList
+        clusters={[cluster(), cluster({ key: "second", count: 6 })]}
+      />,
+    );
+
+    // Two clusters covering nine records: the heading says 2. Saying 9 would
+    // double-count rows the status sections below already show in full.
+    expect(dom.container.textContent).toContain("Reposted roles · 2");
+  });
+});

--- a/src/components/features/JobRepostClusterList.tsx
+++ b/src/components/features/JobRepostClusterList.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JobRepostClusterList — one line per role a company keeps re-listing (#754).
+ *
+ * The affordance this replaces is the point of it. Six saved rows for one role
+ * spread over 49 days used to render 30 **Merge into this one** buttons, each
+ * one a destructive action that would have collapsed the churn into a single
+ * record. This says the true thing instead — *reposted 6×, 49 days* — once per
+ * cluster, and offers nothing: there is nothing here for a user to accept or
+ * decline, so there is no button, no confirm, and no dismissal.
+ *
+ * ## Why one list, and not a notice on each row
+ *
+ * A cluster's records are spread across STATUS buckets — the motivating group
+ * was part `interested`, part `archived` — so no status section can hold the
+ * statement, and repeating it on every member would be six statements for one
+ * fact. Stating it once above the sections keeps the bucket counts honest
+ * (`JobTrackerStatusGroup`'s header count stays the bucket's full length) and
+ * leaves the individual records where the user filed them, reachable in their
+ * own sections below rather than nested inside a second collapse.
+ *
+ * Reuse analysis: display-only, no state, no new primitive. `StatusBadge` from
+ * `@design-system` carries the count; everything else is text on the same
+ * semantic tokens the rows use. Deliberately NOT a `Card` or a bordered banner —
+ * it is a `<section>` + `<h3>` + `<ul>` inside the tracker's existing card, the
+ * shape `JobTrackerStatusGroup` uses, because a second panel above the pipeline
+ * would compete with the pipeline.
+ *
+ * Split out of `JobTracker.tsx` rather than inlined: that file is already past
+ * the ~200 LOC feature guideline.
+ */
+
+import { StatusBadge } from "@design-system";
+import type { JobRepostCluster } from "../../lib/job-repost-clusters.ts";
+
+/** Absolute, never "3 weeks ago". These are capture times spanning months and
+ *  the span is the whole claim — a relative phrase against today's clock would
+ *  drift out from under the number beside it. */
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function JobRepostClusterList({
+  clusters = [],
+}: {
+  /** Every repost cluster in the library (`useJobRepostClusters`). Empty or
+   *  omitted renders nothing — the common library has no re-listed role. */
+  clusters?: readonly JobRepostCluster[];
+}) {
+  if (clusters.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-content-muted">
+        Reposted roles · {clusters.length}
+      </h3>
+      <ul className="flex flex-col gap-2">
+        {clusters.map((cluster) => (
+          <li
+            key={cluster.key}
+            className="flex flex-col gap-1 rounded-md border border-border-light bg-surface-subtle p-2"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge tone="info">Reposted {cluster.count}×</StatusBadge>
+              <span className="text-sm text-content-primary">
+                {cluster.title || "Untitled job"}
+              </span>
+              <span className="text-sm text-content-secondary">{cluster.company}</span>
+            </div>
+            {/* `spanDays` is absent only when no member carries a readable
+                capture time, and then the count is still true — so the line
+                drops the span rather than printing an unreadable one. */}
+            {cluster.spanDays !== undefined &&
+              cluster.firstSeen !== undefined &&
+              cluster.lastSeen !== undefined && (
+                <span className="text-xs text-content-muted">
+                  {formatDate(cluster.firstSeen)} – {formatDate(cluster.lastSeen)} ·{" "}
+                  {cluster.spanDays} days apart
+                </span>
+              )}
+          </li>
+        ))}
+      </ul>
+      <p className="text-sm text-content-muted">
+        Listed more than once over time — kept as separate records, so no merge is
+        offered for them.
+      </p>
+    </section>
+  );
+}

--- a/src/components/features/JobTracker.test.tsx
+++ b/src/components/features/JobTracker.test.tsx
@@ -20,6 +20,7 @@ import type { JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import type { JobRecord, LetterRecord } from "../../lib/storage/index.ts";
 import type { JobRating } from "../../lib/job-search/rating.ts";
 import type { JobDuplicateSuggestion } from "../../hooks/useJobDuplicates.ts";
+import { findRepostClusters } from "../../lib/job-repost-clusters.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -65,6 +66,7 @@ function makeTracker(jobs: JobRecord[]): Tracker {
     merge: vi.fn(async () => {}),
     saveFromMatch: vi.fn(async () => "new-id"),
     exportBackup: vi.fn(async () => {}),
+    archiveOlderThan: vi.fn(async () => 0),
     refresh: vi.fn(async () => {}),
   };
 }
@@ -112,6 +114,18 @@ describe("JobTracker", () => {
     );
     act(() => add?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
     expect(tracker.create).toHaveBeenCalledWith({ title: "New job" });
+  });
+
+  it("renders the bulk-archive control in the header (#759)", () => {
+    // Deep interaction — cutoff input, preview count, confirm — lives in
+    // JobArchiveSweepDialog.test.tsx; this only checks JobTracker wires
+    // `tracker.jobs` / `tracker.archiveOlderThan` through to it at all.
+    const tracker = makeTracker([job({ title: "SWE" })]);
+    act(() => root.render(<JobTracker tracker={tracker} />));
+    const trigger = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent === "Archive old jobs",
+    );
+    expect(trigger).toBeDefined();
   });
 
   it("degrades a stale resume link to 'not linked' instead of a dangling id", () => {
@@ -880,5 +894,87 @@ describe("JobTracker: the duplicate affordance never merges on its own (#746)", 
     const { tracker } = pairedTracker();
     act(() => root.render(<JobTracker tracker={tracker} />));
     expect(container.textContent).not.toContain("Looks like the same posting");
+  });
+});
+
+describe("JobTracker: a repost cluster states the churn instead of offering merges (#754)", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const JUN_15 = Date.UTC(2026, 5, 15);
+
+  /** Six records of one role at one company, first and last 49 days apart, in
+   *  two different status buckets — the shape the issue measured. Every name is
+   *  invented. */
+  function relisted(): JobRecord[] {
+    return Array.from({ length: 6 }, (_unused, i) =>
+      job({
+        id: `r${i}`,
+        title: "Head of Engineering",
+        company: "Bellhaven Talent",
+        status: i === 5 ? "archived" : "interested",
+        createdAt: JUN_15 + Math.round((49 * DAY * i) / 5),
+        updatedAt: JUN_15 + Math.round((49 * DAY * i) / 5),
+      }),
+    );
+  }
+
+  function mount(jobs: JobRecord[]) {
+    const tracker = makeTracker(jobs);
+    const clusters = findRepostClusters(jobs);
+    act(() =>
+      root.render(
+        <JobTracker
+          tracker={tracker}
+          repostClusters={clusters}
+          // The sweep the tracker's own hook runs, done here because this
+          // component is tracker-injected: with the clusters in hand every
+          // pairing in the group is suppressed, so the map is empty.
+          duplicatesByJobId={new Map()}
+          onDismissDuplicate={vi.fn()}
+        />,
+      ),
+    );
+    return tracker;
+  }
+
+  it("renders ONE repost row for the group, stating the count and the span", () => {
+    mount(relisted());
+    const rows = [...container.querySelectorAll("li")].filter((li) =>
+      li.textContent?.includes("Reposted"),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("Reposted 6×");
+    expect(rows[0].textContent).toContain("Head of Engineering");
+    expect(rows[0].textContent).toContain("Bellhaven Talent");
+    expect(rows[0].textContent).toContain("49 days apart");
+  });
+
+  it("offers no merge anywhere in the group, and merges nothing by rendering", () => {
+    const tracker = mount(relisted());
+    const merge = [...container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Merge into this one",
+    );
+    expect(merge).toEqual([]);
+    expect(tracker.merge).not.toHaveBeenCalled();
+  });
+
+  it("still lists all six records in their own status sections", () => {
+    // The statement collapses the OFFER, not the library: a cluster spans
+    // status buckets, so collapsing the rows would strand records out of the
+    // section they were filed in and make the header counts lie.
+    mount(relisted());
+    const header = container.querySelector("header")?.textContent;
+    expect(header).toContain("6");
+    expect(container.textContent).toContain("Interested · 5");
+    expect(container.textContent).toContain("Archived · 1");
+  });
+
+  it("renders nothing for a library with no re-listed role", () => {
+    const jobs = [
+      job({ id: "a", title: "Head of Engineering", createdAt: JUN_15 }),
+      job({ id: "b", title: "Head of Engineering", createdAt: JUN_15 + 3 * DAY }),
+    ];
+    expect(findRepostClusters(jobs)).toEqual([]);
+    mount(jobs);
+    expect(container.textContent).not.toContain("Reposted");
   });
 });

--- a/src/components/features/JobTracker.tsx
+++ b/src/components/features/JobTracker.tsx
@@ -36,11 +36,26 @@
  * a title is edited. Nothing here merges anything; the row's notice offers, and
  * `tracker.merge` only ever runs from a click on it.
  *
+ * Repost clusters (#754): a third derived-on-view sweep, `useJobRepostClusters`,
+ * over the same `tracker.jobs`. It feeds two things — the `JobRepostClusterList`
+ * statement above the sections, and `useJobDuplicates`, which withholds the
+ * merge offer for pairings inside a cluster. The ORDER of those two hook calls
+ * is load-bearing: the clusters must exist before the duplicate sweep can
+ * suppress against them. One role a company has re-listed six times is not five
+ * redundant records, and offering thirty merges on it would have destroyed the
+ * churn signal a click at a time.
+ *
  * Buckets, not raw statuses (#744): sections key on `jobStatusBucket(status)`,
  * so a synced record's `saved` / `scouted` / `shared` share the one Interested
  * section instead of splitting one pipeline stage into four. That mapping is
  * strictly a VIEW concern — this surface never writes a normalised status back
  * over what a producer stored.
+ *
+ * Bulk-archive sweep (#759): `JobArchiveSweepDialog` owns the whole feature —
+ * trigger, cutoff input, live preview count, confirm, and the done state — as
+ * its own sibling file, so this header only wires it to `tracker.jobs` and
+ * `tracker.archiveOlderThan`. Unlike the three sweeps above, this ONE writes:
+ * the dialog's own docblock covers why that write is safe.
  */
 
 import { useMemo } from "react";
@@ -51,6 +66,8 @@ import type { JobRecord, LetterRecord } from "../../lib/storage/index.ts";
 import { jobStatusBucket } from "../../lib/job-status-bucket.ts";
 import { JobTrackerEntry, type LinkableResume } from "./JobTrackerEntry.tsx";
 import { JobTrackerStatusGroup, isCollapsedByDefault } from "./JobTrackerStatusGroup.tsx";
+import { JobRepostClusterList } from "./JobRepostClusterList.tsx";
+import { JobArchiveSweepDialog } from "./JobArchiveSweepDialog.tsx";
 import { useJobTracker, type JobTracker as Tracker } from "../../hooks/useJobTracker.ts";
 import { useSavedJobRatings } from "../../hooks/useSavedJobRatings.ts";
 import { useJobLetters } from "../../hooks/useJobLetters.ts";
@@ -58,6 +75,8 @@ import {
   useJobDuplicates,
   type JobDuplicateSuggestion,
 } from "../../hooks/useJobDuplicates.ts";
+import { useJobRepostClusters } from "../../hooks/useJobRepostClusters.ts";
+import type { JobRepostCluster } from "../../lib/job-repost-clusters.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import type { JobRating } from "../../lib/job-search/rating.ts";
 
@@ -97,6 +116,12 @@ interface JobTrackerProps {
   /** "Not the same" — suppress one pairing durably. Required alongside
    *  `duplicatesByJobId` for either to reach a row. */
   onDismissDuplicate?: (a: string, b: string) => void;
+  /** Roles this library holds more than one record of, spread over more than
+   *  `REPOST_SPAN_DAYS` (#754) — `useJobRepostClusters`' shape. Stated once each
+   *  above the sections; the member records still render in their own status
+   *  sections. Omitted renders no statement, which is what a caller that has not
+   *  run the sweep should get. */
+  repostClusters?: readonly JobRepostCluster[];
 }
 
 /**
@@ -116,6 +141,7 @@ export function JobTrackerSection({
   | "lettersById"
   | "duplicatesByJobId"
   | "onDismissDuplicate"
+  | "repostClusters"
 > & {
   /** The résumé saved jobs are rated against — the `/` handoff `JobsApp` holds.
    *  Must be referentially stable; `useSavedJobRatings` deps on it directly. */
@@ -124,7 +150,9 @@ export function JobTrackerSection({
   const tracker = useJobTracker();
   const ratings = useSavedJobRatings(tracker.jobs, parsed);
   const letters = useJobLetters();
-  const duplicates = useJobDuplicates(tracker.jobs);
+  // Before `useJobDuplicates`, which suppresses against it — see the docblock.
+  const reposts = useJobRepostClusters(tracker.jobs);
+  const duplicates = useJobDuplicates(tracker.jobs, reposts.byJobId);
   return (
     <JobTracker
       tracker={tracker}
@@ -133,6 +161,7 @@ export function JobTrackerSection({
       lettersById={letters.byJobId}
       duplicatesByJobId={duplicates.byJobId}
       onDismissDuplicate={duplicates.dismiss}
+      repostClusters={reposts.clusters}
       {...props}
     />
   );
@@ -148,9 +177,23 @@ export function JobTracker({
   lettersById,
   duplicatesByJobId,
   onDismissDuplicate,
+  repostClusters,
 }: JobTrackerProps) {
-  const { jobs, ready, persisted, usageBytes, update, setStatus, link, unlink, remove, merge, create, exportBackup } =
-    tracker;
+  const {
+    jobs,
+    ready,
+    persisted,
+    usageBytes,
+    update,
+    setStatus,
+    link,
+    unlink,
+    remove,
+    merge,
+    create,
+    exportBackup,
+    archiveOlderThan,
+  } = tracker;
 
   // One pass, bucketed by each job's DISPLAY bucket rather than its literal
   // status string (#744): a synced record's `saved` / `scouted` / `shared` are
@@ -214,6 +257,7 @@ export function JobTracker({
           <Button variant="ghost" size="sm" onClick={() => void exportBackup()}>
             Export backup
           </Button>
+          <JobArchiveSweepDialog jobs={jobs} archiveOlderThan={archiveOlderThan} />
         </div>
       </header>
 
@@ -245,6 +289,9 @@ export function JobTracker({
         </p>
       ) : (
         <div className="flex flex-col gap-4">
+          {/* Above the pipeline, not inside it: a cluster's members are spread
+              across status buckets, so no section owns the statement. */}
+          <JobRepostClusterList clusters={repostClusters} />
           {groups.map(({ bucket, jobs: group }) => (
             <JobTrackerStatusGroup
               key={bucket}

--- a/src/components/features/ResumeLibrary.test.tsx
+++ b/src/components/features/ResumeLibrary.test.tsx
@@ -40,6 +40,7 @@ function entry(overrides: Partial<Entry> = {}): Entry {
     savedAt: Date.now(),
     scoreOverall: 80,
     sourceKind: "pdf",
+    hasCachedParse: true,
     ...overrides,
   };
 }
@@ -52,6 +53,8 @@ function makeLibrary(overrides: Partial<Library> = {}): Library {
     usageBytes: null,
     save: vi.fn(),
     load: vi.fn(),
+    loadError: null,
+    setLoadError: vi.fn(),
     rename: vi.fn(),
     remove: vi.fn(),
     exportBackup: vi.fn(),
@@ -119,6 +122,29 @@ describe("ResumeLibrary: empty-library placement (#573)", () => {
         (b) => b.textContent === "Export backup",
       ),
     ).toBe(false);
+  });
+});
+
+describe("ResumeLibrary: unrecoverable load failure (#756)", () => {
+  it("renders library.loadError through ErrorState in the aria-live region", async () => {
+    const el = await mount(
+      makeLibrary({
+        entries: [entry()],
+        loadError: "Couldn't restore this resume — its saved parse is missing.",
+      }),
+    );
+
+    const live = el.querySelector('[aria-live="polite"]')!;
+    expect(live.textContent).toContain(
+      "Couldn't restore this resume — its saved parse is missing.",
+    );
+    // The entry itself is untouched — a load failure doesn't remove the row.
+    expect(el.textContent).toContain("cv.pdf");
+  });
+
+  it("renders nothing extra when there is no load error", async () => {
+    const el = await mount(makeLibrary({ entries: [entry()], loadError: null }));
+    expect(el.querySelector('[aria-live="polite"]')).toBeNull();
   });
 });
 

--- a/src/components/features/ResumeLibrary.tsx
+++ b/src/components/features/ResumeLibrary.tsx
@@ -43,6 +43,7 @@ export function ResumeLibrary({ library, onLoad }: ResumeLibraryProps) {
     ready,
     persisted,
     usageBytes,
+    loadError,
     rename,
     remove,
     exportBackup,
@@ -56,6 +57,18 @@ export function ResumeLibrary({ library, onLoad }: ResumeLibraryProps) {
 
   // Nothing to show until the initial load resolves.
   if (!ready) return null;
+
+  // A record whose parse can neither be read nor rebuilt from its stored
+  // bytes (#756) — the entry stays in the list (so it can still be deleted),
+  // but Load has nothing to hydrate. Reuses the same `ErrorState` +
+  // `aria-live` pattern as `importStatusRegion` below rather than a new
+  // banner. Can only be non-null once an entry exists, so it has no place in
+  // the empty-library branch.
+  const loadErrorRegion = loadError && (
+    <div aria-live="polite">
+      <ErrorState>{loadError}</ErrorState>
+    </div>
+  );
 
   const importStatusRegion = importStatus && (
     <div aria-live="polite">
@@ -149,6 +162,7 @@ export function ResumeLibrary({ library, onLoad }: ResumeLibraryProps) {
         {!persisted && EVICTION_NOTICE}
       </p>
 
+      {loadErrorRegion}
       {importStatusRegion}
 
       <ul className="flex flex-col gap-2">

--- a/src/components/features/ResumeLibraryEntry.tsx
+++ b/src/components/features/ResumeLibraryEntry.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState } from "react";
-import { Button, EditableField, Dialog } from "@design-system";
+import { Button, EditableField, Dialog, StatusBadge } from "@design-system";
 import { timeAgo } from "../../lib/date-utils.ts";
 import type { ResumeLibraryEntry as Entry } from "../../lib/resume-library.ts";
 
@@ -45,7 +45,14 @@ export function ResumeLibraryEntry({
         <p className="mt-0.5 flex items-center gap-2 text-xs text-content-muted">
           <span className="uppercase tracking-wider">{entry.sourceKind}</span>
           <span aria-hidden>·</span>
-          <span>score {entry.scoreOverall}</span>
+          {entry.hasCachedParse ? (
+            <span>score {entry.scoreOverall}</span>
+          ) : (
+            // No cached parse yet (#757) — never render `score 0` here, since
+            // that reads as a genuine zero rather than "not parsed yet".
+            // Still fully loadable: `Load` re-parses it from the stored bytes.
+            <StatusBadge tone="info">Not parsed yet</StatusBadge>
+          )}
           <span aria-hidden>·</span>
           <span>saved {timeAgo(new Date(entry.savedAt).toISOString())}</span>
         </p>

--- a/src/components/features/SaveJobFromMatch.test.tsx
+++ b/src/components/features/SaveJobFromMatch.test.tsx
@@ -61,6 +61,7 @@ function makeTracker(): Tracker {
     merge: vi.fn(async () => {}),
     saveFromMatch: vi.fn(async () => "new-id"),
     exportBackup: vi.fn(async () => {}),
+    archiveOlderThan: vi.fn(async () => 0),
     refresh: vi.fn(async () => {}),
   };
 }

--- a/src/hooks/useFallbackResume.test.tsx
+++ b/src/hooks/useFallbackResume.test.tsx
@@ -29,7 +29,14 @@ function parsedFor(name: string): HeuristicParsedResume {
 }
 
 function entry(id: string, savedAt: number): ResumeLibraryEntry {
-  return { id, filename: `${id}.pdf`, savedAt, scoreOverall: 80, sourceKind: "pdf" };
+  return {
+    id,
+    filename: `${id}.pdf`,
+    savedAt,
+    scoreOverall: 80,
+    sourceKind: "pdf",
+    hasCachedParse: true,
+  };
 }
 
 /** Just enough of `CascadeResult`/`LoadedResume` for the hook's one read

--- a/src/hooks/useJobDuplicates.test.tsx
+++ b/src/hooks/useJobDuplicates.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useJobDuplicates (#746, #754). The three filters the hook applies on one pass,
+ * proved where they meet rather than one at a time: only actionable tiers reach
+ * a row, a pairing the user dismissed stays dismissed across a remount, and a
+ * pairing inside a repost cluster loses its merge offer while a shared-URL
+ * pairing inside the same cluster keeps one.
+ *
+ * The suppression is the acceptance criterion this file exists for: six records
+ * of one role spread over 49 days used to hand the tracker thirty **Merge**
+ * offers, and every one of them was a destructive action on an employer's
+ * repost.
+ *
+ * Exercised through a probe component, the pattern `useJobLetters.test.tsx`
+ * uses. No `fake-indexeddb`: this hook reads nothing but its arguments and
+ * localStorage. Every company and URL below is invented.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useJobDuplicates, type JobDuplicates } from "./useJobDuplicates.ts";
+import {
+  findRepostClusters,
+  indexRepostClusters,
+  type JobRepostCluster,
+} from "../lib/job-repost-clusters.ts";
+import type { JobRecord } from "../lib/storage/index.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const DAY = 24 * 60 * 60 * 1000;
+const JUN_15 = Date.UTC(2026, 5, 15);
+
+let container: HTMLElement;
+let root: Root;
+let latest: JobDuplicates | undefined;
+
+function Probe({
+  jobs,
+  reposts,
+}: {
+  jobs: readonly JobRecord[];
+  reposts?: ReadonlyMap<string, JobRepostCluster>;
+}) {
+  latest = useJobDuplicates(jobs, reposts);
+  return null;
+}
+
+beforeEach(() => {
+  globalThis.localStorage?.clear();
+  latest = undefined;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function job(over: Partial<JobRecord> & { id: string }): JobRecord {
+  return {
+    createdAt: JUN_15,
+    updatedAt: JUN_15,
+    title: "Head of Engineering",
+    company: "Bellhaven Talent",
+    status: "interested",
+    ...over,
+  };
+}
+
+/** Six records of one role, first and last 49 days apart — the shape of the
+ *  group the issue measured. */
+function relisted(): JobRecord[] {
+  return Array.from({ length: 6 }, (_unused, i) =>
+    job({ id: `r${i}`, createdAt: JUN_15 + Math.round((49 * DAY * i) / 5) }),
+  );
+}
+
+/** Total merge offers across every row — the number that used to be 30. */
+function offerCount(): number {
+  let total = 0;
+  for (const list of latest?.byJobId.values() ?? []) total += list.length;
+  return total;
+}
+
+function mount(jobs: readonly JobRecord[], reposts?: ReadonlyMap<string, JobRepostCluster>) {
+  act(() => root.render(<Probe jobs={jobs} reposts={reposts} />));
+}
+
+describe("useJobDuplicates: a repost cluster withdraws the merge offer (#754)", () => {
+  it("offers merges on the 49-day group when no clusters are passed", () => {
+    // The pre-suppression baseline, so the assertion below cannot pass by the
+    // pairings simply never existing. Records less than REPOST_SPAN_DAYS apart
+    // are still corroborated by proximity, so the group is not silent.
+    mount(relisted());
+    expect(offerCount()).toBeGreaterThan(0);
+  });
+
+  it("withdraws every one of them once the clusters are passed", () => {
+    const jobs = relisted();
+    mount(jobs, indexRepostClusters(findRepostClusters(jobs)));
+    expect(offerCount()).toBe(0);
+    expect(latest?.byJobId.size).toBe(0);
+  });
+
+  it("keeps a shared-URL merge between two members of the same cluster", () => {
+    // `certain` is identity, not inference: six reposts are six URLs, so two
+    // records sharing one is a genuine double-capture of a single posting and
+    // its merge is the one correct offer in the group.
+    const jobs = relisted();
+    const url = "https://boards.example.com/bellhaven/jobs/4012345";
+    jobs[0] = { ...jobs[0], url };
+    jobs[5] = { ...jobs[5], url: `${url}?utm_source=li` };
+    mount(jobs, indexRepostClusters(findRepostClusters(jobs)));
+    expect(latest?.byJobId.get("r0")).toEqual([
+      { job: jobs[5], confidence: "certain" },
+    ]);
+    expect(latest?.byJobId.get("r5")).toEqual([
+      { job: jobs[0], confidence: "certain" },
+    ]);
+    // ...and nothing else in the group regained one.
+    expect(offerCount()).toBe(2);
+  });
+
+  it("leaves a double-capture outside any cluster alone", () => {
+    const jobs = [
+      job({ id: "a", createdAt: JUN_15 }),
+      job({ id: "b", createdAt: JUN_15 + 3 * DAY }),
+    ];
+    mount(jobs, indexRepostClusters(findRepostClusters(jobs)));
+    expect(latest?.byJobId.get("a")).toEqual([{ job: jobs[1], confidence: "probable" }]);
+    expect(latest?.byJobId.get("b")).toEqual([{ job: jobs[0], confidence: "probable" }]);
+  });
+});
+
+describe("useJobDuplicates: dismissal survives the new tier (#754 must not disturb #746)", () => {
+  it("a dismissed pairing stays dismissed across a remount", () => {
+    const jobs = [
+      job({ id: "a", createdAt: JUN_15 }),
+      job({ id: "b", createdAt: JUN_15 + 3 * DAY }),
+    ];
+    mount(jobs);
+    expect(latest?.byJobId.size).toBe(2);
+
+    act(() => latest?.dismiss("a", "b"));
+    expect(latest?.byJobId.size).toBe(0);
+
+    // A reload: fresh root, same localStorage. `jobPairKey`'s shape is what
+    // carries the judgement across, which is why it is pinned in
+    // `job-duplicates.test.ts`.
+    act(() => root.unmount());
+    root = createRoot(container);
+    mount(jobs);
+    expect(latest?.byJobId.size).toBe(0);
+  });
+});

--- a/src/hooks/useJobDuplicates.ts
+++ b/src/hooks/useJobDuplicates.ts
@@ -25,6 +25,17 @@
  * A pairing the user dismissed is filtered on the same pass — reading the
  * dismissals fresh into state at mount, so a reload does not re-offer a merge
  * the user already declined.
+ *
+ * ## And neither do pairings inside a repost cluster (#754)
+ *
+ * Third filter on the same pass, from the same principle. `isRepostSuppressed`
+ * owns the precedence rule and states why in full; the short form is that
+ * cluster membership outranks an inferred tier and is outranked by URL
+ * identity, so a genuine shared-URL double-capture inside a cluster keeps its
+ * offer while the repost pairings lose theirs. The clusters are the caller's to
+ * pass — `useJobRepostClusters` derives them from the same `jobs` array — so
+ * this hook stays usable on its own and a caller that has not swept simply gets
+ * the pre-#754 behaviour.
  */
 
 import { useCallback, useMemo, useState } from "react";
@@ -38,6 +49,10 @@ import {
   dismissJobPair,
   readDismissedJobPairs,
 } from "../lib/job-duplicate-dismissals.ts";
+import {
+  isRepostSuppressed,
+  type JobRepostCluster,
+} from "../lib/job-repost-clusters.ts";
 import type { JobRecord } from "../lib/storage/index.ts";
 
 /** One "this row may be the same posting as that one" suggestion, resolved to
@@ -56,7 +71,13 @@ export interface JobDuplicates {
   dismiss: (a: string, b: string) => void;
 }
 
-export function useJobDuplicates(jobs: readonly JobRecord[]): JobDuplicates {
+export function useJobDuplicates(
+  jobs: readonly JobRecord[],
+  /** Repost clusters over the SAME `jobs` array (`useJobRepostClusters`).
+   *  Omitted suppresses nothing, which is what a caller that has not run that
+   *  sweep should get. */
+  repostsByJobId?: ReadonlyMap<string, JobRepostCluster>,
+): JobDuplicates {
   const [dismissed, setDismissed] = useState<ReadonlySet<string>>(() =>
     readDismissedJobPairs(),
   );
@@ -67,6 +88,7 @@ export function useJobDuplicates(jobs: readonly JobRecord[]): JobDuplicates {
     for (const pair of findDuplicatePairs(jobs)) {
       if (!isActionableDuplicate(pair.confidence)) continue;
       if (dismissed.has(jobPairKey(pair.a, pair.b))) continue;
+      if (repostsByJobId !== undefined && isRepostSuppressed(pair, repostsByJobId)) continue;
       const a = byId.get(pair.a);
       const b = byId.get(pair.b);
       if (a === undefined || b === undefined) continue;
@@ -76,7 +98,12 @@ export function useJobDuplicates(jobs: readonly JobRecord[]): JobDuplicates {
       push(suggestions, b.id, { job: a, confidence: pair.confidence });
     }
     return suggestions;
-  }, [jobs, dismissed]);
+    // `repostsByJobId` is derived from `jobs` by a sibling memo, so it can only
+    // change when `jobs` already has — listing it costs no extra re-fire and
+    // stops a caller that passes a differently-derived map from reading a stale
+    // suppression. (`exhaustive-deps` is not enforced in this repo; this array
+    // is hand-audited both directions.)
+  }, [jobs, dismissed, repostsByJobId]);
 
   const dismiss = useCallback((a: string, b: string) => {
     dismissJobPair(a, b);

--- a/src/hooks/useJobRepostClusters.ts
+++ b/src/hooks/useJobRepostClusters.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useJobRepostClusters — the tracker's view of "which saved rows are one role
+ * this employer keeps re-listing" (#754). A thin subscription wrapper in the
+ * shape `useJobDuplicates` established, which is the shape
+ * `useSectionRewriteLock` established: every rule that decides anything lives in
+ * `src/lib/job-repost-clusters.ts` (pure, testable at module scope) and this
+ * hook holds only the memo.
+ *
+ * Not even one piece of state, unlike `useJobDuplicates` — there is nothing to
+ * dismiss. A repost cluster makes no offer, so there is nothing for a user to
+ * decline; it is a statement about the library, and the library is the whole
+ * input.
+ *
+ * ## Derived on VIEW, never stored
+ *
+ * The rule `useJobDuplicates` and `useSavedJobRatings` follow: a stored verdict
+ * goes stale the moment a title is edited, with nothing to invalidate it. So the
+ * sweep runs over the current list, bucketed rather than quadratic for exactly
+ * this reason, and nothing on the write path is touched.
+ */
+
+import { useMemo } from "react";
+import {
+  findRepostClusters,
+  indexRepostClusters,
+  type JobRepostCluster,
+} from "../lib/job-repost-clusters.ts";
+import type { JobRecord } from "../lib/storage/index.ts";
+
+export interface JobRepostClusters {
+  /** Every cluster in the library, in bucket-discovery order. Empty for a
+   *  library with no re-listed role, which is the common case. */
+  clusters: readonly JobRepostCluster[];
+  /** The same clusters keyed by member id. A job id absent from the map is in
+   *  no cluster. */
+  byJobId: ReadonlyMap<string, JobRepostCluster>;
+}
+
+export function useJobRepostClusters(jobs: readonly JobRecord[]): JobRepostClusters {
+  // `jobs` alone: both functions are module imports, and the sweep reads
+  // nothing else. `useJobTracker` hands down a fresh array on every tracker
+  // write (including a cross-tab one since #760), which is exactly when the
+  // answer can change.
+  return useMemo(() => {
+    const clusters = findRepostClusters(jobs);
+    return { clusters, byJobId: indexRepostClusters(clusters) };
+  }, [jobs]);
+}

--- a/src/hooks/useJobTracker.ts
+++ b/src/hooks/useJobTracker.ts
@@ -22,6 +22,7 @@ import {
   removeJob,
   mergeJobs,
   createTrackedJobFromMatch,
+  archiveInterestedOlderThan,
   type NewJobInput,
   type JobPatch,
 } from "../lib/job-tracker.ts";
@@ -32,6 +33,7 @@ import {
 } from "../lib/storage/index.ts";
 import { estimateStorageUsage } from "../lib/resume-library.ts";
 import type { JobRecord, JobStatus } from "../lib/storage/index.ts";
+import { useLibraryChanges } from "./useLibraryChanges.ts";
 
 export interface JobTracker {
   jobs: JobRecord[];
@@ -59,6 +61,12 @@ export interface JobTracker {
   ) => Promise<string>;
   /** Download the full storage export as a JSON backup file. */
   exportBackup: () => Promise<void>;
+  /** Bulk-archive sweep (#759): archives every Interested job in the CURRENT
+   *  `jobs` list whose `createdAt` is more than `cutoffDays` days old, and
+   *  returns the count archived. Reads the same `jobs` array a caller's own
+   *  `jobsToArchive` preview would see, so the confirmed count and the
+   *  archived count can never disagree. */
+  archiveOlderThan: (cutoffDays: number) => Promise<number>;
   refresh: () => Promise<void>;
 }
 
@@ -82,6 +90,12 @@ export function useJobTracker(): JobTracker {
     void refresh();
     void isStoragePersisted().then(setPersisted);
   }, [refresh]);
+
+  // Re-read on a `jobs` write this hook did not itself make (#760) — another
+  // tab, a restored backup, an out-of-tree producer writing through
+  // `putRecord`. Own mutations below already call `refresh()` directly and
+  // never trigger this (`onLibraryChange` never delivers a tab's own post).
+  useLibraryChanges("jobs", refresh);
 
   /** Ask for durable storage on the first write and reflect the grant, so the
    *  UI can drop the eviction warning — mirrors `useResumeLibrary.save`. */
@@ -160,6 +174,15 @@ export function useJobTracker(): JobTracker {
 
   const exportBackup = useCallback(() => downloadStorageBackup(), []);
 
+  const archiveOlderThan = useCallback(
+    async (cutoffDays: number) => {
+      const count = await archiveInterestedOlderThan(jobs, cutoffDays);
+      await refresh();
+      return count;
+    },
+    [jobs, refresh],
+  );
+
   return {
     jobs,
     ready,
@@ -174,6 +197,7 @@ export function useJobTracker(): JobTracker {
     merge,
     saveFromMatch,
     exportBackup,
+    archiveOlderThan,
     refresh,
   };
 }

--- a/src/hooks/useLibraryChanges.test.tsx
+++ b/src/hooks/useLibraryChanges.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * `useLibraryChanges` (#760): filters by store, calls `onChange` on a
+ * message for its own store, ignores one for another store, and unsubscribes
+ * on unmount. Exercised through a probe component against a real
+ * `BroadcastChannel`, the same harness shape `useResumeLibrary.test.tsx`
+ * uses for its own hook.
+ *
+ * A raw `BroadcastChannel` opened directly on `LIBRARY_CHANGE_CHANNEL_NAME`
+ * stands in for "another tab" — see `library-channel.test.ts` for why that's
+ * the correct stand-in rather than this repo's own `postLibraryChange`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  settleWithoutDelivery,
+  waitForDelivery,
+} from "../lib/storage/__test-utils__/library-channel-delivery.ts";
+import { LIBRARY_CHANGE_CHANNEL_NAME } from "../lib/storage/library-channel.ts";
+import { useLibraryChanges } from "./useLibraryChanges.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLElement;
+let root: Root;
+let outsideChannel: BroadcastChannel;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  outsideChannel = new BroadcastChannel(LIBRARY_CHANGE_CHANNEL_NAME);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  outsideChannel.close();
+});
+
+function mountProbe(store: "jobs" | "resumes", onChange: () => void): void {
+  function Probe() {
+    useLibraryChanges(store, onChange);
+    return null;
+  }
+  act(() => {
+    root.render(<Probe />);
+  });
+}
+
+describe("useLibraryChanges", () => {
+  it("calls onChange for a message naming its own store", async () => {
+    let calls = 0;
+    mountProbe("jobs", () => {
+      calls += 1;
+    });
+
+    await act(async () => {
+      outsideChannel.postMessage({ store: "jobs" });
+      await waitForDelivery(() => expect(calls).toBe(1));
+    });
+
+    expect(calls).toBe(1);
+  });
+
+  it("ignores a message for a different store", async () => {
+    let calls = 0;
+    mountProbe("jobs", () => {
+      calls += 1;
+    });
+
+    await act(async () => {
+      outsideChannel.postMessage({ store: "resumes" });
+      await settleWithoutDelivery();
+    });
+
+    expect(calls).toBe(0);
+  });
+
+  it("stops calling onChange after unmount", async () => {
+    let calls = 0;
+    mountProbe("jobs", () => {
+      calls += 1;
+    });
+
+    act(() => root.unmount());
+
+    outsideChannel.postMessage({ store: "jobs" });
+    await settleWithoutDelivery();
+
+    expect(calls).toBe(0);
+  });
+});

--- a/src/hooks/useLibraryChanges.ts
+++ b/src/hooks/useLibraryChanges.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Subscribes a hook's `refresh` to same-origin writes it did not make (#760).
+ *
+ * `useJobTracker` and `useResumeLibrary` already re-read after every mutation
+ * THEY perform — that's what leaves an open tab stale for a write from
+ * anywhere else: another tab, a restored backup, the browser extension
+ * writing through `putRecord` from a content script. This is the one
+ * cross-cutting piece of that fix that belongs in `src/hooks/` rather than
+ * inline `useEffect` boilerplate repeated in both hooks (per `CLAUDE.md`):
+ * owning the `onLibraryChange` subscription and its teardown once, called by
+ * both.
+ *
+ * Filtered by `store` on purpose rather than firing on every signal: a write
+ * to `resumes` has no reason to re-run `useJobTracker`'s `listJobs` call, and
+ * vice versa. Each hook names only the store its own list is drawn from.
+ */
+
+import { useEffect } from "react";
+import { onLibraryChange, type StoreName } from "../lib/storage/index.ts";
+
+export function useLibraryChanges(store: StoreName, onChange: () => void): void {
+  useEffect(() => {
+    return onLibraryChange((changed) => {
+      if (changed === store) onChange();
+    });
+  }, [store, onChange]);
+}

--- a/src/hooks/useResumeLibrary.test.tsx
+++ b/src/hooks/useResumeLibrary.test.tsx
@@ -148,6 +148,48 @@ describe("useResumeLibrary: delete clears tracked-job links", () => {
   });
 });
 
+describe("useResumeLibrary: load failure has a voice (#756)", () => {
+  it("load() resolves undefined for a record with no snapshot and no stored bytes", async () => {
+    // No `parse` (no cached snapshot) and an empty blob (nothing to re-parse
+    // from, e.g. a DOCX record with no source bytes kept at rest) — the one
+    // genuinely unrecoverable case `loadResumeFromLibrary` still returns
+    // `undefined` for after #755's re-parse fallback.
+    const unrecoverable = await saveResume({
+      filename: "no-bytes.pdf",
+      blob: new Blob([], { type: "application/pdf" }),
+    });
+    const library = await mountLibrary();
+
+    let loaded: unknown;
+    await act(async () => {
+      loaded = await library().load(unrecoverable.id);
+    });
+    expect(loaded).toBeUndefined();
+  });
+
+  it("load() clears a loadError left by a previous failed attempt", async () => {
+    const unrecoverable = await saveResume({
+      filename: "no-bytes.pdf",
+      blob: new Blob([], { type: "application/pdf" }),
+    });
+    const library = await mountLibrary();
+
+    // Simulate App.tsx having set an error after a prior failed load.
+    await act(async () => {
+      library().setLoadError("stale error from a previous attempt");
+    });
+    expect(library().loadError).toBe("stale error from a previous attempt");
+
+    // A new attempt — even one that itself fails — clears the stale error
+    // before it resolves, so App.tsx's fresh `setLoadError` (or lack of one,
+    // on success) is never racing a leftover message.
+    await act(async () => {
+      await library().load(unrecoverable.id);
+    });
+    expect(library().loadError).toBeNull();
+  });
+});
+
 describe("useResumeLibrary: merge-mode import reconciles dangling resume links (#547)", () => {
   it("clears the link on an incoming job whose resumeId nothing in the merge carries", async () => {
     const survivor = await saveResume({

--- a/src/hooks/useResumeLibrary.ts
+++ b/src/hooks/useResumeLibrary.ts
@@ -31,6 +31,7 @@ import {
 import { clearResumeLink, reconcileResumeLinks } from "../lib/job-tracker.ts";
 import type { CascadeResult } from "../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../lib/score/score.ts";
+import { useLibraryChanges } from "./useLibraryChanges.ts";
 
 export interface SaveResumeParams {
   id?: string;
@@ -52,6 +53,13 @@ export interface ResumeLibrary {
   usageBytes: number | null;
   save: (params: SaveResumeParams) => Promise<string>;
   load: (id: string) => Promise<LoadedResume | undefined>;
+  /** Message from the most recent failed `load()`, or null. A fresh `load()`
+   *  call clears it before attempting, so a stale error never outlives the
+   *  failure that produced it — see {@link load}. The caller (`App.tsx`) is
+   *  responsible for setting it when `load()` resolves `undefined`; this hook
+   *  only owns the channel and its clearing. */
+  loadError: string | null;
+  setLoadError: (message: string | null) => void;
   rename: (id: string, filename: string) => Promise<void>;
   remove: (id: string) => Promise<void>;
   /** Download the full storage export as a JSON backup file. */
@@ -70,6 +78,7 @@ export function useResumeLibrary(): ResumeLibrary {
   const [ready, setReady] = useState(false);
   const [persisted, setPersisted] = useState(false);
   const [usageBytes, setUsageBytes] = useState<number | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     const [list, usage] = await Promise.all([
@@ -86,6 +95,12 @@ export function useResumeLibrary(): ResumeLibrary {
     void isStoragePersisted().then(setPersisted);
   }, [refresh]);
 
+  // Re-read on a `resumes` write this hook did not itself make (#760) —
+  // another tab, a restored backup, an out-of-tree producer writing through
+  // `putRecord`. Own mutations below already call `refresh()` directly and
+  // never trigger this (`onLibraryChange` never delivers a tab's own post).
+  useLibraryChanges("resumes", refresh);
+
   const save = useCallback(
     async (params: SaveResumeParams) => {
       // Ask for durable storage on first save; reflect the grant so the UI can
@@ -99,7 +114,14 @@ export function useResumeLibrary(): ResumeLibrary {
     [refresh],
   );
 
-  const load = useCallback((id: string) => loadResumeFromLibrary(id), []);
+  const load = useCallback((id: string) => {
+    // A fresh attempt supersedes whatever the last one left behind — clearing
+    // here (rather than only on success) covers both "a new attempt" and "a
+    // successful load" in one place: on success nothing re-sets it, so it
+    // stays cleared; on failure `App.tsx` sets it after this resolves.
+    setLoadError(null);
+    return loadResumeFromLibrary(id);
+  }, []);
 
   const rename = useCallback(
     async (id: string, filename: string) => {
@@ -178,6 +200,8 @@ export function useResumeLibrary(): ResumeLibrary {
     usageBytes,
     save,
     load,
+    loadError,
+    setLoadError,
     rename,
     remove,
     exportBackup,

--- a/src/lib/job-archive-sweep.test.ts
+++ b/src/lib/job-archive-sweep.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-archive-sweep predicate tests (#759) — module scope, no storage. Covers
+ * the four decisions the issue names: `createdAt` (not `datePosted`) as the
+ * cutoff field, Interested-bucket-only scope, and an unreadable `createdAt`
+ * being spared rather than swept.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  isSweepable,
+  isSweepableBucket,
+  jobsToArchive,
+} from "./job-archive-sweep.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-08-05T00:00:00Z");
+
+function job(over: Partial<JobRecord>): JobRecord {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    createdAt: NOW - 100 * DAY_MS,
+    updatedAt: NOW - 100 * DAY_MS,
+    title: "SWE",
+    company: "Acme",
+    status: "interested",
+    ...over,
+  };
+}
+
+describe("isSweepableBucket", () => {
+  // The half `storage/jobs.ts`'s `archiveJobs` re-evaluates against each row
+  // the instant before writing it, so what matters here is that it answers on
+  // the bucket ALONE — the same answer at confirm time and a minute later,
+  // whatever the row's age.
+  it("accepts an Interested row and every alias that buckets to Interested", () => {
+    for (const status of ["interested", "saved", "scouted", "shared"]) {
+      expect(
+        isSweepableBucket(job({ status: status as JobRecord["status"] })),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects every pipeline bucket the confirm dialog promises to leave alone", () => {
+    for (const status of ["applied", "interviewing", "offer", "rejected", "withdrawn"]) {
+      expect(
+        isSweepableBucket(job({ status: status as JobRecord["status"] })),
+      ).toBe(false);
+    }
+  });
+
+  it("rejects a row already archived, so a re-run is a no-op", () => {
+    expect(isSweepableBucket(job({ status: "archived" }))).toBe(false);
+  });
+
+  it("carries no clock — age cannot change its answer", () => {
+    const fresh = job({ createdAt: NOW });
+    const ancient = job({ createdAt: NOW - 9999 * DAY_MS });
+    expect(isSweepableBucket(fresh)).toBe(true);
+    expect(isSweepableBucket(ancient)).toBe(true);
+  });
+});
+
+describe("isSweepable", () => {
+  it("sweeps an Interested job whose createdAt is older than the cutoff", () => {
+    const j = job({ createdAt: NOW - 40 * DAY_MS });
+    expect(isSweepable(j, 30, NOW)).toBe(true);
+  });
+
+  it("does not sweep a job exactly at the cutoff (strictly older, not at-or-older)", () => {
+    const j = job({ createdAt: NOW - 30 * DAY_MS });
+    expect(isSweepable(j, 30, NOW)).toBe(false);
+  });
+
+  it("does not sweep a job newer than the cutoff", () => {
+    const j = job({ createdAt: NOW - 5 * DAY_MS });
+    expect(isSweepable(j, 30, NOW)).toBe(false);
+  });
+
+  it("reads createdAt, not datePosted — a row with no capture date is still eligible", () => {
+    const j = job({ createdAt: NOW - 40 * DAY_MS, datePosted: undefined });
+    expect(isSweepable(j, 30, NOW)).toBe(true);
+  });
+
+  it.each(["applied", "interviewing", "offer", "rejected"] as const)(
+    "never sweeps a %s job, however old",
+    (status) => {
+      const j = job({ status, createdAt: NOW - 400 * DAY_MS });
+      expect(isSweepable(j, 30, NOW)).toBe(false);
+    },
+  );
+
+  it("a job already archived never matches (no-op, not an exclusion to special-case)", () => {
+    const j = job({ status: "archived", createdAt: NOW - 400 * DAY_MS });
+    expect(isSweepable(j, 30, NOW)).toBe(false);
+  });
+
+  it.each(["saved", "scouted", "shared"])(
+    "sweeps a %s row — it buckets as Interested (#744)",
+    (status) => {
+      const j = job({
+        status: status as JobRecord["status"],
+        createdAt: NOW - 40 * DAY_MS,
+      });
+      expect(isSweepable(j, 30, NOW)).toBe(true);
+    },
+  );
+
+  it("spares a job with no createdAt at all — unreadable is withheld, not swept", () => {
+    const j = job({ createdAt: undefined });
+    expect(isSweepable(j, 30, NOW)).toBe(false);
+  });
+
+  it("spares a job whose createdAt is not a finite number", () => {
+    for (const bad of [Number.NaN, Infinity, "yesterday" as unknown as number, null]) {
+      const j = job({ createdAt: bad as unknown as number });
+      expect(isSweepable(j, 30, NOW)).toBe(false);
+    }
+  });
+});
+
+describe("jobsToArchive", () => {
+  it("returns exactly the sweepable subset, preserving order", () => {
+    const keep = job({ title: "Keep — applied", status: "applied", createdAt: NOW - 400 * DAY_MS });
+    const sweep1 = job({ title: "Sweep 1", createdAt: NOW - 60 * DAY_MS });
+    const tooNew = job({ title: "Too new", createdAt: NOW - 1 * DAY_MS });
+    const sweep2 = job({ title: "Sweep 2", createdAt: NOW - 90 * DAY_MS });
+
+    const result = jobsToArchive([keep, sweep1, tooNew, sweep2], 30, NOW);
+    expect(result.map((j) => j.title)).toEqual(["Sweep 1", "Sweep 2"]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    const j = job({ createdAt: NOW - 1 * DAY_MS });
+    expect(jobsToArchive([j], 30, NOW)).toEqual([]);
+  });
+});

--- a/src/lib/job-archive-sweep.ts
+++ b/src/lib/job-archive-sweep.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-archive-sweep — the predicate behind "archive jobs older than X days"
+ * (#759). Pure, zero-storage: it answers "does this job belong in the
+ * sweep?" and nothing else. `JobArchiveSweepDialog` calls it for the live
+ * preview count and `job-tracker.ts`'s `archiveInterestedOlderThan` calls the
+ * SAME function for the write — one predicate, so the number a user confirms
+ * can never disagree with the rows the sweep actually touches. Sibling of
+ * `job-status-bucket.ts` and `job-duplicates.ts`, testable at module scope
+ * for the same reason.
+ *
+ * ## What the cutoff reads
+ *
+ * `createdAt` — when the row entered THIS library — never `datePosted`. A row
+ * that arrived without a capture has no `datePosted` at all, and those are
+ * exactly the rows a sweep exists to clear; a `datePosted` rule would
+ * silently skip its whole target population and archive only the postings
+ * the user typed in by hand. Every stored job carries `createdAt` by contract
+ * (`putRecord` stamps it), so this is the one date field a sweep can rely on.
+ *
+ * ## What it may touch
+ *
+ * Only rows whose {@link jobStatusBucket} is `"interested"`. `applied` /
+ * `interviewing` / `offer` / `rejected` carry pipeline state the user built
+ * by hand, and a sweep that could reach them is a sweep nobody would run
+ * twice. `archived` is already the destination, so a row already there
+ * simply never matches — a no-op this module doesn't have to special-case.
+ *
+ * That bucket rule is exported on its own as {@link isSweepableBucket},
+ * because it is checked TWICE at different moments: once here, over the
+ * array the preview counted, and once again inside `storage/jobs.ts`'s
+ * `archiveJobs` against the row as it stands the instant before its write
+ * (see that function's docblock for the concurrent-writer case that makes
+ * the second check load-bearing). One exported predicate rather than two
+ * spellings, so the guarantee the confirm dialog states — pipeline rows are
+ * never touched — cannot drift between the two places that enforce it.
+ *
+ * The AGE half is deliberately not re-checked at write time. The cutoff is
+ * the user's decision, taken at confirm against a clock read this module was
+ * given; re-deriving it inside the write would introduce a second clock read
+ * and with it a second way for the preview and the write to disagree.
+ *
+ * ## An unreadable `createdAt` is SPARED, not swept
+ *
+ * A record can arrive from a backup predating any field (same bar as
+ * `job-duplicates.ts`), so `createdAt` is read as `unknown` and checked with
+ * `Number.isFinite` rather than trusted from the type. An unreadable value
+ * degrades to "not old enough to sweep" — the withholding direction, not the
+ * acting one. Sweeping a record this module cannot date is the one-way
+ * mistake: the write bumps `updatedAt` and overwrites whatever vocabulary
+ * (`saved` / `scouted`) the row arrived with, and reversing it is a second
+ * full write, not a rollback (see `job-tracker.ts`'s
+ * `archiveInterestedOlderThan` docblock). Leaving an undateable row in
+ * Interested costs nothing but a repeat sweep once it can be read.
+ */
+
+import { jobStatusBucket } from "./job-status-bucket.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A finite `createdAt` if the field really is one, else `NaN` — every
+ *  comparison below answers `false` to `NaN`, which is the "can't date it,
+ *  don't touch it" reading described above. */
+function createdAtMs(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : Number.NaN;
+}
+
+/**
+ * Is `job` in a bucket a sweep may touch at all — regardless of its age?
+ *
+ * The half of {@link isSweepable} that carries no clock, which is exactly why
+ * it is separable: it can be re-evaluated at any later moment and still mean
+ * the same thing. `archiveInterestedOlderThan` hands it to `archiveJobs` as
+ * the last-instant eligibility check on each row it is about to write; see
+ * this module's docblock.
+ */
+export function isSweepableBucket(job: JobRecord): boolean {
+  return jobStatusBucket(job.status) === "interested";
+}
+
+/**
+ * Does `job` belong in an archive sweep at this cutoff? `now` is injectable
+ * for tests; production callers rely on the default.
+ */
+export function isSweepable(
+  job: JobRecord,
+  cutoffDays: number,
+  now: number = Date.now(),
+): boolean {
+  if (!isSweepableBucket(job)) return false;
+  const createdAt = createdAtMs(job.createdAt);
+  if (!Number.isFinite(createdAt)) return false;
+  return now - createdAt > cutoffDays * DAY_MS;
+}
+
+/**
+ * Every job in `jobs` an archive sweep at this cutoff would touch, in the
+ * caller's order. The one function both the preview count and the write use
+ * — see the module docblock.
+ */
+export function jobsToArchive(
+  jobs: readonly JobRecord[],
+  cutoffDays: number,
+  now: number = Date.now(),
+): JobRecord[] {
+  return jobs.filter((job) => isSweepable(job, cutoffDays, now));
+}

--- a/src/lib/job-duplicates.test.ts
+++ b/src/lib/job-duplicates.test.ts
@@ -14,13 +14,23 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  REPOST_SPAN_DAYS,
   findDuplicatePairs,
   isActionableDuplicate,
+  jobCompanyTitleKey,
   jobDuplicateConfidence,
   jobPairKey,
+  withinRepostSpan,
 } from "./job-duplicates.ts";
 import type { JobRecord } from "./storage/index.ts";
 
+const DAY = 24 * 60 * 60 * 1000;
+
+/** Both records share `createdAt` unless a case overrides it, which since #754
+ *  is load-bearing rather than incidental: capture proximity is the last
+ *  corroborating signal, so a same-instant pair is the corroborated case and
+ *  every `probable` expectation below rests on it. The uncorroborated case is
+ *  its own block. */
 function job(over: Partial<JobRecord>): JobRecord {
   return {
     id: over.id ?? "job-x",
@@ -175,6 +185,190 @@ describe("jobDuplicateConfidence: the `possible` tier", () => {
   });
 });
 
+describe("jobDuplicateConfidence: the `title-only` tier (#754)", () => {
+  /** Two records of one role at one company, captured `days` apart, carrying
+   *  whatever else the case is about. The captured record this models is title +
+   *  company + url and nothing else — 523 of 544 in the measured library. */
+  function apart(days: number, extra: Partial<JobRecord> = {}) {
+    return [
+      job({ id: "a", createdAt: 0, ...extra }),
+      job({ id: "b", createdAt: days * DAY, ...extra }),
+    ] as const;
+  }
+
+  it("company + identical title 49 days apart, with nothing else, is `title-only`", () => {
+    // The core defect: this used to be `probable`, which put a destructive
+    // **Merge** button on an employer's repost.
+    const [a, b] = apart(49);
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+    expect(jobDuplicateConfidence(b, a)).toBe("title-only");
+  });
+
+  it("is below the bar for offering a merge", () => {
+    expect(isActionableDuplicate("title-only")).toBe(false);
+  });
+
+  it("keeps the same-day double-capture at `probable`", () => {
+    // 13 of the 98 measured pairs are same-day. Without proximity as a signal
+    // these lose their merge offer too, and the feature stops working for the
+    // case it exists for.
+    const [a, b] = apart(0);
+    expect(jobDuplicateConfidence(a, b)).toBe("probable");
+  });
+
+  it("treats a span of exactly REPOST_SPAN_DAYS as close enough, and one ms more as not", () => {
+    expect(jobDuplicateConfidence(...apart(REPOST_SPAN_DAYS))).toBe("probable");
+    const a = job({ id: "a", createdAt: 0 });
+    const b = job({ id: "b", createdAt: REPOST_SPAN_DAYS * DAY + 1 });
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+  });
+});
+
+describe("jobDuplicateConfidence: what corroborates a title (#754)", () => {
+  const JD =
+    "This is a role recruiting on behalf of one of our customers. Own the platform roadmap, hire the team, and ship.";
+
+  function apart(days: number, extra: Partial<JobRecord> = {}) {
+    return [
+      job({ id: "a", createdAt: 0, ...extra }),
+      job({ id: "b", createdAt: days * DAY, ...extra }),
+    ] as const;
+  }
+
+  it("an identical description lifts a 49-day-apart pair back to `probable`", () => {
+    // The motivating cluster's six postings had byte-identical descriptions —
+    // evidence that existed and was simply never captured.
+    expect(jobDuplicateConfidence(...apart(49, { jdText: JD }))).toBe("probable");
+  });
+
+  it("two ABSENT descriptions corroborate nothing", () => {
+    expect(jobDuplicateConfidence(...apart(49, { jdText: "" }))).toBe("title-only");
+  });
+
+  it("a merely OVERLAPPING description does not corroborate — identity or nothing", () => {
+    const a = job({ id: "a", createdAt: 0, jdText: JD });
+    const b = job({
+      id: "b",
+      createdAt: 49 * DAY,
+      jdText: `${JD} You will also own hiring for the data team and the on-call rota.`,
+    });
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+  });
+
+  it("the same declared datePosted corroborates", () => {
+    expect(jobDuplicateConfidence(...apart(49, { datePosted: "2026-06-15" }))).toBe(
+      "probable",
+    );
+  });
+
+  it("a DIFFERENT datePosted does not — that is what a repost changes", () => {
+    const a = job({ id: "a", createdAt: 0, datePosted: "2026-06-15" });
+    const b = job({ id: "b", createdAt: 49 * DAY, datePosted: "2026-08-03" });
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+  });
+
+  it("location AND salaryRange together corroborate", () => {
+    expect(
+      jobDuplicateConfidence(
+        ...apart(49, { location: "Austin, TX", salaryRange: "$225k – $325k" }),
+      ),
+    ).toBe("probable");
+  });
+
+  it("location alone does not — every role at a company shares one", () => {
+    expect(jobDuplicateConfidence(...apart(49, { location: "Remote (US)" }))).toBe(
+      "title-only",
+    );
+  });
+
+  it("salaryRange alone does not — a band repeats across a level", () => {
+    expect(jobDuplicateConfidence(...apart(49, { salaryRange: "$225k – $325k" }))).toBe(
+      "title-only",
+    );
+  });
+
+  it("a matching location with a DIFFERENT salary does not corroborate", () => {
+    const a = job({ id: "a", createdAt: 0, location: "Austin, TX", salaryRange: "$180k" });
+    const b = job({
+      id: "b",
+      createdAt: 49 * DAY,
+      location: "Austin, TX",
+      salaryRange: "$260k",
+    });
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+  });
+
+  it("a shared URL still outranks everything — 49 days apart is still `certain`", () => {
+    const url = "https://boards.example.com/bellhaven/jobs/4012345";
+    const a = job({ id: "a", createdAt: 0, url });
+    const b = job({ id: "b", createdAt: 49 * DAY, url: `${url}?utm_source=li` });
+    expect(jobDuplicateConfidence(a, b)).toBe("certain");
+  });
+
+  it("degrades to `title-only` — never a throw — when the corroborating fields are the wrong types", () => {
+    // The totality rule, extended to every field #754 added. A record that
+    // predates these fields, or a producer that wrote a number into one, must
+    // read as "no evidence" and therefore no merge offer.
+    const a = job({ id: "a", createdAt: 0 });
+    const b = job({ id: "b", createdAt: 49 * DAY });
+    Object.assign(a, { datePosted: 20260615, location: {}, salaryRange: [], jdText: 7 });
+    Object.assign(b, { datePosted: 20260615, location: {}, salaryRange: [], jdText: 7 });
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+  });
+
+  it("an unreadable createdAt is missing evidence, not a zero-length span", () => {
+    const a = job({ id: "a" });
+    const b = job({ id: "b" });
+    Object.assign(a, { createdAt: "yesterday" });
+    Object.assign(b, { createdAt: undefined });
+    expect(jobDuplicateConfidence(a, b)).toBe("title-only");
+  });
+});
+
+describe("withinRepostSpan", () => {
+  it("is inclusive at the boundary", () => {
+    expect(withinRepostSpan(0, REPOST_SPAN_DAYS * DAY)).toBe(true);
+    expect(withinRepostSpan(0, REPOST_SPAN_DAYS * DAY + 1)).toBe(false);
+  });
+
+  it("is symmetric", () => {
+    expect(withinRepostSpan(49 * DAY, 0)).toBe(false);
+    expect(withinRepostSpan(0, 49 * DAY)).toBe(false);
+  });
+
+  it("answers false for anything that is not a finite number", () => {
+    for (const bad of ["0", null, undefined, Number.NaN, Number.POSITIVE_INFINITY, {}]) {
+      expect(withinRepostSpan(0, bad)).toBe(false);
+      expect(withinRepostSpan(bad, 0)).toBe(false);
+    }
+  });
+});
+
+describe("jobCompanyTitleKey", () => {
+  it("is one key for two spellings of one role", () => {
+    expect(jobCompanyTitleKey(job({ company: "Acme, Inc.", title: "Staff Engineer" }))).toBe(
+      jobCompanyTitleKey(job({ company: "acme", title: "  staff/engineer " })),
+    );
+  });
+
+  it("is null when either side is blank — missing evidence, not sameness", () => {
+    expect(jobCompanyTitleKey(job({ company: "" }))).toBeNull();
+    expect(jobCompanyTitleKey(job({ title: "" }))).toBeNull();
+  });
+
+  it("is null for a record whose fields are not strings", () => {
+    const hostile = job({ id: "a" });
+    Object.assign(hostile, { company: 42, title: null });
+    expect(jobCompanyTitleKey(hostile)).toBeNull();
+  });
+
+  it("cannot collide two roles that share a concatenation", () => {
+    expect(jobCompanyTitleKey(job({ company: "Acme", title: "Corp Dev" }))).not.toBe(
+      jobCompanyTitleKey(job({ company: "Acme Corp", title: "Dev" })),
+    );
+  });
+});
+
 describe("jobPairKey", () => {
   it("is the same key whichever side asks", () => {
     expect(jobPairKey("a", "b")).toBe(jobPairKey("b", "a"));
@@ -182,6 +376,13 @@ describe("jobPairKey", () => {
 
   it("cannot collide two different pairings that share a concatenation", () => {
     expect(jobPairKey("a b", "c")).not.toBe(jobPairKey("a", "b c"));
+  });
+
+  it("has the SHAPE `job-duplicate-dismissals.ts` already stored (#754 must not change it)", () => {
+    // Dismissals are persisted under this exact string. Changing the shape
+    // would silently un-dismiss every pairing a user has already judged, so the
+    // literal is pinned rather than left to the two `toBe` comparisons above.
+    expect(jobPairKey("b", "a")).toBe("a\u0000b");
   });
 });
 
@@ -225,6 +426,27 @@ describe("findDuplicatePairs", () => {
         job({ id: "c", company: "Initech", title: "" }),
       ]),
     ).toEqual([]);
+  });
+
+  it("still REPORTS an uncorroborated pairing, at `title-only` (#754)", () => {
+    // The sweep's job is to report every tier it can distinguish; dropping the
+    // pairing here would leave `job-repost-clusters.ts` nothing to explain and
+    // the user with two unexplained rows.
+    expect(
+      findDuplicatePairs([
+        job({ id: "a", createdAt: 0 }),
+        job({ id: "b", createdAt: 49 * DAY }),
+      ]),
+    ).toEqual([{ a: "a", b: "b", confidence: "title-only" }]);
+  });
+
+  it("keeps the URL evidence over an uncorroborated title match", () => {
+    expect(
+      findDuplicatePairs([
+        job({ id: "a", createdAt: 0, url: AGGREGATOR }),
+        job({ id: "b", createdAt: 49 * DAY, url: ATS, aliasUrls: [AGGREGATOR] }),
+      ]),
+    ).toEqual([{ a: "a", b: "b", confidence: "certain" }]);
   });
 
   it("finds a pair by alias-alias intersection when neither has it as canonical url", () => {

--- a/src/lib/job-duplicates.ts
+++ b/src/lib/job-duplicates.ts
@@ -30,12 +30,24 @@
  *
  * ## Totality
  *
- * Every field is read through {@link text} / an `Array.isArray` guard rather
- * than trusted from the type. Records reach the `jobs` store through a
- * deliberately permissive write (`saveJob`) and from a backup file that may
- * predate any field here, so a record whose `title` is not a string is
- * reachable — and this function runs on every tracker render. It degrades to
- * "no evidence", never to a throw.
+ * Every field is read through {@link text} / {@link epochMs} / an
+ * `Array.isArray` guard rather than trusted from the type. Records reach the
+ * `jobs` store through a deliberately permissive write (`saveJob`) and from a
+ * backup file that may predate any field here, so a record whose `title` is not
+ * a string is reachable — and this function runs on every tracker render. It
+ * degrades to "no evidence", never to a throw.
+ *
+ * ## Company + title alone is not evidence (#754)
+ *
+ * Measured against a real 541-record library: 523 records carry no `jdText` at
+ * all, so the `possible` tier — the only one that reads a description — can
+ * never fire, and every merge the tracker offered came from title string
+ * equality inside one company bucket. That is not a threshold to tune; it is a
+ * destructive affordance resting on an inference. So an identical title now
+ * needs one CORROBORATING fact ({@link corroborates}) before it reaches
+ * `probable`, and resolves to {@link JobDuplicateConfidence} `title-only`
+ * otherwise — below {@link isActionableDuplicate}, so nothing offers a merge on
+ * it. `job-repost-clusters.ts` is what then speaks for those pairings.
  */
 
 import { canonicalJobUrl } from "./storage/index.ts";
@@ -48,25 +60,35 @@ import type { JobRecord } from "./storage/index.ts";
  *   appears in the other's `aliasUrls`. Somebody with more context than a URL
  *   parser (a user who merged, a producer that followed an "Apply" link) said
  *   these are the same page.
- * - `probable` — same normalised company AND same normalised title. Strong, but
- *   inference: a company really can post two identically-titled roles.
+ * - `probable` — same normalised company AND same normalised title, AND one
+ *   corroborating fact ({@link corroborates}). Still inference — a company
+ *   really can post two identically-titled roles — but no longer inference from
+ *   a single string.
  * - `possible` — same company, similar title, overlapping description. Weak by
  *   construction, and deliberately below the bar {@link isActionableDuplicate}
  *   sets, so no merge affordance is ever offered on it.
+ * - `title-only` — same company and same normalised title, and nothing else
+ *   (#754). The tier that separates a double-capture from an employer reposting
+ *   one role for four months: both used to read as `probable` and both got the
+ *   same **Merge** button, and merging the second kind destroys the record of
+ *   the churn. Weakest of the four and below the actionable bar, so it renders
+ *   no offer; `job-repost-clusters.ts` is what speaks for these pairings.
  */
-export type JobDuplicateConfidence = "certain" | "probable" | "possible";
+export type JobDuplicateConfidence = "certain" | "probable" | "possible" | "title-only";
 
 const CONFIDENCE_RANK: Record<JobDuplicateConfidence, number> = {
-  possible: 1,
-  probable: 2,
-  certain: 3,
+  "title-only": 1,
+  possible: 2,
+  probable: 3,
+  certain: 4,
 };
 
 /**
  * Whether a confidence is strong enough to put a *merge* in front of the user.
- * `probable` and up. A `possible` match is computed, and is worth having as a
- * distinct answer, but offering a destructive action on "same company, similar
- * title" would invert the asymmetry this whole module is written around.
+ * `probable` and up. `possible` and `title-only` are computed, and are worth
+ * having as distinct answers, but offering a destructive action on "same
+ * company, similar title" — or on a bare title string — would invert the
+ * asymmetry this whole module is written around.
  */
 export function isActionableDuplicate(confidence: JobDuplicateConfidence): boolean {
   return CONFIDENCE_RANK[confidence] >= CONFIDENCE_RANK.probable;
@@ -96,6 +118,53 @@ const SIMILAR_TITLE = 0.6;
  *  as overlapping. Same bounded blast radius as {@link SIMILAR_TITLE}. */
 const OVERLAPPING_DESCRIPTION = 0.5;
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How far apart in time two captures of one company+title may sit and still be
+ * read as two captures of ONE posting rather than a repost of it.
+ *
+ * **One constant, two uses**, and that is the point of it living here: it is
+ * both the last corroborating signal in {@link corroborates} and the boundary
+ * `job-repost-clusters.ts` forms a cluster on. A pair is therefore *either*
+ * mergeable *or* clustered and never neither — two separately-tuned numbers
+ * would open a band where a pairing gets no merge offer and no explanation.
+ * That module imports this value and {@link withinRepostSpan} rather than
+ * restating either, for the same reason it imports {@link jobCompanyTitleKey}:
+ * the grouping and the boundary must be one definition or the two surfaces
+ * disagree about the same pair.
+ *
+ * **21 days.** Measured separation between the two records of each pairing that
+ * company+title alone used to call `probable`, over 98 pairs in a real library:
+ * min 0d, p25 3d, median 13d, p75 40d, max 124d — 13 pairs same-day, 29 more
+ * than 30 days apart. Those ends are different phenomena. A same-day pair is a
+ * double-capture (the capture ran twice, or an aggregator and the employer's own
+ * board were both saved) and merging it is right; a 124-day pair is an employer
+ * re-listing a role that never filled, and merging it destroys the only trace of
+ * that. Proximity has to be a signal precisely BECAUSE the common captured
+ * record carries title + company + url and nothing else: drop it and those 13
+ * real duplicates lose their merge button too, and the feature stops working for
+ * the case it exists for.
+ *
+ * A guess in the same sense {@link SIMILAR_TITLE} is — but not with the same
+ * bounded blast radius, because this one gates a destructive offer. Raising it
+ * offers more merges; lowering it offers fewer. The asymmetry says which
+ * direction is the cheap one.
+ */
+export const REPOST_SPAN_DAYS = 21;
+
+const REPOST_SPAN_MS = REPOST_SPAN_DAYS * DAY_MS;
+
+/**
+ * Were these two records captured close enough together for proximity to
+ * corroborate? Takes `unknown` and is total: a capture time that is not a finite
+ * number is missing evidence, so the answer is `false` — never a throw, and
+ * never a silent "yes" off a `NaN` comparison.
+ */
+export function withinRepostSpan(a: unknown, b: unknown): boolean {
+  return Math.abs(epochMs(a) - epochMs(b)) <= REPOST_SPAN_MS;
+}
+
 /** Description tokens shorter than this are dropped before comparing: "a",
  *  "of", "to" appear in every posting ever written and would float the
  *  containment of two unrelated descriptions. Titles are NOT filtered this way —
@@ -111,6 +180,15 @@ const NON_WORD = /[^\p{L}\p{N}]+/gu;
  *  the totality note in the module docblock. */
 function text(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+/** A timestamp field's value if it is really a finite number, otherwise `NaN` —
+ *  which every comparison below answers `false` to, which is the "no evidence"
+ *  reading. `Number.isFinite` and not `typeof`, so an `Infinity` or a `NaN` that
+ *  survived a JSON round-trip is missing evidence rather than a span of
+ *  infinity. */
+function epochMs(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : Number.NaN;
 }
 
 /** Lowercased, punctuation-flattened, whitespace-collapsed. The one place
@@ -188,11 +266,83 @@ interface Fingerprint {
    *  the one expensive step here and only the `possible` tier ever needs it, so
    *  a library where no pair has a similar title never pays for it. */
   jdTokens?: Set<string>;
+  /** Filled by {@link jdNormalisedOf} on first use, for the same reason
+   *  {@link jdTokens} is: only a pair that already agrees on company and title
+   *  ever asks. */
+  jdNormalised?: string;
+
+  // ─── Corroborating facts (#754) ───────────────────────────────────────────
+  // Read through the same guards as everything above: a record can arrive from a
+  // backup that predates any of these fields, or from a producer that wrote the
+  // wrong type into one. A field that is not a string reads as absent, which is
+  // "no evidence" and therefore no merge offer — the safe direction.
+
+  /** Normalised {@link JobRecord.datePosted} — the date the POSTING declares,
+   *  not when we saw it. */
+  datePosted: string;
+  /** Normalised {@link JobRecord.location}. */
+  location: string;
+  /** Normalised {@link JobRecord.salaryRange}. */
+  salaryRange: string;
+  /** Epoch ms this record was first written, or `NaN` when it carries no usable
+   *  one. NOT `updatedAt`: editing a note bumps that, and "when did this arrive"
+   *  is the question proximity answers. */
+  createdAt: number;
 }
 
 function jdTokensOf(print: Fingerprint): Set<string> {
   print.jdTokens ??= tokenSet(print.jdText, DESCRIPTION_TOKEN_MIN_LENGTH);
   return print.jdTokens;
+}
+
+function jdNormalisedOf(print: Fingerprint): string {
+  print.jdNormalised ??= normalise(print.jdText);
+  return print.jdNormalised;
+}
+
+/**
+ * Is there any fact BESIDES the title backing "these two are one posting"?
+ *
+ * Only ever asked of a pair that already agrees on the normalised company and
+ * has byte-identical normalised titles, and the answer is what lifts that pair
+ * from `title-only` to `probable` — i.e. what puts a **Merge** in front of the
+ * user. So every signal here is an equality on a fact a repost would plausibly
+ * CHANGE, and each one is required non-empty: two records that both lack a
+ * field agree about nothing.
+ *
+ * In rough order of strength:
+ *
+ *  1. **Identical description.** The strongest thing short of a shared URL —
+ *     the six-record cluster that motivated #754 turned out to have byte-
+ *     identical descriptions, which simply were never captured. Identity, not
+ *     {@link OVERLAPPING_DESCRIPTION} containment: that threshold's docblock
+ *     justifies itself by only ever gating a tier no affordance acts on, and
+ *     promoting it to gate a destructive one would unbind exactly that.
+ *  2. **The same declared `datePosted`.** A repost is a new posting with a new
+ *     publication date; two captures of one posting quote the same one.
+ *  3. **The same `location` AND the same `salaryRange`.** Conjunction, because
+ *     either alone is nearly free — every role at a company shares "Remote (US)"
+ *     and the bands repeat across a level.
+ *  4. **Captured within {@link REPOST_SPAN_DAYS} of each other.** Weakest, and
+ *     the only one that reaches the common captured record at all: a LinkedIn
+ *     capture is title + company + url and nothing else, so without this the
+ *     genuine same-day double-capture loses its merge offer along with the
+ *     reposts. See {@link REPOST_SPAN_DAYS} for the measured distribution this
+ *     is cut from.
+ */
+function corroborates(a: Fingerprint, b: Fingerprint): boolean {
+  const jd = jdNormalisedOf(a);
+  if (jd !== "" && jd === jdNormalisedOf(b)) return true;
+  if (a.datePosted !== "" && a.datePosted === b.datePosted) return true;
+  if (
+    a.location !== "" &&
+    a.location === b.location &&
+    a.salaryRange !== "" &&
+    a.salaryRange === b.salaryRange
+  ) {
+    return true;
+  }
+  return withinRepostSpan(a.createdAt, b.createdAt);
 }
 
 function fingerprint(job: JobRecord): Fingerprint {
@@ -213,7 +363,35 @@ function fingerprint(job: JobRecord): Fingerprint {
     title: normalise(job.title),
     titleTokens: tokenSet(job.title, 1),
     jdText: text(job.jdText),
+    datePosted: normalise(job.datePosted),
+    location: normalise(job.location),
+    salaryRange: normalise(job.salaryRange),
+    createdAt: epochMs(job.createdAt),
   };
+}
+
+/**
+ * The one key two records must share before company+title evidence is even
+ * considered: normalised company, then normalised title, NUL-joined for the
+ * reason {@link jobPairKey} is. `null` when either side is empty — a blank
+ * company or a blank title is missing evidence, not evidence of sameness, and
+ * without the guard every half-filled row would group with every other one.
+ *
+ * Exported because `job-repost-clusters.ts` groups on exactly this. Two
+ * definitions of "the same role at the same company" would let a pairing be
+ * `title-only` here and belong to no cluster there — the one gap the design
+ * forbids, since such a pair would then get neither a merge offer nor an
+ * explanation of why not.
+ */
+export function jobCompanyTitleKey(job: JobRecord): string | null {
+  const company = normaliseCompany(job.company);
+  const title = normalise(job.title);
+  if (company === "" || title === "") return null;
+  // NUL rather than a printable separator, because normalisation has already
+  // collapsed punctuation to spaces: ("Acme", "Corp Dev") and ("Acme Corp",
+  // "Dev") would otherwise share one key, and grouping two different roles is
+  // how a merge gets offered on nothing.
+  return `${company}\u0000${title}`;
 }
 
 /**
@@ -246,7 +424,15 @@ function compare(a: Fingerprint, b: Fingerprint): JobDuplicateConfidence | null 
   // An empty company is the common case for a half-filled record, not a match:
   // without this, every blank-company job would pair with every other one.
   if (a.company === "" || a.company !== b.company) return null;
-  if (a.title !== "" && a.title === b.title) return "probable";
+  // An identical title is where the destructive offer used to come from with
+  // nothing behind it (#754), so it resolves here and does NOT fall through to
+  // the `possible` tier below: an identical title trivially clears
+  // SIMILAR_TITLE, and letting it land on a tier gated by a threshold
+  // documented as "a guess" would put the decision back where this change took
+  // it from.
+  if (a.title !== "" && a.title === b.title) {
+    return corroborates(a, b) ? "probable" : "title-only";
+  }
   if (containment(a.titleTokens, b.titleTokens) < SIMILAR_TITLE) return null;
   if (containment(jdTokensOf(a), jdTokensOf(b)) < OVERLAPPING_DESCRIPTION) return null;
   return "possible";

--- a/src/lib/job-repost-clusters.test.ts
+++ b/src/lib/job-repost-clusters.test.ts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Repost clusters (#754). The spine is the case the issue measured: a group of
+ * same-company / same-title records spread over weeks is an employer re-listing
+ * one role, not N-1 redundant rows, and merging it destroys the only trace of
+ * the churn.
+ *
+ * Two properties carry the design and are asserted directly rather than
+ * inferred from the examples:
+ *
+ *  1. **Never neither.** Every title-identical pairing at one company is either
+ *     mergeable (`probable`) or inside a cluster. A pairing that got neither a
+ *     merge offer nor an explanation would be the regression this whole change
+ *     is written to avoid.
+ *  2. **Nothing is written.** The module is derived-on-view; a stored verdict
+ *     goes stale the moment a title is edited. Checked structurally against the
+ *     source, the way `job-origin-reach.test.ts` checks its invariant, because
+ *     "no call reaches `saveJob`" is a claim about the file and not about one
+ *     run of it.
+ *
+ * Every company, title and URL below is invented. Minimal typed stubs over full
+ * fixtures, the shape `contact.test.ts` and `job-duplicates.test.ts` use.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  findRepostClusters,
+  indexRepostClusters,
+  isRepostSuppressed,
+} from "./job-repost-clusters.ts";
+import {
+  REPOST_SPAN_DAYS,
+  jobDuplicateConfidence,
+  type JobDuplicatePair,
+} from "./job-duplicates.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+const DAY = 24 * 60 * 60 * 1000;
+/** 2026-06-15T00:00:00Z — the start of the motivating group's span. */
+const JUN_15 = Date.UTC(2026, 5, 15);
+
+function job(over: Partial<JobRecord> & { id: string }): JobRecord {
+  return {
+    createdAt: JUN_15,
+    updatedAt: JUN_15,
+    title: "Head of Engineering",
+    company: "Bellhaven Talent",
+    status: "interested",
+    ...over,
+  };
+}
+
+/** The measured case, generalised: `count` records of one role at one company,
+ *  the first and last `spanDays` apart. */
+function relisted(count: number, spanDays: number): JobRecord[] {
+  return Array.from({ length: count }, (_unused, i) =>
+    job({
+      id: `r${i}`,
+      createdAt: JUN_15 + Math.round((spanDays * DAY * i) / (count - 1)),
+    }),
+  );
+}
+
+describe("findRepostClusters: the motivating group", () => {
+  it("collapses 6 same-company/same-title records spanning 49 days into ONE cluster", () => {
+    const clusters = findRepostClusters(relisted(6, 49));
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].count).toBe(6);
+    expect(clusters[0].ids).toEqual(["r0", "r1", "r2", "r3", "r4", "r5"]);
+    expect(clusters[0].spanDays).toBe(49);
+    expect(clusters[0].firstSeen).toBe(JUN_15);
+    expect(clusters[0].lastSeen).toBe(JUN_15 + 49 * DAY);
+  });
+
+  it("names the company and title in the records' own spelling, not the normalised key", () => {
+    const clusters = findRepostClusters([
+      job({ id: "a", company: "Bellhaven Talent, Inc.", title: "Head of Engineering" }),
+      job({
+        id: "b",
+        company: "bellhaven talent",
+        title: "head of engineering",
+        createdAt: JUN_15 + 49 * DAY,
+      }),
+    ]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].company).toBe("Bellhaven Talent, Inc.");
+    expect(clusters[0].title).toBe("Head of Engineering");
+  });
+
+  it("does NOT cluster a double-capture — two records three days apart", () => {
+    expect(findRepostClusters(relisted(2, 3))).toEqual([]);
+  });
+
+  it("clusters every member once the GROUP span exceeds the boundary, including the close pairs inside it", () => {
+    // 0 / 15 / 30 days. The (0,15) and (15,30) pairings are each inside the
+    // span and merge-worthy on their own, but the group is churn — so all three
+    // belong to the cluster and none of them keeps an offer.
+    const clusters = findRepostClusters([
+      job({ id: "a", createdAt: JUN_15 }),
+      job({ id: "b", createdAt: JUN_15 + 15 * DAY }),
+      job({ id: "c", createdAt: JUN_15 + 30 * DAY }),
+    ]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].ids).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("findRepostClusters: the boundary is REPOST_SPAN_DAYS, inclusive", () => {
+  it("a span of exactly REPOST_SPAN_DAYS is still a double-capture", () => {
+    expect(
+      findRepostClusters([
+        job({ id: "a", createdAt: JUN_15 }),
+        job({ id: "b", createdAt: JUN_15 + REPOST_SPAN_DAYS * DAY }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("one millisecond past it is a repost", () => {
+    expect(
+      findRepostClusters([
+        job({ id: "a", createdAt: JUN_15 }),
+        job({ id: "b", createdAt: JUN_15 + REPOST_SPAN_DAYS * DAY + 1 }),
+      ]),
+    ).toHaveLength(1);
+  });
+});
+
+describe("findRepostClusters: what must never cluster", () => {
+  it("one record on its own is not a cluster", () => {
+    expect(findRepostClusters([job({ id: "a" })])).toEqual([]);
+  });
+
+  it("the same title at two different companies is two roles", () => {
+    expect(
+      findRepostClusters([
+        job({ id: "a", company: "Bellhaven Talent" }),
+        job({ id: "b", company: "Northmoor Systems", createdAt: JUN_15 + 49 * DAY }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("two different titles at one company are two roles", () => {
+    expect(
+      findRepostClusters([
+        job({ id: "a", title: "Head of Engineering" }),
+        job({ id: "b", title: "Director of Finance", createdAt: JUN_15 + 49 * DAY }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("a blank company is missing evidence, not evidence of sameness", () => {
+    expect(
+      findRepostClusters([
+        job({ id: "a", company: "" }),
+        job({ id: "b", company: "", createdAt: JUN_15 + 49 * DAY }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("a blank title is likewise no grouping evidence", () => {
+    expect(
+      findRepostClusters([
+        job({ id: "a", title: "" }),
+        job({ id: "b", title: "", createdAt: JUN_15 + 49 * DAY }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("findRepostClusters: totality", () => {
+  it("survives a record whose fields are not the types they claim", () => {
+    // Reachable: `saveJob` writes whatever a caller supplies, and a restored
+    // backup predates every field read here. A throw would take the whole
+    // tracker render down.
+    const hostile = { id: "b", status: "interested" } as unknown as JobRecord;
+    Object.assign(hostile, {
+      title: 42,
+      company: null,
+      createdAt: "not-a-number",
+      updatedAt: undefined,
+    });
+    expect(() => findRepostClusters([job({ id: "a" }), hostile])).not.toThrow();
+    // Nothing groups with it: its company and title are unreadable, so it is in
+    // no bucket at all.
+    expect(findRepostClusters([job({ id: "a" }), hostile])).toEqual([]);
+  });
+
+  it("clusters a group whose capture time is unreadable, and states no span for it", () => {
+    // Proximity cannot vouch for a record with no usable `createdAt`, so it
+    // cannot sit inside a mergeable group either — the cluster is what keeps
+    // the pairing from falling between the two behaviours. The count is still
+    // true; the span is not stated rather than printed as NaN.
+    const broken = job({ id: "b" });
+    Object.assign(broken, { createdAt: Number.NaN });
+    const clusters = findRepostClusters([job({ id: "a" }), broken]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].count).toBe(2);
+    expect(clusters[0].spanDays).toBeUndefined();
+    expect(clusters[0].firstSeen).toBeUndefined();
+    expect(clusters[0].lastSeen).toBeUndefined();
+  });
+
+  it("reads an Infinity capture time as missing rather than as an infinite span", () => {
+    const broken = job({ id: "b", createdAt: Number.POSITIVE_INFINITY });
+    const clusters = findRepostClusters([job({ id: "a" }), broken]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].spanDays).toBeUndefined();
+  });
+});
+
+describe("findRepostClusters: derived, never stored", () => {
+  it("does not mutate the records it swept", () => {
+    const jobs = relisted(6, 49);
+    const before = structuredClone(jobs);
+    findRepostClusters(jobs);
+    expect(jobs).toEqual(before);
+  });
+
+  it("reports ids without minting, deriving or altering one", () => {
+    const jobs = relisted(3, 49);
+    const [cluster] = findRepostClusters(jobs);
+    expect(cluster.ids).toEqual(jobs.map((each) => each.id));
+  });
+
+  it("the module reaches no write path — structural, so it cannot rot", () => {
+    // The claim is about the FILE, not about one run of it: an added call to
+    // `saveJob` would still pass every behavioural test above.
+    const raw = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "job-repost-clusters.ts"),
+      "utf8",
+    );
+    // Comments stripped first, for the reason `job-origin-reach.test.ts` strips
+    // them on its drift half: the module DOCUMENTS that a merge cascades letters
+    // through `mergeJobs`, and naming the function you are explaining you never
+    // call is not a call. Only executable text can reach a write path.
+    const code = raw.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+    // The strip must not have eaten the module — otherwise this passes by
+    // having nothing left to find.
+    expect(code).toContain("export function findRepostClusters");
+
+    for (const write of [
+      "saveJob",
+      "putRecord",
+      "deleteRecord",
+      "softDeleteRecord",
+      "clearStore",
+      "updateJob",
+      "mergeJobs",
+    ]) {
+      expect(code, `job-repost-clusters.ts must not call ${write}`).not.toContain(write);
+    }
+    // ...and it takes only the TYPE from storage, never the module's runtime.
+    expect(code).toContain('import type { JobRecord } from "./storage/index.ts"');
+  });
+});
+
+describe("indexRepostClusters", () => {
+  it("maps every member to the one cluster object", () => {
+    const clusters = findRepostClusters(relisted(6, 49));
+    const byJobId = indexRepostClusters(clusters);
+    expect(byJobId.size).toBe(6);
+    for (const id of clusters[0].ids) expect(byJobId.get(id)).toBe(clusters[0]);
+  });
+
+  it("leaves an unclustered record out of the map entirely", () => {
+    const byJobId = indexRepostClusters(findRepostClusters(relisted(2, 3)));
+    expect(byJobId.size).toBe(0);
+  });
+});
+
+describe("isRepostSuppressed: cluster membership outranks inference, URL identity outranks it", () => {
+  const byJobId = indexRepostClusters(findRepostClusters(relisted(6, 49)));
+
+  function pair(
+    a: string,
+    b: string,
+    confidence: JobDuplicatePair["confidence"],
+  ): JobDuplicatePair {
+    return { a, b, confidence };
+  }
+
+  it("withholds a `probable` merge between two members of one cluster", () => {
+    expect(isRepostSuppressed(pair("r0", "r1", "probable"), byJobId)).toBe(true);
+  });
+
+  it("KEEPS a `certain` merge between two members of one cluster", () => {
+    // Six reposts are six different postings with six different URLs, so two of
+    // them sharing one URL is a genuine double-capture of a single posting —
+    // the one correct offer in the group, and suppressing it would hide it.
+    expect(isRepostSuppressed(pair("r0", "r1", "certain"), byJobId)).toBe(false);
+  });
+
+  it("keeps a `certain` merge that reaches OUT of the cluster", () => {
+    expect(isRepostSuppressed(pair("r0", "elsewhere", "certain"), byJobId)).toBe(false);
+  });
+
+  it("keeps a `probable` merge whose other side is in no cluster", () => {
+    expect(isRepostSuppressed(pair("r0", "elsewhere", "probable"), byJobId)).toBe(false);
+  });
+
+  it("keeps a `probable` merge across two DIFFERENT clusters", () => {
+    const two = indexRepostClusters(
+      findRepostClusters([
+        ...relisted(2, 49),
+        job({ id: "s0", title: "Staff Platform Engineer" }),
+        job({
+          id: "s1",
+          title: "Staff Platform Engineer",
+          createdAt: JUN_15 + 49 * DAY,
+        }),
+      ]),
+    );
+    expect(two.get("r0")?.key).not.toBe(two.get("s0")?.key);
+    expect(isRepostSuppressed(pair("r0", "s0", "probable"), two)).toBe(false);
+  });
+
+  it("suppresses nothing against an empty index", () => {
+    const empty = indexRepostClusters([]);
+    expect(isRepostSuppressed(pair("r0", "r1", "probable"), empty)).toBe(false);
+  });
+});
+
+describe("the property the two modules share: never neither", () => {
+  it("every title-identical pairing is mergeable OR clustered, across the measured span range", () => {
+    // The separation distribution the issue measured runs 0d…124d; these walk
+    // it, plus the boundary itself from both sides.
+    const spans = [0, 1, 3, 13, REPOST_SPAN_DAYS, REPOST_SPAN_DAYS + 1, 30, 40, 49, 124];
+    for (const days of spans) {
+      const a = job({ id: "a", createdAt: JUN_15 });
+      const b = job({ id: "b", createdAt: JUN_15 + days * DAY });
+      const mergeable = jobDuplicateConfidence(a, b) === "probable";
+      const byJobId = indexRepostClusters(findRepostClusters([a, b]));
+      const clustered =
+        byJobId.get("a") !== undefined && byJobId.get("a") === byJobId.get("b");
+      expect(mergeable || clustered, `${days}d apart fell into neither`).toBe(true);
+      // ...and never both, for a pairing whose only evidence is proximity.
+      expect(mergeable && clustered, `${days}d apart landed in both`).toBe(false);
+    }
+  });
+});

--- a/src/lib/job-repost-clusters.ts
+++ b/src/lib/job-repost-clusters.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * job-repost-clusters — "is this one role the employer keeps re-listing?"
+ * (#754). Pure, zero-storage, zero-UI, sibling of `job-duplicates.ts` and
+ * `job-status-bucket.ts`, and testable at module scope for the same reason.
+ *
+ * ## Why a repost is not a duplicate
+ *
+ * Six saved records, one company, one title, spread over 49 days, are not five
+ * redundant rows. They are the trace of a role that has been advertised since
+ * June, which is precisely the thing a job seeker wants surfaced — and the
+ * tracker used to answer it with five **Merge into this one** buttons per row.
+ * Merging is destructive and cascades letters (`job-tracker.ts`'s `mergeJobs`),
+ * so acting on that offer would have destroyed the churn signal outright.
+ *
+ * So this module says the other thing: it groups those records, states the
+ * count and the span, and {@link isRepostSuppressed} withdraws the merge offer
+ * for pairings inside a cluster. It never merges, never ranks, and never picks
+ * a survivor — that is a user's click, and only ever on evidence this module
+ * declines to weaken.
+ *
+ * ## Derived on VIEW, never stored
+ *
+ * The same rule `useJobDuplicates` and `useSavedJobRatings` follow: a stored
+ * "these six are one repost cluster" verdict goes stale the moment a title is
+ * edited, with nothing to invalidate it. Nothing here writes — no `JobRecord`
+ * field is added, no call reaches `saveJob` / `putRecord` — and nothing here
+ * reads or writes `id` beyond grouping by it and reporting which ids grouped.
+ * An id is never derived, minted, or forked here.
+ *
+ * ## One boundary, shared with `job-duplicates.ts`
+ *
+ * Both the grouping key ({@link jobCompanyTitleKey}) and the time boundary
+ * ({@link withinRepostSpan} / {@link REPOST_SPAN_DAYS}) are IMPORTED, never
+ * restated. That is what makes the design's central property hold:
+ *
+ * > every title-identical pairing at one company is *either* mergeable *or*
+ * > inside a repost cluster, and never neither.
+ *
+ * The proof is one line in each direction. A pairing is `title-only` only when
+ * nothing corroborates it, and the last corroborating signal is capture
+ * proximity — so a `title-only` pairing is two records more than
+ * {@link REPOST_SPAN_DAYS} apart (or one with no usable capture time), which
+ * makes its group's own span exceed the boundary, which is exactly
+ * {@link findRepostClusters}' cluster test. Conversely a group inside the
+ * boundary has every pairing corroborated by proximity, so every pairing in it
+ * is `probable`. Two separately-tuned numbers would open a band where a pairing
+ * gets no merge offer and no explanation of why not.
+ *
+ * ## Totality
+ *
+ * Same bar as `job-duplicates.ts`: a record can arrive from a backup predating
+ * any field, so every value is guarded and a malformed one degrades to "no
+ * evidence" rather than throwing. A member with no usable `createdAt` counts as
+ * NOT within the span — the reading that keeps the property above true, and the
+ * one that withholds a merge rather than offering one on a field nobody can
+ * read.
+ */
+
+import {
+  REPOST_SPAN_DAYS,
+  jobCompanyTitleKey,
+  withinRepostSpan,
+  type JobDuplicatePair,
+} from "./job-duplicates.ts";
+import type { JobRecord } from "./storage/index.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * One role a company has listed more than once over a span wider than
+ * {@link REPOST_SPAN_DAYS}.
+ *
+ * Everything here is derived from the records handed in and none of it is
+ * written back. `company` and `title` are the FIRST member's raw spellings
+ * rather than the normalised key, because the key is a comparison artefact and
+ * a row has to print something a user recognises.
+ */
+export interface JobRepostCluster {
+  /** {@link jobCompanyTitleKey} for the group — stable across a re-sweep of the
+   *  same library, so a row can key on it. Not an id and never stored. */
+  key: string;
+  /** The first member's `company`, verbatim. */
+  company: string;
+  /** The first member's `title`, verbatim. */
+  title: string;
+  /** Every member's `JobRecord.id`, in the caller's order. Grouping only: no
+   *  id here is derived, minted, or written anywhere. */
+  ids: readonly string[];
+  /** `ids.length`, named because it is what the row states. Always >= 2. */
+  count: number;
+  /** Epoch ms of the earliest / latest usable capture time in the group, and
+   *  the whole days between them. All three absent together when no member
+   *  carries a usable `createdAt` — a cluster with a count worth stating and no
+   *  span to state, which the row must render rather than print `NaN days`. */
+  firstSeen?: number;
+  lastSeen?: number;
+  spanDays?: number;
+}
+
+/**
+ * Group a library by {@link jobCompanyTitleKey}.
+ *
+ * Bucketed rather than quadratic, for the reason `findDuplicatePairs` is: the
+ * caller is a tracker render over a library that reaches into the hundreds. A
+ * record whose company or title is blank belongs to no bucket — that is missing
+ * evidence, not evidence of sameness, and {@link jobCompanyTitleKey} is the one
+ * place that decision is made.
+ */
+function bucketByCompanyTitle(
+  jobs: readonly JobRecord[],
+): Map<string, JobRecord[]> {
+  const buckets = new Map<string, JobRecord[]>();
+  for (const job of jobs) {
+    const key = jobCompanyTitleKey(job);
+    if (key === null) continue;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(job);
+    else buckets.set(key, [job]);
+  }
+  return buckets;
+}
+
+/**
+ * The earliest and latest usable capture time across a group, and whether
+ * EVERY member carried one.
+ *
+ * Only usable timestamps take part. A member with an unreadable one cannot be
+ * vouched for by proximity, so `allUsable` false forces the cluster — the same
+ * reading `corroborates` takes, which is what keeps a pairing from falling
+ * between the two behaviours.
+ *
+ * `first`/`last` stay at their infinite seeds when nothing was readable, so
+ * they are only meaningful once `allUsable` has been checked. That is the
+ * contract {@link findRepostClusters} relies on and the reason all three come
+ * back together rather than as two calls a caller could interleave wrongly.
+ */
+function readCapturedSpan(members: readonly JobRecord[]): {
+  first: number;
+  last: number;
+  allUsable: boolean;
+} {
+  let first = Number.POSITIVE_INFINITY;
+  let last = Number.NEGATIVE_INFINITY;
+  let allUsable = true;
+  for (const member of members) {
+    const ms = member.createdAt;
+    if (typeof ms !== "number" || !Number.isFinite(ms)) {
+      allUsable = false;
+      continue;
+    }
+    if (ms < first) first = ms;
+    if (ms > last) last = ms;
+  }
+  return { first, last, allUsable };
+}
+
+/**
+ * Every repost cluster in one library.
+ *
+ * A bucket becomes a cluster when it holds at least two records AND they were
+ * not all captured within {@link REPOST_SPAN_DAYS} of one another. Two records
+ * saved three days apart are a double-capture, and `job-duplicates.ts` offers
+ * the merge for them; only the spread-out group is churn.
+ *
+ * The grouping and the span read live in {@link bucketByCompanyTitle} and
+ * {@link readCapturedSpan} so what remains here is only the cluster DECISION —
+ * the one thing the module docblock's central property is proved against.
+ */
+export function findRepostClusters(jobs: readonly JobRecord[]): JobRepostCluster[] {
+  const clusters: JobRepostCluster[] = [];
+  for (const [key, members] of bucketByCompanyTitle(jobs)) {
+    if (members.length < 2) continue;
+
+    const { first, last, allUsable } = readCapturedSpan(members);
+    if (allUsable && withinRepostSpan(first, last)) continue;
+    // The span is stated only when it covers EVERY member. A partial span read
+    // off the members that happened to be readable would understate the churn
+    // it claims to measure, and the count alone is still true.
+    const spanned = allUsable && first <= last;
+
+    clusters.push({
+      key,
+      company: typeof members[0].company === "string" ? members[0].company : "",
+      title: typeof members[0].title === "string" ? members[0].title : "",
+      ids: members.map((member) => member.id),
+      count: members.length,
+      ...(spanned
+        ? {
+            firstSeen: first,
+            lastSeen: last,
+            spanDays: Math.round((last - first) / DAY_MS),
+          }
+        : {}),
+    });
+  }
+  return clusters;
+}
+
+/**
+ * The same clusters keyed by member id, which is the lookup every caller wants:
+ * a row asks "am I in one", and {@link isRepostSuppressed} asks "are we both in
+ * the same one". Each member maps to the SAME object, so the map costs one
+ * entry per clustered record and nothing else.
+ */
+export function indexRepostClusters(
+  clusters: readonly JobRepostCluster[],
+): ReadonlyMap<string, JobRepostCluster> {
+  const byJobId = new Map<string, JobRepostCluster>();
+  for (const cluster of clusters) {
+    for (const id of cluster.ids) byJobId.set(id, cluster);
+  }
+  return byJobId;
+}
+
+/**
+ * Should this duplicate pairing's merge offer be withheld because the two
+ * records are one employer's repeated listings?
+ *
+ * **The precedence rule, in one sentence: cluster membership outranks every
+ * INFERRED tier and is outranked by URL identity.** Both halves are load-bearing
+ * and neither is symmetric with the other:
+ *
+ *  - A `certain` pairing is never suppressed, even with both records inside one
+ *    cluster. `certain` means the two URL sets intersect — somebody with more
+ *    context than a parser recorded these as one page — and that is identity,
+ *    not inference. Six reposts of a role are six DIFFERENT postings with six
+ *    different URLs, so a shared URL inside a cluster is a genuine
+ *    double-capture of one of them and its merge is exactly right. Suppressing
+ *    it would hide the one correct offer in the group.
+ *  - A `probable` pairing between two members of one cluster IS suppressed, even
+ *    when something corroborated it. The corroboration says "these two records
+ *    describe the same role"; the cluster says "this role has been listed over
+ *    and over", and merging on the first claim destroys the evidence for the
+ *    second. Merging is unrecoverable, so the claim that costs nothing to be
+ *    wrong about wins.
+ *
+ * Checked at the PAIR level — both ids in the same cluster — rather than
+ * "either record is clustered". Today a `probable` pairing implies both members share a
+ * {@link jobCompanyTitleKey} and therefore one cluster, so the two readings
+ * agree; stating the pair-level one keeps that agreement an observation rather
+ * than a dependency, and keeps a `certain` pairing that reaches OUT of a cluster
+ * visibly outside the rule.
+ */
+export function isRepostSuppressed(
+  pair: JobDuplicatePair,
+  byJobId: ReadonlyMap<string, JobRepostCluster>,
+): boolean {
+  if (pair.confidence === "certain") return false;
+  const a = byJobId.get(pair.a);
+  return a !== undefined && a.key === byJobId.get(pair.b)?.key;
+}

--- a/src/lib/job-tracker.test.ts
+++ b/src/lib/job-tracker.test.ts
@@ -28,8 +28,11 @@ import {
   createTrackedJobFromMatch,
   deriveJobTitleFromJd,
   mergeJobs,
+  archiveInterestedOlderThan,
 } from "./job-tracker.ts";
-import { getRecord } from "./storage/crud.ts";
+import { isSweepableBucket, jobsToArchive } from "./job-archive-sweep.ts";
+import { archiveJobs } from "./storage/jobs.ts";
+import { getRecord, putRecord } from "./storage/crud.ts";
 import { saveLetter, lettersForJob } from "./storage/letters.ts";
 import type { JobRecord } from "./storage/types.ts";
 
@@ -194,6 +197,176 @@ describe("job-tracker: link cleanup is housekeeping, not a user edit", () => {
     await new Promise((r) => setTimeout(r, 2));
     const edited = await updateJob(job.id, { notes: "referred by Dana" });
     expect(edited.updatedAt).toBeGreaterThan(before);
+  });
+});
+
+describe("job-tracker: bulk-archive sweep (#759)", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const NOW = Date.now();
+
+  /** Writes a job straight through `putRecord` with an explicit `createdAt`
+   *  — `createJob`/`updateJob` can't backdate one (an update always keeps the
+   *  EXISTING row's `createdAt`, by `putRecord`'s own contract), and this
+   *  sweep is dated entirely off that field. */
+  function plantJob(over: Partial<JobRecord> & { createdAt: number }): Promise<JobRecord> {
+    return putRecord<JobRecord>("jobs", {
+      id: crypto.randomUUID(),
+      title: "SWE",
+      company: "Acme",
+      status: "interested",
+      ...over,
+    });
+  }
+
+  it("archives an Interested job past the cutoff and returns the swept count", async () => {
+    const old = await plantJob({ title: "Old", createdAt: NOW - 60 * DAY_MS });
+    const fresh = await plantJob({ title: "Fresh", createdAt: NOW - 5 * DAY_MS });
+
+    const count = await archiveInterestedOlderThan(await listJobs(), 30, NOW);
+
+    expect(count).toBe(1);
+    expect((await getJobById(old.id))?.status).toBe("archived");
+    expect((await getJobById(fresh.id))?.status).toBe("interested");
+  });
+
+  it("never touches an Applied job, however old — the criterion #759 leads with", async () => {
+    const applied = await plantJob({
+      title: "Already applied",
+      status: "applied",
+      createdAt: NOW - 400 * DAY_MS,
+    });
+
+    const count = await archiveInterestedOlderThan(await listJobs(), 30, NOW);
+
+    expect(count).toBe(0);
+    expect((await getJobById(applied.id))?.status).toBe("applied");
+  });
+
+  it("SPARES a row that stopped being Interested after the preview was computed", async () => {
+    // The confirm dialog promises "Applied, Interviewing, Offer, and Rejected
+    // jobs are never touched." Selecting the ids and writing them are two
+    // different moments, and the sweep is a sequential awaited loop over as
+    // many as ~290 rows — so another tab, the browser extension writing
+    // through `putRecord`, or a sync can move a row out of Interested while
+    // the sweep is still working through the list. Before the write re-checked
+    // the bucket, that row was archived anyway and the hand-built pipeline
+    // state was gone.
+    //
+    // The change is planted between the preview and the call, which is
+    // exactly the window: `jobs` is the array the user was counting, and the
+    // store no longer agrees with it.
+    const sweptAway = await plantJob({ title: "Genuinely old", createdAt: NOW - 60 * DAY_MS });
+    const movedOn = await plantJob({ title: "Applied elsewhere", createdAt: NOW - 60 * DAY_MS });
+
+    const jobs = await listJobs();
+    expect(jobsToArchive(jobs, 30, NOW)).toHaveLength(2);
+
+    await setJobStatus(movedOn.id, "applied");
+    const beforeSweep = await getJobById(movedOn.id);
+
+    const count = await archiveInterestedOlderThan(jobs, 30, NOW);
+
+    // Untouched — not archived, and not even re-stamped.
+    const after = await getJobById(movedOn.id);
+    expect(after?.status).toBe("applied");
+    expect(after?.updatedAt).toBe(beforeSweep?.updatedAt);
+    // The other row was still eligible and still swept: the guard skips a row,
+    // it does not abandon the sweep.
+    expect((await getJobById(sweptAway.id))?.status).toBe("archived");
+    // And the count reports writes that happened, not rows that were listed —
+    // so the dialog's "Archived N jobs." stays true. This is the one case
+    // where it may sit below the preview count.
+    expect(count).toBe(1);
+  });
+
+  it("spares a row moved out of Interested WHILE the loop is running, not just before it", async () => {
+    // The same defect one step further in: the flip lands after the sweep has
+    // already written an earlier row, so it cannot be explained away as
+    // "stale input". `archiveJobs` re-reads and re-judges each row
+    // immediately before that row's own write, so the loop sees it.
+    //
+    // The flip is issued from `archiveInterestedOlderThan`'s own predicate
+    // call for the FIRST row and left un-awaited, so it is queued behind that
+    // row's write and settles before the second row is re-read. If that
+    // ordering ever changed, the assertions below fail loudly rather than
+    // passing for the wrong reason.
+    const first = await plantJob({ title: "First", createdAt: NOW - 60 * DAY_MS });
+    const second = await plantJob({ title: "Second", createdAt: NOW - 60 * DAY_MS });
+
+    const jobs = await listJobs();
+    expect(jobsToArchive(jobs, 30, NOW)).toHaveLength(2);
+
+    let flip: Promise<unknown> | undefined;
+    const archived = await archiveJobs(
+      [first.id, second.id],
+      {
+        stillEligible: (job) => {
+          if (job.id === first.id && flip === undefined) {
+            flip = setJobStatus(second.id, "interviewing");
+          }
+          return isSweepableBucket(job);
+        },
+      },
+    );
+    await flip;
+
+    expect(archived.map((job) => job.id)).toEqual([first.id]);
+    expect((await getJobById(first.id))?.status).toBe("archived");
+    expect((await getJobById(second.id))?.status).toBe("interviewing");
+  });
+
+  it("the swept count matches jobsToArchive's preview count when nothing else writes", async () => {
+    // The #759 agreement, stated precisely rather than loosely. It is about
+    // POLICY: preview and write run one predicate over one array, so the
+    // sweep can never select a row on a rule the preview did not apply, and
+    // no cutoff is re-derived at write time.
+    //
+    // It was never a promise that the two numbers are equal come what may,
+    // and since the write re-checks each row's bucket they can legitimately
+    // differ — downward, and only when another writer moves a row out of
+    // Interested mid-sweep (see the two tests above). This case is the
+    // undisturbed one, which is why nothing else touches the store here.
+    await plantJob({ title: "Sweep me", createdAt: NOW - 90 * DAY_MS });
+    await plantJob({ title: "Keep me", createdAt: NOW - 1 * DAY_MS });
+    await plantJob({
+      title: "Pipeline",
+      status: "interviewing",
+      createdAt: NOW - 900 * DAY_MS,
+    });
+
+    const jobs = await listJobs();
+    const preview = jobsToArchive(jobs, 30, NOW);
+    const count = await archiveInterestedOlderThan(jobs, 30, NOW);
+
+    expect(count).toBe(preview.length);
+    expect(count).toBe(1);
+  });
+
+  it("a cutoff nothing matches archives and writes nothing", async () => {
+    const fresh = await plantJob({ title: "Fresh", createdAt: NOW - 1 * DAY_MS });
+    const before = await getJobById(fresh.id);
+
+    const count = await archiveInterestedOlderThan(await listJobs(), 30, NOW);
+
+    expect(count).toBe(0);
+    const after = await getJobById(fresh.id);
+    expect(after?.status).toBe("interested");
+    expect(after?.updatedAt).toBe(before?.updatedAt);
+  });
+
+  it("overwrites a synced saved/scouted status to the literal archived — one-way (#744)", async () => {
+    const scouted = await plantJob({
+      title: "From a job alert",
+      status: "scouted" as JobRecord["status"],
+      createdAt: NOW - 60 * DAY_MS,
+    });
+
+    const count = await archiveInterestedOlderThan(await listJobs(), 30, NOW);
+
+    expect(count).toBe(1);
+    // The producer's own vocabulary ("scouted") is gone — this is the
+    // documented one-way write, not a bug.
+    expect((await getJobById(scouted.id))?.status).toBe("archived");
   });
 });
 

--- a/src/lib/job-tracker.ts
+++ b/src/lib/job-tracker.ts
@@ -19,10 +19,12 @@ import {
   getJob,
   getAllJobs,
   deleteJob,
+  archiveJobs,
   lettersForJob,
   saveLetter,
 } from "./storage/index.ts";
 import { mergeJobRecords } from "./job-merge.ts";
+import { isSweepableBucket, jobsToArchive } from "./job-archive-sweep.ts";
 import type { JobRecord, JobStatus } from "./storage/index.ts";
 
 /** Fields a caller supplies when creating a tracked job. `status` defaults to
@@ -248,4 +250,50 @@ export function createTrackedJobFromMatch(input: {
   resumeId?: string;
 }): Promise<JobRecord> {
   return createJob({ ...input, status: "interested" });
+}
+
+/**
+ * Bulk-archive sweep (#759): every job in `jobs` whose bucket is Interested
+ * and whose `createdAt` is more than `cutoffDays` days old becomes
+ * `"archived"`. Returns the count actually archived.
+ *
+ * `jobs` is a PARAMETER, not a fresh `getAllJobs()` read, and that is the
+ * point: the caller (`useJobTracker.archiveOlderThan`) computes its live
+ * preview count with `jobsToArchive` over this exact same in-memory array,
+ * and threading it through here — rather than re-listing from storage —
+ * means the set this call SELECTS is exactly the set the user was counting.
+ * No difference in policy, no re-derived cutoff, no second clock read.
+ *
+ * The count this returns can still come out BELOW that preview, and only for
+ * one reason: `archiveJobs` re-checks each row's bucket against storage
+ * immediately before writing it, and skips one that stopped being Interested
+ * while the sweep was running (see that function's docblock). Selection and
+ * preview agree by construction; a row someone else moved to Applied
+ * mid-sweep is deliberately not written, and the returned count says so
+ * rather than counting a write that did not happen. `isSweepableBucket` —
+ * the same predicate `jobsToArchive` filtered on — is what performs that
+ * re-check, so the two can never disagree about what Interested means.
+ *
+ * One-way: every swept row's status becomes the literal string `"archived"`,
+ * which overwrites whatever vocabulary (`saved` / `scouted`) a syncing
+ * producer stored it with — `job-status-bucket.ts`'s whole reason for
+ * existing is that such a rewrite destroys meaning a sync would carry back.
+ * The confirm dialog states this; this function does not re-litigate it.
+ *
+ * The actual writes are `archiveJobs` (`storage/jobs.ts`), which coalesces
+ * the cross-tab change signal to one message regardless of how many rows
+ * this call touches (#760) — see that function's docblock.
+ */
+export async function archiveInterestedOlderThan(
+  jobs: readonly JobRecord[],
+  cutoffDays: number,
+  now: number = Date.now(),
+): Promise<number> {
+  const toArchive = jobsToArchive(jobs, cutoffDays, now);
+  if (toArchive.length === 0) return 0;
+  const archived = await archiveJobs(
+    toArchive.map((job) => job.id),
+    { stillEligible: isSweepableBucket },
+  );
+  return archived.length;
 }

--- a/src/lib/resume-library.test.ts
+++ b/src/lib/resume-library.test.ts
@@ -89,7 +89,7 @@ describe("resume-library: save + list", () => {
     const list = await listLibrary();
     expect(list).toHaveLength(2);
     expect(list.map((e) => e.filename)).toEqual(["tailored.pdf", "general.pdf"]);
-    expect(list[0]).toMatchObject({ scoreOverall: 84, sourceKind: "pdf" });
+    expect(list[0]).toMatchObject({ scoreOverall: 84, sourceKind: "pdf", hasCachedParse: true });
   });
 });
 
@@ -236,6 +236,15 @@ describe("resume-library: record with no cached parse (#693 producer write)", ()
     );
     expect(await loadResumeFromLibrary(rec.id)).toBeUndefined();
     expect(runCascade).not.toHaveBeenCalled();
+  });
+
+  it("listLibrary reports hasCachedParse: false and does not claim a score for it (#757)", async () => {
+    await producerWritten(new Blob([bytes().buffer], { type: "application/pdf" }));
+    const [entry] = await listLibrary();
+    expect(entry.hasCachedParse).toBe(false);
+    // `scoreOverall` is a placeholder here, not a genuine zero — the UI must
+    // read `hasCachedParse` rather than trust this number on its own.
+    expect(entry.scoreOverall).toBe(0);
   });
 });
 

--- a/src/lib/resume-library.ts
+++ b/src/lib/resume-library.ts
@@ -68,9 +68,19 @@ export interface ResumeLibraryEntry {
   filename: string;
   /** Epoch ms of the last save (record `updatedAt`). */
   savedAt: number;
-  /** Overall ATS score captured at save time. */
+  /** Overall ATS score captured at save time. `0` when `hasCachedParse` is
+   *  false — a placeholder, not a genuine zero score; see {@link hasCachedParse}. */
   scoreOverall: number;
   sourceKind: SourceKind;
+  /** Whether this record has a snapshot `readSnapshot` can use (#757). False
+   *  for a record an outside producer wrote through the backup-import door
+   *  with no cached parse — legal, and still loadable: `loadResumeFromLibrary`
+   *  rebuilds it by re-parsing the stored blob (#758). It is NOT a broken
+   *  record, and the UI must not read it as one; it just hasn't been parsed by
+   *  this build yet. `scoreOverall` is meaningless when this is false, which is
+   *  the whole reason it exists — before it, a record with no snapshot and a
+   *  résumé that genuinely scored 0 rendered identically. */
+  hasCachedParse: boolean;
 }
 
 /** Everything App needs to hydrate the "done" state from a saved resume. */
@@ -138,8 +148,10 @@ export async function saveResumeToLibrary(input: {
   return record.id;
 }
 
-/** List saved resumes, newest first. Records with a malformed snapshot are kept
- *  in the list (score 0) rather than hidden — the user can still delete them. */
+/** List saved resumes, newest first. Records with no readable snapshot are kept
+ *  in the list rather than hidden — the user can still delete them — but are
+ *  reported with `hasCachedParse: false` (#757) rather than a `scoreOverall`
+ *  that reads as a genuine zero. */
 export async function listLibrary(): Promise<ResumeLibraryEntry[]> {
   const records = await getAllResumes();
   return records
@@ -151,6 +163,7 @@ export async function listLibrary(): Promise<ResumeLibraryEntry[]> {
         savedAt: r.updatedAt,
         scoreOverall: snap?.score.overall ?? 0,
         sourceKind: snap?.sourceKind ?? "pdf",
+        hasCachedParse: snap !== null,
       };
     })
     .sort((a, b) => b.savedAt - a.savedAt);

--- a/src/lib/storage/__test-utils__/library-channel-delivery.ts
+++ b/src/lib/storage/__test-utils__/library-channel-delivery.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Delivery-timing helpers for every suite that asserts on the library change
+ * channel (#760) — `library-changes.test.ts`, `library-channel.test.ts` and
+ * `useLibraryChanges.test.tsx`.
+ *
+ * ## The flake this exists to remove
+ *
+ * All three files started with the same private helper: a single
+ * `new Promise(r => setTimeout(r, 0))` between the write and the assertion.
+ * That is a bet that one macrotask turn is enough for a `BroadcastChannel`
+ * message to be delivered, and it is not a bet that always pays. Node has a
+ * real global `BroadcastChannel`, so delivery is a genuine cross-port hop
+ * scheduled independently of the timer queue; measured on an idle machine it
+ * lands well inside one turn, but under a full parallel vitest run the timer
+ * callback can win the race. Two of those assertions failed roughly one full
+ * suite run in four.
+ *
+ * The fix is not a longer sleep. It is to stop asserting on a fixed moment,
+ * because the two directions need opposite treatment — which is exactly why
+ * both live here, in one module, sharing one budget.
+ *
+ * ## Positive assertions poll; absence assertions cannot
+ *
+ * A test that expects a message to ARRIVE can retry until it does:
+ * {@link waitForDelivery} polls, so it is correct whenever delivery happens
+ * within the budget and costs nothing when — as is normal — it has already
+ * happened by the first check.
+ *
+ * A test that expects NOTHING to arrive can never be made to poll, and
+ * turning one into a poll would silently destroy it: a message that is merely
+ * slow would let the wait exit early, so the assertion would pass for the
+ * wrong reason. There is no observation that proves a message will never
+ * come; the only honest instrument is a FIXED wait, and its length is the
+ * claim being made. {@link settleWithoutDelivery} therefore waits the WHOLE
+ * of {@link CHANNEL_DELIVERY_BUDGET_MS} — the same budget the positive path is
+ * willing to spend before it gives up and fails.
+ *
+ * Tying the two to one constant is the point of putting them together. It
+ * makes the suite structurally incapable of concluding "nothing arrived"
+ * faster than it would still have accepted "something arrived", which is what
+ * the original single tick did — it declared absence after a delay it had
+ * already been shown was sometimes too short to see a message that WAS sent.
+ */
+
+import { vi } from "vitest";
+
+/**
+ * How long a change signal is allowed to take before a test treats it as
+ * never coming — the budget for both directions above.
+ *
+ * Sized against measurement, not taste: on this Node version a delivery
+ * lands in ~0.01 ms at the median and under 2 ms at the worst of a few
+ * hundred idle samples. The margin here is against event-loop starvation
+ * under a parallel suite, not against the channel itself, so it is set two
+ * orders of magnitude above that worst case. It is a ceiling rather than a
+ * cost: only the absence assertions actually spend it.
+ */
+const CHANNEL_DELIVERY_BUDGET_MS = 500;
+
+/**
+ * Re-run `check` until it stops throwing, or fail once the budget is spent.
+ *
+ * `check` is an ordinary assertion block — write the `expect` you want and
+ * let it throw; the last failure is what surfaces if the budget runs out, so
+ * a genuine regression still reports the values it saw rather than a bare
+ * timeout.
+ *
+ * `vi.waitFor` does the polling. It is vitest's own primitive for this and
+ * the repo keeps one primitive per concern, so this is a thin wrapper that
+ * only pins the shared budget and a tight interval — nothing is re-derived.
+ */
+export function waitForDelivery(check: () => void): Promise<void> {
+  return vi.waitFor(check, {
+    timeout: CHANNEL_DELIVERY_BUDGET_MS,
+    // Well below the budget so a delivery that misses the first, immediate
+    // check is still observed promptly instead of costing a default 50 ms
+    // interval on every positive assertion in the suite.
+    interval: 5,
+  });
+}
+
+/**
+ * Wait the full delivery budget, then resolve — for an assertion that
+ * NOTHING arrived.
+ *
+ * Deliberately a fixed wait and deliberately not `waitForDelivery`'s
+ * early-exit shape; see this module's docblock for why absence is the one
+ * direction polling makes weaker rather than stronger.
+ */
+export function settleWithoutDelivery(): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, CHANNEL_DELIVERY_BUDGET_MS),
+  );
+}

--- a/src/lib/storage/backup.ts
+++ b/src/lib/storage/backup.ts
@@ -48,9 +48,17 @@
  * `arrayBuffer()`, so encode/import are async.
  */
 
-import { getAllRecords, putRecord, clearStore, isLive } from "./crud.ts";
+import {
+  getAllRecords,
+  putRecord,
+  clearStore,
+  isLive,
+  runBatchedWrites,
+} from "./crud.ts";
 import { validateJobRecord } from "./job-record-contract.ts";
 import { validateLetterRecord } from "./letter-contract.ts";
+import { validateResumeRecord } from "./resume-record-contract.ts";
+import { isPlainObject } from "./record-contract.ts";
 import type {
   ResumeRecord,
   JobRecord,
@@ -59,6 +67,16 @@ import type {
   StorageExport,
   StorageExportV2,
 } from "./types.ts";
+
+/** One résumé a restore refused. Sibling of {@link SkippedJob}; `filename`
+ *  rather than `title`/`label` because that is the résumé's own user-facing
+ *  name. */
+export interface SkippedResume {
+  id?: string;
+  filename?: string;
+  /** Every reason the record failed, joined into one sentence. */
+  reason: string;
+}
 
 /** One job a restore refused, named well enough for the user to find it in the
  *  file. `id` / `title` are best-effort: the record failed validation, so they
@@ -83,19 +101,46 @@ export interface SkippedLetter {
  *  written, and not tombstoned (#730). A file's tombstones are written too —
  *  that is the point of exporting them — but counting them would tell the user
  *  a restore brought back jobs that stay invisible, which reads as a bug in the
- *  restore rather than as the deletions it faithfully reproduced.
+ *  restore rather than as the deletions it faithfully reproduced. `resumes`
+ *  counts the same way for a different reason: `resumes` hard-deletes, so
+ *  there are no tombstones to exclude, but since #757 it counts records the
+ *  résumé contract ACCEPTED rather than every record the file carried.
  *
  *  So the three numbers no longer sum to the file's record count. The
  *  `skipped…` lists still account for every record the contract REFUSED, which
  *  is the thing a user can act on; a tombstone was accepted, it just isn't
  *  something to celebrate having restored.
  *
- *  Nothing renders `skippedLetters` yet — #711 ships the store with no UI at
- *  all. It is reported from the first commit anyway because the alternative is
- *  a restore that drops a letter and says nothing, and a counter added later
- *  cannot recover the ones already dropped. */
+ *  Nothing renders `skippedLetters` or `skippedResumes` yet — #711 and #757
+ *  ship their stores with no dedicated UI for a skip list. Both are reported
+ *  from the first commit anyway because the alternative is a restore that
+ *  drops a record and says nothing, and a counter added later cannot recover
+ *  the ones already dropped.
+ *
+ *  `resumesWithoutParse` is not a skip — it counts records ACCEPTED (#757)
+ *  that carry no `parse` payload AT ALL. That is a legal shape (every résumé
+ *  #693's capture door writes has one), and the record is loadable — it just
+ *  has to be re-parsed from its stored bytes on the next `Load` (#758). Kept
+ *  distinct from `skippedResumes` so "this record needs a moment to re-parse"
+ *  never reads as "this record was dropped".
+ *
+ *  **It counts absence, not unreadability, and the two are not the same
+ *  set.** `resume-library.ts#listLibrary`'s `hasCachedParse` asks the stronger
+ *  question — can `readSnapshot` actually get a `result` and a `score` out of
+ *  it — so a record whose `parse` is present but not readable as a snapshot
+ *  is unparsed to the library and NOT counted here. That gap is deliberate
+ *  rather than an oversight: the `SavedResumeSnapshot` shape belongs to
+ *  `resume-library.ts` one layer up, and `resume-record-contract.ts`'s own
+ *  docblock states in terms that this layer does not assert it. Closing the
+ *  gap means moving that judgement down here, which contradicts that
+ *  boundary, or injecting the predicate into `importAll`, which is a channel
+ *  for a number nothing currently renders. Both are worse than naming the
+ *  limit. Anything that starts SHOWING this count should read it off the
+ *  library's predicate instead of this one. */
 export interface ImportCounts {
   resumes: number;
+  skippedResumes: SkippedResume[];
+  resumesWithoutParse: number;
   jobs: number;
   skippedJobs: SkippedJob[];
   letters: number;
@@ -173,10 +218,11 @@ export async function exportToJson(): Promise<string> {
  * back-compat is not a courtesy — an exported backup lives on the user's disk
  * and never learns about a format bump.
  *
- * Every job is put through the capture contract (#693), and every letter
- * through the letter contract (#711), BEFORE any store is touched — the file is
- * the boundary at which `JobRecord` / `LetterRecord` stop being types
- * TypeScript can vouch for. Three things follow from where that check sits:
+ * Every job is put through the capture contract (#693), every letter through
+ * the letter contract (#711), and every résumé through the résumé contract
+ * (#757), BEFORE any store is touched — the file is the boundary at which
+ * `JobRecord` / `LetterRecord` / `ResumeRecord` stop being types TypeScript can
+ * vouch for. Three things follow from where that check sits:
  *
  *  - **Skip the record, not the document.** One malformed job must not cost the
  *    user the other forty, and it must not cost them their resumes.
@@ -186,10 +232,20 @@ export async function exportToJson(): Promise<string> {
  *    unreachable.
  *  - **Report it.** A silently-dropped record is the real failure mode here, so
  *    the skips ride back on {@link ImportCounts} and `ResumeLibrary` announces
- *    them in its `aria-live` region. Skipped LETTERS ride back too but are not
- *    announced yet — there is no letters surface to announce them next to. The
- *    counter still lands now, because one added later cannot recover the
- *    records already dropped in silence.
+ *    skipped JOBS in its `aria-live` region. Skipped LETTERS and RESUMES ride
+ *    back too but are not announced yet — neither has a skip-list surface to
+ *    announce next to. The counters still land now, because one added later
+ *    cannot recover the records already dropped in silence.
+ *
+ * Every write below runs inside `runBatchedWrites` (#760): a restore can be
+ * hundreds of records, and without coalescing each `putRecord`/`clearStore`
+ * call would post its own change signal, driving one full re-read per
+ * message in every other open tab. Emit-side coalescing — one signal per
+ * store touched, posted once the whole restore finishes — was chosen over a
+ * debounce on the receiving hooks because the latter only reduces re-reads;
+ * it cannot make the message count itself bounded, which is what a bulk
+ * import has to prove (see `library-changes.test.ts`'s message-count
+ * assertion).
  */
 export async function importAll(
   data: StorageExport,
@@ -209,44 +265,114 @@ export async function importAll(
   // every backup a user already has on disk still restorable.
   const incomingLetters: unknown[] = data.version === 2 ? data.letters : [];
 
+  const resumes = partitionResumes(data.resumes);
   const jobs = partitionJobs(data.jobs);
   const letters = partitionLetters(incomingLetters);
 
-  if (mode === "replace") {
-    await clearStore("resumes");
-    await clearStore("jobs");
-    // Cleared even when the document is v1 and therefore contributes no
-    // letters. Replace means "make storage match this file", and skipping the
-    // wipe would leave letters whose jobs were just deleted — orphans the
-    // `deleteJob` cascade exists to make impossible.
-    await clearStore("letters");
-  }
+  // The whole restore — the replace-mode wipe and every put below — runs in
+  // one `runBatchedWrites` scope (#760), so a store that gets both cleared
+  // and repopulated here still posts only the one coalesced signal, not one
+  // for the clear and another for the puts.
+  await runBatchedWrites(async () => {
+    if (mode === "replace") {
+      await clearStore("resumes");
+      await clearStore("jobs");
+      // Cleared even when the document is v1 and therefore contributes no
+      // letters. Replace means "make storage match this file", and skipping
+      // the wipe would leave letters whose jobs were just deleted — orphans
+      // the `deleteJob` cascade exists to make impossible.
+      await clearStore("letters");
+    }
 
-  // `touch: false` throughout (#730): a restored record keeps the `updatedAt`
-  // it had when the backup was taken. That timestamp describes the user's last
-  // edit, and a restore is not one — stamping `now` over it collapsed the whole
-  // library into a single instant, which silently reordered a tracker sorted
-  // most-recently-updated-first and, since v4, would tell a replicator that
-  // every record on the device had just changed. A record the file carries no
-  // timestamp for still gets `now` from `putRecord`.
-  for (const { blobBase64, blobType, ...rest } of data.resumes) {
-    const blob = new Blob([base64ToBytes(blobBase64)], { type: blobType });
-    await putRecord<ResumeRecord>("resumes", { ...rest, blob }, { touch: false });
-  }
-  for (const job of jobs.accepted) {
-    await putRecord<JobRecord>("jobs", job, { touch: false });
-  }
-  for (const letter of letters.accepted) {
-    await putRecord<LetterRecord>("letters", letter, { touch: false });
-  }
+    // `touch: false` throughout (#730): a restored record keeps the
+    // `updatedAt` it had when the backup was taken. That timestamp describes
+    // the user's last edit, and a restore is not one — stamping `now` over it
+    // collapsed the whole library into a single instant, which silently
+    // reordered a tracker sorted most-recently-updated-first and, since v4,
+    // would tell a replicator that every record on the device had just
+    // changed. A record the file carries no timestamp for still gets `now`
+    // from `putRecord`.
+    for (const resume of resumes.accepted) {
+      await putRecord<ResumeRecord>("resumes", resume, { touch: false });
+    }
+    for (const job of jobs.accepted) {
+      await putRecord<JobRecord>("jobs", job, { touch: false });
+    }
+    for (const letter of letters.accepted) {
+      await putRecord<LetterRecord>("letters", letter, { touch: false });
+    }
+  });
 
   return {
-    resumes: data.resumes.length,
+    resumes: resumes.accepted.length,
+    skippedResumes: resumes.skipped,
+    resumesWithoutParse: resumes.accepted.filter((r) => r.parse === undefined).length,
     jobs: jobs.accepted.filter(isLive).length,
     skippedJobs: jobs.skipped,
     letters: letters.accepted.filter(isLive).length,
     skippedLetters: letters.skipped,
   };
+}
+
+/**
+ * Split a file's résumés into the ones the résumé contract accepts and the
+ * ones it refused. `blobBase64`/`blobType` are not part of that contract (see
+ * `resume-record-contract.ts`'s module docblock) — checked here, at the one
+ * call site that decodes them, before the rest of the candidate reaches
+ * {@link validateResumeRecord}. Runs before any store is touched — see
+ * {@link importAll}.
+ */
+function partitionResumes(candidates: unknown[]): {
+  accepted: ResumeRecord[];
+  skipped: SkippedResume[];
+} {
+  const accepted: ResumeRecord[] = [];
+  const skipped: SkippedResume[] = [];
+  for (const candidate of candidates) {
+    const blobIssue = resumeBlobFieldsIssue(candidate);
+    if (blobIssue !== undefined) {
+      skipped.push({
+        id: readStringField(candidate, "id"),
+        filename: readStringField(candidate, "filename"),
+        reason: blobIssue,
+      });
+      continue;
+    }
+    // `resumeBlobFieldsIssue` above already proved `candidate` is a plain
+    // object with string `blobBase64`/`blobType`.
+    const { blobBase64, blobType, ...rest } = candidate as Record<string, unknown> & {
+      blobBase64: string;
+      blobType: string;
+    };
+    const validation = validateResumeRecord(rest);
+    if (!validation.ok) {
+      skipped.push({
+        id: readStringField(candidate, "id"),
+        filename: readStringField(candidate, "filename"),
+        reason: validation.reasons.join(" "),
+      });
+      continue;
+    }
+    const blob = new Blob([base64ToBytes(blobBase64)], { type: blobType });
+    accepted.push({ ...validation.record, blob });
+  }
+  return { accepted, skipped };
+}
+
+/** `blobBase64`/`blobType` are the two fields `resume-record-contract.ts`
+ *  deliberately does not check (see its module docblock) — this is where they
+ *  actually are. A candidate that fails this never reaches
+ *  {@link validateResumeRecord} at all, since there would be no bytes to
+ *  rebuild a `Blob` from even if the rest of it were valid. */
+function resumeBlobFieldsIssue(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return "A resume record must be a plain JSON object.";
+  if (typeof value.blobBase64 !== "string") {
+    return "`blobBase64` is required and must be a string.";
+  }
+  if (typeof value.blobType !== "string") {
+    return "`blobType` is required and must be a string.";
+  }
+  return undefined;
 }
 
 /** Split a file's jobs into the ones the capture contract accepts and the ones

--- a/src/lib/storage/crud.ts
+++ b/src/lib/storage/crud.ts
@@ -10,7 +10,100 @@
 
 import type { IDBPDatabase } from "idb";
 import { getDB, UPDATED_AT_INDEX } from "./db.ts";
+import { postLibraryChange } from "./library-channel.ts";
 import type { StoreName, StoredRecord, SyncableStoreName } from "./types.ts";
+
+/**
+ * Emit-side coalescing scope for a bulk write (#760). While at least one scope
+ * is open, a write records which store it touched instead of posting a change
+ * signal immediately; one message per touched store goes out when the LAST
+ * open scope closes, regardless of how many writes happened inside.
+ *
+ * This exists for `importAll` in `backup.ts` and `archiveJobs` in `jobs.ts`
+ * (#759) — both per-record write loops that would otherwise post one message
+ * per record and drive one full re-read per message in every other open tab;
+ * the acceptance bar is a bounded message count for a bulk write, not a
+ * debounce on the receiving side (see `backup.ts` for the reasoning).
+ *
+ * Deliberately not exported past this directory (not part of the barrel in
+ * `index.ts`): an outside producer — the browser extension — writes through
+ * `putRecord` directly and gets the unbatched, per-call behaviour, which is
+ * correct for it too. It isn't running a bulk loop like the two callers
+ * above, so there is nothing here for it to opt into. A future bulk write
+ * from OUTSIDE `src/lib/storage/` belongs beside these two — as a named
+ * primitive in its own store module — rather than as a barrel export of this
+ * seam itself.
+ */
+const batchedStores = new Set<StoreName>();
+
+/**
+ * How many `runBatchedWrites` scopes are open right now.
+ *
+ * A COUNT rather than a nullable "am I the outermost call" flag, and the
+ * difference is the whole correctness of this seam. A flag only distinguishes
+ * genuine call-stack nesting; two independent calls whose lifetimes merely
+ * OVERLAP — each `await`ing its own row loop, interleaved by the event loop —
+ * both look outermost to a flag, so whichever finished first would close the
+ * scope and every subsequent write of the still-running call would fall
+ * through to the unbatched branch and post one message per record again. That
+ * is the exact defect #760's bounded-message-count bar exists to prevent,
+ * reached by two concurrent bulk writers instead of one looping caller.
+ */
+let openScopes = 0;
+
+/**
+ * Run `write` with change signals coalesced — see the module note above.
+ *
+ * Safe under BOTH shapes a second call can take:
+ *
+ *  - **Nested** (a batched caller calling another batched function) — the
+ *    inner scope's close leaves the count above zero, so it posts nothing and
+ *    the outer close carries its stores out.
+ *  - **Concurrent** (two independent calls overlapping in time) — the same
+ *    arithmetic covers it, because the count does not care which call is
+ *    which. Both calls' touched stores accumulate into one set and flush
+ *    together when the LATER one closes.
+ *
+ * That second case defers the earlier call's signal until the later call
+ * finishes, which is more coalescing than a per-call scope would do, and is
+ * sound because of what the message is: `library-channel.ts` carries only a
+ * store name and means "re-read this store" — never "here is what changed",
+ * and never an ordering token. Delivering one signal after both writers are
+ * done therefore makes every subscriber read the state that includes both,
+ * which is strictly fresher than what an earlier flush could have shown. The
+ * delay is bounded by the longer of the two operations, which the subscriber
+ * would have waited out anyway; and the tab that made the writes does not
+ * depend on the message at all (it refreshes directly, and the channel
+ * self-excludes — see `library-channel.ts`).
+ *
+ * The decrement is in a `finally` and precedes the flush, so a write that
+ * THROWS cannot leave the count above zero and wedge every later emit into a
+ * scope that never closes. The stores accumulated before the throw are still
+ * flushed on the way out, which is correct: writes that did land are changes
+ * other tabs must be told about, whether or not the caller finished.
+ */
+export async function runBatchedWrites<T>(write: () => Promise<T>): Promise<T> {
+  openScopes += 1;
+  try {
+    return await write();
+  } finally {
+    openScopes -= 1;
+    if (openScopes === 0) {
+      // Snapshot and clear BEFORE posting: `postLibraryChange` is synchronous
+      // and re-entrant in principle, and a listener that wrote back into the
+      // set being iterated would otherwise lose or re-post a store.
+      const touched = [...batchedStores];
+      batchedStores.clear();
+      for (const store of touched) postLibraryChange(store);
+    }
+  }
+}
+
+/** Post now, or record for the open `runBatchedWrites` scopes to flush. */
+function emitChange(store: StoreName): void {
+  if (openScopes > 0) batchedStores.add(store);
+  else postLibraryChange(store);
+}
 
 /**
  * The store-typed `getDB()` keys `get`/`put` to a specific store's value type,
@@ -64,6 +157,7 @@ export async function putRecord<T extends StoredRecord>(
         : now,
   } as T;
   await db.put(store, written);
+  emitChange(store);
   return written;
 }
 
@@ -149,6 +243,12 @@ export async function listRecordsUpdatedSince<T extends StoredRecord>(
  * This is also why it does not take `putRecord`'s `touch: false`: a deletion is
  * a user action, and floating it to the top of a most-recently-updated-first
  * list is correct — the row is about to stop being rendered anyway.
+ *
+ * Emits a change signal (#760) on the same footing as `putRecord` — a
+ * tombstone is a write through this same funnel, and skipping it would leave
+ * a deleted job or letter visible in every other open tab. Only when the
+ * tombstone is actually written; the early `return false` above is a no-op
+ * and posts nothing, matching "a read posts none".
  */
 export async function softDeleteRecord(
   store: StoreName,
@@ -159,6 +259,7 @@ export async function softDeleteRecord(
   if (existing === undefined || !isLive(existing)) return false;
   const now = Date.now();
   await db.put(store, { ...existing, deletedAt: now, updatedAt: now });
+  emitChange(store);
   return true;
 }
 
@@ -176,10 +277,12 @@ export async function deleteRecord(
 ): Promise<void> {
   const db = await looseDB();
   await db.delete(store, id);
+  emitChange(store);
 }
 
 /** Wipe every record from a store. Used by import (replace mode) and tests. */
 export async function clearStore(store: StoreName): Promise<void> {
   const db = await looseDB();
   await db.clear(store);
+  emitChange(store);
 }

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -18,14 +18,34 @@
  *    capture contract and the cover-letter contract below, both normative for
  *    third-party producers per `docs/job-capture-contract.md` and
  *    `docs/cover-letter-contract.md`). The vocabulary the module only talks to
- *    itself in — `StoredRecord`, `StoreName`, `ResumeRecord`, `SaveResumeInput`,
- *    `ExportedResume`, `StorageExport`, `LETTER_RECORD_RULES`, and the
+ *    itself in — `StoredRecord`, `ResumeRecord`, `SaveResumeInput`,
+ *    `ExportedResume`, `StorageExport`, `LETTER_RECORD_RULES`,
+ *    `RESUME_RECORD_RULES`/`validateResumeRecord` (#757 — unlike the job and
+ *    letter contracts, there is no third-party résumé producer doc to be
+ *    normative for; only `backup.ts` calls it), and the
  *    `exportAll`/`exportToJson`/`importAll` primitives under
  *    {@link downloadStorageBackup} and {@link importFromJson} — is deliberately
- *    absent.
+ *    absent. `postLibraryChange` and its batching seam (`runBatchedWrites`)
+ *    are absent for the same reason: `crud.ts` is the only poster, and
+ *    `backup.ts` and `jobs.ts` (#759) are the only batchers — both live
+ *    inside this directory and reach `runBatchedWrites` directly, so nothing
+ *    outside it needs the seam itself.
+ *
+ *    `SkippedResume` (#757) and `LibraryChangeMessage` (#760) are the two most
+ *    recent applications of that rule, and both are worth naming because their
+ *    siblings DID earn slots: `SkippedJob` has a consumer
+ *    (`ResumeLibraryImportDialog`) and `SkippedLetter` is registered in
+ *    `.fallowrc.jsonc` against `docs/cover-letter-contract.md`. `SkippedResume`
+ *    has neither — no surface renders a refused résumé yet — so it stays on
+ *    `backup.ts`, where {@link ImportCounts} needs it. `LibraryChangeMessage`
+ *    never had a caller in a position to name it, since {@link onLibraryChange}
+ *    hands its subscriber a bare `StoreName` and never the message; it is
+ *    module-local in `library-channel.ts` rather than re-exported here.
  *  - Conversely, a name a consumer needs belongs here. Withholding one is what
  *    produced the deep imports of `./types.ts` this barrel exists to prevent:
  *    `JobStatus` and `JOB_STATUS_ORDER` were reachable no other way.
+ *    `StoreName` joined for the same reason (#760): `useLibraryChanges`
+ *    (`src/hooks/`) has to name the store it's subscribing to.
  *
  * The one standing exception is `src/lib/job-search/board-cache.ts`, which
  * reaches `./crud.ts` for the generic `getRecord`/`putRecord` accessors. There
@@ -42,7 +62,7 @@ export {
   listResumeChoices,
   type ResumeChoice,
 } from "./resumes.ts";
-export { saveJob, getJob, getAllJobs, deleteJob } from "./jobs.ts";
+export { saveJob, getJob, getAllJobs, deleteJob, archiveJobs } from "./jobs.ts";
 export {
   saveLetter,
   getLetter,
@@ -115,4 +135,14 @@ export type {
   LetterProvenance,
   SyncableStoreName,
   SyncCursorRecord,
+  StoreName,
 } from "./types.ts";
+/**
+ * Same-origin change signal (#760) — `useJobTracker`/`useResumeLibrary`
+ * subscribe through `useLibraryChanges` (`src/hooks/`) so an open tab
+ * re-reads after a write made anywhere else: another tab, a restored backup,
+ * an out-of-tree producer writing through `putRecord`. `postLibraryChange`
+ * and the batching seam it rides on stay internal to this directory —
+ * `crud.ts` is the only poster; see `library-channel.ts`.
+ */
+export { onLibraryChange } from "./library-channel.ts";

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -13,6 +13,7 @@ import {
   getAllRecords,
   isLive,
   softDeleteRecord,
+  runBatchedWrites,
 } from "./crud.ts";
 import { deleteLettersForJob } from "./letters.ts";
 import type { JobRecord } from "./types.ts";
@@ -82,4 +83,107 @@ export function getAllJobs(): Promise<JobRecord[]> {
 export async function deleteJob(id: string): Promise<void> {
   await softDeleteRecord("jobs", id);
   await deleteLettersForJob(id);
+}
+
+/** Options for {@link archiveJobs}. One required member, deliberately — see
+ *  that function's docblock for why the eligibility check cannot default. */
+export interface ArchiveJobsOptions {
+  /**
+   * Re-checked against each row as it stands the instant before its write. A
+   * row that answers `false` is SKIPPED, exactly as an id that has vanished
+   * is, and is absent from the returned list.
+   *
+   * Required rather than optional, and injected rather than imported. Both
+   * follow from the same two facts:
+   *
+   *  - **Injected**, because the only predicate that answers this question —
+   *    `job-archive-sweep.ts`'s `isSweepableBucket`, via
+   *    `job-status-bucket.ts` — sits a layer ABOVE `src/lib/storage/`, and
+   *    `job-status-bucket.ts` imports this directory's own barrel. Importing
+   *    it down here would both invert the layering (no non-test module in
+   *    this directory imports from `../`) and close an import cycle
+   *    `index.ts` → `jobs.ts` → `job-status-bucket.ts` → `index.ts`. Passing
+   *    the predicate in keeps the store domain-agnostic, which is the whole
+   *    premise of `saveJob` writing whatever fields it is handed.
+   *  - **Required**, because a default would have to be "everything is still
+   *    eligible", which is precisely the bug this parameter exists to close;
+   *    a future caller that forgot it would silently get the unguarded loop
+   *    back. The type makes forgetting impossible instead.
+   *
+   * It must be a check that carries no clock. See `job-archive-sweep.ts` for
+   * why the sweep's AGE half is settled once, at confirm time, and never
+   * re-derived here.
+   */
+  stillEligible: (job: JobRecord) => boolean;
+}
+
+/**
+ * Set `status: "archived"` on every job in `ids`, one write each. The
+ * bulk-archive sweep (#759) is this store's second per-record write loop —
+ * `backup.ts`'s `importAll` is the first, and the reason `runBatchedWrites`
+ * (`crud.ts`) exists at all. Without it, sweeping ~290 rows in one click
+ * would post ~290 `BroadcastChannel` messages and drive ~290 full re-reads in
+ * every OTHER open tab; wrapping the loop coalesces that to the one message
+ * `runBatchedWrites` already guarantees per store touched.
+ *
+ * Sequential and awaited, not `Promise.all` or chunked — decided at #759: the
+ * writes are a small, one-time, user-confirmed action, and a partial failure
+ * the preview count didn't describe is worse than one that takes slightly
+ * longer to finish.
+ *
+ * ## Why each row is re-read AND re-judged
+ *
+ * `ids` is a list the caller computed at some earlier moment — for the sweep,
+ * when the user was shown a count and clicked Confirm. Because the loop is
+ * sequential and awaited, a row near the end of a ~290-row sweep is written
+ * appreciably later than that decision, and anything may have happened to it
+ * in between: another tab, the browser extension writing through `putRecord`,
+ * or a sync. So each id is re-read through `getJob` and then put to
+ * `stillEligible` immediately before its own write:
+ *
+ *  - **Gone** — deleted or merged away — `getJob` returns undefined and the
+ *    row is skipped, rather than a `saveJob` resurrecting a tombstone.
+ *  - **No longer eligible** — someone moved it to Applied — `stillEligible`
+ *    answers false and the row is skipped the same way. Without this the
+ *    sweep would overwrite that Applied status with `"archived"`, breaking
+ *    the guarantee `JobArchiveSweepDialog` states at the confirm step
+ *    ("Applied, Interviewing, Offer, and Rejected jobs are never touched")
+ *    and destroying pipeline state the user built by hand.
+ *
+ * This narrows the window; it does not make the write atomic. `getJob` and
+ * `saveJob` are two separate IndexedDB transactions, so a writer that lands
+ * between them is still unseen. What changes is the size of the exposure: it
+ * goes from "the entire duration of the sweep, for every row in it" to "the
+ * gap between one row's read and its own write". Closing it completely would
+ * need a read-modify-write inside a single transaction, which this layer does
+ * not currently expose; the residual gap is recorded here rather than papered
+ * over.
+ *
+ * ## What the caller learns about a skip
+ *
+ * Nothing is added for it, on purpose. The return value is already the report:
+ * skipped rows are simply absent, so `archiveInterestedOlderThan` — which
+ * returns `archived.length` — hands `JobArchiveSweepDialog` the number of rows
+ * actually written, and the dialog's "Archived N jobs." is true by
+ * construction. Under a concurrent status change that number is now smaller
+ * than the previewed count, which is the honest outcome: the alternative is
+ * either reporting a count larger than the writes, or building a
+ * skipped-rows channel no surface renders.
+ *
+ * Returns the records actually archived, in `ids` order minus any skipped.
+ */
+export async function archiveJobs(
+  ids: readonly string[],
+  options: ArchiveJobsOptions,
+): Promise<JobRecord[]> {
+  return runBatchedWrites(async () => {
+    const archived: JobRecord[] = [];
+    for (const id of ids) {
+      const existing = await getJob(id);
+      if (existing === undefined) continue;
+      if (!options.stillEligible(existing)) continue;
+      archived.push(await saveJob({ ...existing, status: "archived", id }));
+    }
+    return archived;
+  });
 }

--- a/src/lib/storage/library-changes.test.ts
+++ b/src/lib/storage/library-changes.test.ts
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `crud.ts`'s change-signal emission and `backup.ts`'s bulk-import
+ * coalescing (#760) — the storage-layer half of the fix; `library-channel.ts`
+ * itself is unit-tested in `library-channel.test.ts`.
+ *
+ * Every listener here is a RAW `BroadcastChannel` opened directly on
+ * `LIBRARY_CHANGE_CHANNEL_NAME`, not `onLibraryChange`. `crud.ts` posts
+ * through `library-channel.ts`'s one shared module-scoped object, and
+ * `onLibraryChange` listens through that SAME object — so a listener
+ * registered via `onLibraryChange` would never see these posts (that
+ * self-exclusion is the point, and is asserted directly in
+ * `library-channel.test.ts`). A raw channel is the shape a second tab
+ * actually has, and it's what lets this file observe crud.ts's emissions at
+ * all.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  settleWithoutDelivery,
+  waitForDelivery,
+} from "./__test-utils__/library-channel-delivery.ts";
+import { DB_NAME, closeDB } from "./db.ts";
+import { LIBRARY_CHANGE_CHANNEL_NAME } from "./library-channel.ts";
+import {
+  putRecord,
+  deleteRecord,
+  clearStore,
+  softDeleteRecord,
+  runBatchedWrites,
+} from "./crud.ts";
+import { getAllRecords, getRecord } from "./crud.ts";
+import { saveJob, archiveJobs } from "./jobs.ts";
+import { importAll } from "./backup.ts";
+import type { JobRecord, StorageExport } from "./types.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+/** Every archive in this file sweeps rows that really are still Interested,
+ *  so the last-instant eligibility re-check `archiveJobs` requires (see its
+ *  docblock) is the production one: `job-archive-sweep.ts`'s bucket test,
+ *  spelled out here rather than imported because `src/lib/storage/` does not
+ *  import upward. The one test that needs it to answer FALSE overrides it. */
+const stillInterested = (job: JobRecord) => job.status === "interested";
+
+/** Opens a raw listener on the change channel and hands back the messages it
+ *  has seen plus a teardown. Sibling of `library-channel.test.ts`'s helper —
+ *  duplicated rather than imported because it's the only thing this file
+ *  needs from that pattern. */
+function listenForChanges(): {
+  received: { store: string }[];
+  close: () => void;
+} {
+  const channel = new BroadcastChannel(LIBRARY_CHANGE_CHANNEL_NAME);
+  const received: { store: string }[] = [];
+  channel.addEventListener("message", (event) => {
+    received.push((event as MessageEvent<{ store: string }>).data);
+  });
+  return { received, close: () => channel.close() };
+}
+
+function validJob(id: string): JobRecord {
+  return {
+    id,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    title: `Job ${id}`,
+    company: "Acme",
+    status: "interested",
+  };
+}
+
+describe("crud.ts: writes post one change signal each, reads post none (#760)", () => {
+  it("putRecord posts one message naming the store, carrying no record content or id", async () => {
+    const listener = listenForChanges();
+    try {
+      const job = await putRecord<JobRecord>("jobs", {
+        id: "job-1",
+        title: "SWE",
+        company: "Acme",
+        status: "interested",
+      });
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+      // Sanity: the write really happened, so this isn't passing by accident.
+      expect(job.id).toBe("job-1");
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("deleteRecord posts one message naming the store", async () => {
+    await putRecord<JobRecord>("jobs", { id: "job-1", title: "SWE", company: "Acme", status: "interested" });
+    const listener = listenForChanges();
+    try {
+      await deleteRecord("jobs", "job-1");
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("clearStore posts one message naming the store", async () => {
+    await putRecord<JobRecord>("jobs", { id: "job-1", title: "SWE", company: "Acme", status: "interested" });
+    const listener = listenForChanges();
+    try {
+      await clearStore("jobs");
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("softDeleteRecord posts one message when it actually tombstones a record", async () => {
+    await putRecord<JobRecord>("jobs", { id: "job-1", title: "SWE", company: "Acme", status: "interested" });
+    const listener = listenForChanges();
+    try {
+      const deleted = await softDeleteRecord("jobs", "job-1");
+      expect(deleted).toBe(true);
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("softDeleteRecord posts nothing on a no-op (already deleted / never existed)", async () => {
+    const listener = listenForChanges();
+    try {
+      const deleted = await softDeleteRecord("jobs", "does-not-exist");
+      expect(deleted).toBe(false);
+      await settleWithoutDelivery();
+      expect(listener.received).toEqual([]);
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("a read posts nothing", async () => {
+    await putRecord<JobRecord>("jobs", { id: "job-1", title: "SWE", company: "Acme", status: "interested" });
+    const listener = listenForChanges();
+    try {
+      await getAllRecords<JobRecord>("jobs");
+      await settleWithoutDelivery();
+      expect(listener.received).toEqual([]);
+    } finally {
+      listener.close();
+    }
+  });
+});
+
+describe("backup.ts: importAll coalesces a bulk write to one signal per store (#760)", () => {
+  it("a large replace-mode import posts a bounded message count, not one per record", async () => {
+    const jobCount = 50;
+    const doc: StorageExport = {
+      version: 1,
+      exportedAt: Date.now(),
+      resumes: [],
+      jobs: Array.from({ length: jobCount }, (_, i) => validJob(`job-${i}`)),
+    };
+
+    const listener = listenForChanges();
+    try {
+      const counts = await importAll(doc, "replace");
+      await waitForDelivery(() =>
+        expect(listener.received.map((m) => m.store).sort()).toEqual([
+          "jobs",
+          "letters",
+          "resumes",
+        ]),
+      );
+      expect(counts.jobs).toBe(jobCount);
+      // The whole point: NOT one message per record. Replace mode clears
+      // all three stores regardless of what the document carries, so this
+      // posts exactly one message per store (3) — bounded by the store
+      // count, independent of how many of the 50 job records were written.
+      expect(listener.received.length).toBeLessThan(jobCount);
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("a merge-mode import touching two stores posts at most one signal per store", async () => {
+    await saveJob({ title: "Existing", status: "interested" });
+    const doc: StorageExport = {
+      version: 1,
+      exportedAt: Date.now(),
+      resumes: [],
+      jobs: Array.from({ length: 10 }, (_, i) => validJob(`merge-job-${i}`)),
+    };
+
+    const listener = listenForChanges();
+    try {
+      await importAll(doc, "merge");
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+      // Only `jobs` was touched by this document — `resumes`/`letters` see no
+      // write at all in merge mode with an empty incoming list, so they post
+      // nothing.
+      expect(listener.received).toEqual([{ store: "jobs" }]);
+    } finally {
+      listener.close();
+    }
+  });
+});
+
+describe("jobs.ts: archiveJobs coalesces the bulk-archive sweep to one signal (#759)", () => {
+  it("archiving many rows posts one message, not one per row", async () => {
+    const rowCount = 20;
+    const ids: string[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const job = await saveJob({ title: `Job ${i}`, company: "Acme", status: "interested" });
+      ids.push(job.id);
+    }
+
+    const listener = listenForChanges();
+    try {
+      const archived = await archiveJobs(ids, {
+        stillEligible: stillInterested,
+      });
+      expect(archived).toHaveLength(rowCount);
+      expect(archived.every((j) => j.status === "archived")).toBe(true);
+      // The whole point (#759, same shape as importAll above): NOT one
+      // message per row.
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("skips an id already gone rather than resurrecting it, and still posts nothing for zero live ids", async () => {
+    const listener = listenForChanges();
+    try {
+      const archived = await archiveJobs(["never-existed"], {
+        stillEligible: stillInterested,
+      });
+      expect(archived).toEqual([]);
+      await settleWithoutDelivery();
+      expect(listener.received).toEqual([]);
+    } finally {
+      listener.close();
+    }
+  });
+});
+
+describe("crud.ts: runBatchedWrites coalesces across CONCURRENT scopes, not just nested ones (#760)", () => {
+  it("two overlapping batched calls still post one message per store", async () => {
+    // The regression this file failed to catch. A flag-based "am I the
+    // outermost call" scope only handles genuine call-stack nesting: two
+    // independent calls whose lifetimes overlap both look outermost, so the
+    // one that finishes first closes the scope and every remaining write of
+    // the OTHER falls through to the unbatched branch — one message per
+    // record again, which is precisely what #760's bounded-count bar exists
+    // to rule out.
+    //
+    // Shapes deliberately mismatched, the way the two real callers are: a
+    // short `resumes` write finishing early, and a longer `jobs` loop with an
+    // await between rows (archiveJobs's shape) that keeps running after it.
+    const listener = listenForChanges();
+    try {
+      // The SHORT call opens its scope FIRST and closes it FIRST. That order
+      // is the whole repro: under a flag-based scope it is the one that looks
+      // outermost, so its close tears the scope down while the long call is
+      // still mid-loop, and every remaining `jobs` write falls through to the
+      // unbatched branch.
+      const rowCount = 5;
+      const shortCall = runBatchedWrites(async () => {
+        await putRecord("resumes", { id: "concurrent-resume" });
+      });
+      const longCall = runBatchedWrites(async () => {
+        for (let i = 0; i < rowCount; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          await putRecord<JobRecord>("jobs", {
+            id: `concurrent-job-${i}`,
+            title: "SWE",
+            company: "Acme",
+            status: "interested",
+          });
+        }
+      });
+
+      await Promise.all([shortCall, longCall]);
+
+      await waitForDelivery(() =>
+        expect(listener.received.map((m) => m.store).sort()).toEqual([
+          "jobs",
+          "resumes",
+        ]),
+      );
+      // Both stores, once each — never `rowCount` messages for `jobs`. The
+      // short call's signal is deferred to the long call's close, which is
+      // MORE coalescing than a per-call scope would give and is sound
+      // because the message only ever means "re-read this store".
+      expect(listener.received).toHaveLength(2);
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("a throwing write still flushes what landed and leaves the scope closed", async () => {
+    // Exception safety, both halves. The `finally` must decrement even on a
+    // throw: a counter stuck above zero would wedge every LATER emit into a
+    // scope that never closes, so the next unbatched write would go silent
+    // forever — a far worse failure than the one being fixed. And the writes
+    // that did land before the throw are real changes other tabs must be
+    // told about, so they flush on the way out rather than being discarded.
+    const listener = listenForChanges();
+    try {
+      await expect(
+        runBatchedWrites(async () => {
+          await putRecord<JobRecord>("jobs", {
+            id: "before-throw",
+            title: "SWE",
+            company: "Acme",
+            status: "interested",
+          });
+          throw new Error("write failed");
+        }),
+      ).rejects.toThrow("write failed");
+
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([{ store: "jobs" }]),
+      );
+      expect(await getRecord<JobRecord>("jobs", "before-throw")).toBeDefined();
+
+      // The scope really is closed: a plain unbatched write posts
+      // immediately, which it could not do if the counter were still above
+      // zero.
+      await putRecord("resumes", { id: "after-throw" });
+      await waitForDelivery(() =>
+        expect(listener.received).toEqual([
+          { store: "jobs" },
+          { store: "resumes" },
+        ]),
+      );
+    } finally {
+      listener.close();
+    }
+  });
+});

--- a/src/lib/storage/library-channel.test.ts
+++ b/src/lib/storage/library-channel.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit tests for the low-level change-signal primitive (#760). `crud.ts`'s
+ * own emission and `backup.ts`'s bulk-import coalescing are covered in
+ * `library-changes.test.ts`; this file is only about the `BroadcastChannel`
+ * wrapper itself.
+ *
+ * A real second tab has its OWN `BroadcastChannel` object on this channel
+ * name, so every "another tab wrote" case here opens a raw channel of its
+ * own rather than going through this module's `postLibraryChange` — using
+ * the module's own function for both sides would route through the ONE
+ * shared object `postLibraryChange`/`onLibraryChange` use (see the module
+ * docblock), which is precisely the self-excluded, same-tab case the last
+ * test below asserts.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  settleWithoutDelivery,
+  waitForDelivery,
+} from "./__test-utils__/library-channel-delivery.ts";
+import {
+  postLibraryChange,
+  onLibraryChange,
+  LIBRARY_CHANGE_CHANNEL_NAME,
+} from "./library-channel.ts";
+
+describe("library-channel: onLibraryChange receives a message from another tab", () => {
+  it("delivers the store name a raw channel on the same name posted", async () => {
+    const outsideChannel = new BroadcastChannel(LIBRARY_CHANGE_CHANNEL_NAME);
+    const received: string[] = [];
+    const unsubscribe = onLibraryChange((store) => received.push(store));
+    try {
+      outsideChannel.postMessage({ store: "jobs" });
+      await waitForDelivery(() => expect(received).toEqual(["jobs"]));
+    } finally {
+      unsubscribe();
+      outsideChannel.close();
+    }
+  });
+
+  it("stops delivering after unsubscribe", async () => {
+    const outsideChannel = new BroadcastChannel(LIBRARY_CHANGE_CHANNEL_NAME);
+    const received: string[] = [];
+    const unsubscribe = onLibraryChange((store) => received.push(store));
+    try {
+      unsubscribe();
+      outsideChannel.postMessage({ store: "resumes" });
+      await settleWithoutDelivery();
+      expect(received).toEqual([]);
+    } finally {
+      outsideChannel.close();
+    }
+  });
+});
+
+describe("library-channel: postLibraryChange", () => {
+  it("posts a message carrying only the store name — no record content, no id", async () => {
+    const outsideChannel = new BroadcastChannel(LIBRARY_CHANGE_CHANNEL_NAME);
+    const received: unknown[] = [];
+    try {
+      outsideChannel.addEventListener("message", (event) => {
+        received.push((event as MessageEvent).data);
+      });
+      postLibraryChange("letters");
+      await waitForDelivery(() =>
+        expect(received).toEqual([{ store: "letters" }]),
+      );
+    } finally {
+      outsideChannel.close();
+    }
+  });
+
+  it("never delivers a message to the object that posted it — no self-delivery, no loop (#760)", async () => {
+    // `onLibraryChange` and `postLibraryChange` share ONE module-scoped
+    // `BroadcastChannel` object (see the module docblock). Per spec that
+    // object never receives its own posted message, which is the property
+    // this module leans on to guarantee a tab's own write can never
+    // re-trigger its own subscribers — the mutation that made the write
+    // already calls `refresh()` directly. Asserted directly rather than
+    // trusted as a comment: subscribe and post through the module's OWN
+    // functions (so both sides resolve to the same shared object) and prove
+    // nothing arrives.
+    //
+    // A raw outside channel witnesses the same post. Without it this test
+    // would also pass if `postLibraryChange` had simply done nothing at all —
+    // the two failures are indistinguishable from the subscriber's side. The
+    // witness turns "we saw no message" into "the message was really
+    // broadcast, reached a genuine destination, and still was not delivered
+    // back here", which is the claim the module actually makes.
+    const witness = new BroadcastChannel(LIBRARY_CHANGE_CHANNEL_NAME);
+    const witnessed: unknown[] = [];
+    witness.addEventListener("message", (event) => {
+      witnessed.push((event as MessageEvent).data);
+    });
+    const received: string[] = [];
+    const unsubscribe = onLibraryChange((store) => received.push(store));
+    try {
+      postLibraryChange("jobs");
+      await waitForDelivery(() =>
+        expect(witnessed).toEqual([{ store: "jobs" }]),
+      );
+      // Fixed settle on top, spent AFTER delivery is known to have happened:
+      // absence is the assertion, so it gets the budget rather than an early
+      // exit (see the helper module's docblock).
+      await settleWithoutDelivery();
+      expect(received).toEqual([]);
+    } finally {
+      unsubscribe();
+      witness.close();
+    }
+  });
+});

--- a/src/lib/storage/library-channel.ts
+++ b/src/lib/storage/library-channel.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Same-origin change signal for the local-first stores (#760).
+ *
+ * `useJobTracker` and `useResumeLibrary` only ever re-read after a mutation
+ * THEY made (see each hook's own `refresh` calls) — a write from anywhere
+ * else (another tab, a restored backup, the browser extension's content
+ * script writing through `putRecord`) never reaches an open page, and the
+ * page has no way to find out it went stale. A same-origin `BroadcastChannel`
+ * closes that gap: `crud.ts` posts on it after every write, and any
+ * subscriber re-reads.
+ *
+ * Two invariants this module exists to hold, both load-bearing enough that
+ * getting either wrong would make the fix worse than the bug it fixes:
+ *
+ *  - **No self-delivery.** `postLibraryChange` and `onLibraryChange` share
+ *    one module-scoped `BroadcastChannel` object (`getChannel()` below). Per
+ *    spec, a channel object never receives a message it itself posted, so a
+ *    write made by THIS tab can never re-trigger THIS tab's own subscribers —
+ *    the mutation that caused the write already calls `refresh()` directly,
+ *    and a self-delivered broadcast would only be a redundant re-read that
+ *    could, in a differently-shaped consumer, become a re-entrant loop. Two
+ *    independently-constructed `BroadcastChannel` objects on the same name —
+ *    the shape a second tab actually has — do NOT share that exclusion,
+ *    which is exactly the case this module exists to notify. See
+ *    `library-channel.test.ts` for the assertion, not just a comment.
+ *  - **The global is optional.** `crud.ts` is otherwise environment-agnostic
+ *    (the Node test env, a future non-browser consumer), so every entry
+ *    point here degrades to a no-op behind a `typeof` guard rather than
+ *    throwing or requiring a polyfill.
+ *
+ * The message is `{ store }` and nothing else — no record, no id. Carrying
+ * more would grow this into a second, unvalidated copy of the record shape
+ * that skips `putRecord` entirely; the signal only ever means "re-read this
+ * store", never "here is what changed".
+ */
+
+import type { StoreName } from "./types.ts";
+
+/** One string so a poster and a subscriber can never target two different
+ *  channels by typo. */
+const CHANNEL_NAME = "offlinecv:library-changes";
+
+/** Exported for `library-channel.test.ts` and the hook-level tests that
+ *  simulate a second tab by opening their OWN `BroadcastChannel` on this
+ *  name (a real second tab has its own object the same way) — not part of
+ *  the storage barrel surface, see `index.ts`'s admission rules. */
+export const LIBRARY_CHANGE_CHANNEL_NAME = CHANNEL_NAME;
+
+/** The posted payload. Module-local, not exported: {@link onLibraryChange}
+ *  hands its subscriber a bare {@link StoreName} and never the message, so no
+ *  caller outside this file can be in a position to name this type — and the
+ *  barrel's admission rule (`index.ts`) is that a name earns its slot by
+ *  having a consumer. Widening the payload is a change to this file alone. */
+interface LibraryChangeMessage {
+  /** The store a write touched. See the module docblock for why nothing
+   *  else rides along. */
+  store: StoreName;
+}
+
+// One BroadcastChannel object for the whole module, used for BOTH posting and
+// subscribing — that sharing is what makes self-exclusion apply to this
+// tab's own writes (see the module docblock); two separate objects would not
+// get it. Lazily opened (so an environment that never touches storage never
+// pays for it) and never closed: closing on one subscriber's unmount would
+// silently cut off every OTHER subscriber sharing this same object, so the
+// connection lives for the page's lifetime and the browser reclaims it on
+// unload.
+let channel: BroadcastChannel | undefined;
+let triedOpen = false;
+
+function getChannel(): BroadcastChannel | undefined {
+  if (!triedOpen) {
+    triedOpen = true;
+    if (typeof BroadcastChannel !== "undefined") {
+      channel = new BroadcastChannel(CHANNEL_NAME);
+    }
+  }
+  return channel;
+}
+
+/**
+ * Post a change signal for one store. No-ops when `BroadcastChannel` isn't
+ * available.
+ *
+ * Internal to `src/lib/storage/` — `crud.ts` is the only caller; see its
+ * `runBatchedWrites` for the seam that keeps a bulk import to one message per
+ * store instead of one per record.
+ */
+export function postLibraryChange(store: StoreName): void {
+  getChannel()?.postMessage({ store } satisfies LibraryChangeMessage);
+}
+
+/**
+ * Subscribe to change signals. Returns an unsubscribe function — call it on
+ * unmount. A no-op subscription (a teardown that does nothing) when
+ * `BroadcastChannel` isn't available, so a caller never needs its own
+ * environment check.
+ */
+export function onLibraryChange(
+  handler: (store: StoreName) => void,
+): () => void {
+  const ch = getChannel();
+  if (ch === undefined) return () => {};
+  const listener = (event: MessageEvent<LibraryChangeMessage>) => {
+    handler(event.data.store);
+  };
+  ch.addEventListener("message", listener);
+  return () => ch.removeEventListener("message", listener);
+}

--- a/src/lib/storage/resume-record-contract.test.ts
+++ b/src/lib/storage/resume-record-contract.test.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Résumé-record contract tests (#757). Modeled on
+ * `job-record-contract.test.ts`: a drift-guard pass over
+ * {@link RESUME_RECORD_RULES} exercises every field with no per-field
+ * maintenance, on top of the named-case coverage the issue's acceptance
+ * criteria call for.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  RESUME_RECORD_RULES,
+  validateResumeRecord,
+} from "./resume-record-contract.ts";
+
+/** A record every rule accepts — the baseline each case perturbs one field of.
+ *  `blobBase64`/`blobType` are deliberately absent: they are not part of this
+ *  contract (validated at the `backup.ts` call site instead). */
+function validRecord(): Record<string, unknown> {
+  return {
+    id: "resume-1",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_001_000,
+    filename: "cv.pdf",
+    parse: { result: { marker: "cascade-42" }, score: { overall: 72 }, sourceKind: "pdf" },
+  };
+}
+
+function reasons(value: unknown): string[] {
+  const result = validateResumeRecord(value);
+  return result.ok ? [] : result.reasons;
+}
+
+describe("validateResumeRecord: the baseline", () => {
+  it("accepts a fully-populated record unchanged", () => {
+    const result = validateResumeRecord(validRecord());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record).toEqual(validRecord());
+  });
+
+  it("accepts the minimum: an id and a filename, with parse absent", () => {
+    const result = validateResumeRecord({ id: "resume-1", filename: "cv.pdf" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect("parse" in result.record).toBe(false);
+  });
+
+  it.each([
+    ["a non-object", "not a record"],
+    ["null", null],
+    ["an array", [{ id: "resume-1", filename: "cv.pdf" }]],
+  ])("refuses %s", (_label, value) => {
+    expect(reasons(value)[0]).toMatch(/must be a plain JSON object/);
+  });
+});
+
+describe("validateResumeRecord: the named refusals", () => {
+  it("refuses a missing id", () => {
+    expect(reasons({ filename: "cv.pdf" })).toContainEqual(expect.stringContaining("`id`"));
+  });
+
+  it("refuses an empty id", () => {
+    expect(reasons({ id: "", filename: "cv.pdf" })).toContainEqual(
+      expect.stringContaining("`id`"),
+    );
+  });
+
+  it("refuses a missing filename", () => {
+    expect(reasons({ id: "resume-1" })).toContainEqual(expect.stringContaining("`filename`"));
+  });
+
+  it("refuses an empty filename", () => {
+    expect(reasons({ id: "resume-1", filename: "" })).toContainEqual(
+      expect.stringContaining("`filename`"),
+    );
+  });
+
+  it("refuses a non-string filename", () => {
+    expect(reasons({ id: "resume-1", filename: 42 })).toContainEqual(
+      expect.stringContaining("`filename`"),
+    );
+  });
+
+  it("refuses a record carrying a `__proto__` key", () => {
+    const hostile = JSON.parse(
+      '{"id":"resume-1","filename":"cv.pdf","__proto__":{"admin":true}}',
+    ) as unknown;
+    expect(reasons(hostile)[0]).toMatch(/__proto__/);
+  });
+
+  it("refuses a non-JSON-safe `parse`", () => {
+    expect(reasons({ ...validRecord(), parse: { at: new Date() } })).toContainEqual(
+      expect.stringContaining("parse.at"),
+    );
+  });
+
+  it("refuses a `parse` that is not a plain object", () => {
+    expect(reasons({ ...validRecord(), parse: "not an object" })).toContainEqual(
+      expect.stringContaining("`parse`"),
+    );
+  });
+
+  it("refuses a `parse` carrying a nested `__proto__` key", () => {
+    const hostile = JSON.parse(
+      '{"id":"resume-1","filename":"cv.pdf","parse":{"__proto__":{"admin":true}}}',
+    ) as unknown;
+    expect(reasons(hostile)[0]).toMatch(/__proto__/);
+  });
+});
+
+describe("validateResumeRecord: `parse` absent is accepted — it is a legal shape, not a refusal", () => {
+  it("accepts a record with no `parse` key at all", () => {
+    const result = validateResumeRecord({ id: "resume-1", filename: "cv.pdf" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("normalises `parse: null` to absent, the same legal state readSnapshot treats it as", () => {
+    const result = validateResumeRecord({ id: "resume-1", filename: "cv.pdf", parse: null });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect("parse" in result.record).toBe(false);
+  });
+
+  it("does NOT require `parse.result`/`parse.score` — storage treats `parse` as opaque", () => {
+    // The résumé contract deliberately does not assert the SavedResumeSnapshot
+    // shape (`result`/`score`/`sourceKind`/`shapeVersion`) — that belongs to
+    // `resume-library.ts`, one layer up. `listLibrary`'s `hasCachedParse` is
+    // where an unreadable-but-JSON-safe `parse` is reported, not here.
+    const result = validateResumeRecord({
+      id: "resume-1",
+      filename: "cv.pdf",
+      parse: { anything: "goes" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record.parse).toEqual({ anything: "goes" });
+  });
+});
+
+describe("validateResumeRecord: unknown extra keys are PRESERVED", () => {
+  it("carries an unrecognised field onto the stored record", () => {
+    const result = validateResumeRecord({ ...validRecord(), sourceDevice: "laptop" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.record as unknown as Record<string, unknown>).sourceDevice).toBe("laptop");
+  });
+
+  it("still requires an extra key's value to be JSON-safe", () => {
+    expect(reasons({ ...validRecord(), extra: { when: new Date() } })).toContainEqual(
+      expect.stringContaining("record.extra.when"),
+    );
+  });
+
+  it("does not resurrect a KNOWN field that failed its rule", () => {
+    const result = validateResumeRecord({ ...validRecord(), filename: 42 });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("drift guard: every declared rule actually rejects something", () => {
+  // Iterates the rule map rather than a hand-written field list, so a field
+  // added to `ResumeRecord` (other than `blob`) — which `tsc` forces into the
+  // map — is covered here with no edit.
+  it.each(Object.keys(RESUME_RECORD_RULES))(
+    "`%s` refuses a value no field type admits",
+    (field) => {
+      const result = validateResumeRecord({ ...validRecord(), [field]: () => "nope" });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reasons.join(" ")).toContain(field);
+    },
+  );
+
+  it("names every rule's expectation, so a refusal tells a producer what to send", () => {
+    for (const [field, rule] of Object.entries(RESUME_RECORD_RULES)) {
+      expect(rule.expected, field).toMatch(/\S/);
+    }
+  });
+});

--- a/src/lib/storage/resume-record-contract.ts
+++ b/src/lib/storage/resume-record-contract.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The runtime half of the résumé record contract (#757) — the gate an
+ * externally-authored {@link ResumeRecord} passes through on its way into
+ * IndexedDB via a restored backup file.
+ *
+ * `resumes` was the one store `importAll` wrote with no validation at all,
+ * while `jobs` (`job-record-contract.ts`) and `letters` (`letter-contract.ts`)
+ * both go through a contract built on the same shared machinery,
+ * `record-contract.ts`. This module closes that gap, mirroring
+ * `letter-contract.ts` — the smaller and closer of the two existing models —
+ * rather than hand-rolling a fourth checking style.
+ *
+ * ## `blob` is not part of this contract
+ *
+ * `ExportedResume` (the shape a candidate actually arrives in) replaces
+ * `ResumeRecord.blob` with `blobBase64`/`blobType`; `importAll` decodes those
+ * back into a `Blob` and attaches it AFTER a candidate clears this contract.
+ * `Blob` is not JSON-safe and was never going to survive `findJsonSafetyProblem`
+ * anyway, so the two string fields are validated at the call site in
+ * `backup.ts`, next to where the decode happens, rather than here.
+ *
+ * ## `parse` is validated as JSON-safe, not as a `SavedResumeSnapshot`
+ *
+ * `resume-library.ts`'s own docblock states the boundary this module has to
+ * respect: storage "holds the parse as an opaque `parse` payload" — the
+ * `SavedResumeSnapshot` shape (`result`/`score`/`sourceKind`/`shapeVersion`)
+ * belongs to `resume-library.ts`, one layer up, and is not this module's to
+ * assert. What this layer owns is the promise `record-contract.ts` states for
+ * every field it checks: *is this safe to put in an object store?* — a plain
+ * object, JSON-safe, no own `__proto__` key. A `parse` that clears this bar but
+ * still can't be read as a snapshot (missing `result`/`score`) is not refused
+ * here; it round-trips, and `resume-library.ts#listLibrary`'s `hasCachedParse`
+ * is where that distinction is made and reported to the user — a decision that
+ * layer owns, not this one.
+ *
+ * `parse: null` is normalized to absent before the rules run: `readSnapshot`
+ * treats `parse == null` as "no snapshot" via optional chaining, so a record
+ * that explicitly says `"parse": null` describes the same legal state as one
+ * that omits the key, and should not be refused for failing the object check.
+ *
+ * ## The drift guard
+ *
+ * {@link RESUME_RECORD_RULES} is a mapped type over
+ * `keyof Required<Omit<ResumeRecord, "blob">>`, so adding a field to
+ * `ResumeRecord` (other than `blob`, deliberately excluded above) without a
+ * rule for it fails `tsc`, and a rule with the wrong guard fails `tsc` too —
+ * the same guard `job-record-contract.ts` documents at length.
+ *
+ * ## Why there is no `warnings` channel
+ *
+ * Same reasoning as `letter-contract.ts`: nothing here is accepted-but-suspect
+ * the way an out-of-union `JobStatus` or a non-absolute `url` is. A résumé
+ * accepted without a cached `parse` is not a warning about a wrong value — it
+ * is a legal, common shape (every record `#693`'s capture door writes has one),
+ * and `backup.ts` counts it directly off the accepted list rather than reading
+ * it back out of a per-record warning.
+ */
+
+import type { ResumeRecord } from "./types.ts";
+import {
+  checkDeclaredFields,
+  collectJsonSafeExtras,
+  explainJsonSafety,
+  findJsonSafetyProblem,
+  hasOwn,
+  isFiniteNumber,
+  isNonEmptyString,
+  isPlainObject,
+  FORBIDDEN_KEY,
+  type FieldRule,
+} from "./record-contract.ts";
+
+/** A reason a résumé was refused. One sentence, addressed to whoever has to
+ *  fix the producer or the file. */
+export type ResumeRecordIssue = string;
+
+/** The fields this contract validates — every `ResumeRecord` field except
+ *  `blob`, which is reconstructed from `blobBase64`/`blobType` at the call
+ *  site (see the module docblock). */
+export type ResumeRecordFields = Omit<ResumeRecord, "blob">;
+
+/** Outcome of validating one candidate résumé. See the module docblock for why
+ *  the success branch has no `warnings`. */
+export type ResumeRecordValidation =
+  | { ok: true; record: ResumeRecordFields }
+  | { ok: false; reasons: ResumeRecordIssue[] };
+
+/**
+ * `parse`'s real type is `unknown` (opaque by design), so this checks exactly
+ * what `record-contract.ts` checks everywhere else an opaque field rides
+ * through unexamined — `matchResult` on a job, an extra key on either
+ * contract: a plain object, and JSON-safe all the way down (which also catches
+ * a nested own `__proto__`). See the module docblock for why it does not also
+ * require `result`/`score`.
+ */
+const isReadableParseSnapshot = (value: unknown): value is unknown =>
+  isPlainObject(value) && findJsonSafetyProblem(value, "parse") === null;
+
+/**
+ * One rule per résumé field (minus `blob`). See the drift-guard note in the
+ * module docblock — the mapped type, not this list, is what keeps it complete.
+ *
+ * `createdAt` / `updatedAt` are optional because `putRecord` owns them, the
+ * same reason the job and letter contracts leave them optional. `deletedAt` is
+ * included for the same structural reason `LetterRecord`'s is — `StoredRecord`
+ * declares it on every record — even though nothing in this build ever writes
+ * one onto a résumé (`resumes` hard-deletes; see `backup.ts`'s module
+ * docblock). A file could still carry one from an outside producer, and a
+ * finite epoch-ms number costs nothing to accept.
+ */
+export const RESUME_RECORD_RULES: {
+  [K in keyof Required<ResumeRecordFields>]: FieldRule<Required<ResumeRecordFields>[K]>;
+} = {
+  id: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
+  createdAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  updatedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  deletedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
+  filename: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
+  parse: {
+    required: false,
+    check: isReadableParseSnapshot,
+    expected: "a plain, JSON-safe object",
+    explain: (value) => explainJsonSafety(value, "parse"),
+  },
+};
+
+/** Field names the rules cover — everything else on an incoming record is an
+ *  unknown extra key. */
+const KNOWN_FIELDS = new Set(Object.keys(RESUME_RECORD_RULES));
+
+/**
+ * Validate one candidate résumé (already stripped of `blobBase64`/`blobType`
+ * by the caller) and return it in the shape the store accepts.
+ *
+ * Unknown extra keys are **preserved**, and an own `__proto__` key refuses the
+ * record outright — the same two rules `validateJobRecord` documents at
+ * length, for the same reasons.
+ */
+export function validateResumeRecord(value: unknown): ResumeRecordValidation {
+  if (!isPlainObject(value)) {
+    return { ok: false, reasons: ["A resume record must be a plain JSON object."] };
+  }
+  if (hasOwn(value, FORBIDDEN_KEY)) {
+    return { ok: false, reasons: ["A resume record must not carry a `__proto__` key."] };
+  }
+
+  // See the module docblock: `parse: null` reads as "no snapshot" everywhere
+  // else this record is read, so it is normalized to absent before the
+  // presence check below would otherwise refuse it as a non-object `parse`.
+  const candidate = value.parse === null ? { ...value, parse: undefined } : value;
+
+  const { reasons, checked } = checkDeclaredFields(candidate, RESUME_RECORD_RULES);
+  if (reasons.length > 0) return { ok: false, reasons };
+
+  // Only once the record is otherwise accepted — a refused record has nothing
+  // to preserve, and a preserved key that can't survive the next export would
+  // be preservation in name only.
+  const { extras, problem } = collectJsonSafeExtras(candidate, KNOWN_FIELDS);
+  if (problem) {
+    return { ok: false, reasons: [`\`${problem.path}\`: ${problem.reason}.`] };
+  }
+
+  // `id` and `filename` were just proved to be strings by the rules map, but
+  // `checked` is an erased `Record<string, unknown>`, so that proof lives in
+  // the map rather than in a type the compiler can follow from here. Asserted
+  // through `unknown` because an index-signature type structurally overlaps
+  // nothing.
+  return { ok: true, record: { ...extras, ...checked } as unknown as ResumeRecordFields };
+}

--- a/src/lib/storage/storage.test.ts
+++ b/src/lib/storage/storage.test.ts
@@ -24,7 +24,7 @@ import { exportAll, exportToJson, importAll, importFromJson } from "./backup.ts"
 import { captureJob } from "./capture.ts";
 import { requestStoragePersistence, isStoragePersisted } from "./persist.ts";
 import { tick } from "./__test-utils__/clock.ts";
-import type { JobRecord, StorageExport } from "./types.ts";
+import type { ExportedResume, JobRecord, StorageExport } from "./types.ts";
 
 beforeEach(async () => {
   await closeDB();
@@ -141,6 +141,8 @@ describe("storage: export / import", () => {
     const counts = await importAll(dump);
     expect(counts).toEqual({
       resumes: 1,
+      skippedResumes: [],
+      resumesWithoutParse: 0,
       jobs: 1,
       skippedJobs: [],
       letters: 0,
@@ -199,6 +201,8 @@ describe("storage: export / import", () => {
     const counts = await importAll(dump, "merge");
     expect(counts).toEqual({
       resumes: 1,
+      skippedResumes: [],
+      resumesWithoutParse: 1,
       jobs: 0,
       skippedJobs: [],
       letters: 0,
@@ -252,6 +256,8 @@ describe("storage: export / import", () => {
       const counts = await importFromJson(json, "merge");
       expect(counts).toEqual({
         resumes: 1,
+        skippedResumes: [],
+        resumesWithoutParse: 0,
         jobs: 1,
         skippedJobs: [],
         letters: 0,
@@ -284,6 +290,76 @@ function validJob(overrides: Record<string, unknown> = {}): Record<string, unkno
     ...overrides,
   };
 }
+
+/** A backup document carrying exactly the résumés given, with no jobs — the
+ *  shape the résumé-contract import-validation cases perturb one résumé of. */
+function backupWithResumes(resumes: unknown[]): StorageExport {
+  return {
+    version: 1,
+    exportedAt: Date.now(),
+    resumes: resumes as ExportedResume[],
+    jobs: [],
+  };
+}
+
+function validResumeCandidate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "resume-1",
+    filename: "cv.pdf",
+    blobBase64: btoa("hello"),
+    blobType: "application/pdf",
+    ...overrides,
+  };
+}
+
+describe("storage: import routes every résumé through the résumé contract (#757)", () => {
+  it("imports a good résumé, refuses a malformed one, and reports it in skippedResumes without touching the good record", async () => {
+    const counts = await importAll(
+      backupWithResumes([
+        validResumeCandidate(),
+        validResumeCandidate({ id: "resume-2", filename: "" }),
+      ]),
+    );
+
+    expect(counts.resumes).toBe(1);
+    expect(counts.skippedResumes).toHaveLength(1);
+    expect(counts.skippedResumes[0].id).toBe("resume-2");
+    expect(counts.skippedResumes[0].reason).toContain("`filename`");
+
+    const stored = await getAllResumes();
+    expect(stored.map((r) => r.id)).toEqual(["resume-1"]);
+  });
+
+  it("refuses a résumé missing blobBase64/blobType, reporting it distinctly", async () => {
+    const counts = await importAll(
+      backupWithResumes([{ id: "resume-1", filename: "cv.pdf" }]),
+    );
+    expect(counts.resumes).toBe(0);
+    expect(counts.skippedResumes).toHaveLength(1);
+    expect(counts.skippedResumes[0].reason).toContain("blobBase64");
+  });
+
+  it("counts an accepted résumé with no parse snapshot distinctly from a refusal (not a skip)", async () => {
+    const counts = await importAll(backupWithResumes([validResumeCandidate()]));
+    expect(counts.resumes).toBe(1);
+    expect(counts.resumesWithoutParse).toBe(1);
+    expect(counts.skippedResumes).toEqual([]);
+  });
+
+  it("still round-trips a résumé this app produced itself, unaffected by the new gate", async () => {
+    await saveResume({ filename: "cv.pdf", blob: pdf(), parse: { score: 72 } });
+    const dump = await exportAll();
+
+    await closeDB();
+    await deleteDB(DB_NAME);
+
+    const counts = await importAll(dump);
+    expect(counts.resumes).toBe(1);
+    expect(counts.skippedResumes).toEqual([]);
+    const [restored] = await getAllResumes();
+    expect(restored.parse).toEqual({ score: 72 });
+  });
+});
 
 describe("storage: import routes every job through the capture contract (#693)", () => {
   it("skips a malformed job, imports the rest, and names what it skipped", async () => {
@@ -353,6 +429,8 @@ describe("storage: import routes every job through the capture contract (#693)",
     const counts = await importFromJson(json, "replace");
     expect(counts).toEqual({
       resumes: 0,
+      skippedResumes: [],
+      resumesWithoutParse: 0,
       jobs: 2,
       skippedJobs: [],
       letters: 0,


### PR DESCRIPTION
## Summary

Five issues against the local library, landed together because they share the storage seam and the job-tracker surface. Two of them close correctness holes that were reachable from a real 541-record library; one removes a destructive affordance that was firing on inference alone.

- **#760 — an open tab never learned the library changed under it.** The change signal is emitted from `src/lib/storage/crud.ts` (`putRecord` / `deleteRecord` / `clearStore` / `softDeleteRecord`), **not** from the hooks — that is the whole design decision, because `crud.ts` is the funnel every writer goes through, including a backup import and the browser extension writing from a content script. Emitting from the hooks would have covered only the writes that already triggered a refresh. A new `useLibraryChanges` hook is the single subscriber, consumed by `useJobTracker` and `useResumeLibrary`. Coalescing is emit-side, so a bulk import posts one message per store touched rather than one per record — asserted with a count, not described. The message carries a store name and nothing else; a `typeof` guard keeps the Node test env working with no polyfill added to the setup file.

- **#757 — résumés were the one record type `importAll` wrote with no contract.** Jobs and letters both validate on that same code path, and résumés are the record the other two point at (`JobRecord.resumeId`, `LetterRecord.resumeId`). New `resume-record-contract.ts` is built on the shared `record-contract.ts` helpers rather than hand-rolling checks; `ImportCounts` gained `skippedResumes` and `resumesWithoutParse`. Separately, a record with no cached parse rendered as `score 0` — which a scanned résumé legitimately also scores via the layout-trigger penalty — so a broken record and a bad one were indistinguishable. `ResumeLibraryEntry.hasCachedParse` now drives a distinct "Not parsed yet" state.

- **#756 — an unrecoverable résumé load now says so.** The recovery half of this issue already landed in `acc8411` (#755, which closed the duplicate #758). This ships the remaining half: `useResumeLibrary.loadError`, set by `App.tsx` when a load resolves `undefined`, rendered through the `ErrorState` the library card already imports. No new component, no new banner.

- **#754 — a destructive merge was offered on company + title equality alone.** Against a measured 541-record library that fired for 98 pairs, 29 of them more than a month apart — employer reposts, where merging destroys the churn signal that is the most useful thing about the group. A new `title-only` tier sits below the actionable bar, and company + title equality only reaches `probable` when corroborated: identical `jdText`, equal `datePosted`, equal `location` + `salaryRange`, or a `createdAt` span within `REPOST_SPAN_DAYS = 21`. One constant, two uses — the same boundary forms repost clusters, so a pairing is either mergeable or clustered and never neither. New pure `job-repost-clusters.ts` + `useJobRepostClusters` render one count-and-span row per cluster instead of N×(N−1) merge offers. `certain` (shared-URL) duplicates are never suppressed: cluster membership outranks only *inferred* tiers.

- **#759 — the Interested bucket had no bulk action.** Fed by a job-alert pipeline it stops being a pipeline and becomes an inbox nobody can empty. An age-based sweep keyed on `createdAt` — never `datePosted`, because a row that arrived without a capture has no `datePosted` at all and those are exactly the rows a sweep exists for. One exported pure predicate is shared by the preview count and the write, so the number shown cannot disagree with the rows written. Preview before commit, confirm disabled at zero matches, and the one-way `saved`/`scouted` → `archived` vocabulary overwrite stated at the confirm step.

Closes #760
Closes #759
Closes #757
Closes #756
Closes #754

## Review focus

- `src/lib/storage/jobs.ts:175` — `archiveJobs` re-checks `stillEligible` per row, but `getJob` and `saveJob` are separate IndexedDB transactions. Does the remaining read-to-write gap matter for your threat model, or is narrowing it from "the whole sweep" to "one row" enough here?
- `src/lib/storage/crud.ts:85` — `runBatchedWrites` defers an earlier call's flush until a later overlapping call closes. Is there a caller shape where that deferral is observable to a user, rather than just later?
- `src/lib/job-duplicates.ts` — `REPOST_SPAN_DAYS = 21` is the single boundary governing both corroboration and cluster formation. Does 21 days split double-captures from reposts the way you'd expect on your own library?
- `src/lib/job-repost-clusters.ts:247` — `isRepostSuppressed` lets `certain` through and suppresses `probable` inside a cluster. Does that precedence hold for a pairing that reaches *out* of a cluster?

## Verification

- `npm run verify` passes locally (`fallow` is report-only and ignored per repo convention).
- Full suite: **5142 passing / 10 skipped**, verified over **6 consecutive clean runs**.
- That repeat-run bar exists because review found a **`BroadcastChannel` test-flake class of 10 tests** — every positive-delivery assertion used a single-tick `setTimeout(0)` flush against a delivery that is a queued macrotask. Before the fix the suite failed roughly **1 run in 4**. Positive assertions now poll through a shared helper; absence assertions deliberately keep a fixed settle tied to the same budget, so they cannot conclude "nothing arrived" faster than they would still have accepted "something arrived".
- No fixture binaries are added or changed by this PR; `npm run check:fixtures` exits 0 (58 PDFs, 15 ground-truth sidecars).

## Test plan

- [ ] `npm run typecheck` clean
- [ ] `npm run test` green
- [ ] Two-tab repro for #760: open `/jobs/` in two tabs, mark a job Applied in tab A, confirm tab B updates with no reload
- [ ] Manually verified in `npm run dev` / `npm run preview`

## Adversarial review

Two bounded rounds ran against the accumulated diff **before** this PR was opened, so the human reviewer starts from a reviewed base rather than a first draft.

**Round 1 — `clean: false`.** Three blocking findings, all reproduced end-to-end rather than reasoned about:

1. **`archiveJobs` could archive a row that was no longer Interested** (`src/lib/storage/jobs.ts`). The sweep re-checked only that an id still *existed* before overwriting `status`. Over a sequential ~290-row loop, a concurrent status change from another tab, the extension, or a sync was unseen and got overwritten — falsifying what the confirm dialog promises the user: *"Applied, Interviewing, Offer, and Rejected jobs are never touched."*
2. **`runBatchedWrites` was unsafe for concurrent, non-nested calls** (`src/lib/storage/crud.ts`). The batch scope was a bare module singleton, so two *overlapping* bulk writers let the first to finish tear down the scope while the second fell back to one message per write. Reproduced at 5 messages where 1 was expected. Not reachable through today's UI — the two callers sit on different HTML entry points — but the docblock claimed a safety the code did not have.
3. **The `BroadcastChannel` flake class** described under Verification — 10 tests, of which only 2 had been observed failing.

**Fixes.** `archiveJobs` now takes a **required** injected `stillEligible` predicate, re-checked immediately before each write; required so a future caller cannot silently get the unguarded loop back, and injected because importing `job-status-bucket.ts` down into `src/lib/storage/` would both invert the layering and close an `index.ts → jobs.ts → job-status-bucket.ts → index.ts` cycle. The age half is never re-derived at write time — only the bucket — so no second clock read can diverge from the preview. `runBatchedWrites` got a reference count with the decrement in `finally` ahead of the flush, proven exception-safe including a throw inside a nested scope. The flake class moved to a shared poll-until-delivered helper.

**Round 2 — `clean: true`.** All three verified FIXED by independent reproduction; round 2 additionally covered the nested-throw exception path round 1 had left unverified, and re-confirmed #754's totality (no throw or prototype pollution on `null`/`undefined`/`NaN`/`Infinity`/non-string fields/`__proto__`/cyclic input), `jobPairKey`'s unchanged shape, and the style guards.

**Known limits, recorded rather than papered over:**

- `archiveJobs`'s race is **narrowed, not closed** — `getJob` and `saveJob` are separate transactions, so a writer landing in one row's read-to-write gap is still unseen. Exposure drops from the whole sweep to that gap. Closing it fully needs a transactional read-modify-write this layer does not expose. Stated in the docblock, and tracked in #763.
- **#757 deviates from its own acceptance criterion 4.** The issue asked that a present `parse` satisfy the shape `readSnapshot` accepts (`result`, `score`, `sourceKind`, finite `shapeVersion`); the contract ships JSON-safety-only validation instead. Two verified reasons: `shapeVersion` is typed `string` (`src/lib/resume-library.ts:62`), not a number, and this repo's own tests round-trip `parse: { score: 72 }` with no `result` key (`src/lib/storage/storage.test.ts:103,154`), so a literal reading would have broken them. The user-facing outcome is unchanged — `hasCachedParse` asks the stronger question independently and still renders such a record as "Not parsed yet".
- `backup.ts`'s `resumesWithoutParse` counts *absence* of a parse, not *unreadability*, so it can disagree with `hasCachedParse` for a present-but-garbage snapshot. Documented rather than fixed: aligning them would pull `SavedResumeSnapshot`'s shape down into the storage layer, which `resume-record-contract.ts` explicitly documents as a boundary it does not assert. Nothing renders the count yet.

**Surviving nits** (fallow, report-only): test-boilerplate clone groups across the hook suites.

**Fallow's 5 new code-scanning alerts are fixed, not waived.** After this PR opened, the `fallow` check flagged 4 dead exports and 1 complexity warning. It is report-only and non-blocking (only `verify` is required), but each finding turned out to be real:

- `CHANNEL_DELIVERY_BUDGET_MS` (`__test-utils__/library-channel-delivery.ts`) is read only by its own two helpers, so it is no longer exported.
- `SkippedResume` and `LibraryChangeMessage` left the storage barrel, and `LibraryChangeMessage` is now module-local in `library-channel.ts`. This is the barrel's **own** admission rule applied rather than metric-chasing: `index.ts` states that a name earns a slot "by having a consumer outside this directory, or by being registered in `.fallowrc.jsonc` as intended external API". `SkippedJob` has a consumer (`ResumeLibraryImportDialog`); `SkippedLetter` is registered against `docs/cover-letter-contract.md`; `SkippedResume` had neither — so the earlier "matches the `SkippedJob`/`SkippedLetter` precedent" reading was wrong, and the barrel docblock now records the distinction. `LibraryChangeMessage` never had a caller in a position to name it, since `onLibraryChange` hands its subscriber a bare `StoreName` and never the message.
- `findRepostClusters` (cognitive complexity 31 against a threshold of 15) split into `bucketByCompanyTitle` and `readCapturedSpan`, leaving only the cluster **decision** in the exported function — the one part the module docblock's central property is proved against. Behaviour is unchanged and its 26 tests pass untouched.

`fallow audit --base origin/main` now reports `dead exports 0.0%` and no complexity finding in any function this PR authored. What remains is pre-existing and was not among the 5 new alerts: `App.tsx` (CRITICAL, named as known debt in `CLAUDE.md`), `ResumeLibrary`, `findUrlPairs`, and 6 unused `extension/package.json` dependencies.

**Unrelated, pre-existing — now filed as #762:** on a loaded machine, slow PDF tests (`render-ats-pdf.flush-right-links`, `toJsonResume`, `export-layout-contract`) were observed failing at 5.0–6.6 s against vitest's **default 5000 ms `testTimeout`** — there is no override in `vite.config.ts`. Not touched by this PR and not reproduced on an idle machine, but it is a latent CI flake risk independent of anything here.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #760 | Claude Sonnet 4.6 | high |
| Implementation — #757 | Claude Sonnet 5 | high |
| Implementation — #756 | Claude Sonnet 5 | medium |
| Implementation — #754 | Claude Opus 4.5 | ultra |
| Implementation — #759 | Claude Sonnet 5 | high |
| Adversarial review — round 1 | Claude Sonnet 5 | high |
| Review fixes | Claude Opus 5 (1M context) | ultra |
| Adversarial review — round 2 | Claude Sonnet 5 | high |
| Orchestration + PR | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green in CI | — |

Every model string above is self-reported by the agent that ran that stage, or first-hand for orchestration. None is inferred from the `model:` alias requested.

