### PR TITLE
feat(nav): add a top-level journey rail across both entries (#812)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Card,
   CapabilityStrip,
@@ -20,7 +21,13 @@ import { ShareWithExtensionBar } from "./components/features/ShareWithExtensionB
 import { useAnalyzedResume } from "./hooks/useAnalyzedResume.ts";
 import { useResumeLibrary } from "./hooks/useResumeLibrary.ts";
 import { useReplaceResumeOnDrop } from "./hooks/useReplaceResumeOnDrop.ts";
-import { departToJobs } from "./lib/jobs-departure.ts";
+import { useAutoRestoreResume } from "./hooks/useAutoRestoreResume.ts";
+import {
+  departToJobs,
+  departToJobsAndNavigate,
+} from "./lib/jobs-departure.ts";
+import { deriveJourney, type JourneyStageId } from "./lib/journey.ts";
+import type { LoadedResume } from "./lib/resume-library.ts";
 import { isScoreRevealed } from "./lib/contact.ts";
 
 export default function App() {
@@ -42,6 +49,23 @@ export default function App() {
   // Local-first resume library (#322) — save/reload parsed resumes without
   // re-uploading. Loading hydrates the "done" state from the cached parse.
   const library = useResumeLibrary();
+  // The one mapping from a stored record to the "done" state, shared by the
+  // explicit Load button below and the cold-mount auto-restore (#812) — two
+  // callers of the same hydration must not be able to drift into hydrating
+  // different fields.
+  const hydrateFromLibrary = useCallback(
+    (loaded: LoadedResume) => {
+      loadSavedResume({
+        fileName: loaded.filename,
+        fileSize: loaded.fileSize,
+        bytes: loaded.bytes,
+        sourceKind: loaded.sourceKind,
+        result: loaded.result,
+        score: loaded.score,
+      });
+    },
+    [loadSavedResume],
+  );
   const onLoadSavedResume = async (id: string) => {
     const loaded = await library.load(id);
     if (loaded === undefined) {
@@ -54,15 +78,19 @@ export default function App() {
       );
       return;
     }
-    loadSavedResume({
-      fileName: loaded.filename,
-      fileSize: loaded.fileSize,
-      bytes: loaded.bytes,
-      sourceKind: loaded.sourceKind,
-      result: loaded.result,
-      score: loaded.score,
-    });
+    hydrateFromLibrary(loaded);
   };
+
+  // #812 — bring the most recently saved résumé back on a cold visit, so the
+  // journey rail's first stage reads as satisfied instead of claiming progress
+  // over an app that silently forgot the user's work. Spent once per page
+  // lifetime and only ever from `idle`, so it never fights a drop, a library
+  // Load, or a `reset()` — see the hook.
+  useAutoRestoreResume({
+    phase: state.phase,
+    library,
+    onRestore: hydrateFromLibrary,
+  });
 
   // Once a parse is done the inline DropZone is gone; this restores drag-and-
   // drop so a new resume can replace the current one (confirm-gated, since it
@@ -90,6 +118,93 @@ export default function App() {
   const showingDraftPrompt =
     state.phase === "authoring" && state.pendingDraft !== null;
 
+  // ── The L1 journey rail (#812) ────────────────────────────────────────────
+  //
+  // Every input is derived during render from state this component already
+  // holds. Nothing here may move into a mount-only `useEffect(…, [])`: the
+  // `/jobs/` → `/` return leg is a bfcache restore that never remounts the
+  // tree, so a rail computed at mount would be frozen at whatever it said
+  // before the trip (the #783 defect, and the reason `useTailorHandoff`
+  // listens on `pageshow`).
+
+  // A tab the rail asked `ResultDetailTabs` to open. The nonce is what makes
+  // it an event rather than a value — asking for the tab you are already on is
+  // a repeatable click (see `ResultDetailTabs`).
+  const [tabRequest, setTabRequest] = useState<
+    { id: string; nonce: number } | undefined
+  >(undefined);
+  const requestTab = useCallback((id: string) => {
+    setTabRequest((prev) => ({ id, nonce: (prev?.nonce ?? 0) + 1 }));
+  }, []);
+
+  // JD steering, reported up from `ResultDetailTabs` (which owns
+  // `useTailorHandoff` — see the prop's docblock for why it is not lifted).
+  const [jdContext, setJdContext] = useState<string | null>(null);
+
+  // The mark is cleared HERE, on the canonical "the résumé genuinely changed"
+  // token, rather than by waiting for the reporter to say so. The reporter is
+  // not always mounted: `Result` short-circuits to `LimitedParsingCard` on a
+  // `fonts_unmappable` parse, and `phase: "authoring"` renders
+  // `ReconstructedResume` directly with no `Result` at all — in both cases
+  // `displayResult` is non-null, so a `hasResume` re-guard cannot see the
+  // staleness either, and the rail would keep claiming Tailor with a ✓ over a
+  // different (or blank) résumé for the rest of the page's life. `parseKey` is
+  // null in idle/parsing, the pristine `state.result` in done, and
+  // `authoring:<generation>` while authoring, so one dep covers reset, replace,
+  // blank authoring and the fonts-unmappable branch.
+  //
+  // It cannot clobber valid steering on the ordinary path. The bfcache return
+  // leg from `/jobs/` does not change `parseKey` at all, so this never fires
+  // there; and on a cold reload, `useTailorHandoff` reports via a state update
+  // scheduled from an effect, which lands in a LATER commit than the one this
+  // runs in — so the report always follows the clear rather than being erased
+  // by it. Deps hand-audited both directions (`exhaustive-deps` is NOT enforced
+  // — CLAUDE.md): `parseKey` is the only input, and `setJdContext` is a
+  // React-guaranteed-stable setter that a dep list must not list.
+  useEffect(() => {
+    setJdContext(null);
+  }, [parseKey]);
+
+  // A blank-authoring session counts: a résumé the user is writing from
+  // scratch is still a résumé, and `displayResult` is exactly "there is
+  // something on screen to fix, match, tailor and download".
+  const hasResume = displayResult !== null;
+  // No `hasResume &&` guard on the steering: "steering implies a résumé" is
+  // normalized inside `deriveJourney` itself now (#812), so it holds for every
+  // caller rather than for the two that remembered.
+  const journeyState = useMemo(
+    () =>
+      deriveJourney({
+        entry: "root",
+        hasResume,
+        jdSteering: jdContext !== null,
+      }),
+    [hasResume, jdContext],
+  );
+
+  const onJourneySelect = useCallback(
+    (id: JourneyStageId) => {
+      // The one route off `/` that leaves the document. Through the shared
+      // helper, never hand-rolled: a second definition of "hand the parse over
+      // and mark the departure" is exactly what shipped #700.
+      if (id === "match") {
+        departToJobsAndNavigate(displayResult?.canonical.fields);
+        return;
+      }
+      // `add` is the top of this page — the drop zone when idle, the parse
+      // header (with its Start over control) once a résumé is loaded. The
+      // shell has already scrolled there, so there is nothing else to do; in
+      // particular this must not reset, which would discard the user's work on
+      // a navigation control.
+      if (id === "add") return;
+      // Fix it / Tailor / Download all live behind the reconstructed tab —
+      // the editor, the rewrite affordance and the Download PDF button are all
+      // in it — so all three land there even from another tab.
+      requestTab("reconstructed");
+    },
+    [displayResult, requestTab],
+  );
+
   return (
     // `chips` is deliberately NOT passed: PageShell renders that slot in the
     // header on every phase, so the capability strip stayed pinned above the
@@ -107,7 +222,11 @@ export default function App() {
     // alone on the header-right instead of sharing it. `/jobs` still passes
     // one: it opens straight into a form with no headline of its own, so
     // there the header line is the only orientation.
-    <PageShell badge="alpha" onSavedJobsNavigate={goToSavedJobs}>
+    <PageShell
+      badge="alpha"
+      onSavedJobsNavigate={goToSavedJobs}
+      journey={{ state: journeyState, onSelect: onJourneySelect }}
+    >
       {(state.phase === "idle" ||
         state.phase === "parsing" ||
         state.phase === "error") && (
@@ -288,6 +407,8 @@ export default function App() {
               sourceKind={state.sourceKind}
               onReset={reset}
               edit={edit}
+              requestedTab={tabRequest}
+              onJdContextChange={setJdContext}
             />
             {/* Save-to-library affordance (#322) — saves the edited parse +
                 source bytes so this resume can be reloaded without re-uploading. */}

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -43,6 +43,12 @@ interface ResultProps {
   onReset: () => void;
   /** Lifted edit state (#82) — threaded to ReconstructedResume for inline edits. */
   edit: EditableParse;
+  /** A tab the journey rail asked for (#812) — forwarded untouched to
+   *  `ResultDetailTabs`, which owns the tab state. */
+  requestedTab?: { id: string; nonce: number };
+  /** JD steering reported back up so `/`'s rail can mark the Tailor stage
+   *  (#812) — see `ResultDetailTabs` for why it travels this way. */
+  onJdContextChange?: (jdContext: string | null) => void;
 }
 
 export function Result({
@@ -53,9 +59,14 @@ export function Result({
   sourceKind,
   onReset,
   edit,
+  requestedTab,
+  onJdContextChange,
 }: ResultProps) {
   const isFontsUnmappable = result.triggers.includes("fonts_unmappable");
   if (isFontsUnmappable) {
+    // No tabs on this branch — the rail's stages still resolve to `/`, they
+    // just have no L2 tab to land on, which is correct: there is nothing
+    // parsed to show behind them.
     return <LimitedParsingCard result={result} onReset={onReset} />;
   }
   return (
@@ -67,6 +78,8 @@ export function Result({
       sourceKind={sourceKind}
       onReset={onReset}
       edit={edit}
+      requestedTab={requestedTab}
+      onJdContextChange={onJdContextChange}
     />
   );
 }
@@ -81,6 +94,8 @@ function ParsedCard({
   sourceKind,
   onReset,
   edit,
+  requestedTab,
+  onJdContextChange,
 }: {
   result: CascadeResult;
   parseKey: unknown;
@@ -89,6 +104,8 @@ function ParsedCard({
   sourceKind: SourceKind;
   onReset: () => void;
   edit: EditableParse;
+  requestedTab?: { id: string; nonce: number };
+  onJdContextChange?: (jdContext: string | null) => void;
 }) {
   const triggerCount = result.triggers.length;
 
@@ -234,6 +251,8 @@ function ParsedCard({
         escapeHatch={escapeHatch}
         onRecovered={handleRecovered}
         triggerCount={triggerCount}
+        requestedTab={requestedTab}
+        onJdContextChange={onJdContextChange}
       />
     </div>
   );

--- a/src/components/features/FindJobsLauncher.tsx
+++ b/src/components/features/FindJobsLauncher.tsx
@@ -16,11 +16,24 @@
  * under both the custom-domain "/" base and the "/OfflineCV/" Pages-fallback
  * base (same pattern the other same-origin cross-links use).
  *
- * The stash + the departure marker (#706, so `/jobs/`'s "Back to your resume"
+ * The stash, the departure marker (#706, so `/jobs/`'s "Back to your resume"
  * control knows this trip actually started at `/` and can use a real
- * `history.back()` instead of pushing a fresh, blank `/`) both come from
- * `departToJobs` — the same helper the header's parse-independent "Saved jobs"
- * link (#707) calls, so the two routes off `/` cannot drift apart.
+ * `history.back()` instead of pushing a fresh, blank `/`) and that base-aware
+ * navigation all come from `departToJobsAndNavigate` — shared with the journey
+ * rail's Match-jobs stage (#812), and a sibling of the `departToJobs` the
+ * header's parse-independent "Saved jobs" link (#707) calls. What that unifies
+ * is the MECHANICS of leaving: the marker and the URL, the two things a new
+ * route forgets.
+ *
+ * It does not unify the PAYLOAD, and that axis is still open. This launcher is
+ * handed `activeResult.canonical.fields` — the LLM-escape-hatch-merged parse —
+ * because it renders inside `ParsedCard`, where `llmOverride` is local
+ * `useState` (`Result.tsx`). The rail's Match-jobs stage and the header link
+ * both run in `App`, which cannot see that state and passes
+ * `displayResult.canonical.fields` instead, so a user who recovered a
+ * degenerate parse and then left via the rail ships the PRE-recovery fields.
+ * Closing it means lifting `llmOverride` out of `ParsedCard`; #812 did not,
+ * and the pre-existing `goToSavedJobs` has the same gap.
  *
  * Nothing here fetches, and the navigation is same-origin, so no résumé data
  * leaves the browser at this step.
@@ -30,7 +43,7 @@ import { useMemo } from "react";
 import { Button, Chip } from "@design-system";
 import { buildJobQuery } from "../../lib/job-search/query-builder.ts";
 import { roleFilterForResume, seedExcludeTermsForFamilies } from "../../lib/job-search/role-keywords.ts";
-import { departToJobs } from "../../lib/jobs-departure.ts";
+import { departToJobsAndNavigate } from "../../lib/jobs-departure.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import { JobQuerySummary } from "./JobQuerySummary.tsx";
 
@@ -48,10 +61,7 @@ export function FindJobsLauncher({ parsed }: { parsed: HeuristicParsedResume }) 
 
   const isDegenerate = query.titles.length === 0 && query.skills.length === 0;
 
-  const go = () => {
-    departToJobs(parsed);
-    window.location.href = `${import.meta.env.BASE_URL}jobs/`;
-  };
+  const go = () => departToJobsAndNavigate(parsed);
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/components/features/JourneyRail.test.tsx
+++ b/src/components/features/JourneyRail.test.tsx
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * JourneyRail (#812) — what a user, including one who cannot see colour or the
+ * screen at all, can tell about the arc without clicking anything.
+ *
+ * The click ROUTING (reachable → the surface's callback, unpopulated → the
+ * guidance card) lives in `PageShell`, which owns the blocked-stage state, and
+ * is pinned in `PageShell.test.tsx`. What is pinned here is the rail's own
+ * contract: one current stage, position stated in words, and state carried by
+ * surface + weight + a monochrome mark rather than by colour.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createElement, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { JourneyRail, JourneyGuidance } from "./JourneyRail.tsx";
+import {
+  deriveJourney,
+  journeyStage,
+  type JourneySignals,
+} from "../../lib/journey.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(node: Parameters<Root["render"]>[0]): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(node));
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+});
+
+function rail(signals: Partial<JourneySignals> = {}, onStageClick = vi.fn()) {
+  const journey = deriveJourney({
+    entry: "root",
+    hasResume: false,
+    jdSteering: false,
+    ...signals,
+  });
+  const el = render(
+    createElement(JourneyRail, { journey, onStageClick }),
+  );
+  return { el, onStageClick };
+}
+
+/** The trigger whose accessible sentence names this stage. */
+function trigger(el: HTMLElement, label: string): HTMLButtonElement {
+  const found = [...el.querySelectorAll("button")].find((b) =>
+    b.textContent?.includes(`: ${label}.`),
+  );
+  if (!found) throw new Error(`no rail trigger for ${label}`);
+  return found;
+}
+
+describe("JourneyRail — the arc", () => {
+  it("renders every VISIBLE stage in one ordered list inside a labelled nav", () => {
+    const { el } = rail();
+    const nav = el.querySelector("nav");
+    expect(nav?.getAttribute("aria-label")).toBeTruthy();
+    // Four, not five: `Tailor` is absent on a cold `/`. See the next two.
+    expect(nav?.querySelectorAll("ol > li")).toHaveLength(4);
+  });
+
+  it("hides Tailor on `/` until a JD is actually steering the rewrite", () => {
+    // Tailoring can only ever be STARTED from a specific posting, so on a cold
+    // `/` the rail would be advertising a step whose only instruction is "go
+    // somewhere else and press a different button".
+    expect(() => trigger(rail().el, "Tailor")).toThrow();
+    expect(() => trigger(rail({ hasResume: true }).el, "Tailor")).toThrow();
+
+    const steering = rail({ hasResume: true, jdSteering: true });
+    expect(trigger(steering.el, "Tailor")).toBeTruthy();
+  });
+
+  it("shows Tailor on `/jobs/`, where the button that starts it is on screen", () => {
+    const { el } = rail({ entry: "jobs", hasResume: true });
+    expect(trigger(el, "Tailor")).toBeTruthy();
+    expect(el.querySelectorAll("ol > li")).toHaveLength(5);
+  });
+
+  it("orders Download ahead of the job-search half of the arc", () => {
+    // A user who came only to repair what an extractor reads back is finished
+    // at Download and never needs a job board — so it cannot sit last.
+    const { el } = rail({ entry: "jobs", hasResume: true });
+    const labels = [...el.querySelectorAll("ol > li")].map((li) =>
+      li.querySelector('[aria-hidden="true"] + [aria-hidden="true"]')?.textContent,
+    );
+    expect(labels).toEqual([
+      "Add résumé",
+      "Fix it",
+      "Download",
+      "Match jobs",
+      "Tailor",
+    ]);
+  });
+
+  it("marks exactly one stage as current", () => {
+    const { el } = rail({ hasResume: true });
+    const current = el.querySelectorAll('[aria-current="step"]');
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent).toContain("Fix it");
+  });
+
+  it("states position and state in words, not numerals alone", () => {
+    // A screen reader must get "where am I in this" without counting list
+    // items or reading a bare digit.
+    const { el } = rail({ hasResume: true });
+    expect(trigger(el, "Fix it").textContent).toContain(
+      "Step 2 of 4: Fix it. Current step.",
+    );
+    expect(trigger(el, "Download").textContent).toContain(
+      "Step 3 of 4: Download. Ready.",
+    );
+    expect(trigger(el, "Match jobs").textContent).toContain(
+      "Step 4 of 4: Match jobs. Ready.",
+    );
+  });
+
+  it("counts the announced position over the RENDERED stages, not all five", () => {
+    // "Step 4 of 5" spoken over a four-entry rail is a miscount the listener
+    // has no way to correct, so the count has to follow what is on screen.
+    const cold = rail({ hasResume: true });
+    expect(trigger(cold.el, "Match jobs").textContent).toContain("of 4");
+
+    const jobs = rail({ entry: "jobs", hasResume: true });
+    expect(trigger(jobs.el, "Match jobs").textContent).toContain(
+      "Step 4 of 5: Match jobs. Current step.",
+    );
+    expect(trigger(jobs.el, "Tailor").textContent).toContain(
+      "Step 5 of 5: Tailor. Not ready yet.",
+    );
+  });
+
+  it("hides the visible number, mark and label from the accessible name", () => {
+    // Otherwise the sentence above is announced three times over.
+    const { el } = rail({ hasResume: true });
+    const decorative = trigger(el, "Fix it").querySelectorAll(
+      '[aria-hidden="true"]',
+    );
+    expect(decorative.length).toBeGreaterThanOrEqual(2);
+    expect([...decorative].map((n) => n.textContent)).toContain("Fix it");
+  });
+
+  it("does not carry state on colour alone", () => {
+    // Current = a real surface + weight step (survives a greyscale render);
+    // "has data behind it" = a monochrome text-presentation mark, never a hue.
+    const { el } = rail({ entry: "jobs", hasResume: true });
+    const current = trigger(el, "Match jobs");
+    expect(current.className).toContain("bg-surface-card");
+    expect(current.className).toContain("font-semibold");
+
+    const ready = trigger(el, "Fix it");
+    expect(ready.className).not.toContain("bg-surface-card");
+    expect(ready.textContent).toContain("✓");
+
+    const upcoming = trigger(el, "Tailor");
+    expect(upcoming.textContent).not.toContain("✓");
+  });
+
+  it("gives each of the three states its own marker SHAPE, not just a hue", () => {
+    // The redesign's load-bearing claim. Strip every colour and the three are
+    // still told apart: filled disc, ringed disc, hairline disc.
+    const { el } = rail({ entry: "jobs", hasResume: true });
+    const disc = (label: string) =>
+      trigger(el, label).querySelector('[aria-hidden="true"]')?.className ?? "";
+
+    // All three are discs of the same size — only the treatment differs.
+    for (const label of ["Match jobs", "Fix it", "Tailor"]) {
+      expect(disc(label)).toContain("rounded-full");
+      expect(disc(label)).toContain("h-6");
+    }
+    expect(disc("Match jobs")).toContain("bg-accent-primary"); // current: filled
+    expect(disc("Fix it")).toContain("border-2"); // ready: thick ring
+    expect(disc("Tailor")).toContain("border-border-strong"); // upcoming: hairline
+    expect(disc("Tailor")).not.toContain("border-2");
+  });
+
+  it("keeps 8px between adjacent 44px touch targets", () => {
+    // Two 44px targets separated by a 2px gutter make a mis-tap land on the
+    // NEIGHBOURING stage rather than on nothing.
+    const { el } = rail({ hasResume: true });
+    expect(el.querySelector("ol")?.className).toContain("gap-2");
+  });
+
+  it("keeps the ready mark off a stage with nothing behind it", () => {
+    // A first visit: nothing is populated, so nothing may claim it is.
+    const { el } = rail();
+    expect(el.textContent).not.toContain("✓");
+  });
+
+  it("keeps non-current text off the two tokens that fail contrast on the track", () => {
+    // `content-tertiary` and `content-muted` both land at 4.04:1 against the
+    // recessed track in dark mode, under WCAG 1.4.3's 4.5:1.
+    const { el } = rail({ entry: "jobs", hasResume: true });
+    for (const label of ["Fix it", "Tailor"]) {
+      const button = trigger(el, label);
+      expect(button.className).not.toContain("text-content-tertiary");
+      expect(button.className).not.toContain("text-content-muted");
+    }
+  });
+
+  it("separates a READY stage from an upcoming one by weight and text token", () => {
+    // At `content-secondary` both, the stage the user can act on next looked
+    // identical to the one they cannot use yet.
+    const { el } = rail({ entry: "jobs", hasResume: true });
+    const ready = trigger(el, "Fix it");
+    const upcoming = trigger(el, "Tailor");
+    expect(ready.className).toContain("text-content-primary");
+    expect(ready.className).toContain("font-medium");
+    expect(upcoming.className).toContain("text-content-secondary");
+    expect(upcoming.className).toContain("font-normal");
+  });
+
+  it("gives every trigger a 44px visible minimum and a visible focus ring", () => {
+    const { el } = rail({ hasResume: true });
+    for (const label of ["Add résumé", "Fix it", "Download"]) {
+      const button = trigger(el, label);
+      expect(button.className).toContain("min-h-11");
+      expect(button.className).toContain("min-w-11");
+      expect(button.className).toContain("focus-visible:ring-2");
+    }
+  });
+
+  it("opts out of its transition under prefers-reduced-motion", () => {
+    const { el } = rail({ hasResume: true });
+    const button = trigger(el, "Fix it");
+    expect(button.className).toContain("motion-reduce:transition-none");
+    expect(button.className).toContain("motion-reduce:duration-0");
+  });
+
+  it("reports every click, populated or not — nothing is locked", () => {
+    const { el, onStageClick } = rail();
+    act(() => trigger(el, "Download").click());
+    expect(onStageClick).toHaveBeenCalledWith("download");
+  });
+
+  it("keeps the rail on one row that never scrolls sideways", () => {
+    const { el } = rail({ hasResume: true });
+    const list = el.querySelector("ol");
+    expect(list?.className).toContain("flex");
+    expect(list?.className).not.toContain("flex-wrap");
+    expect(list?.className).not.toContain("overflow-x-auto");
+  });
+});
+
+describe("JourneyGuidance — the empty state a rail owes the user", () => {
+  it("names the stage, explains it, and points back one step", () => {
+    const onGoToPrerequisite = vi.fn();
+    const onDismiss = vi.fn();
+    const el = render(
+      createElement(JourneyGuidance, {
+        stage: journeyStage("tailor"),
+        onGoToPrerequisite,
+        onDismiss,
+      }),
+    );
+    expect(el.textContent).toContain("Pick a job first");
+    const cta = [...el.querySelectorAll("button")].find((b) =>
+      b.textContent?.startsWith("Go to"),
+    );
+    expect(cta?.textContent).toBe("Go to Match jobs");
+    act(() => cta!.click());
+    expect(onGoToPrerequisite).toHaveBeenCalledWith("match");
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("announces itself — the trigger that opened it is off in the header", () => {
+    const el = render(
+      createElement(JourneyGuidance, {
+        stage: journeyStage("download"),
+        onGoToPrerequisite: vi.fn(),
+        onDismiss: vi.fn(),
+      }),
+    );
+    expect(el.querySelector('[role="status"]')).not.toBeNull();
+    expect(el.querySelector('[aria-live="polite"]')).not.toBeNull();
+  });
+
+  it("can be dismissed without going anywhere", () => {
+    const onDismiss = vi.fn();
+    const el = render(
+      createElement(JourneyGuidance, {
+        stage: journeyStage("fix"),
+        onGoToPrerequisite: vi.fn(),
+        onDismiss,
+      }),
+    );
+    const dismiss = [...el.querySelectorAll("button")].find(
+      (b) => b.textContent === "Dismiss",
+    );
+    act(() => dismiss!.click());
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing for the first stage, which has no earlier step", () => {
+    const el = render(
+      createElement(JourneyGuidance, {
+        stage: journeyStage("add"),
+        onGoToPrerequisite: vi.fn(),
+        onDismiss: vi.fn(),
+      }),
+    );
+    expect(el.textContent).toBe("");
+  });
+});

--- a/src/components/features/JourneyRail.tsx
+++ b/src/components/features/JourneyRail.tsx
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * JourneyRail — the L1 arc in the page header, and the guidance card a stage
+ * with nothing behind it shows instead (issue #812).
+ *
+ * Reuse analysis (CLAUDE.md's Reuse Gate). `shared/Stepper.tsx` was the
+ * candidate and is genuinely a different concern, not a second copy of this.
+ * `Stepper` is PANEL-OWNING: `StepperContext` hands `StepPanel` and
+ * `StepperNav` the current step, and every panel it toggles must sit inside the
+ * same React tree as the rail that toggles them. This arc spans two separate
+ * HTML entries (`/` and `/jobs/`) joined by `location.href` navigations and two
+ * sessionStorage handoffs — there is no shared tree for panels to live in, and
+ * three of the five stages resolve to a tab inside another component's state
+ * rather than to a panel at all. `Stepper` also GATES nothing but presents a
+ * sequence terminating in one commit action; this rail deliberately gates
+ * nothing and terminates in nothing. Extending `Stepper` to serve both would
+ * mean making its panels optional, its context optional, and its ownership of
+ * the current step optional — i.e. deleting what makes it a stepper.
+ *
+ * What this file does NOT own: where the rail sits (`PageShell`), what a stage
+ * click does (each surface — see `App.tsx` / `jobs/JobsApp.tsx`), and the
+ * derivation itself (`lib/journey.ts`). Everything here is a pure function of
+ * props, derived during render — no effects, deliberately. The `/jobs/` → `/`
+ * return leg is a bfcache restore that never remounts the tree, so any state
+ * this component computed in a mount-only `useEffect(…, [])` would be frozen at
+ * whatever it was before the trip (the #783 defect).
+ *
+ * Accessibility. There is no ARIA `stepper` role; the established pattern for
+ * an ordered progress trail is a `<nav>` + ordered list whose current item
+ * carries `aria-current="step"` — the same shape `Stepper.tsx`'s rail renders.
+ * Position is stated in WORDS for a screen reader ("Step 2 of 5: Fix it.
+ * Current step.") rather than left to the visual numerals, and the visible
+ * number / mark / label are all `aria-hidden` so the sentence is announced
+ * once, not three times. Position is counted over the stages actually RENDERED
+ * (`journey.stages`), never over the full five — `Tailor` is absent from the
+ * rail on a cold `/`, and "Step 4 of 5" announced over a four-entry list is a
+ * miscount the listener cannot correct.
+ *
+ * State is never carried by colour. Each of the three states has its own disc
+ * SHAPE and its own GLYPH — filled + numeral (current), ringed + ✓ (ready),
+ * hairline + numeral (upcoming) — layered on the surface/weight step #516 asks
+ * for, so the rail resolves in a greyscale render and for a user who cannot
+ * separate the accent hue from the track. Upcoming text stays
+ * `content-secondary`; `content-tertiary` and `content-muted` land at 4.04:1
+ * against the recessed track in dark mode, under WCAG 1.4.3's 4.5:1 (see
+ * `Stepper.tsx`). A READY stage is `content-primary` rather than
+ * `content-secondary`: it is the likeliest next click, and sharing the
+ * upcoming weight made the two indistinguishable.
+ *
+ * Touch targets. `min-h-11` / `min-w-11` (44×44 CSS px) on the triggers is the
+ * VISIBLE box, and it is not redundant with `Button`'s `after:` overlay — that
+ * overlay is a fixed 24×24 SC 2.5.8 floor and governs a different box (see
+ * `Button.tsx`'s docblock).
+ */
+
+import { Button, Card } from "@design-system";
+import {
+  journeyStage,
+  type Journey,
+  type JourneyStage,
+  type JourneyStageId,
+} from "../../lib/journey.ts";
+
+export interface JourneyRailProps {
+  journey: Journey;
+  /** Fires for every stage click. The caller decides whether that means "go
+   *  there" or "explain what is missing" — see `isStageReachable`. */
+  onStageClick: (id: JourneyStageId) => void;
+}
+
+export function JourneyRail({ journey, onStageClick }: JourneyRailProps) {
+  return (
+    <nav aria-label="Your job search, step by step" className="min-w-0">
+      {/* The track is recessed (`bg-surface-subtle`) and the current stage sits
+          on `bg-surface-card` — the #516 selection affordance `Tabs` and
+          `Stepper` both use. Never `overflow-x-auto`: a rail that scrolls
+          sideways hides the very thing it exists to show. Fitting the stages
+          into a 320px viewport without either is the `<li>` sizing below.
+
+          `gap-2` (8px), not the `gap-0.5` this first shipped with: these are
+          adjacent 44px touch targets, and the 8px minimum spacing between them
+          is a rule in its own right — a 2px gutter makes a mis-tap land on the
+          neighbouring stage rather than on nothing. */}
+      <ol className="flex items-stretch gap-2 rounded-md border border-border-light bg-surface-subtle p-1">
+        {journey.stages.map((stage, index) => (
+          <JourneyRailStage
+            key={stage.id}
+            stage={stage}
+            index={index}
+            total={journey.stages.length}
+            isCurrent={stage.id === journey.current}
+            hasData={journey.availability[stage.id]}
+            onClick={() => onStageClick(stage.id)}
+          />
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+function JourneyRailStage({
+  stage,
+  index,
+  total,
+  isCurrent,
+  hasData,
+  onClick,
+}: {
+  stage: JourneyStage;
+  index: number;
+  total: number;
+  isCurrent: boolean;
+  hasData: boolean;
+  onClick: () => void;
+}) {
+  // Three states, three words. "Ready" rather than "Done": availability means
+  // the stage has what it needs, which is not the same as the user having been
+  // there — this rail keeps no completion ledger, on purpose.
+  const state = isCurrent ? "Current step" : hasData ? "Ready" : "Not ready yet";
+
+  // The state marker, and the reason this reads as a journey rather than as a
+  // second tab bar. Each state gets a distinct SHAPE and a distinct GLYPH, not
+  // a colour: filled disc + numeral (current), ringed disc + ✓ (ready), hairline
+  // disc + numeral (upcoming). Greyscale-safe by construction, which is what
+  // #516 asks for — and it survives the two failure modes a flat numeral had,
+  // where the rail was indistinguishable from `Tabs` and the inactive entries
+  // were grey text on a grey track.
+  const marker = isCurrent
+    ? "bg-accent-primary text-content-inverse"
+    : hasData
+      ? "border-2 border-accent-primary text-accent-primary"
+      : "border border-border-strong text-content-secondary";
+
+  return (
+    // Two sizings, expressed as grow/basis rather than `flex-1`/`shrink-0` so
+    // the breakpoints actually override each other (Tailwind emits
+    // `flex-shrink` after the `flex` shorthand, so a `shrink-0` would silently
+    // outrank a later `sm:flex-1`'s shrink half).
+    //   < sm — non-current chips sit at their 44px touch-target floor and drop
+    //          their labels to the marker alone; the current one takes every
+    //          remaining pixel, so the rail fits a 320px viewport with no wrap
+    //          and no h-scroll.
+    //   sm+  — the rail always owns a full row of its own, so equal columns are
+    //          safe at every width above `sm` and there is no third band. The
+    //          `lg:` content-sizing this carried before existed only for the
+    //          in-header-row placement that #812 dropped.
+    <li
+      className={
+        isCurrent
+          ? "min-w-0 grow basis-0"
+          : "min-w-0 grow-0 basis-11 sm:grow sm:basis-0"
+      }
+    >
+      <Button
+        variant="tab"
+        aria-current={isCurrent ? "step" : undefined}
+        onClick={onClick}
+        className={[
+          "min-h-11 w-full min-w-11 gap-2 px-2 sm:px-3",
+          isCurrent
+            ? "bg-surface-card font-semibold text-content-primary shadow-xs ring-1 ring-inset ring-border-light"
+            : hasData
+              ? // A ready stage earns `content-primary`: it has data behind it,
+                // it is the likeliest next click, and at `content-secondary` it
+                // was visually identical to a stage the user cannot use yet.
+                "bg-transparent font-medium text-content-primary hover:bg-surface-hover"
+              : "bg-transparent font-normal text-content-secondary hover:bg-surface-hover hover:text-content-primary",
+        ].join(" ")}
+      >
+        <span
+          aria-hidden="true"
+          className={[
+            "grid h-6 w-6 shrink-0 place-items-center rounded-full text-xs font-semibold leading-none tabular-nums",
+            marker,
+          ].join(" ")}
+        >
+          {/* U+2713 + U+FE0E (VS-15) forces TEXT presentation, so the mark
+              renders monochrome in `currentColor` rather than as a colour
+              pictograph from the OS emoji font (design-system/CLAUDE.md). */}
+          {!isCurrent && hasData ? "✓︎" : index + 1}
+        </span>
+        <span
+          aria-hidden="true"
+          className={isCurrent ? "truncate" : "hidden truncate sm:inline"}
+        >
+          {stage.label}
+        </span>
+        <span className="sr-only">
+          Step {index + 1} of {total}: {stage.label}. {state}.
+        </span>
+      </Button>
+    </li>
+  );
+}
+
+export interface JourneyGuidanceProps {
+  /** The stage the user asked for that has nothing behind it yet. Only a stage
+   *  with an `empty` state ever reaches here — the first stage has none. */
+  stage: JourneyStage;
+  /** Send the user to the prerequisite the guidance names. */
+  onGoToPrerequisite: (id: JourneyStageId) => void;
+  onDismiss: () => void;
+}
+
+/**
+ * The empty state a rail — as opposed to a wizard — owes the user: the click
+ * was allowed, so something has to answer it. Rendered as the first content
+ * block under the header, not as a lock on the trigger.
+ */
+export function JourneyGuidance({
+  stage,
+  onGoToPrerequisite,
+  onDismiss,
+}: JourneyGuidanceProps) {
+  const empty = stage.empty;
+  if (empty === null) return null;
+  const prerequisite = journeyStage(empty.prerequisite);
+
+  return (
+    <Card className="shadow-xs">
+      {/* Announced rather than silently swapped in: the trigger that opened
+          this card is up in the header, so a screen-reader user who activated
+          it gets no other signal that anything happened. The live region is
+          the inner wrapper because `Card` owns only chrome (same shape
+          `Result.tsx`'s verdict block uses). */}
+      <div role="status" aria-live="polite" className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-content-primary">
+          {stage.label}
+        </h2>
+        <p className="max-w-prose text-sm text-content-secondary">
+          {empty.guidance}
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => onGoToPrerequisite(prerequisite.id)}
+          >
+            Go to {prerequisite.label}
+          </Button>
+          <Button variant="ghost" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/features/PageShell.test.tsx
+++ b/src/components/features/PageShell.test.tsx
@@ -38,6 +38,7 @@ import { departToJobs } from "../../lib/jobs-departure.ts";
 import { readJobsHandoff } from "../../lib/jobs-handoff.ts";
 import { readDepartureMarker } from "../../lib/nav-return.ts";
 import { savedJobsHref } from "../../lib/jobs-landing.ts";
+import { deriveJourney, type JourneySignals } from "../../lib/journey.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -159,5 +160,193 @@ describe("PageShell — the Saved jobs link", () => {
     const event = click(link!);
     expect(onSavedJobsNavigate).toHaveBeenCalledTimes(1);
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+// ── The journey rail slot (#812) ──────────────────────────────────────────────
+
+/**
+ * The shell PLACES the rail and owns exactly one thing about it: which stage
+ * the user asked for that has nothing behind it yet, so the guidance card can
+ * render as the first content block under the sticky header. What a stage
+ * MEANS stays in `lib/journey.ts`; what a click DOES stays with the surface.
+ * Both directions of that split are pinned here, because a shell that decided
+ * either one is the bug `PageShell`'s own docblock records.
+ */
+
+function withJourney(
+  signals: Partial<JourneySignals> = {},
+  onSelect = vi.fn(),
+): {
+  el: HTMLElement;
+  onSelect: ReturnType<typeof vi.fn>;
+  /** Re-render the SAME tree with different signals — not a remount, which is
+   *  the whole point for the staleness test below. */
+  resignal: (next: Partial<JourneySignals>) => void;
+} {
+  const build = (over: Partial<JourneySignals>) =>
+    deriveJourney({
+      entry: "root",
+      hasResume: false,
+      jdSteering: false,
+      ...signals,
+      ...over,
+    });
+  const el = render({ journey: { state: build({}), onSelect } });
+  const liveRoot = root;
+  return {
+    el,
+    onSelect,
+    resignal: (next) => {
+      act(() => {
+        liveRoot.render(
+          createElement(PageShell, {
+            badge: "alpha",
+            children: null,
+            journey: { state: build(next), onSelect },
+          }),
+        );
+      });
+    },
+  };
+}
+
+function railTrigger(el: HTMLElement, label: string): HTMLButtonElement {
+  const found = [...el.querySelectorAll("nav button")].find((b) =>
+    b.textContent?.includes(`: ${label}.`),
+  );
+  if (!found) throw new Error(`no rail trigger for ${label}`);
+  return found as HTMLButtonElement;
+}
+
+describe("PageShell — the journey rail", () => {
+  it("renders no rail at all when the surface supplies no journey", () => {
+    const el = render();
+    expect(el.querySelector("nav")).toBeNull();
+  });
+
+  it("renders one rail — not one per breakpoint — when a journey is supplied", () => {
+    // Two rails toggled by `hidden`/`lg:block` would put a second
+    // `aria-current="step"` in the accessibility tree; the layout switch is
+    // done with `flex-wrap` + `order-*` on a single node instead.
+    const { el } = withJourney({ hasResume: true });
+    expect(el.querySelectorAll("nav")).toHaveLength(1);
+    expect(el.querySelectorAll('[aria-current="step"]')).toHaveLength(1);
+  });
+
+  it("gives the rail a full-width row of its own at EVERY width", () => {
+    // Never folded into the header row, even where the space exists: sharing
+    // the row makes the arc read as one more header control beside "Saved
+    // jobs" and the star CTA, which is the L1-vs-L2 confusion #812 removes.
+    const { el } = withJourney({ hasResume: true });
+    const row = el.querySelector("nav")!.parentElement!;
+    expect(row.className).toContain("w-full");
+    // No breakpoint may hand the row back its auto width.
+    expect(row.className).not.toMatch(/\b(sm|md|lg|xl):w-auto\b/);
+    expect(row.className).not.toMatch(/\b(sm|md|lg|xl):w-/);
+  });
+
+  it("pins the header to the top of the viewport", () => {
+    const { el } = withJourney();
+    const header = el.querySelector("header")!;
+    expect(header.className).toContain("sticky");
+    expect(header.className).toContain("top-0");
+    expect(header.className).toContain("z-20");
+    expect(header.className).toContain("bg-surface-base");
+    // The backdrop must bleed over `main`'s own gutters, or content shows
+    // through beside the pinned band.
+    expect(header.className).toContain("-mx-6");
+    expect(header.className).toContain("px-6");
+  });
+
+  it("drops `main`'s top padding so nothing scrolls past above the pinned bar", () => {
+    const { el } = withJourney();
+    const main = el.querySelector("main")!;
+    expect(main.className).toContain("pb-10");
+    expect(main.className).not.toContain("py-10");
+  });
+
+  it("hands a populated stage straight to the surface", () => {
+    const { el, onSelect } = withJourney({ hasResume: true });
+    act(() => railTrigger(el, "Match jobs").click());
+    expect(onSelect).toHaveBeenCalledWith("match");
+    expect(el.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("answers an unpopulated stage with guidance instead of the surface", () => {
+    // Ungated navigation: the click is never swallowed and never locked — it
+    // opens the stage's empty state, and the surface is not told to go
+    // anywhere.
+    // `jdSteering` with no résumé is what puts `Tailor` on a `/` rail while
+    // leaving it unpopulated — the one combination that renders the stage and
+    // still has nothing behind it. (It is also the state `deriveJourney`
+    // normalizes away from `availability`, which is why the ✓ stays off.)
+    const { el, onSelect } = withJourney({ jdSteering: true });
+    act(() => railTrigger(el, "Tailor").click());
+    expect(onSelect).not.toHaveBeenCalled();
+    const card = el.querySelector('[role="status"]');
+    expect(card?.textContent).toContain("Pick a job first");
+    expect(card?.textContent).toContain("Go to Match jobs");
+  });
+
+  it("resolves a chained prerequisite one step at a time", () => {
+    // Tailor's CTA points at Match jobs, which is ALSO unmet on a first visit.
+    // Routing the card's CTA back through the same decision is what keeps it
+    // from dead-ending there.
+    const { el, onSelect } = withJourney({ jdSteering: true });
+    act(() => railTrigger(el, "Tailor").click());
+    const cta = [...el.querySelectorAll('[role="status"] button')].find((b) =>
+      b.textContent?.startsWith("Go to"),
+    ) as HTMLButtonElement;
+    act(() => cta.click());
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(el.querySelector('[role="status"]')?.textContent).toContain(
+      "ranked by how well they fit",
+    );
+  });
+
+  it("lets the first stage through even before anything is populated", () => {
+    // It has no earlier step to send the user back to — a guidance card there
+    // would point at itself.
+    const { el, onSelect } = withJourney();
+    act(() => railTrigger(el, "Add résumé").click());
+    expect(onSelect).toHaveBeenCalledWith("add");
+  });
+
+  it("renders the guidance card outside the pinned header", () => {
+    // A card pinned to the top of the viewport would eat the screen it is
+    // trying to send the user back across.
+    const { el } = withJourney();
+    act(() => railTrigger(el, "Download").click());
+    const card = el.querySelector('[role="status"]')!;
+    expect(el.querySelector("header")!.contains(card)).toBe(false);
+  });
+
+  it("drops the guidance the moment the prerequisite it names lands", () => {
+    // `blockedStage` is RE-DERIVED during render, never cleared from an effect.
+    // Swap the derivation for `askedFor !== null ? journeyStage(askedFor) : null`
+    // — the shape a reader reaches for — and the card outlives what it was
+    // explaining: for a frame in the ordinary case, and forever on the
+    // `/jobs/` → `/` bfcache return leg, where the tree is restored without any
+    // effect re-running at all. Re-render, never remount, so nothing but the
+    // render-time derivation can be doing the clearing here.
+    const { el, resignal } = withJourney({ jdSteering: true });
+    act(() => railTrigger(el, "Tailor").click());
+    expect(el.querySelector('[role="status"]')).not.toBeNull();
+
+    resignal({ hasResume: true, jdSteering: true });
+    expect(el.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("can be dismissed, and comes back on the next ask", () => {
+    const { el } = withJourney();
+    act(() => railTrigger(el, "Download").click());
+    const dismiss = [...el.querySelectorAll('[role="status"] button')].find(
+      (b) => b.textContent === "Dismiss",
+    ) as HTMLButtonElement;
+    act(() => dismiss.click());
+    expect(el.querySelector('[role="status"]')).toBeNull();
+    act(() => railTrigger(el, "Download").click());
+    expect(el.querySelector('[role="status"]')).not.toBeNull();
   });
 });

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -27,15 +27,33 @@
  * bug — the marker means "this trip started at the app root", and shared
  * chrome renders everywhere.
  *
- * Reuse: consumes only `@design-system` primitives/shared components + the
- * useGitHubStars / useUpdateChecker hooks. No raw <button> / hardcoded palette.
+ * The journey rail (#812) arrives the same way: the shell PLACES it — in the
+ * header row from `lg` up, on its own full-width row below that, and its
+ * guidance card as the first content block under the header — and owns nothing
+ * else about it. The surface derives the stages (`deriveJourney`) and decides
+ * what a click does; the ask-and-route state in between is
+ * `useJourneyGuidance`, which is where the render-time derivation of the
+ * blocked stage is documented.
+ *
+ * Reuse: consumes only `@design-system` primitives/shared components, the
+ * `JourneyRail` sibling, and the useGitHubStars / useUpdateChecker /
+ * useJourneyGuidance hooks. No raw <button> / hardcoded palette.
  */
 
 import { useState, type MouseEvent, type ReactNode } from "react";
 import { UpdateBanner, GitHubStarCta } from "@design-system";
 import { useGitHubStars } from "../../hooks/useGitHubStars.ts";
 import { useUpdateChecker } from "../../hooks/useUpdateChecker.ts";
+import {
+  useJourneyGuidance,
+  type JourneyNavigation,
+} from "../../hooks/useJourneyGuidance.ts";
 import { savedJobsHref } from "../../lib/jobs-landing.ts";
+import { JourneyRail, JourneyGuidance } from "./JourneyRail.tsx";
+
+/** The rail contract, owned by `useJourneyGuidance` — aliased here because it
+ *  is also this component's prop shape. */
+export type PageShellJourney = JourneyNavigation;
 
 export interface PageShellProps {
   /**
@@ -68,6 +86,12 @@ export interface PageShellProps {
    * document is the one navigating.
    */
   onSavedJobsNavigate?: () => void;
+  /**
+   * The top-level journey rail (#812). Omitted → no rail, and the header keeps
+   * its pre-#812 single-row shape. Supplied → the rail renders in the header
+   * row from `lg` up and on its own full-width row below that.
+   */
+  journey?: PageShellJourney;
   children: ReactNode;
 }
 
@@ -78,6 +102,7 @@ export function PageShell({
   headerExtra,
   hideSavedJobsLink,
   onSavedJobsNavigate,
+  journey,
   children,
 }: PageShellProps) {
   const { count: starCount } = useGitHubStars();
@@ -88,8 +113,12 @@ export function PageShell({
   const { updateAvailable, reload } = useUpdateChecker();
   const [updateDismissed, setUpdateDismissed] = useState(false);
 
+  // Which stage the user asked for that has nothing behind it yet, and where a
+  // click goes. Derived during render inside the hook — see its docblock.
+  const { blockedStage, onStageClick, dismiss } = useJourneyGuidance(journey);
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-10">
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 pb-10">
       {updateAvailable && !updateDismissed && (
         <UpdateBanner
           onReload={reload}
@@ -97,8 +126,33 @@ export function PageShell({
         />
       )}
 
-      <header className="flex flex-col gap-3">
-        <div className="flex items-center justify-between">
+      {/* Sticky so the rail is a permanent orientation signal rather than
+          something you scroll away from. `-mx-6 px-6` bleeds the backdrop over
+          `main`'s own gutters (without it the blurred band stops short of the
+          page edge and content shows through beside it), and `main` dropped its
+          top padding so the bar sits flush from the first paint — a sticky
+          element keeps its space in flow, so there is no layout shift when it
+          pins, but a gap above it would show unstyled content sliding past.
+          One rail node, not one per breakpoint, and it is a SIBLING of the
+          brand row rather than a wrap-item inside it: now that it always takes
+          a row of its own, living in the wrap row bought nothing and cost it
+          the row's tight `gap-y-2`, which left the track visually welded to the
+          brand. As a sibling it gets the header column's own gap instead.
+
+          THIS BAND'S HEIGHT IS A DEPENDENCY. `styles.css` sets a
+          `scroll-padding-top` on the scrolling root sized to the measured
+          maximum of this header, so that every in-page scroll target — the
+          score tiles' `#contact` / `#reconstructed-resume` hash anchors, and
+          the `scrollIntoView({ block: "start" })` calls in
+          `ReconstructedResume` and `JobSearchResults` — lands below it rather
+          than underneath it. Anything that adds a row here (a `headerExtra`,
+          a longer CTA, a taller rail) has to be re-measured there. */}
+      <header className="sticky top-0 z-20 -mx-6 flex flex-col gap-4 border-b border-border-light bg-surface-base/95 px-6 py-2 backdrop-blur">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          {/* No `shrink-0` on either of the two header-row blocks: the row is
+              `flex-wrap`, and a block that cannot shrink wraps instead — which
+              at 320px turned the brand and the CTAs into two rows of their own.
+              They keep the pre-#812 behaviour of compressing to fit. */}
           <div className="flex items-center gap-2">
             <a
               href={import.meta.env.BASE_URL}
@@ -112,7 +166,7 @@ export function PageShell({
               {badge}
             </span>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="ml-auto flex items-center gap-4">
             {!hideSavedJobsLink && (
               <a
                 href={savedJobsHref()}
@@ -150,8 +204,32 @@ export function PageShell({
             <GitHubStarCta variant="inline" count={starCount} />
           </div>
         </div>
+        {journey && (
+          // Its OWN full-width row at every width — never folded into the brand
+          // row, even where the horizontal space exists. Sharing that row made
+          // the rail read as one more header control sitting beside "Saved
+          // jobs" and the star CTA, which is precisely the L1-vs-L2 confusion
+          // #812 exists to remove; and it forced a third content-sized
+          // breakpoint band whose chips were sized by the narrowest share left
+          // after the brand and the CTAs took theirs. A dedicated row costs one
+          // line of vertical space and gives the arc a register of its own.
+          <div className="w-full min-w-0">
+            <JourneyRail journey={journey.state} onStageClick={onStageClick} />
+          </div>
+        )}
         {chips && <div className="w-full">{chips}</div>}
       </header>
+
+      {blockedStage && (
+        // First content block, OUTSIDE the sticky header: a card pinned to the
+        // top of the viewport would eat the screen it is trying to send the
+        // user back across.
+        <JourneyGuidance
+          stage={blockedStage}
+          onGoToPrerequisite={onStageClick}
+          onDismiss={dismiss}
+        />
+      )}
 
       {children}
 

--- a/src/components/features/PageShell.tsx
+++ b/src/components/features/PageShell.tsx
@@ -27,13 +27,12 @@
  * bug — the marker means "this trip started at the app root", and shared
  * chrome renders everywhere.
  *
- * The journey rail (#812) arrives the same way: the shell PLACES it — in the
- * header row from `lg` up, on its own full-width row below that, and its
- * guidance card as the first content block under the header — and owns nothing
- * else about it. The surface derives the stages (`deriveJourney`) and decides
- * what a click does; the ask-and-route state in between is
- * `useJourneyGuidance`, which is where the render-time derivation of the
- * blocked stage is documented.
+ * The journey rail (#812) arrives the same way: the shell PLACES it — on its
+ * own full-width row at every width, and its guidance card as the first content
+ * block under the header — and owns nothing else about it. The surface derives
+ * the stages (`deriveJourney`) and decides what a click does; the ask-and-route
+ * state in between is `useJourneyGuidance`, which is where the render-time
+ * derivation of the blocked stage is documented.
  *
  * Reuse: consumes only `@design-system` primitives/shared components, the
  * `JourneyRail` sibling, and the useGitHubStars / useUpdateChecker /
@@ -88,8 +87,8 @@ export interface PageShellProps {
   onSavedJobsNavigate?: () => void;
   /**
    * The top-level journey rail (#812). Omitted → no rail, and the header keeps
-   * its pre-#812 single-row shape. Supplied → the rail renders in the header
-   * row from `lg` up and on its own full-width row below that.
+   * its pre-#812 single-row shape. Supplied → the rail renders on its own
+   * full-width row below the brand row at every width.
    */
   journey?: PageShellJourney;
   children: ReactNode;

--- a/src/components/features/ResultDetailTabs.test.tsx
+++ b/src/components/features/ResultDetailTabs.test.tsx
@@ -537,3 +537,115 @@ describe("ResultDetailTabs", () => {
     expect(sessionStorage.getItem(TAILOR_HANDOFF_KEY)).toBeNull();
   });
 });
+
+// ── The journey rail's two wires (#812) ──────────────────────────────────────
+
+/**
+ * `requestedTab` (down) and `onJdContextChange` (up) are the whole of this
+ * component's contract with `/`'s L1 rail, and neither is exercised by anything
+ * above. Both fail silently: a landing request that stops working leaves the
+ * rail's Fix it / Tailor / Download stages as dead clicks, and a steering report
+ * that stops arriving leaves the rail marking — or failing to mark — Tailor
+ * over a résumé that has no steering.
+ */
+describe("ResultDetailTabs — the journey rail wires (#812)", () => {
+  /** Click the tab whose label contains `label`. */
+  function selectTab(el: HTMLElement, label: string) {
+    const tab = [...el.querySelectorAll('[role="tab"]')].find((t) =>
+      (t.textContent ?? "").includes(label),
+    ) as HTMLElement;
+    if (!tab) throw new Error(`no tab labelled ${label}`);
+    act(() => tab.click());
+  }
+
+  function selectedLabel(el: HTMLElement): string {
+    return (
+      el.querySelector('[role="tab"][aria-selected="true"]')?.textContent ?? ""
+    );
+  }
+
+  /** A host whose `requestedTab` this test drives, exactly as `App` does. */
+  function railHost(
+    onJdContextChange?: (jdContext: string | null) => void,
+  ): (requestedTab?: { id: string; nonce: number }) => void {
+    const opts: ControllerOpts = { isAvailable: false };
+    const res = result();
+    const identity = parseIdentity();
+    function RailHost({
+      requestedTab,
+    }: {
+      requestedTab?: { id: string; nonce: number };
+    }) {
+      const edit = useEditableParse();
+      return createElement(ResultDetailTabs, {
+        activeResult: res,
+        parseIdentity: identity,
+        activeScore: score,
+        result: res,
+        sourceKind: "pdf",
+        edit,
+        analysis: controller(opts),
+        escapeHatch: escapeHatchController(opts),
+        onRecovered: () => {},
+        triggerCount: res.triggers.length,
+        requestedTab,
+        onJdContextChange,
+      });
+    }
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const paint = (requestedTab?: { id: string; nonce: number }) => {
+      act(() => {
+        root.render(createElement(RailHost, { requestedTab }));
+      });
+    };
+    paint();
+    return paint;
+  }
+
+  it("honours a REPEAT request for the tab the user is already on", () => {
+    // The nonce is the whole point, and this is the assertion that proves it.
+    // Key the effect on `[requestedTab?.id]` — the shape a reader reaches for —
+    // and the first request below still works, so a test that asked once would
+    // pass either way. The second one is where it dies: the id has not changed,
+    // the effect does not re-fire, and the rail's Fix it / Tailor / Download
+    // stages become dead clicks for the rest of the page's life for any user
+    // who ever navigated away from Reconstructed by hand.
+    const paint = railHost();
+    const el = container;
+
+    selectTab(el, "Raw text & flags");
+    expect(selectedLabel(el)).toContain("Raw text & flags");
+
+    paint({ id: "reconstructed", nonce: 1 });
+    expect(selectedLabel(el)).toContain("Your resume");
+
+    // Same id, next nonce — a second, identical rail click.
+    selectTab(el, "Raw text & flags");
+    expect(selectedLabel(el)).toContain("Raw text & flags");
+    paint({ id: "reconstructed", nonce: 2 });
+    expect(selectedLabel(el)).toContain("Your resume");
+  });
+
+  it("reports null on mount, so a stale Tailor mark cannot outlive its résumé", () => {
+    const reports = vi.fn();
+    railHost(reports);
+    expect(reports).toHaveBeenCalledWith(null);
+  });
+
+  it("reports the steering it consumed, so the rail can mark Tailor", () => {
+    writeTailorHandoff({
+      jdContext: "surface Kubernetes",
+      parseFingerprint: fingerprintOf(result()),
+    });
+    const reports = vi.fn();
+    railHost(reports);
+    // The initial null still goes up first — that ordering is what lets `App`
+    // clear a mark from a previous résumé before this one reports its own.
+    expect(reports.mock.calls.map((c) => c[0])).toEqual([
+      null,
+      "surface Kubernetes",
+    ]);
+  });
+});

--- a/src/components/features/ResultDetailTabs.tsx
+++ b/src/components/features/ResultDetailTabs.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The offlinecv Authors
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Card, Tabs, TabList, Tab, TabPanel } from "@design-system";
 import { ReconstructedResume } from "./ReconstructedResume.tsx";
 import { FindJobsLauncher } from "./FindJobsLauncher.tsx";
@@ -44,6 +44,31 @@ interface ResultDetailTabsProps {
   /** Forwarded to the recovery banner; `ParsedCard` swaps in the LLM parse. */
   onRecovered: (llmParsed: LlmParsedResume) => void;
   triggerCount: number;
+  /**
+   * A tab this surface's journey rail (#812) wants opened. Three of the five
+   * L1 stages — Fix it, Tailor, Download — all live behind the `reconstructed`
+   * tab, so picking one has to land there even when the user is on another.
+   *
+   * Carries a `nonce` because the ID alone is not an event: asking for the tab
+   * you are already on is a legitimate, repeatable click (it also scrolls the
+   * page back to the top), and an id-keyed effect would fire once and then go
+   * quiet.
+   */
+  requestedTab?: { id: string; nonce: number };
+  /**
+   * Reports the JD steering this component consumed, so `/` can mark the
+   * Tailor stage on the rail.
+   *
+   * Deliberately a callback UP rather than a lift of `useTailorHandoff` into
+   * `App`: `consumeTailorHandoff` clears the sessionStorage key
+   * unconditionally, INCLUDING on a fingerprint mismatch, so a copy of that
+   * hook mounted at `App` — where the résumé is absent in `idle`/`parsing` and
+   * only arrives later, via auto-restore or a drop — would drain the payload
+   * against the wrong parse before the real consumer ever sees it. Keeping the
+   * hook here preserves all three invariants its docblock documents; only the
+   * resulting value travels.
+   */
+  onJdContextChange?: (jdContext: string | null) => void;
 }
 
 export function ResultDetailTabs({
@@ -58,6 +83,8 @@ export function ResultDetailTabs({
   escapeHatch,
   onRecovered,
   triggerCount,
+  requestedTab,
+  onJdContextChange,
 }: ResultDetailTabsProps) {
   // `tab` state lives here — only used within this component, not in ParsedCard.
   const [tab, setTab] = useState("reconstructed");
@@ -78,6 +105,36 @@ export function ResultDetailTabs({
     parseIdentity,
     onConsumed: () => setTab("reconstructed"),
   });
+
+  // Latest-value ref so the report effect below can depend on `jdContext`
+  // ALONE. Depending on the callback too would re-fire on every render of a
+  // caller that passes an inline closure, which is every caller.
+  const onJdContextChangeRef = useRef(onJdContextChange);
+  useEffect(() => {
+    onJdContextChangeRef.current = onJdContextChange;
+  });
+  useEffect(() => {
+    onJdContextChangeRef.current?.(jdContext);
+    // Deps hand-audited both directions (`exhaustive-deps` is NOT enforced —
+    // CLAUDE.md): `jdContext` is the whole payload and the only thing whose
+    // change the parent cares about; the callback is read through the ref
+    // above precisely so it cannot add a re-fire of its own. The initial run
+    // (reporting `null`) is wanted — it is what clears a stale mark when this
+    // component remounts onto a résumé with no steering.
+  }, [jdContext]);
+
+  // The rail's landing request (#812). Keyed on the NONCE, with `id` listed
+  // because the body reads it — the two always move together, so `id` adds no
+  // fire of its own. Cannot fight `onConsumed` above: that fires when a tailor
+  // handoff is absorbed (an arrival from `/jobs/`), this fires on a rail click
+  // in THIS document, and neither can happen inside the other's commit. Both
+  // would in any case be asking for the same tab.
+  const requestedNonce = requestedTab?.nonce;
+  const requestedId = requestedTab?.id;
+  useEffect(() => {
+    if (requestedId === undefined) return;
+    setTab(requestedId);
+  }, [requestedNonce, requestedId]);
 
   // The on-device-AI tab (id `quality`) is the canonical on-device-AI surface
   // (#276). It shows whenever there's résumé text to analyze — either running the live

--- a/src/hooks/useAutoRestoreResume.test.tsx
+++ b/src/hooks/useAutoRestoreResume.test.tsx
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useAutoRestoreResume (#812) — the cold-mount rehydration of `/`.
+ *
+ * The library is stubbed rather than driven through `fake-indexeddb`: every
+ * behaviour worth pinning here is about WHEN the hook loads and whether it is
+ * still allowed to apply the result when the read resolves, and a controllable
+ * promise is the only way to hold a read open across a state change. The real
+ * IndexedDB path is `resume-library.ts`'s own concern (covered there).
+ *
+ * The six ways this feature dies silently, all pinned below:
+ *  - it never fires, so a returning user still faces an empty drop zone;
+ *  - it fires again after `reset()`, so the results view cannot be dismissed;
+ *  - it stays armed past the cold mount and ambushes an idle page when another
+ *    tab saves a résumé;
+ *  - it lands on top of a file the user dropped while the read was in flight;
+ *  - it hydrates the wrong résumé over a pending tailor handoff, whose consumer
+ *    then destroys the payload;
+ *  - it throws on a rejecting `load` instead of leaving the app idle.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StrictMode, createElement, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useAutoRestoreResume } from "./useAutoRestoreResume.ts";
+import type { ResumeLibraryEntry, LoadedResume } from "../lib/resume-library.ts";
+import { TAILOR_HANDOFF_KEY } from "../lib/tailor-handoff.ts";
+import type { ParseState } from "./useResumeAnalysis.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  sessionStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const entry = (id: string, savedAt: number): ResumeLibraryEntry => ({
+  id,
+  filename: `${id}.pdf`,
+  savedAt,
+  scoreOverall: 71,
+  sourceKind: "pdf",
+  hasCachedParse: true,
+});
+
+/** A `LoadedResume` stub — only the identity fields are read by these tests;
+ *  the parse/score payloads travel through untouched. */
+const loaded = (id: string): LoadedResume =>
+  ({
+    id,
+    filename: `${id}.pdf`,
+    fileSize: 1234,
+    sourceKind: "pdf",
+    result: {},
+    score: {},
+  }) as unknown as LoadedResume;
+
+interface Harness {
+  onRestore: ReturnType<typeof vi.fn>;
+  load: ReturnType<typeof vi.fn>;
+  setPhase: (phase: ParseState["phase"]) => void;
+  setReady: (ready: boolean) => void;
+  setEntries: (entries: ResumeLibraryEntry[]) => void;
+}
+
+/**
+ * Mount the hook under a probe whose `phase` / `library.ready` this test can
+ * move. `render` is re-invoked (not remounted) so a phase change behaves the
+ * way it does in `App` — a re-render of a still-mounted tree.
+ */
+function mount(
+  options: {
+    entries?: ResumeLibraryEntry[];
+    ready?: boolean;
+    phase?: ParseState["phase"];
+    load?: ReturnType<typeof vi.fn>;
+    strict?: boolean;
+  } = {},
+): Harness {
+  const onRestore = vi.fn();
+  const load =
+    options.load ??
+    vi.fn((id: string) => Promise.resolve<LoadedResume | undefined>(loaded(id)));
+  let phase: ParseState["phase"] = options.phase ?? "idle";
+  let ready = options.ready ?? true;
+  let entries = options.entries ?? [entry("older", 1), entry("newest", 2)];
+
+  function Probe() {
+    useAutoRestoreResume({
+      phase,
+      library: { ready, entries, load },
+      onRestore,
+    });
+    return null;
+  }
+
+  const paint = () => {
+    const tree = createElement(Probe);
+    act(() => root.render(options.strict ? createElement(StrictMode, null, tree) : tree));
+  };
+  paint();
+
+  return {
+    onRestore,
+    load,
+    setPhase: (next) => {
+      phase = next;
+      paint();
+    },
+    setReady: (next) => {
+      ready = next;
+      paint();
+    },
+    // A NEW array every time, the way `useResumeLibrary`'s `refresh()` mints
+    // one — that fresh identity is what re-fires the restore effect.
+    setEntries: (next) => {
+      entries = next;
+      paint();
+    },
+  };
+}
+
+/** Let the stubbed `load` promise settle. */
+const settle = () => act(async () => {});
+
+describe("useAutoRestoreResume", () => {
+  it("restores the most recently saved résumé on a cold idle mount", async () => {
+    const h = mount();
+    await settle();
+    expect(h.load).toHaveBeenCalledWith("newest");
+    expect(h.onRestore).toHaveBeenCalledTimes(1);
+    expect(h.onRestore.mock.calls[0][0].id).toBe("newest");
+  });
+
+  it("waits for the library before deciding there is nothing to restore", async () => {
+    const h = mount({ ready: false });
+    await settle();
+    expect(h.load).not.toHaveBeenCalled();
+    h.setReady(true);
+    await settle();
+    expect(h.onRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the library is empty", async () => {
+    const h = mount({ entries: [] });
+    await settle();
+    expect(h.load).not.toHaveBeenCalled();
+    expect(h.onRestore).not.toHaveBeenCalled();
+  });
+
+  it("stays spent when a résumé is saved AFTER the empty library resolved", async () => {
+    // The attempt is spent the moment the library first resolves, BEFORE the
+    // empty-list check — move it below and this is the ambush that follows:
+    // `useResumeLibrary` subscribes through `useLibraryChanges("resumes", …)`,
+    // so a save in another tab mints a fresh `entries` array, re-fires this
+    // effect, and hydrates a résumé over an idle page the user is standing on
+    // long after arrival. This is a cold-mount restore, not a subscription.
+    const h = mount({ entries: [] });
+    await settle();
+    expect(h.load).not.toHaveBeenCalled();
+
+    h.setEntries([entry("saved-in-another-tab", 3)]);
+    await settle();
+    expect(h.load).not.toHaveBeenCalled();
+    expect(h.onRestore).not.toHaveBeenCalled();
+  });
+
+  it("declines to restore while a tailor handoff is pending", async () => {
+    // #812 S1. The payload names a SPECIFIC parse, and `consumeTailorHandoff`
+    // clears the key even on a fingerprint mismatch — so a restored, unrelated
+    // résumé's consumer would drain the steering rather than pass on it.
+    // Pre-#812 a bfcache miss on the `/jobs/` → `/` return leg left `/` idle
+    // with the payload intact and re-dropping the résumé still applied it;
+    // restoring turns that recoverable state into an unrecoverable one.
+    sessionStorage.setItem(
+      TAILOR_HANDOFF_KEY,
+      JSON.stringify({ jdContext: "Steer toward the JD", parseFingerprint: "deadbeef" }),
+    );
+    const h = mount();
+    await settle();
+    expect(h.load).not.toHaveBeenCalled();
+    expect(h.onRestore).not.toHaveBeenCalled();
+    // And the peek left it for its real consumer.
+    expect(sessionStorage.getItem(TAILOR_HANDOFF_KEY)).not.toBeNull();
+  });
+
+  it("does not restore over a parse that is already on screen", async () => {
+    // The bfcache return leg: the page comes back with its React state — and
+    // its inline edits — intact. Restoring on top of that is data loss.
+    const h = mount({ phase: "done" });
+    await settle();
+    expect(h.load).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire again after reset() returns the app to idle", async () => {
+    // Without the spent-once guard the results view cannot be dismissed: every
+    // "start over" re-hydrates the résumé the user just walked away from.
+    const h = mount();
+    await settle();
+    expect(h.onRestore).toHaveBeenCalledTimes(1);
+
+    h.setPhase("done");
+    h.setPhase("idle");
+    await settle();
+    expect(h.onRestore).toHaveBeenCalledTimes(1);
+    expect(h.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clobber a résumé dropped while the read was in flight", async () => {
+    let release!: (value: LoadedResume | undefined) => void;
+    const load = vi.fn(
+      () => new Promise<LoadedResume | undefined>((res) => (release = res)),
+    );
+    const h = mount({ load });
+    expect(load).toHaveBeenCalledTimes(1);
+
+    // The user drops a file; the record lands a moment later.
+    h.setPhase("parsing");
+    h.setPhase("done");
+    await act(async () => release(loaded("newest")));
+    expect(h.onRestore).not.toHaveBeenCalled();
+  });
+
+  it("leaves the app idle when the load rejects, without throwing", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const load = vi.fn(() => Promise.reject(new Error("IndexedDB is closed")));
+    const h = mount({ load });
+    await settle();
+    expect(h.onRestore).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
+  });
+
+  it("treats an unreadable record as nothing to restore", async () => {
+    const load = vi.fn(() => Promise.resolve(undefined));
+    const h = mount({ load });
+    await settle();
+    expect(h.onRestore).not.toHaveBeenCalled();
+  });
+
+  it("restores exactly once under StrictMode's simulated remount", async () => {
+    // The trap this guards: a per-effect `cancelled` flag tripped by the replay
+    // cleanup, with the replayed setup declining to start a second load because
+    // the attempt is already spent — dead under `npm run dev`, green in CI.
+    const h = mount({ strict: true });
+    await settle();
+    expect(h.load).toHaveBeenCalledTimes(1);
+    expect(h.onRestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useAutoRestoreResume.ts
+++ b/src/hooks/useAutoRestoreResume.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useAutoRestoreResume — bring `/`'s most recently saved résumé back on a cold
+ * mount, without an explicit Load click (issue #812).
+ *
+ * Why this ships with the journey rail rather than on its own: a sticky rail
+ * that is always on screen claiming "you are at step 3" while the app has
+ * silently forgotten the user's work is worse than no rail at all. Three
+ * priorities decide what `/` shows on arrival, and only the second is new here:
+ *
+ *   1. an active parse already in memory — including a page restored from
+ *      bfcache, which comes back with its React state (and its inline edits)
+ *      intact, so there is nothing to restore and this hook must not act;
+ *   2. otherwise, the newest `resumes` record in IndexedDB, hydrated straight
+ *      from its cached parse (this hook);
+ *   3. otherwise, the ordinary idle drop zone.
+ *
+ * This adds no schema change and no new record shape — it is the same
+ * `library.load` `/`'s Saved-resumes picker performs, minus the click, so the
+ * privacy invariant is untouched. It is NOT read-only, though, and calling it
+ * that would hide the one thing that is genuinely new: on a record saved before
+ * the cached-parse shape it expects, `loadResumeFromLibrary` re-runs the whole
+ * cascade over the stored bytes and writes the result back
+ * (`lib/resume-library.ts`). Unprompted, on first paint, for a user who clicked
+ * nothing. That is the cost of the feature, not a detail.
+ *
+ * There is deliberately NO `pageshow` subscription here. The signal that
+ * matters on a bfcache return leg is one that would otherwise be missed because
+ * the tree never remounts (#783) — but the page coming back out of bfcache
+ * already carries the parse it left with, so the correct behaviour on that leg
+ * is to do nothing, which is exactly what a hook with no listener does. The
+ * `spentRef` below makes that true even if a later edit adds one.
+ *
+ * Three guards are load-bearing and none is redundant:
+ *
+ *  - **The attempt is spent once per page lifetime** (`spentRef`). `reset()`
+ *    puts the app back to `phase: "idle"` (`useResumeAnalysis`), so a restore
+ *    keyed on "the app is idle" alone would re-hydrate the very résumé the user
+ *    just dismissed, every time — an un-dismissable results view. The ref is
+ *    also what makes this safe under StrictMode's simulated setup → cleanup →
+ *    setup: refs survive the replay, so the second setup finds the attempt
+ *    already spent and does nothing (the same reasoning `useTailorHandoff`
+ *    documents for preferring a ref to a boolean flag).
+ *  - **The phase is re-checked when the IndexedDB read RESOLVES**, not only
+ *    when it starts. A user who drops a file while the read is in flight must
+ *    not have it clobbered by a record landing a moment later. Read through a
+ *    latest-value ref rather than a closure capture, because the closure froze
+ *    at the render that started the load.
+ *  - **A pending tailor handoff wins over any restore.** A payload waiting in
+ *    sessionStorage names a SPECIFIC parse — the one it was fingerprinted
+ *    against — that this page is expected to be holding when the user returns
+ *    from `/jobs/`. Restoring a different résumé does not merely fail to apply
+ *    the steering: `consumeTailorHandoff` clears the key unconditionally,
+ *    INCLUDING on a fingerprint mismatch, so the restored résumé's consumer
+ *    destroys the payload on its way past. Without this guard a bfcache MISS on
+ *    the return leg — Chrome evicts freely, and this app holds an open
+ *    IndexedDB connection — turns a recoverable state (pre-#812: `/` reloads
+ *    idle, the payload survives, re-dropping the résumé still applies it) into
+ *    an unrecoverable one. Peeked non-destructively via
+ *    {@link hasPendingTailorHandoff}, never by consuming.
+ *
+ * Cancellation is deliberately NOT a per-effect boolean. Under StrictMode the
+ * cleanup runs between the two setups, so a flag set there would cancel the one
+ * in-flight load while the replayed setup declines to start another (spent) —
+ * the feature dead under `npm run dev` and green in CI. `aliveRef` is re-armed
+ * by its own setup instead, so only a real unmount leaves it false.
+ *
+ * `library.load` rejects for real — it is an IndexedDB read, it calls
+ * `blob.arrayBuffer()`, and on a stale-shape record it re-runs the whole
+ * cascade — so the `.catch` is not defensive dressing. Same shape and reasoning
+ * as `useFallbackResume`.
+ */
+
+import { useEffect, useRef } from "react";
+import { newestLibraryEntryId, type LoadedResume } from "../lib/resume-library.ts";
+import { hasPendingTailorHandoff } from "../lib/tailor-handoff.ts";
+import type { ParseState } from "./useResumeAnalysis.ts";
+import type { ResumeLibrary } from "./useResumeLibrary.ts";
+
+/** The slice of `ResumeLibrary` this hook reads — narrowed for the same reason
+ *  `useFallbackResume` narrows its own, so a test can hand it a stub instead of
+ *  the whole hook's surface. */
+export type RestorableResumeLibrary = Pick<
+  ResumeLibrary,
+  "ready" | "entries" | "load"
+>;
+
+export interface AutoRestoreOptions {
+  /** The current parse phase. Restoring is only ever correct from `"idle"`. */
+  phase: ParseState["phase"];
+  library: RestorableResumeLibrary;
+  /** Hydrate the results view from the loaded record. */
+  onRestore: (loaded: LoadedResume) => void;
+}
+
+export function useAutoRestoreResume({
+  phase,
+  library,
+  onRestore,
+}: AutoRestoreOptions): void {
+  // Latest-value refs, refreshed after every render. Declared BEFORE the
+  // restore effect so that within a single commit they already hold this
+  // render's values by the time it runs.
+  const phaseRef = useRef(phase);
+  const onRestoreRef = useRef(onRestore);
+  useEffect(() => {
+    phaseRef.current = phase;
+    onRestoreRef.current = onRestore;
+  });
+
+  // True between mount and a genuine unmount. See the docblock: a plain
+  // per-effect `cancelled` flag would be tripped by StrictMode's replay
+  // cleanup and never re-armed, because the replayed setup finds the attempt
+  // spent and starts nothing new to un-cancel.
+  const aliveRef = useRef(true);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const spentRef = useRef(false);
+
+  useEffect(() => {
+    if (spentRef.current || !library.ready) return;
+    // Spent the moment the library first resolves, whether or not there turns
+    // out to be anything to restore. Waiting for a non-empty list instead would
+    // leave the attempt armed, so a résumé saved LATER — in another tab, or by
+    // a restored backup — would ambush an idle page long after arrival. This is
+    // a cold-mount restore, not a subscription.
+    spentRef.current = true;
+    if (phaseRef.current !== "idle") return;
+    // A specific parse is expected back on this page, and restoring a
+    // different one would get the payload destroyed by the wrong consumer —
+    // see the docblock's third guard. Checked AFTER the attempt is spent: the
+    // decision belongs to this cold mount, and re-arming it would let the
+    // restore fire later, once the handoff is gone, against the résumé the
+    // user by then has on screen.
+    if (hasPendingTailorHandoff()) return;
+    const id = newestLibraryEntryId(library.entries);
+    if (id === undefined) return;
+
+    void library
+      .load(id)
+      .then((loaded) => {
+        if (!aliveRef.current || loaded === undefined) return;
+        // Re-checked here, not just above: a file dropped while this read was
+        // in flight owns the screen, and must not be replaced by the record.
+        if (phaseRef.current !== "idle") return;
+        onRestoreRef.current(loaded);
+      })
+      .catch((err: unknown) => {
+        // Leaving the app idle is the right end state — the drop zone is
+        // exactly what a user with no restorable résumé needs — but without
+        // this the rejection is unhandled and the reason never reaches the
+        // console.
+        console.error("[useAutoRestoreResume] library load failed:", err);
+      });
+    // Deps hand-audited both directions (`exhaustive-deps` is NOT enforced —
+    // CLAUDE.md). `library.ready` is the trigger: it flips false → true exactly
+    // once, when the first `listLibrary()` resolves, and React has already
+    // committed `entries` from that same `refresh()` call by then, so the list
+    // this reads is the loaded one. `library.entries` is listed because the
+    // body reads it, and costs nothing — every run after the first returns on
+    // `spentRef`. `library.load` is a `useCallback` with an empty dep array
+    // (stable). `phase` and `onRestore` are deliberately ABSENT and read
+    // through refs instead: depending on `phase` would re-fire this on every
+    // parse transition, and depending on `onRestore` would re-fire it on every
+    // render of a caller that passes an inline closure — in both cases only to
+    // return on `spentRef`, and in the pre-spent window to race the load that
+    // is already running.
+  }, [library.ready, library.entries, library.load]);
+}

--- a/src/hooks/useFallbackResume.ts
+++ b/src/hooks/useFallbackResume.ts
@@ -22,6 +22,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
+import { newestLibraryEntryId } from "../lib/resume-library.ts";
 import type { ResumeLibrary } from "./useResumeLibrary.ts";
 
 export interface FallbackResume {
@@ -38,15 +39,14 @@ export function useFallbackResume(
   library: FallbackResumeLibrary,
 ): FallbackResume | undefined {
   // Recomputed only from `entries` — NOT `library.ready`, which flips once and
-  // never again, so including it would be a no-op dep. Reduces to the entry
-  // with the largest `savedAt`; `listLibrary` already returns newest-first, but
-  // this does not lean on that ordering staying true.
-  const newestId = useMemo<string | undefined>(() => {
-    if (!active || library.entries.length === 0) return undefined;
-    return library.entries.reduce((newest, entry) =>
-      entry.savedAt > newest.savedAt ? entry : newest,
-    ).id;
-  }, [active, library.entries]);
+  // never again, so including it would be a no-op dep. The "which entry is
+  // newest" rule itself lives in `resume-library.ts` (#812), shared with `/`'s
+  // cold-mount auto-restore, so the two surfaces can never fall back to
+  // different résumés.
+  const newestId = useMemo<string | undefined>(
+    () => (active ? newestLibraryEntryId(library.entries) : undefined),
+    [active, library.entries],
+  );
 
   const [fallback, setFallback] = useState<FallbackResume | undefined>(undefined);
 

--- a/src/hooks/useJourneyGuidance.ts
+++ b/src/hooks/useJourneyGuidance.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useJourneyGuidance — the interaction state behind the L1 journey rail
+ * (issue #812): which stage the user asked for that has nothing behind it yet,
+ * where a click is routed, and the scroll that makes the ask legible.
+ *
+ * Extracted from `PageShell` rather than left inline because this is
+ * cross-cutting interaction state — the same class as `useReplaceResumeOnDrop`
+ * and `useSectionRewriteLock` beside it, and what CLAUDE.md's "Data & hooks"
+ * rule names — while `PageShell` is placement: it decides WHERE the rail and
+ * the card sit and nothing about what a stage means or what a click resolves
+ * to. The shell was 197 LOC before the rail landed on it; keeping the routing
+ * here is also what keeps it under the ~200 LOC line.
+ *
+ * The one invariant a future edit will otherwise "clean up": **`blockedStage`
+ * is derived during render, never carried in an effect.** The card is stale the
+ * instant the missing prerequisite lands — a parse finishes, a handoff
+ * resolves — and an effect-cleared card survives that by a frame in the
+ * ordinary case and FOREVER on the `/jobs/` → `/` bfcache return leg, where the
+ * tree is restored without any effect re-running at all (the #783 defect).
+ * Only the raw ask is state; whether that ask is still blocked is recomputed
+ * from the current journey every render.
+ */
+
+import { useState } from "react";
+import {
+  isStageReachable,
+  journeyStage,
+  type Journey,
+  type JourneyStage,
+  type JourneyStageId,
+} from "../lib/journey.ts";
+
+/** What a surface hands the rail: the derived arc, and what it does about a
+ *  stage the user can actually be sent to. */
+export interface JourneyNavigation {
+  /** The derived arc — see `deriveJourney`. Computed during render by the
+   *  surface, never from a mount-only effect. */
+  state: Journey;
+  /** What this surface does when the user picks a stage it can actually show. */
+  onSelect: (id: JourneyStageId) => void;
+}
+
+export interface JourneyGuidanceState {
+  /** The stage whose empty state should be explained right now, or null. */
+  blockedStage: JourneyStage | null;
+  /** Every rail click AND the guidance card's own CTA come through here. */
+  onStageClick: (id: JourneyStageId) => void;
+  /** Close the card without going anywhere. */
+  dismiss: () => void;
+}
+
+/**
+ * Bring the top of the page — which is where the rail, and any guidance card it
+ * opens, both live — back into view. A rail click that quietly changed a tab
+ * three screens above the user is a click that did nothing.
+ *
+ * `prefers-reduced-motion` has to be consulted in JS: the CSS `scroll-behavior`
+ * cascade does not reach a `behavior: "smooth"` passed here.
+ */
+function scrollToJourney(): void {
+  const reduced =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  try {
+    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+  } catch {
+    // No real scroller (jsdom, an embedded view) — nothing to bring into view.
+  }
+}
+
+export function useJourneyGuidance(
+  journey?: JourneyNavigation,
+): JourneyGuidanceState {
+  // The raw ask, and only the raw ask. See the docblock.
+  const [askedFor, setAskedFor] = useState<JourneyStageId | null>(null);
+
+  const blockedStage =
+    journey !== undefined &&
+    askedFor !== null &&
+    !isStageReachable(journey.state, askedFor)
+      ? journeyStage(askedFor)
+      : null;
+
+  // Plain functions, not `useCallback`: `journey` is an object literal rebuilt
+  // by the surface on every render, so a memo keyed on it would never hit, and
+  // `JourneyRail` renders raw `Button`s that are not memoized either. A
+  // `useCallback` here would be a dep array to keep honest for no saved render.
+  const onStageClick = (id: JourneyStageId) => {
+    if (journey === undefined) return;
+    scrollToJourney();
+    if (isStageReachable(journey.state, id)) {
+      setAskedFor(null);
+      journey.onSelect(id);
+      return;
+    }
+    // Ungated, so the click is never swallowed: it opens the stage's empty
+    // state instead of the stage. The card's own CTA comes back through here,
+    // so a chain (Tailor → Match jobs → Add résumé) resolves one step at a
+    // time rather than dead-ending on a prerequisite that is itself unmet.
+    setAskedFor(id);
+  };
+
+  return { blockedStage, onStageClick, dismiss: () => setAskedFor(null) };
+}

--- a/src/jobs/JobsApp.tsx
+++ b/src/jobs/JobsApp.tsx
@@ -35,7 +35,7 @@
  * explicit Search — see `lib/job-search/providers/keywords.ts`).
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, ErrorState, Tabs, TabList, Tab, TabPanel } from "@design-system";
 import { PageShell } from "../components/features/PageShell.tsx";
 import { FindJobsPanel } from "../components/features/FindJobsPanel.tsx";
@@ -50,6 +50,7 @@ import {
   writeTailorHandoff,
   fingerprintParse,
 } from "../lib/tailor-handoff.ts";
+import { deriveJourney, type JourneyStageId } from "../lib/journey.ts";
 
 // #706: goes to `/` directly, never via history.back() — the empty state only
 // shows when there is no in-progress parse to preserve, so this is a forward
@@ -145,10 +146,62 @@ export default function JobsApp() {
     : undefined;
   const trackerParsed = handoff?.parsed ?? fallback?.parsed;
 
+  // ── The L1 journey rail (#812) ────────────────────────────────────────────
+  //
+  // "Is there a résumé" is answered by EITHER source, not just the handoff.
+  // The rail is an orientation device about the user's journey, not a readout
+  // of what this tab can search with: a saved résumé the Saved-jobs tab is
+  // already rating against is a résumé this browser has, and marking Fix it
+  // "not ready yet" next to it would be false.
+  //
+  // The rail's promise round-trips WHEN the mark came from the library:
+  // `/`'s cold-mount auto-restore (#812) rehydrates that same newest record, so
+  // Fix it lands on it. It does not round-trip when the mark came from a
+  // handoff written by an UNSAVED parse and the return leg misses bfcache —
+  // `/` then reloads with nothing in the library to restore and Fix it lands on
+  // an empty drop zone. That is the pre-#812 outcome for an unsaved parse, not
+  // a regression, and the honest read of this signal is "this browser has a
+  // résumé somewhere", not "Fix it is guaranteed to find one".
+  //
+  // `jdSteering` is flatly false here, and that is not a stub: steering is
+  // WRITTEN on the way out of this surface (`handleTailor` above) and consumed
+  // on `/`, so it can never be active while this page is on screen. The Tailor
+  // stage therefore always shows its empty state here, pointing back at the
+  // Search tab — which is exactly where the "Tailor résumé to this job"
+  // buttons live.
+  const journeyState = useMemo(
+    () =>
+      deriveJourney({
+        entry: "jobs",
+        hasResume: handoff !== null || fallback !== undefined,
+        jdSteering: false,
+      }),
+    [handoff, fallback],
+  );
+
+  const onJourneySelect = useCallback(
+    (id: JourneyStageId) => {
+      // Match jobs IS this surface — the Search tab, which the user may have
+      // switched away from.
+      if (id === "match") {
+        setTab("search");
+        return;
+      }
+      // Every other stage lives on `/`. Through `returnToResumeRoot`, never a
+      // hand-rolled `history.back()`: a real back navigation is what restores
+      // `/`'s in-progress parse and inline edits from bfcache, and it is only
+      // correct when this tab's own departure marker says the trip started
+      // there (#706).
+      returnToResumeRoot(arrivedFromRoot);
+    },
+    [arrivedFromRoot],
+  );
+
   return (
     <PageShell
       subtitle="Find jobs that fit your resume"
       badge="Jobs"
+      journey={{ state: journeyState, onSelect: onJourneySelect }}
       // #707: PageShell's "Saved jobs" link exists to get a user here from one
       // of the other two surfaces — rendered on `/jobs/` itself it would point
       // at the page already open, which is confusing rather than useful.

--- a/src/lib/jobs-departure.ts
+++ b/src/lib/jobs-departure.ts
@@ -47,3 +47,19 @@ export function departToJobs(parsed?: HeuristicParsedResume): void {
   else clearJobsHandoff();
   markDeparture();
 }
+
+/**
+ * Depart AND navigate, for the routes that move the document themselves.
+ *
+ * Two of the three routes off `/` are buttons rather than links — the Find Jobs
+ * tab's launcher and the journey rail's Match-jobs stage (#812) — and both must
+ * assign a BASE-aware URL or the `/OfflineCV/` Pages-fallback deploy 404s. That
+ * is a second thing a new route can forget, so it joins the first here. The
+ * header's "Saved jobs" entry stays a real `<a href>` (open-in-new-tab must
+ * work) and calls {@link departToJobs} alone — which is why the navigation is
+ * not folded into that function itself.
+ */
+export function departToJobsAndNavigate(parsed?: HeuristicParsedResume): void {
+  departToJobs(parsed);
+  window.location.href = `${import.meta.env.BASE_URL}jobs/`;
+}

--- a/src/lib/journey.test.ts
+++ b/src/lib/journey.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The L1 journey derivation (#812).
+ *
+ * What is pinned here is the BEHAVIOUR a user reads off the rail — which stage
+ * says "you are here", and which stages claim to have something behind them —
+ * for each of the five states the two entries can be in. The shape of
+ * `JOURNEY_STAGES` is not asserted beyond the two rules a future edit is most
+ * likely to break silently: `download` is never current, and the first stage
+ * has no empty state to fall back to.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  JOURNEY_STAGES,
+  deriveJourney,
+  isStageReachable,
+  journeyStage,
+  type JourneySignals,
+} from "./journey.ts";
+
+const signals = (over: Partial<JourneySignals> = {}): JourneySignals => ({
+  entry: "root",
+  hasResume: false,
+  jdSteering: false,
+  ...over,
+});
+
+describe("deriveJourney — where the user is", () => {
+  it("puts a first-time visitor on Add résumé, with nothing else populated", () => {
+    const journey = deriveJourney(signals());
+    expect(journey.current).toBe("add");
+    expect(journey.availability).toEqual({
+      add: false,
+      fix: false,
+      match: false,
+      tailor: false,
+      download: false,
+    });
+  });
+
+  it("moves to Fix it once a résumé is on screen, opening the rest of the arc", () => {
+    const journey = deriveJourney(signals({ hasResume: true }));
+    expect(journey.current).toBe("fix");
+    expect(journey.availability.add).toBe(true);
+    expect(journey.availability.match).toBe(true);
+    expect(journey.availability.download).toBe(true);
+    // Tailoring needs a JD, not a résumé — a résumé alone never opens it.
+    expect(journey.availability.tailor).toBe(false);
+  });
+
+  it("moves to Tailor while a JD is steering the rewrite", () => {
+    const journey = deriveJourney(signals({ hasResume: true, jdSteering: true }));
+    expect(journey.current).toBe("tailor");
+    expect(journey.availability.tailor).toBe(true);
+  });
+
+  it("refuses to mark Tailor when steering arrives without a résumé", () => {
+    // Rule 2 of the module docblock: the ✓ mark states "there is data behind
+    // this stage", so marking Tailor over an empty page is a visible lie. Both
+    // of today's callers already guard it — `App` because it clears the
+    // steering on `parseKey`, `JobsApp` because it passes literal `false` — but
+    // an invariant a pure function only holds when its callers remember is one
+    // refactor from not holding, and nothing in the signature says the two
+    // inputs are related. Called directly, on purpose: this is the shape a
+    // third caller would produce.
+    for (const entry of ["root", "jobs"] as const) {
+      const journey = deriveJourney({ entry, hasResume: false, jdSteering: true });
+      expect(journey.availability.tailor).toBe(false);
+      expect(journey.current).not.toBe("tailor");
+    }
+  });
+
+  it("reads /jobs/ as Match jobs when a résumé arrived with the user", () => {
+    const journey = deriveJourney(signals({ entry: "jobs", hasResume: true }));
+    expect(journey.current).toBe("match");
+    expect(journey.availability.match).toBe(true);
+  });
+
+  it("still reads /jobs/ as Match jobs on a direct visit with no résumé", () => {
+    // A user standing on the search surface with nothing to search against is
+    // still standing there — the surface's own empty state says the rest.
+    const journey = deriveJourney(signals({ entry: "jobs" }));
+    expect(journey.current).toBe("match");
+    expect(journey.availability.match).toBe(false);
+    expect(journey.availability.add).toBe(false);
+  });
+
+  it("never parks the user on Download", () => {
+    // The terminal action is reachable from anywhere, but it is not a place
+    // you sit: exporting does not end the journey, and a rail that said so
+    // would stop inviting the edit-and-re-export loop the product is built on.
+    for (const entry of ["root", "jobs"] as const) {
+      for (const hasResume of [false, true]) {
+        for (const jdSteering of [false, true]) {
+          expect(
+            deriveJourney({ entry, hasResume, jdSteering }).current,
+          ).not.toBe("download");
+        }
+      }
+    }
+  });
+});
+
+describe("isStageReachable — a rail, not a wizard", () => {
+  it("lets a first-time visitor click straight through to any stage", () => {
+    // Nothing is locked. An unpopulated stage explains itself; it never
+    // refuses the click.
+    const journey = deriveJourney(signals());
+    expect(isStageReachable(journey, "add")).toBe(true);
+  });
+
+  it("sends an unpopulated later stage to its guidance instead of its content", () => {
+    const journey = deriveJourney(signals());
+    expect(isStageReachable(journey, "fix")).toBe(false);
+    expect(isStageReachable(journey, "match")).toBe(false);
+    expect(isStageReachable(journey, "download")).toBe(false);
+  });
+
+  it("opens every résumé-backed stage once a résumé lands", () => {
+    const journey = deriveJourney(signals({ hasResume: true }));
+    expect(isStageReachable(journey, "fix")).toBe(true);
+    expect(isStageReachable(journey, "match")).toBe(true);
+    expect(isStageReachable(journey, "download")).toBe(true);
+    expect(isStageReachable(journey, "tailor")).toBe(false);
+  });
+
+  it("never shadows the stage the user is already standing on", () => {
+    // `/jobs/` with no résumé: Match jobs has nothing behind it, but the user
+    // is there — covering the search surface with a card telling them to go
+    // elsewhere would hide the surface they just navigated to.
+    const journey = deriveJourney(signals({ entry: "jobs" }));
+    expect(journey.availability.match).toBe(false);
+    expect(isStageReachable(journey, "match")).toBe(true);
+  });
+});
+
+describe("JOURNEY_STAGES", () => {
+  it("gives every stage but the first somewhere to send the user back to", () => {
+    const [first, ...rest] = JOURNEY_STAGES;
+    expect(first.empty).toBeNull();
+    for (const stage of rest) {
+      expect(stage.empty).not.toBeNull();
+      // The CTA must point at a real, EARLIER stage — a prerequisite that
+      // sits later in the arc would loop the user forward into the same wall.
+      const target = JOURNEY_STAGES.findIndex(
+        (s) => s.id === stage.empty?.prerequisite,
+      );
+      expect(target).toBeGreaterThanOrEqual(0);
+      expect(target).toBeLessThan(JOURNEY_STAGES.indexOf(stage));
+    }
+  });
+
+  it("keeps Match jobs from colliding with either surface's L2 tab labels", () => {
+    // `/` has a tab labelled "Find jobs"; `/jobs/` has one labelled "Search".
+    // An L1 stage sharing either name is the ambiguity this rail removes.
+    const labels = JOURNEY_STAGES.map((s) => s.label);
+    expect(labels).toContain("Match jobs");
+    expect(labels).not.toContain("Find jobs");
+    expect(labels).not.toContain("Search");
+  });
+
+  it("resolves every id, and refuses one it does not know", () => {
+    expect(journeyStage("tailor").label).toBe("Tailor");
+    expect(() =>
+      journeyStage("nope" as Parameters<typeof journeyStage>[0]),
+    ).toThrow();
+  });
+
+  it("puts Download ahead of the job-search half of the arc", () => {
+    // A user who came only to repair what an extractor reads back is finished
+    // at Download and never needs a job board, so it cannot be the last stage.
+    const ids = JOURNEY_STAGES.map((s) => s.id);
+    expect(ids).toEqual(["add", "fix", "download", "match", "tailor"]);
+    expect(ids.indexOf("download")).toBeLessThan(ids.indexOf("match"));
+  });
+
+  it("omits Tailor everywhere it could not be started from", () => {
+    // Tailoring only ever begins at a specific posting's button, so a rail
+    // entry for it on a cold `/` names a step with no way in.
+    const ids = (s: Partial<JourneySignals>) =>
+      deriveJourney({
+        entry: "root",
+        hasResume: false,
+        jdSteering: false,
+        ...s,
+      }).stages.map((x) => x.id);
+
+    expect(ids({})).not.toContain("tailor");
+    expect(ids({ hasResume: true })).not.toContain("tailor");
+    // On `/jobs/` the button that starts it is on screen…
+    expect(ids({ entry: "jobs" })).toContain("tailor");
+    // …and on `/` it appears exactly while a JD is steering the rewrite.
+    expect(ids({ hasResume: true, jdSteering: true })).toContain("tailor");
+  });
+
+  it("never omits a stage the user is standing on", () => {
+    // A `current` id absent from `stages` would render a rail with no
+    // `aria-current` at all — the one thing it exists to state.
+    for (const entry of ["root", "jobs"] as const) {
+      for (const hasResume of [false, true]) {
+        for (const jdSteering of [false, true]) {
+          const j = deriveJourney({ entry, hasResume, jdSteering });
+          expect(j.stages.map((s) => s.id)).toContain(j.current);
+        }
+      }
+    }
+  });
+
+  it("keeps availability keyed by every stage, visible or not", () => {
+    // Availability is a fact about the DATA; hiding a rail entry must not
+    // silently drop the answer for it.
+    const j = deriveJourney({
+      entry: "root",
+      hasResume: true,
+      jdSteering: false,
+    });
+    expect(j.stages.map((s) => s.id)).not.toContain("tailor");
+    expect(j.availability.tailor).toBe(false);
+    expect(Object.keys(j.availability).sort()).toEqual(
+      JOURNEY_STAGES.map((s) => s.id).sort(),
+    );
+  });
+});

--- a/src/lib/journey.ts
+++ b/src/lib/journey.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The top-level journey model (issue #812) — the L1 arc the two HTML entries
+ * share.
+ *
+ * The product had navigation vocabulary at two levels and nothing at the top:
+ * L2 tabs ("Your resume", "Find jobs", …) read as peers you pick between, and
+ * building ONE job-search query got a four-step `Stepper` rail while the actual
+ * journey — add a résumé, fix it, download it, match jobs, tailor to one — got
+ * no signal at all, split across `/` and `/jobs/` with only two sessionStorage
+ * handoffs joining them. This module is the arc: five ordered stages, derived
+ * from signals the surfaces already have, of which four are always shown.
+ *
+ * It is a rail, not a wizard. Nothing is locked — a stage with nothing behind
+ * it yet explains what is missing and points back one step (see {@link
+ * isStageReachable} and each stage's `empty`), it does not refuse the click.
+ *
+ * Zero-dep, no IO, no React: the DECISION is factored out from the
+ * `window.location` / storage reads the way `jobs-landing.ts`'s
+ * `resolveInitialJobsTab` and `nav-return.ts`'s `shouldReturnViaHistory` are,
+ * so every branch is unit-testable on plain values. The surfaces
+ * (`App.tsx`, `jobs/JobsApp.tsx`) collect the signals; `PageShell` places the
+ * rail; `components/features/JourneyRail.tsx` draws it.
+ *
+ * Two derivation rules that a future reader will otherwise "fix":
+ *
+ *  1. **`download` is never `current`.** It is the terminal ACTION, not a place
+ *     you sit — a user who has exported is still on `Fix it` (or `Tailor`),
+ *     free to edit and export again. Marking it current the moment an export
+ *     happened would make the rail claim the journey ended.
+ *  2. **`add` is always reachable, and its availability still tracks the
+ *     résumé.** The two are different questions. Reachability is "may the user
+ *     click here" — always yes for the first stage, which has no earlier step
+ *     to point back to. Availability is "is there data behind this stage",
+ *     which is what the rail's ✓ mark states; on `/jobs/` with no résumé
+ *     anywhere, a ✓ on `Add résumé` would be a visible lie.
+ *  3. **VISIBILITY is a third question, separate from both.** `availability`
+ *     stays keyed by every stage id even when {@link Journey.stages} omits
+ *     one — the data either exists or it does not, regardless of what this
+ *     surface draws. Only `tailor` is ever omitted; see `isStageVisible`.
+ */
+
+export type JourneyStageId = "add" | "fix" | "match" | "tailor" | "download";
+
+/** Which HTML entry the rail is rendering on. */
+export type JourneyEntry = "root" | "jobs";
+
+/** What the rail shows when a stage has nothing behind it yet. */
+export interface JourneyStageEmptyState {
+  /**
+   * The guidance card's body. User-facing product copy: it names what the
+   * stage gives the user and what to do first, in the words a visitor arrives
+   * with — never internal vocabulary, never a claim we cannot back.
+   */
+  guidance: string;
+  /** The stage the guidance's CTA sends the user back to. */
+  prerequisite: JourneyStageId;
+}
+
+export interface JourneyStage {
+  id: JourneyStageId;
+  /**
+   * The user-facing stage name. `Match jobs` is deliberate and must not be
+   * renamed to "Find jobs": `/` already has an L2 tab labelled exactly that
+   * (`ResultDetailTabs`) and `/jobs/` has one labelled "Search", and an L1
+   * stage sharing a name with an L2 tab is the exact ambiguity this rail
+   * exists to remove.
+   */
+  label: string;
+  /** Null for the first stage: it is always directly reachable, so it never
+   *  has an empty state to render. */
+  empty: JourneyStageEmptyState | null;
+}
+
+/**
+ * The arc, in order. `Fix it` deliberately collapses three L2 tabs (Your
+ * resume, Local AI feedback, Raw text & flags) into one L1 stage — L1 marks
+ * the arc, L2 owns the detail underneath.
+ */
+export const JOURNEY_STAGES: readonly JourneyStage[] = [
+  {
+    id: "add",
+    label: "Add résumé",
+    empty: null,
+  },
+  {
+    id: "fix",
+    label: "Fix it",
+    empty: {
+      guidance:
+        "See what a text extractor reads back from your file, and correct anything it got wrong — in place, without leaving this page. Add your résumé first.",
+      prerequisite: "add",
+    },
+  },
+  {
+    // `download` sits DIRECTLY after `fix`, ahead of the job-search half of
+    // the arc, because a clean exported PDF is useful on its own: a user who
+    // came only to repair what an extractor reads back is finished here and
+    // never needs a job board. Putting the export last implied the opposite —
+    // that the résumé lane is a prologue to the search lane — and buried the
+    // one action that lets a user leave with something in hand.
+    id: "download",
+    label: "Download",
+    empty: {
+      guidance:
+        // Not "the résumé you fixed here": `/`'s cold-mount auto-restore
+        // (#812) can put a résumé on the page that the user has not touched
+        // this session, and the export works the same either way.
+        "Download a clean, single-column PDF built from the résumé on this page. Add your résumé first.",
+      prerequisite: "add",
+    },
+  },
+  {
+    id: "match",
+    label: "Match jobs",
+    empty: {
+      guidance:
+        "Search job boards and read the results ranked by how well they fit your résumé. Add your résumé first.",
+      prerequisite: "add",
+    },
+  },
+  {
+    id: "tailor",
+    label: "Tailor",
+    empty: {
+      guidance:
+        // "Steers the rewrite" was internal vocabulary naming a feature the
+        // reader may not have met — and this string renders on `/jobs/`, where
+        // there is no rewrite UI on screen at all. Says what the user gets;
+        // the second sentence still names the real button label verbatim.
+        "Tailoring rewrites your résumé against one specific job posting. Pick a job first, then use its “Tailor résumé to this job” button.",
+      prerequisite: "match",
+    },
+  },
+] as const;
+
+/**
+ * Is this stage worth showing at all, given where the user is?
+ *
+ * Only `tailor` is ever hidden, and the reason is that it is the one stage
+ * with no way to *enter it from the rail*. Tailoring is always started from a
+ * SPECIFIC posting — a `JobResultCard`'s "Tailor résumé to this job" button,
+ * or `PasteJdPanel`'s — so on a cold `/` the rail was advertising a step whose
+ * only honest instruction was "go somewhere else and click a different
+ * button". A permanently unreachable stage reads as a broken one.
+ *
+ * So it appears exactly where it means something: on `/jobs/`, where the
+ * button that starts it is on screen, and on `/` while a JD is actually
+ * steering the rewrite — which is the one moment `Tailor` is the current
+ * stage. Everywhere else the arc is four stages, and nothing is hidden that
+ * the user could have acted on.
+ */
+function isStageVisible(
+  id: JourneyStageId,
+  { entry, jdSteering }: Pick<JourneySignals, "entry" | "jdSteering">,
+): boolean {
+  if (id !== "tailor") return true;
+  return entry === "jobs" || jdSteering;
+}
+
+/** The inputs the arc is derived from — all of them already on screen. */
+export interface JourneySignals {
+  /** Which HTML entry this rail is rendering on. */
+  entry: JourneyEntry;
+  /** Is there a parsed résumé this browser can act on right now? */
+  hasResume: boolean;
+  /** Is a JD-driven rewrite steering the résumé (a consumed tailor handoff)? */
+  jdSteering: boolean;
+}
+
+export interface Journey {
+  /** The one stage the user is on. Never `download` — see the module docblock. */
+  current: JourneyStageId;
+  /** Per stage: is there data behind it? Drives the rail's "ready" mark and
+   *  whether a click lands on content or on the guidance card. Keyed by EVERY
+   *  stage id, including ones absent from {@link stages} — availability is a
+   *  fact about the data, not about what is currently on screen. */
+  availability: Record<JourneyStageId, boolean>;
+  /**
+   * The stages to render, in order — {@link JOURNEY_STAGES} minus any the
+   * signals make meaningless here (see `isStageVisible`). The rail must map
+   * over THIS, not the full list, and number the steps from it: "Step 4 of 5"
+   * announced over a four-entry rail is a miscount a screen-reader user has no
+   * way to correct.
+   */
+  stages: readonly JourneyStage[];
+}
+
+/** Look a stage up by id. Throws rather than returning undefined — every id in
+ *  {@link JourneyStageId} is in {@link JOURNEY_STAGES} by construction, and a
+ *  silent undefined would render a blank rail entry instead of failing loudly. */
+export function journeyStage(id: JourneyStageId): JourneyStage {
+  const stage = JOURNEY_STAGES.find((s) => s.id === id);
+  if (stage === undefined) throw new Error(`unknown journey stage: ${id}`);
+  return stage;
+}
+
+/**
+ * Derive the arc from the signals. Pure; safe to call during render, which is
+ * the point — the rail must never depend on a mount-only `useEffect(…, [])`,
+ * because the `/jobs/` → `/` return leg is a bfcache restore and never remounts
+ * the tree (measured on #706, and the exact defect #783 fixed).
+ */
+export function deriveJourney({
+  entry,
+  hasResume,
+  jdSteering,
+}: JourneySignals): Journey {
+  const availability: Record<JourneyStageId, boolean> = {
+    add: hasResume,
+    fix: hasResume,
+    match: hasResume,
+    // `&& hasResume` is normalized HERE rather than left to the callers, even
+    // though both of today's callers already never pass steering without a
+    // résumé. Rule 2 above says the ✓ mark must never be a visible lie, and an
+    // invariant a pure function only holds when its callers remember is one
+    // refactor away from not holding — a third caller reintroduces it silently,
+    // because nothing in the signature says the two inputs are related.
+    tailor: jdSteering && hasResume,
+    download: hasResume,
+  };
+
+  // `/jobs/` IS the Match-jobs stage, whether or not a résumé reached it — a
+  // user standing on the search surface with nothing to search against is
+  // still standing there, and the surface says so in its own empty state.
+  const current: JourneyStageId =
+    entry === "jobs"
+      ? "match"
+      : !hasResume
+        ? "add"
+        : jdSteering
+          ? "tailor"
+          : "fix";
+
+  return {
+    current,
+    availability,
+    stages: JOURNEY_STAGES.filter((s) => isStageVisible(s.id, { entry, jdSteering })),
+  };
+}
+
+/**
+ * Does clicking this stage go somewhere, or does it need explaining first?
+ *
+ * Three ways a click lands on real content: the stage has data behind it, it is
+ * the stage the user is already on (the surface under it is what it is — the
+ * rail must not shadow it with a card), or it is the first stage, which has no
+ * earlier step its guidance could point back to.
+ */
+export function isStageReachable(journey: Journey, id: JourneyStageId): boolean {
+  return (
+    journey.availability[id] ||
+    journey.current === id ||
+    journeyStage(id).empty === null
+  );
+}

--- a/src/lib/resume-library.ts
+++ b/src/lib/resume-library.ts
@@ -169,6 +169,26 @@ export async function listLibrary(): Promise<ResumeLibraryEntry[]> {
     .sort((a, b) => b.savedAt - a.savedAt);
 }
 
+/**
+ * The id of the most recently saved entry, or `undefined` for an empty list.
+ *
+ * Two consumers now ask the same question — `/jobs/`'s tracker fallback
+ * (`useFallbackResume`, #724) and `/`'s cold-mount auto-restore
+ * (`useAutoRestoreResume`, #812) — so the answer has one definition. Reduces to
+ * the largest `savedAt` rather than taking `listLibrary`'s first element: that
+ * function does sort newest-first today, and this deliberately does not lean on
+ * that staying true, since a caller holding a list from anywhere else would get
+ * a silently wrong résumé rather than a type error.
+ */
+export function newestLibraryEntryId(
+  entries: readonly ResumeLibraryEntry[],
+): string | undefined {
+  if (entries.length === 0) return undefined;
+  return entries.reduce((newest, entry) =>
+    entry.savedAt > newest.savedAt ? entry : newest,
+  ).id;
+}
+
 /** The kind a record's stored bytes actually are, for a record whose snapshot
  *  cannot say. Reverse of {@link MIME}; unknown/blank types read as `pdf`,
  *  which is what every producer that writes bytes writes today. */

--- a/src/lib/tailor-handoff.ts
+++ b/src/lib/tailor-handoff.ts
@@ -95,6 +95,39 @@ export function writeTailorHandoff(payload: TailorHandoff): void {
 }
 
 /**
+ * Is a handoff payload waiting, without consuming it?
+ *
+ * Deliberately separate from {@link consumeTailorHandoff}, and pure, for the
+ * same reason `nav-return.ts` keeps `readDepartureMarker` apart from
+ * `clearDepartureMarker`: the clear belongs to the surface that actually
+ * absorbs the payload, never to whoever merely asks whether one exists.
+ *
+ * The caller this exists for is `/`'s cold-mount auto-restore
+ * (`useAutoRestoreResume`, #812). A pending payload means a SPECIFIC parse is
+ * expected back on this page — the one whose fingerprint it carries — so
+ * hydrating a different résumé from the library would hand it to the wrong
+ * consumer, and `consumeTailorHandoff` clears unconditionally, including on the
+ * mismatch, so that consumer would destroy the payload rather than pass on it.
+ * Answering the question with a consuming read would have exactly the same
+ * effect, which is why this one does not.
+ *
+ * Answers only "is the key present and non-empty", not "is it valid for me":
+ * validity is a fingerprint comparison the real consumer makes with its own
+ * parse in hand, and this caller has no parse at all yet.
+ *
+ * Non-throwing: inaccessible storage reads as "nothing pending", which resolves
+ * to the pre-#812 behaviour of restoring normally.
+ */
+export function hasPendingTailorHandoff(): boolean {
+  try {
+    const raw = sessionStorage.getItem(TAILOR_HANDOFF_KEY);
+    return raw !== null && raw.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read AND clear the handoff payload (one-shot), returning it only when it
  * was written for the caller's own parse.
  *

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,8 +2,55 @@
 @import "./design-system/styles/theme.css"; /* semantic vocabulary → var() — stable contract */
 @import "@design-tokens"; /* default raw values — swappable via the Vite @design-tokens alias */
 
+/* `PageShell`'s header is `sticky top-0` (#812), so every scroll target on
+   both entries would otherwise come to rest UNDERNEATH the pinned band: the
+   native `#contact` / `#reconstructed-resume` hash anchors the score tiles
+   link to (`lib/anchors.ts`), and the `scrollIntoView({ block: "start" })`
+   calls in `ReconstructedResume` (Fix now) and `JobSearchResults` (page
+   change). `scroll-padding-top` on the scrolling root is what covers BOTH in
+   one declaration — a per-target `scroll-mt-*` only reaches the hash-anchor
+   half, because `scrollIntoView` honours scroll-padding on the scrollport but
+   is not affected by any margin the caller did not put there.
+
+   Two values, split at `lg`. The rail itself no longer changes layout at any
+   breakpoint — it takes a full-width row of its own everywhere — so the split
+   is now purely about how many rows the BRAND ROW wraps into: below `lg` the
+   brand and the CTA cluster can end up stacked, above it they never do. Height
+   here is otherwise CONTENT-driven, not breakpoint-driven: it depends on the
+   star count's width, on whether the surface passes a `subtitle` and a
+   `headerExtra`, and on the `max-w-5xl` cap that stops the header ever getting
+   wider than ~976px. So each band is sized to the MEASURED MAXIMUM across both
+   entries rather than to a formula, and no third media query is invented for a
+   wrap point that would drift the first time the CTA row changes.
+
+   Measured (Chromium, both entries, 15 widths from 320 to 1920):
+
+     below lg   both entries 147 at 320–414 (brand row and CTA row stack, then
+                the rail's own row below them). `/jobs/` hits 147 again at 640,
+                where its extra `headerExtra` button re-wraps the brand row that
+                `/` keeps on one line — which is why this band is NOT sized from
+                `/` alone                                         → band max 147
+     lg and up  both entries 119 at every width ≥ 1024 — brand row on one line,
+                rail on its own below it. `max-w-5xl` caps the content width, so
+                nothing collapses further no matter how wide the viewport gets
+                                                                  → band max 119
+
+   `/jobs/` is not the incidental case here: it is where `JobSearchResults`
+   fires `scrollIntoView({ block: "start" })` on every results page change.
+   Over-padding costs whitespace above the target; under-padding hides the
+   target, which is the defect. */
 html {
   font-size: 16px;
+  /* 160px: the 147px band, plus 13px so the target is visibly clear of the
+     border rather than flush against it. */
+  scroll-padding-top: 10rem;
+}
+
+@media (min-width: 1024px) {
+  html {
+    /* 128px: the 119px band, plus 9px of the same clearance. */
+    scroll-padding-top: 8rem;
+  }
 }
 
 body {


### PR DESCRIPTION
## Summary

Adds `JourneyRail`, the L1 navigation the product never had: an ordered arc — Add résumé → Fix it → Download → Match jobs → Tailor — rendered from `PageShell` on both HTML entries, in a full-width row of its own at every width. It is a rail, not a wizard: every stage stays clickable, and a stage with no data behind it renders a guidance card naming its prerequisite instead of refusing the click.

Résumé auto-restore on cold mount of `/` ships in the same change because the two are one behaviour — a sticky rail claiming "you are at step 3" while the app has silently forgotten the user's work is worse than no rail at all.

No new `fetch`, no analytics event, no storage schema change, no change to either handoff's payload. The three egress paths are untouched.

Closes #812

## Three decisions that differ from the issue body

The issue body predates a design review on the rendered UI; these supersede it and the body has been annotated to match.

1. **The rail always takes its own row** (issue Decision 3 had it inside the header row from `lg:` up). Sharing the row made the arc read as one more header control beside "Saved jobs" and the star CTA — the exact L1-vs-L2 confusion this issue exists to remove — and forced a third content-sized breakpoint band whose chips were sized by whatever width was left after the brand and CTAs took theirs. It is now a sibling of the brand row, not a wrap-item in it.
2. **Download moved ahead of the job-search half** (was last). A user who came only to repair what a text extractor reads back is finished at Download and never needs a job board; putting the export last implied the résumé lane is a prologue to the search lane.
3. **Tailor renders only where it can be started** (issue Decision 6 derived it purely from `jdContext`). Tailoring always begins at a specific posting's "Tailor résumé to this job" button, so on a cold `/` the rail was advertising a step whose only honest instruction was "go somewhere else and press a different button". It now appears on `/jobs/`, where that button is on screen, and on `/` while a JD is actually steering the rewrite. Everywhere else the arc is four stages.

Consequence worth flagging: the issue's "sticky header ≤ 48px desktop" budget is **not** met — the header is 119px at `lg`+ and 147px below, because a dedicated rail row costs a line. That budget was written assuming the in-header-row placement that decision 1 drops.

## Visual redesign of the rail

The first version rendered as a flat row of numerals on a near-invisible track — indistinguishable from a `Tabs` bar, with inactive entries as grey text on a grey surface. Now each state carries its own **marker shape and glyph**, so all three survive a greyscale render rather than leaning on the accent hue:

| State | Marker | Label |
|---|---|---|
| Current | filled disc + numeral, on `surface-card` | `content-primary`, semibold |
| Ready | ringed disc + ✓ (U+2713 U+FE0E) | `content-primary`, medium |
| Upcoming | hairline disc + numeral | `content-secondary`, normal |

Also fixed: the chips sat `gap-0.5` (2px) apart, so two adjacent 44px touch targets had a 2px gutter and a mis-tap landed on the neighbouring stage. Now 8px.

## Review focus

- `src/lib/journey.ts` — `stages` is the rendered subset and the rail numbers from it. Is there a signal combination where `current` could fall outside `stages`? (There is a test asserting there is not, across all 8 combinations.)
- `src/lib/journey.ts` — `availability` stays keyed by every stage id even when `stages` omits one. Right call, or should a hidden stage have no availability answer at all?
- `src/styles.css` — `scroll-padding-top` is set on the scrolling root, not per target, and the two bands are hand-measured. Does a global root value perturb any nested scroll container or dialog?
- `src/hooks/useAutoRestoreResume.ts:142` — the tailor-handoff gate sits *after* the attempt is spent. Right ordering if a handoff were written between the library resolving and the load returning?
- `src/App.tsx` — `setJdContext(null)` keyed on `parseKey`. Does it cover the two paths that leave `displayResult` non-null with no reporter mounted (blank authoring, `fonts_unmappable`)?

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run verify` green in the pre-push hook — **5566 tests passed**, 337 files, build ✓
- [x] ~50 tests across `journey`, `JourneyRail`, `useAutoRestoreResume`, `PageShell`, `ResultDetailTabs`
- [x] Mutation-verified: five guards each had their protection deliberately broken and every break was caught by a named test
- [x] **Verified in a real browser** (Chromium, both entries) — see below
- [ ] **Not done — browser Back between `/` and `/jobs/`, desktop and mobile.** Playwright's bundled Chromium ships with BackForwardCache disabled, so `event.persisted` is always `false` and no automated run can reproduce or refute it. Issue #812 calls it out as manual-only; it has not been performed.

### Browser verification

Measured on both entries at 15 widths from 320 to 1920:

- Header band: **147px** below `lg` (320–414 on both; `/jobs/` hits it again at 640, where its extra `headerExtra` button re-wraps a brand row that `/` keeps on one line), **119px** at every width ≥ 1024. `scroll-padding-top` is sized from those, and `#contact` / `#reconstructed-resume` were confirmed to land 33px clear of the pinned header at 1424px and 65px clear at 577px — not underneath it.
- At **320px with all five stages** (`/jobs/`): one row, no rail horizontal scroll, no page horizontal scroll, every trigger ≥ 44×44, gap exactly 8px.
- All three marker states confirmed rendering simultaneously on `/` with a résumé present, and Tailor confirmed absent on a cold `/` and present on `/jobs/`.

## Adversarial review — findings deferred out of scope

Real, and deliberately not fixed here. Recorded so they are not lost:

1. **#516 selection affordance is duplicated in a third place outside `src/design-system/`.** The recessed-track + surface/weight pattern is re-implemented in `JourneyRail`; extracting it is a design-system change.
2. **Two L1 stages resolve to the same landing.** `Fix it` and `Download` both land on `/`'s `reconstructed` tab — worth a follow-up on whether Download should open the export path directly.
3. **`llmOverride` payload divergence.** The rail's Match-jobs departure sends pre-recovery fields, matching the pre-existing behaviour of `goToSavedJobs`. Behaviour unchanged here; the `FindJobsLauncher` docblock was narrowed so it no longer over-claims.
4. **`SaveResumeBar` mints a duplicate entry** when saving a résumé that auto-restore put on the page. Auto-restore makes this reachable more often; the behaviour itself pre-exists.
5. **`PageShell` is past the ~200 LOC guideline.** `fallow` additionally flags `App` and `ResultDetailTabs` — all report-only, and both are inherited rather than introduced here.

## Provenance

| Stage | Model | Effort |
|---|---|---|
| Implementation | Claude Opus 5 (subagent, inherited session model) | high |
| Adversarial review — hooks, house style | Claude Opus 5 (subagents, inherited session model) | high |
| Review fixes | Claude Opus 5 (subagent, inherited session model) | high |
| Mutation verification | Claude Opus 5 — run directly, not delegated | high |
| Design revision + browser verification | Claude Opus 5 | high |
| Orchestration + PR | Claude Opus 5 | high |
| Verification | `npm run verify` — green locally; CI pending | — |
