### PR TITLE
feat(jd-match): useJdMatch hook with render-sync keyword + async semantic state machine (#203)

### DIFF
--- a/src/components/features/PasteJdPanel.tsx
+++ b/src/components/features/PasteJdPanel.tsx
@@ -23,25 +23,13 @@
  * what turns a coverage handoff into a navigation back to `/`.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@design-system";
 import { JdInput } from "./JdInput.tsx";
 import { JdMatch } from "./JdMatch.tsx";
-import { extractJdTerms, computeCoverage } from "../../lib/jd-match";
 import { buildJdRewriteContext } from "../../lib/jd-match/rewrite-context.ts";
-// The keyword arm of the `JdMatchResult` union, from the module that already
-// names it. Narrowing to it means `jdMatch && …` narrows all the way to
-// `.coverage` without a tautological `.path === "keyword"` guard on every use;
-// taking the name from `rank.ts` rather than re-deriving it here keeps the
-// discover lane and the paste lane on one definition (#576).
-import type { KeywordJdMatch } from "../../lib/job-search/rank.ts";
+import { useJdMatch } from "../../hooks/useJdMatch.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
-
-/** Debounce the extract → coverage compute so a fast typist does not run
- *  the whole pipeline on every keystroke. 200ms is under the perceptual
- *  threshold for a "typed a character, saw the panel react" loop while still
- *  coalescing a 10-key burst into one compute. */
-const JD_DEBOUNCE_MS = 200;
 
 interface PasteJdPanelProps {
   /** The parsed résumé the coverage check runs against — same shape
@@ -57,34 +45,21 @@ export function PasteJdPanel({ parsed, onTailor }: PasteJdPanelProps) {
   const [open, setOpen] = useState(false);
   const [jdText, setJdText] = useState("");
 
-  // Debounced mirror of `jdText`. The user's keystrokes update `jdText`
-  // immediately (the textarea stays responsive); `debouncedJdText` catches
-  // up after `JD_DEBOUNCE_MS` of quiet, and the coverage memo keys off THAT
-  // — so a 10-key burst runs one compute instead of ten. See
-  // `JD_DEBOUNCE_MS` for the interval rationale.
-  const [debouncedJdText, setDebouncedJdText] = useState("");
-  useEffect(() => {
-    const id = setTimeout(() => setDebouncedJdText(jdText), JD_DEBOUNCE_MS);
-    return () => clearTimeout(id);
-  }, [jdText]);
-
-  // The same three-line extract → coverage composition `rank.ts` runs per
-  // posting — the coverage computation has no second implementation. Narrowed
-  // return type kills the `.path === "keyword"` tautology at the call sites
-  // below (see KeywordJdMatch).
-  const jdMatch = useMemo<KeywordJdMatch | null>(() => {
-    const trimmed = debouncedJdText.trim();
-    if (trimmed.length === 0) return null;
-    const extracted = extractJdTerms(trimmed);
-    if (extracted.all.length === 0) return null;
-    const coverage = computeCoverage(parsed, extracted.all);
-    return {
-      path: "keyword",
-      coverage,
-      terms: extracted.all,
-      nounsDropped: extracted.nounsDropped,
-    };
-  }, [debouncedJdText, parsed]);
+  // Cross-cutting JD-match state (#203) lives in `useJdMatch`. The panel
+  // renders its result; the hook owns the debounce, the extract → coverage
+  // composition, and the (future) semantic path. `semanticOptIn` defaults
+  // to false today — behavior stays byte-identical to pre-#203, and a
+  // follow-up that ships an opt-in UI can flip it without touching the
+  // hook.
+  //
+  // Read the `keyword` floor rather than narrowing `status`: with
+  // `semanticOptIn` false the two are equivalent, but once #204 flips the
+  // flag `status` is occupied by `loading`/`running` for the whole engine
+  // load while keyword coverage is already available. Reading `keyword`
+  // means this panel keeps showing coverage through that window instead of
+  // blanking, and #204 only has to ADD the semantic view on top.
+  const { keyword } = useJdMatch({ parsed, jdText });
+  const jdMatch = keyword?.path === "keyword" ? keyword : null;
 
   // Same one-call gate-and-payload as `JobResultCard` — see its docblock for
   // why the button's visibility must be derived from the built instruction

--- a/src/hooks/useJdMatch.test.tsx
+++ b/src/hooks/useJdMatch.test.tsx
@@ -1,0 +1,819 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useJdMatch (#203) — state-machine coverage exercised through a probe
+ * component. Same pattern as `webllm-controllers.test.tsx`: the WebGPU
+ * detector, model selection, and the semantic orchestrator are mocked so
+ * each test controls the input the hook is reacting to. The keyword-path
+ * functions (`extractJdTerms`, `computeCoverage`) stay REAL — the whole point
+ * of the keyword branch is that its output must match the pre-#203
+ * PasteJdPanel pipeline byte-for-byte, and that parity is worth proving
+ * against the actual deterministic composition.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, StrictMode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+// ── Mocks (engine + capability + model layer only) ──────────────────────────
+
+let webgpu: "available" | "no-webgpu" | "unsupported-os" = "no-webgpu";
+/** Spy-wrapped so tests can assert whether the keyword path touched WebGPU
+ *  at all (issue #203 review: the keyword-only path must not fire the
+ *  WebLLM funnel's top event on `/jobs/`). Reset per test in beforeEach. */
+const detectWebGpuMock = vi.fn(() => Promise.resolve(webgpu));
+
+vi.mock("../lib/webllm/capability.ts", () => ({
+  detectWebGpu: () => detectWebGpuMock(),
+}));
+
+let modelId: string = "test-model";
+vi.mock("./useModelSelection.ts", () => ({
+  useModelSelection: () => ({ selectedModelId: modelId }),
+}));
+
+// Semantic orchestrator: a controllable stub whose behavior each test
+// configures. The real `run-llm-match.ts` is transitively pulled in by the
+// hook's dynamic import; mocking here keeps the WebLLM chunk out of the
+// jsdom test run.
+const runLlmMatchMock = vi.fn();
+vi.mock("../lib/jd-match/llm/run-llm-match.ts", () => ({
+  runLlmMatch: (...args: unknown[]) => runLlmMatchMock(...args),
+}));
+
+import {
+  useJdMatch,
+  type JdMatchStatus,
+  JD_MATCH_DEBOUNCE_MS,
+} from "./useJdMatch.ts";
+import { extractJdTerms } from "../lib/jd-match/extract-jd-terms.ts";
+import { computeCoverage } from "../lib/jd-match/coverage.ts";
+import type { JdMatchResult } from "../lib/jd-match";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type { ProgressUpdate } from "../lib/webllm/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const JD_TEXT =
+  "We are hiring a platform engineer. You will work with Kubernetes, " +
+  "Terraform, and Go to run our production infrastructure.";
+
+const SPARSE_RESUME: HeuristicParsedResume = {
+  skills: ["React"],
+  experience: [
+    { title: "Frontend Engineer", company: "Acme", description: "Built UIs" },
+  ],
+  education: [],
+} as unknown as HeuristicParsedResume;
+
+interface ProbeProps {
+  parsed: HeuristicParsedResume;
+  jdText: string;
+  semanticOptIn?: boolean;
+}
+
+let latestStatus: JdMatchStatus = { kind: "idle" };
+/** The controller's `keyword` floor as of the last render — the channel that
+ *  stays populated even while `status` is occupied by the semantic arm. */
+let latestKeyword: JdMatchResult | null = null;
+/** Every observed render's status, in order. Reset per test in beforeEach.
+ *  Populated by the Probe during render (not in an effect), so it captures
+ *  the RENDER-TIME status — the invariant #203 protects for the keyword arm. */
+const renderStatuses: JdMatchStatus[] = [];
+
+function Probe({ parsed, jdText, semanticOptIn }: ProbeProps) {
+  const { status, keyword } = useJdMatch({ parsed, jdText, semanticOptIn });
+  latestStatus = status;
+  latestKeyword = keyword;
+  renderStatuses.push(status);
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function mount(props: ProbeProps): Promise<void> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<Probe {...props} />);
+    // Flush microtasks INSIDE act so the WebGPU detection promise's
+    // resolve + its .then setState land inside the boundary. Without this
+    // React logs "update was not wrapped in act(...)"; with it the mount
+    // completes deterministically with capability settled to `webgpu`.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function update(props: ProbeProps): void {
+  act(() => root.render(<Probe {...props} />));
+}
+
+/** Advance time past the hook's JD-text debounce so the pipeline runs. */
+function flushDebounce(): void {
+  act(() => {
+    vi.advanceTimersByTime(JD_MATCH_DEBOUNCE_MS + 1);
+  });
+}
+
+/** Flush any pending microtasks so awaited state writes land. */
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Return `latestStatus` widened to the exported union — TS control-flow
+ *  narrowing across a test would otherwise treat later reads as the
+ *  narrowest branch asserted earlier, ignoring `act()`'s side effects that
+ *  re-assign the `let`. */
+function readStatus(): JdMatchStatus {
+  return latestStatus;
+}
+
+/** Assert the current status is `ready` with a keyword-arm result — the
+ *  single check every "no engine touched" test ends with. */
+function expectKeywordReady(): void {
+  expect(latestStatus.kind).toBe("ready");
+  if (latestStatus.kind !== "ready") throw new Error("unreachable");
+  expect(latestStatus.result.path).toBe("keyword");
+  expect(runLlmMatchMock).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  webgpu = "no-webgpu";
+  modelId = "test-model";
+  runLlmMatchMock.mockReset();
+  detectWebGpuMock.mockClear();
+  latestStatus = { kind: "idle" };
+  latestKeyword = null;
+  renderStatuses.length = 0;
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  vi.useRealTimers();
+});
+
+describe("useJdMatch — keyword-only path touches NO WebLLM machinery (#203)", () => {
+  it("mounting with semanticOptIn=false NEVER calls detectWebGpu", async () => {
+    // `detectWebGpu` must not run unconditionally: that fires
+    // `webllm_capability_detected` — the WebLLM funnel's top event — on every
+    // `/jobs/` load, making users who never opted into semantic matching
+    // indistinguishable in the funnel from users who did. The capability
+    // effect is gated on `semanticOptIn` to keep the funnel meaningful.
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT });
+    flushDebounce();
+    await flushMicrotasks();
+    expect(detectWebGpuMock).not.toHaveBeenCalled();
+
+    // Neither does a JD change or a completed keyword transition trigger it.
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT + " more" });
+    flushDebounce();
+    await flushMicrotasks();
+    expect(detectWebGpuMock).not.toHaveBeenCalled();
+  });
+
+  it("flipping semanticOptIn true triggers a capability probe", async () => {
+    // The other half of the gate: once the caller opts in, detection has
+    // to run — otherwise `capability` stays `null` forever and the semantic
+    // path can never activate.
+    webgpu = "available";
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: false });
+    flushDebounce();
+    await flushMicrotasks();
+    expect(detectWebGpuMock).not.toHaveBeenCalled();
+
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    expect(detectWebGpuMock).toHaveBeenCalled();
+  });
+});
+
+describe("useJdMatch — keyword fast path is render-synchronous (#203 timing)", () => {
+  it("keyword: `ready` lands on the SAME render as the debounce fire — no effect flush needed", async () => {
+    // The invariant this test pins: after `setDebouncedJdText` commits, the
+    // very NEXT render (produced by that setState) has `status.kind === "ready"`
+    // — because `useMemo` runs during render, not in an effect. An
+    // effect-driven derivation would commit one intermediate render with
+    // stale status before the effect fired, adding a second commit before
+    // `ready` appeared.
+    //
+    // The probe records `status` on every render. After the debounce fires
+    // (inside act), the LAST render's status must already be `ready` —
+    // without any further microtask flush, effect turn, or setState await.
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT });
+    const rendersAfterMount = renderStatuses.length;
+
+    act(() => {
+      vi.advanceTimersByTime(JD_MATCH_DEBOUNCE_MS + 1);
+    });
+    // NO `await flushMicrotasks()` here — the whole point of this assertion.
+
+    const rendersAfterDebounce = renderStatuses.length;
+    const lastRender = renderStatuses[rendersAfterDebounce - 1]!;
+
+    expect(lastRender.kind).toBe("ready");
+    if (lastRender.kind !== "ready") throw new Error("unreachable");
+    expect(lastRender.result.path).toBe("keyword");
+
+    // And exactly ONE additional render fired for the debounce — the commit
+    // that carries both the new `debouncedJdText` and the useMemo-derived
+    // `ready(keyword)`. An effect-driven derivation would produce TWO extra
+    // renders (one stale, one after the effect). Guarding this count is what
+    // catches a regression back to the effect-driven shape.
+    expect(rendersAfterDebounce - rendersAfterMount).toBe(1);
+  });
+});
+
+describe("useJdMatch — keyword fast path (no engine touched)", () => {
+  it("stays idle on empty JD text (post-debounce, no compute)", async () => {
+    await mount({ parsed: SPARSE_RESUME, jdText: "" });
+    flushDebounce();
+    expect(latestStatus).toEqual({ kind: "idle" });
+    expect(runLlmMatchMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves keyword synchronously when semanticOptIn is false (the default)", async () => {
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT });
+    flushDebounce();
+    expectKeywordReady();
+  });
+
+  it("keyword result matches a fresh extractJdTerms + computeCoverage exactly", async () => {
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT });
+    flushDebounce();
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    if (latestStatus.result.path !== "keyword") throw new Error("unreachable");
+
+    const extracted = extractJdTerms(JD_TEXT);
+    const expectedCoverage = computeCoverage(SPARSE_RESUME, extracted.all);
+    expect(latestStatus.result.terms).toEqual(extracted.all);
+    expect(latestStatus.result.nounsDropped).toBe(extracted.nounsDropped);
+    expect(latestStatus.result.coverage).toEqual(expectedCoverage);
+  });
+
+  it("keyword: JD text with no extractable terms → idle", async () => {
+    // `"     .     "` trims to `"."` — non-empty — so `extractJdTerms` runs
+    // and the zero-terms guard produces `idle`, NOT the trim-to-empty guard.
+    // The complementary trim-to-empty test lives below.
+    await mount({ parsed: SPARSE_RESUME, jdText: "     .     " });
+    flushDebounce();
+    expect(latestStatus).toEqual({ kind: "idle" });
+  });
+
+  it("keyword: trim-to-empty JD (whitespace-only) → idle without hitting extract", async () => {
+    // Exercises the trim-to-empty guard specifically — `\t   \n  ` trims to
+    // `""`, so `trimmedJdText.length === 0` returns null before extract runs.
+    await mount({ parsed: SPARSE_RESUME, jdText: "   \t   \n  " });
+    flushDebounce();
+    expect(latestStatus).toEqual({ kind: "idle" });
+  });
+
+  it("keyword: JD text falls back to keyword when WebGPU is unavailable, even with opt-in", async () => {
+    webgpu = "no-webgpu";
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    expectKeywordReady();
+  });
+
+  it("keyword: JD text falls back to keyword when WebGPU is unsupported-os, even with opt-in", async () => {
+    webgpu = "unsupported-os";
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    expectKeywordReady();
+  });
+});
+
+describe("useJdMatch — semantic path (opt-in + WebGPU available)", () => {
+  beforeEach(() => {
+    webgpu = "available";
+  });
+
+  it("progresses idle → loading → running → ready on a happy semantic run", async () => {
+    // The stub captures the two callbacks so the test can drive the phase
+    // transitions deterministically.
+    let capturedProgress: ((u: ProgressUpdate) => void) | null = null;
+    let capturedInferenceStart: (() => void) | null = null;
+    let resolveRun!: (r: JdMatchResult) => void;
+    const runPromise = new Promise<JdMatchResult>((res) => {
+      resolveRun = res;
+    });
+    runLlmMatchMock.mockImplementation(
+      (
+        _jd: string,
+        _parsed: HeuristicParsedResume,
+        _model: string,
+        onProgress: (u: ProgressUpdate) => void,
+        onInferenceStart: () => void,
+      ) => {
+        capturedProgress = onProgress;
+        capturedInferenceStart = onInferenceStart;
+        return runPromise;
+      },
+    );
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    // Dynamic import + the .then chain each need a microtask flush.
+    await flushMicrotasks();
+
+    // Loading, before any progress fires.
+    expect(latestStatus.kind).toBe("loading");
+
+    // A progress tick moves the update payload but keeps us in loading.
+    act(() =>
+      capturedProgress?.({ progress: 0.4, text: "Downloading weights…" }),
+    );
+    if (latestStatus.kind !== "loading") throw new Error("unreachable");
+    expect(latestStatus.progress).toEqual({
+      progress: 0.4,
+      text: "Downloading weights…",
+    });
+
+    // The engine finished loading; the model is now thinking.
+    act(() => capturedInferenceStart?.());
+    expect(latestStatus.kind).toBe("running");
+
+    // The semantic result lands.
+    const semanticResult: JdMatchResult = {
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 0, partial: 0, missing: 0, total: 0 },
+    };
+    await act(async () => {
+      resolveRun(semanticResult);
+      await runPromise;
+    });
+    expect(latestStatus).toEqual({ kind: "ready", result: semanticResult });
+  });
+
+  it("semantic infrastructure rejection with a live keyword result → ready(keyword), NOT error", async () => {
+    // The realistic trigger is a dynamic-import failure after a deploy
+    // replaces hashed chunks (`jobs/main.tsx`'s `vite:preloadError` reload
+    // is one-shot). If the user was already looking at keyword coverage,
+    // we preserve it rather than replacing it with a raw error string.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    runLlmMatchMock.mockRejectedValue(new Error("chunk load failed"));
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    // The rejection lands one more microtask later.
+    await flushMicrotasks();
+
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    expect(latestStatus.result.path).toBe("keyword");
+    // Independent recompute oracle — the fallback IS the keyword the user
+    // was already looking at, not some other coverage.
+    const extracted = extractJdTerms(JD_TEXT);
+    const expectedCoverage = computeCoverage(SPARSE_RESUME, extracted.all);
+    if (latestStatus.result.path !== "keyword") throw new Error("unreachable");
+    expect(latestStatus.result.coverage).toEqual(expectedCoverage);
+  });
+
+  it("threads the persisted model id and callbacks to runLlmMatch", async () => {
+    runLlmMatchMock.mockResolvedValue({
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 0, partial: 0, missing: 0, total: 0 },
+    } satisfies JdMatchResult);
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+    const [jd, parsed, modelId, onProgress, onInferenceStart] =
+      runLlmMatchMock.mock.calls[0]!;
+    expect(jd).toBe(JD_TEXT);
+    expect(parsed).toBe(SPARSE_RESUME);
+    expect(modelId).toBe("test-model");
+    expect(typeof onProgress).toBe("function");
+    expect(typeof onInferenceStart).toBe("function");
+  });
+});
+
+describe("useJdMatch — semantic input normalization (#203)", () => {
+  it("trailing whitespace on a completed semantic result does NOT restart the LLM run", async () => {
+    // Keying semantic freshness on the RAW debounced text while storing the
+    // TRIMMED one makes a trailing-space edit look like a new input: a
+    // byte-identical trimmed payload behind a fresh reference, so the stale
+    // check fails and a full extract + judge restarts on a change that cannot
+    // alter the answer. Both keyword extraction and semantic freshness
+    // therefore key off the canonical `trimmedJdText`.
+    webgpu = "available";
+    const semanticResult: JdMatchResult = {
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 0, partial: 0, missing: 0, total: 0 },
+    };
+    runLlmMatchMock.mockResolvedValue(semanticResult);
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    // The result lands.
+    await flushMicrotasks();
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    expect(latestStatus.result.path).toBe("semantic");
+
+    // Add trailing whitespace — trims to the same JD.
+    update({
+      parsed: SPARSE_RESUME,
+      jdText: JD_TEXT + "   \t   ",
+      semanticOptIn: true,
+    });
+    flushDebounce();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // Semantic run must NOT have restarted. Also the completed semantic
+    // result must still be visible — the slot's value-comparison detected
+    // that the trimmed inputs are identical and reused the cached state.
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    expect(latestStatus.result).toBe(semanticResult);
+  });
+});
+
+describe("useJdMatch — `keyword` floor is available alongside a semantic status", () => {
+  it("exposes keyword coverage WHILE the semantic arm sits in `loading`", async () => {
+    // `status` cannot carry both — the semantic arm owns `loading`/`running`
+    // for the whole engine-load window, which on a cold cache is minutes. A
+    // consumer reading only `status` would paint an empty spinner over
+    // coverage it already had, so the controller exposes `keyword` too. That
+    // is what makes "keyword is always available" a property of the API and
+    // not just of the docblock.
+    webgpu = "available";
+    runLlmMatchMock.mockReturnValue(new Promise(() => {}));
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+
+    expect(latestStatus.kind).toBe("loading");
+    expect(latestKeyword).not.toBeNull();
+    if (latestKeyword?.path !== "keyword") throw new Error("unreachable");
+    const extracted = extractJdTerms(JD_TEXT);
+    expect(latestKeyword.coverage).toEqual(
+      computeCoverage(SPARSE_RESUME, extracted.all),
+    );
+  });
+
+  it("keyword floor is null exactly when status is idle", async () => {
+    await mount({ parsed: SPARSE_RESUME, jdText: "   \t  " });
+    flushDebounce();
+    expect(latestStatus).toEqual({ kind: "idle" });
+    expect(latestKeyword).toBeNull();
+  });
+});
+
+describe("useJdMatch — opt-out preserves a COMPLETED semantic result", () => {
+  it("opt-out → opt-in with unchanged inputs does NOT re-run the LLM", async () => {
+    // Clearing the slot on every exit threw away a finished answer: an
+    // opt-out → opt-in toggle that changed no input re-ran a full engine
+    // load + extract + judge for a byte-identical result. Only unsettled
+    // slots need clearing, so a `ready` slot now survives the exit.
+    webgpu = "available";
+    const completed: JdMatchResult = {
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 1, partial: 0, missing: 0, total: 1 },
+    };
+    runLlmMatchMock.mockResolvedValue(completed);
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    expect(latestStatus.result).toBe(completed);
+
+    // Opt OUT — status falls back to the keyword arm.
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: false });
+    await flushMicrotasks();
+    const optedOut = readStatus();
+    if (optedOut.kind !== "ready") throw new Error("unreachable");
+    expect(optedOut.result.path).toBe("keyword");
+
+    // Opt back IN with identical JD / parse / model — the cached semantic
+    // result must come straight back, with no second run.
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+    const optedBackIn = readStatus();
+    if (optedBackIn.kind !== "ready") throw new Error("unreachable");
+    expect(optedBackIn.result).toBe(completed);
+  });
+
+  it("opt-out while STILL LOADING clears the slot, so opt-in restarts instead of stranding a spinner", async () => {
+    // The complement, and the reason the retention is conditional: a partial
+    // slot kept across the exit would match on opt-back-in, the effect would
+    // early-return, and nothing would restart the run the id bump had
+    // already orphaned — a spinner that never ends.
+    webgpu = "available";
+    runLlmMatchMock.mockReturnValue(new Promise(() => {}));
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    expect(latestStatus.kind).toBe("loading");
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: false });
+    await flushMicrotasks();
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+
+    // A FRESH run was started — the orphaned one is not being waited on.
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(2);
+    expect(readStatus().kind).toBe("loading");
+  });
+});
+
+describe("useJdMatch — transitions & stale-request protection", () => {
+  it("semantic → keyword: opting OUT INVALIDATES the request id, so LATE progress ticks stop calling setState", async () => {
+    // This test proves the request-id guard (layer 1 of the two-layer
+    // staleness protection), NOT the derived-status mask. Under the pre-fix
+    // shape the effect early-returned WITHOUT bumping the id, so opt-out
+    // during a weight download let every subsequent `onProgress` write to
+    // the slot and re-render the panel for a status the consumer could no
+    // longer observe. Test would stay green there — this one fails there.
+    //
+    // Method: capture the progress callback the hook hands to `runLlmMatch`,
+    // opt out, then fire progress. Under the fix the write is dropped
+    // (mounted-ref true, id mismatch); under the bug it lands and updates
+    // the slot. We assert on WHETHER the slot took a `loading, 0.9` write
+    // by observing the semantic-side status transition path.
+    webgpu = "available";
+    let capturedProgress: ((u: ProgressUpdate) => void) | null = null;
+    const runPromise = new Promise<JdMatchResult>(() => {});
+    runLlmMatchMock.mockImplementation(
+      (
+        _jd: string,
+        _parsed: HeuristicParsedResume,
+        _model: string,
+        onProgress: (u: ProgressUpdate) => void,
+      ) => {
+        capturedProgress = onProgress;
+        return runPromise;
+      },
+    );
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    expect(latestStatus.kind).toBe("loading");
+
+    // Opt out. The effect's early-return now bumps the id and clears the
+    // slot; the derived status flips synchronously to keyword ready.
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: false });
+    expect(latestStatus.kind).toBe("ready");
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    expect(latestStatus.result.path).toBe("keyword");
+
+    // Toggle opt-in back on WITHOUT firing the stale progress. If the id
+    // were NOT bumped on opt-out, the very next slot write (from the OPT-IN
+    // effect starting a NEW run and re-seeding the slot to LOADING_START)
+    // would collide with any late writes from the stale run. We prove the
+    // stale progress cannot land: fire it AFTER the new run has started,
+    // and assert the slot's loading progress remains the fresh one (0)
+    // rather than the stale one (0.9).
+    const secondRunPromise = new Promise<JdMatchResult>(() => {});
+    let secondRunProgress: ((u: ProgressUpdate) => void) | null = null;
+    runLlmMatchMock.mockImplementation(
+      (
+        _jd: string,
+        _parsed: HeuristicParsedResume,
+        _model: string,
+        onProgress: (u: ProgressUpdate) => void,
+      ) => {
+        secondRunProgress = onProgress;
+        return secondRunPromise;
+      },
+    );
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    expect(latestStatus.kind).toBe("loading");
+
+    // Fire the STALE progress callback captured before opt-out. Under the
+    // fix: id was bumped on opt-out AND again on the fresh run, so the
+    // stale callback's id no longer matches. The slot stays on the fresh
+    // run's loading state (progress: 0 from LOADING_START). Assert via
+    // `readStatus()` (widens past TS's stale narrowing from earlier in the
+    // test — `latestStatus` is a `let` re-assigned by Probe on every
+    // render, but TS control-flow doesn't consider act()'s side effects).
+    act(() => capturedProgress?.({ progress: 0.9, text: "STALE" }));
+    const afterStale = readStatus();
+    if (afterStale.kind !== "loading") throw new Error("unreachable");
+    expect(afterStale.progress.progress).toBe(0);
+    expect(afterStale.progress.text).not.toBe("STALE");
+
+    // The FRESH run's progress must still land — proves the id-bump didn't
+    // over-invalidate.
+    act(() => secondRunProgress?.({ progress: 0.5, text: "fresh" }));
+    const afterFresh = readStatus();
+    if (afterFresh.kind !== "loading") throw new Error("unreachable");
+    expect(afterFresh.progress).toEqual({ progress: 0.5, text: "fresh" });
+  });
+
+  it("keyword → semantic: opting IN kicks off the engine load", async () => {
+    webgpu = "available";
+    runLlmMatchMock.mockReturnValue(new Promise(() => {}));
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: false });
+    await flushMicrotasks();
+    flushDebounce();
+    expect(latestStatus.kind).toBe("ready");
+    if (latestStatus.kind !== "ready") throw new Error("unreachable");
+    expect(latestStatus.result.path).toBe("keyword");
+    expect(runLlmMatchMock).not.toHaveBeenCalled();
+
+    // Flip opt-in on.
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    expect(latestStatus.kind).toBe("loading");
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("JD change mid-semantic-run: an old result cannot overwrite the new state", async () => {
+    webgpu = "available";
+    // First run: never resolves (stub returns a forever-pending promise the
+    // test resolves manually).
+    let resolveFirst!: (r: JdMatchResult) => void;
+    const firstRun = new Promise<JdMatchResult>((res) => {
+      resolveFirst = res;
+    });
+    // Second run: also forever-pending — we only care that the FIRST run's
+    // late resolve doesn't clobber the new "loading" state.
+    const secondRun = new Promise<JdMatchResult>(() => {});
+    runLlmMatchMock
+      .mockReturnValueOnce(firstRun)
+      .mockReturnValueOnce(secondRun);
+
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    expect(latestStatus.kind).toBe("loading");
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+
+    // JD text changes → second run kicks off; first is now stale.
+    update({
+      parsed: SPARSE_RESUME,
+      jdText: JD_TEXT + " Additional requirement: Rust.",
+      semanticOptIn: true,
+    });
+    flushDebounce();
+    await flushMicrotasks();
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(2);
+    expect(latestStatus.kind).toBe("loading");
+
+    // Late resolve of the FIRST run — must be dropped.
+    const staleResult: JdMatchResult = {
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 99, partial: 0, missing: 0, total: 99 },
+    };
+    await act(async () => {
+      resolveFirst(staleResult);
+      await firstRun;
+    });
+    // Still loading (the second run has not resolved); the first run's
+    // result was correctly dropped rather than transitioning us to `ready`.
+    expect(latestStatus.kind).toBe("loading");
+  });
+
+  it("StrictMode: the mount effect's double-invoke does NOT leave the mounted-ref stale-false", async () => {
+    // The mountedRef guard has to be re-established in the effect body, not
+    // just at hook creation — otherwise StrictMode's simulated remount
+    // (first effect + cleanup, then a second effect on the SAME hook
+    // instance) leaves the ref pointing at `false` for the real mount and
+    // every semantic write silently no-ops. Repro: mount under StrictMode,
+    // resolve a semantic run — if the guard is broken, the `ready` write
+    // is dropped and status stays `loading`.
+    webgpu = "available";
+    let resolveRun!: (r: JdMatchResult) => void;
+    const runPromise = new Promise<JdMatchResult>((res) => {
+      resolveRun = res;
+    });
+    runLlmMatchMock.mockReturnValue(runPromise);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <Probe parsed={SPARSE_RESUME} jdText={JD_TEXT} semanticOptIn={true} />
+        </StrictMode>,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    flushDebounce();
+    await flushMicrotasks();
+    expect(latestStatus.kind).toBe("loading");
+
+    const semanticResult: JdMatchResult = {
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 0, partial: 0, missing: 0, total: 0 },
+    };
+    await act(async () => {
+      resolveRun(semanticResult);
+      await runPromise;
+    });
+    // If mountedRef were stale-false, this stays "loading" forever.
+    expect(latestStatus).toEqual({ kind: "ready", result: semanticResult });
+  });
+
+  it("model change mid-request: the old model's run cannot overwrite the new one", async () => {
+    // Model-selection changing between two `useJdMatch` renders bumps the
+    // `semanticInputs` identity (its dep tuple includes `selectedModelId`),
+    // so the effect fires with a fresh `myId` and the old run's late
+    // callbacks fail the guard. Verifies the request-id + inputs-identity
+    // pair — not just JD-text change — invalidates a stale semantic write.
+    webgpu = "available";
+    let resolveFirst!: (r: JdMatchResult) => void;
+    const firstRun = new Promise<JdMatchResult>((res) => {
+      resolveFirst = res;
+    });
+    const secondRun = new Promise<JdMatchResult>(() => {});
+    runLlmMatchMock
+      .mockReturnValueOnce(firstRun)
+      .mockReturnValueOnce(secondRun);
+
+    modelId = "model-A";
+    await mount({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    flushDebounce();
+    await flushMicrotasks();
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(1);
+    expect(runLlmMatchMock.mock.calls[0]![2]).toBe("model-A");
+
+    // Model changes — force the hook to re-run (which is what a real
+    // ExternalStore-backed model change does via useSyncExternalStore).
+    modelId = "model-B";
+    update({ parsed: SPARSE_RESUME, jdText: JD_TEXT, semanticOptIn: true });
+    await flushMicrotasks();
+    expect(runLlmMatchMock).toHaveBeenCalledTimes(2);
+    expect(runLlmMatchMock.mock.calls[1]![2]).toBe("model-B");
+    expect(latestStatus.kind).toBe("loading");
+
+    // The FIRST run (against model-A) lands late with a result — must NOT
+    // overwrite the loading state of the new (model-B) run.
+    const staleResult: JdMatchResult = {
+      path: "semantic",
+      verdicts: [],
+      summary: { met: 42, partial: 0, missing: 0, total: 42 },
+    };
+    await act(async () => {
+      resolveFirst(staleResult);
+      await firstRun;
+    });
+    expect(latestStatus.kind).toBe("loading");
+  });
+
+  // DELIBERATELY NOT TESTED: `setSlotIfCurrent`'s `mountedRef` unmount guard.
+  //
+  // No assertion can distinguish that guard being present from absent, so any
+  // such test would be decoration. Both candidate oracles were tried and both
+  // stay GREEN with `if (!mountedRef.current) return;` deleted:
+  //   - A React console warning. React removed "Can't perform a React state
+  //     update on an unmounted component" in v18; the only "unmounted
+  //     component" strings in react-dom 19.2.6 are the internal "Unable to
+  //     find node on an unmounted component" invariant.
+  //   - A render count after unmount. `root.unmount()` tears the tree down,
+  //     so the late `setSemanticSlot` is a React-level no-op — no render
+  //     happens either way.
+  // The guard stays in the hook as intent (React's no-op-on-unmounted is an
+  // implementation detail, not a contract), but a green test claiming to pin
+  // it would misrepresent the coverage, so there isn't one. The `mountedRef`
+  // RE-SET in the mount effect is a different matter: it IS load-bearing and
+  // IS covered — the StrictMode test above fails if it is dropped.
+});

--- a/src/hooks/useJdMatch.ts
+++ b/src/hooks/useJdMatch.ts
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `useJdMatch` — controller for the paste-a-JD → JD-match flow (#203).
+ *
+ * The keyword path is derived SYNCHRONOUSLY via `useMemo` — same shape as the
+ * pre-#203 inline pipeline that lived in `PasteJdPanel`. When the debounced
+ * JD text changes, the keyword result lands on the SAME commit as the input
+ * change; no effect flush is needed to observe it. This is the invariant
+ * the issue's "synchronous keyword fast-resolve" wording protects.
+ *
+ * The keyword arm adds no RUNTIME WebLLM work over pre-#203 — no engine probe,
+ * no capability detection, no WebLLM analytics event on the mount of a
+ * keyword-only consumer. `detectWebGpu` is called only when `semanticOptIn`
+ * flips true; the capability effect is gated on that same input.
+ *
+ * It is NOT a zero-cost import, and the gap is worth stating exactly rather
+ * than rounding to "touches nothing": `useModelSelection` is a hook, so it
+ * cannot be called conditionally, which means a keyword-only consumer still
+ * pays (a) its module-load `readPersistedModelId()` + `readAllConsent()`
+ * localStorage reads, (b) a page-lifetime `storage` listener registered on
+ * first subscribe, and (c) a static `capability.ts` → `analytics.ts` edge in
+ * the `/jobs/` entry chunk (measured: +0.71 kB gzip, and `run-llm-match` stays
+ * a lazy chunk). No analytics EVENT fires — that is the part that would have
+ * polluted the WebLLM funnel's top event. Making the imports conditional too
+ * would mean moving the semantic machinery into a child hook mounted only on
+ * opt-in; #204 can restructure if it turns out to matter.
+ *
+ * The semantic path (`semanticOptIn === true` AND WebGPU available) delegates
+ * to `runLlmMatch` — the same orchestrator #202 landed — through a slot bound
+ * to the input values it was computed for. The slot is compared to current
+ * inputs BY VALUE, not by `useMemo` reference identity: React documents
+ * `useMemo` as a cache it MAY discard (`<Activity>` / offscreen already does),
+ * which would invalidate a completed slot on a byte-identical new reference
+ * and restart a full LLM run. Value comparison is immune.
+ *
+ * `status` is the semantic-refinement channel; `keyword` is the floor. The
+ * controller returns BOTH because `status` cannot express "engine still
+ * loading AND keyword coverage already available" — the semantic arm has to
+ * occupy `loading`/`running` for the whole engine-load window, which on a cold
+ * cache is minutes. Render `keyword` and layer `status` over it; that is what
+ * makes "keyword is always available" true of the API and not just of the
+ * prose.
+ *
+ * State machine — one input, one status object:
+ *
+ *   idle
+ *     · debounced JD is empty (post-trim), or extract yielded zero terms.
+ *   ready (keyword, synchronous, render-time)
+ *     · semantic opt-in is off, OR WebGPU is unavailable, OR still detecting.
+ *       Result is `{ path: "keyword", coverage, terms, nounsDropped }`.
+ *   loading → running → ready (semantic, async)
+ *     · semantic opt-in is on AND WebGPU is available.
+ *       - `loading` while `loadEngine` streams progress (or as a placeholder
+ *         on the first render for a fresh input tuple).
+ *       - `running` after engine load, during extract + judge.
+ *       - `ready` with the assembled JdMatchResult.
+ *   error
+ *     · Kept in the union for #204's opt-in UI to consume, but not reachable
+ *       today: a semantic run only starts when `takingSemanticPath` is true,
+ *       which requires `keywordResult !== null`; the catch snapshots that
+ *       non-null value into `fallbackKeyword` and always writes `ready` on
+ *       an unexpected rejection. A future consumer where the semantic path
+ *       runs without a keyword fallback (a "semantic-only" mode) would
+ *       reach this branch; keeping it here means the surface for that is
+ *       already public.
+ *
+ * Stale-request protection has two layers, both load-bearing on DIFFERENT
+ * scenarios:
+ *   1. `requestIdRef` — a monotonic counter bumped on every semantic run
+ *      start AND on every exit from the semantic path (opt-out, JD cleared,
+ *      capability change). The exit ALSO clears the slot unless it holds a
+ *      `ready` result: a finished answer for unchanged inputs is worth
+ *      caching across an opt-out → opt-in toggle (otherwise the toggle
+ *      re-runs a full engine load + extract + judge for a byte-identical
+ *      result), while a partial slot would strand a spinner and an `error`
+ *      slot would deny a retry. Every callback (`onProgress`, `onInferenceStart`,
+ *      final resolve, catch) checks the id captured at start against the
+ *      current one and drops its own write on a mismatch. This is what stops
+ *      WebLLM's per-tick `onProgress` from re-rendering the panel through a
+ *      hundreds-of-megabytes weight download after the user opted out.
+ *      (`mountedRef` piggybacks on the same gate, but unlike the id it is
+ *      unverifiable intent rather than tested behaviour — see the note on
+ *      `setSlotIfCurrent`.)
+ *   2. Slot-vs-current-input VALUE comparison in the derived status memo.
+ *      A slot whose stored `jdText`/`modelId` don't match current values, or
+ *      whose stored `parsed` reference no longer matches, is invisible to
+ *      the render. This is what stops a stale slot from flashing over a
+ *      newer render even if a late write slipped past layer 1.
+ *
+ * `parsed` identity contract: the hook treats `parsed` by REFERENCE, and the
+ * failure mode is worse than a wasted recompute. A caller that builds `parsed`
+ * inline in render hands over a fresh reference every render, so the slot
+ * never matches, so the effect starts a run and writes the slot, which
+ * re-renders, which mismatches again — an unbounded update loop, not a bounded
+ * "restart once per render". Today's producer is safe: `JobsApp.tsx` reads the
+ * handoff through a lazy `useState` initializer, so the reference is stable for
+ * the whole session, and `FindJobsPanel` passes it straight through. A future
+ * consumer that derives `parsed` MUST memoize it before handing it here.
+ *
+ * WebGPU detection uses `detectWebGpu`, which caches the result for the page
+ * lifetime — the same signal `useResumeRewrite` reads. `useModelSelection`
+ * supplies the persisted model id, so the picker on the WebLLM surfaces
+ * drives which model this hook loads.
+ *
+ * Not a live wiring today: `PasteJdPanel` calls this with `semanticOptIn`
+ * defaulting to `false`, so behavior is byte-identical to pre-#203. A future
+ * issue (#204) that ships a user-visible opt-in (checkbox, consent dialog,
+ * progress copy, semantic verdict UI) can flip the input without changing
+ * this hook.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { detectWebGpu } from "../lib/webllm/capability.ts";
+import { computeCoverage } from "../lib/jd-match/coverage.ts";
+import { extractJdTerms } from "../lib/jd-match/extract-jd-terms.ts";
+import type { JdMatchResult } from "../lib/jd-match";
+import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import type {
+  ProgressUpdate,
+  WebGpuCapability,
+} from "../lib/webllm/types.ts";
+import { useModelSelection } from "./useModelSelection.ts";
+
+/** Debounce interval for the JD text — matches the pre-#203 200ms value
+ *  `PasteJdPanel` used inline. Under the perceptual threshold for a "typed a
+ *  character, saw the panel react" loop while still coalescing a 10-key
+ *  burst into one compute. */
+export const JD_MATCH_DEBOUNCE_MS = 200;
+
+export type JdMatchStatus =
+  | { kind: "idle" }
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "running" }
+  | { kind: "ready"; result: JdMatchResult }
+  | { kind: "error"; message: string };
+
+export interface UseJdMatchOptions {
+  /** The parsed résumé the coverage check runs against.
+   *
+   *  Treated by REFERENCE for semantic-run freshness: a fresh object every
+   *  render will restart the semantic run. Memoize at the caller side; the
+   *  producers this hook has today (`FindJobsPanel` fed from `JobsApp`'s
+   *  handoff, itself a lazy `useState` initializer) already do. */
+  parsed: HeuristicParsedResume;
+  /** Raw JD text; the hook debounces internally. */
+  jdText: string;
+  /**
+   * Opt into the semantic (WebLLM) path. Default `false` → keyword-only,
+   * no engine load, no WebGPU probe, no WebLLM analytics event, byte-
+   * identical to pre-#203 behavior.
+   *
+   * Even when `true`, the hook still resolves to keyword when WebGPU is
+   * unavailable or still being detected — the semantic path is a
+   * best-effort enhancement, not a requirement.
+   */
+  semanticOptIn?: boolean;
+}
+
+export interface JdMatchController {
+  status: JdMatchStatus;
+  /**
+   * The synchronous keyword result for the current debounced JD, whenever one
+   * exists — INDEPENDENT of what `status` is showing.
+   *
+   * `status` alone cannot express "the engine is loading AND keyword coverage
+   * is already available", because the semantic arm has to occupy `loading` /
+   * `running` for the whole engine-load window. On a cold cache that is
+   * minutes, and `keywordResult` is non-null the entire time (it is a
+   * precondition of taking the semantic path at all). A consumer that read
+   * only `status` would have to render an empty progress spinner over
+   * coverage it already had.
+   *
+   * So the docblock's "keyword is always available" is a property of the
+   * CONTROLLER, not of `status`: render `keyword` as the floor and let
+   * `status` layer the semantic refinement on top. `null` only when the JD is
+   * empty/degenerate — exactly when `status` is `idle`.
+   */
+  keyword: JdMatchResult | null;
+}
+
+/** Module-level constants so a keyword-path render's `status` doesn't produce
+ *  a new `{ kind: "idle" }` object identity on every derive (React's setState
+ *  bail-out is reference-based).
+ *
+ *  Frozen because these are shared singletons handed straight to consumers —
+ *  a consumer that wrote to `status.progress` would corrupt the constant for
+ *  every later render and every other consumer on the page. */
+const IDLE_STATUS: JdMatchStatus = Object.freeze({ kind: "idle" });
+/** Typed as the narrower `SemanticSubState` variant so it can seed the
+ *  semantic slot without a widening cast; assignable to `JdMatchStatus`
+ *  since the sub-state is a subset. */
+const LOADING_START: { kind: "loading"; progress: ProgressUpdate } =
+  Object.freeze({
+    kind: "loading",
+    progress: Object.freeze({ progress: 0, text: "Starting…" }),
+  });
+
+/** The tuple the slot's freshness is checked against. Compared by VALUE for
+ *  the primitive fields and by REFERENCE for `parsed` (see the docblock's
+ *  caller-obligation note). */
+interface SemanticInputs {
+  jdText: string;
+  parsed: HeuristicParsedResume;
+  modelId: string;
+}
+
+function semanticInputsMatch(
+  slot: SemanticInputs,
+  jdText: string,
+  parsed: HeuristicParsedResume,
+  modelId: string,
+): boolean {
+  return (
+    slot.jdText === jdText &&
+    slot.parsed === parsed &&
+    slot.modelId === modelId
+  );
+}
+
+/** The semantic sub-state the async orchestration produces. `ready` here is
+ *  the semantic-arm ready (arm chosen by `runLlmMatch`, which may itself
+ *  degrade to a keyword result on internal failure — the arm is still
+ *  determined by the orchestrator, not by the hook). */
+type SemanticSubState =
+  | { kind: "loading"; progress: ProgressUpdate }
+  | { kind: "running" }
+  | { kind: "ready"; result: JdMatchResult }
+  | { kind: "error"; message: string };
+
+interface SemanticSlot {
+  /** Snapshot of the inputs the run was started for. Compared BY VALUE
+   *  against current inputs during render — a mismatch means this slot is
+   *  stale. Immune to `useMemo` cache discards, unlike a reference check. */
+  inputs: SemanticInputs;
+  state: SemanticSubState;
+}
+
+export function useJdMatch(options: UseJdMatchOptions): JdMatchController {
+  const { parsed, jdText, semanticOptIn = false } = options;
+
+  const [debouncedJdText, setDebouncedJdText] = useState("");
+  const [capability, setCapability] = useState<WebGpuCapability | null>(null);
+  const [semanticSlot, setSemanticSlot] = useState<SemanticSlot | null>(null);
+  const { selectedModelId } = useModelSelection();
+
+  // Canonical trimmed JD. Both keyword extraction and semantic freshness key
+  // off THIS value, so a trailing-space edit that trims to the same text
+  // never restarts the LLM run (was: `debouncedJdText` deps produced a fresh
+  // `semanticInputs` reference for byte-identical trimmed content).
+  const trimmedJdText = useMemo(
+    () => debouncedJdText.trim(),
+    [debouncedJdText],
+  );
+
+  // WebGPU capability detection — GATED on `semanticOptIn`. Keyword-only
+  // consumers never call `detectWebGpu`, so no `webllm_capability_detected`
+  // event fires (the WebLLM funnel's top event) and no
+  // `navigator.gpu.requestAdapter()` runs on the `/jobs/` page. `detectWebGpu`
+  // caches its result per page, so an opted-in flip re-uses a cached probe
+  // if one exists. `cancelled` guards against a write after unmount.
+  useEffect(() => {
+    if (!semanticOptIn) return;
+    let cancelled = false;
+    void detectWebGpu().then((c) => {
+      if (!cancelled) setCapability(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [semanticOptIn]);
+
+  // JD text debounce. Only the debounced value drives the pipeline, so a
+  // fast typist runs one compute instead of ten — same 200ms interval
+  // `PasteJdPanel` used inline before this hook existed.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedJdText(jdText), JD_MATCH_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [jdText]);
+
+  // SYNCHRONOUS keyword result — render-time, no effect. Identical shape and
+  // trimming rules to the pre-#203 `PasteJdPanel` inline `useMemo`, so a
+  // keyword-only consumer's status becomes `ready` on the SAME commit as
+  // `debouncedJdText` changes.
+  const keywordResult = useMemo<JdMatchResult | null>(() => {
+    if (trimmedJdText.length === 0) return null;
+    const extracted = extractJdTerms(trimmedJdText);
+    if (extracted.all.length === 0) return null;
+    return {
+      path: "keyword",
+      coverage: computeCoverage(parsed, extracted.all),
+      terms: extracted.all,
+      nounsDropped: extracted.nounsDropped,
+    };
+  }, [trimmedJdText, parsed]);
+
+  // We take the semantic path iff opt-in AND WebGPU available AND we have a
+  // non-null keyword result (empty/degenerate JDs skip semantic entirely,
+  // matching the pre-#203 no-op branch).
+  const takingSemanticPath =
+    semanticOptIn && capability === "available" && keywordResult !== null;
+
+  // Derived status — the single source of truth the consumer reads. Every
+  // branch is a render-time compute; no effect flush is needed for the
+  // keyword arm to become `ready`.
+  const status = useMemo<JdMatchStatus>(() => {
+    if (keywordResult === null) return IDLE_STATUS;
+    if (!takingSemanticPath) {
+      return { kind: "ready", result: keywordResult };
+    }
+    // Semantic path. Compare slot inputs BY VALUE, not by reference — a
+    // useMemo cache discard would invalidate a byte-identical slot otherwise.
+    if (
+      semanticSlot !== null &&
+      semanticInputsMatch(
+        semanticSlot.inputs,
+        trimmedJdText,
+        parsed,
+        selectedModelId,
+      )
+    ) {
+      return semanticSlot.state;
+    }
+    return LOADING_START;
+  }, [
+    keywordResult,
+    takingSemanticPath,
+    semanticSlot,
+    trimmedJdText,
+    parsed,
+    selectedModelId,
+  ]);
+
+  // ── Semantic orchestration ─────────────────────────────────────────────
+  //
+  // The effect below is the ONLY source of async state; the keyword arm and
+  // all synchronous transitions bypass it entirely. Everything below runs
+  // only when a semantic run must be started or is in flight.
+
+  const requestIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    // Re-set on every mount, not just at hook creation: under React
+    // StrictMode the first effect-cleanup fires between the two effect
+    // runs, so a bare `useRef(true)` initializer would leave the ref
+    // stale-`false` on the real mount and every in-flight write would
+    // be dropped as if the component had unmounted.
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Guarded slot writer: `myId` is the request-id snapshot the caller took
+  // at run-start, `inputs` is the snapshot the run was started for.
+  //
+  // The id guard is the load-bearing one — it blocks late writes from a run
+  // whose caller left the semantic path or moved to a newer run, and it is
+  // covered by the stale-progress test.
+  //
+  // The `mountedRef` guard is intent, not verified behaviour: React 19 makes
+  // a setState on an unmounted root a no-op and emits no warning, so no test
+  // can tell it from its own absence (both oracles were tried — see the note
+  // in the test file). It stays because that no-op is an implementation
+  // detail rather than a contract; do not add a test claiming to pin it.
+  const setSlotIfCurrent = useCallback(
+    (myId: number, inputs: SemanticInputs, state: SemanticSubState) => {
+      if (!mountedRef.current) return;
+      if (requestIdRef.current !== myId) return;
+      setSemanticSlot({ inputs, state });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    // Not on the semantic path. Invalidate any in-flight run so its per-tick
+    // `onProgress` writes stop re-rendering the panel through the rest of a
+    // weight download.
+    //
+    // Whether the SLOT survives depends on what is in it, and the two cases
+    // pull in opposite directions:
+    //   - A partial (`loading`/`running`) slot must go. Kept, it would be a
+    //     stuck spinner on opt-back-in: the effect would see inputs that
+    //     still match and early-return, so nothing would ever restart the
+    //     run that the id bump just orphaned.
+    //   - A `ready` slot must stay. It is a finished answer for these exact
+    //     inputs, and clearing it means an opt-out → opt-in toggle throws
+    //     away a multi-minute engine load plus a full extract + judge and
+    //     re-runs all of it for a byte-identical result. Discarding real
+    //     inference on a toggle that changed no input is the expensive half
+    //     of this branch, so it is the half worth keeping.
+    //   - An `error` slot must ALSO go, for a different reason than the
+    //     partial ones: kept, it would early-return on opt-back-in and pin
+    //     the user to a failure with no way to retry short of editing the JD.
+    //     Only `ready` is worth caching; a failure should get another try.
+    // The id bump happens either way — orphaning late writes is what stops
+    // the download-progress re-renders, and it is independent of the slot.
+    if (!takingSemanticPath) {
+      if (semanticSlot !== null) {
+        requestIdRef.current += 1;
+        if (semanticSlot.state.kind !== "ready") setSemanticSlot(null);
+      }
+      return;
+    }
+
+    // Slot is already fresh for these inputs — either from a completed
+    // prior run whose inputs still match (memoized result) or from an
+    // in-flight run this effect already kicked off. Either way, nothing
+    // new to do. Value comparison, per the layer-2 rationale in the docblock.
+    if (
+      semanticSlot !== null &&
+      semanticInputsMatch(
+        semanticSlot.inputs,
+        trimmedJdText,
+        parsed,
+        selectedModelId,
+      )
+    ) {
+      return;
+    }
+
+    // New run. Bump the id so any older in-flight run's writes will fail
+    // the guard, and reset the slot to a fresh `loading` bound to these
+    // inputs so the derived status stops rendering LOADING_START (which
+    // was the render-time placeholder while slot was stale/null).
+    const myId = ++requestIdRef.current;
+    const myInputs: SemanticInputs = {
+      jdText: trimmedJdText,
+      parsed,
+      modelId: selectedModelId,
+    };
+    setSemanticSlot({
+      inputs: myInputs,
+      state: LOADING_START,
+    });
+
+    // Snapshot the keyword result the run should degrade to on unexpected
+    // failure. Captured at effect-start; if it changes mid-run, the effect
+    // re-fires (via `takingSemanticPath`/`keywordResult` deps), bumps the
+    // id, and this closure's late writes fail the guard — so a stale
+    // fallback never reaches the slot.
+    const fallbackKeyword = keywordResult;
+
+    // Dynamic import mirrors the discipline in `run-llm-match.ts`'s
+    // docblock: the WebLLM chunk stays out of the entry bundle until a
+    // user actually opts into semantic matching. Same lazy-load pattern
+    // `useResumeRewrite` relies on transitively through `rewrite-resume.ts`.
+    void import("../lib/jd-match/llm/run-llm-match.ts")
+      .then(({ runLlmMatch }) =>
+        runLlmMatch(
+          myInputs.jdText,
+          myInputs.parsed,
+          myInputs.modelId,
+          (progress) =>
+            setSlotIfCurrent(myId, myInputs, { kind: "loading", progress }),
+          () => setSlotIfCurrent(myId, myInputs, { kind: "running" }),
+        ),
+      )
+      .then((result) => {
+        setSlotIfCurrent(myId, myInputs, { kind: "ready", result });
+      })
+      .catch((err: unknown) => {
+        // `runLlmMatch` is contracted to never reject (every failure falls
+        // back to keyword internally). The realistic trigger here is a
+        // dynamic-import failure after a deploy replaces hashed chunks
+        // (`jobs/main.tsx`'s `vite:preloadError` reload is one-shot; the
+        // second such failure in a session falls straight through). We
+        // preserve the keyword coverage the user was already looking at
+        // rather than replacing it with a raw error string — the docblock
+        // states "keyword is always available" and this catch honors it.
+        console.warn(
+          "[useJdMatch] semantic path failed unexpectedly; preserving keyword:",
+          err,
+        );
+        if (fallbackKeyword !== null) {
+          setSlotIfCurrent(myId, myInputs, {
+            kind: "ready",
+            result: fallbackKeyword,
+          });
+          return;
+        }
+        setSlotIfCurrent(myId, myInputs, {
+          kind: "error",
+          message:
+            err instanceof Error
+              ? err.message
+              : "Couldn't run the semantic JD match.",
+        });
+      });
+    // `keywordResult` is not in the deps: `useMemo`'s inputs (`trimmedJdText`,
+    // `parsed`) are already listed, so any value that would change
+    // `keywordResult` re-fires this effect and starts a fresh run with a fresh
+    // `fallbackKeyword` closure — no stale fallback can reach the slot.
+  }, [
+    takingSemanticPath,
+    trimmedJdText,
+    parsed,
+    selectedModelId,
+    semanticSlot,
+    setSlotIfCurrent,
+  ]);
+
+  return { status, keyword: keywordResult };
+}

--- a/src/lib/jd-match/llm/run-llm-match.test.ts
+++ b/src/lib/jd-match/llm/run-llm-match.test.ts
@@ -38,7 +38,11 @@ vi.mock("./judge-evidence.ts", async (importOriginal) => {
 });
 
 import { runLlmMatch } from "./run-llm-match.ts";
-import { loadEngine } from "../../webllm/web-llm.ts";
+import {
+  acquireInference,
+  loadEngine,
+  releaseInference,
+} from "../../webllm/web-llm.ts";
 import {
   extractRequirements,
   RequirementExtractionError,
@@ -53,6 +57,8 @@ import type { HeuristicParsedResume } from "../../heuristics/types.ts";
 const loadEngineMock = vi.mocked(loadEngine);
 const extractMock = vi.mocked(extractRequirements);
 const judgeMock = vi.mocked(judgeEvidence);
+const acquireMock = vi.mocked(acquireInference);
+const releaseMock = vi.mocked(releaseInference);
 
 const MODEL = "test-model";
 const JD_TEXT =
@@ -150,6 +156,147 @@ describe("runLlmMatch — happy path", () => {
       engine,
       MODEL,
     );
+  });
+
+  it("fires onInferenceStart exactly once, AFTER loadEngine RESOLVES, BEFORE extractRequirements (#203)", async () => {
+    // The load→infer transition is what lets a state-machine consumer
+    // distinguish `loading` from `running` without duplicating the
+    // orchestrator. The trace has to record the RESOLUTION of loadEngine's
+    // promise (not its call time), otherwise a regression to
+    //
+    //   const p = loadEngine(modelId, onProgress);
+    //   onInferenceStart?.();
+    //   const engine = await p;
+    //
+    // would still produce the "correct" ordering in the trace and pass. A
+    // deferred promise + a `.then` marker gives us the actual resolution
+    // event; the deferred is resolved AFTER the runLlmMatch call so an
+    // early `onInferenceStart` would land before "loadEngine.resolve" in
+    // the trace and fail the assertion.
+    const trace: string[] = [];
+    let resolveEngine!: (e: WebLlmEngine) => void;
+    const enginePromise = new Promise<WebLlmEngine>((res) => {
+      resolveEngine = res;
+    });
+    // Marker fires on the ACTUAL resolution of the promise. Chained here
+    // rather than inside `mockImplementation`'s body — that body executes
+    // synchronously on call and would record call time.
+    void enginePromise.then(() => trace.push("loadEngine.resolve"));
+    loadEngineMock.mockReturnValue(enginePromise);
+
+    extractMock.mockImplementation(async () => {
+      trace.push("extractRequirements.call");
+      return [req("req-1", "TypeScript")];
+    });
+    judgeMock.mockResolvedValue([verdict("req-1", "met")]);
+
+    const onInferenceStart = vi.fn(() => trace.push("onInferenceStart"));
+    const runPromise = runLlmMatch(
+      JD_TEXT,
+      parsed(),
+      MODEL,
+      vi.fn(),
+      onInferenceStart,
+    );
+    // Resolve the engine AFTER runLlmMatch is under way. A regression that
+    // fires `onInferenceStart` before awaiting the engine promise would
+    // land it in the trace here (before "loadEngine.resolve").
+    resolveEngine(engine);
+    await runPromise;
+
+    expect(onInferenceStart).toHaveBeenCalledOnce();
+    expect(trace).toEqual([
+      "loadEngine.resolve",
+      "onInferenceStart",
+      "extractRequirements.call",
+    ]);
+  });
+
+  it("does NOT fire onInferenceStart on the fallback branch (engine load failed)", async () => {
+    // The caller stays in `loading` all the way to the fallback keyword
+    // `ready`; a spurious `running` transition would leave the UI briefly
+    // in an inference state that never actually started.
+    loadEngineMock.mockRejectedValue(new Error("WebGPU unavailable"));
+
+    const onInferenceStart = vi.fn();
+    const result = await runLlmMatch(
+      JD_TEXT,
+      parsed(),
+      MODEL,
+      vi.fn(),
+      onInferenceStart,
+    );
+
+    expect(result.path).toBe("keyword");
+    expect(onInferenceStart).not.toHaveBeenCalled();
+  });
+});
+
+describe("runLlmMatch — #148 inference guard brackets the WHOLE load-and-use sequence", () => {
+  it("acquires BEFORE awaiting loadEngine, and releases exactly once", async () => {
+    // `web-llm.ts` is explicit that acquiring AFTER the await is too late:
+    // `await` yields even on the already-loaded fast path, and a concurrent
+    // cross-model load's `evictAllExcept` can see `inflightInferenceCount`
+    // at 0 in that gap and `.unload()` the engine mid-use. So the ordering
+    // — not merely the presence of the call — is the contract. A trace is
+    // what pins ordering; a `toHaveBeenCalled` pair would pass for the
+    // broken "load first, acquire second" shape too.
+    const trace: string[] = [];
+    acquireMock.mockImplementation(() => {
+      trace.push("acquire");
+    });
+    releaseMock.mockImplementation(() => {
+      trace.push("release");
+    });
+    loadEngineMock.mockImplementation(() => {
+      trace.push("loadEngine");
+      return Promise.resolve(engine);
+    });
+    extractMock.mockImplementation(async () => {
+      trace.push("extractRequirements");
+      return [req("req-1", "TypeScript")];
+    });
+    judgeMock.mockImplementation(async () => {
+      trace.push("judgeEvidence");
+      return [verdict("req-1", "met")];
+    });
+
+    await runLlmMatch(JD_TEXT, parsed(), MODEL, vi.fn());
+
+    expect(trace).toEqual([
+      "acquire",
+      "loadEngine",
+      "extractRequirements",
+      "judgeEvidence",
+      "release",
+    ]);
+    expect(acquireMock).toHaveBeenCalledWith(MODEL);
+    expect(releaseMock).toHaveBeenCalledWith(MODEL);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases on the engine-load failure path (the keyword fallback)", async () => {
+    // A leaked acquire would pin `inflightInferenceCount` above zero for the
+    // page's lifetime, parking every later cross-model `.unload()` forever —
+    // so the release has to survive the branch that degrades to keyword.
+    loadEngineMock.mockRejectedValue(new Error("WebGPU unavailable"));
+
+    const result = await runLlmMatch(JD_TEXT, parsed(), MODEL, vi.fn());
+
+    expect(result.path).toBe("keyword");
+    expect(acquireMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases on the empty-extraction degrade path", async () => {
+    // The third exit from the try block — an early `return` rather than a
+    // throw, which is exactly the shape a `finally` is needed to cover.
+    extractMock.mockResolvedValue([]);
+
+    const result = await runLlmMatch(JD_TEXT, parsed(), MODEL, vi.fn());
+
+    expect(result.path).toBe("keyword");
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/jd-match/llm/run-llm-match.ts
+++ b/src/lib/jd-match/llm/run-llm-match.ts
@@ -35,7 +35,11 @@
 
 import type { HeuristicParsedResume } from "../../heuristics/types.ts";
 import type { ProgressUpdate } from "../../webllm/types.ts";
-import { loadEngine } from "../../webllm/web-llm.ts";
+import {
+  acquireInference,
+  loadEngine,
+  releaseInference,
+} from "../../webllm/web-llm.ts";
 import { extractJdTerms } from "../extract-jd-terms.ts";
 import { computeCoverage } from "../coverage.ts";
 import type { JdMatchResult, SemanticMatchSummary } from "../types.ts";
@@ -47,15 +51,54 @@ import { judgeEvidence } from "./judge-evidence.ts";
  * Run the semantic JD-match, degrading to the keyword path on any failure.
  *
  * Never rejects: the promise always resolves to a usable `JdMatchResult`.
+ *
+ * `onInferenceStart` (optional) fires exactly once, after `loadEngine`
+ * resolves and BEFORE `extractRequirements` runs. It lets a state-machine
+ * consumer distinguish the "engine downloading/loading" phase from the
+ * "engine loaded, model is thinking" phase — the two show different UI
+ * (download progress vs. a running indicator). Never fires on the fallback
+ * branch (an engine-load failure): the caller stays in `loading` and then
+ * transitions straight to the fallback `ready`. Kept optional so existing
+ * callers that don't need the distinction are unchanged.
+ *
+ * ## Why the whole body is bracketed by `acquireInference` (#148)
+ *
+ * `web-llm.ts` requires inference callers to acquire BEFORE awaiting
+ * `loadEngine`, not after: `await` yields to the microtask queue even on the
+ * already-loaded fast path, and a concurrent cross-model load's
+ * `evictAllExcept` can see `inflightInferenceCount === 0` in that gap and
+ * `.unload()` the engine out from under us. `judgeEvidence` acquires per
+ * batch, but that is explicitly "defensive belt" — it does not cover
+ * `loadEngine` or `extractRequirements`, which this bracket is what guards.
+ *
+ * The live path this closes: `job-search/sector.ts` classifies on
+ * `DEFAULT_MODEL_ID` on the same `/jobs/` page. If the user's persisted
+ * `selectedModelId` differs, that classify reaches
+ * `evictAllExcept(DEFAULT_MODEL_ID)` and would tear down our engine mid
+ * `extractRequirements` — surfacing as a silent degrade to keyword. The
+ * counter is re-entrant, so `judgeEvidence`'s inner acquire still nests
+ * correctly underneath this one.
  */
 export async function runLlmMatch(
   jdText: string,
   parsed: HeuristicParsedResume,
   modelId: string,
   onProgress: (update: ProgressUpdate) => void,
+  onInferenceStart?: () => void,
 ): Promise<JdMatchResult> {
+  acquireInference(modelId);
   try {
     const engine = await loadEngine(modelId, onProgress);
+    // `onInferenceStart` is a notification, not orchestration — a throwing
+    // consumer callback must not be misattributed as an engine failure by
+    // the surrounding catch (which logs "semantic path failed" and degrades
+    // to keyword). Isolate it. The only in-repo consumer is a `setState`,
+    // so this is defensive belt, not a live scenario.
+    try {
+      onInferenceStart?.();
+    } catch (err) {
+      console.warn("[run-llm-match] onInferenceStart callback threw:", err);
+    }
     const requirements = await extractRequirements(jdText, engine);
     if (requirements.length === 0) {
       // Legitimate empty extraction (#200: not a failure) — but a semantic
@@ -70,6 +113,12 @@ export async function runLlmMatch(
       err,
     );
     return keywordMatch(jdText, parsed);
+  } finally {
+    // Paired with the `acquireInference` above on EVERY exit — the semantic
+    // return, the empty-extraction degrade, and the catch's keyword fallback.
+    // A missed release would pin `inflightInferenceCount` above zero for the
+    // page's lifetime and park every later cross-model `.unload()` forever.
+    releaseInference(modelId);
   }
 }
 


### PR DESCRIPTION
## Summary

Moves JD-match interaction state out of the leaf component ([`PasteJdPanel`](src/components/features/PasteJdPanel.tsx), where PR #576 relocated it from `App.tsx`) into a new [`useJdMatch`](src/hooks/useJdMatch.ts) hook that mirrors `useResumeRewrite`'s async state machine: `idle → loading → running → ready → error`. Keyword stays render-synchronous (the invariant #203's "synchronous keyword fast-resolve" wording protects); semantic is async, delegates to `runLlmMatch`, and is bounded by two staleness layers so a late semantic write cannot overwrite a result the user has since moved past.

**Not user-reachable in this PR** — `PasteJdPanel` passes `semanticOptIn=false`, so behavior on `/jobs/` is unchanged from pre-#203. Per the [#156 epic dependency chain](https://github.com/offlinecv/OfflineCV/issues/156) (`#202 → #203 → #204`), #204 owns the user-facing opt-in toggle, consent dialog, progress copy, and semantic verdict UI. This PR is the controller/API foundation #204 activates.

Refs #203

## Architectural note (why the plan diverged from the issue text)

Issue #203 says "Replace the synchronous `useMemo` JD pipeline in `App.tsx:82-90` with the hook." That line reference predates PR #576, which moved JD-paste out of `App.tsx` into `/jobs/` (specifically into `PasteJdPanel`). `App.tsx` holds no JD state at all today — no `extractJdTerms`, no `computeCoverage`, no `jd-match` import. The correct current-architecture consumer is `PasteJdPanel`, and rewiring it there is what CLAUDE.md's "cross-cutting interaction state belongs in `src/hooks/`" rule points at. Same architectural intent, applied to the surface that actually owns the pipeline.

## Design

**Two output channels, not one.** The controller returns `{ status, keyword }`. `status` is the semantic-refinement channel; `keyword` is the floor, populated whenever the debounced JD yields terms. They are separate because `status` cannot express "engine still loading AND keyword coverage already available" — the semantic arm has to occupy `loading`/`running` for the whole engine-load window, which on a cold cache is minutes. Consumers render `keyword` and layer `status` over it. `PasteJdPanel` reads `keyword`, so it keeps showing coverage through that window once #204 flips the flag, and #204 only has to *add* the semantic view.

**Keyword arm (render-synchronous)** — a `useMemo` over `[trimmedJdText, parsed]` with the identical trim / `extractJdTerms` / `computeCoverage` shape the pre-#203 inline pipeline used. Combined with the derived `status` memo, the keyword result lands on the SAME render commit as the debounce's setState — no effect flush. Pinned by a render-count oracle, not just a value assertion.

**Semantic arm (async, opt-in + WebGPU)** — orchestrated by [`runLlmMatch`](src/lib/jd-match/llm/run-llm-match.ts). Its result lives in a slot bound to the inputs it was computed for. Two-layer staleness protection:

1. A monotonic `requestIdRef`, bumped on every semantic run start **and on every exit from the semantic path**. Every callback (`onProgress`, `onInferenceStart`, final resolve, catch) fails the guard if it belongs to a superseded run — which is what stops WebLLM's per-tick `onProgress` from re-rendering the panel through the rest of a multi-GB weight download after the user opted out.
2. Slot-vs-current-input comparison **by value** (`semanticInputsMatch`), not by `useMemo` reference identity. React documents `useMemo` as a cache it MAY discard (`<Activity>`/offscreen already does); a reference check would invalidate a byte-identical completed slot and restart a full LLM run. Value comparison is immune.

**Slot retention on exit is conditional, and the condition matters.** A `ready` slot survives an opt-out, so an opt-out → opt-in toggle with unchanged JD/parse/model returns the cached result instead of re-running a full engine load + extract + judge for a byte-identical answer. Unsettled slots do not survive: a kept `loading`/`running` slot would match on opt-back-in, the effect would early-return, and nothing would restart the run the id bump had just orphaned — a spinner that never ends. An `error` slot is also cleared, so a failure gets another try rather than pinning the user to it.

**`onInferenceStart` on `runLlmMatch`** — new optional 5th param, fires exactly once after `loadEngine` resolves and before `extractRequirements`, so a state-machine consumer can distinguish `loading` from `running` without duplicating the orchestrator. Backward-compatible; existing four-param callsites unchanged.

**`runLlmMatch` now honours the #148 inference-guard contract.** `web-llm.ts` requires inference callers to `acquireInference` *before* awaiting `loadEngine` — `await` yields even on the already-loaded fast path, and a concurrent cross-model load's `evictAllExcept` can see `inflightInferenceCount === 0` in that gap and `.unload()` the engine mid-use. `runLlmMatch` was the only inference `loadEngine` caller in the tree without the bracket (`judgeEvidence` acquires per batch, but that is explicitly "defensive belt" and covers neither `loadEngine` nor `extractRequirements`). The live path this closes: `job-search/sector.ts` classifies on `DEFAULT_MODEL_ID` on the same `/jobs/` page, so a differing persisted `selectedModelId` could tear our engine down mid-`extractRequirements` and surface as a silent degrade to keyword.

## Review focus

- **Slot retention** — `useJdMatch.ts` `!takingSemanticPath` branch. The `ready`-survives / unsettled-clears split is the subtlest thing here. Both directions are covered by tests that fail if the condition is inverted or dropped, but the reasoning is worth a second read.
- **`keyword` as a second channel** — is `{ status, keyword }` the right shape for #204, or should the semantic arm carry its keyword fallback inside `status`? I went with two channels because it keeps `status` a plain state machine and makes "keyword is always available" true of the API rather than only of the docblock.
- **The `acquireInference` bracket in `run-llm-match.ts`** — the `finally` has to cover three exits (semantic return, empty-extraction degrade, catch fallback). A leaked acquire would pin `inflightInferenceCount` above zero for the page's lifetime and park every later cross-model `.unload()` forever.
- **Effect self-dependency** — the semantic effect depends on `semanticSlot`, which it writes. The value-comparison guard is what short-circuits the re-fire after its own `setSemanticSlot`.

## Known limitations (deliberately out of scope)

Both are latent — nothing reaches them while `semanticOptIn` is false — and both are now filed so #204 doesn't inherit them silently:

- **No cancellation of an in-flight semantic run** (#803). `requestIdRef` only *hides* a superseded run's writes; `runLlmMatch` takes no `AbortSignal` and `acquireInference` is a counter, not a mutex, so it does not serialise either. With the flag live, a paste plus three corrections >200 ms apart leaves four `runLlmMatch` chains in flight against one shared `MLCEngine`, three abandoned but still consuming token slots. Threading an abort contract through `runLlmMatch` → `extractRequirements` → `judgeEvidence` is a change to three modules and does not belong here.
- **`loadEngine` can silently drop a caller's `onProgress`** (#804). Fast path B returns an existing `pendingByModelId` promise and only ever wires the *first* caller's callback to `initProgressCallback`. On `/jobs/`, `sector.ts` may already have called `loadEngine(DEFAULT_MODEL_ID, () => {})`; if that load is still pending, this hook's `onProgress` never fires and status stays at `progress: 0` through the whole download. The fix is a progress fan-out in shared `web-llm.ts`, which touches every WebLLM lane.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean. `/jobs/` entry 86.37 kB → 88.04 kB (+0.71 kB gzip) from the static `capability.ts`/`useModelSelection` edges; `run-llm-match-*.js` stays a lazy 7.04 kB chunk, so the WebLLM runtime is still out of the entry bundle.
- [x] `npx vitest run src/hooks/useJdMatch.test.tsx` → 23/23
- [x] `npx vitest run src/lib/jd-match/llm/run-llm-match.test.ts` → 12/12
- [x] `npx vitest run src/components/features/PasteJdPanel.test.tsx` → 3/3 pre-existing tests unchanged
- [x] `npm run verify`

**Fail-before verification.** Every non-obvious test here was checked by reverting the fix and confirming the test goes red, because a green test that cannot fail is worse than no test:

| Reverted to | Test that goes red |
|---|---|
| Effect-driven status derivation | render-synchronous oracle (`expected 2 to be 1`) |
| Bare `useRef(true)` (no re-set in the mount effect) | StrictMode mounted-ref test |
| `acquireInference` removed | all 3 inference-guard tests |
| `acquireInference` moved to *after* the `await` | 2 of 3 (the trace test catches the ordering) |
| Unconditional `setSemanticSlot(null)` on exit | opt-out-preserves-`ready` test |
| Never clearing the slot on exit | opt-out-while-loading test + the stale-progress test |
| `keyword` nulled on the semantic path | keyword-floor test |

**One guard is deliberately untested**, and the PR says so in both the hook and the test file rather than papering over it: `setSlotIfCurrent`'s `mountedRef` unmount check. React removed the "state update on an unmounted component" warning in v18, and `root.unmount()` makes the late setState a React-level no-op, so *neither* a warning oracle nor a render-count oracle can distinguish the guard from its absence — both were tried and both stay green with the guard deleted. The guard is kept as intent; the vacuous test that previously claimed to cover it is gone.

## Provenance

Initial implementation: Claude Opus 4.7 (1M context), high effort.
Review rounds 1–2 and the round-3 fixes in this body (inference-guard bracket, conditional slot retention, `keyword` channel, frozen status constants, docblock corrections, removal of the vacuous unmount test): Claude Opus 5 (1M context), high effort.
