### PR TITLE
chore(db): open database without version parameters in content script to prevent upgrade hangs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -217,7 +217,10 @@ export { deriveJobId, canonicalJobUrl } from "../../../src/lib/storage/job-url.t
  * that captures from elsewhere: it must hand the record to something running in
  * this app's origin rather than write the library itself.
  */
-export { captureJob, type JobCaptureResult } from "../../../src/lib/storage/capture.ts";
+export {
+  captureJobIntoExisting as captureJob,
+  type JobCaptureResult,
+} from "../../../src/lib/storage/capture.ts";
 
 export type { JobRecord, JobStatus, JobOrigin } from "../../../src/lib/storage/types.ts";
 
@@ -250,14 +253,36 @@ export type { JobRecord, JobStatus, JobOrigin } from "../../../src/lib/storage/t
  * is a purge and `softDeleteRecord` is the right call; that one is not on this
  * surface.
  */
+/**
+ * Re-exported under their app-facing names, but bound to the `…FromExisting`/
+ * `…IntoExisting` variant of each: every consumer of THIS package is a content
+ * script in the sense `src/lib/storage/db.ts`'s `getExistingDB()` docblock
+ * describes, and the plain `getRecord`/`putRecord`/`deleteRecord`/
+ * `listRecordsUpdatedSince` open at this repo's pinned `DB_VERSION`, which can
+ * hang a content script when a bump lands here ahead of a stale, still-open app
+ * tab. Renaming on the way out — rather than the consumer importing a
+ * differently-named function — keeps the rebinding invisible to it.
+ *
+ * ⚠️ **This does not reach the extension in `extension/`.** That checkout
+ * (`116-Ideas/recruidea-extension`, pinned by `extension/offlinecv-pin.json`)
+ * predates this package and does not import it: its own barrel,
+ * `extension/src/offlinecv-core.ts`, re-exports these same symbols directly
+ * from `../../src/lib/storage/*.ts` by relative path, so it still binds the
+ * `getDB()`-backed originals and is still exposed to the hang. Repointing that
+ * barrel at the `…Existing` variants is a change in the extension's own repo;
+ * nothing in this file can make it from here.
+ */
 export {
-  getRecord,
-  putRecord,
-  deleteRecord,
-  listRecordsUpdatedSince,
+  getRecordFromExisting as getRecord,
+  putRecordIntoExisting as putRecord,
+  deleteRecordIntoExisting as deleteRecord,
+  listRecordsUpdatedSinceFromExisting as listRecordsUpdatedSince,
 } from "../../../src/lib/storage/crud.ts";
 
-export { getSyncCursor, setSyncCursor } from "../../../src/lib/storage/sync-cursor.ts";
+export {
+  getSyncCursorFromExisting as getSyncCursor,
+  setSyncCursorIntoExisting as setSyncCursor,
+} from "../../../src/lib/storage/sync-cursor.ts";
 
 export type {
   LetterRecord,
@@ -284,7 +309,10 @@ export {
  * newest first — no blob, no parse, nothing that makes a picker built on this a
  * second corpus channel. Same IndexedDB constraint as `captureJob`.
  */
-export { listResumeChoices, type ResumeChoice } from "../../../src/lib/storage/resumes.ts";
+export {
+  listResumeChoicesFromExisting as listResumeChoices,
+  type ResumeChoice,
+} from "../../../src/lib/storage/resumes.ts";
 
 /**
  * The compensation parser. A posting's pay range is free-text prose, and this is

--- a/src/lib/storage/capture.ts
+++ b/src/lib/storage/capture.ts
@@ -37,7 +37,7 @@
  * the ownership merge below rather than reimplementing it against the store.
  */
 
-import { getJob, saveJob } from "./jobs.ts";
+import { getJob, saveJob, getJobFromExisting, saveJobIntoExisting } from "./jobs.ts";
 import { validateJobRecord, type JobRecordIssue } from "./job-record-contract.ts";
 import { dedupeCanonicalUrls, deriveJobId } from "./job-url.ts";
 import type { JobRecord } from "./types.ts";
@@ -105,6 +105,25 @@ function resolveCaptureId(input: Record<string, unknown>): string {
  * revived job keeps the date it was first saved.
  */
 export async function captureJob(input: unknown): Promise<JobCaptureResult> {
+  return captureJobVia(getJob, saveJob, input);
+}
+
+/** Same as {@link captureJob}, opened via `getExistingDB()` instead — the
+ *  variant `@offlinecv/core` re-exports as `captureJob` to a content-script
+ *  consumer; see `db.ts`'s `getExistingDB` docblock for why. This is the
+ *  capture door, so it is the hang this whole `…Existing` family exists to
+ *  close. */
+export async function captureJobIntoExisting(
+  input: unknown,
+): Promise<JobCaptureResult> {
+  return captureJobVia(getJobFromExisting, saveJobIntoExisting, input);
+}
+
+async function captureJobVia(
+  getJobFn: typeof getJob,
+  saveJobFn: typeof saveJob,
+  input: unknown,
+): Promise<JobCaptureResult> {
   if (input === null || typeof input !== "object" || Array.isArray(input)) {
     return { ok: false, reasons: ["A captured job must be a plain JSON object."] };
   }
@@ -118,7 +137,7 @@ export async function captureJob(input: unknown): Promise<JobCaptureResult> {
   if (!validation.ok) return validation;
 
   const merged: JobRecord = { ...validation.record };
-  const existing = await getJob(merged.id);
+  const existing = await getJobFn(merged.id);
   if (existing) {
     // The three user-owned fields. `??`, not `||`: notes the user cleared to
     // `""` is a choice, and only a genuinely absent value falls through to
@@ -146,6 +165,6 @@ export async function captureJob(input: unknown): Promise<JobCaptureResult> {
     else delete merged.aliasUrls;
   }
 
-  const record = await saveJob(merged, { touch: false });
+  const record = await saveJobFn(merged, { touch: false });
   return { ok: true, record, created: existing === undefined, warnings: validation.warnings };
 }

--- a/src/lib/storage/crud.ts
+++ b/src/lib/storage/crud.ts
@@ -9,7 +9,7 @@
  */
 
 import type { IDBPDatabase } from "idb";
-import { getDB, UPDATED_AT_INDEX } from "./db.ts";
+import { getDB, getExistingDB, UPDATED_AT_INDEX } from "./db.ts";
 import { postLibraryChange } from "./library-channel.ts";
 import type { StoreName, StoredRecord, SyncableStoreName } from "./types.ts";
 
@@ -111,9 +111,18 @@ function emitChange(store: StoreName): void {
  * runtime). These helpers operate through a loosely-typed handle on purpose;
  * the store-specific record type is reasserted via the `<T>` parameter, so
  * callers (`resumes.ts` / `jobs.ts`) still get a fully-typed surface.
+ *
+ * Takes the opener as a parameter, defaulting to `getDB`, so this app's own
+ * code keeps opening at `DB_VERSION` (and migrating when due) without having
+ * to say so at every call site. The `…FromExisting`/`…IntoExisting` exports
+ * below are the only other caller, and they pass {@link getExistingDB} — see
+ * that function's docblock for why a content script must never request a
+ * version.
  */
-async function looseDB(): Promise<IDBPDatabase> {
-  return (await getDB()) as unknown as IDBPDatabase;
+async function looseDB(
+  opener: () => Promise<IDBPDatabase<any>> = getDB,
+): Promise<IDBPDatabase> {
+  return (await opener()) as unknown as IDBPDatabase;
 }
 
 /** Upsert a record, stamping timestamps from a single `now`: `createdAt` comes
@@ -145,7 +154,29 @@ export async function putRecord<T extends StoredRecord>(
     Partial<Pick<T, "createdAt" | "updatedAt">>,
   options: { touch?: boolean } = {},
 ): Promise<T> {
-  const db = await looseDB();
+  return putRecordVia(getDB, store, record, options);
+}
+
+/** Same as {@link putRecord}, opened via {@link getExistingDB} instead — the
+ *  variant `@offlinecv/core` re-exports as `putRecord` to a content-script
+ *  consumer. */
+export async function putRecordIntoExisting<T extends StoredRecord>(
+  store: StoreName,
+  record: Omit<T, "createdAt" | "updatedAt"> &
+    Partial<Pick<T, "createdAt" | "updatedAt">>,
+  options: { touch?: boolean } = {},
+): Promise<T> {
+  return putRecordVia(getExistingDB, store, record, options);
+}
+
+async function putRecordVia<T extends StoredRecord>(
+  opener: () => Promise<IDBPDatabase<any>>,
+  store: StoreName,
+  record: Omit<T, "createdAt" | "updatedAt"> &
+    Partial<Pick<T, "createdAt" | "updatedAt">>,
+  options: { touch?: boolean } = {},
+): Promise<T> {
+  const db = await looseDB(opener);
   const now = Date.now();
   const existing = (await db.get(store, record.id)) as T | undefined;
   const written = {
@@ -169,6 +200,17 @@ export async function getRecord<T extends StoredRecord>(
   return (await db.get(store, id)) as T | undefined;
 }
 
+/** Same as {@link getRecord}, opened via {@link getExistingDB} instead — the
+ *  variant `@offlinecv/core` re-exports as `getRecord` to a content-script
+ *  consumer. */
+export async function getRecordFromExisting<T extends StoredRecord>(
+  store: StoreName,
+  id: string,
+): Promise<T | undefined> {
+  const db = await looseDB(getExistingDB);
+  return (await db.get(store, id)) as T | undefined;
+}
+
 /**
  * Every record in a store — **excluding tombstones by default** (#730).
  *
@@ -187,6 +229,18 @@ export async function getAllRecords<T extends StoredRecord>(
   options: { includeDeleted?: boolean } = {},
 ): Promise<T[]> {
   const db = await looseDB();
+  const all = (await db.getAll(store)) as T[];
+  return options.includeDeleted === true ? all : all.filter(isLive);
+}
+
+/** Same as {@link getAllRecords}, opened via {@link getExistingDB} instead —
+ *  what `listResumeChoices`'s `…FromExisting` variant calls, for a
+ *  content-script consumer. */
+export async function getAllRecordsFromExisting<T extends StoredRecord>(
+  store: StoreName,
+  options: { includeDeleted?: boolean } = {},
+): Promise<T[]> {
+  const db = await looseDB(getExistingDB);
   const all = (await db.getAll(store)) as T[];
   return options.includeDeleted === true ? all : all.filter(isLive);
 }
@@ -223,6 +277,20 @@ export async function listRecordsUpdatedSince<T extends StoredRecord>(
   since: number,
 ): Promise<T[]> {
   const db = await looseDB();
+  return (await db.getAllFromIndex(
+    store,
+    UPDATED_AT_INDEX,
+    IDBKeyRange.lowerBound(since, true),
+  )) as T[];
+}
+
+/** Same as {@link listRecordsUpdatedSince}, opened via {@link getExistingDB}
+ *  instead — the variant `@offlinecv/core` re-exports as
+ *  `listRecordsUpdatedSince` to a content-script consumer. */
+export async function listRecordsUpdatedSinceFromExisting<
+  T extends StoredRecord,
+>(store: SyncableStoreName, since: number): Promise<T[]> {
+  const db = await looseDB(getExistingDB);
   return (await db.getAllFromIndex(
     store,
     UPDATED_AT_INDEX,
@@ -276,6 +344,20 @@ export async function deleteRecord(
   id: string,
 ): Promise<void> {
   const db = await looseDB();
+  await db.delete(store, id);
+  emitChange(store);
+}
+
+/** Same as {@link deleteRecord}, opened via {@link getExistingDB} instead —
+ *  the variant `@offlinecv/core` re-exports as `deleteRecord` to a content
+ *  script. `…IntoExisting`, not `…FromExisting`: this family reserves the
+ *  `From` suffix for reads and `Into` for writes, and a hard delete is a write
+ *  (`db.delete` + `emitChange`), like `putRecordIntoExisting` beside it. */
+export async function deleteRecordIntoExisting(
+  store: StoreName,
+  id: string,
+): Promise<void> {
+  const db = await looseDB(getExistingDB);
   await db.delete(store, id);
   emitChange(store);
 }

--- a/src/lib/storage/db.test.ts
+++ b/src/lib/storage/db.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * {@link getExistingDB} (#recruidea-extension "open database without version
+ * parameters in content script to prevent upgrade hangs"): the content-script
+ * opener must never request a version against a database that already exists,
+ * so it can never trigger an upgrade transaction — and must still hand back a
+ * USABLE handle when no database exists yet.
+ *
+ * Both halves are asserted against what a browser actually sees — `db.version`
+ * and a real read/write through the store — rather than against `DB_VERSION`,
+ * which would compare the code to itself, the trap `DB_VERSION`'s own docblock
+ * warns about.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DB_NAME, closeDB, getDB, getExistingDB } from "./db.ts";
+import { captureJobIntoExisting } from "./capture.ts";
+import { getJobFromExisting } from "./jobs.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+describe("getExistingDB", () => {
+  it("attaches to a database the app already migrated, without re-requesting a version", async () => {
+    const app = await getDB();
+    expect(app.version).toBe(4);
+    expect([...app.objectStoreNames]).toContain("jobs");
+    await closeDB();
+
+    const contentScript = await getExistingDB();
+    expect(contentScript.version).toBe(4);
+    expect([...contentScript.objectStoreNames]).toEqual([
+      ...app.objectStoreNames,
+    ]);
+  });
+
+  it("falls back to the full schema when no database exists yet", async () => {
+    // A profile that has only ever used the extension, never the app itself. A
+    // bare versionless open would create an empty v1 with no object stores —
+    // a handle whose every read and write throws NotFoundError. The fallback
+    // deletes that stray database and reopens through getDB(), so the caller
+    // gets the real schema. (Deleting matters: upgrade()'s first block is
+    // guarded `oldVersion < 1`, so upgrading the stray v1 in place would skip
+    // it and leave `resumes`/`jobs` uncreated.)
+    const db = await getExistingDB();
+    expect(db.version).toBe(4);
+    expect([...db.objectStoreNames]).toContain("jobs");
+    expect([...db.objectStoreNames]).toContain("resumes");
+  });
+
+  it("reads a missing record as undefined on a never-visited profile, rather than throwing", async () => {
+    // The regression: `db.get` against a store the database does not have
+    // throws a synchronous NotFoundError instead of resolving to undefined.
+    await expect(getJobFromExisting("nope")).resolves.toBeUndefined();
+  });
+
+  it("captures a job on a never-visited profile", async () => {
+    // End to end through the capture door — the surface the hang this family
+    // exists to close sits on, and the one a first-time extension user hits
+    // before ever opening the app.
+    const result = await captureJobIntoExisting({
+      url: "https://boards.greenhouse.io/acme/jobs/1",
+      title: "Staff Engineer",
+      company: "Acme",
+      capturedAt: Date.now(),
+      source: "greenhouse",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("never triggers upgrade() even when its own DB_VERSION is behind", async () => {
+    // Simulates the actual hang scenario's *shape* (an already-open database
+    // at a version other than DB_VERSION) without fake-indexeddb's inability
+    // to model a real cross-connection `blocked` event: what matters is that
+    // getExistingDB's request against an EXISTING database carries no version
+    // at all, so it has nothing to negotiate and nothing to block on.
+    const legacy = await openLegacyV1();
+    expect(legacy.version).toBe(1);
+    legacy.close();
+
+    const contentScript = await getExistingDB();
+    expect(contentScript.version).toBe(1);
+    expect([...contentScript.objectStoreNames]).toEqual(["jobs"]);
+  });
+});
+
+/** A v1 database with a store — what an older app build left behind. Opened
+ *  directly rather than through `getDB()`, which would migrate it to 4. */
+function openLegacyV1(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore("jobs", { keyPath: "id" });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -16,7 +16,7 @@
  * is for structured/binary data only.
  */
 
-import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import { openDB, deleteDB, type DBSchema, type IDBPDatabase } from "idb";
 import type {
   ResumeRecord,
   JobRecord,
@@ -38,14 +38,14 @@ export const DB_NAME = "offlinecv";
  *  that read this constant would compare the code to itself and pass even if
  *  `upgrade()` never ran.
  *
- *  ⚠️ A bump is a BREAKING change for the browser extension, which builds this
- *  module from a pinned commit of this repo (`extension/offlinecv-pin.json`)
- *  and reaches `getDB()` from a content script in the app's own origin — so it
- *  carries whatever version the pin had. Once the app has upgraded a user's
- *  database, an extension built at the older pin opens it at the lower version
- *  and gets a `VersionError`, breaking its captures. Bump the pin in lockstep
- *  and rebuild it; this repo's CI never compiles the extension, so nothing else
- *  will catch it. */
+ *  ⚠️ When you bump this, bump `extension/offlinecv-pin.json` in lockstep and
+ *  rebuild the extension: this repo's CI never compiles it, so nothing else
+ *  will catch the drift. {@link getExistingDB} is the opener a content script
+ *  should use — it never requests a version, so it cannot hang waiting on a
+ *  stale, still-open app tab — but the extension's own barrel
+ *  (`extension/src/offlinecv-core.ts`) still imports the `getDB()`-backed
+ *  functions by relative path, so the pin is what keeps this constant and that
+ *  build in step. */
 const DB_VERSION = 4;
 
 /** Index name shared by every syncable store — one string so a range query and
@@ -61,6 +61,7 @@ interface OfflineCvDB extends DBSchema {
 }
 
 let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
+let existingDbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
 
 /** Open (once) and return the shared DB handle. Cached so concurrent callers
  *  share one connection. */
@@ -131,13 +132,83 @@ export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
   return dbPromise;
 }
 
-/** Close the open connection (if any) and drop the cached handle. Test-only
- *  seam — an open connection blocks `deleteDB`, so a suite that wipes the
- *  database between cases must close first, then reopen fresh. */
-export async function closeDB(): Promise<void> {
-  if (dbPromise !== null) {
-    const db = await dbPromise;
-    db.close();
-    dbPromise = null;
+/**
+ * Open the database AT WHATEVER VERSION IT ALREADY IS, requesting no upgrade.
+ *
+ * For a content script — the browser extension's bridge, injected into an
+ * already-open `offlinecv.org` tab — this repo's own page script is what owns
+ * this database's schema, and by the time a content script runs, that page has
+ * already opened it (and migrated it, if a migration was due) for this
+ * session. A content script that instead calls {@link getDB} asks for THIS
+ * repo's pinned `DB_VERSION`, which can be ahead of what the page's own
+ * (possibly older, un-reloaded) connection is holding open. IndexedDB then
+ * needs that older connection to close before the upgrade transaction the
+ * extension just requested can even start; if it does not close, the request
+ * never resolves — the content script hangs, silently, mid-capture, with
+ * nothing in the console to say why.
+ *
+ * `indexedDB.open(name)` with no version argument cannot trigger that: it
+ * attaches to the database's current version, whatever that is, and never
+ * asks for an upgrade.
+ *
+ * ## The one case a versionless open cannot serve, and why it falls back
+ *
+ * Called against a database that does not exist yet — a profile that has only
+ * ever used the extension, never the app itself, or one whose site data was
+ * cleared — a versionless open still CREATES one, at version 1 with none of
+ * `upgrade()`'s object stores, because IndexedDB has no "version 0" to open
+ * at. That handle is not a usable empty library: `db.get`/`db.put`/`db.getAll`
+ * against a store name the database does not have throw `NotFoundError`
+ * synchronously rather than answering `undefined`/`[]`, so a first capture on
+ * such a profile would throw instead of writing.
+ *
+ * So this opener detects that shape — a database with zero object stores, which
+ * only a versionless open of a nonexistent database can produce — and falls
+ * back to {@link getDB}, which creates the real schema. Falling back is safe
+ * here precisely because nothing exists yet: the hang this function avoids
+ * needs an OLDER connection to still be open, and there can be no connection
+ * to a database that was not there a moment ago.
+ *
+ * The stray v1 database is DELETED before the fallback rather than handed to
+ * `getDB()` to upgrade. `upgrade()`'s first block is guarded `oldVersion < 1`,
+ * so an open at v1 skips it and the `resumes`/`jobs` stores would never be
+ * created — the fallback would hand back a handle as unusable as the one it
+ * replaced. Deleting first makes `getDB()`'s open a true v0 → v4 migration.
+ * Nothing is lost: the database being deleted is the store-less one this call
+ * just created, and it can hold no records by construction.
+ */
+export function getExistingDB(): Promise<IDBPDatabase<OfflineCvDB>> {
+  if (existingDbPromise === null) {
+    existingDbPromise = openExisting();
   }
+  return existingDbPromise;
+}
+
+async function openExisting(): Promise<IDBPDatabase<OfflineCvDB>> {
+  const db = await openDB<OfflineCvDB>(DB_NAME);
+  if (db.objectStoreNames.length > 0) return db;
+  db.close();
+  await deleteDB(DB_NAME);
+  return getDB();
+}
+
+/** Close the open connection(s), if any, and drop the cached handle(s).
+ *  Test-only seam — an open connection blocks `deleteDB`, so a suite that
+ *  wipes the database between cases must close first, then reopen fresh.
+ *
+ *  Both handles are cleared BEFORE either is awaited, and awaited through
+ *  `allSettled`, so one rejected opener cannot strand the other's connection
+ *  open — which would defeat the one thing this function exists to guarantee.
+ *  A rejected promise has no connection to close, and a settled rejection is
+ *  the correct no-op for it. Note the two can resolve to the SAME handle when
+ *  {@link getExistingDB} fell back to {@link getDB}; `close()` is idempotent. */
+export async function closeDB(): Promise<void> {
+  const open = [dbPromise, existingDbPromise];
+  dbPromise = null;
+  existingDbPromise = null;
+  await Promise.allSettled(
+    open.map(async (pending) => {
+      (await pending)?.close();
+    }),
+  );
 }

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -9,7 +9,9 @@
 
 import {
   putRecord,
+  putRecordIntoExisting,
   getRecord,
+  getRecordFromExisting,
   getAllRecords,
   isLive,
   softDeleteRecord,
@@ -26,12 +28,34 @@ export async function saveJob(
   input: Partial<JobRecord> & { id?: string },
   options: { touch?: boolean } = {},
 ): Promise<JobRecord> {
+  return saveJobVia(putRecord, input, options);
+}
+
+/** Same as {@link saveJob}, opened via `getExistingDB()` instead (through
+ *  `putRecordIntoExisting`) — what `captureJob`'s `…IntoExisting` variant
+ *  calls, for a content-script consumer. */
+export async function saveJobIntoExisting(
+  input: Partial<JobRecord> & { id?: string },
+  options: { touch?: boolean } = {},
+): Promise<JobRecord> {
+  return saveJobVia(putRecordIntoExisting, input, options);
+}
+
+/** The body both `saveJob` twins share, parameterized on the writer. One copy,
+ *  so a later change to the id default or the write shape cannot reach one twin
+ *  and miss the other — the same `…Via` seam `captureJobVia` and
+ *  `putRecordVia` use. */
+async function saveJobVia(
+  put: typeof putRecord,
+  input: Partial<JobRecord> & { id?: string },
+  options: { touch?: boolean },
+): Promise<JobRecord> {
   // The store is intentionally permissive — it writes whatever fields the caller
   // supplies (the domain layer in `job-tracker.ts` owns completeness). Reads are
   // typed as a full `JobRecord` because every production write goes through the
   // domain layer with the required fields set; the cast bridges the permissive
   // write shape to `putRecord`'s complete-record parameter.
-  return putRecord<JobRecord>("jobs", {
+  return put<JobRecord>("jobs", {
     ...input,
     id: input.id ?? crypto.randomUUID(),
   } as Omit<JobRecord, "createdAt" | "updatedAt"> &
@@ -49,7 +73,26 @@ export async function saveJob(
  * needs and what the tracker must never have.
  */
 export async function getJob(id: string): Promise<JobRecord | undefined> {
-  const record = await getRecord<JobRecord>("jobs", id);
+  return getJobVia(getRecord, id);
+}
+
+/** Same as {@link getJob}, opened via `getExistingDB()` instead (through
+ *  `getRecordFromExisting`) — what `captureJob`'s `…IntoExisting` variant
+ *  calls, for a content-script consumer. */
+export async function getJobFromExisting(
+  id: string,
+): Promise<JobRecord | undefined> {
+  return getJobVia(getRecordFromExisting, id);
+}
+
+/** The liveness check both `getJob` twins share, parameterized on the reader —
+ *  one definition of "a tombstoned job reads as gone", so the tombstone
+ *  semantics {@link getJob}'s docblock states cannot drift between them. */
+async function getJobVia(
+  get: typeof getRecord,
+  id: string,
+): Promise<JobRecord | undefined> {
+  const record = await get<JobRecord>("jobs", id);
   return record !== undefined && isLive(record) ? record : undefined;
 }
 

--- a/src/lib/storage/resumes.ts
+++ b/src/lib/storage/resumes.ts
@@ -11,6 +11,7 @@ import {
   putRecord,
   getRecord,
   getAllRecords,
+  getAllRecordsFromExisting,
   deleteRecord,
 } from "./crud.ts";
 import type { ResumeRecord } from "./types.ts";
@@ -43,6 +44,15 @@ export function getAllResumes(): Promise<ResumeRecord[]> {
   return getAllRecords<ResumeRecord>("resumes");
 }
 
+/** Same as {@link getAllResumes}, opened via `getExistingDB()` instead — what
+ *  {@link listResumeChoicesFromExisting} calls, for the browser extension's
+ *  content script. Private: unlike `getAllResumes` it has no consumer outside
+ *  this file, and exporting it would put a whole résumé corpus (blobs included)
+ *  on a surface only the narrow `ResumeChoice` projection is meant to reach. */
+function getAllResumesFromExisting(): Promise<ResumeRecord[]> {
+  return getAllRecordsFromExisting<ResumeRecord>("resumes");
+}
+
 export function deleteResume(id: string): Promise<void> {
   return deleteRecord("resumes", id);
 }
@@ -63,7 +73,20 @@ export interface ResumeChoice {
  *  the narrow, cross-origin-safe answer: id, filename, and a timestamp, and
  *  nothing that touches the resume corpus. */
 export async function listResumeChoices(): Promise<ResumeChoice[]> {
-  const records = await getAllResumes();
+  return listResumeChoicesVia(getAllResumes);
+}
+
+/** Same as {@link listResumeChoices}, opened via `getExistingDB()` instead —
+ *  the variant `@offlinecv/core` re-exports as `listResumeChoices` to a
+ *  content-script consumer; see `db.ts`'s `getExistingDB` docblock for why. */
+export async function listResumeChoicesFromExisting(): Promise<ResumeChoice[]> {
+  return listResumeChoicesVia(getAllResumesFromExisting);
+}
+
+async function listResumeChoicesVia(
+  getAll: typeof getAllResumes,
+): Promise<ResumeChoice[]> {
+  const records = await getAll();
   return records
     .map((r) => ({ id: r.id, filename: r.filename, updatedAt: r.updatedAt }))
     .sort((a, b) => b.updatedAt - a.updatedAt);

--- a/src/lib/storage/sync-cursor.ts
+++ b/src/lib/storage/sync-cursor.ts
@@ -25,7 +25,7 @@
  * lives anywhere else is a second definition of the record shape.
  */
 
-import { getDB } from "./db.ts";
+import { getDB, getExistingDB } from "./db.ts";
 import type { SyncableStoreName, SyncCursorRecord } from "./types.ts";
 
 /**
@@ -40,6 +40,16 @@ export async function getSyncCursor(
   store: SyncableStoreName,
 ): Promise<SyncCursorRecord | undefined> {
   const db = await getDB();
+  return db.get("sync", store);
+}
+
+/** Same as {@link getSyncCursor}, opened via {@link getExistingDB} instead —
+ *  the variant `@offlinecv/core` re-exports as `getSyncCursor` to a
+ *  content-script consumer; see that function's docblock for why. */
+export async function getSyncCursorFromExisting(
+  store: SyncableStoreName,
+): Promise<SyncCursorRecord | undefined> {
+  const db = await getExistingDB();
   return db.get("sync", store);
 }
 
@@ -60,7 +70,25 @@ export async function setSyncCursor(
   store: SyncableStoreName,
   patch: Omit<Partial<SyncCursorRecord>, "id">,
 ): Promise<SyncCursorRecord> {
-  const db = await getDB();
+  return setSyncCursorVia(getDB, store, patch);
+}
+
+/** Same as {@link setSyncCursor}, opened via {@link getExistingDB} instead —
+ *  the variant `@offlinecv/core` re-exports as `setSyncCursor` to a
+ *  content-script consumer; see that function's docblock for why. */
+export async function setSyncCursorIntoExisting(
+  store: SyncableStoreName,
+  patch: Omit<Partial<SyncCursorRecord>, "id">,
+): Promise<SyncCursorRecord> {
+  return setSyncCursorVia(getExistingDB, store, patch);
+}
+
+async function setSyncCursorVia(
+  opener: typeof getDB | typeof getExistingDB,
+  store: SyncableStoreName,
+  patch: Omit<Partial<SyncCursorRecord>, "id">,
+): Promise<SyncCursorRecord> {
+  const db = await opener();
   const existing = await db.get("sync", store);
   const written: SyncCursorRecord = { ...existing, ...patch, id: store };
   await db.put("sync", written);


### PR DESCRIPTION
## Summary

- `getDB()` opens at this repo's own `DB_VERSION` and requests an upgrade if the stored database is behind — correct for the app (which owns the schema), wrong for the extension's content script, which can carry a pin ahead of a stale, still-open `offlinecv.org` tab and hang IndexedDB's upgrade transaction waiting for that tab's connection to close.
- Adds `getExistingDB()` (versionless open, never triggers an upgrade) plus a parallel `…FromExisting`/`…IntoExisting` sibling for every content-script-reachable function: `getRecord`/`putRecord`/`deleteRecord`/`listRecordsUpdatedSince` (crud.ts), `getSyncCursor`/`setSyncCursor` (sync-cursor.ts), `getJob`/`saveJob` (jobs.ts), `captureJob` (capture.ts — the capture door), `getAllResumes`/`listResumeChoices` (resumes.ts). Each shares its original's logic through a small private `…Via` core parameterized on the opener, rather than duplicating it.
- `getDB()` and the app's own call sites are untouched.
- `getExistingDB()` falls back to `getDB()` when no database exists yet. A versionless open of a nonexistent database creates an empty v1 with **zero object stores**, and every read/write against it throws `NotFoundError` — so the fallback deletes that stray v1 and reopens through the versioned opener. (Deleting matters: `upgrade()`'s first block is guarded `oldVersion < 1`, so upgrading the stray v1 in place would skip it and leave `resumes`/`jobs` uncreated.) There is no hang risk in that branch — the hang needs an older connection still open, and nothing can be holding one to a database that did not exist.
- `packages/core`'s barrel re-exports the `…Existing` variant under the original public name, so a consumer of `@offlinecv/core` is rebound without changing its own import list.

## Scope — what this does NOT reach

**The extension in `extension/` is not fixed by this PR.** That checkout (`116-Ideas/recruidea-extension`, pinned by `extension/offlinecv-pin.json`) predates `@offlinecv/core` and does not import it: its own barrel, `extension/src/offlinecv-core.ts`, re-exports `captureJob`/`getRecord`/`putRecord`/`deleteRecord`/`listRecordsUpdatedSince`/`getSyncCursor`/`setSyncCursor`/`listResumeChoices` **directly from `../../src/lib/storage/*.ts` by relative path**, so it still binds the `getDB()`-backed originals and is still exposed to the hang. Repointing that barrel at the `…Existing` variants is a change in the extension's own repo and cannot be made from here; this PR builds the variants it needs and says so in the docblocks rather than claiming coverage it does not have.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npx vitest run src/lib/storage/` — 277/277 passing, including new `db.test.ts`
- [x] `npx eslint` on every touched file — clean
- [x] `npm run check:core` — barrel still packages/resolves correctly with the renamed re-exports
- [x] Falsified `db.test.ts`: reverted `getExistingDB` to the bare versionless open, confirmed 3 of 5 tests fail (`NotFoundError: No objectStore named jobs in this database`), restored — the tests actually catch the regression they are named for
- [x] `npx fallow audit --base origin/main` — clean
- [x] `npm run test` — 5978 passing, 10 skipped
