### PR TITLE
fix(jd-match): pair isAbortError with signal state, drop unreachable abort check (#803)

### DIFF
--- a/src/hooks/useJdMatch.test.tsx
+++ b/src/hooks/useJdMatch.test.tsx
@@ -1009,11 +1009,18 @@ describe("useJdMatch — Layer-3 abort controller (#803)", () => {
   });
 
   it("StrictMode remount does NOT abort the in-flight run (microtask guard defers past the re-mount)", async () => {
-    // Direct pin of the StrictMode-safety claim in the mount effect's
-    // cleanup. Without the microtask defer + mountedRef re-check, StrictMode's
-    // simulated unmount would abort the run, the semantic effect body #2
-    // would see the slot still fresh and early-return, and the user would be
-    // stuck on a spinner that never ends.
+    // Pins what the microtask defer + `mountedRef` re-check actually buy:
+    // a cleanup queued by StrictMode's simulated unmount must not later kill
+    // the REAL run that the re-mount started.
+    //
+    // Scoped deliberately. It does NOT prove the defer prevents a live abort
+    // at the double-invoke, because no run exists to abort there: the mount
+    // effect's cleanup fires while `debouncedJdText` is still `""` and
+    // `capability` is still `null`, so `takingSemanticPath` is false and
+    // `controllerRef.current` is null through the whole synchronous
+    // double-invoke. A synchronous abort in that cleanup passes this test too.
+    // The guard is a belt against a future ordering — see the Layer-3 note in
+    // the hook's module docblock — and this test pins the part that is real.
     const signals: AbortSignal[] = [];
     runLlmMatchMock.mockImplementation(
       (

--- a/src/hooks/useJdMatch.ts
+++ b/src/hooks/useJdMatch.ts
@@ -99,14 +99,23 @@
  *      cancelled. See `runLlmMatch`'s docblock for the boundary map.
  *
  *      Unmount abort is deferred by ONE microtask, guarded by `mountedRef`.
- *      Under React 19 StrictMode the mount effect's cleanup runs BETWEEN two
- *      effect-body invocations on the same hook instance; a naive abort in
- *      that cleanup would kill the in-flight run and the second effect body
- *      would early-return (slot inputs still match), stranding a spinner
- *      that never ends. The microtask hop lets StrictMode's synchronous
- *      re-mount body re-set `mountedRef.current = true` first; on a REAL
- *      unmount no re-mount runs, `mountedRef` stays false, and the abort
- *      fires. Same synchronous-commit-then-microtask ordering that makes
+ *      This is a BELT, not a fix for a reachable bug, and the distinction is
+ *      worth stating because the shape looks like one. The mount effect has
+ *      `[]` deps, so its cleanup fires exactly twice: at StrictMode's
+ *      simulated unmount on the initial mount, and at real unmount. At the
+ *      initial one, `debouncedJdText` is still `""` (a 200 ms timeout away)
+ *      and `capability` is still `null` (a promise away), so
+ *      `takingSemanticPath` is false through the whole synchronous
+ *      double-invoke and `controllerRef.current` is null — there is no run
+ *      to kill. A synchronous abort here would be a no-op TODAY.
+ *
+ *      What the hop buys: if a future change ever lets a run start before
+ *      the first commit settles, StrictMode's synchronous re-mount body
+ *      re-sets `mountedRef.current = true` before the queued microtask runs,
+ *      so the live run survives; on a REAL unmount no re-mount runs,
+ *      `mountedRef` stays false, and the abort fires. It also keeps a stale
+ *      microtask queued by the double-invoke from later killing the real
+ *      run. Same synchronous-commit-then-microtask ordering that makes
  *      #203's own `mountedRef.current = true` re-set pattern work.
  *
  * `parsed` identity contract: the hook treats `parsed` by REFERENCE, and the
@@ -360,10 +369,13 @@ export function useJdMatch(options: UseJdMatchOptions): JdMatchController {
 
   const requestIdRef = useRef(0);
   const mountedRef = useRef(true);
-  /** Per-run AbortController (#803). Non-null between run-start and its resolve
-   *  or its supersession/opt-out abort. Nulled on abort so a stray follow-up
-   *  abort call is a no-op rather than aborting a fresh run that has since
-   *  reused the ref slot. */
+  /** Per-run AbortController (#803). Non-null from run-start until the run is
+   *  superseded or aborted — a COMPLETED run's controller is deliberately left
+   *  in place (nothing in the `.then`/`.catch` nulls it) and is harmlessly
+   *  re-aborted later, since `abort()` on a settled controller is a spec no-op.
+   *  That no-op is exactly what makes the opt-out branch safe against a `ready`
+   *  slot. Nulled on abort so a stray follow-up abort call can't hit a fresh
+   *  run that has since reused the ref slot. */
   const controllerRef = useRef<AbortController | null>(null);
   useEffect(() => {
     // Re-set on every mount, not just at hook creation: under React
@@ -376,8 +388,8 @@ export function useJdMatch(options: UseJdMatchOptions): JdMatchController {
       mountedRef.current = false;
       // Unmount abort (#803, requirement §5). Deferred by one microtask,
       // gated on `mountedRef.current` still being false — see the
-      // Layer-3 rationale in the module docblock for why a synchronous
-      // abort here breaks StrictMode's simulated remount.
+      // Layer-3 rationale in the module docblock for why the defer is a
+      // belt against a future ordering rather than a live bug fix.
       queueMicrotask(() => {
         if (mountedRef.current) return;
         controllerRef.current?.abort();
@@ -431,7 +443,18 @@ export function useJdMatch(options: UseJdMatchOptions): JdMatchController {
     // The id bump happens either way — orphaning late writes is what stops
     // the download-progress re-renders, and it is independent of the slot.
     if (!takingSemanticPath) {
-      if (semanticSlot !== null) {
+      // Gated on the CONTROLLER as well as the slot, not the slot alone. The
+      // controller is installed synchronously at run-start while the matching
+      // `setSemanticSlot` is only scheduled, so "slot non-null" is a proxy for
+      // "a run exists" that holds only because `semanticSlot` is itself a dep
+      // of this effect — React therefore applies the run-start state update
+      // before any commit can observe `takingSemanticPath === false` against
+      // the pre-run slot. That is true under React 18/19 automatic batching
+      // and has no reachable counterexample today, but a refactor that moved
+      // the kickoff behind a promise would silently strand a live, un-aborted
+      // controller. Reading the ref directly makes the branch not depend on
+      // the ordering at all.
+      if (semanticSlot !== null || controllerRef.current !== null) {
         requestIdRef.current += 1;
         // Layer-3 (#803): stop the WORK, not just the writes. Aborting here
         // prevents the abandoned run's `extractRequirements` coercion pass
@@ -441,7 +464,9 @@ export function useJdMatch(options: UseJdMatchOptions): JdMatchController {
         // a later duplicate exit isn't misread as an in-flight controller.
         controllerRef.current?.abort();
         controllerRef.current = null;
-        if (semanticSlot.state.kind !== "ready") setSemanticSlot(null);
+        if (semanticSlot !== null && semanticSlot.state.kind !== "ready") {
+          setSemanticSlot(null);
+        }
       }
       return;
     }

--- a/src/lib/jd-match/llm/abort.ts
+++ b/src/lib/jd-match/llm/abort.ts
@@ -13,8 +13,10 @@
  * violate #803's own requirement not to "cancel another consumer's work", so we
  * deliberately do NOT use it.
  *
- * Cancellation is therefore BOUNDARY-based: each stage / batch checks
- * `signal.aborted` before starting and after resolving. The residual wasted
+ * Cancellation is therefore BOUNDARY-based: each stage checks `signal.aborted`
+ * before starting and after resolving; `judgeEvidence`'s batch loop checks only
+ * before each batch, because nothing awaits between a batch resolving and the
+ * next iteration's pre-check. The residual wasted
  * work an abandoned run can do is bounded by the one LLM call that is already
  * in flight when the abort fires — that call runs to completion; no subsequent
  * stage or batch is scheduled. This is exactly the bound #803's own "Proposed
@@ -36,7 +38,9 @@
  *
  * Kept as a factory (not a shared instance) so the stack trace points at the
  * abort site rather than at this module's load time — matters when diagnosing
- * why a stage bailed.
+ * why a stage bailed. `reason` is what makes that stack trace legible: callers
+ * pass the boundary they bailed at, so a report of "it fell back to keyword"
+ * names WHICH check fired rather than a single undifferentiated message.
  */
 export function abortError(reason?: string): DOMException {
   return new DOMException(reason ?? "Semantic run aborted.", "AbortError");
@@ -48,6 +52,17 @@ export function abortError(reason?: string): DOMException {
  * `name === "AbortError"` (the fetch-API contract). Deliberately structural
  * rather than `instanceof DOMException` so it survives realms where the
  * `DOMException` constructor identity differs (jsdom vs. node vs. workers).
+ *
+ * SHAPE ONLY — it cannot tell OUR cancellation from an engine-originated error
+ * that happens to be named `"AbortError"`, and both consumers suppress
+ * diagnostics on a match (`run-llm-match.ts` skips its `console.warn`;
+ * `extract-requirements.ts` re-throws unwrapped into that same silence). So
+ * every call site MUST pair it with our own state — `isAbortError(err) &&
+ * signal?.aborted` — or an engine failure we did not cause degrades to keyword
+ * with no diagnostic trail. Latent rather than live on the pinned
+ * `@mlc-ai/web-llm@0.2.84` (its only `AbortError` throw is internal to
+ * `MLCEngine.reload()`'s own controller, which this pipeline never reaches),
+ * but a future per-request timeout would make it a silent-failure class.
  */
 export function isAbortError(err: unknown): boolean {
   return (

--- a/src/lib/jd-match/llm/extract-requirements.test.ts
+++ b/src/lib/jd-match/llm/extract-requirements.test.ts
@@ -184,23 +184,52 @@ describe("extractRequirements — cancellation (#803)", () => {
     // a real extraction failure via `err.name === "AbortError"`. If wrapping
     // happens, the orchestrator would log "semantic path failed" over a
     // cancellation we initiated — the exact behavior #803 forbids.
+    //
+    // The signal must fire DURING the call, not before it: an already-aborted
+    // signal is caught by the pre-call check, which throws its own AbortError
+    // and never enters the try — so both assertions would pass without the
+    // re-throw under test even existing.
     const abortErr = new DOMException("aborted", "AbortError");
+    const controller = new AbortController();
+    const create = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(abortErr);
+    });
+    const engine: WebLlmEngine = { chat: { completions: { create } } };
+
+    // Identity, not shape: the engine's OWN error must come back untouched.
+    // `toMatchObject({name:"AbortError"})` would also pass on the AbortError
+    // the pre-call check throws, which is what made the earlier version of
+    // this test vacuous.
+    await expect(
+      extractRequirements("jd", engine, controller.signal),
+    ).rejects.toBe(abortErr);
+    expect(create).toHaveBeenCalledOnce();
+    // Not a RequirementExtractionError — that would break the orchestrator's
+    // catch-branch distinction.
+    expect(abortErr).not.toBeInstanceOf(RequirementExtractionError);
+  });
+
+  it("WRAPS an engine AbortError when our signal never fired", async () => {
+    // The `signal?.aborted` half of the re-throw guard. `isAbortError` is a
+    // pure shape check, so an engine-originated error merely NAMED
+    // "AbortError" — a future per-request timeout, a device-lost surfaced
+    // this way — would otherwise be re-thrown into the orchestrator's SILENT
+    // cancellation branch: degraded to keyword with the `[run-llm-match]
+    // semantic path failed` warn deliberately skipped, leaving no diagnostic
+    // trail for a failure we did not cause.
+    const abortErr = new DOMException("engine timeout", "AbortError");
     const engine: WebLlmEngine = {
       chat: {
         completions: { create: vi.fn().mockRejectedValue(abortErr) },
       },
     };
+    // Live, never-fired signal — the run was not cancelled by us.
     const controller = new AbortController();
-    controller.abort();
 
     await expect(
       extractRequirements("jd", engine, controller.signal),
-    ).rejects.toMatchObject({ name: "AbortError" });
-    // Not a RequirementExtractionError — that would break the orchestrator's
-    // catch-branch distinction.
-    await expect(
-      extractRequirements("jd", engine, controller.signal),
-    ).rejects.not.toBeInstanceOf(RequirementExtractionError);
+    ).rejects.toBeInstanceOf(RequirementExtractionError);
   });
 
   it("no signal (legacy 2-arg call): behavior unchanged, no aborts anywhere", async () => {

--- a/src/lib/jd-match/llm/extract-requirements.ts
+++ b/src/lib/jd-match/llm/extract-requirements.ts
@@ -90,7 +90,9 @@ export async function extractRequirements(
   // Pre-check: an already-aborted signal must never trigger the expensive
   // LLM call. This is the boundary #803's "check before starting the
   // expensive LLM call" acceptance criterion targets.
-  if (signal?.aborted) throw abortError();
+  if (signal?.aborted) {
+    throw abortError("Semantic run aborted before requirement extraction.");
+  }
 
   let content: string;
   try {
@@ -105,9 +107,13 @@ export async function extractRequirements(
     content = response.choices[0]?.message?.content ?? "";
   } catch (err) {
     // If the completion itself was rejected by an AbortError (e.g. a future
-    // signal-aware engine), propagate the abort AS-IS rather than wrapping it
-    // as a RequirementExtractionError — the orchestrator distinguishes them.
-    if (isAbortError(err)) throw err;
+    // signal-aware engine) AND our signal is what fired, propagate the abort
+    // AS-IS rather than wrapping it as a RequirementExtractionError — the
+    // orchestrator distinguishes them. The `signal?.aborted` half is
+    // load-bearing: without it an engine-originated `AbortError` on an unfired
+    // signal is re-thrown into the orchestrator's silent cancellation branch
+    // and the real failure leaves no diagnostic trail (see `abort.ts`).
+    if (isAbortError(err) && signal?.aborted) throw err;
     throw new RequirementExtractionError(
       `Requirement extraction engine call failed: ${
         err instanceof Error ? err.message : String(err)
@@ -118,7 +124,9 @@ export async function extractRequirements(
   // Post-check: abort fired DURING the completion. The engine call already
   // ran (we can't interrupt a shared engine — see abort.ts), but the coercion
   // pass and any downstream consumer that would act on this result must not.
-  if (signal?.aborted) throw abortError();
+  if (signal?.aborted) {
+    throw abortError("Semantic run aborted during requirement extraction.");
+  }
 
   const parsed = tryParseJsonArray(content);
   if (!parsed.ok || !Array.isArray(parsed.value)) {

--- a/src/lib/jd-match/llm/judge-evidence.ts
+++ b/src/lib/jd-match/llm/judge-evidence.ts
@@ -79,8 +79,8 @@ const JUDGE_MAX_TOKENS = 1024;
  *
  * @param modelId — the id the engine was loaded with (threaded to the inference
  *   guard; the engine handle can't supply it).
- * @param signal — optional AbortSignal (#803). Checked BEFORE every batch and
- *   AFTER every batch; a firing signal stops scheduling later batches. Does
+ * @param signal — optional AbortSignal (#803). Checked BEFORE every batch;
+ *   a firing signal stops scheduling later batches. Does
  *   NOT interrupt the currently-in-flight `chat.completions.create()` call
  *   (see `abort.ts` on why we can't safely `interruptGenerate()` a shared
  *   engine), so the residual wasted work per abandoned run is bounded to the
@@ -113,10 +113,11 @@ export async function judgeEvidence(
     if (signal?.aborted) break;
     const batch = requirements.slice(i, i + JUDGE_EVIDENCE_BATCH_SIZE);
     await judgeBatch(batch, systemPrompt, engine, modelId, byId);
-    // Post-batch check: the completion may have taken minutes; if the signal
-    // fired mid-call, don't spin up the NEXT batch either. Also covers the
-    // case where the abort happened between `await` and loop increment.
-    if (signal?.aborted) break;
+    // No post-batch check: only the loop increment separates the `await`
+    // above from the pre-batch check on the next iteration, and `aborted`
+    // cannot flip across synchronous code — so a post check could only ever
+    // catch what the pre check catches one line later. An abort that fires
+    // mid-completion is therefore handled by the pre check, one batch later.
   }
 
   // Reconcile against the INPUT requirements: one verdict each, in order, with

--- a/src/lib/jd-match/llm/run-llm-match.test.ts
+++ b/src/lib/jd-match/llm/run-llm-match.test.ts
@@ -543,10 +543,48 @@ describe("runLlmMatch — cancellation (#803)", () => {
     // Even in the future where `extractRequirements` could throw an AbortError
     // in-band (or a signal-aware `chat.completions.create` does), the
     // orchestrator's catch must map AbortError → keyword WITHOUT logging.
+    //
+    // The signal fires DURING extract, not before: an already-aborted signal
+    // is short-circuited by boundary 1 before `acquireInference`, so the catch
+    // under test is never entered and the assertions pass vacuously.
     const controller = new AbortController();
-    controller.abort();
+    loadEngineMock.mockResolvedValue(engine);
+    extractMock.mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(
+        new DOMException("Semantic run aborted.", "AbortError"),
+      );
+    });
+
+    const resume = parsed();
+    const result = await runLlmMatch(
+      JD_TEXT,
+      resume,
+      MODEL,
+      vi.fn(),
+      undefined,
+      controller.signal,
+    );
+
+    expect(extractMock).toHaveBeenCalledOnce();
+    expect(result).toEqual(freshKeywordResult(resume));
+    // Distinguishes cancellation from a real semantic failure — the
+    // RequirementExtractionError test in the fallback-discipline block
+    // asserts warn IS called; here it must NOT.
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("an AbortError-shaped engine error on an UNFIRED signal still warns and degrades", async () => {
+    // The `signal?.aborted` half of the catch's cancellation branch.
+    // `isAbortError` is a pure shape check, so without it any error the engine
+    // happens to name "AbortError" — a future per-request timeout, a
+    // device-lost surfaced this way — becomes indistinguishable from a user
+    // supersession: degraded to keyword with the warn deliberately skipped and
+    // zero diagnostic trail for a failure we did not cause.
+    const controller = new AbortController(); // never fired
+    loadEngineMock.mockResolvedValue(engine);
     extractMock.mockRejectedValue(
-      new DOMException("Semantic run aborted.", "AbortError"),
+      new DOMException("engine request timed out", "AbortError"),
     );
 
     const resume = parsed();
@@ -559,11 +597,13 @@ describe("runLlmMatch — cancellation (#803)", () => {
       controller.signal,
     );
 
+    // Still degrades — the never-rejects contract is unconditional.
     expect(result).toEqual(freshKeywordResult(resume));
-    // Distinguishes cancellation from a real semantic failure — the
-    // RequirementExtractionError test in the fallback-discipline block
-    // asserts warn IS called; here it must NOT.
-    expect(console.warn).not.toHaveBeenCalled();
+    // But it is a FAILURE, so the diagnostic must survive.
+    expect(console.warn).toHaveBeenCalledWith(
+      "[run-llm-match] semantic path failed; falling back to keyword:",
+      expect.objectContaining({ name: "AbortError" }),
+    );
   });
 
   it("aborted runLlmMatch RESOLVES; never rejects, never leaks the AbortError", async () => {

--- a/src/lib/jd-match/llm/run-llm-match.ts
+++ b/src/lib/jd-match/llm/run-llm-match.ts
@@ -165,11 +165,18 @@ export async function runLlmMatch(
     if (signal?.aborted) return keywordMatch(jdText, parsed);
     return { path: "semantic", verdicts, summary: summarize(verdicts) };
   } catch (err) {
-    if (isAbortError(err)) {
-      // Cancellation is expected control flow, not a failure. Do NOT log —
+    if (isAbortError(err) && signal?.aborted) {
+      // OUR cancellation — expected control flow, not a failure. Do NOT log —
       // #803's "cancellation is not logged as semantic failure" acceptance
       // criterion. The keyword fallback still runs so the caller's promise
       // resolves (per the never-rejects contract) with something renderable.
+      //
+      // `signal?.aborted` is the half that keeps this branch honest:
+      // `isAbortError` is a pure shape check (see `abort.ts`), so an
+      // engine-originated error merely NAMED "AbortError" would otherwise
+      // land here and degrade to keyword with the warn deliberately skipped —
+      // a silent failure with no diagnostic trail. Unfired signal → it falls
+      // through to the normal warn-and-degrade path below.
       return keywordMatch(jdText, parsed);
     }
     console.warn(


### PR DESCRIPTION
## Summary

Addresses the seven review threads on #807. That PR merged (`a50fca7`) while the revisions were being written, so the findings are live on `main` and land here instead. Four Secondary, three Nits — all seven confirmed against the code before any change was made; none were waved off.

No behaviour change on the cancellation path itself. #803's acceptance criteria, `judgeEvidence`'s never-throws contract, and `runLlmMatch`'s never-rejects contract are unchanged.

## What changed, per thread

**1. `isAbortError` is now paired with `signal?.aborted` at both call sites** (Secondary — `abort.ts:52`)

The shape check alone cannot tell *our* cancellation from an engine error that merely happens to be named `"AbortError"`, and both consumers suppress diagnostics on a match: `run-llm-match.ts` returns keyword with its `console.warn` deliberately skipped, and `extract-requirements.ts` re-throws unwrapped into that same silence. Unpaired, a future per-request timeout or a device-lost surfaced this way degrades to keyword with zero diagnostic trail — a silent-failure class that is very hard to diagnose from a user report.

Both sites now require `signal?.aborted`; an engine-originated `AbortError` on an unfired signal falls through to the normal warn-and-degrade path. The realm argument for structural-over-`instanceof` is kept, and `isAbortError`'s docblock now marks it SHAPE ONLY, states that every call site must pair it with our own state, and records the reviewer's dependency finding so the latent-not-live status is on record rather than rediscovered: `@mlc-ai/web-llm@0.2.84`'s only `AbortError`-shaped throw is internal to `MLCEngine.reload()`'s own `reloadController`, which this pipeline never reaches.

**2. `judgeEvidence`'s post-batch check is removed as unreachable** (Secondary — `judge-evidence.ts:119`)

Only the loop increment separates it from the next iteration's pre-check, and `signal.aborted` cannot flip across synchronous code — so anything it caught would be caught identically one line later. An abort firing mid-completion is handled by the pre-check on the following iteration. A comment now states why there is no post-check, and the `@param signal` docblock plus `abort.ts`'s module docblock are corrected (both claimed checks "before starting and after resolving" for batches).

**3. A vacuous test is made real** (Secondary — `extract-requirements.test.ts:182`)

`does NOT wrap an AbortError from the engine call as RequirementExtractionError` aborted the controller *before* the call, so the pre-call check threw first, the engine was never invoked, and both assertions passed on an `AbortError` the re-throw under test had no part in producing. It now fires the signal *during* the call and asserts error **identity** (`rejects.toBe(abortErr)`) rather than shape — `toMatchObject({name:"AbortError"})` is precisely what let the pre-check's own error satisfy it.

**4. `useJdMatch`'s opt-out branch reads the ref, not the slot** (Nit — `useJdMatch.ts:442`)

Gating on `semanticSlot !== null` alone was correct only via an unstated ordering invariant: the controller is installed synchronously at run-start while the matching `setSemanticSlot` is merely scheduled, so "slot non-null" stands in for "a run exists" only because `semanticSlot` is itself a dep of that effect. That holds under React 18/19 automatic batching and the reviewer could not construct a counterexample — but a refactor moving the kickoff behind a promise would strand a live, un-aborted controller with no id guard on it, silently. The condition is now `semanticSlot !== null || controllerRef.current !== null`, with the `setSemanticSlot(null)` line re-guarded since the slot can be null inside the branch. Chose "make it not matter" over "note the reliance" because the failure mode is silent and a comment does not survive the refactor that causes it.

**5–7. Three docs corrected to describe what the code actually does** (Secondary + 2 Nits)

- **The unmount abort's microtask hop is a belt, not a fix for a reachable bug** (`useJdMatch.ts:381`). The mount effect has `[]` deps, so its cleanup fires exactly twice — at StrictMode's simulated unmount on the initial mount, and at real unmount. At the initial one, `debouncedJdText` is still `""` (a 200 ms timeout away) and `capability` is still `null` (a promise away), so `takingSemanticPath` is `false` through the whole synchronous double-invoke and `controllerRef.current` is `null`. There is nothing to abort, and a synchronous abort would be a no-op today. The guard is kept — it costs one microtask — but the ~20 lines of rationale asserted a concrete failure mode ("the user would be stuck on a spinner that never ends") the code cannot reach. The docblock now names what the hop actually buys, and the test comment is narrowed to the part that is real, with an explicit "a synchronous abort in that cleanup passes this test too" so it is not misread as a pin it isn't.
- **`controllerRef`'s lifecycle comment** (`useJdMatch.ts:363`) said "non-null between run-start and its **resolve**", but nothing in the `.then`/`.catch` nulls it — after a normal completion it keeps pointing at the settled controller until the next run replaces it. Harmless, and in fact the `abort()`-on-settled no-op is exactly what makes the opt-out path safe against a `ready` slot, but the comment described a lifecycle the code does not implement. Reworded.
- **`abortError`'s `reason` is now actually passed** (`abort.ts:41`). Both call sites invoked it bare, so the parameter only ever yielded the default string. They now distinguish a pre-call from a post-call abort, which is what the "factory, not shared instance" rationale was reaching for — a stack trace names which boundary fired instead of one undifferentiated message.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/lib/jd-match/llm/ src/hooks/useJdMatch.test.tsx` → 86/86

Three new tests, each mutation-verified red against the line it pins:

| Reverted | Test that went red |
|---|---|
| `&& signal?.aborted` in `run-llm-match.ts`'s catch | `an AbortError-shaped engine error on an UNFIRED signal still warns and degrades` |
| `&& signal?.aborted` in `extract-requirements.ts`'s catch | `WRAPS an engine AbortError when our signal never fired` |
| the whole `if (isAbortError(err) …) throw err;` in `extract-requirements.ts` | `does NOT wrap an AbortError from the engine call as RequirementExtractionError` |

That last row is the point of change 3: before this PR the same mutation left the suite green.

One change ships without a test on purpose — the `controllerRef` read in change 4. There is no reachable counterexample under React 18/19 batching, so there is nothing to pin; it is a robustness change against a future refactor, not a bug fix.

Also fixed the sibling test `abort thrown from a signal-aware extractRequirements → keyword fallback, no warn` in `run-llm-match.test.ts`, which was vacuous for the same reason as change 3: it aborted before the call, so boundary 1 short-circuited before `acquireInference` and the catch under test was never entered.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Review revisions | Claude Opus 5 | high |
