### PR TITLE
fix: strip trailing middot separator from education degree field

### DIFF
--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -183,7 +183,7 @@ const TRUTH_ANNOTATED_FIELD_FLOOR = 150;
  * `npm run check:baselines` on every run, and bounded here — undescribed debt may
  * not GROW. File the issue and flip the entry to `open`; then lower this.
  */
-const UNFILED_TRUTH_CEILING = 10;
+const UNFILED_TRUTH_CEILING = 9;
 
 /** Generator category = the fixture root's immediate subdirectory. */
 function categoryOf(repoRelPdfPath: string): string {

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -857,3 +857,66 @@ describe("extractEducation — one-line 'Degree Field, Institution' + en-dash da
     expect(value[0].location).toBe("Boston, MA");
   });
 });
+
+describe("extractEducation — cleanField strips leftover edge middot and bullet separators (#835)", () => {
+  it("strips trailing middot separator from degree field", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. Computer Science ·",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBe("Computer Science");
+  });
+
+  it("strips trailing bullet separator from degree field", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "Bachelor of Science in Mathematics •",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("Bachelor of Science");
+    expect(value[0].field).toBe("Mathematics");
+  });
+
+  it("strips leading middot or bullet from degree field", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. · Computer Science",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBe("Computer Science");
+  });
+
+  it("preserves internal middot or ampersand inside compound field names", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. in Computer Science & Engineering ·",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBe("Computer Science & Engineering");
+  });
+
+  it("returns undefined field when only separators survive", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. · • -",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBeUndefined();
+  });
+});
+

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -895,7 +895,35 @@ describe("extractEducation — cleanField strips leftover edge middot and bullet
     expect(value[0].field).toBe("Computer Science");
   });
 
-  it("preserves internal middot or ampersand inside compound field names", () => {
+  it("strips the separator orphaned by the trailing-date cut", () => {
+    // The fixture shape the issue was filed from: the date strip removes "2020"
+    // and leaves the "·" that divided it from the field.
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. Computer Science · 2020",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBe("Computer Science");
+  });
+
+  it("preserves an INTERIOR middot joining a genuine two-part field", () => {
+    // The strip is anchored at both ends, so a separator that is real content
+    // survives. This is what stops a future widening from de-anchoring it.
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. Mathematics · Statistics",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    expect(value[0].field).toBe("Mathematics · Statistics");
+  });
+
+  it("preserves an internal ampersand inside a compound field name", () => {
     const { value } = extractEducation(
       mkEduSection([
         "Springfield State University",
@@ -919,4 +947,3 @@ describe("extractEducation — cleanField strips leftover edge middot and bullet
     expect(value[0].field).toBeUndefined();
   });
 });
-

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -455,7 +455,13 @@ function cleanField(raw: string): string | undefined {
   // Cut a trailing "… , Minor in Economics" / "… , GPA: 3.8" note — a sub-field,
   // not part of the subject.
   f = f.replace(/[,;]\s*(?:minor|major|gpa|concentration)\b.*$/i, "");
-  // Strip leftover edge punctuation and separators (#835).
+  // Strip leftover edge punctuation and separators — the middot/bullet a
+  // template used to divide the header from a field this parse did not keep
+  // ("Computer Science · 2020" loses the year above, leaving the "·", #835).
+  // Anchored at BOTH ends, so an interior separator in a genuine two-part field
+  // ("Mathematics · Statistics") is untouched. This glyph class is a known
+  // duplicate of the ones in `regex.ts` / `line-primitives.ts`, not an
+  // oversight — unifying the separator vocabulary is tracked as #653.
   f = f.replace(/^[\s,;:·•–\-—]+|[\s,;:·•–\-—]+$/g, "").trim();
   return f.length > 0 ? f : undefined;
 }

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -455,8 +455,8 @@ function cleanField(raw: string): string | undefined {
   // Cut a trailing "… , Minor in Economics" / "… , GPA: 3.8" note — a sub-field,
   // not part of the subject.
   f = f.replace(/[,;]\s*(?:minor|major|gpa|concentration)\b.*$/i, "");
-  // Strip leftover edge punctuation.
-  f = f.replace(/^[\s,;:–\-—]+|[\s,;:–\-—]+$/g, "").trim();
+  // Strip leftover edge punctuation and separators (#835).
+  f = f.replace(/^[\s,;:·•–\-—]+|[\s,;:·•–\-—]+$/g, "").trim();
   return f.length > 0 ? f : undefined;
 }
 

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.truth.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.truth.json
@@ -32,12 +32,5 @@
     "SQL",
     "Linux",
     "AWS"
-  ],
-  "knownWrong": {
-    "education.degree": {
-      "issue": null,
-      "status": "unfiled",
-      "note": "The degree's FIELD comes back carrying the header line's own separator: field = “Computer Science ·”, so the degree reads “B.S. Computer Science ·”. The middot is punctuation from the line, not part of the field of study."
-    }
-  }
+  ]
 }


### PR DESCRIPTION
### Summary of Changes
Fixes #835.

When parsing education sections from resume PDFs (such as Google Docs generated PDFs), degree lines often contain trailing middots (`·`) or bullet characters (`•`) used as visual separators before fields that were not extracted or omitted.

`cleanField` in `src/lib/heuristics/extract/education.ts` previously stripped edge punctuation `[\s,;:–\-—]`. This change widens the character set to include `·` (U+00B7) and `•` (U+2022) so trailing and leading separators are trimmed cleanly, without affecting internal characters.

### Verification
- Added comprehensive unit tests in `src/lib/heuristics/extract/education.test.ts` covering trailing middots, trailing bullets, leading middots/bullets, compound internal field preservation, and separator-only fields (61/61 tests pass).
- Updated `tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-minimal.truth.json` by removing the resolved `knownWrong` annotation for `education.degree`.
- Verified `npm run check:baselines`, `npm run check:fixtures`, `npm run typecheck`, and `npm run lint` all pass.
