### PR TITLE
fix(test): provision localStorage before test modules evaluate, not just before each test (#779)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,9 @@
         "typescript-eslint": "^8.34.0",
         "vite": "^7.1.2",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@offlinecv/web",
   "private": true,
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "version": "0.1.0-alpha.1",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/test-setup.test.ts
+++ b/src/test-setup.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Guards the MODULE-SCOPE half of `src/test-setup.ts` (#779).
+ *
+ * The `beforeEach` half needs no guard: every suite that reads `localStorage`
+ * inside a test would fail loudly without it. The module-scope install is the
+ * one that is invisible when it breaks — it only matters to a suite that reads
+ * the global while its own module body is evaluating, which is rare enough that
+ * the gap survived #398 and resurfaced in a file written after it.
+ *
+ * So the capture below is deliberately at module scope, not in a hook. It runs
+ * at the exact moment `letter-egress-ack.test.ts` reads the descriptor it later
+ * restores, and it is the moment that was broken: without the module-scope
+ * install, this file sees Node 22+'s built-in `localStorage` accessor — whose
+ * getter yields no usable `Storage` absent `--localstorage-file` — instead of
+ * the shim. A suite that captures that and restores it afterwards clobbers the
+ * working global for itself and for every test after it in the same worker.
+ *
+ * This file is why a NEW suite cannot reintroduce #779 by copying that
+ * (entirely reasonable) save/restore pattern.
+ */
+
+import { describe, expect, it } from "vitest";
+
+/** Captured at module scope, before any `beforeEach` has run — see above. */
+const atImportTime = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+describe("test-setup provisions localStorage before test modules evaluate (#779)", () => {
+  it("has already installed it by the time a test module body runs", () => {
+    expect(atImportTime).toBeDefined();
+  });
+
+  it("is a data property, not Node's built-in accessor", () => {
+    // The built-in is `{ get, set }`; the shim is `{ value, writable }`. This is
+    // the discriminator — on the built-in, `.value` is undefined and every
+    // `Storage` method is missing.
+    expect(atImportTime?.get).toBeUndefined();
+    expect(atImportTime?.value).toBeDefined();
+  });
+
+  it("exposes a working Storage, not one whose methods are absent", () => {
+    const storage = atImportTime?.value as Storage | undefined;
+    expect(typeof storage?.clear).toBe("function");
+    expect(typeof storage?.setItem).toBe("function");
+    expect(typeof storage?.getItem).toBe("function");
+  });
+
+  it("is configurable, so a suite may swap it and put it back", () => {
+    expect(atImportTime?.configurable).toBe(true);
+  });
+
+  it("survives the capture/swap/restore cycle a hostile-storage suite performs", () => {
+    // Exactly `letter-egress-ack.test.ts`'s shape: install a hostile accessor,
+    // then restore the captured descriptor and use the global again. Before the
+    // module-scope install this threw `localStorage.clear is not a function`,
+    // because what got restored was the built-in accessor rather than the shim.
+    // Guard before the swap, not after: with the module-scope install missing,
+    // `atImportTime` is `undefined` and the restore below throws "Property
+    // description must be an object" — naming this test's own scaffolding
+    // instead of the defect it exists to report, and leaving the hostile
+    // accessor installed for the rest of the case.
+    expect(atImportTime).toBeDefined();
+
+    Object.defineProperty(globalThis, "localStorage", {
+      get: () => undefined,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "localStorage", atImportTime!);
+
+    expect(() => globalThis.localStorage.clear()).not.toThrow();
+    globalThis.localStorage.setItem("ocv_probe", "1");
+    expect(globalThis.localStorage.getItem("ocv_probe")).toBe("1");
+  });
+});

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -4,17 +4,40 @@
 /**
  * Project-wide vitest setup (wired as `test.setupFiles` in `vite.config.ts`).
  *
- * Installs a fresh in-memory `localStorage` shim before EVERY test, globally.
- * The `ocv_*` functional keys touch a `localStorage` that neither the Node env
- * (default) provisions nor Node 22+'s built-in global exposes as a working
- * `Storage` (#398). Doing this once at the workload level — instead of an
- * `import + beforeEach` per file — closes the "new test forgot to install the
- * shim" regression class permanently. Per-test-fresh state means suites still
- * start clean without any `clear()` bookkeeping.
+ * Installs a fresh in-memory `localStorage` shim globally. The `ocv_*`
+ * functional keys touch a `localStorage` that neither the Node env (default)
+ * provisions nor Node 22+'s built-in global exposes as a working `Storage`
+ * (#398) — without `--localstorage-file`, that built-in is an accessor whose
+ * getter yields no usable `Storage`, so `.clear`/`.setItem` are absent.
+ *
+ * It is installed at TWO points, and both are load-bearing:
+ *
+ *   1. **Module scope**, below. A setup file is evaluated before the test
+ *      file's own module body, so this is the only hook that runs early enough
+ *      to be seen by a suite reading `localStorage` at import time. #779: the
+ *      `beforeEach` alone was not enough. `letter-egress-ack.test.ts` captures
+ *      `Object.getOwnPropertyDescriptor(globalThis, "localStorage")` at module
+ *      scope in order to restore it later — a reasonable thing for a suite that
+ *      swaps the global to simulate hostile storage. With only the `beforeEach`
+ *      below, that capture happened first and so captured Node's *built-in*
+ *      accessor; the suite's own `afterEach` then restored that accessor over
+ *      the working shim, and the next `localStorage.clear()` threw. Green on
+ *      CI's Node 20, red on Node 22+ locally — i.e. it read as a broken `main`.
+ *   2. **`beforeEach`**, so each test starts from clean persisted state without
+ *      any `clear()` bookkeeping, and so a test that deliberately swapped the
+ *      global gets a working one back.
+ *
+ * Doing this at the workload level — instead of an `import + beforeEach` per
+ * file — is what keeps a *new* suite from reintroducing the class. #398 fixed
+ * it per-file and it recurred in a file written afterwards; the module-scope
+ * install is what makes the import-time case unreachable too.
  */
 
 import { beforeEach } from "vitest";
 import { installMemoryLocalStorage } from "./hooks/__test-utils__/memory-storage.ts";
+
+// Before any test file's module body — see (1) above.
+installMemoryLocalStorage();
 
 beforeEach(() => {
   installMemoryLocalStorage();


### PR DESCRIPTION
## Summary

`npm run verify` was red on a clean `main` for anyone on Node 22+, tripping the local pre-push gate and the Claude Code Stop hook. CI stayed green because it runs the pinned Node 20, so this only ever appeared locally — and read as a broken `main`.

Fixed by installing the in-memory `Storage` shim at **module scope** in `src/test-setup.ts`, not only inside a `beforeEach`.

Closes #779

## The issue's diagnosis was wrong, and the real cause is narrower

Worth stating up front, because I wrote that diagnosis. #779 (and #398 before it) blamed Node 22+'s built-in `localStorage` **shadowing** jsdom's. It doesn't — I probed it, and inside a test the global is already the repo's own `MemoryStorage` with a working `.clear`.

The actual cause is **ordering**:

| When | `globalThis.localStorage` descriptor |
| --- | --- |
| Test file's **module body** | `{ get, set }` — Node's built-in accessor, whose getter yields no usable `Storage` absent `--localstorage-file` |
| Inside a **test** | `{ value, writable }` — the shim, installed by `test-setup.ts`'s `beforeEach` |

`setupFiles` module code runs before a test file's module body; a `beforeEach` inside it does not. So `letter-egress-ack.test.ts` — which captures the descriptor at module scope so it can restore it after simulating hostile storage, an entirely reasonable thing for that suite to do — captured the **built-in accessor**. Its own `afterEach` then restored that over the working global, and the next `clear()` threw:

```
TypeError: globalThis.localStorage?.clear is not a function
```

Confirmed by printing the descriptor at both moments; after the suite's restore, `globalThis.localStorage` is `undefined`.

## Why this is structural, not another per-file patch

#398 fixed the same class per-file and it recurred here, in a file written afterwards. #779's AC is explicit that a *new* test must not be able to reintroduce it.

`src/test-setup.test.ts` is the guard. It captures at module scope — the exact moment that was broken — and asserts the global is a configurable **data** property exposing a real `Storage`, then round-trips the capture/swap/restore cycle a hostile-storage suite performs.

It bites. Removing the module-scope install:

- fails **3 of its 5** cases (`is a data property, not Node's built-in accessor`, `exposes a working Storage`, `survives the capture/swap/restore cycle`), and
- fails **all 9** `letter-egress-ack` cases.

Restored: 14/14 green.

The `beforeEach` stays. It is what gives each test clean persisted state, and what hands a working global back to a suite that deliberately swapped one.

## Acceptance criteria

- [x] **`verify` green on a clean checkout under both Node 20 and current.** `npm run verify` exits **0** on Node **20.20.2** (pinned) and Node **25.8.1** — 5425 passed / 10 skipped on both. The two affected suites also pass on Node 18.20.0.
- [x] **Not per-file.** Module-scope install + a mutation-checked regression guard, above.
- [x] **A version mismatch names itself.** Declares `engines.node: "^20.19.0 || >=22.12.0"` — the range `vite@7.3.3` and `@vitejs/plugin-react` actually accept, not the looser `>=20` the docs imply (corrected in review). Mirrored into the lockfile root so a later `npm install` leaves no spurious dirty tree. An unsupported runtime now draws `npm WARN EBADENGINE` naming both required and current, instead of opaque `TypeError`s.
- [x] **`memory-storage.ts` is used.** `test-setup.ts` imports `installMemoryLocalStorage` — no second shim introduced.

## Review focus

- `src/test-setup.ts` — the claim that a setup file's module body runs before the test file's is the whole fix. Verified empirically both ways (the guard fails without it), but it is a vitest ordering guarantee worth a second opinion.
- Installing the shim twice (module scope + `beforeEach`) is deliberate. The docblock says why each is load-bearing; if you disagree that both are needed, the `beforeEach` is the one to challenge.
- `engines.node` is a **warning**, not a hard gate — npm does not fail install without `engine-strict`. I chose not to add `engine-strict`, since hard-failing a contributor's install is a bigger call than this issue's scope. Say the word if you want it enforced.
- ~~Tests pass on Node 18 too, so `>=20` documents the range rather than a measured floor.~~ Superseded in review: the floor is now `^20.19.0 || >=22.12.0`, which is `vite`'s own. Node 18 correctly draws EBADENGINE — `vite@7` does not support it, so the earlier note described a floor the toolchain never had.

## Test plan

- [x] `npm run verify` on **Node 20.20.2** — exit 0, 5425 passed
- [x] `npm run verify` on **Node 25.8.1** — exit 0, 5425 passed
- [x] `src/lib/letter-egress-ack.test.ts` — 9/9 on Node 18, 20 and 25 (was 0/9 on 22+)
- [x] Regression guard mutation-checked — removing the module-scope install fails 3 of 5 guard cases and all 9 original cases
- [x] `npm WARN EBADENGINE` confirmed to fire on Node 18 and name both required and current
- [x] `fallow` — no issues in 5 changed files

## Not in this PR

- **The `rollup-plugin-dts` install gap.** A first `verify` on Node 20 failed in `check:core` with `Cannot find package 'rollup-plugin-dts'` — my `node_modules` predated the `@offlinecv/core` workspace (#771). A plain `npm install` fixed it and it is not a repo defect, but it is the same genre of confusing local-only red gate. Mentioning it in case it bites someone else after pulling #771.
- **Correcting #398's and #779's shadowing diagnosis in the issue text.** Recorded here instead; happy to edit #779 if you would rather the issue carry it.

## Provenance

Code implementation via: Claude Opus 5 (1M context). Reasoning effort is not surfaced to the session, so it is omitted rather than guessed.



---

## Review round 2 (all three addressed in `2e797eb`)

- **Lockfile `engines`** — added. Applied that hunk *only*: a full `npm install --package-lock-only` also adds six nested `@tailwindcss/oxide-wasm32-wasi` optional-platform entries, which I verified are **pre-existing drift on untouched `main`** (same 6 appear with no `engines` field at all), so they are not bundled here.
- **`engines` range** — corrected to `vite`'s own `^20.19.0 || >=22.12.0`. `>=20` would have admitted 20.0–20.18, 21.x and 22.0–22.11, which `vite@7` rejects.
- **Guard's failure message** — early `expect(atImportTime).toBeDefined()`, so the broken state now reports `expected undefined to be defined` rather than `Property description must be an object`.
