### PR TITLE
feat(export): bold the category label on categorised skills lines

### DIFF
--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -593,7 +593,11 @@ describe("buildAtsResumeModel", () => {
       "Data Stores",
       "Backend",
     ]);
-    expect(skills.entries[0].headerLine).toBe("Data Stores: PostgreSQL · Redis");
+    // The label leads the line in bold, carried apart from the members so they
+    // keep atomic middot wrapping (#881); its trailing space is drawn.
+    expect(skills.entries[0].headerBoldLead).toBe("Data Stores: ");
+    expect(skills.entries[0].headerLine).toBe("PostgreSQL · Redis");
+    expect(skills.entries[1].headerBoldLead).toBe("Backend: ");
   });
 
   it("drops an empty category so the PDF renders no dangling 'Label:' (#476)", () => {
@@ -625,6 +629,9 @@ describe("buildAtsResumeModel", () => {
     expect(skills.entries[0].fields?.skillCategory).toBe("Data Stores");
     expect(skills.entries[1].fields?.skillCategory).toBeUndefined();
     expect(skills.entries[1].headerLine).toBe("Excel · PowerPoint");
+    // The remainder is a plain flat line — no bold lead to invent a label for
+    // skills the user never grouped (#881 AC).
+    expect(skills.entries[1].headerBoldLead).toBeUndefined();
     // The union across every entry equals the flat list — nothing lost or
     // duplicated.
     const exported = skills.entries.flatMap((e) => e.fields?.skills ?? []);
@@ -653,6 +660,7 @@ describe("buildAtsResumeModel", () => {
     const skills = model.sections.find((s) => s.heading === "Skills")!;
     expect(skills.entries).toHaveLength(1);
     expect(skills.entries[0].headerLine).toBe("React · TypeScript · Node.js");
+    expect(skills.entries[0].headerBoldLead).toBeUndefined();
     expect(skills.entries[0].fields?.skillCategory).toBeUndefined();
   });
 });

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -175,9 +175,24 @@ export interface AtsEntry {
   /**
    * Whether `headerLine` is drawn bold. Defaults to `true` (every role /
    * degree / achievement header is bold); set `false` on the skills entry so
-   * the skills list renders as regular-weight body text (#425).
+   * the skills list renders as regular-weight body text (#425). It governs
+   * `headerLine` only — {@link headerBoldLead} is bold regardless.
    */
   headerBold?: boolean;
+  /**
+   * A bold lead drawn ahead of `headerLine` on its first line, which wraps into
+   * whatever width is left beside it (#881) — the category label of a
+   * categorised skills entry, the only structure that section has.
+   *
+   * It is carried APART from `headerLine` (rather than emitted inside emphasis
+   * sentinels, the way an achievement's "type" label is) because the sentinel
+   * path wraps on plain whitespace words: a bolded label there would break a
+   * multi-word skill mid-name and re-parse it as two skills (#301). The lead
+   * includes its trailing separator space, which is drawn — the members sit
+   * flush against its end, so that space is the only word boundary the re-parse
+   * has between the label and the first member.
+   */
+  headerBoldLead?: string;
   /** Bullet body lines (already stripped of leading markers, non-empty). */
   bullets: string[];
   /**
@@ -847,7 +862,10 @@ export function buildAtsResumeModel(
   let skillsEntries: AtsEntry[];
   if (skillCategories && skillCategories.length > 0) {
     skillsEntries = skillCategories.map((c) => ({
-      headerLine: `${c.label}: ${c.skills.join(" · ")}`,
+      headerLine: c.skills.join(" · "),
+      // The label leads the line in bold (#881) and the members wrap beside it;
+      // see `headerBoldLead` for why it is not glued into `headerLine`.
+      headerBoldLead: `${c.label}: `,
       bullets: [],
       atomicSegments: true,
       headerBold: false,

--- a/src/lib/pdf/render-ats-pdf.ts
+++ b/src/lib/pdf/render-ats-pdf.ts
@@ -82,7 +82,7 @@ import {
   EMPHASIS_CLOSE,
 } from "./auto-bold-metrics.ts";
 import { toJsonResume } from "./to-json-resume.ts";
-import { wrapWordsToLines } from "./text-wrap.ts";
+import { wrapWordsToLines, firstLineInset } from "./text-wrap.ts";
 import {
   bulletSplitFinding,
   collectModelTextFields,
@@ -736,15 +736,26 @@ function makeEmbeddedFontSanitizer(
  * The wrap point only falls between segments (rejoined with
  * `MIDDOT_SEGMENT_SEP`); a segment wider than `maxWidth` on its own falls
  * back to `wrapWordsToLines` for that segment only. Exported for testing.
+ *
+ * `firstLineMaxWidth` narrows line 0 for a bold inset drawn ahead of it (#881)
+ * and behaves exactly as it does in {@link wrapWordsToLines}, including the
+ * empty line 0 an inset too wide to share its line produces. It defaults to
+ * `maxWidth`, which is the pre-#881 wrap.
  */
 export function wrapSegmentsToLines(
   segments: string[],
   font: PdfFont,
   size: number,
   maxWidth: number,
+  firstLineMaxWidth = maxWidth,
 ): string[] {
   if (segments.length === 0) return [];
   const lines: string[] = [];
+  const { limit, needsEmptyFirstLine } = firstLineInset(
+    lines,
+    maxWidth,
+    firstLineMaxWidth,
+  );
   // Seed `current` from the empty string and run EVERY segment — including
   // segments[0] — through the same width check + word-wrap fallback, so an
   // overlong first segment (e.g. a long "Company · Location" org line whose
@@ -754,12 +765,15 @@ export function wrapSegmentsToLines(
     const seg = segments[i];
     const candidate =
       current === "" ? seg : `${current}${MIDDOT_SEGMENT_SEP}${seg}`;
-    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+    if (font.widthOfTextAtSize(candidate, size) <= limit()) {
       current = candidate;
       continue;
     }
     if (current !== "") lines.push(current);
-    if (font.widthOfTextAtSize(seg, size) > maxWidth) {
+    if (needsEmptyFirstLine(font.widthOfTextAtSize(seg, size))) {
+      lines.push("");
+    }
+    if (font.widthOfTextAtSize(seg, size) > limit()) {
       // `wrapWordsToLines` never loops on a single word wider than maxWidth
       // (it emits it as its own line), so this terminates.
       const subLines = wrapWordsToLines(
@@ -767,6 +781,8 @@ export function wrapSegmentsToLines(
         font,
         size,
         maxWidth,
+        false,
+        limit(),
       );
       lines.push(...subLines.slice(0, -1));
       current = subLines[subLines.length - 1] ?? "";
@@ -860,6 +876,19 @@ type DrawTextOpts = {
   hangingIndent?: number;
   uppercase?: boolean;
   atomicSegments?: boolean;
+  /**
+   * A short BOLD lead drawn at the start of the first line, with that line's
+   * wrap width narrowed by its measured width so `text` flows beside it (#881 —
+   * the category label on a categorised skills line).
+   *
+   * This is how a mixed-weight line keeps ATOMIC segment wrapping: routing it
+   * through `drawRuns` instead would bold the lead but wrap `text` on plain
+   * whitespace words, splitting a multi-word skill mid-name (#301). The lead
+   * carries its own trailing separator space — the members are drawn flush
+   * against its measured end, so the space has to be inside the drawn string
+   * for the re-parse to see a word boundary there.
+   */
+  boldLead?: string;
   /** A short tail (a role/degree date range) drawn FLUSH-RIGHT, regular
    *  weight, on the first wrapped line's baseline (#425). */
   rightText?: string;
@@ -1124,6 +1153,7 @@ class Layout {
     size: number,
     maxWidth: number,
     atomicSegments = false,
+    firstLineMaxWidth = maxWidth,
   ): string[] {
     if (atomicSegments && text.includes(MIDDOT_SEGMENT_SEP)) {
       return wrapSegmentsToLines(
@@ -1131,6 +1161,7 @@ class Layout {
         font,
         size,
         maxWidth,
+        firstLineMaxWidth,
       );
     }
     return wrapWordsToLines(
@@ -1138,6 +1169,8 @@ class Layout {
       font,
       size,
       maxWidth,
+      false,
+      firstLineMaxWidth,
     );
   }
 
@@ -1161,13 +1194,21 @@ class Layout {
     maxWidth: number,
     atomic: boolean,
     rightReserve: number,
+    firstLineMaxWidth: number,
   ): string[] {
-    const lines = this.wrap(value, font, size, maxWidth, atomic);
+    const lines = this.wrap(value, font, size, maxWidth, atomic, firstLineMaxWidth);
     if (
       rightReserve > 0 &&
-      font.widthOfTextAtSize(lines[0], size) > maxWidth - rightReserve
+      font.widthOfTextAtSize(lines[0], size) > firstLineMaxWidth - rightReserve
     ) {
-      return this.wrap(value, font, size, maxWidth - rightReserve, atomic);
+      return this.wrap(
+        value,
+        font,
+        size,
+        maxWidth - rightReserve,
+        atomic,
+        firstLineMaxWidth - rightReserve,
+      );
     }
     return lines;
   }
@@ -1191,6 +1232,8 @@ class Layout {
     lineHeight: number;
     rValue: string;
     rSize: number;
+    leadValue: string;
+    leadWidth: number;
   } {
     const size = opts.size ?? this.t.body;
     const font = opts.bold ? this.fonts.bold : this.fonts.regular;
@@ -1204,7 +1247,6 @@ class Layout {
     // sanitize the result — `sanitize` is the final step before measure/draw,
     // and it runs on BOTH font paths (see the constructor doc).
     const cased = opts.uppercase ? text.toUpperCase() : text;
-    const value = this.sanitize(cased);
     const atomic = opts.atomicSegments ?? false;
     const maxWidth = CONTENT_WIDTH - (x - MARGIN);
     const rSize = opts.rightSize ?? size;
@@ -1212,6 +1254,26 @@ class Layout {
     const rightReserve = rValue
       ? this.fonts.regular.widthOfTextAtSize(rValue, rSize) + DATE_COLUMN_GAP
       : 0;
+
+    // The lead is measured in BOLD because that is the weight it is drawn in, so
+    // the width line 0 is narrowed by is the width it actually occupies (#881).
+    //
+    // A lead too wide for a whole line cannot lead one — inset or not, it would
+    // run past the right margin, and it is drawn as one piece so the wrapper
+    // cannot break it. Fold it back into the wrapped text instead: it word-wraps
+    // like any other over-long run, which is exactly what a glued "Label: a · b"
+    // header did before this option existed. The label loses its weight; the
+    // page never loses its margin.
+    const lead = opts.boldLead ? this.sanitize(opts.boldLead) : "";
+    const leadWidth = lead
+      ? this.fonts.bold.widthOfTextAtSize(lead, size)
+      : 0;
+    const leads = leadWidth > 0 && leadWidth <= maxWidth;
+    const leadValue = leads ? lead : "";
+    const inset = leads ? leadWidth : 0;
+    const value = leads
+      ? this.sanitize(cased)
+      : `${lead}${this.sanitize(cased)}`;
 
     // Reserve the flush-right date column when the header collides with it
     // (#436) — see wrapReservingRight for why this is collision-gated, not a
@@ -1223,8 +1285,19 @@ class Layout {
       maxWidth,
       atomic,
       rightReserve,
+      maxWidth - inset,
     );
-    return { lines, font, size, x, lineHeight: size * LINE_GAP, rValue, rSize };
+    return {
+      lines,
+      font,
+      size,
+      x,
+      lineHeight: size * LINE_GAP,
+      rValue,
+      rSize,
+      leadValue,
+      leadWidth: inset,
+    };
   }
 
   /**
@@ -1297,22 +1370,37 @@ class Layout {
    * cursor and paginates as needed.
    */
   drawText(text: string, opts: DrawTextOpts = {}) {
-    const { lines, font, size, x, lineHeight, rValue, rSize } =
+    const { lines, font, size, x, lineHeight, rValue, rSize, leadValue, leadWidth } =
       this.resolveDrawLines(text, opts);
     const color = opts.color ?? this.black;
     const hanging = opts.hangingIndent ?? 0;
     const singleLine = lines.length === 1;
     for (let i = 0; i < lines.length; i++) {
       this.ensureWrappedLine(i, lines.length, lineHeight, opts);
-      const lineX = i === 0 ? x : x + hanging;
+      // The bold lead sits at the line's left edge and the first line's text
+      // starts flush against its measured end (#881); `resolveDrawLines` already
+      // wrapped line 0 to what is left, so this cannot overrun the margin. Line
+      // 0 comes back empty when the lead needs the whole line.
+      const lineX = i === 0 ? x + leadWidth : x + hanging;
       const topY = this.y;
-      this.page.drawText(lines[i], {
-        x: lineX,
-        y: topY - size,
-        size,
-        font,
-        color,
-      });
+      if (i === 0 && leadValue) {
+        this.page.drawText(leadValue, {
+          x,
+          y: topY - size,
+          size,
+          font: this.fonts.bold,
+          color,
+        });
+      }
+      if (lines[i]) {
+        this.page.drawText(lines[i], {
+          x: lineX,
+          y: topY - size,
+          size,
+          font,
+          color,
+        });
+      }
       if (i === 0) {
         this.decorateFirstLine(opts, {
           line: lines[0],
@@ -2044,6 +2132,9 @@ function headerLineOpts(
     // which reads as regular-weight body text (#425).
     bold: entry.headerBold ?? true,
     size: t.header,
+    // Bold category label leading a categorised skills line (#881). Set here so
+    // `entryHeadHeight` measures the inset line 0 the draw will produce.
+    boldLead: entry.headerBoldLead,
     atomicSegments: entry.atomicSegments,
     hangingIndent: entry.headerHangingIndent,
     // Flush-right date on the header line (#425) — set for a title-less role /

--- a/src/lib/pdf/render-findings.ts
+++ b/src/lib/pdf/render-findings.ts
@@ -105,7 +105,10 @@ export function entryPathLabel(
   index: number,
 ): string {
   const heading = sectionHeading || "Section";
-  const name = stripEmphasisSentinels(entry.headerLine || entry.subLine || "").trim();
+  // The bold lead is part of the drawn header line (#881), so it is part of the
+  // name — a categorised skills entry is "Skills → Languages: Python · Go".
+  const header = `${entry.headerBoldLead ?? ""}${entry.headerLine}`.trim();
+  const name = stripEmphasisSentinels(header || entry.subLine || "").trim();
   return name ? `${heading} → ${elide(name)}` : `${heading} → entry ${index + 1}`;
 }
 
@@ -183,6 +186,7 @@ export function collectModelTextFields(
     add(where, section.heading, { uppercase: true });
     section.entries.forEach((entry, i) => {
       const path = entryPathLabel(where, entry, i);
+      add(where, entry.headerBoldLead, { path });
       add(where, entry.headerLine, { path });
       add(where, entry.headerLineDate, { path });
       add(where, entry.subLine, { path });

--- a/src/lib/pdf/skills-wrap-roundtrip.test.ts
+++ b/src/lib/pdf/skills-wrap-roundtrip.test.ts
@@ -35,6 +35,7 @@ import { fileURLToPath } from "node:url";
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { runCascade } from "../heuristics/cascade.ts";
+import { extractFromPdfBytes } from "../heuristics/pdf-extract.ts";
 import { computeAnonymousAtsScore } from "../score/score.ts";
 import type { CascadeResult } from "../heuristics/types.ts";
 import { buildAtsResumeModel } from "./ats-resume-model.ts";
@@ -169,6 +170,207 @@ describe("#791 — a categorised-plus-ungrouped skills list survives export and 
 
   it("loses none to the categorised branch's grouping logic (exact count)", () => {
     expect(reparsedSkills.length).toBe(ALL_SKILLS.length);
+  });
+});
+
+/**
+ * Round-trip regression for #881 — bolding the category label must not cost the
+ * atomic wrap. The label is drawn as an inset on the FIRST line only, so the
+ * members still wrap segment-atomically (a bolded label emitted inside the
+ * emphasis sentinels would route the line to the whitespace-word run wrapper
+ * instead, re-opening #301 on the very line that now has less room).
+ *
+ * Both categories are wide enough to wrap several times at the export's header
+ * size, and every member is multi-word, so a mid-name break would show up as a
+ * skill that fails to come back. The whole section is categorised — the parser
+ * emits the structured `skillCategories` view only when nothing precedes the
+ * first label — so the labels and their membership are asserted too.
+ */
+describe("#881 — a bold category label keeps atomic wrapping on its own line", () => {
+  const CATEGORIES = [
+    {
+      label: "Machine Learning",
+      skills: [
+        "Cloud Data Warehousing",
+        "Machine Learning Operations",
+        "Distributed Systems Design",
+        "Natural Language Processing",
+        "Feature Store Engineering",
+        "Model Serving Infrastructure",
+      ],
+    },
+    {
+      label: "Platform Engineering",
+      skills: [
+        "Site Reliability Engineering",
+        "Continuous Integration Pipelines",
+        "Infrastructure As Code",
+        "Security Incident Response",
+        "Container Orchestration",
+        "Observability Tooling",
+      ],
+    },
+  ];
+  const ALL_SKILLS = CATEGORIES.flatMap((c) => c.skills);
+
+  let reparsedSkills: string[];
+  let reparsedCategories: { label: string; skills: string[] }[] | undefined;
+
+  beforeAll(async () => {
+    const original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const withCategories: CascadeResult = {
+      ...original,
+      canonical: {
+        ...original.canonical,
+        fields: {
+          ...original.canonical.fields,
+          skills: ALL_SKILLS,
+          skillCategories: CATEGORIES,
+        },
+      },
+    };
+    const model = buildAtsResumeModel(withCategories, scoreFor(withCategories));
+    const { bytes } = await renderAtsResumePdf(model);
+    const reparsed = await runCascade(bytes);
+    reparsedSkills = reparsed.canonical.fields.skills ?? [];
+    reparsedCategories = reparsed.canonical.fields.skillCategories;
+  }, 20000);
+
+  it("round-trips every multi-word skill intact — none split at a wrap point (AC)", () => {
+    const reparsedSet = new Set(reparsedSkills);
+    for (const skill of ALL_SKILLS) {
+      expect(reparsedSet.has(skill)).toBe(true);
+    }
+    expect(reparsedSkills.length).toBe(ALL_SKILLS.length);
+  });
+
+  it("re-parses the same category labels and members (AC)", () => {
+    expect(reparsedCategories).toEqual(CATEGORIES);
+  });
+});
+
+/**
+ * #881 AC — a category label long enough to eat line 0 must wrap sanely rather
+ * than run past the right margin. Two shapes, one assertion: a label that fills
+ * most of the line takes line 0 alone and the members start below it, and a
+ * label wider than the whole line stops leading altogether and word-wraps as
+ * ordinary text (it is drawn as one piece, so an inset could not break it).
+ * Asserted on the DRAWN items, since the margin is a geometry property no model
+ * assertion can see.
+ */
+describe("#881 — an over-long category label never overflows the right margin", () => {
+  const RIGHT_EDGE = 612 - 36; // PAGE_WIDTH - MARGIN, per render-ats-pdf.ts.
+  const MEMBERS = ["Cloud Data Warehousing", "Machine Learning Operations"];
+
+  // Scoped to the Skills section on purpose: this fixture's own résumé already
+  // draws one bullet ~2pt past the margin, which is a separate defect on the
+  // bullet path and not what this assertion is about.
+  async function drawnSkillsItems(label: string) {
+    const original = await runCascade(new Uint8Array(readFileSync(FIXTURE)));
+    const withCategory: CascadeResult = {
+      ...original,
+      canonical: {
+        ...original.canonical,
+        fields: {
+          ...original.canonical.fields,
+          skills: MEMBERS,
+          skillCategories: [{ label, skills: MEMBERS }],
+        },
+      },
+    };
+    const model = buildAtsResumeModel(withCategory, scoreFor(withCategory));
+    const { bytes } = await renderAtsResumePdf(model);
+    const { items } = await extractFromPdfBytes(bytes);
+    const heading = items.findIndex((i) => i.str.trim() === "SKILLS");
+    expect(heading).toBeGreaterThan(-1);
+    return items.slice(heading + 1);
+  }
+
+  it("keeps the skills lines inside the margin for a label that fills the line", async () => {
+    const items = await drawnSkillsItems(
+      "Machine Learning And Data Platform Engineering Practice",
+    );
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.x + item.width).toBeLessThanOrEqual(RIGHT_EDGE);
+    }
+  }, 20000);
+
+  it("keeps the skills lines inside the margin for a label wider than the line", async () => {
+    const items = await drawnSkillsItems(
+      "Extremely Long Category Label That Consumes The Entire Available Content Width Of The Page And Then A Good Deal More Besides",
+    );
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.x + item.width).toBeLessThanOrEqual(RIGHT_EDGE);
+    }
+  }, 20000);
+});
+
+/**
+ * Unit coverage for the first-line inset the bold label wraps against (#881) —
+ * the half of the fix `wrapSegmentsToLines` owns. `render-ats-pdf.ts` narrows
+ * line 0 by the lead's BOLD width and draws the members flush against its end,
+ * so the wrapper has to honour two widths and, when the lead leaves no usable
+ * room, hand the lead a line of its own rather than overflow the margin.
+ */
+describe("wrapSegmentsToLines — inset first line (#881)", () => {
+  const SIZE = 10;
+  const MAX_WIDTH = 468;
+  const SEGMENTS = [
+    "Cloud Data Warehousing",
+    "Machine Learning Operations",
+    "Distributed Systems Design",
+    "Security Incident Response",
+  ];
+
+  it("packs line 0 to the narrowed width and the rest to the full width", async () => {
+    const { PDFDocument, StandardFonts } = await loadPdfLibOnce();
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+
+    const inset = 160;
+    const lines = wrapSegmentsToLines(
+      SEGMENTS,
+      font,
+      SIZE,
+      MAX_WIDTH,
+      MAX_WIDTH - inset,
+    );
+    expect(font.widthOfTextAtSize(lines[0], SIZE)).toBeLessThanOrEqual(
+      MAX_WIDTH - inset,
+    );
+    for (const line of lines.slice(1)) {
+      expect(font.widthOfTextAtSize(line, SIZE)).toBeLessThanOrEqual(MAX_WIDTH);
+    }
+    // The inset must cost line 0 room, not integrity: every segment comes back
+    // whole, so no multi-word skill was broken to make it fit.
+    expect(lines.join(" · ").split(" · ")).toEqual(SEGMENTS);
+  });
+
+  it("gives an over-wide lead line 0 to itself instead of overflowing", async () => {
+    const { PDFDocument, StandardFonts } = await loadPdfLibOnce();
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+
+    // A lead consuming all but 4pt of the line: nothing fits beside it.
+    const lines = wrapSegmentsToLines(SEGMENTS, font, SIZE, MAX_WIDTH, 4);
+    expect(lines[0]).toBe("");
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines.slice(1)) {
+      expect(font.widthOfTextAtSize(line, SIZE)).toBeLessThanOrEqual(MAX_WIDTH);
+    }
+    expect(lines.slice(1).join(" · ").split(" · ")).toEqual(SEGMENTS);
+  });
+
+  it("is byte-identical to the un-inset wrap when no lead is passed", async () => {
+    const { PDFDocument, StandardFonts } = await loadPdfLibOnce();
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+
+    expect(wrapSegmentsToLines(SEGMENTS, font, SIZE, MAX_WIDTH, MAX_WIDTH)).toEqual(
+      wrapSegmentsToLines(SEGMENTS, font, SIZE, MAX_WIDTH),
+    );
   });
 });
 

--- a/src/lib/pdf/text-wrap.ts
+++ b/src/lib/pdf/text-wrap.ts
@@ -17,6 +17,32 @@ export interface TextMeasurer {
 }
 
 /**
+ * The "first-line inset" wrap rule shared by `wrapWordsToLines` here and
+ * `wrapSegmentsToLines` in `render-ats-pdf.ts` (#881 review) — extracted so the
+ * empty-line-0 rule can't drift between the word wrapper and the atomic-segment
+ * wrapper the way the rest of this module's docblock already guards against for
+ * a whole-wrap-improvement duplication (#421).
+ *
+ * `limit()` returns the width the line currently being packed (`lines.length`)
+ * should wrap to: `firstLineMaxWidth` for line 0, `maxWidth` for every line
+ * after it. `needsEmptyFirstLine` reports whether the very first unit (a word
+ * or a segment) doesn't fit beside the inset at all — when it doesn't, the
+ * caller seats an empty line 0 so that unit starts fresh on line 1 instead of
+ * running past the inset's right edge.
+ */
+export function firstLineInset(
+  lines: string[],
+  maxWidth: number,
+  firstLineMaxWidth: number,
+): { limit: () => number; needsEmptyFirstLine: (unitWidth: number) => boolean } {
+  return {
+    limit: () => (lines.length === 0 ? firstLineMaxWidth : maxWidth),
+    needsEmptyFirstLine: (unitWidth: number) =>
+      lines.length === 0 && firstLineMaxWidth < maxWidth && unitWidth > firstLineMaxWidth,
+  };
+}
+
+/**
  * Break a single word that is itself wider than `maxWidth` into character-run
  * chunks that each fit. Guarantees progress (at least one char per chunk) so a
  * pathologically narrow `maxWidth` still terminates.
@@ -54,6 +80,13 @@ function breakLongWord(
  *     long URL is a single word with no interior whitespace and there is no
  *     re-parse invariant to protect (#421 Blocking #5).
  *
+ * `firstLineMaxWidth` narrows line 0 only, for a caller drawing an inset ahead
+ * of it (the bold category label on a skills line, #881). When nothing fits
+ * beside the inset, line 0 comes back EMPTY and the words start on line 1 —
+ * the inset then owns its own line instead of pushing the first word past the
+ * right margin. Defaulting it to `maxWidth` disables both the narrowing and the
+ * empty-line rule, so every existing caller wraps exactly as before.
+ *
  * Always terminates: without breaking, an overlong word advances the loop as
  * its own line; with breaking, `breakLongWord` makes at least one char of
  * progress per chunk.
@@ -64,16 +97,22 @@ export function wrapWordsToLines(
   size: number,
   maxWidth: number,
   breakLongWords = false,
+  firstLineMaxWidth = maxWidth,
 ): string[] {
   if (words.length === 0) return [];
   const lines: string[] = [];
+  const { limit, needsEmptyFirstLine } = firstLineInset(
+    lines,
+    maxWidth,
+    firstLineMaxWidth,
+  );
   let current = "";
   for (const word of words) {
     // Extend the current line when the word still fits alongside it; otherwise
     // flush it and fall through to seat `word` on a fresh (empty) line.
     if (current !== "") {
       const candidate = `${current} ${word}`;
-      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      if (font.widthOfTextAtSize(candidate, size) <= limit()) {
         current = candidate;
         continue;
       }
@@ -83,8 +122,11 @@ export function wrapWordsToLines(
     // `current` is empty here: seat `word` as the start of a new line. A word
     // that alone overflows is broken across lines when asked, else emitted whole
     // (the round-trip-safe overflow the résumé renderer relies on).
-    if (breakLongWords && font.widthOfTextAtSize(word, size) > maxWidth) {
-      const chunks = breakLongWord(word, font, size, maxWidth);
+    if (needsEmptyFirstLine(font.widthOfTextAtSize(word, size))) {
+      lines.push("");
+    }
+    if (breakLongWords && font.widthOfTextAtSize(word, size) > limit()) {
+      const chunks = breakLongWord(word, font, size, limit());
       lines.push(...chunks.slice(0, -1));
       current = chunks[chunks.length - 1] ?? "";
     } else {


### PR DESCRIPTION
## Summary
Draws the skills category label (e.g. "Languages:") as a bold inset ahead of `headerLine` instead of routing it through emphasis sentinels, which would move the line onto the whitespace-word run wrapper and reopen #301 (a multi-word skill breaking mid-name on wrap). The inset narrows only the first wrapped line, so members keep atomic middot wrapping; `entryHeadHeight` measures it through the same `headerLineOpts` path used to draw it, so keep-with-next pagination (#629) stays in sync.

Closes #881

## Stack position
Layer 1 of 5. Base: `feat/export-fit-ladder-issue-878` (#879, open/unreviewed).

## Adversarial review
Reviewed as part of the whole 5-layer stack (see layer 5's PR for the full review notes). No blocking findings attributed to this layer in either review round.

## Test plan
- [x] `npm run typecheck`
- [x] Targeted vitest suites (56 tests) + full `src/lib/pdf/` suite (415 tests)
- [x] `npm run lint`