### PR TITLE
feat(storage): optional jobId + companyKey letter scope keys (cover-letter contract v2)

### DIFF
--- a/docs/cover-letter-contract.md
+++ b/docs/cover-letter-contract.md
@@ -1,13 +1,20 @@
-# Cover letter contract (v1)
+# Cover letter contract (v2)
 
 **Audience: anyone writing a cover letter into offlinecv from outside this repo** — a Claude Code
 skill driving `offlinecv.org` through browser automation, the browser extension, a script that
 converts drafts out of another tool. You do not need to read the source to implement this. If a rule
 here and the code disagree, that is a bug; file it.
 
-**Status:** version 1, introduced in [#711](https://github.com/offlinecv/OfflineCV/issues/711).
-Implemented by `src/lib/storage/letter-contract.ts` (validation), `src/lib/storage/letters.ts` (the
-store and its integrity rules), and `src/lib/storage/backup.ts` (export/import).
+**Status:** version 2, introduced in [#766](https://github.com/offlinecv/OfflineCV/issues/766);
+version 1 was [#711](https://github.com/offlinecv/OfflineCV/issues/711). Implemented by
+`src/lib/storage/letter-contract.ts` (validation), `src/lib/storage/letters.ts` (the store and its
+integrity rules), `src/lib/storage/company-key.ts` (the company normaliser), and
+`src/lib/storage/backup.ts` (export/import).
+
+**What v2 changed:** a letter is no longer necessarily *for one job*. `jobId` became **optional** and
+`companyKey` joined it, so a letter can be scoped to a job, to a company, or to nothing at all — the
+letter half of [#765](https://github.com/offlinecv/OfflineCV/issues/765)'s standard → company → job
+hierarchy. **If you already produce letters, nothing you send has to change**: see §6.
 
 Records that violate this contract are **refused**, not repaired. offlinecv would rather tell you
 your record was wrong than store a mangled version of it and report success.
@@ -34,7 +41,7 @@ path that produces a letter, so the validator is the only thing standing between
 the object store, and provenance (§6) is the only thing that will ever distinguish your drafts from
 offlinecv's own.
 
-The **PDF export of a letter is out of scope** in v1. `render-ats-pdf.ts` is résumé-shaped
+The **PDF export of a letter is out of scope**, in v2 as in v1. `render-ats-pdf.ts` is résumé-shaped
 (sections / roles / bullets); a letter is a different document model and needs a different renderer.
 
 ---
@@ -50,22 +57,69 @@ document as-is with no encoding step.
 | Field | Type | Meaning |
 |---|---|---|
 | `id` | non-empty string | Primary key. See §2. |
-| `jobId` | non-empty string | The `JobRecord.id` this letter is for. See §5 — this link is what makes the letter reachable. |
 | `body` | string | The letter itself, **markdown**. May be empty (an empty draft is a real state), but the key must be present. |
 
-### Optional
+### Optional — the scope keys
 
 | Field | Type | Meaning |
 |---|---|---|
-| `label` | string | User-facing name, so two drafts for one job are tellable apart (`"Warm open"`, `"Short version"`). |
+| `jobId` | non-empty string | The `JobRecord.id` this letter is for. |
+| `companyKey` | non-empty string | The company this letter is for, **normalised** — see §1.1. |
+
+These two are optional *individually* but not independent. Their combinations form a three-case
+lattice, and **exactly one reading applies to any record**:
+
+| `jobId` | `companyKey` | Reading |
+|---|---|---|
+| set | — | Letter for one job — every letter that existed before v2 |
+| — | set | Letter for one company |
+| — | — | **Standard** letter |
+
+**A record carrying both is REFUSED**, with a reason naming both fields. It has no single reading,
+and resolving it by precedence would mean picking a rule no producer could guess — your letter would
+be filed somewhere you never asked for. Send one key, or neither.
+
+Each key is a non-empty string **when present**, so `""` is a refusal, not a fourth state. **Absent is
+not empty.** An absent key is a positive statement about scope; `""` reads as *set* to a key check and
+as *unset* to every comparison, which is how a letter ends up in no list at all. If you have no
+company name, send no `companyKey` — that is a standard letter, and it is a legitimate record.
+
+### Optional — everything else
+
+| Field | Type | Meaning |
+|---|---|---|
+| `label` | string | User-facing name, so two drafts for one scope are tellable apart (`"Warm open"`, `"Short version"`). |
 | `resumeId` | non-empty string | The `ResumeRecord.id` this letter was written from. **User-owned.** Cleared, not orphaned, if that résumé is deleted — see §5. |
 | `producer` | object | Provenance. See §6. |
 | `createdAt` / `updatedAt` | finite number (epoch ms) | Timestamps. The store owns them; a backup file carries them so a restore preserves both. |
 | `deletedAt` | finite number (epoch ms) | A **tombstone**: the letter is deleted, and its presence says so. See §5. |
 
-`body` is required but **may be empty**, while `jobId` may not. The asymmetry is deliberate: an
-empty draft is something the user can see and fix, whereas a letter with no job is reachable from
-nothing and survives no cascade.
+`body` is required but **may be empty**, while a scope key that is present may not. The asymmetry is
+deliberate: an empty draft is something the user can see and fix, whereas an empty scope key is a
+claim to a scope that does not exist.
+
+### 1.1 Deriving `companyKey`
+
+**There is no company entity in offlinecv.** `JobRecord.company` is free text captured off a posting
+page; it may be empty, and two postings for one employer may spell it differently or differ only in a
+legal suffix. So `companyKey` is a *normalised string*, not a foreign key.
+
+The normalisation is `deriveCompanyKey` in `src/lib/storage/company-key.ts`: lowercase, collapse
+whitespace, drop punctuation, strip **one** trailing legal suffix (`Inc` · `LLC` · `Ltd` · `Limited` ·
+`Corp` · `Corporation` · `Co` · `GmbH` · `S.A.` · `B.V.` · `Pty`). `Northwind`, `Northwind Inc.` and
+`northwind, inc.` all key to `northwind`. An empty or all-punctuation name yields **`undefined`**, not
+`""` — precisely so a job with no company gives you "no key" rather than a key this contract refuses.
+
+Two things follow, and both are load-bearing:
+
+- **Derive the key; do not send the raw name.** A letter written under `"Northwind Inc."` and looked
+  up under `"Northwind"` is a letter the user cannot find. If you cannot run offlinecv's function,
+  reimplement the rules above exactly.
+- **The key is ADVISORY.** It drives a *suggestion the user confirms* ("You have a letter for
+  Northwind — start from it?"), never an automatic attachment. This is the rule `JobRecord.aliasUrls`
+  already states: a link between two things is never inferred, it is confirmed. Normalisation
+  collides, and the cost of a collision must be a suggestion declined — not a letter silently filed
+  under the wrong employer. Do not build identity on this string.
 
 ### Unknown fields are PRESERVED
 
@@ -131,15 +185,44 @@ until IndexedDB's own clone throws.
 This is the part of the contract with no analogue in the job document, and the two links behave
 differently on purpose.
 
-### Deleting the job CASCADES
+### Deleting the job CASCADES — to that job's letters, and only those
 
-**Deleting a job deletes every letter written for it.** Not orphan-and-keep.
+**Deleting a job deletes every letter written for it.** Not orphan-and-keep. A company letter and a
+standard letter are untouched.
 
-A letter reaches every surface through its job — a letters list is a list *within* a job. So a
-letter whose job is gone is unreachable: nothing can list it, open it, edit it, or delete it.
-Keeping it would not preserve anything the user could ever get back; it would only grow the store
-invisibly, against a browser quota they do not see until it is exceeded. `jobId` is required
-precisely so this rule has no exceptions.
+| Deleted | Job letters for it | Company letters at that company | Standard letters |
+|---|---|---|---|
+| A job | **Deleted** (tombstoned) | Untouched | Untouched |
+| The **last** job at a company | **Deleted** | **Untouched** — it was never that job's | Untouched |
+| A résumé | Kept, `resumeId` cleared | Kept, `resumeId` cleared | Kept, `resumeId` cleared |
+
+There is no delete-company action, because there is no company (§1.1). A company letter and a
+standard letter are therefore only ever deleted **explicitly**, by the user, one letter at a time.
+
+#### Why the cascade is right, and why it is right *only* for job letters
+
+v1 justified the cascade with an argument that no longer holds, and it is worth stating what
+replaced it rather than quietly editing the conclusion. v1 said:
+
+> A letter reaches every surface through its job — a letters list is a list *within* a job. So a
+> letter whose job is gone is unreachable: nothing can list it, open it, edit it, or delete it.
+
+That was true when written, and it is exactly what v2 invalidates. Once standard and company letter
+surfaces exist, a jobless letter is **reachable on its own terms** — it is listed, opened, edited and
+deleted from its own scope, not through a job. So "no job" stopped meaning "no way back".
+
+What survives is the narrower claim, and it is enough. A letter that names a *specific, now-deleted*
+job is unreachable: it is scoped to a row that no longer exists, no list can hold it, and keeping it
+would only grow the store invisibly against a browser quota the user does not see until it is
+exceeded. That is a statement about job letters, and only job letters — which is why `jobId` could
+become optional without weakening it.
+
+**The scoping enforces this by construction, not by a guard.** `deleteLettersForJob` sweeps
+`lettersForJob`, which matches `letter.jobId === jobId`; a company or standard letter has no `jobId`
+at all, and `undefined` never equals a real id. If you are reimplementing this: do **not** widen the
+sweep to "letters at this company", and do not add a redundant second check — the first deletes what
+this contract exists to protect, and the second is a weaker copy of a rule the scoping already makes
+airtight.
 
 The cascade lives in the store (`deleteJob` → `deleteLettersForJob`), not in a UI layer, so no
 caller can forget it. The job record is deleted first: if the letter sweep then fails, the delete
@@ -177,13 +260,26 @@ The repair is written with `touch: false`, so `updatedAt` is **not** stamped. A 
 not make must not reshuffle a list sorted most-recently-updated-first — otherwise deleting one
 résumé floats every letter that merely referenced it to the top.
 
-### Known gap in v1: neither link is reconciled on import
+### Known gap: neither link is reconciled on import
 
 **Merge-mode import can strand either link.** A partial or stale backup from another device can
 graft in a letter whose `jobId` matches no job here — that letter is stored but *unreachable*, since
-§5 says a letter is only ever reached through its job — and equally a letter whose `resumeId` matches
-no résumé here, which is the milder degrade (the letter still opens; its résumé line just reads "not
-linked" forever). Nothing sweeps either one today.
+a letter scoped to a specific job is only ever reached through that job — and equally a letter whose
+`resumeId` matches no résumé here, which is the milder degrade (the letter still opens; its résumé
+line just reads "not linked" forever). Nothing sweeps either one today.
+
+v2 makes this gap strictly **smaller**, not larger. A standard letter has no `jobId` to dangle, and a
+company letter's `companyKey` is a derived string rather than a reference — it points at no record,
+so there is no record whose absence could strand it. A merge-import of a v2 backup therefore strands
+*fewer* letters than the same import under v1, and every letter it does strand is a job letter, for
+the same reason as before.
+
+**Sync is the exception, and it is a real one.** The remote `cover_letters` table has no company
+column, and the extension's `letter-mapping.ts` **refuses a pulled row with no `local_job_id`** while
+happily pushing one — so today a standard or company letter uploads and can never come back, failing
+silently on a second device. That asymmetry must be fixed before letters written under v2 are safe to
+sync: <https://github.com/s-annam/recruidea-extension/issues/55>. Local storage and the backup
+document carry both scope keys fine; it is only the sync path that is short.
 
 Jobs are only half-covered by the existing sweep, and not for the same link: `reconcileResumeLinks`
 clears a dangling **`resumeId` on a job**, so it is the analogue of the *second* case above, not the
@@ -212,18 +308,31 @@ Three version numbers exist and they are not the same thing.
 
 ```jsonc
 "producer": {
-  "contract": 1,                          // required within the object: which version you targeted
+  "contract": 2,                          // required within the object: which version you targeted
   "producer": "claude-code-letter-skill", // optional, free text
   "producerVersion": "0.1.0",             // optional
   "generatedAt": 1753900000000            // optional epoch ms — when YOU generated the draft
 }
 ```
 
+### What the bump to 2 asks of you: nothing
+
+`LETTER_CONTRACT_VERSION` is `2` since #766. A v1 producer — one that always sends `jobId` and has
+never heard of `companyKey` — **keeps working untouched**, and is a valid v2 producer that happens to
+write only job letters. Nothing here refuses a record for saying `"contract": 1`, and the validator
+deliberately does not compare your number against its own (see above).
+
+The bump says there is **more you MAY send**, not that anything you already send became wrong. Take
+it up when you have a reason to: a letter that belongs to an employer rather than to one posting, or
+a standard letter holding the candidate-specific material that has no place on a résumé.
+
 The field is `producer` and the timestamp is `generatedAt`, where a job carries `capture` and
 `capturedAt`. That is the distinction, not an inconsistency: a job is *captured* from a page that
 already existed; a letter is *generated*.
 
-`producer` is **optional**, and its absence means "written by offlinecv itself, contract 1". It
+`producer` is **optional**, and its absence means "written by offlinecv itself, contract 1" — the
+version that was current when the field appeared, and the reading a record with no version has
+forever. It
 exists in v1 rather than later because a producer version cannot be retrofitted: once third-party
 producers are writing records, a record with no version is indistinguishable from one written before
 the field existed, and the ambiguity is permanent. Since offlinecv currently writes **no** letters at
@@ -249,9 +358,8 @@ letters. Replace means "make storage match this file"; skipping the wipe would l
 stranded on jobs the restore just deleted, which is exactly the orphan §5's cascade exists to make
 impossible.
 
-Nothing renders `skippedLetters` yet — v1 ships the store with no UI at all. It is reported from the
-first commit anyway, because a counter added later cannot recover the records already dropped in
-silence.
+Nothing renders `skippedLetters` yet. It has been reported since the first commit anyway, because a
+counter added later cannot recover the records already dropped in silence.
 
 ---
 
@@ -263,14 +371,24 @@ typed over `keyof Required<LetterRecord>` and its guards are typed against each 
 That is the mechanism keeping the validator from quietly ceasing to cover a field. Update this
 document in the same change.
 
-Changing §5's cascade rule, or §2's "no derivation", is a **contract version bump** — both are
-things a producer builds assumptions on top of.
+A **cross-field** rule — one where no single value is wrong on its own — has no home in that map and
+goes in `validateLetterRecord` itself, after `checkDeclaredFields`. The both-scope-keys refusal (§1)
+is the only one today; write the reason so it names every field involved, since a producer that sent
+two fields cannot act on a complaint about one.
+
+Changing §5's cascade rule, §2's "no derivation", or §1's scope lattice is a **contract version
+bump** — all three are things a producer builds assumptions on top of. Relaxing a rule still counts:
+v2 made `jobId` optional, which no existing producer had to react to, and it is a bump anyway,
+because the *readings* of a record changed. Adding a field a producer may ignore is what a bump most
+often means; §6 is where you say so, so nobody reads a new number as a demand.
 
 ---
 
 ## Appendix — a complete example
 
 Every value below is synthetic.
+
+### A job letter — one key, and the shape every v1 letter already had
 
 ```json
 {
@@ -280,11 +398,42 @@ Every value below is synthetic.
   "label": "Short version",
   "body": "Dear hiring team,\n\nI am applying for the Staff Engineer role at Northwind. I have spent the last six years on browser-side document tooling, most recently leading the parser rewrite that cut our extraction failures by half.\n\nI would welcome the chance to talk.\n\nJordan Vance\njordan.vance@example.com",
   "producer": {
-    "contract": 1,
+    "contract": 2,
     "producer": "claude-code-letter-skill",
     "producerVersion": "0.1.0",
     "generatedAt": 1753900000000
   },
+  "createdAt": 1753900000000,
+  "updatedAt": 1753900000000
+}
+```
+
+### A company letter — `companyKey` instead, never both
+
+Note the key is the *derived* form (§1.1), not `"Northwind, Inc."` as the posting printed it.
+
+```json
+{
+  "id": "9c4d1e70-8a52-4b39-8f0d-2e6b7c9a4455",
+  "companyKey": "northwind",
+  "label": "Why Northwind",
+  "body": "I have followed Northwind's work on browser-side document tooling since the 3.0 release, and the reason I keep coming back to it is the same reason I want to work there: the constraint that nothing leaves the device is treated as a product decision rather than a limitation.",
+  "producer": { "contract": 2, "producer": "claude-code-letter-skill" },
+  "createdAt": 1753900000000,
+  "updatedAt": 1753900000000
+}
+```
+
+### A standard letter — neither key
+
+The base the other two are tailored *from* (#765), not a generic letter to submit as-is.
+
+```json
+{
+  "id": "2b7f5a13-6c04-4d8e-91a7-5f3e0d8c6612",
+  "label": "Career change narrative",
+  "body": "After six years in infrastructure I moved deliberately into document tooling, and the throughline is the same one I would bring to this role: I like problems where correctness is checkable and the failure modes are silent.",
+  "producer": { "contract": 2, "producer": "claude-code-letter-skill" },
   "createdAt": 1753900000000,
   "updatedAt": 1753900000000
 }

--- a/src/components/features/LetterEditorDialog.tsx
+++ b/src/components/features/LetterEditorDialog.tsx
@@ -46,8 +46,11 @@ import type { LetterRecord } from "../../lib/storage/index.ts";
 interface LetterEditorDialogProps {
   open: boolean;
   onClose: () => void;
-  /** The job this letter belongs to. Required even when editing, because a
-   *  letter with no `jobId` is unreachable from every surface. */
+  /** The job this letter belongs to. Required even when editing: this dialog
+   *  only ever composes a JOB letter, and one that named no job would be
+   *  unreachable from the only surface that opens it. Since #766 the store
+   *  itself allows a company-scoped or standard letter — neither has an editor
+   *  yet, and giving them one is the sibling issue to #766, not this prop. */
   jobId: string;
   /** The letter being revised. Omitted = compose a new draft. */
   letter?: LetterRecord;

--- a/src/hooks/useJobLetters.test.tsx
+++ b/src/hooks/useJobLetters.test.tsx
@@ -4,9 +4,11 @@
 // @vitest-environment jsdom
 
 /**
- * useJobLetters (#715): the grouping + sort the Saved jobs library depends on
- * for its per-row indicator. Exercised through a probe component against
- * `fake-indexeddb`, same pattern as `useResumeLibrary.test.tsx`.
+ * useJobLetters (#715, #766): the grouping + sort the Saved jobs library depends
+ * on for its per-row indicator, and since #766 the three-way scope split under
+ * it. Exercised through a probe component against `fake-indexeddb`, same pattern
+ * as `useResumeLibrary.test.tsx`; the pure grouping gets its own describe at the
+ * bottom, where the `undefined`-key hazard is visible without a render.
  */
 
 import "fake-indexeddb/auto";
@@ -16,7 +18,8 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { DB_NAME, closeDB, saveLetter } from "../lib/storage/index.ts";
 import { tick } from "../lib/storage/__test-utils__/clock.ts";
-import { useJobLetters, type JobLetters } from "./useJobLetters.ts";
+import type { LetterRecord } from "../lib/storage/index.ts";
+import { useJobLetters, groupByScope, type JobLetters } from "./useJobLetters.ts";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -106,5 +109,69 @@ describe("useJobLetters", () => {
       await latest?.refresh();
     });
     expect(latest?.byJobId.has("job-1")).toBe(true);
+  });
+
+  it("splits the three scopes, with no undefined-keyed entry in byJobId (#766)", async () => {
+    await saveLetter({ jobId: "job-1", body: "for the posting" });
+    await saveLetter({ companyKey: "northwind", body: "why Northwind" });
+    await saveLetter({ body: "my story" });
+    await mount();
+
+    expect([...(latest?.byJobId.keys() ?? [])]).toEqual(["job-1"]);
+    expect([...(latest?.byCompanyKey.keys() ?? [])]).toEqual(["northwind"]);
+    expect(latest?.standard).toHaveLength(1);
+  });
+});
+
+/**
+ * The grouping itself, at module scope. A rendered probe proves the hook wires
+ * it up; these prove the `undefined`-key hazard specifically, which is a
+ * property of the loop and not of the subscription around it.
+ */
+describe("groupByScope (#766)", () => {
+  /** Enough of a `LetterRecord` for the grouping — everything it reads is
+   *  present and nothing it does not is invented. */
+  const letter = (fields: Partial<LetterRecord>): LetterRecord =>
+    ({ id: "l", body: "", createdAt: 0, updatedAt: 0, ...fields }) as LetterRecord;
+
+  it("never creates a literal `undefined` key, the failure it exists to prevent", () => {
+    const grouped = groupByScope([
+      letter({ id: "standard" }),
+      letter({ id: "company", companyKey: "northwind" }),
+    ]);
+    // `Map.set(undefined)` would stringify into an entry every consumer reads as
+    // a job — a bucket no `JobRecord.id` can match, holding letters nothing
+    // would then find.
+    expect(grouped.byJobId.size).toBe(0);
+    expect([...grouped.byJobId.keys()]).not.toContain(undefined);
+    expect([...grouped.byJobId.keys()]).not.toContain("undefined");
+    expect(grouped.standard.map((l) => l.id)).toEqual(["standard"]);
+  });
+
+  it("reads a both-keys record as a job letter — the reading it had under v1", () => {
+    // `validateLetterRecord` refuses this shape, so it can only arrive from a
+    // pre-v2 store or a producer that skipped the validator. Filing it under its
+    // job is the only reading that cannot hide it from a surface that already
+    // existed.
+    const grouped = groupByScope([
+      letter({ id: "both", jobId: "job-1", companyKey: "northwind" }),
+    ]);
+    expect(grouped.byJobId.get("job-1")?.map((l) => l.id)).toEqual(["both"]);
+    expect(grouped.byCompanyKey.size).toBe(0);
+    expect(grouped.standard).toEqual([]);
+  });
+
+  it("sorts every tier most-recently-updated first, standard included", () => {
+    const grouped = groupByScope([
+      letter({ id: "job-old", jobId: "j", updatedAt: 1 }),
+      letter({ id: "job-new", jobId: "j", updatedAt: 2 }),
+      letter({ id: "co-old", companyKey: "c", updatedAt: 1 }),
+      letter({ id: "co-new", companyKey: "c", updatedAt: 2 }),
+      letter({ id: "std-old", updatedAt: 1 }),
+      letter({ id: "std-new", updatedAt: 2 }),
+    ]);
+    expect(grouped.byJobId.get("j")?.map((l) => l.id)).toEqual(["job-new", "job-old"]);
+    expect(grouped.byCompanyKey.get("c")?.map((l) => l.id)).toEqual(["co-new", "co-old"]);
+    expect(grouped.standard.map((l) => l.id)).toEqual(["std-new", "std-old"]);
   });
 });

--- a/src/hooks/useJobLetters.ts
+++ b/src/hooks/useJobLetters.ts
@@ -2,7 +2,12 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * useJobLetters — every letter in the store, grouped by job (#715).
+ * useJobLetters — every letter in the store, grouped by scope (#715, #766).
+ *
+ * The name predates the scopes. Since #766 a letter is scoped to a job, to a
+ * company, or to nothing at all, and this hook reads all three off the one
+ * store pass it already made — renaming it would touch every consumer to say
+ * the same thing, which is a cost the sibling UI issue can pay if it wants to.
  *
  * The `letters` store has no per-job index — `lettersForJob` itself filters
  * `getAllLetters()` in memory rather than querying one (see its own comment
@@ -29,9 +34,69 @@ export interface JobLetters {
   ready: boolean;
   /** Every letter for a job id, most-recently-updated first — the same order
    *  `lettersForJob` returns. A job id absent from this map has no letters,
-   *  which is the signal `JobLetterIndicator` uses to render nothing. */
+   *  which is the signal `JobLetterIndicator` uses to render nothing.
+   *
+   *  Since #766 this holds JOB letters only. A jobless letter is not a job with
+   *  no letters, and folding the two together under a literal `undefined` key
+   *  is what the grouping loop below exists to prevent. */
   byJobId: ReadonlyMap<string, LetterRecord[]>;
+  /** Company-scoped letters by `companyKey` (#766), same order. Kept beside
+   *  `byJobId` rather than inside it: the keyspaces are different — a
+   *  `JobRecord.id` and a derived company key — and one map would let a lookup
+   *  by job id collide with a company that happened to key alike. */
+  byCompanyKey: ReadonlyMap<string, LetterRecord[]>;
+  /** Letters scoped to neither a job nor a company (#766), same order. A flat
+   *  list because there is no key to group by — that is what makes them
+   *  standard. */
+  standard: readonly LetterRecord[];
   refresh: () => Promise<void>;
+}
+
+/**
+ * Split every letter into the three scope tiers of the lattice on
+ * `LetterRecord.jobId` (#766), each list most-recently-updated first.
+ *
+ * At module scope, not inside the hook: it is pure and the interesting part is
+ * the `undefined`-key hazard, which is easier to test on a function than
+ * through a rendered probe.
+ *
+ * A letter carrying BOTH keys is a record `validateLetterRecord` refuses, so it
+ * can only reach here from a store written before v2 or by a producer that
+ * skipped the validator §3 tells it to call. It is read as a job letter — the
+ * reading it would have had under v1, which is the only one that cannot hide it
+ * from a surface that already existed.
+ */
+export function groupByScope(letters: readonly LetterRecord[]): {
+  byJobId: Map<string, LetterRecord[]>;
+  byCompanyKey: Map<string, LetterRecord[]>;
+  standard: LetterRecord[];
+} {
+  const byJobId = new Map<string, LetterRecord[]>();
+  const byCompanyKey = new Map<string, LetterRecord[]>();
+  const standard: LetterRecord[] = [];
+
+  for (const letter of letters) {
+    // The `undefined`-key hazard this loop is written around: `Map.set` on an
+    // absent `jobId` would stringify it into a literal `"undefined"` entry that
+    // every consumer treats as a job — a bucket no `JobRecord.id` can ever
+    // match, holding letters no surface would then find.
+    const key = letter.jobId ?? letter.companyKey;
+    if (key === undefined) {
+      standard.push(letter);
+      continue;
+    }
+    const bucket = letter.jobId !== undefined ? byJobId : byCompanyKey;
+    const existing = bucket.get(key);
+    if (existing) existing.push(letter);
+    else bucket.set(key, [letter]);
+  }
+
+  for (const group of [byJobId, byCompanyKey]) {
+    for (const list of group.values()) list.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+  standard.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  return { byJobId, byCompanyKey, standard };
 }
 
 export function useJobLetters(): JobLetters {
@@ -39,6 +104,10 @@ export function useJobLetters(): JobLetters {
   const [byJobId, setByJobId] = useState<ReadonlyMap<string, LetterRecord[]>>(
     () => new Map(),
   );
+  const [byCompanyKey, setByCompanyKey] = useState<ReadonlyMap<string, LetterRecord[]>>(
+    () => new Map(),
+  );
+  const [standard, setStandard] = useState<readonly LetterRecord[]>(() => []);
 
   // `isStale` lets ONE code path serve both callers: the mount effect passes an
   // unmount guard, an imperative caller passes nothing. It is deliberately
@@ -46,18 +115,11 @@ export function useJobLetters(): JobLetters {
   // parameter is invisible to consumers, and inventing a second copy of the
   // load just to hold the guard is how the two would drift.
   const refresh = useCallback(async (isStale: () => boolean = () => false) => {
-    const letters = await getAllLetters();
-    const grouped = new Map<string, LetterRecord[]>();
-    for (const letter of letters) {
-      const forJob = grouped.get(letter.jobId);
-      if (forJob) forJob.push(letter);
-      else grouped.set(letter.jobId, [letter]);
-    }
-    for (const forJob of grouped.values()) {
-      forJob.sort((a, b) => b.updatedAt - a.updatedAt);
-    }
+    const grouped = groupByScope(await getAllLetters());
     if (isStale()) return;
-    setByJobId(grouped);
+    setByJobId(grouped.byJobId);
+    setByCompanyKey(grouped.byCompanyKey);
+    setStandard(grouped.standard);
     setReady(true);
   }, []);
 
@@ -75,5 +137,5 @@ export function useJobLetters(): JobLetters {
     // `[]`, so this runs once per mount. Nothing else is captured.
   }, [refresh]);
 
-  return { ready, byJobId, refresh };
+  return { ready, byJobId, byCompanyKey, standard, refresh };
 }

--- a/src/lib/storage/company-key.test.ts
+++ b/src/lib/storage/company-key.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * The company normaliser behind `LetterRecord.companyKey` (#766).
+ *
+ * Two properties matter and they pull against each other, so both are asserted
+ * directly rather than through a sample of names: spellings of ONE employer
+ * must converge on one key, and an absent name must yield `undefined` rather
+ * than `""` — which the letter contract refuses, so an empty company that keyed
+ * to `""` would make a letter unwritable instead of unscoped.
+ *
+ * Every company named here is fictional.
+ */
+
+import { describe, it, expect } from "vitest";
+import { deriveCompanyKey } from "./company-key.ts";
+
+describe("deriveCompanyKey (#766)", () => {
+  it("maps every spelling of one employer to a single key", () => {
+    const keys = [
+      "Northwind",
+      "northwind",
+      "  Northwind  ",
+      "Northwind Inc.",
+      "northwind, inc.",
+      "NORTHWIND INC",
+      "Northwind LLC",
+      "Northwind Ltd.",
+      "Northwind Limited",
+      "Northwind Corp.",
+      "Northwind Corporation",
+      "Northwind Co.",
+      "Northwind GmbH",
+      "Northwind S.A.",
+      "Northwind B.V.",
+      "Northwind Pty",
+    ].map(deriveCompanyKey);
+
+    expect(new Set(keys)).toEqual(new Set(["northwind"]));
+  });
+
+  it("collapses internal whitespace without joining separate words", () => {
+    expect(deriveCompanyKey("Northwind   Systems\tGroup")).toBe("northwind systems group");
+    // Under-merge on purpose: nothing says these are one employer, and a false
+    // suggestion costs more than a missing one. See `LEGAL_SUFFIXES`.
+    expect(deriveCompanyKey("Northwind Technologies")).not.toBe("northwind");
+  });
+
+  it("returns undefined when there is no name left to key", () => {
+    expect(deriveCompanyKey("")).toBeUndefined();
+    expect(deriveCompanyKey("   ")).toBeUndefined();
+    expect(deriveCompanyKey("  ,  ")).toBeUndefined();
+    expect(deriveCompanyKey("!!!")).toBeUndefined();
+    expect(deriveCompanyKey(undefined)).toBeUndefined();
+    // Every word was a suffix. `""` would be a key the contract refuses, so the
+    // answer has to be "no key" and not "the empty key".
+    expect(deriveCompanyKey("Inc.")).toBeUndefined();
+    expect(deriveCompanyKey("S.A.")).toBeUndefined();
+  });
+
+  it("never returns an empty string, for any input that returns at all", () => {
+    for (const input of ["", " ", ",", "Inc", "a", "北風", "Ltd Co", "3M"]) {
+      const key = deriveCompanyKey(input);
+      expect(key === undefined || key.length > 0).toBe(true);
+    }
+  });
+
+  it("strips one trailing suffix, not a chain of them", () => {
+    // "Ltd Co" is a (bad) company name, not two suffixes to peel: looping would
+    // leave nothing, and "no key" is the wrong answer for a name that exists.
+    expect(deriveCompanyKey("Ltd Co")).toBe("ltd");
+    expect(deriveCompanyKey("Northwind Inc. Ltd.")).toBe("northwind inc");
+  });
+
+  it("only strips a suffix at the END, and only as a whole word", () => {
+    expect(deriveCompanyKey("Inc Northwind")).toBe("inc northwind");
+    expect(deriveCompanyKey("Incline Systems")).toBe("incline systems");
+    expect(deriveCompanyKey("Cointreau")).toBe("cointreau");
+  });
+
+  it("keeps digits and non-Latin letters, which are name characters", () => {
+    expect(deriveCompanyKey("3M")).toBe("3m");
+    expect(deriveCompanyKey("北風 GmbH")).toBe("北風");
+  });
+});

--- a/src/lib/storage/company-key.ts
+++ b/src/lib/storage/company-key.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * Derive `LetterRecord.companyKey` from a free-text company name (#766).
+ *
+ * There is no company entity in this build. `JobRecord.company` is whatever a
+ * capture read off a posting page — it may be empty, it may carry a legal
+ * suffix one board prints and another does not, it may be spaced or cased
+ * differently between two postings for the same employer. So a company-scoped
+ * letter cannot point at a record; it carries a normalised string instead, and
+ * this is the one definition of that normalisation.
+ *
+ * **The key is advisory.** Per #765 it only ever drives a suggestion the user
+ * confirms ("You have a letter for Northwind — start from it?"). Nothing here
+ * auto-attaches a letter to a job, which is what makes a collision affordable:
+ * two employers that normalise alike cost the user a suggestion they decline,
+ * not a letter silently filed under the wrong company. Treat a match as
+ * evidence, never as identity.
+ *
+ * ## Why this is not `normalizeField` from `job-search/raw-postings.ts`
+ *
+ * That sibling (`raw-postings.ts:32`) does the lowercase + whitespace-collapse
+ * half of this and nothing else, in service of cross-provider dedup: two feeds
+ * printing one posting must not read as two. It is private to that module, has
+ * no legal-suffix handling, and lives in `job-search/` — a layer `storage/`
+ * sits below, so importing it here would invert the layering.
+ *
+ * They are also allowed to drift, which is the substantive reason not to share
+ * one: dedup compares a title and a company *from the same fetch* and wants the
+ * most literal comparison that still tolerates spacing. This compares a company
+ * name against one a user may have typed months earlier on another board, and
+ * wants a rougher key. Folding "Northwind" and "Northwind Inc." together is
+ * correct here and would be a bug there.
+ *
+ * Pure and zero-dep, like `score.ts` — no storage, no DOM, no imports.
+ */
+
+/**
+ * Trailing legal-entity suffixes stripped before keying — the list #766
+ * enumerates, no more.
+ *
+ * Matched whole-word against the ALREADY lowercased, punctuation-stripped token
+ * stream, so `Inc` and `Inc.` are one entry, `S.A.` arrives as the two-word
+ * tail `s a`, and `Corp` cannot half-match `Corporation`. The list is
+ * deliberately short and closed: every entry is a suffix that a job board is
+ * known to print inconsistently for the same employer. It is not a general
+ * company-name cleaner — "Northwind Technologies" and "Northwind" are two
+ * companies as far as this function is concerned, because nothing says they are
+ * not, and a key that over-merges is worse than one that under-merges (an
+ * under-merge shows no suggestion; an over-merge suggests the wrong letter).
+ */
+const LEGAL_SUFFIXES = [
+  "corporation",
+  "limited",
+  "gmbh",
+  "corp",
+  "inc",
+  "llc",
+  "ltd",
+  "pty",
+  "s a",
+  "b v",
+  "co",
+];
+
+/** Everything that is not a letter, a digit, or whitespace — replaced with a
+ *  single space, which IS a word boundary and has to be: `S.A.` has to split
+ *  into the two words `s a` for the two-word entry in {@link LEGAL_SUFFIXES} to
+ *  match it, while `Northwind,` just loses its trailing comma to the trim. */
+const PUNCTUATION = /[^\p{L}\p{N}\s]+/gu;
+
+/**
+ * Normalise a company name into a stable key, or `undefined` when there is no
+ * name to key.
+ *
+ * `undefined` — rather than `""` — is the answer for an empty or
+ * all-punctuation input, and that is load-bearing rather than tidy: `""` is a
+ * *refusal* under the letter contract, so a job whose `company` is blank must
+ * yield "no key" and not a key the record cannot legally carry. A caller can
+ * therefore spread the result straight onto a letter.
+ *
+ * Not exhaustive, and not trying to be — see {@link LEGAL_SUFFIXES} on why an
+ * under-merge is the cheaper failure.
+ */
+export function deriveCompanyKey(company: string | undefined): string | undefined {
+  if (company === undefined) return undefined;
+
+  const words = company
+    .toLowerCase()
+    .replace(PUNCTUATION, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 0);
+
+  // One suffix, not a loop: "Northwind Inc. Ltd." is not a company whose two
+  // suffixes should both come off, it is a name this function has no opinion
+  // about. Stripping repeatedly would also eat a real name — "Ltd Co" is a
+  // (bad) company name, and looping would leave nothing.
+  const stripped = stripTrailingSuffix(words);
+
+  // Every word was a suffix ("Inc."), or there were none to begin with. Either
+  // way there is no name left to key, and a key of `""` is not writable.
+  return stripped.length > 0 ? stripped.join(" ") : undefined;
+}
+
+/** `words` with a trailing {@link LEGAL_SUFFIXES} entry removed, or unchanged
+ *  when none matches. A suffix may be more than one word (`s a`), so this
+ *  matches on the joined tail rather than on the last token alone. */
+function stripTrailingSuffix(words: readonly string[]): readonly string[] {
+  for (const suffix of LEGAL_SUFFIXES) {
+    const parts = suffix.split(" ");
+    if (parts.length > words.length) continue;
+    const tail = words.slice(words.length - parts.length).join(" ");
+    if (tail === suffix) return words.slice(0, words.length - parts.length);
+  }
+  return words;
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -71,6 +71,11 @@ export {
   deleteLetter,
   clearLetterResumeLink,
 } from "./letters.ts";
+// `lettersForCompany`, `standardLetters` (`letters.ts`) and `deriveCompanyKey`
+// (`company-key.ts`) are deliberately NOT re-exported here yet (#766). Nothing
+// in this build reads a company or standard letter — the surfaces that will are
+// the sibling UI issue — and a barrel entry with no importer is dead surface
+// fallow flags as such. Add them here in the change that adds the first caller.
 export {
   requestStoragePersistence,
   isStoragePersisted,

--- a/src/lib/storage/jobs.ts
+++ b/src/lib/storage/jobs.ts
@@ -106,12 +106,19 @@ export function getAllJobs(): Promise<JobRecord[]> {
  * TOMBSTONED rather than removed (#730) — see `StoredRecord.deletedAt`.
  *
  * The cascade lives here, at the store, rather than a layer up in
- * `job-tracker.ts`: `LetterRecord.jobId` is a required parent link, so "no
- * letter outlives its job" is referential integrity, not tracker policy, and
- * putting it behind the one door means no future caller of `deleteJob` can
- * forget it. (Contrast `clearResumeLink`, which is called from the resume-delete
- * path a layer up — that one is cross-aggregate policy about a link, not about
- * a child record's existence.)
+ * `job-tracker.ts`: a letter that CARRIES a `LetterRecord.jobId` is that job's
+ * child, so "no letter outlives the job it names" is referential integrity, not
+ * tracker policy, and putting it behind the one door means no future caller of
+ * `deleteJob` can forget it. (Contrast `clearResumeLink`, which is called from
+ * the resume-delete path a layer up — that one is cross-aggregate policy about
+ * a link, not about a child record's existence.)
+ *
+ * `jobId` is OPTIONAL since #766 — a letter may instead be scoped to a company
+ * or to nothing — which narrows the premise above without weakening it: the
+ * sweep runs through `lettersForJob`, so it reaches a letter only by matching
+ * the id it names, and a jobless letter is not this job's child to cascade to.
+ * See `letters.ts`'s {@link deleteLettersForJob} for why that is enforced by
+ * the scoping rather than by a guard.
  *
  * The job goes first. If the letter sweep then fails, the user's actual
  * intent — the job is gone — still happened; the reverse order would let a

--- a/src/lib/storage/letter-contract.ts
+++ b/src/lib/storage/letter-contract.ts
@@ -61,8 +61,13 @@ import {
  * the validator requires `producer.contract` to be a finite number and does not
  * compare it against this constant, because refusing a record from a future
  * version is the forward-compatibility failure §6 exists to avoid.
+ *
+ * `2` since #766: `jobId` became optional and `companyKey` joined it. The bump
+ * says a producer MAY send more, not that it must — one that always sends
+ * `jobId` and never sends `companyKey` is a valid v2 producer that happens to
+ * write only job letters, and nothing here refuses it or asks it to change.
  */
-export const LETTER_CONTRACT_VERSION = 1;
+export const LETTER_CONTRACT_VERSION = 2;
 
 /** A reason a letter was refused. One sentence, addressed to whoever has to fix
  *  the producer or the file. */
@@ -84,9 +89,16 @@ const isLetterProvenance = (value: unknown): value is LetterProvenance =>
  * `body` is `required` but checked with `isString`, not `isNonEmptyString`: an
  * empty draft is a legitimate state (a producer that created the record before
  * filling it, a user who cleared the text), and refusing it would make the
- * store unable to hold something the user can plainly see. `jobId` is the
- * opposite — a letter with an empty `jobId` is reachable from nothing and would
- * survive no cascade, so emptiness there is a refusal.
+ * store unable to hold something the user can plainly see.
+ *
+ * The two SCOPE keys are the opposite (#766). Both are optional — their three
+ * combinations are what give a letter its scope, and the lattice is documented
+ * on {@link LetterRecord.jobId} — but each is `isNonEmptyString`, so `""` is a
+ * refusal and absent is the only way to say "not scoped by this". Were `""`
+ * accepted it would be a silent fourth state that reads as set to every
+ * `hasOwn` check and as unset to every comparison. The one combination the
+ * rules map cannot express — BOTH keys set — is a cross-field rule and is
+ * checked in {@link validateLetterRecord} instead.
  *
  * `createdAt` / `updatedAt` are optional because `putRecord` owns them: a
  * backup carries them (so `createdAt` survives a restore) and a fresh write
@@ -103,7 +115,8 @@ export const LETTER_RECORD_RULES: {
   // reason: the export document holds deletions so a restore does not resurrect
   // them. See §5 of the contract doc.
   deletedAt: { required: false, check: isFiniteNumber, expected: "a finite epoch-ms number" },
-  jobId: { required: true, check: isNonEmptyString, expected: "a non-empty string" },
+  jobId: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
+  companyKey: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
   resumeId: { required: false, check: isNonEmptyString, expected: "a non-empty string" },
   body: { required: true, check: isString, expected: "a string" },
   label: { required: false, check: isString, expected: "a string" },
@@ -131,6 +144,13 @@ const KNOWN_FIELDS = new Set(Object.keys(LETTER_RECORD_RULES));
  * Nothing is repaired. The job contract defaults an absent `status` because it
  * has a lifecycle a producer can reasonably have no opinion about; a letter has
  * no such field, so every refusal here is a genuine "this record is not one".
+ *
+ * The one rule here that is not in {@link LETTER_RECORD_RULES} is the both-keys
+ * refusal (#766), and it is here because it is CROSS-FIELD: a rules map judges
+ * one value at a time and neither key is wrong on its own. It runs after
+ * `checkDeclaredFields` so a record that is malformed *and* over-scoped is told
+ * about its malformed field first, rather than being handed a scope complaint
+ * about a `jobId` that was never a string.
  */
 export function validateLetterRecord(value: unknown): LetterRecordValidation {
   if (!isPlainObject(value)) {
@@ -143,6 +163,20 @@ export function validateLetterRecord(value: unknown): LetterRecordValidation {
   const { reasons, checked } = checkDeclaredFields(value, LETTER_RECORD_RULES);
   if (reasons.length > 0) return { ok: false, reasons };
 
+  // Scope is a three-case lattice — job, company, or standard — and both keys
+  // set is none of them. Refused rather than resolved by precedence: a producer
+  // that sent both cannot be told which one this build would have honoured, so
+  // picking one would file the letter somewhere it never asked for. `checked`
+  // rather than `value` because a key present as `undefined` is absent.
+  if (checked.jobId !== undefined && checked.companyKey !== undefined) {
+    return {
+      ok: false,
+      reasons: [
+        "A letter record must not carry both `jobId` and `companyKey`: a letter is scoped to one job, or to one company, or to neither (a standard letter).",
+      ],
+    };
+  }
+
   // Only once the record is otherwise accepted — a refused record has nothing
   // to preserve, and a preserved key that can't survive the next export would
   // be preservation in name only.
@@ -151,7 +185,7 @@ export function validateLetterRecord(value: unknown): LetterRecordValidation {
     return { ok: false, reasons: [`\`${problem.path}\`: ${problem.reason}.`] };
   }
 
-  // `id`, `jobId` and `body` were just proved to be strings, and the store owns
+  // `id` and `body` were just proved to be strings, and the store owns
   // `createdAt` / `updatedAt` (see `putRecord`) — but `checked` is an erased
   // `Record<string, unknown>`, so that proof lives in the rules map rather than
   // in a type the compiler can follow from here. Asserted through `unknown`

--- a/src/lib/storage/letters.test.ts
+++ b/src/lib/storage/letters.test.ts
@@ -24,13 +24,20 @@ import {
   getLetter,
   getAllLetters,
   lettersForJob,
+  lettersForCompany,
+  standardLetters,
   deleteLetter,
   deleteLettersForJob,
   clearLetterResumeLink,
 } from "./letters.ts";
 import { saveJob, getAllJobs, deleteJob } from "./jobs.ts";
+import { deriveCompanyKey } from "./company-key.ts";
 import { saveResume, getAllResumes } from "./resumes.ts";
-import { validateLetterRecord, LETTER_RECORD_RULES } from "./letter-contract.ts";
+import {
+  validateLetterRecord,
+  LETTER_RECORD_RULES,
+  LETTER_CONTRACT_VERSION,
+} from "./letter-contract.ts";
 import { exportAll, exportToJson, importAll, importFromJson } from "./backup.ts";
 import { tick } from "./__test-utils__/clock.ts";
 import type { LetterRecord, StorageExport } from "./types.ts";
@@ -87,6 +94,64 @@ describe("storage: letters CRUD (#711)", () => {
   });
 });
 
+describe("storage: letter scope keys (#766)", () => {
+  it("saves a company letter with no jobId and reads it back from lettersForCompany", async () => {
+    const saved = await saveLetter({ companyKey: "northwind", body: BODY, label: "Why here" });
+    expect(saved.jobId).toBeUndefined();
+    expect(saved.companyKey).toBe("northwind");
+
+    expect((await lettersForCompany("northwind")).map((l) => l.id)).toEqual([saved.id]);
+    expect(await lettersForCompany("contoso")).toEqual([]);
+    // It is not a job letter and not a standard one — exactly one reading.
+    expect(await standardLetters()).toEqual([]);
+  });
+
+  it("saves a standard letter with neither key and reads it back from standardLetters", async () => {
+    const saved = await saveLetter({ body: BODY, label: "My story" });
+    expect(saved.jobId).toBeUndefined();
+    expect(saved.companyKey).toBeUndefined();
+
+    expect((await standardLetters()).map((l) => l.id)).toEqual([saved.id]);
+    expect(await lettersForCompany("northwind")).toEqual([]);
+  });
+
+  it("keeps the three scopes apart, each most-recently-updated first", async () => {
+    const older = await saveLetter({ companyKey: "northwind", body: "older" });
+    await tick();
+    const newer = await saveLetter({ companyKey: "northwind", body: "newer" });
+    await saveLetter({ jobId: "job-1", body: "for the posting" });
+    await saveLetter({ body: "standard" });
+
+    expect((await lettersForCompany("northwind")).map((l) => l.id)).toEqual([
+      newer.id,
+      older.id,
+    ]);
+    expect(await lettersForJob("job-1")).toHaveLength(1);
+    expect(await standardLetters()).toHaveLength(1);
+    expect(await getAllLetters()).toHaveLength(4);
+  });
+
+  it("a jobless letter is invisible to lettersForJob, whatever it is asked for", async () => {
+    // The property the cascade rests on, asserted on the reader it rests on:
+    // `undefined` never equals a real id, so no `jobId` argument can reach one.
+    await saveLetter({ companyKey: "northwind", body: "company" });
+    await saveLetter({ body: "standard" });
+    for (const id of ["job-1", "", "undefined", "northwind"]) {
+      expect(await lettersForJob(id)).toEqual([]);
+    }
+  });
+
+  it("company letters are keyed by the DERIVED key, so two spellings find one letter", async () => {
+    // `deriveCompanyKey` is the caller's job, not the store's — the store
+    // compares keys. This is the round trip a suggestion surface will make.
+    const key = deriveCompanyKey("Northwind, Inc.");
+    await saveLetter({ companyKey: key, body: BODY });
+    expect((await lettersForCompany(deriveCompanyKey("northwind")!)).map((l) => l.body)).toEqual([
+      BODY,
+    ]);
+  });
+});
+
 describe("storage: letters follow their job and their résumé (#711)", () => {
   it("CASCADES: deleting a job deletes its letters, and only its letters", async () => {
     const job = await saveJob({ title: "Staff Engineer" });
@@ -103,6 +168,42 @@ describe("storage: letters follow their job and their résumé (#711)", () => {
     expect(await lettersForJob(job.id)).toEqual([]);
     expect((await getAllLetters()).map((l) => l.id)).toEqual([survivor.id]);
     expect((await getAllJobs()).map((j) => j.id)).toEqual([other.id]);
+  });
+
+  it("CASCADES to job letters ONLY — company and standard letters survive (#766)", async () => {
+    // The invariant the whole lattice rests on, asserted directly rather than
+    // inferred from `lettersForJob`'s filter: deleting the LAST job at a company
+    // must not take that company's letter with it, because the letter was never
+    // that job's.
+    const job = await saveJob({ title: "Staff Engineer", company: "Northwind" });
+    const key = deriveCompanyKey("Northwind")!;
+    await saveLetter({ jobId: job.id, body: "for the posting" });
+    const company = await saveLetter({ companyKey: key, body: "why Northwind" });
+    const standard = await saveLetter({ body: "my story" });
+
+    expect(await deleteLettersForJob(job.id)).toBe(1);
+    await deleteJob(job.id);
+
+    expect(await getAllJobs()).toEqual([]);
+    expect(await lettersForJob(job.id)).toEqual([]);
+    expect((await lettersForCompany(key)).map((l) => l.id)).toEqual([company.id]);
+    expect((await standardLetters()).map((l) => l.id)).toEqual([standard.id]);
+    expect((await getAllLetters()).map((l) => l.id).sort()).toEqual(
+      [company.id, standard.id].sort(),
+    );
+  });
+
+  it("the cascade stays idempotent with jobless letters in the store (#766)", async () => {
+    const job = await saveJob({ title: "Staff Engineer" });
+    await saveLetter({ jobId: job.id, body: "for the posting" });
+    await saveLetter({ companyKey: "northwind", body: "why Northwind" });
+    await saveLetter({ body: "my story" });
+
+    expect(await deleteLettersForJob(job.id)).toBe(1);
+    // A retried cascade finds nothing live and must not start counting — or
+    // worse, re-stamping — the letters it was never entitled to touch.
+    expect(await deleteLettersForJob(job.id)).toBe(0);
+    expect(await getAllLetters()).toHaveLength(2);
   });
 
   it("cascade is a no-op for a job that never had a letter", async () => {
@@ -262,12 +363,7 @@ describe("storage: letter contract (#711)", () => {
     expect(result.record).toEqual(validLetter());
   });
 
-  it("names a missing jobId, a non-string body, and a non-JSON-safe field", () => {
-    const missingJob = validateLetterRecord(validLetter({ jobId: undefined }));
-    expect(missingJob.ok).toBe(false);
-    if (missingJob.ok) return;
-    expect(missingJob.reasons.join(" ")).toContain("`jobId` is required");
-
+  it("names a non-string body and a non-JSON-safe field", () => {
     const badBody = validateLetterRecord(validLetter({ body: 42 }));
     expect(badBody.ok).toBe(false);
     if (badBody.ok) return;
@@ -283,10 +379,14 @@ describe("storage: letter contract (#711)", () => {
     expect(notJsonSafe.reasons.join(" ")).toContain("Date");
   });
 
-  it("refuses an empty jobId but accepts an empty body", () => {
-    // A letter with no job is reachable from nothing; an empty draft is a state
-    // the user can plainly see and fix.
+  it("refuses an empty scope key but accepts an empty body", () => {
+    // Absent ≠ empty (#766). An absent key is a scope statement; `""` is a
+    // fourth state that reads as set to `hasOwn` and unset to every comparison,
+    // so it stays a refusal. An empty draft is a state the user can see and fix.
     expect(validateLetterRecord(validLetter({ jobId: "" })).ok).toBe(false);
+    expect(
+      validateLetterRecord(validLetter({ jobId: undefined, companyKey: "" })).ok,
+    ).toBe(false);
     expect(validateLetterRecord(validLetter({ body: "" })).ok).toBe(true);
   });
 
@@ -320,6 +420,54 @@ describe("storage: letter contract (#711)", () => {
     expect(record.revision).toBe(3);
   });
 
+  it("accepts all three scope readings, and refuses the fourth (#766)", () => {
+    const job = validateLetterRecord(validLetter());
+    expect(job.ok).toBe(true);
+
+    const company = validateLetterRecord(
+      validLetter({ jobId: undefined, companyKey: "northwind" }),
+    );
+    expect(company.ok).toBe(true);
+    if (company.ok) expect(company.record.companyKey).toBe("northwind");
+
+    const standard = validateLetterRecord(validLetter({ jobId: undefined }));
+    expect(standard.ok).toBe(true);
+    if (standard.ok) {
+      expect(standard.record.jobId).toBeUndefined();
+      expect(standard.record.companyKey).toBeUndefined();
+    }
+
+    // Both keys set has no single reading, and resolving it by precedence would
+    // file the letter somewhere the producer never asked for.
+    const both = validateLetterRecord(validLetter({ companyKey: "northwind" }));
+    expect(both.ok).toBe(false);
+    if (both.ok) return;
+    const reason = both.reasons.join(" ");
+    expect(reason).toContain("`jobId`");
+    expect(reason).toContain("`companyKey`");
+  });
+
+  it("a v1-shaped record still validates and stores unchanged (#766)", async () => {
+    // The forward-compatibility half of the bump: a producer written against v1
+    // always sends `jobId` and has never heard of `companyKey`. Nothing about it
+    // changes, and it must not have to know the contract moved.
+    const v1 = validLetter({ producer: { contract: 1 } });
+    const result = validateLetterRecord(v1);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.record).toEqual(v1);
+
+    await importAll(backupWith([v1]));
+    const [stored] = await getAllLetters();
+    expect(stored.jobId).toBe("job-1");
+    expect(stored.companyKey).toBeUndefined();
+    expect((await lettersForJob("job-1")).map((l) => l.id)).toEqual(["letter-1"]);
+  });
+
+  it("the contract version is 2, matching the doc header (#766)", () => {
+    expect(LETTER_CONTRACT_VERSION).toBe(2);
+  });
+
   it.each(Object.keys(LETTER_RECORD_RULES))(
     "the rule for `%s` actually rejects something",
     (field) => {
@@ -332,6 +480,22 @@ describe("storage: letter contract (#711)", () => {
     },
   );
 });
+
+/**
+ * A parsed backup document with the two fields no export can reproduce removed:
+ * `exportedAt` (stamped per export) and every record's `updatedAt` (restamped by
+ * `putRecord` on the import write). What is left is what an export → import →
+ * export cycle is required to preserve exactly.
+ */
+function stripVolatile(json: string): unknown {
+  const doc = JSON.parse(json) as {
+    exportedAt?: number;
+    letters?: Record<string, unknown>[];
+  };
+  delete doc.exportedAt;
+  for (const letter of doc.letters ?? []) delete letter.updatedAt;
+  return doc;
+}
 
 /** A backup document carrying exactly the letters given, and nothing else. */
 function backupWith(letters: unknown[]): StorageExport {
@@ -372,6 +536,34 @@ describe("storage: letters through export / import (#711)", () => {
     const [restored] = await getAllLetters();
     expect(restored).toEqual({ ...saved, updatedAt: expect.any(Number) });
     expect(restored.createdAt).toBe(saved.createdAt);
+  });
+
+  it("round-trips a company letter and a standard letter byte-identically (#766)", async () => {
+    // Byte-identical, not merely field-equal: the scope keys ride the backup
+    // document as ordinary JSON, and a company letter that came back as a
+    // standard one would be a letter silently unfiled.
+    await saveLetter({ companyKey: "northwind", body: BODY, label: "Why here" });
+    await saveLetter({ body: "My story", label: "Standard" });
+
+    const first = await exportToJson();
+
+    await closeDB();
+    await deleteDB(DB_NAME);
+    const counts = await importFromJson(first, "replace");
+    expect(counts.letters).toBe(2);
+    expect(counts.skippedLetters).toEqual([]);
+
+    const second = await exportToJson();
+    // `exportedAt` is stamped per export, and `updatedAt` is restamped by
+    // `putRecord` on any write that does not opt out — the pre-existing rule for
+    // every record type. Everything else must be identical, including both
+    // scope keys and the ABSENCE of the one each letter does not carry.
+    expect(stripVolatile(second)).toEqual(stripVolatile(first));
+
+    const company = (await lettersForCompany("northwind"))[0];
+    expect(company.companyKey).toBe("northwind");
+    expect("jobId" in company).toBe(false);
+    expect(await standardLetters()).toHaveLength(1);
   });
 
   it("survives the JSON string round-trip, not just the in-memory object", async () => {
@@ -432,7 +624,9 @@ describe("storage: letters through export / import (#711)", () => {
     const counts = await importAll(
       backupWith([
         validLetter(),
-        validLetter({ id: "letter-2", label: "Second", jobId: undefined }),
+        // `""` rather than an absent `jobId`, which since #766 is a standard
+        // letter and perfectly valid.
+        validLetter({ id: "letter-2", label: "Second", jobId: "" }),
         validLetter({ id: "letter-3", body: null }),
       ]),
     );

--- a/src/lib/storage/letters.ts
+++ b/src/lib/storage/letters.ts
@@ -17,6 +17,22 @@
  * unreachable: {@link deleteLettersForJob} cascades from `deleteJob`, and
  * {@link clearLetterResumeLink} degrades a deleted résumé's link the way
  * `clearResumeLink` already does for jobs.
+ *
+ * Since #766 a letter is scoped to a job, to a company, or to nothing at all —
+ * the lattice on {@link LetterRecord.jobId} — and the three readers here
+ * ({@link lettersForJob}, {@link lettersForCompany}, {@link standardLetters})
+ * partition the store between them for any record the CONTRACT accepted.
+ *
+ * Not for one it did not. `saveLetter` validates nothing by design, so a
+ * both-keyed record — reachable only by skipping `validateLetterRecord`, which
+ * §3 of the contract doc requires a producer to call — comes back from
+ * `lettersForJob` AND `lettersForCompany`. These readers FILTER; they do not
+ * resolve. `useJobLetters`' `groupByScope` does resolve the same record, to
+ * job-only, and the difference is structural rather than a disagreement to
+ * reconcile: a map entry has to choose one bucket, an independent query does
+ * not. Teaching these three a precedence rule would mean encoding a reading for
+ * a shape the contract says cannot exist — the same defensive-second-copy
+ * mistake {@link deleteLettersForJob} warns against below.
  */
 
 import {
@@ -32,18 +48,25 @@ import type { LetterRecord } from "./types.ts";
  * Save a letter. Generates a UUID when `id` is absent; timestamps are managed
  * by `putRecord`.
  *
- * The input is a `Partial<LetterRecord>` narrowed to require `jobId` and
- * `body` — the two fields without which the record means nothing — rather than
- * the fully-specified shape `saveResume` takes. That is the same permissive
- * write `saveJob` makes, for the same reason: a stored letter may carry unknown
- * extra keys the contract PRESERVED on import, and a housekeeping write that
- * spreads a record back through here must not silently drop them.
+ * The input is a `Partial<LetterRecord>` narrowed to require `body` — the one
+ * field without which the record means nothing — rather than the fully-
+ * specified shape `saveResume` takes. That is the same permissive write
+ * `saveJob` makes, for the same reason: a stored letter may carry unknown extra
+ * keys the contract PRESERVED on import, and a housekeeping write that spreads
+ * a record back through here must not silently drop them.
+ *
+ * `jobId` left the required `Pick` in #766, when it became one of two optional
+ * scope keys rather than the record's spine. What replaced it is not a weaker
+ * requirement here but a different one elsewhere: the both-keys-set refusal is
+ * cross-field and lives in `validateLetterRecord`, which §3 of the contract doc
+ * requires a producer to call — `saveLetter` is the raw store wrapper and
+ * validates nothing, exactly as it did before.
  *
  * `touch: false` preserves `updatedAt` for a write the user did not make — see
  * `putRecord`.
  */
 export async function saveLetter(
-  input: Partial<LetterRecord> & Pick<LetterRecord, "jobId" | "body">,
+  input: Partial<LetterRecord> & Pick<LetterRecord, "body">,
   options: { touch?: boolean } = {},
 ): Promise<LetterRecord> {
   return putRecord<LetterRecord>(
@@ -86,14 +109,59 @@ export async function lettersForJob(jobId: string): Promise<LetterRecord[]> {
 }
 
 /**
+ * Every letter written for one company (#766), most-recently-updated first —
+ * the company tier of the scope lattice on {@link LetterRecord.jobId}.
+ *
+ * `companyKey` is a DERIVED, advisory string (see `company-key.ts`), so a
+ * caller holding a `JobRecord` must run `deriveCompanyKey(job.company)` rather
+ * than passing the free text: two spellings of one employer key alike, and
+ * comparing raw names here would make the letter findable only from the posting
+ * it happened to be written beside.
+ */
+export async function lettersForCompany(companyKey: string): Promise<LetterRecord[]> {
+  const letters = await getAllLetters();
+  return letters
+    .filter((letter) => letter.companyKey === companyKey)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * Every letter scoped to neither a job nor a company (#766), most-recently-
+ * updated first — the standard tier, and per #765 the SOURCE the other two are
+ * derived from rather than a fallback beneath them.
+ *
+ * Both keys are tested, not just `jobId`: a record with both is refused by
+ * `validateLetterRecord`, but this store also holds records written before that
+ * validator ran and records a future contract may shape differently, and
+ * "standard" has to mean unscoped by anything rather than merely jobless.
+ */
+export async function standardLetters(): Promise<LetterRecord[]> {
+  const letters = await getAllLetters();
+  return letters
+    .filter((letter) => letter.jobId === undefined && letter.companyKey === undefined)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
  * Cascade: delete every letter written for `jobId`. Returns how many were
  * deleted; a no-op when the job had none.
  *
- * **Cascade, not orphan** — the decision #711 asks to be written down. A letter
- * reaches every surface through its job, so a letter whose job is gone is
+ * **Cascade, not orphan** — the decision #711 asks to be written down. A JOB
+ * letter reaches every surface through its job, so one whose job is gone is
  * unreachable: nothing can list it, open it, or delete it. Orphaning would only
  * grow the store invisibly, and IndexedDB has no quota the user sees until it
- * is exceeded. `jobId` is required precisely so this rule has no exceptions.
+ * is exceeded.
+ *
+ * **Scope-limited by construction, and do not "fix" it with a filter** (#766).
+ * `lettersForJob` matches `letter.jobId === jobId`, and since #766 a company
+ * letter has no `jobId` at all — `undefined` never equals a real id, so the
+ * sweep below cannot see one, and a standard letter is invisible to it for the
+ * same reason. That is the whole guard. A future reader who notices there is no
+ * explicit `companyKey === undefined` check and adds one would be writing a
+ * second, weaker copy of a rule the scoping already enforces; a reader who
+ * instead widens the filter to "any letter at this company" would delete
+ * exactly the records the lattice exists to protect. Deleting the last job at a
+ * company does NOT touch that company's letter: it was never that job's.
  *
  * Called from `deleteJob` rather than a layer up, so the invariant belongs to
  * the store and no future caller can forget it. See §5 of

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -355,11 +355,14 @@ export interface LetterProvenance {
 }
 
 /**
- * A cover letter for one tracked job (#711).
+ * A cover letter, scoped to one job, to one company, or to nothing at all
+ * (#711, #766). The three-case lattice is on {@link LetterRecord.jobId}.
  *
  * A separate store rather than a field on {@link JobRecord} because letters are
- * ITERATED — several drafts per job, and versions of one draft, are the normal
- * case, and a field gives you exactly one forever.
+ * ITERATED — several drafts per scope, and versions of one draft, are the
+ * normal case, and a field gives you exactly one forever. That a letter is no
+ * longer necessarily a job's at all (#766) is the second, independent reason
+ * the same decision was right.
  *
  * Every field is JSON-safe (no `Blob`, unlike `ResumeRecord`), so the whole
  * record rides through the export document as-is with no base64 step.
@@ -371,10 +374,49 @@ export interface LetterProvenance {
  * to describe it in `docs/cover-letter-contract.md`.
  */
 export interface LetterRecord extends StoredRecord {
-  /** The job this letter is for (`JobRecord.id`). Required — a letter with no
-   *  job is unreachable from every surface. Deleting the job CASCADES to its
-   *  letters; see `deleteLettersForJob` and §5 of the contract doc. */
-  jobId: string;
+  /**
+   * The job this letter is for (`JobRecord.id`). Optional since contract v2
+   * (#766), and it is one of two keys that together give a letter its SCOPE.
+   *
+   * Exactly one reading applies to any record:
+   *
+   * | `jobId` | `companyKey` | Reading |
+   * |---|---|---|
+   * | set | — | Letter for one job (every letter written before v2) |
+   * | — | set | Letter for one company |
+   * | — | — | Standard letter |
+   *
+   * **A record carrying BOTH is refused** (`validateLetterRecord`). It has no
+   * single reading, and accepting one would mean picking a precedence rule no
+   * producer could guess. Each key is a non-empty string *when present*, so
+   * `""` stays a refusal rather than becoming a silent fourth state.
+   *
+   * Deleting a job still CASCADES to that job's letters, and cannot reach a
+   * jobless one — `lettersForJob` matches `letter.jobId === jobId` and
+   * `undefined` never equals a real id, so the scoping is what makes the
+   * cascade safe rather than a guard bolted on beside it. See
+   * `deleteLettersForJob` and §5 of the contract doc.
+   *
+   * What v1 said here — that a letter with no job is unreachable from every
+   * surface, so `jobId` had to be required — was true when written and is
+   * exactly what #765 invalidates: once a standard/company letter surface
+   * exists, a jobless letter is reachable.
+   */
+  jobId?: string;
+  /**
+   * The company this letter is for, as a derived key (`deriveCompanyKey` in
+   * `company-key.ts`), for a letter that belongs to an employer rather than to
+   * one posting. See `jobId` above for the lattice the two keys form.
+   *
+   * There is no company entity — {@link JobRecord.company} is free text and may
+   * be empty — so this is a NORMALISED string, not a foreign key, and it is
+   * **advisory**: per #765 it only ever drives a suggestion the user confirms.
+   * Nothing auto-attaches a letter to a job by company match, for the reason
+   * `aliasUrls` gives about links never being inferred: a normaliser collides,
+   * and a false merge must cost a declined suggestion rather than a letter
+   * silently attached to the wrong employer.
+   */
+  companyKey?: string;
   /** Optional link to the saved resume this letter was written from
    *  (`ResumeRecord.id`). Cleared (not orphaned) if that resume is later
    *  deleted — the same rule `JobRecord.resumeId` follows. */


### PR DESCRIPTION
Closes #766. Part of #765 — the store-and-contract half only; no UI.

## What changed

`LetterRecord.jobId` was required and deleting a job cascaded to every letter naming it, so a letter that is not for one specific job could not exist. Both scope keys are now optional and form a three-case lattice, with exactly one reading per record:

| `jobId` | `companyKey` | Reading |
|---|---|---|
| set | — | Letter for one job (every letter that exists today) |
| — | set | Letter for one company |
| — | — | Standard letter |

A record carrying **both is refused**, with a reason naming both fields — it has no single reading, and resolving it by precedence would mean picking a rule no producer could guess. Each key stays `isNonEmptyString` *when present*, so `""` remains a refusal rather than a silent fourth state.

- **`types.ts`** — `jobId?`, new `companyKey?`, docblocks carrying the lattice and why both-set is refused.
- **`letter-contract.ts`** — `jobId` → `required: false`, new `companyKey` rule, `LETTER_CONTRACT_VERSION` → `2`, and the both-set refusal in `validateLetterRecord` (cross-field, so it cannot live in `LETTER_RECORD_RULES`).
- **`company-key.ts`** (new) — pure, zero-dep normaliser: lowercase, collapse whitespace, drop punctuation, strip one trailing legal suffix. Returns `undefined`, never `""`, so a job with no company yields "no key" rather than a key the contract refuses. Its docblock names `normalizeField` in `job-search/raw-postings.ts` and says why they are deliberately not shared (layering, and the two want different roughness).
- **`letters.ts`** — `saveLetter`'s required `Pick` drops to `body`; new `lettersForCompany` and `standardLetters`; `deleteLettersForJob` gains the by-construction safety note.
- **`useJobLetters.ts`** — the grouping loop no longer creates a literal `undefined` map key; `byCompanyKey` and `standard` are exposed beside `byJobId`. The pure `groupByScope` moved to module scope so the hazard is testable without a render.
- **`docs/cover-letter-contract.md` → v2** — §1 (+ a new §1.1 on derivation), §5 **rewritten**, §6, §8, the known-gap paragraph, and the appendix.

## On §5's rewrite

The doc change is a rewrite of the argument, not a tweak to a table row. v1 justified the cascade with:

> A letter reaches every surface through its job … So a letter whose job is gone is unreachable.

That was correct when written and is exactly what this issue invalidates — once a standard/company surface exists, a jobless letter is reachable on its own terms. What survives is the narrower claim, and it is enough: a letter naming a *specific, now-deleted* job is unreachable. That is a statement about job letters only, which is why `jobId` could become optional without weakening it.

The cascade is scope-limited **by construction, not by a new guard**: `lettersForJob` matches `letter.jobId === jobId`, and `undefined` never equals a real id. Both the docblock and §5 say so explicitly, so nobody later "fixes" it with a filter — widening it would delete exactly what the lattice protects, and adding a redundant `companyKey === undefined` check would be a weaker copy of a rule the scoping already makes airtight.

## Acceptance criteria

All met, each with a direct assertion:

- [x] Company letter saves with no `jobId`, reads back from `lettersForCompany`
- [x] Standard letter saves with neither key, reads back from `standardLetters`
- [x] Both keys → refused, reason names both fields
- [x] `jobId: ""` and `companyKey: ""` still refused (absent ≠ empty)
- [x] Deleting a job tombstones its own letters and leaves company + standard letters live — asserted directly, including the delete-the-last-job-at-a-company case
- [x] `deleteLettersForJob` still idempotent, now with jobless letters in the store
- [x] Company + standard letters survive export → import → export byte-identically (`exportedAt` and the `updatedAt` `putRecord` restamps excluded, the pre-existing rule for every record type)
- [x] `useJobLetters` produces no `undefined`-keyed entry
- [x] `Northwind` / `Northwind Inc.` / `northwind, inc.` → one key; `""` and `"  ,  "` → `undefined`
- [x] `LETTER_CONTRACT_VERSION === 2`, asserted against the doc header value
- [x] A v1-shaped record still validates and stores unchanged

## Out of scope, as specified

No UI (the picker, resolution chain and editors are the sibling issue), no auto-attaching a letter to a job by company match, and no `company_key` column or sync mapper.

`lettersForCompany`, `standardLetters` and `deriveCompanyKey` are exported from their own modules but deliberately **not** re-exported through the `storage` barrel or `@offlinecv/core`: nothing in this build reads a company or standard letter yet, and a barrel entry with no importer is dead surface (fallow flags it as exactly that — see below). The change that adds the first caller adds the barrel entry with it. A comment at the barrel site says so, so the omission reads as a decision rather than an oversight.

## ⚠️ Blocking dependency, unverified from here

https://github.com/s-annam/recruidea-extension/issues/55 — `letter-mapping.ts` refuses a pulled letter with no `local_job_id` while happily pushing one, so a standard or company letter uploads and can never come back, failing silently on a second device. **That must land before or with this**, or multi-device users lose every letter this PR makes possible. I could not check its status: the extension repo is not readable from this account.

## Verification

`typecheck` and `lint` clean. Full suite: 6335 passed, 1 failure — `render-ats-pdf.type-scale.test.ts > picks the LARGEST rung…` timed out at 20s under a load average of ~51 from the run itself, and passes in 3.8s in isolation on an idle machine. Unrelated to this change, which touches no PDF code. The final `verify` was not re-run to green locally; CI is the check that matters here.


---

## Update — fallow fix (`148c40c`)

The first push failed the `fallow` check with three `unused-export` errors: `lettersForCompany`, `standardLetters` and `deriveCompanyKey` were re-exported from `src/lib/storage/index.ts` with no importer anywhere (every consumer, tests included, imports from the source module directly). Removed the three barrel entries and left a comment saying why they're absent and when to add them — the same resolution #897 used for its own `unused-export` finding.

`verify` passed on both pushes. Local re-check after the fix: `typecheck`, `lint`, the three affected suites (61 tests), and `fallow audit --base origin/main` all clean.
