### PR TITLE
fix(rewrite): badge emptied-generation sections with distinct emptied state (#877)

### DIFF
--- a/src/components/features/NumberPreservationWarning.tsx
+++ b/src/components/features/NumberPreservationWarning.tsx
@@ -21,14 +21,23 @@
  * the tree reduces to. `"reverted"` must be checked before `"drift"`:
  * `numbersPreserved` is true on a reverted rewrite by construction (#778),
  * so testing it first would read a reverted section as a clean pass.
+ * `"emptied"` (#877) captures when the generation came back completely empty
+ * (the empty-generation exemption in post-process.ts), so it is badged/described
+ * as emptied rather than partial metric drift.
  */
-export type NumberDriftStatus = "reverted" | "drift" | "clean";
+export type NumberDriftStatus = "reverted" | "emptied" | "drift" | "clean";
 
 export function numberDriftStatus(result: {
   numbersPreserved: boolean;
   reverted: boolean;
+  bullets?: readonly string[];
+  text?: string;
 }): NumberDriftStatus {
   if (result.reverted) return "reverted";
+  const isEmptied =
+    (result.bullets !== undefined && result.bullets.length === 0) ||
+    (result.text !== undefined && result.text.trim().length === 0);
+  if (isEmptied) return "emptied";
   if (!result.numbersPreserved) return "drift";
   return "clean";
 }
@@ -46,6 +55,7 @@ export function NumberPreservationWarning({
   dropped,
   added,
   reverted = false,
+  emptied = false,
 }: {
   dropped: readonly string[];
   added: readonly string[];
@@ -56,6 +66,11 @@ export function NumberPreservationWarning({
    * metric they never lost would be wrong.
    */
   reverted?: boolean;
+  /**
+   * The generation came back empty (#877). Changes the copy to distinguish an
+   * emptied section from partial metric drift.
+   */
+  emptied?: boolean;
 }) {
   const detail = describeNumberDrift(dropped, added);
   if (reverted) {
@@ -67,6 +82,18 @@ export function NumberPreservationWarning({
         <span aria-hidden="true">⚠ </span>
         Kept your original — the rewrite {detail}, so I didn’t apply it. Try
         again for a different attempt.
+      </p>
+    );
+  }
+  if (emptied) {
+    const reason = detail ? ` — ${detail}` : "";
+    return (
+      <p
+        role="alert"
+        className="text-2xs leading-snug text-feedback-warning-text"
+      >
+        <span aria-hidden="true">⚠ </span>
+        Section emptied{reason}. Review before saving.
       </p>
     );
   }

--- a/src/components/features/ResumeRewrite.test.ts
+++ b/src/components/features/ResumeRewrite.test.ts
@@ -433,3 +433,53 @@ describe("reverted sections (#778)", () => {
   });
 });
 
+// ── #877: emptied-generation sections badged as emptied ─────────────────────
+
+describe("emptied sections (#877)", () => {
+  const emptiedResult: ResumeRewriteResult = {
+    allNumbersPreserved: false,
+    sections: [
+      {
+        kind: "experience",
+        input: {
+          kind: "experience",
+          id: "experience:0",
+          label: "Engineer — Acme",
+          bullets: ["Managed 10 engineers."],
+        },
+        data: {
+          bullets: [],
+          numbersPreserved: false,
+          reverted: false,
+          droppedNumbers: ["10"],
+          addedNumbers: [],
+        },
+      },
+    ],
+  };
+
+  it("badges an emptied section as 'emptied' instead of 'metric drift'", () => {
+    const status: ResumeRewriteStatus = {
+      kind: "running",
+      progress: {
+        currentIndex: 1,
+        totalSections: 1,
+        currentLabel: null,
+        completed: emptiedResult.sections,
+      },
+    };
+    const html = renderToStaticMarkup(
+      createElement(ResumeRewritePanel, {
+        status,
+        onDismiss: () => {},
+        onApplied: () => {},
+        onUndo: () => {},
+      }),
+    );
+    expect(html).toContain("emptied");
+    expect(html).not.toContain("metric drift");
+    expect(html).not.toContain("kept original");
+  });
+});
+
+

--- a/src/components/features/ResumeRewrite.tsx
+++ b/src/components/features/ResumeRewrite.tsx
@@ -420,33 +420,44 @@ function CompletedList({
 }) {
   return (
     <ul className="flex flex-col gap-1 list-none text-sm text-content-secondary">
-      {outcomes.map((outcome, i) => (
-        <li key={`${outcome.kind}-${i}`} className="flex items-center gap-2">
-          <span aria-hidden="true" className="text-content-muted">
-            ✓
-          </span>
-          <span>{outcome.input.label}</span>
-          {/* #778: a reverted section preserves every number by construction,
-              so `numbersPreserved` alone would render it as a clean pass and
-              the user would never learn their section went unrewritten. */}
-          {numberDriftStatus(outcome.data) === "reverted" && (
-            <span
-              className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-3xs text-feedback-warning-text"
-              title="The rewrite dropped or invented a metric, so the original was kept"
-            >
-              kept original
+      {outcomes.map((outcome, i) => {
+        const driftStatus = numberDriftStatus(outcome.data);
+        return (
+          <li key={`${outcome.kind}-${i}`} className="flex items-center gap-2">
+            <span aria-hidden="true" className="text-content-muted">
+              ✓
             </span>
-          )}
-          {numberDriftStatus(outcome.data) === "drift" && (
-            <span
-              className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-3xs text-feedback-warning-text"
-              title="A metric was altered or removed"
-            >
-              metric drift
-            </span>
-          )}
-        </li>
-      ))}
+            <span>{outcome.input.label}</span>
+            {/* #778: a reverted section preserves every number by construction,
+                so `numbersPreserved` alone would render it as a clean pass and
+                the user would never learn their section went unrewritten. */}
+            {driftStatus === "reverted" && (
+              <span
+                className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-3xs text-feedback-warning-text"
+                title="The rewrite dropped or invented a metric, so the original was kept"
+              >
+                kept original
+              </span>
+            )}
+            {driftStatus === "emptied" && (
+              <span
+                className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-3xs text-feedback-warning-text"
+                title="The rewrite returned no content for this section"
+              >
+                emptied
+              </span>
+            )}
+            {driftStatus === "drift" && (
+              <span
+                className="rounded bg-feedback-warning-bg px-1.5 py-0.5 text-3xs text-feedback-warning-text"
+                title="A metric was altered or removed"
+              >
+                metric drift
+              </span>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/components/features/ResumeRewriteProposed.test.tsx
+++ b/src/components/features/ResumeRewriteProposed.test.tsx
@@ -548,5 +548,77 @@ describe("ProposedPanel — rejected rewrites (#778)", () => {
     const alert = el.querySelector('[role="alert"]');
     expect(alert?.textContent).toContain("invented 5");
   });
+
+  it("renders 'Section emptied' alert when an emptied section dropped metrics (#877)", () => {
+    const emptied: ResumeRewriteResult = {
+      allNumbersPreserved: false,
+      sections: [
+        {
+          kind: "experience",
+          input: {
+            kind: "experience",
+            id: "experience:0",
+            label: "Senior Engineer — Acme",
+            bullets: ["Managed 10 engineers."],
+          },
+          data: {
+            bullets: [],
+            numbersPreserved: false,
+            reverted: false,
+            droppedNumbers: ["10"],
+            addedNumbers: [],
+          },
+        },
+      ],
+    };
+    const el = render(
+      createElement(ProposedPanel, {
+        result: emptied,
+        onDismiss: vi.fn(),
+        onApplied: vi.fn(),
+      }),
+    );
+    const alert = el.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert!.textContent).toContain("Section emptied");
+    expect(alert!.textContent).toContain("removed 10");
+    expect(alert!.textContent).not.toContain("AI altered a metric");
+    expect(alert!.textContent).not.toContain("Kept your original");
+  });
+
+  it("renders 'Section emptied' alert when a non-numeric section is emptied (#877)", () => {
+    const emptiedNonNumeric: ResumeRewriteResult = {
+      allNumbersPreserved: true,
+      sections: [
+        {
+          kind: "experience",
+          input: {
+            kind: "experience",
+            id: "experience:0",
+            label: "Senior Engineer — Acme",
+            bullets: ["Collaborated with product designers."],
+          },
+          data: {
+            bullets: [],
+            numbersPreserved: true,
+            reverted: false,
+            droppedNumbers: [],
+            addedNumbers: [],
+          },
+        },
+      ],
+    };
+    const el = render(
+      createElement(ProposedPanel, {
+        result: emptiedNonNumeric,
+        onDismiss: vi.fn(),
+        onApplied: vi.fn(),
+      }),
+    );
+    const alert = el.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert!.textContent).toContain("Section emptied");
+    expect(alert!.textContent).not.toContain("—");
+  });
 });
 

--- a/src/components/features/ResumeRewriteProposed.tsx
+++ b/src/components/features/ResumeRewriteProposed.tsx
@@ -23,8 +23,7 @@
  */
 
 import { useCallback, useMemo } from "react";
-import { Button, InlineResult, InlineDiff } from "@design-system";
-import { computeTextDiff } from "../../lib/diff/text-diff.ts";
+import { Button, InlineResult } from "@design-system";
 import type {
   ResumeRewriteResult,
   SectionOutcome,
@@ -37,11 +36,39 @@ import { resolveSectionWrites } from "../../lib/rewrite-review/apply-accepted.ts
 import { useRewriteReview, type RewriteReview } from "../../hooks/useRewriteReview.ts";
 import type { SectionRewriteApply } from "./SectionRewrite.tsx";
 import {
-  describeNumberDrift,
   numberDriftStatus,
   NumberPreservationWarning,
 } from "./NumberPreservationWarning.tsx";
 import { BulletReviewRow } from "./RewriteReviewList.tsx";
+import { SectionResult } from "./ResumeRewriteSectionResult.tsx";
+
+interface AggregatedDriftBuckets {
+  reverted: { dropped: string[]; added: string[] };
+  emptied: { dropped: string[]; added: string[] };
+  drift: { dropped: string[]; added: string[] };
+}
+
+/**
+ * Single-pass bucketing across all sections into reverted, emptied, and
+ * metric drift categories (#877).
+ */
+function bucketDriftByStatus(
+  result: ResumeRewriteResult,
+): AggregatedDriftBuckets {
+  const buckets: AggregatedDriftBuckets = {
+    reverted: { dropped: [], added: [] },
+    emptied: { dropped: [], added: [] },
+    drift: { dropped: [], added: [] },
+  };
+  for (const outcome of result.sections) {
+    const status = numberDriftStatus(outcome.data);
+    if (status === "clean") continue;
+    const target = buckets[status];
+    target.dropped.push(...outcome.data.droppedNumbers);
+    target.added.push(...outcome.data.addedNumbers);
+  }
+  return buckets;
+}
 
 /** Per-section apply wiring for the whole-résumé review, keyed by the
  *  `SectionInput.id` (`experience:<index>`, or `summary`). A section with no
@@ -97,18 +124,11 @@ export function ProposedPanel({
    *  Absent → every section renders read-only (graceful fallback). */
   applyBySection?: ResumeRewriteApply;
 }) {
-  const revertedDrift = useMemo(
-    () => aggregateDrift(result, (o) => o.data.reverted),
-    [result],
-  );
-  const emptiedDrift = useMemo(
-    () =>
-      aggregateDrift(
-        result,
-        (o) => !o.data.reverted && !o.data.numbersPreserved,
-      ),
-    [result],
-  );
+  const {
+    reverted: revertedDrift,
+    emptied: emptiedDrift,
+    drift: metricDrift,
+  } = useMemo(() => bucketDriftByStatus(result), [result]);
 
   // Experience sections with an apply wiring become per-bullet reviewable;
   // pair ids are namespaced by section id so the one combined decision map
@@ -225,23 +245,25 @@ export function ProposedPanel({
   // it alone turned the panel warning-coloured on a revert while saying nothing:
   // a border colour, no text, no `role="alert"`. Same condition as
   // `ProposedSection`'s in SectionRewrite.tsx, one level up.
-  const anyReverted = result.sections.some((o) => o.data.reverted);
+  const anyReverted =
+    result.sections.some((o) => o.data.reverted) ||
+    revertedDrift.dropped.length > 0 ||
+    revertedDrift.added.length > 0;
   // A generation that came back empty is NOT reverted — `applyNumberPreservation`
   // deliberately leaves it blank rather than restoring the original (#778,
   // `post-process.ts`) — so its drift can't share the "Kept your original"
   // copy with a genuinely reverted section without misdescribing what
   // happened to it. Split by outcome rather than one aggregate boolean+list
-  // covering every section (#874 review).
-  const anyEmptiedDrift =
-    emptiedDrift.dropped.length > 0 || emptiedDrift.added.length > 0;
+  // covering every section (#874 review, #877).
+  const anyEmptied =
+    result.sections.some((o) => numberDriftStatus(o.data) === "emptied") ||
+    emptiedDrift.dropped.length > 0 ||
+    emptiedDrift.added.length > 0;
+  const anyMetricDrift =
+    metricDrift.dropped.length > 0 || metricDrift.added.length > 0;
 
   const tone =
-    numberDriftStatus({
-      numbersPreserved: result.allNumbersPreserved,
-      reverted: anyReverted,
-    }) === "clean"
-      ? "success"
-      : "warning";
+    anyReverted || anyEmptied || anyMetricDrift ? "warning" : "success";
 
   return (
     <InlineResult tone={tone} className="flex flex-col gap-4">
@@ -252,10 +274,17 @@ export function ProposedPanel({
           reverted
         />
       )}
-      {anyEmptiedDrift && (
+      {anyEmptied && (
         <NumberPreservationWarning
           dropped={emptiedDrift.dropped}
           added={emptiedDrift.added}
+          emptied
+        />
+      )}
+      {anyMetricDrift && (
+        <NumberPreservationWarning
+          dropped={metricDrift.dropped}
+          added={metricDrift.added}
         />
       )}
       <ul className="flex flex-col gap-4 list-none">
@@ -378,69 +407,7 @@ function summaryPairs(
   ];
 }
 
-function SectionResult({ outcome }: { outcome: SectionOutcome }) {
-  if (outcome.kind === "summary") {
-    return (
-      <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
-        <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
-          {outcome.input.label}
-        </h4>
-        <InlineDiff
-          segments={computeTextDiff(
-            outcome.input.text,
-            outcome.data.text || "",
-          )}
-          noChangeLabel={
-            outcome.data.reverted ? revertedLabel(outcome.data) : undefined
-          }
-        />
-      </div>
-    );
-  }
-  // Both sides get the SAME blank filter. A revert hands back the input verbatim
-  // (blanks included) while this side has always dropped them, so filtering only
-  // the original made a section with one blank bullet diff as "changed" — which
-  // suppressed the `noChangeLabel` that exists to stop a revert reading as a
-  // silent no-op (#778).
-  const originalBullets = withoutBlanks(outcome.input.bullets);
-  const proposedBullets = withoutBlanks(outcome.data.bullets);
-  return (
-    <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
-      <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
-        {outcome.input.label}
-      </h4>
-      <InlineDiff
-        segments={computeTextDiff(
-          originalBullets.map((b) => `• ${b}`).join("\n"),
-          proposedBullets.map((b) => `• ${b}`).join("\n"),
-        )}
-        noChangeLabel={
-          outcome.data.reverted ? revertedLabel(outcome.data) : undefined
-        }
-      />
-    </div>
-  );
-}
 
-function withoutBlanks(bullets: readonly string[]): string[] {
-  return bullets.filter((b) => b.trim().length > 0);
-}
-
-/**
- * Why a section in the whole-résumé review shows no redline (#778). Named per
- * section rather than aggregated into the résumé-level warning because the
- * chain rewrites each section independently — one reverting says nothing about
- * the others, and a single banner would leave the reader guessing which.
- */
-function revertedLabel(data: {
-  droppedNumbers: readonly string[];
-  addedNumbers: readonly string[];
-}): string {
-  const detail = describeNumberDrift(data.droppedNumbers, data.addedNumbers);
-  return detail === ""
-    ? "Kept unchanged — the rewrite was rejected."
-    : `Kept unchanged — the rewrite ${detail}.`;
-}
 
 export interface AggregateDrift {
   dropped: string[];

--- a/src/components/features/ResumeRewriteSectionResult.tsx
+++ b/src/components/features/ResumeRewriteSectionResult.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+import { InlineDiff } from "@design-system";
+import { computeTextDiff } from "../../lib/diff/text-diff.ts";
+import type { SectionOutcome } from "../../lib/webllm/rewrite-resume.ts";
+import { describeNumberDrift } from "./NumberPreservationWarning.tsx";
+
+export function SectionResult({ outcome }: { outcome: SectionOutcome }) {
+  if (outcome.kind === "summary") {
+    return (
+      <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
+        <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
+          {outcome.input.label}
+        </h4>
+        <InlineDiff
+          segments={computeTextDiff(
+            outcome.input.text,
+            outcome.data.text || "",
+          )}
+          noChangeLabel={
+            outcome.data.reverted ? revertedLabel(outcome.data) : undefined
+          }
+        />
+      </div>
+    );
+  }
+  // Both sides get the SAME blank filter. A revert hands back the input verbatim
+  // (blanks included) while this side has always dropped them, so filtering only
+  // the original made a section with one blank bullet diff as "changed" — which
+  // suppressed the `noChangeLabel` that exists to stop a revert reading as a
+  // silent no-op (#778).
+  const originalBullets = withoutBlanks(outcome.input.bullets);
+  const proposedBullets = withoutBlanks(outcome.data.bullets);
+  return (
+    <div className="flex flex-col gap-2 rounded border border-border-light bg-surface-card p-3">
+      <h4 className="text-3xs font-semibold uppercase tracking-wider text-content-muted">
+        {outcome.input.label}
+      </h4>
+      <InlineDiff
+        segments={computeTextDiff(
+          originalBullets.map((b) => `• ${b}`).join("\n"),
+          proposedBullets.map((b) => `• ${b}`).join("\n"),
+        )}
+        noChangeLabel={
+          outcome.data.reverted ? revertedLabel(outcome.data) : undefined
+        }
+      />
+    </div>
+  );
+}
+
+function withoutBlanks(bullets: readonly string[]): string[] {
+  return bullets.filter((b) => b.trim().length > 0);
+}
+
+/**
+ * Why a section in the whole-résumé review shows no redline (#778). Named per
+ * section rather than aggregated into the résumé-level warning because the
+ * chain rewrites each section independently — one reverting says nothing about
+ * the others, and a single banner would leave the reader guessing which.
+ */
+function revertedLabel(data: {
+  droppedNumbers: readonly string[];
+  addedNumbers: readonly string[];
+}): string {
+  const detail = describeNumberDrift(data.droppedNumbers, data.addedNumbers);
+  return detail === ""
+    ? "Kept unchanged — the rewrite was rejected."
+    : `Kept unchanged — the rewrite ${detail}.`;
+}

--- a/src/components/features/SectionRewrite.test.ts
+++ b/src/components/features/SectionRewrite.test.ts
@@ -19,6 +19,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { labelFor, ProposedSection, type Status } from "./SectionRewrite.tsx";
 import {
   formatTokens,
+  numberDriftStatus,
   NumberPreservationWarning,
 } from "./NumberPreservationWarning.tsx";
 import type { SectionRewriteResult } from "../../lib/webllm/rewrite-section.ts";
@@ -156,6 +157,105 @@ describe("NumberPreservationWarning — reverted copy (#778)", () => {
   it("defaults to the drift copy when `reverted` is omitted", () => {
     const html = render({ dropped: ["40%"], added: [] });
     expect(html).toContain("removed 40%");
+  });
+});
+
+describe("NumberPreservationWarning — emptied copy (#877)", () => {
+  it("explains the section was emptied rather than altered when metrics were lost", () => {
+    const html = renderToStaticMarkup(
+      createElement(NumberPreservationWarning, {
+        dropped: ["$10M"],
+        added: [],
+        emptied: true,
+      }),
+    );
+    expect(html).toContain("Section emptied — removed $10M. Review before saving.");
+    expect(html).not.toContain("AI altered a metric");
+    expect(html).not.toContain("Kept your original");
+  });
+
+  it("renders a clean emptied notice without trailing dash when no metrics existed", () => {
+    const html = renderToStaticMarkup(
+      createElement(NumberPreservationWarning, {
+        dropped: [],
+        added: [],
+        emptied: true,
+      }),
+    );
+    expect(html).toContain("Section emptied. Review before saving.");
+    expect(html).not.toContain("—");
+  });
+});
+
+describe("numberDriftStatus (#877)", () => {
+  it("returns 'reverted' when reverted is true", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: true,
+        reverted: true,
+        bullets: ["b1"],
+      }),
+    ).toBe("reverted");
+  });
+
+  it("returns 'clean' when numbersPreserved is true and bullets are non-empty", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: true,
+        reverted: false,
+        bullets: ["b1"],
+      }),
+    ).toBe("clean");
+  });
+
+  it("returns 'emptied' when numbersPreserved is true and bullets are empty (non-numeric section)", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: true,
+        reverted: false,
+        bullets: [],
+      }),
+    ).toBe("emptied");
+  });
+
+  it("returns 'emptied' when numbersPreserved is true and text is blank (non-numeric section)", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: true,
+        reverted: false,
+        text: "",
+      }),
+    ).toBe("emptied");
+  });
+
+  it("returns 'emptied' when unpreserved, not reverted, and bullets are empty", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: false,
+        reverted: false,
+        bullets: [],
+      }),
+    ).toBe("emptied");
+  });
+
+  it("returns 'emptied' when unpreserved, not reverted, and text is whitespace", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: false,
+        reverted: false,
+        text: "   ",
+      }),
+    ).toBe("emptied");
+  });
+
+  it("returns 'drift' when unpreserved, not reverted, and content is present", () => {
+    expect(
+      numberDriftStatus({
+        numbersPreserved: false,
+        reverted: false,
+        bullets: ["reworded without number"],
+      }),
+    ).toBe("drift");
   });
 });
 


### PR DESCRIPTION
## Summary
Closes #877.

When a section rewrite generation comes back completely empty (the empty-generation exemption in `applyNumberPreservation`), it is now badged and described as `"emptied"` rather than being collapsed into `"metric drift"` / generic `"AI altered a metric"`.

## Changes
1. **`src/components/features/NumberPreservationWarning.tsx`**:
   - Expanded `NumberDriftStatus` to include `"emptied"` (`"reverted" | "emptied" | "drift" | "clean"`).
   - Evaluated emptiness (`bullets.length === 0 || text.trim().length === 0`) unconditionally before `!numbersPreserved`, ensuring non-numeric sections that return empty are correctly classified as `"emptied"` rather than falling through to `"clean"`.
   - Added `emptied?: boolean` prop to `NumberPreservationWarning` with copy `"Section emptied — {detail}. Review before saving."` (or `"Section emptied. Review before saving."` when no metrics are lost).
2. **`src/components/features/ResumeRewrite.tsx`**:
   - Added distinct `"emptied"` badge in `CompletedList` alongside `"kept original"` and `"metric drift"`, caching `driftStatus` once per row.
3. **`src/components/features/ResumeRewriteProposed.tsx` & `ResumeRewriteSectionResult.tsx`**:
   - Aggregated section outcomes in a single pass via `bucketDriftByStatus` into `reverted`, `emptied`, and `drift` buckets.
   - Rendered distinct `NumberPreservationWarning`s with appropriate copy for each outcome.
   - Extracted `SectionResult` and its diff helpers into sibling file `ResumeRewriteSectionResult.tsx` to maintain file size constraints.
4. **`src/components/features/SectionRewrite.tsx`**:
   - Kept unchanged by design: `useSectionRewrite`'s `onClick` intercepts `result.bullets.length === 0` and sets `status: "error"` before `status` can ever reach `"proposed"`, so an emptied state is unreachable on the per-role panel in production.
5. **Tests**:
   - Added unit and component tests in `SectionRewrite.test.ts`, `ResumeRewrite.test.ts`, and `ResumeRewriteProposed.test.tsx` verifying non-numeric emptied sections, copy formatting, and single-pass bucketing.

## Verification
- `npm run typecheck` & `npm run lint`: 0 errors.
- `npm test`: 382 test files passed, 6,374 tests passed, 0 failures.
- `npm run verify`: Passed 100%.
- `npx fallow audit --base origin/main --gate all`: Clean (0 dead exports, 0 unused types).