### PR TITLE
fix(preserve-numbers): give year classification a context gate (#876)

### DIFF
--- a/src/lib/webllm/preserve-numbers.test.ts
+++ b/src/lib/webllm/preserve-numbers.test.ts
@@ -197,19 +197,13 @@ describe("checkNumbersPreserved", () => {
       // `projects` isn't a people noun, so `Managed 5 projects` is a verb
       // pointing at a non-people object, not a headcount claim.
       expect(
-        checkNumbersPreserved(
-          ["Owned 5 projects."],
-          ["Managed 5 projects."],
-        ),
+        checkNumbersPreserved(["Owned 5 projects."], ["Managed 5 projects."]),
       ).toEqual({ ok: true, dropped: [], added: [] });
       expect(
         checkNumbersPreserved(["Built 8 features."], ["Led 8 features."]),
       ).toEqual({ ok: true, dropped: [], added: [] });
       expect(
-        checkNumbersPreserved(
-          ["Delivered 4 programs."],
-          ["Ran 4 programs."],
-        ),
+        checkNumbersPreserved(["Delivered 4 programs."], ["Ran 4 programs."]),
       ).toEqual({ ok: true, dropped: [], added: [] });
       expect(
         checkNumbersPreserved(
@@ -232,10 +226,7 @@ describe("checkNumbersPreserved", () => {
 
     it("still claims a headcount when a verb-object noun IS a person", () => {
       expect(
-        checkNumbersPreserved(
-          ["Managed 5 engineers."],
-          ["Led 5 engineers."],
-        ),
+        checkNumbersPreserved(["Managed 5 engineers."], ["Led 5 engineers."]),
       ).toEqual({ ok: true, dropped: [], added: [] });
     });
 
@@ -394,9 +385,9 @@ describe("checkNumbersPreserved", () => {
     });
 
     it("is case-insensitive on the multiplier — `10X` matches `10x`", () => {
-      expect(
-        checkNumbersPreserved(["Scaled 10X."], ["Scaled 10x."]).ok,
-      ).toBe(true);
+      expect(checkNumbersPreserved(["Scaled 10X."], ["Scaled 10x."]).ok).toBe(
+        true,
+      );
     });
 
     it("catches a dropped `10+`", () => {
@@ -675,19 +666,472 @@ describe("checkNumbersPreserved", () => {
       expect(result.dropped).toEqual(["12"]);
     });
 
-    it("does NOT extend to year — a year has no unclaimed state to compare against (documented residual)", () => {
-      // Every 4-digit number in 1900-2099 auto-claims as a year regardless of
-      // context (see `bareIntegerClaim`), so "suite 1900" is itself always
-      // claimed — there is no unclaimed bucket for the count-aware guard to
-      // compare against, and this masking case survives. Catching it needs a
-      // context gate on year classification itself (mirroring headcount's
-      // verb/noun check), which is a separate, larger change than this fix;
-      // tracked as a follow-up rather than silently left unmentioned.
+    it("extends to year (#876) — catches a dropped year masked by an unrelated same-value digit", () => {
+      // With year context gating (#876), "suite 1900" is unclaimed while
+      // "in 1900" is claimed as a year. A genuinely dropped year is caught
+      // even when an unrelated 4-digit number of the same value survives.
       const result = checkNumbersPreserved(
         ["Founded the program in 1900.", "Operated out of suite 1900."],
         ["Founded the program.", "Operated out of suite 1900."],
       );
+      expect(result.ok).toBe(false);
+      expect(result.dropped).toEqual(["1900"]);
+    });
+
+    it("catches a dropped year date range across all 6 dash characters (#876)", () => {
+      const dashes = [
+        "-", // U+002D ASCII hyphen
+        "–", // U+2013 en dash
+        "—", // U+2014 em dash
+        "‒", // U+2012 figure dash
+        "‑", // U+2011 non-breaking hyphen
+        "−", // U+2212 minus sign
+      ];
+      for (const dash of dashes) {
+        const input = [`Acme Corp 2019 ${dash} 2021 senior engineer.`];
+        const output = ["Acme Corp senior engineer."];
+        const result = checkNumbersPreserved(input, output);
+        expect(result.ok).toBe(false);
+        expect(result.dropped).toEqual(["2019", "2021"]);
+      }
+    });
+
+    it("catches dropped years with month abbreviations and date slashes (#876)", () => {
+      const result1 = checkNumbersPreserved(
+        ["Sep. 2025 – Apr. 2026: Senior Staff Engineer."],
+        ["Senior Staff Engineer."],
+      );
+      expect(result1.ok).toBe(false);
+      expect(result1.dropped).toEqual(["2025", "2026"]);
+
+      const result2 = checkNumbersPreserved(
+        ["01/2019 - 02/2022: Lead Architect."],
+        ["Lead Architect."],
+      );
+      expect(result2.ok).toBe(false);
+      expect(result2.dropped).toEqual(["2019", "2022"]);
+    });
+
+    it("catches dropped years across common resume forms (#876)", () => {
+      const cases = [
+        ["Speaker at PyCon (2019).", "Speaker at PyCon.", "2019"],
+        ["B.S. Computer Science, 2019.", "B.S. Computer Science.", "2019"],
+        [
+          "Awarded Employee of the Year 2021.",
+          "Awarded Employee of the Year.",
+          "2021",
+        ],
+        ["AWS Certified Architect 2019.", "AWS Certified Architect.", "2019"],
+        ["Shipped the platform 2018.", "Shipped the platform.", "2018"],
+        ["Worked at Acme Corp 2019.", "Worked at Acme Corp.", "2019"],
+        [
+          "Recipient of the 2019 Excellence Award.",
+          "Recipient of the Excellence Award.",
+          "2019",
+        ],
+        ["Winner, 2020 Innovation Award.", "Innovation Award winner.", "2020"],
+        ["Presented at KubeCon 2022.", "Presented at KubeCon.", "2022"],
+      ];
+      for (const [inputStr, outputStr, expectedYear] of cases) {
+        const result = checkNumbersPreserved([inputStr], [outputStr]);
+        expect(result.ok).toBe(false);
+        expect(result.dropped).toEqual([expectedYear]);
+      }
+    });
+
+    it("accepts surviving year in rephrased context (#876)", () => {
+      const result = checkNumbersPreserved(
+        ["Presented at KubeCon in 2022.", "Refactored 2022 legacy modules."],
+        ["KubeCon 2022 speaker; refactored legacy modules."],
+      );
       expect(result.ok).toBe(true);
+      expect(result.dropped).toEqual([]);
+    });
+
+    it("does not falsely report dropped years on plain-English merges of 4-digit quantities (#876)", () => {
+      const mergePairs: [string[], string[]][] = [
+        [
+          ["Delivered the 2000 units.", "Tracked 2000 tickets."],
+          ["Delivered and tracked 2000 items."],
+        ],
+        [
+          ["Reduced by 2000 hours.", "Cut 2000 tickets."],
+          ["Cut 2000 hours and tickets."],
+        ],
+        [
+          ["A total of 2000 records.", "Indexed 2000 rows."],
+          ["Indexed 2000 records and rows."],
+        ],
+        [
+          ["Ran campaign for 2000 customers.", "Emailed 2000 leads."],
+          ["Reached 2000 customers and leads."],
+        ],
+      ];
+      for (const [input, output] of mergePairs) {
+        const result = checkNumbersPreserved(input, output);
+        expect(result.ok).toBe(true);
+        expect(result.dropped).toEqual([]);
+      }
+    });
+
+    it("treats range endpoints uniformly across the 1900-2099 boundary (#876)", () => {
+      const result1 = checkNumbersPreserved(
+        ["Processed 1000-2000 tickets.", "Closed 2000 escalations."],
+        ["Processed 1000 to 2000 tickets."],
+      );
+      expect(result1.ok).toBe(true);
+
+      const result2 = checkNumbersPreserved(
+        ["Processed 50-100 tickets.", "Closed 100 escalations."],
+        ["Processed 50 to 100 tickets."],
+      );
+      expect(result2.ok).toBe(true);
+    });
+
+    it("accepts legitimate temporal reword of an attributive year (#876)", () => {
+      const result = checkNumbersPreserved(
+        ["Recipient of the 2019 Excellence Award."],
+        ["Won the Excellence Award in 2019."],
+      );
+      expect(result.ok).toBe(true);
+      expect(result.added).toEqual([]);
+    });
+
+    it("accepts a year date-anchor at the start of a bullet (#876)", () => {
+      const input = [
+        "2019: Founded the company and led initial product launch.",
+      ];
+      expect(checkNumbersPreserved(input, input).ok).toBe(true);
+      const dropped = checkNumbersPreserved(input, [
+        "Founded the company and led initial product launch.",
+      ]);
+      expect(dropped.ok).toBe(false);
+      expect(dropped.dropped).toEqual(["2019"]);
+    });
+
+    it("accepts a year with month/season prefix or range (#876)", () => {
+      const input = ["Spring 2021: Graduated with honors."];
+      expect(checkNumbersPreserved(input, input).ok).toBe(true);
+      const dropped = checkNumbersPreserved(input, ["Graduated with honors."]);
+      expect(dropped.ok).toBe(false);
+      expect(dropped.dropped).toEqual(["2021"]);
+    });
+
+    it("preserves non-temporal 4-digit quantities while allowing quantity merges (#876 redesign)", () => {
+      // Dropping a concrete 4-digit quantity is defended (main baseline / #778)
+      const dropped = checkNumbersPreserved(
+        ["Delivered 2000 units to production."],
+        ["Delivered units to production."],
+      );
+      expect(dropped.ok).toBe(false);
+      expect(dropped.dropped).toEqual(["2000"]);
+
+      // Merging repeated 4-digit quantities across bullets is accepted
+      const merged = checkNumbersPreserved(
+        ["Delivered 2000 units to production.", "Stocked 2000 SKUs."],
+        ["Stocked 2000 SKUs and delivered units."],
+      );
+      expect(merged.ok).toBe(true);
+      expect(merged.dropped).toEqual([]);
+    });
+
+    it("accepts legitimate reword of a sole year occurrence (#876)", () => {
+      // When "in 1900" is the only occurrence and rewords to an unclaimed digit,
+      // the new unclaimed count allows the reword.
+      const result = checkNumbersPreserved(
+        ["Founded in 1900."],
+        ["Operated as project 1900."],
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("does not treat bare past-tense verbs before 4-digit counts as year claims (#876 review)", () => {
+      const mergePairs: [string[], string[]][] = [
+        [
+          ["Shipped 2000 features.", "Reviewed 2000 PRs."],
+          ["Reviewed 2000 PRs and features."],
+        ],
+        [
+          ["Completed 2000 tickets.", "Logged 2000 hours."],
+          ["Logged 2000 hours and tickets."],
+        ],
+        [
+          ["Launched 2000 campaigns.", "Tracked 2000 leads."],
+          ["Tracked 2000 leads and campaigns."],
+        ],
+      ];
+      for (const [input, output] of mergePairs) {
+        const result = checkNumbersPreserved(input, output);
+        expect(result.ok).toBe(true);
+        expect(result.dropped).toEqual([]);
+      }
+    });
+
+    it("ensures context window slicing is positionally stable and does not match mid-word fragments (#876 review)", () => {
+      // Words ending in "at" (that, great, format, combat) should not fabricate a `\b at \b` match
+      const sentences = [
+        "Team that   absorbed a traffic surge over a 2024 launch.",
+        "Team great  absorbed a traffic surge over a 2024 launch.",
+        "Team format absorbed a traffic surge over a 2024 launch.",
+        "Team combat absorbed a traffic surge over a 2024 launch.",
+      ];
+      for (const s of sentences) {
+        const result = checkNumbersPreserved([s, "Delivered 2024 units."], [
+          "Delivered 2024 units after the surge.",
+        ]);
+        expect(result.ok).toBe(true);
+        expect(result.dropped).toEqual([]);
+      }
+    });
+
+    it("catches an invented 4-digit number or year on the add side (#876 review)", () => {
+      // 1. Invented bare count
+      const r1 = checkNumbersPreserved(
+        ["Delivered units to production."],
+        ["Delivered 2000 units to production."],
+      );
+      expect(r1.ok).toBe(false);
+      expect(r1.added).toEqual(["2000"]);
+
+      // 2. Invented credential/award year
+      const r2 = checkNumbersPreserved(
+        ["Received the Excellence Award."],
+        ["Received the 2019 Excellence Award."],
+      );
+      expect(r2.ok).toBe(false);
+      expect(r2.added).toEqual(["2019"]);
+
+      // 3. Invented temporal preposition year
+      const r3 = checkNumbersPreserved(
+        ["Worked on the platform."],
+        ["Worked on the platform in 2019."],
+      );
+      expect(r3.ok).toBe(false);
+      expect(r3.added).toEqual(["2019"]);
+    });
+
+    it("enforces case sensitivity for CamelCase conference names (#876 review)", () => {
+      // DevCon / KubeCon match
+      const devCon = checkNumbersPreserved(
+        ["Speaker at DevCon 2022."],
+        ["Speaker at conference."],
+      );
+      expect(devCon.ok).toBe(false);
+      expect(devCon.dropped).toEqual(["2022"]);
+
+      // silicon / falcon should NOT match as year cues
+      const silicon = checkNumbersPreserved(
+        ["Produced silicon 2000 wafers.", "Tested 2000 chips."],
+        ["Produced and tested 2000 chips."],
+      );
+      expect(silicon.ok).toBe(true);
+      expect(silicon.dropped).toEqual([]);
+    });
+
+    it("narrows credential prefixes so generic nouns do not claim years (#876 review)", () => {
+      // Certified Architect matches
+      const cert = checkNumbersPreserved(
+        ["AWS Certified Architect 2019."],
+        ["AWS Architect."],
+      );
+      expect(cert.ok).toBe(false);
+      expect(cert.dropped).toEqual(["2019"]);
+
+      // Senior developer / Lead architect as counts do not claim
+      const dev = checkNumbersPreserved(
+        [
+          "Senior developer 2000 hours logged.",
+          "Completed 2000 tasks.",
+        ],
+        ["Completed 2000 tasks and logged hours."],
+      );
+      expect(dev.ok).toBe(true);
+      expect(dev.dropped).toEqual([]);
+    });
+
+    it("treats range endpoints uniformly regardless of short or long left endpoints (#876 review)", () => {
+      const shortLeft = checkNumbersPreserved(
+        ["Processed 50-2000 tickets.", "Closed 2000 escalations."],
+        ["Processed 50 to 2000 tickets."],
+      );
+      expect(shortLeft.ok).toBe(true);
+      expect(shortLeft.dropped).toEqual([]);
+
+      const longLeft = checkNumbersPreserved(
+        ["Processed 1000-2000 tickets.", "Closed 2000 escalations."],
+        ["Processed 1000 to 2000 tickets."],
+      );
+      expect(longLeft.ok).toBe(true);
+      expect(longLeft.dropped).toEqual([]);
+    });
+
+    it("defends multi-word award names and multi-word certifications (#876 review)", () => {
+      const awardAndCertCases = [
+        "Awarded the Excellence Award 2019.",
+        "Won the Innovation Prize 2019.",
+        "Received the Chairman Award 2021.",
+        "AWS Certified Solutions Architect 2019.",
+        "Certified Kubernetes Administrator 2021.",
+        "Google Cloud Certified Professional Cloud Architect 2019.",
+      ];
+      for (const c of awardAndCertCases) {
+        const year = c.match(/\b(2019|2021)\b/)![0];
+        const dropped = checkNumbersPreserved([c], ["Honored for achievements."]);
+        expect(dropped.ok).toBe(false);
+        expect(dropped.dropped).toEqual([year]);
+      }
+
+      // Decoys: "Certified the 2000 units shipped" should not claim 2000 as year
+      const decoy1 = checkNumbersPreserved(
+        ["Certified the 2000 units shipped.", "Tested 2000 units."],
+        ["Tested 2000 units."],
+      );
+      expect(decoy1.ok).toBe(true);
+      expect(decoy1.dropped).toEqual([]);
+
+      const decoy2 = checkNumbersPreserved(
+        ["Senior Architect 2019 promotion.", "Managed 2019 items."],
+        ["Managed 2019 items."],
+      );
+      expect(decoy2.ok).toBe(true);
+      expect(decoy2.dropped).toEqual([]);
+    });
+
+    it("defends leading award and prize year anchors (#876 review round 5)", () => {
+      const leadingAwardCases = [
+        "2019 Excellence Award recipient for outstanding performance.",
+        "• 2019 Innovation Prize winner.",
+        "2021 Founders Medal honoree.",
+      ];
+      for (const c of leadingAwardCases) {
+        const year = c.match(/\b(2019|2021)\b/)![0];
+        const dropped = checkNumbersPreserved([c], ["Recognized for outstanding performance."]);
+        expect(dropped.ok).toBe(false);
+        expect(dropped.dropped).toEqual([year]);
+      }
+    });
+
+    it("accepts dash-then-prose date anchors at bullet start while rejecting numeric ranges (#876 review)", () => {
+      const dashAnchors = [
+        "2019 - Led the platform migration.",
+        "2019 – Led the platform migration.",
+        "• 2019 - Led the platform migration.",
+      ];
+      for (const a of dashAnchors) {
+        const dropped = checkNumbersPreserved([a], ["Led the platform migration."]);
+        expect(dropped.ok).toBe(false);
+        expect(dropped.dropped).toEqual(["2019"]);
+      }
+
+      // Numeric ranges must still NOT be treated as date anchors
+      const numRange = checkNumbersPreserved(
+        ["2000 - 3000 units delivered.", "Stocked 2000 SKUs."],
+        ["Delivered units and stocked 2000 SKUs."],
+      );
+      expect(numRange.ok).toBe(true);
+      expect(numRange.dropped).toEqual([]);
+    });
+
+    it("defends safe bare verbs followed by function words while ignoring count nouns (#876 review)", () => {
+      const safeVerbs = [
+        "Graduated 2019 from MIT.",
+        "Founded 2019 and scaled it.",
+        "Awarded 2019 for excellence.",
+        "Promoted 2019 to staff engineer.",
+      ];
+      for (const v of safeVerbs) {
+        const dropped = checkNumbersPreserved([v], ["Earned distinction."]);
+        expect(dropped.ok).toBe(false);
+        expect(dropped.dropped).toEqual(["2019"]);
+      }
+    });
+
+    it("defends common resume date phrasings with weak prepositions, determiners, and qualifiers (#876 review round 6)", () => {
+      const datePhrasings = [
+        ["Served on the board from 2019.", "Served on the board.", "2019"],
+        ["Rebuilt the pipeline in early 2019.", "Rebuilt the pipeline.", "2019"],
+        ["2019 revenue grew 40%.", "Revenue grew 40%.", "2019"],
+        ["Grew ARR over 2019.", "Grew ARR.", "2019"],
+        ["Owned the roadmap for 2020.", "Owned the roadmap.", "2020"],
+        ["Led the Q4 of 2021 launch.", "Led the Q4 launch.", "2021"],
+        ["Shipped in the summer of 2019.", "Shipped the release.", "2019"],
+        ["Joined the 2019 cohort.", "Joined the cohort.", "2019"],
+        ["Shipped v1 in mid-2020.", "Shipped v1.", "2020"],
+        ["Completed the migration by 2021.", "Completed the migration.", "2021"],
+      ];
+      for (const [before, after, year] of datePhrasings) {
+        const result = checkNumbersPreserved([before], [after]);
+        expect(result.ok).toBe(false);
+        expect(result.dropped).toEqual([year]);
+      }
+
+      // Quantity merges with weak prepositions stay lenient on count collisions
+      const countMerges = [
+        [["Reduced by 2000 hours.", "Tracked 2000 bugs."], ["Tracked 2000 bugs and reduced hours."]],
+        [["Sourced from 2000 vendors.", "Ranked 2000 vendors."], ["Ranked 2000 vendors and sourced."]],
+        [["Built support for 2000 users.", "Onboarded 2000 users."], ["Onboarded 2000 users and built support."]],
+      ];
+      for (const [inputs, outputs] of countMerges) {
+        const result = checkNumbersPreserved(inputs, outputs);
+        expect(result.ok).toBe(true);
+        expect(result.dropped).toEqual([]);
+      }
+    });
+
+    it("does not treat mid-word truncation of long tokens as end-of-bullet (#876 review round 6)", () => {
+      // Tokens longer than context window should not truncate to empty and trigger end-of-bullet matching
+      const result = checkNumbersPreserved(
+        ["Managed 4 third-party-integration-partnerships.", "Phase 4 shipped."],
+        ["Phase 4 shipped; owned partner integrations."],
+      );
+      expect(result.ok).toBe(true);
+      expect(result.dropped).toEqual([]);
+    });
+
+    it("defends lowercase leading award and prize year anchors (#876 review round 6)", () => {
+      const awardCases = [
+        "2019 excellence award recipient.",
+        "2019 innovation prize winner.",
+        "2021 founders medal honoree.",
+        "2019 dean's list scholarship.",
+        "2020 best engineering award winner.",
+        "2019 award for outstanding service.",
+      ];
+      for (const c of awardCases) {
+        const year = c.match(/\b(2019|2020|2021)\b/)![0];
+        const dropped = checkNumbersPreserved([c], ["Recognized for excellence."]);
+        expect(dropped.ok).toBe(false);
+        expect(dropped.dropped).toEqual([year]);
+
+        const preserved = checkNumbersPreserved([c], [`Won the award in ${year}.`]);
+        expect(preserved.ok).toBe(true);
+      }
+    });
+
+    it("requires capitalized venue tokens for strict venue year cues (#876 review round 6)", () => {
+      // Lowercase words after "at" should not strictly claim metrics like "2000 rps"
+      const result = checkNumbersPreserved(
+        ["Sustained throughput at peak load 2000 rps.", "Closed 2000 tickets."],
+        ["Closed 2000 tickets and sustained throughput at peak load."],
+      );
+      expect(result.ok).toBe(true);
+      expect(result.dropped).toEqual([]);
+    });
+
+    it("pins accepted residual: comma/parenthesis cues across two occurrences (#876 review)", () => {
+      // In phrases like "Cut infra spend, 2000 servers decommissioned", the comma
+      // immediately preceding 2000 triggers the year cue in YEAR_PREFIX_CUE (supporting "B.S. CS, 2019").
+      // Under strict count parity, if the surviving output 2000 is merged without a year cue,
+      // it reports dropped 2000. This is an explicit accepted residual trade-off.
+      const result = checkNumbersPreserved(
+        [
+          "Cut infra spend, 2000 servers decommissioned.",
+          "Retired 2000 legacy VMs.",
+        ],
+        ["Cut infra spend and retired 2000 legacy VMs."],
+      );
+      expect(result.ok).toBe(false);
+      expect(result.dropped).toEqual(["2000"]);
     });
 
     it("keeps a range/form drop lenient — an unclaimed same-value digit elsewhere still counts as present", () => {

--- a/src/lib/webllm/preserve-numbers.ts
+++ b/src/lib/webllm/preserve-numbers.ts
@@ -26,7 +26,7 @@
  *   - Approximations: `~50`, `~$4.2M`, `≈30%`  (#778)
  *   - At-least markers: `10+`, `500+`, `$1M+`  (#778)
  *   - Plain numbers with commas/decimals: `1,200`, `3.14`
- *   - Years (1900-2099) and date ranges: `2019`, `2019-2021`
+ *   - Years (1900-2099) in temporal context and date ranges: `2019`, `2019-2021`
  *   - Both endpoints of a numeric range: `50-100`, `10–15%`  (#778)
  *   - Headcounts in people-management context: `led 5`, `managed 8`,
  *     `team of 12`, `5 engineers`
@@ -49,32 +49,31 @@
  * by them:
  *
  * 1. **The claim decides what we look FOR; presence decides whether we found
- *    it — except for a headcount, where a same-value digit that was ALREADY
- *    sitting unclaimed on both sides before the rewrite doesn't count.** For
- *    `form`/`range`/`year`, a claimed input atom is a drop only if its key is
- *    absent from *every* atom on the other side — claimed or not. Whether a
- *    bare integer reads as a range endpoint or a grouped figure depends on the
+ *    it — except for a headcount or year (#876), where a same-value digit that
+ *    was ALREADY sitting unclaimed on both sides before the rewrite doesn't
+ *    count.** For `form`/`range`, a claimed input atom is a drop only if its
+ *    key is absent from *every* atom on the other side — claimed or not. Whether
+ *    a bare integer reads as a range endpoint or a grouped figure depends on the
  *    surrounding prose (`50-100` vs `50 to 100`) or punctuation (`1,200` vs
  *    `1200`), so requiring the other side to re-produce the exact same reading
  *    would make the gate fire on numbers the user typed themselves, purely
- *    because the model re-spelled the phrasing around them; `year` has no
- *    unclaimed state to compare against in the first place (a 4-digit number
- *    in range is always a year, see `bareIntegerClaim`), so the lenient lookup
- *    is also the only one available to it. A headcount is different: its
- *    context (a management verb, a people noun) is common enough to
- *    reproduce by accident on a digit that means something else entirely —
- *    `"Managed a team of 12 engineers"` dropped down to `"Led the
- *    department"`, sitting next to an unrelated, UNCHANGED `"Completed module
- *    12"`, would score clean under a blanket `outputKeys.has`, because the
- *    coincidental `12` was already there before the rewrite touched anything.
- *    So a headcount counts as present only if the output claims it too, OR a
- *    *NEW* unclaimed occurrence of the key appears that the input didn't
- *    already carry — `outputClaimedKeys` and the unclaimed-occurrence counts
- *    below implement exactly that, and the "new" qualifier is what keeps
- *    `"Managed 5 engineers"` → `"Completed phase 5"` (the digit's ONLY
- *    occurrence, reworded away from headcount context) reading as a
- *    legitimate reword rather than a drop. Undecorated keys still share one
- *    `num:` namespace across all four bare-integer readings, because a
+ *    because the model re-spelled the phrasing around them. Headcount and year
+ *    are different: their context (a management verb / people noun, or a
+ *    temporal preposition / date range) is common enough to coincide with a
+ *    digit that means something else entirely — `"Managed a team of 12
+ *    engineers"` dropped down to `"Led the department"`, sitting next to an
+ *    unrelated, UNCHANGED `"Completed module 12"`, or `"Founded the program in
+ *    1900"` dropped next to `"Operated out of suite 1900"`, would score clean
+ *    under a blanket `outputKeys.has`, because the coincidental digit was
+ *    already there before the rewrite touched anything. So a headcount or year
+ *    counts as present only if the output claims it too, OR a *NEW* unclaimed
+ *    occurrence of the key appears that the input didn't already carry —
+ *    `outputClaimedKeys` and the unclaimed-occurrence counts below implement
+ *    exactly that, and the "new" qualifier is what keeps `"Managed 5
+ *    engineers"` → `"Completed phase 5"` or `"Founded in 1900"` → `"Project
+ *    1900"` (the digit's ONLY occurrence, reworded away from temporal context)
+ *    reading as a legitimate reword rather than a drop. Undecorated keys still
+ *    share one `num:` namespace across all four bare-integer readings, because a
  *    headcount, a year, a range endpoint and a comma-grouped figure holding
  *    the same digits are the same value; the presence rule is what differs
  *    per claim kind, not the key they share.
@@ -95,14 +94,18 @@
  *    → `5 engineers` reuses the digit and invents the headcount, and under a
  *    plain rule-1 lookup it scored clean. So an output atom the surrounding
  *    prose reads as a HEADCOUNT counts as present only when the same value is a
- *    claimed fact on the input side too. Every other claim kind keeps the
- *    lenient rule-1 lookup, because for those the unclaimed→claimed move is
- *    exactly the re-spelling rule 1 protects: `50 to 100` → `50-100` (unclaimed
- *    → range) and `1200` → `1,200` (unclaimed → grouped figure) are the same
- *    claim written differently. `12-person` is read as people context for the
- *    same reason — the hyphen is how English attaches the noun, not a different
- *    claim from `12 people`. The residual cost is a people phrasing our lexicon
- *    misses on the input side but recognises on the output side
+ *    claimed fact on the input side too. `year` takes the strict count-parity
+ *    rule on the DROP side (rule 1) to prevent an unrelated digit from masking
+ *    a dropped year, but stays lenient on the ADD side because a year migrates
+ *    into temporal context during a rewrite far more often than a headcount does
+ *    (`"2019 Excellence Award"` → `"Award in 2019"`). Every other claim kind
+ *    keeps the lenient rule-1 lookup, because for those the unclaimed→claimed
+ *    move is exactly the re-spelling rule 1 protects: `50 to 100` → `50-100`
+ *    (unclaimed → range) and `1200` → `1,200` (unclaimed → grouped figure) are
+ *    the same claim written differently. `12-person` is read as people context
+ *    for the same reason — the hyphen is how English attaches the noun, not a
+ *    different claim from `12 people`. The residual cost is a people phrasing
+ *    our lexicon misses on the input side but recognises on the output side
  *    (`a team comprising 5` → `5 engineers`) reverting as an invention; that is
  *    the deliberate trade for catching a headcount the model made up.
  *
@@ -220,7 +223,7 @@ const PEOPLE_CONTEXT_WINDOW = 30;
  * written shape ($, %, x, ~, +, a magnitude suffix, grouping commas, a decimal
  * point); the other three are the prose around a bare integer.
  */
-type NumericClaim = "none" | "form" | "headcount" | "year" | "range";
+type NumericClaim = "none" | "form" | "headcount" | "year" | "year_verb" | "range";
 
 interface ClassifiedAtom {
   /** Match key used for set equality (lowercased so `$5K` ≡ `$5k`). */
@@ -283,13 +286,217 @@ function isDecorated(groups: Record<string, string | undefined>): boolean {
 }
 
 /**
+ * Month names and standard abbreviations (with optional abbreviation period)
+ * used across year prefix and follow cues (#876).
+ */
+const MONTH_NAME =
+  /(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?/i;
+
+/**
+ * Punctuation/dash characters that separate a bullet-initial date anchor from
+ * the following bullet text (#876). Requires date-range dash to be followed by
+ * a year (1900-2099), ongoing marker, or non-numeric prose text so numeric
+ * ranges like `2000 - 3000 units` do not match.
+ */
+const LEADING_DATE_ANCHOR_SEPARATOR = new RegExp(
+  `^\\s*(?:[:.)]` +
+    `|(?:${RANGE_DASH.source}\\s*(?:(?:19\\d\\d|20\\d\\d)|present|current|now|ongoing)\\b)` +
+    `|(?:${RANGE_DASH.source}(?!\\s*\\d)))\\s*`,
+  "i",
+);
+
+/**
+ * Context window (in characters) scanned before and after a 4-digit number
+ * when checking for year context cues (#876). Raised to 64 to hold full
+ * multi-word credential titles (e.g. "Google Cloud Certified Professional Cloud Architect").
+ */
+const YEAR_CONTEXT_WINDOW = 64;
+
+/**
+ * Case-SENSITIVE: CamelCase conference/product names (#876). Kept out of
+ * YEAR_PREFIX_CUE because that regex is /i, which makes [A-Z] match a-z.
+ */
+const YEAR_PREFIX_CUE_CAMEL =
+  /\b[A-Z][A-Za-z0-9]*(?:Con|Conf|Summit|Meetup|Expo|Fest|Symposium|Workshop|Awards?)\s*$/;
+
+/**
+ * Case-SENSITIVE: Capitalized venue/company names following "at" (#876). Kept
+ * out of YEAR_PREFIX_CUE because that regex is /i, which makes [A-Z] match a-z.
+ */
+const YEAR_PREFIX_CUE_VENUE =
+  /\bat\s+(?:[A-Z][A-Za-z0-9&.'-]*\s+)+$/;
+
+/**
+ * Temporal prepositions, verbs, credential/award phrases, month names,
+ * seasons, quarters, parentheses/commas, and range connectors that signal a
+ * 4-digit number (1900–2099) is being used as a year when appearing immediately
+ * before the digit (#876).
+ */
+const YEAR_PREFIX_CUE = new RegExp(
+  "(?:\\b(?:" +
+    "in|since|during|until|through|between|before|after|around|circa|c\\.|" +
+    "as\\s+of|class\\s+of|cohort\\s+of|batch\\s+of|" +
+    "winner,?\\s*|won,?\\s*|recipient\\s+of(?:\\s+the)?|speaker\\s+at|talk\\s+at|presented\\s+at|worked\\s+at|" +
+    "(?:awarded|certified|earned|completed|launched|published|promoted|shipped|graduated|founded|established|joined|built|deployed|released|delivered|led)\\s+(?:the|a|an|our|this)\\s+[A-Za-z0-9&.'-]+\\s+|" +
+    "(?:employee|person|engineer|team|member|volunteer)\\s+of\\s+the\\s+year\\s+|" +
+    "(?:awards?|prizes?|medals?|fellowships?|scholarships?|honou?rs?|certifications?|certificates?)\\s+|" +
+    "(?:certified\\s+(?!(?:the|a|an|our|this)\\b)(?:[A-Za-z0-9&.'-]+\\s+){1,4})|" +
+    `${MONTH_NAME.source}|` +
+    "spring|summer|fall|autumn|winter|" +
+    "q[1-4]|h[1-2]|fy" +
+    ")\\s*|" +
+    `[(,]\\s*|` +
+    `(?:\\b(?:19\\d\\d|20\\d\\d)\\s*(?:${RANGE_DASH.source}|/|to|and)\\s*)|` +
+    `(?:\\b\\d{1,2}\\s*[/.]\\s*))$`,
+  "i",
+);
+
+/**
+ * Weak prepositions, qualifiers, determiners, or temporal adverbs that signal
+ * a 4-digit number is a year when preceding the digit (#876).
+ *
+ * Mapped to the lenient "verb" / `year_verb` tier so legitimate bullet merges
+ * on quantities (e.g. "Reduced by 2000 hours" + "Tracked 2000 bugs") do not
+ * false-revert on count parity, while dropping the year completely is caught.
+ */
+const YEAR_PREFIX_WEAK_CUE = new RegExp(
+  "\\b(?:from|by|for|of|over|the|our|this|early|mid|late)[\\s-]*$",
+  "i",
+);
+
+/**
+ * Bare past-tense action verbs that signal a year when immediately preceding
+ * the digit AND followed by a function word or punctuation (#876).
+ */
+const YEAR_PREFIX_VERB_CUE = new RegExp(
+  "\\b(?:awarded|certified|earned|completed|launched|published|promoted|shipped|graduated|founded|established|joined)\\s*$",
+  "i",
+);
+
+/**
+ * Award and prize titles following a leading 4-digit year (#876).
+ */
+const YEAR_FOLLOW_AWARD_CUE =
+  /^(?:\s+[A-Za-z][A-Za-z0-9&.'-]*)*\s+(?:award|prize|medal|fellowship|scholarship|honou?r)s?\b/i;
+
+/**
+ * Connectives, qualifiers, range markers, or month/season names that signal
+ * a 4-digit number is a year when appearing immediately after the digit (#876).
+ */
+const YEAR_FOLLOW_CUE = new RegExp(
+  "^(?:\\s*(?:" +
+    "onwards?|present|current|now|ongoing|" +
+    "to\\s+(?:(?:19\\d\\d|20\\d\\d)|present|current|now|ongoing)|" +
+    "until\\s+(?:(?:19\\d\\d|20\\d\\d)|present|current|now|ongoing)|" +
+    "through\\s+(?:(?:19\\d\\d|20\\d\\d)|present|current|now|ongoing)|" +
+    "and\\s+(?:19\\d\\d|20\\d\\d)|" +
+    `${MONTH_NAME.source}` +
+    ")\\b|" +
+    `\\s*(?:${RANGE_DASH.source}|/)\\s*(?:(?:19\\d\\d|20\\d\\d)|present|current|now|ongoing)\\b)`,
+  "i",
+);
+
+/**
+ * Slice preceding context without fabricating artificial word boundaries (\b)
+ * when the fixed character window cuts mid-word (#876).
+ */
+function contextSliceBefore(
+  bullet: string,
+  matchStart: number,
+  windowSize: number,
+): string {
+  const rawStart = Math.max(0, matchStart - windowSize);
+  return rawStart > 0 && /\w/.test(bullet[rawStart - 1] ?? "")
+    ? bullet.slice(rawStart, matchStart).replace(/^\S*/, "")
+    : bullet.slice(rawStart, matchStart);
+}
+
+/**
+ * Slice following context without fabricating artificial word boundaries (\b)
+ * when the fixed character window cuts mid-word (#876).
+ */
+function contextSliceAfter(
+  bullet: string,
+  matchEnd: number,
+  windowSize: number,
+): string {
+  const rawEnd = matchEnd + windowSize;
+  if (rawEnd < bullet.length && /\w/.test(bullet[rawEnd] ?? "")) {
+    const stripped = bullet.slice(matchEnd, rawEnd).replace(/\S*$/, "");
+    return stripped.trim().length === 0 ? " …" : stripped;
+  }
+  return bullet.slice(matchEnd, rawEnd);
+}
+
+/**
+ * Does this 4-digit bare integer sit in temporal/year context? (#876)
+ *
+ * Distinguishes high-confidence explicit temporal cues ("strict" parity) from
+ * bare past-tense verb cues or weak prepositions ("verb" — lenient on drop side
+ * to prevent false reverts on plain quantities like "Shipped 2000 to partners").
+ */
+function isYearContext(
+  match: RegExpExecArray,
+  bullet: string,
+  digits: string,
+): "strict" | "verb" | "none" {
+  if (digits.length !== 4) return "none";
+  const year = Number(digits);
+  if (year < 1900 || year > 2099) return "none";
+
+  const matchStart = match.index;
+  const before = contextSliceBefore(bullet, matchStart, YEAR_CONTEXT_WINDOW);
+  const after = contextSliceAfter(
+    bullet,
+    matchStart + digits.length,
+    YEAR_CONTEXT_WINDOW,
+  );
+
+  // 1. Explicit temporal prefix cue (e.g. "in 1900", "since 2019", "Jan 2021", "2019 - 2021", "KubeCon 2022", "at Acme 2020")
+  if (
+    YEAR_PREFIX_CUE.test(before) ||
+    YEAR_PREFIX_CUE_CAMEL.test(before) ||
+    YEAR_PREFIX_CUE_VENUE.test(before)
+  ) {
+    return "strict";
+  }
+
+  // 2. Explicit temporal follow cue (e.g. "2019 onwards", "2019 - Present", "2019 to 2021", "2019 Excellence Award")
+  if (YEAR_FOLLOW_CUE.test(after) || YEAR_FOLLOW_AWARD_CUE.test(after)) {
+    return "strict";
+  }
+
+  // 3. Leading date anchor at the start of a bullet (e.g. "2019: Founded company", "• 2019 - Started role")
+  const leadingText = bullet
+    .slice(0, matchStart)
+    .trim()
+    .replace(/^[-*•⁃–—\s]+/, "");
+  if (leadingText.length === 0 && LEADING_DATE_ANCHOR_SEPARATOR.test(after)) {
+    return "strict";
+  }
+
+  // 1b. Bare past-tense verb followed by a function word, punctuation, or end of bullet (#876)
+  if (YEAR_PREFIX_VERB_CUE.test(before) && FUNCTION_WORD_FOLLOWS.test(after)) {
+    return "verb";
+  }
+
+  // 1c. Weak prepositions, qualifiers, or bullet-initial attributive years (#876)
+  if (YEAR_PREFIX_WEAK_CUE.test(before) || leadingText.length === 0) {
+    return "verb";
+  }
+
+  return "none";
+}
+
+/**
  * What, if anything, makes this bare integer worth defending, given the words
  * around it?
  *
  * Three ways to qualify — a headcount, a year, or one endpoint of a tight
- * range. Everything else ("the 3 of us", "phase 2", "section 4") is noise: it
- * still produces an atom, so the other side can match against it, but it is
- * never itself reported as dropped or added.
+ * range. Everything else ("the 3 of us", "phase 2", "section 4", "suite 1900")
+ * is noise: on the drop side, it is not required to be preserved unless matched
+ * on the other side. On the add side, hallucinated numbers are guarded by
+ * checking whether newly introduced values existed in the input.
  *
  * The match index IS the digit index on this branch: every prefix decoration
  * (approximation, sign, currency) implies `isDecorated`, so a caller that
@@ -306,13 +513,11 @@ function bareIntegerClaim(
   digits: string,
 ): NumericClaim {
   const matchStart = match.index;
-  const before = bullet.slice(
-    Math.max(0, matchStart - PEOPLE_CONTEXT_WINDOW),
-    matchStart,
-  );
-  const after = bullet.slice(
+  const before = contextSliceBefore(bullet, matchStart, PEOPLE_CONTEXT_WINDOW);
+  const after = contextSliceAfter(
+    bullet,
     matchStart + digits.length,
-    matchStart + digits.length + PEOPLE_CONTEXT_WINDOW,
+    PEOPLE_CONTEXT_WINDOW,
   );
 
   // A people noun after the digit is decisive on its own.
@@ -327,9 +532,12 @@ function bareIntegerClaim(
     return "headcount";
   }
 
-  if (digits.length === 4) {
-    const year = Number(digits);
-    if (year >= 1900 && year <= 2099) return "year";
+  const yearKind = isYearContext(match, bullet, digits);
+  if (yearKind === "strict") {
+    return "year";
+  }
+  if (yearKind === "verb") {
+    return "year_verb";
   }
 
   // A range endpoint (#778). `50-100 tickets` used to track NEITHER number:
@@ -338,7 +546,19 @@ function bareIntegerClaim(
   // two endpoints are two independent atoms rather than one `50-100` atom, so a
   // rewrite that re-spells the dash (`50–100`) or the whole range (`50 to 100`)
   // still matches — the dash is detection context, never part of the key.
-  return isRangeEndpoint(match, bullet) ? "range" : "none";
+  if (isRangeEndpoint(match, bullet)) {
+    return "range";
+  }
+
+  // Never demote below main: a 4-digit integer in 1900-2099 that no cue
+  // recognised stays CLAIMED, but leniently. A cue MISS then costs nothing
+  // relative to main; only a strict-tier cue HIT can change the answer (#876 redesign).
+  const n = Number(digits);
+  if (digits.length === 4 && n >= 1900 && n <= 2099) {
+    return "year_verb";
+  }
+
+  return "none";
 }
 
 function classifyAtom(match: RegExpExecArray, bullet: string): ClassifiedAtom {
@@ -353,9 +573,7 @@ function classifyAtom(match: RegExpExecArray, bullet: string): ClassifiedAtom {
   // Grouping commas are presentation, not value: `1,200` and `1200` are the
   // same figure spelled two ways. The KEY drops them so the two spellings
   // match; `display` keeps whichever the author (or the model) wrote, because
-  // that is what the warning copy quotes back. Keying on the literal spelling
-  // is what made "Processed 1,200 orders" → "Processed 1200 orders" report a
-  // dropped `1,200` and revert a rewrite that changed nothing but the comma.
+  // that is what the warning copy quotes back.
   const value = digits.replace(/,/g, "");
 
   if (isDecorated(g)) {
@@ -366,11 +584,8 @@ function classifyAtom(match: RegExpExecArray, bullet: string): ClassifiedAtom {
     };
   }
 
-  // Undecorated. ONE key namespace regardless of what (if anything) qualified
-  // it — a headcount `12`, a year `2019`, a range endpoint `50` and a grouped
-  // `1,200` are the same value as the same digits written with no context and
-  // no commas, and splitting them by namespace is what made `Managed 12 people`
-  // → `Managed a 12-person team` report a dropped `12`.
+  // Undecorated (bare integer, grouped integer `1,200`, or decimal `3.14`).
+  // ONE key namespace (`num:1200`) regardless of grouping.
   return {
     key: `num:${value}`,
     display,
@@ -404,6 +619,14 @@ export interface PreservationResult {
   added: string[];
 }
 
+function is4DigitYearValue(atom: ClassifiedAtom): boolean {
+  if (!atom.key.startsWith("num:")) return false;
+  const digits = atom.key.slice(4);
+  if (digits.length !== 4) return false;
+  const n = Number(digits);
+  return n >= 1900 && n <= 2099;
+}
+
 /**
  * Every claimed atom in `atoms` that `isPresent` cannot find on the other side,
  * reported by its display form in first-encounter order, at most once per key.
@@ -415,12 +638,13 @@ export interface PreservationResult {
  */
 function missingFrom(
   atoms: readonly ClassifiedAtom[],
+  isCandidate: (atom: ClassifiedAtom) => boolean,
   isPresent: (atom: ClassifiedAtom) => boolean,
 ): string[] {
   const reported = new Set<string>();
   const missing: string[] = [];
   for (const atom of atoms) {
-    if (!isClaimed(atom)) continue;
+    if (!isCandidate(atom)) continue;
     if (reported.has(atom.key) || isPresent(atom)) continue;
     reported.add(atom.key);
     missing.push(atom.display);
@@ -434,7 +658,7 @@ function countUnclaimedByKey(
 ): Map<string, number> {
   const counts = new Map<string, number>();
   for (const atom of atoms) {
-    if (isClaimed(atom)) continue;
+    if (isClaimed(atom) && atom.claim !== "year_verb") continue;
     counts.set(atom.key, (counts.get(atom.key) ?? 0) + 1);
   }
   return counts;
@@ -467,42 +691,63 @@ export function checkNumbersPreserved(
   const outputClaimedKeys = new Set(
     outputAtoms.filter(isClaimed).map((a) => a.key),
   );
+  const outputStrictYearKeys = new Set(
+    outputAtoms.filter((a) => a.claim === "year").map((a) => a.key),
+  );
   // Per-key counts of UNCLAIMED occurrences on each side — the baseline of
   // "this digit shows up elsewhere for unrelated reasons" that already
-  // existed before the rewrite touched anything. Only headcount needs this:
-  // it is the one claim kind with a real unclaimed state on the same key
-  // (`num:12` from "team of 12" vs `num:12` from "module 12" of a curriculum).
+  // existed before the rewrite touched anything. Headcount and year (#876) need
+  // this: they are the two claim kinds with a real unclaimed state on the same key
+  // (`num:12` from "team of 12" vs `num:12` from "module 12", or `num:1900` from
+  // "in 1900" vs `num:1900` from "suite 1900").
   const inputUnclaimedCounts = countUnclaimedByKey(inputAtoms);
   const outputUnclaimedCounts = countUnclaimedByKey(outputAtoms);
 
   // Drop: the value is gone from the output in every spelling (rule 1) —
-  // except for a headcount, which counts as present only if the output
-  // claims it too, OR a NEW unclaimed occurrence of the key appears that
+  // except for a headcount and strict year (#876), which count as present only if the
+  // output claims it too, OR a NEW unclaimed occurrence of the key appears that
   // wasn't already there before the rewrite (the "phase 5" masking case
   // below, which rule 1 is right to treat as a reword, not a loss). Without
   // the "new" qualifier, an unrelated digit the input ALREADY carried
   // unclaimed (e.g. "module 12" sitting next to a genuinely-dropped
-  // "12 engineers") would mask the drop just by surviving unchanged — the
-  // masking bug rule 1's blanket `outputKeys.has` used to have. `form`/
-  // `range`/`year` keep the fully lenient lookup: those claims genuinely
-  // depend on prose a rewrite is licensed to move (or, for `year`, have no
-  // unclaimed state to compare against at all), so tightening them risks a
-  // false revert on a legitimate reword rule 1 exists to allow.
-  const dropped = missingFrom(inputAtoms, (atom) => {
-    if (atom.claim !== "headcount") return outputKeys.has(atom.key);
-    if (outputClaimedKeys.has(atom.key)) return true;
-    return (
-      (outputUnclaimedCounts.get(atom.key) ?? 0) >
-      (inputUnclaimedCounts.get(atom.key) ?? 0)
-    );
-  });
+  // "12 engineers", or "suite 1900" sitting next to "in 1900") would mask the
+  // drop just by surviving unchanged — the masking bug rule 1's blanket
+  // `outputKeys.has` used to have. `form`/`range` keep the fully lenient
+  // lookup: those claims genuinely depend on prose a rewrite is licensed to
+  // move, so tightening them risks a false revert on a legitimate reword rule 1
+  // exists to allow.
+  const dropped = missingFrom(
+    inputAtoms,
+    isClaimed,
+    (atom) => {
+      if (atom.claim !== "headcount" && atom.claim !== "year") {
+        return outputKeys.has(atom.key);
+      }
+      const claimedOnOtherSide =
+        atom.claim === "year"
+          ? outputStrictYearKeys.has(atom.key)
+          : outputClaimedKeys.has(atom.key);
+      if (claimedOnOtherSide) return true;
+      return (
+        (outputUnclaimedCounts.get(atom.key) ?? 0) >
+        (inputUnclaimedCounts.get(atom.key) ?? 0)
+      );
+    },
+  );
   // Invention: the same lookup, except that a headcount the output asserts is
   // "present" only if the input asserted that value too (rule 3). `phase 5` →
   // `5 engineers` reuses the digit while making a claim the résumé never made.
-  const added = missingFrom(outputAtoms, (atom) =>
-    atom.claim === "headcount"
-      ? inputClaimedKeys.has(atom.key)
-      : inputKeys.has(atom.key),
+  // `year` / 4-digit years (1900–2099) defend against invented values while
+  // remaining lenient on additions (#876): an output year only needs its numeric
+  // value present in the input in any form (e.g. "2019 Excellence Award" -> "Award in 2019"),
+  // preventing legitimate temporal rewording from being flagged as an invented year.
+  const added = missingFrom(
+    outputAtoms,
+    (atom) => isClaimed(atom) || is4DigitYearValue(atom),
+    (atom) =>
+      atom.claim === "headcount"
+        ? inputClaimedKeys.has(atom.key)
+        : inputKeys.has(atom.key),
   );
 
   return {


### PR DESCRIPTION
## Summary
Resolves #876.

Adopts an **inverted 3-tier promotion architecture** for year classification in `preserve-numbers.ts`:
1. **Baseline Defense (Lenient)**: Every 4-digit number (1900–2099) defaults to `claim: "year_verb"` (claimed, lenient presence lookup). A cue miss *never* loses `main`'s baseline defense, eliminating the need to enumerate every English date phrasing.
2. **Strict Promotion Tier**: The cue gate (`isYearContext`) only ever **promotes** high-confidence temporal cues to `claim: "year"` (strict count parity).
3. **Strict Masking**: A strict year requires the output atom to also carry a strict year claim (`outputStrictYearKeys.has(atom.key)`), preventing noise digits from masking dropped years.

### Architectural Design
- **Drop Side (Rule 1)**:
  - **High-Confidence Temporal Cues (`claim: "year"`)**: Explicit temporal prepositions (`in 1900`, `since 2019`, `Jan 2021`), explicit temporal follow cues (`2019 onwards`, `2019 - Present`, `2019 to 2021`), leading award/prize names (`2019 Excellence Award recipient`), capitalized venue names (`at Google 2019`), and bullet-start date anchors (`2019: Started role`, `• 2019 - ...`). Evaluated against `outputStrictYearKeys` under strict count parity.
  - **Lenient / Un-cued 4-Digit Numbers (`claim: "year_verb"`)**: All other 4-digit numbers (1900–2099), weak prepositions, qualifiers, and bare past-tense verbs (`from 2019`, `by 2021`, `early 2019`, `mid-2020`, `summer of 2019`, `for 2020`, `2019 revenue grew 40%`, `Delivered 2000 units to production`). Evaluated leniently against `outputKeys.has(atom.key)`: complete drops are flagged as errors, while legitimate quantity merges (`Reduced by 2000 hours` + `Tracked 2000 bugs` $\rightarrow$ `Tracked 2000 bugs and reduced hours`) return `ok: true`.
- **Invention Side (Rule 3)**: All bare integers in the 1900–2099 range are audited against the input to prevent hallucinated numbers, while remaining lenient on legitimate temporal rewords (e.g. `"2019 Excellence Award"` $\rightarrow$ `"Award in 2019"`).
- **Residual / Accepted Trade-off**:
  - `[(,]` cues immediately preceding a 4-digit number are included to defend degrees and parenthesized talk years (e.g. `"B.S. CS, 2019"`, `"Speaker (2019)"`). Under strict count parity, if two same-value quantities exist with a preceding comma/parenthesis or leading dash and one is merged away without a year cue, strict count parity reports a drop. This is an explicit accepted residual trade-off for degree, talk, and award defense.

## Changes
1. **`src/lib/webllm/preserve-numbers.ts`**:
   - Implemented the inverted architecture in `bareIntegerClaim`, defaulting 1900–2099 bare integers to `year_verb` (lenient) and promoting high-confidence cues to `year` (strict).
   - Updated `countUnclaimedByKey` to treat `year_verb` (lenient) as non-strict for count-guard evaluation.
   - Updated `checkNumbersPreserved` to require `outputStrictYearKeys.has(atom.key)` for strict `year` claims.
   - Added case-sensitive `YEAR_PREFIX_CUE_VENUE` for capitalized venue names (`at Google 2019`).
   - Made `YEAR_FOLLOW_AWARD_CUE` case-insensitive (`/i`).
   - Updated `contextSliceAfter` so mid-word truncation of long tokens never creates false end-of-bullet matches.

2. **`src/lib/webllm/preserve-numbers.test.ts`**:
   - Added test cases covering weak prepositions, qualifiers, lowercase awards, venue capitalization, and long-token window boundaries.
   - Verified that complete drops of 4-digit numbers are defended while quantity merges stay green.

## Verification
- `npm run verify` passed: **383 test files passed, 6,476 / 6,476 vitest tests green**.
- Single clean squashed commit on branch `sg/preserve-numbers-year-context-gate`.
