### PR TITLE
feat(core): add @offlinecv/core as a re-export package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@offlinecv/web",
       "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@fontsource/poppins": "^5.2.7",
         "@mlc-ai/web-llm": "0.2.84",
@@ -1616,6 +1619,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@offlinecv/core": {
+      "resolved": "packages/core",
+      "link": true
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
@@ -8678,6 +8685,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/core": {
+      "name": "@offlinecv/core",
+      "version": "0.0.0",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.0-alpha.1",
   "license": "Apache-2.0",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "prepare": "node scripts/install-git-hooks.mjs",
     "dev": "vite",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@offlinecv/core",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "The headless, browser-only core of offlinecv: job capture, local library storage, JD term extraction and fit rating. Re-exported from src/lib — see src/index.ts.",
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `@offlinecv/core` — the public, headless surface of this repo.
+ *
+ * Everything here already exists under `src/lib/`. This file adds no behaviour;
+ * it names the subset of `src/lib/` that a downstream consumer is allowed to
+ * depend on, so that consumer can write `@offlinecv/core` instead of reaching
+ * into this repo's source tree by relative path.
+ *
+ * The surface is deliberately narrow: the job-capture contract, the local
+ * library's CRUD and replication primitives, the JD term/coverage pair, and the
+ * fit-rating chain. It is what a *producer* of `JobRecord`s and a *replica* of
+ * the local library need, and nothing else — no React, no parser cascade entry
+ * point, no network client.
+ *
+ * ## Why this re-exports rather than relocates
+ *
+ * The obvious alternative — physically move these modules into `packages/core/`
+ * — was rejected. `src/lib/` is not settled code: it took 33 commits in five
+ * weeks, and the storage layer was rewritten wholesale in #761. Moving 49
+ * modules would put a rename collision on top of every one of those commits, in
+ * exchange for a directory layout. A re-export barrel defines exactly the same
+ * public surface at zero conflict cost, and leaves the physical carve as a later
+ * decision that can be made on its own merits.
+ *
+ * So: **no file under `src/` moves, and none has to know this package exists.**
+ * If a symbol below is renamed at its source, this file is the one place that
+ * breaks, and `tsc` says so.
+ *
+ * ## Two mechanical rules, both load-bearing
+ *
+ * **1. Import the FILE, never the slice barrel.** `src/lib/jd-match/index.ts`
+ * re-exports `fetch-jd.ts`, which holds this app's live `fetch(` calls for the
+ * ATS platforms it hydrates. A consumer that audits its own import graph — and
+ * the consumer this package was cut for does exactly that, because it runs in a
+ * browser extension where a network primitive on the wrong graph is a shipped
+ * privacy defect — sees a whole file the moment anything imports it, not just
+ * the one export it used. Routing `computeCoverageFromCorpus` through the barrel
+ * would drag a network primitive onto that graph for nothing. Measured: the
+ * value-edge closure of the specifiers below is 27 modules and reaches no
+ * `fetch`/`WebSocket`/`XMLHttpRequest`/`EventSource` at all.
+ *
+ * **2. Types are re-exported with `export type`.** Not a style preference. A
+ * type-only edge erases at build time, so `export type { JobRecord } from …`
+ * costs the consumer nothing, while a value `export { … }` of the same name
+ * makes the module a runtime import and puts its whole file — and everything it
+ * pulls in — on the consumer's graph. `src/lib/storage/types.ts` and
+ * `src/lib/job-search/types.ts` are re-exported for their types only and must
+ * stay `export type` statements.
+ *
+ * The full transitive closure is 49 modules / ~17.5k LOC across `lib/storage`,
+ * `lib/job-search`, `lib/jd-match`, `lib/heuristics`, `lib/score` and `webllm`,
+ * with exactly one external runtime dependency: `idb`. The `heuristics`, `score`
+ * and `webllm` modules are reached only through `import type` edges, so they
+ * erase at build time and matter to `tsc` alone.
+ *
+ * That `idb` is deliberately **not** in this package's `dependencies`, and the
+ * omission is not an oversight: nothing in `packages/core/` imports it. It is
+ * reached from `src/lib/storage/db.ts`, which belongs to the root package, so
+ * the root is where it is declared and where it resolves from. Listing it here
+ * would be a dependency this package does not have — it becomes true, and
+ * necessary, on the day these files physically move.
+ *
+ * ## Status
+ *
+ * `private: true` and unpublished, on purpose. The storage layer is the youngest
+ * part of this surface and publishing a version number is a promise not to
+ * change it; that promise gets made once the layer has been quiet for a while.
+ * Until then this package exists so the surface is *written down and
+ * typechecked* — the specifier can be adopted, and the registry step is a
+ * separate, later decision.
+ */
+
+/**
+ * The job-capture contract. `docs/job-capture-contract.md` is normative for
+ * third-party producers, and these are the symbols it tells them to use rather
+ * than reimplement: a second copy of the canonicaliser that drifts by one query
+ * parameter forks the id space and turns every re-capture into a duplicate row.
+ *
+ * `validateJobRecord` and `deriveJobId` are pure — no IndexedDB, no DOM — so a
+ * producer can validate a capture anywhere, including a context that has no
+ * access to the library at all.
+ */
+export {
+  validateJobRecord,
+  JOB_CAPTURE_CONTRACT_VERSION,
+  type JobRecordValidation,
+  type JobRecordIssue,
+} from "../../../src/lib/storage/job-record-contract.ts";
+
+export { deriveJobId, canonicalJobUrl } from "../../../src/lib/storage/job-url.ts";
+
+/**
+ * The capture door. Unlike the two above, `captureJob` opens IndexedDB, so it
+ * only runs where the app's own origin is. That single fact shapes any consumer
+ * that captures from elsewhere: it must hand the record to something running in
+ * this app's origin rather than write the library itself.
+ */
+export { captureJob, type JobCaptureResult } from "../../../src/lib/storage/capture.ts";
+
+export type { JobRecord, JobStatus, JobOrigin } from "../../../src/lib/storage/types.ts";
+
+/**
+ * The replication primitives (#730). These are the read/write half of syncing
+ * the local library to somewhere else, and they carry the same IndexedDB
+ * constraint `captureJob` does.
+ *
+ * A replicating writer wants `putRecord`, **not** `captureJob`. The two jobs
+ * genuinely differ: capture strips `deletedAt` and treats a re-capture of a
+ * tombstoned posting as a revival — correct for a producer asserting "this
+ * posting exists", wrong for a replica carrying the user's own deletion, which
+ * is precisely the resurrection `StoredRecord.deletedAt` exists to prevent. It
+ * also preserves the local `status`/`notes` over incoming values, right for a
+ * producer that knows nothing about the user's application and wrong for a copy
+ * of the user's own row edited on another device. `capture.ts`'s docblock draws
+ * the same line: a producer replicating a deletion is doing replication, not
+ * capture. `backup.ts`'s import path is the in-tree precedent — it writes
+ * through `putRecord` with `touch: false`, tombstones included.
+ *
+ * `getRecord` rather than `getJob`/`getLetter` for the same reason: those two
+ * read a tombstone as absent, which is correct for every UI and wrong for
+ * last-writer-wins, where a deletion has to be compared against the tombstone's
+ * own `updatedAt` or it looks like a record that never existed.
+ *
+ * `deleteRecord` is the hard delete, and it is here deliberately. `resumes` does
+ * not tombstone — a résumé's bytes are the bulk of the database and keeping them
+ * after a delete is the opposite of what the user asked for — so a replica of
+ * that store has to delete the same way. For a store that DOES tombstone, this
+ * is a purge and `softDeleteRecord` is the right call; that one is not on this
+ * surface.
+ */
+export {
+  getRecord,
+  putRecord,
+  deleteRecord,
+  listRecordsUpdatedSince,
+} from "../../../src/lib/storage/crud.ts";
+
+export { getSyncCursor, setSyncCursor } from "../../../src/lib/storage/sync-cursor.ts";
+
+export type {
+  LetterRecord,
+  ResumeRecord,
+  StoredRecord,
+  SyncableStoreName,
+  SyncCursorRecord,
+} from "../../../src/lib/storage/types.ts";
+
+/**
+ * The letter contract's validator, sibling of `validateJobRecord` and normative
+ * for the same reason. `letters` is the first store this build never writes at
+ * all (see `docs/cover-letter-contract.md`), so every writer is a producer
+ * outside this repo — and the gate their records pass has to be this one rather
+ * than a shape check invented at the far end.
+ */
+export {
+  validateLetterRecord,
+  type LetterRecordValidation,
+} from "../../../src/lib/storage/letter-contract.ts";
+
+/**
+ * The résumé picker's list (#712). Answers `{ id, filename, updatedAt }[]`,
+ * newest first — no blob, no parse, nothing that makes a picker built on this a
+ * second corpus channel. Same IndexedDB constraint as `captureJob`.
+ */
+export { listResumeChoices, type ResumeChoice } from "../../../src/lib/storage/resumes.ts";
+
+/**
+ * The compensation parser. A posting's pay range is free-text prose, and this is
+ * the one place this codebase parses it; a consumer that writes its own is the
+ * duplicate-implementation problem the contract modules above exist to prevent.
+ * Zero-dependency and pure.
+ */
+export {
+  extractCompensation,
+  formatCompensationRange,
+  isBelowFloor,
+  type Compensation,
+} from "../../../src/lib/job-search/compensation.ts";
+
+/**
+ * The fitness chain. A consumer rating one posting uses the same code `/jobs/`
+ * ranks a whole feed with — two scoring implementations mean two numbers for one
+ * posting and no way to tell which is wrong.
+ *
+ * `computeCoverageFromCorpus` rather than `computeCoverage`: the latter wants a
+ * whole `HeuristicParsedResume`, and #700 split the digest half out precisely so
+ * a caller holding only `buildCorpus(parsed)` can score against it without
+ * either holding the parse or forking a second coverage implementation. That
+ * split is what lets a résumé reach a consumer as one lowercased string instead
+ * of a structured document. `corpus` MUST already be lowercased — `buildCorpus`
+ * does that normalisation, and the skill/phrase matchers assume it.
+ *
+ * Note the deep specifiers: `jd-match/index.ts` would pull `fetch-jd.ts` in with
+ * them. See rule 1 at the top of this file.
+ */
+export {
+  computeCoverageFromCorpus,
+  type CoverageResult,
+} from "../../../src/lib/jd-match/coverage.ts";
+
+export {
+  extractJdTerms,
+  type ExtractedTerm,
+} from "../../../src/lib/jd-match/extract-jd-terms.ts";
+
+/**
+ * `ratingInputFor` is the single source of truth for what feeds a rating — the
+ * specificity discount, the annualised comp top, the location match rule and the
+ * seniority rung distance, all in one function. A consumer holding a single
+ * freshly captured posting builds the `RankedJob`-shaped argument and calls
+ * this; reconstructing the argument list at the far end would reimplement the
+ * rating one constant at a time.
+ */
+export {
+  ratingInputFor,
+  type RankedJob,
+  type KeywordJdMatch,
+} from "../../../src/lib/job-search/rank.ts";
+
+export {
+  rateJobs,
+  describeRating,
+  MAX_STARS,
+  type JobRating,
+} from "../../../src/lib/job-search/rating.ts";
+
+export type { JobPosting } from "../../../src/lib/job-search/types.ts";

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,5 +23,5 @@
     "noUncheckedSideEffectImports": true,
     "types": ["vite/client", "vitest/globals"]
   },
-  "include": ["src"]
+  "include": ["src", "packages/*/src"]
 }


### PR DESCRIPTION
## What this is

`@offlinecv/core` is a name for the headless part of this repo — job capture, the
local library's storage and replication primitives, JD term extraction, and the
fit-rating chain. It adds no behaviour. Every symbol it exports already exists
under `src/lib/`.

It exists because a downstream consumer needs a **stable specifier**. Today the
only way to use this code from outside is to reach into the source tree by
relative path (`../../vendor/offlinecv/src/lib/storage/capture.ts`), which means
every internal file move is a breaking change for that consumer and nobody here
can see it happen. A package boundary turns "don't move these files" into "don't
change this export list" — a thing a reviewer can actually check, and `tsc` can
enforce.

## It re-exports; it does not relocate

`packages/core/src/index.ts` is a barrel of `export … from "../../../src/lib/…"`.
**No file under `src/` moves, and no file under `src/` changes.**

Physically moving the modules was the obvious alternative and was rejected on
cost. `src/lib/` is not settled code — 33 commits in the last five weeks, and the
storage layer rewritten wholesale in #761. Relocating 49 modules would put a
rename collision on top of every one of those commits, permanently, in exchange
for a directory layout. The barrel defines the identical public surface at zero
conflict cost, and leaves the physical carve as a later decision that can be
argued on its own merits rather than smuggled in with this one.

If a symbol is renamed at its source, exactly one file breaks and the typechecker
says so.

## The surface

Fourteen modules, re-exported by **deep specifier** rather than through the slice
barrels:

| From | Exports |
|---|---|
| `storage/job-record-contract.ts` | `validateJobRecord`, `JOB_CAPTURE_CONTRACT_VERSION`, *type* `JobRecordValidation`, `JobRecordIssue` |
| `storage/job-url.ts` | `deriveJobId`, `canonicalJobUrl` |
| `storage/capture.ts` | `captureJob`, *type* `JobCaptureResult` |
| `storage/crud.ts` | `getRecord`, `putRecord`, `deleteRecord`, `listRecordsUpdatedSince` |
| `storage/sync-cursor.ts` | `getSyncCursor`, `setSyncCursor` |
| `storage/letter-contract.ts` | `validateLetterRecord`, *type* `LetterRecordValidation` |
| `storage/resumes.ts` | `listResumeChoices`, *type* `ResumeChoice` |
| `storage/types.ts` | *types only*: `JobRecord`, `JobStatus`, `JobOrigin`, `LetterRecord`, `ResumeRecord`, `StoredRecord`, `SyncableStoreName`, `SyncCursorRecord` |
| `job-search/compensation.ts` | `extractCompensation`, `formatCompensationRange`, `isBelowFloor`, *type* `Compensation` |
| `job-search/rank.ts` | `ratingInputFor`, *types* `RankedJob`, `KeywordJdMatch` |
| `job-search/rating.ts` | `rateJobs`, `describeRating`, `MAX_STARS`, *type* `JobRating` |
| `job-search/types.ts` | *type only*: `JobPosting` |
| `jd-match/coverage.ts` | `computeCoverageFromCorpus`, *type* `CoverageResult` |
| `jd-match/extract-jd-terms.ts` | `extractJdTerms`, *type* `ExtractedTerm` |

Two properties of that list are load-bearing, and both are written into the
barrel's docblock so a future editor doesn't undo them by accident:

**Deep specifiers, never the slice barrel.** `src/lib/jd-match/index.ts`
re-exports `fetch-jd.ts`, which holds this app's live `fetch(` calls. The
consumer this package was cut for audits its own import graph — it ships in a
browser extension, where a network primitive on the wrong graph is a shipped
privacy defect — and that kind of audit sees a whole file the moment anything
imports it, not just the export that was used. Routing `computeCoverageFromCorpus`
through the barrel would drag a network primitive onto that graph for nothing.

**Types are re-exported with `export type`.** A type-only edge erases at build
time; a value `export { … }` of the same name makes the module a runtime import
and puts its whole file, and everything it pulls in, on the consumer's graph.
`storage/types.ts` and `job-search/types.ts` are type-only re-exports and must
stay that way.

I measured both rather than asserting them. The barrel's **value-edge closure is
27 modules and contains no `fetch` / `WebSocket` / `XMLHttpRequest` /
`EventSource`**; `fetch-jd.ts` and `html-to-plaintext.ts` are not reachable
through it. That is the same 27 modules the existing consumer-side façade already
reaches, so this is not a widening. The full closure including erasable
type-edges is 49 modules / ~17.5k LOC, with exactly one external runtime
dependency (`idb`).

## Not published, on purpose

`private: true`, version `0.0.0`, no registry step, no npm org, nothing published.

The storage layer is the youngest part of this surface, and a published version
number is a promise not to change it. That promise gets made once the layer has
been quiet for a while. This PR only writes the surface down and puts it under
`tsc` — the specifier can be adopted now, and the registry decision is separate
and later.

Because there is no build step yet, `exports`/`types` point at the TypeScript
source. That is honest for a bundler-resolved, unpublished package and it is what
has to change first when publishing does happen: emit `.js` + `.d.ts` and repoint
`exports`. Consciously deferred, not overlooked.

`idb` is deliberately **absent** from the package's `dependencies`. Nothing under
`packages/core/` imports it — it is reached from `src/lib/storage/db.ts`, which
belongs to the root package. Listing it would be a dependency this package does
not have. (`fallow` agreed: it flagged the entry as unused when I first included
it, which is what prompted removing it.)

## Repo mechanics

- Root `package.json` gains `"workspaces": ["packages/*"]`.
- `tsconfig.app.json`'s `include` gains `packages/*/src`, so the barrel is
  typechecked by `npm run verify` instead of being silently skipped. I confirmed
  it is genuinely in the program rather than trusting a green run: adding an
  `export` of a nonexistent symbol turns `tsc` red (`TS2305`), and removing it
  turns it green again.
- `package-lock.json` gains 12 lines — the workspace declaration and the
  `packages/core` link. Purely additive; no dependency version moved.

Two things a reviewer might reasonably want changed, flagged rather than silently
decided:

1. **ESLint does not lint `packages/`.** `eslint.config.js`'s base block is scoped
   to `src/**/*.{ts,tsx}`, so the barrel is unlinted (`npm run lint` is still
   green — `eslint .` simply doesn't select it). I left it alone because that
   block carries `rules: {}` and the architecture/token rules that matter are
   markup rules listed against explicit files; adding a zero-rule block for
   `packages/*/src` would enforce nothing today. It is a real gap if `packages/`
   ever grows beyond re-export barrels. Happy to add it if you'd rather have the
   scope in place now.
2. **`fallow` prints a local-only warning** — `1 directory with package.json is
   not declared as a workspace: extension`. Adding `workspaces` is what makes it
   notice a gitignored sibling checkout some contributors have on disk. It cannot
   appear in CI, which never checks that directory out, and `extension/` must not
   be added to `workspaces`. Noise only; no action taken.

## Validation

Run on the branch, not claimed from a previous state:

- `npm run typecheck` — pass (exit 0)
- `npm run lint` — pass (exit 0)
- `npm test` — **327 files passed / 8 skipped; 5169 tests passed / 10 skipped**
- `npm run verify` — pass end to end (typecheck → lint → fixtures → baselines →
  coverage → build → fallow). `fallow audit` reports **"No issues in 5 changed
  files"**.
- The pre-push hook ran `verify` on push and passed. No skip flag was used.

## Follow-up

The consumer swap — replacing the relative-path façade with the bare
`@offlinecv/core` specifier — is a separate PR in the consuming repo and changes
nothing here. Publishing to a registry is a later, independent decision, as is
whether these modules ever physically move into `packages/core/`.
