### PR TITLE
feat(skills): extract /collapse-pr as the one guarded collapse

### DIFF
--- a/.claude/skills/collapse-pr/SKILL.md
+++ b/.claude/skills/collapse-pr/SKILL.md
@@ -1,0 +1,1083 @@
+---
+name: collapse-pr
+description: Collapse a branch to exactly one commit whose message is the message that lands in `main` — the merge queue derives the squash message and cannot be handed one, so a multi-commit PR merges as bulleted commit soup. Resolves an existing PR's head from origin and rewrites it in a throwaway worktree rather than trusting the local checkout, detects whether the repo even needs a collapse at all, runs five safety gates and a tree-identity assertion before anything is pushed, and is a clean no-op on a branch that already holds one commit. Use when the user says "collapse the PR", "/collapse-pr", "squash this branch to one commit", or when open-pr / revise-pr / pr-review needs the one-commit invariant restored.
+argument-hint: "[<pr-number>] [--repo owner/repo] [--base <ref>] [--in-place] [--message-file <f>] [--authored-worktree <d>] [--authored-path <p>] [--authored-message <m>] [--dry-run] [--yes]"
+---
+
+# Collapse PR
+
+Take a branch from "N scratch commits" to **exactly one commit whose message is
+the message you want in `main`**: resolve the target from `origin` → detect whether
+this repo's merge regime needs a collapse at all → count the commits → run the
+safety gates → compose the message → `reset --soft` + `commit` → **assert the tree
+did not change** → `push --force-with-lease`.
+
+This is the one place the collapse lives. `open-pr` (Step 3.6), `revise-pr`
+(Step 5.1), and `pr-review` (Step 5.5) each *decide* whether to collapse on their
+own terms and then delegate the mechanics here; none of them re-derives the
+rationale below.
+
+## Input
+
+Parse `$ARGUMENTS` for a **PR number** (`849`, `#849`) and optionally `--repo
+owner/repo`, `--base <ref>`, `--in-place`, `--message-file <f>`,
+`--authored-worktree <d>`, `--authored-path <p>` (repeatable),
+`--authored-message <m>`, `--dry-run`, `--yes`.
+
+| Flag | Effect |
+|---|---|
+| `<pr-number>` | The PR whose head is the target. Omit it and Step 0 infers one from the current branch; if there is no PR yet the run continues **in place** on the checkout, and Step 3's PR-dependent gates are trivially satisfied |
+| `--repo owner/repo` | Target repo; defaults to the current one |
+| `--base <ref>` | The ref this branch merges into. Defaults to the PR's own base, or the repo default branch in in-place mode. Pass it when collapsing a **stacked** branch that has no PR yet — collapsing a stack layer against `main` would swallow the parent layer's commits into the child |
+| `--in-place` | Force `MODE=inplace`: **this checkout is the target**, whatever `gh pr view` would have inferred. `open-pr` Step 3.6 always passes it. It does **not** suppress PR discovery — a PR that exists is still read, so gates 3a/3b stay live |
+| `--message-file <f>` | Use this file's contents verbatim as the collapsed message. Nothing is composed |
+| `--authored-worktree <d>` | The **one** checkout whose dirty paths this run authored. `--authored-path` is honoured only there; dirty paths in any *other* worktree are unknown provenance and refuse. Required for `--authored-path` to have any effect |
+| `--authored-path <p>` | Repeatable. A path **this run authored** *in `--authored-worktree`*, so gate 3e may commit it rather than treating it as a stray edit. A whitelist: any dirty path not listed drops that tree to 3e row 2 and refuses |
+| `--authored-message <m>` | Subject for the commit gate 3e row 1 makes. Defaults to `chore: fold in run-authored changes (collapse-pr gate 3e)`. Normally short-lived — the collapse folds it away — but it survives on `origin` if a later hard gate refuses after row 1 pushed, so it must be self-describing rather than invented |
+| `--dry-run` | Run every check, print the gate results and the composed message, change nothing — including gate 3e, which otherwise writes. Exit 0 |
+| `--yes` | Proceed past the two **soft** gates (stale approval, open threads), printing each that fired and why. Never overrides the hard gates (3c, 3d) or 3e's unknown-provenance refusal |
+
+**With a PR number and without `--in-place`, the local checkout is not the target
+and is never rewritten.** Step 0 resolves the head from `origin` and does the work
+in a throwaway worktree. That is a correctness property, not a convenience: see
+*Why the target comes from `origin`* below for the live case where trusting the
+checkout would have destroyed committed work.
+
+**`--in-place` is the inverse claim, and only a caller that owns the checkout may
+make it.** Mode must not be inferred from whether a PR happens to exist: `open-pr`
+Step 3.6 runs pre-push on a checkout that is the *only* copy of the work, and on a
+**re-run** — pushing more commits to a branch whose PR already exists — the
+inference would find that PR, flip to `worktree` mode, and collapse `origin`'s head
+while the new local commits sat unread. `open-pr` Step 4 then skips its own push
+("Step 3.6 collapsed"), so the commits are never published and 3e row 3 resets them
+away. `--in-place` is what makes the caller's notion of the target authoritative.
+
+**`--yes` means "the caller already made this judgement", not "skip the checks."**
+Both `revise-pr` and `pr-review` reach this skill having already decided the
+collapse is correct for their round, and the state they decided on is still
+visible on GitHub when they call — `revise-pr` resolves its threads *after* the
+push, so its threads are legitimately still open here. The gates still run and
+still print; `--yes` only changes whether a soft gate stops the run.
+
+## Why this skill exists
+
+**This section is the single source of truth for the merge-queue rationale.** If
+you are reading `open-pr`, `revise-pr`, or `pr-review` and want to know *why* the
+branch must arrive as one commit, it is here and nowhere else.
+
+`main` merges through a **merge queue**, and the queue's enqueue API carries **no
+commit-message fields** — `EnqueuePullRequestInput` accepts `pullRequestId` /
+`jump` / `expectedHeadOid` and nothing else. So the squash message cannot be
+handed to GitHub at merge time; GitHub *derives* it from repo settings, which on
+`offlinecv/OfflineCV` are:
+
+```
+squash_merge_commit_title:   COMMIT_OR_PR_TITLE
+squash_merge_commit_message: COMMIT_MESSAGES
+```
+
+With those, a **multi-commit** PR merges with every commit message concatenated as
+`* ` bullets — which is how `wip`, `fix lint`, and `address review comments on PR
+#458` end up in `main`'s history permanently. The `COMMIT_OR_` prefix is the only
+lever, and it gives exactly one:
+
+> **A PR with exactly one commit merges with that commit's subject and body
+> verbatim** — PR title and body ignored, no bullet soup, nothing from the PR body
+> leaking into `git log`.
+
+So "the branch reaches the queue as one commit" is a **load-bearing invariant**,
+not a style preference, and the branch's single commit *is* the artifact. Branch
+commits are scratch. `docs/CONTRIBUTING-PROCESS.md` → **Squash messages** states
+the same policy for human contributors who never run a skill.
+
+## Process
+
+### Step 0 — Resolve the target, and never trust the local checkout
+
+Two call shapes reach this skill, and they mean different things by "the branch":
+
+| Caller | Target | Where the rewrite happens |
+|---|---|---|
+| `open-pr` Step 3.6 (always passes `--in-place`) | pre-push — the current checkout **is** the target, whether or not a PR exists yet | **in place**, in the user's checkout |
+| `revise-pr` 5.1, `pr-review` 5.5, standalone `/collapse-pr <N>` | an **existing PR**, whose head lives at `origin` and may have nothing to do with local state | **a throwaway worktree** detached at `origin/$HEAD_REF` |
+
+**The mode comes from the caller first and from PR discovery only as a fallback.**
+`IN_PLACE=1` (set by `--in-place`) pins `MODE=inplace` even when the inference
+below finds a PR; discovery still runs, because gates 3a and 3b need `PR_NUM`
+whichever mode we are in.
+
+```bash
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"   # offlinecv/OfflineCV
+PR_NUM="${PR_NUM:-$(gh pr view --json number -q .number 2>/dev/null || true)}"
+
+if [ -n "$IN_PLACE" ] || [ -z "$PR_NUM" ]; then
+  # ---- in-place mode: this checkout is the source of truth ----
+  # Either the caller asserted it (--in-place) or there is no PR to resolve.
+  MODE=inplace
+  WORKDIR="$(git rev-parse --show-toplevel)"
+  HEAD_REF="$(git rev-parse --abbrev-ref HEAD)"
+  IS_FORK=false
+  BASE_REF="${BASE:-$(gh repo view "$REPO" --json defaultBranchRef -q .defaultBranchRef.name)}"
+  git fetch origin "$BASE_REF"
+  # A PR may still exist on this branch even here (open-pr re-run). PR_NUM is
+  # already set if so, and gates 3a/3b use it — the mode says where the rewrite
+  # happens, not whether the PR-shaped gates apply.
+else
+  # ---- PR mode: origin is the source of truth ----
+  MODE=worktree
+  { read -r HEAD_REF; read -r HEAD_OID; read -r PR_BASE; read -r IS_FORK; } < <(
+    gh pr view "$PR_NUM" --repo "$REPO" \
+      --json headRefName,headRefOid,baseRefName,isCrossRepository \
+      --jq '.headRefName, .headRefOid, .baseRefName, .isCrossRepository')
+  BASE_REF="${BASE:-$PR_BASE}"
+  git fetch origin "$HEAD_REF" "$BASE_REF"
+
+  # The SHA gh reported must still be the SHA we fetched, or someone pushed in
+  # between and every gate below would be judging a stale target.
+  if [ "$(git rev-parse "origin/$HEAD_REF")" != "$HEAD_OID" ]; then
+    # No Step 5b needed here, and this is the only exit in the skill that can say
+    # so: the worktree is created three lines below, so there is nothing to remove.
+    echo "head moved between the PR read and the fetch — re-run" >&2; exit 1
+  fi
+
+  # Keep the mktemp parent in a variable: `git worktree remove` deletes only the
+  # child, so Step 5b has to `rm -rf` the parent or it is orphaned in /tmp.
+  WORKDIR_PARENT="$(mktemp -d)"
+  WORKDIR="$WORKDIR_PARENT/collapse-pr-$PR_NUM"
+  git worktree add --detach "$WORKDIR" "origin/$HEAD_REF"
+fi
+```
+
+**Read the multi-field JSON with `read`, never `eval`.** Git ref names may contain
+`$`, backticks, `;`, `&`, and quotes, so an `eval "$(gh … --jq '"HEAD_REF=\(…)"')"`
+turns a branch name into shell. `--jq '.a, .b, .c'` emits one value per line and
+`read` takes each literally.
+
+**`--detach` is not optional.** The target branch is very often already checked out
+somewhere — the user's main clone, or a sibling agent worktree — and `git worktree
+add <path> <branch>` refuses to check the same branch out twice. Detaching at
+`origin/$HEAD_REF` sidesteps that, and it is the honest description of what we
+want: a disposable head, not a second copy of a branch.
+
+Everything from Step 2 onward runs as `git -C "$WORKDIR" …`. **Run Step 5b on every
+exit path, refusals included.** There is deliberately no `trap`: these steps execute
+as a *sequence of separate Bash calls* carrying values forward by hand, so a handler
+installed here would fire when this call's shell exits — destroying the worktree
+before Step 1 ran. Teardown is an explicit step you invoke, not a handler.
+
+#### Why the target comes from `origin` and not from `HEAD`
+
+**This is not hypothetical.** Dry-running these gates against live PR #842 found the
+user's main checkout on that PR's branch holding a **superseded copy** of one of
+origin's commits — same subject line, different tree — and one commit fewer.
+Collapsing from that checkout would have force-pushed the stale tree and destroyed a
+Windows path-separator test fix that existed only on origin. Resolving from `origin`
+makes the rewrite safe by construction; gate 3e covers the other half of the hazard —
+the local commit the collapse would strand — by preserving it at a branch ref rather
+than by asking anyone to judge it, and carries the case in full as its worked
+example, including why no mechanical test can tell superseded work from unique work.
+
+### Step 0b — The tree-identity assertion, and what it licenses
+
+A collapse is a **pure history rewrite**: `reset --soft` + re-commit changes *which
+commits exist*, never *what the files contain*. So the collapsed commit's tree
+object must be byte-identical to the pre-collapse head's:
+
+```bash
+[ "$PRE_TREE" = "$(git -C "$WORKDIR" rev-parse 'HEAD^{tree}')" ] || abort
+```
+
+Step 5 runs it between the commit and the push. It is cheap, and it is the
+strongest correctness check available here — it proves content preservation
+directly instead of inferring it from a diff. Verified on #842: two commits
+collapsed to one, tree `56a742c98fb9d6afe1370ab5f9432c82abc6c5d3` on both sides,
+zero diff.
+
+**What it licenses: skipping the pre-push hook — in `worktree` mode only.**
+`offlinecv` installs a managed `.git/hooks/pre-push` that runs the full `npm run
+verify` (bypass: `OFFLINECV_SKIP_HOOKS=1`). Worktrees **share `.git/hooks`** with
+the main clone, so that hook fires on a collapse push from a throwaway worktree —
+where it fails immediately for want of `node_modules`. Bootstrapping `node_modules`
+there purely to re-run a suite over a tree that by construction did not change is
+minutes of work for no information.
+
+**"Re-run" is the whole licence, and it does not hold in `inplace` mode.** In
+`worktree` mode the tree came from `origin` — it already passed the hook on the push
+that put it there — and the assertion proves this collapse did not change it, so the
+suite would only be re-verifying a verified tree. In `inplace` mode the tree has
+never been pushed and nothing has verified it; the assertion still proves the
+*collapse* changed nothing, but "changed nothing" over an unverified tree is still
+unverified. `open-pr` Step 3.6 is the `inplace` caller and carries no other local
+verification, so bypassing here would publish an unverified tree to `origin`. **Let
+the hook run in `inplace` mode.**
+
+So, in `worktree` mode: **assert tree identity first, and only then push with the
+bypass set.**
+
+> If the assertion fails, the tree *did* change, the skip is **not** licensed, and
+> the whole collapse aborts. Never skip the hook unconditionally — the assertion is
+> the entire reason the skip is sound, and the mode is the entire reason the
+> assertion is enough.
+
+On a repo with no documented bypass, `git push --no-verify` is the portable
+equivalent — same assertion, same mode restriction, and nothing else licenses it.
+
+### Step 1 — Resolve the base pair, then detect the regime
+
+Ask the repo, don't assume offlinecv. This step is what keeps the skill portable:
+on a repo where the squash message can simply be supplied at merge time, the
+collapse buys nothing and this skill says so and exits 0.
+
+**Two different base refs are in play, and conflating them is the one way this step
+gets a stacked PR wrong.** `BASE_REF` (resolved in Step 0) is what this branch
+merges into *today* and defines the commit range to collapse; `QUEUE_BASE` is the
+branch whose merge regime eventually decides the squash message. They differ
+exactly when the PR is stacked on another feature branch — GitHub retargets the
+child to the default branch once the parent merges, so the child faces the queue no
+matter what its base says today. Probe the regime on `QUEUE_BASE`; collapse against
+`BASE_REF`.
+
+```bash
+OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
+QUEUE_BASE="$(gh repo view "$REPO" --json defaultBranchRef -q .defaultBranchRef.name)"
+
+# Squash-message policy. These two fields live ONLY on the REST repo object —
+# `gh repo view --json squashMergeCommitTitle` is not a field and errors out.
+SQ_TITLE="$(gh api "repos/$REPO" --jq .squash_merge_commit_title)"   # COMMIT_OR_PR_TITLE
+SQ_BODY="$(gh api "repos/$REPO"  --jq .squash_merge_commit_message)" # COMMIT_MESSAGES
+
+# Is a merge queue configured for the branch this change eventually lands on?
+# `mergeQueue` is null when none is configured, and jq indexes null to null,
+# so the `//` default is reached cleanly.
+MQ="$(gh api graphql -f query='
+query($o:String!,$n:String!,$b:String!){
+  repository(owner:$o,name:$n){ mergeQueue(branch:$b){ configuration{ mergeMethod } } }
+}' -f o="$OWNER" -f n="$NAME" -f b="$QUEUE_BASE" \
+  --jq '.data.repository.mergeQueue.configuration.mergeMethod // "none"')"
+```
+
+| `MQ` | `SQ_BODY` | Verdict |
+|---|---|---|
+| `SQUASH` | `COMMIT_MESSAGES` | **Collapse.** The message can't be supplied at merge time and is derived from the commits |
+| `SQUASH` | `PR_BODY` / `BLANK` | **No collapse needed** — the merge body comes from the PR body, not the commits |
+| `MERGE` / `REBASE` | any | **No collapse needed** — the queue isn't squashing, so commit count doesn't decide the message |
+| `none` | any | **No collapse needed** — no queue, so the merger can pass `gh pr merge --squash --subject … --body …` directly |
+
+On any "no collapse needed" row: print the row and the two settings that produced
+it, run **Step 5b**, and **exit 0**. Do not rewrite history to satisfy a constraint
+this repo does not have. Say the one thing the caller needs to hear on the `none` row: whoever
+merges must actually pass `--subject`/`--body`, because the web UI's default
+button will still derive a message from `SQ_TITLE`/`SQ_BODY`.
+
+`--yes` does **not** override this step. It is a capability check, not a safety
+gate — there is no risk being accepted, only work that would accomplish nothing.
+
+### Step 2 — Count the commits (this is what makes the skill idempotent)
+
+Step 0 already fetched `origin/$BASE_REF`, and in `worktree` mode `HEAD` is
+`origin/$HEAD_REF` — so this counts the **remote** head's commits, never the local
+checkout's:
+
+```bash
+BASE_SHA="$(git -C "$WORKDIR" merge-base HEAD "origin/$BASE_REF")"
+N="$(git -C "$WORKDIR" rev-list --count "$BASE_SHA..HEAD")"
+```
+
+| `N` | Do |
+|---|---|
+| `0` | Nothing on the branch — exit 0, say there is nothing to collapse |
+| `1` | **Already one commit** — exit 0, no-op |
+| `>1` | Continue |
+
+Both exit-0 rows run **Step 5b** on the way out. `N == 1` exiting 0 is the whole of
+the idempotence guarantee: a second run of
+`/collapse-pr` on a branch this skill just collapsed does nothing, touches no
+refs, and reports success. Callers may invoke it unconditionally.
+
+`$BASE_SHA..HEAD` (two dots, and anchored on the merge base rather than on
+`origin/$BASE_REF` directly) counts only commits reachable from `HEAD` and not from
+the merge base — so a branch that merged the base *in*, or a base that has moved on
+since the branch forked, still reports the branch's own commit count. `BASE_SHA` is
+also exactly the `reset --soft` target in Step 5, so the count and the rewrite can
+never disagree about where the branch begins.
+
+### Step 3 — Safety gates
+
+`PR_NUM`, `HEAD_REF`, `IS_FORK`, and `MODE` were all resolved in Step 0. `PR_NUM`
+may legitimately be empty: `open-pr` calls this **before the PR exists**, which is
+the cheapest possible moment because three of the five gates are then trivially
+satisfied. On an `open-pr` **re-run** `PR_NUM` is populated while `MODE` is still
+`inplace` — 3a and 3b then fire on their own merits, which is the point of keeping
+mode and PR discovery independent (Step 0).
+
+Each gate below **prints its reason when it fires** — a refusal that only says
+"refused" costs the caller a second run to find out what happened.
+
+**Any refusal below must run Step 5b before stopping.** A refusal is an exit path
+like any other, and there is no `trap` to clean up behind it (Step 0).
+
+| # | Gate | Fires when | Class |
+|---|---|---|---|
+| A | A stale approval would be dismissed | the PR has ≥1 `APPROVED` review and the base dismisses stale reviews on push | **soft** — `--yes` proceeds |
+| B | Unresolved review threads on this PR | ≥1 thread with `isResolved == false` | **soft** — `--yes` proceeds |
+| C | The branch is not ours to rewrite | fork PR, or any commit on the branch was authored by someone else | **hard** — never overridden |
+| D | The push lease would fail | the remote head is not an ancestor of the commit we are about to push | **hard** — never overridden |
+| E | A local checkout diverges from the target | `MODE=worktree` and some worktree on `$HEAD_REF` holds work `origin/$HEAD_REF` does not | **resolves losslessly** — refuses only on uncommitted changes of unknown provenance |
+
+#### 3a — Stale approval (soft)
+
+```bash
+APPROVALS=0
+if [ -n "$PR_NUM" ]; then
+  APPROVALS="$(gh pr view "$PR_NUM" --repo "$REPO" --json latestReviews \
+    --jq '[.latestReviews[] | select(.state == "APPROVED")] | length')"
+fi
+
+# Classic branch protection. Needs admin, so a 403 here is expected, not an error.
+DISMISS="$(gh api "repos/$REPO/branches/$BASE_REF/protection" \
+  --jq '.required_pull_request_reviews.dismiss_stale_reviews' 2>/dev/null || echo unknown)"
+
+# A ruleset can carry the same setting, and this endpoint is readable without admin.
+# `first | if . == null` and not `first // "unknown"`: jq's `//` treats `false` as
+# empty, so a ruleset that explicitly sets the flag to `false` would report
+# "unknown" — which this gate reads as `true` below, firing on a repo that does not
+# dismiss stale reviews at all.
+DISMISS_RULE="$(gh api "repos/$REPO/rules/branches/$BASE_REF" \
+  --jq '[.[] | select(.type == "pull_request")
+             | .parameters.dismiss_stale_reviews_on_push]
+        | first | if . == null then "unknown" else . end' 2>/dev/null \
+  || echo unknown)"
+```
+
+Use `if` blocks, not `[ -n "$PR_NUM" ] && …` one-liners: the `&&` form returns
+non-zero when the guard is false, which aborts the run the moment anything wraps
+this in `set -e`.
+
+Either probe answering `true` fires the gate. `unknown` from **both** also counts
+as `true` — the unreadable case is a contributor without admin, and guessing
+`false` there is guessing in the direction that deadlocks the PR. Say which probe
+answered, so a `--yes` is an informed one rather than a shrug.
+
+Reason to print when it fires: *the force-push dismisses the existing approval;
+`main` requires one, so the PR can no longer enter the merge queue until someone
+reviews it again.* On `offlinecv/OfflineCV` this gate is live —
+`dismiss_stale_reviews` is `true` on `main`.
+
+#### 3b — Unresolved review threads (soft)
+
+```bash
+OPEN_THREADS=0
+if [ -n "$PR_NUM" ]; then
+  OPEN_THREADS="$(gh api graphql -f query='
+  query($owner:String!,$name:String!,$pr:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$pr){ reviewThreads(first:100){ nodes{ isResolved path line } } }
+    }
+  }' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUM" \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+           | select(.isResolved == false)] | length')"
+fi
+```
+
+`-F pr=` (typed integer), never `-f` — the GraphQL variable is `Int!` and a string
+422s.
+
+Reason to print when it fires: *a reviewer with an open thread is coming back for
+another round, and they need to diff **just your delta** — a collapse replaces the
+whole branch and costs them that diff.* This is `revise-pr` Step 5.1's rule; the
+decision of whether this round is the final one belongs to the caller, which is
+why the gate is soft.
+
+#### 3c — Branch ownership (hard)
+
+```bash
+SELF_EMAIL="$(git config user.email)"
+FOREIGN="$(git -C "$WORKDIR" log --format='%ae' "$BASE_SHA..HEAD" \
+  | sort -u | grep -vFx "$SELF_EMAIL" || true)"
+```
+
+`IS_FORK` came from Step 0. Refuse — with no `--yes` path — when either holds:
+
+- **`IS_FORK` is `true`.** The head lives in a fork; we generally lack push rights,
+  and where `maintainerCanModify` grants them, force-pushing a contributor's fork
+  is the most destructive thing this skill could do.
+- **`FOREIGN` is non-empty.** Agent-authored commits use the local git identity
+  and pass; a named contributor's do not. Print the addresses.
+
+**The condition is commit authorship, not the PR author's login.** A maintainer can
+open a PR for a branch someone else wrote, and in that case the login says *ours*
+while the commits say otherwise — the commits are what a force-push destroys, so
+they are what the gate reads. Still print the PR author (`gh pr view --json author
+-q .author.login`) and your own (`gh api user --jq .login`) in the refusal, because
+"whose branch is this" is the first thing the caller will ask.
+
+Two reasons to print, because only the first is obvious: *a force-push replaces
+their commits, so their local branch silently diverges and their next `git pull`
+is a non-fast-forward* — and *the collapsed commit is authored by whoever runs the
+collapse, so their authorship is erased from `main`'s history.* The second is why
+this gate has no override: no flag makes it correct to publish someone else's work
+under your name.
+
+The correct escape hatch is social, not a flag: ask the author to run
+`/collapse-pr` on their own branch, or merge their PR as-is and accept the bullets.
+Run Step 5b, then stop.
+
+#### 3d — The push lease (hard)
+
+```bash
+# Exact ref, not a pattern: `ls-remote --heads origin main` would also match
+# refs/heads/feat/main, and the lease would then be pinned to the wrong branch.
+REMOTE_SHA="$(git ls-remote origin "refs/heads/$HEAD_REF" | cut -f1)"
+
+if [ -n "$REMOTE_SHA" ]; then
+  git -C "$WORKDIR" fetch origin "$HEAD_REF"   # objects must exist to test ancestry
+  if ! git -C "$WORKDIR" merge-base --is-ancestor "$REMOTE_SHA" HEAD; then
+    echo "remote $HEAD_REF has commits we do not have — someone pushed while we worked" >&2
+    exit 1
+  fi
+fi
+```
+
+Refuse — run Step 5b, then stop. Never `--force` past it, never re-fetch and retry:
+someone pushed while we worked, and the only safe answer is to stop and report.
+(The `exit 1` above is shorthand for that; the teardown still has to happen, because
+there is no `trap`.) Pin `REMOTE_SHA` here —
+Step 5 pushes with it as an **explicit** lease, so this gate and the push check the
+same value rather than two ideas of what the remote holds.
+
+In `worktree` mode this gate is normally trivial — `HEAD` *is* `origin/$HEAD_REF`,
+so `REMOTE_SHA` is an ancestor of itself. It stays live because Step 0's fetch and
+this read are separate network round-trips, and a push landing between them is
+exactly the race the lease exists for. In `inplace` mode it is the substantive
+check: it is what stops `open-pr` re-running on a branch someone else has pushed to.
+
+An empty `REMOTE_SHA` is the normal pre-PR case: the branch has never been pushed,
+there is nothing to clobber, and Step 5 does a plain `git push -u` instead.
+
+#### 3e — A local checkout diverges from the target (resolve; refuse only on row 2)
+
+**Only in `MODE=worktree`, and the restriction is code, not prose** — see the guard
+in the scan block below and on every block after it. In `inplace` mode `$WORKDIR`
+*is* the user's checkout on `$HEAD_REF`: being ahead of `origin` is the whole point,
+row 3's `reset --hard` would destroy the very local commits `open-pr` Step 3.6
+exists to collapse and publish, and it would take the staged index with them —
+which no branch ref can capture, so row 3 would not even be lossless. Rows 1 and 2
+never settle that index in `inplace` mode either. This is the same shape as Step
+5b's `if [ "$MODE" = worktree ]` guard, and for the same reason: an unguarded step
+here operates on the tree the caller is standing in.
+
+The `[ "$MODE" = worktree ] || exit 1` line heading each block below is an
+**assertion**, not a refusal: reaching it means the empty-match-list guard was
+bypassed. It needs no Step 5b, because the only mode that can trip it is the mode
+in which Step 5b is itself a no-op.
+
+The rewrite itself is already safe — Step 0 took the target from `origin`, so
+nothing local can leak into it. This gate exists for the *other* half of the hazard:
+local work the collapse is about to strand, which the natural follow-up
+(`git reset --hard origin/$HEAD_REF`, to get back in sync) then destroys.
+
+**Do not try to decide whether that local work is unique or superseded. It is not
+mechanically decidable, and attempting it is the design error this gate used to
+make.** Supersession is semantic, not byte-identical: when `origin` holds an
+amended, strictly *better* version of the same change, `git cherry` still reports
+`+` and a reverse-apply of the local patch still fails. Every available test says
+"unique" about work that plainly is not.
+
+**So make the operation lossless instead of classifying it.** If nothing can be
+lost, nobody has to be asked — and the one row that refuses is the one where
+losslessness is genuinely unavailable, not the one where the answer is merely hard.
+
+**Scan every worktree of this clone, not just `$PWD`.** The branch may be checked
+out in the user's main clone while this skill runs from a sibling agent worktree —
+precisely the shape of the #842 case.
+
+Two bounds, both structural, and neither an accident:
+
+- `git worktree list` sees only worktrees sharing *this* `.git`, so a **separate
+  clone** holding divergent work is invisible and nothing here can catch it.
+- **A detached worktree is invisible too**, by design of the match. `git worktree
+  list --porcelain` prints `detached` where an attached worktree prints `branch
+  refs/heads/…`, so the `awk` below never matches one. That is exactly why Step 0's
+  own `git worktree add --detach` is correct: `$WORKDIR` is on `origin/$HEAD_REF`
+  and would otherwise match its own scan, and be "resolved" against itself. State
+  it, because read as an accident it looks like a hole.
+
+```bash
+# 3e is worktree-mode ONLY. The guard produces an EMPTY match list in inplace
+# mode, which is what makes every block below a no-op there — prose cannot.
+MATCHES_FILE="$(mktemp -t collapse-pr-3e)"
+if [ "$MODE" = worktree ]; then
+  git worktree list --porcelain \
+    | awk -v ref="refs/heads/$HEAD_REF" '
+        /^worktree /   { wt = substr($0, 10) }
+        $0 == "branch " ref { print wt }' > "$MATCHES_FILE"
+else
+  : > "$MATCHES_FILE"
+  echo "3e: skipped — inplace mode, this checkout IS the target"
+fi
+```
+
+**Iterate explicitly.** There may be more than one match, and the rows below are
+the loop *body*, not a one-shot:
+
+```bash
+if [ "$MODE" = worktree ]; then
+  while IFS= read -r WT; do
+    # rows 1 → 2 → 3 → 4 below, in that order, for this $WT
+    :
+  done < "$MATCHES_FILE"
+fi
+```
+
+Where the rows run as separate Bash calls, bind `WT` to one line of
+`$MATCHES_FILE` at a time and finish all four rows for it before moving to the
+next. A bare `$WT` with no iteration behind it is undefined on a multi-match tree.
+
+Resolve each match by **provenance**, in this order. Uncommitted state is settled
+first because row 3's `reset --hard` discards exactly what rows 1 and 2 are about:
+
+| # | Local state | Resolution | Human? |
+|---|---|---|---|
+| 1 | Uncommitted changes **this run authored** — on an explicit path list the caller passed in, *and* `$WT` is the caller's `--authored-worktree` | stage those paths, commit, publish (fast-forward push, or backup + cherry-pick), re-pin the target | no |
+| 2 | Uncommitted changes of **unknown provenance** — including *anything* dirty in a worktree that is not `--authored-worktree` | **refuse** | **yes** |
+| 3 | Local-only **commits** on the target branch | preserve at a real branch ref, then `reset --hard origin/$HEAD_REF` | no |
+| 4 | Nothing local-only, merely behind `origin` | proceed; warn it needs `git reset --hard origin/$HEAD_REF` after the collapse | no |
+
+**The whitelist is scoped to one checkout, because provenance is content in a
+*specific* checkout and `--authored-path` names only path *names*.** Applying one
+global path list to every match is a real hole, not a theoretical one: if the
+user's main clone is also on `$HEAD_REF` with their own uncommitted edits to a
+whitelisted path, an unscoped row 1 would stage, commit and **push the user's
+edits into the PR** — precisely what row 2 exists to forbid. So a dirty path
+counts as run-authored only when **both** hold: `$WT` is `--authored-worktree`,
+and the path is on `--authored-path`. Everything dirty anywhere else is row 2,
+unconditionally.
+
+**`--dry-run` performs none of these writes.** This is the one gate that changes
+state to pass, and it runs in Step 3 — *before* Step 4's dry-run stop — so it would
+otherwise commit, push, branch, and `reset --hard` on a run that promised to change
+nothing. Under `--dry-run`, classify each match and print the row it *would* take,
+including the backup ref name it would create, and move on.
+
+##### Row 1 — uncommitted, known provenance
+
+Only a caller that hands over both an explicit checkout and an explicit list gets
+this row: `--authored-worktree` plus `--authored-path`, which `pr-review` Step 5.5
+fills from its `$FIXED_PATHS`. Any dirty path *not* on the list — or any dirty
+path at all in a worktree that is not `--authored-worktree` — is unknown
+provenance and drops that whole tree to row 2. The list is a whitelist, not a hint.
+
+```bash
+[ "$MODE" = worktree ] || exit 1        # 3e never runs in inplace mode (above)
+
+if [ "$WT" != "${AUTHORED_WORKTREE:-}" ]; then   # :- — the flag is optional
+  # Not the caller's checkout: nothing here is ours by construction.
+  # Any dirty path at all -> row 2.
+  DIRTY_COUNT="$(git -C "$WT" status --porcelain --untracked-files=no -z \
+                 | tr -dc '\0' | wc -c | tr -d ' ')"
+  # Row 2. Run Step 5b before stopping, like every refusal in this skill.
+  [ "$DIRTY_COUNT" = 0 ] || { echo "row 2: $WT is dirty and is not --authored-worktree" >&2; exit 1; }
+fi
+
+# Null-delimited, and `-uno`. Never `cut -c4-`: it mangles rename entries
+# (`R  old -> new`) and git quotes paths containing spaces, so neither form can
+# ever match the whitelist — the tree would silently drop to row 2 with a
+# refusal naming a path the user cannot find.
+git -C "$WT" status --porcelain --untracked-files=no -z \
+  | while IFS= read -r -d '' ENTRY; do
+      XY="${ENTRY:0:2}"; P="${ENTRY:3}"       # `XY PATH`: one space at index 2
+      printf '%s\n' "$P"                      # the NEW path
+      case "$XY" in
+        R*|C*) IFS= read -r -d '' ORIG        # rename/copy: the ORIGINAL path is
+               printf '%s\n' "$ORIG" ;;       # a second NUL-terminated field
+      esac
+    done
+# every path emitted above must appear in $AUTHORED_PATHS, or this is row 2.
+# A rename emits BOTH ends, because committing it touches both.
+
+WT_PRE_FIX_SHA="$(git -C "$WT" rev-parse HEAD)"   # BEFORE the commit — see the push below
+git -C "$WT" add -- ${AUTHORED_PATHS[@]+"${AUTHORED_PATHS[@]}"}   # by path, never `git add -A`/`.`
+git -C "$WT" commit -m "${AUTHORED_MESSAGE:-chore: fold in run-authored changes (collapse-pr gate 3e)}"
+```
+
+**The commit message is supplied, never invented.** `--authored-message` sets it
+and the literal above is the default; nothing derives one from the diff. It is
+usually short-lived — the collapse folds this commit away a moment later — but if a
+*later* hard gate refuses after the push below has landed, it is permanent on
+`origin`, so the default says exactly what it is and which gate made it.
+
+**`--untracked-files=no` is load-bearing on this repo, not a tidiness flag.**
+`offlinecv`'s `.git/info/exclude:18` carries `!/node_modules`, which *un-ignores*
+it, so every checkout that has ever run `npm install` reports `?? node_modules`.
+Counting `??` entries as dirty would fire row 2 in every checkout `pr-review`
+operates in — it has to run `npm run verify`, so it has to have installed — and
+`pr-review` Step 5.5's collapse would refuse 100% of the time on the repo this
+skill was built for. A `reset --hard` does not touch untracked files anyway, so
+they are not what rows 1–3 are protecting. A run-authored **new** file is the one
+case that needs them: intersect the `??` set with `$AUTHORED_PATHS` explicitly
+when the caller says it created files, and never treat the leftovers as dirt.
+
+**Stage by explicit path.** The same tree can also hold the user's unrelated
+in-progress edits — this is `pr-review` Step 5.5's rule (*"stage by path, never
+`git add -A`/`.`"*) and it applies here for the same reason.
+
+**Publishing that commit is not optional, and it is what makes this row a fold-in
+rather than a backup.** The collapse reads `origin/$HEAD_REF` and never this
+checkout (Step 0), so a commit that stays local is simply not in the collapse.
+
+**But the naive `push origin HEAD:$HEAD_REF` pushes the whole branch, and that is
+the #842 hazard performed without a gate.** Rows run 1 → 2 → 3 → 4, so row 1 fires
+*before* row 3 has looked at local-only commits. If `$WT` holds commits `origin`
+lacks, a plain push publishes **all of them** into the PR — the very commits row 3
+merely *backs up*, precisely because whether they are unique or superseded is
+undecidable. Test ancestry first and take the branch that fits:
+
+```bash
+[ "$MODE" = worktree ] || exit 1        # 3e never runs in inplace mode (above)
+
+if git -C "$WT" merge-base --is-ancestor "$WT_PRE_FIX_SHA" "origin/$HEAD_REF"; then
+  # $WT held nothing origin lacks: our new commit is the only delta.
+  git -C "$WT" push origin "HEAD:$HEAD_REF"       # plain, fast-forward only
+else
+  # $WT has local-only commits. Publish OURS and only ours: back the whole tip up
+  # per row 3 first (so nothing is lost), then replay just the fix onto the
+  # remote head inside $WORKDIR, which is already detached at origin/$HEAD_REF.
+  FIX_SHA="$(git -C "$WT" rev-parse HEAD)"
+  # ... row 3's backup of $FIX_SHA runs here, with its own `||` refusal ...
+  git -C "$WORKDIR" cherry-pick "$FIX_SHA"
+  git -C "$WORKDIR" push origin "HEAD:$HEAD_REF"
+fi
+```
+
+`$WT_PRE_FIX_SHA` is `$WT`'s `HEAD` read **before** the `git commit` above.
+Deciding on the post-commit `HEAD` would always answer "not an ancestor" and never
+take the cheap path.
+
+Two consequences of the `else` branch, both worth stating so they are not
+rediscovered later:
+
+- **Row 3 is already half-done for this `$WT`.** The backup above covered the
+  local-only commits *and* the fix commit on top of them, so when row 3 reaches
+  this checkout it must not mint a second ref — only the `reset --hard` remains.
+  Report the one ref.
+- **The cherry-pick can conflict**, because `$WORKDIR` is at `origin/$HEAD_REF`
+  and the fix was written against a different base. On conflict, `git -C
+  "$WORKDIR" cherry-pick --abort`, run Step 5b, and refuse: replaying it by hand
+  would be composing changes nobody reviewed. The backup ref already holds the
+  work, so nothing is lost — name it.
+
+Because the push moves the target, re-pin everything Step 0 and gate 3d read from
+it before continuing:
+
+```bash
+[ "$MODE" = worktree ] || exit 1
+git fetch origin "$HEAD_REF"
+REMOTE_SHA="$(git ls-remote origin "refs/heads/$HEAD_REF" | cut -f1)"
+git -C "$WORKDIR" fetch origin "$HEAD_REF"
+git -C "$WORKDIR" reset --hard "origin/$HEAD_REF"
+BASE_SHA="$(git -C "$WORKDIR" merge-base HEAD "origin/$BASE_REF")"
+```
+
+**If that push is rejected, find out why before blaming anyone.** Three causes
+reach the same rejection message and only one of them is gate 3d's:
+
+| Test | Cause | Answer |
+|---|---|---|
+| `git merge-base --is-ancestor "$REMOTE_SHA" HEAD` **fails** | someone genuinely pushed while we worked — 3d's condition | refuse at 3d, run Step 5b, stop |
+| it **passes**, and this is the `$WT` path | `$WT` was simply *behind* `origin` (row 4's state) and row 1 committed on a stale head. Nobody pushed; 3d already passed against this same `REMOTE_SHA` | fetch, `reset --hard origin/$HEAD_REF` on `$WT`, re-apply the authored paths, retry once — do **not** refuse |
+| the rejection came from `.git/hooks/pre-push` | row 1's push is a plain push from a **real checkout**, so the managed hook fires and runs `npm run verify`. It is *supposed* to: these are new changes, and Step 0b's licence covers only a tree the assertion proved unchanged | fix the failing gate. Never set `OFFLINECV_SKIP_HOOKS=1` here |
+
+Refusing on the second or third row would be wrong: in neither case did anyone
+push, and in the third the tree is unverified rather than contested.
+
+##### Row 2 — uncommitted, unknown provenance (refuse)
+
+The one row a human must decide, and the reason is not that the answer is hard —
+it is that both available answers are wrong to pick unilaterally. Stranding the
+edits loses them; absorbing them publishes changes nobody chose to include, under a
+message that does not describe them, in a commit that lands in `main` verbatim. No
+flag makes that right, so there is no `--yes` path.
+
+**A worktree that is not `--authored-worktree` reaches this row on *any* tracked
+dirt at all**, whatever the path names say. The whitelist is a claim about content
+the caller wrote in a checkout it controls; the same path name in a different
+checkout is a different file with different content, and no flag makes it ours.
+
+Name the paths — and the checkout — not just the fact:
+
+> `/Users/…/offlinecv` is on `epic-811-parser-lane` with uncommitted changes to
+> `src/score/specificity.ts` that this run did not author. Refusing: collapsing
+> would either strand them or absorb them into a commit that does not describe
+> them. Commit them, stash them, or discard them, then re-run.
+
+Run Step 5b, then stop.
+
+##### Row 3 — local-only commits (preserve, then reset)
+
+Lossless by construction, so it needs no human. Take the backup **before** the
+reset, and only on a tree rows 1 and 2 have already cleaned:
+
+```bash
+[ "$MODE" = worktree ] || exit 1        # 3e never runs in inplace mode (above)
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP="collapse-pr-backup/$HEAD_REF-$STAMP"
+
+# The stamp has second resolution, so two runs in the same second collide. Find
+# a free name rather than failing on one — a retry loop would otherwise hit the
+# refusal below every single time.
+i=0
+while git -C "$WT" show-ref --verify --quiet "refs/heads/$BACKUP"; do
+  i=$((i + 1)); BACKUP="collapse-pr-backup/$HEAD_REF-$STAMP-$i"
+done
+
+SAVED="$(git -C "$WT" rev-parse HEAD)"
+
+# The backup is a HARD PRECONDITION, not a courtesy — never let the reset run
+# without it. Chained, so a failed branch creation cannot fall through.
+git -C "$WT" branch "$BACKUP" "$SAVED" || {
+  echo "backup ref '$BACKUP' could not be created; refusing to reset." >&2
+  echo "Nothing was discarded. Fix the ref store and re-run." >&2
+  exit 1
+}
+
+# Creating the ref is not the same as the ref pointing where we meant. Verify.
+[ "$(git -C "$WT" rev-parse "$BACKUP")" = "$SAVED" ] || {
+  echo "backup ref '$BACKUP' does not point at $SAVED — refusing to reset." >&2
+  echo "Nothing was discarded." >&2
+  exit 1
+}
+
+git -C "$WT" reset --hard "origin/$HEAD_REF"
+```
+
+Both `exit 1` paths run **Step 5b** first, like every other exit in this skill.
+
+**Why the `||` and the verification matter more here than anywhere else in this
+skill.** Every other gate fails *closed* — it refuses and the tree is untouched.
+This one changes state, and the only thing standing between a `reset --hard` and
+unrecoverable loss is the two checks above it. These steps run as a sequence of
+separate Bash calls with no `set -e`, so an unchained nonzero exit is *silently
+discarded* and the reset runs anyway; the `||` is what makes the failure stop the
+sequence, and the `rev-parse` comparison is what catches a ref that was created but
+does not name the commit we are about to discard.
+
+**Two real failure modes, and one that isn't.** `git branch` can fail because the
+ref store is read-only or otherwise broken — that is the refusal above. It can also
+fail on a same-second name collision (`fatal: a branch named … already exists`,
+exit 128) — which is why the loop *finds a free name* instead of refusing: a
+refusal there would make every rapid retry fail forever, for no safety gained.
+
+What does **not** happen is a directory/file ref conflict from nested branch names.
+`collapse-pr-backup/feat-<stamp>` and `collapse-pr-backup/feat/foo-<stamp>` coexist
+fine, verified: the `-<stamp>` suffix means the short name is never a bare directory
+component, so `refs/heads/collapse-pr-backup/feat-…` and
+`refs/heads/collapse-pr-backup/feat/foo-…` never collide as path and prefix. Do not
+re-introduce that rationale.
+
+**A branch ref, not the reflog.** The reflog expires and `gc` can reap unreachable
+objects sooner; it also cannot be pushed. A branch ref is permanent until someone
+deletes it, survives `gc`, and can be pushed or cherry-picked from as-is. Refs are
+shared across all worktrees of a clone, so the backup is visible from wherever the
+user is standing.
+
+**Classify for the *message* only — never let it gate the action.** The whole point
+of the backup is that the classification below is unreliable, so it is taken either
+way:
+
+| Signal | What the report says |
+|---|---|
+| every local-only commit is reachable from `origin/$HEAD_REF` | already upstream — the backup is a formality |
+| local `HEAD` is an ancestor of `origin/$HEAD_REF` | merely behind |
+| neither | **possibly unique** — name the backup ref prominently |
+
+**Worked example — PR #842.** The user's main checkout held `6ba92e9`, one commit
+`origin` lacked, sharing a subject line with `origin`'s `3aeae1b` but carrying a
+different tree — indistinguishable by any mechanical test from genuinely unique
+work. Resolved without asking anyone:
+
+```
+preserved   collapse-pr-backup/epic-811-parser-lane-20260815T234430Z -> 6ba92e9
+reset       /Users/…/offlinecv -> 72358ab  (origin/epic-811-parser-lane)
+divergence  0 0 — gate passes
+```
+
+The old behavior was a refusal that asked the user to compare trees by hand. The
+commit is exactly as safe now, and nobody was interrupted.
+
+##### Row 4 — merely behind
+
+```bash
+[ "$MODE" = worktree ] || exit 1        # 3e never runs in inplace mode (above)
+git -C "$WT" rev-list --left-right --count "HEAD...origin/$HEAD_REF"
+#                                            ^ local-only   ^ origin-only
+```
+
+`0` local-only with `>0` origin-only is nothing to preserve. Proceed, and warn that
+this checkout needs `git reset --hard origin/$HEAD_REF` after the collapse — which
+is true of *every* local copy of the branch once the collapse lands, so Step 6
+reports it for all of them, not just this one.
+
+### Step 4 — Compose the message
+
+With `--message-file <f>`, use that file verbatim and skip straight to printing
+it. This is the hand-authored path, and nothing below rewrites it.
+
+Otherwise **write** the message. It is not a concatenation of the branch's commit
+subjects, and it is not a changelog of the work — it describes the change as a
+whole, the way the person who has to `git blame` this line in a year needs it:
+
+```
+feat(score): weight specificity by bullet density (#453)
+
+Bullets with quantified outcomes now dominate the specificity dimension
+instead of raw keyword count, which over-rewarded skill-stuffed resumes.
+
+- add BulletDensity probe in score/specificity.ts
+- bump ATS_SCORE_ALGO_VERSION to 4
+- regenerate corpus goldens
+
+Closes #453
+```
+
+- **Subject:** conventional-commit prefix per `CONTRIBUTING.md`
+  (`feat`/`fix`/`chore`/`refactor`/`docs`/`test`), scoped, imperative.
+- **Trailer:** `Closes #N` only when this PR fully resolves the issue; `Refs #N`
+  otherwise. Same rule the PR body follows.
+- **Drop the process.** `wip`, `fix lint`, `address review comments`, `rebase on
+  main` — none of it describes the change, and all of it is about to become
+  permanent if you keep it.
+- **No AI attribution trailer, and nothing to strip.** Attribution is off by
+  config (`attribution` in `.claude/settings.json` sets `commit` and `pr` to the
+  empty string), so the harness appends nothing; do not add a `Co-Authored-By`,
+  a `Generated with` line, or a session URL by hand. This message lands in `main`
+  verbatim, so the rule matters more here, not less.
+
+Write it to a temp file, **not** into the worktree's `.git`:
+
+```bash
+MSG_FILE="${MESSAGE_FILE:-$(mktemp -t collapse-pr-msg)}"
+```
+
+In `worktree` mode the collapse worktree is deleted on exit, so a message parked in
+its git dir vanishes with it — including on the failure paths, which are exactly
+when you want the text you just wrote to still exist for a retry.
+
+**Print the message and the gate results.** With `--dry-run`, stop here: nothing has
+been staged, committed, or pushed, and no ref has moved — gate 3e held its writes
+back for exactly this reason. Run Step 5b and exit 0.
+
+### Step 5 — Execute
+
+Every command runs in `$WORKDIR` — the throwaway worktree in `worktree` mode, the
+user's checkout in `inplace` mode.
+
+```bash
+PRE_COLLAPSE_SHA="$(git -C "$WORKDIR" rev-parse HEAD)"
+PRE_TREE="$(git -C "$WORKDIR" rev-parse 'HEAD^{tree}')"
+
+git -C "$WORKDIR" reset --soft "$BASE_SHA"      # the same SHA Step 2 counted from
+```
+
+If the index is now empty the branch's commits net to no change (a change and its
+revert). Restore and stop rather than minting an empty commit:
+
+```bash
+if git -C "$WORKDIR" diff --cached --quiet; then
+  git -C "$WORKDIR" reset --soft "$PRE_COLLAPSE_SHA"
+  echo "branch has no net change against $BASE_REF — nothing to collapse" >&2
+  exit 1
+fi
+git -C "$WORKDIR" commit -F "$MSG_FILE"
+```
+
+**Now assert tree identity, before anything reaches the network** (Step 0b):
+
+```bash
+if [ "$PRE_TREE" != "$(git -C "$WORKDIR" rev-parse 'HEAD^{tree}')" ]; then
+  git -C "$WORKDIR" reset --soft "$PRE_COLLAPSE_SHA"
+  echo "collapse changed the tree — aborting, this is not a pure history rewrite" >&2
+  exit 1
+fi
+```
+
+A mismatch means something other than a history rewrite happened — a stray staged
+edit, a hook that rewrote files, a `--message-file` path that was actually a patch.
+Abort; do not push, and do not skip the pre-push hook. (Both `exit 1` paths above
+run Step 5b first.)
+
+Then push, with the lease pinned to the SHA gate 3d read and — **in `worktree` mode
+only** — the hook bypass the assertion licensed (Step 0b):
+
+```bash
+# inplace mode gets an EMPTY prefix: nothing has verified that tree yet, so the
+# pre-push hook is `open-pr`'s only local verification and must run.
+if [ "$MODE" = worktree ]; then SKIP=(env OFFLINECV_SKIP_HOOKS=1); else SKIP=(); fi
+
+# ${SKIP[@]+"${SKIP[@]}"}, not "${SKIP[@]}": on macOS's /bin/bash 3.2 an empty
+# array expanded as "${SKIP[@]}" is an UNBOUND VARIABLE error under `set -u`, so
+# the inplace branch would abort the push instead of running it hook-and-all.
+if [ -n "$REMOTE_SHA" ]; then
+  ${SKIP[@]+"${SKIP[@]}"} git -C "$WORKDIR" \
+    push --force-with-lease="$HEAD_REF:$REMOTE_SHA" origin "HEAD:$HEAD_REF"
+else
+  ${SKIP[@]+"${SKIP[@]}"} git -C "$WORKDIR" \
+    push -u origin "HEAD:$HEAD_REF"          # first push; nothing to lease against
+fi
+```
+
+The bypass is set **inline on the push**, not exported. An `export` earlier in the
+run would silence the repo's managed hooks for every later command too — including
+operations the tree-identity assertion says nothing about, which is precisely the
+unconditional skip Step 0b forbids.
+
+In `inplace` mode the hook therefore runs `npm run verify` on this push, and a red
+gate rejects it. That is the intended outcome, not an obstacle to route around: the
+caller is publishing a tree nothing has verified.
+
+On a repo with no such bypass, `git push --no-verify` is the portable equivalent —
+same `worktree`-mode restriction; on a repo with no pre-push hook at all, drop both.
+
+**The explicit `=<refname>:<expect>` form is required, not a stylistic
+preference.** A bare `--force-with-lease` protects the ref by comparing it to our
+*remote-tracking* ref — and `git push`'s own manual warns that this "interacts
+very badly with anything that implicitly runs `git fetch`". Step 0 and gate 3d
+both fetch, which updates that tracking ref and makes a bare lease vacuously
+true. Pinning the SHA we actually inspected is what keeps the check real.
+**Never bare `--force`.** There is no case in this skill where it is the answer.
+
+Verified on both paths: a valid lease pushes, and a stale lease (a third party
+pushed after the lease was read) is **refused with the remote unchanged**. So the
+lease genuinely is the mid-push guard `pr-review` Step 5.5 relies on, not a
+best-effort gesture.
+
+If the push is rejected anyway — the lease lost a race, or protection refused it —
+put `HEAD` back, **run Step 5b**, and report. This is an exit path like any other
+and there is no `trap` behind it (Step 0). `--soft` is enough and is the safer verb: the
+collapsed commit and `PRE_COLLAPSE_SHA` have byte-identical trees (Step 0b just
+proved it), so moving `HEAD` back leaves the index and worktree clean:
+
+```bash
+git -C "$WORKDIR" reset --soft "$PRE_COLLAPSE_SHA"
+```
+
+In `worktree` mode this matters little — the worktree is about to be deleted — but
+in `inplace` mode it is what leaves the user's branch exactly as it was found, so
+the caller can fall back to a plain push of its own commits.
+
+### Step 5b — Tear down the worktree
+
+**`worktree` mode only — the guard is not optional.** In `inplace` mode `$WORKDIR`
+is the user's own checkout, which in this repo is very often *itself* a linked
+worktree; `git worktree remove --force` on a linked worktree **succeeds** and takes
+its untracked files with it. An unguarded teardown here deletes the tree the caller
+is standing in.
+
+**Never remove the worktree before reading what you need from it** — the new SHA
+for the Step 6 report lives there, so this block comes **first**:
+
+```bash
+NEW_SHA="$(git -C "$WORKDIR" rev-parse HEAD)"     # read BEFORE the teardown
+```
+
+Only then tear it down:
+
+```bash
+if [ "$MODE" = worktree ]; then
+  git worktree remove --force "$WORKDIR"
+  git worktree prune
+  rm -rf "$WORKDIR_PARENT"      # `worktree remove` deletes only the child dir
+fi
+```
+
+**Run this step on every exit path** — success, no-op, and refusal alike. There is
+no `trap` doing it for you (Step 0). `--force` is needed because `git worktree
+remove` refuses a worktree with a modified or untracked tree, and a pre-push hook or
+a stray build artifact can leave one.
+
+**What the collapse costs, and how to recover from a bad one**, are stated once in
+`docs/CONTRIBUTING-PROCESS.md` → **Squash messages**. Two costs land on the caller
+rather than on `main`, and both are why gate 3b exists: reviewers lose the
+per-commit delta (GitHub's `force-pushed … Compare` link is a worse substitute), and
+open review threads may go `isOutdated` once their anchor lines move — so do any
+reply-and-resolve work **after** this push, with thread IDs captured before it.
+
+### Step 6 — Report
+
+Print, in this order: **the mode** (`inplace` or `worktree`) and, in `worktree`
+mode, the `origin/$HEAD_REF` SHA the target was resolved from; the regime verdict
+from Step 1 with the two settings that produced it; the commit count before and
+after; **every gate that fired, with its reason and whether `--yes` carried it**;
+the tree-identity assertion result and the tree hash; the composed message (or the
+`--message-file` path); the new SHA and the SHA it replaced; whether the push was a
+force-with-lease or a first push; and the hook disposition — in `worktree` mode, that
+the pre-push hook was skipped **because the assertion passed**, and in `inplace`
+mode, that it **ran**. In `worktree` mode, add that the worktree was removed; in
+`inplace` mode say nothing about a worktree, because none was created and the user's
+checkout is untouched.
+
+**Report everything gate 3e did, per checkout, and name every backup ref it
+created** — recovery has to be one command read straight off the report, not an
+archaeology exercise:
+
+```
+3e  /Users/…/offlinecv
+    preserved  collapse-pr-backup/epic-811-parser-lane-20260815T234430Z -> 6ba92e9
+               (possibly unique — this ref is the only reference to that commit)
+    reset      -> 72358ab (origin/epic-811-parser-lane)
+```
+
+State the classification (already upstream / merely behind / **possibly unique**) as
+the *hint* it is, never as a verdict — the backup was taken regardless, because the
+classification cannot be trusted. Where 3e committed and published an
+`--authored-path` set (row 1), name the `--authored-worktree` it came from, the
+paths, the resulting SHA, and **which route published it** — a fast-forward push
+from that checkout, or a backup plus a cherry-pick through `$WORKDIR`, because only
+the second leaves a backup ref the reader still has to deal with.
+
+Say so explicitly when 3e was **skipped for `inplace` mode** rather than finding no
+matches: `open-pr` Step 4 keys its own push-skip on the reported mode, and the two
+outcomes are indistinguishable from silence.
+
+Then name every local checkout of the branch with the exact `git reset --hard` it
+now needs — after a collapse, every local copy is stale by construction, and a user
+who is not told will hit a non-fast-forward later with no idea why.
+
+On a no-op run, say which of Step 1 or Step 2 short-circuited it — "nothing to do"
+alone leaves the caller unable to tell a single-commit branch from a repo that
+never needed the skill.
+
+## Rules
+
+The steps above carry the mechanics. These are the things no step states.
+
+- **`--force-with-lease=<branch>:<sha>`, always explicit, never bare `--force`.** A
+  bare lease compares against the remote-tracking ref, which this skill's own
+  fetches have already updated, making it vacuously true. There is no situation in
+  this skill where bare `--force` is the answer — not as a retry, not ever.
+- **Soft gates take `--yes`; hard gates take nothing.** Stale approval and open
+  threads are judgement calls the caller may already have made. Branch ownership and
+  the push lease are not: no flag makes it right to republish someone else's work
+  under your name, or to overwrite a push that landed while you worked.
+- **Mode is the caller's to declare, never inferred from PR existence.** A PR that
+  exists says nothing about which tree holds the work — `open-pr` re-running on an
+  already-open PR has both. `--in-place` pins it; PR discovery still runs, because
+  gates 3a/3b are about the PR and Step 0's mode is about the tree.
+- **Provenance is content in a checkout, not a path name.** `--authored-path` only
+  means anything inside `--authored-worktree`; the same path in another checkout is
+  a different file, and dirt there is row 2 no matter what it is called.
+- **Prefer losslessness to judgement (3e).** Where local work would be stranded,
+  preserve it at a branch ref and proceed — do not stop to ask whether it was
+  superseded, because no mechanical test can tell (`git cherry` and a reverse-apply
+  both cry "unique" over an amended better copy on `origin`). Interrupt a human only
+  for the one case that *cannot* be made lossless: uncommitted changes this run did
+  not author, where stranding loses them and absorbing them publishes changes nobody
+  chose. Classify only to word the report, never to decide.
+- **Nothing is appended for attribution.** The harness's trailers are off by
+  config; do not hand-add a `Co-Authored-By`, a generated-with line, or a session
+  URL to a message that lands verbatim in `main`.
+- **Never bypass the queue with `--admin`** just to hand-write a merge message.
+  The collapse achieves the same thing without skipping required checks.
+- **Don't `rebase -i` a branch clean first.** It is pointless work on commits that
+  are about to be squashed — collapse instead.
+- Pure `gh` + `git` — no external services, no machine-specific paths.

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -136,53 +136,45 @@ area-code-`555` one. The gate scans annotations and metadata as well as text. Wh
 
 ### Step 3.6: Collapse the branch to a single commit
 
-`main` merges through a **merge queue**, and the queue's enqueue API carries **no
-commit-message fields** (`EnqueuePullRequestInput` is `pullRequestId` / `jump` /
-`expectedHeadOid` — nothing else). So the squash message can't be supplied at
-merge time; GitHub *derives* it from repo settings when the queue merges.
+The branch must reach the merge queue holding **one commit whose message is the
+message you want in `main`** — `/collapse-pr`'s *Why this skill exists* has the
+full rationale, and it is the only copy of it. **Delegate the mechanics:**
 
-Those settings are `squash_merge_commit_title: COMMIT_OR_PR_TITLE` and
-`squash_merge_commit_message: COMMIT_MESSAGES`. The lever that gives is:
+> Invoke `/collapse-pr --in-place` (add `--base "$BASE"` when Step 0 overrode the
+> base, so a stacked PR collapses against its parent layer and not `main`). It
+> counts the commits itself and exits 0 on a branch that already holds one, so run
+> it unconditionally.
 
-> **A PR with exactly one commit merges with that commit's subject and body
-> verbatim** — PR title/body ignored, no `* `-bulleted commit soup, nothing from
-> the PR body leaking into `git log`.
+**`--in-place` is mandatory here, not a default worth omitting.** Without it
+`/collapse-pr` infers its mode from whether `gh pr view` finds a PR — and on a
+**re-run** of this skill against a branch whose PR already exists, it does. It
+would then flip to worktree mode, collapse `origin`'s head, and never look at the
+commits you just made locally; Step 4 below would skip its push because "3.6
+collapsed"; and `/collapse-pr` gate 3e row 3 would `reset --hard` the local commits
+away as divergence. The work would be destroyed and both skills would report
+success. `--in-place` is what tells it that this checkout, not `origin`, is the
+target. Step 6's report names the mode it actually ran in — check it.
 
-So the branch must arrive at the queue holding **one commit whose message is the
-message you want in `main`**. Doing it here — before the PR exists — costs
-nothing (there's no approval to dismiss yet).
+**Here is the cheapest moment in the PR's life to do this**, and that is why the
+step sits where it does. In **in-place** mode this checkout *is* the target, so
+there is no throwaway worktree and no remote-vs-local question to settle, and the
+divergence gate (3e) does not apply at all. On a *first* run three of the five
+gates cannot fire: there is no approval to dismiss, no review thread to strand, and
+no 3e. The other two are satisfied by construction on a branch you just created: it
+is yours, and on a first push there is no lease to lose.
 
-```bash
-git log --oneline "origin/$BASE..HEAD" | wc -l    # >1 → collapse
-```
+On a **re-run** the branch may already have a PR, and `--in-place` deliberately does
+not hide that: `/collapse-pr` still reads it, so the stale-approval and open-thread
+gates fire on their own merits, and the lease gate becomes live again — all correct,
+because someone else may have approved, commented, or pushed since. `--in-place`
+fixes *where the rewrite happens*, not *which gates apply*.
 
-If more than one commit, write the combined message and collapse:
-
-```bash
-git reset --soft "$(git merge-base HEAD "origin/$BASE")"
-git commit -F .git/COMMIT_EDITMSG      # the combined message you authored
-```
-
-The combined message is **written, not concatenated** — it describes the change
-as a whole, not the sequence of steps that produced it. Branch commits are
-scratch; this message is the artifact:
-
-```
-feat(score): weight specificity by bullet density (#453)
-
-Bullets with quantified outcomes now dominate the specificity dimension
-instead of raw keyword count, which over-rewarded skill-stuffed resumes.
-
-- add BulletDensity probe in score/specificity.ts
-- bump ATS_SCORE_ALGO_VERSION to 4
-- regenerate corpus goldens
-
-Closes #453
-```
-
-Drop the `wip` / `fix lint` / `address review` commits — they are process, not
-change. Keep the same no-AI-trailer rule as Step 2 (this message lands in `main`,
-so it matters more, not less).
+You still write the message — `/collapse-pr` composes one, but if you already
+prepared a `COMMIT_EDITMSG`, hand it over with `--message-file`. Either way it is
+**written, not concatenated**: it describes the change as a whole, drops the `wip`
+/ `fix lint` / `address review` commits as process rather than change, and carries
+the same no-AI-trailer rule as Step 2 — this message lands in `main` verbatim, so
+it matters more there, not less.
 
 ### Step 4: Push the branch
 
@@ -190,8 +182,21 @@ so it matters more, not less).
 git push -u origin "$BRANCH"
 ```
 
-If the branch already existed on `origin` and Step 3.6 rewrote its history, this
-needs `git push --force-with-lease -u origin "$BRANCH"` (never bare `--force`).
+**Skip this only if Step 3.6 collapsed *and* reported `mode: inplace`** —
+`/collapse-pr` then pushed this checkout itself (with an explicit
+`--force-with-lease` when the branch already existed on `origin`), so pushing again
+here is redundant at best. Push here when it reported a no-op, declined, **or ran
+in `worktree` mode** — that last case means it collapsed `origin`'s head and your
+local commits are still unpublished, so skipping would silently drop them. It
+should never happen given Step 3.6 passes `--in-place`; if the report says
+otherwise, push here and say so.
+
+**Either way the managed `pre-push` hook runs `npm run verify`, and that is this
+skill's only local verification** — so a red gate stops the branch here rather than
+on `origin`. `/collapse-pr` skips that hook **only** in its throwaway-worktree mode,
+where the tree it is pushing already went through it; the in-place mode this step
+uses never skips it. If the push is rejected by the hook, fix the failure — do not
+set `OFFLINECV_SKIP_HOOKS=1` to get past it.
 
 ### Step 5: Create the PR
 
@@ -278,13 +283,11 @@ merge their own PR via admin bypass.)
   optional and phrased as questions; omit the heading when the risk is obvious.
   It is a lead for the reviewer, never a scope bound — `pr-review` audits it for
   accuracy and reviews the whole diff either way.
-- **One commit per PR, message hand-written (Step 3.6).** `main`'s merge queue
-  can't be handed a squash message — it derives one, and with
-  `COMMIT_OR_PR_TITLE` a single-commit PR merges with that commit's message
-  verbatim. So the branch's one commit *is* the message that lands in `main`.
-  Branch commits are scratch; the merge message is the artifact. Collapse before
-  the PR exists (no approval to lose) and never bypass the queue with `--admin`
-  just to hand-write a message.
+- **One commit per PR, message hand-written (Step 3.6).** Delegate the collapse to
+  `/collapse-pr`, which owns both the mechanics and the reason the invariant
+  exists. Collapse *here*, before the PR exists — it is the one moment when the
+  operation has no cost, because there is no approval to dismiss and no reviewer
+  mid-diff. Never bypass the queue with `--admin` just to hand-write a message.
 - **One PR per issue/topic.** Keep the diff focused so a single reviewer can
   approve it quickly.
 - Use a closing keyword (`Closes #N`) only when the PR fully resolves the issue;

--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -236,7 +236,7 @@ is no ask, and the abort message is every PR's reason, not just the first.
 | Conflicting | `.mergeable == "CONFLICTING"` | "PR #N has merge conflicts — resolve them before asking for review." |
 | Mergeability unknown after retries | `.mergeable == "UNKNOWN"` on every attempt (see below) | "GitHub hasn't computed mergeability for PR #N yet (`UNKNOWN` after `<n>` tries) — re-run in a minute." |
 | A check is not green | any `.statusCheckRollup[]` whose `(.conclusion // .state)` is not in `SUCCESS` / `NEUTRAL` / `SKIPPED` | "PR #N has a check that isn't green: `<check name>` is `<conclusion or "still running">` — wait for it or fix it; a red or half-finished PR trains reviewers to skip the ask." |
-| More than one commit | `.commits \| length > 1` | "PR #N has `<n>` commits — collapse to one before asking for review (see `open-pr` Step 3.6)." |
+| More than one commit | `.commits \| length > 1` | "PR #N has `<n>` commits — collapse to one before asking for review: `/collapse-pr <N>`." |
 
 **`UNKNOWN` is not a conflict.** GitHub computes mergeability asynchronously,
 so a freshly-pushed PR — exactly the state `/pr-ready` runs in, right after

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Review an offlinecv pull request adversarially, the way a maintainer does — signal 👀 that review started, judge the diff against the linked issue's acceptance criteria, run the generic /code-review correctness pass, layer offlinecv's own gates, audit description accuracy, structure findings (Blocking / Secondary / Nits), auto-fix & push small items if 0 blockers exist, and post the PR review autonomously at the end — approving the PR including its own fix commit, so a clean PR needs no second round-trip.
+description: Review an offlinecv pull request adversarially, the way a maintainer does — signal 👀 that review started, judge the diff against the linked issue's acceptance criteria, run the generic /code-review correctness pass, layer offlinecv's own gates, audit description accuracy, structure findings (Blocking / Secondary / Nits), auto-fix & push small items if 0 blockers exist, collapse the branch back to one commit via /collapse-pr before the review lands, emit suggestion blocks for what it does not push, and post the PR review autonomously at the end — approving the PR including its own fix commit, so a clean PR needs no second round-trip.
 argument-hint: <#|#N> [--repo owner/repo] [--local] [--effort low|medium|high] [--no-commit]
 ---
 
@@ -12,12 +12,15 @@ the thread": check out the diff → **signal that review started** → read the
 correctness pass → **layer the offlinecv-specific gates** → **then** read the PR
 description and audit it against what the code actually does → structure findings
 **Blocking / Secondary / Nits** → **if 0 blockers & small fixes exist**: apply fixes,
-verify gates, commit & push to PR branch → **post the `gh` PR review automatically at the end**
-(verdict `APPROVE` if 0 blockers — including when the run pushed the fixes itself, so the
-PR leaves the run mergeable — `REQUEST_CHANGES` if ≥1 blocker).
+verify gates, commit, collapse the branch back to one commit, push → **post the `gh` PR
+review automatically at the end** (verdict `APPROVE` if 0 blockers — including when the run
+pushed the fixes itself, so the PR leaves the run mergeable — `REQUEST_CHANGES` if ≥1
+blocker). Findings it does *not* push land as ```` ```suggestion ```` blocks the author can
+apply in one click.
 
 This is the **reviewer-side** sibling of the author-side loop: `open-pr` creates
 the PR, `revise-pr` addresses the review — this skill *is* the review in between.
+All three delegate the one-commit collapse to `/collapse-pr`.
 
 ## The review is adversarial — read the description LAST
 
@@ -396,7 +399,9 @@ out, because the interaction with branch protection is otherwise invisible to a 
   `require_last_push_approval: false`. GitHub blocks self-approval only by the **PR
   author**, so a reviewer approving a commit they just pushed passes cleanly.
 - `dismiss_stale_reviews: true` does not catch it either: the approval is posted *after*
-  the push, so there is no prior approval to dismiss.
+  the push, so there is no prior approval to dismiss. This holds for the collapse's
+  force-push too — same slot, same ordering, and it is precisely why Step 5.5 collapses
+  before the review goes up rather than after.
 
 That is the intended outcome, not a loophole being exploited. The alternative — post the
 nits, wait for the author to apply them, watch the new push dismiss the approval, review
@@ -412,10 +417,33 @@ what the code *does* — however small it looks — is a finding for the author,
 auto-fix. When in doubt about whether an edit is behavioural, it is: leave it as a comment
 and still `APPROVE`.
 
-### Step 5.5 — Auto-fix small items (0 Blockers)
+### Step 5.5 — Auto-fix small items, then collapse (0 Blockers)
 
 If 0 Blocking findings exist AND small fixes (Secondary or Nits) exist AND `--no-commit`
 is NOT set:
+
+**The order is the whole of this step**, and it is not rearrangeable:
+
+```
+fix nits → commit → plain push (fast-forward) → collapse to one commit
+        → derive inline anchors (Step 6)      → post APPROVE on the collapsed head
+```
+
+Three constraints pin it:
+
+- **The plain push comes before the collapse**, because `/collapse-pr` resolves the target
+  from `origin` and rewrites it in a throwaway worktree — it never reads this checkout. A
+  fix commit that is still local at that moment simply would not be in the collapse. Push
+  it first and the collapse operates on a remote head that already contains it.
+- **The collapse comes before the anchors.** It rewrites every SHA on the branch, so
+  anchors derived beforehand belong to commits that no longer exist and `422` the whole
+  review — which is why Step 6 already requires deriving them after the push.
+- **The collapse comes before the approval.** `main` has `dismiss_stale_reviews: true`; do
+  it after and you dismiss the approval you just made, and the PR deadlocks with nothing
+  left to enqueue it.
+
+The first constraint also gives the fallback for free: if the collapse is skipped for any
+reason, the fix is *already pushed*, so "fall back to the plain push" needs no extra step.
 
 1. **Record a restore point and track every path you touch.** The worktree may hold the
    user's own in-progress edits — Step 1's `gh pr checkout` carries a dirty tree onto the
@@ -425,29 +453,176 @@ is NOT set:
    PRE_FIX_SHA="$(git rev-parse HEAD)"
    HEAD_BRANCH="$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName -q .headRefName)"
    FIXED_PATHS=()          # append every path you write, including new files
+
+   # Capture what was ALREADY dirty, before you write anything. These paths are
+   # the user's, not yours, and a path can be on both lists — see step 5.
+   PRE_DIRTY_FILE="$(mktemp -t pr-review-predirty)"
+   git status --porcelain --untracked-files=no -z > "$PRE_DIRTY_FILE"
    ```
+
+   `--untracked-files=no`: this repo's `.git/info/exclude` un-ignores
+   `node_modules`, so `??` entries are noise here, not provenance.
 
 2. **Apply the small fixes** in the checked-out worktree (formatting, comment wording,
    naming, non-behavioral quality fixes). Append each path written to `FIXED_PATHS`.
 3. **Run verification gates** (`npm run verify` or the relevant lint/test commands) to
    confirm a green build and no regressions.
-4. **If verification passes**, commit and push — but check for a mid-review push first:
+4. **If verification passes**, commit — then check for a mid-review push, and push:
    ```bash
    git add -- "${FIXED_PATHS[@]}"        # stage by path, never `git add -A`/`.`
    git commit -m "fix(review): address review nits"
+   # A path that was ALREADY in $PRE_DIRTY_FILE commits the UNION of your fix and
+   # the user's in-progress edit — `git add <file>` cannot stage only your hunks.
+   # Do not fix a nit in a file the user is mid-edit on; leave it as a suggestion
+   # block (Step 5.6) instead.
 
    git fetch origin "$HEAD_BRANCH"
    if ! git merge-base --is-ancestor "origin/$HEAD_BRANCH" HEAD; then
      # the author pushed while the review ran — their commits are not in our history
      echo "head branch moved mid-review; abandoning auto-fix" >&2
    else
-     git push origin HEAD                 # never --force / --force-with-lease here
+     git push origin HEAD                # fast-forward; never --force here
    fi
    ```
-   `--force-with-lease` is the wrong tool on someone else's branch — it would clobber the
-   author. A non-fast-forward means **abandon the auto-fix**, not force it through.
-   Record the pushed SHA for the review body (`Addressed small fixes directly in <sha>.`).
-5. **If verification fails, or the branch moved, or the push is rejected** (fork PR without
+   A non-fast-forward here means **abandon the auto-fix** (step 6 below), not force it
+   through. That is a different condition from a lost lease and it has a different answer:
+   the author's commits are missing from our history, so *any* push of ours would drop
+   them. This push is plain and fast-forward-only — the only force-push in this step is
+   the one `/collapse-pr` makes in step 5, under its own gates.
+
+5. **Only if step 4 pushed.** If verification failed, or the branch moved mid-review, skip
+   straight to step 6 — nothing was pushed, so there is nothing to restore and **no licence
+   to force-push**. Those paths abandon the auto-fix; a collapse there would rewrite a
+   branch on a run that deliberately decided not to touch it, dismissing whatever approval
+   the PR already had, for no gain.
+
+   Otherwise **decide whether to collapse.** The branch on `origin` now holds two commits
+   (or more), and a multi-commit PR merges as `* `-bulleted soup — the invariant `open-pr`
+   established is exactly what step 4 just broke. Restore it, gated on **who owns the
+   branch**:
+
+   | PR head | Auto-fix push | Collapse (force-push) |
+   |---|---|---|
+   | Maintainer's or agent-authored, in-repo branch | yes | **yes** |
+   | Named contributor, in-repo branch | yes, and say so in the body | **no** — a force-push destroys their local branch and rewrites their authorship |
+   | Outside contributor (fork) | usually blocked by permissions | n/a |
+
+   Determine the class from the PR, not from a guess — `isCrossRepository` is the fork
+   test, and the branch's commit authors are the contributor test:
+
+   ```bash
+   gh pr view "$PR_NUM" --repo "$REPO" --json author,isCrossRepository \
+     --jq '{author: .author.login, fork: .isCrossRepository}'
+   git log --format='%ae' "origin/$BASE..HEAD" | sort -u   # all ours? then it is ours
+   ```
+
+   **Collapsing:** delegate to `/collapse-pr`, which resolves the head from `origin`,
+   runs its own gates, and pushes the collapsed branch.
+
+   **Hand it the author's message — do not let it compose one.** The common case is a PR
+   that `open-pr` already left at one hand-authored commit, on top of which step 4 added
+   `fix(review): address review nits`. The correct collapsed message is the author's,
+   unchanged: the added commit is *process, not change*, and a reviewer composing a fresh
+   description of someone else's work — which then lands in `main` verbatim — is not the
+   reviewer's call to make.
+
+   ```bash
+   git log -1 --format=%B "$PRE_FIX_SHA" > /tmp/collapse-msg.txt
+   ```
+
+   > Invoke `/collapse-pr "$PR_NUM" --yes --message-file /tmp/collapse-msg.txt
+   > --authored-worktree "$(git rev-parse --show-toplevel)"`, adding one
+   > `--authored-path <p>` per entry in `$FIXED_PATHS` **that was not already dirty
+   > at step 1** (see below). It exits
+   > **0 having touched nothing** when the branch already holds one commit or this repo
+   > does not need the invariant, and exits **non-zero** when a hard gate refuses. Both
+   > mean the same thing here: *leave the branch as step 4 pushed it*. Neither is a
+   > failure of the review, and neither changes the verdict — but both go in the Step 7
+   > report.
+
+   `$PRE_FIX_SHA` is the head as the author left it (step 1), so `-1` is their commit. The
+   one case where composing is right is a **pre-fix branch that was already multi-commit**
+   — there is no single authored message to preserve, so drop `--message-file` and let
+   `/collapse-pr` write one from the whole change.
+
+   It builds the new commit in a throwaway worktree at `origin/$HEAD_BRANCH`, so **nothing
+   local leaks into what lands**. It reads the head from the remote, which is why step 4's
+   push had to happen first. Its gate 3e may still touch this checkout — resetting it to
+   `origin` after preserving any local-only commit at a `collapse-pr-backup/…` ref — so
+   carry whatever refs it reports into Step 7 verbatim.
+
+   `--yes` covers only the soft gates: a prior third-party approval is about to be
+   dismissed by this push either way, and this run replaces it with its own `APPROVE` a
+   moment later, so the PR still enters the queue with one approval. The gates it cannot
+   override — branch ownership, the push lease, and 3e's stray-edit refusal — are the ones
+   that matter here, and `/collapse-pr` enforces them regardless of the flag.
+
+   **Pass `--authored-worktree` and one `--authored-path` per surviving entry of
+   `$FIXED_PATHS`.** In the normal flow they change nothing — step 4 already committed
+   those paths, so gate 3e sees them clean — but they are what makes a **re-run after a
+   partial failure** work: if step 4 committed nothing, or committed and failed to push,
+   the fixes are sitting uncommitted and 3e can only fold them in if it knows they are
+   ours.
+
+   `--authored-worktree` scopes the whitelist to **this** checkout. Without it, 3e would
+   apply one path list to every worktree on the head branch, and a path the user is
+   editing in their main clone would be staged, committed and pushed into the PR. Path
+   names are not provenance; content in a specific checkout is.
+
+   **Subtract the pre-existing dirty set.** A path can be on both lists at once — Step 1
+   warned that `gh pr checkout` carries a dirty tree onto the PR branch, and the fix you
+   just wrote may land in a file the user was already editing. There is no way to hand 3e
+   "only my hunks" — the flag names *files* — so committing such a file commits the union,
+   publishing the user's in-progress edits into someone else's PR commit. Whitelist only
+   what was clean when you arrived:
+
+   ```bash
+   # Drop from FIXED_PATHS anything that appears in PRE_DIRTY_FILE.
+   comm -23 <(printf '%s\n' ${FIXED_PATHS[@]+"${FIXED_PATHS[@]}"} | sort -u) \
+            <(tr '\0' '\n' < "$PRE_DIRTY_FILE" | cut -c4- | sort -u)
+   ```
+
+   The `cut -c4-` on the right-hand side is coarse — it mangles a rename entry — but
+   it errs by over-subtracting, which drops a path to row 2 and refuses. That is the
+   safe direction; the left-hand side, where a mistake would *widen* the whitelist, is
+   your own literal path list and is exact.
+
+   An overlapping path therefore reaches 3e as unknown provenance and **3e refuses** —
+   which is correct, and is the outcome to report rather than route around. **Do not work
+   around it** by widening the path list to whatever is dirty. A reviewer absorbing a
+   stranger's uncommitted edits into someone else's PR commit is precisely the failure the
+   whole `$FIXED_PATHS` discipline exists to prevent.
+
+   **Not collapsing** (contributor branch, fork, or `/collapse-pr` declined): nothing more
+   to do. Step 4's plain push already landed the fix, which is the fallback.
+
+   Record the head SHA for the review body (`Addressed small fixes directly in <sha>.`).
+   After a collapse that is the **collapsed** head, and the separate `fix(review):` commit
+   no longer exists — re-read it rather than reusing what `git commit` printed in step 4:
+
+   ```bash
+   gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid -q .headRefOid
+   ```
+
+   Your local checkout is now behind the rewritten remote. That is expected and harmless —
+   this skill makes no further pushes — but do not `git pull` it; say so in the report so
+   the user knows their PR-branch checkout needs `git reset --hard origin/$HEAD_BRANCH`.
+
+   **On the force-push, precisely.** This step used to forbid `--force` and
+   `--force-with-lease` outright. The prohibition was aimed at the right hazard — the
+   author pushing mid-review — but `--force-with-lease` **is** the mechanism that detects
+   that hazard, so forbidding it cost the capability and bought no safety. The rule now:
+
+   > Use `--force-with-lease`, pinned to the SHA we inspected. If the lease fails, the
+   > author pushed while the review ran: **skip the collapse**, fall back to the plain
+   > push, and say so in the review body. **Never bare `--force`** — not here, not as a
+   > retry, not ever.
+
+   Same protection, strictly more capability. `/collapse-pr` gate 3d and its Step 5 hold
+   the lease mechanics, including why the lease must name an explicit SHA rather than rely
+   on a remote-tracking ref this run's own `git fetch` has already moved.
+
+6. **If verification fails, or the branch moved, or the push is rejected** (fork PR without
    write access, branch protection, red gate) — revert **only what you wrote**:
 
    ```bash
@@ -463,13 +638,50 @@ is NOT set:
    files, or the failure path leaves the branch dirtier than it found it.
 
    Then note in the review body why the fixes could not land, and leave those findings as
-   comments.
+   comments — as **suggestion blocks** where they qualify (Step 5.6).
 
 **A fix that landed is not a finding.** Anything Step 5.5 actually fixed and pushed must
 **not** also be posted as an inline comment — the anchor now points at corrected code, so
 the author reads a complaint about a line that no longer says that. Move each fixed item
 out of the inline set and into a `## Fixed in <sha>` list in the body. What stays inline is
 only what the author still has to act on.
+
+### Step 5.6 — Suggestion blocks for what you did not push
+
+Every path through Step 5.5 that ends without a pushed fix — `--no-commit`, a fork, a
+contributor branch, a red gate, ≥1 Blocking finding — leaves findings the author has to
+apply by hand. For a whole class of them that hand-application is unnecessary work:
+
+**Emit a ```` ```suggestion ```` block for every Secondary or Nit finding that is a
+localized textual replacement of lines the diff already touches.** GitHub renders it with
+an *Apply suggestion* button; the author commits it in one click, the commit is **theirs**,
+and no branch of theirs is touched. On a fork PR that is strictly better than the prose
+comment it replaces — it is the only form of "let me fix this for you" that needs neither
+write access nor consent negotiated in advance.
+
+````markdown
+```suggestion
+const MAX_BULLET_LEN = 240;   // was: magic number at three call sites
+```
+````
+
+Four mechanics, each of which silently breaks the button if you get it wrong:
+
+- **The block replaces the anchored line range in full** — not a patch, not a fragment.
+  Reproduce the untouched parts of the line, and reproduce the **leading indentation
+  literally**; a suggestion that drops it applies and de-indents the code.
+- **It anchors like any other inline comment** — a `+` line on the RIGHT side of the patch,
+  per Step 6. A finding about unchanged code has no suggestion form; leave it as prose.
+- **Multi-line replacements need `start_line` + `line`** (both `"side": "RIGHT"`), and the
+  block must contain the full replacement for that whole range.
+- **A blocking finding is not a suggestion.** These carry Secondary and Nit findings only.
+
+**What never becomes a suggestion is anything behavioural.** The bound is the same one that
+governs Step 5.5's auto-fix, for the same reason: an *Apply suggestion* click is a one-line
+review, and a behavioural change presented as a one-click fix is a behavioural change
+nobody reviewed. Rename a variable, tighten a comment, hoist a constant, drop a dead
+export — yes. Change a condition, reorder an await, adjust a regex — no; that is a finding
+written in prose, with the failing input spelled out, for the author to decide on.
 
 ### Step 6 — Draft & post (Autonomous)
 
@@ -520,6 +732,11 @@ deletes its anchor line entirely leaves nothing to anchor to, which 422s the who
 and drops it to the body-only fallback. Fetching `files` here, after the push, is what
 keeps the anchors fresh. (Combined with the "a fix that landed is not a finding" rule
 above, the fixed lines carry no comments at all, so the common case never arises.)
+
+**A collapse makes that ordering non-negotiable.** When Step 5.5 collapsed, every SHA on
+the branch was rewritten and the PR's patch is regenerated against a different head, so an
+anchor derived beforehand is not merely drifted — it belongs to commits that no longer
+exist. Any Step 5.6 suggestion blocks anchor off this same post-push `files` call.
 
 ```bash
 gh api "repos/$REPO/pulls/$PR_NUM/files" --paginate \
@@ -584,6 +801,24 @@ back to body-only after a `422`, say that too, and say **whose** push moved the 
 the author's, or Step 5.5's own auto-fix — so the note doesn't blame the author for a
 push this skill made.
 
+Also report **the Step 5.5 push outcome in one line**, because it is the only part of the
+run that rewrote someone's branch: whether the branch was collapsed or left multi-commit
+and **which reason** (author class, lease lost, a `/collapse-pr` gate, `--no-commit`, ≥1
+Blocker), the pre-push head SHA alongside the new one, and how many findings went out as
+Step 5.6 suggestion blocks. A PR that leaves this run multi-commit is a live one-commit
+invariant violation — name it so, so whoever merges knows to collapse before enqueueing.
+
+If the collapse ran, add one line naming **every local checkout of the head branch that is
+now stale** and the `git reset --hard origin/<branch>` each needs — including this run's
+own `gh pr checkout`. The rewrite is on `origin`; nothing local followed it, and a user who
+is not told will hit a non-fast-forward later with no idea why.
+
+**Reproduce any `collapse-pr-backup/…` ref `/collapse-pr` reported, verbatim and in full.**
+Gate 3e creates one when a local checkout held commits `origin` did not, and that ref is
+the only thing keeping those commits reachable — a truncated or paraphrased name is not
+recoverable. Carry its classification across too (*already upstream* / *merely behind* /
+*possibly unique*) as the hint it is, and never as a claim the work was disposable.
+
 ## Rules
 
 - **Issue first, code second, description last.** The issue is the spec, the code
@@ -623,16 +858,49 @@ push this skill made.
   mid-review. Re-anchor against the fresh patch once; if that fails, post body-only
   and move on. Never loop on anchoring.
 - **Autonomous execution; three unattended writes, in this order.** The 👀 reaction
-  (Step 0.6), the auto-fix commit + push (Step 5.5), and the review post (Step 6). Nothing
-  is confirmed with the user — `--local` is the only preview. The reaction is safe *early*
-  because it carries no prose; the other two happen only after the findings exist, and the
-  push is bounded by the next rule.
+  (Step 0.6), the auto-fix commit + push (Step 5.5 — a force-push when it collapses), and
+  the review post (Step 6). Nothing is confirmed with the user — `--local` is the only
+  preview. The reaction is safe *early* because it carries no prose; the other two happen
+  only after the findings exist, and the push is bounded by the next rules.
 - **Auto-fix small items, then approve — including your own commit.** If 0 Blockers exist
   and small fixes remain, apply them, verify (`npm run verify`), commit with a clean
-  message (no trailers), `git push` to the head branch, and post `APPROVE`. That the
-  approval covers a commit this run authored is deliberate: it removes the nit → push →
+  message (no trailers), push to the head branch, and post `APPROVE`. That the approval
+  covers a commit this run authored is deliberate: it removes the nit → push →
   dismissed-approval → re-review cycle, and it is why no follow-up issue is filed for a nit
   that is already fixed. ≥1 Blocker → commit nothing, post `REQUEST_CHANGES`.
+- **Restore the one-commit invariant before the review lands (Step 5.5).** The auto-fix
+  commit is what breaks it, so the collapse rides in the same slot: fix → commit → plain
+  push → `/collapse-pr` → derive anchors → post. The plain push comes first because
+  `/collapse-pr` reads the head from `origin`, not from this checkout. Collapsing *after*
+  the approval would dismiss the approval it just made (`dismiss_stale_reviews: true`) and
+  deadlock the PR, and anchors derived before the collapse belong to commits that no
+  longer exist. **Collapse only on a run that actually pushed** — a run that abandoned the
+  auto-fix has nothing to restore and no reason to rewrite anyone's branch.
+- **The collapsed message is the author's, not the reviewer's.** Pass
+  `--message-file` holding `git log -1 --format=%B "$PRE_FIX_SHA"`. The `fix(review):`
+  commit is process, not change, so the author's message survives untouched — a reviewer
+  does not get to rewrite the description of someone else's work on its way into `main`.
+  Compose one only when the pre-fix branch was itself multi-commit.
+- **The collapse never rewrites this checkout's *history*, but gate 3e may move it.**
+  `/collapse-pr` builds the new commit in a throwaway worktree at `origin/$HEAD_BRANCH`,
+  so nothing local leaks into what lands. Separately, 3e resolves a diverged local
+  checkout losslessly: local-only commits are preserved at a `collapse-pr-backup/…`
+  branch ref and the checkout is reset to `origin`. Surface any such ref in the Step 7
+  report verbatim — it is the only reference to that commit. It refuses only on
+  uncommitted changes this run did not author. Afterwards the local PR-branch checkout is
+  stale by construction — report that it needs `git reset --hard`, and never `git pull` it.
+- **`--force-with-lease`, never bare `--force`.** The lease is not a relaxation of the old
+  never-force-push rule — it is that rule implemented properly: a lost lease *is* the
+  detection of an author who pushed mid-review, and the answer is to skip the collapse,
+  fall back to the plain push, and say so in the review body. Never retry, never escalate.
+- **Never rewrite a branch that is not ours.** Collapse only a maintainer's or
+  agent-authored in-repo branch. A named contributor's branch or a fork gets the plain
+  push at most — a force-push there destroys their local work and republishes it under our
+  name. `/collapse-pr`'s ownership gate has no override flag, by design.
+- **When you don't push, suggest (Step 5.6).** Every Secondary/Nit that is a localized
+  textual replacement of a `+` line becomes a ```` ```suggestion ```` block, so the author
+  applies it in one click and owns the commit. Behavioural findings never do — same bound
+  as the auto-fix.
 - **The bound is behaviour, not size.** The auto-fix commit merges unread by a second
   party, so it may only contain changes that cannot alter behaviour, on a green
   `npm run verify`, with 0 Blockers. A behavioural edit is a finding for the author no
@@ -640,8 +908,9 @@ push this skill made.
 - **The auto-fix revert names paths.** Never `git checkout -- .` — it destroys the user's
   unrelated in-progress work with no reflog while leaving the failed fix's new files
   behind. `git restore --source="$PRE_FIX_SHA" … -- "${FIXED_PATHS[@]}"` plus
-  `git clean -fd --` on the same paths. Never force-push someone else's branch: a
-  non-fast-forward means the author pushed mid-review — abandon the auto-fix and report it.
+  `git clean -fd --` on the same paths. A non-fast-forward before the push is a different
+  condition from a lost lease: the author's commits are missing from our history, so
+  abandon the auto-fix entirely and report it.
 - **Tune stance to the author** — historically complex/untested contributions get an
   extra-careful pass; don't relax the gates because a diff "looks" clean.
 - Pure `gh` + `git` + `npm`/`npx` — no external services, no machine-specific paths.

--- a/.claude/skills/revise-pr/SKILL.md
+++ b/.claude/skills/revise-pr/SKILL.md
@@ -247,16 +247,13 @@ none to add back.
 
 ### Step 5.1: Collapse to a single commit — **final round only**
 
-`main` merges through a **merge queue** whose enqueue API carries no
-commit-message fields, so the squash message is *derived* from repo settings
-(`squash_merge_commit_title: COMMIT_OR_PR_TITLE`). A **one-commit PR merges with
-that commit's message verbatim**; a multi-commit PR merges with every commit
-message concatenated as `* ` bullets — which is how `fix lint` and
-`address review comments on PR #458` end up in `main`'s history forever. See
-`open-pr` Step 3.6 for the full rationale.
+The PR should reach the queue as one commit, or `fix lint` and `address review
+comments on PR #458` land in `main`'s history forever — `/collapse-pr`'s *Why this
+skill exists* has the full rationale and is the only copy of it.
 
-So the PR should reach the queue as one commit. But **do not collapse on every
-round.** Gate it:
+**The mechanics belong to `/collapse-pr`; the decision below belongs here.** That
+split is the point of this step: `/collapse-pr` cannot know whether this is the
+last round, and this skill does. So **do not collapse on every round.** Gate it:
 
 - **Leaving any thread open *on the target*** (you pushed back, or deferred to a
   follow-up issue) → the reviewer is coming back for another round. **Keep the
@@ -274,28 +271,46 @@ different PR that nobody is going to close.
 
 When the gate passes:
 
-```bash
-BASE="$(gh pr view "$PR_NUM" --repo "$REPO" --json baseRefName -q .baseRefName)"
-git fetch origin "$BASE"
-git reset --soft "$(git merge-base HEAD "origin/$BASE")"
-git commit -F .git/COMMIT_EDITMSG      # the combined message for the whole PR
-git push --force-with-lease origin HEAD
-```
+> Invoke `/collapse-pr "$PR_NUM" --yes`. It pushes the collapsed branch itself, so
+> the Step 5 push is the last one this skill makes directly.
 
-Rewrite the message to describe **the change as a whole** — the original intent
-plus whatever review actually changed about it. Not "implement X" + "address
-review": one coherent story of what lands. Drop the review round-trip entirely;
-it's process, not change. `--force-with-lease`, never bare `--force`.
+**Step 5's push must already have happened** — and it has, which is exactly why
+this step sits after it rather than replacing it. `/collapse-pr` resolves the head
+from `origin` and rewrites it in a throwaway worktree; it never reads this
+checkout, so a fix commit still sitting local would simply not be in the collapse.
 
-Two things this costs, stated plainly:
+**If you skipped the push, the collapse ships without your fix — it will not stop
+you.** `/collapse-pr` gate 3e no longer refuses on a diverged checkout; it preserves
+the local-only commit at a `collapse-pr-backup/…` branch ref, resets the checkout to
+`origin`, and names the ref in its report. Nothing is lost, but the PR does not get
+the revision. So: confirm Step 5 pushed before invoking, and if the report names a
+backup ref for this branch, push that commit and re-run rather than assuming the
+round landed.
 
-- **Reviewers lose per-commit history on the branch.** GitHub still posts a
-  `force-pushed … Compare` link, so the old→new diff stays reachable — but it's a
-  worse experience than a clean fixup commit, which is exactly why this is gated
-  to the final round.
-- **Existing review threads may go `isOutdated`** once their anchor lines move.
-  Do Step 6 (reply + resolve) **after** this push, using the thread IDs captured
-  in Step 2 — replying via `in_reply_to` works regardless of outdated state.
+**`--yes` is required here, and the reason is an ordering fact, not impatience.**
+`/collapse-pr`'s soft gates refuse on unresolved threads — and at this moment
+every thread you just addressed is still `isResolved == false` on GitHub, because
+Step 6 resolves them *after* this push (their anchors move when the branch is
+rewritten). So the gate would fire on exactly the run that is supposed to
+collapse. The judgement it guards is the one you made three paragraphs up; `--yes`
+says so, and `/collapse-pr` still prints every gate that fired.
+
+Hand it the message you wrote with `--message-file`, or let it compose one. Either
+way the message describes **the change as a whole** — the original intent plus whatever review
+actually changed about it. Not "implement X" + "address review": one coherent
+story of what lands. Drop the review round-trip entirely; it's process, not
+change.
+
+Two costs specific to this caller, on top of the ones `/collapse-pr` lists:
+
+- **Existing review threads may go `isOutdated`** once their anchor lines move. Do
+  Step 6 (reply + resolve) **after** this push, using the thread IDs captured in
+  Step 2 — replying via `in_reply_to` works regardless of outdated state, so no
+  checkout is needed for it.
+- **This checkout is now stale**, because the branch on `origin` was rewritten and
+  nothing local followed it. Do **not** `git pull` — that would merge the old
+  history back in. Note in the Step 7 report that the branch needs
+  `git reset --hard origin/<branch>`.
 
 **No provenance step here.** Model attribution is retired
 (`docs/CONTRIBUTING-PROCESS.md` → **AI attribution**), so a revision round no
@@ -392,11 +407,11 @@ on a source PR. Link the target PR.
 
 - **Address, push once, then reply.** Don't push commit-by-commit per comment —
   each push dismisses approval. One pass, one push, then close the threads.
-- **Collapse to one commit on the final round only (Step 5.1).** The merge queue
-  derives the squash message and can't be handed one, so a one-commit PR is the
-  only way to control what lands in `main`. But collapse *only* when no thread is
-  left open — a mid-review force-push costs the reviewer the delta diff they came
-  back for.
+- **Collapse to one commit on the final round only (Step 5.1).** `/collapse-pr`
+  owns the mechanics and the rationale; this skill owns the *when*. Collapse
+  *only* when no thread on the target is left open — a mid-review force-push costs
+  the reviewer the delta diff they came back for. Pass `--yes`, because the
+  threads you just addressed are still unresolved on GitHub until Step 6.
 - **Reply to every unresolved thread**, even deferred ones. Resolve only the ones
   you actually fixed (or that are outdated); leave pushback/deferred threads open.
 - **Feedback can come from elsewhere; the code always lands on the target.**

--- a/docs/CONTRIBUTING-PROCESS.md
+++ b/docs/CONTRIBUTING-PROCESS.md
@@ -9,8 +9,9 @@ walkthrough (setup, branch workflow, tests, code style) lives in
 This file is the **rationale**. The rules it explains are enforced closer to where they bite:
 the binding one-liners sit in `CLAUDE.md` → **Hard rules** (always in an agent's context), the
 fixture-PII check is a directory-scoped `CLAUDE.md` in `tests/fixtures/pdfs/`, and each shipping
-skill (`/open-pr`, `/pr-review`, `/revise-pr`, `/implement-batch`, `/pr-ready`) carries its own
-operational copy. Nothing here is load-bearing on its own — if you change a rule, change it in
+skill (`/open-pr`, `/pr-review`, `/revise-pr`, `/collapse-pr`, `/implement-batch`, `/pr-ready`)
+carries its own operational copy — `/collapse-pr` holds the canonical one for the one-commit
+invariant, which the other shipping skills link to rather than restate. Nothing here is load-bearing on its own — if you change a rule, change it in
 those places too, not only here. **AI attribution** is the partial exception: it is enforced by a
 setting in `.claude/settings.json`, so its `CLAUDE.md` counterpart is deliberately thin — a
 one-liner for the harnesses that setting does not reach, rather than prose restating it.
@@ -110,13 +111,22 @@ The `COMMIT_OR_` prefix is the only lever:
 
 So **every PR reaches the queue as a single commit whose message is the message we want in `main`.**
 
-- **`/open-pr` (Step 3.6)** collapses the branch *before* the PR exists — free, since there is no approval to dismiss yet.
-- **`/revise-pr` (Step 5.1)** collapses **only on the final review round**, when no thread is left open. A mid-review force-push costs the reviewer the delta diff they came back for.
+**`/collapse-pr` is the one guarded operation that does it.** Its skill file (`.claude/skills/collapse-pr/SKILL.md`) carries the mechanics and the safety gates — regime detection, stale-approval, open-thread, branch-ownership, push-lease, and local-divergence — plus the tree-identity assertion, and it is a no-op on a branch that already holds one commit. The three callers each decide *whether* to collapse on their own terms and delegate the *how*:
+
+- **`/open-pr` (Step 3.6)** collapses *before* the PR exists — free, since there is no approval to dismiss and no reviewer mid-diff. This is the one shape that runs **in place** on your checkout, and it says so explicitly with `--in-place`: re-running `/open-pr` on a branch whose PR already exists would otherwise be mistaken for the existing-PR shape below, and would collapse `origin`'s head while your new local commits sat unpublished.
+- **`/revise-pr` (Step 5.1)** collapses **only on the final review round**, when no thread is left open on the target. A mid-review force-push costs the reviewer the delta diff they came back for.
+- **`/pr-review` (Step 5.5)** pushes its auto-fix commit, then collapses, then posts the approval — that commit is what breaks the invariant, and collapsing after the approval would dismiss the approval it just made.
+
+**For an existing PR the target is resolved from `origin`, not from your checkout**, and the rewrite happens in a throwaway worktree detached at `origin/<head>`. This is not fussiness: a live dry-run against PR #842 found the main checkout sitting on that PR's branch holding a *superseded copy* of one of origin's commits — same subject line, different tree — and one commit fewer. Collapsing from that checkout would have force-pushed the stale tree and destroyed a fix that existed only on origin. Compare SHAs and trees; subject lines and commit counts do not catch it.
+
+By hand, the operation is:
 
 ```bash
 git reset --soft "$(git merge-base HEAD origin/main)"
 git commit -F .git/COMMIT_EDITMSG     # the combined message, hand-written
-git push --force-with-lease           # never bare --force
+# a collapse must not change the tree — prove it before pushing:
+[ "$(git rev-parse '<pre-collapse-sha>^{tree}')" = "$(git rev-parse 'HEAD^{tree}')" ] || exit 1
+git push --force-with-lease="<branch>:<the-sha-you-inspected>"   # never bare --force
 ```
 
 Rules:
@@ -124,7 +134,9 @@ Rules:
 - **Branch commits are scratch; the merge message is the artifact.** Write the combined message to describe the change *as a whole* — not the sequence of steps that produced it. Drop the review round-trip; it is process, not change.
 - **Don't `rebase -i` a branch clean before merge.** Pointless when it is getting squashed — collapse instead.
 - **Never bypass the queue with `--admin`** just to hand-write a merge message. The collapse achieves the same thing without skipping required checks.
-- **Nothing is lost that squash-merge wasn't already going to discard.** `main` only ever receives one commit per PR; collapsing early changes *when* the intermediate commits are dropped, not *whether*. The collapsed commit's tree is byte-identical to the branch tip's.
+- **Assert tree identity, and let that license the `pre-push` skip — in the throwaway worktree only.** The managed `.git/hooks/pre-push` runs `npm run verify`, worktrees share it, and it cannot run in a throwaway worktree with no `node_modules`. There the skip is sound because the tree came from `origin` and has already been through the hook, and the assertion proves the collapse did not change it: assert byte-identity first, only then push with `OFFLINECV_SKIP_HOOKS=1`. Collapsing **in place** on your own checkout (the `/open-pr` shape) is the opposite case — nothing has verified that tree yet, so **let the hook run**. If the assertion fails the collapse aborts either way — never skip the hook unconditionally.
+- **After a collapse, every local copy of that branch is stale.** Do not `git pull` it; `git reset --hard origin/<branch>`. When `/collapse-pr` runs that reset for you and the checkout held commits `origin` did not, it first preserves them at a `collapse-pr-backup/<branch>-<utc-stamp>` branch ref (with a `-1`, `-2`, … suffix if two runs land in the same second), verifies the ref points where it meant to, and names it in its report — and it refuses to reset at all if either step fails. A real ref, not the reflog, because the reflog expires and cannot be pushed. It does *not* try to decide whether the preserved work was superseded — that is semantic, and `git cherry` and a reverse-apply both report "unique" over an amended better copy on `origin`. Check the ref yourself, then delete it; nothing prunes them for you.
+- **Nothing is lost that squash-merge wasn't already going to discard.** `main` only ever receives one commit per PR; collapsing early changes *when* the intermediate commits are dropped, not *whether*. The collapsed commit's tree is byte-identical to the branch tip's — which is exactly what the assertion above checks.
 - **Recovery, if a collapse goes wrong:** the pre-push SHA is permanently recorded on the PR timeline (`HeadRefForcePushedEvent`, `before`/`after`), the orphaned commit stays viewable at `github.com/<org>/<repo>/commit/<sha>` and downloadable via `gh api repos/<org>/<repo>/commits/<sha> -H "Accept: application/vnd.github.patch"`, and the pusher's local `git reflog` holds it for 90 days. Note that `git fetch origin <sha>` will **not** retrieve it — the server rejects unreachable objects — so restore from the reflog, or apply the patch.
 
 ## Soliciting review (`/pr-ready`)


### PR DESCRIPTION
## Summary

`main` merges through a merge queue whose enqueue API carries no commit-message fields, so GitHub derives the squash message from `squash_merge_commit_message: COMMIT_MESSAGES`. Only a **single-commit** PR merges with a written message; anything else lands in `main` as `* `-bulleted commit soup.

That invariant was maintained by three hand-rolled copies that had already diverged — and `pr-review` broke it outright, pushing an auto-fix commit while explicitly forbidding the force-push needed to restore one commit.

This extracts `.claude/skills/collapse-pr/` as the single owner of both the mechanics and the rationale. `open-pr`, `revise-pr` and `pr-review` keep only their own decision about *whether* to collapse.

Closes #849.

## What the skill enforces

- **Target resolution.** An existing PR's head is read from `origin` and rewritten in a throwaway worktree; the local checkout is never assumed to be the target. `--in-place` lets a caller that genuinely owns the checkout say so, instead of inferring mode from whether a PR happens to exist.
- **Tree-identity assertion.** The collapsed tree must be byte-identical to the pre-collapse head. That assertion — and only it — licenses skipping the managed `pre-push` hook, and only in a throwaway worktree, never in place where the hook is the sole local verification.
- **Five gates.** Stale approval and open threads are soft (`--yes` proceeds); branch ownership and the push lease are hard and never overridable.
- **Gate 3e is lossless, not a refusal.** Whether local work is unique or merely superseded is *not mechanically decidable*, so the skill does not try: commits are preserved at a `collapse-pr-backup/<branch>-<utc>` ref before any reset, and creating that ref is a hard precondition of the reset.
- **`pr-review` ordering.** Collapse sits between the auto-fix push and the review post — the only ordering that works, since the collapse rewrites every SHA (so anchors must come after) and `dismiss_stale_reviews: true` means collapsing after an approval would dismiss it. The author's message is preserved via `--message-file` rather than replaced with one the reviewer wrote.

## Review focus

1. **`collapse-pr` gate 3e (Step 3).** The most destructive code here — it runs `git reset --hard` on a checkout. Check the backup ref is an unconditional precondition on every path, and that the `[ "$MODE" = worktree ]` guards cannot be bypassed.
2. **Row 1's cherry-pick path.** Added late to stop a naive `push HEAD` from publishing local-only commits. Least-reviewed code in the diff.
3. **`pr-review` Step 5.5 ordering** — that no route reaches a force-push after an abandoned auto-fix.
4. **Length.** `collapse-pr` is 1083 lines. Growth is gates and guarded paths; a reviewer may reasonably disagree about how much prose earns its place.

## Test plan

- `npm run verify` green (also enforced by the `pre-push` hook on this branch — not bypassed).
- All four in-scope skill frontmatters parse as strict YAML. (`pr-ready` does not — **pre-existing**, filed as #850, deliberately untouched here.)
- Single-source-of-truth verified: only `collapse-pr` restates the merge-queue rationale; `open-pr` and `revise-pr` carry zero `reset --soft`.
- All cross-referenced step and row numbers resolve across the five files.
- This PR arrives as **exactly one commit**, dogfooding its own invariant.
- Collapse mechanics rehearsed live against PR #842: 2 commits → 1, tree hash `56a742c98fb9d6afe1370ab5f9432c82abc6c5d3` identical on both sides, zero diff. `--force-with-lease` verified on both paths — valid lease accepted, stale lease refused with the remote unchanged.

## Adversarial review

Three rounds ran before this PR was opened. Findings and dispositions:

**Round 1 — 5 blocking, all fixed**
1. Step 5b's `git worktree remove --force` was unguarded; in `inplace` mode `$WORKDIR` is the user's checkout, and linked worktrees delete cleanly. Would have deleted the worktree it was working in.
2. `OFFLINECV_SKIP_HOOKS=1` was applied on both push paths — silently removing `npm run verify` from `open-pr` entirely, since the hook was its only local verification.
3. `trap … EXIT` cannot span separate tool calls, so cleanup either fired immediately or never; two prose claims asserted otherwise.
4. `pr-review` step 5 ran the collapse on paths that had pushed nothing.
5. The collapse replaced the author's commit message with one the reviewer composed.

**Round 2 — 7 blocking, all fixed**
1. Backup ref and `reset --hard` were unconditional siblings; a failed `git branch` fell through to irreversible loss (the skill does not run under `set -e`).
2. Gate 3e's `worktree`-only restriction was prose with **zero** `MODE` references in any of its five code blocks — repeating round 1's lesson.
3. `--authored-path` whitelists path *names*, but provenance is content in a specific checkout; a global list applied across worktrees could publish a user's unrelated edits. No iteration construct existed for multiple matches.
4. Row 1's `push HEAD` published every local-only commit — the #842 hazard, ungated.
5. A rejected row-1 push was misattributed solely to gate 3d; being behind, or the `pre-push` hook, are likelier causes.
6. `status --porcelain` includes `??`, and `.git/info/exclude` un-ignores `node_modules`, so gate 3e would have refused **100% of the time** on this repo.
7. Re-running `open-pr` after a PR exists flipped mode to `worktree`, collapsed origin's head, and discarded local commits while reporting success.

Plus 7 nits (rename/space-safe `status` parsing, bash 3.2 `set -u` array expansion, teardown naming on exit paths, and others).

**Round 3** added ~230 lines (cherry-pick path, `--authored-worktree`, `--in-place`, real mode guards) which **no subagent review has seen** — reviewing that here is the point of opening the PR.

A note on process: a solo verification pass returned "clean" before each of rounds 1 and 2, which then found 5 and 7 blocking defects respectively. Treat the sections above as the areas where direct inspection has been demonstrably unreliable.
