### PR TITLE
fix(skills): quote argument-hint flow sequence in pr-ready frontmatter (#850)

### DIFF
--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-ready
 description: Solicit review on one or more open PRs — autonomously post a short ping asking for a single explicit 👍 by an absolute merge time (appended onto the most recent live ping if one exists, rather than a new standalone message), wait, send at most one reminder, and report per PR which of SILENT / ACKED / REVIEWING / REVIEWED was reached and by whom. Detects an in-progress review from GitHub (the 👀 /pr-review posts) and grants it one bounded grace extension. Carries no review guidance — that lives in the PR body. Never changes a PR's merge state. Use when the user says "pr-ready", "/pr-ready", "ask for review on this PR", "ping reviewers", or has open PRs nobody has looked at yet.
-argument-hint: [<pr-number>[,<pr-number>...]]
+argument-hint: "[<pr-number>[,<pr-number>...]]"
 ---
 
 # PR Ready


### PR DESCRIPTION
## Summary
Fixes #850.

Quotes the `argument-hint` value in `.claude/skills/pr-ready/SKILL.md` frontmatter so that it is parsed as a valid string rather than an invalid unquoted YAML flow sequence.

## Changes
- `.claude/skills/pr-ready/SKILL.md`: `argument-hint: "[<pr-number>[,<pr-number>...]]"`

## Verification
- Verified YAML frontmatter parses cleanly without syntax errors across strict YAML parsers.