### PR TITLE
feat(contact): add a work-authorization field across parse, edit, render and export (#792)

### DIFF
--- a/src/components/features/ContactCard.test.tsx
+++ b/src/components/features/ContactCard.test.tsx
@@ -254,4 +254,74 @@ describe("ContactCard", () => {
     );
     expect(el.textContent).not.toContain("fields detected");
   });
+
+  // ── Work authorization (#792) ─────────────────────────────────────────────
+  // The field is optional BY POLICY: absence must never read as a gap. That
+  // policy is what makes the add affordance load-bearing rather than decorative
+  // — an optional row is hidden when undetected, so without a dedicated entry
+  // point the field would be unreachable for the users who need it most.
+
+  describe("work authorization (#792)", () => {
+    it("renders no gap when absent — not even while editable", () => {
+      const el = render(
+        makeResult({ email: "jane@example.com" }, { email: 0.95 }),
+        { overrides: {}, onFieldChange: () => {} },
+      );
+      const text = el.textContent ?? "";
+      expect(text).not.toContain("Work authorization not detected");
+      // Contrast with a genuinely required field, which DOES read as a gap.
+      expect(text).toContain("+ phone");
+    });
+
+    it("offers a '+ Add work authorization' affordance on the editable card", () => {
+      const el = render(makeResult(), { overrides: {}, onFieldChange: () => {} });
+      const pill = el.querySelector('[aria-label="Add work authorization"]');
+      expect(pill).not.toBeNull();
+      expect(el.textContent).toContain("+ Add work authorization");
+    });
+
+    it("does not offer the affordance on a display-only card", () => {
+      const el = render(makeResult());
+      expect(el.querySelector('[aria-label="Add work authorization"]')).toBeNull();
+    });
+
+    it("commits a typed statement onto the work_authorization override", () => {
+      const commits: Array<[string, string]> = [];
+      const el = render(makeResult(), {
+        overrides: {},
+        onFieldChange: (key, value) => commits.push([key, value]),
+      });
+      const pill = el.querySelector<HTMLElement>(
+        '[aria-label="Add work authorization"]',
+      );
+      act(() => pill!.click());
+      const input = el.querySelector<HTMLInputElement>("input");
+      expect(input).not.toBeNull();
+      // React tracks the DOM value node, so set through the native setter.
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      act(() => {
+        setter.call(input, "US Citizen");
+        input!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      const add = [...el.querySelectorAll("button")].find(
+        (b) => b.textContent === "Add",
+      );
+      act(() => add!.click());
+      expect(commits).toEqual([["work_authorization", "US Citizen"]]);
+    });
+
+    it("renders a stated value on the contact line and stops offering the add", () => {
+      const el = render(
+        makeResult(
+          { work_authorization: "US Citizen", email: "jane@example.com" },
+          { work_authorization: 0.9, email: 0.95 },
+        ),
+      );
+      expect(el.textContent).toContain("US Citizen");
+      expect(el.querySelector('[aria-label="Add work authorization"]')).toBeNull();
+    });
+  });
 });

--- a/src/components/features/ContactDetails.tsx
+++ b/src/components/features/ContactDetails.tsx
@@ -12,10 +12,15 @@
  *   location · email · phone   ← contact line (pipe-joined, present-only)
  *   in/slug   ·   gh/slug      ← links line (glyph-free clickable slugs)
  *
- * When `editable` is set, the editable fields (email/phone/location on the
- * contact line, LinkedIn on the links line) render via the shared
- * `EditableField` primitive; LinkedIn edits the full URL but displays the
+ * When `editable` is set, the editable fields (email/phone/location/work
+ * authorization on the contact line, LinkedIn on the links line) render via the
+ * shared `EditableField` primitive; LinkedIn edits the full URL but displays the
  * derived slug. Otherwise everything is display-only (#146 behavior).
+ *
+ * Work authorization (#792) is the one contact-line row that is OPTIONAL, so it
+ * neither renders a "not detected" pill nor counts as a gap. Its add path is
+ * the `ContactWorkAuthorization` affordance below the line, which exists
+ * because a hidden optional row is otherwise unreachable.
  */
 
 import { formatLinkDisplay, type ContactDisplayField } from "../../lib/contact.ts";
@@ -33,6 +38,7 @@ import type {
 } from "../../hooks/useEditableParse.ts";
 import type { LegacyLinkKey } from "../../lib/score/types.ts";
 import { ContactExtraLinks } from "./ContactExtraLinks.tsx";
+import { ContactWorkAuthorization } from "./ContactWorkAuthorization.tsx";
 import { ProfileLinkAdd } from "./ProfileLinkAdd.tsx";
 
 /** The inline-editable non-link contact fields, mapped 1:1 to their
@@ -44,7 +50,13 @@ const EDITABLE_KEYS: Record<string, keyof ContactOverrides> = {
   email: "email",
   phone: "phone",
   location: "location",
+  work_authorization: "work_authorization",
 };
+
+/** The optional work-authorization contact row (#792). Named once here because
+ *  two places need it: the contact-line filter that suppresses its "not
+ *  detected" pill, and the add affordance that replaces it. */
+const WORK_AUTHORIZATION_KEY = "work_authorization";
 
 type Commit = (key: keyof ContactOverrides, v: string) => void;
 
@@ -103,18 +115,39 @@ export function ContactDetails({
   // The parsed location, threaded into the phone validator's region default so a
   // non-US local-form number isn't falsely flagged (see `validatorFor`).
   const location = contactLine.find((f) => f.key === "location")?.value;
+  // Work authorization (#792) is the one contact-line row whose absence is not
+  // a gap, so it must never draw the "not detected" warning pill the required
+  // rows draw. An absent value is dropped from the line and replaced by the
+  // "+ Add work authorization" affordance below (editable card only); a
+  // low-confidence value still renders, like its siblings, so it can be
+  // confirmed or corrected in place.
+  const segments = contactLine.filter(
+    (f) => f.key !== WORK_AUTHORIZATION_KEY || f.reason !== "absent",
+  );
+  const workAuthorizationAbsent = !segments.some(
+    (f) => f.key === WORK_AUTHORIZATION_KEY,
+  );
   return (
     <>
       {/* Contact line: location / email / phone, pipe-joined, present-only. */}
-      {contactLine.length > 0 && (
+      {segments.length > 0 && (
         <p className="mt-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm">
-          {contactLine.map((field, i) => (
+          {segments.map((field, i) => (
             <span key={field.key} className="inline-flex items-center gap-x-2">
               {i > 0 && <span className="text-content-muted">|</span>}
               {renderContactValue(field, editable, commit, location)}
             </span>
           ))}
         </p>
+      )}
+
+      {/* Reachability for the hidden optional row (#792): without this, a
+          résumé that never stated work authorization offers no way to state
+          it. Editable card only — a display-only card has nothing to add to. */}
+      {editable && workAuthorizationAbsent && (
+        <ContactWorkAuthorization
+          onAdd={(value) => commit(WORK_AUTHORIZATION_KEY, value)}
+        />
       )}
 
       {/* Links line: clickable slugs, middot-separated, license-safe (no logos). */}

--- a/src/components/features/ContactWorkAuthorization.tsx
+++ b/src/components/features/ContactWorkAuthorization.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ContactWorkAuthorization — the "+ Add work authorization" entry point on the
+ * editable contact card (#792).
+ *
+ * Why this exists at all: `work_authorization` is an OPTIONAL contact row, and
+ * `buildContactFields` hides an optional row that was not detected. That is the
+ * right policy call — an absent work-authorization statement must never render
+ * as a gap, because penalising silence about immigration status is not a
+ * defensible thing for this product to do — but it leaves the field unreachable
+ * for the very users who need it: someone whose résumé never stated it has no
+ * row to click. So the editable card carries a dedicated affordance, rendered
+ * only while the value is absent. Once a value exists it renders (and edits)
+ * inline on the contact line like every other contact field, and this component
+ * steps out of the way.
+ *
+ * Reuse analysis: no new markup pattern. It composes `InlineBulletAdd` — the
+ * shared `AddPill`-collapsed, single-line text-add affordance from
+ * `ReconstructedAdd` — rather than re-rolling an input. Deliberately NOT
+ * `ProfileLinkAdd`: that is a URL field whose add path rejects anything
+ * `classifyProfile` cannot parse, which is how "US Citizen" used to be
+ * swallowed (#790). This is free text and accepts the sentence as written.
+ */
+
+import { InlineBulletAdd } from "./ReconstructedAdd.tsx";
+
+export function ContactWorkAuthorization({
+  onAdd,
+}: {
+  /** Commit the entered statement, verbatim, onto the `work_authorization`
+   *  contact override. */
+  onAdd: (value: string) => void;
+}) {
+  return (
+    <div className="mt-2 flex justify-center">
+      <InlineBulletAdd
+        onAdd={onAdd}
+        label="Add work authorization"
+        placeholder="e.g. US Citizen (optional)"
+      />
+    </div>
+  );
+}

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -94,6 +94,10 @@ export interface ContactOverrides {
   phone?: string;
   location?: string;
   headline?: string;
+  /** Work-authorization statement (#792), verbatim free text. Rides this
+   *  existing per-key channel like `location` — `""` is an explicit clear, so
+   *  the same reset/replay plumbing applies with no new state. */
+  work_authorization?: string;
 }
 
 // ── Experience overrides ──────────────────────────────────────────────────────

--- a/src/lib/contact.test.ts
+++ b/src/lib/contact.test.ts
@@ -172,6 +172,76 @@ describe("buildContactFields", () => {
   });
 });
 
+// #792 — the row is optional BY POLICY, so "absent adds no gap" is the
+// behaviour under test, not an implementation detail. The five-required-rows
+// assertions above are its other half: they would have grown to six if the row
+// had been added as required.
+describe("buildContactFields — work authorization (#792)", () => {
+  it("renders no row at all when the résumé states nothing", () => {
+    const fields = buildContactFields(makeCascade());
+    expect(fields.map((f) => f.key)).not.toContain("work_authorization");
+  });
+
+  it("does not change the detected/total ratio by being absent", () => {
+    const { detected, total } = contactCompleteness(
+      buildContactFields(makeCascade({ email: "j@example.com" }, { email: 0.95 })),
+    );
+    expect(total).toBe(5);
+    expect(detected).toBe(1);
+  });
+
+  it("renders on the contact line, after location, when confidently stated", () => {
+    const fields = buildContactFields(
+      makeCascade(
+        { work_authorization: "US Citizen" },
+        { work_authorization: 0.9 },
+      ),
+    );
+    const row = fields.find((f) => f.key === "work_authorization");
+    expect(row).toMatchObject({
+      value: "US Citizen",
+      group: "contact",
+      gated: false,
+      label: "Work authorization",
+    });
+    // Last row overall — after location, which is the contact line's tail.
+    expect(fields.at(-1)!.key).toBe("work_authorization");
+  });
+
+  it("is restored by an override on a résumé the parser found none on", () => {
+    // The hidden-optional-row path: `buildContactFields` drops the row, and
+    // `applyContactOverrides` is what puts the user's typed value back on the
+    // card. Without this, the "+ Add work authorization" affordance would
+    // commit into a void.
+    const fields = applyContactOverrides(buildContactFields(makeCascade()), {
+      work_authorization: "Authorized to work in the US without sponsorship",
+    });
+    expect(fields.find((f) => f.key === "work_authorization")).toMatchObject({
+      value: "Authorized to work in the US without sponsorship",
+      gated: false,
+    });
+  });
+
+  it("reverts to absent — not to a gap row — on an explicit clear", () => {
+    const fields = applyContactOverrides(
+      buildContactFields(
+        makeCascade(
+          { work_authorization: "US Citizen" },
+          { work_authorization: 0.9 },
+        ),
+      ),
+      { work_authorization: "" },
+    );
+    const row = fields.find((f) => f.key === "work_authorization");
+    expect(row).toMatchObject({ value: "", gated: true, reason: "absent" });
+    // And a cleared optional row is not counted as a missing REQUIRED field by
+    // any consumer that reads the gate.
+    expect(criticalDownloadGate(fields, true).map((i) => i.key)).not.toContain(
+      "work_authorization",
+    );
+  });
+});
+
 describe("applyContactOverrides", () => {
   it("passes fields through untouched when no overrides given", () => {
     const fields = buildContactFields(makeCascade());

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -60,6 +60,16 @@ const CONTACT_ROWS: readonly {
   { key: "portfolio_url", label: "Portfolio", group: "link", optional: true },
   { key: "website_url", label: "Website", group: "link", optional: true },
   { key: "location", label: "Location", group: "contact" },
+  // Work authorization (#792) — OPTIONAL by policy, not by convenience. The
+  // disclosure is jurisdiction-specific and protected-class-adjacent, so an
+  // absent value must never render a "not detected" gap nor count against the
+  // detected/total ratio; a résumé that declines to state it must look and
+  // score exactly like one that has nothing to state. Because an undetected
+  // optional row is hidden entirely (see `buildContactFields`), the editable
+  // card carries its own "+ Add work authorization" entry point
+  // (`ContactWorkAuthorization`) — otherwise the field would be unreachable for
+  // exactly the users who need it.
+  { key: "work_authorization", label: "Work authorization", group: "contact", optional: true },
 ];
 
 // TypeScript trick: enumerate the valid keys for indexing `parsed`.
@@ -73,6 +83,7 @@ const FIELD_KEYS = {
   portfolio_url: true,
   website_url: true,
   location: true,
+  work_authorization: true,
 } as const;
 
 /**

--- a/src/lib/edit/apply-overrides.test.ts
+++ b/src/lib/edit/apply-overrides.test.ts
@@ -87,6 +87,37 @@ describe("applyOverrides", () => {
     expect(out.full_name).toBeUndefined();
   });
 
+  // #792 — work authorization rides this same per-key contact channel rather
+  // than a new one, so the create / edit / clear semantics (and the confidence
+  // fold below) are the ones already proven for `location`.
+  it("creates, edits and clears work_authorization through the contact channel (#792)", () => {
+    const created = applyOverrides(
+      baseParsed(),
+      "raw",
+      makeSections(),
+      { work_authorization: "US Citizen" },
+      {},
+      {},
+      [],
+    );
+    expect(created.fields.work_authorization).toBe("US Citizen");
+    // A user-affirmed contact edit earns full confidence, which is what lifts
+    // the display gate AND what carries the value into the exported PDF.
+    expect(created.fieldConfidence.work_authorization).toBe(1);
+
+    const cleared = applyOverrides(
+      { ...baseParsed(), work_authorization: "US Citizen" },
+      "raw",
+      makeSections(),
+      { work_authorization: "" },
+      {},
+      {},
+      [],
+    );
+    expect(cleared.fields.work_authorization).toBeUndefined();
+    expect(cleared.fieldConfidence.work_authorization).toBe(0);
+  });
+
   it("clears a stale phoneIsValid flag when the phone is overridden (#70 review)", () => {
     const parsed: HeuristicParsedResume = {
       ...baseParsed(),

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -91,6 +91,7 @@ const CONTACT_KEYS: readonly (keyof ContactOverrides)[] = [
   "phone",
   "location",
   "headline",
+  "work_authorization",
 ];
 
 /** Leading bullet/numbered markers — mirrors group-bullets.ts LEADING_MARKER_RE. */

--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -207,6 +207,24 @@ function recordTruth(
 }
 
 
+/**
+ * The ONLY corpus fixtures whose page actually states a work-authorization line
+ * (#792), with the statement quoted so an entry can be checked against the PDF
+ * rather than trusted.
+ *
+ * This map is an over-match guard, and it is deliberately an allow-list rather
+ * than a snapshot key: `work_authorization` writes a legal claim onto someone's
+ * résumé and into the PDF they send to employers, so a false positive is far
+ * worse than a miss. Every fixture NOT listed here must come back with the key
+ * absent. If a matcher change makes a new fixture "detect" one, the assertion
+ * fails and the right response is to read the PDF — adding a line here without
+ * doing that defeats the guard.
+ */
+const STATES_WORK_AUTHORIZATION: ReadonlyMap<string, string> = new Map([
+  // Contact line: "973-555-0123 | jordan.bennett@example.com | LinkedIn | GitHub | US Citizen"
+  ["tests/fixtures/pdfs/latex/multi-degree-coursework.pdf", "US Citizen"],
+]);
+
 describe("corpus snapshots", () => {
   if (pdfs.length === 0) {
     // Empty corpus is a valid state — keeps CI green between adding the
@@ -226,6 +244,17 @@ describe("corpus snapshots", () => {
         async () => {
           const bytes = await fsp.readFile(pdfPath);
           const cascade = await runCascade(new Uint8Array(bytes));
+
+          // #792 over-match guard — see `STATES_WORK_AUTHORIZATION`. Asserted
+          // here rather than through the snapshot because the snapshot records
+          // only that a field is populated, never its value, and the value is
+          // the part that would be a fabricated legal claim.
+          expect(
+            cascade.canonical.fields.work_authorization,
+            `${rel}: work_authorization must stay absent unless the page states ` +
+              `one. Read the PDF before adding it to STATES_WORK_AUTHORIZATION.`,
+          ).toBe(STATES_WORK_AUTHORIZATION.get(rel));
+
           const score = computeAnonymousAtsScore({
             parsed: {
               full_name: cascade.canonical.fields.full_name,

--- a/src/lib/heuristics/extract/contact.ts
+++ b/src/lib/heuristics/extract/contact.ts
@@ -21,6 +21,10 @@ import {
 import { escapeRegex } from "../../jd-match/regex-utils.ts";
 import { findFirstPhone, regionFromLocation } from "../phone.ts";
 import { firstMatch, allMatches, isStandaloneUrl } from "./shared.ts";
+import {
+  extractWorkAuthorization,
+  WORK_AUTHORIZATION_CONTACT_CONFIDENCE,
+} from "./work-authorization.ts";
 
 // ── Contact (email, phone, urls, location) ──────────────────────────────────
 
@@ -35,6 +39,9 @@ export interface ContactExtractionResult {
   portfolio_url?: string;
   website_url?: string;
   location?: string;
+  /** Work-authorization statement (#792), verbatim, read off the header contact
+   *  line. Profile-band only — see the doc-comment on `extractContact`. */
+  work_authorization?: string;
   /**
    * Classified contact links (#335), additive. Built from the four legacy
    * `*_url` values above in their fixed precedence order
@@ -52,6 +59,7 @@ export interface ContactExtractionResult {
     portfolio_url: number;
     website_url: number;
     location: number;
+    work_authorization: number;
   };
   /**
    * Provenance / ownership signal (#134). The `PdfLine`s document-wide whose
@@ -357,7 +365,18 @@ function extractOtherUrls(joined: string): {
   return { portfolio, website: websiteCandidates[0] };
 }
 
-function scan(lines: PdfLine[], joined: string): ContactScanResult {
+function scan(
+  lines: PdfLine[],
+  joined: string,
+  /** Whether to read work authorization (#792). FALSE for the doc-wide fallback
+   *  scan. That pass exists to fill contact fields found outside the profile
+   *  band, but `work_authorization` deliberately has NO doc-wide fallback — it
+   *  is band-scoped like `location`, so a statement buried in a bullet cannot
+   *  claim the header — and `extractContact` reads it only from `primary`
+   *  (see the merge below). Computing it here walked every line in the document
+   *  to produce a value that was then discarded. */
+  readWorkAuthorization = true,
+): ContactScanResult {
   const email = firstMatch(EMAIL_RE, joined);
 
   // Extract location BEFORE phone so we can derive the parse region.
@@ -381,6 +400,13 @@ function scan(lines: PdfLine[], joined: string): ContactScanResult {
   // Other URLs that aren't linkedin/github → portfolio/website bucket.
   const { portfolio, website } = extractOtherUrls(joined);
 
+  // Work authorization (#792) reads per-LINE, not off `joined`: the statement is
+  // identified by being a WHOLE `·`/`•`/`|`-delimited segment, and joining the
+  // lines first would let a segment run across a line break.
+  const workAuthorization = readWorkAuthorization
+    ? extractWorkAuthorization(lines)
+    : undefined;
+
   return {
     email,
     phone,
@@ -390,6 +416,7 @@ function scan(lines: PdfLine[], joined: string): ContactScanResult {
     portfolio_url: normalizeUrl(portfolio),
     website_url: normalizeUrl(website),
     location,
+    work_authorization: workAuthorization,
     confidence: {
       email: email ? 0.98 : 0,
       phone: phone ? 0.85 : 0,
@@ -398,6 +425,9 @@ function scan(lines: PdfLine[], joined: string): ContactScanResult {
       portfolio_url: portfolio ? 0.6 : 0,
       website_url: website ? 0.55 : 0,
       location: location ? 0.75 : 0,
+      work_authorization: workAuthorization
+        ? WORK_AUTHORIZATION_CONTACT_CONFIDENCE
+        : 0,
     },
   };
 }
@@ -431,7 +461,7 @@ export function extractContact(
   // (e.g. footer). Fill any missing field from the full-document scan —
   // EXCEPT location, which is bug-prone outside the profile band.
   const fullText = allLines.map((l) => l.text).join(" ");
-  const fallback = scan(allLines, fullText);
+  const fallback = scan(allLines, fullText, /* readWorkAuthorization */ false);
 
   // Annotation fallback: URLs hyperlinked behind a visible word
   // ("LinkedIn", "GitHub") only show up here. GitHub, and LinkedIn on a KNOWN
@@ -620,8 +650,12 @@ export function extractContact(
     portfolio_url: normalizeUrl(portfolio.value),
     website_url: normalizeUrl(website.value),
     profiles,
-    // No fallback for location — see comment above.
+    // No fallback for location — see comment above. Work authorization is
+    // banded the same way and for the same reason (#792): a right-to-work
+    // sentence outside the header is far more likely to be a job requirement or
+    // someone else's paperwork than the candidate's own status.
     location: primary.location,
+    work_authorization: primary.work_authorization,
     confidence: {
       email: Math.max(primary.confidence.email, fallback.confidence.email * 0.8),
       phone: Math.max(primary.confidence.phone, fallback.confidence.phone * 0.8),
@@ -630,6 +664,7 @@ export function extractContact(
       portfolio_url: portfolio.confidence,
       website_url: website.confidence,
       location: primary.confidence.location,
+      work_authorization: primary.confidence.work_authorization,
     },
     consumedLines,
   };

--- a/src/lib/heuristics/extract/work-authorization.test.ts
+++ b/src/lib/heuristics/extract/work-authorization.test.ts
@@ -1,0 +1,549 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Work-authorization extraction (#792).
+ *
+ * The bulk of this file is NEGATIVE cases, deliberately. Under-matching costs a
+ * user one typed line (`ContactWorkAuthorization` is the affordance for it);
+ * over-matching writes a legal claim onto a résumé that never made it, and then
+ * draws it on the PDF they send out. So each guard below names the real string
+ * it protects against rather than asserting a generic "no match".
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  matchWorkAuthorization,
+  matchWorkAuthorizationUngated,
+  extractWorkAuthorization,
+  harvestWorkAuthorization,
+} from "./work-authorization.ts";
+import type { PdfLine, PdfSection } from "../sections.ts";
+import { parseHeuristic } from "../openresume.ts";
+import { mkItems, mkDefaultPages } from "../__test-utils__/mkItem.ts";
+
+const line = (text: string): PdfLine => ({
+  text,
+  page: 1,
+  y: 0,
+  x: 72,
+  items: [],
+  maxFontSize: 10,
+  allCaps: false,
+  gapAbove: 0,
+});
+
+const section = (name: PdfSection["name"], texts: string[]): PdfSection => ({
+  name,
+  lines: texts.map(line),
+});
+
+// ── matchWorkAuthorization ──────────────────────────────────────────────────
+
+/**
+ * Every statement the matcher is required to claim. Hoisted out of the `it.each`
+ * below because the prefilter superset suite at the bottom of this file has to
+ * walk the SAME list — a positive the gate silently stopped admitting is exactly
+ * the failure that suite exists to catch.
+ */
+const CLAIMED = [
+  "US Citizen",
+  "U.S. Citizen",
+  "Canadian Citizen",
+  "US Citizenship",
+  "Dual US/UK Citizen",
+  "Naturalized US Citizen",
+  "Green Card",
+  "Green Card holder",
+  "US Green Card holder",
+  "Permanent Resident",
+  "Lawful Permanent Resident",
+  "Canadian Permanent Resident",
+  "Authorized to work in the US without sponsorship",
+  "Authorized to work in the U.S. without visa sponsorship",
+  "Authorized to work in the United States for any employer",
+  "Authorized to work in the US without restrictions",
+  "Legally authorised to work in the United Kingdom",
+  "Eligible to work in the EU",
+  "Permitted to work in Canada",
+  "Work authorized",
+  "Employment authorized",
+  "Work authorized in the US",
+  "Right to work in the UK",
+  "Unrestricted right to work in the EU",
+  "Work authorization: H-1B",
+  "Work authorization: US Citizen",
+  "Visa status: TN",
+  "Citizenship: US",
+  "Employment eligibility: unrestricted",
+  "No sponsorship required",
+  "Does not require visa sponsorship",
+  "Requires no sponsorship",
+  "Not seeking sponsorship",
+  "Sponsorship not required",
+  "Visa sponsorship not required",
+  "EU passport holder",
+  "British passport holder",
+];
+
+describe("matchWorkAuthorization — statements it claims", () => {
+  it.each(CLAIMED)("claims %j", (text) => {
+    expect(matchWorkAuthorization(text)).toBe(text);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchWorkAuthorization("us citizen")).toBe("us citizen");
+    expect(matchWorkAuthorization("GREEN CARD HOLDER")).toBe("GREEN CARD HOLDER");
+  });
+});
+
+describe("matchWorkAuthorization — over-match guards", () => {
+  it.each([
+    // A job title that merely CONTAINS a status phrase. A prefix-anchored
+    // pattern would claim each of these as an immigration status.
+    "Green Card Program Manager",
+    "Immigration Attorney",
+    "Citizen Bank",
+    "Permanent Resident Artist Program",
+    // Prose that mentions the paperwork rather than declaring a status.
+    "Helped 200 immigrants file work authorization paperwork",
+    "Advised clients on visa sponsorship and relocation",
+    // Ordinary résumé furniture that shares a token.
+    "Right to Left Layout Engineering",
+    "Passport photo booth software",
+    "",
+    "   ",
+  ])("does not claim %j", (text) => {
+    expect(matchWorkAuthorization(text)).toBeUndefined();
+  });
+
+  it("does not claim a bare visa class with no label to give it meaning", () => {
+    // "OPT" is also an abbreviation, "TN" is also a US state code, "EAD" is
+    // also an acronym a résumé may coin. A wrong claim here is the most
+    // consequential kind, so these are matched only when a label introduces
+    // them (see the labelled-form cases above).
+    for (const bare of ["OPT", "CPT", "TN", "EAD", "H-1B"]) {
+      expect(matchWorkAuthorization(bare)).toBeUndefined();
+    }
+  });
+});
+
+describe("matchWorkAuthorization — over-match guards (#792 regression)", () => {
+  // Every string below was CLAIMED by the first cut of this matcher, because
+  // five of its patterns ended in an unconstrained `.{0,60}$` / `.{1,40}$` tail
+  // and two more accepted any run of letters as a nationality qualifier. Each
+  // one would have drawn a fabricated legal claim onto the exported PDF.
+  it.each([
+    // ── reproduced end to end through renderAtsResumePdf → runCascade ──
+    "Work status: Full-time, open to relocation",
+    "Authorized to work with cross-functional teams",
+    "Eligible to work on classified programs",
+    // ── the free nationality qualifier: any word could become one ──
+    "Jane Citizen",
+    "Global Citizen",
+    "Corporate Citizen",
+    "Digital Citizen",
+    // A bare label or noun states no status at all. "CITIZENSHIP" is also a
+    // plausible heading in the very `other` bucket the harvester scans, with
+    // the actual value on the NEXT line.
+    "Citizenship",
+    "citizen",
+    // ── the labelled form's free value ──
+    "Work status: Full-time",
+    "Work permit - expired",
+    // ── found by attacking the fix: the tail must be a right-to-work object,
+    //    not merely a string that mentions one ──
+    "Eligible to work on US government programs",
+    "Authorized to work with US-based clients",
+    "Authorized to work in fast-paced environments",
+    "Authorized to work remotely",
+    "Right to Work laws in Texas",
+    "Right to work legislation research",
+    "Employment eligibility verification (I-9) processing",
+    "Work authorization paperwork for 200 clients",
+    "US Citizen Bank",
+    "Permanent resident of Seattle",
+    "No sponsorship deals closed in Q3",
+    "Sponsorship not needed for the conference booth",
+    "Vaccine passport holder",
+  ])("does not claim %j", (text) => {
+    expect(matchWorkAuthorization(text)).toBeUndefined();
+  });
+
+  it.each([
+    // A bare noun or a valueless label states nothing, and each is a plausible
+    // HEADING inside the very unrouted block `harvestWorkAuthorization` scans —
+    // claiming it would store the heading and skip the value on the next line.
+    "Citizen",
+    "Citizenship",
+    "Visa",
+    "Work permit",
+    "Passport holder",
+    "Right to work",
+    "Authorized to work",
+    "Work authorization",
+  ])("does not claim the valueless %j", (text) => {
+    expect(matchWorkAuthorization(text)).toBeUndefined();
+  });
+
+  it.each([
+    // A label we recognize does not license whatever follows it: the value has
+    // to be a status we can vouch for, or the claim is not ours to make.
+    "Visa status: pending",
+    "Work permit - expired",
+    "Citizenship: applied for",
+    "Work authorization: see attached letter",
+  ])("does not claim a labelled value it cannot vouch for: %j", (text) => {
+    expect(matchWorkAuthorization(text)).toBeUndefined();
+  });
+});
+
+describe("matchWorkAuthorization — normalization", () => {
+  it("drops a trailing full stop and collapses whitespace", () => {
+    expect(
+      matchWorkAuthorization("Authorized to work  in the US without sponsorship."),
+    ).toBe("Authorized to work in the US without sponsorship");
+  });
+
+  it("is idempotent — re-matching a stored value returns it unchanged", () => {
+    // This is what makes parse → export → re-parse stable: the exported contact
+    // line draws the STORED value, so the second pass must land on the same
+    // string rather than normalizing again into a third one.
+    const first = matchWorkAuthorization("US Citizen.");
+    expect(first).toBe("US Citizen");
+    expect(matchWorkAuthorization(first!)).toBe(first);
+  });
+});
+
+// ── the prefilter is a superset of the grammar ──────────────────────────────
+
+describe("matchWorkAuthorization — the prefilter changes no verdict", () => {
+  // `STATUS_PREFILTER` is a cheap literal gate in front of the closed grammar,
+  // there because compiling and tiering up that grammar cost ~860ms on the FIRST
+  // parse of a session — synchronously, on the drop-PDF path. It is only sound
+  // if it is a strict SUPERSET of the grammar: a segment it rejects must be one
+  // no pattern could have claimed anyway.
+  //
+  // That is not arguable from reading the regex — it is a property of eleven
+  // patterns against thirteen literals, and it silently breaks the day someone
+  // adds a twelfth pattern. So it is asserted by DIFFERENTIAL: run the grammar
+  // ungated, run it gated, require agreement. A prefilter that starts rejecting
+  // something the grammar claims fails here rather than in production, where the
+  // symptom would be a résumé quietly losing its work-authorization line.
+
+  it.each(CLAIMED)("admits the claimed statement %j", (text) => {
+    // Directional half of the proof, stated separately because it is the half
+    // that matters: every string the matcher is required to claim clears the
+    // gate. A prefilter that dropped one of these would break a real résumé.
+    expect(matchWorkAuthorization(text)).toBe(matchWorkAuthorizationUngated(text));
+    expect(matchWorkAuthorization(text)).toBe(text);
+  });
+
+  /**
+   * A wider corpus than the assertion sets above: every pattern crossed with a
+   * spread of the closed vocabulary, so the differential covers vocabulary
+   * entries no hand-written case happens to name (the surname-colliding nations
+   * especially — Wales, Ireland, Indian, American). Statements here are NOT
+   * asserted to match; the only claim is that gating agrees with not gating.
+   */
+  const NATIONS_SAMPLE = [
+    "the US",
+    "the U.S.",
+    "the United States",
+    "the UK",
+    "the United Kingdom",
+    "Wales",
+    "Ireland",
+    "India",
+    "Canada",
+    "the EU",
+    "New Zealand",
+    "South Africa",
+    "the Philippines",
+    "Switzerland",
+  ];
+
+  const GENERATED = [
+    ...NATIONS_SAMPLE.flatMap((nation) => {
+      const bare = nation.replace(/^the /, "");
+      return [
+        `${bare} Citizen`,
+        `${bare} Citizenship`,
+        `Naturalized ${bare} Citizen`,
+        `Dual ${bare}/UK Citizen`,
+        `${bare} Green Card holder`,
+        `${bare} Permanent Resident`,
+        `${bare} passport holder`,
+        `Authorized to work in ${nation}`,
+        `Authorised to work within ${nation} without sponsorship`,
+        `Eligible to work in ${nation} for any employer`,
+        `Entitled to work in ${nation} without restrictions`,
+        `Permitted to work in ${nation}`,
+        `Currently authorized to work in ${nation} without any visa sponsorship required`,
+        `Work authorized in ${nation}`,
+        `Employment authorised in ${nation}`,
+        `Right to work in ${nation}`,
+        `Unrestricted right to work in ${nation} with no restrictions`,
+        `Citizenship: ${bare}`,
+        `Immigration status: ${bare} Citizen`,
+        // Near-misses: one unrecognized token is all it takes, and the gate must
+        // not be what rejects them.
+        `Authorized to work in ${nation} on a TN visa`,
+        `Authorized to work in ${nation} (no sponsorship required)`,
+        `${bare} Citizen Advisory Board`,
+        `Jane ${bare}`,
+      ];
+    }),
+    ...[
+      "H-1B",
+      "H1B",
+      "TN",
+      "EAD",
+      "OPT",
+      "STEM OPT",
+      "CPT",
+      "Green Card",
+      "Tier 2",
+      "Skilled Worker visa",
+      "Indefinite Leave to Remain",
+      "Pre-settled status",
+      "L-1A",
+      "unrestricted",
+      "valid",
+      "pending",
+      "expired",
+      "see attached letter",
+    ].flatMap((value) => [
+      `Work authorization: ${value}`,
+      `Work authorisation status: ${value}`,
+      `Employment eligibility: ${value}`,
+      `Visa status: ${value}`,
+      `Visa type: ${value}`,
+      `Work permit - ${value}`,
+      `Immigration status: ${value}`,
+      `Residency status: ${value}`,
+      `Citizenship: ${value}`,
+      // Labels the grammar deliberately does not know, kept so the differential
+      // also covers the label list's edges.
+      `Work status: ${value}`,
+      `Nationality: ${value}`,
+      `Right to work: ${value}`,
+    ]),
+    "Naturalized citizen",
+    "Dual national",
+    "Dual citizen",
+    "Dual citizenship",
+    "Employment Authorization Document (EAD)",
+    "No sponsorship required now or in the future",
+    "Does not require employer sponsorship",
+    "Will not require visa sponsorship",
+    "Requires no sponsorship",
+    "Sponsorship is not necessary",
+    "Visa sponsorship not needed now or in the future",
+    "Authorized to work in the US for any employer without sponsorship",
+    "Authorized to work in the US in the UK for any employer",
+    "Authorized to work in the US for any US employer",
+    "Authorized to work in the US without US sponsorship",
+  ];
+
+  it("never rejects a segment the closed grammar would have claimed", () => {
+    const corpus = [...CLAIMED, ...GENERATED];
+    const divergent = corpus.filter(
+      (text) => matchWorkAuthorization(text) !== matchWorkAuthorizationUngated(text),
+    );
+    // Named rather than counted: a failure here has to say WHICH string the gate
+    // swallowed, or the next reader re-derives the whole superset argument.
+    expect(divergent).toEqual([]);
+  });
+
+  it("covers the negative corpora too — gating cannot invent a match", () => {
+    // The gate can only ever reject, so this direction is structural rather than
+    // at risk. It is asserted anyway because it costs nothing and pins the shape
+    // if the gate is ever rewritten into something that transforms the input.
+    for (const text of [
+      "Green Card Program Manager",
+      "Jane Citizen",
+      "Work status: Full-time, open to relocation",
+      "Authorized to work with cross-functional teams",
+      "Eligible to work on classified programs",
+      "Right to Work laws in Texas",
+      "Vaccine passport holder",
+      "Permanent resident of Seattle",
+      "Led the Wales office",
+      "Shipped the thing",
+      "",
+      "   ",
+    ]) {
+      expect(matchWorkAuthorization(text)).toBe(matchWorkAuthorizationUngated(text));
+      expect(matchWorkAuthorization(text)).toBeUndefined();
+    }
+  });
+});
+
+// ── header contact line ─────────────────────────────────────────────────────
+
+describe("extractWorkAuthorization — header contact line", () => {
+  it.each(["·", "•", "|"])("reads a %s-delimited segment", (sep) => {
+    const lines = [
+      line("Jane Doe"),
+      line(`jane@example.com ${sep} (312) 555-0123 ${sep} Chicago, IL ${sep} US Citizen`),
+    ];
+    expect(extractWorkAuthorization(lines)).toBe("US Citizen");
+  });
+
+  it("reads a statement that occupies a whole header line on its own", () => {
+    expect(
+      extractWorkAuthorization([line("Authorized to work in the US without sponsorship")]),
+    ).toBe("Authorized to work in the US without sponsorship");
+  });
+
+  it("takes the first hit in document order", () => {
+    expect(
+      extractWorkAuthorization([line("US Citizen"), line("Green Card holder")]),
+    ).toBe("US Citizen");
+  });
+
+  it("does not carve a statement out of a segment that says more", () => {
+    // The segment must be consumed WHOLE — a header tagline mentioning the
+    // phrase is not a declaration of status.
+    expect(
+      extractWorkAuthorization([
+        line("Jane Doe · Green Card Program Manager · jane@example.com"),
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+// ── trailing unrouted block ─────────────────────────────────────────────────
+
+describe("harvestWorkAuthorization — trailing unrouted block", () => {
+  it("recovers the statement from an `other` bucket", () => {
+    const sections = [
+      section("experience", ["• Shipped the thing"]),
+      section("other", ["Authorized to work in the US without sponsorship."]),
+    ];
+    expect(harvestWorkAuthorization(sections)).toBe(
+      "Authorized to work in the US without sponsorship",
+    );
+  });
+
+  it("ignores recognized sections — only unrouted buckets are scanned", () => {
+    const sections = [
+      section("experience", ["US Citizen"]),
+      section("summary", ["Green Card holder"]),
+    ];
+    expect(harvestWorkAuthorization(sections)).toBeUndefined();
+  });
+});
+
+// ── end to end through parseHeuristic ───────────────────────────────────────
+
+describe("parseHeuristic — work authorization reaches the parse", () => {
+  const RESUME_BODY = [
+    { text: "EXPERIENCE", fontSize: 13 },
+    { text: "Acme Corp Jan 2022 - Present", fontSize: 11 },
+    { text: "• Led platform migration", fontSize: 10 },
+  ];
+
+  it("parses a contact-line statement into work_authorization (AC: header)", () => {
+    const items = mkItems([
+      { text: "Jane Doe", fontSize: 18 },
+      {
+        text: "jane@example.com · (312) 555-0123 · Chicago, IL · US Citizen",
+        fontSize: 10,
+      },
+      { text: "", fontSize: 10 },
+      ...RESUME_BODY,
+    ]);
+    const result = parseHeuristic(items, mkDefaultPages(items));
+    expect(result.parsed.work_authorization).toBe("US Citizen");
+    expect(result.fieldConfidence.work_authorization).toBe(0.9);
+    // The neighbouring segments are unaffected — the statement is not carved
+    // out of the location, nor does it displace it.
+    expect(result.parsed.location).toBe("Chicago, IL");
+    expect(result.parsed.email).toBe("jane@example.com");
+  });
+
+  it("parses a trailing ADDITIONAL-block statement into work_authorization (AC: section)", () => {
+    const items = mkItems([
+      { text: "Jane Doe", fontSize: 18 },
+      { text: "jane@example.com · Chicago, IL", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      ...RESUME_BODY,
+      { text: "", fontSize: 10 },
+      { text: "ADDITIONAL", fontSize: 13 },
+      { text: "Authorized to work in the US without sponsorship.", fontSize: 10 },
+    ]);
+    const result = parseHeuristic(items, mkDefaultPages(items));
+    expect(result.parsed.work_authorization).toBe(
+      "Authorized to work in the US without sponsorship",
+    );
+    expect(result.fieldConfidence.work_authorization).toBe(0.7);
+    // The regression guard `skills.test.ts` pins from the other side: routing
+    // the line here must not turn it into a skill.
+    expect(result.parsed.skills).toEqual([]);
+  });
+
+  it("prefers the header statement over a trailing block when both are present", () => {
+    const items = mkItems([
+      { text: "Jane Doe", fontSize: 18 },
+      { text: "jane@example.com · Chicago, IL · US Citizen", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      ...RESUME_BODY,
+      { text: "", fontSize: 10 },
+      { text: "ADDITIONAL", fontSize: 13 },
+      { text: "Green Card holder", fontSize: 10 },
+    ]);
+    const result = parseHeuristic(items, mkDefaultPages(items));
+    expect(result.parsed.work_authorization).toBe("US Citizen");
+  });
+
+  it.each([
+    // The three strings an independent reviewer reproduced end to end: each was
+    // claimed VERBATIM as the candidate's work authorization and drawn onto the
+    // exported PDF's contact line. An "Additional Information" heading routes to
+    // `other`, which is exactly what `harvestWorkAuthorization` reads.
+    "Work status: Full-time, open to relocation",
+    "Authorized to work with cross-functional teams",
+    "Eligible to work on classified programs",
+  ])("does not fabricate a status from an ADDITIONAL line: %j", (stated) => {
+    const items = mkItems([
+      { text: "Jane Doe", fontSize: 18 },
+      { text: "jane@example.com · Chicago, IL", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      ...RESUME_BODY,
+      { text: "", fontSize: 10 },
+      { text: "ADDITIONAL INFORMATION", fontSize: 13 },
+      { text: stated, fontSize: 10 },
+    ]);
+    const result = parseHeuristic(items, mkDefaultPages(items));
+    expect(result.parsed).not.toHaveProperty("work_authorization");
+  });
+
+  it("does not read the candidate's SURNAME as a citizenship claim", () => {
+    // The profile band the contact scanner walks includes the name line
+    // (`contact.ts` → `scan(profile.lines, …)`), so a free nationality
+    // qualifier turns "Jane Citizen" into an immigration status.
+    const items = mkItems([
+      { text: "Jane Citizen", fontSize: 18 },
+      { text: "jane@example.com · (312) 555-0123 · Chicago, IL", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      ...RESUME_BODY,
+    ]);
+    const result = parseHeuristic(items, mkDefaultPages(items));
+    expect(result.parsed.full_name).toBe("Jane Citizen");
+    expect(result.parsed).not.toHaveProperty("work_authorization");
+  });
+
+  it("leaves the key ABSENT — not empty — on a résumé that states nothing", () => {
+    const items = mkItems([
+      { text: "Jane Doe", fontSize: 18 },
+      { text: "jane@example.com · (312) 555-0123 · Chicago, IL", fontSize: 10 },
+      { text: "", fontSize: 10 },
+      ...RESUME_BODY,
+    ]);
+    const result = parseHeuristic(items, mkDefaultPages(items));
+    expect(result.parsed).not.toHaveProperty("work_authorization");
+    expect(result.fieldConfidence).not.toHaveProperty("work_authorization");
+  });
+});

--- a/src/lib/heuristics/extract/work-authorization.ts
+++ b/src/lib/heuristics/extract/work-authorization.ts
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Work-authorization extraction (#792) — the narrow matcher behind
+ * `parsed.work_authorization`.
+ *
+ * A résumé states its right-to-work line in one of two places, and this module
+ * owns both readers so they can never drift apart:
+ *
+ *   1. **The header contact line** — a `·`/`•`/`|`-delimited segment beside the
+ *      email/phone/location ("Chicago, IL · jane@example.com · US Citizen").
+ *      This is also the shape our OWN exported PDF writes, so it is what makes
+ *      parse → export → re-parse preserve the value.
+ *   2. **A trailing unrouted block** — the "ADDITIONAL" section that opens an
+ *      `other` bucket, where the statement sits on a line of its own. Before
+ *      this, that line was correctly kept out of `skills` and then dropped on
+ *      the floor.
+ *
+ * ── Why every token has to be one we named on purpose ──
+ * The risk to manage here is over-matching, not under-matching: a false
+ * positive writes a fabricated legal claim onto someone's résumé and into the
+ * PDF they send out, which is far worse than missing a true statement the user
+ * can type in themselves (`ContactWorkAuthorization` exists for that).
+ *
+ * Anchoring is necessary but NOT sufficient, and the first cut of this file
+ * learned that the expensive way. `^right to work\b.{0,60}$` is anchored at
+ * both ends and still consumes the whole segment — but `.{0,60}` accepts *any*
+ * sixty characters, so the `$` bought nothing. That is how the matcher came to
+ * claim "Authorized to work with cross-functional teams", "Eligible to work on
+ * classified programs" and "Work status: Full-time, open to relocation" as
+ * immigration statuses, and how `[a-z.\-/ ]{0,24}citizen$` came to claim the
+ * surname in "Jane Citizen".
+ *
+ * So the rule this module actually enforces is stronger than an anchor: a
+ * statement matches only when **every token it consumed comes from a closed
+ * vocabulary declared below** — {@link NATION}, {@link VISA_CLASS},
+ * {@link STATUS_WORD}, {@link STATUS_LABEL} and the {@link RIGHT_TO_WORK_CLAUSE}
+ * set. There is no open `.{0,n}` run anywhere in `STATUS_PATTERNS`. An
+ * unrecognized word anywhere in the segment is a non-match, by construction.
+ *
+ * The cost is that this file must be edited to learn a new country or a new
+ * visa class. That is the intended trade: growing a closed list is a reviewable
+ * one-line diff, whereas an open tail silently claims strings nobody read.
+ *
+ * The other cost is speed, and it is paid up front: a closed vocabulary is a
+ * large alternation, and the engine's one-time cost to build and tier up those
+ * automata landed on the FIRST parse of a session — the drop-PDF→see-result
+ * path. {@link STATUS_PREFILTER} is the answer: a single cheap literal
+ * alternation, proven a strict superset of the grammar, that every segment must
+ * clear before any pattern runs. A résumé with no right-to-work line now never
+ * compiles the grammar at all. See that constant for the superset argument and
+ * the test that holds it.
+ *
+ * KNOWN NON-MATCHES (deliberate, documented so a reader does not mistake them
+ * for oversights). Each is a real statement we decline to claim because the
+ * token is too ambiguous to anchor safely:
+ *   - Bare visa classes on their own: "H-1B", "OPT", "CPT", "TN eligible",
+ *     "EAD". `OPT`/`TN`/`EAD` collide with ordinary résumé tokens (an
+ *     abbreviation, a two-letter state code, a product name), and a bare class
+ *     name is exactly the case where a wrong claim is most consequential.
+ *     They ARE matched when introduced by a label — "Work authorization: H-1B",
+ *     "Visa status: TN" — because the label carries the meaning.
+ *   - Bare nouns and valueless labels: "Citizen", "Citizenship", "Visa",
+ *     "Work permit", "Passport holder", "Right to work", "Authorized to work".
+ *     None of them names a status, and each is a plausible *heading* inside the
+ *     very unrouted block `harvestWorkAuthorization` scans — with the actual
+ *     value on the next line, which we would then not be reading.
+ *   - A jurisdiction outside {@link NATION}, or a label value outside
+ *     {@link STATUS_VALUE} ("Visa status: pending", "Work permit - expired").
+ *     The first is a gap to close by adding the country; the second is a
+ *     statement whose value we cannot vouch for.
+ *   - Statements with a trailing clause we do not recognize ("Authorized to
+ *     work in the US without sponsorship and open to relocation" — the
+ *     availability half is not a right-to-work clause). Missing one is the safe
+ *     direction.
+ *   - "Nationality: …", which states origin rather than a right to work.
+ *   - A status word with no nation attached: "Naturalized citizen", "Dual
+ *     national". {@link NATION} is what separates a status from a surname, so a
+ *     qualifier alone does not license the claim — "Naturalized US Citizen" and
+ *     "Dual US/UK Citizen" are the covered forms.
+ *   - "Right to work: Yes". `right to work` is a clause opener, not a
+ *     {@link STATUS_LABEL}, so the labelled form does not reach it; the
+ *     unlabelled form requires a {@link RIGHT_TO_WORK_CLAUSE}, and ": Yes" is
+ *     not one.
+ *   - A visa class in a right-to-work sentence rather than after a label:
+ *     "Authorized to work in the US on a TN visa". "on a … visa" is not a
+ *     recognized clause — the labelled "Visa status: TN" is the covered form.
+ *   - Anything with a parenthesised tail: "Authorized to work in the US (no
+ *     sponsorship required)", "Employment Authorization Document (EAD)". No
+ *     pattern admits a bracket, and the second is a document name rather than a
+ *     statement of status.
+ *   - A nation qualifying the employer or the sponsorship rather than the
+ *     jurisdiction: "…for any US employer", "…without US sponsorship". The
+ *     jurisdiction clause is where a nation is read; see {@link ANY_EMPLOYER}.
+ */
+
+import type { PdfLine, PdfSection } from "../sections.ts";
+
+/**
+ * Confidence for a statement read off the header contact line. High: the
+ * segment is delimiter-bounded contact real estate and the pattern consumed all
+ * of it, so there is no prose it could have been carved out of.
+ */
+export const WORK_AUTHORIZATION_CONTACT_CONFIDENCE = 0.9;
+
+/**
+ * Confidence for a statement recovered from a trailing unrouted block. Lower
+ * than the header read — the line is bounded only by the section, not by a
+ * contact delimiter — but comfortably above `CONTACT_DISPLAY_CONFIDENCE_FLOOR`,
+ * since the closed-vocabulary match already did the precision work.
+ */
+export const WORK_AUTHORIZATION_SECTION_CONFIDENCE = 0.7;
+
+/** Segment separators used on header contact lines — including the `•` our own
+ *  exported PDF joins `contactParts` with (`render-ats-pdf.ts`). */
+const SEGMENT_SEPARATORS = /[·•∙|｜]/;
+
+// ── Closed vocabulary ───────────────────────────────────────────────────────
+// Everything below is a regex *source fragment*, composed into `STATUS_PATTERNS`
+// at the bottom. Fragments never contain `^`/`$` or a capture group, so they
+// stay safe to embed anywhere. Longer alternatives are written before the
+// prefixes they extend, purely so the compiled pattern reads the way it matches.
+
+/**
+ * The places a right-to-work statement names, country and nationality adjective
+ * in one alternation because both shapes we read use both forms ("US Citizen",
+ * "authorized to work in the US"). Closed on purpose — see the module docblock.
+ * Adding a country here is the supported way to widen coverage.
+ */
+const NATION = [
+  "u\\.?s\\.?a\\.?",
+  "u\\.?s\\.?",
+  "united states(?: of america)?",
+  "american",
+  "u\\.?k\\.?",
+  "united kingdom",
+  "great britain",
+  "britain",
+  "british",
+  "england",
+  "scotland",
+  "wales",
+  "northern ireland",
+  "irish",
+  "ireland",
+  "e\\.?u\\.?",
+  "european union",
+  "eea",
+  "schengen(?: area)?",
+  "canadian",
+  "canada",
+  "australian",
+  "australia",
+  "new zealand",
+  "indian",
+  "india",
+  "singapore",
+  "german",
+  "germany",
+  "french",
+  "france",
+  "spanish",
+  "spain",
+  "italian",
+  "italy",
+  "dutch",
+  "netherlands",
+  "swiss",
+  "switzerland",
+  "swedish",
+  "sweden",
+  "polish",
+  "poland",
+  "mexican",
+  "mexico",
+  "brazilian",
+  "brazil",
+  "japanese",
+  "japan",
+  "south african",
+  "south africa",
+  "u\\.?a\\.?e\\.?",
+  "united arab emirates",
+  "israeli",
+  "israel",
+  "nigerian",
+  "nigeria",
+  "filipino",
+  "philippines",
+].join("|");
+
+/**
+ * One or more nations, as a dual/multi-status statement writes them:
+ * "Dual US/UK Citizen", "authorized to work in the US and the UK".
+ */
+const NATIONS = `(?:${NATION})(?:(?: ?[/&+] ?| and | or )(?:the )?(?:${NATION}))*`;
+
+/**
+ * The clauses that may follow "…to work" / "right to work". Each is a leading
+ * space plus a recognized right-to-work object: a jurisdiction, an employer
+ * scope, or a sponsorship/restriction disclaimer. Nothing else may follow, so
+ * "…to work with cross-functional teams" has no clause to match and falls out.
+ */
+const IN_JURISDICTION = ` (?:in|within) (?:the |any )?${NATIONS}`;
+// No nation qualifier in the two clauses below, deliberately. Textually
+// embedding `NATION` here bought only "for any **US** employer" / "without
+// **US** sponsorship" — a redundant restatement of the jurisdiction the
+// statement almost always already named — and cost a 59-way alternation copied
+// into every repetition of `RIGHT_TO_WORK_CLAUSE`, which is most of the
+// automaton-construction time the prefilter below exists to avoid paying.
+const ANY_EMPLOYER = " (?:for|with) any (?:employer|company)";
+const NO_SPONSORSHIP =
+  " (?:without|with no)(?: any| current| future| current or future)?" +
+  "(?: visa| employer| work| employment)? sponsorship" +
+  "(?: (?:required|needed|now or in the future))?";
+const NO_RESTRICTIONS = " (?:without|with no)(?: any)? restrictions?";
+const RIGHT_TO_WORK_CLAUSE = `(?:${IN_JURISDICTION}|${ANY_EMPLOYER}|${NO_SPONSORSHIP}|${NO_RESTRICTIONS})`;
+
+/**
+ * Visa and permit classes, matched only when a {@link STATUS_LABEL} introduces
+ * them — the label is what makes an otherwise ambiguous two-letter token
+ * ("TN", "EAD", "OPT") safe to read as an immigration status.
+ */
+const VISA_CLASS = [
+  "h-? ?1-? ?b1?",
+  "h-? ?4",
+  "l-? ?1[ab]?",
+  "l-? ?2",
+  "o-? ?1",
+  "e-? ?2",
+  "e-? ?3",
+  "tn-? ?1?",
+  "j-? ?1",
+  "f-? ?1",
+  "b-? ?1",
+  "(?:stem )?opt",
+  "cpt",
+  "ead",
+  "green ?card",
+  "blue card",
+  "tier 2",
+  "skilled worker(?: visa)?",
+  "indefinite leave to remain",
+  "ilr",
+  "(?:pre-)?settled status",
+  "work permit",
+  "work visa",
+  "student visa",
+  "spouse visa",
+].join("|");
+
+/** Status words a label may introduce — "Employment eligibility: unrestricted". */
+const STATUS_WORD = [
+  "unrestricted",
+  "unlimited",
+  "indefinite",
+  "authori[sz]ed",
+  "eligible",
+  "valid",
+  "active",
+  "yes",
+  "citizenship",
+  "citizen",
+  "national",
+  "(?:lawful |legal )?permanent resident",
+  "naturali[sz]ed(?: citizen)?",
+  "dual",
+  "none required",
+  "none",
+  "not required",
+  "no sponsorship required",
+  "sponsorship not required",
+  "no restrictions?",
+].join("|");
+
+/**
+ * The labels that make a bare status value readable — deliberately excluding
+ * `work status`, which is an AVAILABILITY label ("Work status: Full-time"),
+ * not an authorization one, and excluding a bare `visa`, which is also a
+ * company name a résumé is likely to list.
+ */
+const STATUS_LABEL = [
+  "citizenship",
+  "visa status",
+  "visa type",
+  "work permit",
+  "work (?:authori[sz]ation|eligibility)(?: status)?",
+  "employment (?:authori[sz]ation|eligibility)(?: status)?",
+  "immigration status",
+  "residency status",
+].join("|");
+
+/**
+ * What may appear on the right of a label: a short run of recognized nation /
+ * visa-class / status tokens and nothing else. This is what turns
+ * "Work permit - expired" and "Visa status: pending" into non-matches while
+ * keeping "Work authorization: H-1B" and "Citizenship: US".
+ */
+const STATUS_TOKEN = `(?:${VISA_CLASS}|${STATUS_WORD}|${NATION})`;
+const STATUS_VALUE = `${STATUS_TOKEN}(?:[ /,+&-]+${STATUS_TOKEN}){0,3}`;
+
+/**
+ * Full-segment right-to-work statements, case-insensitive, matched against a
+ * whitespace-collapsed segment with any single trailing sentence terminator
+ * already removed. Every one is anchored at both ends AND composed only from
+ * the closed vocabulary above — see the module docblock for why the anchor
+ * alone was not enough.
+ */
+const STATUS_PATTERNS: readonly RegExp[] = [
+  // "US Citizen", "U.S. Citizenship", "Canadian Citizen", "Dual US/UK Citizen",
+  // "Naturalized US Citizen", "Dual citizen". A nation (or the "dual"
+  // qualifier) is REQUIRED: without one the segment is a noun, and any word at
+  // all could stand in for it — "Jane Citizen", "Global Citizen".
+  new RegExp(
+    `^(?:dual citizen(?:ship)?|(?:(?:dual|naturali[sz]ed) )?${NATIONS} citizen(?:ship)?)$`,
+    "i",
+  ),
+  // "Green Card", "Green Card holder", "US Green Card holder".
+  new RegExp(`^(?:${NATIONS} )?green ?card(?: holder)?$`, "i"),
+  // "Permanent Resident", "Lawful Permanent Resident", "Canadian Permanent
+  // Resident". Not "Permanent resident of Seattle" — nothing may follow.
+  new RegExp(
+    `^(?:${NATIONS} )?(?:lawful |legal )?permanent resident(?: card)?(?: holder)?$`,
+    "i",
+  ),
+  // "Authorized to work in the US without sponsorship", "Legally authorised to
+  // work in the United Kingdom", "Eligible to work in the EU". At least one
+  // recognized clause is required, which is what rejects "…to work with
+  // cross-functional teams" and bare "Authorized to work".
+  new RegExp(
+    "^(?:legally |fully |currently )?(?:authori[sz]ed|eligible|entitled|permitted) to work" +
+      `${RIGHT_TO_WORK_CLAUSE}{1,3}$`,
+    "i",
+  ),
+  // "Work authorized", "Employment authorized" (the phrase an EAD card carries),
+  // "Work authorized in the US". A two-word declaration with no other reading.
+  new RegExp(
+    `^(?:work|employment) authori[sz]ed${RIGHT_TO_WORK_CLAUSE}{0,3}$`,
+    "i",
+  ),
+  // "Right to work in the UK", "Unrestricted right to work in the EU". The
+  // clause is required: "Right to Work laws in Texas" names US labour policy.
+  new RegExp(
+    `^(?:full |unrestricted |permanent )?right to work${RIGHT_TO_WORK_CLAUSE}{1,3}$`,
+    "i",
+  ),
+  // Labelled forms — "Work authorization: H-1B", "Visa status: TN",
+  // "Citizenship: US". The label is what makes a bare visa class safe to claim;
+  // the value allow-list is what stops the label claiming whatever follows it.
+  new RegExp(`^(?:${STATUS_LABEL})\\s*[:–—-]\\s*(?:${STATUS_VALUE})$`, "i"),
+  // "No sponsorship required", "Does not require visa sponsorship",
+  // "Requires no sponsorship", "Not seeking sponsorship".
+  new RegExp(
+    "^(?:(?:will |does |do )?not (?:require|seeking|need)|requires? no|no)" +
+      "(?: any| current| future| ongoing)?(?: visa| employer| work| employment)? sponsorship" +
+      "(?: (?:is )?(?:required|needed|necessary))?(?: now or in the future)?$",
+    "i",
+  ),
+  // "Visa sponsorship not required", "Sponsorship not needed".
+  new RegExp(
+    "^(?:visa |work |employment )?sponsorship (?:is )?not (?:required|needed|necessary)" +
+      "(?: now or in the future)?$",
+    "i",
+  ),
+  // "EU passport holder", "British passport holder". The nation is required —
+  // otherwise any adjective qualifies ("Vaccine passport holder").
+  new RegExp(`^${NATIONS} passport holder$`, "i"),
+];
+
+/**
+ * A cheap literal gate in front of {@link STATUS_PATTERNS} — a segment that
+ * fails this can never match the grammar, so it never pays for it.
+ *
+ * ── Why this exists ──
+ * The closed vocabulary is precise but expensive to *compile and run*:
+ * {@link NATION} is a 59-way alternation that the engine copies once per
+ * textual embedding, and `RIGHT_TO_WORK_CLAUSE{1,3}` multiplies each copy
+ * threefold again. Without this gate the first parse of a session spent ~860ms
+ * building and interpreting those automata — synchronous, on the
+ * drop-PDF→see-result path, over every line of the résumé, twice per parse
+ * (`extractContact` runs its primary and fallback `scan` unconditionally) plus
+ * once more in `harvestWorkAuthorization`. Only the FIRST parse paid it: the
+ * cost is V8 tiering the patterns up, not backtracking, so it is flat in input
+ * length and free thereafter. A user drops one PDF per session, which is
+ * precisely why all of it landed on the one parse they wait for.
+ *
+ * ── Why gating is safe ──
+ * This alternation is a strict SUPERSET of what the grammar can match: every
+ * pattern above is anchored and composed only from the closed vocabulary, and
+ * each one contains at least one literal listed here on EVERY path through it —
+ * `citizen` in the citizenship pattern, `green ?card`, `permanent resident`,
+ * `to work`, `authori[sz]` in "work authorized", `sponsor` in both sponsorship
+ * patterns, `passport holder`, and (for the labelled form) one of
+ * `citizen`/`visa`/`permit`/`authori[sz]`/`eligib`/`immigration`/`residenc`
+ * covering every alternative in {@link STATUS_LABEL}. So a segment this rejects
+ * was going to be a non-match regardless, and the gate changes no verdict.
+ *
+ * That argument is asserted, not just written down: `work-authorization.test.ts`
+ * runs the whole positive corpus through {@link matchWorkAuthorizationUngated}
+ * and requires the gated matcher to agree on every string. Add a pattern whose
+ * vocabulary is not represented here and that test fails loudly, rather than the
+ * new pattern silently never matching.
+ */
+const STATUS_PREFILTER =
+  /citizen|green ?card|permanent resident|to work|sponsor|passport holder|visa|permit|immigration|residenc|authori[sz]|eligib|national/i;
+
+/**
+ * Normalize a candidate to the form the patterns are written against, and to
+ * the form we STORE: whitespace collapsed, and a single trailing sentence
+ * terminator dropped.
+ *
+ * Dropping the terminator is what makes the value idempotent across the
+ * round-trip. A source résumé writes "Authorized to work in the US without
+ * sponsorship."; our contact line draws the stored value beside the email,
+ * where a full stop would read as a typo; the re-parse must then land on the
+ * same string it started from. Normalizing on the way IN is what guarantees
+ * that, since the second pass sees an already-normalized value and changes
+ * nothing.
+ */
+function normalizeSegment(text: string): string {
+  return text.replace(/\s+/g, " ").trim().replace(/[.;,]$/, "").trim();
+}
+
+/**
+ * The work-authorization statement `text` states, or `undefined`. `text` is one
+ * candidate — a contact-line segment or a whole body line — never a paragraph:
+ * the caller is responsible for splitting.
+ */
+export function matchWorkAuthorization(text: string): string | undefined {
+  const normalized = normalizeSegment(text);
+  if (!normalized) return undefined;
+  if (!STATUS_PREFILTER.test(normalized)) return undefined;
+  return matchClosedGrammar(normalized);
+}
+
+/**
+ * {@link matchWorkAuthorization} with {@link STATUS_PREFILTER} skipped.
+ *
+ * Exported for one purpose: the superset test. The prefilter's whole safety
+ * argument is that it never rejects a segment the grammar would have claimed,
+ * and that is only checkable by running the grammar ungated and requiring the
+ * two to agree. Production code must call {@link matchWorkAuthorization} — this
+ * is the slow path the gate exists to avoid.
+ */
+export function matchWorkAuthorizationUngated(
+  text: string,
+): string | undefined {
+  const normalized = normalizeSegment(text);
+  if (!normalized) return undefined;
+  return matchClosedGrammar(normalized);
+}
+
+/** The closed grammar itself, shared by the gated and ungated entry points. */
+function matchClosedGrammar(normalized: string): string | undefined {
+  return STATUS_PATTERNS.some((re) => re.test(normalized))
+    ? normalized
+    : undefined;
+}
+
+/**
+ * Scan header/profile lines for a work-authorization segment, taking the first
+ * hit in document order.
+ *
+ * Like `location` — and unlike email/phone/URLs — this is NOT given a
+ * document-wide fallback. A right-to-work sentence found deep in a body section
+ * is far more likely to be describing a job requirement, a client, or someone
+ * else's paperwork than the candidate's own status. The `other`-bucket reader
+ * below is the one deliberate exception, and it is bounded to unrouted trailing
+ * sections.
+ *
+ * Note that the profile band includes the NAME line, which is precisely why the
+ * citizen pattern may not treat an arbitrary leading word as a nationality: a
+ * candidate surnamed Citizen must not be read as stating a status.
+ */
+export function extractWorkAuthorization(
+  lines: readonly PdfLine[],
+): string | undefined {
+  for (const line of lines) {
+    for (const segment of line.text.split(SEGMENT_SEPARATORS)) {
+      const hit = matchWorkAuthorization(segment);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Recover the statement from a boundary-only `other` bucket — the "ADDITIONAL"
+ * block opened by a header the section router does not recognize, which is
+ * where résumés that keep it out of the header put it.
+ *
+ * Mirrors `harvestInlineLabeledSkills` in `openresume.ts`: same bucket, same
+ * document-order walk. The line is NOT consumed from the section — it stays in
+ * the pool the scorer reads, so routing it here moves no score.
+ */
+export function harvestWorkAuthorization(
+  sections: readonly PdfSection[],
+): string | undefined {
+  for (const section of sections) {
+    if (section.name !== "other") continue;
+    for (const line of section.lines) {
+      const hit = matchWorkAuthorization(line.text);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}

--- a/src/lib/heuristics/localize/roundtrip.ts
+++ b/src/lib/heuristics/localize/roundtrip.ts
@@ -86,6 +86,11 @@ function contactFails(
     "phone",
     "location",
     "linkedin_url",
+    // #792 — the statement rides the exported contact line, so a renderer or
+    // matcher change that drops it (or that re-parses it into a different
+    // string, e.g. by keeping a trailing full stop on one pass only) is a
+    // round-trip regression like any other contact value.
+    "work_authorization",
   ] as const) {
     if (!same(c1[k], c3[k]))
       out.push(`${k}: ${JSON.stringify(c1[k])} → ${JSON.stringify(c3[k])}`);

--- a/src/lib/heuristics/openresume.ts
+++ b/src/lib/heuristics/openresume.ts
@@ -45,6 +45,10 @@ import {
   extractAchievements,
 } from "./extract-fields.ts";
 import { tokenizeSkillLine } from "./extract/skills.ts";
+import {
+  harvestWorkAuthorization,
+  WORK_AUTHORIZATION_SECTION_CONFIDENCE,
+} from "./extract/work-authorization.ts";
 import { rejoinSplitLetters } from "./regex.ts";
 import type { ResumeExperience } from "../score/types.ts";
 
@@ -373,6 +377,20 @@ function buildHeuristicResult(
 
   const ownedSections = stripConsumedLines(sections, contact.consumedLines);
 
+  // Work authorization (#792). The header contact line wins — it is the tighter
+  // read (a delimiter-bounded segment) and it is the shape our own exported PDF
+  // writes, so preferring it is what keeps parse → export → re-parse stable.
+  // Only when the header is silent do we fall back to a trailing unrouted
+  // ("ADDITIONAL") block, the other place résumés put the statement. That line
+  // is deliberately LEFT in its section: it already sat there before #792, so
+  // reading it here adds a field without moving a single score.
+  const headerWorkAuthorization = contact.work_authorization;
+  const workAuthorization =
+    headerWorkAuthorization ?? harvestWorkAuthorization(ownedSections);
+  const workAuthorizationConfidence = headerWorkAuthorization
+    ? contact.confidence.work_authorization
+    : WORK_AUTHORIZATION_SECTION_CONFIDENCE;
+
   const summarySection = findSection(ownedSections, "summary");
   const experienceSection = findSection(ownedSections, "experience");
   const educationSection = findSection(ownedSections, "education");
@@ -423,6 +441,11 @@ function buildHeuristicResult(
       ? { phoneIsValid: contact.phoneIsValid }
       : {}),
     ...(contact.location ? { location: contact.location } : {}),
+    // Work authorization (#792) — see `workAuthorization` above for how the
+    // header read and the trailing-block recovery are ordered. Spread
+    // conditionally, like every other optional contact key, so a résumé that
+    // states nothing produces a byte-identical parse to before.
+    ...(workAuthorization ? { work_authorization: workAuthorization } : {}),
     ...(contact.linkedin_url ? { linkedin_url: contact.linkedin_url } : {}),
     ...(contact.github_url ? { github_url: contact.github_url } : {}),
     ...(contact.portfolio_url ? { portfolio_url: contact.portfolio_url } : {}),
@@ -458,6 +481,9 @@ function buildHeuristicResult(
     email: contact.confidence.email,
     phone: contact.confidence.phone,
     location: contact.confidence.location,
+    ...(workAuthorization
+      ? { work_authorization: workAuthorizationConfidence }
+      : {}),
     linkedin_url: contact.confidence.linkedin_url,
     github_url: contact.confidence.github_url,
     portfolio_url: contact.confidence.portfolio_url,

--- a/src/lib/heuristics/types.ts
+++ b/src/lib/heuristics/types.ts
@@ -178,6 +178,7 @@ export type FieldConfidence = Partial<
     | "email"
     | "phone"
     | "location"
+    | "work_authorization"
     | "linkedin_url"
     | "github_url"
     | "portfolio_url"

--- a/src/lib/job-search/work-authorization-egress.test.ts
+++ b/src/lib/job-search/work-authorization-egress.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Guardrail #2 of #792 — `work_authorization` NEVER egresses.
+ *
+ * `providers/keywords.ts` is the one résumé-derived egress helper in the tree
+ * (see `CLAUDE.md` → Project overview): everything a third-party job feed
+ * receives about the candidate is derived from a `JobQuery`. So the question
+ * this file answers is not "does `keywords.ts` mention the field" — it does
+ * not — but the stronger one: can a work-authorization statement reach a
+ * `JobQuery` at all, and from there any outbound string.
+ *
+ * A candidate's immigration status is the one field on the résumé where an
+ * outbound leak is not merely a privacy slip but a discrimination surface: it
+ * would hand a third party a filterable legal attribute the candidate never
+ * chose to share with them. `ResumeQueryInput` is a `Pick` that excludes the
+ * field, so today the compiler refuses it — the cast below deliberately defeats
+ * that so the RUNTIME behaviour is pinned too, and a future widening of the
+ * `Pick` cannot quietly open the path.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildJobQuery, type ResumeQueryInput } from "./query-builder.ts";
+import { searchPhrase, primaryKeyword } from "./providers/keywords.ts";
+import { buildDeepLinks } from "./deep-links.ts";
+
+const STATEMENT = "Authorized to work in the US without sponsorship";
+
+/** A parsed résumé that states its work authorization, cast past the `Pick`
+ *  that would normally forbid handing the field to the query builder. */
+const RESUME = {
+  current_title: "Staff Software Engineer",
+  headline: "Staff Software Engineer",
+  location: "Chicago, IL",
+  skills: ["TypeScript", "Kubernetes", "PostgreSQL"],
+  experience: [
+    {
+      title: "Staff Software Engineer",
+      company: "Globex",
+      start_date: "Jan 2022",
+      is_current: true,
+    },
+  ],
+  work_authorization: STATEMENT,
+} as unknown as ResumeQueryInput;
+
+/** Every distinctive token of the statement, so a partial leak ("citizen",
+ *  "sponsorship") fails as loudly as a verbatim one. */
+const FORBIDDEN = [
+  STATEMENT,
+  "authorized",
+  "sponsorship",
+  "citizen",
+  "green card",
+  "work_authorization",
+];
+
+function assertClean(where: string, text: string): void {
+  for (const needle of FORBIDDEN) {
+    expect(
+      text.toLowerCase().includes(needle.toLowerCase()),
+      `${where} leaked ${JSON.stringify(needle)}: ${text}`,
+    ).toBe(false);
+  }
+}
+
+describe("#792 guardrail — work authorization never reaches an outbound query", () => {
+  const query = buildJobQuery(RESUME);
+
+  it("does not survive into the JobQuery at all", () => {
+    assertClean("JobQuery", JSON.stringify(query));
+  });
+
+  it("does not reach the full-text search phrase (Remotive / Arbeitnow)", () => {
+    assertClean("searchPhrase", searchPhrase(query));
+    // Sanity: the phrase is non-empty, so the assertion above is not passing
+    // by virtue of an empty string.
+    expect(searchPhrase(query)).toBe("Staff Software Engineer");
+  });
+
+  it("does not reach the tag keyword (Jobicy)", () => {
+    assertClean("primaryKeyword", primaryKeyword(query));
+    expect(primaryKeyword(query).toLowerCase()).toBe("typescript");
+  });
+
+  it("does not reach any built job-board deep link", () => {
+    const links = buildDeepLinks(query);
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) assertClean(`deep link ${link.label}`, link.url);
+  });
+});

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -74,6 +74,11 @@ export interface AtsContact {
   email?: string;
   phone?: string;
   location?: string;
+  /** Work-authorization statement (#792), verbatim free text as the résumé
+   *  states it. The renderer draws it on the contact line after `location` and
+   *  before `links`, adding no new header row. It is NOT a link: it gets no
+   *  `mailto:`/`https:` overlay and no scheme-stripping. */
+  workAuthorization?: string;
   /** LinkedIn / GitHub / portfolio / website / other links, scheme-stripped
    *  for display (`https://www.linkedin.com/in/jane` → `linkedin.com/in/jane`,
    *  #425). */
@@ -273,6 +278,9 @@ export function buildContact(result: CascadeResult): AtsContact {
   const email = valueFor("email");
   const phone = valueFor("phone");
   const location = valueFor("location");
+  // Work authorization (#792) — read through `valueFor` like its siblings, so
+  // the confidence gating and the user's inline edit apply to it identically.
+  const workAuthorization = valueFor("work_authorization");
 
   // Links: since #427 every link edit (including LinkedIn corrections) folds
   // into the parsed slots via `profileOverrides`, so `result.parsed` already
@@ -317,6 +325,7 @@ export function buildContact(result: CascadeResult): AtsContact {
     email: email || undefined,
     phone: phone || undefined,
     location: location || undefined,
+    workAuthorization: workAuthorization || undefined,
     links,
     linkHrefs,
     // `parsed.profiles` is already override-applied (applyOverrides re-derives it

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -508,6 +508,7 @@ export async function findExportGlyphLosses(
   check("Email", contact.email);
   check("Phone", contact.phone);
   check("Location", contact.location);
+  check("Work authorization", contact.workAuthorization);
   for (const link of contact.links) check("Links", link);
   check(model.summaryHeading || "Summary", model.summary);
 
@@ -1493,10 +1494,15 @@ export async function renderAtsResumePdf(
       color: muted,
     });
   }
+  // Work authorization (#792) sits after location and before the links, so the
+  // statement rides the existing contact line and costs the header no extra
+  // row. It is deliberately absent from `linkSpans` below: it is a sentence,
+  // not a URL, so it receives no clickable overlay and no scheme-stripping.
   const contactParts = [
     model.contact.email,
     model.contact.phone,
     model.contact.location,
+    model.contact.workAuthorization,
     ...model.contact.links,
   ].filter((p): p is string => Boolean(p));
   if (contactParts.length > 0) {

--- a/src/lib/pdf/render-work-authorization.test.ts
+++ b/src/lib/pdf/render-work-authorization.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * #792 — the work-authorization statement on the exported contact line.
+ *
+ * Three properties, each of which would be a silent defect if it broke:
+ *   1. It rides the EXISTING contact line, after location and before the links,
+ *      costing the header no extra row. That is the whole reason the field is
+ *      viable on a dense one-page résumé.
+ *   2. It receives no clickable link annotation. It is a sentence, not a URL,
+ *      and an overlay pointing at `https://US Citizen` would ship a broken link
+ *      in a document the user sends to employers.
+ *   3. It is covered by the export's glyph-loss audit, so a statement that
+ *      degrades under the Helvetica/WinAnsi fallback is reported rather than
+ *      silently rewritten.
+ *
+ * Every render + pdfjs read happens ONCE, in `beforeAll` with its own timeout:
+ * a first `getDocument` pays the pdfjs cold start, which overruns the 5s
+ * per-test default when the suite runs under load.
+ */
+
+import { describe, expect, it, beforeAll } from "vitest";
+import { renderAtsResumePdf, findExportGlyphLosses } from "./render-ats-pdf.ts";
+import {
+  extractPdfDrawnLines,
+  type PdfDrawnLine,
+} from "./render-ats-pdf.test-utils.ts";
+import type { AtsResumeModel } from "./ats-resume-model.ts";
+
+const MODEL: AtsResumeModel = {
+  contact: {
+    name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    location: "Chicago, IL",
+    workAuthorization: "US Citizen",
+    links: ["linkedin.com/in/jane"],
+    linkHrefs: ["https://linkedin.com/in/jane"],
+  },
+  sections: [
+    {
+      heading: "Experience",
+      entries: [
+        { headerLine: "Senior PM", subLine: "Acme · Chicago, IL", bullets: ["Shipped it"] },
+      ],
+    },
+  ],
+};
+
+/** The same model with nothing to state — the control for "adds no new line". */
+const SILENT_MODEL: AtsResumeModel = {
+  ...MODEL,
+  contact: { ...MODEL.contact, workAuthorization: undefined },
+};
+
+async function linkAnnotationUrls(bytes: Uint8Array): Promise<string[]> {
+  const pdfjs = await import("pdfjs-dist");
+  const doc = await pdfjs.getDocument({
+    data: bytes.slice(),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+    useSystemFonts: false,
+  }).promise;
+  const urls: string[] = [];
+  for (let p = 1; p <= doc.numPages; p++) {
+    for (const a of await (await doc.getPage(p)).getAnnotations()) {
+      const ann = a as { subtype?: string; url?: string; unsafeUrl?: string };
+      if (ann.subtype === "Link") urls.push(ann.url ?? ann.unsafeUrl ?? "");
+    }
+  }
+  return urls;
+}
+
+describe("renderAtsResumePdf — work authorization on the contact line (#792)", () => {
+  let stated: PdfDrawnLine[];
+  let silent: PdfDrawnLine[];
+  let urls: string[];
+  let glyphLossSites: string[];
+
+  beforeAll(async () => {
+    const bytes = await renderAtsResumePdf(MODEL);
+    stated = await extractPdfDrawnLines(bytes);
+    silent = await extractPdfDrawnLines(await renderAtsResumePdf(SILENT_MODEL));
+    urls = await linkAnnotationUrls(bytes);
+    glyphLossSites = (
+      await findExportGlyphLosses({
+        ...MODEL,
+        // `✓` (U+2713) has no WinAnsi code point; an em dash does, which is why
+        // the sample below is not simply punctuation-heavy.
+        contact: { ...MODEL.contact, workAuthorization: "US Citizen ✓" },
+      })
+    ).map((l) => l.where);
+  }, 60_000);
+
+  const contactLine = (): string => {
+    const line = stated.find((l) => l.text.includes("jane@example.com"));
+    expect(line, "no contact line was drawn").toBeDefined();
+    return line!.text;
+  };
+
+  it("draws it after location and before the links, on the same line", () => {
+    const text = contactLine();
+    expect(text).toContain("US Citizen");
+    expect(text.indexOf("Chicago, IL")).toBeLessThan(text.indexOf("US Citizen"));
+    expect(text.indexOf("US Citizen")).toBeLessThan(
+      text.indexOf("linkedin.com/in/jane"),
+    );
+  });
+
+  it("adds no new header line", () => {
+    expect(stated.length).toBe(silent.length);
+  });
+
+  it("gets no link annotation and no scheme-stripping", () => {
+    // The real links are still clickable — this is not a "nothing is linked" pass.
+    expect(urls).toContain("mailto:jane@example.com");
+    expect(urls).toContain("https://linkedin.com/in/jane");
+    // …and nothing points at the statement.
+    for (const url of urls) expect(url).not.toMatch(/citizen/i);
+    // Drawn verbatim, not put through the link display formatter.
+    expect(contactLine()).toContain("US Citizen");
+  });
+
+  it("is covered by the export glyph-loss audit", () => {
+    // A statement carrying a code point the WinAnsi fallback cannot draw must be
+    // REPORTED, not silently rewritten to `?`. `findExportGlyphLosses` returns
+    // an empty list when the embedded font loads; under Node it does not, which
+    // is the fallback path this audit exists to measure.
+    expect(glyphLossSites).toContain("Work authorization");
+  });
+});

--- a/src/lib/pdf/to-json-resume.test.ts
+++ b/src/lib/pdf/to-json-resume.test.ts
@@ -161,6 +161,28 @@ describe("toJsonResume — basics", () => {
   it("picks basics.url from portfolio/website (the 'other' personal site)", () => {
     expect(basics.url).toBe("https://jane.dev");
   });
+
+  // #792 — work authorization has no home in JSON Resume v1.0.0, so it ships
+  // under the conventional `x_` extension prefix rather than being squeezed
+  // into a standard field that means something else.
+  it("emits basics.x_workAuthorization when the résumé states one", () => {
+    const { basics: stated } = toJsonResume({
+      ...FULL_MODEL,
+      contact: { ...FULL_MODEL.contact, workAuthorization: "US Citizen" },
+    });
+    expect(stated.x_workAuthorization).toBe("US Citizen");
+  });
+
+  it("omits the key entirely when absent, so existing exports are unchanged", () => {
+    // `FULL_MODEL` states nothing, so this is the pre-#792 export shape.
+    expect("x_workAuthorization" in JSON.parse(JSON.stringify(basics))).toBe(false);
+    // A whitespace-only value is treated as absent too — the key never ships empty.
+    const { basics: blank } = toJsonResume({
+      ...FULL_MODEL,
+      contact: { ...FULL_MODEL.contact, workAuthorization: "   " },
+    });
+    expect("x_workAuthorization" in JSON.parse(JSON.stringify(blank))).toBe(false);
+  });
 });
 
 describe("toJsonResume — work", () => {

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -69,6 +69,18 @@ export interface JsonResumeBasics {
   url?: string;
   location?: JsonResumeLocation;
   profiles?: JsonResumeProfile[];
+  /**
+   * DELIBERATE NON-STANDARD EXTENSION (#792). JSON Resume v1.0.0 `basics` has
+   * no work-authorization property and none of its standard fields means this,
+   * so repurposing one (`summary`, `label`) would misreport a legal attribute.
+   * The `x_` prefix is the conventional escape hatch: a consumer validating
+   * strict v1.0.0 ignores the key rather than failing on it.
+   *
+   * Emitted ONLY when the résumé actually states a work-authorization value —
+   * the key is omitted entirely otherwise, so every export from a résumé
+   * without one is byte-identical to what this module produced before #792.
+   */
+  x_workAuthorization?: string;
 }
 
 export interface JsonResumeWork {
@@ -305,6 +317,9 @@ export function basicsFromContact(c: AtsContact): JsonResumeBasics {
     url: pickPrimaryUrl(sourceProfiles),
     location: toJsonResumeLocation(c.location),
     profiles: profiles.length > 0 ? profiles : undefined,
+    // Non-standard `x_` extension — see the field docblock. A blank/whitespace
+    // value is treated as absent so the key never ships empty.
+    x_workAuthorization: c.workAuthorization?.trim() || undefined,
   };
 }
 

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -312,6 +312,22 @@ export interface ResumeData {
    *  under the name instead of silently dropping it (#425 follow-up). */
   headline?: string;
   location?: string;
+  /** Work-authorization / right-to-work statement as the résumé states it,
+   *  VERBATIM: "US Citizen", "Green Card holder", "Authorized to work in the US
+   *  without sponsorship", "EU passport holder".
+   *
+   *  Free text, NEVER an enum (#792). Statuses are numerous, jurisdiction-
+   *  specific, and legally consequential; classifying a candidate's own
+   *  declaration into a fixed set would be lossy in exactly the cases that
+   *  matter and would put this product in the position of asserting someone's
+   *  legal status. Carry what they wrote.
+   *
+   *  Optional everywhere, and absence is NOT a gap: it is never added to
+   *  `completenessChecks` and never a required `CONTACT_ROWS` row, so a résumé
+   *  that declines to disclose immigration status scores identically to one
+   *  that discloses. It is also never derived into a job-search query — see
+   *  `job-search/providers/keywords.ts`, the sole résumé-derived egress helper. */
+  work_authorization?: string;
   linkedin_url?: string;
   portfolio_url?: string;
   github_url?: string;

--- a/src/lib/score/work-authorization-not-scored.test.ts
+++ b/src/lib/score/work-authorization-not-scored.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Guardrail #1 of #792 — `work_authorization` is NEVER scored.
+ *
+ * This is a policy invariant, not a performance one. A résumé that declines to
+ * state immigration status must grade identically to one that states it;
+ * anything else means the product docks a candidate for not disclosing a
+ * protected-class-adjacent legal attribute. "We simply didn't add a
+ * `completenessChecks` entry" is not evidence — a future contributor wiring the
+ * field into the contact-completeness loop would be a one-line change that no
+ * existing test notices. So this asserts the OUTCOME: the same document scored
+ * with and without the field produces a byte-identical `AnonymousAtsScore`.
+ *
+ * The fixture is the corpus's own `multi-degree-coursework.pdf`, whose contact
+ * line reads "… | US Citizen" — a synthetic persona (Jordan Bennett,
+ * `@example.com`, a 555-exchange number), like every fixture in the repo. Using
+ * a real parse rather than a literal is what makes the comparison honest: both
+ * sides share one `rawText` and one `sections` pool, so the ONLY difference
+ * between them is the parsed field itself.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import { computeAnonymousAtsScore } from "./score.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(
+  HERE,
+  "../../..",
+  "tests/fixtures/pdfs/latex/multi-degree-coursework.pdf",
+);
+
+/**
+ * Score a cascade result while handing the scorer the WHOLE parsed field core,
+ * not the hand-picked subset the app's call sites enumerate. That is deliberate:
+ * enumerating the fields at the call site is how `work_authorization` is kept
+ * out today, and a test that copies the enumeration would prove only that the
+ * test enumerates. Passing everything means the guarantee has to hold inside
+ * `computeAnonymousAtsScore` itself.
+ */
+function scoreEverything(cascade: CascadeResult) {
+  return computeAnonymousAtsScore({
+    parsed: cascade.canonical.fields,
+    fieldConfidence: cascade.canonical.fieldConfidence,
+    triggers: cascade.triggers,
+    rawText: cascade.rawText,
+    sections: cascade.canonical.sections,
+  });
+}
+
+describe("#792 guardrail — work_authorization never moves the score", () => {
+  let stated: CascadeResult;
+
+  beforeAll(async () => {
+    stated = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+  });
+
+  it("the fixture really does state one (else everything below is vacuous)", () => {
+    expect(stated.canonical.fields.work_authorization).toBe("US Citizen");
+  });
+
+  it("scores identically with and without the field", () => {
+    const withoutFields = { ...stated.canonical.fields };
+    delete withoutFields.work_authorization;
+    const withoutConfidence = { ...stated.canonical.fieldConfidence };
+    delete withoutConfidence.work_authorization;
+
+    const silent = computeAnonymousAtsScore({
+      parsed: withoutFields,
+      fieldConfidence: withoutConfidence,
+      triggers: stated.triggers,
+      rawText: stated.rawText,
+      sections: stated.canonical.sections,
+    });
+
+    expect(silent).toEqual(scoreEverything(stated));
+  });
+
+  it("never names work authorization as something the résumé is missing", () => {
+    // The equality above catches a WEIGHTED check. This catches the subtler
+    // shape a user actually reads: a gap listed in `completeness.missing`,
+    // which is the surface that tells someone what they are expected to supply.
+    // Asserted on a parse where the field is deliberately ABSENT — the only
+    // state in which a "missing" row could appear at all.
+    const withoutFields = { ...stated.canonical.fields };
+    delete withoutFields.work_authorization;
+    const silent = computeAnonymousAtsScore({
+      parsed: withoutFields,
+      fieldConfidence: stated.canonical.fieldConfidence,
+      triggers: stated.triggers,
+      rawText: stated.rawText,
+      sections: stated.canonical.sections,
+    });
+    expect(
+      silent.completeness.missing.filter((m) =>
+        /authorization|citizen|visa|sponsor/i.test(m),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -22,7 +22,8 @@
       "phoneIsValid",
       "projects",
       "skills",
-      "website_url"
+      "website_url",
+      "work_authorization"
     ],
     "skillsCount": 17,
     "experienceCount": 4,


### PR DESCRIPTION
Supersedes #797, which GitHub auto-closed when its base branch (the layer-02 branch) was deleted on merge and which cannot be reopened. Same commit, same verified diff — `git patch-id` identical to the commit reviewed there. Layers 01 (#795) and 02 (#796) are already on `main`, so this now targets `main` directly and is a single-commit diff.

## What shipped

There was no way to state work authorization on a résumé in offlinecv: no field on `ResumeData`, no row on the contact card, nowhere to draw it in the export, and the parser discarded it when a source résumé already said it. Both stages of #792 land here.

**Stage 1 — model, edit, render, export.** `ResumeData.work_authorization?: string`, free text and never an enum, carried verbatim. It is a `CONTACT_ROWS` entry with `optional: true`, so absence never counts against the detected/total ratio. It rides the existing `ContactOverrides` channel. It renders on the exported PDF's contact line after location and before links — **zero extra header lines** — with no link annotation and no scheme-stripping, and it is covered by the renderer's loss audit. JSON export emits `basics.x_workAuthorization`, omitted entirely when absent so existing exports stay byte-identical.

**A reachability trap, avoided.** Optional contact rows are hidden when absent, so without a dedicated affordance the field would be unreachable for exactly the users who need it — the same trap as #791. There is a "+ Add work authorization" control composing the existing `AddPill` + plain text input. Deliberately **not** `ProfileLinkAdd`, which is a URL field and which layer 01 just made strictly reject non-URLs. One thing the issue did not anticipate: a *cleared* optional row returns as `absent` and would have drawn a "not detected" pill, which the policy forbids — those rows are now filtered out of the contact line and the add pill is offered instead.

**Stage 2 — extraction**, so a source résumé keeps it: a bounded read of the header/contact band, and a harvest from a trailing unrouted section. `skills.test.ts:109` and `:162` are **byte-identical** — the line still never becomes a skill.

## The three guardrails, each with a test that actually proves it

- **Never scored.** No `completenessChecks` entry, not a required row. The test hands `computeAnonymousAtsScore` the **whole** `canonical.fields` — not an enumerated subset that would trivially exclude the field — and asserts an identical `AnonymousAtsScore` with and without it. A résumé that omits it scores exactly as before, so nobody is penalized for declining to disclose immigration status.
- **Never egresses.** Asserted against `buildJobQuery`, `searchPhrase`, `primaryKeyword` and every `buildDeepLinks` URL, with a cast past the `Pick` so the runtime path is pinned rather than only the type. The assertions run against non-empty values, so nothing passes by being empty.
- **Not PII-free.** No new fixture binary enters the repo: the corpus already contained a résumé stating it. `npm run check:fixtures` passes with no bypass — 58 PDFs and 15 ground-truth sidecars, all synthetic.

## One snapshot moved, and why that is correct

`multi-degree-coursework.expected.json` gained exactly one key — `work_authorization` in `fieldsPopulated`. Every count, score and derived value is byte-identical. That fixture's PDF is **unmodified** and already read `973-555-0123 | jordan.bennett@example.com | LinkedIn | GitHub | US Citizen`. This is the feature working on the one corpus résumé that states a statement — a true positive, not a matcher false positive. No other snapshot, baseline, or `KNOWN_FAILURES` entry changed.

## Known gap, deliberate

`to-markdown.ts`'s `formatContactLine` is not wired, so "Download as Markdown" omits the field. Judged **not blocking**: that adapter already omits `phone` — a *required* contact field — because it targets a fixed career-ops `cv.md` shape, so this is pre-existing narrowness of that contract rather than a #792 regression, and the issue's acceptance criteria enumerate the PDF and JSON Resume only. Follow-up worth filing.

## Verification

- `src/lib/heuristics` (corpus + round-trip) — 1385 passed with the work-authorization suites, no snapshot moved beyond the one above.
- Guardrail suites, render, JSON export, contact, overrides, `ContactCard` — all pass.
- Round-trip is genuinely gated: the field was added to `contactFails`, and the fixture carrying it has no `corpus-roundtrip.known-failures.json` entry, so the parse→export→re-parse assertion is live rather than baselined away.
- `typecheck`, `lint`, `check:fixtures` clean. Gates run under Node 20 (`.nvmrc`).
- `verify` passed on CI for this exact diff on the predecessor branch head; the rebase onto `main` is patch-id identical.

Closes #792

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation — #792 | Claude Opus 5 | ultra |
| Fix — matcher over-matching | Claude Opus 5 | ultra |
| Adversarial review (stack-wide) | Claude Opus 4.5 | high |
| Orchestration + PR | Claude Opus 5 | high |

## Adversarial review

Reviewed pre-submit, two rounds, by an independent reviewer prompted to break the change. **One blocking defect was found and fixed on this layer before this PR existed**, and it was the one the issue named as the thing that must not happen.

**The matcher fabricated legal claims.** The `$` anchor the module docblock called load-bearing was cosmetic on five of eleven patterns, each ending in an unconstrained `.{0,60}` tail. Reproduced end-to-end through `renderAtsResumePdf → runCascade`, each of these was claimed verbatim and drawn onto the exported PDF's contact line as the candidate's legal status:

| Ordinary résumé prose | Claimed as work authorization |
|---|---|
| `Work status: Full-time, open to relocation` | verbatim |
| `Authorized to work with cross-functional teams` | verbatim |
| `Eligible to work on classified programs` | verbatim |

At matcher level the citizen pattern also claimed `Jane Citizen` — a **surname** — along with `Global Citizen`, `Corporate Citizen`, `Citizenship` and bare `citizen`. The profile band includes the name line, so that path is reachable.

**The fix rejected the narrow patch and rebuilt the grammar.** The reviewer proposed a lookahead requiring a right-to-work token somewhere in the tail. That was shown to still claim `Eligible to work on US government programs` and `Authorized to work with US-based clients`, because it asks only whether such a token appears, not whether it is the object of "to work" — the exact shape of the confirmed reproductions. Patching the three known strings would have left the class open.

Instead `STATUS_PATTERNS` is now composed from a **closed vocabulary** of named fragments, with **no `.{0,n}` run anywhere**. A segment matches only when every token it consumed is one the module named on purpose; an unrecognized word is a non-match by construction rather than by a per-pattern patch. The invariant is checkable by reading instead of by simulating what sixty arbitrary characters could be.

Evidence: **20 new guards failed before the fix** and pass after; 103 tests in the matcher suite; a 70-string adversarial sweep over `Citizen Watch Company`, `Visa Inc`, `Senior Citizen Services Coordinator` and section headings produced **zero claims**; and an end-to-end test confirms a candidate surnamed `Jane Citizen` parses `full_name` correctly with **no** `work_authorization`. Growth is linear after regex cold-start — no ReDoS.

**The trade, stated plainly:** this file must now be edited to learn a new country or visa class. That is intended. A closed list grows by a reviewable one-line diff; an open tail silently claims strings nobody read. Under-matching is recorded as documented non-matches, including bare visa classes (`H-1B`, `OPT`, `CPT`, `TN`, `EAD`) unlabelled, which remain deliberately unmatched.

**Round 2 found the rewrite cost 860ms on the parse hot path.** Precision was independently confirmed first — over the full text of all 58 fixture PDFs the matcher claims exactly one line (`multi-degree-coursework → "US Citizen"`), a 68-string adversarial probe produced no fabrications, 47 genuine statements still match, and 10 surnames (Citizen, Green, Permanent, Visa, National, Passport, American, Indian, Wales, Ireland) all parse `full_name` correctly with no `work_authorization`. But an A/B swapping only this file measured `parseHeuristic` first-call going `106ms → 966ms`, synchronous, on the drop-PDF→see-result path.

The cause was not backtracking — timings were flat in input length. `NATION` is a 59-way alternation embedded ~4× per clause, and `{1,3}` makes V8 copy the body three times, so each pattern carried ~12 copies of it; the cost is automaton construction, paid once per session then free.

| | First parse |
|---|---|
| Before #792 | ~106ms |
| #792 as first reviewed | ~890ms |
| Now | **~165ms** |

Fixed with a cheap literal prefilter gating the grammar, plus dropping the `NATION` embeddings from `ANY_EMPLOYER` and `NO_SPONSORSHIP` (they only bought "for any *US* employer"). The feature now costs ~55ms on first parse instead of ~780ms.

**The prefilter's safety is locked in differentially, not by re-listing literals.** A prefilter that is not a strict superset of the grammar would silently drop matches. So `matchWorkAuthorizationUngated` is exported purely for testing, and ~600 generated strings plus all 2798 real corpus segments assert `gated === ungated`. Add a twelfth pattern whose vocabulary is not in the prefilter and the suite fails loudly.

`{1,3}` was **kept**, on measurement rather than argument: `{1,2}` saved only ~10–15ms (about 2% of the regression, inside run-to-run noise) against losing a plausible real line, `"Authorized to work in the US for any employer without sponsorship"`. The known consequence is that `{1,3}` still admits a redundant `"Authorized to work in the US in the UK for any employer"` — that stores the user's own garbled sentence verbatim rather than fabricating a status, which is the safe side of this matcher's asymmetry.

**Nits fixed:** a `ContactDetails` docblock claimed low-confidence values still render, which `buildContactFields` contradicts for optional rows; a `ContactCard` test asserting the add affordance disappears passed vacuously on a display-only card where it never renders at all; and the KNOWN NON-MATCHES list gained the forms the closed grammar newly declines (`"Naturalized citizen"`/`"Dual national"` without a nation, `"Right to work: Yes"`, parenthesised tails) so the next reader does not re-derive them.
