### PR TITLE
fix(webllm): stop a list marker shielding the leading bold from cleanRewriteLine (#781)

### DIFF
--- a/src/lib/webllm/post-process.test.ts
+++ b/src/lib/webllm/post-process.test.ts
@@ -168,4 +168,106 @@ describe("cleanRewriteLine", () => {
       ).toBe("Led migration of the **order-processing** pipeline.");
     });
   });
+
+  // ── A list marker must not shield the leading bold (#781) ──────────────────
+  //
+  // `LEADING_BOLD_WORD_PATTERN` is anchored at `^`, and the marker strip used
+  // to run after it, so anything the model put in front of the bold hid it.
+  // This shipped: 19 of 24 Gemma `terse` bullets in the 2026-08-07 eval reports
+  // carry literal `**` at `perBullet[].text` — post-`cleanRewriteLine` output,
+  // i.e. what a downloaded ATS PDF renders as asterisks. That renderer draws
+  // real bold from its own type scale and never interprets markdown, so a
+  // surviving `**` is always garbage.
+  //
+  // Every case below returns the marker-shielded input unchanged against the
+  // pre-fix implementation.
+  describe("list marker in front of a leading bold (#781)", () => {
+    it.each([
+      ["- **Led** the migration of billing.", "dash"],
+      ["* **Led** the migration of billing.", "asterisk"],
+      ["• **Led** the migration of billing.", "bullet glyph"],
+      ["1. **Led** the migration of billing.", "numbered"],
+      ["1) **Led** the migration of billing.", "paren-numbered"],
+      ["-**Led** the migration of billing.", "tight dash, no space"],
+    ])("strips both, leaving no markdown: %s (%s)", (input) => {
+      expect(cleanRewriteLine(input)).toBe("Led the migration of billing.");
+    });
+
+    it("leaves no literal asterisks for any marker shape", () => {
+      // The property the ATS PDF actually depends on, asserted directly rather
+      // than inferred from the equality cases above.
+      for (const marker of ["-", "*", "•", "1.", "1)"]) {
+        expect(cleanRewriteLine(`${marker} **Shipped** the thing.`)).not.toContain(
+          "*",
+        );
+      }
+    });
+
+    it("still reads `*Foo.*` as italics, not as a bullet glyph", () => {
+      // The ordering constraint that made this a loop rather than a swap: the
+      // emphasis strip has to keep beating the marker strip for this shape, or
+      // the leading `*` is eaten as a marker and the trailing one survives.
+      expect(cleanRewriteLine("*Foo.*")).toBe("Foo.");
+      expect(cleanRewriteLine("* Foo.*")).toBe("Foo.");
+    });
+
+    // ── The complementary hazard: a strip OVER-firing on what it uncovered ──
+    //
+    // Every case above shares one body, so they only prove a marker no longer
+    // *shields* the bold. They are blind to a strip mis-firing on the text the
+    // previous pass exposed — which is exactly how the loop first shipped
+    // `- 3.5x revenue growth` → `5x revenue growth`: pass 1 removed `- `, and
+    // pass 2 read the uncovered `3.` as a numbered marker because that branch
+    // allowed zero-or-more trailing space. Silent numeric corruption, on the
+    // path that renders the ATS PDF (#781 review).
+    it.each([
+      ["- 3.5x revenue growth in Q3.", "3.5x revenue growth in Q3."],
+      ["- 2.5M users onboarded.", "2.5M users onboarded."],
+      ["* 1.5x faster builds.", "1.5x faster builds."],
+      ["- 10.5 million records migrated.", "10.5 million records migrated."],
+      ["• 4.2% conversion lift.", "4.2% conversion lift."],
+      // Not marker-prefixed at all — the same branch mangled this on its own.
+      ["3.5x revenue growth.", "3.5x revenue growth."],
+    ])("does not eat a decimal a marker strip uncovers: %s", (input, want) => {
+      expect(cleanRewriteLine(input)).toBe(want);
+    });
+
+    it("preserves every digit of a leading decimal, for any marker", () => {
+      // The number-preservation counterpart to the `not.toContain("*")`
+      // property above. Asserted as a property so a new marker branch has to
+      // satisfy it too, not just the six literals enumerated here.
+      for (const marker of ["-", "*", "•", "1.", "1)"]) {
+        expect(cleanRewriteLine(`${marker} 3.5x revenue growth.`)).toContain(
+          "3.5",
+        );
+      }
+    });
+
+    it("still strips a genuine numbered marker", () => {
+      // The `\s+` requirement must not cost the case the marker strip exists
+      // for. Nothing in the corpus writes a tight `1.Foo`.
+      expect(cleanRewriteLine("1. Shipped the thing.")).toBe(
+        "Shipped the thing.",
+      );
+      expect(cleanRewriteLine("1) Shipped the thing.")).toBe(
+        "Shipped the thing.",
+      );
+    });
+
+    it("converges on stacked markers instead of truncating", () => {
+      // The loop runs to a fixed point rather than a fixed pass count. An
+      // earlier revision capped it at 4 and gave up here, leaving the literal
+      // `**` this function exists to remove.
+      expect(cleanRewriteLine("1. - • - **Led** stuff.")).toBe("Led stuff.");
+    });
+
+    it("leaves mid-line bold alone even when a marker is stripped", () => {
+      // Deliberate, and the one shape this fix does not clear — see the
+      // fixed-point comment in post-process.ts. 18 of the 19 affected eval
+      // bullets carried a leading bold only, so this is the rare tail.
+      expect(
+        cleanRewriteLine("- **Developed** and **implemented** a design system."),
+      ).toBe("Developed and **implemented** a design system.");
+    });
+  });
 });

--- a/src/lib/webllm/post-process.ts
+++ b/src/lib/webllm/post-process.ts
@@ -74,6 +74,33 @@ const CHAT_OPENER_PATTERN = /^here (?:are|is) (?:the )?rewritten\b/i;
  */
 const LEADING_BOLD_WORD_PATTERN = /^\*\*([A-Za-z][\w-]*)\*\*\s+/;
 
+/**
+ * A leading list marker: `1.` / `1)`, `•`, `-`, or `*`.
+ *
+ * The whitespace rules differ per branch, and each one is load-bearing:
+ *
+ *   - **Numbered requires `\s+`.** With `\s*` the alternative matches a bare
+ *     decimal — `3.` in `3.5x revenue growth` — because zero-or-more trailing
+ *     space is satisfied by the `5`. That is harmless while this runs once on
+ *     raw model output (a decimal is rarely line-initial there), but
+ *     `cleanRewriteLine` re-applies it to lines it has already stripped, so
+ *     `- 3.5x revenue growth` became `5x revenue growth`. Silent numeric
+ *     corruption on the product path, in a bullet the rewrite prompt actively
+ *     asks the model to quantify. Nothing needs a tight `1.Foo`.
+ *   - **`-` and `•` allow `\s*`**, so a tight `-Shipped X` still normalizes.
+ *   - **`*` requires `\s+`**, because `*X*` is italics and is handled by the
+ *     paired-emphasis strip instead.
+ */
+const LIST_MARKER_PATTERN = /^(?:\d+[.)]\s+|[•\-]\s*|\*\s+)/;
+
+/**
+ * Runaway guard for the markdown-prefix loop in `cleanRewriteLine` — not a
+ * budget for expected nesting. The loop terminates on its own (every strip
+ * only removes characters); this only bounds a hypothetical future strip that
+ * grows the line. Set well above any real prefix stack so it never truncates.
+ */
+const MAX_PREFIX_PASSES = 32;
+
 export function cleanRewriteLine(line: string): string {
   const trimmed = line.trim();
   if (!trimmed) return "";
@@ -87,30 +114,73 @@ export function cleanRewriteLine(line: string): string {
   // any trailing content the model attached to it.
   const withoutPrefix = trimmed.replace(/^rewritten:\s*/i, "");
 
-  // Strip a leading `**Verb**` markdown bold (single-word capture). This
-  // runs BEFORE the whole-line emphasis strip because that one requires
-  // closing `**` at end-of-line and so doesn't match the inline shape.
-  const withoutLeadingBold = withoutPrefix.replace(
-    LEADING_BOLD_WORD_PATTERN,
-    "$1 ",
-  );
+  // Markdown-prefix stripping, run to a fixed point.
+  //
+  // The three strips below shield each other in BOTH directions, which is why
+  // no single ordering works (#781):
+  //
+  //   - The emphasis strip must precede the marker strip, or the leading `*`
+  //     of an italicized line (`*Foo.*`) is read as a bullet glyph and the
+  //     trailing `*` survives.
+  //   - The marker strip must precede the leading-bold strip, or a marker in
+  //     front of the bold (`- **Led** the migration`) hides it from
+  //     LEADING_BOLD_WORD_PATTERN, which is anchored at `^`. That shipped:
+  //     19 of 24 Gemma `terse` bullets in the 2026-08-07 eval reports carried
+  //     literal `**` through to `perBullet[].text`, i.e. through to what a
+  //     downloaded ATS PDF would render as asterisks. That renderer draws real
+  //     bold from its own type scale and never interprets markdown, so a
+  //     surviving `**` is always garbage, never formatting.
+  //
+  // Looping resolves it without having to pick: each pass peels whatever is
+  // now outermost, and a marker uncovered on one pass is consumed on the next.
+  //
+  // ⚠️ The property each strip must hold is IDEMPOTENCE, not termination.
+  // Termination is trivially guaranteed — every branch only removes characters,
+  // so the line strictly shrinks — and it was never the risk. The real hazard is
+  // that a strip safe to apply once to MODEL OUTPUT may not be safe to re-apply
+  // to its OWN output, because the loop feeds it a line it has already
+  // transformed. LIST_MARKER_PATTERN is where that bit: with `\s*` after the
+  // numbered alternative, pass 1 stripped `- ` from `- 3.5x revenue growth` and
+  // pass 2 read the uncovered `3.` as a numbered marker, yielding
+  // `5x revenue growth`. Requiring `\s+` there is what makes it re-appliable.
+  // Any strip added to this loop must be checked the same way.
+  //
+  // Mid-line bold (`Developed and **implemented** …`) is deliberately NOT
+  // handled here. Two tests pin that as intentional — "does NOT strip emphasis
+  // mid-line" and "does NOT strip mid-bullet bold emphasis" — on the reasoning
+  // that a bold inside a sentence is authored emphasis rather than a model tic.
+  // It is also rare in practice: of the 19 affected eval bullets, 18 carried a
+  // leading bold only. Reversing that contract is a separate decision from
+  // fixing the marker interaction, so it is left to #781's follow-up.
+  let body = withoutPrefix;
+  let before = "";
+  let passes = 0;
+  while (body !== before) {
+    before = body;
 
-  // Strip paired bold/italic markdown delimiters BEFORE list-marker stripping
-  // — otherwise the leading `*` of an italicized line (`*Foo.*`) is misread
-  // as a bullet glyph and the trailing `*` survives. The pattern is paired
-  // (start AND end) so genuine mid-line emphasis is preserved.
-  const withoutEmphasis = withoutLeadingBold
-    .replace(/^\*\*(.+)\*\*$/s, "$1")
-    .replace(/^\*(.+)\*$/s, "$1")
-    .replace(/^_(.+)_$/s, "$1");
+    // Leading `**Verb**` bold (single-word capture) — see the pattern's own
+    // docblock for why multi-word bolds are left alone.
+    body = body.replace(LEADING_BOLD_WORD_PATTERN, "$1 ");
 
-  // Strip a leading list marker. `-` and `•` allow zero-or-more spaces (a
-  // tight `-Shipped X` should still normalize), but `*` requires at least
-  // one trailing space — `*X*` is italics and was already handled above.
-  const withoutBullet = withoutEmphasis.replace(
-    /^(?:\d+[.)]\s*|[•\-]\s*|\*\s+)/,
-    "",
-  );
+    // Paired bold/italic wrapping the WHOLE line. Paired (start AND end) so
+    // genuine mid-line emphasis is preserved.
+    body = body
+      .replace(/^\*\*(.+)\*\*$/s, "$1")
+      .replace(/^\*(.+)\*$/s, "$1")
+      .replace(/^_(.+)_$/s, "$1");
+
+    body = body.replace(LIST_MARKER_PATTERN, "");
+
+    // Runaway guard only. The loop exits on its own the moment a pass changes
+    // nothing, and the strictly-shrinking invariant means that always happens;
+    // this exists so a future strip that somehow grows the line cannot hang the
+    // worker. It is NOT a truncation point tuned to expected input — an earlier
+    // revision capped this at 4, which silently gave up on
+    // `1. - • - **Led** stuff.` and left the literal `**` this function exists
+    // to remove.
+    if (++passes >= MAX_PREFIX_PASSES) break;
+  }
+  const withoutBullet = body;
 
   // Strip surrounding quotes: straight (" ' `) plus smart double (“ ”) and
   // smart single (‘ ’).


### PR DESCRIPTION
## Summary

A model emitting `- **Led** the migration…` shipped literal markdown bold through `cleanRewriteLine` into the accepted rewrite, and from there into the downloaded ATS PDF as asterisks. `render-ats-pdf.ts` draws real bold from its own type scale and never interprets markdown, so a surviving `**` is always garbage — never formatting.

`LEADING_BOLD_WORD_PATTERN` is anchored at `^` and the list-marker strip ran *after* it, so any marker in front of the bold hid it.

It shipped. **19 of 24** Gemma `terse` bullets in the committed 2026-08-07 eval reports carry literal `**` at `records[].rubric.perBullet[].text` — post-`cleanRewriteLine` output. `noPreambleLeak` scores **PASS** on every one, so nothing flagged it.

Closes #781
Closes #782

## Why this is a fixed point, not a reorder

#781 correctly warned the obvious swap is unsafe, and it is — the three strips shield each other in **both** directions:

| Constraint | Why |
|---|---|
| emphasis **before** marker | else the leading `*` of `*Foo.*` is read as a bullet glyph and the trailing `*` survives |
| marker **before** leading-bold | else `- **Led** …` hides the bold from a `^`-anchored pattern — this bug |

Those cannot both hold in one pass. So the three run in a loop until the line stops changing: each pass peels whatever is now outermost, and a marker uncovered on one pass is consumed by the next. Every branch only removes characters, so the line strictly shrinks and the loop always converges; the pass bound is belt-and-braces.

I checked the swap-only fix would have regressed `* Foo.*` (today `"Foo."`, after a naive reorder `"Foo.*"`). The loop preserves it.

## Verified behaviour

| Input | Output |
|---|---|
| `- **Led** the migration.` | `Led the migration.` |
| `* **Led** the migration.` | `Led the migration.` |
| `• **Led** the migration.` | `Led the migration.` |
| `1. **Led** the migration.` | `Led the migration.` |
| `1) **Led** the migration.` | `Led the migration.` |
| `-**Led** the migration.` | `Led the migration.` |
| `*Foo.*` | `Foo.` *(invariant preserved)* |
| `* Foo.*` | `Foo.` *(invariant preserved)* |
| `**Streamlined the** checkout` | unchanged *(multi-word, by design)* |

## Mid-line bold is deliberately out of scope

#781 asked for a decision rather than a default, so: **not stripped**, and the reason is in the code.

Two existing tests pin it as intentional — `does NOT strip emphasis mid-line` and `does NOT strip mid-bullet bold emphasis` — on the reasoning that a bold inside a sentence is authored emphasis, not a model tic. Reversing a tested contract is a separate decision from fixing the marker interaction, and the data says it is the rare tail: of the 19 affected bullets, **18 carried a leading bold only**; exactly one had an additional inline pair.

## The rubric half is split out as #805

#781's last criterion — *"Consider whether the eval rubric should flag residual markdown"* — is filed as **#805** rather than bundled.

The regression guard for *this* defect is already at the better layer: `post-process.test.ts` covers all six marker shapes deterministically and runs in CI on every PR, whereas the eval is a manual WebGPU session. What a rubric criterion adds is different — catching a markdown shape nobody anticipated — and it is not small: it touches `rubric.ts`, `runner.ts`, `report.ts`, `types.ts` and three test files, adds a column to both report tables, and makes every committed report predate it. That is exactly the shape that needed its own PR and its own reporting-path proof (#714) when the Steering column landed in #608.

## Review focus

- `post-process.ts` — the loop is the whole change. If you prefer an explicit two-phase order (marker → emphasis → bold) over iterating, say so; I chose the loop because it does not require me to be right about which shapes nest, and `* Foo.*` showed that intuition is not reliable here.
- The `MAX_PREFIX_PASSES = 4` bound is defensive, not load-bearing — the loop converges on its own. Happy to drop it if you consider it noise.
- Mid-line bold: the call above is arguable. If you would rather clear all `**` on the way to a plain-text PDF, that is a coherent position — it just means retiring two tests deliberately, which I did not want to do silently.

## Test plan

- [x] `npm run verify` on Node 20.20.2 — exit 0, **5457 passed** / 10 skipped
- [x] `post-process.test.ts` 31 passed (22 pre-existing + 9 new)
- [x] **Mutation-checked**: restoring the pre-fix ordering fails **8 of the 9** new cases. The ninth (`*Foo.*` italics) correctly passes both ways — it is the invariant the loop protects, not the fix.
- [x] All six marker shapes assert both exact output *and* the property that matters (`not.toContain("*")`)
- [x] `fallow` — no issues in changed files

## Not in this PR

- **The eval rubric criterion** — #805, with the reasoning above.
- **Mid-line / multi-word bold** — deliberate, documented in code and in #805's context.
- **Re-running the eval to confirm the reports go clean.** The fix is proven at the unit layer; a fresh WebGPU run would confirm it end-to-end but needs a maintainer machine. Worth folding into whatever run happens next rather than commissioning one for this.

## Provenance

Code implementation via: Claude Opus 5 (1M context). Reasoning effort is not surfaced to the session, so it is omitted rather than guessed.



---

## Review round 2 — all four addressed in `cfb7b2c`

**Blocking: the loop mangled decimals.** The marker strip was not idempotent — with `\s*` after the numbered alternative, pass 1 removed `- ` from `- 3.5x revenue growth` and pass 2 read the uncovered `3.` as a numbered marker, yielding `5x revenue growth`. Silent numeric corruption on the product path, which downstream would have surfaced as a `checkNumbersPreserved` warning blaming the model for damage post-processing did. Numbered branch now requires `\s+`. Bare `3.5x revenue growth` — which `main` also mangles — is fixed as a side effect.

**`MAX_PREFIX_PASSES` was a truncation point, not belt-and-braces.** At 4 it silently gave up on `1. - • - **Led** stuff.` and left the literal `**`. Now a `while` to true convergence, bound raised to 32 and documented as a runaway guard only. Constant and a new named `LIST_MARKER_PATTERN` moved to module scope per house style; unused counter removed.

**The comment proved termination when idempotence was the risk.** Reframed: each strip must be safe to re-apply to a line it has already transformed, with the `- 3.5x` path as the worked example.

**The test table was blind to over-firing.** Six cases sharing one body could only prove a marker no longer *shields* the bold. Added decimal-uncovering cases, a digit-preservation property across all five markers, a genuine-numbered-marker case, and a convergence case.

Updated mutation results — 40 tests in `post-process.test.ts`:

| Mutation | Fails |
|---|---|
| revert `\s+` → `\s*` on the numbered branch | 7 |
| cap `MAX_PREFIX_PASSES` back to 4 | 1 |
| restore the pre-fix strip ordering | 8 |

`npm run verify` on Node 20.20.2 — exit 0, **5466 passed**.
