### PR TITLE
fix(parser): retain single-letter language skills

### DIFF
--- a/src/lib/heuristics/corpus.test.ts
+++ b/src/lib/heuristics/corpus.test.ts
@@ -183,7 +183,7 @@ const TRUTH_ANNOTATED_FIELD_FLOOR = 150;
  * `npm run check:baselines` on every run, and bounded here — undescribed debt may
  * not GROW. File the issue and flip the entry to `open`; then lower this.
  */
-const UNFILED_TRUTH_CEILING = 9;
+const UNFILED_TRUTH_CEILING = 8;
 
 /** Generator category = the fixture root's immediate subdirectory. */
 function categoryOf(repoRelPdfPath: string): string {

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -79,6 +79,12 @@ describe("tokenizeSkillLine", () => {
     expect(tokenizeSkillLine(",,,;;;")).toEqual([]);
   });
 
+  it("keeps the defensible single-letter languages and rejects stray glyphs (#832)", () => {
+    const result = tokenizeSkillLine("C, R, D, X");
+    expect(result).toEqual(expect.arrayContaining(["C", "R", "D"]));
+    expect(result).not.toContain("X");
+  });
+
   it("drops the whole cell when a URL is present in a comma-separated list", () => {
     // tokenizeCell's looksLikeContactLink check fires on the ENTIRE cleaned
     // cell before the split.  "github.com/janesmith" matches the path-slash

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -130,6 +130,12 @@ const PROFILE_HOST_RE =
  *  "Socket.io", "ASP.NET") that has no slash. */
 const URLISH_RE = /(https?:\/\/|www\.|\b[a-z0-9-]+\.[a-z]{2,}\/\S)/i;
 
+/** One-character tokens that are real, commonly-listed languages. The length
+ * floor in `isSkillToken` is a noise guard against stray glyphs left by column
+ * splitting; these are the only single characters that are not noise, so they
+ * are allowlisted rather than lowering the floor. */
+const SINGLE_LETTER_SKILLS = new Set(["c", "r", "d"]);
+
 /** True when a candidate skill token is really a professional-profile link
  *  (GitHub / LinkedIn / portfolio, etc.) or its bare heading word. Such links
  *  belong only in the contact/profile section, never in Skills. */
@@ -139,6 +145,7 @@ function looksLikeContactLink(tok: string): boolean {
 }
 
 function isSkillToken(tok: string): boolean {
+  if (tok.length === 1 && SINGLE_LETTER_SKILLS.has(tok.toLowerCase())) return true;
   if (tok.length < 2 || tok.length > 40) return false;
   if (/^\d+$/.test(tok)) return false;
   // A professional-profile link (or its bare "GitHub" / "LinkedIn" heading) is

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
@@ -22,7 +22,7 @@
       "phoneIsValid",
       "skills"
     ],
-    "skillsCount": 11,
+    "skillsCount": 12,
     "experienceCount": 2,
     "educationCount": 1,
     "projectsCount": 0,
@@ -74,7 +74,7 @@
     "sectionSource": "regex",
     "pageCount": 1,
     "rawCharCount": 1428,
-    "extractedCharCount": 1146,
+    "extractedCharCount": 1147,
     "sections": [
       {
         "name": "profile",
@@ -101,7 +101,7 @@
       "hasSummary": false,
       "experienceCount": 2,
       "educationCount": 1,
-      "skillsCount": 11
+      "skillsCount": 12
     },
     "linkAnnotationCount": 0,
     "disagreements": []

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.truth.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.truth.json
@@ -44,9 +44,9 @@
       "note": "Role 2's employer line reads “Multicultural Engineering Program – State Polytechnic University”; `company` comes back as just the university — the program half is not lost, the parser puts it on `team`, but `experience.company` scores the `company` field alone. The identical shape is measured on unknown/single-column-title-below-anchor. Possibly a defensible org/team split rather than a defect — recorded rather than assumed, because ground truth's job is to state what the page says and let a human adjudicate."
     },
     "skills": {
-      "issue": null,
-      "status": "unfiled",
-      "note": "Two independent disagreements on one field: the single-letter token “C” is DROPPED from the Programming Languages row (the identical drop is measured on latex/multi-degree-coursework, so it is not fixture-specific), and “Fluent in Spanish” is admitted as a skill from the “Language:” row."
+      "issue": 833,
+      "status": "open",
+      "note": "The independent disagreement — “Fluent in Spanish” is admitted as a skill from the “Language:” row — is tracked by #833. The separate single-letter “C” drop was fixed by #832."
     }
   }
 }

--- a/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-macfonts.expected.json
@@ -27,7 +27,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 22,
+    "skillsCount": 23,
     "experienceCount": 6,
     "educationCount": 3,
     "projectsCount": 0,
@@ -83,7 +83,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 3205,
-    "extractedCharCount": 2156,
+    "extractedCharCount": 2157,
     "sections": [
       {
         "name": "profile",
@@ -114,7 +114,7 @@
       "hasSummary": false,
       "experienceCount": 6,
       "educationCount": 3,
-      "skillsCount": 22
+      "skillsCount": 23
     },
     "linkAnnotationCount": 9,
     "disagreements": []

--- a/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
+++ b/tests/fixtures/pdfs/latex/deedy-resume-openfonts.expected.json
@@ -27,7 +27,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 22,
+    "skillsCount": 23,
     "experienceCount": 6,
     "educationCount": 3,
     "projectsCount": 0,
@@ -83,7 +83,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 3207,
-    "extractedCharCount": 2158,
+    "extractedCharCount": 2159,
     "sections": [
       {
         "name": "profile",
@@ -114,7 +114,7 @@
       "hasSummary": false,
       "experienceCount": 6,
       "educationCount": 3,
-      "skillsCount": 22
+      "skillsCount": 23
     },
     "linkAnnotationCount": 9,
     "disagreements": []

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.expected.json
@@ -25,7 +25,7 @@
       "website_url",
       "work_authorization"
     ],
-    "skillsCount": 17,
+    "skillsCount": 18,
     "experienceCount": 4,
     "educationCount": 2,
     "projectsCount": 3,
@@ -77,7 +77,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 3428,
-    "extractedCharCount": 2625,
+    "extractedCharCount": 2626,
     "sections": [
       {
         "name": "profile",
@@ -108,7 +108,7 @@
       "hasSummary": false,
       "experienceCount": 4,
       "educationCount": 2,
-      "skillsCount": 17
+      "skillsCount": 18
     },
     "linkAnnotationCount": 6,
     "disagreements": []

--- a/tests/fixtures/pdfs/latex/multi-degree-coursework.truth.json
+++ b/tests/fixtures/pdfs/latex/multi-degree-coursework.truth.json
@@ -58,11 +58,5 @@
     "Raspberry Pi",
     "iOS"
   ],
-  "knownWrong": {
-    "skills": {
-      "issue": null,
-      "status": "unfiled",
-      "note": "The single-letter token “C” is DROPPED from the Languages row while “C++” survives. Second independent measurement of the same drop (see google-docs/google-docs-skia-proxy-role-first-experience)."
-    }
-  }
+  "knownWrong": {}
 }

--- a/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
+++ b/tests/fixtures/pdfs/unknown/pdflib-leading-glyph-skills-header.expected.json
@@ -22,7 +22,7 @@
       "phoneIsValid",
       "skills"
     ],
-    "skillsCount": 8,
+    "skillsCount": 9,
     "experienceCount": 1,
     "educationCount": 1,
     "projectsCount": 0,
@@ -74,7 +74,7 @@
     "sectionSource": "markdown",
     "pageCount": 1,
     "rawCharCount": 462,
-    "extractedCharCount": 289,
+    "extractedCharCount": 290,
     "sections": [
       {
         "name": "profile",
@@ -101,7 +101,7 @@
       "hasSummary": false,
       "experienceCount": 1,
       "educationCount": 1,
-      "skillsCount": 8
+      "skillsCount": 9
     },
     "linkAnnotationCount": 0,
     "disagreements": []


### PR DESCRIPTION
# PR title

fix(parser): retain single-letter language skills

# PR body

Resolves #832

## Summary

The skills parser previously dropped one-character programming languages because `isSkillToken` applied an unconditional two-character minimum. This change allowlists the defensible single-letter languages `C`, `R`, and `D` case-insensitively while preserving the existing noise floor for other stray one-character glyphs.

## Changes

- Added a named `SINGLE_LETTER_SKILLS` allowlist for `c`, `r`, and `d`.
- Added regression coverage proving `C`, `R`, and `D` survive while `X` remains rejected.
- Removed the resolved `skills` knownWrong entry from the LaTeX fixture and rebaked the affected corpus snapshots.
- Updated the Google Docs fixture to retain its independent `Fluent in Spanish` disagreement under issue #833; the separate C-drop disagreement is now resolved by #832.
- Lowered `UNFILED_TRUTH_CEILING` from 9 to 8 after filing/resolving the two repeated C-drop measurements.

## Verification

- Focused heuristic skills tests pass: 46 tests.
- Corpus regression tests pass: 64 tests, 1 intentionally skipped.
- `npm run check:baselines` completes with the expected existing unfiled-fixture warnings; the remaining filed Google Docs skill disagreement is linked to #833.
- Typecheck, lint, and production build pass.
- The full `npm run verify` run reached 358 passing test files and 5,864 passing tests, but is blocked by an unrelated existing `useLibraryChanges` BroadcastChannel/jsdom failure with three unhandled `MessageEvent` errors. No issue #832 tests fail.
