### PR TITLE
fix: prefer a stored reply over a stale listener's instant refusal

### DIFF
--- a/src/components/features/ShareWithExtensionBar.test.tsx
+++ b/src/components/features/ShareWithExtensionBar.test.tsx
@@ -24,6 +24,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { ShareWithExtensionBar } from "./ShareWithExtensionBar.tsx";
 import {
   EXTENSION_CHANNEL,
+  EXTENSION_REPLY_GRACE_MS,
   EXTENSION_REPLY_TIMEOUT_MS,
 } from "../../lib/extension-profile.ts";
 import {
@@ -156,6 +157,14 @@ describe("ShareWithExtensionBar", () => {
       channel: EXTENSION_CHANNEL,
       type: "resume-profile-refused",
       reason: "`corpus` is empty; there is nothing to rate against.",
+    });
+    // A refusal is held for the grace window in case a preferred `stored` from
+    // another responder is still on its way — so the button stays busy after
+    // the extension has answered, and must not re-enable before the outcome is
+    // on screen to click against.
+    expect(buttons()[0].disabled).toBe(true);
+    await act(async () => {
+      vi.advanceTimersByTime(EXTENSION_REPLY_GRACE_MS);
     });
 
     expect(el.textContent).toContain("refused");

--- a/src/lib/extension-profile.test.ts
+++ b/src/lib/extension-profile.test.ts
@@ -15,6 +15,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   EXTENSION_CHANNEL,
+  EXTENSION_REPLY_GRACE_MS,
   EXTENSION_REPLY_TIMEOUT_MS,
   buildSharedResumeProfile,
   clearSharedResumeProfile,
@@ -137,6 +138,9 @@ describe("shareResumeProfile", () => {
       type: "resume-profile-refused",
       reason: "`corpus` is empty; there is nothing to rate against.",
     });
+    // A refusal is a fallback reply — held for the grace window in case a
+    // preferred `stored` from another responder is still on its way.
+    vi.advanceTimersByTime(EXTENSION_REPLY_GRACE_MS);
 
     expect(await settled).toEqual({
       kind: "refused",
@@ -147,10 +151,77 @@ describe("shareResumeProfile", () => {
   it("names a reason even when the refusal carries none", async () => {
     const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
     reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-refused" });
+    vi.advanceTimersByTime(EXTENSION_REPLY_GRACE_MS);
     const outcome = await settled;
 
     expect(outcome.kind).toBe("refused");
     expect(outcome.kind === "refused" && outcome.reason.length).toBeGreaterThan(0);
+  });
+
+  it("prefers a stored reply that arrives after a refusal, within the grace window", async () => {
+    // The actual reported bug (#788): an orphaned content script refuses
+    // instantly while the live one is still writing to storage.
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({
+      channel: EXTENSION_CHANNEL,
+      type: "resume-profile-refused",
+      reason: "orphaned listener",
+    });
+    vi.advanceTimersByTime(EXTENSION_REPLY_GRACE_MS - 1);
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-stored" });
+
+    expect(await settled).toEqual({ kind: "stored" });
+  });
+
+  it("ignores a refusal that arrives after a stored reply already settled", async () => {
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({ channel: EXTENSION_CHANNEL, type: "resume-profile-stored" });
+    reply({
+      channel: EXTENSION_CHANNEL,
+      type: "resume-profile-refused",
+      reason: "too late",
+    });
+
+    expect(await settled).toEqual({ kind: "stored" });
+  });
+
+  it("holds a lone refusal for the grace window before reporting it", async () => {
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    reply({
+      channel: EXTENSION_CHANNEL,
+      type: "resume-profile-refused",
+      reason: "genuine refusal",
+    });
+
+    let pending = true;
+    void settled.then(() => (pending = false));
+
+    // The async advance drains the microtask queue as it goes, so a premature
+    // settle has already flipped the flag by the assertion below. The plain
+    // `advanceTimersByTime` would not: `settled` is one `await` deep, so its
+    // `.then` is queued behind `shareResumeProfile`'s own continuation and the
+    // flag would still read `true` whether or not the promise had resolved.
+    await vi.advanceTimersByTimeAsync(EXTENSION_REPLY_GRACE_MS - 1);
+    expect(pending).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(await settled).toEqual({ kind: "refused", reason: "genuine refusal" });
+  });
+
+  it("reports a fallback that lands inside the last grace window, not no-reply", async () => {
+    // Late enough that the request's own timeout fires before the refusal's
+    // grace timer does. The timeout must report what it holds — reporting
+    // `no-reply` would tell the user nothing answered when something did.
+    const settled = shareResumeProfile(buildSharedResumeProfile(parsed, "r.pdf"));
+    vi.advanceTimersByTime(EXTENSION_REPLY_TIMEOUT_MS - EXTENSION_REPLY_GRACE_MS + 1);
+    reply({
+      channel: EXTENSION_CHANNEL,
+      type: "resume-profile-refused",
+      reason: "late refusal",
+    });
+    vi.advanceTimersByTime(EXTENSION_REPLY_GRACE_MS);
+
+    expect(await settled).toEqual({ kind: "refused", reason: "late refusal" });
   });
 
   it("gives up rather than hanging when nothing is listening", async () => {

--- a/src/lib/extension-profile.ts
+++ b/src/lib/extension-profile.ts
@@ -71,6 +71,19 @@ export const EXTENSION_CHANNEL = "recruidea-extension" as const;
 export const EXTENSION_REPLY_TIMEOUT_MS = 2_000;
 
 /**
+ * How long a lower-priority reply is held before it is reported, in case the
+ * preferred one is still on its way.
+ *
+ * A `postMessage` is delivered to every listener on the page, so one request can
+ * draw two answers when a stale content script from a previous extension load is
+ * still listening beside a live one. The stale one loses its `chrome.*` bindings
+ * and therefore fails instantly, while the live one awaits a real storage write —
+ * so first-reply-wins reports a failure for a share that worked. Short enough
+ * that a genuine refusal still lands while the user is looking at the button.
+ */
+export const EXTENSION_REPLY_GRACE_MS = 300;
+
+/**
  * Everything that crosses. Six fields, and the wire shape is not ours to widen:
  * the extension reads an allow-list off whatever it is handed and drops the
  * rest, so an extra key here would be silently discarded rather than stored.
@@ -264,9 +277,19 @@ function readReply(value: unknown): ExtensionReply | null {
  * Post one message and wait for one of `accepts`, or for the timeout.
  *
  * The listener is attached before the post, so a reply cannot land in the gap.
- * There is no correlation id on this protocol — the reply vocabulary is
- * disjoint per request, and the one control that drives it is disabled while a
- * request is in flight — so the first accepted reply is this request's.
+ * There is no correlation id on this protocol. Two things together make an
+ * accepted reply this request's: the vocabulary is disjoint per request, and
+ * the one control that drives it is disabled while a request is in flight, so
+ * no second request is ever open to claim the reply. Both clauses are
+ * load-bearing — a second sharing control would break the matching, and the
+ * grace window below would let one request's held fallback be superseded by
+ * another's preferred reply.
+ *
+ * What is *not* bounded is the number of **responders** (see {@link
+ * EXTENSION_REPLY_GRACE_MS}), so `accepts` is read as a preference order rather
+ * than a plain set: `accepts[0]` settles the promise the moment it arrives,
+ * while anything later is held for the grace window in case the preferred reply
+ * is still on its way from another responder.
  */
 function sendToExtension<T extends ReplyType>(
   message: OutgoingMessage,
@@ -275,12 +298,16 @@ function sendToExtension<T extends ReplyType>(
   return new Promise((resolve) => {
     const appOrigin = window.location.origin;
     const wanted = new Set<string>(accepts);
+    const preferred = accepts[0];
     let settled = false;
+    let held: Extract<ExtensionReply, { type: T }> | null = null;
+    let grace: ReturnType<typeof setTimeout> | undefined;
 
     function finish(reply: Extract<ExtensionReply, { type: T }> | null): void {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      clearTimeout(grace);
       window.removeEventListener("message", onMessage);
       resolve(reply);
     }
@@ -289,10 +316,21 @@ function sendToExtension<T extends ReplyType>(
       if (!isFromThisPage(event, appOrigin)) return;
       const reply = readReply(event.data);
       if (reply === null || !wanted.has(reply.type)) return;
-      finish(reply as Extract<ExtensionReply, { type: T }>);
+      const accepted = reply as Extract<ExtensionReply, { type: T }>;
+      // The best answer this request can get — nothing later can improve on it.
+      if (accepted.type === preferred) return finish(accepted);
+      // A fallback answer. Keep it, keep listening: a preferred reply from
+      // another responder within the grace window supersedes it.
+      if (held === null) {
+        held = accepted;
+        grace = setTimeout(() => finish(held), EXTENSION_REPLY_GRACE_MS);
+      }
     }
 
-    const timer = setTimeout(() => finish(null), EXTENSION_REPLY_TIMEOUT_MS);
+    // Out of time: report the held fallback if one arrived, else `no-reply`. A
+    // fallback landing inside the last grace window's worth of the timeout is
+    // settled by this timer rather than its own, and must not be downgraded.
+    const timer = setTimeout(() => finish(held), EXTENSION_REPLY_TIMEOUT_MS);
     window.addEventListener("message", onMessage);
     window.postMessage(message, appOrigin);
   });


### PR DESCRIPTION
## Summary

`sendToExtension` resolved on the first accepted reply, and the share request accepts two replies that mean opposite things (`resume-profile-stored` / `resume-profile-refused`). A `postMessage` is delivered to *every* listener on the page, so an orphaned content script — one whose extension was reloaded under an open tab, leaving its `chrome.*` bindings torn down — answers beside the live one. The orphan fails instantly on `chrome.storage` being `undefined` while the live script awaits a real storage write, so the refusal always won the race and a share that had actually succeeded reported *"The extension refused this resume: Cannot read properties of undefined (reading 'local')"*.

`accepts` is now read as a **preference order** rather than a plain set: `accepts[0]` settles the promise the moment it arrives, and any lower-priority reply is held for `EXTENSION_REPLY_GRACE_MS` (300ms) in case a preferred one is still on its way from another responder. The request timeout reports the held fallback instead of downgrading it to `no-reply`. `clearSharedResumeProfile` passes a single accepted type, so it settles on arrival exactly as before and pays no grace cost.

Closes #788

## Review focus

- `src/lib/extension-profile.ts` — the outer timeout now calls `finish(held)`, not `finish(null)`. Does a fallback landing at t ∈ [1700, 2000) reach the user as a refusal rather than as "no extension answered"?
- `src/lib/extension-profile.ts` — the docblock claims an accepted reply is *this* request's because the vocabulary is disjoint **and** the driving control is disabled while a request is in flight. Is the second clause still true of `ShareWithExtensionBar`, and does the grace window widen the window in which a second request could cross-settle?
- `src/lib/extension-profile.test.ts` — "holds a lone refusal for the grace window" asserts a promise has *not* settled yet. Does `advanceTimersByTimeAsync` genuinely drain the queue there, or would the flag read stale regardless?
- Only the share races. `clear-resume-profile` accepts one reply type and `ping`/`pong` latches — is that still true after this change?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/lib/extension-profile.test.ts src/components/features/ShareWithExtensionBar.test.tsx` — 30 passed
- [x] `npm run build` — clean
- [x] `fallow audit --changed-since main` — 0 introduced findings (the pre-existing `readReply` complexity finding is untouched)
- [x] Mutation-checked both directions: reverting the `sendToExtension` change fails exactly the two tests that encode the bug; mutating the timeout's `finish(held)` → `finish(null)` fails exactly the held-fallback test
- [ ] Manual: load `/`, share once (works), reload the extension at `chrome://extensions` **without** reloading the page, share again — the bar should report success, not the `reading 'local'` refusal

## Adversarial review

Two rounds, on the local diff before this PR was opened.

**Round 1 — 1 blocking, fixed.** The test "holds a lone refusal for the grace window before reporting it" passed verbatim against the *unfixed* implementation, so it certified a property it did not check. `settled` is one `await` deep, so its `.then` was queued behind `shareResumeProfile`'s own continuation and the single `await Promise.resolve()` ran before the flag could flip. Now drained with `vi.advanceTimersByTimeAsync`, with a comment explaining why a fixed count of microtask ticks proves nothing. Verified failing against the reverted implementation.

**Round 2 — 0 blocking, 4 nits, all applied.**
1. `finish(held)` at the outer timeout was unasserted — mutating it to `finish(null)` left the suite green. Added "reports a fallback that lands inside the last grace window, not no-reply"; it now kills that mutant.
2. The docblock rewrite had dropped the "the one control that drives it is disabled while a request is in flight" clause, leaving a non-sequitur — disjointness alone does not make a reply this request's. Restored, and named as load-bearing.
3. The React test advanced the clock but never asserted the button stays busy during the grace window — the one user-visible behaviour this diff changes. Now asserted.
4. Swapped the `setImmediate` macrotask hop for `vi.advanceTimersByTimeAsync`, which does not depend on the suite's `toFake` list.

Nits accepted as out of scope: first-fallback-wins keeps the orphan's reason if the live script *also* genuinely refuses (pre-existing, not a regression); `accepts[0]` typing without `noUncheckedIndexedAccess` (unreachable — both call sites pass non-empty literals).

## Notes

- **The extension needs its own fix too** — an orphan guard that stops replying once `chrome.runtime?.id` is gone. That lives in the extension's repo. It is not a substitute for this one: the app cannot tell the two responders apart, and older extension builds already in the wild keep producing the bad reply.
- **A correlation id was considered and rejected** — both responders receive the same request and would echo the same id. The ambiguity is in *who answers*, not in which question was asked.
- The local `pre-push` hook was bypassed with the documented `OFFLINECV_SKIP_HOOKS=1`: `npm run verify` fails locally on `src/lib/letter-egress-ack.test.ts` (`globalThis.localStorage?.clear is not a function`, 9 tests) — unrelated to this change, fails identically on unmodified `main`, and green in CI on `main`, so it is a local-environment artifact (node v25.9.0). Every other gate was run by hand and is listed above.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Diagnosis, plan, review loop, PR | Claude Opus 5 | high |
| Implementation | Claude Sonnet (subagent, `model: sonnet`) | high |
| Adversarial review — rounds 1 & 2 | Claude Opus (subagent, `model: opus`) | high |
| Review fixes | Claude Opus 5 | high |
| Verification | typecheck / lint / vitest / build / fallow — run locally; `verify` green in CI | — |
