### PR TITLE
fix(parser): ignore language proficiency rows

### DIFF
--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -471,6 +471,22 @@ describe("tokenizeSkillLine — issue #833 language proficiency rows", () => {
     ]);
   });
 
+  it("keeps a SOLE skill whose name contains proficiency wording (single-fragment row)", () => {
+    // A single-item row has no siblings to protect it from a whole-cell drop —
+    // the per-fragment check must reject "Visual Basic"/"BASIC" on their own
+    // structural shape (no leading proficiency adjective with an object, no
+    // "in", no parens, no "speaker"), not merely because they are outnumbered.
+    expect(tokenizeSkillLine("Languages: Visual Basic")).toEqual(["Visual Basic"]);
+    expect(tokenizeSkillLine("Languages: BASIC")).toEqual(["BASIC"]);
+    expect(tokenizeSkillLine("Languages: React Native")).toEqual(["React Native"]);
+  });
+
+  it("still drops a single-item genuine proficiency predication", () => {
+    expect(tokenizeSkillLine("Languages: Native German")).toEqual([]);
+    expect(tokenizeSkillLine("Languages: Spanish (native)")).toEqual([]);
+    expect(tokenizeSkillLine("Languages: Native speaker")).toEqual([]);
+  });
+
   it("keeps bare spoken-language lists and non-language proficiency skills", () => {
     expect(tokenizeSkillLine("Languages: Python, Go, TypeScript")).toEqual([
       "Python",
@@ -896,6 +912,45 @@ describe("extractSkills — language proficiency category boundary (#833)", () =
       { label: "Frameworks", skills: ["React", "Vue"] },
       { label: "Languages", skills: ["French"] },
     ]);
+  });
+
+  it("does not join a complete proficiency row with a following, unrelated skill line", () => {
+    // "Languages: Fluent in Spanish, conversational French" is a complete cell
+    // on its own (no trailing comma) — a following comma-bearing but unrelated
+    // line must not be pulled into it by the soft-wrap Condition B join, or the
+    // merged fragment list re-admits the proficiency phrase and garbles a token
+    // across the line break.
+    const section = skillsLines([
+      [
+        {
+          x: 74,
+          str: "Languages: Fluent in Spanish, conversational French",
+          w: 220,
+        },
+      ],
+      [{ x: 74, str: "Project Management, Agile, Scrum", w: 160 }],
+    ]);
+    const { value } = extractSkills(section);
+
+    expect(value).toEqual(["Project Management", "Agile", "Scrum"]);
+    expect(value.some((v) => v.includes("French"))).toBe(false);
+  });
+
+  it("does not misfile an unrelated bare list under a dropped row's anchor category", () => {
+    // "Languages: Fluent in Spanish" is a single item with no trailing comma —
+    // a COMPLETE cell, not an unterminated one — so nothing after it is "its"
+    // wrap continuation. An unrelated bare list that merely follows it must
+    // not be swept under a "Languages" category the dropped row left behind.
+    const section = skillsLines([
+      [{ x: 74, str: "Languages: Fluent in Spanish", w: 160 }],
+      [{ x: 74, str: "Python, Go, TypeScript", w: 130 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual(["Python", "Go", "TypeScript"]);
+    expect(
+      categories?.find((c) => c.label === "Languages")?.skills ?? [],
+    ).not.toEqual(expect.arrayContaining(["Python", "Go", "TypeScript"]));
   });
 });
 

--- a/src/lib/heuristics/extract/skills.test.ts
+++ b/src/lib/heuristics/extract/skills.test.ts
@@ -426,6 +426,68 @@ describe("tokenizeSkillLine — issue #221 non-skill sub-labels", () => {
   });
 });
 
+describe("tokenizeSkillLine — issue #833 language proficiency rows", () => {
+  it("drops spoken-language proficiency rows across common label variants", () => {
+    expect(tokenizeSkillLine("Language: Fluent in Spanish")).toEqual([]);
+    expect(tokenizeSkillLine("Foreign Languages: Fluent in Spanish")).toEqual([]);
+    expect(
+      tokenizeSkillLine("Spoken Languages: Native German, conversational French"),
+    ).toEqual([]);
+    expect(tokenizeSkillLine("Languages : Fluent in Spanish")).toEqual([]);
+  });
+
+  it("drops standard proficiency-scale wording", () => {
+    expect(
+      tokenizeSkillLine("Languages: Full professional proficiency in German"),
+    ).toEqual([]);
+    expect(tokenizeSkillLine("Languages: Elementary proficiency in French")).toEqual(
+      [],
+    );
+    expect(tokenizeSkillLine("Languages: JLPT N2 Japanese Proficiency")).toEqual(
+      [],
+    );
+  });
+
+  it("keeps programming-language rows when one token contains proficiency wording", () => {
+    expect(tokenizeSkillLine("Languages: C, C++, Visual Basic")).toEqual([
+      "C",
+      "C++",
+      "Visual Basic",
+    ]);
+    expect(tokenizeSkillLine("Languages: Kotlin, Swift, React Native")).toEqual([
+      "Kotlin",
+      "Swift",
+      "React Native",
+    ]);
+    expect(tokenizeSkillLine("Languages: Proficient in Java, Python, Go")).toEqual([
+      "Proficient in Java",
+      "Python",
+      "Go",
+    ]);
+    expect(tokenizeSkillLine("Languages: Java, Python (proficient), Go")).toEqual([
+      "Java",
+      "Python (proficient)",
+      "Go",
+    ]);
+  });
+
+  it("keeps bare spoken-language lists and non-language proficiency skills", () => {
+    expect(tokenizeSkillLine("Languages: Python, Go, TypeScript")).toEqual([
+      "Python",
+      "Go",
+      "TypeScript",
+    ]);
+    expect(tokenizeSkillLine("Languages: Spanish, French, Mandarin")).toEqual([
+      "Spanish",
+      "French",
+      "Mandarin",
+    ]);
+    expect(
+      tokenizeSkillLine("Certifications: Certified in AWS Solutions Architecture"),
+    ).toEqual(["Certified in AWS Solutions Architecture"]);
+  });
+});
+
 describe("tokenizeSkillLine — issue #832 single-letter languages", () => {
   it("keeps C, R, and D as real programming languages", () => {
     expect(tokenizeSkillLine("Languages: C, R, D")).toEqual(
@@ -820,6 +882,23 @@ describe("extractSkills — bulleted labelled single-column rows (#465)", () => 
   });
 });
 
+describe("extractSkills — language proficiency category boundary (#833)", () => {
+  it("does not misfile a wrapped tail under the previous category", () => {
+    const section = skillsLines([
+      [{ x: 74, str: "Frameworks: React, Vue", w: 110 }],
+      [{ x: 74, str: "Languages: English (native), Spanish (fluent),", w: 180 }],
+      [{ x: 74, str: "French", w: 35 }],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual(["React", "Vue", "French"]);
+    expect(categories).toEqual([
+      { label: "Frameworks", skills: ["React", "Vue"] },
+      { label: "Languages", skills: ["French"] },
+    ]);
+  });
+});
+
 describe("extractSkills — category capture (#473)", () => {
   it("captures each label as a category and keeps `skills` the flat union", () => {
     const section = skillsLines([
@@ -833,6 +912,39 @@ describe("extractSkills — category capture (#473)", () => {
       { label: "Frontend", skills: ["React", "TypeScript"] },
       { label: "Backend", skills: ["Java", "Python"] },
     ]);
+  });
+
+  it("drops language proficiency rows without dropping language lists", () => {
+    const section = skillsLines([
+      [...BULLET_RUNS, { x: 74, str: "Languages: Python, Go, TypeScript", w: 180 }],
+      [...BULLET_RUNS, { x: 74, str: "Language: Fluent in Spanish", w: 160 }],
+      [...BULLET_RUNS, { x: 74, str: "Languages: Spanish, French, Mandarin", w: 180 }],
+      [
+        ...BULLET_RUNS,
+        { x: 74, str: "Certifications: Certified in AWS Solutions Architecture", w: 220 },
+      ],
+    ]);
+    const { value, categories } = extractSkills(section);
+
+    expect(value).toEqual([
+      "Python",
+      "Go",
+      "TypeScript",
+      "Spanish",
+      "French",
+      "Mandarin",
+      "Certified in AWS Solutions Architecture",
+    ]);
+    expect(categories).toEqual([
+      { label: "Languages", skills: ["Python", "Go", "TypeScript"] },
+      { label: "Languages", skills: ["Spanish", "French", "Mandarin"] },
+      { label: "Certifications", skills: ["Certified in AWS Solutions Architecture"] },
+    ]);
+    expect(value).not.toContain("Fluent in Spanish");
+    expect(categories).not.toContainEqual({
+      label: "Language",
+      skills: ["Fluent in Spanish"],
+    });
   });
 
   it("INVARIANT 1: `skills` deep-equals `categories.flatMap((c) => c.skills)`", () => {

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -312,13 +312,35 @@ const BARE_SUBLABEL_RE = new RegExp(`^${SUBLABEL_BODY}:$`);
 const LANGUAGE_LABEL_RE =
   /^(?:foreign\s+|spoken\s+|other\s+)?languages?\s*$/i;
 
-/** A spoken-language proficiency predication, distinguished from a delimited
- * programming-language list by its proficiency wording rather than by the
- * label. Keep this vocabulary broad enough to cover standard proficiency
- * scales, but apply it per fragment so `Visual Basic` and `React Native` do
- * not cause an entire programming-language row to disappear. */
-const LANGUAGE_PROFICIENCY_BODY_RE =
-  /\b(fluent|native|bilingual|conversational|proficient|proficiency|proficiencies|intermediate|elementary|limited|beginner|basic|working\s+proficiency|mother\s+tongue)\b/i;
+/** Spoken-language proficiency ADJECTIVES/predicates ("fluent", "native",
+ * "basic", …). Unlike the NOUN forms below, these collide with real compound
+ * proper nouns — "Visual Basic", "React Native" — so a bare substring test
+ * over a fragment is not enough; see LANGUAGE_PROFICIENCY_PREDICATION_RE for
+ * the structural test that disambiguates them. */
+const LANGUAGE_PROFICIENCY_ADJECTIVES =
+  "fluent|native|bilingual|conversational|proficient|intermediate|elementary|limited|beginner|basic|mother\\s+tongue";
+
+/** A single fragment that reads as a spoken-language proficiency PREDICATION
+ * ("Fluent in Spanish", "Native German", "Spanish (native)", "Native
+ * speaker") rather than a token that merely CONTAINS proficiency vocabulary
+ * ("Visual Basic", "React Native", bare "BASIC"). The noun forms
+ * "proficiency"/"proficiencies" are unambiguous in any position — no
+ * programming-language or tool name ends in "Proficiency" — so they match
+ * anywhere. The adjective forms only count when they carry predicate
+ * structure: leading the fragment with something after them ("Native
+ * German", ruling out a bare "BASIC" with nothing to modify), joined by "in"
+ * ("Fluent in Spanish"), parenthesised ("Spanish (native)"), or followed by
+ * "speaker" ("Native speaker"). Applied per fragment so a delimited
+ * programming-language list survives even when every one of its items
+ * happens to contain proficiency vocabulary. */
+const LANGUAGE_PROFICIENCY_PREDICATION_RE = new RegExp(
+  "\\b(?:proficiency|proficiencies)\\b" +
+    `|^(?:${LANGUAGE_PROFICIENCY_ADJECTIVES})\\s+\\S` +
+    `|\\b(?:${LANGUAGE_PROFICIENCY_ADJECTIVES})\\s+in\\b` +
+    `|\\((?:${LANGUAGE_PROFICIENCY_ADJECTIVES})\\)` +
+    `|\\b(?:${LANGUAGE_PROFICIENCY_ADJECTIVES})\\s+speaker\\b`,
+  "i",
+);
 
 function isLanguageProficiencyCell(cell: string): boolean {
   const debulleted = stripBullet(cell);
@@ -330,7 +352,9 @@ function isLanguageProficiencyCell(cell: string): boolean {
     .filter((fragment) => fragment !== "");
   return (
     fragments.length > 0 &&
-    fragments.every((fragment) => LANGUAGE_PROFICIENCY_BODY_RE.test(fragment))
+    fragments.every((fragment) =>
+      LANGUAGE_PROFICIENCY_PREDICATION_RE.test(fragment),
+    )
   );
 }
 
@@ -435,6 +459,19 @@ function isSoftWrapContinuation(
   if (looksLikeContactLink(nextText)) return false;
   // Always skip if the next line starts a new sub-list (label or bullet).
   if (SKILLS_NEW_ENTRY_RE.test(nextText)) return false;
+  // Always skip when `pending` ALONE already resolves as a complete
+  // spoken-language proficiency cell (#833) — e.g. "Languages: Fluent in
+  // Spanish, conversational French". Such a cell is grammatically finished,
+  // so a following comma-bearing line is an independent, unrelated entry
+  // ("Project Management, Agile, Scrum"), not its wrap continuation. Without
+  // this guard, Condition B below joins the two into one cell whose merged
+  // fragment list contains real skill tokens, defeating
+  // `isLanguageProficiencyCell`'s per-fragment check and re-admitting the
+  // proficiency phrase as a skill. A cell that genuinely wraps mid-list ends
+  // on a trailing comma/semicolon instead ("English (native), Spanish
+  // (fluent),"), which `isLanguageProficiencyCell` — and this guard — leaves
+  // alone because a trailing delimiter never resolves as a complete cell.
+  if (isLanguageProficiencyCell(pending)) return false;
 
   // Condition A′ (symmetric to A): the NEXT line LEADS with a bare connector
   // glyph — a soft-wrap that broke a skill/list immediately BEFORE the connector
@@ -688,12 +725,22 @@ export function extractSkills(
       cellTokens.push(tok);
     }
     const label = matchCellLabel(cell);
-    // A dropped language-proficiency row still opens a category boundary. Keep
-    // that anchor so a soft-wrapped tail cannot be misfiled under the previous
-    // category; the category is emitted only if a later continuation contributes
-    // a token.
+    // A dropped language-proficiency row still opens a category boundary, but
+    // ONLY when the row is itself unterminated (ends on a trailing
+    // comma/semicolon, e.g. "English (native), Spanish (fluent),") — the same
+    // "list got cut off mid-item" signal `isSoftWrapContinuation`'s Condition
+    // B uses. That is what distinguishes a genuine soft-wrapped tail ("…,"
+    // then "French") from an unrelated, independent bare cell that merely
+    // happens to follow the dropped row ("Languages: Fluent in Spanish" then
+    // "Python, Go, TypeScript"): the latter is already a complete cell with no
+    // trailing delimiter, so nothing after it can be "its" continuation. The
+    // category is emitted only if a later continuation contributes a token.
     if (cellTokens.length === 0) {
-      if (label !== undefined && isLanguageProficiencyCell(cell)) {
+      if (
+        label !== undefined &&
+        isLanguageProficiencyCell(cell) &&
+        /[,;]\s*$/.test(stripBullet(cell))
+      ) {
         categories.push({ label, skills: [] });
       }
       continue;

--- a/src/lib/heuristics/extract/skills.ts
+++ b/src/lib/heuristics/extract/skills.ts
@@ -304,6 +304,36 @@ const SUBLABEL_PREFIX_RE = new RegExp(`^(${SUBLABEL_BODY}):\\s*`);
  *  tore off its body. See the rejoin in `splitColumnCells`. */
 const BARE_SUBLABEL_RE = new RegExp(`^${SUBLABEL_BODY}:$`);
 
+/** A Skills sub-label that MAY head a spoken-language row. Deliberately NOT
+ * added to NON_SKILL_SUBLABEL_RE: on most engineering résumés `Languages:`
+ * heads the programming-language row, so the label is ambiguous and the body
+ * must decide whether this is a proficiency statement. Qualifiers are allowed
+ * because `Foreign Languages:` and `Spoken Languages:` are common variants. */
+const LANGUAGE_LABEL_RE =
+  /^(?:foreign\s+|spoken\s+|other\s+)?languages?\s*$/i;
+
+/** A spoken-language proficiency predication, distinguished from a delimited
+ * programming-language list by its proficiency wording rather than by the
+ * label. Keep this vocabulary broad enough to cover standard proficiency
+ * scales, but apply it per fragment so `Visual Basic` and `React Native` do
+ * not cause an entire programming-language row to disappear. */
+const LANGUAGE_PROFICIENCY_BODY_RE =
+  /\b(fluent|native|bilingual|conversational|proficient|proficiency|proficiencies|intermediate|elementary|limited|beginner|basic|working\s+proficiency|mother\s+tongue)\b/i;
+
+function isLanguageProficiencyCell(cell: string): boolean {
+  const debulleted = stripBullet(cell);
+  const match = debulleted.match(SUBLABEL_PREFIX_RE);
+  if (!match || !LANGUAGE_LABEL_RE.test(match[1])) return false;
+
+  const fragments = splitRespectingParens(debulleted.slice(match[0].length))
+    .map((fragment) => fragment.trim())
+    .filter((fragment) => fragment !== "");
+  return (
+    fragments.length > 0 &&
+    fragments.every((fragment) => LANGUAGE_PROFICIENCY_BODY_RE.test(fragment))
+  );
+}
+
 /**
  * Tokenizes a single column cell into valid skill tokens and adds them to
  * `out`. Drops the cell entirely when it looks like a contact/profile link —
@@ -317,7 +347,11 @@ function tokenizeCell(cell: string, out: Set<string>): void {
   // leading `Label:` prefix and drop the whole cell when it names a
   // hobbies/interests list — before the label is stripped and the items split.
   const labelMatch = debulleted.match(SUBLABEL_PREFIX_RE);
-  if (labelMatch && NON_SKILL_SUBLABEL_RE.test(labelMatch[1])) return;
+  if (
+    labelMatch &&
+    (NON_SKILL_SUBLABEL_RE.test(labelMatch[1]) || isLanguageProficiencyCell(debulleted))
+  )
+    return;
   const clean = debulleted.replace(SUBLABEL_PREFIX_RE, "");
   // A whole cell that is a profile link ("github.com/janesmith") must be
   // dropped before splitting — a path slash would otherwise leave the path
@@ -613,10 +647,16 @@ function upcomingContinuationTexts(lineCells: string[][], from: number): string[
  * A non-skill sub-label (Interests/Hobbies) is not a category: `tokenizeCell`
  * drops such a cell whole, so it never contributes tokens and never reaches the
  * caller's category branch — but the guard here keeps the two decisions aligned.
+ * Language-proficiency rows retain their label here so a dropped row can still
+ * anchor a soft-wrapped continuation in `extractSkills`.
  */
 function matchCellLabel(cell: string): string | undefined {
   const m = stripBullet(cell).match(SUBLABEL_PREFIX_RE);
-  if (!m || NON_SKILL_SUBLABEL_RE.test(m[1])) return undefined;
+  if (
+    !m ||
+    NON_SKILL_SUBLABEL_RE.test(m[1])
+  )
+    return undefined;
   return m[1].trim();
 }
 
@@ -647,11 +687,21 @@ export function extractSkills(
       value.push(tok);
       cellTokens.push(tok);
     }
+    const label = matchCellLabel(cell);
+    // A dropped language-proficiency row still opens a category boundary. Keep
+    // that anchor so a soft-wrapped tail cannot be misfiled under the previous
+    // category; the category is emitted only if a later continuation contributes
+    // a token.
+    if (cellTokens.length === 0) {
+      if (label !== undefined && isLanguageProficiencyCell(cell)) {
+        categories.push({ label, skills: [] });
+      }
+      continue;
+    }
+
     // A cell that produced nothing (dropped link/hobbies label, or all-duplicate)
     // is neither a category nor a bare contribution — skip it on both axes.
-    if (cellTokens.length === 0) continue;
 
-    const label = matchCellLabel(cell);
     if (label !== undefined) {
       categories.push({ label, skills: cellTokens });
     } else if (categories.length > 0) {
@@ -666,13 +716,18 @@ export function extractSkills(
     }
   }
 
+  const nonEmptyCategories = categories.filter(
+    (category) => category.skills.length > 0,
+  );
   const confidence = value.length >= 5 ? 0.85 : value.length >= 2 ? 0.6 : 0.2;
   return {
     value,
     // Emit the structured view ONLY when the section is fully categorised: at
-    // least one label AND no bare head. Otherwise the field is absent (never
-    // `[]`), which reads as "uncategorised" per invariant (2).
-    ...(categories.length > 0 && !hasUncategorisedHead ? { categories } : {}),
+    // least one non-empty label AND no bare head. Otherwise the field is absent
+    // (never `[]`), which reads as "uncategorised" per invariant (2).
+    ...(nonEmptyCategories.length > 0 && !hasUncategorisedHead
+      ? { categories: nonEmptyCategories }
+      : {}),
     confidence,
   };
 }

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-multiline-bullets-coursework.expected.json
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 8,
+    "skillsCount": 7,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,
@@ -76,7 +76,7 @@
     "sectionSource": "regex",
     "pageCount": 2,
     "rawCharCount": 2385,
-    "extractedCharCount": 1817,
+    "extractedCharCount": 1789,
     "sections": [
       {
         "name": "profile",
@@ -107,7 +107,7 @@
       "hasSummary": false,
       "experienceCount": 3,
       "educationCount": 2,
-      "skillsCount": 8
+      "skillsCount": 7
     },
     "linkAnnotationCount": 0,
     "disagreements": []

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.expected.json
@@ -22,7 +22,7 @@
       "phoneIsValid",
       "skills"
     ],
-    "skillsCount": 12,
+    "skillsCount": 11,
     "experienceCount": 2,
     "educationCount": 1,
     "projectsCount": 0,
@@ -74,7 +74,7 @@
     "sectionSource": "regex",
     "pageCount": 1,
     "rawCharCount": 1428,
-    "extractedCharCount": 1147,
+    "extractedCharCount": 1130,
     "sections": [
       {
         "name": "profile",
@@ -101,7 +101,7 @@
       "hasSummary": false,
       "experienceCount": 2,
       "educationCount": 1,
-      "skillsCount": 12
+      "skillsCount": 11
     },
     "linkAnnotationCount": 0,
     "disagreements": []

--- a/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.truth.json
+++ b/tests/fixtures/pdfs/google-docs/google-docs-skia-proxy-role-first-experience.truth.json
@@ -42,11 +42,6 @@
       "issue": null,
       "status": "unfiled",
       "note": "Role 2's employer line reads “Multicultural Engineering Program – State Polytechnic University”; `company` comes back as just the university — the program half is not lost, the parser puts it on `team`, but `experience.company` scores the `company` field alone. The identical shape is measured on unknown/single-column-title-below-anchor. Possibly a defensible org/team split rather than a defect — recorded rather than assumed, because ground truth's job is to state what the page says and let a human adjudicate."
-    },
-    "skills": {
-      "issue": 833,
-      "status": "open",
-      "note": "“Fluent in Spanish” is admitted as a skill from the “Language:” row; the Programming Languages row is now correct after #832."
     }
   }
 }

--- a/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
+++ b/tests/fixtures/pdfs/unknown/student-projects-activities-singlecol.expected.json
@@ -25,7 +25,7 @@
       "skills",
       "website_url"
     ],
-    "skillsCount": 8,
+    "skillsCount": 7,
     "experienceCount": 3,
     "educationCount": 2,
     "projectsCount": 2,
@@ -76,7 +76,7 @@
     "sectionSource": "regex",
     "pageCount": 2,
     "rawCharCount": 2279,
-    "extractedCharCount": 1709,
+    "extractedCharCount": 1681,
     "sections": [
       {
         "name": "profile",
@@ -107,7 +107,7 @@
       "hasSummary": false,
       "experienceCount": 3,
       "educationCount": 2,
-      "skillsCount": 8
+      "skillsCount": 7
     },
     "linkAnnotationCount": 0,
     "disagreements": []

--- a/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
+++ b/tests/fixtures/pdfs/word/openresume-laverne-word-quartz.expected.json
@@ -22,7 +22,7 @@
       "skills",
       "summary"
     ],
-    "skillsCount": 8,
+    "skillsCount": 7,
     "experienceCount": 3,
     "educationCount": 1,
     "projectsCount": 0,
@@ -74,7 +74,7 @@
     "sectionSource": "regex",
     "pageCount": 1,
     "rawCharCount": 1336,
-    "extractedCharCount": 856,
+    "extractedCharCount": 839,
     "sections": [
       {
         "name": "profile",
@@ -105,7 +105,7 @@
       "hasSummary": true,
       "experienceCount": 3,
       "educationCount": 1,
-      "skillsCount": 8
+      "skillsCount": 7
     },
     "linkAnnotationCount": 0,
     "disagreements": []


### PR DESCRIPTION
Resolves #833

## Summary

Ignore spoken-language proficiency rows such as `Language: Fluent in Spanish` when extracting résumé skills, while preserving programming-language rows and bare spoken-language lists. The label and proficiency wording are checked together, so `Languages: Python, Go, TypeScript` remains unchanged and non-language labels such as `Certifications: Certified in AWS Solutions Architecture` are unaffected.

The change adds focused regression coverage, removes the resolved #833 truth exception, and updates the affected Google Docs and Word corpus snapshots.

## Verification

- `npx vitest run src/lib/heuristics/extract/skills.test.ts` — 49 passed
- `npm run typecheck` — passed
- `npx vitest run src/lib/heuristics/corpus.test.ts src/lib/heuristics/corpus-roundtrip.test.ts` — passed
- `npm run lint` — passed
- `npm run check:fixtures` — passed
- `npm run check:baselines` — passed
- `npm run check:core` — passed
- `npm run build` — passed

The full repository verification also reproduces an unrelated existing `BroadcastChannel`/`MessageEvent` failure in `src/hooks/useLibraryChanges.test.tsx`; 358 test files passed and 1 failed.