### PR TITLE
fix(parser): GPA and honors are dropped on parse and lost from the export

### DIFF
--- a/docs/canonical-resume-model.md
+++ b/docs/canonical-resume-model.md
@@ -224,7 +224,7 @@ passes through verbatim and may contain any glyph.
 | `Company, Location` | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (experience mapping) |
 | `Title, Team` (empty-company branch, #466) | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (empty-company branch) |
 | `Institution · Location` | `" · "` | `ats-resume-model.ts` → `buildAtsResumeModel` (education mapping) |
-| `Degree, Field` | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (education mapping) |
+| `Degree, Field, Honors, GPA: <grade>` | `", "` | `ats-resume-model.ts` → `buildAtsResumeModel` (education mapping) |
 | `Type · Title` (achievement) | `" · "` | `ats-resume-model.ts` → `buildAtsResumeModel` (achievement mapping) |
 | Skills, within a category | `" · "` | `ats-resume-model.ts` → `buildAtsResumeModel` (skills mapping) |
 | Header ↔ trailing single-token date | `"  "` (two spaces) | `ats-resume-model.ts` → `buildAtsResumeModel` |

--- a/src/components/features/ReconstructedEducationEntry.tsx
+++ b/src/components/features/ReconstructedEducationEntry.tsx
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * ReconstructedEducationEntry — one editable education row.
+ *
+ * Split out of `ReconstructedEducationSkills.tsx` when the GPA / honors fields
+ * (#883) pushed that file past the ~200 LOC ceiling; its sibling keeps the
+ * SECTION (heading, add/remove wiring, parsed-vs-added index mapping) and
+ * renders this per entry. Render-only: the override fold it displays from is
+ * `lib/edit/education-display.ts`, tested at module scope.
+ */
+
+import type { ResumeEducation } from "../../lib/score/types.ts";
+import type { EducationFieldOverrides } from "../../hooks/useEditableParse.ts";
+import { resolveEducationDisplay } from "../../lib/edit/education-display.ts";
+import { EditableField } from "@design-system";
+import { validateDate } from "../../lib/edit/field-validators.ts";
+import { RemoveButton } from "./ReconstructedAdd.tsx";
+
+export function EducationEntry({
+  edu,
+  overrides,
+  onFieldChange,
+  onRemove,
+  isAdded = false,
+}: {
+  edu: ResumeEducation;
+  overrides: EducationFieldOverrides | undefined;
+  onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
+  /** Remove this entry. Set for a PARSED entry too since #856 — "is this
+   *  user-added?" is {@link isAdded}, never this prop's presence. */
+  onRemove?: () => void;
+  /** User-added entries carry no `field` (major), `gpa` or `honors` slot, so
+   *  those affordances render on PARSED entries only. */
+  isAdded?: boolean;
+}) {
+  const {
+    degree,
+    field,
+    institution,
+    startDate,
+    endDate,
+    dates,
+    gpa,
+    honors,
+    coursework,
+  } = resolveEducationDisplay(edu, overrides);
+
+  // A degree-less program (#238, e.g. "ACME Applied Robotics") keeps its
+  // title in `field`; promote it into the primary (semibold) slot so the entry
+  // doesn't read as an empty "degree not detected". Otherwise the major follows
+  // the degree after a comma ("Bachelor of Science, Mechanical Engineering & …").
+  const majorInPrimary = !degree && Boolean(field);
+  const showMajor = !isAdded && Boolean(field);
+
+  // The editable start/end fields ARE the date display, so the compact `dates`
+  // string would duplicate them. Show it ONLY in the legacy year-only fallback
+  // (no start/end parsed, just a graduation `year`), where no editable field
+  // surfaces it otherwise.
+  const yearOnly = !startDate && !endDate && Boolean(dates);
+
+  return (
+    <li className="flex flex-col gap-0.5 text-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+          {!majorInPrimary && (
+            <EditableField
+              value={degree}
+              placeholder="degree"
+              label="Degree"
+              textWeight="semibold"
+              onCommit={(v) => onFieldChange("degree", v)}
+            />
+          )}
+          {showMajor && (
+            <>
+              {degree && <span className="text-content-muted">,</span>}
+              <EditableField
+                value={field}
+                placeholder="major"
+                label="Field of study"
+                textWeight={majorInPrimary ? "semibold" : undefined}
+                onCommit={(v) => onFieldChange("field", v)}
+              />
+            </>
+          )}
+          <span className="text-content-muted">—</span>
+          <EditableField
+            value={institution}
+            placeholder="institution"
+            label="Institution"
+            onCommit={(v) => onFieldChange("institution", v)}
+          />
+        </div>
+        {onRemove && (
+          <RemoveButton label="Remove education" onClick={onRemove} />
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
+        <EditableField
+          value={startDate}
+          placeholder="start"
+          label="Education start date"
+          textSize="xs"
+          validate={validateDate}
+          onCommit={(v) => onFieldChange("start_date", v)}
+        />
+        <span aria-hidden="true">–</span>
+        <EditableField
+          value={endDate}
+          placeholder="end"
+          label="Education end date"
+          textSize="xs"
+          validate={validateDate}
+          onCommit={(v) => onFieldChange("end_date", v)}
+        />
+        {yearOnly && <span className="text-content-muted">{dates}</span>}
+      </div>
+      {!isAdded && (
+        // Honors and grade (#883). Both render unconditionally on a parsed
+        // entry, so a parse that missed one offers the "+ <noun>" add
+        // affordance — the parser drops these more often than it drops a
+        // degree, and an uncorrectable miss reaches the exported PDF. The
+        // "GPA:" prefix appears only alongside a value: on an empty field the
+        // add affordance already names the thing ("+ GPA"), and a static label
+        // in front of it would read as "GPA: + GPA".
+        <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
+          <EditableField
+            value={honors}
+            placeholder="honors"
+            label="Honors"
+            textSize="xs"
+            onCommit={(v) => onFieldChange("honors", v)}
+          />
+          <span aria-hidden="true">·</span>
+          {gpa && <span className="text-content-muted">GPA:</span>}
+          <EditableField
+            value={gpa}
+            placeholder="GPA"
+            label="GPA"
+            textSize="xs"
+            onCommit={(v) => onFieldChange("gpa", v)}
+          />
+        </div>
+      )}
+      {coursework.length > 0 && (
+        <span className="block text-content-tertiary">
+          Coursework: {coursework.join(" · ")}
+        </span>
+      )}
+    </li>
+  );
+}

--- a/src/components/features/ReconstructedEducationSkills.test.ts
+++ b/src/components/features/ReconstructedEducationSkills.test.ts
@@ -4,11 +4,11 @@
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { EducationSection } from "./ReconstructedEducationSkills.tsx";
 import {
   resolveEduValue,
   resolveEducationDisplay,
-  EducationSection,
-} from "./ReconstructedEducationSkills.tsx";
+} from "../../lib/edit/education-display.ts";
 import type { ResumeEducation } from "../../lib/score/types.ts";
 
 describe("resolveEduValue", () => {
@@ -100,6 +100,31 @@ describe("resolveEducationDisplay", () => {
     expect(d.dates).toBe("2025");
   });
 
+  it("resolves gpa and honors, and applies their overrides (#883)", () => {
+    const edu: ResumeEducation = {
+      degree: "B.S.",
+      institution: "State University",
+      gpa: "3.72/4.00",
+      honors: "cum laude",
+    };
+    expect(resolveEducationDisplay(edu, undefined)).toMatchObject({
+      gpa: "3.72/4.00",
+      honors: "cum laude",
+    });
+    expect(
+      resolveEducationDisplay(edu, { gpa: "8.4/10", honors: "" }),
+    ).toMatchObject({ gpa: "8.4/10", honors: undefined });
+  });
+
+  it("surfaces gpa and honors a parse never found, so the field can be added", () => {
+    expect(
+      resolveEducationDisplay(
+        { degree: "B.S.", institution: "State University" },
+        { gpa: "First Class" },
+      ),
+    ).toMatchObject({ gpa: "First Class", honors: undefined });
+  });
+
   it("defaults coursework to an empty array when absent", () => {
     const noCoursework: ResumeEducation = {
       degree: "BSc",
@@ -180,5 +205,53 @@ describe("EducationSection date-row symmetry (issue 376)", () => {
     expect(html).toContain(`<span aria-hidden="true">+ </span>start`);
     expect(html).toContain(`<span aria-hidden="true">+ </span>end`);
     expect(html).toContain("–");
+  });
+});
+
+describe("EducationSection GPA / honors row (#883)", () => {
+  function renderSection(edu: ResumeEducation, addedCount = 0): string {
+    return renderToStaticMarkup(
+      createElement(EducationSection, {
+        education: [edu],
+        educationOverrides: {},
+        onEducationFieldChange: () => {},
+        addedEducation: addedCount
+          ? [{ id: "added:edu:0", section: "education" as const, title: "" }]
+          : [],
+        originalCount: addedCount ? 0 : 1,
+        parsedIndices: addedCount ? [] : [0],
+        onAddEntry: () => {},
+        onRemoveEntry: () => {},
+        onEntryField: () => {},
+        onPruneEmpty: () => {},
+      }),
+    );
+  }
+
+  it("renders both values, labelling only the grade", () => {
+    const html = renderSection({
+      degree: "B.S.",
+      institution: "State University",
+      gpa: "3.72/4.00",
+      honors: "cum laude",
+    });
+    expect(html).toContain(">cum laude<");
+    expect(html).toContain(">3.72/4.00<");
+    expect(html).toContain(">GPA:<");
+  });
+
+  it("offers an add affordance for each field the parse missed (AC#4)", () => {
+    const html = renderSection({ degree: "B.S.", institution: "State University" });
+    expect(html).toContain(`<span aria-hidden="true">+ </span>honors`);
+    expect(html).toContain(`<span aria-hidden="true">+ </span>GPA`);
+    // No static "GPA:" label in front of an empty field — it would read as
+    // "GPA: + GPA"; the add affordance already names the thing.
+    expect(html).not.toContain(">GPA:<");
+  });
+
+  it("renders no such row on a user-ADDED entry, which has no slot for either", () => {
+    const html = renderSection({ degree: "", institution: "" }, 1);
+    expect(html).not.toContain("honors");
+    expect(html).not.toContain("GPA");
   });
 });

--- a/src/components/features/ReconstructedEducationSkills.tsx
+++ b/src/components/features/ReconstructedEducationSkills.tsx
@@ -5,12 +5,15 @@
  * ReconstructedEducationSkills — the editable Education section of the
  * reconstructed resume (#176). Split out of ReconstructedResume.tsx to keep that
  * container under ~200 LOC; the Skills section moved to its sibling
- * `ReconstructedSkills.tsx` when category editing (#476) grew it past that limit.
+ * `ReconstructedSkills.tsx` when category editing (#476) grew it past that limit,
+ * and the per-entry row moved to `ReconstructedEducationEntry.tsx` when the GPA /
+ * honors fields (#883) did the same here.
  *
  * Education was read-only; since the surface exports to PDF, a parser miss was
  * uncorrectable. It now exposes inline edit affordances wired to the lifted
- * override model (useEditableParse): degree / institution / dates editable via
- * the shared EditableField, a cleared field shows an "+ <noun>" add-affordance.
+ * override model (useEditableParse): degree / institution / dates / GPA / honors
+ * editable via the shared EditableField, a cleared field shows an "+ <noun>"
+ * add-affordance.
  *
  * The override maps live in App and feed applyOverrides → re-grade → PDF, so an
  * edit here moves the ATS score AND the downloaded PDF, not just the display.
@@ -23,23 +26,31 @@ import type {
   AddedEntryField,
 } from "../../hooks/useEditableParse.ts";
 import { parsedEntryKey } from "../../hooks/useEditableParse.ts";
-import { buildEducationDates } from "../../lib/score/entry-dates.ts";
-import { EditableField, SectionHeading } from "@design-system";
-import { validateDate } from "../../lib/edit/field-validators.ts";
-import { AddPill, RemoveButton, sectionExitBlur } from "./ReconstructedAdd.tsx";
+import { SectionHeading } from "@design-system";
+import { AddPill, sectionExitBlur } from "./ReconstructedAdd.tsx";
+import { EducationEntry } from "./ReconstructedEducationEntry.tsx";
 
-/** Map an EducationEntry field name to the flat AddedEntry field it edits.
- *  `field` (major) is intentionally omitted — added entries carry no major slot,
- *  so the major affordance renders on PARSED entries only and never routes here. */
-const EDUCATION_FIELD_MAP: Record<
-  Exclude<keyof EducationFieldOverrides, "field">,
-  AddedEntryField
-> = {
+/** The education fields a USER-ADDED entry can carry. `field` (major), `gpa` and
+ *  `honors` have no slot on `AddedEntry`, so their affordances render on PARSED
+ *  entries only and can never route to `onEntryField`. Deriving the exclusion
+ *  from the map below (rather than restating it) is what keeps a future field
+ *  from being silently dropped instead of failing to compile. */
+type AddedEducationField = Exclude<
+  keyof EducationFieldOverrides,
+  "field" | "gpa" | "honors"
+>;
+
+/** Map an EducationEntry field name to the flat AddedEntry field it edits. */
+const EDUCATION_FIELD_MAP: Record<AddedEducationField, AddedEntryField> = {
   degree: "title",
   institution: "subtitle",
   start_date: "start_date",
   end_date: "end_date",
 };
+
+const isAddedEducationField = (
+  field: keyof EducationFieldOverrides,
+): field is AddedEducationField => field in EDUCATION_FIELD_MAP;
 
 // ── Shared section chrome (mirrors ReconstructedResume's local helpers) ────────
 
@@ -48,152 +59,6 @@ function NotDetected({ what }: { what: string }) {
 }
 
 // ── Education ──────────────────────────────────────────────────────────────────
-
-/** Resolve a field's display value, applying the override ("" = cleared). */
-export function resolveEduValue(
-  parsed: string | undefined,
-  override: string | undefined,
-): string | undefined {
-  if (override === undefined) return parsed || undefined;
-  return override || undefined; // "" clears
-}
-
-/** The resolved education fields an entry renders, after applying overrides. */
-export interface EducationDisplay {
-  degree: string | undefined;
-  /** Subject of study ("Computer Science & Engineering"); for a degree-less
-   *  program (#238) this holds the program title and degree is absent. */
-  field: string | undefined;
-  institution: string | undefined;
-  startDate: string | undefined;
-  endDate: string | undefined;
-  /** Compact display string (e.g. "2018 – 2022"), reflecting date edits. */
-  dates: string;
-  coursework: string[];
-}
-
-/**
- * Fold an education entry's overrides into the display values. Pure (no JSX) so
- * the resolution/clearing/date branches are unit-tested directly — this is the
- * risk-bearing logic; the component is then render-only.
- */
-export function resolveEducationDisplay(
-  edu: ResumeEducation,
-  overrides: EducationFieldOverrides | undefined,
-): EducationDisplay {
-  // Dates: the override fields feed buildEducationDates so the compact display
-  // string reflects edits; the read-only display still falls back to `year`.
-  const startDate = resolveEduValue(edu.start_date, overrides?.start_date);
-  const endDate = resolveEduValue(edu.end_date, overrides?.end_date);
-  return {
-    degree: resolveEduValue(edu.degree, overrides?.degree),
-    field: resolveEduValue(edu.field, overrides?.field),
-    institution: resolveEduValue(edu.institution, overrides?.institution),
-    startDate,
-    endDate,
-    dates: buildEducationDates({ ...edu, start_date: startDate, end_date: endDate }),
-    coursework: edu.coursework ?? [],
-  };
-}
-
-function EducationEntry({
-  edu,
-  overrides,
-  onFieldChange,
-  onRemove,
-  isAdded = false,
-}: {
-  edu: ResumeEducation;
-  overrides: EducationFieldOverrides | undefined;
-  onFieldChange: (field: keyof EducationFieldOverrides, value: string) => void;
-  /** Remove this entry. Set for a PARSED entry too since #856 — "is this
-   *  user-added?" is {@link isAdded}, never this prop's presence. */
-  onRemove?: () => void;
-  /** User-added entries carry no `field` (major) slot, so the major affordance
-   *  renders on PARSED entries only. */
-  isAdded?: boolean;
-}) {
-  const { degree, field, institution, startDate, endDate, dates, coursework } =
-    resolveEducationDisplay(edu, overrides);
-
-  // A degree-less program (#238, e.g. "ACME Applied Robotics") keeps its
-  // title in `field`; promote it into the primary (semibold) slot so the entry
-  // doesn't read as an empty "degree not detected". Otherwise the major follows
-  // the degree after a comma ("Bachelor of Science, Mechanical Engineering & …").
-  const majorInPrimary = !degree && Boolean(field);
-  const showMajor = !isAdded && Boolean(field);
-
-  // The editable start/end fields ARE the date display, so the compact `dates`
-  // string would duplicate them. Show it ONLY in the legacy year-only fallback
-  // (no start/end parsed, just a graduation `year`), where no editable field
-  // surfaces it otherwise.
-  const yearOnly = !startDate && !endDate && Boolean(dates);
-
-  return (
-    <li className="flex flex-col gap-0.5 text-sm">
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-          {!majorInPrimary && (
-            <EditableField
-              value={degree}
-              placeholder="degree"
-              label="Degree"
-              textWeight="semibold"
-              onCommit={(v) => onFieldChange("degree", v)}
-            />
-          )}
-          {showMajor && (
-            <>
-              {degree && <span className="text-content-muted">,</span>}
-              <EditableField
-                value={field}
-                placeholder="major"
-                label="Field of study"
-                textWeight={majorInPrimary ? "semibold" : undefined}
-                onCommit={(v) => onFieldChange("field", v)}
-              />
-            </>
-          )}
-          <span className="text-content-muted">—</span>
-          <EditableField
-            value={institution}
-            placeholder="institution"
-            label="Institution"
-            onCommit={(v) => onFieldChange("institution", v)}
-          />
-        </div>
-        {onRemove && (
-          <RemoveButton label="Remove education" onClick={onRemove} />
-        )}
-      </div>
-      <div className="flex flex-wrap items-center gap-x-1.5 text-content-tertiary">
-        <EditableField
-          value={startDate}
-          placeholder="start"
-          label="Education start date"
-          textSize="xs"
-          validate={validateDate}
-          onCommit={(v) => onFieldChange("start_date", v)}
-        />
-        <span aria-hidden="true">–</span>
-        <EditableField
-          value={endDate}
-          placeholder="end"
-          label="Education end date"
-          textSize="xs"
-          validate={validateDate}
-          onCommit={(v) => onFieldChange("end_date", v)}
-        />
-        {yearOnly && <span className="text-content-muted">{dates}</span>}
-      </div>
-      {coursework.length > 0 && (
-        <span className="block text-content-tertiary">
-          Coursework: {coursework.join(" · ")}
-        </span>
-      )}
-    </li>
-  );
-}
 
 export function EducationSection({
   heading,
@@ -266,10 +131,11 @@ export function EducationSection({
                     onEducationFieldChange(parsedIdx, field, value);
                     return;
                   }
-                  // Added entries carry no major slot; the `field` edit can't
-                  // originate here (the major affordance is parsed-only), and
-                  // EDUCATION_FIELD_MAP has no "field" key — narrow it out.
-                  if (field !== "field")
+                  // An added entry has no major / GPA / honors slot, so those
+                  // edits cannot originate here (their affordances are
+                  // parsed-only) and the map has no key for them — narrow them
+                  // out rather than inventing a destination.
+                  if (isAddedEducationField(field))
                     onEntryField(added.id, EDUCATION_FIELD_MAP[field], value);
                 }}
                 // Education carries no bullets, so this is the one section whose

--- a/src/design-system/primitives/EditableField.test.tsx
+++ b/src/design-system/primitives/EditableField.test.tsx
@@ -119,6 +119,16 @@ describe("EditableField call sites (issue 376 — repo-wide, no site skipped)", 
   const CALL_SITE_RE = /<EditableField\b[\s\S]*?\/>/g;
   const PLACEHOLDER_RE = /placeholder=(?:"([^"]*)"|\{`([^`]*)`\})/;
   const PLAIN_RE = /emptyAffordance=["{]?["']?plain/;
+  /**
+   * A placeholder that is entirely an ACRONYM ("GPA", "URL"). The leading-capital
+   * check above is a proxy for the real rule — "a bare noun, not sentence-case
+   * prose" — and an acronym is a bare noun that has no lowercase form: "+ gpa"
+   * is not the fix for "+ GPA", it is a misspelling. The exemption is deliberately
+   * narrow (the WHOLE placeholder must be one all-caps token), so every defect
+   * this sweep was written for is still caught: "Link URL", "Custom label" and
+   * "Not detected" all carry lowercase letters and fail as before.
+   */
+  const ACRONYM_RE = /^[A-Z]{2,}$/;
 
   const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -144,7 +154,10 @@ describe("EditableField call sites (issue 376 — repo-wide, no site skipped)", 
         // No placeholder at all is the GOOD case: the primitive derives it from
         // `label`, which is what makes "+ not detected" unrepresentable.
         if (!placeholder) continue;
-        if (/not detected/i.test(placeholder) || /^[A-Z]/.test(placeholder)) {
+        if (
+          /not detected/i.test(placeholder) ||
+          (/^[A-Z]/.test(placeholder) && !ACRONYM_RE.test(placeholder))
+        ) {
           offenders.push(`${file}: placeholder="${placeholder}"`);
         }
       }

--- a/src/hooks/useEditableParse.ts
+++ b/src/hooks/useEditableParse.ts
@@ -174,6 +174,10 @@ export interface EducationFieldOverrides {
   institution?: string;
   start_date?: string;
   end_date?: string;
+  /** Grade as written — free text, never validated as a number (#883): the
+   *  scale is part of the value, and "First Class" is as legitimate as "3.9". */
+  gpa?: string;
+  honors?: string;
 }
 
 // ── Achievement overrides (#454) ──────────────────────────────────────────────

--- a/src/lib/edit/apply-overrides.ts
+++ b/src/lib/edit/apply-overrides.ts
@@ -368,6 +368,10 @@ function applyEducationFieldOverrides(
     if (fields.institution !== undefined) edu.institution = fields.institution;
     if (fields.start_date !== undefined) edu.start_date = fields.start_date;
     if (fields.end_date !== undefined) edu.end_date = fields.end_date;
+    // `gpa` / `honors` are optional like `field`: a clear ("") drops the key so
+    // the exporter emits no dangling ", GPA: " on the degree line (#883).
+    if (fields.gpa !== undefined) edu.gpa = fields.gpa || undefined;
+    if (fields.honors !== undefined) edu.honors = fields.honors || undefined;
   }
 }
 

--- a/src/lib/edit/education-display.ts
+++ b/src/lib/edit/education-display.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * education-display — folding an education entry's field overrides into the
+ * values the reconstructed résumé renders.
+ *
+ * Pure and UI-free by design: the resolution / clearing / date branches are the
+ * risk-bearing part of the education edit surface, so they live in `lib/edit/`
+ * beside the other override folds (`apply-overrides`, `experience-dates`) and
+ * are unit tested directly, leaving `ReconstructedEducationEntry` render-only.
+ */
+
+import type { ResumeEducation } from "../score/types.ts";
+import type { EducationFieldOverrides } from "../../hooks/useEditableParse.ts";
+import { buildEducationDates } from "../score/entry-dates.ts";
+
+/** Resolve a field's display value, applying the override ("" = cleared). */
+export function resolveEduValue(
+  parsed: string | undefined,
+  override: string | undefined,
+): string | undefined {
+  if (override === undefined) return parsed || undefined;
+  return override || undefined; // "" clears
+}
+
+/** The resolved education fields an entry renders, after applying overrides. */
+export interface EducationDisplay {
+  degree: string | undefined;
+  /** Subject of study ("Computer Science & Engineering"); for a degree-less
+   *  program (#238) this holds the program title and degree is absent. */
+  field: string | undefined;
+  institution: string | undefined;
+  startDate: string | undefined;
+  endDate: string | undefined;
+  /** Compact display string (e.g. "2018 – 2022"), reflecting date edits. */
+  dates: string;
+  /** Grade as the résumé wrote it, scale included (#883) — never a number. */
+  gpa: string | undefined;
+  honors: string | undefined;
+  coursework: string[];
+}
+
+/**
+ * Fold an education entry's overrides into the display values. Pure (no JSX) so
+ * the resolution/clearing/date branches are unit-tested directly — this is the
+ * risk-bearing logic; the component is then render-only.
+ */
+export function resolveEducationDisplay(
+  edu: ResumeEducation,
+  overrides: EducationFieldOverrides | undefined,
+): EducationDisplay {
+  // Dates: the override fields feed buildEducationDates so the compact display
+  // string reflects edits; the read-only display still falls back to `year`.
+  const startDate = resolveEduValue(edu.start_date, overrides?.start_date);
+  const endDate = resolveEduValue(edu.end_date, overrides?.end_date);
+  return {
+    degree: resolveEduValue(edu.degree, overrides?.degree),
+    field: resolveEduValue(edu.field, overrides?.field),
+    institution: resolveEduValue(edu.institution, overrides?.institution),
+    startDate,
+    endDate,
+    dates: buildEducationDates({ ...edu, start_date: startDate, end_date: endDate }),
+    gpa: resolveEduValue(edu.gpa, overrides?.gpa),
+    honors: resolveEduValue(edu.honors, overrides?.honors),
+    coursework: edu.coursework ?? [],
+  };
+}

--- a/src/lib/heuristics/extract/education-grade.test.ts
+++ b/src/lib/heuristics/extract/education-grade.test.ts
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Unit coverage for the education grade / honors recogniser (#883).
+ *
+ * Three properties are asserted here rather than through the extractor, because
+ * each is a claim about the PREDICATE and would be untestable once a chunk's
+ * segmentation is in the way:
+ *   - values survive VERBATIM, whatever notation and scale the résumé used;
+ *   - an unlabelled honors or classification phrase matches only as a WHOLE
+ *     segment, so ordinary prose containing "with distinction" is inert;
+ *   - `formatGradeNote` is a genuine inverse of the recogniser — the round-trip
+ *     the exporter depends on, pinned as a property over every shape below.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyGradeSegment,
+  cutTrailingGradeNote,
+  formatGradeNote,
+  isEducationNoteSegment,
+  parseEducationGrade,
+} from "./education-grade.ts";
+
+/** Every grade NOTATION the recogniser claims to read, with the value it must
+ *  yield — verbatim, including the source's own spacing around a scale. */
+const GRADE_SHAPES: [line: string, gpa: string][] = [
+  ["GPA: 3.72/4.00", "3.72/4.00"],
+  ["GPA: 3.9/4.0", "3.9/4.0"],
+  ["GPA 3.7", "3.7"],
+  ["GPA: 3.9", "3.9"],
+  ["GPA: 3.7 / 4.0", "3.7 / 4.0"],
+  ["CGPA 8.4/10", "8.4/10"],
+  ["SGPA: 9.1", "9.1"],
+  ["Cumulative GPA: 3.93/4.0", "3.93/4.0"],
+  ["Cum. GPA: 3.83 / 4.0", "3.83 / 4.0"],
+  ["GPA: 85%", "85%"],
+  ["GPA - 3.5", "3.5"],
+  ["3.8 GPA", "3.8"],
+  ["First Class", "First Class"],
+  ["First Class Honours", "First Class Honours"],
+  ["Second Class Upper Division", "Second Class Upper Division"],
+  ["2:1", "2:1"],
+  ["First Division", "First Division"],
+];
+
+describe("classifyGradeSegment — grade notations survive verbatim", () => {
+  for (const [segment, gpa] of GRADE_SHAPES) {
+    it(`reads ${JSON.stringify(segment)} as ${JSON.stringify(gpa)}`, () => {
+      expect(classifyGradeSegment(segment)).toEqual({ kind: "gpa", value: gpa });
+    });
+  }
+
+  it("declines a labelled grade that shares its segment with a subject", () => {
+    // The LABELLED branch is whole-segment too, not just the unlabelled ones.
+    // Its callers delete on a yes — the field cut drops the whole subject for a
+    // lead segment — so an unanchored search here erased "Computer Science".
+    expect(classifyGradeSegment("Computer Science GPA 3.8")).toBeUndefined();
+    expect(classifyGradeSegment("Statistics GPA 3.8")).toBeUndefined();
+    expect(classifyGradeSegment("Economics 3.8 GPA")).toBeUndefined();
+    expect(isEducationNoteSegment("Computer Science GPA 3.8")).toBe(false);
+  });
+
+  it("still reads a qualified grade that IS the whole segment", () => {
+    // The qualifier vocabulary is what keeps the anchoring above from rejecting
+    // the real notes a résumé writes with a leading word.
+    for (const seg of [
+      "Cumulative GPA: 3.93/4.0",
+      "Cum. GPA: 3.83 / 4.0",
+      "Major GPA: 3.9 / 4.0",
+      "Overall GPA 3.5",
+    ]) {
+      expect(classifyGradeSegment(seg)?.kind).toBe("gpa");
+    }
+  });
+
+  it("never normalises a non-4.0 scale to a 4.0 one", () => {
+    // The whole reason `gpa` is a string: 8.4/10 and 3.36/4.0 are the same
+    // standing, and a float would erase which axis the résumé was on.
+    expect(classifyGradeSegment("CGPA 8.4/10")?.value).toBe("8.4/10");
+  });
+
+  it("rejects a bare four-digit year that follows the keyword", () => {
+    // Without the digit-boundary guard this surfaces "202" as a grade.
+    expect(classifyGradeSegment("Best GPA 2020")).toBeUndefined();
+  });
+
+  it("rejects a grade keyword with no value after it", () => {
+    expect(classifyGradeSegment("GPA")).toBeUndefined();
+  });
+});
+
+describe("classifyGradeSegment — honors", () => {
+  for (const phrase of [
+    "cum laude",
+    "Cum Laude",
+    "magna cum laude",
+    "Summa Cum Laude",
+    "with honors",
+    "with honours",
+    "with distinction",
+    "with highest honors",
+  ]) {
+    it(`reads ${JSON.stringify(phrase)} as honors`, () => {
+      expect(classifyGradeSegment(phrase)).toEqual({
+        kind: "honors",
+        value: phrase,
+      });
+    });
+  }
+
+  it("strips an honors LABEL before matching the phrase", () => {
+    expect(classifyGradeSegment("Honors: Magna Cum Laude")).toEqual({
+      kind: "honors",
+      value: "Magna Cum Laude",
+    });
+  });
+
+  it("prefers the classification reading when a phrase is both", () => {
+    // "First Class with Distinction" is ONE classification the résumé wrote —
+    // splitting it across gpa and honors would store half in each.
+    expect(classifyGradeSegment("First Class with Distinction")).toEqual({
+      kind: "gpa",
+      value: "First Class with Distinction",
+    });
+  });
+
+  it("does NOT match an honors phrase buried in prose", () => {
+    // The `compound-certifications-activities-tail` fixture pools exactly this
+    // sentence into its education section. A substring search would read it as
+    // honors on a real degree entry.
+    expect(
+      classifyGradeSegment("Achievements: Graduated B.E. with Distinction"),
+    ).toBeUndefined();
+    expect(
+      classifyGradeSegment("Coursework included a summa cum laude seminar"),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseEducationGrade", () => {
+  it("takes the first grade in document order when several are listed", () => {
+    // A cumulative GPA is written above a major GPA; the cumulative one is what
+    // a reader means by "the GPA".
+    expect(
+      parseEducationGrade([
+        "Magna Cum Laude",
+        "Cum. GPA: 3.83 / 4.0",
+        "Major GPA: 3.9 / 4.0",
+      ]),
+    ).toEqual({ gpa: "3.83 / 4.0", honors: "Magna Cum Laude" });
+  });
+
+  it("reads both off a single degree line", () => {
+    expect(
+      parseEducationGrade([
+        "B.S. in Computer Science, cum laude, GPA: 3.72/4.00",
+      ]),
+    ).toEqual({ gpa: "3.72/4.00", honors: "cum laude" });
+  });
+
+  it("reaches a grade sitting behind a column gap", () => {
+    expect(
+      parseEducationGrade(["Bachelor of Arts, Business Administration\t  GPA:\t  3.5"]),
+    ).toEqual({ gpa: "3.5" });
+  });
+
+  it("reaches a grade buried behind middots on a date/location line", () => {
+    // The module docblock's own defended case, and the one anchoring the
+    // segment predicate must not cost: the whole-LINE pass is unanchored, and
+    // the middot split hands `classifyGradeSegment` a segment the label fills.
+    expect(
+      parseEducationGrade([
+        "Aug. 2021 - May. 2025 · Columbus, Ohio · GPA: 3.7 / 4.0",
+      ]),
+    ).toEqual({ gpa: "3.7 / 4.0" });
+  });
+
+  it("still collects a grade that shares a segment with the subject", () => {
+    // The whole-line pass is what makes the field cut safe to tighten: the
+    // grade is still lifted onto the entry even though no SEGMENT is one.
+    expect(parseEducationGrade(["B.S. in Computer Science GPA 3.8"])).toEqual({
+      gpa: "3.8",
+    });
+  });
+
+  it("returns nothing for an entry that carries neither", () => {
+    expect(
+      parseEducationGrade(["State University", "B.S. Computer Science, 2020"]),
+    ).toEqual({});
+  });
+});
+
+describe("formatGradeNote is the recogniser's inverse", () => {
+  for (const [, gpa] of GRADE_SHAPES) {
+    it(`re-reads ${JSON.stringify(gpa)} from its rendered note`, () => {
+      expect(classifyGradeSegment(formatGradeNote(gpa))).toEqual({
+        kind: "gpa",
+        value: gpa,
+      });
+    });
+  }
+
+  it("labels a numeric value and leaves a classification bare", () => {
+    expect(formatGradeNote("3.72/4.00")).toBe("GPA: 3.72/4.00");
+    expect(formatGradeNote("First Class")).toBe("First Class");
+  });
+});
+
+describe("cutTrailingGradeNote", () => {
+  it("drops an unpunctuated trailing grade and keeps the subject", () => {
+    expect(cutTrailingGradeNote("Computer Science GPA 3.8")).toBe(
+      "Computer Science",
+    );
+    expect(cutTrailingGradeNote("Mathematics, Statistics GPA 3.8")).toBe(
+      "Mathematics, Statistics",
+    );
+    expect(cutTrailingGradeNote("Economics 3.8 GPA")).toBe("Economics");
+    expect(cutTrailingGradeNote("Physics Cum. GPA: 3.83 / 4.0")).toBe("Physics");
+  });
+
+  it("leaves a subject carrying no grade untouched", () => {
+    expect(cutTrailingGradeNote("Computer Science")).toBe("Computer Science");
+    expect(cutTrailingGradeNote("Mathematics, Statistics")).toBe(
+      "Mathematics, Statistics",
+    );
+  });
+
+  it("never empties a field that is nothing BUT a grade", () => {
+    // That decision belongs to `classifyGradeSegment` and the field cut's lead
+    // branch, which drop the field wholesale; emptying it here as well would
+    // give two places the power to erase a field.
+    expect(cutTrailingGradeNote("GPA 3.8")).toBe("GPA 3.8");
+    expect(cutTrailingGradeNote("GPA: 3.72/4.00")).toBe("GPA: 3.72/4.00");
+  });
+});
+
+describe("isEducationNoteSegment", () => {
+  it("covers the minor / major / concentration labels the field cut always had", () => {
+    expect(isEducationNoteSegment("Minor in Economics")).toBe(true);
+    expect(isEducationNoteSegment("Concentration in Robotics")).toBe(true);
+    expect(isEducationNoteSegment("CGPA 8.7/10")).toBe(true);
+  });
+
+  it("leaves a genuine subject alone", () => {
+    expect(isEducationNoteSegment("Computer Science")).toBe(false);
+    expect(isEducationNoteSegment("Statistics")).toBe(false);
+  });
+
+  it("recognizes an SGPA prefix on a malformed, valueless note the same as GPA/CGPA (review nit)", () => {
+    // classifyGradeSegment finds no numeric value in any of these, so it's this
+    // prefix fast path alone that has to catch them — and it must not treat
+    // "sgpa" differently than the "gpa"/"cgpa" it already recognized, since
+    // GRADE_LABEL_SRC ([cs]?gpa) treats all three as the same vocabulary.
+    expect(isEducationNoteSegment("SGPA pending")).toBe(true);
+    expect(isEducationNoteSegment("GPA pending")).toBe(true);
+    expect(isEducationNoteSegment("CGPA pending")).toBe(true);
+  });
+});

--- a/src/lib/heuristics/extract/education-grade.ts
+++ b/src/lib/heuristics/extract/education-grade.ts
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Education GRADE + HONORS recognition (#883) — the one predicate that decides
+ * whether a run of text on an education line is a grade note (`GPA: 3.72/4.00`,
+ * `CGPA 8.4/10`, `First Class`, `2:1`) or a Latin-honors note (`cum laude`,
+ * `with distinction`).
+ *
+ * It exists as its own leaf module because THREE call sites in
+ * `extract/education.ts` need the same answer and must never drift: the
+ * collector that lifts `gpa` / `honors` onto the entry (`parseEducationGrade`),
+ * `cleanField`'s cut that keeps the same text out of the degree's subject field
+ * (`isEducationNoteSegment`), and the chunker's entry-boundary guard that keeps
+ * an annotation line from leading a new entry (`isGradeAnnotationLine`). A
+ * fourth consumer lives in `pdf/ats-resume-model.ts`: `formatGradeNote` renders
+ * the value back into a line this module re-reads, which is what makes the
+ * export round-trip.
+ *
+ * Recognition happens at two SCOPES, and which scope a caller is entitled to is
+ * the module's central distinction:
+ *
+ *   - **Whole LINE** — {@link parseEducationGrade} asks "does this line carry a
+ *     grade anywhere?", so its labelled search is unanchored. That is safe there
+ *     because the collector only lifts a value onto a field of its own; it never
+ *     decides that text is *disposable*. It is also necessary: real résumés bury
+ *     the keyword behind a column gap, a tab run, or a middot
+ *     (`Aug. 2021 - May. 2025 · Columbus, Ohio · GPA: 3.7 / 4.0`), and a
+ *     dash-separated `GPA - 3.5` straddles a segment boundary.
+ *   - **Whole SEGMENT** — {@link classifyGradeSegment} asks "is this segment
+ *     NOTHING BUT a grade note?", and its callers delete on a yes: the field cut
+ *     in `extract/education.ts` drops the segment, and for a lead segment the
+ *     whole subject field with it. Every branch is therefore anchored `^…$`,
+ *     the labelled one included — an unanchored labelled branch read
+ *     `B.S. in Computer Science GPA 3.8` as a pure grade note and silently
+ *     dropped `Computer Science` from the parse, the export, and JD matching.
+ *
+ * The unlabelled branches are anchored for a second, independent reason:
+ * `cum laude` and `First Class` are ordinary English that appears inside prose,
+ * and the education section routinely pools such prose from a mis-routed
+ * compound header — `Achievements: Graduated B.E. with Distinction; mentored 3
+ * interns` (the `compound-certifications-activities-tail` fixture) must NOT
+ * yield honors. A substring search there would fire on it.
+ *
+ * The value is stored VERBATIM — `3.72/4.00`, `3.7 / 4.0`, `8.4/10`,
+ * `First Class`, `2:1` all survive as written. Normalising to a float would
+ * throw away the scale and invent precision the résumé never carried, so the
+ * model field is a string and nothing here parses a number.
+ */
+
+/** A grade NUMBER: 1–3 integer digits, an optional decimal tail, and no further
+ *  digit after it. The `(?!\d)` is load-bearing — without it a 4-digit YEAR
+ *  ("Best GPA 2020") would match its first three digits and surface "202" as a
+ *  grade. With it, every split of a 4-digit run fails and the year is rejected. */
+const GRADE_NUMBER_SRC = String.raw`\d{1,3}(?:\.\d+)?(?!\d)`;
+/** A grade VALUE: a number, an optional `/N` scale, an optional percent sign.
+ *  Whitespace inside the scale is preserved by the capture, so "3.7 / 4.0"
+ *  round-trips as written rather than being re-spaced. */
+const GRADE_VALUE_SRC =
+  GRADE_NUMBER_SRC + String.raw`(?:\s*\/\s*${GRADE_NUMBER_SRC})?(?:\s*%)?`;
+/** The grade-keyword vocabulary: GPA, and the cumulative / semester variants
+ *  Indian and other non-US résumés use. */
+const GRADE_LABEL_SRC = String.raw`[cs]?gpa`;
+
+/** The qualifier words that may sit in front of the grade keyword and still
+ *  leave the run a PURE grade note — `Cumulative GPA: 3.93/4.0`,
+ *  `Cum. GPA: 3.83 / 4.0`, `Major GPA: 3.9 / 4.0`. Deliberately an enumeration
+ *  rather than a permissive `\w+`: arbitrary leading words are precisely what a
+ *  SUBJECT looks like ("Computer Science GPA 3.8"), so a wildcard here would
+ *  hand back the substring search the anchored forms below exist to replace. */
+const GRADE_QUALIFIER_SRC = String.raw`(?:(?:cumulative|cum\.?|overall|major|final|current)\s*)?`;
+
+/** `GPA: 3.8` / `CGPA 8.7/10` / `Cum. GPA: 3.83 / 4.0` — label then value. */
+const GRADE_LABEL_FIRST_SRC = String.raw`${GRADE_QUALIFIER_SRC}\b${GRADE_LABEL_SRC}\b\s*[:\-–—]?\s*(${GRADE_VALUE_SRC})`;
+/** `3.8 GPA` — value then label, the shape openresume's template emits. */
+const GRADE_LABEL_LAST_SRC = String.raw`(${GRADE_VALUE_SRC})\s*\b${GRADE_LABEL_SRC}\b`;
+
+/** The two shapes searched ANYWHERE in a line, for {@link parseEducationGrade}
+ *  alone — see the module docblock for why no other caller may have these. */
+const GRADE_LABEL_FIRST_RE = new RegExp(GRADE_LABEL_FIRST_SRC, "i");
+const GRADE_LABEL_LAST_RE = new RegExp(GRADE_LABEL_LAST_SRC, "i");
+
+/** The same two shapes anchored to a WHOLE segment, for
+ *  {@link classifyGradeSegment}'s "is this segment nothing but a grade?"
+ *  question — the one its callers delete on. */
+const GRADE_LABEL_FIRST_SEGMENT_RE = new RegExp(
+  String.raw`^${GRADE_LABEL_FIRST_SRC}$`,
+  "i",
+);
+const GRADE_LABEL_LAST_SEGMENT_RE = new RegExp(
+  String.raw`^${GRADE_LABEL_LAST_SRC}$`,
+  "i",
+);
+
+/** The same two shapes anchored to the END of a longer run, with at least one
+ *  space in front — a grade that rode onto a subject with no punctuation to
+ *  divide them ("Computer Science GPA 3.8", "Computer Science 3.8 GPA"), which
+ *  the segment split therefore cannot separate. The leading `\s+` is what keeps
+ *  {@link cutTrailingGradeNote} from emptying a field that is nothing BUT a
+ *  grade; deciding that case is {@link classifyGradeSegment}'s job. */
+const TRAILING_GRADE_NOTE_RE = new RegExp(
+  String.raw`\s+(?:${GRADE_LABEL_FIRST_SRC}|${GRADE_LABEL_LAST_SRC})$`,
+  "i",
+);
+
+/** A degree CLASSIFICATION written as a whole segment, with no grade keyword to
+ *  anchor it — the UK/Commonwealth and Indian conventions. Whole-segment only
+ *  (see the module docblock): `class` and `division` are common words. */
+const GRADE_CLASSIFICATION_RE =
+  /^(?:(?:first|second|third)[\s-]class(?:\s+(?:honou?rs|with\s+(?:distinction|merit)|upper\s+division|lower\s+division))?|(?:first|second|third)\s+division|2:[12])$/i;
+
+/** An optional `Honors:` / `Honours —` label in front of the honors phrase, so
+ *  a labelled line reduces to the same anchored phrase a bare one does. Only
+ *  honors-specific labels: `Achievements:` and `Awards:` introduce award LISTS,
+ *  and stripping those would hand prose to the anchored test below. */
+const HONORS_LABEL_RE = /^(?:latin\s+)?honou?rs?\s*[:\-–—]\s*/i;
+/** The honors vocabulary, matched against a WHOLE segment: the Latin set plus
+ *  the English "with <honors|distinction>" forms and their intensifiers. */
+const HONORS_RE =
+  /^(?:(?:summa|magna)\s+)?cum\s+laude$|^(?:graduated\s+)?with\s+(?:high(?:est)?\s+)?(?:honou?rs|distinction)$/i;
+
+/** A bare graduation YEAR trailing a punctuation-delimited segment, with
+ *  whatever whitespace separates it — for {@link annotationSegments} only. A
+ *  composed export line (#883) can glue the year onto an unlabelled honors
+ *  phrase with nothing but a single space ("cum laude 2023"), too narrow a
+ *  gap to trip the tab/2-space cell split below, so the year has to be peeled
+ *  off before the whole-segment test or it never reduces to bare "cum laude".
+ *  A labelled GPA note is unaffected — {@link labelledGrade} searches the raw
+ *  line separately and never sees this stripped copy. */
+const TRAILING_BARE_YEAR_RE = /\s*\b(?:19|20)\d{2}\b\s*$/;
+
+/** Where one run of text on an education line ends and the next begins: a
+ *  comma/semicolon, a middot/bullet, a pipe, or a SPACED dash. The dash must be
+ *  spaced on both sides — an unspaced hyphen belongs inside a hyphenated word
+ *  ("Pre-Med"), where a spaced one divides two runs. Exported as a SOURCE string
+ *  so `extract/education.ts`'s field cut segments a degree line exactly the way
+ *  this module's recogniser does; two hand-kept copies would let the collector
+ *  and the cut disagree about where a note starts. */
+export const EDUCATION_SEGMENT_SPLIT_SRC = String.raw`\s*[,;·•|]\s*|\s+[-–—]\s+`;
+
+/** The punctuation-delimited runs of `line`, whitespace collapsed, empties
+ *  dropped. The coarse granularity — {@link annotationSegments} adds the column
+ *  cells within each run. */
+function coarseSegments(line: string): string[] {
+  return line
+    .split(new RegExp(EDUCATION_SEGMENT_SPLIT_SRC))
+    .map((s) => s.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+}
+
+/** GPA / honors lifted off an education entry's lines. Either may be absent; a
+ *  value is the résumé's own text, never a normalised number. */
+export interface EducationGrade {
+  gpa?: string;
+  honors?: string;
+}
+
+/**
+ * The segments of one line that an UNLABELLED classification / honors phrase may
+ * occupy on its own. Split on punctuation separators and spaced dashes, and —
+ * because a two-column grid puts the honors in a right-hand rail — additionally
+ * on tab runs and column gaps WITHIN each punctuation segment. Both granularities
+ * are returned rather than the finer one alone: a Word template that tabs BETWEEN
+ * every word ("Magna\t  Cum\t  Laude") would shred the phrase at the finer
+ * granularity, while the coarse segment keeps it whole once its internal
+ * whitespace is collapsed.
+ */
+function annotationSegments(line: string): string[] {
+  const out: string[] = [];
+  for (const rawPart of line.split(new RegExp(EDUCATION_SEGMENT_SPLIT_SRC))) {
+    const part = rawPart.replace(TRAILING_BARE_YEAR_RE, "");
+    const whole = part.replace(/\s+/g, " ").trim();
+    if (whole) out.push(whole);
+    for (const cell of part.split(/\t+|\s{2,}/)) {
+      const seg = cell.replace(/\s+/g, " ").trim();
+      if (seg && seg !== whole) out.push(seg);
+    }
+  }
+  return out;
+}
+
+/** The labelled grade value carried anywhere in `line`, or undefined. Label-first
+ *  is tried before label-last so "GPA: 3.8" is never read backwards. Unanchored
+ *  — for {@link parseEducationGrade}'s whole-line pass only. */
+function labelledGrade(line: string): string | undefined {
+  const m = GRADE_LABEL_FIRST_RE.exec(line) ?? GRADE_LABEL_LAST_RE.exec(line);
+  return m?.[1]?.trim();
+}
+
+/** The labelled grade value when it is the ENTIRE segment, or undefined — the
+ *  anchored twin of {@link labelledGrade}, same label-first precedence. */
+function labelledGradeSegment(segment: string): string | undefined {
+  const m =
+    GRADE_LABEL_FIRST_SEGMENT_RE.exec(segment) ??
+    GRADE_LABEL_LAST_SEGMENT_RE.exec(segment);
+  return m?.[1]?.trim();
+}
+
+/**
+ * Classify ONE segment as a grade, an honors phrase, or neither — a WHOLE-segment
+ * predicate in every branch, because callers delete on a yes (module docblock).
+ * Grade wins over honors when both could match — "First Class with Distinction"
+ * is one classification, not a classification plus separate honors, and
+ * splitting it would store half the résumé's phrase in each field.
+ */
+export function classifyGradeSegment(
+  segment: string,
+): { kind: "gpa" | "honors"; value: string } | undefined {
+  const seg = segment.replace(/\s+/g, " ").trim();
+  if (!seg) return undefined;
+  const labelled = labelledGradeSegment(seg);
+  if (labelled) return { kind: "gpa", value: labelled };
+  if (GRADE_CLASSIFICATION_RE.test(seg)) return { kind: "gpa", value: seg };
+  const honors = seg.replace(HONORS_LABEL_RE, "").trim();
+  if (HONORS_RE.test(honors)) return { kind: "honors", value: honors };
+  return undefined;
+}
+
+/**
+ * Drop a labelled grade note that rode onto the END of `field` with no
+ * punctuation in front of it, keeping the subject ahead of it — "Computer
+ * Science GPA 3.8" → "Computer Science".
+ *
+ * The segment-wise field cut cannot reach this one: there is no separator, so
+ * the subject and the note are the SAME segment, and the whole-segment
+ * predicates correctly decline to call that segment a note. Only the grade
+ * KEYWORD tells the two apart, which is why this cut is labelled-only — an
+ * unlabelled classification with no separator ("Economics First Class") is left
+ * alone rather than guessed at, since "First Class" is also ordinary English a
+ * subject could end in.
+ */
+export function cutTrailingGradeNote(field: string): string {
+  return field.replace(TRAILING_GRADE_NOTE_RE, "").trim();
+}
+
+/** The minor/major/GPA/concentration prefixes `isEducationNoteSegment` cuts on
+ *  sight, built from `GRADE_LABEL_SRC` rather than a hand-duplicated `c?gpa` so
+ *  it recognizes `sgpa` the same way the labelled-grade regexes above do — a
+ *  hand-copy previously drifted and missed it. */
+const NOTE_PREFIX_RE = new RegExp(
+  String.raw`^(?:minor|major|${GRADE_LABEL_SRC}|concentration)\b`,
+  "i",
+);
+
+/**
+ * Whether `segment` is a sub-field NOTE that rode along on a degree line rather
+ * than part of the subject — a grade, an honors phrase, or the minor/major/
+ * concentration labels `cleanField` has always cut. The single predicate behind
+ * both the field cut and the collector, so the two can never disagree about
+ * what counts as an annotation.
+ */
+export function isEducationNoteSegment(segment: string): boolean {
+  const seg = segment.trim();
+  if (!seg) return false;
+  if (NOTE_PREFIX_RE.test(seg)) return true;
+  return classifyGradeSegment(seg) !== undefined;
+}
+
+/**
+ * Whether a whole LINE is nothing but a grade / honors annotation — "Magna Cum
+ * Laude", "GPA: 3.9 · First Class". Every segment must be one, so a line that
+ * also carries real entry text is not claimed.
+ *
+ * Used as an entry-BOUNDARY guard: such a line is a property of the entry above
+ * it and must never be read as the lead of a new one. It complements
+ * `PROGRAM_NOTE_RE`, which recognises the same idea by prefix (`GPA:`, `Minor`,
+ * `Coursework`) and so cannot see an unlabelled honors phrase.
+ */
+export function isGradeAnnotationLine(line: string): boolean {
+  const segments = coarseSegments(line);
+  return (
+    segments.length > 0 &&
+    segments.every((s) => classifyGradeSegment(s) !== undefined)
+  );
+}
+
+/**
+ * Render a stored `gpa` value back into a line the parser reads as that same
+ * value — the export's half of the round-trip (#883). A classification is
+ * emitted BARE, because "GPA: First Class" is not how anyone writes it and the
+ * unlabelled recogniser already reads it back; everything else takes the `GPA: `
+ * label, which is what makes a numeric value recognisable at all.
+ *
+ * The equality check is the contract, not decoration: the bare branch is taken
+ * only when re-reading the bare string yields the identical value, so a value
+ * the recogniser would re-read DIFFERENTLY can never take it. A hand-typed value
+ * outside the recogniser's vocabulary ("Top 5%") still renders correctly in the
+ * PDF and is simply not recovered by a re-parse — display is not lost, only the
+ * structured field is.
+ */
+export function formatGradeNote(value: string): string {
+  const bare = classifyGradeSegment(value);
+  if (bare?.kind === "gpa" && bare.value === value) return value;
+  return `GPA: ${value}`;
+}
+
+/**
+ * Collect the entry's GPA and honors from its lines, in document order — the
+ * first of each kind wins. Order matters on a résumé that lists several grades
+ * ("Cum. GPA: 3.83 / 4.0" above "Major GPA: 3.9 / 4.0"): the cumulative one is
+ * written first and is the one a reader means by "the GPA".
+ *
+ * Each line is read at BOTH scopes, and the two are not redundant. The
+ * unanchored whole-line pass is the only one that can reach a labelled grade
+ * buried in a longer line — behind a column gap, a tab run, a middot, or a
+ * dash-separated "GPA - 3.5" whose label and value straddle a segment boundary.
+ * The per-segment pass is the only one that can reach an UNLABELLED
+ * classification or honors phrase, which has no keyword to find it by and is
+ * therefore recognised only as a whole segment. Being the sole caller entitled
+ * to the unanchored search is what keeps that search out of the field cut, where
+ * it would delete a real subject.
+ */
+export function parseEducationGrade(
+  lines: readonly string[],
+): EducationGrade {
+  const out: EducationGrade = {};
+  for (const line of lines) {
+    if (!out.gpa) {
+      const labelled = labelledGrade(line);
+      if (labelled) out.gpa = labelled;
+    }
+    for (const segment of annotationSegments(line)) {
+      const hit = classifyGradeSegment(segment);
+      if (!hit) continue;
+      if (hit.kind === "gpa") out.gpa ??= hit.value;
+      else out.honors ??= hit.value;
+    }
+    if (out.gpa && out.honors) break;
+  }
+  return out;
+}

--- a/src/lib/heuristics/extract/education.gpa-honors.test.ts
+++ b/src/lib/heuristics/extract/education.gpa-honors.test.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * #883 — GPA and Latin honors reach the canonical résumé.
+ *
+ * Before this, both were discarded at Tier 1: the chunker recognised a
+ * `GPA: …` line only well enough to stop it opening a phantom entry, and
+ * nothing collected it, so the value never reached the reconstructed résumé,
+ * the export, the JSON Resume attachment, or JD matching. Worse, an inline
+ * note rode INTO the subject — `B.S. Computer Science · GPA 3.7` parsed to a
+ * field of `"Computer Science · GPA 3.7"`.
+ *
+ * These assert the extractor's half. The recogniser's own vocabulary lives in
+ * `education-grade.test.ts`; the export/re-parse half is pinned by the corpus
+ * round-trip gate (which compares `gpa`/`honors` per entry) and by
+ * `render-education-grade.repro.test.ts`.
+ *
+ * Synthetic personas only, per the fixtures PII policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEducation } from "./education.ts";
+import { type PdfLine, type PdfSection } from "../sections.ts";
+
+const mkLine = (text: string): PdfLine => ({
+  page: 0,
+  y: 0,
+  x: 0,
+  items: [],
+  text,
+  maxFontSize: 11,
+  allCaps: false,
+  gapAbove: 0,
+});
+const mkEduSection = (texts: string[]): PdfSection => ({
+  name: "education",
+  lines: texts.map(mkLine),
+});
+
+describe("extractEducation — GPA / honors on the degree line (#883)", () => {
+  it("lifts both off the degree line and leaves the subject clean", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "The University of Texas at Dallas                                   May 2024",
+        "B.S. in Computer Science, cum laude, GPA: 3.72/4.00",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].degree).toBe("B.S.");
+    // The honors phrase used to survive the field cut, which anchored on
+    // `[,;]\s*gpa` and so stopped at the GPA it could see, not at the first
+    // annotation: the field came back as "Computer Science, cum laude".
+    expect(value[0].field).toBe("Computer Science");
+    expect(value[0].gpa).toBe("3.72/4.00");
+    expect(value[0].honors).toBe("cum laude");
+  });
+
+  it("keeps a middot-separated grade out of the subject", () => {
+    const { value } = extractEducation(
+      mkEduSection(["Springfield State University", "B.S. Computer Science · GPA 3.7"]),
+    );
+    expect(value[0].field).toBe("Computer Science");
+    expect(value[0].gpa).toBe("3.7");
+  });
+
+  it("keeps a trailing-label grade out of the subject", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Northwind University",
+        "Bachelor of Science in Computer Science - 3.8 GPA",
+      ]),
+    );
+    expect(value[0].field).toBe("Computer Science");
+    expect(value[0].gpa).toBe("3.8");
+  });
+
+  it("keeps the subject when the grade rides on with NO separator", () => {
+    // The regression this file's other cases could not catch: every one of them
+    // puts a comma or a middot in front of the note, so the segment split alone
+    // separated subject from grade. With no separator the two are ONE segment,
+    // and an unanchored labelled search called that whole segment a grade note —
+    // for a LEAD segment the field cut drops the field entirely, so "Computer
+    // Science" vanished from the parse, from the export, and from JD matching.
+    const { value } = extractEducation(
+      mkEduSection(["Northwind University", "B.S. in Computer Science GPA 3.8"]),
+    );
+    expect(value[0].field).toBe("Computer Science");
+    expect(value[0].gpa).toBe("3.8");
+  });
+
+  it("keeps BOTH halves of a two-part subject when the grade rides on with no separator", () => {
+    // Same defect one segment further in: here the field cut reached the note
+    // through `isEducationNoteSegment` instead, so only the trailing half of the
+    // subject was lost. The field must come back exactly as it does without the
+    // grade on the line.
+    const { value } = extractEducation(
+      mkEduSection([
+        "Northwind University",
+        "B.S. in Mathematics, Statistics GPA 3.8",
+      ]),
+    );
+    expect(value[0].field).toBe("Mathematics, Statistics");
+    expect(value[0].gpa).toBe("3.8");
+  });
+
+  it("keeps the subject when an unpunctuated grade is written label-last", () => {
+    const { value } = extractEducation(
+      mkEduSection(["Northwind University", "B.S. in Economics 3.8 GPA"]),
+    );
+    expect(value[0].field).toBe("Economics");
+    expect(value[0].gpa).toBe("3.8");
+  });
+
+  it("does not mistake a two-part subject for a note", () => {
+    const { value } = extractEducation(
+      mkEduSection(["Northwind College", "B.A. Mathematics · Statistics, 2021"]),
+    );
+    expect(value[0].field).toBe("Mathematics · Statistics");
+    expect(value[0].gpa).toBeUndefined();
+  });
+});
+
+describe("extractEducation — GPA on a standalone annotation line (#883)", () => {
+  it("captures it without splitting off a phantom entry", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Springfield State University",
+        "B.S. Computer Science, 2017",
+        "GPA: 3.9/4.0",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].institution).toBe("Springfield State University");
+    expect(value[0].gpa).toBe("3.9/4.0");
+  });
+
+  it("captures an honors line of its own", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Northwind University",
+        "B.S. Computer Science, 2017",
+        "Magna Cum Laude",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].honors).toBe("Magna Cum Laude");
+  });
+
+  it("attributes each annotation line to the entry it sits under", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "Northwind University",
+        "M.S. Data Science, 2022 - 2024",
+        "GPA: 3.9",
+        "Springfield State University",
+        "B.S. Computer Science, 2018 - 2022",
+        "GPA: 3.4",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value.map((e) => e.gpa)).toEqual(["3.9", "3.4"]);
+  });
+
+  it("keeps a note with its own entry when the NEXT line opens a degree", () => {
+    // Degree-first ordering: the note is followed immediately by the next
+    // entry's degree line, so the hint-less-entry lookahead reads the note
+    // itself as the boundary. Pre-#883 that flushed the chunk AT the note,
+    // handing the M.S.'s grade to the B.S. below it.
+    const { value } = extractEducation(
+      mkEduSection([
+        "M.S. Data Science, 2024",
+        "Northwind University",
+        "GPA: 3.9",
+        "B.S. Computer Science, 2022",
+        "Springfield State University",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value.map((e) => e.degree)).toEqual(["M.S.", "B.S."]);
+    expect(value.map((e) => e.gpa)).toEqual(["3.9", undefined]);
+  });
+
+  it("does the same for an unlabelled honors line, which has no prefix to match", () => {
+    const { value } = extractEducation(
+      mkEduSection([
+        "M.S. Data Science, 2024",
+        "Northwind University",
+        "Magna Cum Laude",
+        "B.S. Computer Science, 2022",
+        "Springfield State University",
+      ]),
+    );
+    expect(value).toHaveLength(2);
+    expect(value.map((e) => e.honors)).toEqual(["Magna Cum Laude", undefined]);
+  });
+
+  it("does not read an honors phrase out of pooled body prose", () => {
+    // A mis-routed compound header ("CERTIFICATIONS & ACTIVITIES") pools
+    // sentences into the education section (#462/#467). "Graduated B.E. with
+    // Distinction" is a sentence ABOUT a degree, not an honors annotation on
+    // this entry — a substring search would claim it.
+    const { value } = extractEducation(
+      mkEduSection([
+        "Ridgemont College",
+        "B.E. in Computer Science, 2021",
+        "Achievements: Graduated B.E. with Distinction; mentored 3 interns",
+      ]),
+    );
+    expect(value[0].honors).toBeUndefined();
+  });
+});
+
+describe("extractEducation — grade notations are preserved, never normalised (#883)", () => {
+  const cases: [line: string, gpa: string][] = [
+    ["B.Tech Computer Science, CGPA: 8.4/10", "8.4/10"],
+    ["B.S. Computer Science, GPA: 3.9", "3.9"],
+    ["B.A. Economics, First Class", "First Class"],
+    ["B.A. Economics, 2:1", "2:1"],
+    ["B.Com Accounting, GPA: 85%", "85%"],
+  ];
+  for (const [line, gpa] of cases) {
+    it(`keeps ${JSON.stringify(gpa)} exactly as written`, () => {
+      const { value } = extractEducation(
+        mkEduSection(["Northwind University", line]),
+      );
+      expect(value[0].gpa).toBe(gpa);
+      // The subject must not carry the grade text as well.
+      expect(value[0].field ?? "").not.toMatch(/gpa|class|\d/i);
+    });
+  }
+});

--- a/src/lib/heuristics/extract/education.test.ts
+++ b/src/lib/heuristics/extract/education.test.ts
@@ -334,6 +334,25 @@ describe("extractEducation — capstone/project sub-line stays annotation, not s
     expect(value).toHaveLength(2);
     expect(value[0].institution).toBe("Cornell University");
   });
+
+  it("does NOT split an honor-society line into a phantom entry, even with a year (#883 review round 2)", () => {
+    // "Phi Beta Kappa, cum laude 2021" carries no EDUCATION_ANNOTATION_RE
+    // keyword ("honor society" isn't "honors"), and once the trailing "cum
+    // laude" note is cut for the #883 GPA-rescue check, "Phi Beta Kappa"
+    // reads exactly like a real degree-less program title. This is why
+    // isInlineDatedProgram's #883 rescue is scoped to GPA-kind notes only —
+    // an honors-kind note falls back to testing the un-cut line, where "cum
+    // laude" still correctly vetoes it as an annotation.
+    const { value } = extractEducation(
+      mkEduSection([
+        "Harvard University                                   May 2022",
+        "B.A. in Economics",
+        "Phi Beta Kappa, cum laude 2021",
+      ]),
+    );
+    expect(value).toHaveLength(1);
+    expect(value[0].institution).toBe("Harvard University");
+  });
 });
 
 describe("extractEducation — degree/field split + location peel (#222)", () => {

--- a/src/lib/heuristics/extract/education.ts
+++ b/src/lib/heuristics/extract/education.ts
@@ -11,6 +11,7 @@ import {
   NUMERIC_MONTH_YEAR_RE,
   US_STATE_CODE_RE,
   COUNTRY_GAZETTEER,
+  PROGRAM_NOTE_RE,
 } from "../regex.ts";
 import {
   isBulletLine,
@@ -19,6 +20,14 @@ import {
   stripBullet,
 } from "../line-primitives.ts";
 import { isDateOnlyLine, isEntryHeaderShape } from "../entry-blocks.ts";
+import {
+  EDUCATION_SEGMENT_SPLIT_SRC,
+  classifyGradeSegment,
+  cutTrailingGradeNote,
+  isEducationNoteSegment,
+  isGradeAnnotationLine,
+  parseEducationGrade,
+} from "./education-grade.ts";
 import { avgScore } from "./shared.ts";
 
 // ── Education ───────────────────────────────────────────────────────────────
@@ -367,6 +376,56 @@ function isInlineDatedProgram(line: string): boolean {
   // ("20XX …", "Sep 20XX – May 20XX") is rejected on the same footing as a
   // real-year lead.
   if (DATE_LEAD_RE.test(t)) return false;
+  // Drop a trailing "| City, Region" location segment before measuring the
+  // program remainder — a date+location line ("… 2011 | Kolkata, India") must
+  // not pass on the strength of its city words.
+  const noLocation = t.replace(/[|,]\s*[A-Z][A-Za-z.\-]+(?:\s*,\s*[A-Za-z.\-]+)*$/, "");
+  // Strip years and date connective words (seasons / months / range words) —
+  // a real program name leaves substantive text, a bare date line leaves
+  // nothing. Done BEFORE the note-cut and the annotation-keyword test below
+  // (#883): a composed export line can carry a real GPA/honors NOTE right
+  // after the year with no punctuation to separate them ("Certificate, cum
+  // laude  2023"), and the note-cut needs the year already gone to see "cum
+  // laude" as its own clean trailing segment rather than "cum laude  2023",
+  // which no note pattern recognizes.
+  const datesStripped = noLocation
+    .replace(/\b(19|20)\d{2}\b/g, "")
+    .replace(new RegExp(String.raw`\b` + REDACTED_YEAR + String.raw`\b`, "gi"), "")
+    .replace(
+      /\b(?:spring|summer|fall|autumn|winter|present|jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b/gi,
+      "",
+    );
+  // A trailing GPA NOTE the exporter composed onto this line (#883) is a
+  // recognized structured sub-field, not free-form annotation prose — cut it
+  // with the same predicate {@link cleanField} uses (`cutFieldNotes`) before
+  // testing for the keywords below. Without this, a real degree-less program
+  // that merely carries its own GPA ("Applied Robotics Certificate, GPA:
+  // 3.9") is vetoed by the exact keyword that must otherwise reject genuine
+  // annotation prose.
+  //
+  // Gated to a GPA-kind note ONLY — never an unlabelled honors phrase like
+  // "cum laude". A GPA note is unambiguous structured data that essentially
+  // never appears on genuine annotation prose; a bare Latin-honors phrase is
+  // exactly the shape a real annotation line ALSO takes ("Phi Beta Kappa, cum
+  // laude 2021" — an honor-society mention, not a program). Rescuing on
+  // honors alone turned that line into a phantom degree-less entry (review
+  // round 2 regression, pinned by the "Phi Beta Kappa" case in
+  // education.test.ts). So a degree-less program that carries ONLY honors —
+  // no degree line, no GPA — is a known, accepted gap: the honors value still
+  // reaches the exported PDF text, it just doesn't survive a re-parse. The
+  // degree-BEARING path (a real `degree` field present) is unaffected either
+  // way — it never reaches this function at all.
+  const notesStripped = cutFieldNotes(datesStripped);
+  const cutSuffix = datesStripped.slice(notesStripped.length);
+  const rescueIsGpaOnly =
+    cutSuffix.length === 0 ||
+    cutSuffix
+      .replace(/^\s*[,;·•|]\s*|^\s+[-–—]\s+/, "")
+      .split(new RegExp(EDUCATION_SEGMENT_SPLIT_SRC))
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .every((seg) => classifyGradeSegment(seg)?.kind === "gpa");
+  const testTarget = rescueIsGpaOnly ? notesStripped : datesStripped;
   // An honors / awards / activity annotation that happens to carry a year
   // ("Dean's List 2021", "Honors Thesis: … (2024)", "Teaching Assistant for …
   // (2022 - 2023)", "Study Abroad, Florence 2021", "Capstone Project: Sentiment
@@ -374,28 +433,18 @@ function isInlineDatedProgram(line: string): boolean {
   // it must not split off a phantom degree-less entry (#219, #251). These read as
   // annotations, not program names, so an exact keyword denylist is safe: a real
   // second program ("MIT Applied Data Science (2023)", "Google Data Analytics
-  // Certificate 2022") carries none of them. NOTE: "project" is denied only in its
-  // annotation shape — a qualifier-led "Senior/Final/… Project" or a "Project: …"
-  // sub-line — NOT bare anywhere, so a genuine credential title that merely contains
-  // the word ("Project Management Certificate 2022", PMP) still splits into its own
-  // program entry (#251 adversarial review).
-  if (EDUCATION_ANNOTATION_RE.test(t) || /\bproject\s*:/i.test(t))
+  // Certificate 2022") carries none of them, and neither does one that also
+  // carries its own recognized GPA note (#883) — `testTarget` has already cut
+  // that trailing note when it's GPA-kind, so the test below only sees the
+  // program text and any UNRECOGNIZED annotation prose that rode along with
+  // it. NOTE: "project" is denied only in its annotation shape — a
+  // qualifier-led "Senior/Final/… Project" or a "Project: …" sub-line — NOT
+  // bare anywhere, so a genuine credential title that merely contains the
+  // word ("Project Management Certificate 2022", PMP) still splits into its
+  // own program entry (#251 adversarial review).
+  if (EDUCATION_ANNOTATION_RE.test(testTarget) || /\bproject\s*:/i.test(testTarget))
     return false;
-  // Drop a trailing "| City, Region" location segment before measuring the
-  // program remainder — a date+location line ("… 2011 | Kolkata, India") must
-  // not pass on the strength of its city words.
-  const noLocation = t.replace(/[|,]\s*[A-Z][A-Za-z.\-]+(?:\s*,\s*[A-Za-z.\-]+)*$/, "");
-  // Strip years and date connective words (seasons / months / range words); a
-  // real program name leaves substantive text, a bare date line leaves nothing.
-  const remainder = noLocation
-    .replace(/\b(19|20)\d{2}\b/g, "")
-    .replace(new RegExp(String.raw`\b` + REDACTED_YEAR + String.raw`\b`, "gi"), "")
-    .replace(
-      /\b(?:spring|summer|fall|autumn|winter|present|jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\b/gi,
-      "",
-    )
-    .replace(/[\s,–\-—|/().:]+/g, "")
-    .trim();
+  const remainder = testTarget.replace(/[\s,–\-—|/().:]+/g, "").trim();
   return remainder.length >= 3;
 }
 
@@ -436,9 +485,46 @@ function isProgramLeadAt(
   return isInstitutionLine(partner);
 }
 
+/** Cut a degree field at the first trailing sub-field NOTE segment — a grade, an
+ *  honors phrase, or a minor/major/concentration label ({@link
+ *  isEducationNoteSegment}). Segment-wise rather than a keyword regex over the
+ *  whole string, so a note reached through an EARLIER non-note segment is still
+ *  cut ("Computer Science, cum laude, GPA: 3.72/4.00" → "Computer Science", where
+ *  a `[,;]\s*gpa`-anchored cut left "cum laude" glued on), while an interior
+ *  separator inside a genuine two-part subject ("Mathematics · Statistics") is
+ *  untouched.
+ *
+ *  The LEAD segment is treated asymmetrically, and the asymmetry is load-bearing.
+ *  When it is a GRADE or HONORS note the whole field is dropped: the line carries
+ *  no subject at all, the note's content is already on `gpa`/`honors`, and
+ *  keeping it would both duplicate the value and break the round-trip (the
+ *  exporter re-emits it from `gpa`, so a re-parse would find it twice). When it
+ *  is a `Minor`/`Major`/`Concentration` label it is KEPT, as before #883: those
+ *  name a real subject ("Major in Data Science") that no other field would
+ *  receive, so dropping them would lose it outright. */
+function cutFieldNotes(f: string): string {
+  // Built per call, not hoisted: a shared `/g` regex carries `lastIndex` between
+  // calls, and this function returns early from inside the scan.
+  const re = new RegExp(EDUCATION_SEGMENT_SPLIT_SRC, "g");
+  let segStart = 0;
+  let prevSegEnd = -1;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(f)) !== null) {
+    const seg = f.slice(segStart, m.index);
+    if (prevSegEnd < 0 && classifyGradeSegment(seg)) return "";
+    if (prevSegEnd >= 0 && isEducationNoteSegment(seg))
+      return f.slice(0, prevSegEnd);
+    prevSegEnd = m.index;
+    segStart = m.index + m[0].length;
+  }
+  const last = f.slice(segStart);
+  if (prevSegEnd < 0) return classifyGradeSegment(last) ? "" : f;
+  return isEducationNoteSegment(last) ? f.slice(0, prevSegEnd) : f;
+}
+
 /** Trim a parsed field string down to the subject, cutting any trailing date,
- *  column break, pipe, or GPA/Minor/Major note that rode along on the degree
- *  line ("Computer Science   Sep. 2024 - Jun. 2027" → "Computer Science").
+ *  column break, pipe, or GPA/honors/Minor/Major note that rode along on the
+ *  degree line ("Computer Science   Sep. 2024 - Jun. 2027" → "Computer Science").
  *  Returns undefined when nothing substantive survives. */
 function cleanField(raw: string): string | undefined {
   let f = raw
@@ -452,9 +538,15 @@ function cleanField(raw: string): string | undefined {
   // templates ship, so a reconstructed institution sub-line that carries it
   // (#297) normalizes to the same field as its degree header.
   f = f.replace(CLEAN_FIELD_DATE_RE, "");
-  // Cut a trailing "… , Minor in Economics" / "… , GPA: 3.8" note — a sub-field,
-  // not part of the subject.
-  f = f.replace(/[,;]\s*(?:minor|major|gpa|concentration)\b.*$/i, "");
+  // Cut a trailing "… , Minor in Economics" / "… , GPA: 3.8" / "… , cum laude"
+  // note — a sub-field, not part of the subject. Since #883 the grade and honors
+  // halves are ALSO lifted onto the entry, so this cut and that collection read
+  // the same predicate and cannot disagree about what a note is.
+  f = cutFieldNotes(f);
+  // Then cut a grade that rode onto the subject with NO separator in front of it
+  // ("Computer Science GPA 3.8") — the segment-wise cut above cannot see it,
+  // because subject and note are one segment there (#883).
+  f = cutTrailingGradeNote(f);
   // Strip leftover edge punctuation and separators — the middot/bullet a
   // template used to divide the header from a field this parse did not keep
   // ("Computer Science · 2020" loses the year above, leaving the "·", #835).
@@ -931,6 +1023,15 @@ function educationFromChunk(chunk: string[]): {
   const dates = parseEducationDates(datesInput);
   const hasDate = !!(dates.start_date || dates.end_date);
 
+  // Grade + honors (#883). Read off the WHOLE chunk, not just the degree line:
+  // a résumé writes them either inline after the subject ("B.S. in Computer
+  // Science, cum laude, GPA: 3.72/4.00") or on their own annotation line under
+  // the entry, and both belong to the same qualification. They contribute
+  // nothing to `score` — the confidence weights are the three fields an entry
+  // must have (institution / degree / date), and an entry is no more or less
+  // confidently parsed for carrying a GPA.
+  const { gpa, honors } = parseEducationGrade(chunk);
+
   let score = 0;
   if (institution) score += 0.3;
   if (degree) score += 0.4;
@@ -942,6 +1043,8 @@ function educationFromChunk(chunk: string[]): {
       degree,
       ...(field ? { field } : {}),
       ...(location ? { location } : {}),
+      ...(gpa ? { gpa } : {}),
+      ...(honors ? { honors } : {}),
       ...educationDateFields(dates),
     },
     score: Math.min(score, 1),
@@ -1137,6 +1240,15 @@ export function extractEducation(
       hasDegree &&
       hasInstitution &&
       !isDateOnlyLine(text) &&
+      // …and is not itself a sub-field NOTE (#883). The next-line lookahead
+      // below was the only thing keeping "GPA: 3.8" inside its entry, and it
+      // fails on a Degree-then-Degree ordering where the note IS followed by a
+      // degree: the note then leads the next chunk and its grade is attributed
+      // to the wrong qualification. `PROGRAM_NOTE_RE` recognises the labelled
+      // notes by prefix; `isGradeAnnotationLine` covers an unlabelled honors
+      // phrase ("Magna Cum Laude"), which has no prefix to recognise.
+      !PROGRAM_NOTE_RE.test(text) &&
+      !isGradeAnnotationLine(text) &&
       // Same `isRealEntryHeader` gate as `isDeg` above (#462/#467): a phantom
       // DEGREE_RE hit on a body-prose "Graduated B.E. with Distinction" sentence
       // must not persuade the chunker that this hint-less line leads a new

--- a/src/lib/heuristics/localize/roundtrip.ts
+++ b/src/lib/heuristics/localize/roundtrip.ts
@@ -68,6 +68,22 @@ export const ROUNDTRIP_CATEGORY_CLASS: Readonly<
   render: "roundtrip-render-crash",
 };
 
+/** The education fields every round-trip consumer compares. One list, three
+ *  readers (the corpus gate's ratchet, the dev harness's value diff, and the
+ *  localizer's boolean) — a fourth field added to only one of them would make
+ *  the gate and the localizer disagree about whether the same hop regressed.
+ *  `gpa` / `honors` (#883) belong here for the same reason `degree` does: they
+ *  are written onto the exported degree line and read back off it, so a
+ *  renderer or recogniser change that drops one, or re-reads it as a different
+ *  string, is a round-trip regression. */
+const EDUCATION_ROUNDTRIP_KEYS = [
+  "degree",
+  "field",
+  "institution",
+  "gpa",
+  "honors",
+] as const;
+
 const same = (a: unknown, b: unknown): boolean =>
   JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
 
@@ -224,7 +240,7 @@ export function invariantFailures(
     education: entryListFails(
       c1.education ?? [],
       c3.education ?? [],
-      ["degree", "field", "institution"] as const,
+      EDUCATION_ROUNDTRIP_KEYS,
       "entry",
     ),
     skills: sk1 !== sk3 ? [`count ${sk1} → ${sk3}`] : [],
@@ -251,7 +267,7 @@ export function harnessDiff(
     education: entryValueFails(
       c1.education ?? [],
       c3.education ?? [],
-      ["degree", "field", "institution"] as const,
+      EDUCATION_ROUNDTRIP_KEYS,
       "entry",
     ),
     skills: skillsValueFails(c1.skills ?? [], c3.skills ?? []),
@@ -301,7 +317,7 @@ export function localizeRoundtripHop(
     entryValueFails(
       c1.education ?? [],
       c3.education ?? [],
-      ["degree", "field", "institution"] as const,
+      EDUCATION_ROUNDTRIP_KEYS,
       "entry",
     ).length > 0;
   const skillsChanged =

--- a/src/lib/jd-match/coverage.ts
+++ b/src/lib/jd-match/coverage.ts
@@ -9,8 +9,8 @@
  *
  * Coverage rules:
  *   - Build a flat lowercased corpus from the resume — summary, skills array,
- *     experience titles + descriptions, education degree + institution +
- *     description.
+ *     experience titles + descriptions, education degree + field +
+ *     institution.
  *   - For each JD term:
  *       · `skill` source: check any alias of that canonical ID against the
  *         corpus, word-boundary-aware via the same regex shape as the JD
@@ -104,7 +104,9 @@ export function computeCoverageFromCorpus(
  *
  * `parsed` is the cascade's HeuristicParsedResume — `skills: string[]`,
  * `experience[].description`, `summary?`, `education[]`. We tolerate any
- * field being missing.
+ * field being missing. Education contributes its degree / field / institution
+ * only: `ResumeEducation` carried a `description` that no producer ever wrote
+ * (#883), so the read was dead and is gone along with the field.
  *
  * A thin wrapper over `computeCoverageFromCorpus`, kept at its original
  * signature so every existing caller is untouched. This is the ONLY place the
@@ -144,7 +146,7 @@ export function buildResumeProjection(parsed: HeuristicParsedResume): string {
     // part of an education entry a JD ever asks for: measured on a real résumé,
     // a posting requiring "Computer Science" scored it MISSING against a CS
     // graduate purely because the field never reached the corpus.
-    pushPresent(parts, edu.degree, edu.field, edu.institution, edu.description);
+    pushPresent(parts, edu.degree, edu.field, edu.institution);
   }
   return parts.join("\n");
 }

--- a/src/lib/pdf/ats-resume-model.test.ts
+++ b/src/lib/pdf/ats-resume-model.test.ts
@@ -663,4 +663,69 @@ describe("buildAtsResumeModel", () => {
     expect(skills.entries[0].headerBoldLead).toBeUndefined();
     expect(skills.entries[0].fields?.skillCategory).toBeUndefined();
   });
+
+  it("composes honors and grade onto the degree line, in résumé order (#883)", () => {
+    const result = makeResult({
+      education: [
+        {
+          degree: "B.S.",
+          field: "Computer Science",
+          institution: "State University",
+          honors: "cum laude",
+          gpa: "3.72/4.00",
+          year: "2024",
+        },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const edu = model.sections.find((s) => s.heading === "Education")!;
+    expect(edu.entries[0].headerLine).toBe(
+      "B.S., Computer Science, cum laude, GPA: 3.72/4.00",
+    );
+    // Never a bullet: a bullet under an education entry re-parses as coursework.
+    expect(edu.entries[0].bullets).toEqual([]);
+    expect(edu.entries[0].fields?.score).toBe("3.72/4.00");
+  });
+
+  it("leaves a classification unlabelled — 'GPA: First Class' is not a thing (#883)", () => {
+    const result = makeResult({
+      education: [
+        {
+          degree: "B.A.",
+          field: "Economics",
+          institution: "Northwind University",
+          gpa: "First Class",
+          year: "2024",
+        },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const edu = model.sections.find((s) => s.heading === "Education")!;
+    expect(edu.entries[0].headerLine).toBe("B.A., Economics, First Class");
+  });
+
+  it("carries honors and grade on a degree-LESS program header too (#883)", () => {
+    const result = makeResult({
+      education: [
+        {
+          degree: "",
+          field: "Applied Robotics Certificate",
+          institution: "Northwind Institute",
+          gpa: "3.5",
+          year: "2023",
+        },
+      ],
+    });
+    const model = buildAtsResumeModel(result, makeScore([]));
+    const edu = model.sections.find((s) => s.heading === "Education")!;
+    expect(edu.entries[0].headerLine).toContain("Applied Robotics Certificate");
+    expect(edu.entries[0].headerLine).toContain("GPA: 3.5");
+  });
+
+  it("emits no dangling separator when an entry carries neither (#883)", () => {
+    const model = buildAtsResumeModel(makeResult(), makeScore([]));
+    const edu = model.sections.find((s) => s.heading === "Education")!;
+    expect(edu.entries[0].headerLine).toBe("BS Computer Science");
+    expect(edu.entries[0].fields?.score).toBeUndefined();
+  });
 });

--- a/src/lib/pdf/ats-resume-model.ts
+++ b/src/lib/pdf/ats-resume-model.ts
@@ -48,6 +48,7 @@ import {
   buildProjectDates,
 } from "../score/entry-dates.ts";
 import { isLoneDateRange } from "../heuristics/line-primitives.ts";
+import { formatGradeNote } from "../heuristics/extract/education-grade.ts";
 import { formatExperienceDateRange } from "../edit/experience-dates.ts";
 import { projectDisplay } from "../heuristics/projections.ts";
 import { EMPHASIS_OPEN, EMPHASIS_CLOSE } from "./auto-bold-metrics.ts";
@@ -132,6 +133,10 @@ export interface AtsEntryFields {
   url?: string;
   /** JSON Resume `education.courses` — relevant-coursework items (#164). */
   courses?: string[];
+  /** JSON Resume `education.score` — the grade as the résumé wrote it, scale and
+   *  all ("3.72/4.00", "First Class", #883). A string, matching both the spec's
+   *  free-form `score` and `ResumeEducation.gpa`. */
+  score?: string;
   /** JSON Resume `skills` — the flat skill list, carried on the skills entry
    *  (whose `headerLine` is the same list joined by " · "). On a CATEGORISED
    *  skills entry (#473) this holds that ONE category's members. */
@@ -725,7 +730,19 @@ export function buildAtsResumeModel(
     // whitespace gap so it becomes the entry's date anchor. Emitting the old
     // glued "Degree — Institution" one-liner did not round-trip: re-parsing
     // collapsed degree/field/institution into each other (#291).
-    const degreeField = [edu.degree, edu.field].filter(Boolean).join(", ");
+    // Honors and grade ride the degree line, in the order and shape a résumé
+    // writes them — "B.S., Computer Science, cum laude, GPA: 3.72/4.00" (#883).
+    // `edu.gpa` holds only the VALUE ("3.72/4.00", "First Class"), so
+    // `formatGradeNote` — the extractor's own inverse — decides whether it needs
+    // the `GPA: ` label to be recognised on re-parse. They must NOT become
+    // bullets: a bullet under an education entry re-parses as coursework.
+    const eduNotes = [
+      edu.honors,
+      edu.gpa ? formatGradeNote(edu.gpa) : undefined,
+    ].filter(Boolean);
+    const degreeField = [edu.degree, edu.field, ...eduNotes]
+      .filter(Boolean)
+      .join(", ");
     const org = joinHeader([edu.institution, edu.location], " · ");
     // Spaced " – " range (the experience shape) so the re-parser recognizes and
     // strips the date anchor off the institution line; `buildEducationDates`'
@@ -777,14 +794,20 @@ export function buildAtsResumeModel(
       endDate: edu.end_date || edu.year || undefined,
       courses:
         edu.coursework && edu.coursework.length > 0 ? edu.coursework : undefined,
+      // JSON Resume carries the grade on `education[].score` (#883). Honors has
+      // no slot in the spec, so it is deliberately NOT mapped — it survives the
+      // PDF export on the degree line and nowhere else in the JSON.
+      score: edu.gpa || undefined,
     };
     if (!edu.degree && edu.field) {
       // Degree-less program: the field title leads the header, the graduation
       // date flush-right on that same header line (the #302 inline-dated cue),
-      // institution alone on the sub-line.
+      // institution alone on the sub-line. `degreeField` IS the field here (the
+      // degree half is empty) plus any honors/grade notes, so the two header
+      // shapes compose their notes in one place.
       if (rightAlignEduDate) {
         return {
-          headerLine: edu.field,
+          headerLine: degreeField,
           headerLineDate: eduDates,
           subLine: org || undefined,
           bullets,
@@ -792,7 +815,7 @@ export function buildAtsResumeModel(
         };
       }
       return {
-        headerLine: [edu.field, eduDates].filter(Boolean).join("  "),
+        headerLine: [degreeField, eduDates].filter(Boolean).join("  "),
         subLine: org || undefined,
         bullets,
         fields: eduFields,

--- a/src/lib/pdf/render-education-grade.repro.test.ts
+++ b/src/lib/pdf/render-education-grade.repro.test.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * #883 AC#1 end to end — the issue's own source line, through the real exporter
+ * and back:
+ *
+ *   B.S. in Computer Science, cum laude, GPA: 3.72/4.00
+ *
+ * The two halves are pinned separately elsewhere: `extract/education.gpa-honors`
+ * proves that line PARSES to `gpa` / `honors`, and the corpus round-trip gate
+ * compares both fields on all 60 fixtures. Neither covers the composed shape the
+ * exporter invents for values a fixture does not happen to carry together —
+ * honors AND a slash-scale grade on one degree line — so this drives that shape
+ * through `buildAtsResumeModel` → `renderAtsResumePdf` → `runCascade`.
+ *
+ * No new fixture: the input is a parse built in code, so the assertions are
+ * about the render↔re-parse hop and nothing else. Synthetic persona throughout,
+ * per the fixtures PII policy.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { runCascade } from "../heuristics/cascade.ts";
+import { computeAnonymousAtsScore } from "../score/score.ts";
+import type { CascadeResult } from "../heuristics/types.ts";
+import type { ResumeEducation } from "../score/types.ts";
+import { ACCOMPLISHMENT_SECTION_NAMES } from "../heuristics/sections.ts";
+import { buildAtsResumeModel } from "./ats-resume-model.ts";
+import { renderAtsResumePdf } from "./render-ats-pdf.ts";
+
+function parseWithEducation(education: ResumeEducation[]): CascadeResult {
+  return {
+    canonical: {
+      sections: {
+        byName: new Map(),
+        accomplishmentSections: ACCOMPLISHMENT_SECTION_NAMES,
+        source: "regex",
+      },
+      fields: {
+        full_name: "Jane Candidate",
+        email: "jane@example.com",
+        phone: "(312) 555-0123",
+        location: "Dallas, TX",
+        summary: "Backend engineer focused on distributed systems.",
+        skills: ["TypeScript", "Go"],
+        experience: [
+          {
+            title: "Software Engineer",
+            company: "Northwind Systems",
+            start_date: "2024",
+            end_date: "2026",
+            description: "Cut p99 latency 40% across the ingestion path",
+          },
+        ],
+        education,
+        projects: [],
+        heuristic_achievements: [],
+      },
+      fieldConfidence: {},
+    },
+    confidence: 0.9,
+    triggers: [],
+    suggestedEscalation: "none",
+    tiers: ["t1_openresume"],
+    rawText: "",
+  } as unknown as CascadeResult;
+}
+
+async function roundtrip(education: ResumeEducation[]): Promise<ResumeEducation[]> {
+  const parse1 = parseWithEducation(education);
+  const score = computeAnonymousAtsScore({
+    parsed: parse1.canonical.fields,
+    fieldConfidence: parse1.canonical.fieldConfidence,
+    triggers: parse1.triggers,
+    rawText: parse1.rawText,
+    sections: parse1.canonical.sections,
+  });
+  const { bytes } = await renderAtsResumePdf(buildAtsResumeModel(parse1, score));
+  const parse3 = await runCascade(bytes);
+  return parse3.canonical.fields.education ?? [];
+}
+
+describe("#883 — GPA and honors survive parse → export → re-parse", () => {
+  let reparsed: ResumeEducation[];
+
+  beforeAll(async () => {
+    reparsed = await roundtrip([
+      {
+        degree: "B.S.",
+        field: "Computer Science",
+        institution: "The University of Texas at Dallas",
+        honors: "cum laude",
+        gpa: "3.72/4.00",
+        end_date: "May 2024",
+        year: "2024",
+      },
+    ]);
+  }, 30000);
+
+  it("recovers the entry with all four fields intact", () => {
+    expect(reparsed).toHaveLength(1);
+    expect(reparsed[0].degree).toBe("B.S.");
+    expect(reparsed[0].field).toBe("Computer Science");
+    expect(reparsed[0].institution).toBe("The University of Texas at Dallas");
+  });
+
+  it("recovers the grade with its scale, not a rounded number", () => {
+    expect(reparsed[0].gpa).toBe("3.72/4.00");
+  });
+
+  it("recovers the honors phrase", () => {
+    expect(reparsed[0].honors).toBe("cum laude");
+  });
+
+  it("leaves neither glued into the subject or the institution", () => {
+    expect(reparsed[0].field ?? "").not.toMatch(/gpa|laude/i);
+    expect(reparsed[0].institution ?? "").not.toMatch(/gpa|laude/i);
+  });
+
+  it("round-trips a non-4.0 scale and an unlabelled classification", async () => {
+    const [scaled, classified] = await Promise.all([
+      roundtrip([
+        {
+          degree: "B.Tech",
+          field: "Computer Science",
+          institution: "Northwind Institute of Technology",
+          gpa: "8.4/10",
+          year: "2022",
+        },
+      ]),
+      roundtrip([
+        {
+          degree: "B.A.",
+          field: "Economics",
+          institution: "Ridgemont College",
+          gpa: "First Class",
+          year: "2022",
+        },
+      ]),
+    ]);
+    expect(scaled[0]?.gpa).toBe("8.4/10");
+    expect(classified[0]?.gpa).toBe("First Class");
+  }, 30000);
+});
+
+describe("#883 review — a degree-LESS program entry's honors survives the same round-trip", () => {
+  // The composed headerLine has no degree line to anchor recognition — the
+  // program title and its honors/grade note are the ONLY text on the entry's
+  // lead line. Pinned separately from the degree-bearing suite above because
+  // this shape is recognized by isProgramLeadAt/isInlineDatedProgram
+  // (education.ts), a different code path than the degree-line collector.
+  it("known limitation: an honors-ONLY degree-less program loses its title, but keeps the entry and the honors", async () => {
+    // Round 1 of this review rescued isInlineDatedProgram's annotation veto for
+    // ANY recognized trailing note, honors included — which fixed this case, but
+    // also let "Phi Beta Kappa, cum laude 2021" (a real honor-society mention, no
+    // program at all) read as a phantom degree-less program (pinned in
+    // education.test.ts). Round 2 narrowed the rescue to GPA-kind notes only,
+    // because a GPA note is unambiguous structured data while a bare honors
+    // phrase is exactly the shape a genuine annotation line also takes — no
+    // mechanical test tells "Applied Robotics Certificate" and "Phi Beta Kappa"
+    // apart. So an honors-only degree-less program (no gpa, no degree line) is a
+    // known, accepted gap: `isProgramLeadAt` no longer recognizes the lead line,
+    // so `field` (the program title) is lost — but `parseEducationGrade` still
+    // scans the chunk independently and recovers `honors`, and the generic
+    // institution scan still recovers `institution`, so the entry survives in
+    // degraded form rather than disappearing outright. The GPA-bearing sibling
+    // below, and every degree-BEARING case (a different code path entirely,
+    // untouched by this gate), still round-trip in full.
+    const reparsed = await roundtrip([
+      {
+        degree: "",
+        field: "Applied Robotics Certificate",
+        institution: "Northwind Institute",
+        honors: "cum laude",
+        year: "2023",
+      },
+    ]);
+    expect(reparsed).toHaveLength(1);
+    expect(reparsed[0].institution).toBe("Northwind Institute");
+    expect(reparsed[0].honors).toBe("cum laude");
+    expect(reparsed[0].field).toBeUndefined();
+  });
+
+  it("recovers a degree-less program's GPA too", async () => {
+    const reparsed = await roundtrip([
+      {
+        degree: "",
+        field: "Data Analytics Certificate",
+        institution: "Ridgemont Institute",
+        gpa: "3.9/4.0",
+        year: "2023",
+      },
+    ]);
+    expect(reparsed).toHaveLength(1);
+    expect(reparsed[0].field).toBe("Data Analytics Certificate");
+    expect(reparsed[0].gpa).toBe("3.9/4.0");
+  });
+});

--- a/src/lib/pdf/to-json-resume.test.ts
+++ b/src/lib/pdf/to-json-resume.test.ts
@@ -90,7 +90,7 @@ const FULL_MODEL: AtsResumeModel = {
       kind: "education",
       entries: [
         {
-          headerLine: "B.S., Computer Science",
+          headerLine: "B.S., Computer Science, cum laude, GPA: 3.72/4.00",
           bullets: ["Coursework: Algorithms, Databases"],
           fields: {
             organization: "State University",
@@ -98,6 +98,7 @@ const FULL_MODEL: AtsResumeModel = {
             area: "Computer Science",
             endDate: "2019",
             courses: ["Algorithms", "Databases"],
+            score: "3.72/4.00",
           },
         },
       ],
@@ -209,7 +210,7 @@ describe("toJsonResume — work", () => {
 describe("toJsonResume — education, skills, projects", () => {
   const doc = toJsonResume(FULL_MODEL);
 
-  it("maps education institution/studyType/area/courses", () => {
+  it("maps education institution/studyType/area/courses/score", () => {
     expect(doc.education[0]).toEqual({
       institution: "State University",
       studyType: "B.S.",
@@ -217,7 +218,17 @@ describe("toJsonResume — education, skills, projects", () => {
       startDate: undefined,
       endDate: "2019",
       courses: ["Algorithms", "Databases"],
+      // JSON Resume's own grade slot (#883), free-form so the scale survives.
+      score: "3.72/4.00",
     });
+  });
+
+  it("invents no field for honors, which the spec has no slot for (#883)", () => {
+    // The honors phrase rides the exported PDF's degree line and is captured on
+    // the canonical model; the JSON export must not smuggle it into `score` or
+    // conjure a non-spec key for it.
+    expect(doc.education[0].score).toBe("3.72/4.00");
+    expect(JSON.stringify(doc.education[0])).not.toMatch(/laude/i);
   });
 
   it("maps each skill to { name }", () => {

--- a/src/lib/pdf/to-json-resume.ts
+++ b/src/lib/pdf/to-json-resume.ts
@@ -99,6 +99,11 @@ export interface JsonResumeEducation {
   startDate?: string;
   endDate?: string;
   courses?: string[];
+  /** JSON Resume `education[].score` — the grade, free-form per the spec, so the
+   *  résumé's own notation and scale survive ("3.72/4.00", "8.4/10", "First
+   *  Class", #883). Honors has no field in the spec and is deliberately not
+   *  invented here. */
+  score?: string;
 }
 
 export interface JsonResumeSkill {
@@ -372,6 +377,7 @@ function toEducation(fields: AtsEntryFields): JsonResumeEducation {
     startDate: normalizeJsonResumeDate(fields.startDate),
     endDate: normalizeJsonResumeDate(fields.endDate),
     courses: fields.courses,
+    score: fields.score,
   };
 }
 

--- a/src/lib/score/types.ts
+++ b/src/lib/score/types.ts
@@ -187,7 +187,17 @@ export interface ResumeEducation {
    *  `start_date`. */
   end_date?: string;
   end_date_precision?: "day" | "month" | "year" | null;
-  description?: string;
+  /** Grade exactly as the résumé wrote it — "3.72/4.00", "3.9", "8.4/10",
+   *  "85%", "First Class", "2:1". A STRING on purpose (#883): normalising to a
+   *  number drops the scale, so a 8.4/10 and a 3.9/4.0 would compare as if they
+   *  were on the same axis, and a classification would have no representation at
+   *  all. Nothing downstream does arithmetic on it. */
+  gpa?: string;
+  /** Latin honors / distinction as written — "cum laude", "magna cum laude",
+   *  "with distinction" (#883). Distinct from `gpa`: a résumé can carry either,
+   *  both, or neither, and JSON Resume has a slot for the grade
+   *  (`education[].score`) but none for honors. */
+  honors?: string;
   /** Relevant-coursework items recovered from bullet lines inside the education
    *  section (e.g. a "Relevant Coursework" block, #164). Section-level by nature
    *  — attribution to a specific degree is ambiguous, so the heuristic parser


### PR DESCRIPTION
## Summary
Adds `gpa`/`honors` to `ResumeEducation` (free-form strings — a scale or classification isn't a number) and a single shared predicate, `education-grade.ts`, that recognizes a labelled GPA value, an unlabelled classification (First Class, 2:1), or a Latin-honors phrase, whether inline on the degree line or on its own annotation line. The extractor, the degree-field cut, and the entry-boundary guard all read that one predicate so they can't disagree about what counts as a note. The exporter composes them back onto the degree line and the extractor's formatter is its own inverse, so the round trip holds; GPA additionally maps to JSON Resume's `education[].score`. Both fields are editable, with the existing "+ add" affordance for a parse that missed one.

Resolves the dead `ResumeEducation.description` field noted in the issue by deleting it along with its unused read in `jd-match/coverage.ts`.

Closes #883

## Stack position
Layer 3 of 5. Depends on #886. Base: `gh-879-02-contact-link-affordance`.

## Adversarial review
Round 1 found a **blocking** defect in this layer, fixed here: `classifyGradeSegment`'s labelled-grade branch was unanchored, so an unpunctuated `"B.S. in Computer Science GPA 3.8"` classified as "nothing but a grade note" and the field cut dropped the entire subject (`field`), not just the grade — silently losing e.g. "Computer Science" from the parse, the export, and JD-matching coverage. Fixed by anchoring `classifyGradeSegment`'s own use of the label patterns to the whole segment (keeping the original unanchored search for `parseEducationGrade`'s whole-line pass, which is correct and unaffected) and adding `cutTrailingGradeNote` to strip an unpunctuated trailing grade note that shares a segment with the subject. Round 2 confirmed the fix end-to-end, including the bare-`"GPA 3.8"`-as-whole-field edge case (correctly emptied by the existing note-cut, not double-processed) and the module's own defended buried-grade case (still passes).

## Test plan
- [x] `npm run typecheck`
- [x] Targeted + heuristics suites, full corpus round-trip (1592+ tests)
- [x] `npm run check:baselines` (unchanged vs pre-stack)
- [x] `npm run lint`