### PR TITLE
fix(skills): make '+ Add category' reachable on a flat list and keep ungrouped skills in the export (#791)

### DIFF
--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -1419,7 +1419,7 @@ export function ReconstructedResume({
           deleteSkillCategory(parsed.skillCategories ?? [], i)
         }
         onAddCategory={(label) =>
-          addSkillCategory(parsed.skillCategories ?? [], label)
+          addSkillCategory(parsed.skillCategories ?? [], parsed.skills, label)
         }
         onAddSkillToCategory={(i, skill) =>
           addSkillToCategory(parsed.skillCategories ?? [], i, skill)

--- a/src/components/features/ReconstructedSkills.test.ts
+++ b/src/components/features/ReconstructedSkills.test.ts
@@ -92,12 +92,36 @@ describe("SkillsSection rendering", () => {
     expect(html).toContain("empty");
   });
 
-  it("renders a flat list with no category chrome when uncategorised", () => {
+  it("renders a flat list with no PER-CATEGORY chrome when uncategorised", () => {
     const html = render(["React", "TypeScript"]);
     expect(html).not.toContain("Rename");
-    expect(html).not.toContain("Add category");
     expect(html).toContain("React");
     expect(html).toContain("TypeScript");
+  });
+
+  // ── "+ Add category" reachability (#791) ────────────────────────────────────
+  // #476 shipped full category editing but left the control reachable only
+  // once a category already existed — a flat comma list (the common case) had
+  // no way to create the first one. These pin down the reachability fix and
+  // the #791 stated decision on the zero-skills edge case.
+
+  it("offers Add category on an uncategorised résumé that HAS skills — the reachability fix", () => {
+    const html = render(["React", "TypeScript"]);
+    expect(html).toContain("Add category");
+    // Both ways to start are visible together — grouping is optional, adding a
+    // skill still works even before any category exists.
+    expect(html).toContain("Add skill");
+  });
+
+  it("does NOT offer Add category on a résumé with NO skills at all (#791 stated decision)", () => {
+    const html = render([]);
+    expect(html).not.toContain("Add category");
+    expect(html).toContain("No skills detected");
+  });
+
+  it("still offers Add category (for a further category) once one already exists", () => {
+    const html = render(["React", "TypeScript", "Java", "Go"], cats);
+    expect(html).toContain("Add category");
   });
 
   it("gives an ungrouped chip a Move menu so it can be regrouped (issue 476 nit)", () => {

--- a/src/components/features/ReconstructedSkills.tsx
+++ b/src/components/features/ReconstructedSkills.tsx
@@ -21,9 +21,17 @@
  * already met by the keyboard menu, so DnD is a pure pointer nicety where a
  * dependency in this bundle-conscious codebase isn't justified.
  *
+ * #476 left "+ Add category" reachable only once a category already existed —
+ * a flat comma-separated Skills section (the common case) had no way to create
+ * the first one. #791 makes it reachable whenever the section has any skill at
+ * all, and creating that first category leaves the existing skills UNGROUPED
+ * (a trailing chip row, via `partitionSkillCategories` below) rather than
+ * sweeping them in or inventing a synthetic "Other" bucket.
+ *
  * Display-only otherwise: it renders the edited grouping (`skillCategories`,
- * which for a categorised résumé the override snapshot keeps in lockstep with the
- * flat `skills` list) and routes every edit up to the lifted override model.
+ * which for a categorised résumé may cover only a SUBSET of the flat `skills`
+ * list once ungrouped skills exist — see `skills-categories.ts`) and routes
+ * every edit up to the lifted override model.
  */
 
 import { useState } from "react";
@@ -202,10 +210,20 @@ export function SkillsSection({
     setDragging(null);
   };
 
+  // #791 stated decision: on a résumé with NO skills at all, show only the
+  // NotDetected empty state (+ AddSkillInput below) — not "+ Add category" too.
+  // A category with nothing to put in it isn't useful, and the empty state
+  // shouldn't offer two competing ways to start. Any résumé with at least one
+  // skill gets the category control, whether or not it's grouped yet — that's
+  // the reachability #791 fixes: a flat comma list is the common case, and
+  // grouping it required a category to exist before "+ Add category" ever
+  // rendered.
+  const showEmptyState = skills.length === 0 && !categorised;
+
   return (
     <section className="flex flex-col gap-2">
       <SectionHeading>{heading ?? "Skills"}</SectionHeading>
-      {skills.length === 0 && !categorised ? (
+      {showEmptyState ? (
         <NotDetected what="skills" />
       ) : categorised ? (
         <div className="flex flex-col gap-1.5">
@@ -239,11 +257,14 @@ export function SkillsSection({
               onDragStartSkill={setDragging}
             />
           )}
-          <AddCategoryInput onAdd={onAddCategory} />
         </div>
       ) : (
         <SkillChipRow skills={skills} onRemoveSkill={onRemoveSkill} />
       )}
+      {/* Reachable whenever there's at least one skill (#791) — both alongside
+       *  the flat chip row (creating the FIRST category) and inside the
+       *  categorised view (adding another one). */}
+      {!showEmptyState && <AddCategoryInput onAdd={onAddCategory} />}
       {!categorised && <AddSkillInput skills={skills} onAdd={onAddSkill} />}
       <div className="sr-only" aria-live="polite" role="status">
         {announcement}

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -158,7 +158,7 @@ describe("useEditableParse — Skills category edits (#476)", () => {
   });
 
   it("resetAll clears the category snapshot back to pristine", () => {
-    act(() => api.addSkillCategory(cats, "Data"));
+    act(() => api.addSkillCategory(cats, cats.flatMap((c) => c.skills), "Data"));
     expect(api.skillsOverride.categories).toBeDefined();
     act(() => api.resetAll());
     expect(api.skillsOverride.categories).toBeUndefined();
@@ -175,6 +175,32 @@ describe("useEditableParse — Skills category edits (#476)", () => {
     expect(api.skillsOverride.categories).toBeUndefined();
     act(() => api.replay(saved));
     expect(api.skillsOverride.categories?.map((c) => c.label)).toEqual(["UI"]);
+  });
+
+  it("replay restores the ungrouped remainder, not just the categories (#791)", () => {
+    // Seeding the remainder needs a grouping that does NOT already cover every
+    // skill — the flat-résumé case the "+ Add category" affordance unlocks.
+    const flat = {
+      skills: ["React", "TypeScript", "Figma"],
+      skillCategories: undefined,
+    };
+    act(() => api.addSkillCategory([], flat.skills, "UI"));
+    act(() => api.moveSkillToCategory(api.skillsOverride.categories!, "React", 0));
+    expect(api.skillsOverride.ungrouped).toEqual(["TypeScript", "Figma"]);
+
+    const saved = api.snapshot;
+    act(() => api.resetAll());
+    act(() => api.replay(saved));
+
+    // Restoring `categories` alone would strand these two: `computeEditedSkills`
+    // reads a missing `ungrouped` as "no remainder" and the flat list collapses
+    // to the grouped member only — the #791 data loss, on the restore path.
+    expect(api.skillsOverride.ungrouped).toEqual(["TypeScript", "Figma"]);
+    expect(computeEditedSkills(flat, api.skillsOverride).skills).toEqual([
+      "React",
+      "TypeScript",
+      "Figma",
+    ]);
   });
 
   it("delete-all-categories then flat addSkill does NOT resurrect deleted skills (#415)", () => {
@@ -231,6 +257,202 @@ describe("useEditableParse — Skills category edits (#476)", () => {
   });
 });
 
+describe("useEditableParse — ungrouped remainder on the first category (#791)", () => {
+  const flat = ["Python", "SQL", "Excel"];
+
+  it("creating the first category leaves every existing skill ungrouped, not swept in", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    expect(api.skillsOverride.categories).toEqual([
+      { label: "Leadership", skills: [] },
+    ]);
+
+    const parsed = { skills: flat, skillCategories: undefined };
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    // Nothing was swept into the new category…
+    expect(result.skillCategories![0].skills).toEqual([]);
+    // …but the flat union still has every original skill.
+    expect(new Set(result.skills)).toEqual(new Set(flat));
+  });
+
+  it("a second addSkillCategory call leaves the pool alone (the recompute is idempotent)", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() =>
+      api.addSkillCategory(api.skillsOverride.categories!, flat, "Backend"),
+    );
+    expect(api.skillsOverride.ungrouped).toEqual(flat);
+  });
+
+  // Both sequences below reach a state the old once-only seed left inconsistent:
+  // a non-empty `categories` snapshot alongside populated flat `removed`/`added`.
+  // `computeEditedSkills` treats that as unreachable — it throws in DEV and
+  // ignores the flat edits in prod, i.e. the skill vanishes from the UI and the
+  // exported PDF. Both are reachable because the flat chip row and
+  // "+ Add category" now render together (#791).
+
+  it("a flat remove made before the first category survives creating it", () => {
+    const parsed = { skills: flat, skillCategories: undefined };
+    act(() => api.removeSkill("Excel"));
+    const rendered = computeEditedSkills(parsed, api.skillsOverride).skills;
+    expect(rendered).toEqual(["Python", "SQL"]);
+
+    act(() => api.addSkillCategory([], rendered, "Leadership"));
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "Python",
+      "SQL",
+    ]);
+    // Folded into the snapshot, not left dangling beside it.
+    expect(api.skillsOverride.removed).toEqual([]);
+  });
+
+  it("a flat add made while degraded survives creating a category again", () => {
+    const parsed = { skills: flat, skillCategories: undefined };
+    // First category → delete it: the section degrades to uncategorised, so the
+    // flat AddSkillInput is live again while `ungrouped` is already seeded.
+    act(() => api.addSkillCategory([], flat, "Product"));
+    act(() => api.deleteSkillCategory(api.skillsOverride.categories!, 0));
+    act(() => api.addSkill("Rust"));
+    const rendered = computeEditedSkills(parsed, api.skillsOverride).skills;
+    expect(rendered).toContain("Rust");
+
+    // "+ Add category" again. The seed must recompute from the rendered list, or
+    // the categorised branch (which ignores `added`) drops "Rust" silently.
+    act(() =>
+      api.addSkillCategory(api.skillsOverride.categories!, rendered, "Product"),
+    );
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    expect(new Set(result.skills)).toEqual(new Set([...flat, "Rust"]));
+    expect(api.skillsOverride.added).toEqual([]);
+  });
+
+  it("moving an ungrouped skill into a category claims it (Move menu / DnD path)", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() =>
+      api.moveSkillToCategory(api.skillsOverride.categories!, "SQL", 0),
+    );
+    const parsed = { skills: flat, skillCategories: undefined };
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    expect(result.skillCategories![0].skills).toEqual(["SQL"]);
+    // The flat SET is unchanged — SQL moved, nothing was lost or duplicated.
+    expect(new Set(result.skills)).toEqual(new Set(flat));
+  });
+
+  it("removing an ungrouped skill deletes it — the trailing row's Remove button", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() =>
+      api.removeCategorySkill(api.skillsOverride.categories!, "Excel"),
+    );
+    const parsed = { skills: flat, skillCategories: undefined };
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    expect(result.skills).not.toContain("Excel");
+    expect(new Set(result.skills)).toEqual(new Set(["Python", "SQL"]));
+  });
+
+  it("deleting a category destroys a skill moved into it — it does not fall back to ungrouped", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() =>
+      api.moveSkillToCategory(api.skillsOverride.categories!, "SQL", 0),
+    );
+    act(() => api.deleteSkillCategory(api.skillsOverride.categories!, 0));
+    const parsed = { skills: flat, skillCategories: undefined };
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    // SQL was inside the deleted category — the confirm dialog's promise
+    // ("removes the category and all the skills in it") must hold: SQL is
+    // gone, not resurrected as ungrouped.
+    expect(result.skills).toEqual(["Python", "Excel"]);
+    expect(result.skillCategories).toBeUndefined();
+  });
+
+  // The flat setters are categorisation-aware (#791): `SkillTermGuidance` — and
+  // any future flat writer — is wired to `addSkill`, which is reachable on a
+  // categorised résumé now that "+ Add category" renders on a flat one. Routing
+  // a flat write into `added`/`removed` while a non-empty snapshot exists is the
+  // one state `computeEditedSkills` rejects: it throws in DEV (an ErrorBoundary
+  // crash, since it runs in a render-phase memo) and drops the skill silently in
+  // prod. The door is closed in the setter, not by convention at each call site.
+
+  it("addSkill on a categorised résumé lands in ungrouped, not the flat `added`", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() => api.addSkill("Kubernetes"));
+
+    // Before the setters became categorisation-aware this threw here — and this
+    // runs in a render-phase memo (`useAnalyzedResume`), so the throw was an
+    // ErrorBoundary crash of the whole editor, two clicks from a fresh parse.
+    const parsed = { skills: flat, skillCategories: undefined };
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    expect(result.skills).toContain("Kubernetes");
+    expect(new Set(result.skills)).toEqual(new Set([...flat, "Kubernetes"]));
+
+    expect(api.skillsOverride.added).toEqual([]);
+    expect(api.skillsOverride.ungrouped).toEqual([...flat, "Kubernetes"]);
+    expect(api.hasEdits).toBe(true);
+  });
+
+  it("addSkill while categorised canonicalizes and no-ops on blanks/dupes", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() => api.addSkillToCategory(api.skillsOverride.categories!, 0, "SQL"));
+    // Canonicalized, like the uncategorised path ("js" → "JavaScript").
+    act(() => api.addSkill("js"));
+    expect(api.skillsOverride.ungrouped).toContain("JavaScript");
+
+    const before = api.skillsOverride.ungrouped;
+    act(() => api.addSkill("   "));
+    act(() => api.addSkill("javascript")); // already ungrouped (case-insensitive)
+    act(() => api.addSkill("sql")); // already GROUPED — not a second copy
+    expect(api.skillsOverride.ungrouped).toEqual(before);
+    expect(api.skillsOverride.added).toEqual([]);
+  });
+
+  it("a categorised flat add survives snapshot → replay", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() => api.addSkill("Kubernetes"));
+    const saved = api.snapshot;
+    // It rides in `ungrouped`, which replay restores WITH `categories` — the
+    // `so.added.forEach(addSkill)` leg has nothing to replay.
+    expect(saved.skillsOverride.added).toEqual([]);
+
+    act(() => api.resetAll());
+    act(() => api.replay(saved));
+
+    const parsed = { skills: flat, skillCategories: undefined };
+    expect(new Set(computeEditedSkills(parsed, api.skillsOverride).skills)).toEqual(
+      new Set([...flat, "Kubernetes"]),
+    );
+  });
+
+  it("removeSkill while categorised deletes from ungrouped AND from a category", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() => api.moveSkillToCategory(api.skillsOverride.categories!, "SQL", 0));
+
+    // An ungrouped skill…
+    act(() => api.removeSkill("Excel"));
+    // …and a grouped one. A flat remove must reach both, or the chip stays.
+    act(() => api.removeSkill("SQL"));
+
+    expect(api.skillsOverride.removed).toEqual([]);
+    expect(api.skillsOverride.ungrouped).toEqual(["Python"]);
+    expect(api.skillsOverride.categories).toEqual([
+      { label: "Leadership", skills: [] },
+    ]);
+
+    const parsed = { skills: flat, skillCategories: undefined };
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "Python",
+    ]);
+  });
+
+  it("typing an ungrouped skill's name into a category's add-input also claims it (no stale duplicate)", () => {
+    act(() => api.addSkillCategory([], flat, "Leadership"));
+    act(() =>
+      api.addSkillToCategory(api.skillsOverride.categories!, 0, "SQL"),
+    );
+    // A later delete of that category must not resurrect SQL via a stale
+    // ungrouped entry.
+    act(() => api.deleteSkillCategory(api.skillsOverride.categories!, 0));
+    const parsed = { skills: flat, skillCategories: undefined };
+    const result = computeEditedSkills(parsed, api.skillsOverride);
+    expect(result.skills).toEqual(["Python", "Excel"]);
+  });
+});
 
 // ── Summary override (#625) ───────────────────────────────────────────────────
 

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -68,10 +68,13 @@ import {
 import {
   addCategory as addSkillCategoryTx,
   addSkillToCategory as addSkillToCategoryTx,
+  addUngroupedSkill,
   deleteCategory as deleteSkillCategoryTx,
   isEmptySkillsOverride,
   moveSkillBetweenCategories,
+  presentAnywhere as skillPresentInCategories,
   removeSkillFromCategories,
+  removeUngroupedSkill,
   renameCategory as renameSkillCategoryTx,
 } from "../lib/edit/skills-categories.ts";
 import type { SkillCategory } from "../lib/heuristics/types.ts";
@@ -432,15 +435,30 @@ export interface ProfileOverride {
  * single categorised skill) is a pure array→array transform in
  * `skills-categories.ts` producing the next snapshot, so a rename is not a
  * delete-plus-add and a move is not a remove-plus-add. When present it is
- * authoritative: `applyOverrides` flattens it to the flat `skills`, so the #473
- * invariant holds by construction and the flat `removed`/`added` are unused.
- * Absent means the categorised grouping is untouched (or the résumé is
- * uncategorised). Reset clears it back to `undefined` in one step.
+ * authoritative: `applyOverrides` flattens it (unioned with `ungrouped`, #791)
+ * to the flat `skills`, so the flat `removed`/`added` are unused. Absent means
+ * the categorised grouping is untouched (or the résumé is uncategorised). Reset
+ * clears it back to `undefined` in one step.
+ *
+ * `ungrouped` (#791) is the sibling set `categories` doesn't cover — skills that
+ * exist but were never dragged/moved into a category. It's seeded exactly once,
+ * by `addSkillCategory`, the moment the FIRST category is created on a résumé
+ * whose skills weren't already 100% grouped (the common case: a flat comma
+ * list). Every op that moves a skill INTO a category (`moveSkillToCategory`,
+ * `removeCategorySkill` — the trailing chip row shares both with the category
+ * rows) drops it from here too, so a skill is in `categories` XOR `ungrouped`,
+ * never both and never neither while it still exists. The FLAT `addSkill` /
+ * `removeSkill` write here too whenever `categories` is non-empty (#791): the
+ * flat `removed`/`added` are unusable beside a snapshot, and a flat writer that
+ * knows nothing about categories still has to land somewhere. `deleteSkillCategory`
+ * deliberately does NOT move its members here — deleting a category destroys
+ * them (the confirm dialog says so), it doesn't return them to the pool.
  */
 export interface SkillsOverride {
   removed: string[];
   added: string[];
   categories?: SkillCategory[];
+  ungrouped?: string[];
 }
 
 const EMPTY_SKILLS_OVERRIDE: SkillsOverride = { removed: [], added: [] };
@@ -632,16 +650,19 @@ export interface EditableParse {
   /** Add/remove edits against parsed.skills. */
   skillsOverride: SkillsOverride;
   /** Add a (canonicalized) skill. No-op for blank input or an exact dupe of an
-   *  already-present skill. Re-adding a previously-removed skill un-removes it. */
+   *  already-present skill. Re-adding a previously-removed skill un-removes it.
+   *  CATEGORISATION-AWARE (#791): while a non-empty grouping snapshot exists the
+   *  skill joins {@link SkillsOverride.ungrouped} instead of the flat `added`,
+   *  so a caller that knows nothing about categories — `SkillTermGuidance`'s
+   *  missing-term pill — cannot mint the state `computeEditedSkills` rejects. */
   addSkill: (skill: string) => void;
-  /** Remove a skill by its display text — the UNCATEGORISED delete-single-skill
-   *  path (drops it whether it came from the parse or a prior flat add). For a
-   *  categorised résumé the editor uses {@link removeCategorySkill} instead so
-   *  the grouping snapshot stays authoritative. */
+  /** Remove a skill by its display text (drops it whether it came from the parse
+   *  or a prior flat add). CATEGORISATION-AWARE, symmetrically with
+   *  {@link addSkill}: while a non-empty snapshot exists it deletes from BOTH
+   *  halves of the grouping, so it behaves like {@link removeCategorySkill}
+   *  (which the editor still wires the chip Remove buttons to) rather than
+   *  emitting a flat `removed` key the categorised branch rejects. */
   removeSkill: (skill: string) => void;
-  /** The current edited Skills grouping — the {@link SkillsOverride.categories}
-   *  snapshot when a category edit has been made, else `undefined`. */
-  skillCategoriesOverride: SkillCategory[] | undefined;
   /** Rename the category at `index` in `cats` (the current rendered grouping) —
    *  label-only, members untouched (#476). */
   renameSkillCategory: (
@@ -653,8 +674,20 @@ export interface EditableParse {
    *  behind the caller's confirmation dialog. */
   deleteSkillCategory: (cats: readonly SkillCategory[], index: number) => void;
   /** Append a new empty category with `label`; populate via
-   *  {@link addSkillToCategory}. */
-  addSkillCategory: (cats: readonly SkillCategory[], label: string) => void;
+   *  {@link addSkillToCategory}. `skills` is the current rendered flat list, and
+   *  {@link SkillsOverride.ungrouped} is recomputed from it on EVERY call — the
+   *  skills no category claims (#791: creating the FIRST category on an
+   *  uncategorised résumé must not sweep the existing skills into it, so they
+   *  need a home to stay visible in). Recomputing rather than seeding once is
+   *  what keeps a flat add/remove made while the section was uncategorised: the
+   *  rendered list already includes it, and the flat `removed`/`added` are
+   *  cleared as it folds in. On an already-categorised résumé the recompute
+   *  reproduces the existing pool exactly. */
+  addSkillCategory: (
+    cats: readonly SkillCategory[],
+    skills: readonly string[],
+    label: string,
+  ) => void;
   /** Add a (canonicalized) skill into the category at `index`. No-op for blank
    *  input or a dupe of any already-present skill. */
   addSkillToCategory: (
@@ -663,7 +696,9 @@ export interface EditableParse {
     skill: string,
   ) => void;
   /** Move a skill (by display text) into the category at `destIndex` — one
-   *  atomic op. The DnD drop and the keyboard "Move to" control both call this. */
+   *  atomic op. The DnD drop and the keyboard "Move to" control both call this,
+   *  for a chip in a category row OR the trailing ungrouped row (#791): moving
+   *  an ungrouped skill in also drops it from {@link SkillsOverride.ungrouped}. */
   moveSkillToCategory: (
     cats: readonly SkillCategory[],
     skill: string,
@@ -671,7 +706,8 @@ export interface EditableParse {
   ) => void;
   /** Remove a single skill from the categorised grouping — the categorised
    *  delete-single-skill path (the source category stays present even if now
-   *  empty). */
+   *  empty). Also the ungrouped row's Remove (#791): a skill found in neither
+   *  `cats` nor `ungrouped` is simply not there, so this is safe either way. */
   removeCategorySkill: (cats: readonly SkillCategory[], skill: string) => void;
   /** The complete override state as a JSON-safe value (#456) — the one shape
    *  every consumer that must carry edits across a boundary uses (draft
@@ -938,11 +974,37 @@ export function useEditableParse(): EditableParse {
     setSummaryOverride(value);
   }, []);
 
+  // Both flat setters are CATEGORISATION-AWARE (#791). While a non-empty
+  // grouping snapshot exists, `categories` + `ungrouped` are the authoritative
+  // flat list and `computeEditedSkills` REJECTS a populated `removed`/`added`
+  // beside them — it throws in DEV (from a render-phase memo, so an
+  // ErrorBoundary crash of the editor) and drops the edit silently in prod. So
+  // the flat write routes into `ungrouped`/`categories` instead of emitting the
+  // flat halves. Closing the door here rather than at each call site is what
+  // makes it hold for writers that never see the grouping: `SkillTermGuidance`'s
+  // "add this missing term" pill calls `addSkill` directly, and "+ Add category"
+  // is reachable on EVERY résumé since #791, so the two compose in two clicks.
+  // `categories: []` (degraded to uncategorised) is deliberately NOT this case —
+  // the flat AddSkillInput is the live editor there, and `computeEditedSkills`
+  // composes the flat halves on top of `ungrouped`.
+
   const addSkill = useCallback((skill: string) => {
     const canonical = canonicalizeSkill(skill);
     if (!canonical) return;
     const key = canonical.toLowerCase();
     setSkillsOverride((prev) => {
+      if (prev.categories && prev.categories.length > 0) {
+        // Dedup lives in the transform, so the no-op rules match the categorised
+        // add-input's exactly (blank / already grouped / already ungrouped).
+        return {
+          ...prev,
+          ungrouped: addUngroupedSkill(
+            prev.categories,
+            prev.ungrouped ?? [],
+            canonical,
+          ),
+        };
+      }
       // Re-adding a previously-removed skill simply un-removes it.
       const removed = prev.removed.filter((r) => r !== key);
       // Don't duplicate an already-added skill (case-insensitive).
@@ -960,6 +1022,17 @@ export function useEditableParse(): EditableParse {
     const key = skill.trim().toLowerCase();
     if (!key) return;
     setSkillsOverride((prev) => {
+      if (prev.categories && prev.categories.length > 0) {
+        // A flat remove must reach a GROUPED skill too — the caller doesn't know
+        // which half holds it — so this runs both transforms, exactly as
+        // `removeCategorySkill` does. The source category stays present even if
+        // it is now empty (empty-but-present).
+        return {
+          ...prev,
+          categories: removeSkillFromCategories(prev.categories, key),
+          ungrouped: removeUngroupedSkill(prev.ungrouped, key),
+        };
+      }
       // Drop from `added` if it was a user-added skill...
       const added = prev.added.filter((a) => a.toLowerCase() !== key);
       // ...and record the key in `removed` so a parsed skill of the same name is
@@ -981,6 +1054,19 @@ export function useEditableParse(): EditableParse {
     setSkillsOverride((prev) => ({ ...prev, categories: next }));
   }, []);
 
+  /** Restore BOTH halves of an edited grouping from a snapshot (#791) — the
+   *  categories and the ungrouped remainder they don't cover. Only the replay
+   *  path uses this; live edits go through the individual ops, which keep the
+   *  two in lockstep themselves. Separate from {@link setSkillCategories}
+   *  because that one deliberately leaves `ungrouped` alone: a rename or a
+   *  category delete must not disturb the remainder. */
+  const restoreSkillsGrouping = useCallback(
+    (categories: SkillCategory[], ungrouped: string[] | undefined) => {
+      setSkillsOverride((prev) => ({ ...prev, categories, ungrouped }));
+    },
+    [],
+  );
+
   const renameSkillCategory = useCallback(
     (cats: readonly SkillCategory[], index: number, label: string) => {
       setSkillCategories(renameSkillCategoryTx(cats, index, label));
@@ -996,31 +1082,69 @@ export function useEditableParse(): EditableParse {
   );
 
   const addSkillCategory = useCallback(
-    (cats: readonly SkillCategory[], label: string) => {
-      setSkillCategories(addSkillCategoryTx(cats, label));
+    (cats: readonly SkillCategory[], skills: readonly string[], label: string) => {
+      setSkillsOverride((prev) => ({
+        ...prev,
+        // `skills` is the CURRENT rendered flat list, i.e. already post-flat-edit,
+        // so recomputing the pool from it both seeds the first category and folds
+        // in any flat add/remove made while the section was uncategorised. The
+        // flat halves must then be cleared: a non-empty `categories` alongside a
+        // populated `removed`/`added` is what computeEditedSkills rejects, and
+        // its categorised branch ignores them anyway — leaving them would throw
+        // in DEV and silently drop the edit in prod (#791).
+        removed: [],
+        added: [],
+        categories: addSkillCategoryTx(cats, label),
+        ungrouped: skills.filter((s) => !skillPresentInCategories(cats, s)),
+      }));
     },
-    [setSkillCategories],
+    [],
   );
 
   const addSkillToCategory = useCallback(
     (cats: readonly SkillCategory[], index: number, skill: string) => {
-      setSkillCategories(addSkillToCategoryTx(cats, index, skill));
+      const canonical = canonicalizeSkill(skill);
+      setSkillsOverride((prev) => {
+        const categories = addSkillToCategoryTx(cats, index, skill);
+        if (!canonical) return { ...prev, categories };
+        // Typing an already-ungrouped skill's exact name here (instead of using
+        // "Move to") must not leave a stale copy in the pool — a later category
+        // delete must not resurrect it (#791, mirrors moveSkillToCategory).
+        return {
+          ...prev,
+          categories,
+          ungrouped: removeUngroupedSkill(prev.ungrouped, canonical),
+        };
+      });
     },
-    [setSkillCategories],
+    [],
   );
 
   const moveSkillToCategory = useCallback(
     (cats: readonly SkillCategory[], skill: string, destIndex: number) => {
-      setSkillCategories(moveSkillBetweenCategories(cats, skill, destIndex));
+      setSkillsOverride((prev) => ({
+        ...prev,
+        categories: moveSkillBetweenCategories(cats, skill, destIndex),
+        // Claimed by a category now — drop it from the ungrouped pool if that's
+        // where it came from (a no-op otherwise, e.g. moving between two
+        // categories never touches this).
+        ungrouped: removeUngroupedSkill(prev.ungrouped, skill),
+      }));
     },
-    [setSkillCategories],
+    [],
   );
 
   const removeCategorySkill = useCallback(
     (cats: readonly SkillCategory[], skill: string) => {
-      setSkillCategories(removeSkillFromCategories(cats, skill));
+      setSkillsOverride((prev) => ({
+        ...prev,
+        // No-op if `skill` isn't in any category — true for the ungrouped row's
+        // Remove button (#791), which this same callback serves.
+        categories: removeSkillFromCategories(cats, skill),
+        ungrouped: removeUngroupedSkill(prev.ungrouped, skill),
+      }));
     },
-    [setSkillCategories],
+    [],
   );
 
   const addEntry = useCallback((section: AddableSection) => {
@@ -1305,7 +1429,12 @@ export function useEditableParse(): EditableParse {
       // restores it — no per-op id remapping (the snapshot carries no ids). The
       // flat add/remove replay as before, for uncategorised résumés.
       const so = snap.skillsOverride;
-      if (so.categories) setSkillCategories(so.categories);
+      // `ungrouped` restores WITH `categories`, never separately (#791): it is
+      // the half of the grouping no category claims, and `computeEditedSkills`
+      // reads a missing one as "no remainder". Restoring the snapshot without it
+      // would silently drop every ungrouped skill on replay — the same data loss
+      // #791 exists to prevent, just moved onto the restore path.
+      if (so.categories) restoreSkillsGrouping(so.categories, so.ungrouped);
       so.added.forEach((skill) => addSkill(skill));
       so.removed.forEach((skill) => removeSkill(skill));
 
@@ -1352,7 +1481,7 @@ export function useEditableParse(): EditableParse {
       setAchievementField,
       addSkill,
       removeSkill,
-      setSkillCategories,
+      restoreSkillsGrouping,
       setSummaryField,
       addEntry,
       setEntryField,
@@ -1437,7 +1566,6 @@ export function useEditableParse(): EditableParse {
     skillsOverride,
     addSkill,
     removeSkill,
-    skillCategoriesOverride: skillsOverride.categories,
     renameSkillCategory,
     deleteSkillCategory,
     addSkillCategory,

--- a/src/lib/edit/skills-categories.test.ts
+++ b/src/lib/edit/skills-categories.test.ts
@@ -13,11 +13,13 @@ import { describe, it, expect } from "vitest";
 import {
   addCategory,
   addSkillToCategory,
+  addUngroupedSkill,
   computeEditedSkills,
   deleteCategory,
   isEmptySkillsOverride,
   moveSkillBetweenCategories,
   removeSkillFromCategories,
+  removeUngroupedSkill,
   renameCategory,
 } from "./skills-categories.ts";
 import type { SkillCategory } from "../heuristics/types.ts";
@@ -165,6 +167,47 @@ describe("delete a single skill (categorised)", () => {
   });
 });
 
+describe("ungrouped-remainder transforms — what makes the flat setters safe (#791)", () => {
+  const pool = ["Excel", "Figma"];
+
+  it("appends a canonicalized skill to the remainder", () => {
+    expect(addUngroupedSkill(cats(), pool, "js")).toEqual([
+      "Excel",
+      "Figma",
+      "JavaScript",
+    ]);
+    // Pure — the input array is not mutated.
+    expect(pool).toEqual(["Excel", "Figma"]);
+  });
+
+  it("no-ops on blank input", () => {
+    expect(addUngroupedSkill(cats(), pool, "   ")).toEqual(pool);
+    expect(addUngroupedSkill(cats(), pool, "")).toEqual(pool);
+  });
+
+  it("no-ops on a dupe of an already-ungrouped skill (case-insensitive)", () => {
+    expect(addUngroupedSkill(cats(), pool, "excel")).toEqual(pool);
+  });
+
+  it("no-ops on a skill a CATEGORY already holds — never a doubled chip", () => {
+    // Same uniqueness rule as addSkillToCategory, so the flat and the
+    // categorised add-input agree about what a duplicate is.
+    expect(addUngroupedSkill(cats(), pool, "redis")).toEqual(pool);
+    expect(addSkillToCategory(cats(), 1, "redis")).toEqual(cats());
+  });
+
+  it("removes case-insensitively, tolerating whitespace and a missing pool", () => {
+    expect(removeUngroupedSkill(pool, " excel ")).toEqual(["Figma"]);
+    expect(removeUngroupedSkill(pool, "Rust")).toEqual(pool);
+    expect(removeUngroupedSkill(undefined, "Excel")).toEqual([]);
+  });
+
+  it("a flat add + remove pair round-trips the remainder", () => {
+    const added = addUngroupedSkill(cats(), pool, "Rust");
+    expect(removeUngroupedSkill(added, "rust")).toEqual(pool);
+  });
+});
+
 describe("all-deleted snapshot composes flat edits on an EMPTY base (#415)", () => {
   // Pristine categorised résumé (the flat list is the flattening of the groups).
   const pristine = {
@@ -268,5 +311,66 @@ describe("non-empty snapshot + flat edits (unreachable-by-design guard)", () => 
     });
     expect(result.skills).toEqual(["Rust"]);
     expect(result.skillCategories).toBeUndefined();
+  });
+});
+
+describe("ungrouped remainder (#791)", () => {
+  const parsed = { skills: [] as string[] }; // categorised branch ignores `parsed`.
+  const leadership = (): SkillCategory[] => [{ label: "Leadership", skills: [] }];
+
+  it("a non-empty category snapshot is unioned with `ungrouped`, not replaced by it", () => {
+    const result = computeEditedSkills(parsed, {
+      removed: [],
+      added: [],
+      categories: leadership(),
+      ungrouped: ["Excel", "PowerPoint"],
+    });
+    expect(result.skillCategories).toEqual(leadership());
+    expect(result.skills).toEqual(["Excel", "PowerPoint"]);
+  });
+
+  it("grouped members and the ungrouped remainder both appear, grouped first", () => {
+    const grouped = [{ label: "Backend", skills: ["Java", "Python"] }];
+    const result = computeEditedSkills(parsed, {
+      removed: [],
+      added: [],
+      categories: grouped,
+      ungrouped: ["Excel"],
+    });
+    expect(result.skills).toEqual(["Java", "Python", "Excel"]);
+  });
+
+  it("an absent `ungrouped` behaves exactly like an empty one (pre-#791 callers unaffected)", () => {
+    const result = computeEditedSkills(parsed, {
+      removed: [],
+      added: [],
+      categories: cats(),
+    });
+    expect(result.skills).toEqual(cats().flatMap((c) => c.skills));
+  });
+
+  it("degrading to uncategorised (last category deleted) keeps the ungrouped remainder, not just flat edits", () => {
+    const result = computeEditedSkills(parsed, {
+      removed: [],
+      added: [],
+      categories: [],
+      ungrouped: ["Excel", "PowerPoint"],
+    });
+    expect(result.skills).toEqual(["Excel", "PowerPoint"]);
+    expect(result.skillCategories).toBeUndefined();
+  });
+});
+
+describe("moveSkillBetweenCategories — a skill not yet in any category (#791)", () => {
+  it("claims it into the destination instead of no-op'ing", () => {
+    const result = moveSkillBetweenCategories(cats(), "Excel", 1);
+    expect(result[1].skills).toContain("Excel");
+    // The categories the skill WASN'T already in are untouched.
+    expect(result[0].skills).toEqual(cats()[0].skills);
+  });
+
+  it("still respects an out-of-range destination (existing contract)", () => {
+    const result = moveSkillBetweenCategories(cats(), "Excel", 99);
+    expect(result).toEqual(cats());
   });
 });

--- a/src/lib/edit/skills-categories.ts
+++ b/src/lib/edit/skills-categories.ts
@@ -18,11 +18,21 @@
  * {@link moveSkillBetweenCategories} on the current snapshot, so there is one
  * mutation code path with two ways to invoke it.
  *
- * The load-bearing invariant (from #473, and the whole point of doing this in one
- * place): the flat `skills` array ALWAYS deep-equals
- * `skillCategories.flatMap((c) => c.skills)` — because {@link computeEditedSkills}
- * DERIVES the flat list from the snapshot by flattening, never maintaining the two
- * independently.
+ * The load-bearing invariant through #790 was that the flat `skills` array
+ * ALWAYS deep-equals `skillCategories.flatMap((c) => c.skills)`. #791 breaks
+ * that on purpose: creating the FIRST category on an uncategorised résumé must
+ * not sweep the existing skills into it or invent a synthetic bucket for them
+ * (the #791 stated decision), so the grouping can legitimately cover only a
+ * SUBSET of the flat list. The invariant becomes `skills ⊇ flatMap(categories)`;
+ * {@link SkillsOverride.ungrouped} carries the remainder — whatever `categories`
+ * doesn't (yet) claim — as its own tracked set, seeded once (by the caller, when
+ * the first category is created) and updated in lockstep by every op that moves
+ * a skill in or out of the grouping — including the FLAT add/remove setters,
+ * which route through `addUngroupedSkill`/`removeUngroupedSkill` rather than
+ * emit `removed`/`added` while a category exists. It can't be re-derived by diffing the
+ * pristine parse against the current `categories` on every call: that can't tell
+ * "never grouped" (stays ungrouped) apart from "grouped, then its category was
+ * deleted" (gone for good) — see {@link computeEditedSkills}.
  *
  * Empty-category policy (the #476 stated decision): emptying a category (deleting
  * its last chip, or moving its last member out) leaves an EMPTY-BUT-PRESENT
@@ -52,8 +62,12 @@ export function isEmptySkillsOverride(o: SkillsOverride): boolean {
   );
 }
 
-/** True when any category in `cats` already holds `skill` (case-insensitive). */
-function presentAnywhere(cats: readonly SkillCategory[], skill: string): boolean {
+/** True when any category in `cats` already holds `skill` (case-insensitive).
+ *  Exported for {@link useEditableParse}'s one-time ungrouped seed (#791). */
+export function presentAnywhere(
+  cats: readonly SkillCategory[],
+  skill: string,
+): boolean {
   const lc = skill.toLowerCase();
   return cats.some((c) => c.skills.some((s) => s.toLowerCase() === lc));
 }
@@ -116,8 +130,15 @@ export function addSkillToCategory(
  * Move `skill` (matched case-insensitively) into the category at `destIndex` —
  * one atomic op. It leaves whatever category currently holds it (which may empty
  * that category — empty-but-present) and joins the destination; a no-op when it
- * is already in the destination or when either endpoint can't be resolved. The
+ * is already in the destination or when the destination can't be resolved. The
  * flat SET is unchanged; only the grouping (and possibly the flat order) moves.
+ *
+ * `skill` not being found in ANY category is not an error (#791): it means the
+ * skill is currently in the UNGROUPED remainder rather than another category —
+ * the trailing chip row's "Move to" also calls this. There is nowhere to splice
+ * it out of, so it's simply added at the destination; the caller (`useEditableParse`)
+ * is responsible for dropping it from {@link SkillsOverride.ungrouped} so it isn't
+ * carried in both places.
  */
 export function moveSkillBetweenCategories(
   cats: readonly SkillCategory[],
@@ -136,7 +157,7 @@ export function moveSkillBetweenCategories(
     next[i].skills.splice(at, 1);
     break;
   }
-  if (display === undefined) return next;
+  display ??= skill; // not in any category — an ungrouped skill moving in.
   const dest = next[destIndex];
   if (!dest.skills.some((s) => s.toLowerCase() === lc)) dest.skills.push(display);
   return next;
@@ -154,6 +175,45 @@ export function removeSkillFromCategories(
     ...c,
     skills: c.skills.filter((s) => s.toLowerCase() !== lc),
   }));
+}
+
+// ── Ungrouped-remainder transforms (#791) ─────────────────────────────────────
+//
+// The remainder is the OTHER half of the grouping, so it gets the same treatment
+// as `categories`: pure array→array transforms here, not set logic inlined in the
+// hook. These two are what make the FLAT setters (`addSkill`/`removeSkill`)
+// categorisation-aware — with a non-empty snapshot the flat `removed`/`added`
+// are unusable (`computeEditedSkills` rejects them), so a flat write has to land
+// in the grouping instead.
+
+/** Add a (canonicalized) skill to the ungrouped remainder — the flat "add skill"
+ *  path on a résumé that already has a category. No-op for blank input, for a
+ *  dupe of an already-ungrouped skill, or for one a category already holds, all
+ *  case-insensitively: the same uniqueness {@link addSkillToCategory} enforces,
+ *  so the two entry points can't produce a doubled chip between them. */
+export function addUngroupedSkill(
+  cats: readonly SkillCategory[],
+  ungrouped: readonly string[],
+  skill: string,
+): string[] {
+  const next = [...ungrouped];
+  const canonical = canonicalizeSkill(skill);
+  if (!canonical || presentAnywhere(cats, canonical)) return next;
+  const lc = canonical.toLowerCase();
+  if (next.some((s) => s.toLowerCase() === lc)) return next;
+  next.push(canonical);
+  return next;
+}
+
+/** Drop `skill` (case-insensitive) from the ungrouped remainder — the sibling of
+ *  {@link removeSkillFromCategories}. A delete runs BOTH: a skill is in
+ *  `categories` XOR `ungrouped`, and no caller knows which without looking. */
+export function removeUngroupedSkill(
+  ungrouped: readonly string[] | undefined,
+  skill: string,
+): string[] {
+  const lc = skill.trim().toLowerCase();
+  return (ungrouped ?? []).filter((s) => s.toLowerCase() !== lc);
 }
 
 // ── Reducer (override → edited skills) ────────────────────────────────────────
@@ -199,17 +259,28 @@ function applyFlatEdits(
  * Apply a {@link SkillsOverride} to a parsed résumé's skills.
  *
  * When a category SNAPSHOT is present, it IS the edited grouping: the flat list
- * is its flattening, so the #473 invariant holds by construction.
+ * is `categories` flattened, UNION {@link SkillsOverride.ungrouped} — the skills
+ * that exist but aren't (yet) claimed by any category (#791). `ungrouped` is
+ * trusted as given rather than re-derived from the pristine parse on every call:
+ * `parsed.skills` minus `flatMap(categories)` is AMBIGUOUS on its own — it can't
+ * tell a skill that was never grouped (must stay visible) apart from one whose
+ * category was just deleted (must stay gone, per the delete confirmation's own
+ * promise). Only the caller (`useEditableParse`), which sees each op as it
+ * happens, can keep that distinction; this function just trusts the set it's
+ * handed.
  *
  * An all-deleted snapshot (`categories: []`) degrades the section to
- * uncategorised — `SkillsSection` then renders the flat `AddSkillInput` wired to
- * the flat `addSkill`/`removeSkill` setters. Those flat edits are composed ON TOP
- * of the emptied snapshot (an EMPTY base), NOT re-derived from the pristine parse:
- * re-deriving from `parsed.skills` would resurrect every skill the user just
- * deleted (#415). `categories: []` (present, empty — distinct from absent) is what
- * keeps this branch selected over the pristine flat branch below; the flat setters
- * therefore MUST preserve the `[]` snapshot through subsequent adds/removes so the
- * override never falls back into the pristine branch.
+ * uncategorised — `SkillsSection` then renders the flat `AddSkillInput`, and the
+ * flat `addSkill`/`removeSkill` setters emit `added`/`removed` again (they route
+ * into the grouping only while a NON-EMPTY snapshot exists, and `[]` is empty by
+ * definition — the distinction is load-bearing). Those flat edits are composed ON TOP
+ * of `ungrouped` (whatever survived the degrade), NOT re-derived from the
+ * pristine parse: re-deriving from `parsed.skills` would resurrect every skill a
+ * deleted category took with it (#415/#791). `categories: []` (present, empty —
+ * distinct from absent) is what keeps this branch selected over the pristine flat
+ * branch below; the flat setters therefore MUST preserve the `[]` snapshot (and
+ * `ungrouped`) through subsequent adds/removes so the override never falls back
+ * into the pristine branch.
  *
  * With no snapshot (`categories` ABSENT), the résumé is either uncategorised or
  * categorised-untouched: apply the flat `removed` / `added` to the pristine parse
@@ -226,25 +297,40 @@ export function computeEditedSkills(
 ): SkillsResult {
   if (override.categories) {
     const cats = override.categories;
-    // Degraded-to-uncategorised: flat edits accumulate on the emptied snapshot.
-    if (cats.length === 0) return { skills: applyFlatEdits([], override) };
-    // A non-empty snapshot is authoritative: the flat list is DERIVED from it, so
-    // honouring `removed`/`added` here would break the load-bearing invariant
-    // `skills === flatMap(categories)`. The editor never emits flat edits while a
-    // category survives (every categorised edit is snapshotted; the flat
-    // AddSkillInput renders only once the section has degraded to uncategorised),
-    // so those fields are structurally empty on this branch. Assert it in dev
-    // rather than silently drop a flat edit a future caller might wrongly attach.
+    const ungrouped = override.ungrouped ?? [];
+    // Degraded-to-uncategorised: flat edits accumulate on the ungrouped
+    // remainder, never the pristine parse (#415/#791).
+    if (cats.length === 0) return { skills: applyFlatEdits(ungrouped, override) };
+    // A non-empty snapshot's grouped members plus the tracked ungrouped
+    // remainder are authoritative. Honouring `removed`/`added` here too would
+    // let a flat edit drift the flat list out from under BOTH of those, so they
+    // stay structurally empty on this branch: every categorised edit (including
+    // one on an ungrouped skill) instead goes through `categories`/`ungrouped`.
+    // That is enforced in the SETTERS — `useEditableParse`'s flat
+    // `addSkill`/`removeSkill` route into `ungrouped`/`categories` whenever a
+    // non-empty snapshot exists — not by the flat AddSkillInput being unrendered,
+    // which never covered non-UI writers (`SkillTermGuidance` writes through the
+    // flat `addSkill`). Assert it in dev rather than silently drop a flat edit a
+    // future caller might wrongly attach.
     if (
       import.meta.env?.DEV &&
       (override.removed.length > 0 || override.added.length > 0)
     ) {
       throw new Error(
         "computeEditedSkills: flat removed/added with a non-empty category " +
-          "snapshot — unreachable by design (would violate skills === flatMap(categories))",
+          "snapshot — unreachable by design (would violate skills ⊇ flatMap(categories))",
       );
     }
-    return { skills: cats.flatMap((c) => c.skills), skillCategories: cats };
+    // Reuse applyFlatEdits as a dedup'ing union: `ungrouped` never overlaps a
+    // grouped member by construction (every op that grants one to a category
+    // also drops it from `ungrouped`), so this is a plain concat in practice.
+    return {
+      skills: applyFlatEdits(cats.flatMap((c) => c.skills), {
+        removed: [],
+        added: ungrouped,
+      }),
+      skillCategories: cats,
+    };
   }
 
   const kept = applyFlatEdits(parsed.skills, override);

--- a/src/lib/heuristics/types.ts
+++ b/src/lib/heuristics/types.ts
@@ -137,13 +137,29 @@ export type HeuristicParsedResume = Partial<ParsedResume> & {
   skills: string[];
   /**
    * Structured view of a CATEGORISED Skills section (#473) — additive over the
-   * flat `skills`. Two invariants hold whenever this is present:
+   * flat `skills`. Two invariants hold whenever this is present AT PARSE TIME:
    *   1. `skills` deep-equals `skillCategories.flatMap((c) => c.skills)` — the
    *      flat list is the union of the categories' members, in document order.
    *   2. Present ONLY when the section was actually categorised. A plain comma
    *      list has no categories: the field is ABSENT (undefined), never `[]`,
    *      never a synthetic `{ label: "", skills: [...] }` bucket. Absent means
    *      "the résumé did not say", not "there are no categories".
+   *
+   * Invariant 1 is a PARSE-TIME guarantee only (#791) — the EDIT lane may
+   * legitimately violate it. Creating the first category on a résumé that
+   * wasn't already categorised must not sweep the existing skills into it (nor
+   * invent a synthetic "Other" bucket for them), so `skills` can exceed
+   * `skillCategories.flatMap(...)` once a user has edited the grouping; the
+   * remainder is "ungrouped" — present in the flat list but claimed by no
+   * category. `partitionSkillCategories` (`ReconstructedSkills.tsx`) and the
+   * exported-PDF skills projection (`ats-resume-model.ts`) are the two
+   * consumers that compute and render/emit that remainder. Both subtract the
+   * categories' members from the flat list, but they match differently — the
+   * editor by exact string, the projection case-insensitively. That cannot
+   * diverge today because the edit lane only ever puts a string INTO a category
+   * that it took from the flat list (or added to both), so the two sides are
+   * the same string and agree under either match. See `skills-categories.ts`
+   * for how the edit lane tracks it.
    */
   skillCategories?: SkillCategory[];
   experience: ResumeExperience[];

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -608,4 +608,51 @@ describe("buildAtsResumeModel", () => {
     const skills = model.sections.find((s) => s.heading === "Skills")!;
     expect(skills.entries.map((e) => e.fields?.skillCategory)).toEqual(["Backend"]);
   });
+
+  // ── Ungrouped remainder (#791) ───────────────────────────────────────────────
+  // `skillCategories` may cover only a SUBSET of the flat `skills` list once a
+  // user has created the first category on a résumé that wasn't already fully
+  // grouped — see the `types.ts` docblock and `skills-categories.ts`.
+
+  it("appends the remainder as one trailing, uncategorised entry after the categories", () => {
+    const result = makeResult({
+      skills: ["PostgreSQL", "Redis", "Excel", "PowerPoint"],
+      skillCategories: [{ label: "Data Stores", skills: ["PostgreSQL", "Redis"] }],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const skills = model.sections.find((s) => s.heading === "Skills")!;
+    expect(skills.entries).toHaveLength(2); // 1 category + 1 trailing remainder.
+    expect(skills.entries[0].fields?.skillCategory).toBe("Data Stores");
+    expect(skills.entries[1].fields?.skillCategory).toBeUndefined();
+    expect(skills.entries[1].headerLine).toBe("Excel · PowerPoint");
+    // The union across every entry equals the flat list — nothing lost or
+    // duplicated.
+    const exported = skills.entries.flatMap((e) => e.fields?.skills ?? []);
+    expect(new Set(exported)).toEqual(new Set(result.canonical.fields.skills));
+  });
+
+  it("a category snapshot with no remainder is unchanged — no trailing entry (byte-identical, #791 AC)", () => {
+    const result = makeResult({
+      skills: ["PostgreSQL", "Redis", "Java"],
+      skillCategories: [
+        { label: "Data Stores", skills: ["PostgreSQL", "Redis"] },
+        { label: "Backend", skills: ["Java"] },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const skills = model.sections.find((s) => s.heading === "Skills")!;
+    expect(skills.entries).toHaveLength(2);
+    expect(skills.entries.every((e) => e.fields?.skillCategory !== undefined)).toBe(
+      true,
+    );
+  });
+
+  it("a fully uncategorised résumé still exports the single flat entry (byte-identical, #791 AC)", () => {
+    const result = makeResult({ skills: ["React", "TypeScript", "Node.js"] });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const skills = model.sections.find((s) => s.heading === "Skills")!;
+    expect(skills.entries).toHaveLength(1);
+    expect(skills.entries[0].headerLine).toBe("React · TypeScript · Node.js");
+    expect(skills.entries[0].fields?.skillCategory).toBeUndefined();
+  });
 });

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -813,34 +813,49 @@ export function buildAtsResumeModel(
   // as before (byte-identical). Both read as regular-weight body text (#425) and
   // keep segments atomic so a multi-word skill never wraps mid-name (#301).
   // Drop empty categories (an editor "empty-but-present" state, #476) so the PDF
-  // never renders a dangling "Label:" with nothing after it; the flat list is
-  // already the flatten of the non-empty ones, so this stays invariant-safe.
+  // never renders a dangling "Label:" with nothing after it.
+  //
+  // #791: `skillCategories` may now cover only a SUBSET of the flat `skills`
+  // list — creating the first category on an uncategorised résumé leaves the
+  // rest ungrouped rather than sweeping them in (see `skills-categories.ts`).
+  // The flat list is no longer guaranteed to be the flatten of the non-empty
+  // categories, so the remainder is computed the same way the editor's trailing
+  // chip row does (`partitionSkillCategories` in `ReconstructedSkills.tsx`) and
+  // appended as one more entry, with no `skillCategory` field — the same shape
+  // the fully-uncategorised branch already produces below, so it reads (and
+  // re-parses) as a plain flat skills line. A fully categorised parse still has
+  // no remainder (invariant #1 in `types.ts` still holds AT PARSE TIME), so this
+  // is a no-op there — byte-identical to before.
   const skillCategories = parsed.skillCategories?.filter(
     (c) => c.skills.length > 0,
   );
-  const skillsEntries: AtsEntry[] =
-    skillCategories && skillCategories.length > 0
-      ? skillCategories.map((c) => ({
-          headerLine: `${c.label}: ${c.skills.join(" · ")}`,
-          bullets: [],
-          atomicSegments: true,
-          headerBold: false,
-          fields: { skills: [...c.skills], skillCategory: c.label },
-        }))
-      : skills.length > 0
-        ? [
-            {
-              headerLine: skills.join(" · "),
-              bullets: [],
-              atomicSegments: true,
-              // Skills read as regular-weight body text, not a bold header (#425).
-              headerBold: false,
-              // The flat skill list, carried structurally so the JSON export
-              // (#334) maps `skills[] ← { name }` without re-splitting the header.
-              fields: { skills: [...skills] },
-            },
-          ]
-        : [];
+  const flatSkillsEntry = (members: string[]): AtsEntry => ({
+    headerLine: members.join(" · "),
+    bullets: [],
+    atomicSegments: true,
+    // Skills read as regular-weight body text, not a bold header (#425).
+    headerBold: false,
+    // The flat skill list, carried structurally so the JSON export (#334) maps
+    // `skills[] ← { name }` without re-splitting the header.
+    fields: { skills: [...members] },
+  });
+  let skillsEntries: AtsEntry[];
+  if (skillCategories && skillCategories.length > 0) {
+    skillsEntries = skillCategories.map((c) => ({
+      headerLine: `${c.label}: ${c.skills.join(" · ")}`,
+      bullets: [],
+      atomicSegments: true,
+      headerBold: false,
+      fields: { skills: [...c.skills], skillCategory: c.label },
+    }));
+    const grouped = new Set(
+      skillCategories.flatMap((c) => c.skills.map((s) => s.toLowerCase())),
+    );
+    const ungrouped = skills.filter((s) => !grouped.has(s.toLowerCase()));
+    if (ungrouped.length > 0) skillsEntries.push(flatSkillsEntry(ungrouped));
+  } else {
+    skillsEntries = skills.length > 0 ? [flatSkillsEntry(skills)] : [];
+  }
 
   const achievementsAbove =
     parsed.achievements_placement === "above_experience";

--- a/src/lib/pdf/skills-wrap-roundtrip.test.ts
+++ b/src/lib/pdf/skills-wrap-roundtrip.test.ts
@@ -123,6 +123,56 @@ describe("#301 — multi-word skill does not split at the line-wrap boundary", (
 });
 
 /**
+ * Round-trip regression for #791 — a category that covers only a SUBSET of the
+ * flat skills list (the ungrouped remainder created by the first-category
+ * reachability fix) must not drop the remainder on export. Reuses the same
+ * fixture-read + override technique as the #301 block above: no new PDF.
+ */
+describe("#791 — a categorised-plus-ungrouped skills list survives export and re-parse", () => {
+  const CATEGORIES = [
+    { label: "Data Stores", skills: ["PostgreSQL", "Redis"] },
+    { label: "Backend", skills: ["Java", "Golang"] },
+  ];
+  const UNGROUPED = ["Excel", "PowerPoint", "Tableau"];
+  const ALL_SKILLS = [...CATEGORIES.flatMap((c) => c.skills), ...UNGROUPED];
+
+  let reparsedSkills: string[];
+
+  beforeAll(async () => {
+    const original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const withMixedSkills: CascadeResult = {
+      ...original,
+      canonical: {
+        ...original.canonical,
+        fields: {
+          ...original.canonical.fields,
+          skills: ALL_SKILLS,
+          skillCategories: CATEGORIES,
+        },
+      },
+    };
+    const model = buildAtsResumeModel(
+      withMixedSkills,
+      scoreFor(withMixedSkills),
+    );
+    const bytes = await renderAtsResumePdf(model);
+    const reparsed = await runCascade(bytes);
+    reparsedSkills = reparsed.canonical.fields.skills ?? [];
+  }, 20000);
+
+  it("round-trips every skill — categorised AND ungrouped alike", () => {
+    const reparsedSet = new Set(reparsedSkills);
+    for (const skill of ALL_SKILLS) {
+      expect(reparsedSet.has(skill)).toBe(true);
+    }
+  });
+
+  it("loses none to the categorised branch's grouping logic (exact count)", () => {
+    expect(reparsedSkills.length).toBe(ALL_SKILLS.length);
+  });
+});
+
+/**
  * Regression for the `wrapSegmentsToLines` first-segment bug: `segments[0]`
  * used to be assigned to `current` before the loop and never measured, so an
  * overlong FIRST segment (a "Company · Location" org line whose company name


### PR DESCRIPTION
Layer 02 of 3. Depends on the layer-01 PR — review this against that branch, not against `main`.

## What shipped

`#476` built rename / delete / add / move for skill categories. All of it was unreachable on a résumé whose Skills section is a plain comma list — the common case — because `+ Add category` rendered only when categories already existed. `AddCategoryInput` now renders in both arms, so the first category can be created.

**The exported PDF no longer drops ungrouped skills.** `buildAtsResumeModel` treated "has categories" and "has a flat list" as mutually exclusive, which held only while `skills === skillCategories.flatMap(...)` was guaranteed. The moment a user creates the first category on a flat résumé that stops being true. The categorised branch now appends a trailing uncategorised entry for the remainder.

**Design decision, stated in code per #476:** creating the first category leaves existing skills ungrouped. The new category is born empty and the user moves skills in with the controls #476 built. No sweeping, no synthetic `Other` bucket that would then appear verbatim in the exported PDF.

## The issue's root-cause analysis was wrong, and this PR is bigger because of it

#791 asserted *"Nothing below the UI is missing… This is a reachability gap, not a missing capability."* That is not correct, and building only what it described would have shipped a worse bug than the one being fixed.

`computeEditedSkills` **derives** the flat `skills` list from `categories.flatMap(...)` whenever a category snapshot is present. So creating the first category on a flat 26-skill résumé would set the snapshot to `[{Leadership, []}]` and collapse `skills` to `[]` — every skill gone from **edit state**, not merely from the export.

The fix is a tracked `ungrouped` set on `SkillsOverride`: the half of the grouping no category claims. It is recomputed from the rendered skills list whenever a category is created, and every op that moves a skill into a category drops it from the pool, so a skill is in `categories` XOR `ungrouped` — never both, never neither while it still exists. `deleteSkillCategory` deliberately does **not** return its members to the pool; deleting a category destroys them, as its confirm dialog promises (#415).

`types.ts`'s `skillCategories` docblock now states that invariant 1 is a **parse-time** guarantee only, since the edit lane may legitimately violate it.

## Verification

- Scoped suites (`useEditableParse`, `skills-categories`, `ReconstructedSkills`, `ats-resume-model`) — 104 passed.
- `src/lib/heuristics` — 1271 passed, **no snapshot moved**.
- Round-trip invariants (`corpus-roundtrip`, `render-roundtrip.repro`) pass.
- `typecheck`, `lint` clean. Gates run under Node 20 (`.nvmrc`).

Byte-identity criteria hold: a fully uncategorised résumé and a fully categorised parsed résumé both export exactly as before — only the mixed case changes. Empty categories are still dropped.

Closes #791

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #791 | unreported (requested: sonnet) | high |
| Fix — snapshot-replay data loss | Claude Opus 5 | — |
| Fix — review findings | Claude Opus 5 | — |
| Adversarial review (stack-wide) | Claude Opus 4.5 | high |
| Orchestration + PR | Claude Opus 5 | high |

The implementation agent for this layer never returned its structured report despite two requests, so its model string is genuinely unknown; the alias requested was `sonnet`. It is recorded as unreported rather than inferred from the alias.

## Adversarial review

Reviewed pre-submit, two rounds, by an independent reviewer prompted to break the change. **Two blocking defects were found and fixed on this layer before this PR existed** — both were the same class the issue set out to eliminate, entering through different doors.

**1. Snapshot replay dropped the ungrouped remainder.** Found during orchestration, not by the reviewer. `SkillsOverride` is the #456 snapshot type, so `ungrouped` serialized into a draft — but the replay path restored only `categories`, so `computeEditedSkills` read the remainder as absent and the flat list collapsed to grouped members. Every ungrouped skill vanished on draft restore. Fixed with a `restoreSkillsGrouping` callback that restores both halves; regression test confirmed failing before the fix (`expected undefined to deeply equal [ 'TypeScript', 'Figma' ]`).

**2. Flat-edit leakage into the category snapshot.** `addSkillCategory` spread `...prev`, setting a non-empty `categories` while `removed`/`added` were still populated — a combination `computeEditedSkills` treats as unreachable-by-design. This layer's own reachability fix is what made it reachable. Two proven paths:
- **DEV crash** — flat chip Remove, then `+ Add category` → throws `unreachable by design`.
- **PROD silent loss** — create category → delete it → flat-add `"Rust"` → `+ Add category` again → `"Rust"` gone from the UI and the exported PDF. The once-only seed guard neither re-seeded nor folded it in.

Fixed by clearing `removed`/`added` and recomputing `ungrouped` on every call. That is lossless because the `skills` argument is the rendered post-`applyOverrides` list — verified at the real call site rather than assumed. Two regression tests, one per sequence, both confirmed failing before the fix; the second asserts the **prod** outcome directly rather than only the DEV throw that masked it.

**Nits fixed:** the `types.ts` docblock claimed the UI and the export projection "derive it the same way… so they can't drift" — they do not (the editor matches by exact string, the export lowercases both sides). The claim now states the actual difference and why it cannot diverge today. Dead `skillCategoriesOverride` was removed from the hook's public surface after confirming zero consumers repo-wide.

**3. A sibling flat writer left the same door open.** Round 2 found that `SkillTermGuidance` writes through the flat `addSkill`, re-creating the identical forbidden state: `addSkillCategory` then `addSkill("Kubernetes")` → `computeEditedSkills` throws. Because it is called from a render-phase `useMemo`, that is a DEV ErrorBoundary crash of the whole editor two clicks from a fresh parse, and a silent skill loss in PROD.

This one **pre-exists on `main`** — the throw and the `onAddSkill={addSkill}` wiring are unchanged since #605 — but this PR widens who can reach it from "résumés that parsed as categorised" to "every résumé", because `AddCategoryInput` moves out of the `categorised` branch. It is fixed here rather than deferred.

The fix closes the class **by construction** rather than patching the one caller: `addSkill`/`removeSkill` are now categorisation-aware. When `categories` is non-empty, an add lands in `ungrouped` and a remove goes through the existing `removeSkillFromCategories` transform plus the pool, so `added`/`removed` can no longer be populated alongside a live snapshot. Any future flat writer stays correct without knowing categories exist. Three new transforms' worth of set logic lives in `src/lib/edit/skills-categories.ts`, not the hook, and three pre-existing inline `ungrouped` filters were collapsed onto the new helper rather than left as parallel copies. All four new tests confirmed failing before the fix.

Comments that asserted the now-false premise were corrected: `computeEditedSkills` claimed the state was unreachable because "the flat AddSkillInput is unreachable while any category survives", which never covered non-UI writers.

**One residual, documented and not reachable today:** `restoreSkillsGrouping` preserves `prev.removed`/`prev.added`, so replaying a categorised snapshot onto an already-dirty flat state would re-create the combination. Both live `replay` call sites (`useAnalyzedResume.ts` draft-resume, `useJdFitResume.ts` handoff-on-mount) replay onto pristine state, so it is unreachable in the app; closing it needs a merge-semantics decision (fold the flat halves into the restored `ungrouped`, or drop them) that was deliberately not made unilaterally.

**Refuted with evidence** (recorded so they are not re-investigated): the `ungrouped` XOR invariant holds across every op including the case-sensitivity paths — `canonicalizeSkill` normalises case, so the exact-vs-lowercase divergence documented in `types.ts` stays unreachable; no sibling of the replay bug exists — `jd-fit-handoff` and `jobs-handoff` carry the *applied* résumé, not the override; the PDF byte-identity criteria hold, including the edge where a snapshot's only category is empty; and `addSkillCategory`'s recompute is genuinely lossless at the real call site, which is its only caller.
