### PR TITLE
feat(core): export the job-board providers on a ./job-search subpath

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -24,10 +24,29 @@
   // in fallow's excluded-inherited bucket and each newly added generator
   // resurfaced as a fresh "dead code" finding on whichever PR added it (#665).
   // They are entry points in the same sense the `.mjs` tests above are.
+  //
+  // `packages/core/src/job-search.ts` is `@offlinecv/core`'s SECOND published
+  // entry point (the `./job-search` subpath), and nothing in this repo imports
+  // it — its consumer is downstream, across a submodule pin. That is true of the
+  // `.` entry too, and fallow finds `packages/core/src/index.ts` on its own
+  // while reporting this one as an unreachable file. Measured rather than
+  // assumed: swapping which of the two `exports` names as `"."` changed nothing,
+  // so it is not following `exports` — the only difference between the two files
+  // is that one of them is called `index.ts`. Registering it here rather than
+  // renaming it into `job-search/index.ts`, because the emitted path is what
+  // `exports` and `files` point at and a directory would move it for a linter's
+  // benefit. A third entry point costs six edits across five files, and a line here
+  // is one of them — the others are `packages/core/package.json`'s `exports` and
+  // `files`, `tsconfig.build.json`'s `include`, `rollup.dts.config.mjs`, and
+  // `scripts/check-core-package.mjs`'s `EXPECTED_EXPORTS` + `ENTRY_CLOSURES` +
+  // `PROBE`. The same list is spelled out in `packages/core/src/index.ts`'s
+  // docblock and in that script's `THIRD_ENTRY_CHECKLIST`, which is the copy its
+  // failure message quotes.
   "entry": [
     "jd-spike.html",
     "eval-rewrite.html",
     "parse-eval.html",
+    "packages/core/src/job-search.ts",
     "scripts/**/*.test.mjs",
     "scripts/fixtures/gen-*.mjs",
     "scripts/check-contrast.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,19 +3,24 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
-  "description": "The headless, browser-only core of offlinecv: job capture, local library storage, JD term extraction and fit rating. Re-exported from src/lib — see src/index.ts.",
+  "description": "The headless, browser-only core of offlinecv: job capture, local library storage, JD term extraction and fit rating, with the network-bearing job-board provider adapters on a separate ./job-search subpath. Re-exported from src/lib — see src/index.ts and src/job-search.ts.",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/packages/core/src/index.js"
+    },
+    "./job-search": {
+      "types": "./dist/job-search.d.ts",
+      "default": "./dist/packages/core/src/job-search.js"
     }
   },
   "files": [
     "dist/**/*.js",
     "dist/**/*.json",
-    "dist/index.d.ts"
+    "dist/index.d.ts",
+    "dist/job-search.d.ts"
   ],
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json && rollup -c rollup.dts.config.mjs",

--- a/packages/core/rollup.dts.config.mjs
+++ b/packages/core/rollup.dts.config.mjs
@@ -39,12 +39,30 @@
 
 import dts from "rollup-plugin-dts";
 
-export default {
-  // The per-file declaration tree `tsc -p tsconfig.build.json` emits. The path
-  // carries the `packages/core/src` nesting because `rootDir` has to cover the
-  // `../../../src/lib/…` closure the barrel re-exports through.
-  input: "dist/packages/core/src/index.d.ts",
-  output: { file: "dist/index.d.ts", format: "es" },
+/**
+ * One bundle per entry point in `package.json`'s `exports`, and the two are a
+ * set that has to be kept in step by hand: an entry with no bundle here ships a
+ * `types` path the tarball does not contain, which `check:core`'s assertion 1
+ * fails at pack time rather than a consumer discovering it as silent `any`.
+ *
+ * They are separate bundles rather than one with two outputs because they are
+ * two independent declaration graphs — `job-search` is the network-bearing
+ * subpath and shares only `JobPosting` with `.`. `rollup-plugin-dts` inlines
+ * that shared type into both, which is correct: a `.d.ts` describes a surface,
+ * and duplicating a structural type across two surfaces costs a consumer
+ * nothing at runtime and keeps either bundle readable on its own.
+ *
+ * The input paths carry the `packages/core/src` nesting because `rootDir` has
+ * to cover the `../../../src/lib/…` closure both entries re-export through.
+ */
+const entries = [
+  ["dist/packages/core/src/index.d.ts", "dist/index.d.ts"],
+  ["dist/packages/core/src/job-search.d.ts", "dist/job-search.d.ts"],
+];
+
+export default entries.map(([input, file]) => ({
+  input,
+  output: { file, format: "es" },
   external: ["idb"],
   plugins: [dts()],
-};
+}));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,13 @@
  * depend on, so that consumer can write `@offlinecv/core` instead of reaching
  * into this repo's source tree by relative path.
  *
+ * This file is the **`.` entry point**, and the distinction now matters: the
+ * package has a second one, `@offlinecv/core/job-search` (`src/job-search.ts`),
+ * carrying the job-board provider adapters. Every claim below is about THIS
+ * entry unless it says otherwise, and the network-free one is about this entry
+ * *because* the other entry is not — see "Two entry points, and only one of them
+ * is network-free" below before quoting either.
+ *
  * The surface is deliberately narrow: the job-capture contract, the local
  * library's CRUD and replication primitives, the JD term/coverage pair, and the
  * fit-rating chain. It is what a *producer* of `JobRecord`s and a *replica* of
@@ -41,8 +48,9 @@
  * would drag a network primitive onto that graph for nothing. Measured: the
  * value-edge closure of the specifiers below is 27 modules and reaches no
  * `fetch`/`WebSocket`/`XMLHttpRequest`/`EventSource` at all. That is a statement
- * about the value-edge closure and not about the tarball's file list, which is
- * larger — see "The tarball ships more files than the graph reaches" below.
+ * about **this entry's** value-edge closure, and not about the tarball's file
+ * list, which is larger — see "The tarball ships more files than the graph
+ * reaches" below.
  *
  * **2. Types are re-exported with `export type`.** Not a style preference. A
  * type-only edge erases at build time, so `export type { JobRecord } from …`
@@ -52,35 +60,65 @@
  * `src/lib/job-search/types.ts` are re-exported for their types only and must
  * stay `export type` statements.
  *
- * The full transitive closure is 49 modules / ~17.5k LOC across `lib/storage`,
- * `lib/job-search`, `lib/jd-match`, `lib/heuristics`, `lib/score` and `webllm`,
- * with exactly one external runtime dependency: `idb`. The `heuristics`, `score`
- * and `webllm` modules are reached only through `import type` edges, so they
- * erase from the runtime graph — but not from the tarball.
+ * This entry's full transitive closure, `import type` edges included, is 49
+ * modules / ~17.5k LOC across `lib/storage`, `lib/job-search`, `lib/jd-match`,
+ * `lib/heuristics`, `lib/score` and `webllm`, with exactly one external runtime
+ * dependency: `idb`. The `heuristics`, `score` and `webllm` modules are reached
+ * only through `import type` edges, so they erase from the runtime graph — but
+ * not from the tarball.
+ *
+ * ## Two entry points, and only one of them is network-free
+ *
+ * `@offlinecv/core/job-search` is the second, and it is the deliberately
+ * network-BEARING half: the provider adapters call public job feeds, so every
+ * one of them holds a `fetch(`. It is a separate subpath precisely so that fact
+ * cannot arrive here by accident. Read `src/job-search.ts`'s own docblock for
+ * the full argument; the two facts that belong on this side of the seam are:
+ *
+ *   - **The two runtime closures are disjoint.** Measured: 27 modules from this
+ *     entry, 11 from `./job-search`, zero modules in common. Importing one
+ *     cannot pull the other in, in either direction, which is what makes the
+ *     network-free claim above survive the subpath's existence rather than merely
+ *     coexist with it.
+ *   - **The separation is a consumer's gate, not a preference.** The extension
+ *     this package was cut for walks the import graph of each of its entry
+ *     points and asserts the network primitives it reaches are exactly an
+ *     allow-list of one. Four of its five surfaces must reach none. A consumer
+ *     doing that audit must keep `./job-search` off every graph that has to stay
+ *     network-free, and there is no safe subset of it to reach for instead.
  *
  * ## The tarball ships more files than the graph reaches
  *
  * `tsc` emits a `.js` for every file in the program, the ones reached only by
  * `import type` included, and `files` ships all of them. So `npm pack` produces
- * 49 modules of which 27 are reachable from this barrel — and three of the
- * unreachable 22 read exactly like the thing this file says is absent:
+ * 62 modules, of which 38 are reachable — 27 from this barrel and 11 from
+ * `./job-search` — and two of the unreachable 24 read exactly like the thing
+ * this file says is absent:
  *
- *   - `dist/src/lib/jd-match/fetch-jd.js` — a live `fetch(url, …)`
  *   - `dist/src/lib/analytics.js` — `import.meta.env`, `await import("posthog-js")`
  *   - `dist/src/lib/webllm/web-llm.js` — `await import("@mlc-ai/web-llm")`
  *
- * Neither dynamic import is in `dependencies`, and nothing can load either file:
- * `exports` declares no subpath, so a consumer reaching for one gets
- * `ERR_PACKAGE_PATH_NOT_EXPORTED` (verified), and no reachable module imports
- * them. Unreachable dead JS a reader can open — not an egress path.
+ * (`dist/src/lib/jd-match/fetch-jd.js` used to head that list. It is now
+ * genuinely loadable — the provider adapters take `htmlToPlaintext` from it — so
+ * it moved off the dead-JS list and onto `./job-search`'s closure, where its
+ * `fetch(` is neither a surprise nor a capability that closure lacked.)
  *
- * The network-free claim above is therefore about the RUNTIME GRAPH rather than
- * the file list, and on the graph it holds exactly: 27 modules, no network
- * primitive, one bare import (`idb`). Which means grepping the tarball for
- * `fetch(` is the wrong audit — it finds `fetch-jd.js` plus two prose mentions
- * in comments. Walk the value edges out of `dist/packages/core/src/index.js`
- * instead; that is the graph a consumer actually loads, and what `check:core`'s
- * probe exercises when it imports the package by specifier.
+ * Neither dynamic import is in `dependencies`, and nothing can load either file:
+ * `exports` declares two subpaths and no wildcard, so a consumer reaching for
+ * any other path — including a `dist/…` one — gets
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` (verified, and asserted by `check:core`), and
+ * no reachable module imports them. Unreachable dead JS a reader can open — not
+ * an egress path.
+ *
+ * The network-free claim above is therefore about **this entry's** RUNTIME GRAPH
+ * rather than about the file list, and on that graph it holds exactly: 27
+ * modules, no network primitive, one bare import (`idb`). Which means grepping
+ * the tarball for `fetch(` is the wrong audit twice over — it finds the seven
+ * modules that legitimately fetch on the OTHER entry, plus prose mentions in
+ * comments, and says nothing about which entry a consumer imported. Walk the
+ * value edges out of `dist/packages/core/src/index.js` instead; that is the
+ * graph a consumer of `.` actually loads, and what `check:core`'s probe
+ * exercises when it imports the package by specifier.
  *
  * `idb` **is** in this package's `dependencies`, and #772 is the reason it now
  * is. While this was a bare re-export barrel the omission was right: nothing
@@ -119,7 +157,28 @@
  * The tarball ships no `.ts`, so a per-file declaration tree would dangle on
  * every internal import and a consumer would silently get `any`.
  * `rollup.dts.config.mjs` bundles the declarations into one specifier-free
- * `dist/index.d.ts`, and `files` ships that instead of the tree.
+ * file per entry point — `dist/index.d.ts` and `dist/job-search.d.ts` — and
+ * `files` ships those instead of the tree.
+ *
+ * ## What a third entry point costs
+ *
+ * Six edits, across five files, that no single tool checks together — the same list
+ * is written out in `tsconfig.build.json`, `.fallowrc.jsonc` and
+ * `check-core-package.mjs`'s `THIRD_ENTRY_CHECKLIST`, and they used to be three
+ * different, shorter lists:
+ *
+ *   1. `package.json` → `exports` (the subpath, with `types` + `default`)
+ *   2. `package.json` → `files` (its `dist/<name>.d.ts`)
+ *   3. `tsconfig.build.json` → `include`, or `tsc` emits no `.js` for it
+ *   4. `rollup.dts.config.mjs` → a declaration bundle
+ *   5. `scripts/check-core-package.mjs` → `EXPECTED_EXPORTS`, `ENTRY_CLOSURES`,
+ *      and a `PROBE` static import
+ *   6. `.fallowrc.jsonc` → `entry`, unless the new file is called `index.ts`
+ *
+ * `check:core` is what turns a missed one into a pack-time failure rather than a
+ * consumer's silent `any` — including a missed (5), which is the one that used
+ * to pass: it cross-checks the subpaths `exports` publishes against both
+ * hand-written tables, in both directions, and fails by subpath name.
  *
  * `npm run check:core` (`scripts/check-core-package.mjs`, wired into `verify`)
  * is what makes any of this checkable from in here. Everything else in this
@@ -287,4 +346,12 @@ export {
   type JobRating,
 } from "../../../src/lib/job-search/rating.ts";
 
+/**
+ * `JobPosting` is on `./job-search` as well, and deliberately on both. It is the
+ * shape a captured posting is *rated* in, which a consumer needs whether or not
+ * it ever searches — and it is what an adapter *returns*, which a consumer of the
+ * subpath cannot do without. A type-only re-export erases, so the duplication
+ * costs nothing at runtime; narrowing it to one entry would only force some
+ * importer to reach for the other.
+ */
 export type { JobPosting } from "../../../src/lib/job-search/types.ts";

--- a/packages/core/src/job-search.ts
+++ b/packages/core/src/job-search.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `@offlinecv/core/job-search` — the job-board provider adapters, and the
+ * **deliberately network-bearing** half of this package.
+ *
+ * Everything reachable from here fetches. That is not a defect being disclosed;
+ * it is the entire product of the module. A `JobProvider` exists to call a
+ * public job feed over HTTPS and map the response into `JobPosting`, so a
+ * consumer importing this subpath is asking for exactly one thing: outbound
+ * requests to third-party job boards.
+ *
+ * ## Why this is a separate subpath and not part of the main barrel
+ *
+ * `./index.ts` — the `.` entry, this file's sibling — makes a measured
+ * claim: the value-edge closure of its specifiers reaches no `fetch` /
+ * `WebSocket` / `XMLHttpRequest` / `EventSource` at all. That claim is not
+ * decoration. The consumer this package was cut for is a private browser
+ * extension, and its `no-network.test.ts` walks the transitive import graph
+ * from each of its
+ * entry points — content scripts, side panel, options page, offscreen document
+ * — through its single seam file `src/offlinecv-core.ts`, and asserts that the
+ * network primitives it reaches are exactly an allow-list of one. A content
+ * script that can reach `fetch` runs in `offlinecv.org`'s address space with a
+ * network primitive in scope, which in that repo is a shipped privacy defect
+ * rather than a lint finding.
+ *
+ * So exporting the adapters from the main barrel would not have been a wider
+ * surface — it would have been a **broken gate**. The barrel's own rule 1
+ * ("import the FILE, never the slice barrel") exists because
+ * `src/lib/jd-match/index.ts` re-exports `fetch-jd.ts`; routing one coverage
+ * function through that barrel would have dragged a network primitive onto the
+ * consumer's audited graph for nothing. Adding the providers to the same entry
+ * would have done it deliberately, for every importer, including the four that
+ * must never have it.
+ *
+ * A second subpath is what lets both facts be true at once. `.` stays exactly
+ * as network-free as it was; a consumer that wants the feeds names them, and
+ * naming them is visible in its own import graph.
+ *
+ * ## What a consumer auditing its import graph has to do
+ *
+ * **Keep this specifier off any graph that must stay network-free.** There is no
+ * subset of this module that is safe for such a graph — `getProviders` returns
+ * objects whose `search` is a `fetch` — so the audit is per-entry-point, not
+ * per-symbol. In the extension that means the service worker (the one context
+ * where `fetch` is un-banned) and nothing else.
+ *
+ * Two mechanical consequences for that consumer, both worth knowing before the
+ * first import rather than after the gate goes red:
+ *
+ *  - Its walker follows relative specifiers only, filing every bare one into an
+ *    `externals` list it asserts by whole-list equality; it does not resolve
+ *    `@offlinecv/core` through `exports` today, because the extension reaches
+ *    this repo by relative path through its `src/offlinecv-core.ts` seam. A
+ *    consumer that switches to the package specifier has to teach the walker
+ *    `exports` resolution for **both** keys — a subpath is a different key from
+ *    `.` — or this whole closure drops out of the graph it was added to audit,
+ *    and has to add the new specifier to the externals list.
+ *  - Its network allow-list is compared for equality, so the worker graph will
+ *    need an explicit entry per fetching module reached here. That is the
+ *    correct shape: an allow-list naming the file and the primitive, never a
+ *    loosened pattern.
+ *
+ * ## Rule 1 still holds, and was checked rather than assumed
+ *
+ * `KEYLESS_PROVIDERS` and `getProviders` are taken from
+ * `src/lib/job-search/providers/index.ts`, which is a barrel by filename only:
+ * it contains no `export … from` statement and **defines** both symbols itself.
+ * Its imports are the six adapter files (value) plus `JobProvider` and
+ * `CompanyEntry` (`import type`, so erased under `verbatimModuleSyntax`). Taking
+ * the symbols from that file therefore drags nothing the three named adapter
+ * files below would not have dragged anyway — measured, not reasoned: the
+ * value-edge closure of this entry is 11 modules, adding nothing beyond the six
+ * adapters, their shared keyword helper, and the HTML-stripper those adapters
+ * reach.
+ *
+ * ## The one import here that surprises people
+ *
+ * Every adapter takes `htmlToPlaintext` from `src/lib/jd-match/fetch-jd.ts`,
+ * which re-exports it from `html-to-plaintext.ts` and also holds this app's live
+ * ATS-hydration `fetch(` calls. On any other graph that would be rule 1's exact
+ * failure. Here it changes nothing that could be changed: the adapters fetch on
+ * their own account, so `fetch-jd.ts` adds no capability this closure did not
+ * already have. It is named rather than quietly tolerated because a reader
+ * comparing this closure against the main barrel's will find it, and should
+ * find the reason next to it.
+ *
+ * ## Privacy: what actually leaves
+ *
+ * Unchanged from the in-app lane, and `src/lib/job-search/CLAUDE.md` is
+ * normative for it. The keyless aggregator feeds egress a short **keyword
+ * string** derived from the user-editable query title/skills
+ * (`providers/keywords.ts`, the sole resume-derived egress helper in the repo) —
+ * never résumé text. The company-board adapters egress only the **public company
+ * slug** plus static caps. A consumer that builds a `JobQuery` out of anything
+ * richer than that widens the egress this repo's copy is written against.
+ */
+
+/**
+ * The fan-out registry.
+ *
+ * `getProviders` is the single seam that decides who participates in a search —
+ * the always-on keyless feeds, plus any company-board providers the caller
+ * passes in. Called with no argument it answers exactly `KEYLESS_PROVIDERS`,
+ * which is the shape a poller with no company selection wants.
+ *
+ * `KEYLESS_PROVIDERS` is exported alongside it so a consumer can name the
+ * always-on set — for a per-provider concurrency budget, say, or a degraded
+ * notice — without a call whose default it would then have to trust.
+ */
+export { KEYLESS_PROVIDERS, getProviders } from "../../../src/lib/job-search/providers/index.ts";
+
+/**
+ * The three company ATS-board factories, one per vendor, each taking the public
+ * board slug and the display name to label results with.
+ *
+ * The registry's own `makeCompanyProvider` dispatches to these from a
+ * `CompanyEntry`, and is deliberately NOT on this surface: an entry carries a
+ * `sectors` list that only means something to the in-app sector selector, so a
+ * consumer holding a slug and a vendor would have to invent `sectors: []` to
+ * satisfy a type it has no use for. These three take what such a consumer
+ * actually has.
+ *
+ * `hydrateGreenhouse` and `hydrateLever` are not optional extras. Greenhouse has
+ * no server-side search, so `search()` fetches the LIGHT index and every posting
+ * comes back with `description: ""`; Lever's inline description is stripped on a
+ * cached board. A consumer that ranks on description and skips the hydrate step
+ * is ranking every company posting against an empty string — so the pair ships
+ * with the factories rather than being rediscovered. Call them only for the
+ * postings that survive filtering, never for a whole board; that bound is the
+ * caller's to keep. Ashby has no hydrate step because it returns
+ * `descriptionPlain` inline.
+ *
+ * **The hydrators take a job id, not a posting, so `greenhouseJobId` and
+ * `leverJobId` ship with them.** A `JobPosting` from these boards carries
+ * `id: "{vendor}:{slug}:{jobId}"`, and recovering the third field is the other
+ * half of the hydrate contract — exporting the hydrators without it would leave
+ * a consumer to rediscover the shape. It is not the one-liner it looks like:
+ * `lastIndexOf(":")` is wrong on a slug that itself contains a colon, and wrong
+ * again on the posting `url` these adapters fall back to when a board omits the
+ * id. Both helpers return `""` on a shape mismatch, which the caller reads as
+ * "not hydratable".
+ *
+ * **They differ on failure, and the difference decides how you batch.**
+ * `hydrateGreenhouse` REJECTS on a non-ok response; `hydrateLever` never throws
+ * and resolves `""`. So `Promise.all(page.map(p => hydrateGreenhouse(…)))` loses
+ * a whole page of descriptions to one 404 — settle per item instead. The in-app
+ * caller only avoids the trap because `hydrateDescriptions` runs them through
+ * `mapWithConcurrency`, which is settle-per-item and is deliberately NOT on this
+ * surface: it lives behind `company-boards.ts`, whose closure reaches the
+ * IndexedDB board cache and therefore `.`'s storage modules, and pulling it here
+ * would make the two entries' runtime closures overlap. A consumer batching
+ * these writes its own bound.
+ */
+export {
+  makeGreenhouseProvider,
+  hydrateGreenhouse,
+  greenhouseJobId,
+} from "../../../src/lib/job-search/providers/greenhouse.ts";
+
+export {
+  makeLeverProvider,
+  hydrateLever,
+  leverJobId,
+} from "../../../src/lib/job-search/providers/lever.ts";
+
+export { makeAshbyProvider } from "../../../src/lib/job-search/providers/ashby.ts";
+
+/**
+ * The contract, `export type` for the main barrel's rule 2 reason — a type-only
+ * edge erases, a value edge would put the module and everything under it on the
+ * consumer's runtime graph.
+ *
+ * `JobProvider.search(query, signal)` MUST be given an `AbortSignal` it can
+ * thread into `fetch`, and it REJECTS on transport or parse failure. The in-app
+ * orchestrator runs the fan-out through `Promise.allSettled` for that reason; a
+ * poller that awaits them in sequence loses every remaining feed to the first
+ * unreachable one.
+ *
+ * `JobQuery` is re-exported from `query-builder.ts` because it is the argument
+ * type and a consumer cannot call an adapter without it. `buildJobQuery` itself
+ * is not here: it derives a query from a whole `HeuristicParsedResume`, which is
+ * precisely the object the extension consumer is built never to hold. A
+ * `JobQuery` literal — titles, skills, and the optional filters — is the whole
+ * contract, and every field is documented at its source.
+ *
+ * `JobPosting` is on the main barrel too, and stays there. It is the shape a
+ * captured posting is rated in, which a consumer needs whether or not it ever
+ * searches; duplicating a type-only re-export costs nothing at runtime and
+ * removing it from `.` would break every importer that has one today.
+ */
+export type {
+  JobProvider,
+  JobPosting,
+} from "../../../src/lib/job-search/types.ts";
+
+export type { JobQuery } from "../../../src/lib/job-search/query-builder.ts";

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -23,17 +23,37 @@
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
 
-    // Load-bearing for the privacy property the barrel's docblock claims. The
-    // surface is 27 value modules plus 22 reached only through `import type`
-    // edges. What `verbatimModuleSyntax` guarantees is narrower than "those 22
-    // erase": it guarantees the EMIT MATCHES THE SOURCE SYNTAX — an
-    // `import type`/`export type` erases, a plain `import`/`export` is
-    // preserved, and no elision heuristic decides either way behind our backs.
-    // The erasing is done by the barrel's disciplined `export type` statements;
-    // this flag is what makes that value/type split auditable by reading
-    // `src/index.ts`. Turn one of those 22 into a plain `export` and the flag
-    // will faithfully preserve it — growing the runtime graph past the 27 that
-    // were audited to reach no `fetch`/`WebSocket`.
+    // Load-bearing for the privacy property the barrels' docblocks claim. The
+    // program is 62 modules: 38 are value-reachable (27 from `src/index.ts`, 11
+    // from `src/job-search.ts`, and those two sets are disjoint), and the other
+    // 24 are reachable from neither entry.
+    //
+    // `import type` edges are how those 24 get into the program, but NOT how all
+    // of them got there directly — 13 of the 24 have an ordinary value edge into
+    // them from another module that is itself only type-reachable, so they enter
+    // BEHIND a type edge rather than through one. `job-search/sector.ts` is the
+    // clearest case: nothing imports it for a value, but its own
+    // `await import()`s put `webllm/capability.ts`, `models.ts`, `web-llm.ts`
+    // and `json-repair.ts` in the program, and `webllm/capability.ts` in turn
+    // pulls `analytics.ts`. None of that reaches either entry's runtime graph,
+    // which is the property that matters here — but "reached only through
+    // `import type` edges" would be the wrong reason to believe it.
+    // What `verbatimModuleSyntax`
+    // guarantees is narrower than "those 24 erase": it guarantees the EMIT
+    // MATCHES THE SOURCE SYNTAX — an `import type`/`export type` erases, a plain
+    // `import`/`export` is preserved, and no elision heuristic decides either way
+    // behind our backs. The erasing is done by the barrels' disciplined
+    // `export type` statements; this flag is what makes that value/type split
+    // auditable by reading the two entry files. Turn one of those 24 into a plain
+    // `export` and the flag will faithfully preserve it — growing whichever
+    // runtime graph it lands on, and `src/index.ts`'s is the one that was audited
+    // to reach no `fetch`/`WebSocket`.
+    //
+    // The disjointness is what keeps that audit meaningful now that one entry
+    // fetches on purpose: a value edge from `src/index.ts` into the provider
+    // adapters would put a network primitive on the network-free entry's graph,
+    // and this flag is what makes such an edge visible in the emit rather than a
+    // question about the compiler's elision rules.
     "verbatimModuleSyntax": true,
 
     // `src/lib/analytics.ts` reads `import.meta.env`. It is on the closure
@@ -57,5 +77,17 @@
     "outDir": "dist",
     "noEmit": false
   },
-  "include": ["src/index.ts"]
+  // Both entry points. `src/job-search.ts` is the second, network-BEARING
+  // subpath (`@offlinecv/core/job-search`) and has to be listed here or `tsc`
+  // never sees it: an entry absent from the program emits no `.js`, `files`
+  // ships nothing for it, and the `exports` map points at a path the tarball
+  // does not contain — a failure that only appears at pack time.
+  //
+  // A third entry point costs six edits across five files, and this is one of them.
+  // The full list lives in `src/index.ts`'s docblock and in
+  // `check-core-package.mjs`'s `THIRD_ENTRY_CHECKLIST`; in short:
+  // `package.json`'s `exports` and `files`, this `include`,
+  // `rollup.dts.config.mjs`, `check-core-package.mjs`'s `EXPECTED_EXPORTS` +
+  // `ENTRY_CLOSURES` + `PROBE`, and `.fallowrc.jsonc`'s `entry`.
+  "include": ["src/index.ts", "src/job-search.ts"]
 }

--- a/scripts/check-core-package.mjs
+++ b/scripts/check-core-package.mjs
@@ -29,12 +29,12 @@
  * missing dependency cannot be satisfied by walking up into the repo's own
  * `node_modules`, which would turn the check into theatre.
  *
- * FIVE THINGS ARE ASSERTED, and each one maps to a way the tarball can be wrong:
+ * SEVEN THINGS ARE ASSERTED, and each one maps to a way the tarball can be wrong:
  *
  *   1. Its SHAPE. No TypeScript source ships (that was the original defect), the
- *      per-file `.d.ts` tree does not ship either — `dist/index.d.ts` is the
- *      only declaration, because the per-file tree is unusable (see 4) — and
- *      every relative specifier in every shipped `.js` resolves to a file that
+ *      per-file `.d.ts` tree does not ship either — the only declarations are one
+ *      bundle per `exports` entry, because the per-file tree is unusable (see 4)
+ *      — and every relative specifier in every shipped `.js` resolves to a file that
  *      also ships. That last one covers what assertion 2 structurally cannot:
  *      the probe imports the entry, so it only ever exercises the REACHABLE
  *      graph, while `tsc` emits a `.js` for every file in the program and
@@ -48,33 +48,45 @@
  *      `./sections.config.json` with no `with { type: "json" }` and so cannot
  *      itself load under Node, but the JSON does ship and the specifier does
  *      resolve, which is all this asserts.
- *   2. Its RUNTIME. The entry imports under plain Node with only its declared
- *      dependencies present, exports exactly the 22 names the barrel promises,
- *      and two of them are exercised for BEHAVIOUR rather than existence —
- *      `deriveJobId` has to still strip tracking parameters, `MAX_STARS` has to
- *      still be 5. A shape-only assertion passes on a tarball that exports 22
- *      broken functions.
+ *   2. Its RUNTIME. Every entry `EXPECTED_EXPORTS` names imports under plain
+ *      Node with only the declared dependencies present, exporting exactly the
+ *      names its barrel promises — and assertion 7 is what makes "every entry
+ *      `EXPECTED_EXPORTS` names" the same set as "every entry `exports`
+ *      publishes", which it was not until that assertion existed. Three names
+ *      are exercised for BEHAVIOUR rather than
+ *      existence — `deriveJobId` has to still strip tracking parameters,
+ *      `MAX_STARS` has to still be 5, and `getProviders()` has to still answer
+ *      the three keyless feeds in display order. A shape-only assertion passes
+ *      on a tarball that exports twenty-nine broken functions.
+ *      The same assertion covers what `exports` REFUSES: three subpaths that
+ *      name real shipped files have to fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`
+ *      (see `UNEXPORTED_SUBPATHS`). That is the only thing standing between a
+ *      consumer and the 24 unreachable emitted modules, two of which
+ *      dynamic-import packages this one does not depend on.
  *   3. Its TYPES, from a consumer's position: a generated project resolves
- *      `@offlinecv/core` under `moduleResolution: "nodenext"` with
+ *      `@offlinecv/core` and `@offlinecv/core/job-search` under
+ *      `moduleResolution: "nodenext"` with
  *      `skipLibCheck: false` — the strictest configuration a plain Node consumer
  *      can have, and the first one to break. It carries a `@ts-expect-error`
  *      that only holds if the declarations were really read; if they resolved to
  *      nothing the symbols would widen to `any`, the expected error would
  *      vanish, and TypeScript would fail the unused directive.
- *   4. That no relative specifier survives in `dist/index.d.ts`. This is the
- *      subtle one. `rewriteRelativeImportExtensions` rewrites this repo's
- *      explicit `./foo.ts` specifiers to `./foo.js` in the JS output but NOT in
- *      the `.d.ts` output (TypeScript 5.8.3, under both `bundler` and
+ *   4. That no relative specifier survives in any shipped declaration bundle.
+ *      This is the subtle one. `rewriteRelativeImportExtensions` rewrites this
+ *      repo's explicit `./foo.ts` specifiers to `./foo.js` in the JS output but
+ *      NOT in the `.d.ts` output (TypeScript 5.8.3, under both `bundler` and
  *      `nodenext`). Since no `.ts` ships, a per-file declaration tree would
  *      dangle — which is why `rollup.dts.config.mjs` bundles the declarations
- *      into one specifier-free file, and why this assertion is how we find out
- *      if that step is ever removed or regresses.
+ *      into one specifier-free file per entry, and why this assertion is how we
+ *      find out if that step is ever removed or regresses.
  *   5. That every declared dependency is REQUIRED, not merely sufficient. The
  *      `node_modules/` above proves the list is big enough; nothing in it
  *      notices a dependency the code never imports, because a surplus symlink
  *      breaks nothing. So `dependencies` is compared, in both directions,
- *      against the packages a breadth-first walk from the entry actually
- *      reaches. Reachability rather than the file list, because the shipped
+ *      against the packages a breadth-first walk from EVERY entry actually
+ *      reaches — the union, because `dependencies` is one list for the whole
+ *      package and a package imported only from `./job-search` is still
+ *      required. Reachability rather than the file list, because the shipped
  *      remainder is full of modules nothing loads — two of them import
  *      `posthog-js` and `@mlc-ai/web-llm`, neither of which this package
  *      depends on in any sense a consumer would recognise.
@@ -85,6 +97,21 @@
  *      verdict about this package that is right. Walking the emitted graph can,
  *      which is why the suppression buys a stronger assertion rather than
  *      losing one.
+ *   6. Each entry's value-edge CLOSURE: how many modules it reaches, how many of
+ *      those name a network primitive, and that no two entries share one. This
+ *      is the property the `./job-search` split exists to create, and nothing
+ *      else here can see it. Assertion 2 catches a provider SYMBOL moved onto
+ *      `.`; only a graph walk catches a value EDGE, and the edge is the cheaper
+ *      accident — a single `import "…/fetch-jd.ts";` side-effect line changes no
+ *      export name at all while putting a live `fetch(` on the entry whose
+ *      docblock says it reaches none. See `ENTRY_CLOSURES`.
+ *   7. That the manifest's `exports`, `EXPECTED_EXPORTS` and `ENTRY_CLOSURES`
+ *      describe the SAME set of subpaths. Assertions 1, 4, 5 and 6 read their
+ *      subpaths off the manifest and follow a new entry automatically; the two
+ *      tables above are hand-written and do not. Until this was asserted, a
+ *      subpath added to `exports` and nowhere else published an unreviewed
+ *      export surface with the gate green — counted in the success line,
+ *      typechecked for nothing, asserted about in no way.
  *
  * HERMETIC BY CONSTRUCTION: nothing here touches the network. The dependency
  * `node_modules` is symlinked from the repo's existing install rather than
@@ -108,36 +135,162 @@ const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const PKG_NAME = "@offlinecv/core";
 
 /**
- * The package's whole runtime surface, spelled out rather than snapshotted.
+ * The package's whole runtime surface, spelled out rather than snapshotted, one
+ * list per entry point in `exports`.
  *
  * A published export list is an API promise, so a change to it should be a
- * deliberate edit to this array in the same commit — not a diff nobody reads.
- * The names are asserted as an exact SET, so an accidental ADDITION fails here
- * too: publishing a symbol is much easier than un-publishing one.
+ * deliberate edit to this object in the same commit — not a diff nobody reads.
+ * The names are asserted as an exact SET per subpath, so an accidental ADDITION
+ * fails here too: publishing a symbol is much easier than un-publishing one.
+ *
+ * Keyed by subpath rather than flattened into one list, because WHICH entry a
+ * symbol is on is the load-bearing part. `./job-search` is the network-bearing
+ * half of this package — every adapter it exports holds a `fetch(` — and the
+ * whole reason it is a second subpath is that `.`'s consumers audit their import
+ * graphs and must not reach one. A flat list would go green on a commit that
+ * moved a provider onto `.`, which is exactly the regression the split exists to
+ * prevent; this shape fails it by name.
  */
-const EXPECTED_EXPORTS = [
-  "JOB_CAPTURE_CONTRACT_VERSION",
-  "MAX_STARS",
-  "canonicalJobUrl",
-  "captureJob",
-  "computeCoverageFromCorpus",
-  "deleteRecord",
-  "deriveJobId",
-  "describeRating",
-  "extractCompensation",
-  "extractJdTerms",
-  "formatCompensationRange",
-  "getRecord",
-  "getSyncCursor",
-  "isBelowFloor",
-  "listRecordsUpdatedSince",
-  "listResumeChoices",
-  "putRecord",
-  "rateJobs",
-  "ratingInputFor",
-  "setSyncCursor",
-  "validateJobRecord",
-  "validateLetterRecord",
+const EXPECTED_EXPORTS = {
+  ".": [
+    "JOB_CAPTURE_CONTRACT_VERSION",
+    "MAX_STARS",
+    "canonicalJobUrl",
+    "captureJob",
+    "computeCoverageFromCorpus",
+    "deleteRecord",
+    "deriveJobId",
+    "describeRating",
+    "extractCompensation",
+    "extractJdTerms",
+    "formatCompensationRange",
+    "getRecord",
+    "getSyncCursor",
+    "isBelowFloor",
+    "listRecordsUpdatedSince",
+    "listResumeChoices",
+    "putRecord",
+    "rateJobs",
+    "ratingInputFor",
+    "setSyncCursor",
+    "validateJobRecord",
+    "validateLetterRecord",
+  ],
+  "./job-search": [
+    "KEYLESS_PROVIDERS",
+    "getProviders",
+    "greenhouseJobId",
+    "hydrateGreenhouse",
+    "hydrateLever",
+    "leverJobId",
+    "makeAshbyProvider",
+    "makeGreenhouseProvider",
+    "makeLeverProvider",
+  ],
+};
+
+/**
+ * The VALUE-EDGE CLOSURE of each entry, measured on the emitted `dist/` — the
+ * property the two-entry split exists to create, and the one thing no other
+ * assertion here can see.
+ *
+ * `EXPECTED_EXPORTS` above catches a provider SYMBOL moved onto `.`. It cannot
+ * catch a value EDGE, which is the cheaper mistake by far: one
+ * `import "…/fetch-jd.ts";` side-effect line in `src/index.ts` leaves the export
+ * set byte-identical while taking that closure from 27 modules to 29, putting a
+ * live `fetch(` on it, and making the two closures overlap. At that point every
+ * network-free claim in `src/index.ts`, `src/job-search.ts` and
+ * `tsconfig.build.json` is false — in a public repo — and the downstream
+ * extension's `no-network.test.ts` is the first thing that finds out.
+ *
+ * So the numbers are asserted, exactly, in both directions. They are named
+ * constants sitting next to the docblocks they defend precisely so a legitimate
+ * change has to come here and update them deliberately, rather than watching a
+ * threshold absorb it.
+ *
+ *   modules              — the count of shipped `.js` files the entry reaches by
+ *                          value edges, itself included.
+ *   networkBearingModules — how many of those name a network primitive. ZERO is
+ *                          `.`'s whole claim. SEVEN is `./job-search`'s product,
+ *                          asserted in the same breath so a closure that quietly
+ *                          became a stub fails too — the six adapters plus
+ *                          `jd-match/fetch-jd.js`, which they take
+ *                          `htmlToPlaintext` from.
+ *
+ * Every key here is cross-checked against `exports` and `EXPECTED_EXPORTS` (see
+ * `checkPublishedSubpaths`), so a third entry cannot skip this table and leave
+ * the assertion silently covering two of three surfaces.
+ */
+const ENTRY_CLOSURES = {
+  ".": { modules: 27, networkBearingModules: 0 },
+  "./job-search": { modules: 11, networkBearingModules: 7 },
+};
+
+/**
+ * The four primitives a network-free claim is about.
+ *
+ * Matched by PARSING the emitted JavaScript rather than sweeping it, for the
+ * same reason `importSpecifiers` does — and here the difference is not
+ * theoretical but load-bearing on the very first run. `tsc` preserves docblocks
+ * into the emit verbatim, and the emitted `.` entry contains the sentence "the
+ * value-edge closure of the specifiers below is 27 modules and reaches no
+ * `fetch`/`WebSocket`/…" — so the obvious `/\b(fetch|…)\s*\(/` sweep reports
+ * FOUR network primitives in the one file whose whole claim is that it has
+ * none. A comment is not a node; the parse simply does not see it.
+ *
+ * The parse is also strictly stronger than the sweep on real code: it reads
+ * `globalThis.fetch(url)` (a property-access NAME) and a bare alias
+ * `const f = fetch;` (no paren follows, so no `\s*\(` sweep can), while
+ * declining to flag a BINDING of the same name — `function fetch()`,
+ * `let fetch`, `{ fetch: myImpl }` — which introduces a local rather than
+ * reading the global.
+ *
+ * KNOWN LIMIT, shared with every static scanner: a computed access
+ * (`globalThis["fet" + "ch"]`) has no identifier to read. Anything determined
+ * enough to write that is past what a gate in this repo is defending against.
+ */
+const NETWORK_PRIMITIVES = new Set(["fetch", "WebSocket", "XMLHttpRequest", "EventSource"]);
+
+/**
+ * Every place a THIRD entry point has to be added. Written once, here, and
+ * quoted by the failure message below rather than paraphrased in each file —
+ * three separately-drifting copies of this list is what let the gap
+ * `checkPublishedSubpaths` now closes exist in the first place.
+ */
+const THIRD_ENTRY_CHECKLIST = [
+  "packages/core/package.json → `exports` (the subpath, with `types` + `default`)",
+  "packages/core/package.json → `files` (its `dist/<name>.d.ts`)",
+  "packages/core/tsconfig.build.json → `include` (or `tsc` emits no `.js` for it)",
+  "packages/core/rollup.dts.config.mjs → a declaration bundle",
+  "scripts/check-core-package.mjs → EXPECTED_EXPORTS, ENTRY_CLOSURES, and a PROBE static import",
+  ".fallowrc.jsonc → `entry` (unless the file is named `index.ts`)",
+];
+
+/**
+ * Subpaths a consumer might plausibly reach for and must NOT get.
+ *
+ * This is the assertion behind the barrels' claim that the unreachable dead JS
+ * in the tarball "is not an egress path". `analytics.js` and `web-llm.js` are
+ * shipped, are unreachable from either entry, and dynamic-import packages this
+ * one does not depend on; what stops a consumer loading them anyway is `exports`
+ * declaring two subpaths and no wildcard. Verified rather than asserted, because
+ * a single `"./*"` entry added for convenience would silently publish all 62
+ * emitted modules.
+ *
+ * The three are deliberately different shapes, and only the first two name a
+ * file the tarball really ships — for those, an absent path would prove nothing,
+ * since it would fail for the boring reason. The THIRD names no shipped file and
+ * is not meant to: it is a deep subpath under an already-exported prefix, the
+ * shape a `"./job-search/*"` pattern would publish, which the first two (both
+ * `dist/…` paths, covered by a bare `"./*"`) would not catch. There is no
+ * false-pass risk in that: Node resolves `exports` by pattern match and never
+ * touches the filesystem for a subpath the map does not name, so the refusal
+ * this asserts is `exports`' doing rather than the file's absence.
+ */
+const UNEXPORTED_SUBPATHS = [
+  "@offlinecv/core/dist/src/lib/analytics.js",
+  "@offlinecv/core/dist/packages/core/src/index.js",
+  "@offlinecv/core/job-search/providers",
 ];
 
 /**
@@ -149,12 +302,42 @@ const EXPECTED_EXPORTS = [
  * failure message in this gate is written in one place.
  */
 const PROBE = `import * as core from "@offlinecv/core";
+import * as jobSearch from "@offlinecv/core/job-search";
+
+// The subpath list is generated from EXPECTED_EXPORTS rather than written twice.
+// Spelled out, a third entry added there and forgotten here would report every
+// one of its names as missing — a correct failure with a misleading message. The
+// static imports above stay static because a namespace object is what the export
+// check needs and because a bare \`import()\` of a subpath nobody declared would
+// fail for the wrong reason; they are asserted against this list below.
+const exports = {};
+for (const subpath of ${JSON.stringify(Object.keys(EXPECTED_EXPORTS))}) {
+  const loaded = subpath === "." ? core : subpath === "./job-search" ? jobSearch : null;
+  if (loaded === null) throw new Error(\`PROBE has no static import for the "\${subpath}" entry — add one.\`);
+  exports[subpath] = Object.keys(loaded).sort();
+}
+
+const blocked = {};
+for (const specifier of ${JSON.stringify(UNEXPORTED_SUBPATHS)}) {
+  try {
+    await import(specifier);
+    blocked[specifier] = "RESOLVED";
+  } catch (err) {
+    blocked[specifier] = err?.code ?? String(err?.message ?? err);
+  }
+}
 
 process.stdout.write(
   JSON.stringify({
-    exports: Object.keys(core).sort(),
+    exports,
+    blocked,
     jobId: core.deriveJobId("https://ex.com/j/1?utm_source=x"),
     maxStars: core.MAX_STARS,
+    // Behaviour behind the subpath, for assertion 2's reason: a shape-only check
+    // passes on a tarball exporting seven broken adapters. \`getProviders()\` with
+    // no argument must still answer exactly the always-on keyless set, which is
+    // the call a poller with no company selection makes.
+    keylessIds: jobSearch.getProviders().map((provider) => provider.id),
   }),
 );
 `;
@@ -169,6 +352,8 @@ process.stdout.write(
  */
 const CONSUMER_TS = `import { deriveJobId, validateJobRecord, MAX_STARS, ratingInputFor } from "@offlinecv/core";
 import type { JobRecord, RankedJob, CoverageResult } from "@offlinecv/core";
+import { getProviders } from "@offlinecv/core/job-search";
+import type { JobPosting, JobQuery } from "@offlinecv/core/job-search";
 
 export const id: string | undefined = deriveJobId("https://ex.com/j/1");
 export const stars: number = MAX_STARS;
@@ -186,6 +371,18 @@ export function consume(record: JobRecord, ranked: RankedJob, coverage: Coverage
     ratingInputFor(ranked, undefined, undefined, undefined),
     coverage,
   ] as const;
+}
+
+// The subpath's declarations, exercised the way a poller uses them: build a
+// \`JobQuery\` literal (the extension consumer cannot call \`buildJobQuery\` — that
+// wants a whole parsed résumé, which it is built never to hold), fan out, and
+// get \`JobPosting[]\` back. If \`dist/job-search.d.ts\` failed to resolve, every
+// symbol here would widen to \`any\` and the annotations would stop meaning
+// anything — which is what the \`@ts-expect-error\` above catches for \`.\`.
+export async function search(signal: AbortSignal): Promise<JobPosting[]> {
+  const query: JobQuery = { titles: ["Staff Engineer"], skills: ["typescript"] };
+  const results = await Promise.all(getProviders().map((provider) => provider.search(query, signal)));
+  return results.flat();
 }
 `;
 
@@ -330,7 +527,7 @@ function packageNameOf(specifier) {
  *    graph — every shipped module's specifiers, keyed by path — so assertion 5
  *    can walk it without re-parsing.
  */
-function checkTarballShape(shipped, pkg, fail) {
+function checkTarballShape(shipped, pkg, declarationEntries, fail) {
   const graph = new Map();
   const sources = shipped.filter((p) => p.endsWith(".ts") && !p.endsWith(".d.ts"));
   if (sources.length > 0)
@@ -339,15 +536,26 @@ function checkTarballShape(shipped, pkg, fail) {
         `No runtime resolves a \`.ts\` specifier; \`files\` must ship the BUILD OUTPUT, not \`src/\`.`,
     );
 
+  // The expected set is READ OFF `exports[*].types` rather than hardcoded, so a
+  // new entry point moves what this asserts instead of failing here for the
+  // wrong reason — and so an entry whose bundle was never wired into
+  // `rollup.dts.config.mjs` fails as "the tarball has no …" rather than shipping
+  // a `types` path that resolves to nothing.
   const declarations = shipped.filter((p) => p.endsWith(".d.ts"));
-  if (!declarations.includes("dist/index.d.ts"))
-    fail("the tarball has no `dist/index.d.ts` — the bundled declaration `exports.types` points at.");
-  const extra = declarations.filter((p) => p !== "dist/index.d.ts");
+  for (const expected of declarationEntries) {
+    if (!declarations.includes(expected))
+      fail(
+        `the tarball has no \`${expected}\` — a bundled declaration an \`exports\` entry's ` +
+          `\`types\` points at. Add it to \`rollup.dts.config.mjs\` and to \`files\`.`,
+      );
+  }
+  const extra = declarations.filter((p) => !declarationEntries.includes(p));
   if (extra.length > 0)
     fail(
-      `the tarball ships ${extra.length} per-file declaration(s) alongside the bundle — ` +
-        `${extra.slice(0, 5).join(", ")}. They carry unresolvable \`.ts\` specifiers (see assertion 4); ` +
-        `narrow \`files\` so only \`dist/index.d.ts\` ships.`,
+      `the tarball ships ${extra.length} per-file declaration(s) alongside the ` +
+        `${declarationEntries.length} bundle(s) — ${extra.slice(0, 5).join(", ")}. They carry ` +
+        `unresolvable \`.ts\` specifiers (see assertion 4); narrow \`files\` so only ` +
+        `${declarationEntries.join(", ")} ship.`,
     );
 
   // Every internal edge lands on a file that shipped. Bare specifiers are
@@ -383,6 +591,175 @@ function checkTarballShape(shipped, pkg, fail) {
 }
 
 /**
+ * Every network primitive NAMED in one emitted JavaScript file.
+ *
+ * Parsed, not swept — see `NETWORK_PRIMITIVES` for why the obvious regex reports
+ * four `fetch(`s in the one file whose entire claim is that it has none.
+ */
+function networkPrimitivesIn(source) {
+  // `setParentNodes` is what lets the binding/reference distinction below be
+  // made at all; `importSpecifiers` does not need it and does not pay for it.
+  const parsed = ts.createSourceFile("emitted.js", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const found = new Set();
+
+  const visit = (node) => {
+    if (ts.isIdentifier(node) && NETWORK_PRIMITIVES.has(node.text)) {
+      const parent = node.parent;
+      // A BINDING of the name rather than a READ of the global: `function
+      // fetch()`, `let fetch`, `class fetch`, `{ fetch: myImpl }`. Introducing a
+      // local called `fetch` reaches no network. The one `name` position that is
+      // still a read is a property access — `globalThis.fetch` — so it is
+      // excluded from the exclusion.
+      const isBinding =
+        parent !== undefined &&
+        !ts.isPropertyAccessExpression(parent) &&
+        !ts.isShorthandPropertyAssignment(parent) &&
+        "name" in parent &&
+        parent.name === node;
+      if (!isBinding) found.add(node.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(parsed, visit);
+  return [...found].sort();
+}
+
+/**
+ * 6. The value-edge CLOSURE of each entry: its size, its network primitives, and
+ *    its disjointness from every other entry's.
+ *
+ * This is the assertion the two-entry split exists for, and until it was written
+ * nothing in the repo made the property it creates checkable. `EXPECTED_EXPORTS`
+ * sees a provider SYMBOL arriving on `.`; only a graph walk sees a value EDGE,
+ * and the edge is the cheaper accident — a bare `import "…/fetch-jd.ts";` moves
+ * no export name at all.
+ *
+ * Walked over `graph`, which assertion 1 already built by parsing every shipped
+ * `.js` and already proved lands only on files that ship. The three claims are
+ * asserted separately rather than rolled into one number because they fail for
+ * different reasons and a reader needs to know which: a count drift is a
+ * dependency someone added, a network primitive on `.` is a shipped privacy
+ * defect, and an overlap is the seam itself dissolving.
+ */
+function checkEntryClosures(graph, pkg, entryFor, fail) {
+  const closures = new Map();
+
+  for (const [subpath, entry] of entryFor) {
+    // A subpath with no row here is already failing by name in
+    // `checkPublishedSubpaths`; walking it would only add a second, vaguer
+    // message about a table it was never in.
+    const expected = ENTRY_CLOSURES[subpath];
+    if (!expected) continue;
+
+    const closure = new Set([entry]);
+    for (const queue = [entry]; queue.length > 0; ) {
+      const file = queue.shift();
+      for (const specifier of graph.get(file) ?? []) {
+        if (!specifier.startsWith(".")) continue;
+        const resolved = posix.normalize(posix.join(posix.dirname(file), specifier));
+        if (closure.has(resolved)) continue;
+        closure.add(resolved);
+        queue.push(resolved);
+      }
+    }
+    closures.set(subpath, closure);
+
+    if (closure.size !== expected.modules)
+      fail(
+        `the \`${subpath}\` entry's value-edge closure is ${closure.size} module(s), and ENTRY_CLOSURES ` +
+          `says ${expected.modules}. Either an edge was added that should not have been, or the change is ` +
+          `intended and this gate's constant has to move with it — in the same commit, alongside the ` +
+          `docblock in the entry file \`${entry}\` is emitted from and the one in ` +
+          `\`packages/core/tsconfig.build.json\`, both of which quote the same number.`,
+      );
+
+    const bearing = [...closure]
+      .filter((file) => graph.has(file))
+      .map((file) => [file, networkPrimitivesIn(readFileSync(join(pkg, file), "utf8"))])
+      .filter(([, primitives]) => primitives.length > 0);
+
+    if (bearing.length !== expected.networkBearingModules)
+      fail(
+        `the \`${subpath}\` entry's closure names a network primitive in ${bearing.length} module(s), and ` +
+          `ENTRY_CLOSURES says ${expected.networkBearingModules}` +
+          (bearing.length > 0 ? ` — ${bearing.map(([f, p]) => `${f} (${p.join(", ")})`).join(", ")}` : "") +
+          `. ${
+            expected.networkBearingModules === 0
+              ? `\`${subpath}\` is the entry whose docblock claims its value-edge closure reaches no ` +
+                `\`fetch\`/\`WebSocket\`/\`XMLHttpRequest\`/\`EventSource\` at all, and the downstream ` +
+                `extension asserts exactly that for four of its five entry points. A module here is that ` +
+                `claim going false. Put the code on \`./job-search\` instead.`
+              : `That entry is network-BEARING on purpose, so a DROP is the suspicious direction: it means ` +
+                `an adapter fell out of the closure, not that anything got safer.`
+          }`,
+      );
+  }
+
+  // Disjointness, pairwise. Two entries today, so this is one comparison — but
+  // written as a sweep because the failure a third entry would introduce is
+  // exactly the one nobody would think to look for.
+  const walked = [...closures.entries()];
+  for (let i = 0; i < walked.length; i += 1) {
+    for (let j = i + 1; j < walked.length; j += 1) {
+      const [leftPath, left] = walked[i];
+      const [rightPath, right] = walked[j];
+      const shared = [...left].filter((file) => right.has(file));
+      if (shared.length > 0)
+        fail(
+          `the \`${leftPath}\` and \`${rightPath}\` closures share ${shared.length} module(s) — ` +
+            `${shared.slice(0, 5).join(", ")}. They are asserted DISJOINT: that is what makes importing ` +
+            `one unable to pull the other in, and what lets \`.\`'s network-free claim survive the ` +
+            `existence of a fetching sibling rather than merely sit next to it.`,
+        );
+    }
+  }
+}
+
+/**
+ * 7. The three lists of published subpaths agree: `exports` in the manifest,
+ *    `EXPECTED_EXPORTS`, and `ENTRY_CLOSURES`.
+ *
+ * WITHOUT THIS THE GATE IS PARTLY VACUOUS, and that was live. Assertions 1, 4, 5
+ * and 6 read their subpaths OFF the manifest, so they follow a new entry
+ * automatically. Assertion 2 reads `EXPECTED_EXPORTS`, which is hand-written. So
+ * a subpath added to `exports` and to nothing else published an entirely
+ * unreviewed export surface with the gate green — reproduced by adding
+ * `"./sneaky"` and changing nothing else: `✓ … 29 export(s) across 3 entry
+ * point(s)`. It COUNTED the new entry, typechecked nothing for it, and asserted
+ * nothing about its published names.
+ *
+ * Set equality in every direction is the fix, and it has to be every direction:
+ * a stale row left in either hand-written table after an entry is withdrawn
+ * makes that table's assertion silently cover a surface that no longer exists.
+ */
+function checkPublishedSubpaths(published, fail) {
+  const tables = [
+    ["EXPECTED_EXPORTS", Object.keys(EXPECTED_EXPORTS)],
+    ["ENTRY_CLOSURES", Object.keys(ENTRY_CLOSURES)],
+  ];
+
+  for (const [name, gated] of tables) {
+    const ungated = published.filter((subpath) => !gated.includes(subpath));
+    if (ungated.length > 0)
+      fail(
+        `\`exports\` publishes ${ungated.map((s) => `"${s}"`).join(", ")}, which ${name} does not name. ` +
+          `Nothing else in this gate would notice: an entry point is a published API surface, and this ` +
+          `one would ship with no assertion about ` +
+          `${name === "EXPECTED_EXPORTS" ? "the names it exports" : "the modules and network primitives its closure reaches"}. ` +
+          `A third entry point needs all of:\n    ${THIRD_ENTRY_CHECKLIST.join("\n    ")}`,
+      );
+
+    const stale = gated.filter((subpath) => !published.includes(subpath));
+    if (stale.length > 0)
+      fail(
+        `${name} names ${stale.map((s) => `"${s}"`).join(", ")}, which \`exports\` does not publish. ` +
+          `That row asserts nothing — drop it, or restore the \`exports\` entry it was written for.`,
+      );
+  }
+}
+
+/**
  * 5. Necessity: `dependencies` and the packages the tarball actually loads agree.
  *
  * Judged over the REACHABLE graph — a breadth-first walk from the entry
@@ -401,18 +778,27 @@ function checkTarballShape(shipped, pkg, fail) {
  * missing direction is already fatal at import time, but it is asserted here too
  * so the failure names the specifier instead of an `ERR_MODULE_NOT_FOUND` stack.
  */
-function checkDeclaredDependencies(declared, graph, entry, fail) {
+function checkDeclaredDependencies(declared, graph, entries, fail) {
   // Without this the walk starts nowhere, reaches nothing, and reports every
   // declared dependency as surplus — a confident wrong answer rather than a
   // failure. `exports` moving is exactly the change that would cause it.
-  if (!graph.has(entry)) {
-    fail(`the entry \`exports\` points at (${entry}) is not among the shipped modules this gate parsed.`);
+  const missing = entries.filter((entry) => !graph.has(entry));
+  if (missing.length > 0) {
+    fail(
+      `${missing.length} entr${missing.length === 1 ? "y" : "ies"} \`exports\` points at ` +
+        `(${missing.join(", ")}) ${missing.length === 1 ? "is" : "are"} not among the shipped ` +
+        `modules this gate parsed.`,
+    );
     return;
   }
 
+  // The UNION across every entry point, because `dependencies` is one list for
+  // the whole package: a package imported only from `./job-search` is still
+  // required, and judging `.` alone would report it as surplus and tell the
+  // reader to delete it.
   const required = new Set();
-  const seen = new Set([entry]);
-  for (const queue = [entry]; queue.length > 0; ) {
+  const seen = new Set(entries);
+  for (const queue = [...entries]; queue.length > 0; ) {
     const file = queue.shift();
     for (const specifier of graph.get(file) ?? []) {
       if (!specifier.startsWith(".")) {
@@ -446,17 +832,24 @@ function checkDeclaredDependencies(declared, graph, entry, fail) {
     );
 }
 
-/** 2. Runtime: the exact export set, plus behaviour behind two of the names. */
+/**
+ * 2. Runtime: the exact export set PER SUBPATH, behaviour behind three of the
+ *    names, and the subpaths `exports` must refuse.
+ */
 function checkRuntimeSurface(probe, fail) {
-  const missing = EXPECTED_EXPORTS.filter((name) => !probe.exports.includes(name));
-  const unexpected = probe.exports.filter((name) => !EXPECTED_EXPORTS.includes(name));
-  if (missing.length > 0) fail(`the tarball is missing export(s): ${missing.join(", ")}`);
-  if (unexpected.length > 0)
-    fail(
-      `the tarball exports name(s) this gate does not know about: ${unexpected.join(", ")}. ` +
-        `If that is intended, add them to EXPECTED_EXPORTS in the same commit — a published ` +
-        `export is a promise.`,
-    );
+  for (const [subpath, expected] of Object.entries(EXPECTED_EXPORTS)) {
+    const actual = probe.exports[subpath] ?? [];
+    const missing = expected.filter((name) => !actual.includes(name));
+    const unexpected = actual.filter((name) => !expected.includes(name));
+    if (missing.length > 0) fail(`\`${subpath}\` is missing export(s): ${missing.join(", ")}`);
+    if (unexpected.length > 0)
+      fail(
+        `\`${subpath}\` exports name(s) this gate does not know about: ${unexpected.join(", ")}. ` +
+          `If that is intended, add them to EXPECTED_EXPORTS in the same commit — a published ` +
+          `export is a promise, and WHICH subpath carries it is part of it: \`./job-search\` is ` +
+          `the network-bearing entry and \`.\` is the one consumers audit for reaching no \`fetch\`.`,
+      );
+  }
 
   // Behaviour, not shape. `deriveJobId` canonicalising the URL is the whole
   // reason `docs/job-capture-contract.md` tells producers to use it rather than
@@ -465,14 +858,58 @@ function checkRuntimeSurface(probe, fail) {
   if (probe.jobId !== "job:ex.com/j/1")
     fail(`deriveJobId() returned ${JSON.stringify(probe.jobId)} through the tarball, expected "job:ex.com/j/1"`);
   if (probe.maxStars !== 5) fail(`MAX_STARS is ${JSON.stringify(probe.maxStars)} through the tarball, expected 5`);
+
+  // The keyless set, in display order — `search.ts`'s fan-out and every
+  // consumer's default poll are the same three feeds. An adapter silently
+  // dropping out of the registry is a search that quietly returns less.
+  const keyless = (probe.keylessIds ?? []).join(", ");
+  if (keyless !== "remotive, arbeitnow, jobicy")
+    fail(
+      `getProviders() answered [${keyless}] through the tarball, expected ` +
+        `[remotive, arbeitnow, jobicy] — the always-on keyless set, in display order.`,
+    );
+
+  // What `exports` REFUSES, which is the other half of what it publishes. See
+  // UNEXPORTED_SUBPATHS: the tarball's unreachable dead JS is only harmless
+  // because none of it can be loaded by name.
+  //
+  // The KEY SET is asserted before the loop, and that is not belt-and-braces.
+  // `Object.entries(probe.blocked ?? {})` iterates zero times and passes if
+  // `blocked` is ever absent from the probe's output — while the success line
+  // below still prints "3 unexported subpath(s) refused". This is the same
+  // vacuity class the probe already had once (it built `blocked` and never
+  // emitted it), moved one layer up, where the emit is guarded by nothing.
+  // `probe.exports` and `probe.keylessIds` are structurally protected — a
+  // missing export set fails as missing names, a missing id list as the wrong
+  // provider order — and `blocked` is the one field where ABSENT and PASS are
+  // the same outcome. A count alone would not do it either: three refusals for
+  // three specifiers nobody asked about would satisfy it.
+  const reported = Object.keys(probe.blocked ?? {}).sort();
+  const requested = [...UNEXPORTED_SUBPATHS].sort();
+  if (reported.join("\u0000") !== requested.join("\u0000"))
+    fail(
+      `the probe reported refusal outcomes for [${reported.join(", ")}], expected exactly the ` +
+        `${UNEXPORTED_SUBPATHS.length} subpath(s) in UNEXPORTED_SUBPATHS [${requested.join(", ")}]. ` +
+        `An absent or partial \`blocked\` makes the loop below iterate over nothing and pass, so the ` +
+        `refusals have to be counted by name before they are judged.`,
+    );
+
+  for (const [specifier, outcome] of Object.entries(probe.blocked ?? {})) {
+    if (outcome !== "ERR_PACKAGE_PATH_NOT_EXPORTED")
+      fail(
+        `importing "${specifier}" gave ${outcome}, expected ERR_PACKAGE_PATH_NOT_EXPORTED. ` +
+          `\`exports\` must name every published subpath explicitly and carry no wildcard — a ` +
+          `\`"./*"\` entry publishes every emitted module, the unreachable dead JS included.`,
+      );
+  }
 }
 
-/** 4. No relative specifier survives the declaration bundle. */
-function checkDeclarationBundle(dts, fail) {
+/** 4. No relative specifier survives any declaration bundle. */
+function checkDeclarationBundle(name, dts, fail) {
   const relative = [...dts.matchAll(/\bfrom\s*["'](\.[^"']*)["']/g)].map((m) => m[1]);
   if (relative.length > 0)
     fail(
-      `dist/index.d.ts still imports ${relative.length} relative specifier(s) — ${[...new Set(relative)].slice(0, 5).join(", ")}. ` +
+      `${name} still imports ${relative.length} relative specifier(s) — ${[...new Set(relative)].slice(0, 5).join(", ")}. ` +
         `The tarball ships no per-file declarations for them to resolve to, so a consumer would ` +
         `fall back to \`any\` or fail outright. \`rollup.dts.config.mjs\` exists to inline these.`,
     );
@@ -506,16 +943,42 @@ async function main() {
     run("tar", ["-xzf", join(tmp, tarball), "-C", extractRoot], ROOT);
     const pkg = join(extractRoot, "package");
 
-    const graph = checkTarballShape(shipped, pkg, fail);
-
     // The load-bearing step: ONLY the declared dependencies, and they come from
     // the repo's install rather than the registry so this stays offline.
     const manifest = JSON.parse(readFileSync(join(pkg, "package.json"), "utf8"));
     const declared = Object.keys(manifest.dependencies ?? {});
-    // Read off `exports` rather than hardcoded, so repointing the entry moves
-    // what assertion 5 walks instead of silently leaving it behind.
-    const entry = posix.normalize(manifest.exports?.["."]?.default ?? "");
-    checkDeclaredDependencies(declared, graph, entry, fail);
+    // Read off `exports` rather than hardcoded, so repointing or adding an entry
+    // moves what assertions 1, 4 and 5 look at instead of silently leaving it
+    // behind. Every subpath is a published surface and each gets the same
+    // treatment; the map's shape is asserted here too, since an entry missing
+    // `default` or `types` would otherwise quietly drop out of all three.
+    const subpaths = Object.entries(manifest.exports ?? {});
+    if (subpaths.length === 0) fail("the tarball's `exports` map is empty — nothing is published.");
+    const entries = [];
+    const declarationEntries = [];
+    // Keyed by subpath as well as listed, because assertion 6 judges each
+    // closure against the row `ENTRY_CLOSURES` holds for THAT subpath — a
+    // positional list would silently pair the wrong numbers with the wrong entry
+    // the first time `exports` is reordered.
+    const entryFor = new Map();
+    for (const [subpath, target] of subpaths) {
+      if (typeof target?.default !== "string" || typeof target?.types !== "string") {
+        fail(`the \`exports\` entry for "${subpath}" is missing a string \`default\` or \`types\`.`);
+        continue;
+      }
+      entries.push(posix.normalize(target.default));
+      declarationEntries.push(posix.normalize(target.types));
+      entryFor.set(subpath, posix.normalize(target.default));
+    }
+
+    // Before anything reads the hand-written tables: they have to be about the
+    // same set of subpaths `exports` publishes, or the assertions that follow
+    // cover a subset of the surface while reporting on all of it.
+    checkPublishedSubpaths([...entryFor.keys()], fail);
+
+    const graph = checkTarballShape(shipped, pkg, declarationEntries, fail);
+    checkDeclaredDependencies(declared, graph, entries, fail);
+    checkEntryClosures(graph, pkg, entryFor, fail);
     mkdirSync(join(pkg, "node_modules"));
     for (const dep of declared) {
       const source = join(ROOT, "node_modules", dep);
@@ -544,14 +1007,25 @@ async function main() {
 
     checkRuntimeSurface(JSON.parse(run(process.execPath, ["probe.mjs"], consumer)), fail);
     run(join(ROOT, "node_modules", ".bin", "tsc"), ["-p", join(consumer, "tsconfig.json")], consumer);
-    checkDeclarationBundle(readFileSync(join(pkg, "dist", "index.d.ts"), "utf8"), fail);
+    for (const declaration of declarationEntries)
+      checkDeclarationBundle(declaration, readFileSync(join(pkg, declaration), "utf8"), fail);
 
     if (failures.length === 0) {
+      const exportCount = Object.values(EXPECTED_EXPORTS).reduce((n, names) => n + names.length, 0);
+      // Every number here is one an assertion above just proved. The closure
+      // line is spelled out per entry rather than summed because the whole point
+      // of the split is WHICH entry reaches a `fetch`, and a total would hide it.
+      const closureLine = Object.entries(ENTRY_CLOSURES)
+        .map(([subpath, { modules, networkBearingModules }]) => `${subpath} ${modules} modules/${networkBearingModules} fetching`)
+        .join(", ");
       console.log(
         `✓ ${PKG_NAME} is publishable: ${shipped.length} file(s) packed, ` +
-          `${EXPECTED_EXPORTS.length} export(s) imported under plain Node with only ` +
-          `${declared.length === 0 ? "no" : declared.join(", ")} dependenc${declared.length === 1 ? "y" : "ies"} ` +
-          `present, and a \`nodenext\` consumer typechecks against dist/index.d.ts with skipLibCheck off.`,
+          `${exportCount} export(s) across ${entries.length} entry point(s) imported under plain ` +
+          `Node with only ${declared.length === 0 ? "no" : declared.join(", ")} ` +
+          `dependenc${declared.length === 1 ? "y" : "ies"} present, ` +
+          `${UNEXPORTED_SUBPATHS.length} unexported subpath(s) refused, disjoint value-edge closures ` +
+          `(${closureLine}), and a \`nodenext\` consumer ` +
+          `typechecks against ${declarationEntries.join(" + ")} with skipLibCheck off.`,
       );
       return;
     }

--- a/src/lib/job-search/company-boards.test.ts
+++ b/src/lib/job-search/company-boards.test.ts
@@ -48,7 +48,14 @@ vi.mock("./providers/index.ts", () => ({
   }),
 }));
 
-vi.mock("./providers/greenhouse.ts", () => ({
+// Only the FETCHING half of each adapter is stubbed. `greenhouseJobId` /
+// `leverJobId` are pure prefix-strippers that live in these same modules, and
+// the pipeline calls them to turn a posting id back into a job id — stubbing
+// the module wholesale would hand it `undefined` and make every hydrate call
+// count meaningless. `importActual` keeps them real; their own unit tests live
+// beside them in `providers/{greenhouse,lever}.test.ts`.
+vi.mock("./providers/greenhouse.ts", async (importActual) => ({
+  ...(await importActual<typeof import("./providers/greenhouse.ts")>()),
   hydrateGreenhouse: async (_slug: string, jobId: string) => {
     hoisted.hydrateCalls.push(jobId);
     if (hoisted.hydrateFailIds.has(jobId)) throw new Error("404");
@@ -56,20 +63,15 @@ vi.mock("./providers/greenhouse.ts", () => ({
   },
 }));
 
-vi.mock("./providers/lever.ts", () => ({
+vi.mock("./providers/lever.ts", async (importActual) => ({
+  ...(await importActual<typeof import("./providers/lever.ts")>()),
   hydrateLever: async (_slug: string, jobId: string) => {
     hoisted.leverHydrateCalls.push(jobId);
     return `lever description for ${jobId}`;
   },
 }));
 
-import {
-  makeBoardProvider,
-  makeBoardProviders,
-  greenhouseJobId,
-  leverJobId,
-  hydrateDescriptions,
-} from "./company-boards.ts";
+import { makeBoardProvider, makeBoardProviders, hydrateDescriptions } from "./company-boards.ts";
 import { DEFAULT_PER_COMPANY_CAP } from "./role-keywords.ts";
 import { readCachedBoard } from "./board-cache.ts";
 
@@ -111,35 +113,6 @@ beforeEach(async () => {
   hoisted.leverHydrateCalls = [];
   hoisted.boardError = null;
   hoisted.hydrateFailIds = new Set();
-});
-
-describe("greenhouseJobId", () => {
-  it("strips the known prefix", () => {
-    expect(greenhouseJobId("stripe", "greenhouse:stripe:12345")).toBe("12345");
-  });
-
-  it("returns '' for a posting from another provider", () => {
-    expect(greenhouseJobId("stripe", "lever:stripe:abc")).toBe("");
-  });
-
-  it("is not fooled by a slug containing a colon-like segment", () => {
-    // A trailing-colon search would return "b:9" here; prefix-stripping is exact.
-    expect(greenhouseJobId("a:b", "greenhouse:a:b:9")).toBe("9");
-  });
-});
-
-describe("leverJobId", () => {
-  it("strips the known prefix", () => {
-    expect(leverJobId("palantir", "lever:palantir:abc-123")).toBe("abc-123");
-  });
-
-  it("returns '' for a posting from another provider", () => {
-    expect(leverJobId("palantir", "greenhouse:palantir:9")).toBe("");
-  });
-
-  it("is not fooled by a slug containing a colon-like segment", () => {
-    expect(leverJobId("a:b", "lever:a:b:9")).toBe("9");
-  });
 });
 
 describe("makeBoardProvider — filter and cap run BEFORE hydration", () => {

--- a/src/lib/job-search/company-boards.ts
+++ b/src/lib/job-search/company-boards.ts
@@ -70,8 +70,8 @@ import {
   type RoleFilter,
 } from "./role-keywords.ts";
 import { makeCompanyProvider } from "./providers/index.ts";
-import { hydrateGreenhouse } from "./providers/greenhouse.ts";
-import { hydrateLever } from "./providers/lever.ts";
+import { hydrateGreenhouse, greenhouseJobId } from "./providers/greenhouse.ts";
+import { hydrateLever, leverJobId } from "./providers/lever.ts";
 import { readCachedBoard, writeCachedBoard } from "./board-cache.ts";
 import { mapWithConcurrency } from "./concurrency.ts";
 
@@ -82,26 +82,6 @@ import { mapWithConcurrency } from "./concurrency.ts";
  * of requests to one origin.
  */
 const HYDRATE_CONCURRENCY = 4;
-
-/** `id` on a Greenhouse posting is `greenhouse:{slug}:{jobId}` (see
- *  `providers/greenhouse.ts`). Recover the job id by stripping the known
- *  prefix — a substring search for the last ":" would break on a slug that
- *  itself contains one. Returns "" when the shape doesn't match, which the
- *  caller reads as "not hydratable". */
-export function greenhouseJobId(slug: string, postingId: string): string {
-  const prefix = `greenhouse:${slug}:`;
-  return postingId.startsWith(prefix) ? postingId.slice(prefix.length) : "";
-}
-
-/** `id` on a Lever posting is `lever:{slug}:{jobId}` (see `providers/lever.ts`).
- *  Recover the job id by stripping the known prefix, exactly as
- *  `greenhouseJobId` does — a last-":" search would break on a slug that itself
- *  contains one. Returns "" when the shape doesn't match, read by the caller as
- *  "not hydratable". */
-export function leverJobId(slug: string, postingId: string): string {
-  const prefix = `lever:${slug}:`;
-  return postingId.startsWith(prefix) ? postingId.slice(prefix.length) : "";
-}
 
 /**
  * Fill in `description` for the postings that survived filtering + capping.

--- a/src/lib/job-search/providers/greenhouse.test.ts
+++ b/src/lib/job-search/providers/greenhouse.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { makeGreenhouseProvider, hydrateGreenhouse } from "./greenhouse.ts";
+import { makeGreenhouseProvider, hydrateGreenhouse, greenhouseJobId } from "./greenhouse.ts";
 import type { JobQuery } from "../query-builder.ts";
 
 const query: JobQuery = { titles: ["Backend Engineer"], skills: ["Go", "Python"] };
@@ -169,5 +169,20 @@ describe("hydrateGreenhouse", () => {
   it("tolerates a missing content field", async () => {
     mockFetch({ id: 1, title: "Engineer" });
     await expect(hydrateGreenhouse("acme", "1", new AbortController().signal)).resolves.toBe("");
+  });
+});
+
+describe("greenhouseJobId", () => {
+  it("strips the known prefix", () => {
+    expect(greenhouseJobId("stripe", "greenhouse:stripe:12345")).toBe("12345");
+  });
+
+  it("returns '' for a posting from another provider", () => {
+    expect(greenhouseJobId("stripe", "lever:stripe:abc")).toBe("");
+  });
+
+  it("is not fooled by a slug containing a colon-like segment", () => {
+    // A trailing-colon search would return "b:9" here; prefix-stripping is exact.
+    expect(greenhouseJobId("a:b", "greenhouse:a:b:9")).toBe("9");
   });
 });

--- a/src/lib/job-search/providers/greenhouse.ts
+++ b/src/lib/job-search/providers/greenhouse.ts
@@ -88,9 +88,28 @@ export function makeGreenhouseProvider(slug: string, companyName = slug): JobPro
 }
 
 /**
+ * Recover the Greenhouse job id from a posting id this adapter minted.
+ *
+ * `mapJob` above builds `id` as `greenhouse:{slug}:{jobId}`, so the recovery
+ * belongs next to the mint: strip the known prefix. A substring search for the
+ * last ":" would break on a slug that itself contains one, and `url` is a
+ * legitimate fallback for a board that omits the id — and it contains ":" too.
+ * Returns "" when the shape doesn't match, which the caller reads as "not
+ * hydratable".
+ */
+export function greenhouseJobId(slug: string, postingId: string): string {
+  const prefix = `greenhouse:${slug}:`;
+  return postingId.startsWith(prefix) ? postingId.slice(prefix.length) : "";
+}
+
+/**
  * Lazy per-job hydrate: fetches one Greenhouse posting and returns its
  * `content` as plaintext. Called only for postings that survive the #534
  * title filter and per-company cap — never for the whole board.
+ *
+ * REJECTS on a non-ok response, unlike its Lever counterpart, which resolves
+ * `""`. A caller batching a page of postings must settle per item —
+ * `Promise.all` loses the whole page to a single 404.
  */
 export async function hydrateGreenhouse(
   slug: string,

--- a/src/lib/job-search/providers/lever.test.ts
+++ b/src/lib/job-search/providers/lever.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 The offlinecv Authors
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { makeLeverProvider, hydrateLever } from "./lever.ts";
+import { makeLeverProvider, hydrateLever, leverJobId } from "./lever.ts";
 import type { JobQuery } from "../query-builder.ts";
 
 const query: JobQuery = { titles: ["Backend Engineer"], skills: ["Go", "Python"] };
@@ -156,5 +156,19 @@ describe("hydrateLever", () => {
     await hydrateLever("acme", "job-1");
     const [url] = fetchMock.mock.calls[0];
     expect(url as string).toBe("https://api.lever.co/v0/postings/acme/job-1?mode=json");
+  });
+});
+
+describe("leverJobId", () => {
+  it("strips the known prefix", () => {
+    expect(leverJobId("palantir", "lever:palantir:abc-123")).toBe("abc-123");
+  });
+
+  it("returns '' for a posting from another provider", () => {
+    expect(leverJobId("palantir", "greenhouse:palantir:9")).toBe("");
+  });
+
+  it("is not fooled by a slug containing a colon-like segment", () => {
+    expect(leverJobId("a:b", "lever:a:b:9")).toBe("9");
   });
 });

--- a/src/lib/job-search/providers/lever.ts
+++ b/src/lib/job-search/providers/lever.ts
@@ -104,6 +104,20 @@ export function makeLeverProvider(slug: string, companyName = slug): JobProvider
 }
 
 /**
+ * Recover the Lever job id from a posting id this adapter minted.
+ *
+ * `mapJob` above builds `id` as `lever:{slug}:{jobId}`, so the recovery belongs
+ * next to the mint: strip the known prefix, exactly as `greenhouseJobId` does.
+ * A last-":" search would break on a slug that itself contains one, and on the
+ * `url` fallback a board without an id produces. Returns "" when the shape
+ * doesn't match, read by the caller as "not hydratable".
+ */
+export function leverJobId(slug: string, postingId: string): string {
+  const prefix = `lever:${slug}:`;
+  return postingId.startsWith(prefix) ? postingId.slice(prefix.length) : "";
+}
+
+/**
  * Lazy per-job hydrate: fetches one Lever posting and returns its plaintext
  * description. Called only for survivors whose cached light-index row had its
  * description stripped — never for the whole board.


### PR DESCRIPTION
Adds a second published entry point, `@offlinecv/core/job-search`, carrying the job-board provider adapters — so a downstream consumer can call the feeds without putting a `fetch` on the `.` entry's value-edge closure.

## Why a subpath rather than a wider barrel

`packages/core/src/index.ts` makes a measured claim: its value-edge closure reaches no `fetch` / `WebSocket` / `XMLHttpRequest` / `EventSource`. That claim is load-bearing, not decorative — the private capture extension this package was cut for walks the import graph of each of its entry points through a single seam file and asserts exactly that, and four of its five surfaces must reach none. A content script that can reach `fetch` runs in `offlinecv.org`'s address space with a network primitive in scope.

Every provider adapter holds a `fetch(`. Putting them on `.` would not have widened a surface; it would have broken that gate. A second subpath lets both facts be true at once.

Measured on the emitted `dist/`:

| Entry | Modules | Network primitives | Externals |
|---|---|---|---|
| `.` | 27 | 0 | `idb` |
| `./job-search` | 11 | 7 modules hold `fetch(` | none |

Intersection **0**. Importing one cannot pull in the other, in either direction.

## Surface

Nine values — `getProviders`, `KEYLESS_PROVIDERS`, the three company-board factories, the Greenhouse/Lever hydrators, and the two helpers that recover the `jobId` those hydrators take — plus `JobProvider`, `JobPosting`, `JobQuery` as types.

`makeCompanyProvider` is deliberately absent: its `CompanyEntry` carries a `sectors` list that only means something to the in-app sector selector, so a caller holding a slug and a vendor would have to invent `sectors: []`. The three factories take what such a caller actually has.

The hydrators are deliberately present. Greenhouse has no server-side search, so `search()` fetches the light index and every posting comes back `description: ""`; a consumer that ranks on description without hydrating ranks every company posting against an empty string.

`greenhouseJobId` / `leverJobId` **move** from `company-boards.ts` into the adapter modules they describe, rather than being re-exported from where they lived. Re-exporting would have enlarged this entry's closure; relocating keeps them inside the closure it already reaches, so the surface grows and the closure does not. Their unit tests move with them, unchanged. `company-boards.test.ts` stubs those adapter modules, so it now spreads `importActual` and stubs only the fetching half — a wholesale mock would hand the pipeline `undefined` for the id and make every hydrate-call assertion meaningless.

## The gate grew rather than being worked around

`check:core` previously asserted the export *set* per entry. It could catch a provider symbol moved onto `.`; it could not catch a value *edge*, which is the cheaper mistake. It now BFSes each entry's value edges over the modules it already parses and asserts the per-entry module counts, that `.` reaches no network primitive, and that the closures are disjoint. The counts are named constants sitting beside the docblock claims they defend.

Three further holes closed in the same file:

- **`exports` ↔ expected-export map are cross-checked both ways.** Assertions had been generalized onto entries read off the manifest while the export-set assertion stayed keyed to a hand-written list, so a subpath added to one and not the other published an entirely unasserted surface with the gate green.
- **The unexported-subpath probe asserts its result count before iterating** — the same vacuity class this change had already fixed one instance of, one layer up.
- **The three "what a third entry point costs" checklists** disagreed with each other and all omitted this gate. They now name the same six places.

Docblock corrections the change made necessary: `.`'s network-free claim is scoped to that entry rather than left standing unqualified next to a fetching sibling, and `fetch-jd.js` moves off its "unreachable dead JS" list — the adapters take `htmlToPlaintext` from it, so it is genuinely loadable now.

`.fallowrc.jsonc` registers the new entry. fallow reported it as an unused file; swapping which entry `exports` names as `"."` changed nothing, so it keys on the filename `index.ts` rather than following `exports`. A specific-file allow-list entry, not a loosened pattern.

## Verification

`npm run verify` green. Beyond that, the assertions were **falsified rather than merely observed passing** — three times during authoring, three more during review, and the two that matter re-run independently before merge:

| Planted violation | Result |
|---|---|
| A `"./sneaky"` subpath in `exports`, absent from the expected-export map | ✗ fails, naming the subpath and listing all six places a new entry must be registered |
| `import "../../../src/lib/jd-match/fetch-jd.ts";` appended to the barrel — export set byte-identical | ✗ fails three ways: closure 29≠27, 1 network primitive in `.`, closures share 2 modules |
| A `"./*"` wildcard in `exports` | ✗ all three unexported-subpath assertions fire |
| Removing the `job-search` dts bundle from the rollup config | ✗ tarball-shape assertion + consumer typecheck (TS7016) |
| Removing the new entry from `.fallowrc.jsonc` | ✗ `fallow audit` reports it unused — confirming the registration suppresses a genuine false positive rather than a real finding |

The second row is the one to weigh: **before this PR that case passed silently**, leaving five public docblock claims false with the downstream extension's gate as the only thing that would have noticed.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation | Claude Opus 5 | ultra |
| Adversarial review | Claude Opus 5 | ultra |
| Review fixes | unreported (requested: opus) | ultra |
| Orchestration + PR | Claude Opus 5 | ultra |
| Review revisions | Claude Opus 5 (1M context) | unreported |

## Adversarial review

One round, pre-submit. **1 blocking, 7 nits — all fixed in this PR**, none deferred.

The reviewer independently re-derived every closure number using a different method from the author's (`es-module-lexer` BFS over the emitted `dist/` vs a TypeScript-compiler walk). All of 27 / 11 / disjoint / 38 / 62 / 24 / seven-fetching-modules reproduced exactly, as did the pre-existing "49 modules / ~17.5k LOC" claim.

- **[blocking]** `exports` and the hand-written expected-export map could drift, publishing an unasserted surface with the gate green. Reproduced with a planted subpath. → cross-check both ways.
- **[nit, fixed]** Nothing asserted the property the change exists to create; a side-effect import defeated the gate silently. → the closure assertion above. Ranked nit only because the claims were true at the time; it was the highest-value finding.
- **[nit, fixed]** A comment claimed three probe subpaths "name real shipped files"; one does not ship.
- **[nit, fixed]** The unexported-subpath loop passed vacuously if its input key was absent.
- **[nit, fixed]** Three disagreeing new-entry checklists, all omitting this gate.
- **[nit, fixed]** Half a two-part contract exported — hydrators without the id helpers.
- **[nit, fixed]** The hydrate paragraph never mentioned that `hydrateGreenhouse` rejects on non-ok while `hydrateLever` resolves `""`; a consumer writing `Promise.all(...)` loses a whole page to one 404.
- **[nit, fixed]** `tsconfig.build.json` said 24 modules are reached "only through `import type` edges"; two are there via a dynamic `import()` instead.

The reviewer also confirmed the rule-1 question this change raises: `providers/index.ts` is a barrel by filename only — no `export … from`, both symbols defined in the file, non-adapter imports all `import type` — so taking them from it drags nothing the three named adapter files would not have.

