### PR TITLE
test: make stable sort assertions non-vacuous

### DIFF
--- a/src/lib/job-search/query-builder.test.ts
+++ b/src/lib/job-search/query-builder.test.ts
@@ -417,8 +417,12 @@ describe("buildJobQuery", () => {
     });
     const query = buildJobQuery(parsed);
     // Canonical tier keeps its own relative order (Python before Java)...
+    expect(query.skills).toContain("Python");
+    expect(query.skills).toContain("Java");
     expect(query.skills.indexOf("Python")).toBeLessThan(query.skills.indexOf("Java"));
     // ...and the unrecognized tier keeps its own relative order too.
+    expect(query.skills).toContain("Underwater Basket Weaving");
+    expect(query.skills).toContain("Competitive Juggling");
     expect(query.skills.indexOf("Underwater Basket Weaving")).toBeLessThan(
       query.skills.indexOf("Competitive Juggling"),
     );


### PR DESCRIPTION
Resolves #857

## Summary

The stable-sort test now explicitly verifies that each compared skill is present before checking relative order. This prevents `indexOf(...)` from returning `-1` for both values and making the ordering assertions pass vacuously.

The change covers both tiers exercised by the test:

- canonical skills: `Python` and `Java`
- unrecognized skills: `Underwater Basket Weaving` and `Competitive Juggling`

## Verification

- `npm run verify` passes, including type-checking, linting, tests, build, and static analysis.
- The unrelated full-suite `BroadcastChannel` failure was reproduced on untouched upstream `main`; it is not caused by this test-only change.
