### PR TITLE
docs: add a one-page architecture map for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@ Thanks for picking up a piece of this. offlinecv is a browser-side PDF
 parser audit and job-search workbench. Code lives under `src/`, license is
 [Apache-2.0](./LICENSE) (patent grant included; see `NOTICE`). See
 [`README.md`](./README.md) for what offlinecv is and what it surfaces;
-see [`CLAUDE.md`](./CLAUDE.md) for the pipeline shape and tier layout; and see
+see [`docs/architecture.md`](./docs/architecture.md) for a one-page map of the
+pipeline and where each piece lives (and [`CLAUDE.md`](./CLAUDE.md) for the same
+ground in more depth); and see
 [`docs/CONTRIBUTING-PROCESS.md`](./docs/CONTRIBUTING-PROCESS.md) for the shipping
 process this file summarizes — the **test-fixture PII policy** (mandatory before
 you add any PDF), AI attribution, squash messages, and deploy.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ encoding doesn't decode to characters. For that last case the parser falls
 back to the PDF's embedded link annotations as recovered signal, so a
 candidate can still see what survived.
 
-New contributors: see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup,
-branch + commit conventions, and the PR checklist.
+New contributors: see [`docs/architecture.md`](./docs/architecture.md) for a
+one-page map of the pipeline and which folder each piece lives in, and
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup, branch + commit conventions,
+and the PR checklist.
 
 ## Quick start
 
@@ -215,7 +217,7 @@ and the rest of the UI is unaffected. Because the request originates in your
 browser, **your IP address is seen by GitHub** (a US third party) as a result
 of loading the app.
 
-### Job-search feeds (Find jobs tab)
+### Job-search feeds
 
 The **Find jobs** tab can fetch a sample of live postings from free, keyless,
 CORS-open job feeds and rank them against your parsed résumé. These requests

--- a/docs/architecture-diagram.svg
+++ b/docs/architecture-diagram.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1098 412" width="1098" height="412" role="img" aria-labelledby="t d">
+<title id="t">OfflineCV architecture at a glance</title>
+<desc id="d">The OfflineCV pipeline drawn inside a dashed box labelled "your browser tab": drop a résumé file, read it with pdf.js, parse it in tiers, score it, edit it, export an ATS-safe PDF. Local storage and job matching also sit inside the box. Three dashed arrows leave the box — a keyword string, a pasted job-description URL, and a product-analytics event — and a footnote names what else leaves, including the on-device model download.</desc>
+<defs><marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#8793A3"/></marker></defs>
+<rect x="0" y="0" width="1098" height="412" fill="#FFF8EA"/>
+<rect x="2" y="22" width="1094" height="270" rx="14" fill="#FFFFFF" fill-opacity="0.55" stroke="#00A6A6" stroke-width="2" stroke-dasharray="9 6"/>
+<rect x="24" y="13" width="196" height="18" fill="#FFF8EA"/>
+<text x="34" y="26" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#00A6A6" text-anchor="start" letter-spacing="1.4">YOUR BROWSER TAB</text>
+<rect x="27.0" y="48" width="5" height="96" rx="2.5" fill="#3157D5"/>
+<rect x="36.0" y="48" width="149" height="96" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="50.0" y="69" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#3157D5" text-anchor="start" letter-spacing="1.2">01</text>
+<text x="50.0" y="90" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#101A3A" text-anchor="start">Drop</text>
+<text x="50.0" y="108" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">PDF, DOCX or Markdown</text>
+<text x="50.0" y="121" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">from your own machine</text>
+<text x="50.0" y="137" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">components/DropZone</text>
+<path d="M 190.6 90.0 L 198.6 96.0 L 190.6 102.0" fill="none" stroke="#8793A3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="204.2" y="48" width="5" height="96" rx="2.5" fill="#3157D5"/>
+<rect x="213.2" y="48" width="149" height="96" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="227.2" y="69" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#3157D5" text-anchor="start" letter-spacing="1.2">02</text>
+<text x="227.2" y="90" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#101A3A" text-anchor="start">Read</text>
+<text x="227.2" y="108" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">Tier 0 — pdf.js text</text>
+<text x="227.2" y="121" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">+ layout probes</text>
+<text x="227.2" y="137" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/heuristics</text>
+<path d="M 367.8 90.0 L 375.8 96.0 L 367.8 102.0" fill="none" stroke="#8793A3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="381.4" y="48" width="5" height="96" rx="2.5" fill="#3157D5"/>
+<rect x="390.4" y="48" width="149" height="96" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="404.4" y="69" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#3157D5" text-anchor="start" letter-spacing="1.2">03</text>
+<text x="404.4" y="90" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#101A3A" text-anchor="start">Parse</text>
+<text x="404.4" y="108" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">Tier 1 heuristics,</text>
+<text x="404.4" y="121" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">Tier 1.5 regex fill-in</text>
+<text x="404.4" y="137" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/heuristics</text>
+<path d="M 545.0 90.0 L 553.0 96.0 L 545.0 102.0" fill="none" stroke="#8793A3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="558.5999999999999" y="48" width="5" height="96" rx="2.5" fill="#00A6A6"/>
+<rect x="567.5999999999999" y="48" width="149" height="96" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="581.5999999999999" y="69" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#00A6A6" text-anchor="start" letter-spacing="1.2">04</text>
+<text x="581.5999999999999" y="90" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#101A3A" text-anchor="start">Score</text>
+<text x="581.5999999999999" y="108" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">3 dimensions, then a</text>
+<text x="581.5999999999999" y="121" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">layout penalty</text>
+<text x="581.5999999999999" y="137" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/score</text>
+<path d="M 722.1999999999999 90.0 L 730.1999999999999 96.0 L 722.1999999999999 102.0" fill="none" stroke="#8793A3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="735.8" y="48" width="5" height="96" rx="2.5" fill="#00A6A6"/>
+<rect x="744.8" y="48" width="149" height="96" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="758.8" y="69" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#00A6A6" text-anchor="start" letter-spacing="1.2">05</text>
+<text x="758.8" y="90" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#101A3A" text-anchor="start">Edit</text>
+<text x="758.8" y="108" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">inline fixes, plus</text>
+<text x="758.8" y="121" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">on-device AI rewrite</text>
+<text x="758.8" y="137" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/edit · lib/webllm</text>
+<path d="M 899.4 90.0 L 907.4 96.0 L 899.4 102.0" fill="none" stroke="#8793A3" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="913.0" y="48" width="5" height="96" rx="2.5" fill="#F5A623"/>
+<rect x="922.0" y="48" width="149" height="96" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="936.0" y="69" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5A623" text-anchor="start" letter-spacing="1.2">06</text>
+<text x="936.0" y="90" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" fill="#101A3A" text-anchor="start">Export</text>
+<text x="936.0" y="108" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">ATS-safe PDF,</text>
+<text x="936.0" y="121" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">Markdown, audit report</text>
+<text x="936.0" y="137" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/pdf</text>
+<text x="27" y="162" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#8793A3" text-anchor="start" letter-spacing="1.3">ALSO INSIDE THE TAB</text>
+<rect x="27" y="172" width="5" height="64" rx="2.5" fill="#00A6A6"/>
+<rect x="36" y="172" width="504" height="64" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="50" y="196" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#101A3A" text-anchor="start">Saved on your device</text>
+<text x="50" y="213" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">Autosaves to an IndexedDB library on your first edit — never before.</text>
+<text x="50" y="228" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/storage</text>
+<rect x="558" y="172" width="5" height="64" rx="2.5" fill="#F5A623"/>
+<rect x="567" y="172" width="504" height="64" rx="8" fill="#FFFFFF" stroke="#E6E1D6" stroke-width="1"/>
+<text x="581" y="196" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#101A3A" text-anchor="start">Match jobs — the /jobs/ lane</text>
+<text x="581" y="213" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10.5" font-weight="400" fill="#5F6B7A" text-anchor="start">Ranks live postings against the résumé you just parsed; save and track them.</text>
+<text x="581" y="228" font-family="'Aptos Mono', 'Cascadia Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">lib/job-search · lib/jd-match</text>
+<text x="27" y="262" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#00A6A6" text-anchor="start">Your résumé bytes and your résumé text never leave this box.</text>
+<text x="1071" y="312" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#8793A3" text-anchor="end" letter-spacing="1.3">WHAT DOES LEAVE</text>
+<path d="M 35 292 V 322" fill="none" stroke="#8793A3" stroke-width="1.4" stroke-dasharray="4 4" marker-end="url(#ah)" opacity="0.85"/>
+<text x="27" y="344" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#101A3A" text-anchor="start">A keyword string</text>
+<text x="27" y="360" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" fill="#5F6B7A" text-anchor="start">Your job title and skills reach the job</text>
+<text x="27" y="373" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" fill="#5F6B7A" text-anchor="start">feeds. Never your résumé text.</text>
+<path d="M 387 292 V 322" fill="none" stroke="#8793A3" stroke-width="1.4" stroke-dasharray="4 4" marker-end="url(#ah)" opacity="0.85"/>
+<text x="379" y="344" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#101A3A" text-anchor="start">A job-description URL</text>
+<text x="379" y="360" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" fill="#5F6B7A" text-anchor="start">Only when you paste one — it fetches that</text>
+<text x="379" y="373" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" fill="#5F6B7A" text-anchor="start">public posting page, nothing else.</text>
+<path d="M 739 292 V 322" fill="none" stroke="#8793A3" stroke-width="1.4" stroke-dasharray="4 4" marker-end="url(#ah)" opacity="0.85"/>
+<text x="731" y="344" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#101A3A" text-anchor="start">A product-analytics event</text>
+<text x="731" y="360" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" fill="#5F6B7A" text-anchor="start">Hosted build only. The open-source build</text>
+<text x="731" y="373" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" fill="#5F6B7A" text-anchor="start">you clone ships none.</text>
+<text x="27" y="398" font-family="Aptos, 'Segoe UI', Inter, system-ui, -apple-system, Helvetica, Arial, sans-serif" font-size="9.5" font-weight="400" fill="#8793A3" text-anchor="start">Also leaving the tab: the on-device model download (1.6–2.3 GB) and the company job boards. The GitHub star count is third-party; the version check is same-origin. Any third-party call reveals your IP — full list in docs/architecture.md.</text>
+</svg>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,123 @@
+# Architecture at a glance
+
+A one-page map of offlinecv for someone about to make their first change.
+It is deliberately shallow: enough to know which folder your issue lives in,
+and which constraint you must not break on the way.
+
+![The offlinecv pipeline drawn inside a dashed box labelled "your browser tab":
+drop a résumé file, read it with pdf.js, parse it in tiers, score it, edit it,
+export an ATS-safe PDF. Local storage and job matching also sit inside the box.
+Three dashed arrows leave the box — a keyword string, a pasted job-description
+URL, and a product-analytics event — and a footnote names what else leaves,
+including the on-device model download.](./architecture-diagram.svg)
+
+## The one constraint
+
+**The PDF bytes and the résumé text never leave the browser.** Every box in the
+dashed area above runs in the visitor's tab; nothing in it sends your résumé
+to a server, because offlinecv has no backend of its own.
+
+Scope that claim to **data custody, not runtime**. "Everything runs on your
+device" is falsifiable — several things do cross the line, and they are listed
+below rather than hidden. When you write copy, a docblock, or a PR description
+that touches this, say what is true of the *data*, and check what the app
+actually calls before you say anything about the network.
+
+Grepping `fetch(` under `src/` is where that check starts, not where it ends.
+The largest call the app makes — the on-device model download — is issued
+inside `@mlc-ai/web-llm` and never appears as a `fetch(` literal in this repo.
+Read the table below, and watch a real session in devtools before you write
+down a number.
+
+There is **no BYOK cloud-LLM provider in the tree**. A few docblocks mention
+one; it is unbuilt ([#320](https://github.com/offlinecv/OfflineCV/issues/320)).
+Don't describe a cloud model path as if it ships.
+
+## The parse cascade
+
+`runCascade()` in `src/lib/heuristics/` runs three tiers over the bytes and
+returns one `CascadeResult`. Each tier is dynamic-imported so the entry chunk
+stays small.
+
+| Tier | Module | Does |
+|---|---|---|
+| 0 | `pdf-extract.ts` (pdf.js) + `pdf-layout.ts` | Pulls text items, pages, raw text and link annotations; probes for scanned and two-column layouts |
+| 1 | `openresume.ts` | Heuristic structured parse — the main event |
+| 1.5 | `regex-fallback.ts` | Fills in individual fields tier 1 missed |
+
+`computeAnonymousAtsScore()` (`src/lib/score/score.ts`) then scores the result on
+Specificity (0.4), Structure (0.3) and Completeness (0.3), multiplied by a
+layout-trigger penalty — 1.0, 0.85, 0.70, or 0 if the PDF is scanned. See
+[`docs/scoring.md`](./scoring.md) for the dimensions in detail.
+
+## Where things live
+
+Everything below is under `src/`.
+
+| Area | Folder |
+|---|---|
+| The drop target | `components/DropZone.tsx` |
+| Parse cascade and its tiers | `lib/heuristics/` |
+| Scoring | `lib/score/` |
+| Inline edits and overrides | `lib/edit/` |
+| On-device AI (WebGPU): parse, critique, rewrite | `lib/webllm/` |
+| PDF / Markdown / audit-report export | `lib/pdf/` |
+| IndexedDB résumé and job library | `lib/storage/` |
+| Job discovery, ranking, deep links | `lib/job-search/` |
+| Matching a résumé to a job description | `lib/jd-match/` |
+| Shared UI primitives and tokens | `design-system/` |
+
+The build ships two HTML entries: `/` is the parser-audit lane (drop → parse →
+score → edit → export) and `/jobs/` is the job-search lane. `/jobs/` has no drop
+zone — parsing is `/`'s job, and the parsed résumé travels between them through
+`sessionStorage`.
+
+A parsed résumé is written to IndexedDB **automatically only once you have
+edited it** (`src/hooks/useAutosaveResume.ts`). Someone who drops a PDF, reads
+the score and leaves has left nothing at rest. The one way a record exists
+before an edit is if you ask for it: the parse header offers an explicit **Save
+to library** for keeping an unedited parse
+(`src/components/features/ParsedHeader.tsx`). That is a stronger promise than
+"saves locally" and it is easy to break by accident — see
+[IndexedDB](../README.md#indexeddb-local-first-storage) in the README.
+
+## What leaves the tab
+
+| What | When | Where it lives |
+|---|---|---|
+| A keyword string — your job title and skills, never résumé text | You click "Search jobs" | [`lib/job-search/providers/keywords.ts`](../src/lib/job-search/providers/keywords.ts) |
+| A public company slug — no résumé text, no keywords | The same search, against the company boards (Greenhouse, Lever, Ashby) | [`lib/job-search/company-boards.ts`](../src/lib/job-search/company-boards.ts) |
+| A job-description URL | You paste one into the JD panel | [`lib/jd-match/fetch-jd.ts`](../src/lib/jd-match/fetch-jd.ts) |
+| A model-file request — 1.6–2.3 GB from `huggingface.co` and `raw.githubusercontent.com` | You start an on-device AI action and accept that model's licence | [`lib/webllm/web-llm.ts`](../src/lib/webllm/web-llm.ts) |
+| A product-analytics event — and, if you send feedback, the opt-in email and free text you typed | Hosted builds only; dead-code-eliminated when `VITE_POSTHOG_KEY` is unset, so a clone ships none | [`lib/analytics.ts`](../src/lib/analytics.ts) |
+
+One further call carries neither résumé data nor anything you typed — the
+footer's GitHub star count (`src/hooks/useGitHubStars.ts`). The version check
+(`src/lib/version.ts`) is **same-origin**: it fetches this app's own
+`version.json`, so no third party is involved.
+
+Every row in the table above reveals the visitor's IP to that third party. The
+README covers several of them in more detail:
+[Telemetry](../README.md#telemetry),
+[GitHub star count](../README.md#github-star-count),
+[Job-search feeds](../README.md#job-search-feeds).
+
+## Making your first change
+
+1. Pick something from the [open `good first issue`
+   list](https://github.com/offlinecv/OfflineCV/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+   and comment that you're starting —
+   [Claiming an issue](../CONTRIBUTING.md#claiming-an-issue) explains why the
+   comment matters.
+2. Find the row in [Where things live](#where-things-live) that matches it, and
+   open the closest existing file in that folder before writing anything. The
+   repo has a consistent house style and the fastest way to match it is to
+   mirror a neighbour.
+3. Run the gates: `npm run verify:quick` — typecheck, lint, and the tests your
+   change touches. Lint is the one that enforces the design-system and
+   colour-token rules, so running it here rather than at push time is what
+   saves you a surprise. `npm run verify` is the full pre-push gate and runs
+   automatically on `git push`.
+
+`CLAUDE.md` carries the same pipeline in more depth, alongside the rules for
+writing code in this repo. Read it when this page runs out.


### PR DESCRIPTION
## What changed

Adds `docs/architecture.md` — a one-page map of offlinecv aimed at someone
about to make their first change, plus the diagram it is built around
(`docs/architecture-diagram.svg`), and links it from `README.md` and
`CONTRIBUTING.md`.

Today a first-time contributor's only orientation is `CLAUDE.md`, which is
explicitly written for *writing code* rather than for finding your way around.
`CONTRIBUTING.md` even points there "for the pipeline shape and tier layout".
That is a lot to ask of someone whose actual question is "which folder does my
issue live in".

The page carries four things and stops:

- **The diagram.** The parse lane — drop → read → parse → score → edit →
  export — drawn inside a dashed *your browser tab* boundary, with local
  storage and the `/jobs/` lane also inside it. Every box names the folder it
  lives in.
- **The trust boundary, stated once.** Scoped to data custody rather than
  runtime, with the three things that genuinely cross the line drawn *below*
  it instead of left out.
- **A folder map** keyed to the diagram, so the picture resolves to a path.
- **The cascade tiers and the score weights**, as a table, linking
  `docs/scoring.md` for the detail.

## On the egress claims

Anything describing this boundary is easy to get subtly wrong, so the numbers
came from the code rather than from existing prose: the `fetch(` call sites
were grepped, and the two calls that are *not* résumé-related — the footer's
GitHub star count and the version check — are named on the page and in the
diagram's footnote rather than quietly dropped. The README's IP-disclosure
point is carried over and links back to the three README sections that already
make it in detail. No claim on the page is broader than what the README
already commits to.

The page also states that there is no BYOK cloud-LLM provider in the tree
(#320 is unbuilt), since a few docblocks mention one and it is a natural thing
for a newcomer to mis-describe.

## Verification

- Every file path cited on the page was checked to exist.
- `npm run verify` passes — typecheck, lint, full test suite, build, and
  fallow clean on all 4 changed files.
- Docs-only: no source, no test, and no build-config change.

## Note on the diagram

The SVG is deliberately self-contained and themed to read on both light and
dark GitHub. It was drawn for the upcoming student open-source session, so it
does double duty — but it is checked in here because the repo needs a
contributor map regardless of that session.

Refs #901, #902
