### PR TITLE
eval(rewrite): measure steering adherence across the model registry, answering #608 half 2 (#608)

### DIFF
--- a/src/lib/webllm/eval/README.md
+++ b/src/lib/webllm/eval/README.md
@@ -38,8 +38,13 @@ Real models run only in a browser. The entry point is the dev-only
 
 ```sh
 npm run eval:rewrite
-# opens http://localhost:5173/offlinecv/eval-rewrite.html
+# opens https://localhost:5173/eval-rewrite.html
 ```
+
+HTTPS, and no `/offlinecv/` prefix. The dev server is TLS by default
+(`basicSsl`, self-signed — accept the warning once; WebGPU needs a
+secure context), and `BASE_PATH` is `/` unless `VITE_BASE_PATH` says
+otherwise. Both halves of the old URL were stale and 404ed.
 
 **One model per tab.** The page asks you to pick a model from the
 dropdown, then click **Run eval** — it loads that model only, runs every

--- a/src/lib/webllm/eval/adherence.test.ts
+++ b/src/lib/webllm/eval/adherence.test.ts
@@ -44,6 +44,23 @@ describe("scoreAdherence — forbidden-word", () => {
     expect(scoreAdherence(FORBIDDEN, ["SPEARHEADED the rollout"])).toBe(false);
   });
 
+  it("FAILS at 3-of-4 compliant — adherence is all-or-nothing, not an average", () => {
+    // The committed `steering-forbidden-word` fixture is four bullets, so this
+    // is the shape the 100% Steering column in
+    // tests/fixtures/rewrite/reports/README.md actually rests on: a model that
+    // obeyed on three bullets and slipped on the fourth scores `false`, not
+    // 75%. Without this case the README's mutation-check claim has no
+    // assertion behind it at the fixture's own bullet count.
+    expect(
+      scoreAdherence(FORBIDDEN, [
+        "Led the billing migration across 12 markets",
+        "Cut scope churn 30% with a quarterly planning process",
+        "Rolled out the design system to four product teams",
+        "Spearheaded the vendor consolidation review",
+      ]),
+    ).toBe(false);
+  });
+
   it("matches on a word boundary, not a substring", () => {
     // "spearheadedness" is not the word the instruction forbade. A substring
     // check would fail a compliant output and understate adherence.

--- a/src/lib/webllm/eval/run-eval-browser.ts
+++ b/src/lib/webllm/eval/run-eval-browser.ts
@@ -5,7 +5,7 @@
  * Browser entry for the rewrite-quality eval harness.
  *
  * Reached via `npm run eval:rewrite` → opens
- * `/offlinecv/eval-rewrite.html` in the dev server. Loads the model
+ * `/eval-rewrite.html` in the dev server. Loads the model
  * the user picked, runs every prompt variant against every fixture,
  * scores with the deterministic rubric, and renders a downloadable
  * JSON + Markdown report.

--- a/src/lib/webllm/spike/README.md
+++ b/src/lib/webllm/spike/README.md
@@ -16,7 +16,7 @@ design commitment:
 ## How to run
 
 1. Start the dev server: `npm run dev`
-2. Open: `http://localhost:5173/offlinecv/jd-spike.html`
+2. Open: `https://localhost:5173/jd-spike.html`
 3. Select **Qwen 2.5 (1.5B)** (default) in the model picker.
 4. Set **Repeats** (default 3 — higher values give better failure-rate estimates).
 5. Click **Run spike** — the model downloads on first run (~1.6 GB); subsequent runs use the cached IndexedDB copy.

--- a/src/lib/webllm/spike/jd-spike-browser.ts
+++ b/src/lib/webllm/spike/jd-spike-browser.ts
@@ -5,7 +5,7 @@
  * Browser entry for the JD-extraction + evidence-judging spike (issue #198).
  *
  * Reached via `npm run eval:jd-spike` or by opening
- * `http://localhost:5173/offlinecv/jd-spike.html` while the dev server
+ * `https://localhost:5173/jd-spike.html` while the dev server
  * is running. Loads the selected model via WebLLM, runs the spike
  * measurement over the 3 inline fixtures (see fixtures.ts), and offers
  * downloadable JSON + Markdown reports.

--- a/tests/fixtures/rewrite/reports/README.md
+++ b/tests/fixtures/rewrite/reports/README.md
@@ -25,7 +25,7 @@ PR descriptions.
 ## Workflow
 
 ```sh
-npm run eval:rewrite        # opens /offlinecv/eval-rewrite.html with WebGPU
+npm run eval:rewrite        # opens https://localhost:5173/eval-rewrite.html (WebGPU)
 # in the browser: click "Run eval", wait, download both report files
 mv ~/Downloads/eval-rewrite-*.json tests/fixtures/rewrite/reports/
 mv ~/Downloads/eval-rewrite-*.md   tests/fixtures/rewrite/reports/
@@ -33,24 +33,125 @@ git add tests/fixtures/rewrite/reports/
 git commit -m "eval(rewrite): snapshot YYYY-MM-DD run"
 ```
 
-## ⚠️ The committed reports predate the Steering column (#608)
+## The 2026-06-23 reports predate the Steering column (#608)
 
-The three reports here are from **2026-06-23** — the first WebGPU runs
-captured on a maintainer machine, which is why the directory shipped
-empty with the harness rather than carrying a synthetic placeholder.
-Their aggregate table carries these eight criteria columns after `Model`
-and `Variant`:
+The three reports from **2026-06-23** were the first WebGPU runs captured
+on a maintainer machine, which is why the directory shipped empty with the
+harness rather than carrying a synthetic placeholder. Their aggregate table
+carries these eight criteria columns after `Model` and `Variant`:
 `Numbers | One-line | Verb | Length | No-preamble | Dedup | Judge | Aggregate`.
 The **Steering** column and the `steering-forbidden-word` fixture arrived
 later with #608's adherence criterion, so those runs measured nothing
-about steering adherence — the question #608 half 2 exists to answer.
+about steering adherence.
 
 **They are not evidence about half 2, in either direction.** Their absence
 of a Steering column is an artifact of when they were run, not a finding.
-Half 2 stays open until a fresh run of the full registry produces one.
 
-When you take that run, the reading is on the model × variant axes — a
-low rate on one model only is a default-model question, not a prompt one.
+## #608 half 2 — steering adherence, answered on the whole registry
+
+The **2026-08-07** reports are the first carrying a real Steering column,
+and they cover every model in `MODEL_REGISTRY` × every shipped prompt
+variant. **All nine cells are 100%:**
+
+| Model | Baseline (shipped) | Terse (rules-only) | Examples-led (few-shot) |
+| --- | --- | --- | --- |
+| Qwen 2.5 (1.5B) — `DEFAULT_MODEL_ID` | **100%** | **100%** | **100%** |
+| Gemma 2 (2B) | **100%** | **100%** | **100%** |
+| Llama 3.2 (3B) | **100%** | **100%** | **100%** |
+
+**Half 2 does not reproduce anywhere.** The user report that opened it —
+"the rewrite ignores my typed instructions" — does not survive measurement
+on any model the app ships, under any prompt variant. That settles two of
+the three causes #608 proposed: it is not prompt-length dilution (the terse
+variant scores the same as the verbose ones) and not model variance (three
+models of different families and sizes agree exactly).
+
+**Per-section repetition is untouched either way.** A `RewriteFixture` is
+one résumé section (`src/lib/webllm/eval/types.ts`) and the runner passes
+`fixture.bullets` as a single unit, so every eval record is a single
+section. #608's hypothesis is about the steering suffix being re-appended
+per section across the multi-section loop in
+`src/lib/webllm/rewrite-resume.ts` — which accumulates `usedVerbs` /
+`usedPhrases` context between sections and which this harness never enters.
+A single-section probe cannot observe that cause, in either direction.
+
+That is a conclusion, not a dismissal: #608 listed "adherence is fine ⇒
+close half 2 as not-reproducible, with the eval as the evidence and a
+permanent regression guard" as a legitimate outcome, and the fixture now
+stands as that guard.
+
+### What this does NOT establish
+
+One limit, worth stating before the number gets cited as more than it is:
+the probe contributes **one scored cell per (model, variant)**, so nine
+cells rest on nine generations of a single four-bullet fixture with a
+single forbidden-word instruction. That is enough to refute "instructions
+are ignored" — a defect that severe would have shown up immediately — and
+not enough to characterise adherence across instruction *kinds*. A
+whole-document instruction ("cut this to one page") is a different claim
+that the architecture still cannot honour section-by-section; that is why
+#608 Phase 3 fixed the steering box's copy instead of the prompt.
+
+Adherence is also the *only* criterion that is uniformly clean. The same
+runs show `Numbers` between 0% and 80% (#778) and `Dedup` at 0% in eight of
+nine cells — unrelated to #608, but visible in these files and worth its own
+look rather than being read as noise.
+
+A third anomaly is in these files and no criterion catches it: **19 of the
+24 Gemma 2 `terse` bullets ship literal markdown bold** — `"**Led** the
+migration of the billing platform…"`. Those are `perBullet[].text`, i.e.
+*post*-`cleanRewriteLine` output, which is what would land in a downloaded
+ATS PDF as literal asterisks; `noPreambleLeak` scores PASS on every one. The
+cause is ordering inside `cleanRewriteLine`
+(`src/lib/webllm/post-process.ts`): the leading-`**Verb**` strip is anchored
+at `^` and runs before the list-marker strip, so a marker shields the bold —
+
+```
+cleanRewriteLine("**Led** the migration…")   → "Led the migration…"
+cleanRewriteLine("- **Led** the migration…") → "**Led** the migration…"
+```
+
+— and the same holds for `*`, `•` and `1.`. Tracked as **#781**, not fixed
+here: the current strip order exists to protect the `*Foo.*` italics case,
+so the reorder needs its own regression test rather than riding along on a
+reports commit.
+
+### How to audit the Steering number yourself
+
+Unlike the aggregate rates, this one is checkable from the committed file.
+The JSON keeps each generated bullet at `records[].rubric.perBullet[].text`,
+so the verdict can be re-derived rather than trusted:
+
+```sh
+python3 -c "
+import json,glob
+for f in sorted(glob.glob('tests/fixtures/rewrite/reports/*2026-08-07*.json')):
+    d=json.load(open(f))
+    for x in d['records']:
+        if x['fixtureId']!='steering-forbidden-word': continue
+        for b in x['rubric']['perBullet']:
+            print(d['modelIds'][0], x['variantId'],
+                  'spearheaded' in b['text'].lower(), b['text'][:60])
+"
+```
+
+All **36** bullets (4 bullets × 3 variants × 3 models) come back `False`,
+with a varied lead verb each time — Migrated / Led / Rolled out /
+Coordinated / Implemented / Managed. The probe is non-trivial by
+construction: all four *input* bullets begin with the forbidden word, so
+echoing the input scores 0%.
+
+`scoreAdherence` itself is unit-tested
+(`src/lib/webllm/eval/adherence.test.ts`) and was mutation-checked against
+this exact fixture before the number was accepted: echoing the input scores
+`false`, a compliant rewrite `true`, 3-of-4 compliant `false`, and empty
+output `false` — so a pass cannot be bought with a truncated or empty
+generation.
+
+### Reading a future run
+
+The reading is on the model × variant axes — a low rate on one model only
+is a default-model question, not a prompt one.
 `src/lib/webllm/eval/README.md` has the full table.
 
 The reporting path itself is covered by

--- a/tests/fixtures/rewrite/reports/eval-rewrite-gemma-2-2b-it-q4f16-1-mlc-2026-08-07T04-52-07-435Z.json
+++ b/tests/fixtures/rewrite/reports/eval-rewrite-gemma-2-2b-it-q4f16-1-mlc-2026-08-07T04-52-07-435Z.json
@@ -1,0 +1,1020 @@
+{
+  "startedAt": "2026-08-07T04:49:02.749Z",
+  "appVersion": "72ad3c1",
+  "modelIds": [
+    "gemma-2-2b-it-q4f16_1-MLC"
+  ],
+  "variantIds": [
+    "baseline",
+    "terse",
+    "examples-led"
+  ],
+  "fixtureIds": [
+    "weak-marketing-generalist",
+    "strong-backend-engineer",
+    "numeric-growth-pm",
+    "redundant-support-lead",
+    "steering-forbidden-word"
+  ],
+  "judgeEnabled": false,
+  "records": [
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Developed and executed marketing campaigns that increased social media engagement by 20% and website traffic by 15%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Contributed to content creation, email blasts, and other promotional materials that boosted brand awareness by 10%.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Supported the team with daily tasks and provided administrative support to ensure seamless project execution.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Collaborated with senior team members to plan and coordinate marketing events, resulting in a 15% increase in attendance and a 10% reduction in event-related costs.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Provided strategic input and creative direction to weekly meetings, contributing to a 5% improvement in campaign effectiveness.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "20%",
+          "15%",
+          "10%",
+          "15%",
+          "10%",
+          "5%"
+        ]
+      },
+      "rewriteDurationMs": 28654,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led a Kafka-based migration of the order-processing pipeline, reducing median latency by 38% across 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed a horizontally-sharded Postgres layout that absorbed a 4x traffic surge during the 2024 product launch without requiring read-replica failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored five engineers through code review and pairing sessions, resulting in the delivery of 23 production features across two quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Reduced cloud spend by $180,000 annually through rightsizing 60 underused instances and consolidating three staging environments into a single tenant-isolated environment.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Built a deterministic load generator that replays 24 hours of production traffic in 90 minutes, enabling four teams to conduct regression checks.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "5",
+          "$180K"
+        ],
+        "addedNumbers": [
+          "$180,000"
+        ]
+      },
+      "rewriteDurationMs": 22405,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Increased weekly active users by 1500% to reach 1.8 million users between 2022 and 2024.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Spearheaded a growth team that generated $4.2 million in incremental ARR through pricing-page experiments and a two-tier paywall redesign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Optimized the checkout process, resulting in a 23% conversion rate increase and a 55% reduction in median time-to-purchase.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Successfully achieved 100% activation targets and 85% acquisition targets across three quarterly objectives in FY2023.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Secured a $250,000 co-marketing budget with two partner brands, generating 11.5 million impressions and 38,000 signups through a six-week campaign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "120K",
+          "1.8M",
+          "14%",
+          "$4.2M",
+          "4.5",
+          "$250K",
+          "11.5M",
+          "38K"
+        ],
+        "addedNumbers": [
+          "1500%",
+          "1.8",
+          "$4.2",
+          "55%",
+          "$250,000",
+          "11.5",
+          "38,000"
+        ]
+      },
+      "rewriteDurationMs": 12072,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Triaged and resolved over 200 customer support tickets per week across email and chat channels.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Successfully managed a 200-ticket queue per week, prioritizing customer support requests by SLA and severity.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Handled an average of 200 customer support tickets per week, effectively addressing inquiries from various channels.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Successfully resolved escalated billing disputes for 40 enterprise accounts, recovering a total of $85,000 in disputed charges.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Reduced onboarding time for new support representatives by 30 days through a 3-week training program, resulting in a 40% reduction in ramp time.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "$85K"
+        ],
+        "addedNumbers": [
+          "$85,000",
+          "40%"
+        ]
+      },
+      "rewriteDurationMs": 8854,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Developed a new billing platform across 12 regional markets.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Streamlined quarterly planning processes for a 9-person team, resulting in a 30% reduction in scope churn.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Launched an internal design system, which was adopted by 4 product squads.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Reduced mean time to recovery for the checkout service from 45 minutes to 11 minutes.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 6260,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "**Spearheaded** various marketing initiatives, supporting the team with day-to-day activities and ensuring seamless execution.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "**Developed** and executed social media campaigns that significantly increased engagement across multiple channels.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "**Conducted** content writing and email blast campaigns, resulting in a [quantifiable result] increase in brand awareness.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "**Collaborated** with senior team members to plan and coordinate marketing events and initiatives, contributing to [quantifiable result] in brand visibility.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "**Actively** participated in weekly meetings, providing strategic input and creative direction as needed.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 7179,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "**Led** the migration of the order-processing pipeline to event-driven Kafka topics, achieving a 38% reduction in median latency across 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "**Designed** a horizontally-sharded Postgres layout that absorbed a 4x traffic surge during the 2024 product launch without requiring read-replica failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "**Mentored** five engineers through code-review and pairing sessions, contributing to the delivery of 23 production features over two quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "**Reduced** cloud spend by $180,000 annually through rightsizing 60 underutilized instances and consolidating three staging environments into a single tenant-isolated environment.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "**Developed** a deterministic load generator that replicated 24 hours of production traffic in 90 minutes, enabling four teams to conduct regression checks.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "5",
+          "$180K"
+        ],
+        "addedNumbers": [
+          "$180,000"
+        ]
+      },
+      "rewriteDurationMs": 13914,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "**Increased** weekly active users by 1500% (120,000 to 1.8 million) through the development and execution of seven onboarding experiments, significantly improving day-7 retention by 14%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "**Spearheaded** a six-person growth team that generated $4.2 million in incremental ARR through successful pricing-page experiments and a two-tier paywall redesign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "**Streamlined** the checkout process, resulting in a 23% increase in conversion rates and a 90% reduction in median time-to-purchase, from 4.5 minutes to 90 seconds.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "**Successfully** owned and achieved all three quarterly OKRs, including acquisition, activation, and retention, with 100% activation target attainment and 85% acquisition target attainment in FY2023.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "**Collaborated** with two partner brands to secure a $250,000 co-marketing budget, generating 11.5 million impressions and 38,000 signups across a six-week campaign.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "120K",
+          "1.8M",
+          "2022",
+          "2024",
+          "$4.2M",
+          "$250K",
+          "11.5M",
+          "38K"
+        ],
+        "addedNumbers": [
+          "1500%",
+          "120,000",
+          "1.8",
+          "$4.2",
+          "90%",
+          "$250,000",
+          "11.5",
+          "38,000"
+        ]
+      },
+      "rewriteDurationMs": 15845,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Triaged and responded to over 200 customer support tickets per week, utilizing email and chat channels to provide timely and effective support.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Optimized a 200-ticket weekly queue by prioritizing customer inquiries based on SLA and severity, ensuring efficient resolution.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Successfully resolved an average of 200 customer support tickets per week, effectively addressing inquiries from various sources.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Negotiated and resolved escalated billing disputes for 40 enterprise accounts, successfully recovering $85,000 in disputed charges.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Developed and implemented a comprehensive onboarding program for 8 new support representatives, significantly reducing ramp time from 60 to 28 days.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "$85K"
+        ],
+        "addedNumbers": [
+          "$85,000"
+        ]
+      },
+      "rewriteDurationMs": 8946,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "**Led** the migration of the billing platform to a new payments provider across 12 regional markets.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "**Facilitated** a quarterly planning process for a 9-person team, resulting in a 30% reduction in scope churn.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "**Developed** and **implemented** an internal design system adopted by 4 product squads.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "**Managed** incident response for the checkout service, reducing mean time to recovery from 45 minutes to 11 minutes.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 6401,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded social media campaigns, generating a 15% increase in website traffic and a 20% boost in follower engagement.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Contributed to email blast content creation, resulting in a 10% lift in open rates and a 8% increase in click-through rates.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Developed and executed promotional materials, including blog posts and landing pages, that drove a 12% conversion rate.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Supported senior team members in planning and coordinating marketing events, resulting in a 25% increase in event attendance and a 15% reduction in overall event preparation time.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Provided strategic input and creative direction during weekly meetings, contributing to a 5% improvement in campaign effectiveness and a 10% increase in market share.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "15%",
+          "20%",
+          "10%",
+          "8%",
+          "12%",
+          "25%",
+          "15%",
+          "5%",
+          "10%"
+        ]
+      },
+      "rewriteDurationMs": 10190,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the order-processing pipeline to event-driven Kafka topics, reducing median latency by 38% across 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed a horizontally-sharded Postgres layout that absorbed a 4x traffic surge during the 2024 product launch without read-replica failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored five engineers through code-review and pairing sessions, resulting in the delivery of 23 production features over two consecutive quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Optimized cloud infrastructure, reducing annual cloud spend by $180,000 through rightsizing 60 underused instances and consolidating three staging environments into a single tenant-isolated environment.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Developed a deterministic load generator that replays 24 hours of production traffic in 90 minutes, enabling four teams to conduct regression checks with greater efficiency.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "5",
+          "$180K"
+        ],
+        "addedNumbers": [
+          "$180,000"
+        ]
+      },
+      "rewriteDurationMs": 11845,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Increased weekly active users by 1500% (120,000 to 1.8 million) between 2022 and 2024 by launching seven onboarding experiments, resulting in a 14% improvement in day-7 retention.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Led a six-person growth team that generated $4.2 million in incremental ARR through pricing-page experiments and a two-tier paywall redesign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Optimized the checkout process, increasing conversion rates by 23% and reducing median time-to-purchase from 4.5 minutes to 90 seconds.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Achieved 100% activation targets and 85% acquisition targets across three quarterly OKRs, spanning acquisition, activation, and retention.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Secured a $250,000 co-marketing budget with two partner brands, generating 11.5 million impressions and 38,000 signups across a six-week campaign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "120K",
+          "1.8M",
+          "$4.2M",
+          "$250K",
+          "11.5M",
+          "38K"
+        ],
+        "addedNumbers": [
+          "1500%",
+          "120,000",
+          "1.8",
+          "$4.2",
+          "$250,000",
+          "11.5",
+          "38,000"
+        ]
+      },
+      "rewriteDurationMs": 14669,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": true,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Triaged an average of 200+ inbound customer support tickets per week across email and chat channels, ensuring timely response and resolution.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Optimized ticket queue management, prioritizing by SLA and severity, resulting in a 200/week average ticket resolution rate.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Resolved escalated billing disputes for 40 enterprise accounts, successfully recovering $85,000 in disputed charges.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Developed and implemented a comprehensive onboarding program for 8 new support representatives, significantly reducing ramp time from 60 days to 28 days.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "$85K"
+        ],
+        "addedNumbers": [
+          "$85,000"
+        ]
+      },
+      "rewriteDurationMs": 8761,
+      "error": null
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the billing platform to a new payments provider across 12 regional markets, resulting in a 10% increase in transaction volume.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Implemented a quarterly planning process for a 9-person team, resulting in a 30% reduction in scope churn.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Developed and launched an internal design system, which was adopted by 4 product squads.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Responded to and mitigated checkout service incidents, reducing mean time to recovery from 45 minutes to 11 minutes.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "10%"
+        ]
+      },
+      "rewriteDurationMs": 8620,
+      "error": null
+    }
+  ],
+  "aggregates": [
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "baseline",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.2,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.4,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.6571428571428571
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "terse",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.4,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.4,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.6857142857142857
+    },
+    {
+      "modelId": "gemma-2-2b-it-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.4,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 1,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.7714285714285715
+    }
+  ]
+}

--- a/tests/fixtures/rewrite/reports/eval-rewrite-gemma-2-2b-it-q4f16-1-mlc-2026-08-07T04-52-07-435Z.md
+++ b/tests/fixtures/rewrite/reports/eval-rewrite-gemma-2-2b-it-q4f16-1-mlc-2026-08-07T04-52-07-435Z.md
@@ -1,0 +1,51 @@
+# Rewrite eval report
+
+- **Started:** 2026-08-07T04:49:02.749Z
+- **App version:** `72ad3c1`
+- **Models:** 1
+- **Prompt variants:** 3
+- **Fixtures:** 5
+- **LLM judge:** disabled (default)
+
+## Aggregate (per model × variant)
+
+| Model | Variant | Numbers | One-line | Verb | Length | No-preamble | Dedup | Steering | Judge | **Aggregate** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Gemma 2 (2B) | Baseline (shipped) | 20% | 100% | 40% | 100% | 100% | 0% | 100% | — | **66%** |
+| Gemma 2 (2B) | Terse (rules-only) | 40% | 100% | 40% | 100% | 100% | 0% | 100% | — | **69%** |
+| Gemma 2 (2B) | Examples-led (few-shot) | 0% | 100% | 40% | 100% | 100% | 100% | 100% | — | **77%** |
+
+## Per-cell records
+
+### Gemma 2 (2B)
+
+#### Baseline (shipped)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | fail | fail | PASS | PASS | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | PASS | PASS | PASS | PASS | — | PASS |  |
+
+#### Terse (rules-only)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | PASS | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | fail | fail | PASS | PASS | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | PASS | PASS | PASS | PASS | — | PASS |  |
+
+#### Examples-led (few-shot)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 4 | fail | fail | PASS | PASS | PASS | — |  |
+| steering-forbidden-word | weak | 4 → 4 | fail | fail | PASS | PASS | — | PASS |  |
+

--- a/tests/fixtures/rewrite/reports/eval-rewrite-llama-3-2-3b-instruct-q4f16-1-mlc-2026-08-07T05-01-09-126Z.json
+++ b/tests/fixtures/rewrite/reports/eval-rewrite-llama-3-2-3b-instruct-q4f16-1-mlc-2026-08-07T05-01-09-126Z.json
@@ -1,0 +1,1005 @@
+{
+  "startedAt": "2026-08-07T04:57:58.840Z",
+  "appVersion": "72ad3c1",
+  "modelIds": [
+    "Llama-3.2-3B-Instruct-q4f16_1-MLC"
+  ],
+  "variantIds": [
+    "baseline",
+    "terse",
+    "examples-led"
+  ],
+  "fixtureIds": [
+    "weak-marketing-generalist",
+    "strong-backend-engineer",
+    "numeric-growth-pm",
+    "redundant-support-lead",
+    "steering-forbidden-word"
+  ],
+  "judgeEnabled": false,
+  "records": [
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Developed and executed comprehensive marketing strategies to drive business growth.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Led social media campaigns, resulting in 25% increase in engagement and 50% boost in follower growth.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Crafted high-quality content, including blog posts, email newsletters, and promotional materials, to enhance brand visibility.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Coordinated and executed large-scale marketing events, including trade shows and product launches, with a 95% attendee satisfaction rate.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Facilitated strategic planning sessions, providing actionable insights and creative direction that informed marketing decisions.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "25%",
+          "50%",
+          "95%"
+        ]
+      },
+      "rewriteDurationMs": 11252,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the order-processing pipeline to event-driven Kafka topics, achieving a 38% reduction in median latency across 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed a horizontally-sharded Postgres layout that successfully absorbed a 4x traffic surge during the 2024 product launch, without read-replica failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored 5 engineers through code-review and pairing sessions, resulting in the shipping of 23 production features over 2 quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Reduced cloud spend by $180,000 annually by rightsizing 60 underused instances and consolidating 3 staging environments into a single tenant-isolated one.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Built a deterministic load generator that replays 24 hours of production traffic in just 90 minutes, utilized by 4 teams for regression checks.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "$180K"
+        ],
+        "addedNumbers": [
+          "$180,000"
+        ]
+      },
+      "rewriteDurationMs": 10513,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Expanded weekly active users to 1.8M between 2022 and 2024 through a series of 7 onboarding experiments, resulting in a 14% day-7 retention rate increase.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Spearheaded a 6-person growth squad that drove $4.2M in incremental ARR through pricing-page experiments and a 2-tier paywall redesign, achieving a 100% return on investment.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Streamlined checkout processes, lifting conversion rates by 23% and reducing median time-to-purchase from 4.5 minutes to 90 seconds.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Set and achieved 100% of quarterly OKRs in FY2023, hitting all activation targets and 85% of acquisition targets across acquisition, activation, and retention.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Secured a $250K co-marketing budget with 2 partner brands, delivering 11.5M impressions and 38K signups across a 6-week campaign, exceeding campaign goals by 15%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "120K"
+        ],
+        "addedNumbers": [
+          "100%",
+          "15%"
+        ]
+      },
+      "rewriteDurationMs": 12837,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Triaged 200+ inbound customer support tickets per week, achieving a 95% first-response rate across email and chat channels.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Prioritized a 200/week ticket queue across email and chat, ensuring 99% of tickets were resolved within the SLA timeframe.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Handled a high-volume email and chat ticket stream, processing an average of 200 tickets per week while maintaining a 4.2-star customer satisfaction rating.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Resolved 40 escalated billing disputes for 40 enterprise accounts, recovering $85K in disputed charges and reducing average dispute resolution time by 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Developed and implemented a 3-week training program that reduced onboard time for new support representatives from 60 days to 28 days, resulting in a 25% increase in team productivity.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "95%",
+          "99%",
+          "4.2",
+          "30%",
+          "25%"
+        ]
+      },
+      "rewriteDurationMs": 10842,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the billing platform to a new payments provider across 12 regional markets, resulting in a 25% increase in customer adoption.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Developed and executed a quarterly planning process for a 9-person team, significantly reducing scope churn by 30% and improving project delivery timelines.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Managed the rollout of an internal design system adopted by 4 product squads, resulting in a 50% decrease in design iteration time and a 20% increase in team productivity.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Coordinated and executed incident response for the checkout service, reducing mean time to recovery from 45 minutes to 11 minutes and minimizing business disruptions.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "25%",
+          "50%",
+          "20%"
+        ]
+      },
+      "rewriteDurationMs": 9966,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded marketing task management, driving team efficiency and productivity through effective task delegation and prioritization.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Conceptualized and executed social media campaigns, resulting in 25% increase in engagement and 50% growth in followers.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Crafted high-quality content for email blasts, blog posts, and social media platforms, achieving a 30% open rate and 20% conversion rate.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Coordinated with senior team members to plan and execute marketing events, resulting in a 90% attendance rate and 25% sales boost.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Contributed to weekly strategy sessions, providing actionable insights and creative direction that informed marketing decisions and drove business growth.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "25%",
+          "50%",
+          "30%",
+          "20%",
+          "90%",
+          "25%"
+        ]
+      },
+      "rewriteDurationMs": 16330,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded a high-visibility migration to event-driven Kafka topics, slashing median latency by 38% and streamlining operations for 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Spearheaded the design and implementation of a horizontally-sharded Postgres layout, which successfully absorbed a 4x traffic surge during a 2024 product launch without read-replica failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored and guided 5 engineers through code-review and pairing sessions, driving the delivery of 23 production features over 2 quarters with zero rollback incidents and significant team productivity gains.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Spearheaded a cloud cost optimization initiative, reducing annualized cloud spend by $180K by rightsizing 60 underutilized instances and consolidating 3 staging environments into a single tenant-isolated one.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Designed and developed a deterministic load generator that can replay 24 hours of production traffic in just 90 minutes, a critical tool used by 4 teams for regression checks and ensuring application quality.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 14593,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded a 15-month onboarding experiment series, launching 7 experiments that collectively increased weekly active users by 1,500% and reached 1.8M users by 2024.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Spearheaded a 6-person growth squad that executed 12 pricing-page experiments and a 2-tier paywall redesign, driving $4.2M in incremental ARR growth.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Spearheaded a checkout overhaul that reduced free-to-paid conversion friction, resulting in a 23% lift in conversions and a median time-to-purchase of 3.5 minutes.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Owned and executed 3 quarterly OKRs spanning acquisition, activation, and retention, achieving 100% of activation targets and 85% of acquisition targets in FY2023.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Negotiated a $250K co-marketing budget with 2 partner brands, delivering 11.5M impressions and 38K signups across a 6-week campaign that exceeded projected ROI by 25%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "120K",
+          "2022",
+          "14%",
+          "4.5"
+        ],
+        "addedNumbers": [
+          "1,500%",
+          "3.5",
+          "25%"
+        ]
+      },
+      "rewriteDurationMs": 14912,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded a high-volume inbound customer support operation, triaging over 200 tickets per week across multiple email and chat channels.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Spearheaded a 200-ticket-per-week ticket queue, expertly prioritizing by SLA and severity to ensure timely resolution and exceptional customer satisfaction.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Consistently handled a high-volume of customer support tickets, resolving over 200 per week from email and chat sources while maintaining a high level of accuracy and efficiency.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Successfully resolved escalated billing disputes for 40 enterprise accounts, recovering $85,000 in disputed charges and delivering a 100% customer satisfaction rate.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Designed and implemented a comprehensive onboarding program for 8 new support representatives, cutting ramp time from 60 days to just 28 days and ensuring seamless integration into the team.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "$85K"
+        ],
+        "addedNumbers": [
+          "$85,000",
+          "100%"
+        ]
+      },
+      "rewriteDurationMs": 12271,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the billing platform to a new payments provider across 12 regional markets, resulting in a 99% uptime rate and a 25% reduction in customer complaints.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Managed a quarterly planning process for a 9-person team, implementing a scope management framework that eliminated 30% of scope changes and improved project delivery timelines by 15%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Oversaw the rollout of an internal design system adopted by 4 product squads, resulting in a 95% adoption rate and a 40% reduction in design-related errors.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Coordinated incident response for the checkout service, implementing a new incident response plan that reduced mean time to recovery from 45 minutes to 11 minutes, resulting in a 99.5% customer satisfaction rate.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "99%",
+          "25%",
+          "15%",
+          "95%",
+          "40%",
+          "99.5%"
+        ]
+      },
+      "rewriteDurationMs": 15702,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded daily operations, ensuring seamless team performance and timely support for senior members.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Conceptualized and executed 5 social media campaigns that drove 25% increase in followers and 15% boost in engagement.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Crafted and edited 8 blog posts, 4 email newsletters, and 2 promotional videos, resulting in 20% rise in website traffic.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Coordinated 3 marketing events, including a product launch and trade show, with a 95% attendee satisfaction rate.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Facilitated weekly strategy sessions, providing actionable insights that informed 30% of the team's creative direction.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "25%",
+          "15%",
+          "20%",
+          "95%",
+          "30%"
+        ]
+      },
+      "rewriteDurationMs": 10784,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the order-processing pipeline to event-driven Kafka topics, resulting in a 38% reduction in median latency across 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed a horizontally-sharded Postgres layout that absorbed a 4x traffic surge during the 2024 product launch, avoiding read-replica failover and ensuring high availability.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored 5 engineers through code-review and pairing sessions, delivering 23 production features over 2 quarters with zero rollback incidents and improved team collaboration.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Rightsized 60 underused instances, reducing cloud spend by $180K annually, and consolidated 3 staging environments into a single tenant-isolated one, improving operational efficiency.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Built a deterministic load generator that replays 24 hours of production traffic in just 90 minutes, providing a reliable regression testing framework for 4 teams.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 12418,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded a 15x user acquisition campaign, growing weekly active users from 120K to 1.8M between 2022 and 2024 through 7 onboarding experiments that boosted day-7 retention by 14%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Spearheaded a 6-person growth squad that drove $4.2M in incremental ARR through A/B testing and a 2-tier paywall redesign, achieving a 25% increase in pricing-page conversions.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Streamlined checkout processes, lifting conversion rates by 23% and reducing median time-to-purchase from 4.5 minutes to 90 seconds with a 30% reduction in friction.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Set and achieved 100% of activation targets and 85% of acquisition targets in FY2023, meeting 95% of quarterly OKR milestones spanning acquisition, activation, and retention.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Secured a $250K co-marketing budget with 2 partner brands, delivering 11.5M impressions and 38K signups across a 6-week campaign that outperformed projections by 15%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "25%",
+          "30%",
+          "95%",
+          "15%"
+        ]
+      },
+      "rewriteDurationMs": 17161,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Streamlined ticket triage, resolving 95% of customer support tickets within 2 hours of receipt across email and chat channels.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Optimized ticket queue management, reducing wait times by 30% and ensuring 99% of high-priority tickets were addressed within 4 hours.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Processed a record 220 customer support tickets per week from email and chat sources, maintaining a 95% customer satisfaction rating.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Resolved 42 high-priority billing disputes for enterprise accounts, recovering $80,000 in disputed charges and improving customer retention by 25%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Designed and implemented a 3-week onboarding program that reduced support representative ramp time from 60 days to 28 days, resulting in a 90% first-call resolution rate.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "$85K"
+        ],
+        "addedNumbers": [
+          "95%",
+          "30%",
+          "99%",
+          "95%",
+          "$80,000",
+          "25%",
+          "90%"
+        ]
+      },
+      "rewriteDurationMs": 11428,
+      "error": null
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": false,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the billing platform to a new payments provider across 12 regional markets, resulting in a 25% reduction in operational costs.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Coordinated quarterly planning sessions for a 9-person team, minimizing scope changes and reducing churn by 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Initiated the rollout of an internal design system, which was adopted by 4 product squads and increased design efficiency by 40%.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Managed incident response for the checkout service, significantly reducing mean time to recovery from 45 minutes to 11 minutes and improving overall customer satisfaction.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "25%",
+          "40%"
+        ]
+      },
+      "rewriteDurationMs": 8758,
+      "error": null
+    }
+  ],
+  "aggregates": [
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.4,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.6285714285714287
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.2,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.4,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 0,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.5142857142857143
+    },
+    {
+      "modelId": "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.2,
+      "oneLineRate": 1,
+      "actionVerbRate": 0,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 0,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.4571428571428572
+    }
+  ]
+}

--- a/tests/fixtures/rewrite/reports/eval-rewrite-llama-3-2-3b-instruct-q4f16-1-mlc-2026-08-07T05-01-09-126Z.md
+++ b/tests/fixtures/rewrite/reports/eval-rewrite-llama-3-2-3b-instruct-q4f16-1-mlc-2026-08-07T05-01-09-126Z.md
@@ -1,0 +1,51 @@
+# Rewrite eval report
+
+- **Started:** 2026-08-07T04:57:58.840Z
+- **App version:** `72ad3c1`
+- **Models:** 1
+- **Prompt variants:** 3
+- **Fixtures:** 5
+- **LLM judge:** disabled (default)
+
+## Aggregate (per model × variant)
+
+| Model | Variant | Numbers | One-line | Verb | Length | No-preamble | Dedup | Steering | Judge | **Aggregate** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Llama 3.2 (3B) | Baseline (shipped) | 0% | 100% | 40% | 100% | 100% | 0% | 100% | — | **63%** |
+| Llama 3.2 (3B) | Terse (rules-only) | 20% | 100% | 40% | 100% | 0% | 0% | 100% | — | **51%** |
+| Llama 3.2 (3B) | Examples-led (few-shot) | 20% | 100% | 0% | 100% | 0% | 0% | 100% | — | **46%** |
+
+## Per-cell records
+
+### Llama 3.2 (3B)
+
+#### Baseline (shipped)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | fail | fail | PASS | PASS | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | fail | PASS | PASS | PASS | — | PASS |  |
+
+#### Terse (rules-only)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | fail | fail | PASS | fail | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | PASS | PASS | PASS | fail | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | PASS | PASS | fail | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | fail | fail | PASS | fail | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | fail | fail | PASS | fail | — | PASS |  |
+
+#### Examples-led (few-shot)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | fail | fail | PASS | fail | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | PASS | fail | PASS | fail | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | fail | PASS | fail | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | fail | fail | PASS | fail | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | fail | fail | PASS | fail | — | PASS |  |
+

--- a/tests/fixtures/rewrite/reports/eval-rewrite-qwen2-5-1-5b-instruct-q4f16-1-mlc-2026-08-07T03-13-05-794Z.json
+++ b/tests/fixtures/rewrite/reports/eval-rewrite-qwen2-5-1-5b-instruct-q4f16-1-mlc-2026-08-07T03-13-05-794Z.json
@@ -1,0 +1,958 @@
+{
+  "startedAt": "2026-08-07T03:11:15.457Z",
+  "appVersion": "72ad3c1",
+  "modelIds": [
+    "Qwen2.5-1.5B-Instruct-q4f16_1-MLC"
+  ],
+  "variantIds": [
+    "baseline",
+    "terse",
+    "examples-led"
+  ],
+  "fixtureIds": [
+    "weak-marketing-generalist",
+    "strong-backend-engineer",
+    "numeric-growth-pm",
+    "redundant-support-lead",
+    "steering-forbidden-word"
+  ],
+  "judgeEnabled": false,
+  "records": [
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Managed marketing tasks and supported team with day-to-day activities.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Executed social media campaigns to boost engagement.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Coordinated content creation, email blasts, and promotional efforts for the brand.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Assisted senior team members in planning and coordinating marketing events and initiatives.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Participated in weekly meetings to provide input on strategy and creative direction as needed.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 6291,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Streamlined order-processing pipeline to Kafka topics, reducing median latency by 38% across 12 services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed horizontally-sharded Postgres layout that absorbed a 4x traffic surge during product launch without failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored engineers through code-review and pairing sessions, shipping 23 production features over 2 quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Reduced cloud spend $180K annually by rightsizing underused instances and consolidating staging environments.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Built deterministic load generator for regression checks used by 4 teams.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "2024",
+          "5"
+        ],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 7140,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Achieved a 14x increase in weekly active users from 120K to 1.8M between 2022 and 2024 by shipping 7 onboarding experiments, lifting day-7 retention.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Led a growth squad that drove $4.2M incremental annual recurring revenue through pricing-page experiments and a 2-tier paywall redesign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Reduced free-to-paid conversion friction with an overhaul of the checkout process, lifting conversion 23% and cutting median time-to-purchase from 4.5 minutes to 90 seconds.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Managed quarterly OKRs spanning acquisition, activation, and retention; hit 100% of activation targets and 85% of acquisition targets in FY2023.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Negotiated a co-marketing budget of $250K with two partner brands, delivering 11.5M impressions and 38K signups across a 6-week campaign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "14%"
+        ],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 12581,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Streamlined customer support operations, triaging and resolving 200+ tickets weekly across email and chat channels.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Managed a high-volume ticket queue of 200/week from email and chat sources, prioritizing by SLA and severity.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Handled customer support tickets at an average rate of around 200 per week from email and chat sources.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Resolved escalated billing disputes for 40 enterprise accounts, recovering $85K in disputed charges.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Successfully onboarded new support representatives within a 3-week training program that reduced ramp time to 28 days.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 6925,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Migrated billing platform to new payments provider across 12 regional markets, scope churn reduced by 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Led quarterly planning process for a 9-person team, scope churn cut by 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Rolled out internal design system adopted by 4 product squads.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Coordinated incident response for checkout service, MTTR reduced from 45 minutes to 11 minutes.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "30%"
+        ]
+      },
+      "rewriteDurationMs": 4710,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Managed marketing tasks and supported day-to-day activities, handling various campaigns.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Coordinated social media efforts to increase engagement on channels like Facebook and Twitter.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Wrote content for email blasts and promotional materials, supporting creative direction.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Planned events and initiatives with senior team members, coordinating their execution.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Participated in weekly meetings, providing input on strategy and creative direction as needed.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 3921,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Streamlined the order-processing pipeline to Kafka topics, reducing median latency by 38% across 12 downstream services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed a horizontally-sharded Postgres layout that handled a 4x traffic surge during a product launch without failover.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored engineers through code reviews and pairing sessions, shipping 23 production features over two quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Reduced cloud spend $180K annually by rightsizing underused instances and consolidating staging environments into one tenant-isolated environment.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Built a deterministic load generator for replaying 24 hours of production traffic, used by four teams for regression checks.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "2024",
+          "5"
+        ],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 6684,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Achieved a 14% increase in day-7 retention by shipping 7 onboarding experiments, growing weekly active users from 120K to 1.8M between 2022 and 2024.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Led a growth squad that drove $4.2M incremental ARR through pricing-page experiments and a 2-tier paywall redesign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Reduced free-to-paid conversion friction with an overhaul of the checkout process, lifting conversion 23% and cutting median time-to-purchase from 4.5 minutes to 90 seconds.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Managed quarterly OKRs spanning acquisition, activation, and retention; hit 100% of activation targets and 85% of acquisition targets in FY2023.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Negotiated a co-marketing budget of $250K with two partner brands, delivering 11.5M impressions and 38K signups across a 6-week campaign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 10912,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Triaged and resolved 200+ inbound customer support tickets per week across email and chat channels, achieving an average SLA of <SLA> minutes.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Managed a 200/week ticket queue prioritizing by SLA and severity, with handoffs to senior agents for escalated issues.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Handled customer support tickets at a rate of around 200 per week from email and chat sources, focusing on high-priority cases first.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Resolved 40 enterprise billing disputes in less than 7 days, recovering $85K in disputed charges.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Onboarded new support representatives within a 3-week training program that reduced ramp time from 60 days to 28 days.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 7614,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the billing platform to a new payments provider across 12 regional markets, achieving significant market penetration and customer satisfaction.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Coordinated a successful quarterly planning process for a 9-person team, resulting in a scope churn reduction of 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Implemented an internal design system that was adopted by 4 product squads, enhancing collaboration and efficiency within the organization.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Managed incident response efforts for the checkout service, significantly reducing mean time to recovery from 45 minutes to just 11 minutes.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 5615,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "weak-marketing-generalist",
+      "fixtureKind": "weak",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Spearheaded marketing efforts, enhancing engagement through 40% increase in social media reach.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Crafted and launched successful campaigns on multiple channels to boost brand awareness by 35%.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Coordinated content creation and distribution for email newsletters and digital assets, driving open rates up to 60%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Collaborated with senior team members to plan and execute impactful events, increasing attendance by 25%.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Regularly attended meetings to align strategy and creative direction, contributing valuable insights to the team.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "40%",
+          "35%",
+          "60%",
+          "25%"
+        ]
+      },
+      "rewriteDurationMs": 6001,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "strong-backend-engineer",
+      "fixtureKind": "strong",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the order-processing pipeline to Kafka, slashing median latency by 38% across 12 services.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Designed a horizontally-sharded Postgres layout that handled a 4x traffic surge during a product launch without failovers.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Mentored engineers through code reviews and pair programming sessions, shipping 23 production features over two quarters with zero rollback incidents.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Rightsized six underused instances and consolidated three staging environments into one tenant-isolated environment, reducing cloud spend $180K annually.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Built a deterministic load generator for regression checks used by four teams in 90 minutes after replaying 24 hours of production traffic.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "2024",
+          "5"
+        ],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 7870,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "numeric-growth-pm",
+      "fixtureKind": "numeric",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Oversaw a 12x growth in weekly active users from 120K to 1.8M, driving an 14% increase in day-7 retention through the implementation of seven onboarding experiments.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Led a team of six that generated $4.2M in incremental annual recurring revenue (ARR) via pricing-page experiments and a two-tier paywall redesign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Reduced free-to-paid conversion friction with a checkout overhaul, lifting conversion rates by 23% while cutting median time-to-purchase from 4.5 minutes to 90 seconds.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Managed three quarterly Objectives & Key Results (OKRs), achieving 100% activation targets and 85% acquisition targets during FY2023.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Negotiated a $250K co-marketing budget with two partner brands, generating 11.5 million impressions and 38,000 signups across a six-week campaign.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [
+          "2022",
+          "2024",
+          "11.5M",
+          "38K"
+        ],
+        "addedNumbers": [
+          "11.5",
+          "38,000"
+        ]
+      },
+      "rewriteDurationMs": 11736,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "redundant-support-lead",
+      "fixtureKind": "redundant",
+      "inputBulletCount": 5,
+      "outputBulletCount": 5,
+      "rubric": {
+        "numbersPreserved": true,
+        "oneLinePerBullet": true,
+        "actionVerbLead": false,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": false,
+        "steeringAdherence": null,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Streamlined customer support response time, triaging 200+ tickets per week across email and chat channels.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Managed a high-volume ticket queue of 200/week from email and chat sources, prioritizing by SLA and severity.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Handled customer support tickets at an average rate of around 200 per week from email and chat sources.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Resolved escalated billing disputes for 40 enterprise accounts, recovering $85K in disputed charges.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 4,
+            "text": "Successfully onboarded 8 new support representatives with a streamlined 3-week training program that reduced ramp time to 28 days.",
+            "startsWithActionVerb": false,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": []
+      },
+      "rewriteDurationMs": 6987,
+      "error": null
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "fixtureId": "steering-forbidden-word",
+      "fixtureKind": "weak",
+      "inputBulletCount": 4,
+      "outputBulletCount": 4,
+      "rubric": {
+        "numbersPreserved": false,
+        "oneLinePerBullet": true,
+        "actionVerbLead": true,
+        "lengthSanity": true,
+        "noPreambleLeak": true,
+        "dedupEffective": null,
+        "steeringAdherence": true,
+        "judgeCoherence": null,
+        "perBullet": [
+          {
+            "index": 0,
+            "text": "Led the migration of the billing platform to a new payments provider across 12 regional markets, driving scope churn reduction by 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 1,
+            "text": "Coordinated quarterly planning for a 9-person team, slashing scope churn by 30%.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 2,
+            "text": "Implemented an internal design system adopted by 4 product squads, enhancing collaboration and efficiency.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          },
+          {
+            "index": 3,
+            "text": "Managed incident response for the checkout service, reducing mean time to recovery from 45 minutes to 11 minutes.",
+            "startsWithActionVerb": true,
+            "lengthOk": true,
+            "oneLine": true
+          }
+        ],
+        "droppedNumbers": [],
+        "addedNumbers": [
+          "30%"
+        ]
+      },
+      "rewriteDurationMs": 5344,
+      "error": null
+    }
+  ],
+  "aggregates": [
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "baseline",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.4,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.4,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.6857142857142857
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "terse",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.8,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.6,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.7714285714285715
+    },
+    {
+      "modelId": "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+      "variantId": "examples-led",
+      "scoredFixtures": 5,
+      "numbersPreservedRate": 0.2,
+      "oneLineRate": 1,
+      "actionVerbRate": 0.2,
+      "lengthSanityRate": 1,
+      "noPreambleLeakRate": 1,
+      "dedupEffectiveRate": 0,
+      "steeringAdherenceRate": 1,
+      "judgeMean": null,
+      "aggregateScore": 0.6285714285714287
+    }
+  ]
+}

--- a/tests/fixtures/rewrite/reports/eval-rewrite-qwen2-5-1-5b-instruct-q4f16-1-mlc-2026-08-07T03-13-05-794Z.md
+++ b/tests/fixtures/rewrite/reports/eval-rewrite-qwen2-5-1-5b-instruct-q4f16-1-mlc-2026-08-07T03-13-05-794Z.md
@@ -1,0 +1,51 @@
+# Rewrite eval report
+
+- **Started:** 2026-08-07T03:11:15.457Z
+- **App version:** `72ad3c1`
+- **Models:** 1
+- **Prompt variants:** 3
+- **Fixtures:** 5
+- **LLM judge:** disabled (default)
+
+## Aggregate (per model × variant)
+
+| Model | Variant | Numbers | One-line | Verb | Length | No-preamble | Dedup | Steering | Judge | **Aggregate** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Qwen 2.5 (1.5B) | Baseline (shipped) | 40% | 100% | 40% | 100% | 100% | 0% | 100% | — | **69%** |
+| Qwen 2.5 (1.5B) | Terse (rules-only) | 80% | 100% | 60% | 100% | 100% | 0% | 100% | — | **77%** |
+| Qwen 2.5 (1.5B) | Examples-led (few-shot) | 20% | 100% | 20% | 100% | 100% | 0% | 100% | — | **63%** |
+
+## Per-cell records
+
+### Qwen 2.5 (1.5B)
+
+#### Baseline (shipped)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | PASS | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | PASS | fail | PASS | PASS | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | fail | fail | PASS | PASS | — | PASS |  |
+
+#### Terse (rules-only)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | PASS | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | PASS | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | PASS | PASS | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | PASS | fail | PASS | PASS | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | PASS | PASS | PASS | PASS | — | PASS |  |
+
+#### Examples-led (few-shot)
+
+| Fixture | Kind | In → Out | Numbers | Verb | Length | Preamble | Dedup | Steering | Error |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| weak-marketing-generalist | weak | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| strong-backend-engineer | strong | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| numeric-growth-pm | numeric | 5 → 5 | fail | fail | PASS | PASS | — | — |  |
+| redundant-support-lead | redundant | 5 → 5 | PASS | fail | PASS | PASS | fail | — |  |
+| steering-forbidden-word | weak | 4 → 4 | fail | PASS | PASS | PASS | — | PASS |  |
+


### PR DESCRIPTION
## Summary

The last open piece of #608. Half 1 (wiring the app's findings into the rewrite prompt) shipped in #666; the adherence scorer, fixture and reporting-path proof shipped in #666/#714. What was left was the one criterion nobody could satisfy from a keyboard: **run the eval across the shipped model list and state a conclusion for half 2.**

This lands the first eval reports carrying a real **Steering** column — one per registry model. **All nine cells are 100%:**

| Model | Baseline (shipped) | Terse (rules-only) | Examples-led (few-shot) |
| --- | --- | --- | --- |
| Qwen 2.5 (1.5B) — `DEFAULT_MODEL_ID` | **100%** | **100%** | **100%** |
| Gemma 2 (2B) | **100%** | **100%** | **100%** |
| Llama 3.2 (3B) | **100%** | **100%** | **100%** |

**Half 2 does not reproduce anywhere.** The report that opened it — "the rewrite ignores my typed instructions" — does not survive measurement on any model the app ships, under any prompt variant.

That accounts for **two** of the three causes #608 proposed:

- **not prompt-length dilution** — the terse (rules-only) variant scores identically to the verbose ones;
- **not model variance** — three families across 1.5B/2B/3B agree exactly;
- **per-section repetition is untouched either way** — a `RewriteFixture` is "one résumé-section fixture" (`eval/types.ts`) and the runner passes `fixture.bullets` as a single unit, so every record is one section. This harness cannot exercise the several-sections loop that hypothesis is about. *(Corrected in review — an earlier draft claimed all three were ruled out, which read as evidence but was true only because there is exactly one section per run.)*

#608 listed "adherence is fine ⇒ close half 2 as not-reproducible, with the eval as the evidence and a permanent regression guard" as a legitimate outcome. This is that, and the fixture stays behind as the guard.

Closes #608

## The number is auditable, not asserted

Worth stating plainly, because a uniform 100% invites the question:

- The reports keep every generated bullet at `records[].rubric.perBullet[].text`. All **36** output bullets (4 × 3 variants × 3 models) are free of the forbidden word, with varied lead verbs — Migrated / Led / Rolled out / Coordinated / Implemented / Managed. The README carries a copy-pasteable snippet to re-derive this from the committed JSON; I ran it verbatim against all three files.
- The probe is **non-trivial by construction**: all four *input* bullets begin with "Spearheaded", so echoing the input scores 0%.
- Real inference, not a stub: 110.3s / 184.6s / 189.8s total per model, 3.9–28.7s per rewrite.
- Each run: 15 records = 3 variants × 5 fixtures, **0 errored**, `appVersion 72ad3c1` — all three ran the same code.
- `steeringAdherence` is populated only on the probe fixture and `null` on the other 12 records per run — the scoping the criterion was designed for.
- `scoreAdherence` was mutation-checked against this exact fixture before any number was accepted: echoing the input → `false`, compliant rewrite → `true`, 3-of-4 compliant → `false`, empty output → `false`. A pass cannot be bought with a truncated generation. The 3-of-4 case had no test behind it when the README cited it (review nit) — it now does (`adherence.test.ts`), and I mutation-checked *that*: swapping the scorer to majority-pass fails it.

## What this does NOT establish

Recorded in the reports README rather than left to a reader's charity: the probe contributes **one scored cell per (model, variant)**, so nine cells rest on nine generations of a single four-bullet fixture with a single forbidden-word instruction. Enough to refute "instructions are ignored" — a defect that severe would have shown up immediately — and not enough to characterise adherence across instruction *kinds*. A whole-document instruction ("cut this to one page") remains something the architecture cannot honour section-by-section, which is why #608 Phase 3 fixed the steering box's copy rather than the prompt.

## Also in this PR

Stale dev-server URLs in the harness docs pointed at `http://localhost:5173/offlinecv/…` — wrong on both counts (no `/offlinecv/` prefix under the current base, and the dev server is HTTPS via `basicSsl`). I verified the eval URL 404s against a live server before changing it. It is the first thing anyone follows when taking one of these runs, so it belongs with the run rather than in a separate PR.

Review caught that my first sweep grepped for the `/offlinecv/` prefix and so missed files with only the wrong *scheme*. Now swept on both patterns: `parse-eval/README.md` (flagged in review) plus **`CONTRIBUTING.md`**, which the review did not flag and which is the first file a new contributor reads — `README.md` and `CLAUDE.md` already said `https://`, so it was the lone outlier. Zero `http://localhost:5173` or `/offlinecv/` dev URLs remain anywhere in the tree.

## Review focus

- `tests/fixtures/rewrite/reports/README.md` — the conclusion is the deliverable. Does a uniform 100% across nine cells read as suspicious rather than clean? My argument that it isn't: the scorer was mutation-checked in all four directions, the probe fails on echoed input, and the outputs are in the artifact for anyone to grep.
- **`Numbers 0–80%` and `Dedup 0%` are visibly poor in these same reports** — now filed as **#778**, not left as a remark. They are other criteria outside #608's scope, and the 2026-06-23 baselines are not comparable (they predate the current fixture set), so this PR ships the files that show the problem without pretending to fix it. Reviewers should decide whether #778 outranks whatever is next, because a rewriter dropping `$4.2M` from a bullet is a worse user outcome than the one this PR closes.
- The commit bundles a doc fix with the eval snapshot. Reviewer's call was to keep it together; leaving it as one commit.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/lib/webllm` green — 441 passed
- [x] `npm run check:fixtures` green — 58 PDFs + 15 sidecars, all synthetic
- [x] All three report JSONs swept for PII before committing: every string-valued path enumerated; no emails or phone numbers; all free text is model output over the synthetic fixtures
- [x] Steering verdict re-derived from the committed artifacts — 36/36 bullets clean
- [x] `scoreAdherence` mutation-checked against the shipped fixture, all four directions
- [ ] `npm run verify` — **not green locally, and not because of this branch.** 9 tests in `src/lib/letter-egress-ack.test.ts` fail identically on unmodified `origin/main`; they pass on Node 18 and fail on Node 25 (native `localStorage` breaks that file's `afterEach`). `.nvmrc` pins 20 and CI runs it, so CI is the authority — and CI `verify` is **green** on this PR. Filed as **#779**; pushed with `OFFLINECV_SKIP_HOOKS=1` rather than tick a box I could not honestly tick.

## Not in this PR — and where each piece lives instead

Nothing here is left as prose in a squashed commit message. All three real problems this work surfaced are filed — #778, #779 and #782:

- **Any prompt or model change for adherence.** #608 required measurement to precede a fix; the measurement says there is nothing to fix on the adherence path. Nothing outstanding, no follow-up needed.
- **Number preservation is failing — #778.** These reports show `numbersPreservedRate` between 0% and 80%, with **8 of 9 cells at or below 50%**, dropping salary figures (`$180K`, `$85K`, `$250K`), user counts (`120K`, `1.8M`) and percentages (`14%`). That is the rewrite's headline guardrail — `SECTION_REWRITE_SYSTEM_PROMPT` says "Preserve every concrete number from the input EXACTLY" — and it is not holding on any model, including the default. Filed with the per-fixture dropped-number table and four fix directions. **Out of scope here, but more serious than the criterion this PR closes.**
- **`dedupEffectiveRate` is 0 in 8 of 9 cells** — recorded as a secondary section of #778 rather than its own issue, because the rate is computed over `redundant` fixtures only and there is exactly one, so it is one fixture failing repeatedly rather than a broad sample.
- **Rewritten bullets ship literal markdown bold — #782.** Found in review, not by me: **19 of 20 Gemma "terse" bullets** carry `**Led** the migration…` in `perBullet[].text`, which is *post*-`cleanRewriteLine` output — so it is what would reach an exported ATS PDF. Root cause is ordering in `post-process.ts`: the leading-`**Verb**` strip is anchored at start-of-line and runs *before* the list-marker strip, so any of `-`, `*`, `•`, `1.` shields the bold. I reproduced all four marker forms by direct execution. `noPreambleLeak` passes on every affected record, so no criterion catches it. Filed with the caveat that the fix is not simply reordering — the current order deliberately protects the `*Foo.*` italics case.
- **`verify` is red on Node 22+ — #779.** `letter-egress-ack.test.ts` fails 9/9 on Node 25 and passes 9/9 on Node 18, on unmodified `main`. This is **#398 recurring in a file written after it was closed**, which argues for pinning the test environment rather than patching a third file. Why this PR's `verify` box is unticked.

#776 (cross-model adherence) was opened when Gemma and Llama looked unrunnable, and is **closed as completed** — both runs succeeded on a retry and are committed here.

## Provenance

Code implementation via: Claude Opus 5 (1M context). Reasoning effort is not surfaced to the session, so it is omitted rather than guessed.
Eval runs: executed by the maintainer in Chrome with WebGPU. The JSONs are the unmodified harness downloads; their Markdown siblings were regenerated from those JSONs via `renderMarkdownReport` (only the JSON was saved during the runs).
