### PR TITLE
feat(export): pre-download validation pass for glyph loss and bullet-page splits (#621)

### DIFF
--- a/src/components/features/ExportDialog.test.tsx
+++ b/src/components/features/ExportDialog.test.tsx
@@ -25,6 +25,7 @@ import { createRoot, type Root } from "react-dom/client";
 import type { CascadeResult } from "../../lib/heuristics/types.ts";
 import type { AnonymousAtsScore } from "../../lib/score/score.ts";
 import type { ContactOverrides } from "../../hooks/useEditableParse.ts";
+import type { RenderFinding } from "../../lib/pdf/render-findings.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -33,6 +34,9 @@ const pdfDownload = vi.fn();
 const markdownDownload = vi.fn();
 const reportDownload = vi.fn(() => Promise.resolve(true));
 let pdfError: string | null = null;
+/** #621 export findings the PDF row surfaces — empty for a clean export, which
+ *  is what every case here renders unless it says otherwise. */
+let pdfFindings: RenderFinding[] = [];
 
 /** What each hook was handed as its journey Download-stage mark site (#826).
  *  The success point lives inside the hooks, so what this component owns — and
@@ -46,7 +50,12 @@ vi.mock("../../hooks/useDownloadPdf.ts", () => ({
     onDownloaded?: () => void,
   ) => {
     captured.pdf = onDownloaded;
-    return { download: pdfDownload, isGenerating: false, error: pdfError };
+    return {
+      download: pdfDownload,
+      isGenerating: false,
+      error: pdfError,
+      findings: pdfFindings,
+    };
   },
 }));
 vi.mock("../../hooks/useDownloadMarkdown.ts", () => ({
@@ -154,6 +163,7 @@ beforeEach(() => {
   markdownDownload.mockClear();
   reportDownload.mockClear();
   pdfError = null;
+  pdfFindings = [];
   // jsdom does not implement modal dialogs in every version, and the primitive
   // calls `showModal()` from an effect. Stubbed to a plain open so the tests
   // exercise the dialog's CONTENT rather than the UA's modality.
@@ -420,5 +430,47 @@ describe("ExportDialog", () => {
       captured[key]?.();
     }
     expect(onExported).toHaveBeenCalledTimes(3);
+  });
+
+  // #621 — the export reports what it could not render cleanly, on the row that
+  // produced the file. Advisory: the user already has the PDF.
+  describe("export findings", () => {
+    it("renders NO warning chrome when the export was clean", () => {
+      // The common case. A permanent "0 issues" strip on the download row would
+      // train every user to stop reading it.
+      const el = render(exportable());
+      expect(text(el)).not.toContain("Check the export");
+      expect(el.querySelector("[aria-live]:not([aria-live=\"off\"]) ul")).toBeNull();
+    });
+
+    it("names the field and states what happened, never colour alone", () => {
+      pdfFindings = [
+        {
+          kind: "glyph-degraded",
+          severity: "warning",
+          sourceField: "Experience \u2192 Staff Engineer \u00b7 Acme \u2192 bullet 3",
+          detail: 'The export font has no glyph for "\u2605", so it was drawn as "?".',
+        },
+      ];
+      const el = render(exportable());
+      // The badge carries a WORD, not just a tone.
+      expect(text(el)).toContain("Check the export");
+      expect(text(el)).toContain("Experience \u2192 Staff Engineer \u00b7 Acme \u2192 bullet 3");
+      expect(text(el)).toContain("\u2605");
+      // And it says the file arrived — a finding is not a refusal.
+      expect(text(el)).toContain("Your PDF downloaded");
+    });
+
+    it("counts the overflow instead of listing forty rows", () => {
+      pdfFindings = Array.from({ length: 8 }, (_, i) => ({
+        kind: "glyph-degraded" as const,
+        severity: "info" as const,
+        sourceField: `Experience \u2192 Role ${i + 1}`,
+        detail: 'The export font has no glyph for "\u2192", so it was drawn as "->".',
+      }));
+      const el = render(exportable());
+      expect(el.querySelectorAll("li")).toHaveLength(5);
+      expect(text(el)).toContain("and 3 more");
+    });
   });
 });

--- a/src/components/features/ExportDialog.tsx
+++ b/src/components/features/ExportDialog.tsx
@@ -73,6 +73,7 @@ import {
 } from "../../lib/contact.ts";
 import { ExportGateBody, fixFirstGap } from "./ExportGateBody.tsx";
 import { ExportRow, ExportReportRow } from "./ExportRows.tsx";
+import { ExportFindings } from "./ExportFindings.tsx";
 import { useDownloadPdf } from "../../hooks/useDownloadPdf.ts";
 import { useDownloadMarkdown } from "../../hooks/useDownloadMarkdown.ts";
 import { useDownloadReport } from "../../hooks/useDownloadReport.ts";
@@ -198,6 +199,11 @@ export function ExportDialog({
             >
               {pdf.isGenerating ? "Generating…" : "Download PDF"}
             </Button>
+            {/* What the export could not draw cleanly (#621) — advisory, and
+                renders NOTHING for the clean résumé that is the common case.
+                It sits on the row that produced the file, beside the row's own
+                `ErrorState`, because that is the surface already mounted. */}
+            <ExportFindings findings={pdf.findings} />
           </ExportRow>
 
           <ExportRow

--- a/src/components/features/ExportFindings.tsx
+++ b/src/components/features/ExportFindings.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ExportFindings — what the exporter could not render cleanly, shown on the row
+ * that produced the file (#621).
+ *
+ * Reuse analysis (CLAUDE.md Golden Rule). This is NOT a new banner primitive.
+ * The design-system barrel deliberately ships no Toast/Snackbar, and its house
+ * pattern for "an action finished and has something to say" is to confirm IN the
+ * surface already mounted rather than open a new one — so this swaps content
+ * into `ExportRow`, beside the `ErrorState` that already reports a failed
+ * export, and carries its status on the shared `StatusBadge`. Nothing new is
+ * added to the design system.
+ *
+ * Three rules it exists to keep:
+ *
+ *  1. **Zero findings renders NOTHING.** Not an empty "0 issues" panel, not a
+ *     green all-clear. Most résumés are clean, and a permanent status strip on
+ *     the download row would teach every user to stop reading it.
+ *  2. **Never colour alone.** The badge carries the WORD, the sentence states
+ *     the count, and every finding names its own field — the tone is
+ *     reinforcement.
+ *  3. **Advisory, never a blocker.** The user already has their PDF by the time
+ *     this renders; the copy says so. Refusing a download is `useDownloadPdf`'s
+ *     #664 font gate and stays there.
+ *
+ * `aria-live="polite"` announces the swap. The parent format list is itself a
+ * polite live region, so the announcement would happen regardless; declaring it
+ * here keeps the guarantee attached to the component that needs it rather than
+ * to a container that could be restructured.
+ */
+
+import { StatusBadge } from "@design-system";
+import type { RenderFinding } from "../../lib/pdf/render-findings.ts";
+
+/**
+ * How many findings are listed before the rest are counted. A résumé pasted from
+ * a source full of arrows can produce one finding per bullet; forty rows in a
+ * dialog is a wall, and the first few already say what kind of thing is wrong
+ * and where to start.
+ */
+const MAX_LISTED = 5;
+
+export function ExportFindings({
+  findings,
+}: {
+  findings: readonly RenderFinding[];
+}) {
+  if (findings.length === 0) return null;
+  const listed = findings.slice(0, MAX_LISTED);
+  const rest = findings.length - listed.length;
+  // `warning` when anything was actually destroyed; `info` when every finding is
+  // a substitution that still reads correctly (an arrow drawn as "->").
+  const tone = findings.some((f) => f.severity === "warning") ? "warning" : "info";
+
+  return (
+    <div aria-live="polite" className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusBadge tone={tone}>Check the export</StatusBadge>
+        <p className="text-sm text-content-secondary">
+          Your PDF downloaded, but{" "}
+          {findings.length === 1
+            ? "one thing"
+            : `${findings.length} things`}{" "}
+          did not come out as written.
+        </p>
+      </div>
+      <ul className="flex flex-col gap-1">
+        {listed.map((finding, idx) => (
+          <li
+            key={`${finding.kind}:${finding.sourceField}:${finding.detail}:${idx}`}
+            className="text-sm text-content-tertiary"
+          >
+            <span className="font-medium text-content-secondary">
+              {finding.sourceField}
+            </span>{" "}
+            — {finding.detail}
+          </li>
+        ))}
+      </ul>
+      {rest > 0 && (
+        <p className="text-sm text-content-tertiary">
+          …and {rest} more like {rest === 1 ? "this" : "these"}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDownloadPdf.ts
+++ b/src/hooks/useDownloadPdf.ts
@@ -17,6 +17,11 @@
  * résumé bytes leave the browser, which is the actual guarantee. Say custody,
  * not runtime.
  *
+ * It also carries the export's own findings (#621) — what the renderer could
+ * not draw cleanly — back to the surface. Those are ADVISORY and arrive only
+ * after the bytes have reached the user: the refusal below is the one thing that
+ * stops a download, and reporting must never grow into a second one.
+ *
  * This hook owns the refusal for #664. When the Poppins fetch fails, the
  * renderer falls back to Helvetica, whose WinAnsi codec replaces anything
  * outside it with `?` — including a candidate's own name. Rather than hand back
@@ -37,6 +42,7 @@ import {
   renderAtsResumePdf,
   type ExportGlyphLoss,
 } from "../lib/pdf/render-ats-pdf.ts";
+import type { RenderFinding } from "../lib/pdf/render-findings.ts";
 import { slugifyName, triggerBlobDownload } from "../lib/download/blob-download.ts";
 import { trackDownloadCompleted, type DownloadSource } from "../lib/analytics.ts";
 import { clearBlankDraft } from "./useResumeAnalysis.ts";
@@ -45,6 +51,13 @@ export interface UseDownloadPdf {
   download: () => Promise<void>;
   isGenerating: boolean;
   error: string | null;
+  /**
+   * What the LAST completed render could not draw cleanly (#621) — empty until a
+   * download has run, and empty again the moment the next one starts, so the
+   * surface can never show findings that belong to a résumé the user has since
+   * edited. Advisory only: the download already happened.
+   */
+  findings: RenderFinding[];
 }
 
 /** Turn a candidate name into a safe, lower-kebab PDF filename. */
@@ -87,10 +100,14 @@ export function useDownloadPdf(
 ): UseDownloadPdf {
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [findings, setFindings] = useState<RenderFinding[]>([]);
 
   const download = useCallback(async () => {
     setIsGenerating(true);
     setError(null);
+    // Cleared up front, alongside `error`, for the same reason: a stale report
+    // about the PREVIOUS export would read as a verdict on this one.
+    setFindings([]);
     try {
       const model = buildAtsResumeModel(result, score);
 
@@ -105,7 +122,7 @@ export function useDownloadPdf(
         return;
       }
 
-      const bytes = await renderAtsResumePdf(model);
+      const { bytes, findings: rendered } = await renderAtsResumePdf(model);
       // `bytes.slice()` copies into a fresh ArrayBuffer-backed view so Blob gets
       // a clean buffer.
       triggerBlobDownload(
@@ -113,6 +130,9 @@ export function useDownloadPdf(
         "application/pdf",
         filenameFromName(model.contact.name),
       );
+      // AFTER the download, never before: a finding is a report on the file the
+      // user now has, not a gate in front of it (#621).
+      setFindings(rendered);
 
       // Distinguish a from-scratch authored download from an uploaded one
       // (#313). `tiers` is empty ONLY for `buildBlankResult()`'s output —
@@ -137,5 +157,5 @@ export function useDownloadPdf(
     // is keyed to the résumé that was on screen then.
   }, [result, score, onDownloaded]);
 
-  return { download, isGenerating, error };
+  return { download, isGenerating, error, findings };
 }

--- a/src/lib/edit/description-override-roundtrip.repro.test.ts
+++ b/src/lib/edit/description-override-roundtrip.repro.test.ts
@@ -114,7 +114,7 @@ describe("descriptionOverrides edit-leg round-trip (#489)", { timeout: 20000 }, 
       display,
       scoreEditedResume(applied, p1.triggers, []),
     );
-    const p3 = await runCascade(await renderAtsResumePdf(model));
+    const p3 = await runCascade((await renderAtsResumePdf(model)).bytes);
 
     const p3Text = JSON.stringify(p3.canonical.fields);
     expect(p3Text.includes(NEW_DESCRIPTION)).toBe(true);

--- a/src/lib/heuristics/corpus-edit-roundtrip.test.ts
+++ b/src/lib/heuristics/corpus-edit-roundtrip.test.ts
@@ -543,7 +543,7 @@ async function editRoundtrip(
       display,
       scoreEditedResume(applied, p1.triggers, Object.keys(edits.bullets)),
     );
-    return { p3: await runCascade(await renderAtsResumePdf(model)) };
+    return { p3: await runCascade((await renderAtsResumePdf(model)).bytes) };
   } catch (err) {
     return { renderError: `export/re-parse threw: ${(err as Error).message}` };
   }

--- a/src/lib/heuristics/multi-experience-roundtrip.test.ts
+++ b/src/lib/heuristics/multi-experience-roundtrip.test.ts
@@ -97,7 +97,7 @@ describe("#311 multiple experience sections — parse + round-trip", { timeout: 
     const bytes = await fsp.readFile(FIXTURE);
     const parse1 = await runCascade(new Uint8Array(bytes));
     const model = buildAtsResumeModel(parse1, scoreOf(parse1));
-    const exportedBytes = await renderAtsResumePdf(model);
+    const { bytes: exportedBytes } = await renderAtsResumePdf(model);
     const parse3 = await runCascade(new Uint8Array(exportedBytes));
 
     // Two distinct experience-category groups on the way IN. (The export

--- a/src/lib/heuristics/roundtrip-hop.ts
+++ b/src/lib/heuristics/roundtrip-hop.ts
@@ -78,7 +78,7 @@ export async function runRoundtripHop(
     layer = HOP_LAYERS[1];
     const model = buildAtsResumeModel(before, score);
     layer = HOP_LAYERS[2];
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     layer = HOP_LAYERS[3];
     return { after: await runCascade(bytes) };
   } catch (err) {

--- a/src/lib/pdf/export-layout-contract.test.ts
+++ b/src/lib/pdf/export-layout-contract.test.ts
@@ -185,7 +185,7 @@ async function drawnLines(
   build: ModelBuilder,
   filler: number,
 ): Promise<PdfDrawnLine[]> {
-  return extractPdfDrawnLines(await renderAtsResumePdf(build(filler)));
+  return extractPdfDrawnLines((await renderAtsResumePdf(build(filler))).bytes);
 }
 
 /** Index of the single drawn line containing `token` (fails if 0 or 2+ match). */
@@ -766,7 +766,7 @@ describe("export layout contract — keep-with-next pagination (#629)", () => {
         },
       ],
     };
-    const lines = await extractPdfDrawnLines(await renderAtsResumePdf(model));
+    const lines = await extractPdfDrawnLines((await renderAtsResumePdf(model)).bytes);
     const pages = Math.max(...lines.map((l) => l.page));
     const densest = Math.max(
       ...Array.from({ length: pages }, (_, i) => linesOnPage(lines, i + 1)),
@@ -827,7 +827,7 @@ describe("export layout contract — the Summary body honours widow control", ()
    *  {@link bulletLinesPerPage} returns, so a `1` is the widow. */
   async function summaryLinesPerPage(words: number): Promise<number[]> {
     const lines = await extractPdfDrawnLines(
-      await renderAtsResumePdf(summaryModel(words)),
+      (await renderAtsResumePdf(summaryModel(words))).bytes,
     );
     const perPage = new Map<number, number>();
     for (const line of lines) {

--- a/src/lib/pdf/render-ats-pdf.flush-right-links.test.ts
+++ b/src/lib/pdf/render-ats-pdf.flush-right-links.test.ts
@@ -90,7 +90,7 @@ const MODEL: AtsResumeModel = {
 
 describe("renderAtsResumePdf — flush-right dates + link annotations (#425)", () => {
   it("draws the entry date flush-right against the content margin", async () => {
-    const { items } = await inspect(await renderAtsResumePdf(MODEL));
+    const { items } = await inspect((await renderAtsResumePdf(MODEL)).bytes);
     // A year token from the date range, on the right side of the page.
     const dateItems = items.filter((i) => /20(20|23)/.test(i.str) && i.x > 300);
     expect(dateItems.length).toBeGreaterThan(0);
@@ -105,7 +105,7 @@ describe("renderAtsResumePdf — flush-right dates + link annotations (#425)", (
   });
 
   it("registers clickable URI link annotations for the contact links", async () => {
-    const { links } = await inspect(await renderAtsResumePdf(MODEL));
+    const { links } = await inspect((await renderAtsResumePdf(MODEL)).bytes);
     expect(links).toContain("https://linkedin.com/in/jane");
     expect(links).toContain("https://github.com/jane");
     expect(links).toContain("mailto:jane@example.com");
@@ -125,7 +125,7 @@ describe("renderAtsResumePdf — flush-right dates + link annotations (#425)", (
       },
       sections: [],
     };
-    const { annots } = await inspect(await renderAtsResumePdf(model));
+    const { annots } = await inspect((await renderAtsResumePdf(model)).bytes);
     const email = annots.find((a) => a.url === "mailto:jane@example.com");
     const site = annots.find((a) => a.url.startsWith("https://example.com"));
     expect(email).toBeDefined();
@@ -148,7 +148,7 @@ describe("renderAtsResumePdf — flush-right dates + link annotations (#425)", (
     };
     // pdfjs may normalize a bare-host URL with a trailing slash, so match on the
     // scheme+host rather than an exact string.
-    const { links } = await inspect(await renderAtsResumePdf(model));
+    const { links } = await inspect((await renderAtsResumePdf(model)).bytes);
     expect(links.some((u) => u.startsWith("https://www.jane.dev"))).toBe(true);
     expect(links.some((u) => u.startsWith("http://portfolio.example"))).toBe(true);
     // The naive display-rebuilt targets (www dropped, forced https) must NOT appear.

--- a/src/lib/pdf/render-ats-pdf.fonts.test.ts
+++ b/src/lib/pdf/render-ats-pdf.fonts.test.ts
@@ -123,7 +123,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
     vi.resetModules();
     const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-    const bytes = await renderAtsResumePdf(model("Poppins embed check"));
+    const { bytes } = await renderAtsResumePdf(model("Poppins embed check"));
     expect(fetchMock).toHaveBeenCalled();
     await expect(hasEmbeddedFontFile2(bytes)).resolves.toBe(true);
   });
@@ -133,7 +133,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
     vi.resetModules();
     const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-    const bytes = await renderAtsResumePdf(model("fallback check"));
+    const { bytes } = await renderAtsResumePdf(model("fallback check"));
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBeGreaterThan(500);
     await expect(hasEmbeddedFontFile2(bytes)).resolves.toBe(false);
@@ -146,7 +146,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
     const { renderAtsResumePdf: renderEmbedded } = await import(
       "./render-ats-pdf.ts"
     );
-    const embeddedBytes = await renderEmbedded(model("Łukasz, Wrocław"));
+    const { bytes: embeddedBytes } = await renderEmbedded(model("Łukasz, Wrocław"));
     const embeddedText = await extractPdfText(embeddedBytes);
     expect(embeddedText).toContain("ł");
 
@@ -157,7 +157,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
     const { renderAtsResumePdf: renderFallback } = await import(
       "./render-ats-pdf.ts"
     );
-    const fallbackBytes = await renderFallback(model("Łukasz, Wrocław"));
+    const { bytes: fallbackBytes } = await renderFallback(model("Łukasz, Wrocław"));
     const fallbackText = await extractPdfText(fallbackBytes);
     expect(fallbackText).not.toContain("ł");
     expect(fallbackText).toContain("?");
@@ -186,7 +186,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
         vi.resetModules();
         const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-        const bytes = await renderAtsResumePdf(model(`Alpha ${ch} Omega`));
+        const { bytes } = await renderAtsResumePdf(model(`Alpha ${ch} Omega`));
         const text = await extractPdfText(bytes);
 
         // The defect, stated directly.
@@ -209,7 +209,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
       vi.resetModules();
       const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-      const bytes = await renderAtsResumePdf(model("Łukasz → Wrocław"));
+      const { bytes } = await renderAtsResumePdf(model("Łukasz → Wrocław"));
       const text = await extractPdfText(bytes);
 
       await expect(hasEmbeddedFontFile2(bytes)).resolves.toBe(true);
@@ -238,7 +238,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
         vi.resetModules();
         const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-        const bytes = await renderAtsResumePdf(model("Alpha \0 Omega"));
+        const { bytes } = await renderAtsResumePdf(model("Alpha \0 Omega"));
         const text = await extractPdfText(bytes);
 
         expect(text).not.toContain("\0");
@@ -259,7 +259,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
       vi.resetModules();
       const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-      const bytes = await renderAtsResumePdf({
+      const { bytes } = await renderAtsResumePdf({
         contact: { name: "Jane Candidate", links: [] },
         sections: [
           {
@@ -289,7 +289,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
       vi.resetModules();
       const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-      const bytes = await renderAtsResumePdf(model("http error check"));
+      const { bytes } = await renderAtsResumePdf(model("http error check"));
 
       expect(fetchMock).toHaveBeenCalled();
       // The load bailed on the status. Without the check we would have read the
@@ -310,7 +310,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
       vi.resetModules();
       const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
 
-      const first = await renderAtsResumePdf(model("attempt one"));
+      const { bytes: first } = await renderAtsResumePdf(model("attempt one"));
       await expect(hasEmbeddedFontFile2(first)).resolves.toBe(false);
       const callsWhileFailing = failing.mock.calls.length;
       expect(callsWhileFailing).toBeGreaterThan(0);
@@ -319,7 +319,7 @@ describe("Poppins font embed (#314)", { timeout: 20000 }, () => {
       // point. The same module instance, with its cache already poisoned by the
       // failure above, must issue a fresh request.
       const recovered = stubFetchSucceeds();
-      const second = await renderAtsResumePdf(model("attempt two"));
+      const { bytes: second } = await renderAtsResumePdf(model("attempt two"));
 
       expect(recovered).toHaveBeenCalled();
       await expect(hasEmbeddedFontFile2(second)).resolves.toBe(true);

--- a/src/lib/pdf/render-ats-pdf.test.ts
+++ b/src/lib/pdf/render-ats-pdf.test.ts
@@ -45,14 +45,14 @@ const MODEL: AtsResumeModel = {
 
 describe("renderAtsResumePdf", () => {
   it("returns a non-trivial PDF with the %PDF magic header", async () => {
-    const bytes = await renderAtsResumePdf(MODEL);
+    const { bytes } = await renderAtsResumePdf(MODEL);
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBeGreaterThan(500);
     expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-");
   });
 
   it("produces selectable, searchable text (AC#3) for name + headings", async () => {
-    const bytes = await renderAtsResumePdf(MODEL);
+    const { bytes } = await renderAtsResumePdf(MODEL);
     const text = await extractPdfText(bytes);
     expect(text).toContain("Jane Candidate");
     expect(text).toMatch(/EXPERIENCE/i);
@@ -74,7 +74,7 @@ describe("renderAtsResumePdf", () => {
       contact: { name: "Jane Candidate", links: [] },
       sections: [{ heading: "Experience", entries: manyEntries }],
     };
-    const bytes = await renderAtsResumePdf(bigModel);
+    const { bytes } = await renderAtsResumePdf(bigModel);
     const pdfjs = await import("pdfjs-dist");
     const doc = await pdfjs.getDocument({
       data: bytes.slice(),
@@ -111,7 +111,7 @@ describe("renderAtsResumePdf", () => {
       ],
     };
 
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     const pdfjs = await import("pdfjs-dist");
     const doc = await pdfjs.getDocument({
       data: bytes.slice(),
@@ -171,7 +171,7 @@ describe("renderAtsResumePdf", () => {
       ],
     };
 
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     const pdfjs = await import("pdfjs-dist");
     const doc = await pdfjs.getDocument({
       data: bytes.slice(),
@@ -229,9 +229,8 @@ describe("renderAtsResumePdf", () => {
     ];
 
     it.each(crashingGlyphs)("does not throw on %s", async (_label, text) => {
-      await expect(renderAtsResumePdf(glyphModel(text))).resolves.toBeInstanceOf(
-        Uint8Array,
-      );
+      const { bytes } = await renderAtsResumePdf(glyphModel(text));
+      expect(bytes).toBeInstanceOf(Uint8Array);
     });
 
     // #298 review — a section heading is drawn with `uppercase: true`, and
@@ -257,9 +256,8 @@ describe("renderAtsResumePdf", () => {
     it.each(caseExpandingHeadings)(
       "does not throw on an uppercased heading with %s",
       async (_label, heading) => {
-        await expect(
-          renderAtsResumePdf(headingModel(heading)),
-        ).resolves.toBeInstanceOf(Uint8Array);
+        const { bytes } = await renderAtsResumePdf(headingModel(heading));
+        expect(bytes).toBeInstanceOf(Uint8Array);
       },
     );
 
@@ -281,9 +279,8 @@ describe("renderAtsResumePdf", () => {
         0x2600, 0x4e2d, 0xfb01, 0x1f680,
       ];
       const text = codePoints.map((cp) => String.fromCodePoint(cp)).join(" X ");
-      await expect(renderAtsResumePdf(glyphModel(text))).resolves.toBeInstanceOf(
-        Uint8Array,
-      );
+      const { bytes } = await renderAtsResumePdf(glyphModel(text));
+      expect(bytes).toBeInstanceOf(Uint8Array);
     });
   });
 
@@ -383,7 +380,7 @@ describe("#425 render — headline + metric bold", () => {
       },
       sections: [],
     };
-    const text = await extractPdfText(await renderAtsResumePdf(model));
+    const text = await extractPdfText((await renderAtsResumePdf(model)).bytes);
     expect(text).toContain("Jane Candidate");
     expect(text).toContain("Engineering Lead");
   });
@@ -404,7 +401,7 @@ describe("#425 render — headline + metric bold", () => {
         },
       ],
     };
-    const text = await extractPdfText(await renderAtsResumePdf(model));
+    const text = await extractPdfText((await renderAtsResumePdf(model)).bytes);
     // The emphasis markers are stripped before drawing, so no `*` reaches the
     // page — the visible text is the un-emphasized bullet (round-trip guard).
     // `extractPdfText` emits each drawn run as a separate token, so assert the
@@ -434,7 +431,7 @@ describe("#425 render — headline + metric bold", () => {
         },
       ],
     };
-    const text = await extractPdfText(await renderAtsResumePdf(model));
+    const text = await extractPdfText((await renderAtsResumePdf(model)).bytes);
     expect(text).not.toContain(EMPHASIS_OPEN);
     expect(text).not.toContain(EMPHASIS_CLOSE);
     for (const token of ["Patent", "US10275736B1", "editor", "2019"])

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -61,6 +61,14 @@
  * estimated. This is manual pdf-lib layout, not an HTML/Chromium print path —
  * CSS `break-after: avoid` / `orphans` / `widows` do not apply here.
  *
+ * The engine also REPORTS what it could not render cleanly (#621): it returns
+ * `{ bytes, findings }`, where a finding names a character the export font had
+ * no glyph for, or a bullet a page break fell inside. Both are observations of
+ * decisions the draw pass makes anyway — the font-matched sanitizer, and the
+ * `ensure` that moved the cursor to a new page — so `bytes` is unchanged by
+ * their presence. The shape lives in `render-findings.ts`; see there for why a
+ * finding is advisory, never a refusal and never a score input.
+ *
  * The `rgb()` colors here are PDF graphics-state values (black text, a muted
  * gray rule) — NOT Tailwind tokens. The style guard scans component/feature
  * code, not this draw module.
@@ -75,6 +83,14 @@ import {
 } from "./auto-bold-metrics.ts";
 import { toJsonResume } from "./to-json-resume.ts";
 import { wrapWordsToLines } from "./text-wrap.ts";
+import {
+  bulletSplitFinding,
+  collectModelTextFields,
+  entryPathLabel,
+  findGlyphFindings,
+  type BulletSplit,
+  type RenderFinding,
+} from "./render-findings.ts";
 import poppinsRegularUrl from "../../assets/fonts/Poppins-Regular.ttf?url";
 import poppinsBoldUrl from "../../assets/fonts/Poppins-Bold.ttf?url";
 
@@ -460,11 +476,13 @@ export interface ExportGlyphLoss {
  *
  *  1. **It lives here, not in `renderAtsResumePdf`.** An earlier design gave the
  *     renderer a policy parameter so the browser could ask to refuse while the
- *     corpus harness asked to degrade. `renderAtsResumePdf` has ~35 call sites,
- *     all typed `Promise<Uint8Array>` — every round-trip, export-layout and
- *     repro test in the repo. A separate probe leaves all of them untouched, and
- *     leaves the corpus round-trip oracle (which needs a rendered PDF, degraded
- *     or not) working by construction rather than by opt-out.
+ *     corpus harness asked to degrade. A separate probe leaves the renderer's
+ *     ~35 call sites — every round-trip, export-layout and repro test in the
+ *     repo — free to keep rendering, and leaves the corpus round-trip oracle
+ *     (which needs a rendered PDF, degraded or not) working by construction
+ *     rather than by opt-out. The renderer now REPORTS what it degraded (#621),
+ *     which is the complement of this, not a replacement: reporting never
+ *     refuses.
  *  2. **Empty when the embedded font loads.** It shares the memoized
  *     {@link loadPoppinsBytes}, so the probe and the subsequent render make one
  *     fetch attempt between them, not two. On the failure path the memo is
@@ -478,11 +496,19 @@ export interface ExportGlyphLoss {
  *
  * Deliberate limit: this covers the **fallback** path only. On the embedded path
  * `toEmbeddedFontSafe` can still emit `?` for a code point Poppins lacks (`★`,
- * `✓`) — decorative symbols, not identity fields, and outside #664's scope. It
- * is also mildly conservative: headings are uppercased before sanitizing at draw
- * time, and this probe reads the un-cased text, so a character that would
- * upper-case into WinAnsi could be reported as a loss it isn't. That errs toward
- * asking the user, which is the safe direction.
+ * `✓`) — decorative symbols, not identity fields, and outside #664's scope. That
+ * half is now REPORTED rather than refused, by the export findings
+ * `renderAtsResumePdf` returns (#621); this remains the only gate that stops a
+ * download.
+ *
+ * The field walk is shared with those findings ({@link collectModelTextFields}),
+ * which corrects two things this probe used to get wrong and which only showed
+ * up once one walk had to serve both. It scanned `headerLine` with the emphasis
+ * sentinels still in it, so every auto-bolded achievement header reported U+E000
+ * as a loss and could refuse a download over a character that is stripped before
+ * it ever reaches a font; and it skipped the summary HEADING, which is drawn.
+ * Both are the safe direction to move in — one false refusal fewer, one real
+ * loss more.
  */
 export async function findExportGlyphLosses(
   model: AtsResumeModel,
@@ -496,37 +522,18 @@ export async function findExportGlyphLosses(
   }
 
   const losses: ExportGlyphLoss[] = [];
-  const check = (where: string, text: string | undefined): void => {
-    if (!text) return;
+  for (const { where, text } of collectModelTextFields(model)) {
+    // The COARSE label, not the walk's `path`: this list is read out in a
+    // sentence ("...every character in your Name, Experience and Skills"), so it
+    // names fields to check rather than enumerating entries inside them.
+    //
+    // Deliberately reads the UN-cased text even for a heading the renderer will
+    // upper-case, which is mildly conservative: a character that would
+    // upper-case into WinAnsi can be reported as a loss it isn't. That errs
+    // toward asking the user, which is the safe direction for a refusal.
     const degraded = toWinAnsi(text);
     if (degraded !== text) losses.push({ where, original: text, degraded });
-  };
-
-  const { contact } = model;
-  check("Name", contact.name);
-  check("Headline", contact.headline);
-  check("Email", contact.email);
-  check("Phone", contact.phone);
-  check("Location", contact.location);
-  check("Work authorization", contact.workAuthorization);
-  for (const link of contact.links) check("Links", link);
-  check(model.summaryHeading || "Summary", model.summary);
-
-  for (const section of model.sections) {
-    // The section's own heading labels its entries, so a loss inside Experience
-    // reads as "Experience" rather than as an index into a model the user has
-    // never seen.
-    const where = section.heading || "Section";
-    check(where, section.heading);
-    for (const entry of section.entries) {
-      check(where, entry.headerLine);
-      check(where, entry.headerLineDate);
-      check(where, entry.subLine);
-      check(where, entry.subLineDate);
-      for (const bullet of entry.bullets) check(where, bullet);
-    }
   }
-
   return losses;
 }
 
@@ -804,6 +811,14 @@ type DrawTextOpts = {
    *  {@link Layout.drawBullet}, and only for an entry's second-to-last bullet.
    *  Like `widowControl`, not an input to wrapping. */
   followKeepHeight?: number;
+  /**
+   * Called when a page break falls BETWEEN two lines of this block (#621) —
+   * observation only, never a layout input, so a caller that passes it renders
+   * byte-identical output to one that does not. Set only by
+   * {@link Layout.drawBullet}: the summary body is the other `widowControl`
+   * block and a break inside it is ordinary prose flow, not a defect.
+   */
+  onPageSplit?: (split: BulletSplit) => void;
 };
 
 /**
@@ -813,6 +828,12 @@ type DrawTextOpts = {
 class Layout {
   page: Page;
   y: number;
+  /**
+   * How many pages have been started, 1-based. Read ONLY to notice that a
+   * pagination decision moved the cursor to a new page (#621) — nothing in the
+   * layout consults it, so it cannot influence a single drawn byte.
+   */
+  private pageOrdinal = 1;
 
   constructor(
     private doc: Doc,
@@ -838,6 +859,7 @@ class Layout {
   private newPage() {
     this.page = this.doc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
     this.y = PAGE_HEIGHT - MARGIN;
+    this.pageOrdinal++;
   }
 
   /**
@@ -941,17 +963,30 @@ class Layout {
     index: number,
     total: number,
     lineHeight: number,
-    opts: { widowControl?: boolean; followKeepHeight?: number },
+    opts: {
+      widowControl?: boolean;
+      followKeepHeight?: number;
+      onPageSplit?: (split: BulletSplit) => void;
+    },
   ) {
     const startsTail =
       (opts.widowControl ?? false) &&
       total >= 2 * BULLET_KEEP_LINES &&
       index === total - BULLET_KEEP_LINES;
+    const pageBefore = this.pageOrdinal;
     this.ensure(
       startsTail
         ? BULLET_KEEP_LINES * lineHeight + (opts.followKeepHeight ?? 0)
         : lineHeight,
     );
+    // Report a break that landed INSIDE the block (#621). `index > 0` is the
+    // whole test: a break before the first line PLACES the block (it moves
+    // whole, which is what every reservation above exists to arrange), while a
+    // break after it SPLITS the block. Purely observational — the reservation
+    // was already made above and nothing here can change it.
+    if (index > 0 && this.pageOrdinal !== pageBefore) {
+      opts.onPageSplit?.({ totalLines: total, linesBeforeBreak: index });
+    }
   }
 
   advance(points: number) {
@@ -1222,7 +1257,14 @@ class Layout {
     text: string,
     size: number,
     hangingIndent: number,
-    opts: { alreadyReserved?: boolean; followKeepHeight?: number } = {},
+    opts: {
+      alreadyReserved?: boolean;
+      followKeepHeight?: number;
+      /** Fired at most ONCE, for the FIRST page break that falls inside this
+       *  bullet (#621). A bullet taller than a page breaks more than once; that
+       *  is still one bullet to fix, so the caller gets one finding. */
+      onSplit?: (split: BulletSplit) => void;
+    } = {},
   ) {
     // Break-position control (#629 orphan half, #631 widow half): a wrapped
     // bullet reserves `bulletKeepLines` lines before it starts, so it can never
@@ -1260,6 +1302,14 @@ class Layout {
       // does, so reserve only when the block asks for more than that.
       if (height > lineHeight) this.ensureBlock(height);
     }
+    let splitReported = false;
+    const onPageSplit = opts.onSplit
+      ? (split: BulletSplit) => {
+          if (splitReported) return;
+          splitReported = true;
+          opts.onSplit?.(split);
+        }
+      : undefined;
     const marked = autoBoldMetrics(text);
     if (!marked.includes(EMPHASIS_OPEN)) {
       this.drawText(`${BULLET_MARKER}${text}`, {
@@ -1267,12 +1317,14 @@ class Layout {
         hangingIndent,
         widowControl: true,
         followKeepHeight: followKeep,
+        onPageSplit,
       });
       return;
     }
     this.drawRuns(parseBoldRuns(marked), size, hangingIndent, {
       widowControl: true,
       followKeepHeight: followKeep,
+      onPageSplit,
     });
   }
 
@@ -1379,6 +1431,7 @@ class Layout {
       color?: RGB;
       widowControl?: boolean;
       followKeepHeight?: number;
+      onPageSplit?: (split: BulletSplit) => void;
     } = {},
   ) {
     const marker = opts.marker ?? BULLET_MARKER;
@@ -1455,10 +1508,29 @@ class Layout {
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-/** Render an ATS résumé model to PDF bytes (Uint8Array). */
+/** What {@link renderAtsResumePdf} hands back: the PDF, and what it could not
+ *  render cleanly on the way to producing it (#621). */
+export interface RenderAtsPdfResult {
+  bytes: Uint8Array;
+  /** Empty for a clean résumé — the common case, and the one that must render
+   *  no warning chrome at all downstream. */
+  findings: RenderFinding[];
+}
+
+/**
+ * Render an ATS résumé model to PDF bytes, plus the export findings gathered
+ * while drawing them (#621).
+ *
+ * The findings are ADVISORY and produced strictly as a side observation: the
+ * glyph pass reads the same font-matched sanitizer the draw uses, and the
+ * pagination pass watches breaks the reservations above already placed. Neither
+ * feeds a layout decision, so `bytes` for a clean résumé is byte-for-byte what
+ * this function produced before findings existed — the property the round-trip
+ * corpus pins.
+ */
 export async function renderAtsResumePdf(
   model: AtsResumeModel,
-): Promise<Uint8Array> {
+): Promise<RenderAtsPdfResult> {
   const parts = await loadPdfLibOnce();
   const { PDFDocument, rgb } = parts;
 
@@ -1466,6 +1538,13 @@ export async function renderAtsResumePdf(
   doc.setTitle(model.contact.name || "Resume");
 
   const { regular, bold, sanitize } = await loadFonts(doc, parts);
+
+  // Glyph coverage is decided by the font that was ACTUALLY loaded above, so
+  // this runs after `loadFonts` and against its sanitizer, never a guess about
+  // which path was taken. It touches no page and embeds no glyph — the coverage
+  // predicate reads its own fontkit faces, not pdf-lib's embedded subset — so it
+  // cannot perturb the bytes below.
+  const findings: RenderFinding[] = findGlyphFindings(model, sanitize);
 
   const black = rgb(0.1, 0.1, 0.1);
   const gray = rgb(0.55, 0.55, 0.55);
@@ -1570,7 +1649,12 @@ export async function renderAtsResumePdf(
         : 0,
     );
     for (let i = 0; i < section.entries.length; i++) {
-      drawEntry(layout, section.entries[i], muted);
+      drawEntry(layout, section.entries[i], muted, {
+        // The SAME label `collectModelTextFields` gives this entry, so a glyph
+        // finding and a pagination finding about one role name it identically.
+        entryPath: entryPathLabel(section.heading || "Section", section.entries[i], i),
+        findings,
+      });
       if (i < section.entries.length - 1) layout.advance(GAP_BETWEEN_ENTRIES);
     }
     layout.advance(GAP_BETWEEN_ENTRIES);
@@ -1602,7 +1686,7 @@ export async function renderAtsResumePdf(
     description: "JSON Resume (jsonresume.org) — machine-readable copy",
   });
 
-  return doc.save();
+  return { bytes: await doc.save(), findings };
 }
 
 /** The `drawText` options for a section/summary heading — shared by the draw and
@@ -1830,7 +1914,14 @@ function trailingBulletKeepHeight(layout: Layout, entry: AtsEntry): number {
   return bulletKeepLines(lines) * SIZE_BODY * LINE_GAP;
 }
 
-function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
+function drawEntry(
+  layout: Layout,
+  entry: AtsEntry,
+  mutedColor: RGB,
+  /** Where to file a finding raised while drawing this entry, and what to call
+   *  the entry when filing it (#621). */
+  report: { entryPath: string; findings: RenderFinding[] },
+) {
   // Keep-with-next (#629): commit to this page only if the header AND its first
   // bullet's keep-opening (`bulletKeepLines` of its lines — all of them when it
   // is too short to split) fit together, so the header is never the final drawn
@@ -1885,6 +1976,8 @@ function drawEntry(layout: Layout, entry: AtsEntry, mutedColor: RGB) {
     layout.drawBullet(entry.bullets[i], SIZE_BODY, BULLET_INDENT, {
       alreadyReserved: i === 0 && keepHeight > 0,
       followKeepHeight: i === entry.bullets.length - 2 ? trailingKeep : 0,
+      onSplit: (split) =>
+        report.findings.push(bulletSplitFinding(report.entryPath, i, split)),
     });
   }
 }

--- a/src/lib/pdf/render-findings.test.ts
+++ b/src/lib/pdf/render-findings.test.ts
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Export findings — the pre-download validation pass (#621).
+ *
+ * Two families, exercised through the REAL renderer rather than the finding
+ * helpers alone, because both are claims about the render: the glyph pass is
+ * only meaningful against the font that was actually embedded, and a page break
+ * only exists once something has been paginated.
+ *
+ * The font path is chosen the same way `render-ats-pdf.fonts.test.ts` chooses
+ * it — by stubbing `fetch` and re-importing the module — so the embedded-Poppins
+ * case (this issue's target: a character the embedded font has no glyph for) is
+ * tested on the embedded path and not by accident on the Helvetica fallback.
+ *
+ * PII-free: every model here is synthetic.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AtsEntry, AtsResumeModel } from "./ats-resume-model.ts";
+import { findGlyphFindings, type RenderFinding } from "./render-findings.ts";
+import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
+
+const FONTS_DIR = fileURLToPath(new URL("../../assets/fonts/", import.meta.url));
+const REGULAR_BYTES = readFileSync(`${FONTS_DIR}Poppins-Regular.ttf`);
+const BOLD_BYTES = readFileSync(`${FONTS_DIR}Poppins-Bold.ttf`);
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+/** Serve the real vendored TTFs, so the render takes the EMBEDDED path. */
+function stubFetchSucceeds() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL) => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      arrayBuffer: async () =>
+        toArrayBuffer(String(input).includes("Bold") ? BOLD_BYTES : REGULAR_BYTES),
+    })) as unknown as typeof fetch,
+  );
+}
+
+/** Load the renderer with a clean module registry, so the memoized font promise
+ *  from a previous case cannot leak the wrong font path into this one. */
+async function loadRenderer() {
+  vi.resetModules();
+  return import("./render-ats-pdf.ts");
+}
+
+async function renderFindings(model: AtsResumeModel): Promise<RenderFinding[]> {
+  const { renderAtsResumePdf } = await loadRenderer();
+  return (await renderAtsResumePdf(model)).findings;
+}
+
+const CLEAN: AtsResumeModel = {
+  contact: {
+    name: "Jane Candidate",
+    email: "jane@example.com",
+    phone: "(312) 555-0123",
+    links: ["linkedin.com/in/jane"],
+  },
+  summary: "Shipped things. Cut deploy time from 42 minutes to 9.",
+  sections: [
+    {
+      heading: "Experience",
+      entries: [
+        {
+          headerLine: "Staff Engineer",
+          subLine: "Acme · Springfield, IL",
+          subLineDate: "2021 — Present",
+          bullets: ["Drove the platform migration end to end."],
+        },
+      ],
+    },
+  ],
+};
+
+describe("export findings — glyph coverage (#621)", { timeout: 30000 }, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("reports nothing for a clean résumé on the embedded font path", async () => {
+    // The load-bearing negative. Most résumés are ASCII, the embedded font draws
+    // them perfectly, and a report that fired here would put permanent warning
+    // chrome on every download.
+    stubFetchSucceeds();
+    await expect(renderFindings(CLEAN)).resolves.toEqual([]);
+  });
+
+  it("does not report a Latin-Extended glyph the embedded font DOES cover", async () => {
+    // Poppins covers ś/ł. Reporting them would be the #664 false positive
+    // wearing a different hat — and it is the whole reason the embedded path
+    // exists.
+    stubFetchSucceeds();
+    await expect(
+      renderFindings({
+        contact: { name: "Anna Wiśniewska", links: [] },
+        summary: "Worked in Wrocław with Łukasz.",
+        sections: [],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("names the character AND its source field for a glyph the font lacks", async () => {
+    // Poppins has no glyph for ★ (verified in render-ats-pdf.fonts.test.ts), so
+    // the export draws "?" — the exact silent degradation #621 exists to stop
+    // being silent.
+    stubFetchSucceeds();
+    const findings = await renderFindings({
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [
+        {
+          heading: "Work History",
+          entries: [
+            {
+              headerLine: "Staff Engineer · Acme",
+              bullets: ["Ran the review board", "Migrated ★ to the new stack"],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("glyph-degraded");
+    expect(findings[0].severity).toBe("warning");
+    // The character itself — "a glyph was dropped" is not actionable.
+    expect(findings[0].detail).toContain("★");
+    expect(findings[0].detail).toContain('"?"');
+    // …and where it is: section, entry, and WHICH bullet. The clean first bullet
+    // must not be blamed for the second one's character.
+    expect(findings[0].sourceField).toBe(
+      "Work History → Staff Engineer · Acme → bullet 2",
+    );
+  });
+
+  it("locates a glyph loss in a named contact field", async () => {
+    stubFetchSucceeds();
+    const findings = await renderFindings({
+      contact: { name: "Jane ✓ Candidate", links: [] },
+      sections: [],
+    });
+    expect(findings.map((f) => f.sourceField)).toEqual(["Name"]);
+  });
+
+  it("indexes individual contact links", async () => {
+    stubFetchSucceeds();
+    const findings = await renderFindings({
+      contact: {
+        name: "Jane Candidate",
+        links: ["linkedin.com/in/jane", "github.com/jane-★", "portfolio.com/★"],
+      },
+      sections: [],
+    });
+    expect(findings.map((f) => f.sourceField)).toEqual([
+      "Links → link 2",
+      "Links → link 3",
+    ]);
+  });
+
+  it("reports a transliterated glyph as info, not as a warning", async () => {
+    // "→" is degraded — the export draws "->" — but the meaning survives, so it
+    // is worth stating and not worth alarming over. Grading every substitution
+    // `warning` would make the badge meaningless on the one that destroys text.
+    stubFetchSucceeds();
+    const findings = await renderFindings({
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [
+        {
+          heading: "Experience",
+          entries: [
+            { headerLine: "Intern → Engineer · Acme", bullets: ["Did work"] },
+          ],
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("info");
+    expect(findings[0].detail).toContain("->");
+  });
+
+  it("collapses repeats of one character within one field to a single finding", async () => {
+    // A bullet with four arrows is one thing to fix, not four.
+    stubFetchSucceeds();
+    const findings = await renderFindings({
+      contact: { name: "Jane Candidate", links: [] },
+      sections: [
+        {
+          heading: "Experience",
+          entries: [
+            { headerLine: "Engineer · Acme", bullets: ["a ★ b ★ c ★ d ★ e"] },
+          ],
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("does not mistake the auto-bold sentinels for uncovered glyphs", async () => {
+    // An achievement header arrives from `ats-resume-model.ts` with the
+    // Private-Use-Area emphasis markers already in it. They are stripped before
+    // any font sees them, so scanning text that still carries them would report
+    // U+E000 as a loss on every achievement — and, on the fallback path, could
+    // refuse a download over a character that is never drawn.
+    stubFetchSucceeds();
+    await expect(
+      renderFindings({
+        contact: { name: "Jane Candidate", links: [] },
+        sections: [
+          {
+            heading: "Achievements",
+            entries: [
+              {
+                headerLine: `${EMPHASIS_OPEN}Award${EMPHASIS_CLOSE} \u00b7 Shipped the platform \u00b7 2024`,
+                headerBold: false,
+                bullets: [],
+              },
+            ],
+          },
+        ],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("checks a heading through the case transform the renderer applies", async () => {
+    // Headings are drawn upper-cased, and `toUpperCase()` can turn a covered
+    // glyph into an uncovered one: µ (U+00B5) becomes Μ (U+039C, Greek capital
+    // mu), which Poppins has no glyph for. Scanning the raw text would miss
+    // exactly the loss the draw is about to produce.
+    stubFetchSucceeds();
+    const { renderAtsResumePdf } = await loadRenderer();
+    const heading = "µ-services";
+    const raw = (
+      await renderAtsResumePdf({
+        contact: { name: "Jane Candidate", links: [] },
+        // Same text NOT in a heading: drawn as-is, and Poppins covers µ, so it
+        // is the control that proves the case transform is what makes the
+        // difference rather than the character itself.
+        summary: heading,
+        sections: [],
+      })
+    ).findings;
+    expect(raw).toEqual([]);
+
+    const cased = (
+      await renderAtsResumePdf({
+        contact: { name: "Jane Candidate", links: [] },
+        sections: [
+          {
+            heading,
+            entries: [{ headerLine: "Engineer · Acme", bullets: ["Did work"] }],
+          },
+        ],
+      })
+    ).findings;
+    expect(cased.map((f) => f.sourceField)).toEqual([heading]);
+    // The reported character is what the user typed (µ, U+00B5), not what the
+    // case transform drew (Μ, U+039C) — the user can search their résumé for
+    // the former; the latter is provably absent from their input.
+    expect(cased[0]!.detail).toContain('"µ" (U+00B5)');
+    expect(cased[0]!.detail).not.toContain("U+039C");
+  });
+});
+
+// ── What counts as a degradation at all ─────────────────────────────────────
+//
+// Driven through `findGlyphFindings` with an INJECTED sanitizer rather than a
+// render, because the rule under test is "which substitutions are worth
+// reporting" and a real font either covers a probe character or does not — which
+// would make each case pass for whichever reason the font happened to supply.
+
+describe("export findings — invisible degradations are not reported", () => {
+  const model = (name: string): AtsResumeModel => ({
+    contact: { name, links: [] },
+    sections: [],
+  });
+
+  /** Maps exactly the characters named, passes everything else through. */
+  const mapping = (table: Record<string, string>) => (text: string) =>
+    [...text].map((ch) => table[ch] ?? ch).join("");
+
+  it("ignores a mark dropped outright", () => {
+    // A zero-width space or a stray control character is removed by both
+    // sanitizers. Nothing the user can see changes, so a finding is noise.
+    expect(
+      findGlyphFindings(model("Jane\u200b Doe"), mapping({ "\u200b": "" })),
+    ).toEqual([]);
+  });
+
+  it("ignores an exotic space normalised to an ordinary one", () => {
+    expect(
+      findGlyphFindings(model("Jane\u2009Doe"), mapping({ "\u2009": " " })),
+    ).toEqual([]);
+  });
+
+  it("DOES report a visible substitution", () => {
+    // The control for both cases above: the rule is "invisible", not "any
+    // substitution".
+    const findings = findGlyphFindings(
+      model("Jane ★ Doe"),
+      mapping({ "★": "?" }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warning");
+  });
+
+  it("interpolates the character's code point into the detail message", () => {
+    // An invisible character absent from the table (such as VS16 U+FE0F) falls
+    // through to "?"; naming the code point keeps the message actionable even
+    // when the character itself cannot be seen.
+    const findings = findGlyphFindings(
+      model("Jane\uFE0F Doe"),
+      mapping({ "\uFE0F": "?" }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toContain('no glyph for "\uFE0F" (U+FE0F)');
+  });
+});
+
+// ── Pagination: a page break inside a bullet (#621) ──────────────────────────
+//
+// Same synthesis strategy as `export-layout-contract.test.ts`: a filler entry of
+// single-line bullets pushes the subject bullet down one line at a time, so some
+// filler count puts the natural page break inside it. The count is FOUND by
+// bisection rather than hard-coded, so the test keeps straddling the break if
+// the page geometry ever changes.
+
+/** Wraps to exactly four drawn lines under the Helvetica fallback — the shortest
+ *  bullet that can legally split (2/2), and therefore the shortest one this
+ *  finding can fire on. */
+const FOUR_LINE_BULLET =
+  "BULLETSTART partnered across engineering, product and design to land a " +
+  "platform initiative that measurably improved customer outcomes BULLETTWO " +
+  "and then carried the same practice into the wider organisation, writing " +
+  "the runbooks BULLETTHREE and training the on-call rotation before handing " +
+  "the whole programme over to its permanent owners BULLETEND";
+
+/** Wraps to exactly three drawn lines — indivisible under #630/#631, so it must
+ *  move whole and must never produce this finding. */
+const THREE_LINE_BULLET =
+  "BULLETSTART partnered across engineering, product and design to land a " +
+  "platform initiative that measurably improved customer outcomes BULLETMID " +
+  "and then carried the same practice into the wider organisation BULLETEND";
+
+function modelWith(subject: AtsEntry, filler: number): AtsResumeModel {
+  return {
+    contact: { name: "Jane Candidate", links: [] },
+    sections: [
+      {
+        heading: "Experience",
+        entries: [
+          {
+            headerLine: "Filler Role · Filler Company, Springfield, IL",
+            bullets: Array.from(
+              { length: filler },
+              () => "Filler bullet kept deliberately short.",
+            ),
+          },
+          subject,
+        ],
+      },
+    ],
+  };
+}
+
+describe(
+  "export findings — a page break inside a bullet (#621)",
+  { timeout: 60000 },
+  () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+    });
+
+    /** Findings + which page each bullet token landed on, for one filler count. */
+    async function probe(subject: AtsEntry, filler: number) {
+      const { renderAtsResumePdf } = await import("./render-ats-pdf.ts");
+      const { extractPdfDrawnLines } = await import(
+        "./render-ats-pdf.test-utils.ts"
+      );
+      const { bytes, findings } = await renderAtsResumePdf(
+        modelWith(subject, filler),
+      );
+      const lines = await extractPdfDrawnLines(bytes);
+      const pageOf = (token: string) => {
+        const hit = lines.find((l) => l.text.includes(token));
+        expect(hit, `expected "${token}" to be drawn`).toBeDefined();
+        return hit!.page;
+      };
+      return { findings, pageOf };
+    }
+
+    /** Smallest filler count that pushes `token` off page 1 — monotone, because
+     *  every filler bullet is exactly one line, so a bisection is exact. */
+    async function boundaryN(subject: AtsEntry, token: string, max = 80) {
+      expect((await probe(subject, 0)).pageOf(token)).toBe(1);
+      expect((await probe(subject, max)).pageOf(token)).toBeGreaterThan(1);
+      let lo = 0;
+      let hi = max;
+      while (hi - lo > 1) {
+        const mid = Math.floor((lo + hi) / 2);
+        if ((await probe(subject, mid)).pageOf(token) > 1) hi = mid;
+        else lo = mid;
+      }
+      return hi;
+    }
+
+    const fourLineSubject: AtsEntry = {
+      headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+      bullets: ["ALPHABULLET short first bullet.", FOUR_LINE_BULLET],
+    };
+
+    it("names the entry when a 4+ line bullet falls across a page break", async () => {
+      const n = await boundaryN(fourLineSubject, "BULLETSTART");
+      // Non-vacuity: at the boundary the bullet really IS split — its first and
+      // last drawn lines land on different pages. Without this the assertion
+      // below could pass on a render that never split anything.
+      let sawSplit = false;
+      for (const filler of [n - 2, n - 1, n, n + 1]) {
+        const { findings, pageOf } = await probe(fourLineSubject, filler);
+        const split = pageOf("BULLETSTART") !== pageOf("BULLETEND");
+        const paginationFindings = findings.filter(
+          (f) => f.kind === "bullet-page-break",
+        );
+        if (!split) {
+          expect(
+            paginationFindings,
+            `filler=${filler}: reported a split that did not happen`,
+          ).toEqual([]);
+          continue;
+        }
+        sawSplit = true;
+        expect(paginationFindings).toHaveLength(1);
+        expect(paginationFindings[0].severity).toBe("warning");
+        // Names the entry — and which of its bullets.
+        expect(paginationFindings[0].sourceField).toBe(
+          "Experience → SUBJECTROLE · Subject Company, Springfield, IL → bullet 2",
+        );
+        expect(paginationFindings[0].detail).toContain("4 lines");
+      }
+      expect(
+        sawSplit,
+        "no filler count in the window actually split the bullet — the test is vacuous",
+      ).toBe(true);
+    });
+
+    it("reports nothing for a 3-line bullet, which #630 keeps whole", async () => {
+      // The residual-case boundary. A three-line bullet has no legal split
+      // position, so it moves whole and there is nothing to report — which is
+      // why this finding is the 4+ line case in practice without being gated on
+      // a line count.
+      const subject: AtsEntry = {
+        headerLine: "SUBJECTROLE · Subject Company, Springfield, IL",
+        bullets: ["ALPHABULLET short first bullet.", THREE_LINE_BULLET],
+      };
+      const n = await boundaryN(subject, "BULLETSTART");
+      for (const filler of [n - 2, n - 1, n, n + 1]) {
+        const { findings, pageOf } = await probe(subject, filler);
+        // Non-vacuity: the bullet really did cross the page boundary as a unit.
+        expect(pageOf("BULLETEND")).toBe(pageOf("BULLETSTART"));
+        expect(
+          findings.filter((f) => f.kind === "bullet-page-break"),
+          `filler=${filler}: reported a split on an indivisible bullet`,
+        ).toEqual([]);
+      }
+    });
+
+    it("reports nothing when nothing paginates", async () => {
+      const { findings } = await probe(fourLineSubject, 0);
+      expect(findings).toEqual([]);
+    });
+  },
+);

--- a/src/lib/pdf/render-findings.ts
+++ b/src/lib/pdf/render-findings.ts
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * render-findings — the structured defect report the résumé exporter returns
+ * alongside its bytes (#621).
+ *
+ * The Download PDF is presented as the ATS-safe artifact, and until now the
+ * renderer degraded silently on input it could not lay out cleanly: a character
+ * outside the embedded font's coverage was written to the text layer as a
+ * replacement (or, before #664, as U+0000), and a page break could fall inside a
+ * long bullet. Both were only ever found by hexdumping a downloaded résumé. This
+ * module defines what a finding IS; `render-ats-pdf.ts` accumulates them during
+ * the draw pass, because it is the only layer that knows which font was actually
+ * embedded and where the page breaks landed.
+ *
+ * A finding is ADVISORY. It never blocks the download (the user still gets the
+ * PDF), and it is emphatically NOT a score input — this reports on the EXPORT,
+ * not on résumé quality, so nothing here reaches `computeAnonymousAtsScore`.
+ *
+ * NOT in `render-audit-report.ts`, despite the name. That module renders the
+ * score-audit PDF — a whole separate artifact ABOUT the résumé — and it already
+ * imports `toWinAnsi` FROM `render-ats-pdf.ts`. Putting the finding type there
+ * would point the renderer at its own consumer for a type it produces. This is
+ * the leaf both can depend on.
+ *
+ * `sourceField` is the part that makes a finding actionable: "an arrow was
+ * dropped" is not, "an arrow was dropped from Experience → Staff Engineer · Acme
+ * → bullet 3" is. Everything here is a pure function of the model plus the
+ * renderer's own font/pagination decisions — no pdf-lib import, so it stays
+ * testable without a render.
+ */
+
+import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
+import type { AtsEntry, AtsResumeModel } from "./ats-resume-model.ts";
+
+/**
+ * What went wrong. Only the two kinds #621 requires are modelled; the finding
+ * SHAPE is deliberately wide enough for the deferred ones (an entry header
+ * orphaned at a page bottom, text overflowing the content column) to join as
+ * additional members without changing any consumer.
+ */
+export type RenderFindingKind = "glyph-degraded" | "bullet-page-break";
+
+/**
+ * How much the user loses.
+ *
+ * `warning` — information was destroyed or the reading order broke.
+ * `info` — the output differs from what was authored but still reads correctly
+ *          (an arrow drawn as `->`), so it is worth stating and not worth
+ *          alarming over.
+ */
+export type RenderFindingSeverity = "warning" | "info";
+
+/** One thing the exporter could not render cleanly. */
+export interface RenderFinding {
+  kind: RenderFindingKind;
+  severity: RenderFindingSeverity;
+  /** Where in the user's OWN résumé the defect is, in their own words — a
+   *  contact field name, or "Experience → Staff Engineer · Acme → bullet 3".
+   *  Never a code path; this is shown to the user. */
+  sourceField: string;
+  /** One sentence naming what happened, specifically enough to act on. */
+  detail: string;
+}
+
+/**
+ * Strip the Private-Use-Area emphasis sentinels `auto-bold-metrics.ts` uses to
+ * mark auto-bolded metrics.
+ *
+ * They are renderer plumbing: `parseBoldRuns` removes them before any text is
+ * measured or drawn, so they never reach a font and can never be a glyph loss.
+ * Scanning text that still carries them reports U+E000 as an uncovered
+ * character — a false positive on every achievement header, which is the one
+ * model field built with the sentinels already in it.
+ */
+function stripEmphasisSentinels(text: string): string {
+  return text.split(EMPHASIS_OPEN).join("").split(EMPHASIS_CLOSE).join("");
+}
+
+/** Longest entry name carried in a `sourceField` before it is elided. The skills
+ *  entry's `headerLine` is the entire skills list, so an uncapped label would be
+ *  a paragraph. */
+const MAX_ENTRY_LABEL = 60;
+
+function elide(text: string): string {
+  return text.length <= MAX_ENTRY_LABEL
+    ? text
+    : `${text.slice(0, MAX_ENTRY_LABEL - 1).trimEnd()}…`;
+}
+
+/**
+ * The `sourceField` prefix for everything inside one entry — "Experience →
+ * Staff Engineer · Acme".
+ *
+ * Shared by the glyph walk and the pagination detector so both families of
+ * finding name the same entry the same way; a user reading two findings about
+ * one role must be able to tell they are about one role. Falls back to the
+ * 1-based position only when the entry has no header and no sub-line to name it
+ * by, which is the bullets-only shape.
+ */
+export function entryPathLabel(
+  sectionHeading: string,
+  entry: AtsEntry,
+  index: number,
+): string {
+  const heading = sectionHeading || "Section";
+  const name = stripEmphasisSentinels(entry.headerLine || entry.subLine || "").trim();
+  return name ? `${heading} → ${elide(name)}` : `${heading} → entry ${index + 1}`;
+}
+
+/** One string the renderer will draw, with the labels a finding reports it by. */
+export interface ModelTextField {
+  /** COARSE label — a contact field name, "Summary", or the section's own
+   *  heading. This is the vocabulary `findExportGlyphLosses`' refusal message
+   *  lists, and it stays coarse on purpose: that message names fields to check,
+   *  it does not enumerate them. */
+  where: string;
+  /** FINE label — `where`, plus the entry and (for a bullet) its 1-based index.
+   *  What a finding's `sourceField` carries. */
+  path: string;
+  /** The text as the model holds it, sentinels already stripped. */
+  text: string;
+  /** True when the renderer draws this field upper-cased (`HEADING_OPTS`), so a
+   *  coverage check must run on the CASED text. `toUpperCase()` can map a
+   *  covered glyph to an uncovered one — µ (U+00B5) becomes Μ (U+039C, Greek
+   *  capital mu) — so scanning the raw text would miss exactly the loss the
+   *  draw is about to produce. */
+  uppercase?: boolean;
+}
+
+/**
+ * Every string `renderAtsResumePdf` will draw, in draw order, each tagged with
+ * how to name it to the user.
+ *
+ * One walk, two consumers: `findExportGlyphLosses` (the #664 pre-render refusal,
+ * which reads `where`) and {@link findGlyphFindings} (this issue's report, which
+ * reads `path`). A second copy of this walk would drift the moment a field is
+ * added to the model — the fields are the contract, and only the labels differ.
+ */
+export function collectModelTextFields(
+  model: AtsResumeModel,
+): ModelTextField[] {
+  const out: ModelTextField[] = [];
+  const add = (
+    where: string,
+    text: string | undefined,
+    opts: { path?: string; uppercase?: boolean } = {},
+  ) => {
+    if (!text) return;
+    out.push({
+      where,
+      path: opts.path ?? where,
+      text: stripEmphasisSentinels(text),
+      uppercase: opts.uppercase,
+    });
+  };
+
+  const { contact } = model;
+  add("Name", contact.name);
+  add("Headline", contact.headline);
+  add("Email", contact.email);
+  add("Phone", contact.phone);
+  add("Location", contact.location);
+  add("Work authorization", contact.workAuthorization);
+  contact.links.forEach((link, i) =>
+    add("Links", link, { path: `Links → link ${i + 1}` }),
+  );
+
+  const summaryHeading = model.summaryHeading || "Summary";
+  if (model.summary) {
+    // The heading is DRAWN (upper-cased), so it is checked too — `where` stays
+    // the heading either way, which is how the user names that block.
+    add(summaryHeading, summaryHeading, { uppercase: true });
+    add(summaryHeading, model.summary);
+  }
+
+  for (const section of model.sections) {
+    // The section's own heading labels its entries, so a loss inside Experience
+    // reads as "Experience" rather than as an index into a model the user has
+    // never seen.
+    const where = section.heading || "Section";
+    add(where, section.heading, { uppercase: true });
+    section.entries.forEach((entry, i) => {
+      const path = entryPathLabel(where, entry, i);
+      add(where, entry.headerLine, { path });
+      add(where, entry.headerLineDate, { path });
+      add(where, entry.subLine, { path });
+      add(where, entry.subLineDate, { path });
+      entry.bullets.forEach((bullet, b) =>
+        add(where, bullet, { path: `${path} → bullet ${b + 1}` }),
+      );
+    });
+  }
+
+  return out;
+}
+
+/**
+ * True when a sanitizer's substitution changes nothing the user can SEE, so
+ * reporting it would be noise rather than a finding.
+ *
+ * Two cases, both from the shared transliteration table: an invisible mark
+ * dropped outright (a zero-width space, a stray control character), and an
+ * exotic space normalised to an ordinary one. Everything else — a replacement
+ * `?`, an arrow spelled `->`, a ligature expanded — changes the drawn page and
+ * is reported.
+ */
+function isInvisibleDegradation(ch: string, drawn: string): boolean {
+  return drawn === "" || (drawn === " " && /\p{Zs}/u.test(ch));
+}
+
+/**
+ * Every character the export font could not draw as authored, one finding per
+ * (field, character) pair (#621).
+ *
+ * `sanitize` is the renderer's OWN font-matched sanitizer — Poppins' coverage
+ * predicate on the embedded path, `toWinAnsi` on the Helvetica fallback — so
+ * this measures the font that is actually on the page rather than a guess about
+ * it. That is what makes the pass render-time: swap the font and the answer
+ * changes with it.
+ *
+ * Character-wise by construction. Both sanitizers are pure per-code-point maps,
+ * so probing one character at a time gives exactly the substitutions the whole
+ * string would receive — and it is the only way to NAME the character, which the
+ * finding must do. Repeats within one field collapse to one finding: a bullet
+ * with four arrows is one thing to fix.
+ *
+ * Iterates the AUTHORED text, not the cased text `uppercase` fields draw as.
+ * The case transform still has to run before the coverage probe — that's what
+ * catches µ→Μ — but the finding must name what the user actually typed and can
+ * search for, not the drawn glyph the case transform produced along the way.
+ */
+export function findGlyphFindings(
+  model: AtsResumeModel,
+  sanitize: (text: string) => string,
+): RenderFinding[] {
+  const findings: RenderFinding[] = [];
+  for (const field of collectModelTextFields(model)) {
+    const seen = new Set<string>();
+    for (const ch of field.text) {
+      if (seen.has(ch)) continue;
+      seen.add(ch);
+      const cased = field.uppercase ? ch.toUpperCase() : ch;
+      const drawn = sanitize(cased);
+      if (drawn === cased || isInvisibleDegradation(cased, drawn)) continue;
+      findings.push({
+        kind: "glyph-degraded",
+        // A "?" destroys the character outright; a transliteration keeps its
+        // meaning and only changes its spelling.
+        severity: drawn === "?" ? "warning" : "info",
+        sourceField: field.path,
+        detail:
+          `The export font has no glyph for "${ch}" (U+${ch
+            .codePointAt(0)!
+            .toString(16)
+            .toUpperCase()
+            .padStart(4, "0")}), so it was drawn as "${drawn}".`,
+      });
+    }
+  }
+  return findings;
+}
+
+/** Where a page break landed inside one wrapped block. */
+export interface BulletSplit {
+  /** Drawn lines the bullet wraps to, in total. */
+  totalLines: number;
+  /** Lines drawn before the break — i.e. how many stayed on the first page. */
+  linesBeforeBreak: number;
+}
+
+/**
+ * The finding for a bullet a page break fell inside (#621).
+ *
+ * In practice this is exclusively the 4+ line case, and that is a property of
+ * the renderer rather than a filter applied here: #630/#631 make a bullet with
+ * no legal split position (`totalLines < 2 * BULLET_KEEP_LINES`, so one to three
+ * lines) reserve its FULL height, which means the break falls before it and it
+ * moves whole. Gating this on a line count as well would be a second, weaker
+ * statement of that same rule — and would silence the one shape that escapes it,
+ * a keep-block so tall `ensureBlock` has to ignore it as unsatisfiable. Report
+ * the split that actually happened; the count is in the message.
+ */
+export function bulletSplitFinding(
+  entryPath: string,
+  bulletIndex: number,
+  split: BulletSplit,
+): RenderFinding {
+  const after = split.totalLines - split.linesBeforeBreak;
+  return {
+    kind: "bullet-page-break",
+    severity: "warning",
+    sourceField: `${entryPath} → bullet ${bulletIndex + 1}`,
+    detail:
+      `This bullet wraps to ${split.totalLines} lines and a page break falls ` +
+      `inside it — ${split.linesBeforeBreak} ${
+        split.linesBeforeBreak === 1 ? "line" : "lines"
+      } on one page, ${after} on the next.`,
+  };
+}

--- a/src/lib/pdf/render-roundtrip-achievement-add.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-achievement-add.repro.test.ts
@@ -94,7 +94,7 @@ describe("#455 — an added achievement round-trips through the export", () => {
       {},
     );
     model = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("composes the added type + description into the canonical title", () => {

--- a/src/lib/pdf/render-roundtrip-achievement-edit.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-achievement-edit.repro.test.ts
@@ -102,7 +102,7 @@ describe("#454 — an edited achievement round-trips through the export", () => 
       },
     );
     model = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("bolds exactly the edited type label, and nothing else", () => {

--- a/src/lib/pdf/render-roundtrip-education-lone-year.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-education-lone-year.repro.test.ts
@@ -94,7 +94,7 @@ describe("#618 — degreed entry with a lone graduation year", () => {
       }),
       fakeScore,
     );
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("renders `2023` as flush-right `subLineDate` — no glue on the sub-line", () => {
@@ -171,7 +171,7 @@ describe("#618 — regression guard for #302 (two degree-less entries stay two)"
       }),
       fakeScore,
     );
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("re-parses BOTH degree-less entries as SEPARATE entries, not one merged", () => {
@@ -207,7 +207,7 @@ describe("#618 — control: a range date on Education still round-trips exactly 
       }),
       fakeScore,
     );
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("range: sub-line free of the date, `subLineDate` carries the range (pre-#618 shape)", () => {

--- a/src/lib/pdf/render-roundtrip-empty-company-location.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-empty-company-location.repro.test.ts
@@ -80,7 +80,7 @@ describe("empty-company + location round-trip (#466 / PR #483 review)", () => {
 
   beforeAll(async () => {
     model = buildAtsResumeModel(makeResult(), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("emits Title,Team on the header line and City,ST on a subLine", () => {

--- a/src/lib/pdf/render-roundtrip-entry-remove.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-entry-remove.repro.test.ts
@@ -122,7 +122,7 @@ describe("#856 — a deleted entry stays out of the exported PDF", { timeout: 20
       new Set(["experience:0", "education:0", "achievements:0"]),
     );
     const model = buildAtsResumeModel(makeResult(edited.fields), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("drops the deleted role and keeps the survivor's own edit", () => {

--- a/src/lib/pdf/render-roundtrip-header-vs-entry.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-header-vs-entry.repro.test.ts
@@ -97,7 +97,7 @@ describe("§7 header-vs-entry — a one-line `Title  Dates` role routes as a dat
 
   beforeAll(async () => {
     model = buildAtsResumeModel(makeResult(), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("renders the title-only role with its range drawn flush-right on the header (the entry cue)", () => {

--- a/src/lib/pdf/render-roundtrip-headline.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-headline.repro.test.ts
@@ -61,7 +61,7 @@ describe("Headline round-trip", () => {
     };
     const modifiedCascade = { ...baseCascade, canonical };
     const model = buildAtsResumeModel(modifiedCascade, scoreFor(modifiedCascade));
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     const reparsed = await runCascade(bytes);
     return {
       headline: reparsed.canonical.fields.headline,

--- a/src/lib/pdf/render-roundtrip-literal-asterisks.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-literal-asterisks.repro.test.ts
@@ -84,7 +84,7 @@ describe("#284/#425 — literal `**` in a bullet round-trips byte-identically", 
 
   beforeAll(async () => {
     const model = buildAtsResumeModel(makeResult(), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("re-parses each role's description with its literal `**` intact", () => {

--- a/src/lib/pdf/render-roundtrip-lone-end-date.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-lone-end-date.repro.test.ts
@@ -118,7 +118,7 @@ async function renderAndReparse(
     linkAnnotations: [],
     rawText: "",
   } as unknown as CascadeResult;
-  const bytes = await renderAtsResumePdf(buildAtsResumeModel(display, STUB_SCORE));
+  const { bytes } = await renderAtsResumePdf(buildAtsResumeModel(display, STUB_SCORE));
   return runCascade(bytes);
 }
 

--- a/src/lib/pdf/render-roundtrip-summary-edit.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-summary-edit.repro.test.ts
@@ -119,7 +119,7 @@ describe("#625 — an edited summary round-trips through the export", { timeout:
     const model = exportModel(edited);
     expect(model.summary).toBe(edited);
 
-    const reparsed = await runCascade(await renderAtsResumePdf(model));
+    const reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
     expect(reparsed.rawText).toContain(edited);
     expect(reparsed.rawText).not.toContain(PARSED_SUMMARY);
   });
@@ -136,7 +136,7 @@ describe("#625 — an edited summary round-trips through the export", { timeout:
     const model = exportModel(override);
     expect(model.summary).toBeUndefined();
 
-    const reparsed = await runCascade(await renderAtsResumePdf(model));
+    const reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
     expect(reparsed.rawText).not.toContain(PARSED_SUMMARY);
     expect(reparsed.rawText).not.toContain(HEADING);
     // The rest of the résumé is untouched — the clear removed a section, not

--- a/src/lib/pdf/render-roundtrip-team.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-team.repro.test.ts
@@ -87,7 +87,7 @@ describe("#425 — team on the org line round-trips through the parser", () => {
 
   beforeAll(async () => {
     model = buildAtsResumeModel(makeResult(), fakeScore);
-    reparsed = await runCascade(await renderAtsResumePdf(model));
+    reparsed = await runCascade((await renderAtsResumePdf(model)).bytes);
   });
 
   it("renders the team as the trailing middot segment on the one-line header", () => {

--- a/src/lib/pdf/render-roundtrip-www-link.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-www-link.repro.test.ts
@@ -71,7 +71,7 @@ describe("#425 — full www-strip contact link round-trips", { timeout: 20000 },
     // The displayed link is fully stripped (no scheme, no www).
     expect(model.contact.links).toContain("linkedin.com/in/janesmith");
 
-    const p3 = await runCascade(await renderAtsResumePdf(model));
+    const p3 = await runCascade((await renderAtsResumePdf(model)).bytes);
     // The www-less display re-parses to the same canonical linkedin_url.
     expect(p3.canonical.fields.linkedin_url).toBe(p1.canonical.fields.linkedin_url);
     expect(p3.canonical.fields.linkedin_url).toBe("https://linkedin.com/in/janesmith");

--- a/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip-year-only.repro.test.ts
@@ -71,7 +71,7 @@ describe("#358 — year-only experience role round-trips (no title/company swap,
 
   beforeAll(async () => {
     const original = makeResult();
-    const bytes = await renderAtsResumePdf(buildAtsResumeModel(original, STUB_SCORE));
+    const { bytes } = await renderAtsResumePdf(buildAtsResumeModel(original, STUB_SCORE));
     reparsed = await runCascade(bytes);
   });
 

--- a/src/lib/pdf/render-roundtrip.repro.test.ts
+++ b/src/lib/pdf/render-roundtrip.repro.test.ts
@@ -73,7 +73,7 @@ describe("#284 — Download-PDF reconstructed résumé round-trips through the p
   beforeAll(async () => {
     original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
     const model = buildAtsResumeModel(original, scoreFor(original));
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     reparsed = await runCascade(bytes);
   });
 

--- a/src/lib/pdf/render-work-authorization.test.ts
+++ b/src/lib/pdf/render-work-authorization.test.ts
@@ -79,9 +79,9 @@ describe("renderAtsResumePdf — work authorization on the contact line (#792)",
   let glyphLossSites: string[];
 
   beforeAll(async () => {
-    const bytes = await renderAtsResumePdf(MODEL);
+    const { bytes } = await renderAtsResumePdf(MODEL);
     stated = await extractPdfDrawnLines(bytes);
-    silent = await extractPdfDrawnLines(await renderAtsResumePdf(SILENT_MODEL));
+    silent = await extractPdfDrawnLines((await renderAtsResumePdf(SILENT_MODEL)).bytes);
     urls = await linkAnnotationUrls(bytes);
     glyphLossSites = (
       await findExportGlyphLosses({

--- a/src/lib/pdf/skills-wrap-roundtrip.test.ts
+++ b/src/lib/pdf/skills-wrap-roundtrip.test.ts
@@ -105,7 +105,7 @@ describe("#301 — multi-word skill does not split at the line-wrap boundary", (
       withSyntheticSkills,
       scoreFor(withSyntheticSkills),
     );
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     const reparsed = await runCascade(bytes);
     reparsedSkills = reparsed.canonical.fields.skills ?? [];
   }, 20000);
@@ -155,7 +155,7 @@ describe("#791 — a categorised-plus-ungrouped skills list survives export and 
       withMixedSkills,
       scoreFor(withMixedSkills),
     );
-    const bytes = await renderAtsResumePdf(model);
+    const { bytes } = await renderAtsResumePdf(model);
     const reparsed = await runCascade(bytes);
     reparsedSkills = reparsed.canonical.fields.skills ?? [];
   }, 20000);


### PR DESCRIPTION
## Summary

Adds a pre-download validation pass to the Download PDF renderer: `renderAtsResumePdf`
now returns `{ bytes, findings }` instead of just `bytes`, without changing the bytes
produced for a clean résumé.

Two finding kinds, both advisory (never blocks the download):
- **Glyph loss** — a character outside the embedded font's subset degrades/drops in
  the text layer; the finding names the character and its source field.
- **Bullet page-split** — a 4+ line bullet wraps across a page break (2–3 line bullets
  are already indivisible per #630 and correctly do not trigger this).

Clean résumés produce zero findings and render no warning chrome. The warning surface
(`ExportFindings`, new) reuses `StatusBadge` from `@design-system` — no new banner
primitive.

Out of scope (per the issue): entry-header-orphan and column-overflow detection;
wiring findings into any UX beyond the export dialog itself.

## Verification

- `corpus-roundtrip.test.ts` and all 13 `render-roundtrip-*.repro.test.ts` green,
  no rendered byte changes — verified via a draw-signature comparison (page count +
  every pdfjs draw operator + args + link annotations) across all 58 corpus fixtures,
  21 multi-page configs, and a glyph-degrading model, since pdf-lib stamps a
  timestamp so a literal byte diff isn't meaningful.
- New `render-findings.test.ts` (14 tests): glyph-loss naming, 4+-line split naming,
  2–3 line non-reproduction, zero-findings-on-clean, fail-before proof (detectors
  neutered → 6/14 fail; restored → all pass).
- `npm run typecheck` / `npm run lint` clean. Full suite green as part of the
  whole-stack verification (see #874's summary).

## Stack position

Layer 2 of 4. Base: #871. Depends on #871.

## Adversarial review

Reviewed across both rounds; this layer had **nits only**, no blocking findings:
- No explicit test pins byte-identical output for a clean résumé at the render level
  (verified structurally instead — the glyph-loss detector reads the embedded font
  via `fontkit` directly, not through pdf-lib's `PdfFont`, so it can't perturb the
  embedded subset it inspects).
- A couple of pointless expression statements in `render-ats-pdf.fonts.test.ts`.
- A content-derived React key in `ExportFindings` could theoretically collide if two
  entries share the same header line + finding kind + detail.

None blocking; left for a human pass if worth chasing.

Closes #621
