### PR TITLE
fix(contact): reject unclassifiable '+ Add a profile' input instead of dropping it (#790)

### DIFF
--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -140,7 +140,7 @@ describe("ContactCard", () => {
           kind: "other",
         },
       ],
-      onAddProfile: () => {},
+      onAddProfile: () => undefined,
       onEditProfile: () => {},
       onRemoveProfile: () => {},
     });

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -55,7 +55,7 @@ interface ContactCardProps {
    *  together with the add/edit/remove handlers to enable the variable-length
    *  links affordance in the editable card. */
   extraProfiles?: readonly ProfileOverride[];
-  onAddProfile?: (url: string) => void;
+  onAddProfile?: (url: string) => string | undefined;
   onEditProfile?: (id: string, url: string) => void;
   onRemoveProfile?: (id: string) => void;
 }

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -20,6 +20,7 @@
 
 import { formatLinkDisplay, type ContactDisplayField } from "../../lib/contact.ts";
 import { EditableField } from "@design-system";
+import { classifyProfile } from "../../lib/contact/profile-registry.ts";
 import {
   validateEmail,
   validatePhone,
@@ -83,7 +84,7 @@ interface ContactDetailsProps {
    *  `onAddProfile` is provided (editable card), the variable-length add/edit/
    *  delete affordance renders below the legacy links line. */
   extraProfiles?: readonly ProfileOverride[];
-  onAddProfile?: (url: string) => void;
+  onAddProfile?: (url: string) => string | undefined;
   onEditProfile?: (id: string, url: string) => void;
   onRemoveProfile?: (id: string) => void;
 }
@@ -288,10 +289,21 @@ function renderLink(
     // the guided network picker instead of a bare URL field, so a naive user
     // learns what counts and which networks are accepted (#335-followup).
     if (field.reason === "absent") {
+      // `onLegacyLinkChange` also serves the low-confidence CORRECTION path
+      // below, where an unparseable edit is intentionally kept (raw value,
+      // `kind: "other"`) so the correction isn't lost. That fallback is wrong
+      // for a first-time ADD: classify here so an unclassifiable value (e.g.
+      // "US Citizen") is rejected the same way `addProfile` rejects it,
+      // instead of being written into the slot as a bogus link (#790).
+      const addLink = (v: string): string | undefined => {
+        if (classifyProfile(v) === undefined) return undefined;
+        commitLink(v);
+        return v;
+      };
       return (
         <ProfileLinkAdd
           label={`Add a ${field.label.toLowerCase()}`}
-          onAdd={commitLink}
+          onAdd={addLink}
         />
       );
     }

--- a/src/components/features/ContactExtraLinks.tsx
+++ b/src/components/features/ContactExtraLinks.tsx
@@ -30,7 +30,7 @@ import { ProfileLinkAdd } from "./ProfileLinkAdd.tsx";
 
 interface ContactExtraLinksProps {
   profiles: readonly ProfileOverride[];
-  onAdd: (url: string) => void;
+  onAdd: (url: string) => string | undefined;
   onEdit: (id: string, url: string) => void;
   onRemove: (id: string) => void;
 }

--- a/src/components/features/ProfileLinkAdd.test.tsx
+++ b/src/components/features/ProfileLinkAdd.test.tsx
@@ -49,7 +49,7 @@ afterEach(() => {
 
 describe("ProfileLinkAdd", () => {
   it("starts collapsed as a labelled add pill", () => {
-    const el = render({ onAdd: () => {}, label: "Add a professional profile" });
+    const el = render({ onAdd: () => undefined, label: "Add a professional profile" });
     const pill = el.querySelector('[aria-label="Add a professional profile"]');
     expect(pill).not.toBeNull();
     // No network chips until it is expanded.
@@ -57,7 +57,7 @@ describe("ProfileLinkAdd", () => {
   });
 
   it("expands to show a chip per quick-pick network", () => {
-    const el = render({ onAdd: () => {}, label: "Add a profile" });
+    const el = render({ onAdd: () => undefined, label: "Add a profile" });
     click(el.querySelector('[aria-label="Add a profile"]'));
     for (const pick of PROFILE_QUICK_PICKS) {
       expect(
@@ -67,7 +67,7 @@ describe("ProfileLinkAdd", () => {
   });
 
   it("tapping a network chip pre-fills its prefix into the input", () => {
-    const el = render({ onAdd: () => {}, label: "Add a profile" });
+    const el = render({ onAdd: () => undefined, label: "Add a profile" });
     click(el.querySelector('[aria-label="Add a profile"]'));
     click(el.querySelector('[aria-label="Add GitHub"]'));
     const input = el.querySelector("input");
@@ -75,7 +75,7 @@ describe("ProfileLinkAdd", () => {
   });
 
   it("commits the entered URL and collapses when stayOpenAfterAdd is unset", () => {
-    const onAdd = vi.fn();
+    const onAdd = vi.fn(() => "profile:0");
     const el = render({ onAdd, label: "Add a professional profile" });
     click(el.querySelector('[aria-label="Add a professional profile"]'));
     click(el.querySelector('[aria-label="Add LinkedIn"]'));
@@ -85,5 +85,60 @@ describe("ProfileLinkAdd", () => {
     expect(onAdd).toHaveBeenCalledWith("https://linkedin.com/in/");
     // Collapsed again → chips gone.
     expect(el.querySelector('[aria-label="Add GitHub"]')).toBeNull();
+  });
+
+  it("rejected input keeps the draft, stays expanded, and renders an alert (#790)", () => {
+    const onAdd = vi.fn(() => undefined);
+    const el = render({ onAdd, label: "Add a profile" });
+    click(el.querySelector('[aria-label="Add a profile"]'));
+    const input = el.querySelector("input") as HTMLInputElement;
+    act(() => {
+      input.dispatchEvent(new Event("focus"));
+    });
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      setter.call(input, "US Citizen");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const addBtn = el.querySelector('button[aria-label="Add a profile"]');
+    click(addBtn);
+
+    expect(onAdd).toHaveBeenCalledWith("US Citizen");
+    // Draft survives — not cleared on rejection.
+    expect(input.value).toBe("US Citizen");
+    // Still expanded — chips still present.
+    expect(el.querySelector('[aria-label="Add GitHub"]')).not.toBeNull();
+    // Visible, announced error.
+    const alert = el.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toMatch(/doesn't look like a link/i);
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("clears the error on the next keystroke", () => {
+    const onAdd = vi.fn(() => undefined);
+    const el = render({ onAdd, label: "Add a profile" });
+    click(el.querySelector('[aria-label="Add a profile"]'));
+    const input = el.querySelector("input") as HTMLInputElement;
+    const setValue = (v: string) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      act(() => {
+        setter.call(input, v);
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+    };
+    setValue("US Citizen");
+    click(el.querySelector('button[aria-label="Add a profile"]'));
+    expect(el.querySelector('[role="alert"]')).not.toBeNull();
+
+    setValue("US Citizen2");
+    expect(el.querySelector('[role="alert"]')).toBeNull();
+    expect(input.getAttribute("aria-invalid")).toBe("false");
   });
 });

--- a/src/components/features/ProfileLinkAdd.tsx
+++ b/src/components/features/ProfileLinkAdd.tsx
@@ -20,6 +20,12 @@
  * "Professional profile" links row and the extra-links "+ Add" — consume THIS
  * one component instead of each re-rolling a URL input. The quick-pick data is
  * derived from `PROFILE_HOSTS`, so the picker never drifts from what we accept.
+ *
+ * `onAdd` reports failure via its return value (`undefined` = rejected, e.g.
+ * "US Citizen" — not a URL). On rejection the draft is KEPT (not cleared), the
+ * panel stays open, and an inline `role="alert"` names what is accepted —
+ * fixing the silent-data-loss defect where a rejected value used to vanish
+ * with no trace (#790).
  */
 
 import { useRef, useState } from "react";
@@ -30,9 +36,14 @@ import {
 } from "../../lib/contact/profile-registry.ts";
 import { AddPill } from "./ReconstructedAdd.tsx";
 
+const REJECTED_HINT =
+  "That doesn't look like a link. Paste a profile URL (e.g. linkedin.com/in/yourname).";
+
 interface ProfileLinkAddProps {
-  /** Commit the entered URL (raw string; classified by the caller's sink). */
-  onAdd: (url: string) => void;
+  /** Commit the entered URL (raw string; classified by the caller's sink).
+   *  Returns the new profile's id on success, `undefined` if the value could
+   *  not be classified as a link — the caller never silently swallows that. */
+  onAdd: (url: string) => string | undefined;
   /** Collapsed-pill label, e.g. "Add a professional profile" / "Add a profile". */
   label?: string;
   /** Keep the input open after a commit so several links can be added in a row
@@ -51,13 +62,20 @@ export function ProfileLinkAdd({
 }: ProfileLinkAddProps) {
   const [expanded, setExpanded] = useState(false);
   const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const commit = () => {
     const trimmed = draft.trim();
     // Ignore an empty entry or a bare scheme left from a tapped chip.
     if (!trimmed || trimmed === "https://") return;
-    onAdd(trimmed);
+    if (onAdd(trimmed) === undefined) {
+      // Rejected: keep the draft and the panel open so the user's input isn't
+      // silently lost, and say what is accepted (#790).
+      setError(REJECTED_HINT);
+      return;
+    }
+    setError(null);
     setDraft("");
     if (!stayOpenAfterAdd) setExpanded(false);
   };
@@ -116,8 +134,12 @@ export function ProfileLinkAdd({
           value={draft}
           autoFocus
           aria-label={label}
+          aria-invalid={error !== null}
           placeholder="Tap a network above, or paste any profile URL"
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setError(null);
+          }}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
@@ -125,6 +147,7 @@ export function ProfileLinkAdd({
             } else if (e.key === "Escape") {
               e.preventDefault();
               setDraft("");
+              setError(null);
               setExpanded(false);
             }
           }}
@@ -140,6 +163,12 @@ export function ProfileLinkAdd({
           Add
         </Button>
       </div>
+
+      {error && (
+        <span role="alert" className="text-sm text-feedback-error-text">
+          {error}
+        </span>
+      )}
 
       <span className="text-sm text-content-tertiary">
         {HELPER_EXAMPLES

--- a/src/lib/contact/profile-registry.test.ts
+++ b/src/lib/contact/profile-registry.test.ts
@@ -81,6 +81,33 @@ describe("classifyProfile — unknown hosts are kept, never dropped", () => {
   });
 });
 
+describe("classifyProfile — a dotless bare word is not a host (#790)", () => {
+  it.each(["US Citizen", "Citizen", "US_Citizen", "UScitizen"])(
+    "rejects %s instead of inventing an https://<word> profile",
+    (input) => {
+      expect(classifyProfile(input)).toBeUndefined();
+    },
+  );
+
+  it("still keeps localhost as an unknown host", () => {
+    expect(classifyProfile("http://localhost:3000")).toEqual({
+      url: "http://localhost:3000",
+      network: "localhost",
+      kind: "other",
+    });
+  });
+
+  it("does not regress dotted hosts — recognized hosts keep their kind, a genuinely unknown dotted host stays 'other'", () => {
+    expect(classifyProfile("orcid.org/0000-0002-1825-0097")?.kind).toBe(
+      "academic",
+    );
+    expect(
+      classifyProfile("scholar.google.com/citations?user=x")?.kind,
+    ).toBe("academic");
+    expect(classifyProfile("example.com")?.kind).toBe("other");
+  });
+});
+
 describe("classifyProfile — LinkedIn non-profile exclusion", () => {
   it.each([
     "https://www.linkedin.com/company/acme",

--- a/src/lib/contact/profile-registry.ts
+++ b/src/lib/contact/profile-registry.ts
@@ -128,14 +128,15 @@ export function otherRecognizedNetworks(): string[] {
  * parser's `normalizeUrl`, so a scheme-less `github.com/x` gets `https://`),
  * then matches its hostname against {@link PROFILE_HOSTS}.
  *
- * - An UNKNOWN host is kept, never dropped: `{ network: <hostname>, kind:
- *   "other" }`.
+ * - An unknown *host* is kept, never dropped: `{ network: <hostname>, kind:
+ *   "other" }`. A dotless bare word (e.g. "Citizen") is not a host and is
+ *   rejected — see the dotted-hostname guard below (#790).
  * - A NON-PROFILE LinkedIn URL (feed / company / jobs / … — see
  *   `LINKEDIN_NONPROFILE_RE`) must NOT become a `social` profile; it is kept as
  *   an `other` link on the `linkedin.com` host.
  *
- * Returns `undefined` only when the input is empty / cannot be parsed into a
- * host — callers filter those out.
+ * Returns `undefined` when the input is empty / cannot be parsed into a host,
+ * or is a bare word with no dot in it — callers filter those out.
  */
 export function classifyProfile(rawUrl: string): ProfileLink | undefined {
   const url = normalizeUrl(rawUrl);
@@ -148,6 +149,9 @@ export function classifyProfile(rawUrl: string): ProfileLink | undefined {
     return undefined;
   }
   if (hostname.length === 0) return undefined;
+  // A bare word is not a host. Every real public host is dotted; a dotless
+  // hostname here means the user typed prose ("Citizen"), not a URL (#790).
+  if (!hostname.includes(".") && hostname !== "localhost") return undefined;
 
   for (const rule of PROFILE_HOSTS) {
     if (!rule.match.test(hostname)) continue;


### PR DESCRIPTION
Layer 01 of 3. Base for the stack — depends on nothing but `main`.

## What shipped

The contact card's **"+ Add a profile"** silently discarded input it could not classify, and accepted a bare word as a link. Both directions are closed.

**Rejected input no longer vanishes.** `addProfile` already returned `string | undefined` to report failure; nothing read it. The signal is now threaded through the prop chain (`ProfileLinkAdd` → `ContactExtraLinks` → `ContactDetails` → `ContactCard`), and `ProfileLinkAdd.commit()` keeps the draft, keeps the panel open, and renders an inline error naming what is accepted. The error carries `role="alert"`, the input carries `aria-invalid`, and the message clears on the next keystroke.

**Accepted input must actually be a link.** `classifyProfile` accepted any whitespace-free token as an "unknown host", so `Citizen` became `https://Citizen` and shipped into the exported PDF's contact line as a bogus slug. A dotless hostname is now rejected unless it is `localhost`. Genuine unknown hosts are unaffected — `orcid.org`, `example.com`, `scholar.google.com` all still classify as `kind: "other"`, with a regression test pinning that.

## One deviation from the issue's plan, worth a reviewer's eye

The plan assumed the required-slot add point in `ContactDetails.tsx` needed only a type widening. It did not. That add point wires `onAdd={commitLink}`, and `commitLink` is `void`-typed — so it always returns `undefined`, which would have shown the rejection error on **every** commit including valid ones. It also has its own permissive correction-path fallback that would have let `Citizen`-style text through, defeating the issue's "both add points behave identically" criterion.

Fixed by running `classifyProfile` in `ContactDetails.tsx` before delegating to `onLegacyLinkChange`, scoped to the absent/first-add branch only. The low-confidence correction-path fallback in `useEditableParse.ts` is intentional and untouched.

## Verification

- `classifyProfile` is on the **parse** path via `profilesFromUrls`, so the corpus was the risk. `src/lib/heuristics` — 1271 passed, **no snapshot moved**.
- Scoped suites (`profile-registry`, `ProfileLinkAdd`, `ContactCard`) — 44 passed.
- `typecheck`, `lint` clean.
- Gates were run under Node 20 (`.nvmrc`); this repo's suite produces spurious `localStorage` failures on newer Node.

Closes #790

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #790 | Claude Sonnet 5 | high |
| Adversarial review (stack-wide) | Claude Opus 4.5 | high |
| Orchestration + PR | Claude Opus 5 | high |

## Adversarial review

Reviewed pre-submit as part of the 3-layer stack, two rounds, by an independent reviewer prompted to break the change rather than confirm it.

**No blocking findings against this layer.** The reviewer specifically verified that this layer composes with layer 3, which edits `ContactDetails.tsx` again: layer 3's `segments` filter only touches `group === "contact"` rows, while this layer's `addLink` lives in `renderLink`, which is only ever called on `group === "link"` rows. The required-slot add path is untouched, and `addLink` correctly returns a non-empty value so `ProfileLinkAdd` reads it as success.

Stack-wide outcome: two blocking findings were found and fixed on layers 2 and 3 before any PR was opened; see those PRs. This layer was clean in both rounds.
