### PR TITLE
feat(job-search): persist the company shortlist, expose it read-only to the extension

### DIFF
--- a/src/components/features/CompanyTargets.test.tsx
+++ b/src/components/features/CompanyTargets.test.tsx
@@ -12,9 +12,17 @@
  * The assertions that matter are the ones the fan-out depends on: what
  * `selected` contains after a toggle, and that a sector switch re-seeds it —
  * because that array is passed straight to `searchJobs`.
+ *
+ * Since #864 the hook also reaches IndexedDB (the persisted watchlist), so
+ * this suite runs against `fake-indexeddb/auto` like `watched-companies.test.ts`
+ * — without it, every mount's dynamic import of `watched-companies.ts` would
+ * throw (no `indexedDB` global in plain jsdom), which the hook's own `catch`
+ * swallows into an empty, unreadable pool.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createElement } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -26,8 +34,18 @@ import {
   COMPANY_LIMIT,
   type CompanyTargets as CompanyTargetsState,
 } from "../../hooks/useCompanyTargets.ts";
+import { DB_NAME, closeDB } from "../../lib/storage/db.ts";
+import {
+  getWatchedCompanies,
+  saveWatchedCompany,
+} from "../../lib/job-search/watched-companies.ts";
 import type { HeuristicParsedResume } from "../../lib/heuristics/types.ts";
 import type { CompanyEntry } from "../../lib/job-search/company-registry.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -130,12 +148,54 @@ async function expand(): Promise<void> {
   });
 }
 
+/**
+ * Runs `body` with IndexedDB unavailable — the private-browsing / content-
+ * blocker / corporate-policy shape, where `open()` throws outright. Same
+ * simulation `board-cache.test.ts` uses; `closeDB()` on both sides so neither
+ * the cached handle from an earlier test nor the poisoned one from this test
+ * leaks across the boundary.
+ */
+async function withStorageBlocked(body: () => Promise<void>): Promise<void> {
+  const original = globalThis.indexedDB;
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: {
+      open() {
+        throw new Error("storage disabled");
+      },
+    },
+  });
+  await closeDB();
+  try {
+    await body();
+  } finally {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: original,
+    });
+    await closeDB();
+  }
+}
+
 function buttons(): HTMLButtonElement[] {
   return [...(container?.querySelectorAll("button") ?? [])] as HTMLButtonElement[];
 }
 
+/** The per-company SELECT toggles — `aria-pressed` but no `aria-label` (the
+ *  pin buttons below carry both, so the absence of a label is what tells
+ *  the two apart). */
 function companyButtons(): HTMLButtonElement[] {
-  return buttons().filter((b) => b.hasAttribute("aria-pressed"));
+  return buttons().filter(
+    (b) => b.hasAttribute("aria-pressed") && !b.hasAttribute("aria-label"),
+  );
+}
+
+/** The per-company PIN toggles (#864) — `aria-pressed` with an `aria-label`
+ *  ("Watch …" / "Stop watching …"), independent of the select toggle above. */
+function pinButtons(): HTMLButtonElement[] {
+  return buttons().filter(
+    (b) => b.hasAttribute("aria-pressed") && b.hasAttribute("aria-label"),
+  );
 }
 
 describe("useCompanyTargets", () => {
@@ -225,6 +285,153 @@ describe("useCompanyTargets", () => {
   });
 });
 
+/** #864: with the `watched` store empty, mount seeds from the sector guess as
+ *  before; once it holds a saved shortlist, a fresh mount shows THAT instead —
+ *  the sector heuristic no longer overwrites a decision the user already
+ *  made. Seeded directly through `saveWatchedCompany`, the real write path a
+ *  pin click drives, per this suite's own top-of-file harness note. */
+describe("useCompanyTargets persisted shortlist", () => {
+  it("with an empty store, seeds from the sector guess exactly as before", async () => {
+    await mount(fintechResume);
+    expect(latest?.sector).toBe("fintech");
+    expect(latest?.suggested.length).toBeGreaterThan(0);
+    expect(latest?.selected).toEqual(latest?.suggested);
+  });
+
+  it("with a saved shortlist, a fresh mount shows it instead of the sector guess", async () => {
+    // A gaming company, saved ahead of a mount whose résumé classifies as
+    // fintech — the saved shortlist must win regardless of what the résumé
+    // would otherwise suggest.
+    const discord: CompanyEntry = {
+      name: "Discord",
+      ats: "greenhouse",
+      slug: "discord",
+      sectors: ["gaming", "consumer-social"],
+    };
+    await saveWatchedCompany(discord);
+
+    await mount(fintechResume);
+
+    expect(latest?.suggested.map(companyKey)).toEqual([companyKey(discord)]);
+    expect(latest?.suggested[0].name).toBe("Discord");
+    // Freshly seeded from the watchlist: every entry starts selected, same as
+    // a fresh sector-seeded pool would.
+    expect(latest?.selected).toEqual(latest?.suggested);
+    // The header text and "try other sector" affordance still work off the
+    // real classifier guess — only the POOL source changed.
+    expect(latest?.sector).toBe("fintech");
+  });
+
+  it("a saved shortlist is what a fresh mount shows, marked watched", async () => {
+    const discord: CompanyEntry = {
+      name: "Discord",
+      ats: "greenhouse",
+      slug: "discord",
+      sectors: ["gaming"],
+    };
+    await saveWatchedCompany(discord);
+
+    await mount(fintechResume);
+
+    expect(latest?.isWatched(latest!.suggested[0])).toBe(true);
+  });
+
+  it("a chip toggle for one search does not mutate the saved shortlist", async () => {
+    const discord: CompanyEntry = {
+      name: "Discord",
+      ats: "greenhouse",
+      slug: "discord",
+      sectors: ["gaming"],
+    };
+    await saveWatchedCompany(discord);
+    await mount(fintechResume);
+    const entry = latest!.suggested[0];
+
+    await act(async () => latest!.toggle(entry));
+    expect(latest?.isSelected(entry)).toBe(false);
+
+    // Unmount and remount: an exploratory deselect must not have touched the
+    // persisted store — the next mount still shows the same saved shortlist.
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    await mount(fintechResume);
+
+    expect(latest?.suggested.map(companyKey)).toEqual([companyKey(discord)]);
+    expect(latest?.selected).toEqual(latest?.suggested);
+  });
+
+  // The regression #864 could have shipped: before this store existed, the
+  // sector heuristic and the company registry had ZERO storage dependency, so
+  // a profile with IndexedDB blocked still got suggestions. Reading the
+  // watchlist inside the same try block as those two imports would have handed
+  // that user the keyless-only search instead.
+  it("still seeds from the sector guess when IndexedDB is unavailable", async () => {
+    await withStorageBlocked(async () => {
+      await mount(fintechResume);
+
+      expect(latest?.sector).toBe("fintech");
+      expect(latest?.suggested.length).toBeGreaterThan(0);
+      expect(latest?.selected).toEqual(latest?.suggested);
+    });
+  });
+
+  // A failed READ must not disarm the save path: the module loaded fine, so
+  // the pin still works for the rest of the session.
+  it("can still pin a company after the initial watchlist read failed", async () => {
+    await withStorageBlocked(async () => {
+      await mount(fintechResume);
+    });
+    const entry = latest!.suggested[0];
+
+    await act(async () => {
+      pinButtons()[0].click();
+    });
+    // `toggleWatched` returns void — the write is fire-and-forget, and this one
+    // also has to reopen the database `withStorageBlocked` closed behind it, so
+    // poll for the row instead of assuming a fixed number of ticks is enough. A
+    // dead `watchedApiRef` (no save ever issued) exhausts the deadline and the
+    // assertion below then reports the empty list, which is the real failure.
+    const deadline = Date.now() + 3_000;
+    let saved = await getWatchedCompanies();
+    while (saved.length === 0 && Date.now() < deadline) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      saved = await getWatchedCompanies();
+    }
+
+    expect(latest?.isWatched(entry)).toBe(true);
+    expect(saved.map((c) => `${c.ats}:${c.slug}`)).toEqual([companyKey(entry)]);
+  });
+
+  // #897 review: an uncapped watchlist branch fed a `selected` of unbounded
+  // width straight into the board fan-out — the same COMPANY_LIMIT the sector
+  // branch already respects (docblock above the constant) must hold here too.
+  it("caps a shortlist larger than COMPANY_LIMIT, all still auto-selected", async () => {
+    for (let i = 0; i < COMPANY_LIMIT + 3; i++) {
+      await saveWatchedCompany({
+        name: `Watched ${i}`,
+        ats: "greenhouse",
+        slug: `watched-${i}`,
+        sectors: [],
+      });
+    }
+
+    await mount(fintechResume);
+
+    expect(latest?.suggested.length).toBe(COMPANY_LIMIT);
+    expect(latest?.selected).toEqual(latest?.suggested);
+    const savedKeys = new Set(
+      (await getWatchedCompanies()).map((c) => `${c.ats}:${c.slug}`),
+    );
+    for (const entry of latest!.suggested) {
+      expect(savedKeys.has(companyKey(entry))).toBe(true);
+    }
+  });
+});
+
 describe("CompanyTargets rendering", () => {
   it("renders one toggle per suggested company, all pressed initially", async () => {
     await mount(fintechResume);
@@ -283,6 +490,55 @@ describe("CompanyTargets rendering", () => {
   it("notes that self-hosted-careers employers aren't reachable here", async () => {
     await mount(fintechResume);
     expect(container?.textContent).toContain("their own careers site");
+  });
+});
+
+/** #864: the per-chip pin — the save affordance for the persisted watchlist,
+ *  independent of the select toggle used for THIS search. */
+describe("CompanyTargets watchlist pin", () => {
+  it("renders one pin button per suggested company, none pressed initially", async () => {
+    await mount(fintechResume);
+    expect(pinButtons()).toHaveLength(latest!.suggested.length);
+    expect(pinButtons().every((b) => b.getAttribute("aria-pressed") === "false")).toBe(
+      true,
+    );
+  });
+
+  it("clicking a pin toggles aria-pressed and calls toggleWatched for that entry", async () => {
+    await mount(fintechResume);
+    const entry = latest!.suggested[0];
+
+    await act(async () => {
+      pinButtons()[0].click();
+    });
+
+    expect(latest?.isWatched(entry)).toBe(true);
+    expect(pinButtons()[0].getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("toggling the SELECT button does not change watched state", async () => {
+    await mount(fintechResume);
+    const entry = latest!.suggested[0];
+
+    await act(async () => {
+      companyButtons()[0].click();
+    });
+
+    expect(latest?.isSelected(entry)).toBe(false);
+    expect(latest?.isWatched(entry)).toBe(false);
+    expect(pinButtons()[0].getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("toggling a pin does not change selection state", async () => {
+    await mount(fintechResume);
+    const entry = latest!.suggested[0];
+
+    await act(async () => {
+      pinButtons()[0].click();
+    });
+
+    expect(latest?.isSelected(entry)).toBe(true);
+    expect(companyButtons()[0].getAttribute("aria-pressed")).toBe("true");
   });
 });
 

--- a/src/components/features/CompanyTargets.tsx
+++ b/src/components/features/CompanyTargets.tsx
@@ -117,22 +117,48 @@ export function CompanyTargets({ targets }: { targets: CompanyTargetsState }) {
           <div className="flex flex-wrap gap-1.5">
             {suggested.map((entry: CompanyEntry) => {
               const isOn = targets.isSelected(entry);
+              const isWatched = targets.isWatched(entry);
               return (
-                <Button
+                <div
                   key={`${entry.ats}:${entry.slug}`}
-                  variant="ghost"
-                  size="sm"
-                  aria-pressed={isOn}
-                  onClick={() => targets.toggle(entry)}
                   className={
                     isOn
-                      ? "rounded-full border border-accent-primary px-2.5 py-1"
-                      : "rounded-full border border-border-light px-2.5 py-1 text-content-secondary"
+                      ? "flex items-center rounded-full border border-accent-primary"
+                      : "flex items-center rounded-full border border-border-light"
                   }
                 >
-                  <span aria-hidden="true">{isOn ? "✓︎" : "+"}</span>
-                  {entry.name}
-                </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-pressed={isOn}
+                    onClick={() => targets.toggle(entry)}
+                    className={
+                      isOn ? "px-2.5 py-1" : "px-2.5 py-1 text-content-secondary"
+                    }
+                  >
+                    <span aria-hidden="true">{isOn ? "✓︎" : "+"}</span>
+                    {entry.name}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-pressed={isWatched}
+                    aria-label={
+                      isWatched ? `Stop watching ${entry.name}` : `Watch ${entry.name}`
+                    }
+                    onClick={() => targets.toggleWatched(entry)}
+                    className="px-1.5 py-1"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={
+                        isWatched ? "text-accent-primary" : "text-content-secondary"
+                      }
+                    >
+                      {isWatched ? "★" : "☆"}
+                    </span>
+                  </Button>
+                </div>
               );
             })}
           </div>

--- a/src/components/features/JobQueryEditor.test.tsx
+++ b/src/components/features/JobQueryEditor.test.tsx
@@ -44,6 +44,8 @@ const NO_COMPANIES: CompanyTargets = {
   isSelected: () => false,
   toggle: () => {},
   switchToRunnerUp: () => {},
+  isWatched: () => false,
+  toggleWatched: () => {},
 };
 
 /**

--- a/src/hooks/useCompanyTargets.ts
+++ b/src/hooks/useCompanyTargets.ts
@@ -10,7 +10,7 @@
  * both need it: the panel passes `selected` to `searchJobs`, the component
  * toggles it.
  *
- * TWO DELIBERATE CHOICES:
+ * THREE DELIBERATE CHOICES:
  *
  * 1. HEURISTIC CLASSIFIER, NOT `classifySector`. `sector.ts` also exports the
  *    semantic `classifySector`, which loads a WebLLM model when WebGPU is
@@ -27,7 +27,22 @@
  *    its `JobQuery` — "local scratch state seeded once from the parse".
  *    NOTE: `exhaustive-deps` is NOT enabled in this repo, so nothing would
  *    have flagged the alternative; the empty dep array is a decision, not an
- *    oversight.
+ *    oversight. Since #864, the seed source itself branches on mount: the
+ *    persisted watchlist (`watched-companies.ts`) wins over the sector guess
+ *    when it is non-empty — see choice 3 below — but which source wins is
+ *    still decided exactly once, at mount, for the same reason.
+ *
+ * 3. A PER-CHIP PIN, NOT THE SEARCH-SELECTION TOGGLE, IS THE SAVE AFFORDANCE
+ *    (#864). Toggling a chip for THIS search (`toggle`/`isSelected`) and
+ *    saving a company to the PERSISTED shortlist (`toggleWatched`/`isWatched`)
+ *    are two different user intents and stay two different controls. A
+ *    "save current selection" button was the other option considered and was
+ *    rejected: it would silently DISCARD any previously pinned company that
+ *    isn't in this session's sector-suggested pool (a user who pinned
+ *    companies across two different sector guesses over two visits would have
+ *    one visit's save button erase the other's picks). A per-chip pin has no
+ *    such collision — pinning and unpinning compose one company at a time,
+ *    regardless of which sector guess is currently on screen.
  *
  * The registry and the sector taxonomy are dynamic-imported (the cascade-tier
  * pattern) so neither reaches the entry chunk — the panel renders before they
@@ -38,6 +53,54 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { HeuristicParsedResume } from "../lib/heuristics/types.ts";
 import type { CompanyEntry } from "../lib/job-search/company-registry.ts";
 import type { Sector } from "../lib/job-search/sector.ts";
+import type { WatchedCompany } from "../lib/job-search/watched-companies.ts";
+
+/** Signatures of the dynamically-imported save/remove functions, without a
+ *  static import — the module itself is lazy-loaded (see the mount effect
+ *  below), and `typeof import(...)` names its exports' types with no runtime
+ *  cost. */
+type WatchedCompaniesApi = {
+  save: typeof import("../lib/job-search/watched-companies.ts").saveWatchedCompany;
+  remove: typeof import("../lib/job-search/watched-companies.ts").removeWatchedCompany;
+};
+
+/**
+ * The watchlist half of the mount seed, isolated from the sector half.
+ *
+ * A storage failure — IndexedDB blocked by private browsing, a content
+ * blocker, or corporate policy, so `openDB()` throws — must cost ONLY the
+ * watchlist. The sector heuristic and the company registry have no storage
+ * dependency and worked regardless before #864; sharing one try block with
+ * this read would let a blocked `openDB()` blank `sector`/`suggested` too and
+ * degrade a working surface to the keyless-only search.
+ *
+ * The two failure modes are kept apart on purpose. A failed MODULE LOAD leaves
+ * no api to call, so `toggleWatched` becomes a no-op. A failed READ still
+ * hands back the api, so pinning saves and unpinning removes for the rest of
+ * the session — the shortlist just didn't seed. Both answer with the same
+ * empty list an untouched store gives, so the seeding path downstream cannot
+ * tell "no storage" from "nothing saved yet", which is exactly right.
+ */
+async function loadWatchlist(): Promise<{
+  api: WatchedCompaniesApi | null;
+  watched: WatchedCompany[];
+}> {
+  let module: typeof import("../lib/job-search/watched-companies.ts");
+  try {
+    module = await import("../lib/job-search/watched-companies.ts");
+  } catch {
+    return { api: null, watched: [] };
+  }
+  const api = {
+    save: module.saveWatchedCompany,
+    remove: module.removeWatchedCompany,
+  };
+  try {
+    return { api, watched: await module.getWatchedCompanies() };
+  } catch {
+    return { api, watched: [] };
+  }
+}
 
 /**
  * How many companies a sector suggests (#542). Together with
@@ -61,6 +124,22 @@ export const COMPANY_LIMIT = 14;
 /** Stable identity for a registry entry. `slug` alone collides across vendors. */
 export function companyKey(entry: CompanyEntry): string {
   return `${entry.ats}:${entry.slug}`;
+}
+
+/** Same identity as {@link companyKey}, read off a `WatchedCompany` — kept
+ *  separate rather than routing a `WatchedCompany` through `companyKey`
+ *  itself, since the two types diverge (a watched company has no `sectors`). */
+function watchedCompanyToKey(entry: WatchedCompany): string {
+  return `${entry.ats}:${entry.slug}`;
+}
+
+/** A watched company, reshaped as the `CompanyEntry` `suggested`/`selected`
+ *  expect. `sectors: []` is a placeholder: nothing downstream of `suggested`/
+ *  `selected` reads a `CompanyEntry`'s `sectors` field (verified via grep —
+ *  the only reader is `companiesForSector` itself, which never sees a
+ *  watched-derived entry), so an empty array costs nothing. */
+function toCompanyEntry(entry: WatchedCompany): CompanyEntry {
+  return { name: entry.displayName, ats: entry.ats, slug: entry.slug, sectors: [] };
 }
 
 /** Add/remove one key from a selection set, returning a new set. */
@@ -88,6 +167,12 @@ export interface CompanyTargets {
   toggle(entry: CompanyEntry): void;
   /** Re-suggest against `runnerUp`; no-op when there isn't one. */
   switchToRunnerUp(): void;
+  /** True once this entry is on the persisted shortlist (independent of
+   *  `isSelected` — see the hook's docblock, third deliberate choice). */
+  isWatched(entry: CompanyEntry): boolean;
+  /** Pin/unpin `entry` on the persisted shortlist. Does NOT change
+   *  `isSelected`/`selected` for the current search. */
+  toggleWatched(entry: CompanyEntry): void;
 }
 
 export function useCompanyTargets(parsed: HeuristicParsedResume): CompanyTargets {
@@ -96,6 +181,9 @@ export function useCompanyTargets(parsed: HeuristicParsedResume): CompanyTargets
   const [runnerUp, setRunnerUp] = useState<Sector | null>(null);
   const [suggested, setSuggested] = useState<CompanyEntry[]>([]);
   const [keys, setKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const [watchedKeys, setWatchedKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
 
   // The lazily-imported registry lookup, kept so `switchToRunnerUp` can
   // re-query without a second dynamic import round-trip.
@@ -104,29 +192,66 @@ export function useCompanyTargets(parsed: HeuristicParsedResume): CompanyTargets
   >(null);
   const parsedRef = useRef(parsed);
   parsedRef.current = parsed;
+  // The lazily-imported save/remove functions, kept so `toggleWatched` can
+  // call them without a second dynamic import round-trip.
+  const watchedApiRef = useRef<WatchedCompaniesApi | null>(null);
+  // Mirrors `watchedKeys` so `toggleWatched` reads current state without a
+  // stale closure — the same reason `parsedRef` mirrors `parsed`.
+  const watchedKeysRef = useRef(watchedKeys);
+  watchedKeysRef.current = watchedKeys;
 
   // Mount-only on purpose — see the docblock.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        const [{ classifySectorHeuristic }, { companiesForSector }] =
-          await Promise.all([
-            import("../lib/job-search/sector.ts"),
-            import("../lib/job-search/company-registry.ts"),
-          ]);
+        const [
+          { classifySectorHeuristic },
+          { companiesForSector },
+          watchlist,
+        ] = await Promise.all([
+          import("../lib/job-search/sector.ts"),
+          import("../lib/job-search/company-registry.ts"),
+          // Resolves rather than rejects on a storage failure, so a blocked
+          // IndexedDB cannot take the two imports beside it down with it.
+          loadWatchlist(),
+        ]);
         if (cancelled) return;
         const guess = classifySectorHeuristic(parsedRef.current);
-        const pool = companiesForSector(guess.sector, COMPANY_LIMIT);
+        const watched = watchlist.watched;
+
+        // Every setter below fires together, after every await has settled —
+        // a throw partway through (a chunk that never loads) must not leave
+        // `sector` set while `suggested`/`keys` stay empty.
+        watchedApiRef.current = watchlist.api;
         lookupRef.current = companiesForSector;
         setSector(guess.sector);
         setRunnerUp(guess.runnerUp ?? null);
+        setWatchedKeys(new Set(watched.map(watchedCompanyToKey)));
+
+        // A saved shortlist wins over the sector guess — see choice 2/3 in
+        // the docblock. `sector`/`runnerUp` above are set regardless, for
+        // the header text and the "try other sector" affordance; only the
+        // POOL a fresh mount shows changes source.
+        // Capped and ordered most-recently-pinned-first, same as the sector
+        // branch caps at COMPANY_LIMIT — the watchlist otherwise grows past it
+        // across visits/sectors with nothing to bound the board fan-out (#897
+        // review). A bare slice would drop pins in storage-insertion order,
+        // which has no relationship to what the user pinned most recently.
+        const pool =
+          watched.length > 0
+            ? [...watched]
+                .sort((a, b) => b.addedAt - a.addedAt)
+                .slice(0, COMPANY_LIMIT)
+                .map(toCompanyEntry)
+            : companiesForSector(guess.sector, COMPANY_LIMIT);
         setSuggested(pool);
         setKeys(new Set(pool.map(companyKey)));
       } catch {
-        // Chunk failed to load (offline first-load). Company targeting is
-        // additive: leaving `suggested` empty degrades to the keyless-only
-        // search rather than breaking the panel.
+        // The sector/registry chunk failed to load (offline first-load) —
+        // `loadWatchlist` never reaches here, by construction. Company
+        // targeting is additive: leaving `suggested` empty degrades to the
+        // keyless-only search rather than breaking the panel.
       } finally {
         if (!cancelled) setReady(true);
       }
@@ -138,6 +263,23 @@ export function useCompanyTargets(parsed: HeuristicParsedResume): CompanyTargets
 
   const toggle = useCallback((entry: CompanyEntry) => {
     setKeys((current) => toggleKey(current, companyKey(entry)));
+  }, []);
+
+  const toggleWatched = useCallback((entry: CompanyEntry) => {
+    const key = companyKey(entry);
+    const wasWatched = watchedKeysRef.current.has(key);
+    setWatchedKeys((current) => toggleKey(current, key));
+    const api = watchedApiRef.current;
+    if (!api) return;
+    // Swallowed for the same reason `loadWatchlist` swallows the read: on a
+    // profile where storage is blocked the write rejects on every pin, and an
+    // unhandled rejection per click is the only thing that would come of
+    // propagating it. The optimistic state above still shows the pin for this
+    // session; nothing is silently lost that storage could have kept.
+    void (wasWatched
+      ? api.remove(entry.ats, entry.slug)
+      : api.save(entry)
+    ).catch(() => {});
   }, []);
 
   const switchToRunnerUp = useCallback(() => {
@@ -163,5 +305,7 @@ export function useCompanyTargets(parsed: HeuristicParsedResume): CompanyTargets
     isSelected: (entry) => keys.has(companyKey(entry)),
     toggle,
     switchToRunnerUp,
+    isWatched: (entry) => watchedKeys.has(companyKey(entry)),
+    toggleWatched,
   };
 }

--- a/src/hooks/useWatchedCompaniesBridge.ts
+++ b/src/hooks/useWatchedCompaniesBridge.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Mounts the read-only watched-companies responder
+ * (`lib/watched-companies-bridge.ts`) for the lifetime of the page (#864).
+ *
+ * Called once from `JobsApp.tsx` — the only surface `useCompanyTargets`/the
+ * watched shortlist exists on. Not mounted on `/` since there is nothing
+ * there for the extension to ask about.
+ */
+
+import { useEffect } from "react";
+import { listenForWatchedCompaniesRequests } from "../lib/watched-companies-bridge.ts";
+
+export function useWatchedCompaniesBridge(): void {
+  useEffect(() => listenForWatchedCompaniesRequests(), []);
+}

--- a/src/jobs/JobsApp.tsx
+++ b/src/jobs/JobsApp.tsx
@@ -47,6 +47,7 @@ import { resolveInitialJobsTab, type JobsTabId } from "../lib/jobs-landing.ts";
 import { useArrivedFromRoot } from "../hooks/useArrivedFromRoot.ts";
 import { useResumeLibrary } from "../hooks/useResumeLibrary.ts";
 import { useFallbackResume } from "../hooks/useFallbackResume.ts";
+import { useWatchedCompaniesBridge } from "../hooks/useWatchedCompaniesBridge.ts";
 import {
   writeTailorHandoff,
   fingerprintParse,
@@ -62,6 +63,10 @@ function goToResume() {
 }
 
 export default function JobsApp() {
+  // #864: answers the extension's read-only `get-watched-companies` request
+  // for the lifetime of this page. No return value to wire up.
+  useWatchedCompaniesBridge();
+
   // Read once, on first render (lazy initializer): the payload is inert JSON and
   // the read is non-destructive, so there is no StrictMode double-invoke hazard
   // of the kind a destructive consume would.

--- a/src/lib/extension-profile.ts
+++ b/src/lib/extension-profile.ts
@@ -243,7 +243,7 @@ const REPLY_TYPES: ReadonlySet<string> = new Set<ReplyType>([
  * can read the parse directly — but a forged `resume-profile-stored` would make
  * this surface report a share that never happened, and that is cheap to refuse.
  */
-function isFromThisPage(event: MessageEvent<unknown>, appOrigin: string): boolean {
+export function isFromThisPage(event: MessageEvent<unknown>, appOrigin: string): boolean {
   return event.source === window && event.origin === appOrigin;
 }
 

--- a/src/lib/job-search/watched-companies.test.ts
+++ b/src/lib/job-search/watched-companies.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * watched-companies.ts tests (#864). Run against `fake-indexeddb/auto`, same
+ * as `board-cache.test.ts` — the real `idb` + schema-upgrade path is
+ * exercised, which is also what proves the `DB_VERSION` 4 → 5 bump actually
+ * creates the `watched` store.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB, openDB } from "idb";
+import { describe, it, expect, beforeEach } from "vitest";
+import { DB_NAME, getDB, closeDB } from "../storage/db.ts";
+import {
+  getWatchedCompanies,
+  saveWatchedCompany,
+  removeWatchedCompany,
+  watchedCompanyKey,
+} from "./watched-companies.ts";
+import type { CompanyEntry } from "./company-registry.ts";
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+});
+
+const stripe: CompanyEntry = {
+  name: "Stripe",
+  ats: "greenhouse",
+  slug: "stripe",
+  sectors: ["fintech"],
+};
+
+describe("watchedCompanyKey", () => {
+  it("namespaces by vendor, since one slug can exist on two ATSes", () => {
+    expect(watchedCompanyKey("greenhouse", "circle")).not.toBe(
+      watchedCompanyKey("ashby", "circle"),
+    );
+  });
+});
+
+describe("watched companies", () => {
+  it("returns an empty list on an empty store", async () => {
+    expect(await getWatchedCompanies()).toEqual([]);
+  });
+
+  it("reads back what it saved", async () => {
+    await saveWatchedCompany(stripe);
+    const companies = await getWatchedCompanies();
+    expect(companies).toHaveLength(1);
+    expect(companies[0]).toMatchObject({
+      id: watchedCompanyKey("greenhouse", "stripe"),
+      ats: "greenhouse",
+      slug: "stripe",
+      displayName: "Stripe",
+    });
+    expect(typeof companies[0].addedAt).toBe("number");
+  });
+
+  it("saving the same ats+slug twice yields one row, and the second save's displayName wins", async () => {
+    await saveWatchedCompany(stripe);
+    await saveWatchedCompany({ ...stripe, name: "Stripe, Inc." });
+
+    const companies = await getWatchedCompanies();
+    expect(companies).toHaveLength(1);
+    expect(companies[0].displayName).toBe("Stripe, Inc.");
+  });
+
+  it("keeps vendors with the same slug separate", async () => {
+    await saveWatchedCompany(stripe);
+    await saveWatchedCompany({ ...stripe, ats: "ashby" });
+
+    const companies = await getWatchedCompanies();
+    expect(companies).toHaveLength(2);
+  });
+
+  it("removes a saved company", async () => {
+    await saveWatchedCompany(stripe);
+    await removeWatchedCompany("greenhouse", "stripe");
+
+    expect(await getWatchedCompanies()).toEqual([]);
+  });
+
+  it("removing a company that was never saved is a no-op", async () => {
+    await expect(removeWatchedCompany("greenhouse", "nobody")).resolves.toBeUndefined();
+    expect(await getWatchedCompanies()).toEqual([]);
+  });
+});
+
+describe("storage: schema migration v4 → v5 (#864)", () => {
+  async function seedV4Profile(): Promise<void> {
+    const legacy = await openDB(DB_NAME, 4, {
+      upgrade(db, oldVersion, _newVersion, tx) {
+        if (oldVersion < 1) {
+          db.createObjectStore("resumes", { keyPath: "id" });
+          db.createObjectStore("jobs", { keyPath: "id" });
+        }
+        if (oldVersion < 2) db.createObjectStore("boards", { keyPath: "id" });
+        if (oldVersion < 3) db.createObjectStore("letters", { keyPath: "id" });
+        if (oldVersion < 4) {
+          for (const store of ["resumes", "jobs", "letters"] as const) {
+            tx.objectStore(store).createIndex("updatedAt", "updatedAt");
+          }
+          db.createObjectStore("sync", { keyPath: "id" });
+        }
+      },
+    });
+    await legacy.put("jobs", {
+      id: "job-1",
+      title: "Staff Engineer",
+      company: "Acme",
+      status: "applied",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    legacy.close();
+  }
+
+  it("migrates a v4 profile to v5, adding the watched store and preserving existing records", async () => {
+    await seedV4Profile();
+
+    const db = await getDB();
+    expect(db.version).toBe(5);
+    expect(db.objectStoreNames.contains("watched")).toBe(true);
+
+    const companies = await getWatchedCompanies();
+    expect(companies).toEqual([]);
+
+    await saveWatchedCompany(stripe);
+    expect(await getWatchedCompanies()).toHaveLength(1);
+  });
+});

--- a/src/lib/job-search/watched-companies.ts
+++ b/src/lib/job-search/watched-companies.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * IndexedDB accessor for the persisted company watchlist (#864).
+ *
+ * Reaches `../storage/crud.ts` directly rather than routing through a
+ * domain-agnostic `storage/watched.ts` module — mirroring `board-cache.ts`,
+ * the one other job-search module that does this (see the exception note on
+ * `storage/index.ts`'s barrel docblock). There is no such module because this
+ * store has exactly one domain consumer (`useCompanyTargets`) and one bridge
+ * reader (`watched-companies-bridge.ts`), both in this repo, unlike jobs and
+ * letters, which are public producer contracts other repos write against.
+ *
+ * Key shape `${ats}:${slug}` — the same natural-key reasoning as
+ * `boardCacheKey` in `board-cache.ts` and `companyKey` in
+ * `useCompanyTargets.ts`: the same slug can exist on two vendors and mean two
+ * different companies, and re-saving the same company is an upsert, not a
+ * duplicate.
+ */
+
+import { getAllRecords, putRecord, deleteRecord } from "../storage/crud.ts";
+import type { WatchedCompanyRecord } from "../storage/types.ts";
+import type { Ats, CompanyEntry } from "./company-registry.ts";
+
+export interface WatchedCompany {
+  id: string;
+  ats: Ats;
+  slug: string;
+  displayName: string;
+  addedAt: number;
+}
+
+/** Natural key: same shape as `boardCacheKey`/`companyKey` elsewhere in this
+ *  lane — not shared, by the same house convention those two follow. */
+export function watchedCompanyKey(ats: Ats, slug: string): string {
+  return `${ats}:${slug}`;
+}
+
+function toWatchedCompany(record: WatchedCompanyRecord): WatchedCompany {
+  return {
+    id: record.id,
+    ats: record.ats as Ats,
+    slug: record.slug,
+    displayName: record.displayName,
+    addedAt: record.createdAt,
+  };
+}
+
+/** The whole saved shortlist, in no particular guaranteed order (small — a
+ *  handful of rows — so callers that care about order sort it themselves). */
+export async function getWatchedCompanies(): Promise<WatchedCompany[]> {
+  const records = await getAllRecords<WatchedCompanyRecord>("watched");
+  return records.map(toWatchedCompany);
+}
+
+/** Upsert one company onto the shortlist. Re-saving the same `ats`+`slug`
+ *  updates the existing row (same `id`) rather than duplicating it. */
+export async function saveWatchedCompany(entry: CompanyEntry): Promise<WatchedCompany> {
+  const record = await putRecord<WatchedCompanyRecord>("watched", {
+    id: watchedCompanyKey(entry.ats, entry.slug),
+    ats: entry.ats,
+    slug: entry.slug,
+    displayName: entry.name,
+  });
+  return toWatchedCompany(record);
+}
+
+/** Remove one company from the shortlist. No-op (does not throw) if it
+ *  wasn't there. */
+export async function removeWatchedCompany(ats: Ats, slug: string): Promise<void> {
+  await deleteRecord("watched", watchedCompanyKey(ats, slug));
+}

--- a/src/lib/storage/db.test.ts
+++ b/src/lib/storage/db.test.ts
@@ -29,12 +29,12 @@ beforeEach(async () => {
 describe("getExistingDB", () => {
   it("attaches to a database the app already migrated, without re-requesting a version", async () => {
     const app = await getDB();
-    expect(app.version).toBe(4);
+    expect(app.version).toBe(5);
     expect([...app.objectStoreNames]).toContain("jobs");
     await closeDB();
 
     const contentScript = await getExistingDB();
-    expect(contentScript.version).toBe(4);
+    expect(contentScript.version).toBe(5);
     expect([...contentScript.objectStoreNames]).toEqual([
       ...app.objectStoreNames,
     ]);
@@ -49,7 +49,7 @@ describe("getExistingDB", () => {
     // guarded `oldVersion < 1`, so upgrading the stray v1 in place would skip
     // it and leave `resumes`/`jobs` uncreated.)
     const db = await getExistingDB();
-    expect(db.version).toBe(4);
+    expect(db.version).toBe(5);
     expect([...db.objectStoreNames]).toContain("jobs");
     expect([...db.objectStoreNames]).toContain("resumes");
   });

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -4,8 +4,9 @@
 /**
  * IndexedDB handle for the local-first storage foundation (#321).
  *
- * One database, five object stores (`resumes`, `jobs`, `boards`, `letters` and
- * the `sync` bookmarks that describe three of them), opened through the ~1KB
+ * One database, six object stores (`resumes`, `jobs`, `boards`, `letters`,
+ * `watched` and the `sync` bookmarks that describe three of them), opened
+ * through the ~1KB
  * `idb` wrapper. Schema versioning lives here from day one: every future store
  * or index is a `DB_VERSION` bump with a matching branch in `upgrade()`, so an
  * existing user's data migrates forward instead of stranding. `upgrade()` runs
@@ -23,6 +24,7 @@ import type {
   BoardCacheRecord,
   LetterRecord,
   SyncCursorRecord,
+  WatchedCompanyRecord,
 } from "./types.ts";
 
 // Renamed from "resumelint" during the OfflineCV rename (#498). Safe to change
@@ -46,7 +48,7 @@ export const DB_NAME = "offlinecv";
  *  (`extension/src/offlinecv-core.ts`) still imports the `getDB()`-backed
  *  functions by relative path, so the pin is what keeps this constant and that
  *  build in step. */
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 
 /** Index name shared by every syncable store — one string so a range query and
  *  the three `createIndex` calls cannot drift apart. */
@@ -58,6 +60,7 @@ interface OfflineCvDB extends DBSchema {
   boards: { key: string; value: BoardCacheRecord };
   letters: { key: string; value: LetterRecord; indexes: { updatedAt: number } };
   sync: { key: string; value: SyncCursorRecord };
+  watched: { key: string; value: WatchedCompanyRecord };
 }
 
 let dbPromise: Promise<IDBPDatabase<OfflineCvDB>> | null = null;
@@ -125,6 +128,16 @@ export function getDB(): Promise<IDBPDatabase<OfflineCvDB>> {
             tx.objectStore(store).createIndex(UPDATED_AT_INDEX, "updatedAt");
           }
           db.createObjectStore("sync", { keyPath: "id" });
+        }
+        // v4 → v5 (#864): the persisted company-watchlist store. Additive like
+        // every block above — an existing user's résumés/jobs/letters/sync state
+        // is untouched, and this new store simply starts empty, which is the
+        // correct reading of "never saved a shortlist". No index: `useCompanyTargets`
+        // reads the whole (small) store on mount, same as `getAllLetters` does for
+        // `letters` — see the `oldVersion < 3` note above for why an index isn't
+        // worth it before a caller needs one.
+        if (oldVersion < 5) {
+          db.createObjectStore("watched", { keyPath: "id" });
         }
       },
     });

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -47,10 +47,13 @@
  *    `StoreName` joined for the same reason (#760): `useLibraryChanges`
  *    (`src/hooks/`) has to name the store it's subscribing to.
  *
- * The one standing exception is `src/lib/job-search/board-cache.ts`, which
- * reaches `./crud.ts` for the generic `getRecord`/`putRecord` accessors. There
- * is no `boards.ts` domain module to wrap them, and routing it here would pull
- * `backup.ts` + `resumes.ts` into the job-search chunk for two functions.
+ * The standing exceptions are `src/lib/job-search/board-cache.ts` and
+ * `src/lib/job-search/watched-companies.ts` (#864), which reach `./crud.ts`
+ * directly for the generic `getRecord`/`putRecord`/`getAllRecords`/
+ * `deleteRecord` accessors. Neither has a domain module here to wrap it — a
+ * `boards.ts` or `watched.ts` would exist for exactly one job-search caller
+ * each — and routing either through this barrel would pull `backup.ts` +
+ * `resumes.ts` into the job-search chunk for a couple of functions.
  */
 
 export { DB_NAME, closeDB } from "./db.ts";

--- a/src/lib/storage/letters.test.ts
+++ b/src/lib/storage/letters.test.ts
@@ -202,12 +202,12 @@ describe("storage: letters schema migration v2 → v3 (#711)", () => {
     // Read the OPEN database's version, not the module constant — a test that
     // compared `DB_VERSION` to itself would pass even if `upgrade()` never ran.
     //
-    // The literal moves with every schema bump (4 since #730) because a v2
+    // The literal moves with every schema bump (5 since #864) because a v2
     // profile migrates ALL the way forward, not one step: `upgrade()` runs for
     // the whole range `(oldVersion, DB_VERSION]`. What this case is actually
     // about is the `letters` store below — that a profile written before it
     // existed comes back with it present and its resumes and jobs untouched.
-    expect(db.version).toBe(4);
+    expect(db.version).toBe(5);
     expect(db.objectStoreNames.contains("letters")).toBe(true);
 
     expect((await getAllResumes()).map((r) => r.filename)).toEqual(["cv.pdf"]);

--- a/src/lib/storage/sync-schema.test.ts
+++ b/src/lib/storage/sync-schema.test.ts
@@ -94,8 +94,10 @@ describe("storage: schema migration v3 → v4 (#730)", () => {
 
     const db = await getDB();
     // The OPEN database's version, not the module constant — see the note in
-    // `db.ts` on why `DB_VERSION` is private.
-    expect(db.version).toBe(4);
+    // `db.ts` on why `DB_VERSION` is private. Pinned to the CURRENT
+    // `DB_VERSION` (5 as of #864), not literally 4: `getDB()` always migrates
+    // to whatever `DB_VERSION` is now, past v4 as later stores are added.
+    expect(db.version).toBe(5);
 
     expect((await getAllResumes()).map((r) => r.filename)).toEqual(["cv.pdf"]);
     expect((await getAllJobs()).map((j) => j.title)).toEqual(["Staff Engineer"]);
@@ -135,7 +137,7 @@ describe("storage: schema migration v3 → v4 (#730)", () => {
     // oldVersion 0 runs every block in one transaction, so block 4 creates its
     // indexes on stores blocks 1 and 3 made moments earlier.
     const db = await getDB();
-    expect(db.version).toBe(4);
+    expect(db.version).toBe(5);
     expect(db.objectStoreNames.contains("sync")).toBe(true);
     expect(
       Array.from(db.transaction("jobs").objectStore("jobs").indexNames),

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -316,6 +316,23 @@ export const JOB_ORIGINS: readonly JobOrigin[] = [
   "manual",
 ];
 
+/** A company on the user's persisted job-search shortlist (#864) — a
+ *  statement of user intent, unlike `BoardCacheRecord`'s re-fetchable cache.
+ *  `ats` is kept as a bare string rather than importing job-search's `Ats`
+ *  union, for the same reason `BoardCacheRecord.postings` stays `unknown[]`:
+ *  this module doesn't import the job-search graph. Not in
+ *  `SyncableStoreName` and absent from the backup document — local-first,
+ *  per-browser, no account, no export (see the issue's out-of-scope list). */
+export interface WatchedCompanyRecord extends StoredRecord {
+  /** ATS vendor — `"greenhouse"` | `"lever"` | `"ashby"`, mirrored from
+   *  job-search's `Ats` union. */
+  ats: string;
+  /** The ATS board slug, e.g. "stripe". */
+  slug: string;
+  /** Display name, e.g. "Stripe". */
+  displayName: string;
+}
+
 /** A cached company ATS board: the light-index postings one board returned,
  *  keyed `${ats}:${slug}` (#533). A pure CACHE — deliberately absent from the
  *  backup document, because re-fetching a board is cheap and a stale export
@@ -397,7 +414,7 @@ export interface LetterRecord extends StoredRecord {
  * neither, so it gets its own two-function accessor (`sync-cursor.ts`) rather
  * than a cast that would let `putRecord` write a `createdAt` onto a bookmark.
  */
-export type StoreName = "resumes" | "jobs" | "boards" | "letters";
+export type StoreName = "resumes" | "jobs" | "boards" | "letters" | "watched";
 
 /** A resume as it appears in an export file: blob replaced by base64 + MIME so
  *  the whole backup is a single JSON document. */

--- a/src/lib/watched-companies-bridge.test.ts
+++ b/src/lib/watched-companies-bridge.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the read-only watched-companies responder (#864). Mirrors
+ * `extension-profile.test.ts`'s harness — replies are dispatched as synthetic
+ * `MessageEvent`s and outgoing posts are recorded, per
+ * `__test-utils__/extension-channel.ts`'s docblock on why jsdom cannot
+ * exercise the accept path on its own. Needs `fake-indexeddb/auto`, unlike
+ * `extension-profile.test.ts`, because `getWatchedCompanies` hits IndexedDB.
+ */
+
+import "fake-indexeddb/auto";
+import { deleteDB } from "idb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EXTENSION_CHANNEL } from "./extension-profile.ts";
+import { listenForWatchedCompaniesRequests } from "./watched-companies-bridge.ts";
+import { DB_NAME, closeDB } from "./storage/db.ts";
+import { saveWatchedCompany } from "./job-search/watched-companies.ts";
+import {
+  dispatchFromExtension as reply,
+  recordPostMessage,
+  type PostedMessage,
+} from "./__test-utils__/extension-channel.ts";
+
+let posted: PostedMessage[];
+let unsubscribe: (() => void) | null = null;
+
+beforeEach(async () => {
+  await closeDB();
+  await deleteDB(DB_NAME);
+  posted = recordPostMessage();
+});
+
+afterEach(() => {
+  unsubscribe?.();
+  unsubscribe = null;
+  vi.restoreAllMocks();
+});
+
+/**
+ * Waits for the responder's async `getWatchedCompanies().then(...)` to post
+ * its reply, polling a bounded number of ticks rather than a single one — the
+ * real IndexedDB round-trip through `fake-indexeddb` takes more than one
+ * microtask, and under-waiting here left a reply landing mid-way through the
+ * NEXT test, past that test's own `deleteDB`, and threw an unhandled
+ * `InvalidStateError` from a transaction against an already-deleted database.
+ * A fixed tick budget rather than a wall-clock deadline, so the "nothing
+ * arrives" negative tests don't each pay a real-time timeout.
+ */
+async function flush(): Promise<void> {
+  for (let tick = 0; tick < 50 && posted.length === 0; tick++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/** Simulates a blocked IndexedDB (private browsing, a content blocker, corporate
+ *  policy) — mirrors `CompanyTargets.test.tsx`'s helper of the same name. */
+async function withStorageBlocked(body: () => Promise<void>): Promise<void> {
+  const original = globalThis.indexedDB;
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: {
+      open() {
+        throw new Error("storage disabled");
+      },
+    },
+  });
+  await closeDB();
+  try {
+    await body();
+  } finally {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: original,
+    });
+    await closeDB();
+  }
+}
+
+describe("listenForWatchedCompaniesRequests", () => {
+  it("replies with an empty list on an empty store", async () => {
+    unsubscribe = listenForWatchedCompaniesRequests();
+    reply({ channel: EXTENSION_CHANNEL, type: "get-watched-companies" });
+    await flush();
+
+    expect(posted).toHaveLength(1);
+    expect(posted[0].targetOrigin).toBe(window.location.origin);
+    expect(posted[0].message).toEqual({
+      channel: EXTENSION_CHANNEL,
+      type: "watched-companies",
+      ok: true,
+      companies: [],
+    });
+  });
+
+  it("replies with ok: false, distinguishable from a genuinely empty store, on a read failure", async () => {
+    await withStorageBlocked(async () => {
+      unsubscribe = listenForWatchedCompaniesRequests();
+      reply({ channel: EXTENSION_CHANNEL, type: "get-watched-companies" });
+      await flush();
+
+      expect(posted).toHaveLength(1);
+      expect(posted[0].message).toEqual({
+        channel: EXTENSION_CHANNEL,
+        type: "watched-companies",
+        ok: false,
+        companies: [],
+      });
+    });
+  });
+
+  it("replies with the saved companies, in the wire shape", async () => {
+    const saved = await saveWatchedCompany({
+      name: "Stripe",
+      ats: "greenhouse",
+      slug: "stripe",
+      sectors: ["fintech"],
+    });
+    unsubscribe = listenForWatchedCompaniesRequests();
+    reply({ channel: EXTENSION_CHANNEL, type: "get-watched-companies" });
+    await flush();
+
+    expect(posted).toHaveLength(1);
+    const message = posted[0].message as { companies: unknown[] };
+    expect(message.companies).toEqual([
+      {
+        id: saved.id,
+        ats: "greenhouse",
+        slug: "stripe",
+        displayName: "Stripe",
+        addedAt: saved.addedAt,
+      },
+    ]);
+  });
+
+  it("ignores a request from another origin", async () => {
+    unsubscribe = listenForWatchedCompaniesRequests();
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { channel: EXTENSION_CHANNEL, type: "get-watched-companies" },
+        origin: "https://not-us.example",
+        source: window,
+      }),
+    );
+    await flush();
+
+    expect(posted).toHaveLength(0);
+  });
+
+  it("ignores a request that did not come from this window", async () => {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    unsubscribe = listenForWatchedCompaniesRequests();
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { channel: EXTENSION_CHANNEL, type: "get-watched-companies" },
+        origin: window.location.origin,
+        source: frame.contentWindow,
+      }),
+    );
+    await flush();
+
+    expect(posted).toHaveLength(0);
+    frame.remove();
+  });
+
+  it("ignores an unrelated message type", async () => {
+    unsubscribe = listenForWatchedCompaniesRequests();
+    reply({ channel: EXTENSION_CHANNEL, type: "ping" });
+    await flush();
+
+    expect(posted).toHaveLength(0);
+  });
+
+  it("stops answering after unsubscribe", async () => {
+    unsubscribe = listenForWatchedCompaniesRequests();
+    unsubscribe();
+    unsubscribe = null;
+
+    reply({ channel: EXTENSION_CHANNEL, type: "get-watched-companies" });
+    await flush();
+
+    expect(posted).toHaveLength(0);
+  });
+});

--- a/src/lib/watched-companies-bridge.ts
+++ b/src/lib/watched-companies-bridge.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The read-only app → extension door for the persisted company watchlist
+ * (#864).
+ *
+ * A SEPARATE module from `extension-profile.ts`, per that module's own scope
+ * (one fixed résumé digest, click-gated) — see the reasoning there and the
+ * `company-search-link.ts` precedent for why a second concern gets a second,
+ * separately-audited file rather than widening an already-audited one.
+ *
+ * This channel runs the OPPOSITE direction of every flow in
+ * `extension-profile.ts`: there the app always initiates a request and the
+ * extension replies; here the EXTENSION initiates a request
+ * (`get-watched-companies`) and this module answers it — so this file owns
+ * an always-listening responder rather than a one-shot request/reply.
+ *
+ * **READ-ONLY.** There is no message here that lets the extension write into
+ * the `watched` store — the app owns its own data, and adding a write path is
+ * explicitly out of scope for #864.
+ *
+ * **NO NETWORK.** Reading IndexedDB and posting to a same-tab listener
+ * touches no network primitive — the same property `extension-profile.ts`
+ * asserts of itself, and it holds here for the same reason.
+ *
+ * **Why the "explicit user action, or nothing" rule from `extension-profile.ts`
+ * doesn't carry over.** That module gates on a click because sharing creates a
+ * second on-device copy of a résumé digest outside this origin — a location
+ * the user didn't pick. This responder listens ambiently for the page's
+ * lifetime instead, and that's deliberate: the watchlist is a handful of
+ * company names the user already chose to save *in this app*, not sensitive
+ * corpus text, and answering "what's on it" on request is the whole point of
+ * a read-only door — gating each read behind a click would make the shortlist
+ * useless to the extension. The property that DOES still hold is READ-ONLY:
+ * this file never lets the extension write back, so there's no new copy this
+ * app doesn't already have.
+ */
+
+import { EXTENSION_CHANNEL, isFromThisPage } from "./extension-profile.ts";
+import type { WatchedCompany } from "./job-search/watched-companies.ts";
+
+/** Wire shape of one watched company, as posted to the extension. Kept as its
+ *  own type rather than a re-export of `WatchedCompany` — this is the WIRE
+ *  contract, and the two may drift on purpose later even though they are
+ *  identical today. */
+interface WatchedCompanyWire {
+  id: string;
+  ats: string;
+  slug: string;
+  displayName: string;
+  addedAt: number;
+}
+
+type IncomingRequest = {
+  channel: typeof EXTENSION_CHANNEL;
+  type: "get-watched-companies";
+};
+type OutgoingReply = {
+  channel: typeof EXTENSION_CHANNEL;
+  type: "watched-companies";
+  /** False only on a read failure (storage blocked, IndexedDB threw) — an
+   *  untouched store still replies `ok: true` with an empty list, so the
+   *  extension can tell "no information" apart from "nothing saved". */
+  ok: boolean;
+  companies: WatchedCompanyWire[];
+};
+
+function isGetWatchedCompaniesRequest(value: unknown): value is IncomingRequest {
+  if (value === null || typeof value !== "object") return false;
+  const message = value as { channel?: unknown; type?: unknown };
+  return message.channel === EXTENSION_CHANNEL && message.type === "get-watched-companies";
+}
+
+function toWire(company: WatchedCompany): WatchedCompanyWire {
+  return { ...company };
+}
+
+/**
+ * Start answering `get-watched-companies` requests from the extension. Call
+ * once per page (see `useWatchedCompaniesBridge`); returns the unsubscribe.
+ *
+ * Same-origin check reuses `extension-profile.ts`'s `isFromThisPage`: a
+ * `postMessage` to `window` is visible to every same-page listener, so
+ * `event.source === window` rejects a post from an embedded frame and the
+ * origin check rejects a cross-origin frame holding a handle to this window.
+ */
+export function listenForWatchedCompaniesRequests(): () => void {
+  const appOrigin = window.location.origin;
+  const onMessage = (event: MessageEvent<unknown>) => {
+    if (!isFromThisPage(event, appOrigin)) return;
+    if (!isGetWatchedCompaniesRequest(event.data)) return;
+    void import("./job-search/watched-companies.ts")
+      .then((m) => m.getWatchedCompanies())
+      .then((companies) => {
+        const reply: OutgoingReply = {
+          channel: EXTENSION_CHANNEL,
+          type: "watched-companies",
+          ok: true,
+          companies: companies.map(toWire),
+        };
+        window.postMessage(reply, appOrigin);
+      })
+      .catch(() => {
+        const reply: OutgoingReply = {
+          channel: EXTENSION_CHANNEL,
+          type: "watched-companies",
+          ok: false,
+          companies: [],
+        };
+        window.postMessage(reply, appOrigin);
+      });
+  };
+  window.addEventListener("message", onMessage);
+  return () => window.removeEventListener("message", onMessage);
+}


### PR DESCRIPTION
## Summary

`useCompanyTargets` selected companies from a sector guess but kept the shortlist in memory only, so a reload replaced a user's hand-picked companies with the heuristic's suggestion again. Adds a persisted `watched` IndexedDB store (DB_VERSION 4 → 5) and a per-chip pin affordance (`isWatched`/`toggleWatched`) that saves independently of the per-search selection toggle, so a saved shortlist survives a reload and wins over the sector seed on mount without stomping in-session edits. Also adds a read-only `get-watched-companies` message on a new, separately-audited extension bridge (`watched-companies-bridge.ts`), per the issue's clarification comment.

Closes #864

## Review focus

- `src/hooks/useCompanyTargets.ts` — `loadWatchlist()` isolates the new IndexedDB read from the pre-existing sector/registry dynamic imports, so a blocked/unavailable IndexedDB degrades only the shortlist, never the storage-independent sector-heuristic suggestions. Does the failure isolation actually hold in every combination (chunk-load failure vs read failure vs both)?
- `src/hooks/useCompanyTargets.ts:toggleWatched` — the optimistic `setWatchedKeys` runs before the `watchedApiRef` null-check, so a failed module-load lets the pin visually toggle without persisting (self-resolves on remount). Worth a look, not blocking.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test` green (full suite, 381 files / 6336 passed)
- [x] Adversarial review: 2 rounds, 1 blocking finding fixed (storage-failure regression isolation), 2 nits surviving (see Review focus above and the v4→v5 migration-coverage nit)

## Adversarial review

Two rounds, standalone `/implement-issue` review loop (independent `code-reviewer` subagent per round, adversarial framing).

**Round 1** — 1 blocking, 1 nit.
- **Blocking**: `useCompanyTargets.ts`'s mount effect shared one try/catch between the new `getWatchedCompanies()` IndexedDB read and the pre-existing sector-classification/company-registry dynamic imports. A blocked/unavailable IndexedDB (private browsing, a content blocker, corporate policy) would blank the sector-heuristic suggestions too — a regression, since that path had no storage dependency before this PR. **Fixed**: extracted `loadWatchlist()`, which never rejects — the chunk-load and the read each get their own try/catch, falling back to an empty list on either failure while keeping `watchedApiRef` populated so `toggleWatched` still works going forward. Covered by two new tests simulating a blocked `indexedDB.open`.
- **Nit**: no v4→v5 migration test using the real-legacy-version-database-first pattern `letters.test.ts`/`sync-schema.test.ts` use (existing tests only exercise the fresh-v0-install path). Left open — coverage gap, not a suspected defect.

**Round 2** — re-verified the fix fresh (not just re-read the report), 0 blocking, 1 new nit.
- **Nit**: `toggleWatched`'s optimistic `setWatchedKeys` runs before the `watchedApiRef` null-check, so a failed *module-load* (rarer than the blocked-storage case round 1 fixed) lets the pin visually toggle without persisting — self-resolves on remount, no crash or data loss. Left open.

`clean` after round 2 (zero blocking findings survive). Both surviving nits are also called out under Review focus above.
