### PR TITLE
fix: peel a tab-justified flush-right location off the title

### DIFF
--- a/src/lib/heuristics/entry-blocks.ts
+++ b/src/lib/heuristics/entry-blocks.ts
@@ -38,12 +38,14 @@ import {
   dateSeparator,
   parseDateRange,
   stripDateRange,
+  isBareLocationString,
   isBulletLine,
   isPageFurniture,
   isProseLine,
   looksLikeBelowAnchorProse,
   stripBullet,
 } from "./line-primitives.ts";
+import { mergeItemText, splitOnFlushRightGap } from "./line-assembly.ts";
 
 // ── Shared entry-header shape recognition ───────────────────────────────────
 //
@@ -1263,6 +1265,54 @@ function nextHeaderStart(
 }
 
 /**
+ * Peel a flush-right bare-location trailer off a below-anchor header line.
+ *
+ * A tab-justified sub-line ("Software Developer" at the left margin, "Remote"
+ * right-aligned on the SAME PDF row) reaches us as one `PdfLine`: pdfjs draws
+ * the justification as a single whitespace-only item whose own width spans the
+ * gap, so no adjacent-pair gap exists for line assembly to cut on and
+ * `mergeItemText` collapses the run to one space — `"Software Developer
+ * Remote"`, with the location welded into the title and no downstream pass able
+ * to tell where the seam was (#891).
+ *
+ * `splitOnFlushRightGap` recovers the seam from the geometry; this function
+ * decides whether to act on it. The gate is deliberately narrow: the trailer
+ * must whole-match the closed bare-location/work-mode vocabulary
+ * (`isBareLocationString`), so an ordinary multi-word title never splits, and
+ * the #425 flush-right-DATE shape — the other thing templates park at the right
+ * margin — is not a bare location and stays merged onto its header line.
+ *
+ * Splitting here rather than in line assembly keeps the shared
+ * `columnGapCuts` / `rowIsMultiColumn` machinery untouched (see
+ * {@link splitOnFlushRightGap}), and it lands the two halves in exactly the
+ * shape `disambiguateCompanyTitle` already parses correctly when a template
+ * puts the location on its own row: the trailer becomes a separate header
+ * candidate, falls into the `team` slot, and `rescueTeamLocation`
+ * (`experience-disambiguate.ts`) promotes it to `location`. No new
+ * field-mapping logic — the peel only makes the same-row case LOOK like the
+ * separate-row case.
+ *
+ * Both halves inherit the source line's page/y/font metadata; only `text`,
+ * `items` and the trailer's `x` are rebuilt. Sharing the y is deliberate —
+ * `foldBelowAnchorLines` folds on a POSITIVE y-delta, so two same-row halves
+ * can never be re-glued by the fold. Returns `[line]` unchanged whenever the
+ * row carries no flush-right gap, the trailer is not a bare location, or
+ * either half is nothing but whitespace.
+ */
+function peelFlushRightLocation(line: PdfLine): PdfLine[] {
+  const split = splitOnFlushRightGap(line.items);
+  if (!split) return [line];
+  const trailerText = mergeItemText(split.trailer).trim();
+  if (!trailerText || !isBareLocationString(trailerText)) return [line];
+  const headText = mergeItemText(split.head).trim();
+  if (!headText) return [line];
+  return [
+    { ...line, items: split.head, text: headText },
+    { ...line, items: split.trailer, text: trailerText, x: split.trailer[0].x },
+  ];
+}
+
+/**
  * Fold consecutive below-anchor `PdfLine`s into logical strings using the same
  * sub-paragraph y-gap signal `buildEntryBlock`'s `bodyUnits` loop uses on
  * bullets. A wrapped role-scope paragraph rendered by pdfjs as three lines
@@ -1524,7 +1574,7 @@ function buildEntryBlock(
       break;
     }
     if (isWrappedContinuation(lines[i], markerX)) continue;
-    belowHeaderLines.push(lines[i]);
+    belowHeaderLines.push(...peelFlushRightLocation(lines[i]));
   }
 
   // Assemble header lines in document order — above lines, the anchor line

--- a/src/lib/heuristics/extract/experience-disambiguate.ts
+++ b/src/lib/heuristics/extract/experience-disambiguate.ts
@@ -8,6 +8,11 @@ import {
   COUNTRY_GAZETTEER,
   matchSectionHeader,
 } from "../regex.ts";
+import {
+  BARE_LOCATION_RE,
+  MULTIWORD_US_CITY_ALT,
+  isBareLocationString,
+} from "../line-primitives.ts";
 import { looksLikeTitle, looksLikeCompany } from "./shared.ts";
 
 /** The role fields `disambiguateCompanyTitle` maps a header block onto. */
@@ -37,43 +42,6 @@ type Split = {
 
 const LEGAL_SUFFIX_RE =
   /^(inc\.?|llc|l\.l\.c\.?|ltd\.?|corp\.?|co\.?|gmbh|plc|lp|llp|pc|s\.a\.?|n\.a\.?|sa)$/i;
-
-/** Multi-word US cities recognized by BOTH the whole-string `BARE_LOCATION_RE`
- *  (case-insensitive) and the embedded-fold `KNOWN_MULTIWORD_US_CITY_RE`
- *  (case-sensitive Title-case). Single source of truth so the two can't drift
- *  apart. Longest-first so "New York City" wins over "New York" in the embedded
- *  alternation (regex first-match); order is irrelevant for the `^…$`-anchored
- *  `BARE_LOCATION_RE`.
- *
- *  Silicon-Valley/Peninsula additions (#616): "Mountain View", "Palo Alto",
- *  "Menlo Park" are the multi-word tech-hub cities that show up co-located
- *  with Globex/Meta/Stanford in a `Title · Company, City · Team` middot header
- *  with NO trailing state suffix. Without the vocab entry, Pass F of
- *  `stripLocationSuffix` (bare-city tail check) failed to full-match them and
- *  the middle segment stayed whole ("Globex, Mountain View" → company). Same
- *  closed-vocab discipline as the pre-existing entries: a real company that
- *  merely contains one of these tokens ("Mountain View Software") still fails
- *  the `^…$`-anchored full-string match.
- *
- *  #634 review follow-up: "Santa Clara", "Redwood City" and "Ann Arbor" close
- *  the three headers the review reproduced as still-broken (Nvidia, Meta, Ford).
- *  They do NOT make the vocabulary complete — this list is a closed set by
- *  design, so any multi-word city outside it still folds into `company`. That
- *  narrowing is the standing limitation of the approach, not a bug to be fixed
- *  by growing the list without bound; see `experience.multiword-city.test.ts`,
- *  which pins both halves (a listed city splits; an unlisted one does not, and
- *  a company merely containing a listed city stays whole). */
-const MULTIWORD_US_CITY_ALT =
-  "New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City|Mountain View|Palo Alto|Menlo Park|Santa Clara|Redwood City|Ann Arbor";
-
-/** Bare city/region names (no "City, ST" state tail, so `US_LOCATION_RE` misses
- *  them) that show up as a `"Title, Location"` header tail — must NOT be cleaved
- *  off as the company. Exact whole-string match keeps a real company that merely
- *  contains a city word ("New York Times", "Boston Consulting") splittable. */
-const BARE_LOCATION_RE = new RegExp(
-  `^(remote|hybrid|on-?site|${MULTIWORD_US_CITY_ALT}|washington|washington d\\.?c\\.?|boston|chicago|seattle|austin|denver|portland|atlanta|dallas|houston|phoenix|miami|detroit|philadelphia|pittsburgh|minneapolis|nashville|charlotte|columbus|indianapolis|baltimore|sacramento|raleigh|london|paris|berlin|munich|tokyo|singapore|bangalore|bengaluru|mumbai|delhi|hyderabad|toronto|vancouver|sydney|melbourne|dublin|amsterdam)$`,
-  "i",
-);
 
 /** True when the comma tail reads like a location rather than an employer —
  *  either a "City, ST"/"City, Country" shape, a bare well-known city, or a
@@ -485,46 +453,6 @@ function anchorCarriesOrgSignal(text: string): boolean {
   // reconstructed-export signature our own emit appends to a location-less
   // company sub-line, ats-resume-model.ts) — either bounded by whitespace/edge.
   return /(?:^|\s)·(?:\s|$)/.test(text);
-}
-
-/**
- * True when `s` is ENTIRELY a bare location string — a lone US state code, a
- * bare well-known city, or a "City, ST" / "City, Country" shape that spans the
- * WHOLE string (not merely a trailing suffix). The full-length check on the
- * US/intl matches distinguishes a self-contained location ("Pomona, CA",
- * "Mountain View, CA") from a company that merely carries a trailing city
- * ("Globex, Toronto, Canada", where INTL_LOCATION_RE matches only a substring).
- *
- * Shape is NOT sufficient — the comma-tail must resolve against a REAL location
- * signal, not merely a "CapWords, CapWords" shape. `US_LOCATION_RE` /
- * `INTL_LOCATION_RE` are generic Title-Case-pair matchers (regex.ts:42/45), so
- * on their own they full-match a comma-formatted job title whose role word is
- * outside the finite `looksLikeTitle` keyword list ("Buyer, Home Goods",
- * "Merchandiser, Footwear", "Barista, Downtown Store"), silently erasing a real
- * title into `location` (the #325 step-5 rescue false-positive class). So each
- * shape branch additionally requires its tail to be in a CLOSED vocabulary — a
- * valid 2-letter USPS code (`US_STATE_CODE_RE`) or a real country
- * (`COUNTRY_GAZETTEER`) — the same closed-vocabulary discipline
- * `stripLocationSuffix` already applies. A generic Title-Case tail
- * ("Home Goods", "Footwear") is in neither set and stays a title.
- *
- * The single shared bare-location predicate in {@link disambiguateCompanyTitle}:
- * the step-3a rotate-guard (negated — a rotatable "Company, City, Country" is
- * NOT a whole-string location), the step-3b `team`→location rescue, and the
- * step-5 `title`→location rescue all route through it, so the same closed-vocab
- * discipline gates every path and no branch can reintroduce the shape-only leak.
- */
-function isBareLocationString(s: string): boolean {
-  const usLoc = US_LOCATION_RE.exec(s);
-  const intlLoc = INTL_LOCATION_RE.exec(s);
-  return (
-    US_STATE_CODE_RE.test(s) ||
-    BARE_LOCATION_RE.test(s) ||
-    (usLoc !== null && usLoc[0].length === s.length && US_STATE_CODE_RE.test(usLoc[2])) ||
-    (intlLoc !== null &&
-      intlLoc[0].length === s.length &&
-      COUNTRY_GAZETTEER.has(intlLoc[2].toLowerCase()))
-  );
 }
 
 /** Result of the leading-section-header strip: the surviving header lines, the

--- a/src/lib/heuristics/extract/experience.location.test.ts
+++ b/src/lib/heuristics/extract/experience.location.test.ts
@@ -18,6 +18,11 @@
  *      — country is not a 2-letter USPS code so Pass A/B missed it;
  *        Pass C (COUNTRY_GAZETTEER) now strips it.
  *
+ *   4. Tab-justified flush-right sub-line on ONE PDF row (#891):
+ *      "Software Developer" + a wide whitespace-only run + "Remote"
+ *      — pdfjs draws the justification as a single blank item, so line
+ *        assembly saw no gap to cut on and welded the two cells together.
+ *
  * Synthetic personas only, per the fixtures PII policy.
  */
 
@@ -26,7 +31,7 @@ import { groupIntoLines, splitIntoSections, findSection } from "../sections.ts";
 import { extractExperience } from "../extract-fields.ts";
 import { mkItems } from "../__test-utils__/mkItem.ts";
 
-function roleFromSection(specs: Array<{ text: string; fontSize?: number }>) {
+function roleFromSection(specs: Array<{ text: string; fontSize?: number; x?: number; lineIndex?: number }>) {
   const sections = splitIntoSections(groupIntoLines(mkItems(specs)));
   const experience = findSection(sections, "experience");
   expect(experience).toBeDefined();
@@ -421,5 +426,132 @@ describe("role location extraction (#218)", () => {
         expect(role.location).toBe("Seoul, S.Korea");
       });
     });
+  });
+});
+
+describe("tab-justified flush-right location (#891)", () => {
+  // pdfjs renders a right-aligned cell on a shared row as THREE items with no
+  // gap between any adjacent pair: the left cell, one whitespace-only item
+  // whose own `width` spans the justification, then the right cell. Chain each
+  // x to the previous item's `x + width` (`mkItem` computes
+  // `width = text.length * fontSize * 0.5`, so 5.5pt/char at the default
+  // fontSize 11) to reproduce that adjacent-gap-of-zero shape exactly.
+  const TITLE_X = 41.76;
+  const TITLE = "Software Developer";
+  const GAP_X = TITLE_X + TITLE.length * 5.5; // 140.76
+  const GAP = " ".repeat(72); // 396pt wide — well past COLUMN_GAP_THRESHOLD (50)
+  const TRAILER_X = GAP_X + GAP.length * 5.5; // 536.76
+
+  /** The motivating shape: company + date anchor, then a single PDF row
+   *  carrying the title at the left margin and `trailer` flush right. */
+  function roleFromJustifiedRow(trailer: string) {
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13, lineIndex: 0 },
+      { text: "Acme Corp", x: TITLE_X, lineIndex: 1 },
+      { text: "Sep. 2025 - Apr. 2026", x: TITLE_X, lineIndex: 2 },
+      { text: TITLE, x: TITLE_X, lineIndex: 3 },
+      { text: GAP, x: GAP_X, lineIndex: 3 },
+      { text: trailer, x: TRAILER_X, lineIndex: 3 },
+      {
+        text: "• Automated risk-scoring pipeline for 1M accounts.",
+        x: TITLE_X,
+        lineIndex: 4,
+      },
+    ]);
+    expect(roles).toHaveLength(1);
+    return roles[0];
+  }
+
+  it("peels a flush-right work-mode keyword off the title (primary AC)", () => {
+    // Pre-#891: title === "Software Developer Remote", location undefined.
+    const role = roleFromJustifiedRow("Remote");
+    expect(role.title).toBe("Software Developer");
+    expect(role.title).not.toContain("Remote");
+    expect(role.location).toBe("Remote");
+    expect(role.company).toBe("Acme Corp");
+    expect(role.start_date).toBe("Sep. 2025");
+  });
+
+  it("peels the other work-mode keywords BARE_LOCATION_RE knows", () => {
+    expect(roleFromJustifiedRow("Hybrid").location).toBe("Hybrid");
+    expect(roleFromJustifiedRow("Hybrid").title).toBe("Software Developer");
+    expect(roleFromJustifiedRow("On-site").location).toBe("On-site");
+    expect(roleFromJustifiedRow("On-site").title).toBe("Software Developer");
+  });
+
+  it("keeps a flush-right 'City, ST' off the title", () => {
+    // Not a #891 fail-before case — a welded "Software Developer Bellevue, WA"
+    // was already rescued downstream by `stripLocationSuffix`'s "City, ST"
+    // pass. Pinned so the peel, which now claims this row first, lands the
+    // same fields the suffix strip used to.
+    const role = roleFromJustifiedRow("Bellevue, WA");
+    expect(role.title).toBe("Software Developer");
+    expect(role.location).toBe("Bellevue, WA");
+  });
+
+  it("no-regression: an ordinary multi-word title with normal spacing is not split", () => {
+    // No whitespace-only item wide enough to be a justification rail, so the
+    // peel is a strict no-op and the title survives whole.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13, lineIndex: 0 },
+      { text: "Acme Corp", x: TITLE_X, lineIndex: 1 },
+      { text: "Sep. 2025 - Apr. 2026", x: TITLE_X, lineIndex: 2 },
+      { text: "Senior", x: TITLE_X, lineIndex: 3 },
+      { text: "   ", x: TITLE_X + 33, lineIndex: 3 },
+      { text: "Software Developer", x: TITLE_X + 49.5, lineIndex: 3 },
+      {
+        text: "• Automated risk-scoring pipeline for 1M accounts.",
+        x: TITLE_X,
+        lineIndex: 4,
+      },
+    ]);
+    expect(roles).toHaveLength(1);
+    expect(roles[0].title).toBe("Senior Software Developer");
+    expect(roles[0].location).toBeUndefined();
+  });
+
+  it("no-regression: a flush-right DATE stays merged onto its header line (#425)", () => {
+    // The other thing templates park at the right margin. It is not a bare
+    // location, so the peel declines and the #425 exemption's behaviour holds:
+    // the date parses off the header instead of becoming a location.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13, lineIndex: 0 },
+      { text: "Acme Corp", x: TITLE_X, lineIndex: 1 },
+      { text: TITLE, x: TITLE_X, lineIndex: 2 },
+      { text: GAP, x: GAP_X, lineIndex: 2 },
+      { text: "Sep. 2025 - Apr. 2026", x: TRAILER_X, lineIndex: 2 },
+      {
+        text: "• Automated risk-scoring pipeline for 1M accounts.",
+        x: TITLE_X,
+        lineIndex: 3,
+      },
+    ]);
+    expect(roles).toHaveLength(1);
+    expect(roles[0].title).toBe("Software Developer");
+    expect(roles[0].start_date).toBe("Sep. 2025");
+    expect(roles[0].end_date).toBe("Apr. 2026");
+    expect(roles[0].location).toBeUndefined();
+  });
+
+  it("no-regression: a location on a genuinely separate PDF row still resolves", () => {
+    // The shape the same résumé's other roles use — location on its own row at
+    // a different y, which already parsed correctly before #891. The row
+    // carries no whitespace-only item, so `splitOnFlushRightGap` returns
+    // undefined and this path is byte-for-byte untouched.
+    const roles = roleFromSection([
+      { text: "EXPERIENCE", fontSize: 13, lineIndex: 0 },
+      { text: "Acme Corp", x: TITLE_X, lineIndex: 1 },
+      { text: "Sep. 2025 - Apr. 2026", x: TITLE_X, lineIndex: 2 },
+      { text: TITLE, x: TITLE_X, lineIndex: 3 },
+      { text: "Bellevue, WA", x: TITLE_X, lineIndex: 4 },
+      {
+        text: "• Automated risk-scoring pipeline for 1M accounts.",
+        x: TITLE_X,
+        lineIndex: 5,
+      },
+    ]);
+    expect(roles).toHaveLength(1);
+    expect(roles[0].title).toBe("Software Developer");
+    expect(roles[0].location).toBe("Bellevue, WA");
   });
 });

--- a/src/lib/heuristics/line-assembly.flush-right-gap.test.ts
+++ b/src/lib/heuristics/line-assembly.flush-right-gap.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * `splitOnFlushRightGap` — the geometry half of the tab-justified flush-right
+ * fix (#891).
+ *
+ * Geometry mirrors the real PDF row from the issue: `"Software Developer"` at
+ * x≈41.76, a single whitespace-only text item ~415pt wide spanning the
+ * justification, then `"Remote"` at x≈539.95. The two adjacent-pair gaps are
+ * ~0 — that is exactly why `columnGapCuts` cannot see this shape — so the
+ * helper keys on the blank item's own declared `width` instead.
+ */
+
+import { describe, it, expect } from "vitest";
+import { splitOnFlushRightGap } from "./line-assembly.ts";
+import type { PdfTextItem } from "./types.ts";
+
+/** Item at `x` whose declared width is `width` — the two numbers the helper
+ *  reads. Everything else is inert filler. */
+function item(str: string, x: number, width: number): PdfTextItem {
+  return {
+    page: 1,
+    str,
+    x,
+    y: 114,
+    width,
+    height: 11,
+    fontSize: 11,
+    fontName: "font-11",
+    hasEOL: true,
+  };
+}
+
+// The issue's row, verbatim: title ends at 124.66, the blank run spans
+// 124.66 → 539.95 (415.29pt), "Remote" starts where the blank run ends. No
+// real gap between any adjacent pair.
+const TITLE = item("Software Developer", 41.76, 82.9);
+const BLANK = item("                              ", 124.66, 415.29);
+const REMOTE = item("Remote", 539.95, 32.05);
+
+describe("splitOnFlushRightGap (#891)", () => {
+  it("splits a tab-justified row at the wide whitespace-only item", () => {
+    const split = splitOnFlushRightGap([TITLE, BLANK, REMOTE]);
+    expect(split).toBeDefined();
+    expect(split?.head).toEqual([TITLE]);
+    expect(split?.trailer).toEqual([REMOTE]);
+  });
+
+  it("keeps every item on the correct side when each cell is multi-run", () => {
+    const lead = item("Software", 41.76, 45);
+    const rest = item("Developer", 88, 48);
+    const city = item("Bellevue,", 500, 40);
+    const state = item("WA", 542, 14);
+    const split = splitOnFlushRightGap([lead, rest, BLANK, city, state]);
+    expect(split?.head).toEqual([lead, rest]);
+    expect(split?.trailer).toEqual([city, state]);
+  });
+
+  it("returns undefined when the row carries no whitespace-only item", () => {
+    expect(splitOnFlushRightGap([TITLE, REMOTE])).toBeUndefined();
+  });
+
+  it("returns undefined for ordinary inter-word spacing below the column threshold", () => {
+    // A 33pt blank is word/run spacing, not a justification rail — the same
+    // 50pt `COLUMN_GAP_THRESHOLD` the line splitter uses gates both.
+    const narrow = item("      ", 124.66, 33);
+    expect(splitOnFlushRightGap([TITLE, narrow, REMOTE])).toBeUndefined();
+  });
+
+  it("returns undefined for a leading or trailing blank item (padding, not a separator)", () => {
+    expect(splitOnFlushRightGap([BLANK, TITLE, REMOTE])).toBeUndefined();
+    expect(splitOnFlushRightGap([TITLE, REMOTE, BLANK])).toBeUndefined();
+  });
+
+  it("returns undefined for a row of fewer than three items", () => {
+    expect(splitOnFlushRightGap([])).toBeUndefined();
+    expect(splitOnFlushRightGap([BLANK])).toBeUndefined();
+    expect(splitOnFlushRightGap([TITLE, BLANK])).toBeUndefined();
+  });
+
+  it("splits at the FIRST qualifying blank when a row carries several", () => {
+    const second = item("                    ", 572, 60);
+    const tail = item("Hybrid", 632, 30);
+    const split = splitOnFlushRightGap([TITLE, BLANK, REMOTE, second, tail]);
+    expect(split?.head).toEqual([TITLE]);
+    expect(split?.trailer).toEqual([REMOTE, second, tail]);
+  });
+});

--- a/src/lib/heuristics/line-assembly.ts
+++ b/src/lib/heuristics/line-assembly.ts
@@ -138,6 +138,46 @@ function columnGapCuts(sorted: PdfTextItem[]): number[] {
   return cuts;
 }
 
+/**
+ * Split an x-sorted, same-row item run at a tab-justified flush-right gap:
+ * `{ head, trailer }` around the first interior whitespace-only item wider than
+ * `COLUMN_GAP_THRESHOLD`, or `undefined` when the row carries no such item.
+ *
+ * Why this is NOT part of `columnGapCuts` (#891). `columnGapCuts` measures the
+ * gap BETWEEN adjacent items, and a tab-justified flush-right sub-line does not
+ * present one: pdfjs renders the stretched padding as a single whitespace-only
+ * text item whose own declared `width` spans the gap, so the adjacent-pair gap
+ * on both sides of it is ~0 and no cut ever fires. The row then merges into one
+ * `PdfLine` and `mergeItemText` collapses the 400pt blank run to a single
+ * space — `"Software Developer Remote"`, with the geometry that separated the
+ * two cells destroyed and unrecoverable downstream.
+ *
+ * Why it is a standalone helper rather than a broader cut rule inside the
+ * shared chokepoint: `columnGapCuts` feeds BOTH the line splitter (`flush`) and
+ * the embedded-grid detector (`rowIsMultiColumn`), so teaching it to cut after
+ * any wide whitespace item re-bands genuine layouts — 21 tests regressed when
+ * that was tried during #891 triage, including page-footer text bleeding back
+ * into role titles on the #283 repro fixture. This helper therefore exposes the
+ * geometry and leaves the decision to the one caller that can qualify it by
+ * content (`entry-blocks.ts`, which peels the trailer only when it is a bare
+ * location). Line grouping itself is untouched.
+ *
+ * `sorted` must be left-to-right by x — `PdfLine.items` already is, so callers
+ * pass `line.items` directly. Interior-only: a leading or trailing blank item
+ * is padding, not a separator, and yields `undefined`.
+ */
+export function splitOnFlushRightGap(
+  sorted: PdfTextItem[],
+): { head: PdfTextItem[]; trailer: PdfTextItem[] } | undefined {
+  for (let i = 1; i < sorted.length - 1; i++) {
+    const it = sorted[i];
+    if (it.str.trim() === "" && it.width > COLUMN_GAP_THRESHOLD) {
+      return { head: sorted.slice(0, i), trailer: sorted.slice(i + 1) };
+    }
+  }
+  return undefined;
+}
+
 /** A row is "multi-column" when its x-sorted items carry a column-sized
  *  horizontal gap (the same `COLUMN_GAP_THRESHOLD` the line splitter uses),
  *  after the #425 flush-right-date exemption — so a lone flush-right date rail is

--- a/src/lib/heuristics/line-primitives.ts
+++ b/src/lib/heuristics/line-primitives.ts
@@ -3,7 +3,8 @@
 
 /**
  * Leaf-level line primitives shared by the entry-block parser and the field
- * extractors: bullet detection/stripping and date-range parsing.
+ * extractors: bullet detection/stripping, date-range parsing, and the
+ * closed-vocabulary bare-location predicate.
  *
  * These live in their own module to break the import cycle that arises when
  * `entry-blocks.ts` (the shared windowing primitive) and `extract-fields.ts`
@@ -16,10 +17,14 @@
 import { startsWithActionVerb } from "../lexicon/action-verbs.ts";
 import type { PdfLine } from "./line-model.ts";
 import {
+  COUNTRY_GAZETTEER,
   DATE_RANGE_RE,
+  INTL_LOCATION_RE,
   MONTH_YEAR_RE,
   NUMERIC_MONTH_YEAR_RE,
   STRICT_MONTH_YEAR_RE,
+  US_LOCATION_RE,
+  US_STATE_CODE_RE,
   YEAR_RE,
 } from "./regex.ts";
 
@@ -324,6 +329,89 @@ const CV_FURNITURE_RE = /(?:^|\s)cv(?:$|\s)/i;
  *  that lands mid-section on a page break is stripped on every entry path. */
 export function isPageFurniture(line: PdfLine): boolean {
   return PAGE_FURNITURE_RE.test(line.text) || CV_FURNITURE_RE.test(line.text);
+}
+
+/** Multi-word US cities recognized by BOTH the whole-string `BARE_LOCATION_RE`
+ *  (case-insensitive) and the embedded-fold `KNOWN_MULTIWORD_US_CITY_RE`
+ *  (case-sensitive Title-case). Single source of truth so the two can't drift
+ *  apart. Longest-first so "New York City" wins over "New York" in the embedded
+ *  alternation (regex first-match); order is irrelevant for the `^…$`-anchored
+ *  `BARE_LOCATION_RE`.
+ *
+ *  Silicon-Valley/Peninsula additions (#616): "Mountain View", "Palo Alto",
+ *  "Menlo Park" are the multi-word tech-hub cities that show up co-located
+ *  with Globex/Meta/Stanford in a `Title · Company, City · Team` middot header
+ *  with NO trailing state suffix. Without the vocab entry, Pass F of
+ *  `stripLocationSuffix` (bare-city tail check) failed to full-match them and
+ *  the middle segment stayed whole ("Globex, Mountain View" → company). Same
+ *  closed-vocab discipline as the pre-existing entries: a real company that
+ *  merely contains one of these tokens ("Mountain View Software") still fails
+ *  the `^…$`-anchored full-string match.
+ *
+ *  #634 review follow-up: "Santa Clara", "Redwood City" and "Ann Arbor" close
+ *  the three headers the review reproduced as still-broken (Nvidia, Meta, Ford).
+ *  They do NOT make the vocabulary complete — this list is a closed set by
+ *  design, so any multi-word city outside it still folds into `company`. That
+ *  narrowing is the standing limitation of the approach, not a bug to be fixed
+ *  by growing the list without bound; see `experience.multiword-city.test.ts`,
+ *  which pins both halves (a listed city splits; an unlisted one does not, and
+ *  a company merely containing a listed city stays whole). */
+export const MULTIWORD_US_CITY_ALT =
+  "New York City|New York|New Orleans|San Francisco|San Diego|San Jose|San Antonio|Los Angeles|Las Vegas|Salt Lake City|Mountain View|Palo Alto|Menlo Park|Santa Clara|Redwood City|Ann Arbor";
+
+/** Bare city/region names (no "City, ST" state tail, so `US_LOCATION_RE` misses
+ *  them) that show up as a `"Title, Location"` header tail — must NOT be cleaved
+ *  off as the company. Exact whole-string match keeps a real company that merely
+ *  contains a city word ("New York Times", "Boston Consulting") splittable. */
+export const BARE_LOCATION_RE = new RegExp(
+  `^(remote|hybrid|on-?site|${MULTIWORD_US_CITY_ALT}|washington|washington d\\.?c\\.?|boston|chicago|seattle|austin|denver|portland|atlanta|dallas|houston|phoenix|miami|detroit|philadelphia|pittsburgh|minneapolis|nashville|charlotte|columbus|indianapolis|baltimore|sacramento|raleigh|london|paris|berlin|munich|tokyo|singapore|bangalore|bengaluru|mumbai|delhi|hyderabad|toronto|vancouver|sydney|melbourne|dublin|amsterdam)$`,
+  "i",
+);
+
+/**
+ * True when `s` is ENTIRELY a bare location string — a lone US state code, a
+ * bare well-known city, or a "City, ST" / "City, Country" shape that spans the
+ * WHOLE string (not merely a trailing suffix). The full-length check on the
+ * US/intl matches distinguishes a self-contained location ("Pomona, CA",
+ * "Mountain View, CA") from a company that merely carries a trailing city
+ * ("Globex, Toronto, Canada", where INTL_LOCATION_RE matches only a substring).
+ *
+ * Shape is NOT sufficient — the comma-tail must resolve against a REAL location
+ * signal, not merely a "CapWords, CapWords" shape. `US_LOCATION_RE` /
+ * `INTL_LOCATION_RE` are generic Title-Case-pair matchers (regex.ts:42/45), so
+ * on their own they full-match a comma-formatted job title whose role word is
+ * outside the finite `looksLikeTitle` keyword list ("Buyer, Home Goods",
+ * "Merchandiser, Footwear", "Barista, Downtown Store"), silently erasing a real
+ * title into `location` (the #325 step-5 rescue false-positive class). So each
+ * shape branch additionally requires its tail to be in a CLOSED vocabulary — a
+ * valid 2-letter USPS code (`US_STATE_CODE_RE`) or a real country
+ * (`COUNTRY_GAZETTEER`) — the same closed-vocabulary discipline
+ * `stripLocationSuffix` already applies. A generic Title-Case tail
+ * ("Home Goods", "Footwear") is in neither set and stays a title.
+ *
+ * The single shared bare-location predicate in {@link disambiguateCompanyTitle}:
+ * the step-3a rotate-guard (negated — a rotatable "Company, City, Country" is
+ * NOT a whole-string location), the step-3b `team`→location rescue, and the
+ * step-5 `title`→location rescue all route through it, so the same closed-vocab
+ * discipline gates every path and no branch can reintroduce the shape-only leak.
+ *
+ * Lives here rather than in `experience-disambiguate.ts` (#891) because
+ * `entry-blocks.ts` — which sits BELOW the extractors — needs the same
+ * vocabulary to qualify a flush-right trailer before it peels one
+ * (`peelFlushRightLocation`). Sharing the predicate is what keeps the two
+ * layers from disagreeing about what counts as a location.
+ */
+export function isBareLocationString(s: string): boolean {
+  const usLoc = US_LOCATION_RE.exec(s);
+  const intlLoc = INTL_LOCATION_RE.exec(s);
+  return (
+    US_STATE_CODE_RE.test(s) ||
+    BARE_LOCATION_RE.test(s) ||
+    (usLoc !== null && usLoc[0].length === s.length && US_STATE_CODE_RE.test(usLoc[2])) ||
+    (intlLoc !== null &&
+      intlLoc[0].length === s.length &&
+      COUNTRY_GAZETTEER.has(intlLoc[2].toLowerCase()))
+  );
 }
 
 /** Collapse internal whitespace and trim — the canonical date-token normalizer. */


### PR DESCRIPTION
## Summary

A title with a work-mode/location keyword right-aligned on the **same** PDF row ("Software Developer" … "Remote") arrived welded into one string, so `location` stayed empty and `title` carried the keyword. pdfjs draws the justification as ONE whitespace-only text item whose own `width` spans the gap, so the adjacent-pair gap on both sides is ~0, `columnGapCuts` never fires, and `mergeItemText` collapses the 400pt blank run to a single space — destroying the only evidence of the seam.

Rather than broaden `columnGapCuts` (the shared chokepoint for the line splitter *and* `rowIsMultiColumn`; cutting there after any wide blank item regressed 21 tests during triage), the geometry and the decision are separated: `splitOnFlushRightGap` exposes the seam and nothing in line grouping calls it; `peelFlushRightLocation` acts on it, only for a below-anchor header candidate whose trailer whole-matches the closed bare-location vocabulary. The peel adds no field-mapping logic — it lands the two halves in the shape `disambiguateCompanyTitle` already parses correctly for a separate-row location, so `rescueTeamLocation` promotes the trailer as before.

`MULTIWORD_US_CITY_ALT` / `BARE_LOCATION_RE` / `isBareLocationString` move **verbatim** from `extract/experience-disambiguate.ts` to `line-primitives.ts` so `entry-blocks.ts` — which sits below the extractors — shares the predicate instead of forking the vocabulary.

Closes #891

## Review focus

- `src/lib/heuristics/entry-blocks.ts:1576` — the peel runs *after* the loop's `isWrappedContinuation` check, so the flush-right trailer's far-right `x` is never used to reject it. Is that the right side of the check for every below-anchor shape, or does it let something through that the margin test was meant to drop?
- `src/lib/heuristics/entry-blocks.ts:1267` — both halves keep the source line's `y`, and `foldBelowAnchorLines` only folds on a *positive* y-delta. Does any other consumer of `belowHeaderLines` assume strictly increasing y, or tolerate two lines at the same y?
- `src/lib/heuristics/line-assembly.ts:141` — the gate is "interior whitespace-only item wider than `COLUMN_GAP_THRESHOLD`". Is a 50pt blank item reachable by ordinary word spacing at a large font size, and would the `isBareLocationString` trailer gate still catch it if so?
- Relocation into `line-primitives.ts` is meant to be byte-identical — worth confirming the three symbols moved unchanged and that nothing in `experience-disambiguate.ts` silently lost a `../regex.ts` import it still needs.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/lib/heuristics` green (75 files) — `corpus.test.ts` and `page-furniture-experience.repro.test.ts` both pass, the two suites the issue warned about
- [x] `npm run verify` green (378 files / 6251 tests, build, fixture + baseline gates)
- [x] Fail-before confirmed: reverting only the `entry-blocks.ts` wiring fails the new repro cases (`'Software Developer Remote'` vs `'Software Developer'`, `undefined` vs `'Hybrid'`) and nothing else