### PR TITLE
feat: [edit] A parsed entry cannot be deleted from the reconstructed résumé — only user-ADDED ones (achievement, role, education, project) (#856)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Strict 3-tier architecture. Primitives + shared-composed live in `src/design-sys
 
 **The Reuse Gate (soft).** Before adding a new *workflow surface*, search for an existing surface that already owns that capability and extend it. A parallel surface is allowed only with a written "Reuse analysis" justifying why (genuinely different interaction model, or isolation requirement). A hook (`scripts/hooks/reuse_surface_reminder.sh`) warns on new files under `src/components/`.
 
-**Size.** Keep feature components under ~200 LOC; decompose past that. ⚠️ **Known debt — do not imitate:** `ReconstructedResume.tsx` (1338), `SectionRewrite.tsx` (607), `ModelSelector.tsx` (556), `ReconstructedRole.tsx` (483) all violate this. If you are editing one, prefer extracting your change into a new sibling over growing the file further.
+**Size.** Keep feature components under ~200 LOC; decompose past that. ⚠️ **Known debt — do not imitate:** `ReconstructedResume.tsx` (1489), `SectionRewrite.tsx` (607), `ModelSelector.tsx` (556), `ReconstructedRole.tsx` (490) all violate this. If you are editing one, prefer extracting your change into a new sibling over growing the file further.
 
 ## Styling & tokens
 

--- a/src/components/features/ExperienceSection.other-bullets.test.tsx
+++ b/src/components/features/ExperienceSection.other-bullets.test.tsx
@@ -224,6 +224,9 @@ function Harness() {
     addedBullets: edit.addedBullets,
     addedExperience: edit.addedEntries.filter((e) => e.section === "experience"),
     originalCount: 1,
+    // Identity: no parsed entry is deleted here, so a render position IS its
+    // parsed index (#856).
+    parsedIndices: [0],
     onAddEntry: () => edit.addEntry("experience"),
     onRemoveEntry: edit.removeEntry,
     onEntryField: edit.setEntryField,

--- a/src/components/features/ExperienceSection.prune-hold.test.tsx
+++ b/src/components/features/ExperienceSection.prune-hold.test.tsx
@@ -166,6 +166,9 @@ function Harness() {
     addedExperience: edit.addedEntries.filter((e) => e.section === "experience"),
     // Index 0 is the parsed role; indices 1+ are the user-added ones.
     originalCount: 1,
+    // Identity: no parsed entry is deleted here, so a render position IS its
+    // parsed index (#856).
+    parsedIndices: [0],
     onAddEntry: () => edit.addEntry("experience"),
     onRemoveEntry: edit.removeEntry,
     onEntryField: edit.setEntryField,

--- a/src/components/features/ExperienceSection.test.tsx
+++ b/src/components/features/ExperienceSection.test.tsx
@@ -109,6 +109,9 @@ function Harness() {
     addedBullets: {},
     addedExperience: [],
     originalCount: EXPERIENCES.length,
+    // Identity: nothing is deleted in this harness, so a render position IS its
+    // parsed index (#856).
+    parsedIndices: EXPERIENCES.map((_, i) => i),
     onAddEntry: () => {},
     onRemoveEntry: () => {},
     onEntryField: () => {},

--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -125,6 +125,9 @@ describe("EducationSection date-row symmetry (issue 376)", () => {
         onEducationFieldChange: () => {},
         addedEducation: [],
         originalCount: 1,
+        // Identity: nothing is deleted in this harness, so a render position IS
+        // its parsed index (#856).
+        parsedIndices: [0],
         onAddEntry: () => {},
         onRemoveEntry: () => {},
         onEntryField: () => {},

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -22,6 +22,7 @@ import type {
   AddedEntry,
   AddedEntryField,
 } from "../../hooks/useEditableParse.ts";
+import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
 import { buildEducationDates } from "../../lib/score/entry-dates.ts";
 import { EditableField, SectionHeading } from "@design-system";
 import { validateDate } from "../../lib/edit/field-validators.ts";
@@ -105,7 +106,8 @@ function EducationEntry({
   edu: ResumeEducation;
   overrides: EducationFieldOverrides | undefined;
   onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
-  /** Remove this entry (only set for user-ADDED entries). */
+  /** Remove this entry. Set for a PARSED entry too since #856 — "is this
+   *  user-added?" is {@link isAdded}, never this prop's presence. */
   onRemove?: () => void;
   /** User-added entries carry no `field` (major) slot, so the major affordance
    *  renders on PARSED entries only. */
@@ -200,6 +202,7 @@ export function EducationSection({
   onEducationFieldChange,
   addedEducation,
   originalCount,
+  parsedIndices,
   onAddEntry,
   onRemoveEntry,
   onEntryField,
@@ -209,6 +212,8 @@ export function EducationSection({
   heading?: string;
   education: ResumeEducation[];
   educationOverrides: Record<number, EducationFieldOverrides>;
+  /** `index` is the entry's PARSED index — the key space `educationOverrides`
+   *  uses — not its render position (#856). */
   onEducationFieldChange: (
     index: number,
     field: keyof EducationFieldOverrides,
@@ -216,10 +221,14 @@ export function EducationSection({
   ) => void;
   /** User-added education entries, append-aligned to indices ≥ originalCount. */
   addedEducation: AddedEntry[];
-  /** Count of PARSED education entries; indices at/above this are user-added. */
+  /** Count of PARSED education entries still rendered; indices at/above this
+   *  are user-added. */
   originalCount: number;
+  /** Render position → PARSED index for the surviving parsed entries (#856),
+   *  from `survivingParsedIndices`. Identity until one is deleted. */
+  parsedIndices: readonly number[];
   onAddEntry: () => void;
-  onRemoveEntry: (id: string) => void;
+  onRemoveEntry: (key: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
   /** Drop a blank added entry when focus leaves the section (#379). */
   onPruneEmpty: () => void;
@@ -239,14 +248,22 @@ export function EducationSection({
               i >= originalCount
                 ? addedEducation[i - originalCount]
                 : undefined;
+            // PARSED index, not the render position — see `parsedIndices`.
+            const parsedIdx = parsedIndices[i] ?? i;
+            const entryKey = added
+              ? added.id
+              : parsedEntryKey("education", parsedIdx);
             return (
               <EducationEntry
-                key={added ? added.id : i}
+                // The ENTRY key, not the render position (#856): a deletion
+                // shifts every later row up one, and a position key would hand
+                // the deleted row's in-flight edit state to its successor.
+                key={entryKey}
                 edu={edu}
-                overrides={added ? undefined : educationOverrides[i]}
+                overrides={added ? undefined : educationOverrides[parsedIdx]}
                 onFieldChange={(field, value) => {
                   if (!added) {
-                    onEducationFieldChange(i, field, value);
+                    onEducationFieldChange(parsedIdx, field, value);
                     return;
                   }
                   // Added entries carry no major slot; the `field` edit can't
@@ -255,7 +272,10 @@ export function EducationSection({
                   if (field !== "field")
                     onEntryField(added.id, EDUCATION_FIELD_MAP[field], value);
                 }}
-                onRemove={added ? () => onRemoveEntry(added.id) : undefined}
+                // Education carries no bullets, so this is the one section whose
+                // delete is the bare `removeEntry` (#856) rather than the
+                // bullets-first `removeEntryWithBullets`.
+                onRemove={() => onRemoveEntry(entryKey)}
                 isAdded={Boolean(added)}
               />
             );

--- a/src/components/features/ReconstructedResume.remove-parsed-entry.test.tsx
+++ b/src/components/features/ReconstructedResume.remove-parsed-entry.test.tsx
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * #856 — the rendered delete affordance on a PARSED entry, and the index it
+ * writes with.
+ *
+ * Two things can only be caught here, above the hook and below the pipeline:
+ *
+ * 1. The affordance EXISTS on a parsed entry. Before #856 every section gated
+ *    its `RemoveButton` on the entry being user-added, which is the whole
+ *    report: a phantom achievement could be blanked field by field but never
+ *    dropped, and still shipped into the Download PDF.
+ * 2. The key that crosses the component boundary is the PARSED index, not the
+ *    render position. `applyOverrides` filters a deleted entry out of the array
+ *    this section maps over, so from the first deletion on the two diverge —
+ *    and `achievementOverrides`, `descriptionOverrides` and the tombstone set
+ *    are all keyed by the parsed one. Writing a render position into any of them
+ *    rebinds a survivor's edits to its neighbour's, silently and plausibly.
+ *
+ * Achievements is the section the report came from, and the one where all three
+ * of those channels meet, so it is the one rendered. Spies rather than a live
+ * hook: the claim is about which key crosses the boundary, which a spy states
+ * directly and a re-graded pipeline only implies.
+ *
+ * jsdom + raw `createRoot`, matching `ExperienceSection.test.tsx`.
+ */
+
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { AchievementsSection } from "./ReconstructedResume.tsx";
+import { survivingParsedIndices } from "../../hooks/useEditableParse.ts";
+import type { AddedEntry } from "../../hooks/useEditableParse.ts";
+import { bulletId } from "../../lib/score/bullet-id.ts";
+import type { BulletGroup } from "../../lib/score/group-bullets.ts";
+import type { BulletObservation } from "../../lib/score/score.ts";
+import type { HeuristicAchievement } from "../../lib/score/types.ts";
+
+function bullet(index: number, text: string): BulletObservation {
+  return {
+    text,
+    id: bulletId(text, 0),
+    index,
+    hasMetric: true,
+    startsWithActionVerb: true,
+    wellFormedLength: true,
+    wordCount: 9,
+  };
+}
+
+const PARSED: readonly HeuristicAchievement[] = [
+  { type: "Patent", title: "Phantom method", year: "2019" },
+  { type: "Award", title: "Best Paper", year: "2020" },
+  { type: "Talk", title: "Scaling parsers", year: "2021" },
+];
+
+const CITED = "Cited by 40 downstream filings.";
+
+/** Index-aligned groups, as `buildEntryGroups` hands them over. Only the middle
+ *  entry carries bullets, so the cascade has something to be wrong about. */
+function groupsFor(achievements: readonly HeuristicAchievement[]): BulletGroup[] {
+  return achievements.map((a, i) => ({
+    experienceIndex: i,
+    experience: { title: a.title },
+    bullets: a.title === "Best Paper" ? [bullet(0, CITED)] : [],
+  }));
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+interface Spies {
+  onRemoveEntry: ReturnType<typeof vi.fn>;
+  onRemoveBullet: ReturnType<typeof vi.fn>;
+  onAchievementField: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Render the section over `achievements` with `removedEntries` already applied
+ * — i.e. exactly the state the container is in on the render AFTER a deletion:
+ * the array is filtered, and `parsedIndices` is the map back.
+ */
+function render(
+  achievements: readonly HeuristicAchievement[],
+  removedEntries: ReadonlySet<string> = new Set(),
+  added: AddedEntry[] = [],
+): Spies {
+  const spies: Spies = {
+    onRemoveEntry: vi.fn(),
+    onRemoveBullet: vi.fn(() => true),
+    onAchievementField: vi.fn(),
+  };
+  const originalCount = achievements.length - added.length;
+  act(() =>
+    root.render(
+      createElement(AchievementsSection, {
+        achievements: [...achievements],
+        groups: groupsFor(achievements),
+        addedAchievements: added,
+        originalCount,
+        parsedIndices: survivingParsedIndices(
+          "achievements",
+          removedEntries,
+          originalCount,
+        ),
+        onAddEntry: () => {},
+        onEntryField: () => {},
+        onAddBullet: () => {},
+        onPruneEmpty: () => {},
+        ...spies,
+      }),
+    ),
+  );
+  return spies;
+}
+
+function removeButtons(): HTMLElement[] {
+  return [
+    ...container.querySelectorAll<HTMLElement>('[aria-label="Remove achievement"]'),
+  ];
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the parsed-entry remove affordance (#856)", () => {
+  it("renders one on EVERY entry, parsed and added alike", () => {
+    render(PARSED);
+    expect(removeButtons()).toHaveLength(3);
+  });
+
+  it("deletes by the entry's parsedEntryKey, and takes its bullets", () => {
+    const spies = render(PARSED);
+    act(() => removeButtons()[1].click());
+
+    expect(spies.onRemoveEntry).toHaveBeenCalledExactlyOnceWith(
+      "achievements:1",
+    );
+    // Bullets go through `removeBullet` — dropping the entry cannot take them
+    // out of `sections`, which is the pool the anonymous scorer grades.
+    expect(spies.onRemoveBullet).toHaveBeenCalledExactlyOnceWith(
+      bulletId(CITED, 0),
+      { entryKey: "achievements:1", text: CITED },
+    );
+  });
+
+  it("deletes a bullet-less entry with no bullet writes at all", () => {
+    const spies = render(PARSED);
+    act(() => removeButtons()[0].click());
+    expect(spies.onRemoveEntry).toHaveBeenCalledExactlyOnceWith(
+      "achievements:0",
+    );
+    expect(spies.onRemoveBullet).not.toHaveBeenCalled();
+  });
+
+  it("still removes a user-ADDED entry by its own id", () => {
+    const added: AddedEntry = {
+      id: "added:7",
+      section: "achievements",
+      title: "Hand-typed award",
+    };
+    const spies = render(
+      [...PARSED, { title: added.title }],
+      new Set(),
+      [added],
+    );
+    act(() => removeButtons()[3].click());
+    expect(spies.onRemoveEntry).toHaveBeenCalledExactlyOnceWith("added:7");
+  });
+});
+
+describe("index resolution after a deletion (#856)", () => {
+  // The render AFTER deleting parsed index 0: the array the section maps over
+  // has been filtered, so render position 0 is now parsed index 1.
+  const AFTER = PARSED.slice(1);
+  const REMOVED = new Set(["achievements:0"]);
+
+  it("deletes the NEXT entry by its parsed index, not its render position", () => {
+    const spies = render(AFTER, REMOVED);
+    expect(removeButtons()).toHaveLength(2);
+
+    act(() => removeButtons()[0].click());
+    // Render position 0 — "achievements:0" here would be a no-op re-delete of
+    // the entry that is already gone, leaving this one un-deletable forever.
+    expect(spies.onRemoveEntry).toHaveBeenCalledExactlyOnceWith(
+      "achievements:1",
+    );
+    expect(spies.onRemoveBullet).toHaveBeenCalledExactlyOnceWith(
+      bulletId(CITED, 0),
+      { entryKey: "achievements:1", text: CITED },
+    );
+  });
+
+  it("files a surviving entry's field edit under its parsed index", () => {
+    const spies = render(AFTER, REMOVED);
+    // The year cell of the SECOND surviving entry — parsed index 2. Read mode
+    // names the control "Edit <label>" (`EditableField`, WCAG 2.5.3).
+    const years = [
+      ...container.querySelectorAll<HTMLElement>('[aria-label="Edit Year"]'),
+    ];
+    expect(years).toHaveLength(2);
+
+    act(() => years[1].click());
+    const input = container.querySelector<HTMLInputElement>("input");
+    expect(input).not.toBeNull();
+    act(() => {
+      // Through the prototype setter, so React's own value tracker sees the
+      // change and does not swallow the synthetic `input` event.
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!.call(input!, "2023");
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    act(() =>
+      input!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      ),
+    );
+
+    // Render position 1 — `(1, …)` here would overwrite the OTHER survivor.
+    expect(spies.onAchievementField).toHaveBeenCalledExactlyOnceWith(
+      2,
+      "year",
+      "2023",
+    );
+  });
+});

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -83,7 +83,11 @@ import type {
   AddedBulletRef,
   AddedBullets,
 } from "../../hooks/useEditableParse.ts";
-import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
+import {
+  parsedEntryKey,
+  survivingParsedIndices,
+} from "../../hooks/useEditableParse.ts";
+import { removeEntryWithBullets } from "../../lib/edit/entry-remove.ts";
 import { useAddedEntryPruneHold } from "../../hooks/useAddedEntryPruneHold.ts";
 import {
   batchUndoTargets,
@@ -406,6 +410,7 @@ export function ExperienceSection({
   addedBullets,
   addedExperience,
   originalCount,
+  parsedIndices,
   onAddEntry,
   onRemoveEntry,
   onEntryField,
@@ -435,6 +440,9 @@ export function ExperienceSection({
   onRewriteApplied?: () => void;
   hasBullets: boolean;
   experienceOverrides: Record<number, ExperienceFieldOverrides>;
+  /** `index` is the role's PARSED index — the key space `experienceOverrides`
+   *  uses — NOT its render position. The two diverge once a parsed role is
+   *  deleted (#856); {@link parsedIndices} is the map between them. */
   onExperienceFieldChange: (
     index: number,
     field: keyof ExperienceFieldOverrides,
@@ -456,10 +464,14 @@ export function ExperienceSection({
   addedBullets: AddedBullets;
   /** User-added experience entries, append-aligned to indices ≥ originalCount. */
   addedExperience: AddedEntry[];
-  /** Count of PARSED experience roles; indices at/above this are user-added. */
+  /** Count of PARSED experience roles still rendered; indices at/above this are
+   *  user-added. */
   originalCount: number;
+  /** Render position → PARSED index for the surviving parsed roles (#856), from
+   *  {@link survivingParsedIndices}. Identity until a parsed role is deleted. */
+  parsedIndices: readonly number[];
   onAddEntry: () => void;
-  onRemoveEntry: (id: string) => void;
+  onRemoveEntry: (key: string) => void;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
   onAddBullet: (entryKey: string, text: string) => void;
   /** Snapshot the slots a rewrite batch will write, for a one-action undo of
@@ -478,6 +490,15 @@ export function ExperienceSection({
 }) {
   // "Other" is appended with a null index; real roles carry their index.
   const roleCount = groups.filter((g) => g.experienceIndex !== null).length;
+
+  // A rendered role's PARSED index — the key space `experienceOverrides` and
+  // every `addedBullets` bucket use. `applyOverrides` filters deleted parsed
+  // roles out of the array the groups were built over (#856), so the render
+  // position stops being the parsed index after the first deletion. An index at
+  // or above `originalCount` is a user-ADDED role, appended after every
+  // survivor, and never reaches an index-keyed map at all.
+  const parsedIndexOf = (idx: number): number =>
+    idx < originalCount ? (parsedIndices[idx] ?? idx) : idx;
 
   // Per-entry prune hold (#637 half 2). Created HERE — the ids it holds are
   // only meaningful to this section's `pruneEmptyAddedEntries` call, and the
@@ -526,11 +547,19 @@ export function ExperienceSection({
       if (idx === null) continue;
       const added =
         idx >= originalCount ? addedExperience[idx - originalCount] : undefined;
-      const entryKey = added ? added.id : parsedEntryKey("experience", idx);
+      const entryKey = added
+        ? added.id
+        : parsedEntryKey("experience", parsedIndexOf(idx));
       const bucketRef = (obsId: string): AddedBulletRef | undefined => {
         const text = group.bullets.find((b) => b.id === obsId)?.text;
         return text === undefined ? undefined : { entryKey, text };
       };
+      // NOTE the two `experience:<n>` strings here are in DIFFERENT index
+      // spaces and only look alike. This map's key is the rewrite-chain section
+      // id `buildResumeSections` mints from the RENDER position, and both ends
+      // are built in the same render, so it stays internally consistent.
+      // `entryKey` above is the persisted `addedBullets` bucket key and must be
+      // the PARSED index. They coincide until a parsed role is deleted (#856).
       map.set(`experience:${idx}`, {
         obsIds: group.bullets.map((b) => b.id),
         // Entry-aware like the per-role path (#637, #657): a rewrite accepted on
@@ -549,6 +578,7 @@ export function ExperienceSection({
   }, [
     groups,
     originalCount,
+    parsedIndices,
     addedExperience,
     onBulletChange,
     onRemoveBullet,
@@ -623,23 +653,27 @@ export function ExperienceSection({
               idx >= originalCount
                 ? addedExperience[idx - originalCount]
                 : undefined;
+            const parsedIdx = parsedIndexOf(idx);
             // The one bucket this role owns — its added id, or its parsed-entry
             // key. Adds append to it, a rewrite batch's undo snapshots it, and
             // (since #637) a remove of a user-added bullet splices it.
             const roleEntryKey = added
               ? added.id
-              : parsedEntryKey("experience", idx);
+              : parsedEntryKey("experience", parsedIdx);
             const entry = (
               <RoleEntry
-                key={added ? added.id : idx}
+                // The ENTRY key, not the render position (#856): a deletion
+                // shifts every later row up one, and a position key would hand
+                // the deleted row's in-flight edit state to its successor.
+                key={roleEntryKey}
                 group={group}
                 experienceIndex={idx}
-                overrides={added ? undefined : experienceOverrides[idx]}
+                overrides={added ? undefined : experienceOverrides[parsedIdx]}
                 onFieldChange={(field, value) => {
                   if (added) {
                     onEntryField(added.id, EXPERIENCE_FIELD_MAP[field], value);
                   } else {
-                    onExperienceFieldChange(idx, field, value);
+                    onExperienceFieldChange(parsedIdx, field, value);
                   }
                 }}
                 onBulletChange={onBulletChange}
@@ -648,13 +682,21 @@ export function ExperienceSection({
                 captureUndo={(writes) =>
                   captureBulletUndo(batchUndoTargets(writes, roleEntryKey))
                 }
-                onRemove={added ? () => onRemoveEntry(added.id) : undefined}
+                // Set for a PARSED role too since #856 — its own key tombstones
+                // the entry, and the bullets under it go through `removeBullet`
+                // (see `removeEntryWithBullets` for why they have to).
+                onRemove={() =>
+                  removeEntryWithBullets(roleEntryKey, group.bullets, {
+                    onRemoveEntry,
+                    onRemoveBullet,
+                  })
+                }
                 entryKey={roleEntryKey}
                 pruneHold={pruneHold}
               />
             );
             return subHeading ? (
-              <Fragment key={added ? added.id : idx}>
+              <Fragment key={roleEntryKey}>
                 <SectionHeading>{subHeading}</SectionHeading>
                 {entry}
               </Fragment>
@@ -675,10 +717,12 @@ export function ExperienceSection({
 
 /**
  * Projects render as their OWN section (#95) — a name-led header + the same
- * graded bullet rows used everywhere else (`ResumeBulletRow`). Parsed projects
- * stay read-only; user-ADDED projects expose an editable name, a "+ Add bullet"
- * affordance, and a remove control (#180-followup), so an added project's
- * bullets grade and export like any other.
+ * graded bullet rows used everywhere else (`ResumeBulletRow`). A parsed
+ * project's name stays read-only; user-ADDED projects expose an editable name
+ * and a "+ Add bullet" affordance (#180-followup), so an added project's
+ * bullets grade and export like any other. BOTH carry a remove control since
+ * #856 — a phantom project the parser stitched together was previously
+ * uncorrectable and shipped into the Download PDF.
  */
 function ProjectsSection({
   heading,
@@ -687,8 +731,10 @@ function ProjectsSection({
   descriptionOverrides,
   addedProjects,
   originalCount,
+  parsedIndices,
   onAddEntry,
   onRemoveEntry,
+  onRemoveBullet,
   onEntryField,
   onDescriptionField,
   onAddBullet,
@@ -703,9 +749,16 @@ function ProjectsSection({
    *  a CLEARED prose field mounted (so the clear is reversible in-session). */
   descriptionOverrides: DescriptionOverrides;
   addedProjects: AddedEntry[];
+  /** Count of PARSED projects still rendered; indices at/above are user-added. */
   originalCount: number;
+  /** Render position → PARSED index for the surviving parsed projects (#856),
+   *  from {@link survivingParsedIndices}. Identity until one is deleted. */
+  parsedIndices: readonly number[];
   onAddEntry: () => void;
-  onRemoveEntry: (id: string) => void;
+  onRemoveEntry: (key: string) => void;
+  /** Drop one bullet, so deleting an entry can take its bullets out of the
+   *  graded pool with it (#856) — see `removeEntryWithBullets`. */
+  onRemoveBullet: (id: string, added?: AddedBulletRef) => boolean;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
   /** Commit an edit to a parsed project's prose description (#489). */
   onDescriptionField: (key: string, value: string | undefined) => void;
@@ -724,7 +777,11 @@ function ProjectsSection({
           const group = groups[i];
           const added =
             i >= originalCount ? addedProjects[i - originalCount] : undefined;
-          const descKey = parsedEntryKey("projects", i);
+          // PARSED index, not the render position: `applyOverrides` filters
+          // deleted entries out, so the two diverge after the first delete
+          // (#856) and `descriptionOverrides` is keyed by the parsed one.
+          const descKey = parsedEntryKey("projects", parsedIndices[i] ?? i);
+          const entryKey = added ? added.id : descKey;
           // Keep the prose field mounted once the user has touched it, even after
           // an authoritative clear ("" override) drops `project.description` — so
           // the clear stays reversible in-session instead of collapsing to the
@@ -734,7 +791,9 @@ function ProjectsSection({
             .filter(Boolean)
             .join(" · ");
           return (
-            <div key={added ? added.id : i} className="flex flex-col gap-1.5">
+            // The ENTRY key, not the render position (#856) — see the same note
+            // in `ExperienceSection`.
+            <div key={entryKey} className="flex flex-col gap-1.5">
               <div className="flex items-start justify-between gap-2">
                 {added ? (
                   <EditableField
@@ -751,12 +810,15 @@ function ProjectsSection({
                     {header || "Untitled project"}
                   </h3>
                 )}
-                {added && (
-                  <RemoveButton
-                    label="Remove project"
-                    onClick={() => onRemoveEntry(added.id)}
-                  />
-                )}
+                <RemoveButton
+                  label="Remove project"
+                  onClick={() =>
+                    removeEntryWithBullets(entryKey, group?.bullets ?? [], {
+                      onRemoveEntry,
+                      onRemoveBullet,
+                    })
+                  }
+                />
               </div>
               {group && group.bullets.length > 0 ? (
                 <ul className="list-none">
@@ -891,16 +953,24 @@ function AchievementHeader({
  * Both branches are editable: a PARSED achievement's type / title / year through
  * `AchievementHeader` (#454, overrides keyed by parsed index and already folded
  * into `achievements` by `applyOverrides`), a user-ADDED one through the flat
- * `AddedEntry` fields (#455).
+ * `AddedEntry` fields (#455). Both are also removable since #856 — this is the
+ * section the report came from: a phantom achievement could be blanked field by
+ * field but never actually dropped, so it still shipped into the Download PDF.
  */
-function AchievementsSection({
+// Exported for `ReconstructedResume.remove-parsed-entry.test.tsx` only — the
+// render-position → parsed-index resolution (#856) is a property of THIS
+// component, so the regression test has to render it. Not part of the surface
+// any other module imports; same arrangement as `ExperienceSection` above.
+export function AchievementsSection({
   heading,
   achievements,
   groups,
   addedAchievements,
   originalCount,
+  parsedIndices,
   onAddEntry,
   onRemoveEntry,
+  onRemoveBullet,
   onEntryField,
   onAchievementField,
   onAddBullet,
@@ -912,9 +982,18 @@ function AchievementsSection({
   /** Pre-built achievement groups, index-aligned with `achievements`. */
   groups: BulletGroup[];
   addedAchievements: AddedEntry[];
+  /** Count of PARSED achievements still rendered; at/above this are user-added. */
   originalCount: number;
+  /** Render position → PARSED index for the surviving parsed achievements
+   *  (#856), from {@link survivingParsedIndices}. Identity until one is
+   *  deleted — after which `achievementOverrides`' keys would otherwise rebind
+   *  each survivor's edits to its neighbour's. */
+  parsedIndices: readonly number[];
   onAddEntry: () => void;
-  onRemoveEntry: (id: string) => void;
+  onRemoveEntry: (key: string) => void;
+  /** Drop one bullet, so deleting an entry can take its bullets out of the
+   *  graded pool with it (#856) — see `removeEntryWithBullets`. */
+  onRemoveBullet: (id: string, added?: AddedBulletRef) => boolean;
   onEntryField: (id: string, field: AddedEntryField, value: string) => void;
   onAchievementField: (
     index: number,
@@ -938,8 +1017,15 @@ function AchievementsSection({
             i >= originalCount
               ? addedAchievements[i - originalCount]
               : undefined;
+          // PARSED index, not the render position — see `parsedIndices`.
+          const parsedIdx = parsedIndices[i] ?? i;
+          const entryKey = added
+            ? added.id
+            : parsedEntryKey("achievements", parsedIdx);
           return (
-            <div key={added ? added.id : i} className="flex flex-col gap-1.5">
+            // The ENTRY key, not the render position (#856) — see the same note
+            // in `ExperienceSection`.
+            <div key={entryKey} className="flex flex-col gap-1.5">
               <div className="flex items-start justify-between gap-2">
                 {added ? (
                   // Same header as a parsed achievement — an added entry stores
@@ -964,16 +1050,19 @@ function AchievementsSection({
                     year={achievement.year}
                     yearSeparator={achievement.year_separator}
                     onFieldChange={(field, value) =>
-                      onAchievementField(i, field, value)
+                      onAchievementField(parsedIdx, field, value)
                     }
                   />
                 )}
-                {added && (
-                  <RemoveButton
-                    label="Remove achievement"
-                    onClick={() => onRemoveEntry(added.id)}
-                  />
-                )}
+                <RemoveButton
+                  label="Remove achievement"
+                  onClick={() =>
+                    removeEntryWithBullets(entryKey, group?.bullets ?? [], {
+                      onRemoveEntry,
+                      onRemoveBullet,
+                    })
+                  }
+                />
               </div>
               {group && group.bullets.length > 0 && (
                 <ul className="list-none">
@@ -1078,6 +1167,7 @@ export function ReconstructedResume({
     descriptionOverrides,
     setDescriptionField,
     removeBullet,
+    removedEntries,
     educationOverrides,
     setEducationField,
     setAchievementField,
@@ -1140,6 +1230,43 @@ export function ReconstructedResume({
   const originalProjCount = projects.length - addedProjects.length;
   const originalAchCount = achievements.length - addedAchievements.length;
 
+  // Render position → PARSED index, per section (#856). `applyOverrides` filters
+  // a deleted parsed entry out of these arrays, so from the first deletion on, a
+  // rendered row's position is NOT the index its overrides are keyed by. Every
+  // section resolves through the map rather than re-deriving one, so the four
+  // cannot drift; see `survivingParsedIndices` for why it is enumerated rather
+  // than computed by subtraction.
+  const expParsedIndices = survivingParsedIndices(
+    "experience",
+    removedEntries,
+    originalExpCount,
+  );
+  const eduParsedIndices = survivingParsedIndices(
+    "education",
+    removedEntries,
+    originalEduCount,
+  );
+  const projParsedIndices = survivingParsedIndices(
+    "projects",
+    removedEntries,
+    originalProjCount,
+  );
+  const achParsedIndices = survivingParsedIndices(
+    "achievements",
+    removedEntries,
+    originalAchCount,
+  );
+
+  // The RESOLVED experience entry behind a parsed index — what the #672 date
+  // rule compares a commit against. It sits at the entry's RENDER position, so
+  // the map has to be walked back the other way; identity while nothing is
+  // deleted. Undefined for an index no row renders, which simply opts that
+  // commit out of the rule rather than resolving it against a neighbour.
+  const resolvedExperience = (parsedIndex: number) => {
+    const pos = expParsedIndices.indexOf(parsedIndex);
+    return pos < 0 ? undefined : parsed.experience[pos];
+  };
+
   // One grouping pass over experiences + projects + achievements so their
   // bullets are attributed to their own entry and never leak into the experience
   // "Other" group (#95, #96). The "Other" group (bullets matched to none) renders
@@ -1179,9 +1306,11 @@ export function ReconstructedResume({
       groups={achievementGroups}
       addedAchievements={addedAchievements}
       originalCount={originalAchCount}
+      parsedIndices={achParsedIndices}
       onAddEntry={() => addEntry("achievements")}
       onPruneEmpty={() => pruneEmptyAddedEntries("achievements")}
       onRemoveEntry={removeEntry}
+      onRemoveBullet={removeBullet}
       onEntryField={setEntryField}
       onAchievementField={setAchievementField}
       onAddBullet={addBullet}
@@ -1277,7 +1406,7 @@ export function ReconstructedResume({
         // the pre-write override map so the sparse write-back does not compare a
         // previously-overridden key against a base that contains it.
         onExperienceFieldChange={(index, field, value) =>
-          setExperienceField(index, field, value, parsed.experience[index])
+          setExperienceField(index, field, value, resolvedExperience(index))
         }
         onBulletChange={(index, value, original) =>
           setBulletField(index, value, original)
@@ -1286,6 +1415,7 @@ export function ReconstructedResume({
         addedBullets={edit.addedBullets}
         addedExperience={addedExperience}
         originalCount={originalExpCount}
+        parsedIndices={expParsedIndices}
         onAddEntry={() => addEntry("experience")}
         onPruneEmpty={(isHeld) => pruneEmptyAddedEntries("experience", isHeld)}
         onRemoveEntry={removeEntry}
@@ -1301,9 +1431,11 @@ export function ReconstructedResume({
         descriptionOverrides={descriptionOverrides}
         addedProjects={addedProjects}
         originalCount={originalProjCount}
+        parsedIndices={projParsedIndices}
         onAddEntry={() => addEntry("projects")}
         onPruneEmpty={() => pruneEmptyAddedEntries("projects")}
         onRemoveEntry={removeEntry}
+        onRemoveBullet={removeBullet}
         onEntryField={setEntryField}
         onDescriptionField={setDescriptionField}
         onAddBullet={addBullet}
@@ -1318,6 +1450,7 @@ export function ReconstructedResume({
         }
         addedEducation={addedEducation}
         originalCount={originalEduCount}
+        parsedIndices={eduParsedIndices}
         onAddEntry={() => addEntry("education")}
         onPruneEmpty={() => pruneEmptyAddedEntries("education")}
         onRemoveEntry={removeEntry}

--- a/src/components/features/ReconstructedRole.tsx
+++ b/src/components/features/ReconstructedRole.tsx
@@ -259,7 +259,7 @@ interface RoleEntryProps {
   /** Commit a bullet edit, keyed by BulletObservation.id (#82, #648). The
    *  optional third argument identifies the added-bullets bucket + line, which
    *  is the ONLY way to reach a user-ADDED bullet (#657); this component
-   *  supplies it from `entryKey`, exactly as it does for a removal. */
+   *  supplies it from `entryKey`, just as it does for a removal. */
   onBulletChange?: (id: string, value: string, added?: AddedBulletRef) => void;
   /** Append a new bullet to this role (#180-followup). Renders a "+ Add bullet"
    *  affordance under the bullet list when provided. */
@@ -283,8 +283,10 @@ interface RoleEntryProps {
   /** Snapshot the slots a rewrite batch will write, so the whole batch can be
    *  reversed in one action (issue 510). Omitted → no Undo is offered. */
   captureUndo?: SectionRewriteApply["captureUndo"];
-  /** Remove this role (only set for user-ADDED roles). Renders an X control in
-   *  the header row when provided. */
+  /** Remove this role. Renders an X control in the header row when provided —
+   *  set for a PARSED role too since #856, so "is this role user-added?" is read
+   *  off `entryKey` (see `isAdded` below) rather than off this prop's presence.
+   *  Absent only for the "Other bullets" bucket, which owns no entry. */
   onRemove?: () => void;
   /** A remove-confirmation control owned by an ANCESTOR, for a group that can
    *  disappear from the render list when its last bullet goes (the "Other
@@ -321,6 +323,11 @@ export function RoleEntry({
   // gate let it destroy. Scoped to that timer: the section-exit prune (#379)
   // still reads a draft as emptiness, which is pre-existing and filed on its own.
   const rootRef = useRef<HTMLDivElement>(null);
+  // Whether this row is a user-ADDED role. Read off `entryKey`, not off
+  // `onRemove` (#856): a parsed role now carries a remove control too, so the
+  // presence of that prop no longer distinguishes the two. Same test
+  // `useHoldWhile` below already makes — only an added entry is prunable.
+  const isAdded = entryKey !== undefined && isAddedEntryKey(entryKey);
   // Tag every write issued from this role's own rows with the bucket that owns
   // them, so a USER-ADDED bullet is spliced (#637) or rewritten (#657) in
   // `addedBullets` rather than filed under an id that reaches nothing there.
@@ -353,7 +360,7 @@ export function RoleEntry({
   // (focus containment, and an open text control).
   useHoldWhile(
     pruneHold,
-    entryKey !== undefined && isAddedEntryKey(entryKey) ? entryKey : undefined,
+    isAdded ? entryKey : undefined,
     hostsStrip && removes.pending,
     rootRef,
   );
@@ -457,13 +464,13 @@ export function RoleEntry({
           {rewritePanel}
         </>
       ) : (
-        // A user-added role (onRemove set) starts empty — the "+ Add bullet"
-        // affordance below is its call to action, so suppress the note for it.
-        // A PARSED role with no bullets still shows the note: that the parser
-        // found none is the diagnostic signal this surface exists to expose —
-        // UNLESS the empty state is because the last bullet was just removed
-        // (#626), which the confirmation strip below already explains.
-        !onRemove &&
+        // A user-added role starts empty — the "+ Add bullet" affordance below
+        // is its call to action, so suppress the note for it. A PARSED role with
+        // no bullets still shows the note: that the parser found none is the
+        // diagnostic signal this surface exists to expose — UNLESS the empty
+        // state is because the last bullet was just removed (#626), which the
+        // confirmation strip below already explains.
+        !isAdded &&
         !removes.pending && (
           <p className="text-sm text-content-tertiary">
             No bullet-shaped lines detected.

--- a/src/hooks/useAnalyzedResume.ts
+++ b/src/hooks/useAnalyzedResume.ts
@@ -123,6 +123,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     bulletOverrides,
     descriptionOverrides,
     removedBullets,
+    removedEntries,
     educationOverrides,
     achievementOverrides,
     skillsOverride,
@@ -177,6 +178,7 @@ export function useAnalyzedResume(): AnalyzedResume {
       achievementOverrides,
       descriptionOverrides,
       summaryOverride,
+      removedEntries,
     );
   }, [
     base,
@@ -192,6 +194,7 @@ export function useAnalyzedResume(): AnalyzedResume {
     addedEntries,
     addedBullets,
     removedBullets,
+    removedEntries,
     profileOverrides,
   ]);
 
@@ -281,6 +284,11 @@ export function useAnalyzedResume(): AnalyzedResume {
     addedEntries,
     addedBullets,
     removedBullets,
+    // Deleting a parsed entry moves the score twice over (#856): Completeness
+    // counts `experience`/`education` entries, and a title-only entry's own
+    // pooled line leaves `sections` with it. Both are `editedCore` effects, so
+    // this dep is what the hand-maintained invariant above demands.
+    removedEntries,
     // Derived from `bulletOverrides` + `removedBullets`, both already above, so
     // this dep adds no re-grade of its own — listed because the memo reads it.
     claimedBulletKeys,

--- a/src/hooks/useEditableParse.removed-entry.test.tsx
+++ b/src/hooks/useEditableParse.removed-entry.test.tsx
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * #856 — deleting a PARSED entry, driven end-to-end.
+ *
+ * Proving it at the hook boundary would prove nothing: the whole defect was that
+ * the UI had no affordance and the hook had no state for one, so "the set now
+ * has a key in it" is not the claim. Each case below therefore folds the REAL
+ * `useEditableParse` state through the REAL `applyOverrides` →
+ * `computeAnonymousAtsScore` → `buildAtsResumeModel` chain that `/` runs, and
+ * asserts against the three surfaces the issue names: the rendered parse, the
+ * score, and the exported PDF.
+ *
+ * The delete gesture is the shipped one (`removeEntryWithBullets`), not a bare
+ * `removeEntry` — the bullets are a separate write, and calling only half of it
+ * is the failure mode the helper exists to prevent.
+ *
+ * The achievement fixture is TITLE-ONLY on purpose: it is parsed out of a single
+ * `•`-marked line, so that line stays in the graded pool with no description to
+ * attribute it to (`suppressTitleOwnedBullets` hides it from the UI). It is the
+ * one shape where deleting the entry is not enough on its own.
+ *
+ * Mounted with raw `createRoot`, matching `useEditableParse.test.tsx` (the
+ * project has no @testing-library/react).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  useEditableParse,
+  parsedEntryKey,
+  survivingParsedIndices,
+  type EditableParse,
+  type EditSnapshot,
+} from "./useEditableParse.ts";
+import { removeEntryWithBullets } from "../lib/edit/entry-remove.ts";
+import { applyOverrides } from "../lib/edit/apply-overrides.ts";
+import {
+  computeAnonymousAtsScore,
+  type AnonymousAtsScore,
+  type BulletObservation,
+} from "../lib/score/score.ts";
+import { buildAtsResumeModel } from "../lib/pdf/ats-resume-model.ts";
+import { groupBulletsByExperience } from "../lib/score/group-bullets.ts";
+import { projectScoreSections } from "../lib/heuristics/projections.ts";
+import { buildBlankResult } from "../lib/heuristics/empty-result.ts";
+import { toCanonicalResume } from "../lib/heuristics/canonical.ts";
+import type { SectionedResume } from "../lib/heuristics/sections.ts";
+import type { CascadeResult } from "../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const LATENCY = "Cut p99 checkout latency by 38% via edge caching.";
+const ONBOARDING = "Reduced onboarding time from 5 days to 2 days.";
+const PATENT_LINE = "Patent · Issued US10275736B1, 2019";
+
+function sections(lines: readonly string[]): SectionedResume {
+  const byName = new Map<string, readonly string[]>([["experience", lines]]);
+  return {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
+
+const SOURCE_LINES = [`• ${LATENCY}`, `• ${ONBOARDING}`, `• ${PATENT_LINE}`];
+
+/** Two parsed roles (so a delete has a neighbour to get wrong) plus one
+ *  title-only achievement. */
+function baseResult(): CascadeResult {
+  const blank = buildBlankResult();
+  return {
+    ...blank,
+    rawText: SOURCE_LINES.join("\n"),
+    canonical: toCanonicalResume(
+      {
+        full_name: "Robin Vasquez",
+        email: "robin.vasquez@example.com",
+        skills: ["typescript"],
+        education: [],
+        experience: [
+          {
+            title: "Staff Engineer",
+            company: "Northwind Systems",
+            start_date: "2020",
+            end_date: "2024",
+            description: LATENCY,
+          },
+          {
+            title: "Engineer",
+            company: "Cascadia Analytics",
+            start_date: "2017",
+            end_date: "2020",
+            description: ONBOARDING,
+          },
+        ],
+        heuristic_achievements: [
+          { type: "Patent", title: "Issued US10275736B1", year: "2019" },
+        ],
+      },
+      sections(SOURCE_LINES),
+      {},
+    ),
+  };
+}
+
+/** The frozen base-parse observation pool (`doneScoreBullets` on `/`). */
+const OBSERVATIONS: readonly BulletObservation[] = (() => {
+  const base = baseResult();
+  return (
+    computeAnonymousAtsScore({
+      parsed: base.canonical.fields,
+      fieldConfidence: base.canonical.fieldConfidence,
+      triggers: [],
+      rawText: base.rawText,
+      sections: base.canonical.sections,
+    }).bullets ?? []
+  );
+})();
+
+interface Regraded {
+  score: AnonymousAtsScore;
+  bulletTexts: string[];
+  rawText: string;
+  roleTitles: string[];
+  achievementTitles: string[];
+  /** Every header line the Download PDF would draw, across all sections. */
+  exportedHeaders: string[];
+  /** Every bullet the Download PDF would draw. */
+  exportedBullets: string[];
+}
+
+/** Run the exact `/` pipeline over the hook's current override state. */
+function regrade(api: EditableParse): Regraded {
+  const base = baseResult();
+  const core = applyOverrides(
+    base.canonical.fields,
+    base.rawText,
+    base.canonical.sections,
+    api.contactOverrides,
+    api.experienceOverrides,
+    api.bulletOverrides,
+    OBSERVATIONS,
+    api.educationOverrides,
+    api.skillsOverride,
+    api.addedEntries,
+    api.addedBullets,
+    api.removedBullets,
+    api.profileOverrides,
+    base.canonical.fieldConfidence,
+    api.achievementOverrides,
+    api.descriptionOverrides,
+    api.summaryOverride,
+    api.removedEntries,
+  );
+  const score = computeAnonymousAtsScore({
+    parsed: core.fields,
+    fieldConfidence: core.fieldConfidence,
+    triggers: base.triggers,
+    rawText: core.rawText,
+    sections: projectScoreSections(core),
+  });
+  const display: CascadeResult = {
+    ...base,
+    canonical: {
+      ...base.canonical,
+      fields: core.fields,
+      fieldConfidence: core.fieldConfidence,
+    },
+  };
+  const model = buildAtsResumeModel(display, score);
+  return {
+    score,
+    bulletTexts: (score.bullets ?? []).map((b) => b.text),
+    rawText: core.rawText,
+    roleTitles: core.fields.experience.map((e) => e.title),
+    achievementTitles: (core.fields.heuristic_achievements ?? []).map(
+      (a) => a.title,
+    ),
+    exportedHeaders: model.sections.flatMap((s) =>
+      s.entries.map((e) => e.headerLine),
+    ),
+    exportedBullets: model.sections.flatMap((s) =>
+      s.entries.flatMap((e) => e.bullets),
+    ),
+  };
+}
+
+/** The rendered bullet group for one parsed role, as `ReconstructedResume`
+ *  builds it — the rows whose ids the delete gesture cascades over. */
+function roleBullets(api: EditableParse, renderPos: number): BulletObservation[] {
+  const r = regrade(api);
+  const groups = groupBulletsByExperience(
+    [...(r.score.bullets ?? [])],
+    // Only the experience slice matters here; achievements are title-only.
+    baseResult().canonical.fields.experience.map((e) => ({
+      title: e.title,
+      description: e.description,
+    })),
+  );
+  return groups.find((g) => g.experienceIndex === renderPos)?.bullets ?? [];
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let api: EditableParse;
+
+function Probe() {
+  api = useEditableParse();
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Probe />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("deleting a parsed ACHIEVEMENT (#856, the reported case)", () => {
+  it("drops it from the parse, the score and the exported PDF", () => {
+    const before = regrade(api);
+    expect(before.achievementTitles).toEqual(["Issued US10275736B1"]);
+    expect(before.exportedHeaders.join(" ")).toContain("US10275736B1");
+    expect(before.bulletTexts).toHaveLength(3);
+
+    act(() =>
+      removeEntryWithBullets(parsedEntryKey("achievements", 0), [], {
+        onRemoveEntry: api.removeEntry,
+        onRemoveBullet: api.removeBullet,
+      }),
+    );
+
+    const after = regrade(api);
+    expect(after.achievementTitles).toEqual([]);
+    expect(after.exportedHeaders.join(" ")).not.toContain("US10275736B1");
+    // Its own `•` source line left the graded pool with it — the entry carries
+    // no description, so nothing else could have taken it out.
+    expect(after.bulletTexts).toEqual([LATENCY, ONBOARDING]);
+    expect(after.rawText).not.toContain("US10275736B1");
+    expect(after.score.specificity).not.toEqual(before.score.specificity);
+  });
+
+  it("stays deleted across a re-render, and marks the résumé edited", () => {
+    expect(api.hasEdits).toBe(false);
+    act(() => api.removeEntry(parsedEntryKey("achievements", 0)));
+    expect(api.hasEdits).toBe(true);
+    expect([...api.removedEntries]).toEqual(["achievements:0"]);
+
+    // A second render of the same state must not resurrect it.
+    act(() => root.render(<Probe />));
+    expect([...api.removedEntries]).toEqual(["achievements:0"]);
+    expect(regrade(api).achievementTitles).toEqual([]);
+  });
+
+  it("is idempotent", () => {
+    act(() => api.removeEntry(parsedEntryKey("achievements", 0)));
+    const first = api.removedEntries;
+    act(() => api.removeEntry(parsedEntryKey("achievements", 0)));
+    expect(api.removedEntries).toBe(first);
+  });
+});
+
+describe("deleting a parsed ROLE (#856)", () => {
+  it("takes its bullets out of the score, rawText and the export", () => {
+    const bullets = roleBullets(api, 0);
+    expect(bullets.map((b) => b.text)).toEqual([LATENCY]);
+
+    act(() =>
+      removeEntryWithBullets(parsedEntryKey("experience", 0), bullets, {
+        onRemoveEntry: api.removeEntry,
+        onRemoveBullet: api.removeBullet,
+      }),
+    );
+
+    const after = regrade(api);
+    expect(after.roleTitles).toEqual(["Engineer"]);
+    expect(after.bulletTexts).not.toContain(LATENCY);
+    expect(after.bulletTexts).toContain(ONBOARDING);
+    expect(after.rawText).not.toContain(LATENCY);
+    expect(after.exportedBullets).not.toContain(LATENCY);
+    expect(after.exportedBullets).toContain(ONBOARDING);
+  });
+
+  it("also drops bullets the user ADDED to that role", () => {
+    const added = "Shipped a design system used by 40 engineers.";
+    act(() => api.addBullet(parsedEntryKey("experience", 0), added));
+    expect(regrade(api).bulletTexts).toContain(added);
+
+    act(() =>
+      removeEntryWithBullets(parsedEntryKey("experience", 0), roleBullets(api, 0), {
+        onRemoveEntry: api.removeEntry,
+        onRemoveBullet: api.removeBullet,
+      }),
+    );
+
+    // The bucket is folded in DOWNSTREAM of the tombstone filter, so nothing
+    // but `removeEntry` deleting it stops these lines from going on grading.
+    expect(api.addedBullets).not.toHaveProperty("experience:0");
+    expect(regrade(api).bulletTexts).toEqual([ONBOARDING, PATENT_LINE]);
+  });
+
+  it("leaves the SURVIVING role's own header edit on the right role", () => {
+    // The UI resolves render position → parsed index through
+    // `survivingParsedIndices`; feeding it the render position instead would
+    // file this edit under index 0, i.e. against the role just deleted.
+    act(() => api.removeEntry(parsedEntryKey("experience", 0)));
+    const parsedIdx = survivingParsedIndices("experience", api.removedEntries, 1);
+    expect(parsedIdx).toEqual([1]);
+
+    act(() => api.setExperienceField(parsedIdx[0], "title", "Senior Engineer"));
+    expect(regrade(api).roleTitles).toEqual(["Senior Engineer"]);
+  });
+});
+
+describe("snapshot / replay / reset (#856)", () => {
+  it("round-trips a deletion through snapshot → replay", () => {
+    act(() => api.removeEntry(parsedEntryKey("achievements", 0)));
+    act(() => api.removeEntry(parsedEntryKey("experience", 1)));
+    const snap: EditSnapshot = api.snapshot;
+    expect(snap.removedEntries).toEqual(["achievements:0", "experience:1"]);
+
+    act(() => api.resetAll());
+    expect(api.removedEntries.size).toBe(0);
+    expect(api.hasEdits).toBe(false);
+    expect(regrade(api).roleTitles).toEqual(["Staff Engineer", "Engineer"]);
+
+    act(() => api.replay(snap));
+    expect([...api.removedEntries].sort()).toEqual([
+      "achievements:0",
+      "experience:1",
+    ]);
+    expect(regrade(api).roleTitles).toEqual(["Staff Engineer"]);
+    expect(regrade(api).achievementTitles).toEqual([]);
+  });
+
+  it("replays a snapshot written BEFORE this change without throwing", () => {
+    // `EditSnapshot` is persisted (the blank draft in localStorage, the résumé
+    // library), so a draft saved before #856 carries no `removedEntries` key at
+    // all — the same back-compat contract `descriptionOverrides` has.
+    const legacy = JSON.parse(
+      JSON.stringify({ ...api.snapshot, removedEntries: undefined }),
+    ) as EditSnapshot;
+    expect(legacy.removedEntries).toBeUndefined();
+
+    act(() => api.replay(legacy));
+    expect(api.removedEntries.size).toBe(0);
+    expect(regrade(api).roleTitles).toEqual(["Staff Engineer", "Engineer"]);
+  });
+
+  it("does not resurrect a deleted entry's added bullets on replay", () => {
+    // A live session cannot write this pair (the delete empties the bucket), so
+    // this pins the ORDER of the two replay steps against a hand-edited or
+    // migrated snapshot rather than against ordinary use.
+    const snap: EditSnapshot = {
+      ...api.snapshot,
+      addedBullets: { "experience:0": ["Ghost bullet nobody should grade."] },
+      removedEntries: ["experience:0"],
+    };
+    act(() => api.replay(snap));
+    expect(api.addedBullets).toEqual({});
+    expect(regrade(api).bulletTexts).not.toContain(
+      "Ghost bullet nobody should grade.",
+    );
+  });
+});
+
+describe("no regression to user-ADDED entry removal (#856)", () => {
+  it("still splices the added entry out rather than tombstoning it", () => {
+    let id = "";
+    act(() => {
+      id = api.addEntry("experience");
+      api.setEntryField(id, "title", "Principal Engineer");
+    });
+    act(() => api.addBullet(id, "Ran the platform group."));
+    expect(regrade(api).roleTitles).toContain("Principal Engineer");
+
+    act(() => api.removeEntry(id));
+    expect(api.addedEntries).toEqual([]);
+    expect(api.addedBullets).toEqual({});
+    // An added id must never land in the tombstone set — nothing downstream
+    // could resolve it, and it would keep `hasEdits` true forever.
+    expect(api.removedEntries.size).toBe(0);
+    expect(api.hasEdits).toBe(false);
+    expect(regrade(api).roleTitles).toEqual(["Staff Engineer", "Engineer"]);
+  });
+});
+
+describe("survivingParsedIndices (#856)", () => {
+  it("is the identity when nothing is deleted", () => {
+    expect(survivingParsedIndices("experience", new Set(), 3)).toEqual([0, 1, 2]);
+  });
+
+  it("skips the deleted indices, in display order", () => {
+    const removed = new Set(["achievements:0", "achievements:2"]);
+    expect(survivingParsedIndices("achievements", removed, 2)).toEqual([1, 3]);
+  });
+
+  it("is unaffected by a tombstone for an index the parse no longer has", () => {
+    // Subtracting the SET's size would over-shift every survivor here.
+    const removed = new Set(["education:1", "education:9"]);
+    expect(survivingParsedIndices("education", removed, 2)).toEqual([0, 2]);
+  });
+
+  it("ignores tombstones for other sections", () => {
+    const removed = new Set(["projects:0", "added:4"]);
+    expect(survivingParsedIndices("experience", removed, 2)).toEqual([0, 1]);
+  });
+});

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -252,6 +252,16 @@ export interface EditSnapshot {
   /** Optional: drafts persisted before #427 carry link edits on
    *  `contactOverrides.{...}_url` instead — `migrateBlankDraft` upconverts. */
   profileOverrides?: ProfileOverride[];
+  /**
+   * {@link parsedEntryKey} tombstones for PARSED entries the user deleted
+   * (#856). An array, not a `Set` — a `Set` isn't JSON-safe.
+   *
+   * Optional: drafts persisted before #856 carry no such key, and `replay`
+   * defaults it to `[]`. Only PARSED keys ever land here; deleting a user-ADDED
+   * entry splices it out of `addedEntries` instead, so the two are never both
+   * describing the same entry.
+   */
+  removedEntries?: string[];
 }
 
 // ── Added entries + bullets ─────────────────────────────────────────────────
@@ -371,6 +381,44 @@ const ADDED_ENTRY_ID_PREFIX = "added:";
 /** The stable bullet key for a PARSED entry at `index` within `section`. */
 export function parsedEntryKey(section: AddableSection, index: number): string {
   return `${section}:${index}`;
+}
+
+/**
+ * The PARSED indices a section still renders, in display order (#856).
+ *
+ * `applyOverrides` FILTERS tombstoned entries out of the parsed arrays, so a
+ * rendered position stops being its parsed index the moment an earlier entry is
+ * deleted — while every per-entry channel stays keyed by the PARSED index:
+ * `experienceOverrides` / `educationOverrides` / `achievementOverrides`,
+ * `descriptionOverrides`, an entry's `addedBullets` bucket, and
+ * {@link EditableParse.removedEntries} itself. Feeding a render position into
+ * any of those after a deletion rebinds a surviving entry's edits to its
+ * neighbour's — the exact failure the tombstone design prevents one level down,
+ * arriving instead through the UI. Every caller resolves through here.
+ *
+ * `renderedCount` is how many PARSED entries the section is currently rendering
+ * (the section array's length minus its user-added entries), which the callers
+ * already compute to split added entries back out.
+ *
+ * Enumerating `[0, ∞)` and taking the first `renderedCount` survivors is what
+ * makes this exact rather than arithmetic. A tombstone can name an index the
+ * parse no longer has — a replayed draft, the same staleness
+ * `applyEducationFieldOverrides`' own `if (!edu) continue` absorbs — and such a
+ * key removes nothing, so subtracting the SET's size would over-shift every
+ * surviving entry. Taking survivors instead is unaffected by it: the first
+ * `renderedCount` members of `[0, ∞) \ removedEntries` are exactly the indices
+ * that survived, because every stale key sits above them.
+ */
+export function survivingParsedIndices(
+  section: AddableSection,
+  removedEntries: ReadonlySet<string>,
+  renderedCount: number,
+): number[] {
+  const out: number[] = [];
+  for (let i = 0; out.length < renderedCount; i++) {
+    if (!removedEntries.has(parsedEntryKey(section, i))) out.push(i);
+  }
+  return out;
 }
 
 /**
@@ -570,6 +618,12 @@ export interface EditableParse {
    *  removals, #211) — folded by applyOverrides to drop the line from the graded
    *  pool, rawText, and the role description. */
   removedBullets: ReadonlySet<string>;
+  /** {@link parsedEntryKey} tombstones for PARSED entries the user deleted
+   *  (#856). Folded LAST by applyOverrides, so the index-keyed override maps
+   *  above resolve against the un-renumbered arrays. Consumers that render a
+   *  section must map render position → parsed index through
+   *  {@link survivingParsedIndices}. */
+  removedEntries: ReadonlySet<string>;
   /**
    * Drop one bullet.
    *
@@ -613,8 +667,24 @@ export interface EditableParse {
   addedEntries: AddedEntry[];
   /** Append a new (empty-header) entry to a section. Returns its stable id. */
   addEntry: (section: AddableSection) => string;
-  /** Remove a previously-added entry by id (also drops its added bullets). */
-  removeEntry: (id: string) => void;
+  /**
+   * Remove one entry, PARSED or user-ADDED (#856), by its entry key — an added
+   * entry's `id`, or a parsed entry's {@link parsedEntryKey}. Also drops that
+   * entry's `addedBullets` bucket, which both kinds own under the same key.
+   *
+   * The two kinds are recorded differently because they exist differently. An
+   * added entry is a row in `addedEntries` and is simply spliced out. A parsed
+   * entry is a row in the parse itself, which the override maps address BY
+   * INDEX — so it is TOMBSTONED in {@link removedEntries} and filtered out at
+   * the end of `applyOverrides`, leaving every index-keyed edit above resolving
+   * against the array it was captured on. Idempotent either way.
+   *
+   * It does NOT drop the entry's bullets: a `•` line the entry does not itself
+   * own is not findable from the entry's fields, so the caller pairs this with
+   * `removeBullet` per rendered row — see `removeEntryWithBullets`, the one
+   * definition of the whole gesture.
+   */
+  removeEntry: (key: string) => void;
   /** Drop every EMPTY user-added entry in a section — one the user opened with
    *  "+ Add …" and left with no populated field and no bullets (#379). Called
    *  when focus leaves the section, so a blank ghost entry never persists in the
@@ -849,6 +919,13 @@ export function useEditableParse(): EditableParse {
   const [descriptionOverrides, setDescriptionOverrides] =
     useState<DescriptionOverrides>({});
   const [removedBullets, setRemovedBullets] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  // Tombstones for deleted PARSED entries (#856) — the entry-level analogue of
+  // `removedBullets`. No mirror ref beside it, unlike that one: `removeEntry`
+  // reports nothing back to its caller, so nothing here has to read the
+  // committed set synchronously.
+  const [removedEntries, setRemovedEntries] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
   const [educationOverrides, setEducationOverrides] = useState<
@@ -1347,12 +1424,29 @@ export function useEditableParse(): EditableParse {
   }, []);
 
   const removeEntry = useCallback(
-    (id: string) => {
-      setAddedEntries((prev) => prev.filter((e) => e.id !== id));
+    (key: string) => {
+      if (isAddedEntryKey(key)) {
+        setAddedEntries((prev) => prev.filter((e) => e.id !== key));
+      } else {
+        // A PARSED entry is tombstoned, never spliced (#856) — see
+        // `applyRemovedEntries` for why renumbering the parsed arrays here would
+        // rebind every later entry's index-keyed edits.
+        setRemovedEntries((prev) => {
+          if (prev.has(key)) return prev;
+          const next = new Set(prev);
+          next.add(key);
+          return next;
+        });
+      }
+      // Both kinds own an `addedBullets` bucket under this same key, and it is
+      // folded in DOWNSTREAM of the tombstone filter (`applyAddedEntriesAndBullets`
+      // runs first, appending its lines to the graded pool). Dropping the bucket
+      // is therefore not cleanup — it is the only thing that stops a deleted
+      // entry's user-added bullets from going on grading the résumé.
       const prev = addedBulletsRef.current;
-      if (!(id in prev)) return;
+      if (!(key in prev)) return;
       const next = { ...prev };
-      delete next[id];
+      delete next[key];
       writeAddedBullets(next);
     },
     [writeAddedBullets],
@@ -1570,6 +1664,7 @@ export function useEditableParse(): EditableParse {
     setBulletOverrides({});
     setDescriptionOverrides({});
     setRemovedBullets(new Set());
+    setRemovedEntries(new Set());
     setEducationOverrides({});
     setAchievementOverrides({});
     setSkillsOverride(EMPTY_SKILLS_OVERRIDE);
@@ -1598,6 +1693,7 @@ export function useEditableParse(): EditableParse {
       addedEntries,
       addedBullets,
       profileOverrides,
+      removedEntries: [...removedEntries],
     }),
     [
       contactOverrides,
@@ -1612,6 +1708,7 @@ export function useEditableParse(): EditableParse {
       addedEntries,
       addedBullets,
       profileOverrides,
+      removedEntries,
     ],
   );
 
@@ -1729,6 +1826,19 @@ export function useEditableParse(): EditableParse {
         bullets.forEach((text) => addBullet(mappedKey, text));
       }
 
+      // Deleted PARSED entries (#856). `?? []` because a draft or saved résumé
+      // written before this field existed carries no such key — the same
+      // back-compat default `descriptionOverrides` takes above.
+      //
+      // AFTER the two added-* loops on purpose: `removeEntry` also drops the
+      // entry's `addedBullets` bucket, so replaying it last means a snapshot
+      // that somehow carries both a tombstone and that entry's bucket resolves
+      // to the same state a live delete produces, rather than to a bucket the
+      // restore just re-created. (A live session cannot write that pair — the
+      // delete empties the bucket — so this is about a hand-edited or migrated
+      // snapshot, not about ordinary use.)
+      (snap.removedEntries ?? []).forEach((key) => removeEntry(key));
+
       // Contact-link overrides (#427): corrections (carrying a legacyKey) replay
       // through `setLegacyLink`; extras replay through `addProfile`. Fresh ids
       // are minted on replay — the old per-session ids are never reused.
@@ -1752,6 +1862,7 @@ export function useEditableParse(): EditableParse {
       addEntry,
       setEntryField,
       addBullet,
+      removeEntry,
       setLegacyLink,
       addProfile,
     ],
@@ -1762,6 +1873,7 @@ export function useEditableParse(): EditableParse {
     if (Object.keys(bulletOverrides).length > 0) return true;
     if (Object.keys(descriptionOverrides).length > 0) return true;
     if (removedBullets.size > 0) return true;
+    if (removedEntries.size > 0) return true;
     if (!isEmptySkillsOverride(skillsOverride)) return true;
     // Present-vs-absent, not truthy: `""` is an authoritative clear of the
     // summary and is very much an edit.
@@ -1790,6 +1902,7 @@ export function useEditableParse(): EditableParse {
     bulletOverrides,
     descriptionOverrides,
     removedBullets,
+    removedEntries,
     educationOverrides,
     achievementOverrides,
     skillsOverride,
@@ -1810,6 +1923,7 @@ export function useEditableParse(): EditableParse {
     setDescriptionField,
     removedBullets,
     removeBullet,
+    removedEntries,
     educationOverrides,
     setEducationField,
     achievementOverrides,

--- a/src/lib/edit/apply-overrides.removed-entry.test.ts
+++ b/src/lib/edit/apply-overrides.removed-entry.test.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * #856 — a PARSED entry the user deleted has to leave the résumé, and every
+ * entry that SURVIVES the deletion has to keep its own edits.
+ *
+ * The second half is the load-bearing one and the reason `removedEntries` is a
+ * tombstone set folded LAST rather than a splice. `applyExperienceHeader-
+ * Overrides`, `applyEducationFieldOverrides` and `applyAchievementOverrides`
+ * are each keyed by PARSED ARRAY INDEX; removing entry 0 by splicing it out of
+ * the array before they run shifts every later entry down one, so entry 2's
+ * title edit silently lands on what used to be entry 3. Nothing throws and the
+ * count is right — the résumé just quietly says the wrong thing. The first
+ * describe block below is that regression, run against all three index-keyed
+ * sections.
+ */
+
+import { describe, it, expect } from "vitest";
+import { applyOverrides } from "./apply-overrides.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { HeuristicParsedResume } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import { projectScoreSections } from "../heuristics/projections.ts";
+
+/** Positional stand-ins for `applyOverrides`' long default tail, so each case
+ *  below spells out only the arguments it actually exercises. */
+const NO_CONTACT = {};
+const NO_OBS: never[] = [];
+
+function makeSections(lines: readonly string[] = []): SectionedResume {
+  const byName = new Map<string, readonly string[]>();
+  if (lines.length > 0) byName.set("experience", lines);
+  return {
+    byName: byName as SectionedResume["byName"],
+    accomplishmentSections: ["experience", "projects", "achievements"],
+    source: "regex",
+  };
+}
+
+/** Three of everything, so "delete the first, keep the other two straight" is
+ *  expressible in each index-keyed section. */
+function baseParsed(): HeuristicParsedResume {
+  return {
+    full_name: "Robin Vasquez",
+    email: "robin.vasquez@example.com",
+    skills: ["typescript"],
+    experience: [
+      { title: "Intern", company: "Initech", description: "Filed reports" },
+      { title: "Engineer", company: "Acme", description: "Built a thing" },
+      { title: "Staff Engineer", company: "Globex", description: "Led a team" },
+    ],
+    education: [
+      { degree: "AA", institution: "City College" },
+      { degree: "BS", institution: "State University" },
+      { degree: "MS", institution: "Tech Institute" },
+    ],
+    projects: [
+      { name: "Ghost Project", description: "Stitched out of two blocks" },
+      { name: "Real Project", description: "Shipped it" },
+    ],
+    heuristic_achievements: [
+      { type: "Patent", title: "Phantom method", year: "2019" },
+      { type: "Award", title: "Best Paper", year: "2020" },
+      { type: "Talk", title: "Scaling parsers", year: "2021" },
+    ],
+  };
+}
+
+/** `applyOverrides` with only the arguments a removal case needs. */
+function fold(
+  parsed: HeuristicParsedResume,
+  opts: {
+    rawText?: string;
+    sections?: SectionedResume;
+    experience?: Parameters<typeof applyOverrides>[4];
+    education?: Parameters<typeof applyOverrides>[7];
+    achievements?: Parameters<typeof applyOverrides>[14];
+    descriptions?: Parameters<typeof applyOverrides>[15];
+    removedEntries?: ReadonlySet<string>;
+  } = {},
+) {
+  return applyOverrides(
+    parsed,
+    opts.rawText ?? "",
+    opts.sections ?? makeSections(),
+    NO_CONTACT,
+    opts.experience ?? {},
+    {},
+    NO_OBS,
+    opts.education ?? {},
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    opts.achievements ?? {},
+    opts.descriptions ?? {},
+    undefined,
+    opts.removedEntries ?? new Set(),
+  );
+}
+
+describe("#856 index integrity — a deletion must not rebind a survivor's edits", () => {
+  it("keeps each surviving ACHIEVEMENT holding its own override", () => {
+    const { fields } = fold(baseParsed(), {
+      achievements: { 1: { title: "Best Paper (revised)" }, 2: { year: "2022" } },
+      removedEntries: new Set(["achievements:0"]),
+    });
+
+    const titles = fields.heuristic_achievements!.map((a) => a.title);
+    expect(titles).toEqual(["Best Paper (revised)", "Scaling parsers"]);
+    // The year edit filed against index 2 must still be on index 2's entry —
+    // under a splice-first fold it would have landed on the "Award" above.
+    expect(fields.heuristic_achievements![1].year).toBe("2022");
+    expect(fields.heuristic_achievements![0].year).toBe("2020");
+  });
+
+  it("keeps each surviving EXPERIENCE role holding its own override", () => {
+    const { fields } = fold(baseParsed(), {
+      experience: { 1: { title: "Senior Engineer" }, 2: { company: "Globex Inc." } },
+      removedEntries: new Set(["experience:0"]),
+    });
+
+    expect(fields.experience.map((e) => e.title)).toEqual([
+      "Senior Engineer",
+      "Staff Engineer",
+    ]);
+    expect(fields.experience[1].company).toBe("Globex Inc.");
+    expect(fields.experience[0].company).toBe("Acme");
+  });
+
+  it("keeps each surviving EDUCATION entry holding its own override", () => {
+    const { fields } = fold(baseParsed(), {
+      education: { 1: { degree: "B.S." }, 2: { institution: "MIT" } },
+      removedEntries: new Set(["education:0"]),
+    });
+
+    expect(fields.education.map((e) => e.degree)).toEqual(["B.S.", "MS"]);
+    expect(fields.education[1].institution).toBe("MIT");
+    expect(fields.education[0].institution).toBe("State University");
+  });
+
+  it("keeps a surviving entry's PROSE description override (#489 keys too)", () => {
+    const { fields } = fold(baseParsed(), {
+      descriptions: { "projects:1": "Rewritten blurb" },
+      removedEntries: new Set(["projects:0"]),
+    });
+
+    expect(fields.projects).toEqual([
+      { name: "Real Project", description: "Rewritten blurb" },
+    ]);
+  });
+
+  it("removes two entries in one fold without shifting the second's key", () => {
+    const { fields } = fold(baseParsed(), {
+      achievements: { 2: { title: "Scaling parsers, revisited" } },
+      removedEntries: new Set(["achievements:0", "achievements:1"]),
+    });
+
+    expect(fields.heuristic_achievements).toEqual([
+      { type: "Talk", title: "Scaling parsers, revisited", year: "2021" },
+    ]);
+  });
+});
+
+describe("#856 fold basics", () => {
+  it("is a no-op with an empty tombstone set", () => {
+    const { fields } = fold(baseParsed());
+    expect(fields.experience).toHaveLength(3);
+    expect(fields.education).toHaveLength(3);
+    expect(fields.projects).toHaveLength(2);
+    expect(fields.heuristic_achievements).toHaveLength(3);
+  });
+
+  it("never mutates the input parse", () => {
+    const parsed = baseParsed();
+    fold(parsed, {
+      removedEntries: new Set([
+        "experience:0",
+        "education:0",
+        "projects:0",
+        "achievements:0",
+      ]),
+    });
+    expect(parsed.experience).toHaveLength(3);
+    expect(parsed.education).toHaveLength(3);
+    expect(parsed.projects).toHaveLength(2);
+    expect(parsed.heuristic_achievements).toHaveLength(3);
+  });
+
+  it("ignores a tombstone the parse has no entry for", () => {
+    // A stale key out of a replayed draft, the same staleness the index-keyed
+    // override maps absorb with `if (!edu) continue`.
+    const { fields } = fold(baseParsed(), {
+      removedEntries: new Set(["achievements:99", "coursework:0", "projects:"]),
+    });
+    expect(fields.heuristic_achievements).toHaveLength(3);
+    expect(fields.projects).toHaveLength(2);
+  });
+
+  it("ignores an ADDED entry's id — those are spliced out upstream", () => {
+    const { fields } = fold(baseParsed(), {
+      removedEntries: new Set(["added:3"]),
+    });
+    expect(fields.experience).toHaveLength(3);
+  });
+});
+
+describe("#856 the deleted entry's own source line", () => {
+  // The shape that makes this more than cosmetic: a title-only achievement is
+  // parsed OUT of a `•`-marked line, so that line is in the pool the anonymous
+  // scorer grades even though the entry carries no description. Deleting the
+  // entry without dropping the line leaves its content grading the résumé.
+  const OWNED = "• Patent · Issued US10275736B1, 2019";
+  const KEPT = "• Cut p99 checkout latency by 38% via edge caching.";
+
+  function titleOnlyParsed(): HeuristicParsedResume {
+    return {
+      full_name: "Robin Vasquez",
+      email: "robin.vasquez@example.com",
+      skills: [],
+      experience: [],
+      education: [],
+      heuristic_achievements: [
+        { type: "Patent", title: "Issued US10275736B1", year: "2019" },
+      ],
+    };
+  }
+
+  it("drops the line from rawText AND from the graded pool", () => {
+    const before = fold(titleOnlyParsed(), {
+      rawText: `${OWNED}\n${KEPT}`,
+      sections: makeSections([OWNED, KEPT]),
+    });
+    const after = fold(titleOnlyParsed(), {
+      rawText: `${OWNED}\n${KEPT}`,
+      sections: makeSections([OWNED, KEPT]),
+      removedEntries: new Set(["achievements:0"]),
+    });
+
+    expect(before.rawText).toContain("US10275736B1");
+    expect(after.rawText).toBe(KEPT);
+    expect(after.fields.heuristic_achievements).toEqual([]);
+
+    const grade = (r: typeof before) =>
+      computeAnonymousAtsScore({
+        parsed: r.fields,
+        fieldConfidence: r.fieldConfidence,
+        triggers: [],
+        rawText: r.rawText,
+        sections: projectScoreSections(r),
+      });
+    expect(grade(before).bullets?.map((b) => b.text)).toHaveLength(2);
+    // The pooled line left with the entry — the whole point.
+    expect(grade(after).bullets?.map((b) => b.text)).toEqual([
+      "Cut p99 checkout latency by 38% via edge caching.",
+    ]);
+  });
+
+  it("drops the title's own line out of a two-line header, and only that", () => {
+    // "Title" over "Company · dates". Only the first line is identifiable from
+    // the entry's fields, so only it goes — the model keeps no source-line
+    // provenance to tell us the second line belongs to the same entry.
+    const out = fold(baseParsed(), {
+      rawText: "Engineer\nAcme · 2020–2022\n• Built a thing",
+      sections: makeSections(["• Built a thing"]),
+      removedEntries: new Set(["experience:1"]),
+    });
+    expect(out.rawText).toBe("Acme · 2020–2022\n• Built a thing");
+    expect(out.fields.experience.map((e) => e.title)).toEqual([
+      "Intern",
+      "Staff Engineer",
+    ]);
+  });
+
+  it("leaves rawText untouched when no line matches the entry at all", () => {
+    // A glued one-line header is not reconstructable from the split fields.
+    // Best effort by construction, and safe when it misses: the pass never
+    // guesses, and the lines it can miss are the UNMARKED ones the bullet pool
+    // ignores — so a miss costs a stale line in a disclosure, never a score.
+    const raw = "Engineer — Acme · 2020–2022\n• Built a thing";
+    const out = fold(baseParsed(), {
+      rawText: raw,
+      sections: makeSections(["• Built a thing"]),
+      removedEntries: new Set(["experience:1"]),
+    });
+    expect(out.rawText).toBe(raw);
+    expect(out.fields.experience).toHaveLength(2);
+  });
+
+  it("does not touch a bullet that merely shares a PREFIX with the title", () => {
+    // Ownership is exact on the residue-tolerant key, never containment — the
+    // same guarantee `suppressTitleOwnedBullets` rests on.
+    const near = "• Issued US10275736B1 after a three-year prosecution";
+    const out = fold(titleOnlyParsed(), {
+      rawText: near,
+      sections: makeSections([near]),
+      removedEntries: new Set(["achievements:0"]),
+    });
+    expect(out.rawText).toBe(near);
+  });
+});

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -38,7 +38,10 @@ import type { BulletObservation } from "../score/score.ts";
 import type { HeuristicAchievement } from "../score/types.ts";
 import type { SectionedResume } from "../heuristics/sections.ts";
 import type { SectionName } from "../heuristics/regex.ts";
-import { normalizeBulletText } from "../score/group-bullets.ts";
+import {
+  isTitleOwnedLine,
+  normalizeBulletText,
+} from "../score/group-bullets.ts";
 import {
   applyNormalizedExperienceDates,
   normalizeExperienceDates,
@@ -495,33 +498,49 @@ function applySkillOverrides(
 // over one of them. This collapses what were six near-identical bodies
 // (previously duplicated clone groups flagged by fallow) into three shared
 // traversals.
+//
+// They take the match as a PREDICATE rather than as the original text (#856):
+// removing a deleted entry's own header line walks the same three containers,
+// but identifies its line by title OWNERSHIP (`isTitleOwnedLine`) rather than by
+// bullet-text equality. Keeping one traversal and varying only the predicate is
+// what stops the entry removal growing a fourth near-identical copy of it.
 
-/** Index of the first line whose normalised form equals `target`, or -1. */
+/** Decides whether one line of a container is the line a mutation targets. */
+type LineMatcher = (line: string) => boolean;
+
+/** Match a bullet line: normalised equality with `originalText`. `null` when
+ *  `originalText` normalises to empty, which names no line at all. */
+function bulletLineMatcher(originalText: string): LineMatcher | null {
+  const target = normalizeBulletText(originalText);
+  if (!target) return null;
+  return (line) => normalizeBulletText(line) === target;
+}
+
+/** Index of the first line satisfying `matches`, or -1. */
 function findMatchingLineIndex(
   lines: readonly string[],
-  target: string,
+  matches: LineMatcher,
 ): number {
   for (let i = 0; i < lines.length; i++) {
-    if (normalizeBulletText(lines[i]) === target) return i;
+    if (matches(lines[i])) return i;
   }
   return -1;
 }
 
 /**
- * Split `rawText` into lines, find the first line matching `originalText`,
+ * Split `rawText` into lines, find the first line satisfying `matches`,
  * and let `mutate` rewrite the (mutable) lines array in place at that index
  * (replace the entry, or splice it out). Returns the rejoined text, or the
- * input unchanged when no line matches.
+ * input unchanged when no line matches (or the matcher is `null`).
  */
 function withMatchedRawTextLine(
   rawText: string,
-  originalText: string,
+  matches: LineMatcher | null,
   mutate: (lines: string[], idx: number) => void,
 ): string {
-  const target = normalizeBulletText(originalText);
-  if (!target) return rawText;
+  if (!matches) return rawText;
   const lines = rawText.split(/\r?\n/);
-  const idx = findMatchingLineIndex(lines, target);
+  const idx = findMatchingLineIndex(lines, matches);
   if (idx < 0) return rawText;
   mutate(lines, idx);
   return lines.join("\n");
@@ -529,24 +548,23 @@ function withMatchedRawTextLine(
 
 /**
  * Walk `sections.accomplishmentSections` in policy order, find the first
- * section whose lines contain a line matching `originalText`, and let
+ * section whose lines contain a line satisfying `matches`, and let
  * `mutate` rewrite a CLONED copy of that section's lines in place at the
  * matched index. Returns a NEW {@link SectionedResume} with a cloned
  * `byName` map (only the mutated section's array is cloned), or the input
- * unchanged when no line matches anywhere.
+ * unchanged when no line matches anywhere (or the matcher is `null`).
  */
 function withMatchedSectionLine(
   sections: SectionedResume,
-  originalText: string,
+  matches: LineMatcher | null,
   mutate: (lines: string[], idx: number) => void,
 ): SectionedResume {
-  const target = normalizeBulletText(originalText);
-  if (!target) return sections;
+  if (!matches) return sections;
 
   for (const name of sections.accomplishmentSections) {
     const lines = sections.byName.get(name);
     if (!lines) continue;
-    const idx = findMatchingLineIndex(lines, target);
+    const idx = findMatchingLineIndex(lines, matches);
     if (idx < 0) continue;
     const nextLines = lines.slice();
     mutate(nextLines, idx);
@@ -561,25 +579,24 @@ function withMatchedSectionLine(
 
 /**
  * Walk `experience` in order, find the first role whose (newline-split)
- * `description` contains a line matching `originalText`, and let `mutate`
+ * `description` contains a line satisfying `matches`, and let `mutate`
  * rewrite that role's description lines in place at the matched index —
  * mirroring `groupBulletsByExperience`'s first-match tiebreak so the bullet
  * lands in the same role the UI grouped it under. Mutates the role's
  * `description` directly (the caller already cloned the experience entries);
- * a no-op when no role matches.
+ * a no-op when no role matches (or the matcher is `null`).
  */
 function withMatchedDescriptionLine(
   experience: HeuristicParsedResume["experience"],
-  originalText: string,
+  matches: LineMatcher | null,
   mutate: (lines: string[], idx: number) => void,
 ): void {
-  const target = normalizeBulletText(originalText);
-  if (!target) return;
+  if (!matches) return;
 
   for (const exp of experience) {
     if (!exp.description) continue;
     const descLines = exp.description.split("\n");
-    const idx = findMatchingLineIndex(descLines, target);
+    const idx = findMatchingLineIndex(descLines, matches);
     if (idx < 0) continue;
     mutate(descLines, idx);
     exp.description = descLines.join("\n");
@@ -600,10 +617,14 @@ function replaceBulletInRawText(
   originalText: string,
   editedText: string,
 ): string {
-  return withMatchedRawTextLine(rawText, originalText, (lines, idx) => {
-    const marker = lines[idx].match(LEADING_MARKER_RE)?.[0] ?? "";
-    lines[idx] = marker + editedText;
-  });
+  return withMatchedRawTextLine(
+    rawText,
+    bulletLineMatcher(originalText),
+    (lines, idx) => {
+      const marker = lines[idx].match(LEADING_MARKER_RE)?.[0] ?? "";
+      lines[idx] = marker + editedText;
+    },
+  );
 }
 
 /**
@@ -622,10 +643,14 @@ function replaceBulletInSections(
   originalText: string,
   editedText: string,
 ): SectionedResume {
-  return withMatchedSectionLine(sections, originalText, (lines, idx) => {
-    const marker = lines[idx].match(LEADING_MARKER_RE)?.[0] ?? "";
-    lines[idx] = marker + editedText;
-  });
+  return withMatchedSectionLine(
+    sections,
+    bulletLineMatcher(originalText),
+    (lines, idx) => {
+      const marker = lines[idx].match(LEADING_MARKER_RE)?.[0] ?? "";
+      lines[idx] = marker + editedText;
+    },
+  );
 }
 
 /**
@@ -640,9 +665,13 @@ function replaceBulletInDescriptions(
   originalText: string,
   editedText: string,
 ): void {
-  withMatchedDescriptionLine(experience, originalText, (lines, idx) => {
-    lines[idx] = editedText;
-  });
+  withMatchedDescriptionLine(
+    experience,
+    bulletLineMatcher(originalText),
+    (lines, idx) => {
+      lines[idx] = editedText;
+    },
+  );
 }
 
 /**
@@ -655,9 +684,13 @@ function removeBulletFromRawText(
   rawText: string,
   originalText: string,
 ): string {
-  return withMatchedRawTextLine(rawText, originalText, (lines, idx) => {
-    lines.splice(idx, 1);
-  });
+  return withMatchedRawTextLine(
+    rawText,
+    bulletLineMatcher(originalText),
+    (lines, idx) => {
+      lines.splice(idx, 1);
+    },
+  );
 }
 
 /**
@@ -670,9 +703,13 @@ function removeBulletFromSections(
   sections: SectionedResume,
   originalText: string,
 ): SectionedResume {
-  return withMatchedSectionLine(sections, originalText, (lines, idx) => {
-    lines.splice(idx, 1);
-  });
+  return withMatchedSectionLine(
+    sections,
+    bulletLineMatcher(originalText),
+    (lines, idx) => {
+      lines.splice(idx, 1);
+    },
+  );
 }
 
 /**
@@ -684,9 +721,13 @@ function removeBulletFromDescriptions(
   experience: HeuristicParsedResume["experience"],
   originalText: string,
 ): void {
-  withMatchedDescriptionLine(experience, originalText, (lines, idx) => {
-    lines.splice(idx, 1);
-  });
+  withMatchedDescriptionLine(
+    experience,
+    bulletLineMatcher(originalText),
+    (lines, idx) => {
+      lines.splice(idx, 1);
+    },
+  );
 }
 
 // ── Bullet override application ─────────────────────────────────────────────
@@ -961,6 +1002,175 @@ function applyAddedBulletsToExistingEntries(
   return poolLines;
 }
 
+// ── Removed entries (#856) ───────────────────────────────────────────────────
+
+/**
+ * The sections an entry TOMBSTONE can name — the `<section>` half of a
+ * `parsedEntryKey`. Deliberately the same four `AddableSection` accepts: every
+ * section that can gain a user-added entry can also lose a parsed one.
+ */
+const REMOVABLE_SECTIONS = [
+  "experience",
+  "education",
+  "projects",
+  "achievements",
+] as const;
+
+type RemovableSection = (typeof REMOVABLE_SECTIONS)[number];
+
+/** Split a `"<section>:<index>"` tombstone, or `undefined` when the key names
+ *  no removable parsed entry (an added-entry id, or a malformed key).
+ *
+ *  The index half is matched as DIGITS, not coerced with `Number`: `Number("")`
+ *  is `0` and `Number.isInteger(0)` is true, so a truncated `"projects:"` would
+ *  otherwise silently delete the section's FIRST entry. */
+function parseRemovedEntryKey(
+  key: string,
+): { section: RemovableSection; index: number } | undefined {
+  const colon = key.indexOf(":");
+  if (colon < 0) return undefined;
+  const section = key.slice(0, colon);
+  const digits = key.slice(colon + 1);
+  if (!/^\d+$/.test(digits)) return undefined;
+  const match = REMOVABLE_SECTIONS.find((s) => s === section);
+  if (match === undefined) return undefined;
+  return { section: match, index: Number(digits) };
+}
+
+/**
+ * Drop the tombstoned entries of ONE section out of `nextParsed`, returning the
+ * dropped entries' owned titles so the caller can find their source lines.
+ *
+ * `filter`, not `splice`: every array here is either already a clone (the entry
+ * point clones experience + education) or replaced wholesale by a fresh array,
+ * so the input parse is never mutated — the same purity contract the rest of
+ * this module keeps.
+ */
+function dropRemovedEntries(
+  nextParsed: HeuristicParsedResume,
+  section: RemovableSection,
+  indices: ReadonlySet<number>,
+): string[] {
+  const titles: string[] = [];
+  function keep<T>(
+    list: readonly T[],
+    titleOf: (entry: T) => string | undefined,
+  ): T[] {
+    const out: T[] = [];
+    list.forEach((entry, i) => {
+      if (!indices.has(i)) {
+        out.push(entry);
+        return;
+      }
+      const title = titleOf(entry);
+      if (title) titles.push(title);
+    });
+    return out;
+  }
+
+  if (section === "experience") {
+    nextParsed.experience = keep(nextParsed.experience, (e) => e.title);
+  } else if (section === "education") {
+    nextParsed.education = keep(nextParsed.education, (e) => e.degree);
+  } else if (section === "projects") {
+    // `?` rather than `!`: a tombstone can outlive the array it was keyed
+    // against (a replayed draft whose re-parse produced no projects), exactly as
+    // the index-keyed override maps can — see `resolveParsedDescriptionTarget`.
+    if (nextParsed.projects) {
+      nextParsed.projects = keep(nextParsed.projects, (p) => p.name);
+    }
+  } else if (nextParsed.heuristic_achievements) {
+    nextParsed.heuristic_achievements = keep(
+      nextParsed.heuristic_achievements,
+      (a) => a.title,
+    );
+  }
+  return titles;
+}
+
+/**
+ * Fold `removedEntries` — user deletions of PARSED entries (#856) — into the
+ * parsed arrays and the two line views.
+ *
+ * TOMBSTONE, NOT SPLICE, and this runs LAST for that reason. Every per-entry
+ * override map (`applyExperienceHeaderOverrides`,
+ * `applyEducationFieldOverrides`, `applyAchievementOverrides`,
+ * `applyDescriptionOverrides`) is keyed by PARSED ARRAY INDEX, and so is the
+ * `addedBullets` bucket key of a parsed entry. Filtering an entry out before any
+ * of those have run shifts every later index and silently rebinds each later
+ * entry's edits to the wrong entry. Running after them — and after
+ * `applyAddedEntriesAndBullets`, which only APPENDS, so parsed index `i` is
+ * still at position `i` — leaves every key resolving against the array it was
+ * captured on.
+ *
+ * The entry's BULLETS are not this pass's job. They are dropped through
+ * `removedBullets` by the caller's own delete handler
+ * (`removeEntryWithBullets`), which reuses the tested
+ * `removeBulletFromRawText` / `…Sections` / `…Descriptions` trio rather than
+ * teaching this pass a second kind of text surgery — and that has to happen
+ * there anyway, because a line the entry does not own (an ordinary `•` bullet)
+ * is not findable from the entry's fields at all.
+ *
+ * What IS this pass's job is the one line the entry itself owns. Dropping the
+ * entry takes its `description` (hence the export and the JD-coverage pool) with
+ * it, but `rawText` and `sections` are parallel views the entry never owned, so
+ * its own line survives there. For the shape that matters most — a title-only
+ * achievement/project, parsed out of a single `•`-marked line — that surviving
+ * line is a POOLED BULLET, so leaving it would keep grading Specificity /
+ * Structure for an entry that is no longer on screen. {@link isTitleOwnedLine}
+ * is the scorer's own ownership relation (the one `suppressTitleOwnedBullets`
+ * hides such a line on), so the two cannot drift.
+ *
+ * BEST-EFFORT BY CONSTRUCTION, and safe when it misses: the parsed model keeps
+ * no source-line provenance, so a multi-line header ("Title" over "Company ·
+ * dates") matches nothing and the line simply stays in the raw-text view. That
+ * costs a stale line in a disclosure; it never costs a wrong score, because the
+ * lines this can miss are the UNMARKED ones the bullet pool ignores.
+ *
+ * It can also MIS-HIT, and that is benign for a different reason. The array
+ * filter above is by index, but the line search that follows has only the title,
+ * and {@link withMatchedRawTextLine} takes the FIRST match — so when two parsed
+ * entries collide on {@link isTitleOwnedLine} (the duplicated-role shape #856
+ * exists to fix), deleting the later one removes the earlier one's line. Exact
+ * duplicates are indistinguishable, so the resulting views are identical either
+ * way; near-duplicates that still collide leave a line the SURVIVING entry's
+ * title also owns, which `suppressTitleOwnedBullets` keeps out of the graded
+ * pool regardless. Either way the score is unaffected and the cost is at most one
+ * wrong line in the raw-text disclosure.
+ */
+function applyRemovedEntries(
+  nextParsed: HeuristicParsedResume,
+  views: BulletViews,
+  removedEntries: ReadonlySet<string>,
+): BulletViews {
+  if (removedEntries.size === 0) return views;
+
+  // Group by section first so each array is filtered exactly once — a
+  // per-key filter would renumber the array under the keys still to come.
+  const bySection = new Map<RemovableSection, Set<number>>();
+  for (const key of removedEntries) {
+    const target = parseRemovedEntryKey(key);
+    if (!target) continue;
+    const indices = bySection.get(target.section) ?? new Set<number>();
+    indices.add(target.index);
+    bySection.set(target.section, indices);
+  }
+
+  let { rawText, sections } = views;
+  for (const [section, indices] of bySection) {
+    for (const title of dropRemovedEntries(nextParsed, section, indices)) {
+      const matches: LineMatcher = (line) => isTitleOwnedLine(line, title);
+      rawText = withMatchedRawTextLine(rawText, matches, (lines, idx) => {
+        lines.splice(idx, 1);
+      });
+      sections = withMatchedSectionLine(sections, matches, (lines, idx) => {
+        lines.splice(idx, 1);
+      });
+    }
+  }
+  return { rawText, sections };
+}
+
 // ── Entry point ──────────────────────────────────────────────────────────────
 
 /**
@@ -1023,6 +1233,11 @@ function applyAddedBulletsToExistingEntries(
  *                  drops the heading AND the body from the exported PDF); any
  *                  other value replaces it verbatim. Feeds the Completeness
  *                  ≥20-char threshold, so an edit re-grades. Default `undefined`.
+ * @param removedEntries {@link parsedEntryKey} tombstones for PARSED entries the
+ *                  user deleted (#856) — `"achievements:2"`. Folded LAST, after
+ *                  every index-keyed pass above, so no surviving entry's edits
+ *                  are rebound to its neighbour; see {@link applyRemovedEntries}.
+ *                  Default empty set.
  */
 export function applyOverrides(
   parsed: HeuristicParsedResume,
@@ -1042,6 +1257,7 @@ export function applyOverrides(
   achievements: Record<number, AchievementFieldOverrides> = {},
   descriptionOverrides: DescriptionOverrides = {},
   summaryOverride: string | undefined = undefined,
+  removedEntries: ReadonlySet<string> = new Set(),
 ): ApplyOverridesResult {
   // Clone so the original parse is never mutated. experience + education entries
   // are cloned individually because we rewrite fields on them; skills is cloned
@@ -1098,9 +1314,17 @@ export function applyOverrides(
     addedBullets,
   );
 
+  // LAST — after every index-keyed pass above, and after the append that only
+  // ever grows the arrays at the tail. See {@link applyRemovedEntries}.
+  const finalViews = applyRemovedEntries(
+    nextParsed,
+    { rawText: views.rawText, sections: nextSections },
+    removedEntries,
+  );
+
   return {
-    ...toCanonicalResume(nextParsed, nextSections, nextConfidence),
-    rawText: views.rawText,
+    ...toCanonicalResume(nextParsed, finalViews.sections, nextConfidence),
+    rawText: finalViews.rawText,
   };
 }
 

--- a/src/lib/edit/entry-remove.ts
+++ b/src/lib/edit/entry-remove.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * removeEntryWithBullets — the ONE definition of "delete this entry" for the
+ * reconstructed résumé (#856).
+ *
+ * Every section's remove control routes through here rather than calling
+ * `removeEntry` directly, because deleting an entry takes TWO writes against the
+ * edit model and the second one is not obvious.
+ *
+ * `removeEntry` drops the entry from the parsed arrays — which takes its
+ * `description` with it, and so takes the Download PDF, the JD-coverage pool and
+ * the Completeness entry count. What it cannot take is the entry's BULLETS,
+ * because the graded bullet pool is `sections`: a parallel line view built from
+ * the extracted text, which the entry never owned a reference into. A bullet
+ * left there goes on grading Specificity / Structure for an entry that is no
+ * longer on screen, and goes on showing in "Raw text & flags". So each rendered
+ * row is dropped through the existing `removeBullet`, which already knows how to
+ * splice one line out of all three line containers (`removeBulletFromRawText` /
+ * `…Sections` / `…Descriptions`) and how to reach a user-ADDED row in its
+ * `addedBullets` bucket. `applyRemovedEntries` is deliberately not taught a
+ * second kind of text surgery for this: a `•` line the entry does not itself own
+ * is not findable from the entry's fields at all, only from the rendered group.
+ *
+ * ORDER IS FIXED, bullets first. `removeBullet` matches an added row inside the
+ * entry's bucket, and `removeEntry` deletes that bucket outright — so reversing
+ * the two would leave every added row with nothing to splice. Both orders happen
+ * to end correct today (the bucket delete covers those rows on its own), and
+ * pinning the order is what keeps it that way if either side changes.
+ */
+
+import type { AddedBulletRef } from "../../hooks/useEditableParse.ts";
+import type { BulletObservation } from "../score/score.ts";
+
+/** The two edit-model writers an entry deletion needs. Both are already threaded
+ *  into every section for their own sake; `onRemoveBullet` is absent only where
+ *  a section has no bullets at all (Education). */
+export interface EntryRemoveHandlers {
+  /** {@link EditableParse.removeEntry} — added id or {@link parsedEntryKey}. */
+  onRemoveEntry: (key: string) => void;
+  /** {@link EditableParse.removeBullet}. Omitted for a bullet-less section. */
+  onRemoveBullet?: (id: string, added?: AddedBulletRef) => boolean;
+}
+
+/**
+ * Delete the entry keyed `entryKey` along with every bullet rendered under it.
+ *
+ * `bullets` is the entry's rendered group — the re-graded rows the user can
+ * actually see — so `b.text` is each row's CURRENT text, which is what both
+ * halves of `removeBullet`'s routing match on.
+ */
+export function removeEntryWithBullets(
+  entryKey: string,
+  bullets: readonly BulletObservation[],
+  { onRemoveEntry, onRemoveBullet }: EntryRemoveHandlers,
+): void {
+  for (const bullet of bullets) {
+    onRemoveBullet?.(bullet.id, { entryKey, text: bullet.text });
+  }
+  onRemoveEntry(entryKey);
+}

--- a/src/lib/pdf/render-roundtrip-entry-remove.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-entry-remove.repro.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Round-trip guard for #856 — a deleted PARSED entry must not come back out of
+ * the exported PDF.
+ *
+ * The reconstructed view now removes a parsed role / degree / project /
+ * achievement, and the whole point of the fix is the artifact: before it, a
+ * phantom entry could be blanked field by field and still shipped, because the
+ * Download PDF is built from the canonical fields (`ats-resume-model.ts`) and
+ * nothing ever dropped the entry from them. Asserting on the model alone would
+ * not close that loop — this renders the real PDF and re-parses it, so the claim
+ * is about the document a user would actually send.
+ *
+ * The surviving neighbours are asserted just as hard: a deletion that took the
+ * wrong entry, or renumbered the survivors' edits, would land here too.
+ *
+ * PII-free: synthetic persona, all fields fabricated.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { applyOverrides } from "../edit/apply-overrides.ts";
+import type { AnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult, HeuristicParsedResume } from "../heuristics/types.ts";
+import type { SectionedResume } from "../heuristics/sections.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+const GHOST_ROLE = "Interim Coordinator";
+const KEPT_ROLE = "Staff Engineer";
+const GHOST_DEGREE = "Certificate of Attendance";
+const KEPT_DEGREE = "Bachelor of Science";
+
+const PARSED: HeuristicParsedResume = {
+  full_name: "Jane Candidate",
+  email: "jane@example.com",
+  phone: "(312) 555-0123",
+  location: "Chicago, IL",
+  summary: "Platform engineer with a decade of distributed-systems experience.",
+  skills: ["TypeScript", "Go", "PostgreSQL"],
+  experience: [
+    // Index 0 is the phantom the parser stitched out of a page break.
+    {
+      title: GHOST_ROLE,
+      company: "Nowhere Holdings",
+      start_date: "2015",
+      end_date: "2016",
+      description: "Attended the weekly sync",
+    },
+    {
+      title: KEPT_ROLE,
+      company: "Acme",
+      location: "Chicago, IL",
+      start_date: "2021",
+      end_date: "2024",
+      description:
+        "Led migration of legacy auth to OAuth for 50K users\nCut p99 checkout latency by 38%",
+    },
+  ],
+  education: [
+    { degree: GHOST_DEGREE, institution: "Nowhere Institute", end_date: "2014" },
+    {
+      degree: KEPT_DEGREE,
+      field: "Computer Science",
+      institution: "State University",
+      end_date: "2015",
+    },
+  ],
+  heuristic_achievements: [
+    { type: "Patent", title: "Bulk catalog editor for marketplaces", year: "2019" },
+    { type: "Award", title: "Engineering excellence recognition", year: "2022" },
+  ],
+};
+
+const EMPTY_SECTIONS: SectionedResume = {
+  byName: new Map() as SectionedResume["byName"],
+  accomplishmentSections: ["experience", "projects", "achievements"],
+  source: "regex",
+};
+
+function makeResult(fields: HeuristicParsedResume): CascadeResult {
+  return {
+    canonical: { fields, sections: EMPTY_SECTIONS, fieldConfidence: {} },
+    confidence: 1,
+    triggers: [],
+    linkAnnotations: [],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+const fakeScore = { bullets: [] } as unknown as AnonymousAtsScore;
+
+// A real render + re-parse, which is fast alone but exceeds the 5s default
+// under a coverage-instrumented full-suite run; scoped here rather than
+// globally (#360), matching the siblings in this directory.
+describe("#856 — a deleted entry stays out of the exported PDF", { timeout: 20000 }, () => {
+  let reparsed: CascadeResult;
+
+  beforeAll(async () => {
+    // Delete the FIRST entry of each section, and edit the survivor of one of
+    // them — the pair that a renumbering bug would silently swap.
+    const edited = applyOverrides(
+      PARSED,
+      "",
+      EMPTY_SECTIONS,
+      {},
+      { 1: { company: "Acme Corp." } },
+      {},
+      [],
+      {},
+      undefined,
+      [],
+      {},
+      undefined,
+      undefined,
+      undefined,
+      {},
+      {},
+      undefined,
+      new Set(["experience:0", "education:0", "achievements:0"]),
+    );
+    const model = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
+    reparsed = await runCascade(await renderAtsResumePdf(model));
+  });
+
+  it("drops the deleted role and keeps the survivor's own edit", () => {
+    const experience = reparsed.canonical.fields.experience;
+    expect(experience.map((e) => e.title)).toEqual([KEPT_ROLE]);
+    // The header override filed against parsed index 1 followed ITS role, not
+    // the neighbour a splice-first fold would have shifted into that slot.
+    expect(experience[0].company).toBe("Acme Corp.");
+    expect(reparsed.rawText).not.toContain(GHOST_ROLE);
+  });
+
+  it("drops the deleted education entry", () => {
+    const education = reparsed.canonical.fields.education;
+    expect(education.map((e) => e.degree)).toEqual([KEPT_DEGREE]);
+    expect(reparsed.rawText).not.toContain(GHOST_DEGREE);
+  });
+
+  it("drops the deleted achievement", () => {
+    const achievements = reparsed.canonical.fields.heuristic_achievements ?? [];
+    expect(achievements.map((a) => a.title)).toEqual([
+      "Engineering excellence recognition",
+    ]);
+    expect(reparsed.rawText).not.toContain("Bulk catalog editor");
+  });
+
+  it("keeps the surviving role's bullets intact", () => {
+    const description = reparsed.canonical.fields.experience[0].description ?? "";
+    expect(description).toContain("OAuth for 50K users");
+    expect(description).toContain("Cut p99 checkout latency by 38%");
+    expect(description).not.toContain("Attended the weekly sync");
+  });
+});

--- a/src/lib/score/group-bullets.ts
+++ b/src/lib/score/group-bullets.ts
@@ -245,6 +245,26 @@ function stripAchievementLabel(key: string): string | null {
 }
 
 /**
+ * True when `key` (already in {@link normalizeTitleKey} form) names a line one
+ * of `ownedKeys` owns — matching on EITHER the whole key or the key minus a
+ * leading achievement type run (#456), the composed-vs-split reconciliation
+ * described on {@link stripAchievementLabel}. The second candidate is additive:
+ * it only ever matches more, and it is keyed on the entry's canonical `title`,
+ * so editing an achievement's `type` cannot move the key off the raw line it has
+ * to match.
+ *
+ * The ONE place the ownership relation is defined, shared by the two directions
+ * that must agree on it: {@link suppressTitleOwnedBullets} hides a line the
+ * entry owns, {@link isTitleOwnedLine} finds the same line so deleting the entry
+ * can drop it (#856).
+ */
+function matchesOwnedKey(key: string, ownedKeys: ReadonlySet<string>): boolean {
+  if (ownedKeys.has(key)) return true;
+  const unlabelled = stripAchievementLabel(key);
+  return unlabelled !== null && ownedKeys.has(unlabelled);
+}
+
+/**
  * Drop from a bullet list every bullet whose content is already OWNED by a
  * title-only entry — i.e. a `• Label … [year]` achievement/project that renders
  * its whole line as a header and carries no `description` for the grouper to
@@ -252,12 +272,6 @@ function stripAchievementLabel(key: string): string | null {
  * the same content twice. We suppress it from "Other" rather than re-attributing
  * it to the entry: the entry's own title already IS that content, so rendering it
  * again as the entry's bullet would just move the duplicate, not remove it.
- *
- * A bullet matches on EITHER its whole key or its key minus a leading achievement
- * type run (#456) — the composed-vs-split reconciliation described on
- * {@link stripAchievementLabel}. The second candidate is additive: it only ever
- * suppresses more, and it is keyed on the entry's canonical `title`, so editing an
- * achievement's `type` cannot move the key off the raw line it has to match.
  *
  * Ownership is exact on the residue-tolerant {@link normalizeTitleKey} — a tight
  * key, not substring containment — so a genuinely-unmatched bullet that merely
@@ -276,12 +290,36 @@ export function suppressTitleOwnedBullets(
     if (key) ownedKeys.add(key);
   }
   if (ownedKeys.size === 0) return [...bullets];
-  return bullets.filter((b) => {
-    const key = normalizeTitleKey(b.text);
-    if (ownedKeys.has(key)) return false;
-    const unlabelled = stripAchievementLabel(key);
-    return !(unlabelled && ownedKeys.has(unlabelled));
-  });
+  return bullets.filter(
+    (b) => !matchesOwnedKey(normalizeTitleKey(b.text), ownedKeys),
+  );
+}
+
+/**
+ * True when `line` is a source line the entry titled `title` OWNS — the exact
+ * relation {@link suppressTitleOwnedBullets} hides a bullet on, exposed so the
+ * INVERSE operation can reuse it: deleting a parsed entry (#856) has to drop the
+ * entry's own line from `rawText` and from the graded section pool, and that line
+ * is not otherwise identifiable (the parsed model keeps no source-line
+ * provenance).
+ *
+ * Getting this from the suppressor rather than from a second matcher is what
+ * makes the two agree by construction. It matters most for the case the
+ * suppressor exists for: a title-only achievement/project is parsed OUT of a
+ * `•`-marked line, so that line stays in the pool the anonymous scorer grades
+ * even though nothing renders it — deleting the entry with a matcher that
+ * disagreed here would leave its content grading the résumé forever.
+ *
+ * Exact-key, never containment, for the reason spelled out on the suppressor: a
+ * different entry's line that merely shares a prefix is not owned.
+ */
+export function isTitleOwnedLine(
+  line: string,
+  title: string | undefined,
+): boolean {
+  const owned = normalizeTitleKey(title ?? "");
+  if (!owned) return false;
+  return matchesOwnedKey(normalizeTitleKey(line), new Set([owned]));
 }
 
 // ── Header formatting ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements #856: parsed entries (achievement, role, education, project) can now be deleted from the reconstructed résumé, not only user-added ones.

Design is the `removedEntries` tombstone set the issue specified — mark, run every index-keyed override pass, then filter once at the end of `applyOverrides`, so no override rebinds to a neighbour.

### Deviations from the issue plan

Three deliberate departures from the issue's implementation plan, all additive to its intent:

1. NO `removedEntriesRef` (plan Step 1). The `removedBulletsRef` it mirrors exists solely so `removeBullet` can read the committed set to decide its boolean return; `removeEntry` returns void, so a ref beside `removedEntries` would have had no reader. Omitted rather than shipped dead.

2. ADDED a UI index-remap the plan does not mention, and it is load-bearing. The plan's Step 4 resolves the delete key as `parsedEntryKey(<section>, i)` where `i` is the render index. Because Step 3 filters tombstoned entries out of the parsed arrays, `i` stops being the parsed index after the first deletion — so that line would (a) re-delete the already-gone entry instead of the clicked one, and (b) leave every neighbouring `onAchievementField(i, …)` / `educationOverrides[i]` / `descriptionOverrides` key rebound to the wrong entry, which is the exact failure the tombstone design prevents one level down. `survivingParsedIndices` (exported from `useEditableParse.ts`) is the single map every section resolves through. It enumerates survivors rather than subtracting the set's size, so a stale tombstone naming an index the parse no longer has cannot over-shift.

3. The entry's own source-line removal (plan Step 3) reuses the SCORER's ownership relation rather than a new "normalise-and-match-first-line" matcher. `normalizeTitleKey` + `stripAchievementLabel` (already private in `group-bullets.ts`) are what `suppressTitleOwnedBullets` hides an entry-owned line on; `isTitleOwnedLine` exposes the inverse, sharing one extracted `matchesOwnedKey` so the two cannot drift. This is not cosmetic: a title-only achievement/project is parsed OUT of a `•`-marked line, so that line is in the graded pool with no description to attribute it to — deleting the entry without dropping the line leaves its content grading the résumé forever. It is best-effort and documented as such (the parsed model keeps no source-line provenance, so a glued one-line header matches nothing and the line stays in the raw-text view); safe when it misses, since the lines it can miss are the UNMARKED ones the bullet pool ignores.

Two smaller notes:
- Entry `key`s in all four sections moved from the render position to the entry key. A position key would hand a deleted row's in-flight edit state to its successor — newly reachable now that parsed rows can disappear.
- One drive-by, forced: `ReconstructedRole.tsx:262` carried a pre-existing "exactly" inside a `/** */` block, which `scripts/hooks/check_conventions.py` rule 2 blocks on (block comments are deliberately scanned) — it fired on every edit to that file. Reworded to "just as". Comment text only.

Also fixed while testing: `parseRemovedEntryKey` matches the index half as DIGITS rather than coercing with `Number`. `Number("")` is 0 and `Number.isInteger(0)` is true, so a truncated `"projects:"` key would have silently deleted the section's FIRST entry. Pinned by a test.

### Files changed

- `src/hooks/useEditableParse.ts`
- `src/hooks/useAnalyzedResume.ts`
- `src/lib/edit/apply-overrides.ts`
- `src/lib/score/group-bullets.ts`
- `src/components/features/EntryRemove.ts`
- `src/components/features/ReconstructedResume.tsx`
- `src/components/features/ReconstructedRole.tsx`
- `src/components/features/ReconstructedEducationSkills.tsx`
- `src/components/features/ExperienceSection.test.tsx`
- `src/components/features/ExperienceSection.other-bullets.test.tsx`
- `src/components/features/ExperienceSection.prune-hold.test.tsx`
- `src/components/features/ReconstructedEducationSkills.test.ts`
- `src/components/features/ReconstructedResume.remove-parsed-entry.test.tsx`
- `src/hooks/useEditableParse.removed-entry.test.tsx`
- `src/lib/edit/apply-overrides.removed-entry.test.ts`
- `src/lib/pdf/render-roundtrip-entry-remove.repro.test.ts`

### Validation

- `npm run typecheck` — pass — tsc -b --noEmit — no output, exit 0
- `npm run lint` — pass — eslint . — no output, exit 0
- `npm test` — pass — Test Files 363 passed | 8 skipped (371); Tests 5901 passed | 10 skipped (5911); Duration 19.77s

### Adversarial review

Not yet run. The run halted at submit (a stray `fake` git remote made `gh stack submit` ambiguous), so the review pass never executed. Reviewer notes below are from `npx fallow audit` only.

### Handoff

New exports the next issue can build on:

- `useEditableParse.ts`
  - `EditableParse.removedEntries: ReadonlySet<string>` — parsedEntryKey tombstones.
  - `EditSnapshot.removedEntries?: string[]` — OPTIONAL, so pre-#856 persisted drafts replay; `replay` defaults it to `[]`. Any new consumer must keep it optional.
  - `removeEntry(key: string)` — widened from "added id" to "added id OR parsedEntryKey". Also deletes that key's `addedBullets` bucket for BOTH kinds.
  - `survivingParsedIndices(section, removedEntries, renderedCount): number[]` — render position → PARSED index. ANY new surface that renders a parsed section and writes an index-keyed override MUST resolve through this.

- `lib/score/group-bullets.ts`: `isTitleOwnedLine(line, title)` — the entry-owns-this-line relation, shared with `suppressTitleOwnedBullets`.

- `components/features/EntryRemove.ts`: `removeEntryWithBullets(entryKey, bullets, {onRemoveEntry, onRemoveBullet})` — the one definition of the delete gesture. Bullets first, then the entry.

- `applyOverrides` gained an 18th positional param `removedEntries: ReadonlySet<string> = new Set()`. A 19th param must be appended AFTER it, and `applyRemovedEntries` must stay the LAST pass (it runs after `applyAddedEntriesAndBullets`) or index-keyed overrides rebind.

- `AchievementsSection` is now exported from `ReconstructedResume.tsx` (test-only, like `ExperienceSection`).

Two landmines documented in code, worth knowing:
- Inside `ExperienceSection`, the `experience:<n>` strings in `rewriteApplyBySection` are in TWO different index spaces — the map KEY is the rewrite-chain section id (RENDER position, matching `buildResumeSections`), while `entryKey` is the `addedBullets` bucket key (PARSED index). They coincide only until a parsed role is deleted.
- Achievement and project bullets are still read-only per-row (issue explicitly out of scope). Step 4 threaded `onRemoveBullet` into both sections for the delete cascade, so that follow-up is now mostly prop-threading down to `ResumeBulletRow`.

Not touched, per the issue's "Not in scope": per-bullet edit/remove on achievements/projects, an undo-delete toast, and the 18-param positional signature of `applyOverrides`.

Closes #856
