### PR TITLE
chore(core): make @offlinecv/core publishable and gate the tarball

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -37,8 +37,38 @@
   // not an npm package — it's `@import`ed from src/styles.css. Fallow's dependency
   // scanner has no view of the Vite alias, so it reports an "unlisted dependency".
   // Teach it the specifier is intentional.
+  // `idb` (#772) is the second entry and a different kind of false positive from
+  // the alias above. `@offlinecv/core` declares it, and no file under
+  // `packages/core/` imports it. Both halves are true and neither is a defect:
+  // that package is a BARREL — `packages/core/src/index.ts` re-exports from
+  // `../../../src/lib/**`, its build emits that whole closure into
+  // `packages/core/dist/`, and `idb` is reached from `src/lib/storage/db.ts`
+  // INSIDE the emitted copy the tarball ships. Drop the dependency and the
+  // published package throws `ERR_MODULE_NOT_FOUND` on first import. fallow
+  // scopes dependency analysis to the workspace DIRECTORY, so it cannot reach a
+  // verdict about this one that is right.
+  //
+  // This entry is GLOBAL, and that is a real cost, not a preference — unlike the
+  // `ignoreExports` blocks below, which are all file-scoped. It was tried both
+  // scoped ways first: an `overrides` entry with `unused-dependencies: "off"`
+  // (matching `packages/core/package.json` and `packages/core/**`) and a nested
+  // `packages/core/.fallowrc.jsonc`. fallow 2.96 honours neither for a
+  // dependency finding — the finding attaches to a manifest, and per-file
+  // overrides apply to rules that attach to source files. So the root manifest's
+  // own `idb` goes unchecked as collateral. What that gives up: if
+  // `src/lib/storage/db.ts` ever stopped importing `idb`, fallow would no longer
+  // report the root dependency as dead. Narrow this the day fallow can scope it.
+  //
+  // For the package this is actually about, the check is not lost but relocated
+  // and strengthened. `npm run check:core` (scripts/check-core-package.mjs,
+  // assertion 5) packs the tarball, walks the module graph reachable from the
+  // entry `exports` points at, and fails on a declared dependency nothing in it
+  // imports — over the emitted closure fallow can't see, in both directions, and
+  // on reachability rather than the file list. Verified to fail: adding a surplus
+  // dependency to that manifest reports it by name.
   "ignoreDependencies": [
-    "@design-tokens"
+    "@design-tokens",
+    "idb"
   ],
 
   // Complexity/CRAP thresholds only apply to shipped product code. The dev-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,17 @@ jobs:
       - run: npm run check:baselines
         env:
           GH_TOKEN: ${{ github.token }}
+      # Publishable-tarball gate (#772). Mirrored here rather than left inside
+      # `npm run verify` because branch protection requires THIS job, and every
+      # other step above is a bundler or a typechecker: none of them loads
+      # `@offlinecv/core` the way a published consumer does, so the whole class
+      # of "the tarball is wrong" — `exports` pointing at a path that does not
+      # ship, a dependency reached from the emit but absent from
+      # `dependencies` — is invisible to them. Without this line a push that
+      # skips the pre-push hook merges green and only the daily
+      # `promote-release.yml` (which does run `npm run verify`) goes red, after
+      # the fact.
+      - run: npm run check:core
       # Run the suite with coverage so the fallow step below can compute
       # accurate per-function CRAP scores (coverage/coverage-final.json).
       - run: npm run test:coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 COMMIT_EDITMSG
 node_modules/
+# Build output. Unanchored on purpose, so it covers BOTH `vite build`'s root
+# `dist/` and `packages/core/dist/` — the emitted JS + bundled declaration that
+# `@offlinecv/core` publishes (#772). That one is rebuilt by the package's
+# `prepare`, so a committed copy would only ever be a stale one.
 dist/
 .env.local
 .env.*.local

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -106,7 +106,11 @@ export default [
   // ── Global ignores ──────────────────────────────────────────────────────
   {
     ignores: [
-      "dist/**",
+      // Build output, wherever it lands. Anchored `dist/**` only matched
+      // `vite build`'s root output, so `eslint .` walked the 49 emitted files
+      // under `packages/core/dist/` (#772) — generated JS, linted against rules
+      // written for hand-authored source. Unanchored, both are covered.
+      "**/dist/**",
       "node_modules/**",
       "*.config.js",
       "*.config.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
         "globals": "^16.2.0",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
+        "rollup": "^4.60.4",
+        "rollup-plugin-dts": "^6.5.1",
         "tailwindcss": "^4.3.1",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.34.0",
@@ -7036,6 +7038,72 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.5.1.tgz",
+      "integrity": "sha512-jODTXp3H7MK/Ur/ErtsrQ0G1GvaCmc3du+y5pNrdBMf6d7HlL2Nd/N6TkEr+f75CkUj01zEoEd7y2elH0eHi1Q==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "convert-source-map": "^2.0.0",
+        "magic-string": "^0.30.21"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^8.0.0"
+      },
+      "peerDependencies": {
+        "@typescript/typescript6": "^6",
+        "rollup": "^3 || ^4",
+        "typescript": "^4.5 || ^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@typescript/typescript6": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -8689,7 +8757,14 @@
     "packages/core": {
       "name": "@offlinecv/core",
       "version": "0.0.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "idb": "^8.0.3"
+      },
+      "devDependencies": {
+        "rollup": "^4.60.4",
+        "rollup-plugin-dts": "^6.5.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "lint": "eslint .",
     "check:fixtures": "node scripts/check-fixture-pii.mjs",
     "check:baselines": "node scripts/check-known-failures.mjs",
+    "check:core": "node scripts/check-core-package.mjs",
     "test:coverage": "vitest run --coverage",
-    "verify": "tsc -b --noEmit && eslint . && npm run check:fixtures && npm run check:baselines && vitest run --coverage && vite build && (fallow audit --base origin/main --coverage coverage/coverage-final.json || echo 'fallow audit exited non-zero (report-only, ignored)')"
+    "verify": "tsc -b --noEmit && eslint . && npm run check:fixtures && npm run check:baselines && npm run check:core && vitest run --coverage && vite build && (fallow audit --base origin/main --coverage coverage/coverage-final.json || echo 'fallow audit exited non-zero (report-only, ignored)')"
   },
   "dependencies": {
     "@fontsource/poppins": "^5.2.7",
@@ -60,6 +61,8 @@
     "globals": "^16.2.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
+    "rollup": "^4.60.4",
+    "rollup-plugin-dts": "^6.5.1",
     "tailwindcss": "^4.3.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.0",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,11 +5,27 @@
   "license": "Apache-2.0",
   "description": "The headless, browser-only core of offlinecv: job capture, local library storage, JD term extraction and fit rating. Re-exported from src/lib — see src/index.ts.",
   "type": "module",
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/packages/core/src/index.js"
     }
+  },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.json",
+    "dist/index.d.ts"
+  ],
+  "scripts": {
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json && rollup -c rollup.dts.config.mjs",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "idb": "^8.0.3"
+  },
+  "devDependencies": {
+    "rollup": "^4.60.4",
+    "rollup-plugin-dts": "^6.5.1"
   }
 }

--- a/packages/core/rollup.dts.config.mjs
+++ b/packages/core/rollup.dts.config.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Declaration bundler for `@offlinecv/core` (#772).
+ *
+ * This step exists to work around one specific TypeScript behaviour, and it is
+ * worth naming precisely so nobody deletes it as redundant with `tsc`.
+ *
+ * `tsconfig.build.json` sets `rewriteRelativeImportExtensions`, which rewrites
+ * this repo's explicit `./foo.ts` specifiers to `./foo.js` — but **only in the
+ * JavaScript output**. Verified on TypeScript 5.8.3, under both
+ * `moduleResolution: "bundler"` and `"nodenext"`: the generated `.d.ts` keeps
+ * the `.ts` specifier verbatim. The tarball ships no `.ts` files (see `files`
+ * in package.json), so a consumer typechecking against a plain per-file `.d.ts`
+ * tree would chase `./crud.ts` into a file that is not there and fall back to
+ * `any` — or, with `skipLibCheck: false`, simply fail.
+ *
+ * Bundling the declarations erases the problem rather than patching it: every
+ * internal specifier is inlined, so the published `dist/index.d.ts` has no
+ * relative imports left to resolve. `check:core` asserts exactly that, plus a
+ * `nodenext` consumer typecheck with `skipLibCheck: false` — the configuration
+ * a plain Node consumer actually uses, and the one that regresses first if this
+ * step is removed.
+ *
+ * `idb` stays external because it is a real runtime dependency the consumer
+ * installs (see `dependencies` in package.json); inlining a third party's types
+ * into our surface would fork them at our version.
+ *
+ * Licensing, recorded deliberately rather than discovered later: this repo vets
+ * OSS licenses before adopting a dependency, and `rollup-plugin-dts` is
+ * **LGPL-3.0-only** — the only non-permissive license anywhere near this build.
+ * It is a build-time `devDependency` that reads `.d.ts` files and writes one
+ * back out; nothing of it is linked, bundled or otherwise carried into the
+ * emitted artifact, so the tarball stays cleanly Apache-2.0. Anything that
+ * changed that — a runtime helper injected into the output, say — would make it
+ * a licensing decision rather than a tooling one.
+ */
+
+import dts from "rollup-plugin-dts";
+
+export default {
+  // The per-file declaration tree `tsc -p tsconfig.build.json` emits. The path
+  // carries the `packages/core/src` nesting because `rootDir` has to cover the
+  // `../../../src/lib/…` closure the barrel re-exports through.
+  input: "dist/packages/core/src/index.d.ts",
+  output: { file: "dist/index.d.ts", format: "es" },
+  external: ["idb"],
+  plugins: [dts()],
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,9 @@
  * the one export it used. Routing `computeCoverageFromCorpus` through the barrel
  * would drag a network primitive onto that graph for nothing. Measured: the
  * value-edge closure of the specifiers below is 27 modules and reaches no
- * `fetch`/`WebSocket`/`XMLHttpRequest`/`EventSource` at all.
+ * `fetch`/`WebSocket`/`XMLHttpRequest`/`EventSource` at all. That is a statement
+ * about the value-edge closure and not about the tarball's file list, which is
+ * larger — see "The tarball ships more files than the graph reaches" below.
  *
  * **2. Types are re-exported with `export type`.** Not a style preference. A
  * type-only edge erases at build time, so `export type { JobRecord } from …`
@@ -54,23 +56,81 @@
  * `lib/job-search`, `lib/jd-match`, `lib/heuristics`, `lib/score` and `webllm`,
  * with exactly one external runtime dependency: `idb`. The `heuristics`, `score`
  * and `webllm` modules are reached only through `import type` edges, so they
- * erase at build time and matter to `tsc` alone.
+ * erase from the runtime graph — but not from the tarball.
  *
- * That `idb` is deliberately **not** in this package's `dependencies`, and the
- * omission is not an oversight: nothing in `packages/core/` imports it. It is
- * reached from `src/lib/storage/db.ts`, which belongs to the root package, so
- * the root is where it is declared and where it resolves from. Listing it here
- * would be a dependency this package does not have — it becomes true, and
- * necessary, on the day these files physically move.
+ * ## The tarball ships more files than the graph reaches
+ *
+ * `tsc` emits a `.js` for every file in the program, the ones reached only by
+ * `import type` included, and `files` ships all of them. So `npm pack` produces
+ * 49 modules of which 27 are reachable from this barrel — and three of the
+ * unreachable 22 read exactly like the thing this file says is absent:
+ *
+ *   - `dist/src/lib/jd-match/fetch-jd.js` — a live `fetch(url, …)`
+ *   - `dist/src/lib/analytics.js` — `import.meta.env`, `await import("posthog-js")`
+ *   - `dist/src/lib/webllm/web-llm.js` — `await import("@mlc-ai/web-llm")`
+ *
+ * Neither dynamic import is in `dependencies`, and nothing can load either file:
+ * `exports` declares no subpath, so a consumer reaching for one gets
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` (verified), and no reachable module imports
+ * them. Unreachable dead JS a reader can open — not an egress path.
+ *
+ * The network-free claim above is therefore about the RUNTIME GRAPH rather than
+ * the file list, and on the graph it holds exactly: 27 modules, no network
+ * primitive, one bare import (`idb`). Which means grepping the tarball for
+ * `fetch(` is the wrong audit — it finds `fetch-jd.js` plus two prose mentions
+ * in comments. Walk the value edges out of `dist/packages/core/src/index.js`
+ * instead; that is the graph a consumer actually loads, and what `check:core`'s
+ * probe exercises when it imports the package by specifier.
+ *
+ * `idb` **is** in this package's `dependencies`, and #772 is the reason it now
+ * is. While this was a bare re-export barrel the omission was right: nothing
+ * under `packages/core/` imported `idb`, it was reached from
+ * `src/lib/storage/db.ts` which belongs to the root package, and declaring it
+ * would have claimed a dependency this package did not have. Building the
+ * package changed the fact rather than the reasoning — the tarball now carries
+ * its own emitted copy of that closure, so `dist/…/storage/db.js` holds the
+ * `import … from "idb"` with nothing above it to resolve from. It became a real
+ * dependency at BUILD time, not on the day these files physically move.
+ * `check:core` is what keeps that honest: it imports the packed tarball with
+ * only the declared dependencies symlinked in, so dropping `idb` fails with
+ * `ERR_MODULE_NOT_FOUND` naming `storage/db.js`.
  *
  * ## Status
  *
- * `private: true` and unpublished, on purpose. The storage layer is the youngest
- * part of this surface and publishing a version number is a promise not to
- * change it; that promise gets made once the layer has been quiet for a while.
- * Until then this package exists so the surface is *written down and
- * typechecked* — the specifier can be adopted, and the registry step is a
- * separate, later decision.
+ * `private: true` and unpublished, on purpose, and #772 did not change that.
+ * The storage layer is the youngest part of this surface and publishing a
+ * version number is a promise not to change it; that promise gets made once the
+ * layer has been quiet for a while.
+ *
+ * What #772 did change is that the package is now BUILDABLE, which it was not.
+ * `exports` used to point at this very file — correct for a bundler resolving a
+ * workspace link, and unpublishable in a second sense: `private: true` was all
+ * that stood between that `exports` map and a publish, and dropping that one
+ * line would have handed every Node consumer a file full of type annotations
+ * and `.ts` specifiers. `npm run build -w @offlinecv/core` now emits JS and
+ * declarations (`tsconfig.build.json`), `exports` points at the emitted entry,
+ * and `prepare` runs the build — which is what keeps a workspace/`file:` link
+ * consumer working now that `exports` no longer names `src/`.
+ *
+ * The build has two steps and the second is not decoration.
+ * `rewriteRelativeImportExtensions` turns this repo's explicit `./foo.ts`
+ * specifiers into `./foo.js` in the JavaScript — but **not** in the `.d.ts`
+ * output (verified on TypeScript 5.8.3, under both `bundler` and `nodenext`).
+ * The tarball ships no `.ts`, so a per-file declaration tree would dangle on
+ * every internal import and a consumer would silently get `any`.
+ * `rollup.dts.config.mjs` bundles the declarations into one specifier-free
+ * `dist/index.d.ts`, and `files` ships that instead of the tree.
+ *
+ * `npm run check:core` (`scripts/check-core-package.mjs`, wired into `verify`)
+ * is what makes any of this checkable from in here. Everything else in this
+ * repo is a bundler, so a broken tarball stayed invisible until the registry,
+ * where the fix costs a version bump rather than a commit. It packs the
+ * package, imports it under plain Node with ONLY its declared dependencies
+ * present, and typechecks a generated consumer against it under `nodenext`
+ * with `skipLibCheck: false`.
+ *
+ * So what is left before the registry is the decision about the version
+ * promise — no longer an unbuilt prerequisite underneath it.
  */
 
 /**

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,61 @@
+{
+  // The emit config for `@offlinecv/core` (#772). It cannot extend
+  // `tsconfig.app.json` or `tsconfig.node.json`: both are `noEmit`, because in
+  // this repo `tsc` only ever typechecks and `vite build` produces the bundles.
+  // This package is the one artifact that has to leave the repo as JavaScript,
+  // so it owns the only emitting config in the tree.
+  "compilerOptions": {
+    "target": "ES2022",
+    // `DOM` is not optional. The storage layer this package re-exports is built
+    // on IndexedDB and BroadcastChannel, so the closure does not typecheck at
+    // all without the browser lib — the package is browser-only by design and
+    // the config says so.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    // The repo writes relative imports with an explicit `.ts` extension, which
+    // no runtime resolves. These two options are what turn that convention into
+    // shippable JS: `tsc` accepts the `.ts` specifier on input and rewrites it
+    // to `.js` in the emitted JavaScript. It does NOT rewrite the `.d.ts` output
+    // (verified on TS 5.8.3) — that gap is what `rollup.dts.config.mjs` exists
+    // to close, and why the tarball ships a single bundled declaration.
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+
+    // Load-bearing for the privacy property the barrel's docblock claims. The
+    // surface is 27 value modules plus 22 reached only through `import type`
+    // edges. What `verbatimModuleSyntax` guarantees is narrower than "those 22
+    // erase": it guarantees the EMIT MATCHES THE SOURCE SYNTAX — an
+    // `import type`/`export type` erases, a plain `import`/`export` is
+    // preserved, and no elision heuristic decides either way behind our backs.
+    // The erasing is done by the barrel's disciplined `export type` statements;
+    // this flag is what makes that value/type split auditable by reading
+    // `src/index.ts`. Turn one of those 22 into a plain `export` and the flag
+    // will faithfully preserve it — growing the runtime graph past the 27 that
+    // were audited to reach no `fetch`/`WebSocket`.
+    "verbatimModuleSyntax": true,
+
+    // `src/lib/analytics.ts` reads `import.meta.env`. It is on the closure
+    // through a type edge only, so it erases at runtime, but `tsc` still has to
+    // typecheck it — and outside `tsconfig.app.json` that is four
+    // `TS2339: Property 'env' does not exist on type 'ImportMeta'`.
+    "types": ["vite/client"],
+
+    "declaration": true,
+    // No `declarationMap`, no `sourceMap`: `files` in package.json ships no
+    // sources, so either map would resolve to nothing in a consumer's tarball.
+
+    "strict": true,
+    "skipLibCheck": true,
+
+    // The barrel re-exports through `../../../src/lib/…`, so the emit closure
+    // reaches outside this package and `rootDir` has to cover the repo root.
+    // The consequence is the nesting in `dist/packages/core/src/index.js` —
+    // expected, and what `exports` points at.
+    "rootDir": "../..",
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["src/index.ts"]
+}

--- a/scripts/check-core-package.mjs
+++ b/scripts/check-core-package.mjs
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Publishability gate for `@offlinecv/core` (#772). Packs the package the way
+ * `npm publish` would and consumes the resulting tarball the way a stranger
+ * would, so the tarball's defects surface here rather than in the registry.
+ *
+ * WHY THIS EXISTS AT ALL. Every other check in this repo is a bundler. `tsc -b
+ * --noEmit` typechecks the sources, `vite build` bundles them, and the one
+ * consumer that exists resolves the package through a workspace link and
+ * compiles its TypeScript itself. None of them loads the package the way a
+ * published consumer does, so the entire class of "the tarball is wrong" is
+ * invisible from inside the repo — green CI right up to the publish, where the
+ * fix costs a version bump instead of a commit. Before #772 the `exports` map
+ * pointed straight at `src/index.ts`, and `private: true` was the only thing
+ * refusing the publish: dropping that one line would have handed every Node
+ * consumer a file full of type annotations. #772 is what made that stop being
+ * true, and this gate is what keeps it from becoming true again.
+ *
+ * THE LOAD-BEARING PART is not the import — it is the `node_modules/` this
+ * script builds around the extracted tarball. It contains exactly the packages
+ * the tarball's own `dependencies` names, symlinked out of the repo's install,
+ * and nothing else. That is what makes the dependency list a claim under test:
+ * `idb` is reached from `src/lib/storage/db.ts` and is now inside the emitted
+ * copy this package ships, so dropping it from `dependencies` has to fail here.
+ * It does — verified by deleting it and watching the import throw
+ * `ERR_MODULE_NOT_FOUND`. Everything runs under the OS temp dir precisely so a
+ * missing dependency cannot be satisfied by walking up into the repo's own
+ * `node_modules`, which would turn the check into theatre.
+ *
+ * FIVE THINGS ARE ASSERTED, and each one maps to a way the tarball can be wrong:
+ *
+ *   1. Its SHAPE. No TypeScript source ships (that was the original defect), the
+ *      per-file `.d.ts` tree does not ship either — `dist/index.d.ts` is the
+ *      only declaration, because the per-file tree is unusable (see 4) — and
+ *      every relative specifier in every shipped `.js` resolves to a file that
+ *      also ships. That last one covers what assertion 2 structurally cannot:
+ *      the probe imports the entry, so it only ever exercises the REACHABLE
+ *      graph, while `tsc` emits a `.js` for every file in the program and
+ *      `files` ships all of them. The unreachable remainder is never loaded by
+ *      anything, so a dangling import inside it is silent forever. It is not
+ *      hypothetical: 87 extensionless relative imports (`"../heuristics/
+ *      sections"`, `"../html-to-markdown"`, …) survive elsewhere under `src/`,
+ *      none of them in the emit closure today, and this package is `"type":
+ *      "module"` — Node ESM does no extension search, so the first one pulled
+ *      in ships broken. Reading is not resolution: `sections.config.js` imports
+ *      `./sections.config.json` with no `with { type: "json" }` and so cannot
+ *      itself load under Node, but the JSON does ship and the specifier does
+ *      resolve, which is all this asserts.
+ *   2. Its RUNTIME. The entry imports under plain Node with only its declared
+ *      dependencies present, exports exactly the 22 names the barrel promises,
+ *      and two of them are exercised for BEHAVIOUR rather than existence —
+ *      `deriveJobId` has to still strip tracking parameters, `MAX_STARS` has to
+ *      still be 5. A shape-only assertion passes on a tarball that exports 22
+ *      broken functions.
+ *   3. Its TYPES, from a consumer's position: a generated project resolves
+ *      `@offlinecv/core` under `moduleResolution: "nodenext"` with
+ *      `skipLibCheck: false` — the strictest configuration a plain Node consumer
+ *      can have, and the first one to break. It carries a `@ts-expect-error`
+ *      that only holds if the declarations were really read; if they resolved to
+ *      nothing the symbols would widen to `any`, the expected error would
+ *      vanish, and TypeScript would fail the unused directive.
+ *   4. That no relative specifier survives in `dist/index.d.ts`. This is the
+ *      subtle one. `rewriteRelativeImportExtensions` rewrites this repo's
+ *      explicit `./foo.ts` specifiers to `./foo.js` in the JS output but NOT in
+ *      the `.d.ts` output (TypeScript 5.8.3, under both `bundler` and
+ *      `nodenext`). Since no `.ts` ships, a per-file declaration tree would
+ *      dangle — which is why `rollup.dts.config.mjs` bundles the declarations
+ *      into one specifier-free file, and why this assertion is how we find out
+ *      if that step is ever removed or regresses.
+ *   5. That every declared dependency is REQUIRED, not merely sufficient. The
+ *      `node_modules/` above proves the list is big enough; nothing in it
+ *      notices a dependency the code never imports, because a surplus symlink
+ *      breaks nothing. So `dependencies` is compared, in both directions,
+ *      against the packages a breadth-first walk from the entry actually
+ *      reaches. Reachability rather than the file list, because the shipped
+ *      remainder is full of modules nothing loads — two of them import
+ *      `posthog-js` and `@mlc-ai/web-llm`, neither of which this package
+ *      depends on in any sense a consumer would recognise.
+ *      This is also what stands in for the rule `.fallowrc.jsonc` turns off
+ *      here. fallow scopes dependency analysis to the workspace DIRECTORY, and
+ *      `idb` is reached from the emit closure rather than from anything under
+ *      `packages/core/`, so fallow reads it as unused and cannot reach a
+ *      verdict about this package that is right. Walking the emitted graph can,
+ *      which is why the suppression buys a stronger assertion rather than
+ *      losing one.
+ *
+ * HERMETIC BY CONSTRUCTION: nothing here touches the network. The dependency
+ * `node_modules` is symlinked from the repo's existing install rather than
+ * installed from the registry, which is both offline AND the stronger test — a
+ * registry install would happily resolve a transitive dependency this package
+ * forgot to declare.
+ *
+ * Run:  npm run check:core
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, posix } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PKG_NAME = "@offlinecv/core";
+
+/**
+ * The package's whole runtime surface, spelled out rather than snapshotted.
+ *
+ * A published export list is an API promise, so a change to it should be a
+ * deliberate edit to this array in the same commit — not a diff nobody reads.
+ * The names are asserted as an exact SET, so an accidental ADDITION fails here
+ * too: publishing a symbol is much easier than un-publishing one.
+ */
+const EXPECTED_EXPORTS = [
+  "JOB_CAPTURE_CONTRACT_VERSION",
+  "MAX_STARS",
+  "canonicalJobUrl",
+  "captureJob",
+  "computeCoverageFromCorpus",
+  "deleteRecord",
+  "deriveJobId",
+  "describeRating",
+  "extractCompensation",
+  "extractJdTerms",
+  "formatCompensationRange",
+  "getRecord",
+  "getSyncCursor",
+  "isBelowFloor",
+  "listRecordsUpdatedSince",
+  "listResumeChoices",
+  "putRecord",
+  "rateJobs",
+  "ratingInputFor",
+  "setSyncCursor",
+  "validateJobRecord",
+  "validateLetterRecord",
+];
+
+/**
+ * Runs inside the extracted tarball's world. It imports by SPECIFIER, never by
+ * path, so the `exports` map is what is under test — a path import would pass on
+ * a package whose `exports` points nowhere.
+ *
+ * It reports rather than judges: the assertions live in the parent so every
+ * failure message in this gate is written in one place.
+ */
+const PROBE = `import * as core from "@offlinecv/core";
+
+process.stdout.write(
+  JSON.stringify({
+    exports: Object.keys(core).sort(),
+    jobId: core.deriveJobId("https://ex.com/j/1?utm_source=x"),
+    maxStars: core.MAX_STARS,
+  }),
+);
+`;
+
+/**
+ * The consumer TypeScript. Deliberately small, and every line of it is an
+ * assertion about the declarations rather than about this repo's logic.
+ *
+ * `ratingInputFor` takes a `RatingSignalSource`, which is not exported — a
+ * consumer holding a `RankedJob` passes it structurally, and this file is where
+ * we find out if that stops being true through the published surface.
+ */
+const CONSUMER_TS = `import { deriveJobId, validateJobRecord, MAX_STARS, ratingInputFor } from "@offlinecv/core";
+import type { JobRecord, RankedJob, CoverageResult } from "@offlinecv/core";
+
+export const id: string | undefined = deriveJobId("https://ex.com/j/1");
+export const stars: number = MAX_STARS;
+
+// \`deriveJobId\` answers \`string | undefined\` — a URL it cannot canonicalise has
+// no id. If the declarations failed to resolve, every symbol here would widen to
+// \`any\`, this error would not happen, and TypeScript would fail the unused
+// directive. That is the point: it fails in BOTH directions.
+// @ts-expect-error deriveJobId can miss, so its result is not assignable to string
+export const mustNotCompile: string = deriveJobId("https://ex.com/j/1");
+
+export function consume(record: JobRecord, ranked: RankedJob, coverage: CoverageResult) {
+  return [
+    validateJobRecord(record),
+    ratingInputFor(ranked, undefined, undefined, undefined),
+    coverage,
+  ] as const;
+}
+`;
+
+const CONSUMER_TSCONFIG = {
+  compilerOptions: {
+    target: "ES2022",
+    // The surface is browser-only — its declarations name IndexedDB and
+    // BroadcastChannel types, so a consumer without the DOM lib cannot read them
+    // at all. Saying so here keeps that a stated constraint rather than a
+    // surprise.
+    lib: ["ES2022", "DOM", "DOM.Iterable"],
+    module: "nodenext",
+    moduleResolution: "nodenext",
+    strict: true,
+    // The whole point of the run. `skipLibCheck: true` — this repo's own setting
+    // — would swallow exactly the dangling-specifier defect assertion 4 guards.
+    skipLibCheck: false,
+    noEmit: true,
+    // No ambient `@types/*` from anywhere: the package must typecheck on its own
+    // declarations, not on whatever a consumer happens to have installed.
+    types: [],
+  },
+  include: ["consumer.ts"],
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * What the tarball CONTAINS, read out of the tarball rather than off the
+ * extracted tree — the two can differ (this script writes a `node_modules/`
+ * into the extraction below), and the shipped file list is the thing under
+ * test. npm tarballs always root every entry at `package/`.
+ */
+function packedFiles(listing) {
+  return listing
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.endsWith("/"))
+    .map((line) => line.replace(/^package\//, ""))
+    .sort();
+}
+
+/**
+ * Every import/export specifier in one emitted JavaScript file.
+ *
+ * The scan PARSES the file with `ts.createSourceFile` — the compiler's own
+ * parser — and reads the module specifiers off the resulting AST, precisely so
+ * it sees what the compiler sees rather than what a regex guesses. A pattern
+ * sweep has to choose between two failures and both are live on this emit.
+ * Unanchored, it reads prose as code: the docblocks survive into the emit
+ * verbatim, so one comment documenting a relative dynamic import fails the gate
+ * naming a specifier that does not exist. Anchored to column 0, it cannot cross
+ * a quote inside the statement, which is exactly what an ES2022 arbitrary
+ * module namespace name puts there — `export { X as "some-name" } from "…"`,
+ * emitted verbatim under this repo's build flags — so the statement is skipped
+ * and its specifier never checked at all. That is the same dangling-specifier
+ * defect this gate exists to catch, differing only in the export name. A parse
+ * has neither problem: a comment is not a node and a string literal in
+ * expression position is not an `ImportDeclaration`, while a string export name
+ * is just another node inside a clause the parser already understands.
+ * `typescript` is already a direct root `devDependency`, so reaching for it adds
+ * nothing to the install.
+ *
+ * WHY A PARSE RATHER THAN A SCAN. This one function has now shipped a dangling
+ * specifier twice, each time by silently dropping a whole statement form while
+ * the gate still printed `✓ publishable`: a hand-rolled line-anchored regex
+ * could not cross the quote in `export { X as "s" } from "…"`, and its
+ * replacement, `ts.preProcessFile`, is a token scanner rather than a parser and
+ * missed `export * as ns from "…"` — its asterisk branch looks only for `from`
+ * and has no `as` handling, unlike the import branch beside it. Both approximate
+ * the module grammar and both lost to it. A silent PER-STATEMENT miss is the
+ * worst failure mode this gate has, because everything around it still looks
+ * right — the build is green, the probe imports, the file list is correct, and
+ * the one edge nobody checked ships broken. That is the constraint this function
+ * guards, and only the real parser guards it.
+ *
+ * KNOWN LIMIT, shared by every static scanner including this one: a COMPUTED
+ * dynamic import has no literal specifier to report — `tsc` emits those as
+ * ``__rewriteRelativeImportExtension(`./${name}.ts`)`` — so a template-literal
+ * import cannot be resolved here, or by the compiler.
+ */
+function importSpecifiers(source) {
+  const parsed = ts.createSourceFile("emitted.js", source, ts.ScriptTarget.Latest, false, ts.ScriptKind.JS);
+  const specifiers = [];
+
+  // Only a real string literal is a resolvable specifier. A computed or
+  // template-literal one (see KNOWN LIMIT) is skipped rather than stringified,
+  // which would invent a path and fail the gate on a specifier nobody wrote.
+  const record = (node) => {
+    if (node && ts.isStringLiteral(node)) specifiers.push(node.text);
+  };
+
+  const visit = (node) => {
+    // `ExportDeclaration` is the load-bearing one: it is every `export … from`
+    // form at once — `export * from`, `export * as ns from`, `export * as "s"
+    // from`, `export { X as "s" } from` — so covering the node covers all of
+    // them, including the ones a scanner has to special-case one at a time.
+    // Its `moduleSpecifier` is absent on a local `export { X }`, which `record`
+    // handles.
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) record(node.moduleSpecifier);
+    else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) record(node.arguments[0]);
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(parsed, visit);
+  return specifiers;
+}
+
+/**
+ * `execFileSync` with the child's stderr folded into the thrown message.
+ *
+ * Without this, a failing `tsc` or a failing `node` surfaces as
+ * `Command failed with exit code 1` and the diagnostic — the thing that names
+ * WHICH export is missing or WHICH type stopped resolving — is discarded.
+ */
+function run(file, args, cwd) {
+  try {
+    return execFileSync(file, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (err) {
+    const detail = [err?.stdout, err?.stderr].map((s) => String(s ?? "").trim()).filter(Boolean).join("\n");
+    throw new Error(`\`${file} ${args.join(" ")}\` failed:\n${detail || String(err?.message ?? err)}`);
+  }
+}
+
+// ── The four assertions ─────────────────────────────────────────────────────
+
+/**
+ * The npm package a bare specifier resolves to: `idb` from `idb`, `foo` from
+ * `foo/bar.js`, `@scope/pkg` from `@scope/pkg/sub`. Node builtins answer null —
+ * they are satisfied by the runtime, so they are never a dependency.
+ */
+function packageNameOf(specifier) {
+  if (specifier.startsWith("node:")) return null;
+  const segments = specifier.split("/");
+  const name = specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+  return builtinModules.includes(name) ? null : name;
+}
+
+/**
+ * 1. Shape: no TypeScript source, one declaration file rather than a tree, and
+ *    no shipped module importing a sibling that did not ship. Returns the module
+ *    graph — every shipped module's specifiers, keyed by path — so assertion 5
+ *    can walk it without re-parsing.
+ */
+function checkTarballShape(shipped, pkg, fail) {
+  const graph = new Map();
+  const sources = shipped.filter((p) => p.endsWith(".ts") && !p.endsWith(".d.ts"));
+  if (sources.length > 0)
+    fail(
+      `the tarball ships ${sources.length} TypeScript source file(s) — ${sources.slice(0, 5).join(", ")}. ` +
+        `No runtime resolves a \`.ts\` specifier; \`files\` must ship the BUILD OUTPUT, not \`src/\`.`,
+    );
+
+  const declarations = shipped.filter((p) => p.endsWith(".d.ts"));
+  if (!declarations.includes("dist/index.d.ts"))
+    fail("the tarball has no `dist/index.d.ts` — the bundled declaration `exports.types` points at.");
+  const extra = declarations.filter((p) => p !== "dist/index.d.ts");
+  if (extra.length > 0)
+    fail(
+      `the tarball ships ${extra.length} per-file declaration(s) alongside the bundle — ` +
+        `${extra.slice(0, 5).join(", ")}. They carry unresolvable \`.ts\` specifiers (see assertion 4); ` +
+        `narrow \`files\` so only \`dist/index.d.ts\` ships.`,
+    );
+
+  // Every internal edge lands on a file that shipped. Bare specifiers are
+  // assertion 2's job (they resolve against `dependencies`, which the probe puts
+  // under test); these are the ones only the tarball's own file list can answer.
+  const packedSet = new Set(shipped);
+  // `.mjs`/`.cjs` as well as `.js` — defence in depth, not a live check. `files`
+  // ships `dist/**/*.js` only, so the `.mjs` a future `.mts` source would emit
+  // cannot reach `shipped` unless `files` is widened in the same change. The
+  // wider pattern does not close that gap on its own; it means only one of the
+  // two edits has to be remembered rather than both.
+  for (const file of shipped.filter((p) => /\.[mc]?js$/.test(p))) {
+    const source = readFileSync(join(pkg, file), "utf8");
+    const specifiers = importSpecifiers(source);
+    graph.set(file, specifiers);
+    for (const specifier of specifiers) {
+      if (!specifier.startsWith(".")) continue;
+      // Exact resolution, deliberately: `"type": "module"` means Node ESM, which
+      // appends no extension and tries no `/index.js`. An extensionless
+      // specifier resolving to nothing here is the real runtime behaviour.
+      const resolved = posix.normalize(posix.join(posix.dirname(file), specifier));
+      if (!packedSet.has(resolved))
+        fail(
+          `${file} imports "${specifier}", which resolves to ${resolved} — a path the tarball does not ship. ` +
+            `Under \`"type": "module"\` Node appends no extension and tries no \`/index.js\`, so this import ` +
+            `throws \`ERR_MODULE_NOT_FOUND\` the first time anything loads ${file}. Either give the specifier ` +
+            `the explicit extension this repo's convention requires, or ship the missing file via \`files\`.`,
+        );
+    }
+  }
+
+  return graph;
+}
+
+/**
+ * 5. Necessity: `dependencies` and the packages the tarball actually loads agree.
+ *
+ * Judged over the REACHABLE graph — a breadth-first walk from the entry
+ * `exports` points at, following the relative edges assertion 1 already proved
+ * land on shipped files — and not over the shipped file list. The difference is
+ * load-bearing here, because `tsc` emits a `.js` for every file in the program
+ * and `files` ships all of them: the unreachable remainder includes modules that
+ * import `posthog-js` and `@mlc-ai/web-llm`, and nothing ever loads them. A
+ * consumer that installed those would be paying for code Node never resolves.
+ * Reachability is what decides whether a package is a dependency; shipping a
+ * file that mentions it is not.
+ *
+ * The direction that matters is EXTRA — a dependency nothing imports, which no
+ * other assertion can see, because the `node_modules/` built for assertion 2
+ * proves only that the list is big ENOUGH. A surplus symlink breaks nothing. The
+ * missing direction is already fatal at import time, but it is asserted here too
+ * so the failure names the specifier instead of an `ERR_MODULE_NOT_FOUND` stack.
+ */
+function checkDeclaredDependencies(declared, graph, entry, fail) {
+  // Without this the walk starts nowhere, reaches nothing, and reports every
+  // declared dependency as surplus — a confident wrong answer rather than a
+  // failure. `exports` moving is exactly the change that would cause it.
+  if (!graph.has(entry)) {
+    fail(`the entry \`exports\` points at (${entry}) is not among the shipped modules this gate parsed.`);
+    return;
+  }
+
+  const required = new Set();
+  const seen = new Set([entry]);
+  for (const queue = [entry]; queue.length > 0; ) {
+    const file = queue.shift();
+    for (const specifier of graph.get(file) ?? []) {
+      if (!specifier.startsWith(".")) {
+        const name = packageNameOf(specifier);
+        if (name) required.add(name);
+        continue;
+      }
+      const resolved = posix.normalize(posix.join(posix.dirname(file), specifier));
+      if (seen.has(resolved)) continue;
+      seen.add(resolved);
+      queue.push(resolved);
+    }
+  }
+
+  const extra = declared.filter((name) => !required.has(name));
+  if (extra.length > 0)
+    fail(
+      `${PKG_NAME} declares dependenc${extra.length === 1 ? "y" : "ies"} nothing reachable from the ` +
+        `entry imports: ${extra.join(", ")}. Every consumer pays to install ` +
+        `${extra.length === 1 ? "it" : "them"} for code Node never loads; drop ` +
+        `${extra.length === 1 ? "it" : "them"} from \`dependencies\`, or export the module that needs ` +
+        `${extra.length === 1 ? "it" : "them"}.`,
+    );
+
+  const undeclared = [...required].filter((name) => !declared.includes(name));
+  if (undeclared.length > 0)
+    fail(
+      `the tarball imports ${undeclared.join(", ")} but does not declare ` +
+        `${undeclared.length === 1 ? "it" : "them"} in \`dependencies\`. A consumer's install would not ` +
+        `place ${undeclared.length === 1 ? "it" : "them"}, so the import throws \`ERR_MODULE_NOT_FOUND\`.`,
+    );
+}
+
+/** 2. Runtime: the exact export set, plus behaviour behind two of the names. */
+function checkRuntimeSurface(probe, fail) {
+  const missing = EXPECTED_EXPORTS.filter((name) => !probe.exports.includes(name));
+  const unexpected = probe.exports.filter((name) => !EXPECTED_EXPORTS.includes(name));
+  if (missing.length > 0) fail(`the tarball is missing export(s): ${missing.join(", ")}`);
+  if (unexpected.length > 0)
+    fail(
+      `the tarball exports name(s) this gate does not know about: ${unexpected.join(", ")}. ` +
+        `If that is intended, add them to EXPECTED_EXPORTS in the same commit — a published ` +
+        `export is a promise.`,
+    );
+
+  // Behaviour, not shape. `deriveJobId` canonicalising the URL is the whole
+  // reason `docs/job-capture-contract.md` tells producers to use it rather than
+  // roll their own: a copy that keeps `utm_source` forks the id space and turns
+  // every re-capture into a duplicate row.
+  if (probe.jobId !== "job:ex.com/j/1")
+    fail(`deriveJobId() returned ${JSON.stringify(probe.jobId)} through the tarball, expected "job:ex.com/j/1"`);
+  if (probe.maxStars !== 5) fail(`MAX_STARS is ${JSON.stringify(probe.maxStars)} through the tarball, expected 5`);
+}
+
+/** 4. No relative specifier survives the declaration bundle. */
+function checkDeclarationBundle(dts, fail) {
+  const relative = [...dts.matchAll(/\bfrom\s*["'](\.[^"']*)["']/g)].map((m) => m[1]);
+  if (relative.length > 0)
+    fail(
+      `dist/index.d.ts still imports ${relative.length} relative specifier(s) — ${[...new Set(relative)].slice(0, 5).join(", ")}. ` +
+        `The tarball ships no per-file declarations for them to resolve to, so a consumer would ` +
+        `fall back to \`any\` or fail outright. \`rollup.dts.config.mjs\` exists to inline these.`,
+    );
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const failures = [];
+  const fail = (message) => failures.push(message);
+
+  const tmp = mkdtempSync(join(tmpdir(), "offlinecv-core-pack-"));
+  try {
+    // `npm pack` runs the package's `prepare`, so the tarball is built from
+    // current sources either way — but building explicitly first means a broken
+    // build reports as a broken build rather than as a mystery inside `pack`.
+    run("npm", ["run", "build", "-w", PKG_NAME], ROOT);
+    run("npm", ["pack", "-w", PKG_NAME, "--pack-destination", tmp], ROOT);
+
+    const tarball = readdirSync(tmp).find((name) => name.endsWith(".tgz"));
+    if (!tarball) throw new Error(`\`npm pack\` produced no tarball in ${tmp}`);
+
+    // The file LIST comes from the tarball and the file BODIES from the
+    // extraction, so the shape check has to run after this — but it still judges
+    // only what `tar -tzf` reported, before the `node_modules/` written below
+    // makes the extracted tree stop matching what ships.
+    const shipped = packedFiles(run("tar", ["-tzf", join(tmp, tarball)], ROOT));
+
+    const extractRoot = join(tmp, "extracted");
+    mkdirSync(extractRoot);
+    run("tar", ["-xzf", join(tmp, tarball), "-C", extractRoot], ROOT);
+    const pkg = join(extractRoot, "package");
+
+    const graph = checkTarballShape(shipped, pkg, fail);
+
+    // The load-bearing step: ONLY the declared dependencies, and they come from
+    // the repo's install rather than the registry so this stays offline.
+    const manifest = JSON.parse(readFileSync(join(pkg, "package.json"), "utf8"));
+    const declared = Object.keys(manifest.dependencies ?? {});
+    // Read off `exports` rather than hardcoded, so repointing the entry moves
+    // what assertion 5 walks instead of silently leaving it behind.
+    const entry = posix.normalize(manifest.exports?.["."]?.default ?? "");
+    checkDeclaredDependencies(declared, graph, entry, fail);
+    mkdirSync(join(pkg, "node_modules"));
+    for (const dep of declared) {
+      const source = join(ROOT, "node_modules", dep);
+      if (!existsSync(source))
+        throw new Error(
+          `${PKG_NAME} declares "${dep}", which is not installed at the repo root — ` +
+            `run \`npm install\` before this gate, or fix the dependency name.`,
+        );
+      const target = join(pkg, "node_modules", dep);
+      mkdirSync(dirname(target), { recursive: true });
+      symlinkSync(source, target, "dir");
+    }
+
+    // A consumer that reaches the package the only way a stranger can: by name,
+    // through `exports`.
+    const consumer = join(tmp, "consumer");
+    mkdirSync(join(consumer, "node_modules", "@offlinecv"), { recursive: true });
+    symlinkSync(pkg, join(consumer, "node_modules", "@offlinecv", "core"), "dir");
+    writeFileSync(
+      join(consumer, "package.json"),
+      JSON.stringify({ name: "core-tarball-consumer", version: "0.0.0", private: true, type: "module" }, null, 2),
+    );
+    writeFileSync(join(consumer, "probe.mjs"), PROBE);
+    writeFileSync(join(consumer, "consumer.ts"), CONSUMER_TS);
+    writeFileSync(join(consumer, "tsconfig.json"), JSON.stringify(CONSUMER_TSCONFIG, null, 2));
+
+    checkRuntimeSurface(JSON.parse(run(process.execPath, ["probe.mjs"], consumer)), fail);
+    run(join(ROOT, "node_modules", ".bin", "tsc"), ["-p", join(consumer, "tsconfig.json")], consumer);
+    checkDeclarationBundle(readFileSync(join(pkg, "dist", "index.d.ts"), "utf8"), fail);
+
+    if (failures.length === 0) {
+      console.log(
+        `✓ ${PKG_NAME} is publishable: ${shipped.length} file(s) packed, ` +
+          `${EXPECTED_EXPORTS.length} export(s) imported under plain Node with only ` +
+          `${declared.length === 0 ? "no" : declared.join(", ")} dependenc${declared.length === 1 ? "y" : "ies"} ` +
+          `present, and a \`nodenext\` consumer typechecks against dist/index.d.ts with skipLibCheck off.`,
+      );
+      return;
+    }
+    for (const failure of failures) console.error(`✗ ${failure}`);
+    console.error(
+      `\n${failures.length} problem(s) would ship in the ${PKG_NAME} tarball. ` +
+        `See scripts/check-core-package.mjs for what each assertion protects.`,
+    );
+    process.exitCode = 1;
+  } catch (err) {
+    // A thrown error is the pack/import/typecheck itself failing — which IS the
+    // finding, not an infrastructure problem to swallow.
+    console.error(`✗ ${PKG_NAME} could not be packed and consumed:\n${err.message}`);
+    // Anything already COLLECTED still prints. The two are usually the same
+    // defect seen twice, and the collected one is the readable half: an
+    // undeclared dependency is a named specifier here and an
+    // `ERR_MODULE_NOT_FOUND` stack above. Losing it to the throw would hide the
+    // sentence that says what to change.
+    for (const failure of failures) console.error(`✗ ${failure}`);
+    process.exitCode = 1;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
-import { CASCADE_VERSION } from "./heuristics/types";
-import type { LayoutTrigger, ParseEvent } from "./heuristics/types";
-import type { WebGpuCapability } from "./webllm/types";
-import type { Browser, Os } from "./webllm/platform";
-import type { AtsPlatform } from "./jd-match/fetch-jd";
+import { CASCADE_VERSION } from "./heuristics/types.ts";
+import type { LayoutTrigger, ParseEvent } from "./heuristics/types.ts";
+import type { WebGpuCapability } from "./webllm/types.ts";
+import type { Browser, Os } from "./webllm/platform.ts";
+import type { AtsPlatform } from "./jd-match/fetch-jd.ts";
 
 type PostHog = {
   capture: (event: string, props?: Record<string, unknown>) => void;


### PR DESCRIPTION
## Summary

`@offlinecv/core` (#771) was consumable only by a bundler: its `exports` map pointed at raw TypeScript, so a published tarball would have handed every Node consumer a file full of type annotations and `.ts` specifiers. This emits a real `dist/`, repoints the package at it, makes `idb` a declared dependency, and adds a gate that proves the tarball resolves under plain Node before it can ship.

Closes #772

Three things surfaced while building it that the issue didn't anticipate:

- **TypeScript 5.8.3's `rewriteRelativeImportExtensions` does not rewrite `.d.ts` output.** Confirmed with a minimal repro under both `bundler` and `nodenext`: `.js` emits `./dep.js`, `.d.ts` emits `./dep.ts`. Since the tarball ships no `.ts`, a plain emitted declaration tree would be unresolvable — which is why declarations are bundled into a single `dist/index.d.ts` rather than shipped per-file.
- **`publishConfig` can't be used.** `npm pack` does not apply `publishConfig.exports` rewrites on npm 10.8.2, so the "keep `exports` on `src/`, rewrite at publish" approach cannot be smoke-tested — which would defeat the point. `exports` is repointed directly, and the package's `prepare` script is what keeps the existing link consumer resolving.
- **`src/lib/analytics.ts` used four extensionless relative imports.** It's reached only through type edges so it erases at runtime, but it emitted an unresolvable specifier into the tarball.

**After the first CI run**, fallow raised two error-level alerts, both about `packages/core/package.json`: `idb` unused and `rollup-plugin-dts` unlisted. Both were real reports of a real scoping limit rather than noise to wave through, and each got a different answer. `rollup` and `rollup-plugin-dts` are now declared by the package whose build script runs them, which is what should have been true anyway. `idb` cannot be fixed that way — the import lives in the emit closure, not in the workspace directory fallow scans — so it is suppressed, and `check:core` grew a fifth assertion that walks the emitted module graph and fails on a declared dependency nothing reachable imports. The suppression buys a strictly stronger check for this package than the one it silences.

## Review focus

- `scripts/check-core-package.mjs:253` — the specifier scan is now a real AST parse. Two earlier implementations each silently dropped a whole statement form (a regex that couldn't cross a quote, then `ts.preProcessFile`, whose asterisk branch has no `as` handling). Is there a statement form the three node predicates still miss?
- `packages/core/package.json:22` — `prepare` runs the build on every `npm install`/`npm ci`. Does the lifecycle ordering hold in every install shape, and is a failing `prepare` an acceptable way to break installs?
- `.github/workflows/ci.yml` — the `verify` job enumerates its steps by hand rather than calling `npm run verify`, so the npm script and CI both needed the edit. Did anything else get missed by that split?
- `.fallowrc.jsonc` — `idb` is suppressed GLOBALLY, unlike every file-scoped entry around it, because fallow 2.96 honours neither a per-file `overrides` rule nor a nested workspace config for a manifest-level finding. The cost is that the root manifest's own `idb` goes unchecked too. Is the reachability assertion in `check:core` a fair trade for that, or should the dependency analysis be scoped some other way?
- `packages/core/src/index.ts` — the tarball ships 22 unreachable type-only modules as dead JS, three of which contain a `fetch` call or undeclared dynamic imports. Does the docblock scope the network-free claim accurately enough, given it's about the runtime graph and not the file list?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (5192 passed / 10 skipped)
- [x] `npm run verify` green end to end (via pre-push hook)
- [x] `node scripts/check-core-package.mjs` green — 53 files packed, 22 exports imported under plain Node with only `idb` present, `nodenext` consumer typechecks against `dist/index.d.ts` with `skipLibCheck` off
- [x] Gate proven to fail when it should: removing `idb` from `dependencies` exits non-zero (`ERR_MODULE_NOT_FOUND`)
- [x] Consumer typechecks under `bundler`, `node16` and `nodenext` with `skipLibCheck: false`
- [x] Emitted runtime graph independently walked: 27 reachable modules, sole bare specifier `idb`, zero `fetch`/`WebSocket`/`XMLHttpRequest`/`EventSource`/`import.meta`
- [x] `npm ci --dry-run` clean — the workspace's new devDependencies are in sync with the lockfile
- [x] Assertion 5 proven to fail when it should: adding a surplus `typescript` dependency to `packages/core/package.json` reports it by name and exits non-zero

## Adversarial review

Three review rounds, each run by an independent subagent against the working diff before this PR was opened. Rounds 2 and 3 each found a real blocking defect that the round before it missed.

**Round 1 — 1 blocking, fixed.** `check:core` was wired into the `verify` npm script but not into `.github/workflows/ci.yml`, which enumerates its steps by hand and is the job branch protection actually requires. A hook-skipping push could have merged a broken tarball green, with only the daily `promote-release.yml` catching it after the fact. Also fixed from this round: the build never cleaned `outDir` (stale emit both survived a rebuild and shipped); the barrel docblock's network-free claim contradicted the tarball's file list; `packages/core/` had no `LICENSE` despite declaring Apache-2.0; and a `verbatimModuleSyntax` comment stated the guarantee backwards.

**Round 2 — 1 blocking, fixed.** The newly added specifier check used line-anchored regexes whose character class could not cross a quote, so `export { X as "name" } from "…"` was skipped entirely — demonstrated end to end, with the gate printing `✓ publishable` while shipping a dangling specifier. Replaced with `ts.preProcessFile`. The same round found that the anchoring bought nothing (anchored and naive sweeps found identical results) and corrected a false claim that `npm publish` "would have succeeded" — `private: true` means npm refuses outright.

**Round 3 — 1 blocking, fixed.** `ts.preProcessFile` is a token scanner, not a parser, and silently dropped `export * as ns from "…"` — root-caused to its `tryConsumeExport` asterisk branch having no `AsKeyword` handling, unlike the import side. Replaced with a real `ts.createSourceFile` AST walk, which collects every `ImportDeclaration`/`ExportDeclaration` module specifier plus dynamic `import()` calls, so all `export … from` forms collapse into one node rather than needing case-by-case handling.

The fix was accepted against a 10-case evasion matrix — 8 shapes that must fail the gate (including both shapes that defeated the earlier implementations) and 2 that must pass, so it could not converge by simply flagging everything. All 10 behaved correctly, with non-vacuity confirmed on both must-pass cases. Coverage parity held exactly across all three implementations (67 relative specifier occurrences / 48 unique over the 49 built files), ruling out a scan that passes by finding nothing.

**Surviving non-blocking items**, deliberately not addressed here:

- The tarball ships 22 unreachable type-only modules as dead JS, because `tsc` emits a `.js` for every file in the program. Documented in the barrel docblock rather than narrowed; deep import is blocked (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
- `sections.config.js` cannot load under Node (bare JSON import with no `with { type: "json" }`). Unreachable, so nothing hits it.
- A computed/template-literal dynamic import cannot be resolved by any static scanner. Recorded as a `KNOWN LIMIT` in the gate rather than left silent.
- `check-core-package.mjs` is POSIX-only (`execFileSync("npm")`, `symlinkSync`). CI is ubuntu, devs are on darwin.
- fallow's one remaining finding is `initAnalytics`'s CRAP score in `src/lib/analytics.ts`. It is pre-existing (this diff only added `.ts` to four import specifiers in that file, which is enough for the diff-scoped audit to surface it), it is `note`-level so it raises no alert, and per `CLAUDE.md` a CRAP finding is never blocking on its own.

**License note:** `rollup-plugin-dts` is LGPL-3.0-only. It is a build-time devDependency that links nothing into the Apache-2.0 output; this is recorded in `rollup.dts.config.mjs`'s docblock rather than left implicit.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #772 | Claude Opus (subagent; exact version not self-reported) | high |
| Adversarial review — 3 rounds | Claude Opus (subagents; exact versions not self-reported) | high |
| Review fixes — 3 rounds | Claude Opus (subagents; exact versions not self-reported) | high |
| Commit preparation | Claude Sonnet (subagent; exact version not self-reported) | — |
| Planning, orchestration + PR | Claude Opus 5 (1M context) | high |
| fallow fixes (post-CI revision) | Claude Opus 5 (1M context) | high |
| Verification | `npm run verify` — green locally via pre-push hook and in CI | — |
