### PR TITLE
feat(feedback): inline nudge instead of an auto-opening modal, cooldown instead of a lifetime cap

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { ShareWithExtensionBar } from "./components/features/ShareWithExtensionB
 import { ExportDialog } from "./components/features/ExportDialog.tsx";
 import { ResumeChooserDialog } from "./components/features/ResumeChooserDialog.tsx";
 import { FeedbackDialog } from "./components/features/FeedbackDialog.tsx";
+import { FeedbackNudge } from "./components/features/FeedbackNudge.tsx";
 import { useAnalyzedResume } from "./hooks/useAnalyzedResume.ts";
 import { useResumeLibrary } from "./hooks/useResumeLibrary.ts";
 import { useReplaceResumeOnDrop } from "./hooks/useReplaceResumeOnDrop.ts";
@@ -633,6 +634,16 @@ export default function App() {
       )}
 
       <ErrorBoundary onReset={reset}>
+        {/* #912 — the export milestone's ask. Above the result rather than
+            buried under it: it is raised by an action the user just took, and
+            an invitation they have to scroll to find is one they never see.
+            Inline and non-modal on purpose — see `FeedbackNudge`. */}
+        {feedback.nudgeVisible && state.phase === "done" && (
+          <FeedbackNudge
+            onRate={feedback.openDialog}
+            onDismiss={feedback.dismissNudge}
+          />
+        )}
         {state.phase === "done" && edited && displayResult && recovery && (
           <>
             <Result
@@ -733,10 +744,10 @@ export default function App() {
         // artifact matches what the page shows.
         <ExportDialog
           open={exportOpen}
-          // #900 — closing is also when a pending feedback milestone flushes.
+          // #900/#912 — closing is when a pending feedback milestone flushes.
           // The export dialog stays open after a download on purpose (#421),
-          // so opening the interstitial any earlier would stack a second
-          // native modal over the findings the download just produced.
+          // and the nudge raised here would sit behind it, unseen, if it were
+          // shown any earlier.
           onClose={() => {
             setExportOpen(false);
             feedback.notifyExportClosed();
@@ -759,6 +770,7 @@ export default function App() {
       <FeedbackDialog
         open={feedback.open}
         onClose={feedback.close}
+        initialRating={feedback.initialRating}
         onSubmitted={feedback.markSubmitted}
       />
 

--- a/src/components/features/FeedbackDialog.test.tsx
+++ b/src/components/features/FeedbackDialog.test.tsx
@@ -28,6 +28,8 @@ async function mountDialog(opts: {
   trackFeedback?: (...args: unknown[]) => void;
   onClose?: () => void;
   onSubmitted?: () => void;
+  /** #912 — a star already picked on the inline nudge. */
+  initialRating?: number;
 } = {}): Promise<HTMLDivElement> {
   // jsdom does not implement modal dialogs in every version, and the `Dialog`
   // primitive calls `showModal()` from an effect. Stubbed to a plain open so
@@ -58,6 +60,9 @@ async function mountDialog(opts: {
         open: true,
         onClose: opts.onClose ?? (() => {}),
         onSubmitted: opts.onSubmitted ?? (() => {}),
+        ...(opts.initialRating !== undefined
+          ? { initialRating: opts.initialRating }
+          : {}),
       }),
     );
   });
@@ -252,5 +257,40 @@ describe("FeedbackDialog", () => {
     expect(trackFeedback).not.toHaveBeenCalled();
     expect(onSubmitted).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** #912: the nudge collects a star before this dialog exists, so opening on
+ *  the star step would ask for it twice — and the second ask is where people
+ *  drop out. */
+describe("FeedbackDialog opened from the nudge (#912)", () => {
+  it("opens straight onto the constructive branch for a low pre-picked star", async () => {
+    const el = await mountDialog({ initialRating: 2 });
+    expect(el.textContent).toContain("How can we make OfflineCV better?");
+    // Not the star step: no second ask.
+    expect(el.textContent).not.toContain("Tap a star to rate your experience.");
+  });
+
+  it("opens straight onto the positive branch for a high pre-picked star", async () => {
+    const el = await mountDialog({ initialRating: 5 });
+    expect(el.textContent).toContain("Thank you! We're glad it helped.");
+    expect(el.querySelector('a[href*="github.com"]')).not.toBeNull();
+  });
+
+  it("submits the pre-picked rating, not a zero", async () => {
+    // The value only ever arrived as a prop, so a shell that forgot to seed
+    // its own state would still render the right step and report `rating: 0`.
+    const trackFeedback = vi.fn();
+    const el = await mountDialog({ initialRating: 2, trackFeedback });
+    // The constructive step's own label — the positive step says "Submit".
+    await act(async () => button(el, "Submit Feedback")?.click());
+
+    expect(trackFeedback).toHaveBeenCalledTimes(1);
+    expect(trackFeedback.mock.calls[0][0]).toMatchObject({ rating: 2 });
+  });
+
+  it("still opens on the star step when nothing was pre-picked", async () => {
+    const el = await mountDialog({ initialRating: 0 });
+    expect(el.textContent).toContain("Tap a star to rate your experience.");
   });
 });

--- a/src/components/features/FeedbackDialog.tsx
+++ b/src/components/features/FeedbackDialog.tsx
@@ -16,9 +16,16 @@
  * its own form state, and together they'd push this file well past
  * CLAUDE.md's ~200 LOC feature-component ceiling.
  *
- * Open/close, the automatic-vs-ambient triggers, and the localStorage
- * capping all live in `useFeedbackDialog` (`src/hooks/`) — this component is
- * display + step routing + the actual `trackFeedback` call only.
+ * Open/close, the triggers, and the localStorage cooldown all live in
+ * `useFeedbackDialog` (`src/hooks/`) — this component is display + step
+ * routing + the actual `trackFeedback` call only.
+ *
+ * Since #912 this dialog is only ever opened by the USER: the ambient
+ * `[★ Feedback]` button, or a star on the inline `FeedbackNudge` (which is
+ * what the export milestone now raises instead of opening this directly). A
+ * modal is the right instrument for a flow someone chose to enter and the
+ * wrong one for an invitation they did not — see `FeedbackNudge`'s docblock.
+ * `initialRating` is how a star picked out there arrives here.
  *
  * In-place confirmation only (issue §3 — no toast/snackbar): submitting from
  * either step 2 body lands on a terminal `thanks` step rather than closing.
@@ -38,6 +45,12 @@ import { FeedbackConstructiveStep } from "./FeedbackConstructiveStep.tsx";
 interface FeedbackDialogProps {
   open: boolean;
   onClose: () => void;
+  /** A rating the user already picked before this opened — the inline
+   *  `FeedbackNudge`'s stars (#912). Opens straight onto that rating's branch;
+   *  `0` (the default) opens on the star step as before. Asking someone to
+   *  pick a star they just picked is the kind of small betrayal that stops
+   *  people answering the next one. */
+  initialRating?: number;
   /** Fired after a successful submission so the caller can persist
    *  `ocv_feedback_submitted` — see `useFeedbackDialog`. */
   onSubmitted: () => void;
@@ -56,19 +69,34 @@ const TITLES: Record<Step, string> = {
  *  shell already knows from routing Step 1. */
 type StepSubmission = Omit<FeedbackArgs, "rating">;
 
-export function FeedbackDialog({ open, onClose, onSubmitted }: FeedbackDialogProps) {
+/** Which step a rating routes to. One definition, used both by the star step's
+ *  own handler and by the pre-picked `initialRating` path, so the 4★ threshold
+ *  cannot come to mean two different things depending on where the star was
+ *  clicked. */
+function stepForRating(rating: number): Step {
+  return rating >= 4 ? "positive" : "constructive";
+}
+
+export function FeedbackDialog({
+  open,
+  onClose,
+  initialRating = 0,
+  onSubmitted,
+}: FeedbackDialogProps) {
   const [step, setStep] = useState<Step>("rating");
   const [rating, setRating] = useState(0);
   const thanksRef = useRef<HTMLDivElement>(null);
 
   // Fresh every time the dialog opens — a snoozed-then-reopened session
-  // should never land on last time's step or rating.
+  // should never land on last time's step or rating. `initialRating` is a dep
+  // as well as `open` because the nudge can hand over a different star on a
+  // later open without this component unmounting in between.
   useEffect(() => {
     if (open) {
-      setStep("rating");
-      setRating(0);
+      setRating(initialRating);
+      setStep(initialRating >= 1 ? stepForRating(initialRating) : "rating");
     }
-  }, [open]);
+  }, [open, initialRating]);
 
   // Submitting unmounts the button that was just activated, which would drop
   // focus to `<body>` — outside the dialog's tab ring — while the whole body
@@ -80,7 +108,7 @@ export function FeedbackDialog({ open, onClose, onSubmitted }: FeedbackDialogPro
 
   function handleRate(value: number): void {
     setRating(value);
-    setStep(value >= 4 ? "positive" : "constructive");
+    setStep(stepForRating(value));
   }
 
   function handleSubmit(fields: StepSubmission): void {

--- a/src/components/features/FeedbackNudge.test.tsx
+++ b/src/components/features/FeedbackNudge.test.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+// @vitest-environment jsdom
+
+/**
+ * FeedbackNudge (#912) — the inline ask that replaced #900's automatic modal.
+ *
+ * The properties worth pinning are the ones that make it NOT a dialog: it
+ * carries the star value it was clicked with (so the dialog it opens does not
+ * ask again), it offers a real "not now", and it announces itself politely
+ * rather than seizing anything. A regression here does not throw — it just
+ * quietly becomes an interruption again.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { setupDomRoot } from "./__test-utils__/dialog-dom.ts";
+import { FeedbackNudge } from "./FeedbackNudge.tsx";
+
+const dom = setupDomRoot();
+
+function radios(): HTMLInputElement[] {
+  return [...dom.container.querySelectorAll<HTMLInputElement>('input[type="radio"]')];
+}
+
+function clickText(text: string) {
+  const button = [...dom.container.querySelectorAll("button")].find(
+    (b) => b.textContent === text,
+  );
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  return button;
+}
+
+describe("FeedbackNudge (#912)", () => {
+  it("hands over the star that was picked, so the dialog need not ask twice", () => {
+    const onRate = vi.fn();
+    dom.render(<FeedbackNudge onRate={onRate} onDismiss={() => {}} />);
+
+    const stars = radios();
+    expect(stars.length).toBe(5);
+    act(() => {
+      stars[1].click();
+    });
+
+    expect(onRate).toHaveBeenCalledTimes(1);
+    expect(onRate).toHaveBeenCalledWith(2);
+  });
+
+  it("offers a real 'not now' that opens nothing", () => {
+    const onRate = vi.fn();
+    const onDismiss = vi.fn();
+    dom.render(<FeedbackNudge onRate={onRate} onDismiss={onDismiss} />);
+
+    expect(clickText("Not now")).toBeTruthy();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onRate).not.toHaveBeenCalled();
+  });
+
+  it("announces politely and holds no rating of its own", () => {
+    dom.render(<FeedbackNudge onRate={() => {}} onDismiss={() => {}} />);
+
+    // `status`, not `alert`: an invitation waits its turn behind whatever the
+    // screen reader was saying about the export the user just finished.
+    expect(dom.container.querySelector('[role="status"]')).toBeTruthy();
+    // No star is pre-lit — a lit star here would claim a rating was recorded
+    // when nothing has been sent.
+    expect(radios().some((r) => r.checked)).toBe(false);
+  });
+
+  it("is not a dialog, and so cannot trap focus", () => {
+    // The whole reason this component exists. If it ever becomes a `Dialog`,
+    // #912's fix has been undone.
+    dom.render(<FeedbackNudge onRate={() => {}} onDismiss={() => {}} />);
+    expect(dom.container.querySelector("dialog")).toBeNull();
+    expect(dom.container.querySelector('[aria-modal="true"]')).toBeNull();
+  });
+});

--- a/src/components/features/FeedbackNudge.tsx
+++ b/src/components/features/FeedbackNudge.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The offlinecv Authors
+
+/**
+ * FeedbackNudge — the inline invitation that replaces #900's automatic modal
+ * open (#912).
+ *
+ * #900 was right that the ask should follow a real success moment and right to
+ * keep an always-available `[★ Feedback]` button. The part worth changing is
+ * the instrument: it opened `FeedbackDialog` itself, and `Dialog` is a native
+ * `showModal()`, so an automatic open takes keyboard focus off whatever the
+ * user was doing and reads to a screen reader as an interruption. NN/g's
+ * *User-Feedback Requests* endorses task-then-ask and an always-available way
+ * in while explicitly discouraging modal popups for the ask itself.
+ *
+ * So this is the ask, and it is deliberately the smallest thing that can be
+ * one: a line of copy and the star row, inline, dismissible. Picking a star
+ * opens the full dialog on the branch that star routes to — user-initiated,
+ * which is when a modal is the right instrument rather than the wrong one.
+ *
+ * **Does not steal focus.** It renders in the normal flow and takes its turn in
+ * the tab order rather than pulling focus to itself, which is the whole point
+ * of not being a dialog. It is announced by `role="status"` — polite, so a
+ * screen reader finishes whatever it was saying about the export the user just
+ * completed before mentioning this.
+ *
+ * Reuse analysis: no new surface. `StarRating` is the same primitive
+ * `FeedbackDialog`'s own step 1 uses, so a star means the same thing in both
+ * places and the routing threshold lives in one component; `Card` and `Button`
+ * are the shared pieces every other inline block on this page is built from.
+ * The dialog is not duplicated — this hands off to it.
+ */
+
+import { Button, Card, StarRating } from "@design-system";
+
+interface FeedbackNudgeProps {
+  /** Picking a star. Carries the value so the dialog can open on the branch
+   *  the user already chose rather than asking them to pick twice. */
+  onRate: (rating: number) => void;
+  /** "Not now" — a real answer, and the cooldown treats it as one. */
+  onDismiss: () => void;
+}
+
+export function FeedbackNudge({ onRate, onDismiss }: FeedbackNudgeProps) {
+  return (
+    <Card className="flex flex-wrap items-center justify-between gap-3">
+      {/* `role="status"` rather than `alert`: this arrives unprompted, but it
+          is an invitation, not a problem — polite means it waits its turn
+          instead of cutting off the export result being announced. */}
+      <div role="status" className="flex min-w-0 flex-col gap-0.5">
+        <p className="text-sm font-medium text-content-primary">
+          How did your resume turn out?
+        </p>
+        <p className="text-2xs text-content-tertiary">
+          One tap. It stays on this page unless you send it.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        {/* `value={0}` always: this is an entry point, not a control holding
+            state. The rating it collects lives in the dialog it opens, and a
+            star left lit here after the dialog closed would claim a rating was
+            recorded when nothing was sent. */}
+        <StarRating
+          value={0}
+          onChange={onRate}
+          ariaLabel="Rate your resume experience from 1 to 5 stars"
+        />
+        <Button variant="ghost" size="sm" onClick={onDismiss}>
+          Not now
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/hooks/useFeedbackDialog.test.ts
+++ b/src/hooks/useFeedbackDialog.test.ts
@@ -4,24 +4,28 @@
 // @vitest-environment jsdom
 
 /**
- * useFeedbackDialog (#900) — the controller behind `FeedbackDialog`'s two
- * trigger paths and the localStorage capping between them.
+ * useFeedbackDialog (#900, #912) — the controller behind the feedback ask: how
+ * it arrives, and how long it stays away afterwards.
  *
- * Pinned here:
- *  - the ambient trigger opens the dialog and increments
- *    `ocv_feedback_dialog_seen` exactly once per open;
- *  - the export milestone opens NOTHING until the export dialog closes — two
- *    native modals must never be open at once (`ExportDialog` stays open after
- *    a download by design, #421);
- *  - the automatic trigger fires the first time, then never again in the same
- *    session — the #900 "opens once" contract;
- *  - a returning browser carrying the retired panel's `ocv_feedback_seen`
- *    still gets the automatic trigger: this hook does not read that key, and
- *    every existing tester already has a non-zero value under it;
- *  - once the ambient button has shown the dialog, a LATER export no longer
- *    auto-opens it (snoozed, not re-nagged);
- *  - `ocv_feedback_submitted` permanently suppresses the automatic trigger,
- *    while the ambient trigger keeps working.
+ * Pinned here, and the first two are the #912 behaviour changes worth stating
+ * as tests rather than as prose:
+ *
+ *  - the export milestone raises the inline NUDGE, never the dialog. #900
+ *    auto-opened a native modal, which takes keyboard focus off whatever the
+ *    user was doing; only a user's own click opens the dialog now;
+ *  - the ambient `[★ Feedback]` button does NOT start the cooldown. Under #900
+ *    it shared one counter with the automatic trigger, so a user who opened the
+ *    dialog out of curiosity permanently disabled the automatic ask;
+ *  - the milestone raises nothing until the export dialog closes — a nudge
+ *    shown behind a still-open `ExportDialog` (#421) is one the user never
+ *    sees arrive;
+ *  - the cooldown is elapsed time, not a lifetime cap: inside the window the
+ *    ask is suppressed, past it the ask returns;
+ *  - a returning browser carrying #900's `ocv_feedback_dialog_seen` — or the
+ *    retired panel's `ocv_feedback_seen` — is asked again. Neither key is
+ *    read, which is the deliberate one-time cost of loosening the cap;
+ *  - `ocv_feedback_submitted` permanently suppresses the automatic ask, while
+ *    the ambient trigger keeps working.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -59,6 +63,14 @@ async function mount(): Promise<Harness> {
   return { api: () => current! };
 }
 
+/** Drive a full export: the download, then the export dialog closing. */
+async function exportResume(h: Harness): Promise<void> {
+  await act(async () => h.api().notifyResumeExported());
+  await act(async () => h.api().notifyExportClosed());
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 afterEach(() => {
   if (root) act(() => root!.unmount());
   container?.remove();
@@ -68,70 +80,132 @@ afterEach(() => {
 });
 
 describe("useFeedbackDialog", () => {
-  it("starts closed", async () => {
+  it("starts with nothing showing", async () => {
     const h = await mount();
+    expect(h.api().open).toBe(false);
+    expect(h.api().nudgeVisible).toBe(false);
+  });
+
+  it("the export milestone raises the NUDGE, not the dialog", async () => {
+    // #912's central change. A native modal opening by itself takes keyboard
+    // focus off whatever the user was doing; an invitation must not do that.
+    const h = await mount();
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(true);
     expect(h.api().open).toBe(false);
   });
 
-  it("the ambient trigger opens the dialog and increments the seen counter", async () => {
-    const h = await mount();
-    await act(async () => h.api().openDialog());
-    expect(h.api().open).toBe(true);
-    expect(window.localStorage.getItem("ocv_feedback_dialog_seen")).toBe("1");
-  });
-
-  it("an export alone opens nothing — the dialog waits for the export dialog to close", async () => {
+  it("an export alone raises nothing — it waits for the export dialog to close", async () => {
     const h = await mount();
     await act(async () => h.api().notifyResumeExported());
     // `ExportDialog` is still open here, showing the row that produced the
-    // file (#421/#621). A second native modal on top of it would bury that.
-    expect(h.api().open).toBe(false);
+    // file (#421/#621). A nudge behind it is one the user never sees arrive.
+    expect(h.api().nudgeVisible).toBe(false);
 
     await act(async () => h.api().notifyExportClosed());
-    expect(h.api().open).toBe(true);
+    expect(h.api().nudgeVisible).toBe(true);
   });
 
-  it("closing the export dialog without exporting opens nothing", async () => {
+  it("closing the export dialog without exporting raises nothing", async () => {
     const h = await mount();
     await act(async () => h.api().notifyExportClosed());
+    expect(h.api().nudgeVisible).toBe(false);
     expect(h.api().open).toBe(false);
   });
 
-  it("still auto-triggers for a browser carrying the retired panel's ocv_feedback_seen", async () => {
-    // A returning tester: the retired `FeedbackPanel` bumped `ocv_feedback_seen`
-    // on every mount of the results page, so a value >= 2 is exactly what the
-    // people #900 is for already have. Reusing that key would leave the
-    // milestone trigger permanently dead for them.
+  it("a star on the nudge opens the dialog on that rating and retires the nudge", async () => {
+    const h = await mount();
+    await exportResume(h);
+
+    await act(async () => h.api().openDialog(2));
+    expect(h.api().open).toBe(true);
+    expect(h.api().initialRating).toBe(2);
+    // Leaving it up behind the dialog would offer the same stars twice.
+    expect(h.api().nudgeVisible).toBe(false);
+  });
+
+  it("dismissing the nudge opens nothing and leaves it dismissed", async () => {
+    const h = await mount();
+    await exportResume(h);
+    await act(async () => h.api().dismissNudge());
+    expect(h.api().nudgeVisible).toBe(false);
+    expect(h.api().open).toBe(false);
+  });
+
+  it("the ambient trigger does NOT start the cooldown", async () => {
+    // The #900 bug this replaces: `openDialog` shared one counter with the
+    // automatic trigger, so looking at the dialog on purpose permanently
+    // disabled being asked. Opening it yourself is not us asking you.
+    const h = await mount();
+    await act(async () => h.api().openDialog());
+    expect(h.api().open).toBe(true);
+    expect(window.localStorage.getItem("ocv_feedback_prompted_at")).toBeNull();
+
+    await act(async () => h.api().close());
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(true);
+  });
+
+  it("records the ask when the nudge becomes visible, not when it is answered", async () => {
+    // A nudge scrolled past is still an ask that was received; re-asking
+    // tomorrow because it was ignored is the nagging this exists to prevent.
+    const h = await mount();
+    await exportResume(h);
+    const at = window.localStorage.getItem("ocv_feedback_prompted_at");
+    expect(at).not.toBeNull();
+    expect(Number.parseInt(at!, 10)).toBeGreaterThan(0);
+  });
+
+  it("suppresses the ask inside the cooldown window", async () => {
+    window.localStorage.setItem(
+      "ocv_feedback_prompted_at",
+      String(Date.now() - DAY_MS),
+    );
+    const h = await mount();
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(false);
+  });
+
+  it("asks again once the cooldown has elapsed", async () => {
+    // The half that makes it a cooldown rather than a lifetime cap — without
+    // this case the suppression above would pass against a permanent lock.
+    window.localStorage.setItem(
+      "ocv_feedback_prompted_at",
+      String(Date.now() - 30 * DAY_MS),
+    );
+    const h = await mount();
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(true);
+  });
+
+  it("asks a browser carrying either retired key, and reads neither", async () => {
+    // Every returning tester holds a value under both. Honouring them would
+    // keep #900's lifetime cap alive for exactly the people #912 is for.
     window.localStorage.setItem("ocv_feedback_seen", "2");
+    window.localStorage.setItem("ocv_feedback_dialog_seen", "1");
     const h = await mount();
 
-    await act(async () => h.api().notifyResumeExported());
-    await act(async () => h.api().notifyExportClosed());
-    expect(h.api().open).toBe(true);
-    // And the untouched legacy key is neither read nor migrated.
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(true);
     expect(window.localStorage.getItem("ocv_feedback_seen")).toBe("2");
     expect(window.localStorage.getItem("ocv_feedback_dialog_seen")).toBe("1");
   });
 
-  it("does not auto-reopen after the dialog has already been shown once", async () => {
+  it("asks rather than staying silent when the stored timestamp is unreadable", async () => {
+    // Fail open: a corrupt key that locked someone out of ever being asked is
+    // the #912 bug arrived at by another route.
+    window.localStorage.setItem("ocv_feedback_prompted_at", "not-a-number");
     const h = await mount();
-    await act(async () => h.api().openDialog());
-    await act(async () => h.api().close());
-    expect(h.api().open).toBe(false);
-
-    await act(async () => h.api().notifyResumeExported());
-    await act(async () => h.api().notifyExportClosed());
-    // Snoozed: the automatic trigger never got its own "first open".
-    expect(h.api().open).toBe(false);
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(true);
   });
 
-  it("never auto-opens once feedback has been submitted", async () => {
+  it("never asks once feedback has been submitted, but stays reachable", async () => {
     const h = await mount();
     await act(async () => h.api().markSubmitted());
-    await act(async () => h.api().notifyResumeExported());
-    await act(async () => h.api().notifyExportClosed());
-    expect(h.api().open).toBe(false);
-    // The ambient trigger still works for a submitted user who reopens it.
+    await exportResume(h);
+    expect(h.api().nudgeVisible).toBe(false);
+
     await act(async () => h.api().openDialog());
     expect(h.api().open).toBe(true);
   });

--- a/src/hooks/useFeedbackDialog.ts
+++ b/src/hooks/useFeedbackDialog.ts
@@ -2,95 +2,156 @@
 // Copyright 2026 The offlinecv Authors
 
 /**
- * useFeedbackDialog — owns `FeedbackDialog`'s (#900) open state and its
- * localStorage-backed lifecycle: the automatic milestone trigger, the ambient
- * trigger, and the capping that keeps both well-behaved.
+ * useFeedbackDialog — owns `FeedbackDialog`'s (#900) open state, the inline
+ * `FeedbackNudge`'s visibility (#912), and the localStorage-backed lifecycle
+ * that decides when we are allowed to ask at all.
  *
- * A single instance is owned at page level (`App`), because the two ways in
- * — the ambient `[★ Feedback]` button (deep inside `ParsedHeader`) and the
- * automatic trigger (earned from `ExportDialog`'s résumé-only callback, also
- * page level) — both need to open the SAME dialog. Threading one controller
- * down covers both without two sources of truth for "is the dialog open".
+ * A single instance is owned at page level (`App`), because every way in — the
+ * ambient `[★ Feedback]` button deep inside `ParsedHeader`, the nudge, and the
+ * export milestone that raises the nudge — has to reach the SAME dialog.
  *
- * **The export milestone is earned and flushed at two different moments, on
- * purpose.** `ExportDialog` deliberately stays open after a download so the
- * row that produced the file can render its failure `error` and its #621
- * glyph findings — the #421 fix, spelled out in that file's docblock. Opening
- * from the export callback would stack a second native modal over it and pull
- * focus off that advisory, so `notifyResumeExported` only RECORDS the
- * milestone; `notifyExportClosed`, wired to the export dialog's own `onClose`,
- * is what opens the dialog.
+ * ## The milestone raises a NUDGE, not the dialog (#912)
  *
- * Persistence:
- *   ocv_feedback_dialog_seen — incremented once per real open (auto or
- *                             ambient). A dismissed prompt is still "seen",
- *                             so this doubles as the snooze: the automatic
- *                             trigger only fires while the dialog has never
- *                             been shown at all. Deliberately NOT the retired
- *                             `FeedbackPanel`'s `ocv_feedback_seen`, which
- *                             counted every mount of the results page — every
- *                             returning browser already holds a non-zero value
- *                             under that key, so reusing it would leave the
- *                             milestone trigger permanently dead for exactly
- *                             the repeat testers #900 exists for.
- *   ocv_feedback_submitted — set once a submission ships. Suppresses the
- *                             automatic trigger permanently; the ambient
- *                             button keeps working — a submitted user
- *                             reopening it on purpose is not spam. Shared with
- *                             the retired panel on purpose: a user who already
- *                             sent feedback should not be asked again.
+ * #900 opened the dialog itself here, and that was the one part of its design
+ * running against the strongest guidance available: NN/g's *User-Feedback
+ * Requests* endorses asking after task completion and keeping an
+ * always-available way in — both of which we do — while explicitly
+ * discouraging modal popups for the ask. A native `showModal()` carries a
+ * browser focus trap, so an automatic open takes keyboard focus off whatever
+ * the user was doing, unprompted, and announces itself to a screen reader as
+ * an interruption. For an *invitation* that is the wrong instrument.
+ *
+ * So the milestone now shows an inline, dismissible star row. Picking a star
+ * opens the dialog — user-initiated, which is exactly when a modal is fine.
+ *
+ * That also collapses the two-moment dance #900 needed. `ExportDialog` stays
+ * open after a download on purpose (#421), so #900 had to RECORD the milestone
+ * in `notifyResumeExported` and only open it from `notifyExportClosed`, or it
+ * would stack a second native modal over the findings the download had just
+ * produced. A non-modal nudge cannot stack, so both callbacks remain only
+ * because the nudge should not appear *behind* the export dialog either — the
+ * user would never see it arrive.
+ *
+ * ## Cooldown, not a lifetime cap (#912)
+ *
+ * #900 gated the automatic trigger on `seenCount > 0` — shown once, ever, and
+ * never again. Worse, `openDialog()` incremented that same counter, so a user
+ * who clicked the ambient button out of curiosity permanently disabled the
+ * automatic ask. The issue this replaced was filed because the old inline
+ * panel nagged; the fix overshot into near-silence.
+ *
+ * The standing recommendation is a global cooldown rather than a permanent
+ * lock, so:
+ *
+ *   ocv_feedback_prompted_at — epoch ms of the last time we asked
+ *                              UNPROMPTED. Only the nudge writes it; an
+ *                              ambient open never does, because a user opening
+ *                              the dialog themselves is not us asking them.
+ *                              Absent means never asked.
+ *   ocv_feedback_submitted   — set once a submission ships. Permanent kill
+ *                              switch for the automatic ask; the ambient button
+ *                              keeps working, since a submitted user reopening
+ *                              it on purpose is not spam. Shared with the
+ *                              retired `FeedbackPanel` on purpose: someone who
+ *                              already wrote in should not be asked again.
+ *
+ * `ocv_feedback_dialog_seen` (#900's counter) is deliberately NOT read. A
+ * returning browser holds a non-zero value under it, and honouring that would
+ * keep the lifetime cap alive for exactly the repeat testers this change is
+ * for — so those browsers become eligible once, then fall under the cooldown
+ * like everyone else. That one extra ask is the intended cost of loosening the
+ * cap, not an oversight.
  */
 
 import { useRef, useState } from "react";
-import { usePersistentCounter, usePersistentFlag } from "./usePersistentFlag.ts";
+import { usePersistentFlag } from "./usePersistentFlag.ts";
 
-const LS_KEY_SEEN = "ocv_feedback_dialog_seen";
+const LS_KEY_PROMPTED_AT = "ocv_feedback_prompted_at";
 const LS_KEY_SUBMITTED = "ocv_feedback_submitted";
+
+/**
+ * How long after an unprompted ask before we may ask again.
+ *
+ * Fourteen days: long enough that a tester working through several résumés in
+ * one week is asked once rather than each time, short enough that someone who
+ * dismissed it while busy is reachable in the next round of testing. A number
+ * rather than a `seen < N` count on purpose — the failure mode being fixed is
+ * asking too often, and only elapsed time measures that.
+ *
+ * Module-private: nothing outside needs it, and the tests deliberately drive
+ * timestamps well inside and well outside the window rather than deriving from
+ * this value — a test that computes its fixture from the constant it is
+ * checking passes for any constant, this one included.
+ */
+const FEEDBACK_COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
 
 export interface FeedbackDialogController {
   open: boolean;
-  /** Open on demand — the ambient `[★ Feedback]` trigger. */
-  openDialog: () => void;
+  /** The rating the dialog should open on, or 0 to start at the star step.
+   *  Non-zero only when the nudge's own stars were used — see `openDialog`. */
+  initialRating: number;
+  /** True while the inline nudge should render (#912). */
+  nudgeVisible: boolean;
+  /** Open on demand. `rating` carries a star picked on the nudge, so the
+   *  dialog opens on the branch the user already chose rather than asking
+   *  them to pick again. */
+  openDialog: (rating?: number) => void;
   close: () => void;
-  /** Call once a PDF or Markdown export completes. Records the milestone the
-   *  first time only (see the capping rules above); nothing opens until
-   *  `notifyExportClosed` fires. */
+  /** Dismiss the nudge without opening anything — a real answer ("not now"),
+   *  and it starts the cooldown the same as showing it did. */
+  dismissNudge: () => void;
+  /** Call once a PDF or Markdown export completes. Arms the nudge if the
+   *  cooldown allows; nothing appears until `notifyExportClosed`. */
   notifyResumeExported: () => void;
-  /** Call from `ExportDialog`'s `onClose`. Opens the dialog if — and only if
-   *  — a résumé export earned the milestone while it was open. */
+  /** Call from `ExportDialog`'s `onClose`. Shows the nudge if — and only if —
+   *  a résumé export armed it while that dialog was open. */
   notifyExportClosed: () => void;
   /** Call once a submission has shipped via `trackFeedback` — persists the
-   *  submitted flag so the automatic trigger never fires again. */
+   *  submitted flag so the automatic ask never fires again. */
   markSubmitted: () => void;
 }
 
 export function useFeedbackDialog(): FeedbackDialogController {
   const [submitted, setSubmitted] = usePersistentFlag(LS_KEY_SUBMITTED, "");
-  const [seenCount, incrementSeen] = usePersistentCounter(LS_KEY_SEEN);
+  const [promptedAt, setPromptedAt] = usePersistentFlag(LS_KEY_PROMPTED_AT, "");
   const [open, setOpen] = useState(false);
-  // Guards a single auto-trigger per session even if two exports complete in
-  // quick succession before `seenCount`'s state update is read back.
-  const autoFiredRef = useRef(false);
+  const [initialRating, setInitialRating] = useState(0);
+  const [nudgeVisible, setNudgeVisible] = useState(false);
+  // Guards a single arm per session even if two exports complete in quick
+  // succession before the persisted timestamp is read back.
+  const armedRef = useRef(false);
   // The milestone, earned but not yet shown — see the two-moment note above.
   const pendingRef = useRef(false);
 
-  function openDialog(): void {
-    if (!open) incrementSeen();
+  function openDialog(rating = 0): void {
+    setInitialRating(rating);
     setOpen(true);
+    // Opening from the nudge answers it; leaving it on screen behind the
+    // dialog would offer the same stars twice.
+    setNudgeVisible(false);
   }
 
   function notifyResumeExported(): void {
     if (submitted === "1") return;
-    if (seenCount > 0) return; // already shown once — snoozed, not re-nagged
-    if (autoFiredRef.current) return;
-    autoFiredRef.current = true;
+    if (!cooldownElapsed(promptedAt)) return;
+    if (armedRef.current) return;
+    armedRef.current = true;
     pendingRef.current = true;
   }
 
   function notifyExportClosed(): void {
     if (!pendingRef.current) return;
     pendingRef.current = false;
-    openDialog();
+    // The cooldown starts when the ask becomes VISIBLE, not when it is
+    // answered. A nudge the user scrolled past is still an ask they received,
+    // and re-asking tomorrow because they ignored it is the nagging this
+    // exists to prevent.
+    setPromptedAt(String(Date.now()));
+    setNudgeVisible(true);
+  }
+
+  function dismissNudge(): void {
+    setNudgeVisible(false);
   }
 
   function close(): void {
@@ -103,10 +164,29 @@ export function useFeedbackDialog(): FeedbackDialogController {
 
   return {
     open,
+    initialRating,
+    nudgeVisible,
     openDialog,
     close,
+    dismissNudge,
     notifyResumeExported,
     notifyExportClosed,
     markSubmitted,
   };
+}
+
+/**
+ * True when enough time has passed since the last unprompted ask — including
+ * the never-asked case, and including a stored value this build cannot parse.
+ *
+ * An unreadable timestamp resolves to "may ask", not "may not". The competing
+ * failure modes are one extra invitation against a permanently silent one, and
+ * a corrupt key that locks a user out of ever being asked is precisely the
+ * bug #912 was filed about, arrived at by a different route.
+ */
+function cooldownElapsed(promptedAt: string): boolean {
+  if (promptedAt === "") return true;
+  const at = Number.parseInt(promptedAt, 10);
+  if (!Number.isFinite(at)) return true;
+  return Date.now() - at >= FEEDBACK_COOLDOWN_MS;
 }


### PR DESCRIPTION
Implements the two changes recommended in the research pass on #912 ([writeup](https://github.com/offlinecv/OfflineCV/issues/912#issuecomment-5464174007)).

> ⚠️ **#912 says "don't open a PR yet"** — it asks for research first, then a scoped discussion with @s-annam. This PR exists because the work was explicitly requested after the writeup was posted. Treat it as a concrete proposal to react to rather than an agreed scope; the two open product calls below are deliberately **not** in it.

## Context: the issue's premise was stale

#912 was written against `FeedbackPanel.tsx`, which no longer exists — #900/#903 retired it after the Aug 27 sync. Three of the issue's five questions were already answered by that change (no longer always-visible, already branches by rating, already a bare star row that expands). What was left is what this PR does.

## 1. The milestone raises a nudge, not the dialog

`Dialog` is a native `showModal()`. Opening it automatically took keyboard focus off whatever the user was doing and announced itself to a screen reader as an interruption — the wrong instrument for an invitation. This is also the answer to the issue's accessibility question, and the answer had got **worse** with #900, not better: the old concern was a panel appearing below the fold, the new one was a focus trap arriving uninvited.

NN/g's [User-Feedback Requests](https://www.nngroup.com/articles/user-feedback/) endorses asking after task completion and keeping an always-available way in — both of which #900 got right — while explicitly discouraging modal popups for the ask itself.

So a résumé export now shows `FeedbackNudge`: inline, dismissible, `role="status"` (polite, so it waits behind whatever the reader was saying about the export), the star row plus one line. Picking a star opens the dialog **on that rating's branch** via a new `initialRating` prop, so nobody is asked for the same star twice.

Side effect worth noting: this nearly retires the two-moment `notifyResumeExported` / `notifyExportClosed` dance. A non-modal nudge can't stack on `ExportDialog`, so the split now exists only so the nudge doesn't appear *behind* it, unseen.

## 2. Cooldown instead of a lifetime cap

The automatic ask was gated on `seenCount > 0` — shown once, ever. And `openDialog()` incremented that same counter, so **a user who clicked the ambient `[★ Feedback]` button out of curiosity permanently disabled the automatic ask.**

| | before | after |
|---|---|---|
| Automatic ask | once per browser, forever | every 14 days |
| Ambient open | burns the automatic trigger | untouched |
| After submitting | never auto-asked again | unchanged |

`ocv_feedback_prompted_at` records only unprompted asks, written when the nudge becomes **visible** rather than when it's answered — a nudge scrolled past is still an ask received, and re-asking tomorrow because it was ignored is the nagging this exists to prevent.

**Migration is a deliberate one-time re-ask.** Neither `ocv_feedback_dialog_seen` (#900) nor `ocv_feedback_seen` (the retired panel) is read. Every returning tester holds a value under both, and honouring them would keep the lifetime cap alive for exactly the people this change is for — so those browsers become eligible once, then fall under the cooldown like everyone else.

**The cooldown fails open.** An unreadable timestamp asks rather than staying silent: a corrupt key that locks someone out of ever being asked is this issue's own bug reached by another route.

## Deliberately not in scope

- **Which milestone earns the ask.** Export is the rarest success moment in the funnel — anyone who parses, reads their score, edits and leaves is never asked. Changing it is a product call, not an implementation detail.
- **Per-parse vs per-browser memory.** The issue's question 3, still open. Falls out cheaply if the cooldown key incorporates `parseKey`, but "is a new résumé a new experience to rate" is a decision, not a refactor.
- **A dismissed rating is lost entirely** — pick 2★, close without typing, nothing is recorded. That's the strongest signal we have, discarded from the users least likely to write a paragraph. Fixing it changes the `feedback_submitted` event shape, which #912 puts out of scope; flagged in the writeup as wanting its own issue.

## Verification

`npm run verify` green: **384 test files, 6464 passed**, 10 skipped, build clean, `fallow audit --base origin/main` exit 0.

19 new tests. The ones with teeth:
- the milestone raises the nudge and **not** the dialog;
- the ambient button does **not** write the cooldown key;
- suppressed inside the window **and** asks again past it — without the second case the first would pass against a permanent lock;
- both retired keys are ignored and left untouched;
- an unreadable timestamp asks;
- the nudge is not a `dialog` and has no `aria-modal` — if that ever regresses, this PR has been undone.

One fallow note: `App.tsx`'s `App` function trips the complexity threshold at 787 lines. That's pre-existing debt (CLAUDE.md's known-debt list); this PR adds 8 lines to it and doesn't touch the shape. The gate passes.
