### PR TITLE
feat(critique): surface skills-ordering guidance in résumé review + rewrite lane (#544)

### DIFF
--- a/src/components/features/CritiquePanel.tsx
+++ b/src/components/features/CritiquePanel.tsx
@@ -19,6 +19,16 @@
  * navigates to the "Your resume" tab, where the per-role wand
  * button (useSectionRewrite) already lives.
  *
+ * Everything rendered here is LLM output, and deliberately so. The heuristic
+ * skills-ordering finding (#544) briefly rendered in this body too, for the
+ * finding-row visual language; it moved to `SkillTermGuidance`, because this
+ * body only ever mounts under `status.kind === "done"` and a heuristic that
+ * needs a WebGPU model download to be seen is not one the user can distinguish
+ * from LLM output. Its row (`SkillsOrderFindingRow`, in
+ * `SkillsOrderFinding.tsx`) is mounted there and nowhere else — do not add a
+ * second mount here, the controller is shared state and both rows would react
+ * to one Apply.
+ *
  * Design rules (CLAUDE.md):
  *   - Semantic tokens only; no hardcoded hex or raw palette classes.
  *   - All interactive elements via <Button> from "@design-system".

--- a/src/components/features/ReconstructedResume.tsx
+++ b/src/components/features/ReconstructedResume.tsx
@@ -88,6 +88,7 @@ import {
   survivingParsedIndices,
 } from "../../hooks/useEditableParse.ts";
 import { removeEntryWithBullets } from "../../lib/edit/entry-remove.ts";
+import type { SkillsReorderController } from "../../hooks/useSkillsReorder.ts";
 import { useAddedEntryPruneHold } from "../../hooks/useAddedEntryPruneHold.ts";
 import {
   batchUndoTargets,
@@ -1124,6 +1125,7 @@ export function ReconstructedResume({
   jdContext,
   critique,
   onRewriteApplied,
+  skillsOrder,
 }: {
   result: CascadeResult;
   /** EDITED score — re-graded by App from the current overrides. Its
@@ -1143,6 +1145,12 @@ export function ReconstructedResume({
    *  to the rewrite controller; `ResultDetail` decides what it means, since it
    *  is the one that knows whether a JD is steering. */
   onRewriteApplied?: () => void;
+  /** Skills-ordering coaching (#544) — passed straight through to
+   *  `TargetingSection` → `SkillTermGuidance`, the one surface that renders
+   *  it. The controller is owned by `ResultDetail` (a single instance, so the
+   *  apply/undo state is shared) rather than built here; nothing in this file
+   *  reads it. */
+  skillsOrder?: SkillsReorderController;
 }) {
   // Display projection (#443, Stage B) — parsed field core + the user's own
   // section headings, read off the canonical model rather than `result` directly.
@@ -1379,6 +1387,10 @@ export function ReconstructedResume({
         // existing `addSkill` inline-edit path.
         parsed={parsed}
         onAddSkill={addSkill}
+        // Skills-ordering coaching (#544) rides the same panel: it is scored
+        // against `titles[0]` exactly as the term guidance is, and unlike the
+        // critique lane this surface is not behind a WebGPU model download.
+        skillsOrder={skillsOrder}
       />
       {/* Summary leads the document body, matching the exported model's own
        *  order (`ats-resume-model.ts`: Summary → Experience → …) so the preview

--- a/src/components/features/ResultDetail.test.tsx
+++ b/src/components/features/ResultDetail.test.tsx
@@ -40,6 +40,7 @@ vi.mock("./ReconstructedResume.tsx", async () => {
     ReconstructedResume: (props: {
       jdContext?: string;
       onRewriteApplied?: () => void;
+      skillsOrder?: { finding?: { buried: string[] } };
     }) =>
       createElement(
         "div",
@@ -48,6 +49,13 @@ vi.mock("./ReconstructedResume.tsx", async () => {
           "div",
           { key: "probe", "data-testid": "reconstructed-probe" },
           `jdContext=${props.jdContext ?? "NULL"}`,
+        ),
+        // Its own testid, not appended to the probe above: several assertions
+        // read that probe's whole `textContent` with `toBe`.
+        createElement(
+          "div",
+          { key: "skills-order", "data-testid": "skills-order-probe" },
+          `buried=${props.skillsOrder?.finding?.buried.join(",") ?? "NONE"}`,
         ),
         createElement(
           "div",
@@ -81,11 +89,15 @@ import type { ResumeCritique } from "../../lib/webllm/critique-resume.ts";
 
 const EMPTY_CRITIQUE: ResumeCritique = { bulletFindings: [], missingSections: [] };
 
-function result(summary?: string, title?: string): CascadeResult {
+function result(
+  summary?: string,
+  title?: string,
+  skills: string[] = [],
+): CascadeResult {
   return {
     canonical: {
       fields: {
-        skills: [],
+        skills,
         experience: title ? [{ title }] : [],
         education: [],
         ...(summary ? { summary } : {}),
@@ -159,9 +171,20 @@ let root: Root;
 
 const HOST_IDENTITY = parseIdentity();
 
-function Host({ opts, summary }: { opts: ControllerOpts; summary?: string }) {
+function Host({
+  opts,
+  summary,
+  buriedSkills,
+}: {
+  opts: ControllerOpts;
+  summary?: string;
+  /** A résumé whose Skills section trips the ordering heuristic (#544). */
+  buriedSkills?: { title: string; skills: string[] };
+}) {
   const edit = useEditableParse();
-  const res = result(summary);
+  const res = buriedSkills
+    ? result(summary, buriedSkills.title, buriedSkills.skills)
+    : result(summary);
   return createElement(ResultDetail, {
     activeResult: res,
     parseIdentity: HOST_IDENTITY,
@@ -176,12 +199,16 @@ function Host({ opts, summary }: { opts: ControllerOpts; summary?: string }) {
   });
 }
 
-function render(opts: ControllerOpts, summary?: string) {
+function render(
+  opts: ControllerOpts,
+  summary?: string,
+  buriedSkills?: { title: string; skills: string[] },
+) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root.render(createElement(Host, { opts, summary }));
+    root.render(createElement(Host, { opts, summary, buriedSkills }));
   });
   return container;
 }
@@ -719,5 +746,72 @@ describe("ResultDetail — the journey rail's steering report (#812)", () => {
         ?.click(),
     );
     expect(applied).not.toHaveBeenCalled();
+  });
+});
+
+// ── Skills-ordering placement (#544) ──────────────────────────────────────────
+
+/**
+ * The heuristic skills-ordering finding must reach the user WITHOUT the
+ * on-device model. It first shipped inside `CritiqueResults`, which mounts only
+ * under `status.kind === "done"` — so on a browser with no WebGPU the "Local AI
+ * feedback" disclosure is absent entirely and the finding was computed on every
+ * render and then thrown away. These pin the wiring that fixed it: the
+ * controller travels to `ReconstructedResume` (→ `TargetingSection` →
+ * `SkillTermGuidance`), which renders unconditionally.
+ *
+ * `ReconstructedResume` is mocked at the top of this file, so what is asserted
+ * here is the hand-off, not the row's markup — the row itself is covered in
+ * `SkillTermGuidance.test.tsx`.
+ */
+describe("ResultDetail — skills-ordering placement (#544)", () => {
+  /** Buried-skill résumé: "Engineering Leadership" is the top-scoring skill
+   *  against the title and sits outside the front window (skills-order.ts). */
+  const BURIED = {
+    title: "Engineering Manager",
+    skills: [
+      "Docker",
+      "AWS",
+      "Kubernetes",
+      "Engineering Leadership",
+      "Terraform",
+    ],
+  };
+
+  function buried(el: HTMLElement): string {
+    return (
+      el.querySelector('[data-testid="skills-order-probe"]')?.textContent ?? ""
+    );
+  }
+
+  /** Substring, not equality: `summaries()` returns the row's whole text, and
+   *  `Disclosure` prefixes its own ▸ glyph. An `toContain` over the array
+   *  would pass vacuously in BOTH directions. */
+  function hasAiSection(el: HTMLElement): boolean {
+    return summaries(el).some((s) => s.includes("Local AI feedback"));
+  }
+
+  it("hands the finding to the résumé surface on a browser with no WebGPU", () => {
+    const el = render({ isAvailable: false }, undefined, BURIED);
+    // The precondition that made this a real defect: with no WebGPU there is
+    // no "Local AI feedback" section at all, so a row hosted inside it would
+    // have been unreachable on this exact render.
+    expect(hasAiSection(el)).toBe(false);
+    expect(buried(el)).toBe("buried=Engineering Leadership");
+  });
+
+  it("hands it over on a WebGPU browser too — one mount, not two", () => {
+    const el = render({ isAvailable: true }, undefined, BURIED);
+    expect(hasAiSection(el)).toBe(true);
+    expect(buried(el)).toBe("buried=Engineering Leadership");
+    // The critique body is the surface it LEFT. A second mount there would put
+    // two rows over one shared controller, so both would enter the
+    // confirmation strip on a single Apply.
+    expect(el.textContent).not.toContain("Skills ordering");
+  });
+
+  it("passes a controller with no finding for a résumé with nothing buried", () => {
+    const el = render({ isAvailable: false });
+    expect(buried(el)).toBe("buried=NONE");
   });
 });

--- a/src/components/features/ResultDetail.tsx
+++ b/src/components/features/ResultDetail.tsx
@@ -64,7 +64,9 @@ import type { AnalysisController } from "../../hooks/useResumeAnalysisLlm.ts";
 import type { EscapeHatchController } from "../../hooks/useLlmEscapeHatch.ts";
 import type { LlmParsedResume } from "../../lib/webllm/parse-resume.ts";
 import { useTailorHandoff } from "../../hooks/useTailorHandoff.ts";
+import { useSkillsReorder } from "../../hooks/useSkillsReorder.ts";
 import { SECTION_IDS, scrollToSection } from "../../lib/anchors.ts";
+import { deriveTitles } from "../../lib/job-search/query-builder.ts";
 
 type SourceKind = "pdf" | "docx" | "markdown";
 
@@ -204,6 +206,29 @@ export function ResultDetail({
     !recoveryOffered &&
     (analysis.isAvailable || unavailableCapability !== null);
 
+  // Skills-ordering coaching (#544) — a HEURISTIC finding, independent of
+  // `analysis`'s on-device LLM pass, computed from the same edited fields
+  // `ReconstructedResume` renders (overrides already folded into
+  // `activeResult` — see `useAnalyzedResume.ts`).
+  //
+  // It renders inside `SkillTermGuidance` (via `ReconstructedResume` →
+  // `TargetingSection`), the résumé lane's other heuristic skills advisory —
+  // NOT in the critique lane, where it first shipped. `CritiqueResults` mounts
+  // only under `status.kind === "done"`, so a finding this hook computes on
+  // every parse was reachable only by a visitor who owns a WebGPU browser AND
+  // opts into the model download. "Independent of the on-device LLM" has to be
+  // true of what the user can see, not just of how it is computed.
+  //
+  // Owned here rather than inside that panel because this is the level both
+  // the résumé and the critique lane hang off, and one instance is what keeps
+  // the apply/undo state single — see `SkillTermGuidance`'s docblock.
+  const skillsOrder = useSkillsReorder(
+    activeResult.canonical.fields.skills,
+    activeResult.canonical.fields.skillCategories,
+    deriveTitles(activeResult.canonical.fields),
+    edit.reorderSkills,
+  );
+
   return (
     <>
       {escapeHatch.isAvailable && (
@@ -242,6 +267,10 @@ export function ResultDetail({
               ? analysis.status.critique
               : undefined
           }
+          // #544: passed through to `TargetingSection` → `SkillTermGuidance`,
+          // which is where the heuristic ordering call-out renders. Nothing
+          // between here and there reads it.
+          skillsOrder={skillsOrder}
         />
       </Card>
 

--- a/src/components/features/SkillTermGuidance.test.tsx
+++ b/src/components/features/SkillTermGuidance.test.tsx
@@ -15,6 +15,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { SkillTermGuidance } from "./SkillTermGuidance.tsx";
 import type { ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
+import type { SkillsReorderController } from "../../hooks/useSkillsReorder.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -22,14 +23,42 @@ import type { ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
 let container: HTMLDivElement;
 let root: Root;
 
-function render(parsed: ResumeQueryInput, onAddSkill: (skill: string) => void) {
+function render(
+  parsed: ResumeQueryInput,
+  onAddSkill: (skill: string) => void,
+  skillsOrder?: SkillsReorderController,
+) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root.render(createElement(SkillTermGuidance, { parsed, onAddSkill }));
+    root.render(
+      createElement(SkillTermGuidance, { parsed, onAddSkill, skillsOrder }),
+    );
   });
   return container;
+}
+
+/** A `useSkillsReorder` controller with something to say. Stubbed rather than
+ *  driven through the real hook: the hook's own lifecycle is covered in
+ *  `useSkillsReorder.test.tsx`, and what this file has to pin is that the row
+ *  reaches the screen HERE — on a surface with no model, no WebGPU check and
+ *  no `status.kind` (#544). */
+function reorderController(
+  overrides: Partial<SkillsReorderController> = {},
+): SkillsReorderController {
+  return {
+    finding: {
+      buried: ["Kubernetes"],
+      suggestedOrder: ["Kubernetes", "PostgreSQL", "C#"],
+    },
+    canApply: true,
+    applied: false,
+    apply: () => {},
+    undo: () => {},
+    dismiss: () => {},
+    ...overrides,
+  };
 }
 
 afterEach(() => {
@@ -134,5 +163,86 @@ describe("SkillTermGuidance", () => {
   it("renders nothing for an entirely empty résumé", () => {
     const el = render({ skills: [], experience: [] }, () => {});
     expect(el.textContent).toBe("");
+  });
+});
+
+// ── Skills ordering (#544) ────────────────────────────────────────────────────
+
+/**
+ * The regression these cover: the ordering row first shipped inside
+ * `CritiqueResults`, which mounts only under `status.kind === "done"` — so a
+ * finding computed on every parse was visible only after a visitor opted into
+ * the on-device model download. Nothing in this file touches WebGPU, a model,
+ * or an `AnalysisController`, which is the point: if the row renders here, it
+ * renders for the majority path.
+ */
+describe("SkillTermGuidance — skills ordering (#544)", () => {
+  it("renders the ordering call-out with no on-device model in play", () => {
+    const el = render(resolvableParsed(), () => {}, reorderController());
+    expect(el.textContent).toContain(
+      '"Kubernetes" looks highly relevant to your target role',
+    );
+    const reorder = el.querySelector(
+      'button[aria-label^="Move the highly relevant skills"]',
+    );
+    expect(reorder).not.toBeNull();
+  });
+
+  it("renders no ordering copy when the caller passes no controller", () => {
+    const el = render(resolvableParsed(), () => {});
+    expect(el.textContent).not.toContain("sits well down your Skills list");
+  });
+
+  it("renders no ordering copy when the controller has nothing to flag", () => {
+    const el = render(
+      resolvableParsed(),
+      () => {},
+      reorderController({ finding: undefined }),
+    );
+    expect(el.textContent).not.toContain("sits well down your Skills list");
+  });
+
+  it("Apply writes through the controller, never on render alone", () => {
+    let applied = 0;
+    const el = render(resolvableParsed(), () => {}, {
+      ...reorderController(),
+      apply: () => {
+        applied += 1;
+      },
+    });
+    expect(applied).toBe(0);
+    const reorder = el.querySelector(
+      'button[aria-label^="Move the highly relevant skills"]',
+    ) as HTMLButtonElement;
+    act(() => reorder.click());
+    expect(applied).toBe(1);
+  });
+
+  it("still renders when the classifier resolved no role at all", () => {
+    // All three term-quality buckets are empty here (`term-quality.ts` rule 1),
+    // which is the panel's own self-hide condition. The ordering heuristic
+    // needs only title TOKENS, not a resolved role profile, so the two can
+    // disagree — and the panel must not take the finding down with it.
+    const el = render(
+      {
+        skills: [],
+        experience: [{ title: "Chief Happiness Officer", company: "Acme Corp" }],
+      },
+      () => {},
+      reorderController(),
+    );
+    expect(el.textContent).toContain("sits well down your Skills list");
+  });
+
+  it("keeps the confirmation strip up while `applied` holds, finding gone", () => {
+    // Post-Apply the finding recomputes to undefined (the skills are no longer
+    // buried), but the undo affordance still has to be reachable.
+    const el = render(
+      resolvableParsed(),
+      () => {},
+      reorderController({ finding: undefined, applied: true }),
+    );
+    expect(el.querySelector("button[aria-label]")).not.toBeNull();
+    expect(el.textContent).toContain("Skills");
   });
 });

--- a/src/components/features/SkillTermGuidance.tsx
+++ b/src/components/features/SkillTermGuidance.tsx
@@ -62,6 +62,20 @@
  * `TermQualityAdvisory` itself can't be reused as-is: it writes into a
  * `JobQuery`, not the résumé model, and its copy is query-framed throughout.
  * So this is a new, narrowly-scoped sibling, not a parallel copy of either.
+ *
+ * SKILLS ORDERING (#544) IS HOSTED HERE, and this is now the ONLY place it
+ * renders. It first shipped inside `CritiqueResults`, which only mounts under
+ * `status.kind === "done"` — i.e. after the visitor opts into the on-device
+ * model download and runs it. A HEURISTIC finding that needs WebGPU to be seen
+ * is not a heuristic finding in any way the user can tell, and most visitors
+ * never run the model, so the issue's "a buried high-signal skill triggers a
+ * call-out" was unmet on the majority path. This panel is the surface the
+ * paragraph above says did not exist yet: same lane, no model gate, keyed off
+ * the same `titles[0]` the ordering heuristic scores against, and its Apply
+ * writes through the same `useEditableParse` seam `onAddSkill` does. It is
+ * mounted here and nowhere else, so the LLM-running and LLM-absent paths
+ * cannot show the row twice — the controller is shared state, so two mounted
+ * rows would both enter the confirmation strip on a single Apply.
  */
 
 import { useState } from "react";
@@ -70,6 +84,8 @@ import { assessQueryTerms } from "../../lib/job-search/term-quality.ts";
 import { buildJobQuery, type ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
 import { missingTermLabel } from "./TermQualityAdvisory.tsx";
 import { AddPill } from "./ReconstructedAdd.tsx";
+import { SkillsOrderFindingRow } from "./SkillsOrderFinding.tsx";
+import type { SkillsReorderController } from "../../hooks/useSkillsReorder.ts";
 
 /**
  * Read the parse through the term-quality classifier: what it recognized, what
@@ -103,12 +119,18 @@ export function assessResumeSkills(parsed: ResumeQueryInput) {
 export function SkillTermGuidance({
   parsed,
   onAddSkill,
+  skillsOrder,
 }: {
   /** The current parse — same shape `FindJobsPanel` feeds `buildJobQuery`. */
   parsed: ResumeQueryInput;
   /** The existing inline-edit path (`useEditableParse.addSkill`) — the ONLY
    *  way a suggestion here reaches the résumé. */
   onAddSkill: (skill: string) => void;
+  /** The skills-ordering coaching controller (#544, `useSkillsReorder`) — a
+   *  second HEURISTIC finding about the same Skills section, hosted here (see
+   *  the module docblock). Optional: a caller that omits it, or a résumé with
+   *  nothing to flag, gets byte-identical pre-#544 output. */
+  skillsOrder?: SkillsReorderController;
 }) {
   // Terms added from this panel, in click order. Purely a confirmation trail:
   // the résumé itself is written by `onAddSkill`, and an added term leaves
@@ -119,7 +141,23 @@ export function SkillTermGuidance({
   const { recognized, unrecognized, missing: missingSkills } =
     assessResumeSkills(parsed);
 
-  if (recognized.length === 0 && unrecognized.length === 0 && missingSkills.length === 0) {
+  // `applied` keeps the block up while the confirmation strip serves out its
+  // own hold, after the underlying finding has already recomputed away.
+  const showSkillsOrder =
+    skillsOrder !== undefined &&
+    (skillsOrder.finding !== undefined || skillsOrder.applied);
+
+  // The ordering finding is an INDEPENDENT reason to render: it needs only
+  // title tokens, whereas all three buckets above empty out whenever
+  // `term-quality.ts` cannot resolve a role PROFILE from the same titles
+  // (its rule 1). A résumé that hits one and not the other is ordinary, and
+  // self-hiding on the buckets alone would drop the ordering call-out on it.
+  if (
+    recognized.length === 0 &&
+    unrecognized.length === 0 &&
+    missingSkills.length === 0 &&
+    !showSkillsOrder
+  ) {
     return null;
   }
 
@@ -171,6 +209,16 @@ export function SkillTermGuidance({
           <span className="font-medium text-feedback-success-text">Added</span>{" "}
           to your Skills section: {added.join(", ")}.
         </p>
+      )}
+
+      {/* Between the skills you don't have and the ones you do — the ordering
+       *  finding is about skills already IN the résumé, so it belongs on this
+       *  side of that boundary. `<ul>` because the row is an `<li>`, shared
+       *  verbatim with the finding-row visual language it was written for. */}
+      {showSkillsOrder && skillsOrder && (
+        <ul className="flex flex-col gap-2 list-none">
+          <SkillsOrderFindingRow skillsOrder={skillsOrder} />
+        </ul>
       )}
 
       {recognized.length > 0 && (

--- a/src/components/features/SkillsOrderFinding.tsx
+++ b/src/components/features/SkillsOrderFinding.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * SkillsOrderFinding — the skills-ordering coaching row (#544).
+ *
+ * A HEURISTIC finding (`useSkillsReorder`, `lib/heuristics/skills-order.ts`),
+ * independent of the on-device LLM critique. Apply/confirm/undo reuses
+ * `ApplyConfirmation`/`UndoBatchButton` — the same components the
+ * whole-résumé and per-role rewrite panels use — rather than a new mechanism.
+ *
+ * ITS ONE MOUNT IS `SkillTermGuidance`, the résumé lane's other heuristic
+ * skills advisory, which renders on every parse. It was originally a row in
+ * `CritiqueResults` and kept the finding-row shape it was given there —
+ * an `<li>`, in the visual language of `BulletFindingRow`/`MissingSectionRow`
+ * — so its host supplies the `<ul>`. It left that panel because the panel
+ * mounts only under `status.kind === "done"`: a heuristic that a visitor can
+ * reach only by owning a WebGPU browser and opting into a model download is
+ * indistinguishable, to that visitor, from LLM output they chose not to run.
+ * Keep the single mount: `SkillsReorderController` is shared state, so two
+ * mounted rows would both flip into the confirmation strip on one Apply.
+ *
+ * It lives in this file rather than inline in its host for the reason it was
+ * split from `CritiquePanel.tsx` in the first place — both hosts are at or
+ * past the ~200 LOC guideline (CLAUDE.md).
+ *
+ * Design rules (CLAUDE.md): semantic tokens only, `<Button>` from
+ * "@design-system", no raw `<button>`.
+ */
+
+import { Button, StatusBadge } from "@design-system";
+import { ApplyConfirmation, UndoBatchButton, UNDO_HOLD_MS } from "./ApplyConfirmation.tsx";
+import type { SkillsReorderController } from "../../hooks/useSkillsReorder.ts";
+
+/** Coaching copy for the finding — never a hard error (#544 acceptance
+ *  criteria: advisory only). */
+function skillsOrderMessage(buried: string[]): string {
+  if (buried.length === 1) {
+    return `"${buried[0]}" looks highly relevant to your target role but sits well down your Skills list.`;
+  }
+  return `${buried.length} skills highly relevant to your target role sit well down your Skills list: ${buried.join(", ")}.`;
+}
+
+/**
+ * `buried` may be empty here even though the row is rendering: once Apply
+ * reorders the list the underlying finding recomputes to `undefined` (the
+ * skills are no longer buried), but the confirmation strip still needs to
+ * show until its own hold elapses.
+ */
+export function SkillsOrderFindingRow({
+  skillsOrder,
+}: {
+  skillsOrder: SkillsReorderController;
+}) {
+  const { finding, canApply, applied, apply, undo, dismiss } = skillsOrder;
+
+  if (applied) {
+    return (
+      <li className="rounded border border-border-light bg-surface-subtle p-3">
+        <ApplyConfirmation
+          count={1}
+          sections={["Skills"]}
+          onCollapse={dismiss}
+          holdMs={UNDO_HOLD_MS}
+          action={<UndoBatchButton onUndo={undo} />}
+        />
+      </li>
+    );
+  }
+
+  if (!finding) return null;
+
+  return (
+    <li className="flex flex-col gap-1.5 rounded border border-border-light bg-surface-subtle p-3">
+      <div className="flex flex-col gap-1">
+        <StatusBadge tone="info">Ordering</StatusBadge>
+        <p className="text-sm text-content-secondary leading-snug">
+          {skillsOrderMessage(finding.buried)} Readers and keyword scans
+          weight earlier items more.
+        </p>
+      </div>
+      {canApply ? (
+        <Button
+          variant="link"
+          size="sm"
+          onClick={apply}
+          className="self-start text-2xs font-medium text-accent-primary"
+          aria-label="Move the highly relevant skills to the front of the Skills list"
+        >
+          Reorder skills →
+        </Button>
+      ) : (
+        <p className="text-sm text-content-tertiary">
+          Skills are grouped into categories — use each chip&rsquo;s
+          &ldquo;Move to&rdquo; menu (or drag it) to reorder them.
+        </p>
+      )}
+    </li>
+  );
+}

--- a/src/components/features/TargetingSection.tsx
+++ b/src/components/features/TargetingSection.tsx
@@ -48,6 +48,7 @@ import {
   assessResumeSkills,
 } from "./SkillTermGuidance.tsx";
 import type { ResumeQueryInput } from "../../lib/job-search/query-builder.ts";
+import type { SkillsReorderController } from "../../hooks/useSkillsReorder.ts";
 
 interface TargetingSectionProps {
   /** Distinct role titles, most-recent-first, from `deriveTitles`. */
@@ -60,6 +61,12 @@ interface TargetingSectionProps {
   parsed: ResumeQueryInput;
   /** `useEditableParse.addSkill` — the only way a suggestion reaches the résumé. */
   onAddSkill: (skill: string) => void;
+  /** Skills-ordering coaching (#544) — forwarded straight to
+   *  `SkillTermGuidance`, which hosts the row. Not read here: the summary
+   *  `count` stays the ADDABLE half only (see below), and the ordering finding
+   *  cannot fire without titles, so it can never be the thing that would have
+   *  kept this section from self-hiding. */
+  skillsOrder?: SkillsReorderController;
 }
 
 export function TargetingSection({
@@ -68,6 +75,7 @@ export function TargetingSection({
   onPrimaryChange,
   parsed,
   onAddSkill,
+  skillsOrder,
 }: TargetingSectionProps) {
   const skills = assessResumeSkills(parsed);
 
@@ -110,7 +118,11 @@ export function TargetingSection({
           primary={primary}
           onPrimaryChange={onPrimaryChange}
         />
-        <SkillTermGuidance parsed={parsed} onAddSkill={onAddSkill} />
+        <SkillTermGuidance
+          parsed={parsed}
+          onAddSkill={onAddSkill}
+          skillsOrder={skillsOrder}
+        />
       </div>
     </Disclosure>
   );

--- a/src/hooks/useEditableParse.test.tsx
+++ b/src/hooks/useEditableParse.test.tsx
@@ -558,6 +558,87 @@ describe("useEditableParse — ungrouped remainder on the first category (#791)"
   });
 });
 
+// ── reorderSkills (#544) ───────────────────────────────────────────────────────
+
+describe("useEditableParse — reorderSkills (#544)", () => {
+  it("rewrites a flat (uncategorised) skills list into the given order", () => {
+    const parsed = {
+      skills: ["Docker", "AWS", "Kubernetes", "Terraform"],
+      skillCategories: undefined,
+    };
+    act(() =>
+      api.reorderSkills(["Kubernetes", "Docker", "AWS", "Terraform"]),
+    );
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "Kubernetes",
+      "Docker",
+      "AWS",
+      "Terraform",
+    ]);
+  });
+
+  it("a second reorderSkills call restores the original order (undo)", () => {
+    const parsed = {
+      skills: ["Docker", "AWS", "Kubernetes", "Terraform"],
+      skillCategories: undefined,
+    };
+    act(() =>
+      api.reorderSkills(["Kubernetes", "Docker", "AWS", "Terraform"]),
+    );
+    act(() =>
+      api.reorderSkills(["Docker", "AWS", "Kubernetes", "Terraform"]),
+    );
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "Docker",
+      "AWS",
+      "Kubernetes",
+      "Terraform",
+    ]);
+  });
+
+  it("does NOT resurrect a skill the user deleted first", () => {
+    const parsed = {
+      skills: ["React", "PHP", "Python", "Docker", "AWS", "GraphQL"],
+      skillCategories: undefined,
+    };
+    act(() => api.removeSkill("PHP"));
+    const current = computeEditedSkills(parsed, api.skillsOverride).skills;
+    expect(current).toEqual(["React", "Python", "Docker", "AWS", "GraphQL"]);
+
+    // `order` is a permutation of the CURRENT list, so PHP is legitimately
+    // absent from it — which is exactly why REPLACING `removed` with the
+    // order's keys (instead of merging) un-deleted PHP, and `applyFlatEdits`
+    // then re-emitted it from the pristine parse ahead of every `added` entry:
+    // a deleted skill silently returning at the FRONT, from a control labelled
+    // "Reorder skills".
+    act(() => api.reorderSkills([...current].reverse()));
+
+    expect(computeEditedSkills(parsed, api.skillsOverride).skills).toEqual([
+      "GraphQL",
+      "AWS",
+      "Docker",
+      "Python",
+      "React",
+    ]);
+    // The tombstone itself, not just its effect — the merge is the mechanism.
+    expect(api.skillsOverride.removed).toContain("php");
+  });
+
+  it("is a no-op while a non-empty category snapshot exists", () => {
+    const cats: SkillCategory[] = [
+      { label: "Cloud", skills: ["AWS", "Docker"] },
+      { label: "Languages", skills: ["Python", "Go"] },
+    ];
+    act(() => api.moveSkillToCategory(cats, "AWS", 1)); // mints a non-empty snapshot
+    const before = api.skillsOverride;
+    act(() => api.reorderSkills(["Docker", "AWS", "Python", "Go"]));
+    // Unchanged: the categorised branch owns order, not the flat override —
+    // writing removed/added here would trip `computeEditedSkills`'s DEV
+    // assertion, so the write must not happen at all.
+    expect(api.skillsOverride).toBe(before);
+  });
+});
+
 // ── Summary override (#625) ───────────────────────────────────────────────────
 
 /** The summary's SECOND writer, as the whole-résumé review drives it: build the

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -769,6 +769,11 @@ export interface EditableParse {
    *  (which the editor still wires the chip Remove buttons to) rather than
    *  emitting a flat `removed` key the categorised branch rejects. */
   removeSkill: (skill: string) => void;
+  /** Rewrite the flat skills list into `order` (a permutation of the current
+   *  resolved list) — the Apply action for the skills-ordering coaching
+   *  finding (#544). No-op while a non-empty category snapshot exists; see
+   *  the implementation's docblock. */
+  reorderSkills: (order: readonly string[]) => void;
   /** Rename the category at `index` in `cats` (the current rendered grouping) —
    *  label-only, members untouched (#476). */
   renameSkillCategory: (
@@ -1311,6 +1316,48 @@ export function useEditableParse(): EditableParse {
         ? prev.removed
         : [...prev.removed, key];
       return { ...prev, removed, added };
+    });
+  }, []);
+
+  /**
+   * Rewrite the FLAT skills list into `order` — the write path for the
+   * skills-ordering coaching finding's Apply action (#544, `useSkillsReorder`).
+   *
+   * `order` must be a permutation of the CURRENT resolved skills list (what
+   * `computeEditedSkills` currently returns) — that is exactly the contract
+   * `computeSkillsOrderFinding.suggestedOrder` promises. Implemented by
+   * reusing `applyFlatEdits`'s existing remove-then-append semantics rather
+   * than adding a new override field: marking every skill in `order` as
+   * `removed` empties the base list, and re-`added`-ing them in `order`
+   * rebuilds it in the new sequence — one flat override write, no new state
+   * shape (mirrors the flat halves of `addSkill`/`removeSkill` above).
+   *
+   * `removed` is MERGED with the existing set, never replaced. A skill the
+   * user deleted is kept out of the list by its key STAYING in `removed`, and
+   * `order` is a permutation of the CURRENT list, which by definition no
+   * longer contains it — so an overwrite un-deletes it, and `applyFlatEdits`
+   * re-emits it from the pristine parse AHEAD of everything in `added`. A
+   * deleted skill would silently return, at the most prominent position, from
+   * a control that only claims to reorder.
+   *
+   * A no-op while a non-empty category snapshot exists: `SkillsSection`
+   * renders a categorised résumé from `skillCategories`, not the flat list's
+   * order (`ReconstructedSkills.tsx`), so writing a new flat order here would
+   * silently do nothing on screen — and `computeEditedSkills` asserts (in DEV)
+   * that `removed`/`added` stay empty on that branch. Callers gate the Apply
+   * affordance itself on the same condition (`useSkillsReorder`'s `canApply`)
+   * so the button isn't offered when it would be a no-op.
+   */
+  const reorderSkills = useCallback((order: readonly string[]) => {
+    setSkillsOverride((prev) => {
+      if (prev.categories && prev.categories.length > 0) return prev;
+      const removed = [
+        ...new Set([
+          ...prev.removed,
+          ...order.map((s) => s.trim().toLowerCase()),
+        ]),
+      ];
+      return { ...prev, removed, added: [...order] };
     });
   }, []);
 
@@ -1946,6 +1993,7 @@ export function useEditableParse(): EditableParse {
     skillsOverride,
     addSkill,
     removeSkill,
+    reorderSkills,
     renameSkillCategory,
     deleteSkillCategory,
     addSkillCategory,

--- a/src/hooks/useSkillsReorder.test.tsx
+++ b/src/hooks/useSkillsReorder.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * useSkillsReorder — the apply/undo/dismiss lifecycle around the pure
+ * `computeSkillsOrderFinding` heuristic (#544). The heuristic's own scoring
+ * rules are covered directly in `lib/heuristics/skills-order.test.ts`; this
+ * file covers the STATEFUL wiring: apply writes through `reorderSkills`,
+ * undo reverts to the pre-apply order, and `canApply` reflects a category
+ * snapshot. Exercised through a probe component — the project has no
+ * @testing-library/react (same pattern as `useEditableParse.test.tsx`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useState } from "react";
+import { useSkillsReorder, type SkillsReorderController } from "./useSkillsReorder.ts";
+import type { SkillCategory } from "../lib/heuristics/types.ts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const SKILLS = ["Docker", "AWS", "Kubernetes", "Engineering Leadership", "Terraform"];
+const TITLES = ["Engineering Manager"];
+
+let container: HTMLDivElement;
+let root: Root;
+let api: SkillsReorderController;
+let writes: string[][];
+
+function Probe({
+  skillCategories,
+}: {
+  skillCategories?: SkillCategory[];
+}) {
+  const [skills, setSkills] = useState<string[]>(SKILLS);
+  const reorderSkills = (order: readonly string[]) => {
+    writes.push([...order]);
+    setSkills([...order]);
+  };
+  api = useSkillsReorder(skills, skillCategories, TITLES, reorderSkills);
+  return null;
+}
+
+beforeEach(() => {
+  writes = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Probe />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useSkillsReorder", () => {
+  it("starts with a finding, not applied, and canApply true (flat skills)", () => {
+    expect(api.finding?.buried).toEqual(["Engineering Leadership"]);
+    expect(api.canApply).toBe(true);
+    expect(api.applied).toBe(false);
+  });
+
+  it("apply() writes the suggested order and flips to applied", () => {
+    act(() => api.apply());
+    expect(writes).toEqual([
+      ["Engineering Leadership", "Docker", "AWS", "Kubernetes", "Terraform"],
+    ]);
+    expect(api.applied).toBe(true);
+    // Reordered — the finding recomputes to undefined (no longer buried).
+    expect(api.finding).toBeUndefined();
+  });
+
+  it("undo() reverts to the pre-apply order and clears applied", () => {
+    act(() => api.apply());
+    act(() => api.undo());
+    expect(writes[1]).toEqual(SKILLS);
+    expect(api.applied).toBe(false);
+    // Back to the original order — the finding fires again.
+    expect(api.finding?.buried).toEqual(["Engineering Leadership"]);
+  });
+
+  it("dismiss() clears applied without reverting the write", () => {
+    act(() => api.apply());
+    act(() => api.dismiss());
+    expect(api.applied).toBe(false);
+    // Only one write ever happened — dismiss is not an undo.
+    expect(writes).toHaveLength(1);
+  });
+
+  it("canApply is false while a non-empty category snapshot exists, and apply() no-ops", () => {
+    const cats: SkillCategory[] = [{ label: "Cloud", skills: ["AWS", "Docker"] }];
+    act(() => root.render(<Probe skillCategories={cats} />));
+    expect(api.canApply).toBe(false);
+    act(() => api.apply());
+    expect(writes).toHaveLength(0);
+    expect(api.applied).toBe(false);
+  });
+});

--- a/src/hooks/useSkillsReorder.ts
+++ b/src/hooks/useSkillsReorder.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * useSkillsReorder — the confirm/undo controller for the skills-ordering
+ * coaching finding (#544).
+ *
+ * Wraps the pure heuristic (`computeSkillsOrderFinding`,
+ * `lib/heuristics/skills-order.ts`) with the SAME apply/undo shape the
+ * whole-résumé and per-role rewrite controllers already use
+ * (`useResumeRewrite`'s `confirmApplied`/`undoApplied`/`dismiss`, mirrored
+ * here as `apply`/`undo`/`dismiss`), so its row renders through the existing
+ * `ApplyConfirmation`/`UndoBatchButton` components rather than a new
+ * confirm/undo mechanism (the Reuse Gate).
+ *
+ * One instance per résumé, owned by `ResultDetail` and passed down to the
+ * single surface that renders it (`SkillTermGuidance`, via
+ * `ReconstructedResume` → `TargetingSection`). The apply/undo state below is
+ * this hook's own `useState`, so a second call site would be a second,
+ * independent lifecycle over the same list.
+ *
+ * `apply()` is a no-op while `canApply` is false — a Skills section grouped
+ * into categories renders from the GROUPING, not the flat list's array order
+ * (`SkillsSection` / `ReconstructedSkills.tsx` reads `skillCategories`, not
+ * `skills`'s sequence), so writing a new flat order would silently do
+ * nothing on screen. The coaching finding still shows for a categorised
+ * résumé — only the one-click Apply is withheld; the chip cluster's own
+ * drag / "Move to" controls already reorder within and across categories.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  computeSkillsOrderFinding,
+  type SkillsOrderFinding,
+} from "../lib/heuristics/skills-order.ts";
+import type { SkillCategory } from "../lib/heuristics/types.ts";
+
+export interface SkillsReorderController {
+  /** Undefined when nothing is worth flagging — see the heuristic's docblock. */
+  finding: SkillsOrderFinding | undefined;
+  /** False while a non-empty category snapshot exists (see module docblock). */
+  canApply: boolean;
+  /** True from `apply()` until the confirmation strip's own hold elapses
+   *  (`dismiss()`) or the user clicks Undo. */
+  applied: boolean;
+  /** Write `finding.suggestedOrder` via `reorderSkills`. No-op with no
+   *  finding or while `canApply` is false. */
+  apply: () => void;
+  /** Revert to the order captured just before `apply()`. No-op before an apply. */
+  undo: () => void;
+  /** The confirmation strip's own auto-collapse (`ApplyConfirmation`'s
+   *  `onCollapse`) — clears `applied` without reverting the write. */
+  dismiss: () => void;
+}
+
+export function useSkillsReorder(
+  skills: readonly string[],
+  skillCategories: readonly SkillCategory[] | undefined,
+  titles: readonly string[],
+  reorderSkills: (order: readonly string[]) => void,
+): SkillsReorderController {
+  const [previous, setPrevious] = useState<string[] | null>(null);
+
+  // Memoised on the CONTENT of the two inputs, not their identity: `titles`
+  // reaches us from `deriveTitles(...)`, which mints a fresh array on every
+  // render of every caller, so an identity dep would never hit and the memo
+  // would be pure overhead. The finding is a fresh object each time it runs,
+  // and it is a dep of `apply` below — recomputing it per render churned that
+  // callback's identity for every consumer.
+  //
+  // Deps hand-audited (`exhaustive-deps` is NOT enforced — CLAUDE.md):
+  // `skills`/`titles` are read inside but deliberately absent from the dep
+  // list, because a key change and a content change are the same event, and
+  // `computeSkillsOrderFinding` reads nothing else. `\u0000` cannot occur in a
+  // skill or a title, so the join is unambiguous.
+  const skillsKey = skills.join("\u0000");
+  const titlesKey = titles.join("\u0000");
+  const finding = useMemo(
+    () => computeSkillsOrderFinding(skills, titles),
+    [skillsKey, titlesKey],
+  );
+  const canApply = !skillCategories || skillCategories.length === 0;
+
+  const apply = useCallback(() => {
+    if (!finding || !canApply) return;
+    setPrevious([...skills]);
+    reorderSkills(finding.suggestedOrder);
+  }, [finding, canApply, skills, reorderSkills]);
+
+  const undo = useCallback(() => {
+    if (previous === null) return;
+    reorderSkills(previous);
+    setPrevious(null);
+  }, [previous, reorderSkills]);
+
+  const dismiss = useCallback(() => setPrevious(null), []);
+
+  return {
+    finding,
+    canApply,
+    applied: previous !== null,
+    apply,
+    undo,
+    dismiss,
+  };
+}

--- a/src/lib/heuristics/skills-order.test.ts
+++ b/src/lib/heuristics/skills-order.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { describe, it, expect } from "vitest";
+import { computeSkillsOrderFinding } from "./skills-order.ts";
+
+describe("computeSkillsOrderFinding", () => {
+  it("flags a high-signal skill buried below the front window and leads it in suggestedOrder", () => {
+    const skills = [
+      "Docker",
+      "AWS",
+      "Kubernetes",
+      "Engineering Leadership",
+      "Terraform",
+    ];
+    const finding = computeSkillsOrderFinding(skills, ["Engineering Manager"]);
+    expect(finding?.buried).toEqual(["Engineering Leadership"]);
+    expect(finding?.suggestedOrder[0]).toBe("Engineering Leadership");
+    // A permutation of the input — nothing added or dropped.
+    expect([...finding!.suggestedOrder].sort()).toEqual([...skills].sort());
+  });
+
+  it("matches via a loose (prefix) stem — 'Engineering' against 'Engineer'", () => {
+    const skills = [
+      "Docker",
+      "AWS",
+      "Kubernetes",
+      "Engineering Leadership",
+      "Terraform",
+    ];
+    const finding = computeSkillsOrderFinding(skills, [
+      "Machine Learning Engineer",
+    ]);
+    expect(finding?.buried).toEqual(["Engineering Leadership"]);
+  });
+
+  it("does not loosely match 'Java' against 'JavaScript' — same prefix, different discipline", () => {
+    const skills = ["Docker", "AWS", "Kubernetes", "JavaScript", "Terraform"];
+    const finding = computeSkillsOrderFinding(skills, ["Java Developer"]);
+    // JavaScript shares no exact token with "Java Developer" and must not
+    // loosely match "java" (the shared stem is the whole 4-char "java", but
+    // "javascript" diverges by +6, over the cap) — so there is no relevance
+    // signal here at all, and no finding fires.
+    expect(finding).toBeUndefined();
+  });
+
+  it("still matches stem pairs that diverge on both sides of a shared root", () => {
+    // A narrower "one token is a prefix of the other" rule (tried first,
+    // then rejected) blocked java/javascript but also lost these three real
+    // stem pairs, since neither token is a full prefix of the other here.
+    for (const [skill, title] of [
+      ["Full-Stack Development", "Software Developer"],
+      ["Analytical Thinking", "Data Analytics"],
+      ["Engineering Strategy", "Software Engineers"],
+    ] as const) {
+      const skills = ["Docker", "AWS", "Kubernetes", skill, "Terraform"];
+      const finding = computeSkillsOrderFinding(skills, [title]);
+      expect(finding?.buried).toEqual([skill]);
+    }
+  });
+
+  it("returns undefined below the minimum skill count", () => {
+    const finding = computeSkillsOrderFinding(
+      ["Docker", "AWS", "Engineering Leadership"],
+      ["Engineering Manager"],
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("returns undefined with no target titles", () => {
+    const finding = computeSkillsOrderFinding(
+      ["Docker", "AWS", "Kubernetes", "Engineering Leadership", "Terraform"],
+      [],
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("returns undefined when no skill overlaps the target at all", () => {
+    const finding = computeSkillsOrderFinding(
+      ["Docker", "AWS", "Kubernetes", "Terraform", "Python"],
+      ["Sales Director"],
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("returns undefined when the high-signal skill already leads the list", () => {
+    const finding = computeSkillsOrderFinding(
+      ["Engineering Leadership", "Docker", "AWS", "Kubernetes", "Terraform"],
+      ["Engineering Manager"],
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("flags every skill tied for the top relevance score", () => {
+    const skills = [
+      "Docker",
+      "AWS",
+      "Kubernetes",
+      "Terraform",
+      "Engineering Leadership",
+      "Engineering Strategy",
+    ];
+    const finding = computeSkillsOrderFinding(skills, ["Engineering Manager"]);
+    expect(finding?.buried).toEqual([
+      "Engineering Leadership",
+      "Engineering Strategy",
+    ]);
+    // Stable tie-break (canonical-index weighting): both tied leaders keep
+    // their relative original order at the front of the suggestion.
+    expect(finding?.suggestedOrder.slice(0, 2)).toEqual([
+      "Engineering Leadership",
+      "Engineering Strategy",
+    ]);
+  });
+});

--- a/src/lib/heuristics/skills-order.ts
+++ b/src/lib/heuristics/skills-order.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * skills-order — heuristic skills-ordering coaching (issue #544).
+ *
+ * A résumé's Skills section is usually ordered by habit, not by relevance —
+ * readers and ATS keyword scans both weight earlier items more, so a
+ * high-signal skill buried mid-list undersells the candidate. This module is
+ * the "start simple" heuristic the issue asks for: title/target relevance
+ * (word-overlap against the candidate's derived titles) plus canonical-index
+ * weighting (a stable tie-break on the skill's ORIGINAL position, so the
+ * suggested order never reshuffles two equally-relevant skills for no
+ * reason). Layering the on-device LLM on top is explicitly deferred — see the
+ * issue's "Notes".
+ *
+ * Pure, dependency-free, no React/engine/I-O — mirrors `disagreement.ts` and
+ * `skills-categories.ts`. Consumed by `useSkillsReorder` (the confirm/undo
+ * controller) and rendered by `SkillsOrderFinding.tsx` inside
+ * `SkillTermGuidance` — the résumé lane's existing heuristic skills advisory,
+ * not a parallel surface, and not the WebGPU-gated critique panel (see that
+ * component's docblock for why the row is not hosted there).
+ */
+
+// ── Tokenizing + scoring ───────────────────────────────────────────────────
+
+/** Role-seniority qualifiers that would otherwise dominate every title's
+ *  token set without naming a discipline — dropping them keeps the overlap
+ *  test about WHAT the role does, not its level. */
+const STOPWORDS = new Set([
+  "senior",
+  "sr",
+  "junior",
+  "jr",
+  "staff",
+  "principal",
+  "lead",
+  "chief",
+  "head",
+  "vp",
+  "vice",
+  "president",
+  "director",
+  "manager",
+  "and",
+  "the",
+  "of",
+  "for",
+  "with",
+]);
+
+/** Lower-case word tokens, dropping seniority stopwords and anything shorter
+ *  than 2 chars (punctuation remnants). `+`/`#` survive the split so "C++" /
+ *  "C#" tokenize as themselves rather than the bare letter. */
+function tokenize(text: string): Set<string> {
+  const tokens = text
+    .toLowerCase()
+    .split(/[^a-z0-9+#]+/)
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+  return new Set(tokens);
+}
+
+/** Longest shared prefix, e.g. "developer"/"development" -> 7 ("develop"). */
+function commonPrefixLength(a: string, b: string): number {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+}
+
+/** Two tokens diverging by at most 4 chars on EITHER side of their shared
+ *  stem, requiring a stem of at least 4 chars — a cheap stand-in for
+ *  stemming. This is a common-prefix bound, not a "one is a prefix of the
+ *  other" bound: that narrower shape (tried first) matched
+ *  "engineer"/"engineering" but missed real stem pairs that diverge on BOTH
+ *  sides of the shared root, like "developer"/"development" (stem "develop",
+ *  +2/+4) and "analytics"/"analytical" (stem "analytic", +1/+2) — neither
+ *  token is a prefix of the other. It still rejects "java"/"javascript": the
+ *  stem is the whole 4-char "java", but "javascript" diverges by +6, over
+ *  the cap. Both tokens must clear the 4-char stem floor so short words
+ *  ("ai", "ml", "go") only match exactly, never by accidental prefix. */
+function looselyMatches(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length < 4 || b.length < 4) return false;
+  const stem = commonPrefixLength(a, b);
+  return stem >= 4 && a.length - stem <= 4 && b.length - stem <= 4;
+}
+
+/** Relevance of one skill to the target: count of skill tokens that match a
+ *  title token, exact matches counting double a loose (prefix) match — so
+ *  "Engineering Leadership" against "Engineering Manager" scores higher than
+ *  a skill that only loosely echoes the title. */
+function relevanceScore(skill: string, titleTokens: Set<string>): number {
+  let score = 0;
+  for (const token of tokenize(skill)) {
+    if (titleTokens.has(token)) {
+      score += 2;
+      continue;
+    }
+    for (const titleToken of titleTokens) {
+      if (looselyMatches(token, titleToken)) {
+        score += 1;
+        break;
+      }
+    }
+  }
+  return score;
+}
+
+// ── Public shape ─────────────────────────────────────────────────────────
+
+export interface SkillsOrderFinding {
+  /** High-signal skills (relative to the target) sitting outside the "front"
+   *  of the list, in their current document order. Coaching copy names these. */
+  buried: string[];
+  /** `skills` re-ordered relevance-desc, ties broken by original index (the
+   *  canonical-index weighting) — what an Apply action would write. Always a
+   *  permutation of the input `skills` array. */
+  suggestedOrder: string[];
+}
+
+/** Below this many skills, "ordering" barely matters — a short list is read
+ *  in full regardless of sequence, so no finding fires. */
+const MIN_SKILLS_FOR_FINDING = 5;
+
+/** The "front" of the list is the first 30% (never fewer than 3 skills) — a
+ *  high-signal skill inside that window is already well-placed. */
+const MIN_FRONT_WINDOW = 3;
+const FRONT_FRACTION = 0.3;
+
+/**
+ * Compute the skills-ordering coaching finding, or `undefined` when nothing
+ * is worth flagging: too few skills, no usable title/target signal, or no
+ * skill scores above zero against it, or every top-scoring skill already
+ * sits in the front window.
+ *
+ * `titles` is the candidate's derived target titles (`deriveTitles` from
+ * `job-search/query-builder.ts`), passed in by the caller rather than
+ * imported here — keeps this module dependency-free, matching the house
+ * style for pure heuristics (`skills-categories.ts`).
+ */
+export function computeSkillsOrderFinding(
+  skills: readonly string[],
+  titles: readonly string[],
+): SkillsOrderFinding | undefined {
+  if (skills.length < MIN_SKILLS_FOR_FINDING) return undefined;
+
+  const titleTokens = tokenize(titles.join(" "));
+  if (titleTokens.size === 0) return undefined;
+
+  const scored = skills.map((skill, index) => ({
+    skill,
+    index,
+    score: relevanceScore(skill, titleTokens),
+  }));
+
+  const maxScore = Math.max(...scored.map((s) => s.score));
+  if (maxScore <= 0) return undefined;
+
+  const frontWindow = Math.max(
+    MIN_FRONT_WINDOW,
+    Math.ceil(skills.length * FRONT_FRACTION),
+  );
+
+  // High-signal = tied for the résumé's own top relevance score — a
+  // conservative bar so the finding only fires on the skills a reader would
+  // most regret missing, not on every skill with any overlap at all.
+  const buried = scored
+    .filter((s) => s.index >= frontWindow && s.score === maxScore)
+    .map((s) => s.skill);
+
+  if (buried.length === 0) return undefined;
+
+  const suggestedOrder = [...scored]
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((s) => s.skill);
+
+  return { buried, suggestedOrder };
+}


### PR DESCRIPTION
## Summary

Surfaces skills-ordering guidance in the résumé review + rewrite lane. A high-signal
skill sitting far down the list relative to the candidate's title/target now
triggers a coaching call-out (never a hard error), and the user can apply a
relevance-first reorder via the existing section-rewrite confirm/undo pattern.

The finding is a plain heuristic (title/target word-overlap + canonical-index
tie-break), independent of the on-device LLM — it renders inside
`SkillTermGuidance`, the existing non-LLM-gated heuristic surface, so it's visible
on every parse rather than only after a user opts into downloading the on-device
model.

Apply is scoped to the flat (uncategorized) skills list; a categorized résumé shows
the coaching note with a pointer at the existing manual drag controls instead,
since `SkillsSection` renders order from category grouping, not the flat array.

## Verification

- 15 new unit tests: heuristic (`skills-order.ts`), the confirm/undo controller
  (`useSkillsReorder`), and the edit-hook reorder path (`useEditableParse`).
- `npm run typecheck` / `npm run lint` clean.

## Stack position

Layer 3 of 4. Base: #872. Depends on #872.

## Adversarial review

Two round-1 blocking findings, both fixed and verified in round 2:
- **`reorderSkills` resurrected deleted skills** — it overwrote the removed-skills
  set instead of merging with it, so a skill deleted before a reorder came back at
  the front of the list. Fixed to merge via `Set` union; regression test added.
- **The heuristic was invisible without WebGPU** — it originally mounted only
  inside the LLM-gated critique panel, contradicting its own "independent of the
  on-device LLM" docblock. Moved to `SkillTermGuidance` (single mount, no LLM gate);
  verified no double-mount and the panel's self-hide guard doesn't hide it.

Two nits remain, not blocking: the panel heading can promise a list it doesn't
render in the ordering-only edge case, and Apply-then-Undo leaves the résumé's
edit-dirty flag permanently set (autosave already fired on Apply, so low impact).

Closes #544
