### PR TITLE
feat(jobs): share the parsed résumé with the capture extension

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { PageShell } from "./components/features/PageShell.tsx";
 import { ReplaceResumeDropOverlay } from "./components/features/ReplaceResumeDropOverlay.tsx";
 import { ResumeLibrary } from "./components/features/ResumeLibrary.tsx";
 import { SaveResumeBar } from "./components/features/SaveResumeBar.tsx";
+import { ShareWithExtensionBar } from "./components/features/ShareWithExtensionBar.tsx";
 import { useAnalyzedResume } from "./hooks/useAnalyzedResume.ts";
 import { useResumeLibrary } from "./hooks/useResumeLibrary.ts";
 import { useReplaceResumeOnDrop } from "./hooks/useReplaceResumeOnDrop.ts";
@@ -320,6 +321,15 @@ export default function App() {
               sourceKind={state.sourceKind}
               result={displayResult}
               score={edited.score}
+            />
+            {/* Hand the parse to the capture extension (#620) — self-hides when
+                no extension answers a probe, so it costs nothing on the visit
+                of everyone who runs none. `canonical.fields` is the same shape
+                `departToJobs` hands `/jobs/`; the file name becomes the label
+                the extension's panel shows beside its rating. */}
+            <ShareWithExtensionBar
+              parsed={displayResult.canonical.fields}
+              fileName={state.fileName}
             />
             {jdFitEnabled && (
               // Cross-sell sits *below* the result as a quiet follow-on, not a

--- a/src/components/features/ShareWithExtensionBar.test.tsx
+++ b/src/components/features/ShareWithExtensionBar.test.tsx
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the résumé → extension share control (#620).
+ *
+ * Four things this asserts that nothing else would catch: the bar is absent
+ * until an extension answers, the corpus and the file-name label are what
+ * actually go out on the click, a refusal reaches the user in the extension's
+ * own words, and a silent extension ends the interaction instead of leaving the
+ * button spinning.
+ *
+ * Replies are synthetic and outgoing posts are recorded, through the shared
+ * harness in `lib/__test-utils__/extension-channel.ts` — see it for why jsdom's
+ * own `postMessage` cannot drive this.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ShareWithExtensionBar } from "./ShareWithExtensionBar.tsx";
+import {
+  EXTENSION_CHANNEL,
+  EXTENSION_REPLY_TIMEOUT_MS,
+} from "../../lib/extension-profile.ts";
+import {
+  dispatchFromExtension,
+  recordPostMessage,
+  type PostedMessage,
+} from "../../lib/__test-utils__/extension-channel.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  location: "Austin, TX",
+  skills: ["TypeScript"],
+  experience: [{ company: "Globex", title: "Staff Frontend Engineer" }],
+  education: [],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let posted: PostedMessage[];
+
+function render() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(ShareWithExtensionBar, { parsed, fileName: "dana-resume.pdf" }));
+  });
+  return container;
+}
+
+function buttons(): HTMLButtonElement[] {
+  return [...container.querySelectorAll("button")];
+}
+
+async function deliver(data: unknown): Promise<void> {
+  await act(async () => {
+    dispatchFromExtension(data);
+  });
+}
+
+/** Mount and let an extension answer the presence probe. */
+async function renderWithExtension(): Promise<HTMLElement> {
+  const el = render();
+  await deliver({ channel: EXTENSION_CHANNEL, type: "pong", version: "1.4.0" });
+  return el;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+  await act(async () => {
+    button.click();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  posted = recordPostMessage();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("ShareWithExtensionBar", () => {
+  it("renders nothing until an extension answers the probe", () => {
+    const el = render();
+
+    expect(el.textContent).toBe("");
+    // The probe itself is the only message sent, and it carries no résumé data.
+    expect(posted).toEqual([
+      {
+        message: { channel: EXTENSION_CHANNEL, type: "ping" },
+        targetOrigin: window.location.origin,
+      },
+    ]);
+  });
+
+  it("appears once an extension has answered", async () => {
+    const el = await renderWithExtension();
+
+    expect(el.textContent).toContain("Share this resume with the browser extension");
+    expect(buttons()[0].textContent).toContain("Share with extension");
+    expect(buttons()[1].textContent).toContain("Stop sharing");
+  });
+
+  it("sends the corpus and the file-name label on the click, to this origin only", async () => {
+    await renderWithExtension();
+    await click(buttons()[0]);
+
+    const share = posted.at(-1);
+    expect(share?.targetOrigin).toBe(window.location.origin);
+    const message = share?.message as {
+      channel: string;
+      type: string;
+      profile: { corpus: string; label: string; contactName?: string; seniorityRung?: number };
+    };
+    expect(message.channel).toBe(EXTENSION_CHANNEL);
+    expect(message.type).toBe("set-resume-profile");
+    expect(message.profile.label).toBe("dana-resume.pdf");
+    expect(message.profile.corpus).toContain("staff frontend engineer");
+    expect(message.profile.contactName).toBe("Dana Fixture");
+    expect(message.profile.seniorityRung).toBe(5);
+  });
+
+  it("does not share on mount — only on the click", async () => {
+    await renderWithExtension();
+
+    expect(posted.map((p) => (p.message as { type: string }).type)).toEqual(["ping"]);
+  });
+
+  it("confirms a stored profile by naming the résumé it will rate against", async () => {
+    const el = await renderWithExtension();
+    await click(buttons()[0]);
+    await deliver({ channel: EXTENSION_CHANNEL, type: "resume-profile-stored" });
+
+    expect(el.textContent).toContain("dana-resume.pdf");
+    expect(el.textContent).toContain("Shared.");
+    expect(buttons()[0].disabled).toBe(false);
+  });
+
+  it("surfaces a refusal in the extension's own words", async () => {
+    const el = await renderWithExtension();
+    await click(buttons()[0]);
+    await deliver({
+      channel: EXTENSION_CHANNEL,
+      type: "resume-profile-refused",
+      reason: "`corpus` is empty; there is nothing to rate against.",
+    });
+
+    expect(el.textContent).toContain("refused");
+    expect(el.textContent).toContain("there is nothing to rate against");
+  });
+
+  it("ends the interaction when nothing answers, instead of spinning forever", async () => {
+    const el = await renderWithExtension();
+    await click(buttons()[0]);
+    expect(buttons()[0].disabled).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS);
+    });
+
+    expect(el.textContent).toContain("No extension answered");
+    expect(buttons()[0].disabled).toBe(false);
+  });
+
+  it("offers stop-sharing without having shared, and reports an empty clear honestly", async () => {
+    const el = await renderWithExtension();
+    await click(buttons()[1]);
+
+    expect((posted.at(-1)?.message as { type: string }).type).toBe("clear-resume-profile");
+
+    await deliver({ channel: EXTENSION_CHANNEL, type: "resume-profile-cleared", cleared: false });
+    expect(el.textContent).toContain("Nothing to stop");
+  });
+
+  it("confirms a clear that dropped something", async () => {
+    const el = await renderWithExtension();
+    await click(buttons()[1]);
+    await deliver({ channel: EXTENSION_CHANNEL, type: "resume-profile-cleared", cleared: true });
+
+    expect(el.textContent).toContain("Stopped sharing");
+  });
+});

--- a/src/components/features/ShareWithExtensionBar.tsx
+++ b/src/components/features/ShareWithExtensionBar.tsx
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ShareWithExtensionBar — hand this résumé to the browser extension, so the
+ * postings it captures on job boards can be rated against it.
+ *
+ * Sits under the parsed result beside `SaveResumeBar`, and is the same shape of
+ * affordance: a quiet secondary bar for a follow-on action, never a banner
+ * competing with the user's own score. It lives on `/` rather than on `/jobs/`
+ * for two reasons that both point the same way — this is the only surface that
+ * knows the résumé's **file name**, which is the label the extension's panel
+ * shows when it names what it rated against, and it is where a user sent here
+ * by the extension ("no résumé shared yet") actually lands. `/jobs/` needs a
+ * handoff before it holds a résumé at all, so the control would be missing on
+ * exactly the visit that came looking for it.
+ *
+ * **Renders nothing unless an extension answers a probe** (see
+ * `useExtensionPresence`). The large majority of visitors run no extension, and
+ * a permanent bar offering them an integration they do not have is an
+ * advertisement, not an affordance.
+ *
+ * Every outcome is surfaced, including the two that are not success:
+ *
+ *  - a **refusal** carries the extension's own reason verbatim, because the one
+ *    that can actually happen ("`corpus` is empty; there is nothing to rate
+ *    against") names a fixable state of the résumé, and paraphrasing it here
+ *    would put a second wording of the extension's rule in this repo;
+ *  - **no reply** is reported as no reply. Nothing sends a negative
+ *    acknowledgement, so this surface cannot tell "not installed" from
+ *    "installed after this tab opened" — and the second is the likelier one
+ *    here, since the probe already answered, which is why the copy offers a
+ *    reload rather than an install.
+ *
+ * Stop sharing is offered unconditionally rather than only after a share. This
+ * page cannot know whether the extension holds a profile — there is no message
+ * that asks — and a control hidden on a guess is a control missing exactly when
+ * a user who shared in an earlier session comes back to undo it. `cleared:
+ * false` is a real answer and says so.
+ */
+
+import { useState } from "react";
+import { Button, ErrorState, InlineResult } from "@design-system";
+import { useExtensionPresence } from "../../hooks/useExtensionPresence.ts";
+import {
+  buildSharedResumeProfile,
+  clearSharedResumeProfile,
+  shareResumeProfile,
+  type ClearOutcome,
+  type ShareOutcome,
+} from "../../lib/extension-profile.ts";
+import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
+
+interface ShareWithExtensionBarProps {
+  /** The EDITED parse — the user's corrections are what they want rated. */
+  parsed: HeuristicParsedResume;
+  /** Becomes the profile's label, so the extension's panel can name the résumé
+   *  it is rating against instead of implying it knows which one this is. */
+  fileName: string;
+}
+
+type BarOutcome = ShareOutcome | ClearOutcome;
+
+interface Feedback {
+  tone: "success" | "warning" | "error";
+  message: string;
+}
+
+function feedbackFor(outcome: BarOutcome, fileName: string): Feedback {
+  switch (outcome.kind) {
+    case "stored":
+      return {
+        tone: "success",
+        message: `Shared. The extension will rate the jobs you capture against ${fileName}.`,
+      };
+    case "refused":
+      return { tone: "error", message: `The extension refused this resume: ${outcome.reason}` };
+    case "cleared":
+      return outcome.cleared
+        ? { tone: "success", message: "Stopped sharing — the extension has dropped this resume." }
+        : { tone: "warning", message: "Nothing to stop: the extension held no resume from this app." };
+    case "no-reply":
+      return {
+        tone: "warning",
+        message:
+          "No extension answered. If you installed or updated it while this tab was open, reload the page and try again.",
+      };
+  }
+}
+
+/** The outcome strip. Its own component so the bar's render stays readable and
+ *  the success/failure split lives in one place: `InlineResult` is this repo's
+ *  success chrome and `ErrorState` its warning/error chrome, the same pairing
+ *  `ResumeLibrary` uses for its import result. */
+function ShareFeedback({ feedback }: { feedback: Feedback }) {
+  return (
+    <div aria-live="polite">
+      {feedback.tone === "success" ? (
+        <InlineResult tone="success">
+          <span className="text-sm text-content-secondary">{feedback.message}</span>
+        </InlineResult>
+      ) : (
+        <ErrorState tone={feedback.tone === "warning" ? "warning" : "error"}>
+          {feedback.message}
+        </ErrorState>
+      )}
+    </div>
+  );
+}
+
+export function ShareWithExtensionBar({ parsed, fileName }: ShareWithExtensionBarProps) {
+  const present = useExtensionPresence();
+  const [busy, setBusy] = useState(false);
+  const [outcome, setOutcome] = useState<BarOutcome | null>(null);
+
+  // After the hooks, never before: an early return above them would change the
+  // hook order between renders the moment the probe answers.
+  if (!present) return null;
+
+  // One flag for both buttons: the reply vocabularies are disjoint, but a share
+  // and a clear in flight together would still race each other's write.
+  const run = async (action: () => Promise<BarOutcome>) => {
+    setBusy(true);
+    setOutcome(null);
+    try {
+      setOutcome(await action());
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const feedback = outcome === null ? null : feedbackFor(outcome, fileName);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border-light bg-surface-subtle px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-content-secondary">
+          Share this resume with the browser extension so it can rate the jobs
+          you capture. Nothing is uploaded from this page — the extension keeps
+          its own copy, on this device.
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={() =>
+              void run(() => shareResumeProfile(buildSharedResumeProfile(parsed, fileName)))
+            }
+          >
+            {busy ? "Working…" : "Share with extension"}
+          </Button>
+          <Button
+            variant="link"
+            size="sm"
+            disabled={busy}
+            onClick={() => void run(clearSharedResumeProfile)}
+          >
+            Stop sharing
+          </Button>
+        </div>
+      </div>
+      {feedback !== null && <ShareFeedback feedback={feedback} />}
+    </div>
+  );
+}

--- a/src/hooks/useExtensionPresence.ts
+++ b/src/hooks/useExtensionPresence.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useExtensionPresence — "is a browser extension listening on this page?"
+ *
+ * The share control it gates (`ShareWithExtensionBar`) is useful to the small
+ * minority of visitors who run the capture extension and is noise to everyone
+ * else, so it renders only once something has answered a probe. The probe is a
+ * bare `ping` on the résumé-profile channel: it carries no résumé data, which
+ * is what makes it the one message in this lane allowed to fire without a
+ * click. See `lib/extension-profile.ts`.
+ *
+ * **A `false` is not proof of absence, and nothing here may say otherwise.** No
+ * extension sends a negative acknowledgement, so silence covers "not
+ * installed", "disabled", "installed after this tab opened" (Chrome does not
+ * inject a declared content script into an already-open tab) and "answered a
+ * millisecond after we stopped caring", and this hook cannot tell them apart.
+ * It therefore only ever HIDES an affordance — it must never be used to state
+ * that the user has no extension, and it latches on: once true, always true for
+ * the life of the mount, because the answer cannot become false without a
+ * message nobody sends.
+ *
+ * Two probes rather than one. A declared content script runs at `document_idle`,
+ * which Chrome may schedule before `window.onload` or after it, so a probe sent
+ * by a component that mounted early can precede the listener that would answer
+ * it — a race that is invisible when it happens, because the symptom is a
+ * control that simply never appears. The retry costs one empty message.
+ */
+
+import { useEffect, useState } from "react";
+import { onExtensionPong, postExtensionPing } from "../lib/extension-profile.ts";
+
+/** Delay before the second probe — see the docblock for the race it covers. */
+const PROBE_RETRY_MS = 1_000;
+
+export function useExtensionPresence(): boolean {
+  const [present, setPresent] = useState(false);
+
+  useEffect(() => {
+    // Listener first: a `pong` that arrives before we subscribe is a `pong`
+    // nobody hears, and there is no second one to fall back on.
+    const unsubscribe = onExtensionPong(() => setPresent(true));
+    postExtensionPing();
+    const retry = setTimeout(postExtensionPing, PROBE_RETRY_MS);
+    return () => {
+      clearTimeout(retry);
+      unsubscribe();
+    };
+    // Deps hand-audited both ways (`exhaustive-deps` is NOT enforced here —
+    // CLAUDE.md): the effect closes over nothing but `setPresent`, which React
+    // guarantees stable, so `[]` is complete and any added dep would only
+    // re-probe for no behaviour change.
+  }, []);
+
+  return present;
+}

--- a/src/lib/__test-utils__/extension-channel.ts
+++ b/src/lib/__test-utils__/extension-channel.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Test harness for the résumé-profile channel (`lib/extension-profile.ts`).
+ *
+ * Shared by the transport's own suite and the share control's, because both
+ * need the same two things and jsdom provides neither faithfully:
+ *
+ *  - **A recorded `postMessage`.** jsdom will happily deliver a real
+ *    same-window post, but it hands the listener `origin: ""` and
+ *    `source: null` — both of which the sender is right to refuse, so a real
+ *    round trip cannot exercise the accept path at all. Recording the call
+ *    instead is also what lets the `targetOrigin` assertion be exact.
+ *  - **A faithful inbound message.** {@link dispatchFromExtension} sets the
+ *    origin and source a browser sets when a content script posts to the page
+ *    it is injected in.
+ *
+ * Deliberately does NOT wrap anything in `act`: one caller renders React and
+ * the other does not, and a harness that guessed wrong would either warn on
+ * every call or swallow the update.
+ */
+
+import { vi } from "vitest";
+
+export interface PostedMessage {
+  message: unknown;
+  targetOrigin: unknown;
+}
+
+/**
+ * Replace `window.postMessage` with a recorder for the current test. Returns
+ * the log, in call order. Undo with `vi.restoreAllMocks()`.
+ */
+export function recordPostMessage(): PostedMessage[] {
+  const posted: PostedMessage[] = [];
+  vi.spyOn(window, "postMessage").mockImplementation(((
+    message: unknown,
+    targetOrigin: unknown,
+  ) => {
+    posted.push({ message, targetOrigin });
+  }) as typeof window.postMessage);
+  return posted;
+}
+
+/** Deliver `data` the way the extension's content script does: this window,
+ *  this origin. */
+export function dispatchFromExtension(data: unknown): void {
+  window.dispatchEvent(
+    new MessageEvent("message", { data, origin: window.location.origin, source: window }),
+  );
+}

--- a/src/lib/extension-profile.test.ts
+++ b/src/lib/extension-profile.test.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the app's half of the résumé-profile channel (#620).
+ *
+ * Replies are dispatched as synthetic `MessageEvent`s rather than by letting
+ * jsdom deliver a real `window.postMessage`, and outgoing posts are recorded
+ * rather than delivered — see `__test-utils__/extension-channel.ts` for why
+ * jsdom cannot exercise the accept path on its own.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EXTENSION_CHANNEL,
+  EXTENSION_REPLY_TIMEOUT_MS,
+  buildSharedResumeProfile,
+  clearSharedResumeProfile,
+  onExtensionPong,
+  postExtensionPing,
+  shareResumeProfile,
+} from "./extension-profile.ts";
+import {
+  dispatchFromExtension as reply,
+  recordPostMessage,
+  type PostedMessage,
+} from "./__test-utils__/extension-channel.ts";
+import type { HeuristicParsedResume } from "./heuristics/types.ts";
+
+/** The whole allow-list the extension reads off a shared profile. A key outside
+ *  it is silently dropped there, so emitting one here is dead weight at best. */
+const ALLOWED_PROFILE_KEYS = [
+  "compFloor",
+  "contactName",
+  "corpus",
+  "label",
+  "location",
+  "seniorityRung",
+];
+
+const parsed: HeuristicParsedResume = {
+  full_name: "Dana Fixture",
+  location: "Austin, TX",
+  summary: "Builds distributed systems.",
+  skills: ["TypeScript", "GraphQL"],
+  experience: [
+    {
+      company: "Globex",
+      title: "Staff Frontend Engineer",
+      description: "Led a platform migration.",
+    },
+  ],
+  education: [],
+};
+
+let posted: PostedMessage[];
+
+beforeEach(() => {
+  // Only the timer functions — React's scheduler and the microtask queue stay
+  // real, so an `await` still settles without pumping a fake clock.
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  posted = recordPostMessage();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("buildSharedResumeProfile", () => {
+  it("reduces the parse to the six fields the rating chain reads", () => {
+    const profile = buildSharedResumeProfile(parsed, "dana-resume.pdf");
+
+    expect(Object.keys(profile).every((k) => ALLOWED_PROFILE_KEYS.includes(k))).toBe(true);
+    expect(profile.label).toBe("dana-resume.pdf");
+    expect(profile.contactName).toBe("Dana Fixture");
+    expect(profile.location).toBe("Austin, TX");
+    // "Staff" on the single ordered ladder — derived through `buildJobQuery`,
+    // the same derivation `/jobs/` seeds its search with, never a second one.
+    expect(profile.seniorityRung).toBe(5);
+  });
+
+  it("sends the corpus, lowercased, and never the structured résumé", () => {
+    const profile = buildSharedResumeProfile(parsed, "dana-resume.pdf");
+
+    expect(profile.corpus).toContain("staff frontend engineer");
+    expect(profile.corpus).toContain("typescript");
+    expect(profile.corpus).toBe(profile.corpus.toLowerCase());
+    // The shape, not just the values: an `experience` array crossing the
+    // boundary is the thing `resume-profile.ts`'s allow-list exists to stop,
+    // and the sender must not be the half that tries it.
+    expect(profile).not.toHaveProperty("experience");
+    expect(profile).not.toHaveProperty("skills");
+  });
+
+  it("omits a blank name or location rather than sending an empty string", () => {
+    const profile = buildSharedResumeProfile(
+      { ...parsed, full_name: "   ", location: "" },
+      "dana-resume.pdf",
+    );
+
+    expect(profile.contactName).toBeUndefined();
+    expect(profile.location).toBeUndefined();
+  });
+});
+
+describe("shareResumeProfile", () => {
+  it("posts to this page's own origin — never a wildcard", async () => {
+    const profile = buildSharedResumeProfile(parsed, "dana-resume.pdf");
+    const settled = shareResumeProfile(profile);
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-stored" });
+    await settled;
+
+    expect(posted).toHaveLength(1);
+    expect(posted[0].targetOrigin).toBe(window.location.origin);
+    expect(posted[0].targetOrigin).not.toBe("*");
+    expect(posted[0].message).toEqual({
+      channel: EXTENSION_CHANNEL,
+      type: "set-resume-profile",
+      profile,
+    });
+  });
+
+  it("resolves stored when the extension confirms", async () => {
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-stored" });
+
+    expect(await settled).toEqual({ kind: "stored" });
+  });
+
+  it("surfaces a refusal with the extension's own reason", async () => {
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({
+      channel: EXTENSION_CHANNEL,
+      type: "resume-profile-refused",
+      reason: "`corpus` is empty; there is nothing to rate against.",
+    });
+
+    expect(await settled).toEqual({
+      kind: "refused",
+      reason: "`corpus` is empty; there is nothing to rate against.",
+    });
+  });
+
+  it("names a reason even when the refusal carries none", async () => {
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-refused" });
+    const outcome = await settled;
+
+    expect(outcome.kind).toBe("refused");
+    expect(outcome.kind === "refused" && outcome.reason.length).toBeGreaterThan(0);
+  });
+
+  it("gives up rather than hanging when nothing is listening", async () => {
+    // The no-extension case: no message ever comes back, so an unbounded await
+    // would leave the control spinning forever.
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS);
+
+    expect(await settled).toEqual({ kind: "no-reply" });
+  });
+
+  it("does not read its own outgoing message as a reply", async () => {
+    // `postMessage` to `window` is delivered to this module's own listener too.
+    // A guard that checked only the channel marker would resolve here.
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({ channel: EXTENSION_CHANNEL, type: "set-resume-profile", profile: {} });
+    vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS);
+
+    expect(await settled).toEqual({ kind: "no-reply" });
+  });
+
+  it("ignores a reply from another origin", async () => {
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { channel: EXTENSION_CHANNEL, type: "resume-profile-stored" },
+        origin: "https://not-us.example",
+        source: window,
+      }),
+    );
+    vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS);
+
+    expect(await settled).toEqual({ kind: "no-reply" });
+  });
+
+  it("ignores a reply that did not come from this window", async () => {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { channel: EXTENSION_CHANNEL, type: "resume-profile-stored" },
+        origin: window.location.origin,
+        source: frame.contentWindow,
+      }),
+    );
+    vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS);
+
+    expect(await settled).toEqual({ kind: "no-reply" });
+    frame.remove();
+  });
+});
+
+describe("clearSharedResumeProfile", () => {
+  it("asks the extension to drop the profile and reports what it dropped", async () => {
+    const settled = clearSharedResumeProfile();
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-cleared", cleared: true });
+
+    expect(await settled).toEqual({ kind: "cleared", cleared: true });
+    expect(posted[0].message).toEqual({
+      channel: EXTENSION_CHANNEL,
+      type: "clear-resume-profile",
+    });
+    expect(posted[0].targetOrigin).toBe(window.location.origin);
+  });
+
+  it("reports an empty clear as an answer, not a failure", async () => {
+    const settled = clearSharedResumeProfile();
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-cleared", cleared: false });
+
+    expect(await settled).toEqual({ kind: "cleared", cleared: false });
+  });
+
+  it("gives up when nothing is listening", async () => {
+    const settled = clearSharedResumeProfile();
+    vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS);
+
+    expect(await settled).toEqual({ kind: "no-reply" });
+  });
+});
+
+describe("the presence probe", () => {
+  it("carries no résumé data", () => {
+    postExtensionPing();
+
+    expect(posted).toEqual([
+      { message: { channel: EXTENSION_CHANNEL, type: "ping" }, targetOrigin: window.location.origin },
+    ]);
+  });
+
+  it("reports a pong and stops on unsubscribe", () => {
+    const seen: string[] = [];
+    const unsubscribe = onExtensionPong((version) => seen.push(version));
+
+    reply({ channel: EXTENSION_CHANNEL, type: "pong", version: "1.4.0" });
+    expect(seen).toEqual(["1.4.0"]);
+
+    unsubscribe();
+    reply({ channel: EXTENSION_CHANNEL, type: "pong", version: "1.4.1" });
+    expect(seen).toEqual(["1.4.0"]);
+  });
+
+  it("ignores a pong from another origin", () => {
+    const seen: string[] = [];
+    onExtensionPong((version) => seen.push(version));
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { channel: EXTENSION_CHANNEL, type: "pong", version: "1.4.0" },
+        origin: "https://not-us.example",
+        source: window,
+      }),
+    );
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/src/lib/extension-profile.ts
+++ b/src/lib/extension-profile.ts
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The résumé-profile channel — this app's half of the app → browser-extension
+ * bridge.
+ *
+ * The extension captures a job posting from a job board and rates it against
+ * the user's résumé using this repo's own code (`extractJdTerms` →
+ * `computeCoverageFromCorpus` → `ratingInputFor` → `rateJobs`). It cannot read
+ * the résumé to do that: its service worker lives on a `chrome-extension://`
+ * origin and the parse never leaves this one. So the app hands over the small,
+ * fixed digest that chain actually consumes — {@link SharedResumeProfile} —
+ * and nothing else. **The structured résumé never crosses.**
+ *
+ * ## The three checks on the receiving end, and what they demand here
+ *
+ * The extension's content script refuses a message unless `event.source` is the
+ * window itself, `event.origin` is its own origin, and that origin is one it
+ * declares the app on. None of the three is ours to relax, and together they
+ * fix how this module must post: from the app's own top-level document, to
+ * `window`, with an explicit same-origin `targetOrigin` — never `"*"`, which
+ * would offer the digest to whatever frame happened to be listening.
+ *
+ * ## An explicit user action, or nothing
+ *
+ * A corpus is the user's résumé text with the line breaks taken out. Storing it
+ * in the extension creates a **second on-device copy outside this origin** —
+ * not egress, and not a break in the custody claim, but a new location the user
+ * did not pick. So {@link shareResumeProfile} runs on a click and on nothing
+ * else: no ambient push on load, none on save, none on edit.
+ * {@link clearSharedResumeProfile} is the way back out, and
+ * {@link postExtensionPing} — the one thing here that fires without a click —
+ * carries no résumé data at all, only "are you there?".
+ *
+ * ## No network, and no new exposure
+ *
+ * Nothing here fetches. A same-origin `window.postMessage` is visible to every
+ * script already sharing this page's context — which is a set that can read the
+ * parse out of memory anyway — so the digest reaches no reader that did not
+ * already have the whole résumé. `providers/keywords.ts` remains the sole
+ * resume-derived **egress** helper; this is a hop inside one browser tab.
+ *
+ * ## Absent by design: `compFloor`
+ *
+ * `ratingInputFor` reads a fourth scalar, an annual pay floor. It has no
+ * counterpart on this surface — it is typed into the `/jobs/` search form
+ * (`CompFloorInput`) and exists nowhere else — and a floor the user never set
+ * would be a number this app invented. The extension treats an absent axis as
+ * neutral rather than as zero, so omitting it costs a signal and tells no lie.
+ */
+
+import { buildCorpus } from "./jd-match/coverage.ts";
+import { buildJobQuery } from "./job-search/query-builder.ts";
+import { seniorityRung } from "./job-search/seniority.ts";
+import type { HeuristicParsedResume } from "./heuristics/types.ts";
+
+/** The channel marker both ends stamp on every message. Fixed by the
+ *  extension's protocol — see its README, "The résumé profile channel". */
+export const EXTENSION_CHANNEL = "recruidea-extension" as const;
+
+/**
+ * How long to wait for a reply before reporting that none came.
+ *
+ * There is no negative acknowledgement to wait for: an uninstalled, disabled or
+ * not-yet-injected extension simply never answers, so an unbounded `await`
+ * would hang the control forever. Two seconds is far past the round trip (one
+ * `postMessage` hop plus a `chrome.storage.local` write) and short enough that
+ * a user who has no extension learns so while still looking at the button.
+ */
+export const EXTENSION_REPLY_TIMEOUT_MS = 2_000;
+
+/**
+ * Everything that crosses. Six fields, and the wire shape is not ours to widen:
+ * the extension reads an allow-list off whatever it is handed and drops the
+ * rest, so an extra key here would be silently discarded rather than stored.
+ */
+export interface SharedResumeProfile {
+  /** `buildCorpus(parsed)` — the résumé as one lowercased string. The only
+   *  thing coverage matching ever reads. */
+  corpus: string;
+  /** What the extension's panel calls this résumé, so it can name what it is
+   *  rating against. The file name, which is the one label a user recognises. */
+  label: string;
+  /** The parsed contact name. **The one field here whose value can leave the
+   *  device**: the extension offers it as the pre-fill when it asks the user to
+   *  confirm their name at sign-up, and the confirmed value is written to their
+   *  own row. Sent anyway — omitting it does not make sign-up private, it just
+   *  makes the name box empty. */
+  contactName?: string;
+  /** Ladder rung derived from the résumé's own titles, as `rank.ts` reads it. */
+  seniorityRung?: number;
+  /** Free-text location, as `rank.ts` compares it. */
+  location?: string;
+}
+
+/** What a share attempt ended as. `no-reply` is a statement about the reply,
+ *  not about the extension: nothing answered in {@link
+ *  EXTENSION_REPLY_TIMEOUT_MS}, which is what an absent, disabled or
+ *  not-yet-injected extension looks like from here — and is indistinguishable
+ *  from all three. */
+export type ShareOutcome =
+  | { kind: "stored" }
+  | { kind: "refused"; reason: string }
+  | { kind: "no-reply" };
+
+/** What a clear attempt ended as. `cleared: false` means the extension had
+ *  nothing stored — a real answer, not a failure. */
+export type ClearOutcome = { kind: "cleared"; cleared: boolean } | { kind: "no-reply" };
+
+/**
+ * Reduce a parse to the digest the extension's rating chain consumes.
+ *
+ * `location` and the seniority rung come from `buildJobQuery`, the same
+ * derivation that seeds the `/jobs/` search form, rather than from a second
+ * reading of the parse — two derivations of "which title carries the level" is
+ * the fastest route to two ratings that disagree about the same résumé. It does
+ * more work than these two fields need (it also ranks skills), which is
+ * affordable on a click and cheaper than owning a private copy of the rule.
+ */
+export function buildSharedResumeProfile(
+  parsed: HeuristicParsedResume,
+  label: string,
+): SharedResumeProfile {
+  const query = buildJobQuery(parsed);
+  return {
+    corpus: buildCorpus(parsed),
+    label,
+    contactName: nonEmpty(parsed.full_name),
+    seniorityRung: seniorityRung(query.seniority),
+    location: nonEmpty(query.location),
+  };
+}
+
+/** Trimmed-non-empty, or undefined. An empty string is not a location or a
+ *  name; sending one would only make the extension store a blank. */
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/** Share the digest. Call from a click handler and nowhere else. */
+export async function shareResumeProfile(
+  profile: SharedResumeProfile,
+): Promise<ShareOutcome> {
+  const reply = await sendToExtension(
+    { channel: EXTENSION_CHANNEL, type: "set-resume-profile", profile },
+    ["resume-profile-stored", "resume-profile-refused"],
+  );
+  if (reply === null) return { kind: "no-reply" };
+  if (reply.type === "resume-profile-stored") return { kind: "stored" };
+  return { kind: "refused", reason: reply.reason };
+}
+
+/** Ask the extension to drop whatever profile it holds. */
+export async function clearSharedResumeProfile(): Promise<ClearOutcome> {
+  const reply = await sendToExtension({ channel: EXTENSION_CHANNEL, type: "clear-resume-profile" }, [
+    "resume-profile-cleared",
+  ]);
+  return reply === null ? { kind: "no-reply" } : { kind: "cleared", cleared: reply.cleared };
+}
+
+/**
+ * Post a bare presence probe. Carries no résumé data — it exists so the app can
+ * tell whether an extension is listening without knowing its id, which is the
+ * only way to keep the share control off the screen of the large majority of
+ * visitors who have no extension at all.
+ *
+ * Fire-and-forget, deliberately: the answer arrives through
+ * {@link onExtensionPong}, so a caller can keep one listener open across
+ * several probes instead of racing a timeout per probe.
+ */
+export function postExtensionPing(): void {
+  const appOrigin = window.location.origin;
+  window.postMessage({ channel: EXTENSION_CHANNEL, type: "ping" }, appOrigin);
+}
+
+/** Listen for `pong`. Returns the unsubscribe. */
+export function onExtensionPong(handler: (version: string) => void): () => void {
+  const appOrigin = window.location.origin;
+  const onMessage = (event: MessageEvent<unknown>) => {
+    if (!isFromThisPage(event, appOrigin)) return;
+    const reply = readReply(event.data);
+    if (reply?.type === "pong") handler(reply.version);
+  };
+  window.addEventListener("message", onMessage);
+  return () => window.removeEventListener("message", onMessage);
+}
+
+// ── The wire ─────────────────────────────────────────────────────────────────
+
+/** Messages this app posts. Mirrors the extension's `PageChannelMessage`. */
+type OutgoingMessage =
+  | { channel: typeof EXTENSION_CHANNEL; type: "ping" }
+  | { channel: typeof EXTENSION_CHANNEL; type: "set-resume-profile"; profile: SharedResumeProfile }
+  | { channel: typeof EXTENSION_CHANNEL; type: "clear-resume-profile" };
+
+/** Messages the extension posts back. Mirrors its `PageChannelReply`. */
+type ExtensionReply =
+  | { type: "pong"; version: string }
+  | { type: "resume-profile-stored" }
+  | { type: "resume-profile-refused"; reason: string }
+  | { type: "resume-profile-cleared"; cleared: boolean };
+
+type ReplyType = ExtensionReply["type"];
+
+/**
+ * The reply vocabulary, as a set.
+ *
+ * Membership is what separates a reply from an echo, and that distinction is
+ * load-bearing rather than tidy: a `postMessage` to `window` is delivered to
+ * every listener on this page **including this module's own**, so each request
+ * below sees its own outgoing message arrive a tick later carrying the same
+ * channel marker. A guard that checked only the channel would resolve the share
+ * promise on the share request.
+ */
+const REPLY_TYPES: ReadonlySet<string> = new Set<ReplyType>([
+  "pong",
+  "resume-profile-stored",
+  "resume-profile-refused",
+  "resume-profile-cleared",
+]);
+
+/**
+ * The two sender checks, mirroring the extension's own.
+ *
+ * `event.source === window` rejects a post from an embedded frame; the origin
+ * comparison rejects one from a cross-origin frame holding a handle to this
+ * window. Neither buys much against a script already running in this page — it
+ * can read the parse directly — but a forged `resume-profile-stored` would make
+ * this surface report a share that never happened, and that is cheap to refuse.
+ */
+function isFromThisPage(event: MessageEvent<unknown>, appOrigin: string): boolean {
+  return event.source === window && event.origin === appOrigin;
+}
+
+/** Read a reply out of an untrusted payload, or null. Fields are read
+ *  defensively for the same reason the type set exists: anything on this page
+ *  can post, so a malformed `refused` must not surface as `undefined`. */
+function readReply(value: unknown): ExtensionReply | null {
+  if (value === null || typeof value !== "object") return null;
+  const message = value as { channel?: unknown; type?: unknown; reason?: unknown; version?: unknown; cleared?: unknown };
+  if (message.channel !== EXTENSION_CHANNEL) return null;
+  if (typeof message.type !== "string" || !REPLY_TYPES.has(message.type)) return null;
+  switch (message.type as ReplyType) {
+    case "pong":
+      return { type: "pong", version: typeof message.version === "string" ? message.version : "" };
+    case "resume-profile-stored":
+      return { type: "resume-profile-stored" };
+    case "resume-profile-refused":
+      return {
+        type: "resume-profile-refused",
+        reason:
+          typeof message.reason === "string" && message.reason !== ""
+            ? message.reason
+            : "The extension refused it without saying why.",
+      };
+    case "resume-profile-cleared":
+      return { type: "resume-profile-cleared", cleared: message.cleared === true };
+  }
+}
+
+/**
+ * Post one message and wait for one of `accepts`, or for the timeout.
+ *
+ * The listener is attached before the post, so a reply cannot land in the gap.
+ * There is no correlation id on this protocol — the reply vocabulary is
+ * disjoint per request, and the one control that drives it is disabled while a
+ * request is in flight — so the first accepted reply is this request's.
+ */
+function sendToExtension<T extends ReplyType>(
+  message: OutgoingMessage,
+  accepts: readonly T[],
+): Promise<Extract<ExtensionReply, { type: T }> | null> {
+  return new Promise((resolve) => {
+    const appOrigin = window.location.origin;
+    const wanted = new Set<string>(accepts);
+    let settled = false;
+
+    function finish(reply: Extract<ExtensionReply, { type: T }> | null): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      window.removeEventListener("message", onMessage);
+      resolve(reply);
+    }
+
+    function onMessage(event: MessageEvent<unknown>): void {
+      if (!isFromThisPage(event, appOrigin)) return;
+      const reply = readReply(event.data);
+      if (reply === null || !wanted.has(reply.type)) return;
+      finish(reply as Extract<ExtensionReply, { type: T }>);
+    }
+
+    const timer = setTimeout(() => finish(null), EXTENSION_REPLY_TIMEOUT_MS);
+    window.addEventListener("message", onMessage);
+    window.postMessage(message, appOrigin);
+  });
+}

--- a/src/lib/job-origin-reach.test.ts
+++ b/src/lib/job-origin-reach.test.ts
@@ -58,14 +58,39 @@ const ALLOWED = new Set([
  */
 const ORIGIN_READ = /\.origin\b/;
 
+/**
+ * Reads of an `origin` that is a WEB origin, not a `JobRecord` field — the
+ * false positives {@link FALSE_POSITIVE_HINT} predicted, stripped out before
+ * the scan rather than excused file by file.
+ *
+ * They arrived with the résumé-profile sender (#620): `lib/extension-profile.ts`
+ * has to name the page's own origin as a `postMessage` target and compare an
+ * incoming `event.origin` against it, and both of those are the thing the
+ * extension's bridge REQUIRES — a sender that dodged them to keep this gate
+ * quiet would be the actual defect. Narrowing here is what the hint asks for
+ * and is strictly safer than the alternative it warns against: adding that file
+ * to {@link ALLOWED} would exempt it from a genuine `job.origin` read too.
+ *
+ * Deliberately a closed list of receivers rather than a general "any origin
+ * that looks web-ish". A new spelling (`self.origin`, `frame.origin`) is a line
+ * somebody has to add here, on a diff a reviewer reads.
+ */
+const WEB_ORIGIN_READ = /\b(?:window\.location|location|event|new URL\([^)]*\))\.origin\b/g;
+
+/** True when `source` reads `origin` off something that is not a web origin —
+ *  i.e. what #745 is actually about. */
+function readsRecordOrigin(source: string): boolean {
+  return ORIGIN_READ.test(source.replace(WEB_ORIGIN_READ, ""));
+}
+
 /** Named on the offender assertion, because `\.origin\b` matches a property
  *  called `origin` on ANY object and the tree is only clean of the others by
  *  luck of what has been written so far. */
 const FALSE_POSITIVE_HINT =
   "A `new URL(u).origin`, `location.origin` or `event.origin` (the standard " +
   "postMessage sender check) is NOT a `JobRecord.origin` read and NOT a #745 " +
-  "violation — narrow this regex to exclude it rather than adding the file to " +
-  "ALLOWED, which would let a real read in through the same door.";
+  "violation — narrow WEB_ORIGIN_READ to exclude it rather than adding the file " +
+  "to ALLOWED, which would let a real read in through the same door.";
 
 /** Source with comments removed, for the drift assertion only — see the "two
  *  halves" section of the module docblock. Crude on purpose: a `//` inside a
@@ -102,7 +127,7 @@ describe("JobRecord.origin: read only by the validator and the tracker row (#745
     for (const file of collectSourceFiles(SRC_ROOT)) {
       const relPath = relative(SRC_ROOT, file).split("\\").join("/");
       if (ALLOWED.has(relPath)) continue;
-      if (ORIGIN_READ.test(readFileSync(file, "utf8"))) offenders.push(relPath);
+      if (readsRecordOrigin(readFileSync(file, "utf8"))) offenders.push(relPath);
     }
     expect(offenders, FALSE_POSITIVE_HINT).toEqual([]);
   });
@@ -115,7 +140,7 @@ describe("JobRecord.origin: read only by the validator and the tracker row (#745
     // that DESCRIBES the read cannot stand in for the read.
     for (const relPath of ALLOWED) {
       const code = stripComments(readFileSync(join(SRC_ROOT, relPath), "utf8"));
-      expect(ORIGIN_READ.test(code), `${relPath} no longer reads \`origin\` in code`).toBe(true);
+      expect(readsRecordOrigin(code), `${relPath} no longer reads \`origin\` in code`).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary

Nothing in this app has ever posted `set-resume-profile`, so the browser extension's résumé corpus was **always empty in production** and the fit rating it shows beside a captured posting could never render. The consumer half — validation, storage, and the rating chain that reads it — was already complete on the other side of the bridge; there was simply no sender. This is the sender.

Tracked in the private consumer repo as `116-Ideas/recruidea#620`. No issue in this repo — the submodule bump and the extension panel's empty-state copy follow there, not here.

### What crosses, and what does not

The digest the rating chain actually reads, and nothing else: `buildCorpus(parsed)`, a label, the contact name, and the location + seniority rung derived through `buildJobQuery` — the same derivation `/jobs/` seeds its search with, so the two surfaces cannot disagree about the same résumé. **The structured résumé never crosses.** Not that it merely shouldn't: the extension reads an allow-list off whatever it is handed and drops the rest, so this sender is the half that has to not try.

`compFloor` is omitted **deliberately**. `ratingInputFor` reads a fourth scalar, an annual pay floor, and it has no counterpart on this surface — it is typed into the `/jobs/` search form and exists nowhere else. Inventing one the user never set is worse than the neutral axis an absent one already resolves to. Worth knowing downstream: the extension's `RATING_SCOPE` copy says the profile carries "your level, location and pay floor", and the floor will always be absent from a profile this sender writes.

### Why it lives on `/` and not `/jobs/`

`/jobs/` looked like the natural home — it is the surface that holds all three query scalars. Two things overrule that, and both point at `/`:

- This is the **only surface that knows the résumé's file name**, which is the label the extension's panel renders when it names what it rated against ("Ratings use: …"). `/jobs/` receives only a `HeuristicParsedResume` over the sessionStorage handoff, and widening that payload for a label would break the rule its own module docblock sets.
- It is where a user sent here by the extension's "no résumé shared" prompt **actually lands**. `/jobs/` needs a handoff before it holds a résumé at all, so on a direct visit the control would be missing on exactly the trip that came looking for it.

The cost is `compFloor`, above. The measured trade was worth it.

### It renders nothing unless an extension answers

Gated on a `ping` probe (`useExtensionPresence`). The large majority of visitors run no extension, and a permanent bar offering them an integration they do not have is an advertisement, not an affordance. That probe is the one message in this lane allowed to fire without a click, and it carries no résumé data. A negative is never treated as proof of absence — it only ever hides an affordance.

### Every outcome is surfaced, including the two that are not success

- A **refusal** carries the extension's reason verbatim. The one that can actually happen — "`corpus` is empty; there is nothing to rate against" — names a fixable state of the résumé, and paraphrasing it here would put a second wording of the extension's rule in this repo.
- **No reply** is reported as no reply. Nothing sends a negative acknowledgement, so an unbounded `await` would leave the control spinning forever on a browser with no extension. Bounded at 2s, and the copy offers a reload rather than an install, because the probe already answered once.

### The gate this change had to touch

`src/lib/job-origin-reach.test.ts` scans every non-test file under `src/` for `/\.origin\b/` **in raw source, comments included**, and fails on anything outside a two-entry allowlist. A `postMessage` sender cannot exist without `window.location.origin` and `event.origin` — and both are things the extension's bridge *requires*, so a sender that dodged them to keep this gate quiet would be the actual defect.

That test's own `FALSE_POSITIVE_HINT` had already predicted this and prescribes the remedy: *"narrow this regex to exclude it rather than adding the file to ALLOWED, which would let a real read in through the same door."* Followed exactly — a `WEB_ORIGIN_READ` strip of a **closed list** of receivers, applied through one helper used by both halves of the test. This narrows; it does not exempt the file.

**Falsified, not observed green.** Planted `return job.origin;` inside `extension-profile.ts` itself — the file holding both web-origin reads — and the offender assertion went red naming `lib/extension-profile.ts`. Restored; green again.

## Review focus

- `src/lib/job-origin-reach.test.ts:54` — the narrowing is the one place this PR weakens a scan's raw pattern. Is the closed receiver list (`window.location`, `location`, `event`, `new URL(…)`) the right shape, and is applying it to the **drift** half too (not just the offender half) correct, or should that half keep the unnarrowed regex?
- `src/lib/extension-profile.ts:203` — `REPLY_TYPES` membership is what stops the module resolving on its own echo, since a same-window post is delivered to its own listener. Is a disjoint vocabulary a strong enough substitute for a correlation id, given the control is disabled while a request is in flight?
- `src/hooks/useExtensionPresence.ts` — two probes (0 ms, 1000 ms) because `document_idle` may schedule the content script either side of `window.onload`. Is the retry earning its keep given the bar only mounts after a user has dropped a file, or is it speculative?
- `src/components/features/ShareWithExtensionBar.tsx:70` — the copy claims "Nothing is uploaded from this page — the extension keeps its own copy, on this device." Scoped to *this page* on purpose: `contactName` is the one field on this channel whose value can later leave the device, via the extension's own sign-up flow. Is that scoping honest enough, or does it read as a blanket promise this repo cannot keep?
- `src/lib/extension-profile.ts:120` — `buildJobQuery` is called for two fields and also ranks skills it throws away. Reuse over a second derivation, on a click handler. Right call?
- `src/App.tsx` — the bar is mounted unconditionally in the `done` phase and self-hides. `App` is already 376 lines and CRAP-CRITICAL (pre-existing); this adds 10.

## Test plan

- [x] `npm run verify` green end to end, exit 0 — typecheck, eslint, `check:fixtures`, `check:baselines`, `check:core`, `vitest run --coverage` (**5219 passed / 10 skipped**), `vite build`, fallow
- [x] Re-run by the `pre-push` hook against the pushed commit — green
- [x] 26 new tests: 17 on the transport/protocol, 9 on the control
- [x] Sender posts to `window.location.origin` and **never** `"*"` — asserted directly
- [x] Refuses a reply from another origin, and one whose `source` is not this window
- [x] Does not resolve on its own echoed request
- [x] Missing extension resolves `no-reply` and re-enables the control — asserted at both the transport and the UI layer
- [x] Nothing is shared on mount; the only message before a click is the data-free `ping`
- [x] Origin gate falsified by planting a real `job.origin` read in the new module (red), then restored (green)
- [x] fallow clean on the changed set after two fixes it found: a duplicated test harness (extracted to `lib/__test-utils__/extension-channel.ts`) and a 68-line render (split out `ShareFeedback`). The one remaining finding is `App`, inherited
- [x] Bundle cost measured before choosing a static import: `skills.ts`, `query-builder.ts` and `seniority.ts` are already eager on `/`, so the marginal add is `coverage.ts` alone (6.9 KB source) — which is why this is not behind an `await import()` the way `useSavedJobRatings` needs
- [ ] **Not exercised against a real extension build.** Every assertion here is against the protocol as the consumer defines it, not against a loaded extension. The end-to-end check — a captured posting rendering stars — belongs to the submodule bump on the other side.

## Provenance

Code implementation via: Claude Opus 5
Verification: `npm run verify` — green locally and via the pre-push hook
