### PR TITLE
perf(verify): scope the local test run, cache Tier 0 extraction, narrow the Stop hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,20 +63,38 @@ Release planning runs on GitHub Milestones (P1 Friends & Family → P4 Post-Publ
 Vite 7 + React 19 + TypeScript 5.8 + Tailwind 3.4. Vitest runs against `vite.config.ts` (Node env, globals on). pdfjs-dist 4.x; the worker is configured once at app boot in `src/main.tsx` via Vite's `?url` import. No router (single-page app), no SSR/prerender. Analytics are env-gated (`VITE_POSTHOG_KEY`) and dead-code-eliminated when unset — see `src/lib/analytics.ts`.
 
 ```bash
-npm run dev        # vite dev server (https://localhost:5173 — TLS, self-signed)
-npm run dev:http   # plain http, for LAN demos; costs WebGPU (see README)
-npm run build      # tsc -b && vite build → dist/
-npm run test       # vitest run
-npm run typecheck  # tsc -b --noEmit
-npm run lint       # eslint .
-npm run verify     # full local CI mirror: typecheck → lint → coverage → build → fallow
+npm run dev          # vite dev server (https://localhost:5173 — TLS, self-signed)
+npm run dev:http     # plain http, for LAN demos; costs WebGPU (see README)
+npm run build        # tsc -b && vite build → dist/
+npm run test         # vitest run
+npm run typecheck    # tsc -b --noEmit
+npm run lint         # eslint .
+npm run verify:quick # inner-loop gate: typecheck → lint → change-scoped tests
+npm run verify       # local pre-push gate: typecheck → lint → gates → tests → build → fallow
 ```
 
-`npm run verify` is the canonical pre-push gate — the exact CI sequence. A git `pre-push` hook runs it automatically (installed by `npm install`); bypass with `OFFLINECV_SKIP_HOOKS=1`.
+**Three layers, cheapest first** (#828). `verify:quick` runs on every Claude Code Stop that followed a `src/**.ts{,x}` edit (`scripts/hooks/lint_and_test.sh`) — many times an hour, so it carries only what a bad edit actually breaks. `npm run verify` is the canonical pre-push gate, run automatically by a git `pre-push` hook (installed by `npm install`). CI runs everything with coverage.
+
+Nothing `verify:quick` skips is skipped for good — the build, `check:core`, `check:fixtures`, `check:baselines` and fallow all re-run at pre-push — and each is also inapplicable at Stop by construction, since the sentinel only fires for `.ts`/`.tsx` under `src/`: `tsc -b --noEmit` already types the sources `vite build` would bundle; `check:core` packs the `@offlinecv/core` tarball, which is not under `src/`; `check:fixtures` and `check:baselines` read PDFs and JSON sidecars, which a `.ts` edit cannot change; and fallow is report-only anyway. Bypass every local layer with `OFFLINECV_SKIP_HOOKS=1`.
+
+**`verify` is no longer the exact CI sequence, on purpose** (#828). CI runs the whole suite with coverage every time; `verify` runs `npm run test:changed`, which scopes the run to `vitest --changed` when *every* changed path is an added-or-modified `.ts`/`.tsx` under `src/`, and runs everything otherwise — a fixture, a JSON baseline, a lockfile, a config, anything under `scripts/`, or any deletion or rename all fall back to the full suite, because vitest's module graph cannot see those. `OFFLINECV_FULL_TESTS=1` forces the full run. Branch protection requires the CI job, so a local under-selection costs a red check, never a bad merge — do not treat a green `verify` as CI having passed.
 
 **fallow is report-only inside `verify`.** The step ends `|| echo '…report-only, ignored'`, so a `fallow audit` exit 1 (complexity / CRAP / duplication) does **not** fail `verify` — branch protection requires only the `verify` job. A fallow complexity/CRAP finding on a PR is a **Nit / Secondary**, never Blocking on its own.
 
-**While iterating, prefer the narrow gate** — `npx vitest run <path>` on the files you touched, plus `npm run typecheck`. Save the full `verify` for when you think you're done. It runs coverage + build + fallow and is slow enough to cost you iterations.
+**While iterating, prefer the narrow gate** — `npx vitest run <path>` on the files you touched, plus `npm run typecheck`; `npm run verify:quick` is the same idea with the selection made for you, and is what the Stop hook runs. Save `verify` for when you think you're done: it still runs the build, the packaging and fixture gates, and fallow, and on any change it cannot scope it still runs all 348 test files.
+
+**Killing a test run does not kill its workers.** vitest runs files in a `tinypool` fork pool, and the forks are not in the parent's wait chain — Ctrl-C, an agent tool timeout, or a killed background task reaps the parent and leaves the pool spinning at ~100% CPU per worker. Nine survived one interrupted run here and pushed load average to 110. They own no port and no lockfile, so nothing complains; they just make every later timing wrong. **After any interrupted or timed-out run, reap explicitly** — do not assume the tool that killed it did:
+
+```bash
+pkill -f vitest || true    # matches the pool workers, which retitle to "vitest N"
+uptime                     # 1-minute average should fall back toward idle
+```
+
+**Do not measure anything on a loaded machine.** Check `uptime` first; if the 1-minute load average is above the core count (`sysctl -n hw.ncpu`), a timing is noise, not signal. This is not hypothetical — the same probe measured 43s and 126s; the first root-cause diagnosis in #828 was wrong because of it, and so was its follow-up claim that `poolOptions.forks.isolate=false` "never finished inside 600s" — and so was the 78s that replaced *that*, since it finishes in ~25s on a genuinely idle machine. Note also that most cores here are efficiency cores (`hw.perflevel1.logicalcpu`), so identical work lands on very different clocks run to run. Quote a comparison, not an absolute, and say what else was running.
+
+**Tier 0 extraction is cached on disk during tests** (#829). Six suites re-parse the same 58 fixtures in separate forks, and pdfjs extraction is ~82% of a parse and a pure function of the bytes, so `test.alias` in `vite.config.ts` redirects the one specifier `cascade.ts` dynamic-imports to `src/lib/heuristics/__test-utils__/extract-cache.ts`. Nothing in the production bundle is involved and no suite changed — they all still call `runCascade(bytes)`. Worth ~40% of the wall on those six suites, ~4% on a full run.
+
+The cache key is the bytes plus a fingerprint of every source file the extraction transitively reaches (walked, not hand-listed), plus `vite.config.ts` and the `pdfjs-dist` version — so editing a Tier 1 file leaves it warm while editing `line-assembly.ts` cools it. **It must fail closed**: a stale entry turns the corpus green against work it never did, which is worse than the slowness. `UPDATE_FIXTURES=1` (so `npm run bake-fixtures`) bypasses it in both directions. To rule it out while debugging a parse, `OFFLINECV_NO_EXTRACT_CACHE=1 npx vitest run …`, or `rm -rf node_modules/.cache/offlinecv-extract`. One caveat it is worth knowing about: `PdfTextItem.fontName` is labelled per loaded document by pdfjs, so a cached result carries labels a fresh extraction would not — safe because the field is opaque and `dropDecorativeGlyphs` has already consumed it, and pinned to that one field by `extract-cache.test.ts`.
 
 ## Pipeline shape
 

--- a/docs/CONTRIBUTING-PROCESS.md
+++ b/docs/CONTRIBUTING-PROCESS.md
@@ -11,9 +11,9 @@ the binding one-liners sit in `CLAUDE.md` → **Hard rules** (always in an agent
 fixture-PII check is a directory-scoped `CLAUDE.md` in `tests/fixtures/pdfs/`, and each shipping
 skill (`/open-pr`, `/pr-review`, `/revise-pr`, `/implement-batch`, `/pr-ready`) carries its own
 operational copy. Nothing here is load-bearing on its own — if you change a rule, change it in
-those places too, not only here. The exception is **AI attribution**, which has no `CLAUDE.md`
-counterpart on purpose: it is enforced by a setting in `.claude/settings.json`, and a prose rule
-restating a setting is context an agent has to spend reconciling.
+those places too, not only here. **AI attribution** is the partial exception: it is enforced by a
+setting in `.claude/settings.json`, so its `CLAUDE.md` counterpart is deliberately thin — a
+one-liner for the harnesses that setting does not reach, rather than prose restating it.
 
 ## Test fixtures — PII policy (non-negotiable)
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:changed": "node scripts/select-tests.mjs",
     "bake-fixtures": "UPDATE_FIXTURES=1 vitest run src/lib/heuristics/corpus.test.ts",
     "fidelity": "vite-node scripts/fidelity.ts --",
     "fixture-derive": "vite-node scripts/fixture-derive.ts --",
@@ -31,7 +32,8 @@
     "check:baselines": "node scripts/check-known-failures.mjs",
     "check:core": "node scripts/check-core-package.mjs",
     "test:coverage": "vitest run --coverage",
-    "verify": "tsc -b --noEmit && eslint . && npm run check:fixtures && npm run check:baselines && npm run check:core && vitest run --coverage && vite build && (fallow audit --base origin/main --coverage coverage/coverage-final.json || echo 'fallow audit exited non-zero (report-only, ignored)')"
+    "verify:quick": "tsc -b --noEmit && eslint . && npm run test:changed",
+    "verify": "tsc -b --noEmit && eslint . && npm run check:fixtures && npm run check:baselines && npm run check:core && npm run test:changed && vite build && (fallow audit --base origin/main || echo 'fallow audit exited non-zero (report-only, ignored)')"
   },
   "dependencies": {
     "@fontsource/poppins": "^5.2.7",

--- a/scripts/hooks/check_conventions.py
+++ b/scripts/hooks/check_conventions.py
@@ -17,8 +17,9 @@ Checks:
    ``src/lib/analytics.ts``. The build-time ``VITE_POSTHOG_KEY`` gate
    only dead-code-eliminates the SDK when every touchpoint funnels
    through that single file. Memory: pattern_env_gated_oss_telemetry.
-4. Tier discipline — only ``src/lib/heuristics/cascade.ts`` (and
-   ``*.test.ts`` files) may import the tier modules ``pdf-extract``,
+4. Tier discipline — only ``src/lib/heuristics/cascade.ts`` (plus
+   ``*.test.ts`` files and anything under a ``__test-utils__/``
+   directory) may import the tier modules ``pdf-extract``,
    ``openresume``, or ``regex-fallback``. Production code goes through
    ``runCascade()``. CLAUDE.md "Pipeline shape".
 5. No raw ``console.log`` in ``src/lib/``. Easy to slip in during
@@ -78,6 +79,14 @@ def main() -> None:
 
     rel_str = str(rel)
     is_test = ".test." in fp.name
+    # Test-only, but not a test *file*: helpers under `__test-utils__/`. The
+    # repo already treats that directory as non-production (vite.config.ts
+    # drops `src/**/__test-utils__/**` from coverage), and #829 put a real
+    # consumer there — the aliased stand-in for `pdf-extract.ts`, which has to
+    # name the tier module it wraps. Rule 4 below exempts it for that reason;
+    # the SPDX rule deliberately does not, since these files still ship in the
+    # OSS tree.
+    is_test_only = is_test or "__test-utils__" in rel.parts
 
     # 1: SPDX header on non-test source files. (Test files inherit
     # licensing from the package; the 3-line block is for distributed
@@ -115,9 +124,9 @@ def main() -> None:
                 f"Memory: pattern_env_gated_oss_telemetry.",
             )
 
-    # 4: tier discipline. Only cascade.ts (and *.test.ts files) may name
+    # 4: tier discipline. Only cascade.ts (and test-only code) may name
     # the tier modules in an import. Production code calls runCascade.
-    if rel_str != CASCADE_REL and not is_test:
+    if rel_str != CASCADE_REL and not is_test_only:
         for mod in TIER_MODULES:
             # Match the bare module token in any import shape:
             #   import … from "./pdf-extract"

--- a/scripts/hooks/lint_and_test.sh
+++ b/scripts/hooks/lint_and_test.sh
@@ -2,12 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 The offlinecv Authors
 #
-# Stop hook: when format_typescript.sh's per-session sentinel exists,
-# run `npm run verify` (the full local CI mirror — typecheck, lint,
-# coverage, build, and report-only fallow). Exits non-zero on failure so
-# the transcript surfaces red checks even when Claude said "done."
+# Stop hook: when format_typescript.sh's per-session sentinel exists, run
+# `npm run verify:quick` — typecheck, lint, and the change-scoped test run.
+# Exits non-zero on failure so the transcript surfaces red checks even when
+# Claude said "done."
 #
-# Override: OFFLINECV_SKIP_HOOKS=1.
+# WHY NOT THE FULL `verify` (#828). This fires on EVERY Stop that followed a
+# `src/**.ts{,x}` edit — many times an hour — and it is the innermost of three
+# layers, not the last one:
+#
+#   Stop (here)  typecheck + lint + change-scoped tests
+#   pre-push     `npm run verify` (scripts/install-git-hooks.mjs)
+#   CI           the whole suite with coverage, plus build and fallow
+#
+# So everything this drops is re-run before the change can leave the machine,
+# and dropping it buys back the inner loop:
+#
+#   - `vite build` — `tsc -b --noEmit` already types the same sources; a
+#     bundler-only break is rare and pre-push catches it.
+#   - `check:core` — packs and consumes the `@offlinecv/core` tarball. The
+#     sentinel only fires for `src/`, which that package does not live in.
+#   - `check:fixtures` / `check:baselines` — read PDFs and JSON sidecars. Same
+#     argument: a `.ts` edit cannot change either. (The PII rule is a hard rule,
+#     so note what this does NOT weaken: `verify` at pre-push and CI both still
+#     run `check:fixtures`, and the fixture edit that would trip it is not a
+#     `.ts` edit, so it never set this sentinel in the first place.)
+#   - `fallow audit` — report-only inside `verify` already; its exit is ignored.
+#
+# Override: OFFLINECV_SKIP_HOOKS=1. `OFFLINECV_FULL_TESTS=1` still forces the
+# scoped test run back to the whole suite (see scripts/select-tests.mjs).
 
 set -euo pipefail
 
@@ -32,8 +55,8 @@ cd "$REPO_ROOT"
 # Fresh clone before `npm install`: don't fail Stop on it.
 [[ -f package.json && -d node_modules ]] || exit 0
 
-if ! out="$(npm run --silent verify 2>&1)"; then
-  echo "offlinecv stop hook: verify failed (typecheck/lint/test/build)" >&2
+if ! out="$(npm run --silent verify:quick 2>&1)"; then
+  echo "offlinecv stop hook: verify:quick failed (typecheck/lint/tests)" >&2
   printf '%s\n' "$out" | tail -40 >&2
   exit 2
 fi

--- a/scripts/select-tests.mjs
+++ b/scripts/select-tests.mjs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Change-scoped test selector for the LOCAL pre-push gate (#828).
+ *
+ * `npm run verify` ran the whole suite on every push: 348 files, ~165s, of which
+ * 64% is spent parsing the fixture PDFs through pdfjs whether or not the push
+ * touched the parser. This script decides — from the changed paths alone —
+ * whether that whole suite is needed, and otherwise hands vitest a `--changed`
+ * range so it selects tests off its own module graph.
+ *
+ * CI IS UNCHANGED and still runs everything (`.github/workflows/ci.yml` calls
+ * `npm run test:coverage` directly, not this script). That asymmetry is the whole
+ * safety argument: branch protection requires the CI `verify` job, so a local
+ * under-selection can cost a red check, never a bad merge. Nothing here is
+ * allowed to become the last line of defence.
+ *
+ * ── Why vitest's graph, and not a hand-maintained "heavy suites" list ──
+ * The obvious design is to tag the slow suites and skip them unless a trigger
+ * path changes. It was measured and rejected. The 18 slowest files transitively
+ * reach 93 modules across 12 directories — `heuristics/`, `pdf/`, `edit/`,
+ * `score/`, but also `contact/`, `lexicon/`, `rewrite-review/`, `webllm/`,
+ * `hooks/` and two files loose in `src/lib/`. A hand-written trigger list over
+ * that surface is wrong the first time someone adds an import, and it fails
+ * SILENTLY (the test is skipped, the gate stays green). `vitest --changed` reads
+ * the real graph, so it cannot drift. It also follows the tier `import()`s in
+ * `cascade.ts` — verified by editing `openresume.ts`, which is reached only
+ * dynamically, and watching all three corpus suites get selected.
+ *
+ * ── The one thing the graph cannot see ──
+ * The corpus suites do not IMPORT their fixtures. They `readdirSync` the
+ * `tests/fixtures/pdfs/` tree and `readFileSync` each PDF (see
+ * `corpus.test.ts:116`, `projections.test.ts:122`,
+ * `export-layout-contract.test.ts:68`), and the same is true of every
+ * `*.expected.json` snapshot, `*.truth.json` ground truth and
+ * `*.known-failures.json` ratchet. None of those files is a module, so adding a
+ * fixture is invisible to `--changed` — the exact change that most needs the
+ * corpus to run selects nothing at all.
+ *
+ * Hence the rule, which is deliberately one sentence rather than a trigger table:
+ * SCOPE THE RUN ONLY WHEN EVERY CHANGED PATH IS AN ADDED-OR-MODIFIED `.ts`/`.tsx`
+ * FILE UNDER `src/`. Anything else — a fixture, a JSON baseline, a lockfile, a
+ * config, anything under `scripts/` or `packages/`, or ANY deletion or rename —
+ * runs the full suite. Every unknown fails toward running more, so a future file
+ * type nobody thought about is safe by default, and the failure mode of getting
+ * the rule wrong is a slow gate rather than a missed regression.
+ *
+ * Deletions are called out separately because they are the one SOURCE change the
+ * graph mishandles: a deleted module is absent from the graph it used to be in,
+ * so its dependents' tests are not selected and the breakage surfaces only in CI.
+ *
+ * Escape hatch: `OFFLINECV_FULL_TESTS=1` forces the full suite. It composes with
+ * the existing `OFFLINECV_SKIP_HOOKS=1`, which skips the gate entirely.
+ */
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/** Where the push range is measured from when the caller names no base. */
+export const DEFAULT_BASE = "origin/main";
+
+/**
+ * Decide what to run from a `git diff --name-status` listing.
+ *
+ * Pure over already-collected git output so the rule is unit-testable without a
+ * repository — the collection below is the part that needs one.
+ *
+ * @param {Array<{status: string, path: string}>} changes
+ * @returns {{mode: "full" | "changed", reason: string}}
+ */
+export function decideSelection(changes) {
+  if (changes.length === 0) {
+    // No diff at all. Something is off with the range (a stale `origin/main`, a
+    // detached HEAD), and an empty selection would make the gate a no-op, which
+    // is the one outcome worse than a slow gate.
+    return { mode: "full", reason: "no changed paths resolved from the range" };
+  }
+
+  for (const { status, path } of changes) {
+    // `git diff --name-status` prefixes renames/copies with a similarity score
+    // (`R096`, `C075`); a bare letter is everything else.
+    const kind = status[0];
+    if (kind !== "A" && kind !== "M") {
+      return { mode: "full", reason: `${path} is not an add or a modify (${status})` };
+    }
+    if (!path.startsWith("src/")) {
+      return { mode: "full", reason: `${path} is outside src/` };
+    }
+    if (!path.endsWith(".ts") && !path.endsWith(".tsx")) {
+      return { mode: "full", reason: `${path} is not a module vitest can graph` };
+    }
+  }
+
+  return {
+    mode: "changed",
+    reason: `${changes.length} changed path(s), all added/modified TS under src/`,
+  };
+}
+
+/** Run a git command, returning its stdout or `null` if git itself failed. */
+function git(args) {
+  const run = spawnSync("git", args, { encoding: "utf8" });
+  if (run.status !== 0) return null;
+  return run.stdout;
+}
+
+/**
+ * Collect every path the push would carry: committed changes since `base`, plus
+ * whatever is still uncommitted. The gate runs before a push but a developer can
+ * invoke it by hand mid-edit, and a selection that ignored the working tree
+ * would test a tree that does not exist.
+ *
+ * @returns {{changes: Array<{status: string, path: string}>, base: string} | null}
+ *   `null` when the base ref cannot be resolved — the caller runs everything.
+ */
+export function collectChanges(base = DEFAULT_BASE) {
+  if (git(["rev-parse", "--verify", "--quiet", `${base}^{commit}`]) === null) {
+    return null;
+  }
+
+  const ranges = [
+    ["diff", "--name-status", `${base}...HEAD`],
+    ["diff", "--name-status", "HEAD"],
+  ];
+
+  /** @type {Map<string, string>} */
+  const byPath = new Map();
+  for (const args of ranges) {
+    const out = git(args);
+    if (out === null) return null;
+    for (const line of out.split("\n")) {
+      if (!line.trim()) continue;
+      const [status, ...paths] = line.split("\t");
+      // A rename line carries both the old and the new path; the old one is the
+      // deletion half, and `decideSelection` rejects the whole run on the status
+      // anyway, so recording either is enough.
+      for (const path of paths) byPath.set(path, status);
+    }
+  }
+
+  // Untracked files are additions git's diff does not report.
+  const untracked = git(["ls-files", "--others", "--exclude-standard"]);
+  if (untracked !== null) {
+    for (const line of untracked.split("\n")) {
+      if (line.trim()) byPath.set(line, "A");
+    }
+  }
+
+  return {
+    base,
+    changes: [...byPath].map(([path, status]) => ({ status, path })),
+  };
+}
+
+async function main() {
+  const base = process.argv[2] ?? DEFAULT_BASE;
+  const forced = process.env.OFFLINECV_FULL_TESTS === "1";
+
+  const collected = forced ? null : collectChanges(base);
+  const decision = forced
+    ? { mode: "full", reason: "OFFLINECV_FULL_TESTS=1" }
+    : collected === null
+      ? { mode: "full", reason: `cannot resolve ${base}` }
+      : decideSelection(collected.changes);
+
+  const args =
+    decision.mode === "full" ? ["run"] : ["run", "--changed", collected.base];
+
+  console.log(
+    decision.mode === "full"
+      ? `▸ full suite — ${decision.reason}`
+      : `▸ scoped to changes since ${collected.base} — ${decision.reason}`,
+  );
+
+  const run = spawnSync("npx", ["vitest", ...args], { stdio: "inherit" });
+  process.exitCode = run.status ?? 1;
+}
+
+// Only select when run as a script; importing this module (the unit tests do)
+// must not shell out to vitest.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/scripts/select-tests.test.mjs
+++ b/scripts/select-tests.test.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit tests for the local test selector (#828).
+ *
+ * `decideSelection` is the whole gate — every path below it either runs vitest
+ * or does not — and it only ever gets one thing wrong in a way that matters:
+ * scoping a run that should have been full. So the assertions here are about
+ * what it REFUSES to scope. Each case is a real input class that carries a
+ * regression vitest's module graph cannot see: a fixture PDF and a JSON baseline
+ * (read off disk, never imported), a deletion (absent from the graph it used to
+ * be in), a lockfile (pdfjs-dist and pdf-lib both live behind it).
+ *
+ * The single "scoped" case is deliberately outnumbered. Under-running is the
+ * failure mode with teeth; over-running only costs time.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { decideSelection } from "./select-tests.mjs";
+
+const mode = (changes) => decideSelection(changes).mode;
+
+describe("decideSelection", () => {
+  it("scopes when every change is added-or-modified TS under src/", () => {
+    expect(
+      mode([
+        { status: "M", path: "src/lib/heuristics/openresume.ts" },
+        { status: "A", path: "src/components/features/CritiquePanel.tsx" },
+      ]),
+    ).toBe("changed");
+  });
+
+  it("runs everything when a fixture PDF changes — the corpus reads it off disk, so the graph is blind to it", () => {
+    expect(
+      mode([{ status: "A", path: "tests/fixtures/pdfs/latex/new-persona.pdf" }]),
+    ).toBe("full");
+  });
+
+  it("runs everything when a JSON baseline changes, for the same reason as the PDF", () => {
+    expect(
+      mode([
+        { status: "M", path: "src/lib/heuristics/corpus-roundtrip.known-failures.json" },
+      ]),
+    ).toBe("full");
+  });
+
+  it("runs everything on a deletion — the dependents of a deleted module are not in the graph either", () => {
+    expect(mode([{ status: "D", path: "src/lib/heuristics/sweep.ts" }])).toBe(
+      "full",
+    );
+  });
+
+  it("runs everything on a rename, which git reports with a similarity score", () => {
+    expect(mode([{ status: "R096", path: "src/lib/score/score.ts" }])).toBe(
+      "full",
+    );
+  });
+
+  it("runs everything when the lockfile moves — pdfjs-dist and pdf-lib are behind it", () => {
+    expect(mode([{ status: "M", path: "package-lock.json" }])).toBe("full");
+  });
+
+  it("runs everything for a change under scripts/, which is outside src/", () => {
+    expect(mode([{ status: "M", path: "scripts/check-fixture-pii.mjs" }])).toBe(
+      "full",
+    );
+  });
+
+  it("runs everything when the range resolves to nothing, rather than becoming a no-op gate", () => {
+    expect(mode([])).toBe("full");
+  });
+
+  it("runs everything when one path in an otherwise-scopable set disqualifies it", () => {
+    expect(
+      mode([
+        { status: "M", path: "src/lib/heuristics/openresume.ts" },
+        { status: "M", path: "vite.config.ts" },
+      ]),
+    ).toBe("full");
+  });
+
+  it("names the disqualifying path, so a full run is explainable rather than mysterious", () => {
+    expect(
+      decideSelection([{ status: "M", path: "vite.config.ts" }]).reason,
+    ).toContain("vite.config.ts");
+  });
+});

--- a/src/lib/heuristics/__test-utils__/extract-cache.test.ts
+++ b/src/lib/heuristics/__test-utils__/extract-cache.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Guards the three ways the #829 extraction cache could quietly lie:
+ *
+ *   1. The serializer drops `columnBoundaries` (a `Map`, which
+ *      `JSON.stringify` renders `{}` with no error), degrading every
+ *      two-column fixture to interleaved text while the corpus stays green.
+ *   2. The source fingerprint stops descending, so an edit to a module the
+ *      extraction actually reaches leaves a stale entry servable.
+ *   3. The alias in `vite.config.ts` stops taking effect, so the cache is
+ *      simply never used and the issue silently reopens.
+ *
+ * The two-column fixture is not incidental — case 1 is invisible on a
+ * single-column one, where `columnBoundaries` is absent to begin with.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, afterEach, beforeEach, describe, it, expect } from "vitest";
+
+import {
+  cacheEntryPath,
+  deserializeExtract,
+  extractFromPdfBytes as cachedExtract,
+  KEEP_ENTRIES,
+  MAX_ENTRIES,
+  prune,
+  serializeExtract,
+  sourceFingerprint,
+} from "./extract-cache.ts";
+// NOT aliased: the redirect matches the literal specifier "./pdf-extract.ts",
+// and this one starts with "../". That asymmetry is the whole mechanism, and it
+// is what lets this file hold the real extraction and the cached one side by
+// side. See the alias comment in vite.config.ts.
+import { extractFromPdfBytes as uncachedExtract } from "../pdf-extract.ts";
+import type { PdfExtractResult } from "../types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..");
+const TWO_COLUMN_FIXTURE = join(
+  REPO_ROOT,
+  "tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-two-column.pdf",
+);
+
+const POISON = "planted by extract-cache.test.ts";
+
+const twoColumnBytes = () => new Uint8Array(readFileSync(TWO_COLUMN_FIXTURE));
+
+/**
+ * The two-column fixture plus ignorable trailing bytes. Anything after `%%EOF`
+ * is ignored by a PDF reader, so this parses like the fixture but hashes to a
+ * key nothing else looks up — which is what lets these tests write to, and
+ * plant wrong entries in, a cache the six corpus suites share across forks.
+ * One `tag` per test keeps them from colliding with each other.
+ */
+const probeBytes = (tag: string) =>
+  new Uint8Array([
+    ...twoColumnBytes(),
+    ...new TextEncoder().encode(`\n% offlinecv extract-cache probe ${tag}\n`),
+  ]);
+
+/**
+ * Rewrite pdfjs's per-document font labels to their first-occurrence index, so
+ * two extractions of the same bytes compare on what the labels *partition* —
+ * which is all `dropDecorativeGlyphs` uses them for — rather than on the
+ * arbitrary strings. See "diverges from a fresh extraction in fontName ALONE".
+ */
+function canonicalFontNames(result: PdfExtractResult): PdfExtractResult {
+  const seen = new Map<string, string>();
+  return {
+    ...result,
+    items: result.items.map((item) => {
+      let label = seen.get(item.fontName);
+      if (label === undefined) {
+        label = `font#${seen.size}`;
+        seen.set(item.fontName, label);
+      }
+      return { ...item, fontName: label };
+    }),
+  };
+}
+
+const scratchDirs: string[] = [];
+const scratchEntries: string[] = [];
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+  for (const entry of scratchEntries) rmSync(entry, { force: true });
+});
+
+describe("extract-cache serialization", () => {
+  it("round-trips a two-column extraction without losing columnBoundaries", async () => {
+    const original = await uncachedExtract(twoColumnBytes());
+
+    // Fail loudly if the fixture stops being two-column — otherwise this whole
+    // test degrades into the single-column case it exists to avoid.
+    expect(original.columnBoundaries).toBeInstanceOf(Map);
+    expect(original.columnBoundaries?.size).toBeGreaterThan(0);
+
+    const restored = deserializeExtract(serializeExtract(original));
+
+    expect(restored?.columnBoundaries).toBeInstanceOf(Map);
+    expect([...(restored?.columnBoundaries ?? [])]).toEqual([
+      ...(original.columnBoundaries ?? []),
+    ]);
+    expect(restored).toEqual(original);
+  });
+
+  it("round-trips a single-column extraction, leaving columnBoundaries absent", () => {
+    const single: PdfExtractResult = {
+      items: [],
+      pages: [{ page: 1, width: 612, height: 792, charCount: 0 }],
+      text: "",
+      rawCharCount: 0,
+      linkAnnotations: [],
+    };
+
+    const restored = deserializeExtract(serializeExtract(single));
+
+    expect(restored).toEqual(single);
+    expect(restored && "columnBoundaries" in restored).toBe(false);
+  });
+
+  it("preserves extractionFailureReason", () => {
+    const failed: PdfExtractResult = {
+      items: [],
+      pages: [],
+      text: "",
+      rawCharCount: 0,
+      linkAnnotations: [],
+      extractionFailureReason: "fonts_unmappable",
+    };
+
+    expect(deserializeExtract(serializeExtract(failed))).toEqual(failed);
+  });
+
+  it("refuses malformed JSON rather than throwing", () => {
+    expect(deserializeExtract("{not json")).toBeUndefined();
+  });
+
+  it("refuses an entry written by a different schema version", () => {
+    expect(
+      deserializeExtract(JSON.stringify({ schemaVersion: 0, items: [] })),
+    ).toBeUndefined();
+  });
+});
+
+describe("extract-cache source fingerprint", () => {
+  it("descends into what extraction actually reaches, not just the entry module", () => {
+    const named = sourceFingerprint().files.map((f) =>
+      f.replace(`${REPO_ROOT}/`, ""),
+    );
+
+    // `pdf-extract` imports the first two directly; `line-assembly` pulls in
+    // the third. A walk that stopped at the entry module would still LOOK
+    // correct until it served a stale extraction, so assert the closure.
+    expect(named).toContain("src/lib/heuristics/pdf-extract.ts");
+    expect(named).toContain("src/lib/heuristics/line-assembly.ts");
+    expect(named).toContain("src/lib/heuristics/pdf-layout.ts");
+    expect(named).toContain("src/lib/heuristics/line-primitives.ts");
+  });
+
+  it("changes when a TRANSITIVELY imported file's contents change", () => {
+    const dir = mkdtempSync(join(tmpdir(), "offlinecv-fingerprint-"));
+    scratchDirs.push(dir);
+    const entry = join(dir, "entry.ts");
+    const leaf = join(dir, "leaf.ts");
+    writeFileSync(entry, `import { x } from "./leaf.ts";\nexport const y = x;\n`);
+    writeFileSync(leaf, `export const x = 1;\n`);
+
+    const before = sourceFingerprint(entry).digest;
+    writeFileSync(leaf, `export const x = 2;\n`);
+    const after = sourceFingerprint(entry).digest;
+
+    // The entry module is byte-identical across both calls. If the digest is
+    // unchanged, the walk never descended and every leaf edit is invisible.
+    expect(after).not.toEqual(before);
+  });
+
+  it("is stable when nothing changed", () => {
+    expect(sourceFingerprint().digest).toEqual(sourceFingerprint().digest);
+  });
+});
+
+describe("extract-cache eviction", () => {
+  it("keeps the recently READ entries and drops the rest", () => {
+    const dir = mkdtempSync(join(tmpdir(), "offlinecv-prune-"));
+    scratchDirs.push(dir);
+
+    // Written oldest-first, which is how the real cache fills: the fixtures go
+    // in on the first run and the throwaway round-trip renders pile up after.
+    // Evicting by age alone would therefore drop exactly the entries worth
+    // keeping, so age and recency are set in opposite orders here.
+    const total = MAX_ENTRIES + 50;
+    for (let i = 0; i < total; i++) {
+      const file = join(dir, `entry-${String(i).padStart(4, "0")}.json`);
+      writeFileSync(file, "{}");
+      const usedAt = new Date(1_700_000_000_000 + (total - i) * 1000);
+      utimesSync(file, usedAt, usedAt);
+    }
+
+    prune(dir);
+
+    const left = readdirSync(dir).sort();
+    expect(left).toHaveLength(KEEP_ENTRIES);
+    // The first-written entries were read most recently, so they survive.
+    expect(left[0]).toBe("entry-0000.json");
+    expect(left.at(-1)).toBe(`entry-${String(KEEP_ENTRIES - 1).padStart(4, "0")}.json`);
+  });
+
+  it("leaves a cache under the cap untouched", () => {
+    const dir = mkdtempSync(join(tmpdir(), "offlinecv-prune-"));
+    scratchDirs.push(dir);
+    for (let i = 0; i < 10; i++) writeFileSync(join(dir, `e-${i}.json`), "{}");
+
+    prune(dir);
+
+    expect(readdirSync(dir)).toHaveLength(10);
+  });
+});
+
+describe("extract-cache wiring", () => {
+  // These tests assert the cache FIRES, so they have to own both switches that
+  // turn it off — otherwise a run that sets either one globally (a bake, or the
+  // `OFFLINECV_NO_EXTRACT_CACHE=1` control run used to measure the cache's
+  // effect) fails them for doing exactly what it asked for.
+  const SWITCHES = ["OFFLINECV_NO_EXTRACT_CACHE", "UPDATE_FIXTURES"] as const;
+  let saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved = Object.fromEntries(SWITCHES.map((k) => [k, process.env[k]]));
+    for (const k of SWITCHES) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of SWITCHES) {
+      const previous = saved[k];
+      if (previous === undefined) delete process.env[k];
+      else process.env[k] = previous;
+    }
+  });
+
+  it("is what runCascade's Tier 0 actually reaches", async () => {
+    // The end-to-end proof, and the only one that matters: the redirect exists
+    // to intercept `cascade.ts`'s `import("./pdf-extract.ts")`. Asserted by
+    // side effect rather than by module identity, because a cache entry
+    // appearing for bytes only `runCascade` was handed cannot happen any other
+    // way — and because tsc cannot resolve a specifier that only vitest aliases.
+    const bytes = probeBytes("cascade-wiring");
+    const entry = cacheEntryPath(bytes);
+    scratchEntries.push(entry);
+    rmSync(entry, { force: true });
+
+    const { runCascade } = await import("../cascade.ts");
+    await runCascade(bytes);
+
+    expect(existsSync(entry)).toBe(true);
+  });
+
+  it("keeps forwarding the real module's other exports", async () => {
+    // `export *`, not a hand-listed re-export set: the stand-in has to stay a
+    // drop-in when `pdf-extract.ts` grows an export, and a list would go stale
+    // as a resolution failure in whichever module imported the missing name.
+    const self = await import("./extract-cache.ts");
+    expect(typeof self.assembleTextFromLines).toBe("function");
+    expect(typeof self.dropDecorativeGlyphs).toBe("function");
+  });
+
+  it("serves a second call from disk with a result equal to the uncached one", async () => {
+    // Fresh bytes per call, deliberately: pdfjs TRANSFERS the buffer it is
+    // handed to its worker, so a second `getDocument` over the same array
+    // throws `DataCloneError` on a detached buffer. A cache hit never detaches,
+    // which is why reusing one array here would pass and fail by turns.
+    const first = await cachedExtract(twoColumnBytes());
+    const second = await cachedExtract(twoColumnBytes()); // read back off disk
+    const uncached = await uncachedExtract(twoColumnBytes());
+
+    expect(second).toEqual(first);
+    expect(canonicalFontNames(second)).toEqual(canonicalFontNames(uncached));
+    expect(second.columnBoundaries).toBeInstanceOf(Map);
+  });
+
+  it("diverges from a fresh extraction in fontName ALONE", async () => {
+    // pdfjs labels fonts per loaded-document, not per file: the same bytes come
+    // back as `g_d1_f4` in one process and `g_d5_f4` in another. So a cached
+    // result carries labels a fresh extraction would not have produced.
+    //
+    // That is safe only because `fontName` is opaque — `dropDecorativeGlyphs`
+    // is its one consumer, it groups by the label rather than reading it, and
+    // it has already run by the time a result is cached. Nothing else in `src/`
+    // touches the field and no golden records it. This test is what makes that
+    // narrow: if any OTHER field ever stops being a pure function of the bytes,
+    // it fails here instead of the cache quietly serving a diverging result.
+    const fresh = await uncachedExtract(twoColumnBytes());
+    const alsoFresh = await uncachedExtract(twoColumnBytes());
+
+    expect(canonicalFontNames(alsoFresh)).toEqual(canonicalFontNames(fresh));
+    const labels = (r: PdfExtractResult) => r.items.map((i) => i.fontName);
+    expect(labels(alsoFresh)).not.toEqual(labels(fresh));
+  });
+
+  it("reads the entry it wrote, and skips it entirely under UPDATE_FIXTURES", async () => {
+    // Probe bytes, not a fixture's: this plants a deliberately WRONG entry, and
+    // the six corpus suites share this cache across forks. Trailing bytes after
+    // %%EOF are ignored by any PDF reader, so this parses like the fixture but
+    // hashes to a key nothing else will ever look up.
+    const entry = cacheEntryPath(probeBytes("poison"));
+    const real = await uncachedExtract(probeBytes("poison"));
+    scratchEntries.push(entry);
+
+    mkdirSync(dirname(entry), { recursive: true });
+    writeFileSync(entry, serializeExtract({ ...real, text: POISON }));
+
+    // Cache live: the planted entry comes back, which is the only way to know
+    // the read path fired at all rather than silently re-extracting.
+    expect((await cachedExtract(probeBytes("poison"))).text).toBe(POISON);
+
+    // Restored by the afterEach above.
+    process.env.UPDATE_FIXTURES = "1";
+    const baked = await cachedExtract(probeBytes("poison"));
+    expect(baked.text).not.toBe(POISON);
+    expect(baked.text).toEqual(real.text);
+    expect(baked.columnBoundaries).toBeInstanceOf(Map);
+  });
+});

--- a/src/lib/heuristics/__test-utils__/extract-cache.ts
+++ b/src/lib/heuristics/__test-utils__/extract-cache.ts
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Test-only disk cache in front of Tier 0 extraction (#829).
+ *
+ * Six suites — `corpus`, `corpus-roundtrip`, `corpus-edit-roundtrip`,
+ * `projections`, `sections` and `export-layout-contract` — each walk
+ * `tests/fixtures/pdfs/` and push all 58 fixtures back through `runCascade`
+ * from raw bytes. They run in separate `tinypool` forks, so a module-level
+ * memo cannot help them; the same pdfjs work is redone several hundred times
+ * per run. Extraction is ~82% of a parse (212ms of a 257ms `runCascade`) and
+ * is a pure function of the bytes, so it is the one slice that is safely
+ * shareable across processes. On disk it is.
+ *
+ * **This module is never imported by production code and never bundled.** It
+ * is reached only through `test.alias` in `vite.config.ts`, which redirects the
+ * literal specifier `"./pdf-extract.ts"` — the one `cascade.ts` dynamic-imports
+ * — at resolve time, under vitest only. The six suites keep calling
+ * `runCascade(bytes)` and are unchanged. `export *` below forwards every other
+ * export of the real module unchanged, so this stays a drop-in even if
+ * `pdf-extract.ts` grows exports; the local `extractFromPdfBytes` shadows the
+ * star export per ESM's rules.
+ *
+ * **The key is the whole difficulty, and it fails closed.** A cache that hands
+ * back a stale extraction for changed parser code turns the corpus green
+ * against work it never did — strictly worse than the slowness it fixes. So
+ * the key mixes the bytes with a fingerprint of every source file the
+ * extraction actually reaches, computed by walking the relative-import closure
+ * of `pdf-extract.ts` rather than from a hand-maintained list (a list goes
+ * stale silently, and the failure mode of a stale list here is a green lie).
+ * Non-relative imports are not walked — `pdfjs-dist` is covered by its
+ * resolved version, and the test-only `legacy` alias that selects its build
+ * lives in `vite.config.ts`, which is hashed whole. Any read or parse failure
+ * recomputes. `UPDATE_FIXTURES=1` (i.e. `npm run bake-fixtures`) bypasses the
+ * cache entirely in both directions: a bake that reads its own stale entry is
+ * how a wrong golden gets committed.
+ *
+ * `PdfExtractResult.columnBoundaries` is a `Map`, which `JSON.stringify`
+ * renders as `{}` silently — losing it degrades every two-column fixture to
+ * interleaved text with no error. Hence the explicit serializer below and the
+ * two-column round-trip assertion in `extract-cache.test.ts`, not a bare
+ * `JSON.stringify`.
+ *
+ * **One field is not a pure function of the bytes: `PdfTextItem.fontName`.**
+ * pdfjs labels fonts per loaded *document* (`g_d1_f4` in one process, `g_d5_f4`
+ * in the next), so a cached result carries labels a fresh extraction would not
+ * have produced. That is safe here, and narrowly so: the labels are opaque,
+ * `dropDecorativeGlyphs` is their only consumer and groups by them rather than
+ * reading them, and it has already run before anything is cached. No other
+ * module in `src/` reads the field and no golden records it. `extract-cache.test.ts`
+ * pins that divergence to `fontName` alone, so a second field going
+ * byte-dependent fails a test instead of quietly changing what the corpus sees.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { extractFromPdfBytes as extractUncached } from "../pdf-extract.ts";
+import type { PdfExtractResult } from "../types.ts";
+
+export * from "../pdf-extract.ts";
+
+const HEURISTICS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = resolve(HEURISTICS_DIR, "..", "..", "..");
+const CACHE_DIR = join(REPO_ROOT, "node_modules", ".cache", "offlinecv-extract");
+
+/** Bump when the on-disk shape below changes, so old entries are ignored. */
+const SCHEMA_VERSION = 1;
+
+/** Eviction thresholds — see `prune()`. The 58 fixtures are the working set. */
+export const MAX_ENTRIES = 600;
+export const KEEP_ENTRIES = 300;
+/** Sweep on every Nth write in a process, not on every one. */
+const PRUNE_INTERVAL = 32;
+
+/**
+ * Matches both `from "…"` and `import("…")` so a tier reached only by dynamic
+ * import still lands in the fingerprint. Deliberately a scan, not a parser:
+ * over-matching a specifier inside a comment or string costs one extra file in
+ * the hash, which is safe. Under-matching would not be.
+ */
+const IMPORT_SPECIFIER_RE = /(?:from\s*|import\s*\(\s*)["']([^"']+)["']/g;
+
+// ── Cache key ───────────────────────────────────────────────────────────────
+
+/**
+ * Hash every source file reachable from `pdf-extract.ts` through relative
+ * imports, plus `vite.config.ts` and the resolved `pdfjs-dist` version.
+ *
+ * Exported for `extract-cache.test.ts`, which asserts the closure actually
+ * reaches the modules extraction depends on — a fingerprint that silently
+ * stopped walking would be indistinguishable from a correct one until it
+ * served a stale extraction.
+ */
+export function sourceFingerprint(entry = join(HEURISTICS_DIR, "pdf-extract.ts")): {
+  files: string[];
+  digest: string;
+} {
+  const hashes = new Map<string, string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (hashes.has(file)) continue;
+    let src: string;
+    try {
+      src = readFileSync(file, "utf8");
+    } catch {
+      // A specifier we resolved to a path that isn't a file (an extensionless
+      // import, a package that looked relative). Record the miss so the digest
+      // still changes if it later becomes real.
+      hashes.set(file, "<unreadable>");
+      continue;
+    }
+    hashes.set(file, sha256(src));
+    for (const [, spec] of src.matchAll(IMPORT_SPECIFIER_RE)) {
+      if (!spec.startsWith(".")) continue;
+      queue.push(resolve(dirname(file), spec));
+    }
+  }
+
+  const files = [...hashes.keys()].sort();
+  const h = createHash("sha256");
+  for (const f of files) h.update(f).update("\0").update(hashes.get(f) as string).update("\0");
+  h.update(readSafely(join(REPO_ROOT, "vite.config.ts")));
+  h.update(pdfjsVersion());
+  return { files, digest: h.digest("hex") };
+}
+
+function sha256(input: string | Uint8Array): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function readSafely(file: string): string {
+  try {
+    return readFileSync(file, "utf8");
+  } catch {
+    return `<unreadable:${file}>`;
+  }
+}
+
+function pdfjsVersion(): string {
+  try {
+    const pkg = readFileSync(
+      join(REPO_ROOT, "node_modules", "pdfjs-dist", "package.json"),
+      "utf8",
+    );
+    return String((JSON.parse(pkg) as { version?: unknown }).version ?? "unknown");
+  } catch {
+    return "unknown";
+  }
+}
+
+let fingerprint: string | undefined;
+function cachedFingerprint(): string {
+  fingerprint ??= sourceFingerprint().digest;
+  return fingerprint;
+}
+
+// ── Serialization ───────────────────────────────────────────────────────────
+
+/**
+ * On-disk shape. Identical to `PdfExtractResult` except `columnBoundaries`,
+ * which is a `Map` in memory and entry pairs here — see the module docblock.
+ */
+interface SerializedExtract
+  extends Omit<PdfExtractResult, "columnBoundaries"> {
+  schemaVersion: number;
+  columnBoundaries?: [number, number][];
+}
+
+export function serializeExtract(result: PdfExtractResult): string {
+  const { columnBoundaries, ...rest } = result;
+  const payload: SerializedExtract = {
+    schemaVersion: SCHEMA_VERSION,
+    ...rest,
+    ...(columnBoundaries ? { columnBoundaries: [...columnBoundaries] } : {}),
+  };
+  return JSON.stringify(payload);
+}
+
+/** Returns `undefined` for anything this build cannot trust — see fail-closed. */
+export function deserializeExtract(json: string): PdfExtractResult | undefined {
+  let payload: SerializedExtract;
+  try {
+    payload = JSON.parse(json) as SerializedExtract;
+  } catch {
+    return undefined;
+  }
+  if (payload?.schemaVersion !== SCHEMA_VERSION) return undefined;
+  const { schemaVersion: _schemaVersion, columnBoundaries, ...rest } = payload;
+  return {
+    ...rest,
+    ...(columnBoundaries ? { columnBoundaries: new Map(columnBoundaries) } : {}),
+  };
+}
+
+// ── The cached wrapper ──────────────────────────────────────────────────────
+
+/** True when the caller must see a real extraction, not a remembered one. */
+function bypassed(): boolean {
+  return (
+    process.env.UPDATE_FIXTURES === "1" ||
+    process.env.OFFLINECV_NO_EXTRACT_CACHE === "1"
+  );
+}
+
+/**
+ * Where a given input's entry lives. Exported so `extract-cache.test.ts` can
+ * plant a known-wrong entry and prove the cache is genuinely read — and
+ * genuinely skipped under `UPDATE_FIXTURES=1`. Asserting the cached result
+ * merely *equals* the uncached one proves neither, since that holds whether the
+ * cache fired or not.
+ */
+export function cacheEntryPath(bytes: Uint8Array | ArrayBuffer): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const key = sha256(view).slice(0, 32) + "-" + cachedFingerprint().slice(0, 16);
+  return join(CACHE_DIR, `${key}.json`);
+}
+
+export async function extractFromPdfBytes(
+  bytes: Uint8Array | ArrayBuffer,
+): Promise<PdfExtractResult> {
+  if (bypassed()) return extractUncached(bytes);
+
+  const file = cacheEntryPath(bytes);
+
+  try {
+    const hit = deserializeExtract(readFileSync(file, "utf8"));
+    if (hit) {
+      touch(file);
+      return hit;
+    }
+  } catch {
+    // Miss, or an entry another fork is mid-write. Fall through and extract.
+  }
+
+  const result = await extractUncached(bytes);
+  writeAtomically(file, serializeExtract(result));
+  return result;
+}
+
+/**
+ * Mark an entry as just-used, so `prune()` evicts by least-recently-read
+ * rather than by age. Without this the 58 fixture entries — the only ones with
+ * any reuse value — are the oldest on disk and would be the first evicted.
+ */
+function touch(file: string): void {
+  try {
+    const now = new Date();
+    utimesSync(file, now, now);
+  } catch {
+    // Best effort; a missed touch only costs eviction accuracy.
+  }
+}
+
+/**
+ * Keep the cache bounded. The round-trip suites extract PDFs they rendered
+ * moments earlier, and `pdf-lib` stamps a creation date, so those bytes differ
+ * every run: ~120 entries (~2 MB) per run that are written and never read
+ * again. Left alone the directory grows without limit inside `node_modules`,
+ * where nobody would think to look for it.
+ *
+ * Runs on a write, not on every call, and only every `PRUNE_INTERVAL`th one —
+ * a `readdir` + `stat` sweep per extraction would cost more than the cache
+ * saves.
+ */
+export function prune(dir = CACHE_DIR): void {
+  try {
+    const entries = readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, usedAt: statSync(path).mtimeMs };
+      });
+    if (entries.length <= MAX_ENTRIES) return;
+    entries.sort((a, b) => a.usedAt - b.usedAt);
+    for (const { path } of entries.slice(0, entries.length - KEEP_ENTRIES)) {
+      try {
+        unlinkSync(path);
+      } catch {
+        // Another fork got there first.
+      }
+    }
+  } catch {
+    // No cache dir yet, or a racing sweep. Nothing to bound.
+  }
+}
+
+/**
+ * Write via a per-process temp file plus `rename`, so a reader in another fork
+ * sees either no entry or a complete one — never a truncated JSON that would
+ * be discarded (correct, but wasted work) on every concurrent run.
+ */
+let writes = 0;
+
+function writeAtomically(file: string, contents: string): void {
+  const tmp = `${file}.${process.pid}.tmp`;
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    writeFileSync(tmp, contents);
+    renameSync(tmp, file);
+    if (++writes % PRUNE_INTERVAL === 0) prune();
+  } catch {
+    // A full disk or a read-only tree must not fail a test run — the cache is
+    // an optimisation, and the uncached result has already been computed.
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // Nothing to clean up.
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -260,6 +260,53 @@ export default defineConfig({
       "scripts/**/*.test.mjs",
     ],
     globals: true,
+    // Raised off vitest's 5000 ms default (#762), because 5s is below what these
+    // tests HONESTLY COST — not because something is hanging.
+    //
+    // Measured on the 24 heaviest files: 453s of test CPU, 78s wall. One
+    // `extractFromPdfBytes` over a fixture is 212ms and one `runCascade` is
+    // 257ms (so ~82% of a parse is pdfjs), and a render is ~500ms. A round-trip
+    // `it` in `corpus-roundtrip` / `corpus-edit-roundtrip` does parse → render →
+    // re-parse on a REAL fixture, several times over, which lands at 6–8s of
+    // genuine work before any load. Under 5s, three of them failed at 7282ms and
+    // 6661ms; at 20s all 24 files pass. Nothing was rescued from a hang — the
+    // ceiling was simply under the floor.
+    //
+    // And the floor moves. These timings were taken on a developer laptop that
+    // was also running a video call and several other node processes; the same
+    // probe came back 43s and 126s on different attempts, and a single warm
+    // extraction loop varies ~19% run to run. A local gate has to survive the
+    // machine it actually runs on, which is never idle — so the ceiling is set
+    // well above the worst observed run, not just above the median one.
+    //
+    // Do not "fix" this by tuning the worker count or the pool kind. Both were
+    // measured and are WORSE: `--maxWorkers=4` takes 155s against 78s (identical
+    // test CPU — the default fork pool is already at ~5.8x parallelism, so it is
+    // not oversubscribed), and `--pool=threads` takes 347s against 99s on the
+    // rest of the suite while failing 8 files.
+    //
+    // `poolOptions.forks.isolate=false` is much faster and is still not used.
+    // The full suite finishes in ~25s under it against ~95s isolated. An earlier
+    // note in this file recorded it as "never finished inside 600s"; that reading
+    // was taken while nine orphaned vitest workers pinned the machine at load
+    // average 110, and it was wrong — as was the 78s/98s pair that replaced it.
+    //
+    // The reason it stays off is not speed. vitest resets the module-mock
+    // registry and the module cache once per file, and BOTH resets are gated on
+    // `isolate` (`runBaseTests`: `if (isolate) { executor.mocker.reset();
+    // resetModules(...) }`). So `vi.mock` is file-scoped *because of* that reset,
+    // not on its own — turning the flag off does not expose leaked state, it
+    // deletes the mechanism that makes file-scoped module mocks work. The
+    // failures it produces are all in the 21 of 346 files that call `vi.mock`,
+    // are all "the mock did not apply", and vary run to run with fork
+    // scheduling. See #830 (closed, not planned) for the full trace.
+    //
+    // The per-fixture half of the cost is handled rather than tracked: Tier 0
+    // extraction is now served from a disk cache shared across forks (#829, see
+    // the `alias` block below), which is worth ~40% of the wall on the six
+    // corpus suites and ~4% on a full run.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     // Install the in-memory localStorage shim before every test, workload-wide,
     // so no suite has to remember to import it (#398). See src/test-setup.ts.
     setupFiles: ["src/test-setup.ts"],
@@ -288,6 +335,7 @@ export default defineConfig({
         "src/**/*.{ts,tsx}",
         "scripts/check-fixture-pii.mjs",
         "scripts/check-known-failures.mjs",
+        "scripts/select-tests.mjs",
         "scripts/seo-artifacts.ts",
       ],
       exclude: [
@@ -302,10 +350,28 @@ export default defineConfig({
         "src/**/main.tsx",
       ],
     },
-    // Force pdfjs-dist to its legacy build during tests so the Node 20+
-    // env doesn't trip on `Promise.withResolvers()` (Node 22+) in the
-    // browser entry. The production bundle still ships the browser build.
+    // Test-only module redirects.
     alias: {
+      // Redirect the ONE specifier `cascade.ts` dynamic-imports for Tier 0 to a
+      // caching stand-in (#829). Six suites re-parse the same 58 fixtures in
+      // separate forks, and extraction — ~82% of a parse — is a pure function
+      // of the bytes, so it is shareable through a disk cache. Doing it at
+      // resolve time keeps the wrapper out of the production bundle entirely
+      // and leaves all six suites calling `runCascade(bytes)` unchanged.
+      //
+      // Vite matches a string `find` as a prefix of the raw specifier, so this
+      // hits `cascade.ts`'s `"./pdf-extract.ts"` and NOT the stand-in's own
+      // `"../pdf-extract.ts"` — that difference is what stops the redirect
+      // looping back on itself. Keep the two specifiers distinct.
+      "./pdf-extract.ts": fileURLToPath(
+        new URL(
+          "./src/lib/heuristics/__test-utils__/extract-cache.ts",
+          import.meta.url,
+        ),
+      ),
+      // Force pdfjs-dist to its legacy build during tests so the Node 20+
+      // env doesn't trip on `Promise.withResolvers()` (Node 22+) in the
+      // browser entry. The production bundle still ships the browser build.
       "pdfjs-dist": "pdfjs-dist/legacy/build/pdf.mjs",
       "@design-system": DESIGN_SYSTEM_DEFAULT,
     },


### PR DESCRIPTION
## Why

`npm run verify` — the `pre-push` hook — ran the whole suite with coverage on every push, regardless of what changed:

| Step | Wall |
|---|---|
| `npm run test` (348 files) | 165s |
| `npm run test:coverage` | 281s |
| typecheck / lint / check:fixtures / check:baselines / check:core / build | 17 / 14 / 3 / 4 / 18 / 33 = 89s |
| **`npm run verify`** | **~370s** |

34 test files touch `tests/fixtures/` and account for **64%** of aggregate test time (238s of 371s CPU). All of it runs on a one-line component edit.

**CI is not touched.** `.github/workflows/ci.yml` still calls `npm run test:coverage` and runs everything. Branch protection requires that job, so a local under-selection costs a red check, never a bad merge.

## What this PR does

The first round of this PR changed only **how often** the suite is paid for, and said so. That was a fair answer to "does this fix the root cause?" — no. This round adds the half that does: it makes the run itself cheaper, and it retracts three earlier readings — two that were artifacts of a loaded machine, and one that was a straight misdiagnosis.

**1. `verify` calls `npm run test:changed` instead of `vitest run --coverage`.**

`scripts/select-tests.mjs` hands vitest a `--changed origin/main` range **only when every changed path is an added-or-modified `.ts`/`.tsx` under `src/`**, and runs the full suite otherwise. Every unknown fails toward running more.

**2. Tier 0 extraction is served from a disk cache during tests** — closes #829. Details below.

**3. Coverage leaves the local gate** (−116s). Its only local consumer was `fallow audit --coverage`, which is report-only (`|| echo …`) and gates nothing — there is no `thresholds` block. CI computes its own coverage for the SARIF upload. `--coverage` is dropped from the local fallow call too, so a stale report cannot be silently fed in.

**4. `testTimeout`/`hookTimeout` 5000 ms → 20s** — closes #762. 5s is below what these tests honestly cost: a round-trip `it` does parse → render → re-parse on a real fixture several times over, which is 6–8s of genuine work. Under 5s, three failed at 7282 ms and 6661 ms. Nothing was rescued from a hang — the ceiling was under the floor.

**5. The Claude Code Stop hook stops running a push-time gate.** Everything above makes `verify` cheaper; this asks for it less often. `scripts/hooks/lint_and_test.sh` has been running the whole of `npm run verify` — build, packaging gate, fallow and all — on **every Stop that followed a `src/**.ts{,x}` edit**, which is many times an hour. New `npm run verify:quick` (typecheck → lint → `test:changed`) is what it runs now, making the layers cheapest-first: **Stop** → **pre-push** (`npm run verify`, unchanged) → **CI** (whole suite + coverage).

Nothing it drops is dropped for good — each is re-run at pre-push, and each is also inapplicable at Stop by construction, since the sentinel only fires for `.ts`/`.tsx` under `src/`:

| Dropped from Stop | Why it cannot matter there |
|---|---|
| `vite build` | `tsc -b --noEmit` already types the same sources |
| `check:core` | packs the `@offlinecv/core` tarball, which is not under `src/` |
| `check:fixtures` / `check:baselines` | read PDFs and JSON sidecars — not a `.ts` edit |
| `fallow audit` | report-only inside `verify` already; its exit is ignored |

Fixture PII is a hard rule, so to be explicit: this weakens nothing. The fixture edit that would trip `check:fixtures` is not a `.ts` edit, so it never set the sentinel; pre-push and CI both still run it.

`verify` itself is **byte-identical** and deliberately not re-expressed in terms of `verify:quick` — the composition that would share those two commands also reorders the cheap gates behind the test run, so a fixture-PII violation would report *after* the full suite instead of before it. Two repeated commands is the cheaper cost.

**6. One unrelated sentence in `docs/CONTRIBUTING-PROCESS.md`.** Rebased onto #827, which retired the AI-attribution prose rule and then restored a one-liner during review — leaving that file's preamble asserting the rule has no `CLAUDE.md` counterpart "on purpose", contradicting both the restored rule and the same file's own attribution section. Raised as a non-blocking suggestion on #827 and carried here rather than spending a PR on three lines. Off-topic for this branch; skip it in review if you'd rather it moved.

## The extraction cache (#829)

Six suites — `corpus`, `corpus-roundtrip`, `corpus-edit-roundtrip`, `projections`, `sections`, `export-layout-contract` — each `readdirSync` the fixture tree and push all 58 fixtures back through `runCascade` from raw bytes, in separate `tinypool` forks that cannot share a result. Extraction is **~82% of a parse** (212ms of 257ms) and is a pure function of the bytes, so it is the one slice that is safely shareable across processes.

**Integration is one line of config and zero lines of test code.** `test.alias` redirects the single specifier `cascade.ts` dynamic-imports — `"./pdf-extract.ts"` — to a stand-in under `__test-utils__/`. No suite changed; all six still call `runCascade(bytes)`. The redirect matches `"./pdf-extract.ts"` and not the stand-in's own `"../pdf-extract.ts"`, which is what stops it looping.

**Nothing reaches production.** Checked against `dist/`: no reference to the module, no `node:fs`/`node:crypto` import.

### The key fails closed

A stale entry turns the corpus green against work it never did — strictly worse than the slowness it fixes. The key mixes the bytes with a fingerprint of **every source file the extraction transitively reaches**, walked from `pdf-extract.ts` rather than hand-listed, plus `vite.config.ts` and the `pdfjs-dist` version for what a relative-import walk cannot see. A stale hand-list would be indistinguishable from a correct one right up until it served a wrong extraction — the same argument the selector rests on.

- `UPDATE_FIXTURES=1` (so `npm run bake-fixtures`) bypasses reads **and** writes. A bake that reads its own stale entry is how a wrong golden gets committed.
- `OFFLINECV_NO_EXTRACT_CACHE=1` is the debugging escape hatch.
- Any read or parse failure recomputes.

### Two hazards pinned by tests rather than assumed

**`columnBoundaries` is a `Map`**, which `JSON.stringify` renders `{}` with no error. Losing it degrades every two-column fixture to interleaved text while the corpus stays green. Hence an explicit serializer, and a round-trip assertion **on a two-column fixture specifically** — the same test on a single-column one passes with the field silently gone.

**`fontName` turns out not to be a pure function of the bytes.** pdfjs labels fonts per loaded *document*, so the same PDF is `g_d1_f4` in one process and `g_d5_f4` in the next. That is safe only narrowly: the labels are opaque, `dropDecorativeGlyphs` is their one consumer and groups by them rather than reading them, and it has already run before anything is cached. A test pins the divergence to that field alone, so a second field going process-dependent fails a test instead of quietly changing what the corpus sees.

### Bounded

The round-trip suites extract PDFs they rendered moments earlier, and `pdf-lib` stamps a creation date — so ~120 entries (~2 MB) **per run** are written and never read again. Left alone the directory grew without limit inside `node_modules`. Entries are touched on read and evicted **least-recently-read** first, because the 58 fixture entries are also the oldest and evicting by age would drop exactly the ones with reuse value. Verified live: 518 entries → 361 after a sweep.

### Measured

Interleaved (control / warm / control / warm, so drift hits both arms). On the **six corpus suites** — the scope `--changed` selects after a parser edit:

| | wall | test CPU |
|---|---|---|
| control (`OFFLINECV_NO_EXTRACT_CACHE=1`) | 20.85s | 66.5s |
| warm cache | **12.58s** | **29.6s** |

−40% wall, −55% test CPU. On a **full run**: 98.3s → 94.8s wall, −17.7% test CPU. The full run's wall is dominated by per-file setup the cache does not touch, which is not reachable without giving up per-file isolation — see below.

342 test files green in both arms.

## Three readings from earlier rounds were wrong

The first two were taken while nine orphaned vitest workers were pinning this machine at **load average 110** — the failure mode this branch also documents in CLAUDE.md.

**Contention was not the cause of the timeouts.** The default fork pool is already right: `--maxWorkers=4` takes 155s against 78s with *identical* test CPU (452s vs 453s — ~5.8× parallelism, not oversubscribed), and `--pool=threads` takes 347s against 99s while failing 8 files.

**`poolOptions.forks.isolate=false` does not hang.** It was recorded as "did not finish inside 600s". It does not hang at all — on an idle machine (load 2.3 of 10 cores) it finishes the full suite in **~25s against ~95s**.

**And the reason given for setting it aside was also wrong.** The previous revision of this PR said 3 files fail under it "on state their siblings leak". They do not. vitest resets the module-mock registry and the module cache once per file, and **both resets are gated on `isolate`**:

```js
// vitest@3.2.6, runBaseTests
for (const file of files) {
  if (isolate) {
    executor.mocker.reset();
    resetModules(workerState.moduleCache, true);
  }
```

So `vi.mock` is file-scoped *because of* that reset, not on its own. `isolate: false` does not expose leaked state — it deletes the mechanism that makes file-scoped module mocks work. The evidence matches: every file that fails under it is among the **21 of 346** that call `vi.mock`, every failure is *the mock did not apply* rather than a stateful assertion, and the failing set moves with fork scheduling (two consecutive full runs gave 3 files / 25 tests, then 1 file / 4 tests).

That leaves nothing to fix. Under today's `isolate: true` no state crosses a file boundary, so no test is passing for the wrong reason and none can start to. The lever is still real — ~70s of local wall — but its price is file-scoped `vi.mock` across 21 files, which is a deliberate trade and not this PR's to make. #830 is **closed as not planned** with the full trace.

`vite.config.ts` and `CLAUDE.md` carry the corrected mechanism rather than the misreading, so the wrong version cannot be re-cited from the tree.

## Verification

- 342 test files green, run 4× (2 control / 2 warm arms), plus 4× more during the cache measurement.
- 15 new tests for the cache, including a **fail-before proof**: removing the alias reddens exactly the wiring test and nothing else.
- The cache tests own both bypass switches, so a run that sets either globally does not fail them for doing what it asked.
- `tsc -b --noEmit`, `eslint .`, `check:fixtures`, `check:baselines`, `check:core`, `vite build` all clean.
- `dist/` grepped for the cache module and for `node:fs`/`node:crypto` — absent.
- Fixture PII: no fixtures added or changed; `check:fixtures` passes (58 PDFs, 15 sidecars).

`npm run verify` end-to-end **passes locally**, through the `pre-push` hook, on the pushed commit — including fallow, which reports no issues in the 11 changed files. This is also the proof that `verify` survived the `verify:quick` split intact: the push would have been refused otherwise. The earlier rounds could not complete it — the laptop was at load 40–140 from unrelated processes and the run exceeded a 10-minute budget twice — so every step was run individually then. CI is still the gate.

The Stop hook was exercised **the way Claude Code invokes it** — sentinel dropped, `{"session_id": …}` fed on stdin — at load average 4.9 on 10 cores: exit 0 in 123s, sentinel consumed. That 123s is the *worst* case, not the typical one: this branch's own diff touches `scripts/`, so the selector correctly refuses to scope and runs all 348 files. The case the change is for — one edited `.ts` under `src/` — is whatever `vitest --changed` selects, plus typecheck and lint.

The measurements above were re-run after the first round's diagnosis was challenged and did not survive; the numbers here are from the surviving pass, not that one.

Closes #762
Closes #829




