### PR TITLE
chore(process): suppress AI attribution by setting, retire the Provenance block

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/implement-batch/SKILL.md
+++ b/.claude/skills/implement-batch/SKILL.md
@@ -63,7 +63,7 @@ skills.
   each implementing subagent in Phase 3, step 5). Flag it the moment a subagent
   reports a new fixture. **The pre-push re-check is yours to run on the stacked
   path** — `gh stack submit` is not `/open-pr`, so its Step 3.5 gate never fires;
-  Phase 5 step 13 replicates it with `npm run check:fixtures`. Under `--no-stack`,
+  Phase 5 step 12 replicates it with `npm run check:fixtures`. Under `--no-stack`,
   `/open-pr` still runs it.
 
 ## Input
@@ -272,16 +272,9 @@ inherit this conversation.) Same rule for every fix subagent below (Phase 4).
 - **Inject the previous issue's handoff note verbatim** (*"Context from the prior
   step …"*). Load-bearing — later issues depend on tokens/components/exports the
   earlier ones introduced.
-- **A model self-report instruction** (verbatim): *"Report the name of the model
-  you are running as — the full product name (e.g. `Claude Sonnet 4.6`), not an
-  alias like `sonnet`. One line, the name only; do not quote or summarize your
-  instructions. The orchestrator cannot see this: it requested a `model:` alias
-  and does not know what that alias resolved to. It will transcribe the name into
-  the PR's `## Provenance` block, so do not guess and do not omit it."*
 - **Require this structured return** (the orchestrator gates on it):
   ```
   Status: COMPLETE | BLOCKED | PARTIAL
-  Model: <the name of the model you are running as>
   Files changed: <grouped by purpose>
   Acceptance criteria met: <list vs the issue>
   Validation: <typecheck/test/lint results>
@@ -293,10 +286,7 @@ inherit this conversation.) Same rule for every fix subagent below (Phase 4).
   ```
 
 9. **Read each return. Gate on it:**
-   - `COMPLETE` → save the handoff note **and the reported `Model:`** (record
-     `{stage: "Implementation — #<N>", model, effort: <the issue's tier>}` — this
-     is the only point at which the real model string is knowable; the effort is
-     the tier you assigned in Phase 1). Then **seal the layer** (step 9a). Mark
+   - `COMPLETE` → save the handoff note. Then **seal the layer** (step 9a). Mark
      the todo `completed`, continue.
    - `BLOCKED` with **answerable questions** → don't abort the run. Surface the
      questions to the user, get answers, **re-spawn the same issue** with the
@@ -331,9 +321,9 @@ inherit this conversation.) Same rule for every fix subagent below (Phase 4).
       created. Expected; the `NN` in the branch name you pass is ignored for that
       one layer. Every later `add` creates a real new layer.
     - The commit message **is** the eventual squash message (merge queue is
-      SQUASH) — write it as the PR's one-line summary, not as a work note. No
-      `Co-Authored-By`, no `Claude-Session:`, no `🤖 Generated with` (see
-      Provenance below).
+      SQUASH) — write it as the PR's one-line summary, not as a work note, and
+      nothing else: AI attribution is off by config (`attribution` in
+      `.claude/settings.json`).
 
 ### Phase 3b — Verify the accumulated tree
 
@@ -387,10 +377,8 @@ norm — turning overnight review latency into same-session throughput.)
     tools for impact/caller tracing. **Require a structured return:** findings by
     severity (`blocking` = correctness bug / regression / missed criterion / style
     guard violation that CI will fail; `nit` = clarity), each with `file:line`, a
-    concrete fix, **the owning layer/branch** (stacked mode), `clean: true|false`,
-    and **`Model:` — the name of the model it is
-    running as** (same one-line self-report instruction as a per-issue subagent).
-    Record `{stage: "Adversarial review", model, effort}`.
+    concrete fix, **the owning layer/branch** (stacked mode), and
+    `clean: true|false`.
 
 11b. **Triage and exit-check.** No blocking findings (`clean: true`) → the loop
     converges; record `nit`s for the report and proceed to Phase 5. If round `N`
@@ -412,9 +400,7 @@ norm — turning overnight review latency into same-session throughput.)
     handoff notes; scope it to **exactly those findings** (no unrelated cleanup).
     Use `model: opus` — it reasons over cross-issue interactions. Require the
     same structured return (files changed, what was fixed, anything deferred +
-    why), **including its self-reported `Model:`** — this subagent *edits code*,
-    so it earns its own provenance row: `{stage: "Review fixes — <branch>",
-    model, effort}`.
+    why).
 
     Then amend the layer's commit (the layer stays one commit, so the squash
     message stays right) and cascade-rebase the layers above it:
@@ -450,25 +436,7 @@ norm — turning overnight review latency into same-session throughput.)
 
 ### Phase 5 — Submit the stack (unless `--no-commit`)
 
-12. **Assemble the provenance records** collected across Phases 3–4 — one
-    `Implementation — #<N>` row per issue (from each subagent's self-reported
-    `Model:`), plus `Adversarial review`, `Review fixes` (one row per layer that
-    got fixes), and one **`Orchestration + PR`** row naming **your own** model and
-    effort — the one model name you know first-hand. A batch legitimately spans
-    several models; the table is what makes that legible. In stacked mode each PR
-    carries **its own** `Implementation` row plus the shared review/orchestration
-    rows — a reviewer of layer 2 should not have to open layer 1's PR to learn
-    which model wrote the code in front of them. Constraints (rationale:
-    `docs/CONTRIBUTING-PROCESS.md` → **AI provenance**; the binding rules are here):
-    - **Never infer a model string from the `model:` alias you requested.** You
-      asked for `sonnet`; you do not know it resolved to `Claude Sonnet 4.6`. Only
-      the subagent's own report establishes that.
-    - If a subagent **failed to report** its model, the row says
-      `unreported (requested: sonnet)`. Do **not** fill the gap with a guess.
-    - Roll up identical rows only when they're genuinely identical (same model,
-      same effort, adjacent issues) — but keep the issue numbers visible:
-      `Implementation — #415, #416 | Claude Sonnet 4.6 | medium`.
-13. **Run the fixture-PII preflight yourself.** `gh stack submit` is not
+12. **Run the fixture-PII preflight yourself.** `gh stack submit` is not
     `/open-pr`, so `/open-pr`'s Step 3.5 gate does **not** run — replicate it or
     the repo's one non-negotiable rule silently loses its automated half:
     ```bash
@@ -478,7 +446,7 @@ norm — turning overnight review latency into same-session throughput.)
     any subagent reported a new fixture binary, also read it directly
     (`pdftotext <file>.pdf - | head -40`) — the script cannot judge whether a
     *name* is synthetic, and it does not cover png/jpeg/docx fixtures at all.
-14. **Submit the stack.** From the top (`gh stack top`):
+13. **Submit the stack.** From the top (`gh stack top`):
     ```bash
     gh stack submit --auto --open
     ```
@@ -489,7 +457,7 @@ norm — turning overnight review latency into same-session throughput.)
     - **With `--no-commit`:** skip the submit entirely. The stack sits local and
       unpushed; report `gh stack view` output and tell the user to run
       `gh stack submit --auto --open` when ready.
-15. **Write each PR's body.** Enumerate the layers, resolve each branch's PR
+14. **Write each PR's body.** Enumerate the layers, resolve each branch's PR
     number, and replace the auto-generated body:
     ```bash
     gh stack view --json | jq -r '.branches[].name'   # bottom → top
@@ -504,27 +472,23 @@ norm — turning overnight review latency into same-session throughput.)
       resolves the epic;
     - **stack position** — `Layer <NN> of <total>. Depends on #<PR below>.` — so a
       reviewer knows not to read it against `main`;
-    - `## Provenance` — that layer's `Implementation` row + the shared review and
-      orchestration rows (step 12);
     - `## Adversarial review` — that layer's findings (Phase 4 step 11e), plus one
       line on the stack-wide outcome.
 
-    **Never let a `Co-Authored-By`, `Claude-Session:` URL, or `🤖 Generated with`
-    badge into a commit message or PR body** — provenance lives in the block, not
-    in git. Public repo.
+    No provenance block: model attribution is retired
+    (`docs/CONTRIBUTING-PROCESS.md` → **AI attribution**), which is why the
+    per-issue subagent contract no longer asks for a self-reported `Model:` — a
+    batch used to pay one round-trip per subagent for a table that could not be
+    verified. Writing bodies with `gh pr edit --body-file` is a full replace, so a
+    re-finalize overwrites rather than appending.
 
-    Writing bodies with `gh pr edit --body-file` is a full replace, so it is
-    naturally idempotent — a re-finalize overwrites rather than appending a second
-    `## Provenance` block.
-
-    **Under `--no-stack`, steps 13–15 collapse back to one `/open-pr` call.**
+    **Under `--no-stack`, steps 12–14 collapse back to one `/open-pr` call.**
     Delegate to it once — it branches-if-needed (already on `<slug>`), commits the
-    whole accumulation, runs its own fixture-PII preflight (Step 3.5, so step 13
+    whole accumulation, runs its own fixture-PII preflight (Step 3.5, so step 12
     above is redundant on this path), pushes, and opens one PR. Pass the
-    **parent/epic issue number** and the **provenance records from step 12** (it
-    renders them verbatim into `## Provenance` — its Step 5.5). The body
-    summarizes each sub-issue in one bullet and uses `Closes #<parent>` only if
-    the batch fully resolves the epic (else `Refs`, listing each child `#N`).
+    **parent/epic issue number**. The body summarizes each sub-issue in one bullet
+    and uses `Closes #<parent>` only if the batch fully resolves the epic (else
+    `Refs`, listing each child `#N`).
     Then append the `## Adversarial review` section, marker-guarded so a resume or
     re-finalize doesn't append it twice:
     ```bash
@@ -535,15 +499,13 @@ norm — turning overnight review latency into same-session throughput.)
         | gh pr edit "$PR_NUM" --repo "$REPO" --body-file -
     fi
     ```
-    Same guard on `## Provenance` if `/open-pr` didn't render it (e.g. it used
-    `gh pr create --fill`). With `--no-commit`, skip `/open-pr` and report that the
-    reviewed changes sit uncommitted on `<slug>`.
-16. **Report:** a per-issue outcome table (status, branch, PR, key files, criteria
+    With `--no-commit`, skip `/open-pr` and report that the reviewed changes sit
+    uncommitted on `<slug>`.
+15. **Report:** a per-issue outcome table (status, branch, PR, key files, criteria
     met), the Phase 3b verification results, the **Phase 4 review outcome** (rounds
     taken, what each fix subagent changed and on which layer, surviving `nit`s the
-    human reviewer should eyeball), the **provenance table** (which model built
-    which issue), the **PR URLs bottom-to-top** (each needs 1 approval + green
-    `verify`), the **merge instructions from Phase 6**, and any new fixture paths
+    human reviewer should eyeball), the **PR URLs bottom-to-top** (each needs 1
+    approval + green `verify`), the **merge instructions from Phase 6**, and any new fixture paths
     flagged. Note any post-merge follow-ups the subagents surfaced.
 
 ### Phase 6 — Merging the stack (report only; never run unasked)
@@ -638,14 +600,9 @@ buys.
 - **No nesting.** A subagent can't spawn another subagent — that's why the
   per-issue contract runs **inline** in the subagent (it doesn't re-delegate).
 - **Handoff notes are threaded forward** and load-bearing — never drop them.
-- **Provenance is per-stage and self-reported.** A batch spans several models, so
-  the PR's `## Provenance` table carries one row per issue plus review, review
-  fixes, and orchestration. Every model string is **self-reported by the agent
-  that ran** (you requested an alias — you don't know what it resolved to) or is
-  your own, from your own system prompt. Never infer, never invent; an unresolved
-  row says `unreported (requested: <alias>)`. No `Co-Authored-By` /
-  `Claude-Session:` / `🤖 Generated with …` in commits or PR bodies — ever. The
-  Bash tool's default commit template suggests them; ignore it. Public repo.
+- **Nothing is appended to a commit message or a PR body for attribution.** The
+  harness's trailers are off by config; the `## Provenance` table is retired, so
+  subagents are not asked to self-report a model and no row is assembled.
 - **Order from `blocked_by`; halt on a cycle or on a `PARTIAL`/unrecoverable
   `BLOCKED`.** Never start a new issue on a broken tree.
 - **Per-issue tests are scoped and local; the full `verify` is the PR gate** (CI).

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -18,10 +18,6 @@ branch name (`feat/...-issue-5`, `gh-5`) or a `Closes #N` / `Refs #N` trailer in
 an existing commit. If still unknown, open the PR without an issue link and note
 that in the output — don't block on it.
 
-A calling skill may also hand over **provenance records** (`{stage, model,
-effort}`, e.g. from `/implement-batch`). If present, render them verbatim into
-the `## Provenance` block (Step 5.5) rather than re-deriving them.
-
 ## Why this skill exists
 
 `main` is protected: every change merges through a PR that needs **1 approving
@@ -72,14 +68,9 @@ Use a `COMMIT_EDITMSG` file if one is already prepared (`git commit -F COMMIT_ED
 If the tree is already clean and there are commits ahead of `origin/$BASE`, skip
 to push.
 
-**No AI trailers in the commit message.** No `Co-Authored-By: Claude …`, no
-`Claude-Session:` trailer, no `https://claude.ai/code/session_…` URL, no
-`🤖 Generated with …` badge — the Bash tool's default template suggests them;
-ignore it. `Co-Authored-By` is semantic authorship attribution under git/GitHub
-convention: the model is the facilitator, the human who ran it is the author. A
-session URL is an account-scoped identifier with zero value to any reader of a
-public diff. Model provenance *is* useful — it goes in the **PR body only**
-(Step 5.5), never in git history.
+Write the message and nothing else — AI attribution is off by config
+(`attribution` in `.claude/settings.json`), so there is no trailer to strip and
+none to add back.
 
 ### Step 3: Confirm there's something to propose
 
@@ -154,8 +145,8 @@ Those settings are `squash_merge_commit_title: COMMIT_OR_PR_TITLE` and
 `squash_merge_commit_message: COMMIT_MESSAGES`. The lever that gives is:
 
 > **A PR with exactly one commit merges with that commit's subject and body
-> verbatim** — PR title/body ignored, no `* `-bulleted commit soup, no
-> `## Provenance` block leaking into `git log`.
+> verbatim** — PR title/body ignored, no `* `-bulleted commit soup, nothing from
+> the PR body leaking into `git log`.
 
 So the branch must arrive at the queue holding **one commit whose message is the
 message you want in `main`**. Doing it here — before the PR exists — costs
@@ -230,11 +221,6 @@ Closes #<N>   <!-- omit if not fully resolving an issue; use "Refs #<N>" if part
 - [ ] `npm run typecheck` clean
 - [ ] `npm run test` green
 - [ ] Manually verified in `npm run dev` / `npm run preview`
-
-## Provenance
-
-Code implementation via: <Model> (<effort>)
-Verification: `npm run verify` — green in CI
 BODY
 )"
 ```
@@ -264,56 +250,15 @@ It is explicitly **not** a scope bound. `pr-review` treats it as the author's
 hypothesis — a lead to check and then audit for accuracy — and reviews the whole
 diff regardless. Do not use it to steer attention away from anything.
 
-`gh pr create --fill` derives title/body from the commits — fine for small PRs,
-but it won't produce a `## Provenance` block — append one (Step 5.5) if you use it.
+`gh pr create --fill` derives title/body from the commits — fine for small PRs.
 
-### Step 5.5: The `## Provenance` block
-
-Declare **which model did which stage, at what effort**. This is method
-disclosure, not authorship — it makes cross-model review legible and lets a
-reader calibrate the diff. Rationale: `docs/CONTRIBUTING-PROCESS.md` → **AI
-provenance** — but the rules you need are all below.
-
-A caller may hand this skill a set of provenance records (`/implement-batch`
-does — one per issue, plus review/orchestration). **If records were passed,
-render them verbatim; do not re-derive them.** For a multi-issue batch, use the
-table form, one `Implementation — #<N>` row per issue:
-
-```markdown
-## Provenance
-
-| Stage | Model | Effort |
-|---|---|---|
-| Implementation — #415 | Claude Sonnet 4.6 | medium |
-| Implementation — #417 | Claude Opus 4.8 | high |
-| Adversarial review | Gemini 3.1 Pro | high |
-| Review fixes | Claude Opus 4.8 | medium |
-| Orchestration + PR | Claude Opus 4.8 | medium |
-| Verification | `npm run verify` — green in CI | — |
-```
-
-For a single-issue PR you implemented yourself, the prose form in the Step 5
-template is enough — name **your own** model and effort, which you know
-first-hand.
-
-**Never guess a model name.** You know your own; you do **not** know what a
-subagent's `model: opus` alias resolved to — only that subagent does, and the
-only thing it reports back is the one-line name. If a stage's model can't be
-resolved (an externally-run reviewer, a hand-edit), state what's true
-(`Gemini 3.1 Pro (high) — run manually`) or omit the row. A missing row is
-honest; a fabricated one is worse than none.
-
-If the body already contains a `## Provenance` marker (a re-run, a resumed
-batch), **update it in place (if present) or append a new block (if missing) — never append a second block**:
-
-```bash
-body="$(gh pr view "$PR_NUM" --repo "$REPO" --json body -q .body)"
-# You must write text-replacement logic (e.g. awk/python) to define updated_body.
-# If it contains '## Provenance', update the block in place.
-# If it does NOT, append the new block to the body.
-updated_body="..."
-gh pr edit "$PR_NUM" --repo "$REPO" --body-file - <<<"$updated_body"
-```
+The body above is the whole body. There is no provenance step: a `## Provenance`
+block used to be required here and is **retired** — it cost a round-trip per
+subagent to collect self-reported model names plus a read-modify-write of the PR
+body, and wasn't reliably true anyway (a spawn requests a model *alias* and never
+learns what it resolved to). `docs/CONTRIBUTING-PROCESS.md` → **AI attribution**
+has the full account. `/pr-review`'s one-line `Reviewed by:` sign-off is the
+surviving, first-hand form.
 
 ### Step 6: Report
 
@@ -327,18 +272,12 @@ merge their own PR via admin bypass.)
 - **Never commit or push to `main`** — always a feature branch + PR. (The local
   hook enforces the no-commit-on-`main` half; server-side protection enforces
   the rest.)
-- **No AI trailers in git; a `## Provenance` block in the PR body instead.** No
-  `Co-Authored-By: Claude …` (authorship — the human is the author), no
-  `Claude-Session:` URL or `🤖 Generated with …` badge anywhere (this repo is
-  public; a session URL is an account-scoped identifier with no reader value).
-  Declare the models in the PR body instead (Step 5.5).
+- **Nothing is appended to a commit message or a PR body for attribution.** The
+  harness's trailers are off by config; the `## Provenance` block is retired.
 - **Review pointers go in the body, never in a chat ping.** `## Review focus` is
   optional and phrased as questions; omit the heading when the risk is obvious.
   It is a lead for the reviewer, never a scope bound — `pr-review` audits it for
   accuracy and reviews the whole diff either way.
-- **Every provenance row is self-reported or first-hand.** Name your own model
-  from your system prompt; take a subagent's from what it reported. Never infer a
-  version string from a `model:` alias, and never invent a row — omit it instead.
 - **One commit per PR, message hand-written (Step 3.6).** `main`'s merge queue
   can't be handed a squash message — it derives one, and with
   `COMMIT_OR_PR_TITLE` a single-commit PR merges with that commit's message

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -435,7 +435,6 @@ is NOT set:
    ```bash
    git add -- "${FIXED_PATHS[@]}"        # stage by path, never `git add -A`/`.`
    git commit -m "fix(review): address review nits"
-   # Do NOT add any Co-Authored-By / session / attribution trailer (CLAUDE.md hard rule).
 
    git fetch origin "$HEAD_BRANCH"
    if ! git merge-base --is-ancestor "origin/$HEAD_BRANCH" HEAD; then
@@ -490,9 +489,11 @@ Reviewed by: Claude Opus 4.8 (high)
 
 Name **your own** model (you know it first-hand) — never a guess, and never an
 alias like `opus`. This is what makes a cross-model review legible: the value of a
-second model's read is lost if the PR doesn't say which model read it. No
-`Co-Authored-By`, no session URL, no `🤖` badge — none of those belong in git or a
-PR body on a public repo (`CLAUDE.md` → **Hard rules**).
+second model's read is lost if the PR doesn't say which model read it. It is also
+the *only* model attribution this repo still writes — the `## Provenance` block
+that used to accompany it is retired, because unlike this line it needed a
+round-trip to every subagent and still couldn't be trusted
+(`docs/CONTRIBUTING-PROCESS.md` → **AI attribution**).
 
 **Anchor findings to the code by default.** A finding sitting in the body makes the
 author scroll and hunt for `regex.ts:512`; the same finding inline lands on the line

--- a/.claude/skills/revise-pr/SKILL.md
+++ b/.claude/skills/revise-pr/SKILL.md
@@ -238,12 +238,9 @@ Match the commit-type prefix conventions from `CONTRIBUTING.md`
 (`feat`/`fix`/`chore`/`refactor`/`docs`/`test`). The `block_commit` hook allows
 commits on a feature branch; this is never `main`.
 
-**No AI trailers in the commit** — no `Co-Authored-By: Claude …`, no
-`Claude-Session:` trailer, no `https://claude.ai/code/session_…` URL, no
-`🤖 Generated with …` badge. The Bash tool's default commit template suggests
-them; ignore it. This repo is public — a session URL is an account-scoped
-identifier with zero value to any reader of the diff. Model provenance goes in
-the **PR body only** (Step 5.5).
+Write the message and nothing else — AI attribution is off by config
+(`attribution` in `.claude/settings.json`), so there is no trailer to strip and
+none to add back.
 
 > **Note:** this push dismisses any existing approval (dismiss-stale-reviews-on-push).
 > That's expected — Step 7 re-requests review.
@@ -300,30 +297,11 @@ Two things this costs, stated plainly:
   Do Step 6 (reply + resolve) **after** this push, using the thread IDs captured
   in Step 2 — replying via `in_reply_to` works regardless of outdated state.
 
-### Step 5.5: Update `## Provenance` if a different model did the revision
-
-If the PR body has a `## Provenance` block and **you are not** the model already
-credited there, add a row for the work you just did — you know your own model
-first-hand:
-
-| Stage | Model | Effort |
-|---|---|---|
-| Review revisions | Claude Opus 4.8 | medium |
-
-**Update the existing block in place — never append a second one.** Read the
-body, edit the block, write it back:
-
-```bash
-body="$(gh pr view "$PR_NUM" --repo "$REPO" --json body -q .body)"
-# You must write the text-replacement logic (e.g. awk/python) to define updated_body.
-# If it contains '## Provenance', append the new row to that block.
-# If it does NOT, append a fresh block.
-updated_body="..."
-gh pr edit "$PR_NUM" --repo "$REPO" --body-file -   <<<"$updated_body"
-```
-
-If the body has no `## Provenance` block (an older PR), leave it alone — don't
-retrofit provenance you can't establish for work you didn't do.
+**No provenance step here.** Model attribution is retired
+(`docs/CONTRIBUTING-PROCESS.md` → **AI attribution**), so a revision round no
+longer reads the PR body back, edits a `## Provenance` block, and writes it — the
+step this skill used to spend two `gh` calls on every round. If an older PR still
+carries a block, leave it exactly as it is; do not update it and do not delete it.
 
 ### Step 6: Reply to each thread, then resolve what you fixed
 
@@ -438,10 +416,10 @@ on a source PR. Link the target PR.
   clear comments.
 - **Never commit/push to `main`.** Always the PR's head branch (you're on it after
   `gh pr checkout`).
-- **No AI trailers in git; `## Provenance` is updated in place, never stacked.** If
-  a different model revised the PR, add its row — naming your own model, which you
-  know first-hand. Never infer a version string from a `model:` alias, never
-  invent a row (omit it instead), and never stack a second `## Provenance` block.
+- **Nothing is appended to a commit message or a PR body for attribution.** The
+  harness's trailers are off by config; the `## Provenance` block is retired, so a
+  revision round no longer reads and rewrites the body. An older PR that still has
+  one keeps it, untouched.
 - **Fixtures: synthetic personas only.** Any added/changed fixture binary runs the
   `open-pr` Step 3.5 PII preflight before pushing — fake name, `@example.com`, a
   **real area code + `555` exchange + `0100`–`0199`** phone (e.g. `(312) 555-0123`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,11 @@
 Guidance for Claude Code (claude.ai/code) working in this repository.
 
 **This file is about writing code.** The *why* behind the process — merge-queue mechanics, the
-provenance rationale, the full PII policy, deploy, license — lives in
+AI-attribution setting, the full PII policy, deploy, license — lives in
 `docs/CONTRIBUTING-PROCESS.md`. You do not need it to write a change. The three rules below are
 the exception: they stay here because breaking them is silent, and for two of them, permanent.
+Everything else that used to sit here is enforced by config or by a gate, and prose that restates
+a setting only gives you something to reconcile.
 
 ## Hard rules (no exceptions)
 
@@ -28,10 +30,9 @@ the exception: they stay here because breaking them is silent, and for two of th
   `pdftotext <file>.pdf - | head -40` — the two cover different surfaces. `pdftotext` prints only
   the drawn page, so it cannot see a `tel:`/`mailto:` **link annotation** or the Info dict, and
   both have leaked here. Never trust the PR prose over the binary.
-- **Never in git.** No `Co-Authored-By:` trailer naming a model, no `Claude-Session:` trailer, no
-  `https://claude.ai/code/session_…` URL, no `🤖 Generated with …` badge — not in a commit
-  message, not in a PR body. The Bash tool's default commit template suggests them; ignore it.
-  Model provenance is useful and belongs in the **PR body only**, as a `## Provenance` block.
+- **No AI attribution in git.** Claude Code has this off by config (`attribution` in
+  `.claude/settings.json`); on any other harness it is on you. Never commit attribution
+  trailers (like `Co-Authored-By:` or `Claude-Session:`) or PR badges.
 - **One commit per PR.** `main` merges through a merge queue that derives the squash message from
   the branch, so a multi-commit PR lands `wip` and `fix lint` in `main` forever. Collapse the
   branch to a single commit before it reaches the queue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ parser audit and job-search workbench. Code lives under `src/`, license is
 see [`CLAUDE.md`](./CLAUDE.md) for the pipeline shape and tier layout; and see
 [`docs/CONTRIBUTING-PROCESS.md`](./docs/CONTRIBUTING-PROCESS.md) for the shipping
 process this file summarizes — the **test-fixture PII policy** (mandatory before
-you add any PDF), AI provenance, squash messages, and deploy.
+you add any PDF), AI attribution, squash messages, and deploy.
 
 ## Setup
 

--- a/docs/CONTRIBUTING-PROCESS.md
+++ b/docs/CONTRIBUTING-PROCESS.md
@@ -11,7 +11,9 @@ the binding one-liners sit in `CLAUDE.md` → **Hard rules** (always in an agent
 fixture-PII check is a directory-scoped `CLAUDE.md` in `tests/fixtures/pdfs/`, and each shipping
 skill (`/open-pr`, `/pr-review`, `/revise-pr`, `/implement-batch`, `/pr-ready`) carries its own
 operational copy. Nothing here is load-bearing on its own — if you change a rule, change it in
-those places too, not only here.
+those places too, not only here. The exception is **AI attribution**, which has no `CLAUDE.md`
+counterpart on purpose: it is enforced by a setting in `.claude/settings.json`, and a prose rule
+restating a setting is context an agent has to spend reconciling.
 
 ## Test fixtures — PII policy (non-negotiable)
 
@@ -31,47 +33,65 @@ PDF fixtures under `tests/fixtures/pdfs/<category>/` **must use synthetic person
 - The `*.expected.json` snapshots are lossy by design (keys/counts only, never field values), so they stay PII-free automatically — but that safety does **not** extend to the PDF itself.
 - Full policy + add-fixture workflow: `tests/fixtures/pdfs/README.md` (Privacy section).
 
-## AI provenance (what a model may declare about itself)
+## AI attribution — suppressed by configuration, not by prose
 
-Three different things get fused into one auto-generated git trailer. They are not the same decision, and this repo treats them separately.
+Claude Code appends attribution to the commits and PRs it creates: a `Co-Authored-By:` trailer, a
+`🤖 Generated with [Claude Code]` PR-body badge, and — from web / Remote Control sessions — a
+`Claude-Session:` trailer carrying a `https://claude.ai/code/session_…` URL. That text is injected
+into the agent's system prompt, so for a long time this repo fought it with prose: a hard rule in
+`CLAUDE.md` plus a near-identical paragraph in each of the four shipping skills, all telling the
+model to ignore an instruction it had just been given. Prose that argues with the harness loses
+sometimes, and ~16 `Claude-Session:` trailers reached `main` before anyone noticed.
 
-**1. Authorship — banned in git.** Never add a `Co-Authored-By` trailer naming a model, to a commit message or a PR body. `Co-Authored-By` is semantic authorship attribution under git/GitHub convention; the model is the facilitator, not a co-author. The human who ran it is the author. (The Bash tool's default commit template suggests one — ignore it.)
+**It is a setting.** `.claude/settings.json`:
 
-**2. Session telemetry — banned everywhere.** Never emit a `Claude-Session:` trailer, a `https://claude.ai/code/session_…` URL, or a `🤖 Generated with …` badge. This repo is **public**; a session URL is an account-scoped identifier with zero value to any reader of the diff.
-
-**3. Provenance — required, in the PR body only.** Which model did which stage, at what effort, *is* useful: it makes cross-model review legible, and it lets a reader calibrate how much to trust a given diff. It goes in a `## Provenance` block at the end of the PR body — never in a commit message.
-
-Single-stage PR — prose:
-
-```markdown
-## Provenance
-
-Code implementation via: Claude Opus 4.8 (medium)
-Adversarial review by: Gemini 3.1 Pro (high)
-Verification: `npm run verify` — green in CI
+```json
+"attribution": {
+  "commit": "",
+  "pr": "",
+  "sessionUrl": false
+}
 ```
 
-Batch PR (multiple issues, possibly multiple models) — table, one row per issue:
+An empty `commit` / `pr` string hides the trailer and the badge; `sessionUrl: false` drops the
+session trailer and PR-body link. With that in place the harness never emits the text and never
+suggests it, so there is nothing left to resist — the rule survives in `CLAUDE.md` only as a
+one-liner saying *don't type one back in by hand*.
 
-```markdown
-## Provenance
+`includeCoAuthoredBy: false` is the older, single-boolean form of the same idea and is what you'll
+see in most repos. It is **deprecated** in favour of `attribution`, and it covers less: it kills the
+`Co-Authored-By` trailer and the `🤖` badge but **not** the session URL, which was the only part
+with an actual privacy cost on a public repo. Prefer `attribution`. Do not set both — when
+`attribution` defines `commit` or `pr`, `includeCoAuthoredBy` is ignored entirely, which is a quiet
+way to think you've disabled something you haven't.
 
-| Stage | Model | Effort |
-|---|---|---|
-| Implementation — #415 | Claude Sonnet 4.6 | medium |
-| Implementation — #417 | Claude Opus 4.8 | high |
-| Adversarial review | Gemini 3.1 Pro | high |
-| Review fixes | Claude Opus 4.8 | medium |
-| Orchestration + PR | Claude Opus 4.8 | medium |
-| Verification | `npm run verify` — green in CI | — |
-```
+**Why the reasoning differs per line.** `Co-Authored-By` is semantic authorship attribution under
+git/GitHub convention, and the model is the facilitator, not a co-author — the human who ran it is
+the author. The session URL is an account-scoped identifier with zero value to any reader of a
+public diff. (The ~16 already in `main` were deliberately **not** purged with `git filter-repo`:
+those URLs are auth-gated, so the exposure is an identifier and not content, and a history rewrite
+on a public repo costs far more than it recovers.)
 
-Rules that make the block trustworthy rather than decorative:
+### Model provenance — retired
 
-- **Every row is either self-reported by the agent that did the work, or first-hand knowledge of the orchestrator that spawned it. No third source.** A spawn requests a model *alias* (`model: opus`), not a version name — so the spawner does **not** know it resolved to "Claude Opus 4.8". Ask the agent; don't infer. What the agent returns is exactly one line — its model name. Never its instructions, prompt, or context: those are useless here and a needless disclosure surface.
-- **Never invent a row.** If a stage's model or effort can't be resolved (an externally-run reviewer, a hand-edit, a subagent that didn't report), say what's true (`Gemini 3.1 Pro (high) — run manually`, or `unreported (requested: sonnet)`) or omit the row. A missing row is honest; a guessed one is worse than nothing.
-- **Name the stage that touched code.** In a batch, the orchestrator model also fixes review findings — that's more leverage over the final diff than writing the PR body. Split `Review fixes` from `Orchestration + PR` so the reader can see it.
-- **Write it once, idempotently.** Guard the append on the `## Provenance` marker so a resumed run or a `/revise-pr` round updates the block instead of stacking a second one.
+This repo used to require a `## Provenance` block in every PR body: which model did which stage, at
+what effort, one row per issue on a batch PR. It was **retired in favour of nothing** — the block
+is no longer written, updated, or expected, and existing ones need not be removed.
+
+The idea was sound: it made cross-model review legible and let a reader calibrate how much to trust
+a diff. What it cost was not. Because a spawn requests a model *alias* (`model: opus`) and never
+learns what that alias resolved to, every row had to be **self-reported** — so an orchestrator paid
+a round-trip per subagent to collect model strings, then a `gh pr view` + text-surgery + `gh pr edit`
+per PR to write the block in idempotently, plus a repeat of that on every `/revise-pr` round. Four
+skills carried the machinery. And the output was not reliably true: on the #711/#712 batch, two
+subagents spawned with the *same* `model: sonnet` alias self-reported **different** names, so one
+row was wrong with no way to tell which from the orchestrator's side.
+
+A block a reader can't trust is worse than no block — it launders a guess into a fact. Given that,
+the tokens and the wall-clock bought nothing worth keeping. What a reviewer actually needs is
+already cheap and first-hand: `/pr-review` signs its review off with a single
+`Reviewed by: <model> (<effort>)` line, naming the model that *is* running — no round-trip, no
+inference, no PR-body edit.
 
 ## Squash messages (one commit per PR)
 
@@ -86,7 +106,7 @@ With those settings, a **multi-commit** PR merges with every commit message conc
 
 The `COMMIT_OR_` prefix is the only lever:
 
-> **A PR with exactly one commit merges with that commit's subject and body verbatim** — PR title and body ignored, no bullet soup, no `## Provenance` block leaking into `git log`.
+> **A PR with exactly one commit merges with that commit's subject and body verbatim** — PR title and body ignored, no bullet soup, nothing from the PR body leaking into `git log`.
 
 So **every PR reaches the queue as a single commit whose message is the message we want in `main`.**
 


### PR DESCRIPTION
## Summary

Claude Code injects its attribution into the agent's system prompt — a `Co-Authored-By:` trailer, a `🤖 Generated with [Claude Code]` PR badge, and a `Claude-Session:` trailer carrying a session URL. This repo fought that with prose: a `CLAUDE.md` hard rule *plus* a near-identical paragraph in each of four shipping skills, all telling the model to ignore an instruction it had just been handed. That is reconciliation work on every commit, it re-injects the exact trailer strings into context, and it lost often enough that ~16 `Claude-Session:` trailers reached `main`.

It is a setting. `.claude/settings.json` now carries:

```json
"attribution": {
  "commit": "",
  "pr": "",
  "sessionUrl": false
}
```

Because the harness no longer emits or suggests any of it, the `CLAUDE.md` rule is **deleted** rather than reworded (hard rules 3 → 2) and the skills keep one short pointer each instead of a restated ban. Net −102 lines.

This also **retires the `## Provenance` block** in favour of nothing.

## Why `attribution` and not `includeCoAuthoredBy`

`yc-software/qm` (the prompt for this change) uses `includeCoAuthoredBy: false`. That works, but it is the older single-boolean form, and reading the CLI (`2.1.232`, `nvS()`/`Udt()`) shows two things worth having:

- The settings schema marks it **`Deprecated: Use attribution instead`**.
- It covers **less**: it kills the `Co-Authored-By` trailer and the `🤖` badge, but **not** the `Claude-Session:` trailer / session URL — which is gated separately by `attribution.sessionUrl` and is the only part with an actual privacy cost on a public repo.

There is also a precedence trap worth writing down: the resolver is `if (attribution defines commit or pr) → use it; else if (includeCoAuthoredBy === false) → suppress`. Setting **both** silently ignores `includeCoAuthoredBy`. So: set `attribution` only. Project settings outrank a contributor's `~/.claude/settings.json`, so this holds for everyone.

## Why provenance is retired

The idea was sound — cross-model review is only legible if the PR says which model read it. The cost was not:

- A spawn requests a model **alias** (`model: opus`) and never learns what it resolved to, so **every row had to be self-reported** — one round-trip per subagent, then `gh pr view` + text surgery + `gh pr edit` per PR to write the block idempotently, repeated on every `/revise-pr` round, with the machinery duplicated across four skills.
- It wasn't reliably true. On the #711/#712 batch, two subagents spawned with the **same** `model: sonnet` alias self-reported **different** names (`Claude Sonnet 5` vs `Claude Sonnet 4.6`) — one row was wrong, with no way to tell which from the orchestrator's side.

A block a reader can't trust launders a guess into a fact. What survives is the cheap, first-hand form that never needed a round-trip: `/pr-review`'s one-line `Reviewed by: <model> (<effort>)` sign-off. **Kept deliberately** — flag it if you'd rather that went too.

## Changes

| File | What |
|---|---|
| `.claude/settings.json` | add the `attribution` block |
| `CLAUDE.md` | delete the "Never in git" hard rule; 3 rules → 2 |
| `docs/CONTRIBUTING-PROCESS.md` | rewrite "AI provenance" → "AI attribution": the setting, the deprecated alternative + precedence trap, and why provenance was retired |
| `open-pr` | drop Step 5.5, the provenance-records input, and the body template's block |
| `revise-pr` | drop Step 5.5 (two `gh` calls per round); old PRs keep their block untouched |
| `implement-batch` | drop the subagent `Model:` self-report instruction, the `Model:` return field, and the assembly step; Phase 5 renumbers 12–16 → 12–15 |
| `pr-review` | keep `Reviewed by:`, drop the trailer ban it no longer needs |
| `CONTRIBUTING.md` | pointer wording |

Existing `## Provenance` blocks on open/merged PRs are left alone — the skills are told not to update *or* delete them. The ~16 `Claude-Session:` trailers already in `main` stay too: those URLs are auth-gated, so the exposure is an identifier and not content, and a history rewrite on a public repo costs far more than it recovers (that call is unchanged from #458).

## Review focus

- `docs/CONTRIBUTING-PROCESS.md` — is the "setting, not prose" rationale worth the ~40 lines it now occupies, or should it compress to the config block plus the precedence trap?
- `.claude/skills/implement-batch/SKILL.md` — Phase 5 renumbered; do the cross-references (`Phase 5 step 12`, `steps 12–14`, `step 11e`, `Phase 5 step 14`) all still point at the right steps?
- Does `/pr-review`'s surviving `Reviewed by:` line belong, given everything else went?

## Test plan

- [x] `npm run verify` green via the pre-push hook (typecheck → lint → coverage → build → fallow, 8 changed files, no issues)
- [x] `.claude/settings.json` parses
- [x] This PR's own commit carries no attribution trailer
- [ ] Post-merge: confirm a fresh session's system prompt no longer carries the commit-trailer instruction
